### PR TITLE
Fix Claude reset time assignment

### DIFF
--- a/Tests/CodexBarTests/StatusProbeTests.swift
+++ b/Tests/CodexBarTests/StatusProbeTests.swift
@@ -86,6 +86,28 @@ struct StatusProbeTests {
     }
 
     @Test
+    func parseClaudeStatus_withCorruptedSessionResetPrefix_doesNotShiftResets() throws {
+        let sample = """
+        Current session
+        40% used
+        Reses 3pm (Europe/Vienna)
+        Current week (all models)
+        10% used
+        Resets Nov 27
+        Current week (Sonnet only)
+        0% used
+        Resets Nov 27
+        """
+        let snap = try ClaudeStatusProbe.parse(text: sample)
+        #expect(snap.sessionPercentLeft == 60)
+        #expect(snap.weeklyPercentLeft == 90)
+        #expect(snap.opusPercentLeft == 100)
+        #expect(snap.primaryResetDescription == "Resets 3pm (Europe/Vienna)")
+        #expect(snap.secondaryResetDescription == "Resets Nov 27")
+        #expect(snap.opusResetDescription == "Resets Nov 27")
+    }
+
+    @Test
     func parseClaudeStatusLegacyOpusLabel() throws {
         let sample = """
         Current session


### PR DESCRIPTION
Fixes #27

- Associate reset lines with their corresponding usage block (Session/Weekly/Sonnet) instead of relying on global "Resets …" ordering.
- Repair common PTY redraw corruption so Session reset isn't dropped (which previously caused the 1-line shift).
- Add regression test for corrupted session reset prefix.

Commands run:
- `pnpm check`
- `swift test`
- `./Scripts/compile_and_run.sh` (with `APP_IDENTITY` override for local signing)
