### PR TITLE
fix(antigravity): add -a flag to lsof for correct PID filtering

### DIFF
--- a/Sources/CodexBarCore/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/AntigravityStatusProbe.swift
@@ -371,7 +371,7 @@ public struct AntigravityStatusProbe: Sendable {
         let env = ProcessInfo.processInfo.environment
         let result = try await SubprocessRunner.run(
             binary: lsof,
-            arguments: ["-nP", "-iTCP", "-sTCP:LISTEN", "-p", String(pid)],
+            arguments: ["-nP", "-iTCP", "-sTCP:LISTEN", "-a", "-p", String(pid)],
             environment: env,
             timeout: timeout,
             label: "antigravity-lsof")


### PR DESCRIPTION
Without the -a (AND) flag, lsof treats -iTCP and -p as OR conditions, returning listening ports from ALL processes instead of only the specified PID. This caused Antigravity port detection to potentially connect to wrong endpoints.

The fix adds -a between -sTCP:LISTEN and -p to properly AND the conditions, ensuring only the Antigravity language server's ports are returned.