### PR TITLE
Add weekly pace indicator

### DIFF
--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -109,6 +109,9 @@ struct MenuDescriptor {
             Self.appendRateWindow(entries: &entries, title: meta.sessionLabel, window: snap.primary)
             if let weekly = snap.secondary {
                 Self.appendRateWindow(entries: &entries, title: meta.weeklyLabel, window: weekly)
+                if let paceText = UsagePaceText.weekly(provider: provider, window: weekly) {
+                    entries.append(.text(paceText, .secondary))
+                }
             } else if provider == .claude {
                 entries.append(.text("Weekly usage unavailable for this account.", .secondary))
             }

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -459,7 +459,8 @@ extension StatusItemController {
             isRefreshing: self.store.isRefreshing,
             lastError: self.store.error(for: target),
             usageBarsShowUsed: self.settings.usageBarsShowUsed,
-            tokenCostUsageEnabled: self.settings.isCCUsageCostUsageEffectivelyEnabled(for: target))
+            tokenCostUsageEnabled: self.settings.isCCUsageCostUsageEffectivelyEnabled(for: target),
+            now: Date())
         return UsageMenuCardView.Model.make(input)
     }
 }

--- a/Sources/CodexBar/UsagePaceText.swift
+++ b/Sources/CodexBar/UsagePaceText.swift
@@ -1,0 +1,48 @@
+import CodexBarCore
+import Foundation
+
+enum UsagePaceText {
+    static func weekly(provider: UsageProvider, window: RateWindow, now: Date = .init()) -> String? {
+        guard provider == .codex || provider == .claude else { return nil }
+        guard let pace = UsagePace.weekly(window: window, now: now, defaultWindowMinutes: 10080) else { return nil }
+
+        let label = Self.label(for: pace.stage)
+        let deltaSuffix = Self.deltaSuffix(for: pace)
+        let etaSuffix = Self.etaSuffix(for: pace, now: now)
+
+        if let etaSuffix {
+            return "Pace: \(label)\(deltaSuffix) · \(etaSuffix)"
+        }
+        return "Pace: \(label)\(deltaSuffix)"
+    }
+
+    private static func label(for stage: UsagePace.Stage) -> String {
+        switch stage {
+        case .onTrack: "On track"
+        case .slightlyAhead, .ahead, .farAhead: "High"
+        case .slightlyBehind, .behind, .farBehind: "Low"
+        }
+    }
+
+    private static func deltaSuffix(for pace: UsagePace) -> String {
+        let deltaValue = Int(abs(pace.deltaPercent).rounded())
+        let sign = pace.deltaPercent >= 0 ? "+" : "-"
+        return " (\(sign)\(deltaValue)%)"
+    }
+
+    private static func etaSuffix(for pace: UsagePace, now: Date) -> String? {
+        if pace.willLastToReset { return "Lasts to reset" }
+        guard let etaSeconds = pace.etaSeconds else { return nil }
+        return Self.leftText(seconds: etaSeconds, now: now)
+    }
+
+    private static func leftText(seconds: TimeInterval, now: Date) -> String {
+        let date = now.addingTimeInterval(seconds)
+        let countdown = UsageFormatter.resetCountdownDescription(from: date, now: now)
+        if countdown == "now" { return "now" }
+        if countdown.hasPrefix("in ") {
+            return "\(countdown.dropFirst(3)) left"
+        }
+        return "\(countdown) left"
+    }
+}

--- a/Sources/CodexBarCore/UsagePace.swift
+++ b/Sources/CodexBarCore/UsagePace.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+public struct UsagePace: Sendable {
+    public enum Stage: Sendable {
+        case onTrack
+        case slightlyAhead
+        case ahead
+        case farAhead
+        case slightlyBehind
+        case behind
+        case farBehind
+    }
+
+    public let stage: Stage
+    public let deltaPercent: Double
+    public let expectedUsedPercent: Double
+    public let actualUsedPercent: Double
+    public let etaSeconds: TimeInterval?
+    public let willLastToReset: Bool
+
+    public static func weekly(
+        window: RateWindow,
+        now: Date = .init(),
+        defaultWindowMinutes: Int = 10080) -> UsagePace?
+    {
+        guard let resetsAt = window.resetsAt else { return nil }
+        let minutes = window.windowMinutes ?? defaultWindowMinutes
+        guard minutes > 0 else { return nil }
+
+        let duration = TimeInterval(minutes) * 60
+        let timeUntilReset = resetsAt.timeIntervalSince(now)
+        guard timeUntilReset > 0 else { return nil }
+        guard timeUntilReset <= duration else { return nil }
+        let elapsed = Self.clamp(duration - timeUntilReset, lower: 0, upper: duration)
+        let expected = Self.clamp((elapsed / duration) * 100, lower: 0, upper: 100)
+        let actual = Self.clamp(window.usedPercent, lower: 0, upper: 100)
+        if elapsed == 0, actual > 0 {
+            return nil
+        }
+        let delta = actual - expected
+        let stage = Self.stage(for: delta)
+
+        var etaSeconds: TimeInterval?
+        var willLastToReset = false
+
+        if elapsed > 0, actual > 0 {
+            let rate = actual / elapsed
+            if rate > 0 {
+                let remaining = max(0, 100 - actual)
+                let candidate = remaining / rate
+                if candidate >= timeUntilReset {
+                    willLastToReset = true
+                } else {
+                    etaSeconds = candidate
+                }
+            }
+        } else if elapsed > 0, actual == 0 {
+            willLastToReset = true
+        }
+
+        return UsagePace(
+            stage: stage,
+            deltaPercent: delta,
+            expectedUsedPercent: expected,
+            actualUsedPercent: actual,
+            etaSeconds: etaSeconds,
+            willLastToReset: willLastToReset)
+    }
+
+    private static func stage(for delta: Double) -> Stage {
+        let absDelta = abs(delta)
+        if absDelta <= 2 { return .onTrack }
+        if absDelta <= 6 { return delta >= 0 ? .slightlyAhead : .slightlyBehind }
+        if absDelta <= 12 { return delta >= 0 ? .ahead : .behind }
+        return delta >= 0 ? .farAhead : .farBehind
+    }
+
+    private static func clamp(_ value: Double, lower: Double, upper: Double) -> Double {
+        min(upper, max(lower, value))
+    }
+}

--- a/Tests/CodexBarTests/MenuCardModelTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelTests.swift
@@ -51,7 +51,8 @@ struct MenuCardModelTests {
             isRefreshing: false,
             lastError: nil,
             usageBarsShowUsed: false,
-            tokenCostUsageEnabled: false))
+            tokenCostUsageEnabled: false,
+            now: now))
 
         #expect(model.providerName == "Codex")
         #expect(model.metrics.count == 2)
@@ -103,7 +104,8 @@ struct MenuCardModelTests {
             isRefreshing: false,
             lastError: nil,
             usageBarsShowUsed: true,
-            tokenCostUsageEnabled: false))
+            tokenCostUsageEnabled: false,
+            now: now))
 
         #expect(model.metrics.first?.title == "Session")
         #expect(model.metrics.first?.percent == 22)
@@ -145,7 +147,8 @@ struct MenuCardModelTests {
             isRefreshing: false,
             lastError: nil,
             usageBarsShowUsed: false,
-            tokenCostUsageEnabled: false))
+            tokenCostUsageEnabled: false,
+            now: now))
 
         #expect(model.metrics.contains { $0.title == "Code review" && $0.percent == 73 })
     }
@@ -180,7 +183,8 @@ struct MenuCardModelTests {
             isRefreshing: false,
             lastError: nil,
             usageBarsShowUsed: false,
-            tokenCostUsageEnabled: false))
+            tokenCostUsageEnabled: false,
+            now: now))
 
         #expect(model.metrics.count == 1)
         #expect(model.metrics.first?.title == "Session")
@@ -204,7 +208,8 @@ struct MenuCardModelTests {
             isRefreshing: false,
             lastError: "Probe failed for Codex",
             usageBarsShowUsed: false,
-            tokenCostUsageEnabled: false))
+            tokenCostUsageEnabled: false,
+            now: Date()))
 
         #expect(model.subtitleStyle == .error)
         #expect(model.subtitleText.contains("Probe failed"))
@@ -228,7 +233,8 @@ struct MenuCardModelTests {
             isRefreshing: false,
             lastError: nil,
             usageBarsShowUsed: false,
-            tokenCostUsageEnabled: false))
+            tokenCostUsageEnabled: false,
+            now: Date()))
 
         #expect(model.planText == nil)
         #expect(model.email.isEmpty)

--- a/Tests/CodexBarTests/UsagePaceTextTests.swift
+++ b/Tests/CodexBarTests/UsagePaceTextTests.swift
@@ -1,0 +1,81 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@Suite
+struct UsagePaceTextTests {
+    @Test
+    func weeklyPaceText_includesEtaWhenRunningOutBeforeReset() {
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 50,
+            windowMinutes: 10080,
+            resetsAt: now.addingTimeInterval(4 * 24 * 3600),
+            resetDescription: nil)
+
+        let text = UsagePaceText.weekly(provider: .codex, window: window, now: now)
+
+        #expect(text == "Pace: High (+7%) · 3d left")
+    }
+
+    @Test
+    func weeklyPaceText_showsResetSafeWhenPaceIsSlow() {
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 10,
+            windowMinutes: 10080,
+            resetsAt: now.addingTimeInterval(4 * 24 * 3600),
+            resetDescription: nil)
+
+        let text = UsagePaceText.weekly(provider: .codex, window: window, now: now)
+
+        #expect(text == "Pace: Low (-33%) · Lasts to reset")
+    }
+
+    @Test
+    func weeklyPaceText_hidesWhenResetIsMissing() {
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 10,
+            windowMinutes: 10080,
+            resetsAt: nil,
+            resetDescription: nil)
+
+        let text = UsagePaceText.weekly(provider: .codex, window: window, now: now)
+
+        #expect(text == nil)
+    }
+
+    @Test
+    func weeklyPaceText_hidesWhenResetIsInPastOrTooFar() {
+        let now = Date(timeIntervalSince1970: 0)
+        let pastWindow = RateWindow(
+            usedPercent: 10,
+            windowMinutes: 10080,
+            resetsAt: now.addingTimeInterval(-60),
+            resetDescription: nil)
+        let farFutureWindow = RateWindow(
+            usedPercent: 10,
+            windowMinutes: 10080,
+            resetsAt: now.addingTimeInterval(9 * 24 * 3600),
+            resetDescription: nil)
+
+        #expect(UsagePaceText.weekly(provider: .codex, window: pastWindow, now: now) == nil)
+        #expect(UsagePaceText.weekly(provider: .codex, window: farFutureWindow, now: now) == nil)
+    }
+
+    @Test
+    func weeklyPaceText_hidesWhenNoElapsedButUsageExists() {
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 5,
+            windowMinutes: 10080,
+            resetsAt: now.addingTimeInterval(7 * 24 * 3600),
+            resetDescription: nil)
+
+        let text = UsagePaceText.weekly(provider: .codex, window: window, now: now)
+
+        #expect(text == nil)
+    }
+}


### PR DESCRIPTION
## Summary
This adds a simple weekly pace hint so users can quickly tell if they’re trending low/on‑track/high for the week. It shows a short label plus the delta and a relative run‑out estimate when it’s safe to compute.

## User impact
- In the menu card (and text menu), the Weekly section now includes a single line like:
  - "Pace: Low (-3%) · Lasts to reset"
  - "Pace: On track (+1%) · 2d left"
  - "Pace: High (+8%) · 3d left"
- Only shown for Codex/Claude weekly usage.

## Behavior details
- Uses weekly reset time and window length to estimate expected usage by now and compare to actual usage.
- Shows relative ETA if the current pace would run out before reset; otherwise shows "Lasts to reset".
- Hides the pace line if reset timing is missing or inconsistent (avoids misleading output).

## Testing
- swiftformat Sources Tests
- swiftlint --strict
- COREPACK_ENABLE_AUTO_PIN=0 pnpm check

## Screenshots
<img width="310" height="515" alt="Screenshot 2025-12-21 at 12 32 11" src="https://github.com/user-attachments/assets/e2d99e9d-8ccd-4c99-b3ac-72e4021c101f" />

