### PR TITLE
Route Claude subscription users to usage page instead of billing

### DIFF
--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -692,10 +692,16 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             ?? (self.store.isEnabled(.codex) ? .codex : self.store.enabledProviders().first)
 
         let provider = preferred ?? .codex
-        guard
-            let urlString = self.store.metadata(for: provider).dashboardURL,
-            let url = URL(string: urlString)
-        else { return }
+        let meta = self.store.metadata(for: provider)
+
+        // For Claude, route subscription users to claude.ai/settings/usage instead of console billing
+        let urlString: String? = if provider == .claude, self.store.isClaudeSubscription() {
+            meta.subscriptionDashboardURL ?? meta.dashboardURL
+        } else {
+            meta.dashboardURL
+        }
+
+        guard let urlString, let url = URL(string: urlString) else { return }
         NSWorkspace.shared.open(url)
     }
 

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -134,6 +134,27 @@ final class UsageStore: ObservableObject {
         self.status(for: provider)?.indicator ?? .none
     }
 
+    /// Returns the login method (plan type) for the specified provider, if available.
+    func loginMethod(for provider: UsageProvider) -> String? {
+        self.snapshots[provider]?.loginMethod
+    }
+
+    /// Returns true if the Claude account appears to be a subscription (Max, Pro, Ultra, Team).
+    /// Returns false for API users or when plan cannot be determined.
+    func isClaudeSubscription() -> Bool {
+        Self.isSubscriptionPlan(self.loginMethod(for: .claude))
+    }
+
+    /// Determines if a login method string indicates a Claude subscription plan.
+    /// Known subscription indicators: Max, Pro, Ultra, Team (case-insensitive).
+    nonisolated static func isSubscriptionPlan(_ loginMethod: String?) -> Bool {
+        guard let method = loginMethod?.lowercased(), !method.isEmpty else {
+            return false
+        }
+        let subscriptionIndicators = ["max", "pro", "ultra", "team"]
+        return subscriptionIndicators.contains { method.contains($0) }
+    }
+
     func version(for provider: UsageProvider) -> String? {
         switch provider {
         case .codex: self.codexVersion

--- a/Sources/CodexBarCore/Providers.swift
+++ b/Sources/CodexBarCore/Providers.swift
@@ -18,6 +18,7 @@ public struct ProviderMetadata: Sendable {
     public let cliName: String
     public let defaultEnabled: Bool
     public let dashboardURL: String?
+    public let subscriptionDashboardURL: String?
     public let statusPageURL: String?
 
     public init(
@@ -33,6 +34,7 @@ public struct ProviderMetadata: Sendable {
         cliName: String,
         defaultEnabled: Bool,
         dashboardURL: String?,
+        subscriptionDashboardURL: String? = nil,
         statusPageURL: String?)
     {
         self.id = id
@@ -47,6 +49,7 @@ public struct ProviderMetadata: Sendable {
         self.cliName = cliName
         self.defaultEnabled = defaultEnabled
         self.dashboardURL = dashboardURL
+        self.subscriptionDashboardURL = subscriptionDashboardURL
         self.statusPageURL = statusPageURL
     }
 }
@@ -80,6 +83,7 @@ public enum ProviderDefaults {
             cliName: "claude",
             defaultEnabled: false,
             dashboardURL: "https://console.anthropic.com/settings/billing",
+            subscriptionDashboardURL: "https://claude.ai/settings/usage",
             statusPageURL: "https://status.claude.com/"),
     ]
 }

--- a/Tests/CodexBarTests/SubscriptionDetectionTests.swift
+++ b/Tests/CodexBarTests/SubscriptionDetectionTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+@Suite
+struct SubscriptionDetectionTests {
+    // MARK: - Subscription plans should be detected
+
+    @Test
+    func detectsMaxPlan() {
+        #expect(UsageStore.isSubscriptionPlan("Claude Max") == true)
+        #expect(UsageStore.isSubscriptionPlan("Max") == true)
+        #expect(UsageStore.isSubscriptionPlan("claude max") == true)
+        #expect(UsageStore.isSubscriptionPlan("MAX") == true)
+    }
+
+    @Test
+    func detectsProPlan() {
+        #expect(UsageStore.isSubscriptionPlan("Claude Pro") == true)
+        #expect(UsageStore.isSubscriptionPlan("Pro") == true)
+        #expect(UsageStore.isSubscriptionPlan("pro") == true)
+    }
+
+    @Test
+    func detectsUltraPlan() {
+        #expect(UsageStore.isSubscriptionPlan("Claude Ultra") == true)
+        #expect(UsageStore.isSubscriptionPlan("Ultra") == true)
+        #expect(UsageStore.isSubscriptionPlan("ultra") == true)
+    }
+
+    @Test
+    func detectsTeamPlan() {
+        #expect(UsageStore.isSubscriptionPlan("Claude Team") == true)
+        #expect(UsageStore.isSubscriptionPlan("Team") == true)
+        #expect(UsageStore.isSubscriptionPlan("team") == true)
+    }
+
+    // MARK: - Non-subscription plans should return false
+
+    @Test
+    func nilLoginMethodReturnsFalse() {
+        #expect(UsageStore.isSubscriptionPlan(nil) == false)
+    }
+
+    @Test
+    func emptyLoginMethodReturnsFalse() {
+        #expect(UsageStore.isSubscriptionPlan("") == false)
+        #expect(UsageStore.isSubscriptionPlan("   ") == false)
+    }
+
+    @Test
+    func unknownPlanReturnsFalse() {
+        #expect(UsageStore.isSubscriptionPlan("API") == false)
+        #expect(UsageStore.isSubscriptionPlan("Free") == false)
+        #expect(UsageStore.isSubscriptionPlan("Unknown") == false)
+        #expect(UsageStore.isSubscriptionPlan("Claude") == false)
+    }
+
+    @Test
+    func apiKeyUsersReturnFalse() {
+        // API users typically don't have a login method or have non-subscription identifiers
+        #expect(UsageStore.isSubscriptionPlan("api_key") == false)
+        #expect(UsageStore.isSubscriptionPlan("console") == false)
+    }
+}


### PR DESCRIPTION
## Summary

Clicking "Usage Dashboard" for Claude now opens the correct URL based on account type:
- Subscription users (Max, Pro, Ultra, Team) go to claude.ai/settings/usage
- API users go to console.anthropic.com/settings/billing

Previously all Claude users were sent to the billing page regardless of account type.

---

*Disclosure: This fix was created with assistance from Claude Code.*