### PR TITLE
Handle multiple nvm bin paths

### DIFF
--- a/Sources/CodexBar/UsageFetcher.swift
+++ b/Sources/CodexBar/UsageFetcher.swift
@@ -282,6 +282,12 @@ private final class CodexRPCClient: @unchecked Sendable {
     /// Builds a PATH that works in hardened contexts by appending common install locations (Homebrew, bun, nvm, npm).
     static func seededPATH(from env: [String: String]) -> String {
         let home = NSHomeDirectory()
+        let nvmVersionsDir = "\(home)/.nvm/versions/node"
+        let nvmBins: [String] = if let versions = try? FileManager.default.contentsOfDirectory(atPath: nvmVersionsDir) {
+            versions.map { "\(nvmVersionsDir)/\($0)/bin" }
+        } else {
+            []
+        }
         let defaultPath = [
             "/usr/bin",
             "/bin",
@@ -291,15 +297,15 @@ private final class CodexRPCClient: @unchecked Sendable {
             "/usr/local/bin",
             "\(home)/.bun/bin",
             "\(home)/.nvm/versions/node/current/bin",
-            "\(home)/.nvm/versions/node/*/bin",
             "\(home)/.npm-global/bin",
             "\(home)/.local/share/fnm",
             "\(home)/.fnm",
-        ].joined(separator: ":")
+        ] + nvmBins
+        let joined = defaultPath.joined(separator: ":")
         if let existing = env["PATH"], !existing.isEmpty {
-            return "\(existing):\(defaultPath)"
+            return "\(existing):\(joined)"
         }
-        return defaultPath
+        return joined
     }
 }
 
@@ -312,6 +318,12 @@ struct UsageFetcher: Sendable {
     /// npm).
     static func seededPATH(from env: [String: String]) -> String {
         let home = NSHomeDirectory()
+        let nvmVersionsDir = "\(home)/.nvm/versions/node"
+        let nvmBins: [String] = if let versions = try? FileManager.default.contentsOfDirectory(atPath: nvmVersionsDir) {
+            versions.map { "\(nvmVersionsDir)/\($0)/bin" }
+        } else {
+            []
+        }
         let defaultPath = [
             "/usr/bin",
             "/bin",
@@ -321,15 +333,15 @@ struct UsageFetcher: Sendable {
             "/usr/local/bin",
             "\(home)/.bun/bin",
             "\(home)/.nvm/versions/node/current/bin",
-            "\(home)/.nvm/versions/node/*/bin",
             "\(home)/.npm-global/bin",
             "\(home)/.local/share/fnm",
             "\(home)/.fnm",
-        ].joined(separator: ":")
+        ] + nvmBins
+        let joined = defaultPath.joined(separator: ":")
         if let existing = env["PATH"], !existing.isEmpty {
-            return "\(existing):\(defaultPath)"
+            return "\(existing):\(joined)"
         }
-        return defaultPath
+        return joined
     }
 
     init(environment: [String: String] = ProcessInfo.processInfo.environment) {


### PR DESCRIPTION
**Summary**
CodexBar couldn’t find the codex binary when it was installed via nvm because PATH seeding added a literal `~/.nvm/versions/node/*/bin` segment, which never globbed to real versioned `bin` folders. As a result, the RPC probe failed with "Codex RPC probe failed: Malformed response: codex app-server closed stdout" when the CLI wasn’t on PATH.

**What changed**
- `Sources/CodexBar/UsageFetcher.swift`: Enumerate real `~/.nvm/versions/node/*/bin` directories when seeding PATH for RPC and TTY probes, replacing the non-expanding wildcard entry

**Before**
<img width="593" height="364" alt="1" src="https://github.com/user-attachments/assets/25d0c9ea-85b8-434a-81c3-9efb867279b2" />

<img width="282" height="438" alt="2" src="https://github.com/user-attachments/assets/b76ec02e-000b-4eef-923b-b5ab9fce51e9" />

**After**
<img width="220" height="436" alt="3" src="https://github.com/user-attachments/assets/60f3d1f1-4a75-44a4-af10-bd344416991b" />

**Testing**
- swift build
- swift test
- ./Scripts/compile_and_run.sh