### PR TITLE
Fix Claude trust prompt handling

### DIFF
--- a/Sources/CodexBarCore/TTYCommandRunner.swift
+++ b/Sources/CodexBarCore/TTYCommandRunner.swift
@@ -12,6 +12,7 @@ public struct TTYCommandRunner {
         public var rows: UInt16 = 50
         public var cols: UInt16 = 160
         public var timeout: TimeInterval = 20.0
+        public var workingDirectory: URL?
         public var extraArgs: [String] = []
         public var sendEnterEvery: TimeInterval?
         public var sendOnSubstrings: [String: String]
@@ -23,6 +24,7 @@ public struct TTYCommandRunner {
             rows: UInt16 = 50,
             cols: UInt16 = 160,
             timeout: TimeInterval = 20.0,
+            workingDirectory: URL? = nil,
             extraArgs: [String] = [],
             sendEnterEvery: TimeInterval? = nil,
             sendOnSubstrings: [String: String] = [:],
@@ -33,6 +35,7 @@ public struct TTYCommandRunner {
             self.rows = rows
             self.cols = cols
             self.timeout = timeout
+            self.workingDirectory = workingDirectory
             self.extraArgs = extraArgs
             self.sendEnterEvery = sendEnterEvery
             self.sendOnSubstrings = sendOnSubstrings
@@ -97,7 +100,12 @@ public struct TTYCommandRunner {
         // Mirror RPC PATH seeding so CLIs installed via npm/nvm/fnm/bun still launch in hardened builds,
         // but keep the caller’s environment (HOME, LANG, BUN_INSTALL, etc.) so the CLIs can find their
         // auth/config files.
-        proc.environment = Self.enrichedEnvironment()
+        var env = Self.enrichedEnvironment()
+        if let workingDirectory = options.workingDirectory {
+            proc.currentDirectoryURL = workingDirectory
+            env["PWD"] = workingDirectory.path
+        }
+        proc.environment = env
 
         var cleanedUp = false
         var didLaunch = false

--- a/Tests/CodexBarTests/StatusProbeTests.swift
+++ b/Tests/CodexBarTests/StatusProbeTests.swift
@@ -188,6 +188,24 @@ struct StatusProbeTests {
     }
 
     @Test
+    func surfacesClaudeFolderTrustPrompt() {
+        let sample = """
+        Do you trust the files in this folder?
+
+        /Users/example/project
+        """
+
+        do {
+            _ = try ClaudeStatusProbe.parse(text: sample)
+            #expect(Bool(false), "Parsing should fail for folder trust prompt")
+        } catch let ClaudeStatusProbeError.parseFailed(message) {
+            #expect(message.lowercased().contains("trust"))
+        } catch {
+            #expect(Bool(false), "Unexpected error: \(error)")
+        }
+    }
+
+    @Test
     func parsesClaudeResetTimeOnly() {
         let now = Date(timeIntervalSince1970: 1_733_690_000)
         let parsed = ClaudeStatusProbe.parseResetDate(from: "Resets 12:59pm (Europe/Helsinki)", now: now)

--- a/Tests/CodexBarTests/TTYCommandRunnerTests.swift
+++ b/Tests/CodexBarTests/TTYCommandRunnerTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import CodexBarCore
 
@@ -44,5 +45,17 @@ struct TTYCommandRunnerEnvTests {
         #expect(merged["BUN_INSTALL"] == "/Users/tester/.bun")
         #expect(merged["SHELL"] == "/bin/zsh")
         #expect((merged["PATH"] ?? "").contains("/custom/bin"))
+    }
+
+    @Test
+    func setsWorkingDirectoryWhenProvided() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("codexbar-tty-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let runner = TTYCommandRunner()
+        let result = try runner.run(binary: "/bin/pwd", send: "", options: .init(timeout: 3, workingDirectory: dir))
+        let clean = result.text.replacingOccurrences(of: "\r", with: "")
+        #expect(clean.contains(dir.path))
     }
 }


### PR DESCRIPTION
Fixes Claude usage probe when Claude Code shows the interactive folder trust prompt.

- Run the Claude PTY probe in a stable app-owned directory and auto-advance past trust/continue prompts.
- Add `workingDirectory` support to `TTYCommandRunner` and coverage tests.

Commands:
- `pnpm check`
- `swift test`
- `swift run CodexBarCLI usage --provider claude --format text`
