### PR TITLE
fix: support Bun/npm installations for Gemini OAuth token refresh

### DIFF
--- a/Sources/CodexBarCore/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/GeminiStatusProbe.swift
@@ -388,15 +388,22 @@ public struct GeminiStatusProbe: Sendable {
         }
 
         // Navigate from bin/gemini to the oauth2.js file
-        // Typical path: .../libexec/lib/node_modules/@google/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js
+        // Homebrew path: .../libexec/lib/node_modules/@google/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js
+        // Bun/npm path: .../node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js (sibling package)
         let binDir = (realPath as NSString).deletingLastPathComponent
         let baseDir = (binDir as NSString).deletingLastPathComponent
 
         let oauthSubpath =
             "node_modules/@google/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js"
+        let oauthFile = "dist/src/code_assist/oauth2.js"
         let possiblePaths = [
+            // Homebrew nested structure
             "\(baseDir)/libexec/lib/\(oauthSubpath)",
             "\(baseDir)/lib/\(oauthSubpath)",
+            // Bun/npm sibling structure: gemini-cli-core is a sibling to gemini-cli
+            "\(baseDir)/../gemini-cli-core/\(oauthFile)",
+            // npm nested inside gemini-cli
+            "\(baseDir)/node_modules/@google/gemini-cli-core/\(oauthFile)",
         ]
 
         for path in possiblePaths {


### PR DESCRIPTION
## Summary

- Adds search paths for Bun/npm-style Gemini CLI installations where `@google/gemini-cli-core` is a sibling package rather than nested inside `@google/gemini-cli`
- Fixes OAuth token refresh failures for users who installed Gemini CLI via Bun or npm

## Root Cause

When refreshing expired OAuth tokens, CodexBar extracts client credentials from the Gemini CLI's `oauth2.js` file. The existing code only searched Homebrew-style nested paths:
```
.../libexec/lib/node_modules/@google/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js
```

With Bun/npm installations, packages are siblings:
```
.../node_modules/@google/gemini-cli/
.../node_modules/@google/gemini-cli-core/   ← sibling, not nested
```

Fixes #35

## Test Plan

- [x] Verified path resolution works with Bun installation
- [x] All 29 existing Gemini tests pass
- [x] Build succeeds