### PR TITLE
feat: add build script for ad-hoc signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ swift build -c release          # or debug for development
 open CodexBar.app
 ```
 
+### Building without an Apple Developer account
+If you don't have an Apple Developer account, use the ad-hoc signing script:
+
+```bash
+./Scripts/build_unsigned.sh        # builds with ad-hoc signing (release by default)
+./Scripts/build_unsigned.sh debug  # or build debug version
+open CodexBar.app
+```
+
+**Note:** Ad-hoc signed apps:
+- Run on your local Mac
+- Cannot be distributed to others (Gatekeeper will block)
+- May have limited keychain access (use `~/.claude/.credentials.json` for Claude OAuth)
+- Auto-updates won't work (requires proper code signing)
+
+To export Claude credentials for ad-hoc builds:
+```bash
+security find-generic-password -s "Claude Code-credentials" -w > ~/.claude/.credentials.json
+```
+
 ## Adding a provider
 - Start here: `docs/provider.md` (provider authoring guide + target architecture).
 

--- a/Scripts/build_unsigned.sh
+++ b/Scripts/build_unsigned.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# Build CodexBar with ad-hoc signing (no Apple Developer account required)
+# This app will run on your local machine but cannot be distributed
+
+set -euo pipefail
+CONF=${1:-release}
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$ROOT"
+
+# Load version info
+source "$ROOT/version.env"
+
+# Force a clean build to avoid stale binaries.
+rm -rf "$ROOT/.build"
+swift package clean >/dev/null 2>&1 || true
+
+swift build -c "$CONF" --arch arm64
+
+APP="$ROOT/CodexBar.app"
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources" "$APP/Contents/Frameworks"
+mkdir -p "$APP/Contents/Helpers" "$APP/Contents/PlugIns"
+
+# Convert new .icon bundle to .icns if present (macOS 14+/IconStudio export)
+ICON_SOURCE="$ROOT/Icon.icon"
+ICON_TARGET="$ROOT/Icon.icns"
+if [[ -f "$ICON_SOURCE" ]]; then
+  iconutil --convert icns --output "$ICON_TARGET" "$ICON_SOURCE"
+fi
+
+BUNDLE_ID="com.steipete.codexbar"
+FEED_URL="https://raw.githubusercontent.com/steipete/CodexBar/main/appcast.xml"
+AUTO_CHECKS=true
+LOWER_CONF=$(printf "%s" "$CONF" | tr '[:upper:]' '[:lower:]')
+if [[ "$LOWER_CONF" == "debug" ]]; then
+  BUNDLE_ID="com.steipete.codexbar.debug"
+  FEED_URL=""
+  AUTO_CHECKS=false
+fi
+WIDGET_BUNDLE_ID="${BUNDLE_ID}.widget"
+APP_GROUP_ID="group.com.steipete.codexbar"
+if [[ "$BUNDLE_ID" == *".debug"* ]]; then
+  APP_GROUP_ID="group.com.steipete.codexbar.debug"
+fi
+ENTITLEMENTS_DIR="$ROOT/.build/entitlements"
+APP_ENTITLEMENTS="${ENTITLEMENTS_DIR}/CodexBar.entitlements"
+WIDGET_ENTITLEMENTS="${ENTITLEMENTS_DIR}/CodexBarWidget.entitlements"
+mkdir -p "$ENTITLEMENTS_DIR"
+
+cat > "$APP_ENTITLEMENTS" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>${APP_GROUP_ID}</string>
+    </array>
+</dict>
+</plist>
+PLIST
+cat > "$WIDGET_ENTITLEMENTS" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>${APP_GROUP_ID}</string>
+    </array>
+</dict>
+</plist>
+PLIST
+BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+GIT_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+cat > "$APP/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key><string>CodexBar</string>
+    <key>CFBundleDisplayName</key><string>CodexBar</string>
+    <key>CFBundleIdentifier</key><string>${BUNDLE_ID}</string>
+    <key>CFBundleExecutable</key><string>CodexBar</string>
+    <key>CFBundlePackageType</key><string>APPL</string>
+    <key>CFBundleShortVersionString</key><string>${MARKETING_VERSION}</string>
+    <key>CFBundleVersion</key><string>${BUILD_NUMBER}</string>
+    <key>LSMinimumSystemVersion</key><string>15.0</string>
+    <key>LSUIElement</key><true/>
+    <key>CFBundleIconFile</key><string>Icon</string>
+    <key>NSHumanReadableCopyright</key><string>© 2025 Peter Steinberger. MIT License.</string>
+    <key>SUFeedURL</key><string>${FEED_URL}</string>
+    <key>SUPublicEDKey</key><string>AGCY8w5vHirVfGGDGc8Szc5iuOqupZSh9pMj/Qs67XI=</string>
+    <key>SUEnableAutomaticChecks</key><${AUTO_CHECKS}/>
+    <key>CodexBuildTimestamp</key><string>${BUILD_TIMESTAMP}</string>
+    <key>CodexGitCommit</key><string>${GIT_COMMIT}</string>
+</dict>
+</plist>
+PLIST
+
+cp ".build/$CONF/CodexBar" "$APP/Contents/MacOS/CodexBar"
+chmod +x "$APP/Contents/MacOS/CodexBar"
+# Ship CodexBarCLI alongside the app for easy symlinking.
+if [[ -f ".build/$CONF/CodexBarCLI" ]]; then
+  cp ".build/$CONF/CodexBarCLI" "$APP/Contents/Helpers/CodexBarCLI"
+  chmod +x "$APP/Contents/Helpers/CodexBarCLI"
+fi
+# Watchdog helper: ensures `claude` probes die when CodexBar crashes/gets killed.
+if [[ -f ".build/$CONF/CodexBarClaudeWatchdog" ]]; then
+  cp ".build/$CONF/CodexBarClaudeWatchdog" "$APP/Contents/Helpers/CodexBarClaudeWatchdog"
+  chmod +x "$APP/Contents/Helpers/CodexBarClaudeWatchdog"
+fi
+if [[ -f ".build/$CONF/CodexBarWidget" ]]; then
+  WIDGET_APP="$APP/Contents/PlugIns/CodexBarWidget.appex"
+  mkdir -p "$WIDGET_APP/Contents/MacOS" "$WIDGET_APP/Contents/Resources"
+  cat > "$WIDGET_APP/Contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key><string>CodexBarWidget</string>
+    <key>CFBundleDisplayName</key><string>CodexBar</string>
+    <key>CFBundleIdentifier</key><string>${WIDGET_BUNDLE_ID}</string>
+    <key>CFBundleExecutable</key><string>CodexBarWidget</string>
+    <key>CFBundlePackageType</key><string>XPC!</string>
+    <key>CFBundleShortVersionString</key><string>${MARKETING_VERSION}</string>
+    <key>CFBundleVersion</key><string>${BUILD_NUMBER}</string>
+    <key>LSMinimumSystemVersion</key><string>15.0</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key><string>com.apple.widgetkit-extension</string>
+        <key>NSExtensionPrincipalClass</key><string>CodexBarWidget.CodexBarWidgetBundle</string>
+    </dict>
+</dict>
+</plist>
+PLIST
+  cp ".build/$CONF/CodexBarWidget" "$WIDGET_APP/Contents/MacOS/CodexBarWidget"
+  chmod +x "$WIDGET_APP/Contents/MacOS/CodexBarWidget"
+fi
+# Embed Sparkle.framework
+if [[ -d ".build/$CONF/Sparkle.framework" ]]; then
+  cp -R ".build/$CONF/Sparkle.framework" "$APP/Contents/Frameworks/"
+  chmod -R a+rX "$APP/Contents/Frameworks/Sparkle.framework"
+  install_name_tool -add_rpath "@executable_path/../Frameworks" "$APP/Contents/MacOS/CodexBar"
+
+  # Ad-hoc sign Sparkle and all nested components (no Developer ID required)
+  SPARKLE="$APP/Contents/Frameworks/Sparkle.framework"
+  CODESIGN_ARGS=(--force --sign "-")
+  function resign() { codesign "${CODESIGN_ARGS[@]}" "$1"; }
+
+  # Sign innermost binaries first, then the framework root to seal resources
+  resign "$SPARKLE"
+  resign "$SPARKLE/Versions/B/Sparkle"
+  resign "$SPARKLE/Versions/B/Autoupdate"
+  resign "$SPARKLE/Versions/B/Updater.app"
+  resign "$SPARKLE/Versions/B/Updater.app/Contents/MacOS/Updater"
+  resign "$SPARKLE/Versions/B/XPCServices/Downloader.xpc"
+  resign "$SPARKLE/Versions/B/XPCServices/Downloader.xpc/Contents/MacOS/Downloader"
+  resign "$SPARKLE/Versions/B/XPCServices/Installer.xpc"
+  resign "$SPARKLE/Versions/B/XPCServices/Installer.xpc/Contents/MacOS/Installer"
+  resign "$SPARKLE/Versions/B"
+  resign "$SPARKLE"
+fi
+
+if [[ -f "$ICON_TARGET" ]]; then
+  cp "$ICON_TARGET" "$APP/Contents/Resources/Icon.icns"
+fi
+
+# Bundle app resources (provider icons, etc.).
+APP_RESOURCES_DIR="$ROOT/Sources/CodexBar/Resources"
+if [[ -d "$APP_RESOURCES_DIR" ]]; then
+  cp -R "$APP_RESOURCES_DIR/." "$APP/Contents/Resources/"
+fi
+
+# Strip extended attributes to prevent AppleDouble (._*) files that break code sealing
+xattr -cr "$APP"
+find "$APP" -name '._*' -delete
+
+# Ad-hoc sign widget extension if present
+if [[ -d "${APP}/Contents/PlugIns/CodexBarWidget.appex" ]]; then
+  codesign --force --sign "-" \
+    --entitlements "$WIDGET_ENTITLEMENTS" \
+    "$APP/Contents/PlugIns/CodexBarWidget.appex/Contents/MacOS/CodexBarWidget"
+  codesign --force --sign "-" \
+    --entitlements "$WIDGET_ENTITLEMENTS" \
+    "$APP/Contents/PlugIns/CodexBarWidget.appex"
+fi
+
+# Finally ad-hoc sign the app bundle itself
+codesign --force --sign "-" \
+  --entitlements "$APP_ENTITLEMENTS" \
+  "$APP"
+
+echo "Created $APP (ad-hoc signed - runs locally but not distributable)"


### PR DESCRIPTION
## Summary

Adds a build script that enables building CodexBar without an Apple Developer account using ad-hoc code signing.

## Motivation

Currently, `package_app.sh` requires a Developer ID certificate for code signing, which creates a barrier for:
- Contributors who want to test their changes locally
- Users who want to build from source for personal use
- Developers without a paid Apple Developer account ($99/year)

## Solution

New `Scripts/build_unsigned.sh` that:
- Uses ad-hoc signing (`--sign "-"`) instead of Developer ID
- Maintains the same build structure as `package_app.sh`
- Clearly documents limitations and workarounds
- Supports both release and debug builds

## Changes

### New File: `Scripts/build_unsigned.sh`
- Complete build script with ad-hoc signing
- Signs all components: main app, Sparkle framework, widget extension
- Identical structure to `package_app.sh` but with `-` signing identity
- Executable permissions set

### Updated: `README.md`
- New section "Building without an Apple Developer account"
- Clear usage instructions
- Documents limitations (no distribution, keychain restrictions, no auto-update)
- Provides workaround for Claude OAuth credentials

## Testing

- ✅ Successfully builds release and debug versions
- ✅ App runs locally with ad-hoc signing
- ✅ All components properly signed
- ✅ Works with exported Claude credentials

## Usage

```bash
./Scripts/build_unsigned.sh        # release build (default)
./Scripts/build_unsigned.sh debug  # debug build
open CodexBar.app
```

For Claude OAuth with ad-hoc builds:
```bash
security find-generic-password -s "Claude Code-credentials" -w > ~/.claude/.credentials.json
```

## Limitations (Documented)

Ad-hoc signed builds:
- ✅ Run on your local Mac
- ❌ Cannot be distributed (Gatekeeper blocks)
- ⚠️ Limited keychain access (file-based credentials work)
- ❌ Auto-updates disabled (requires proper signing)

## Benefits

1. **Lower barrier to entry** - No $99/year Developer account needed
2. **Faster development cycle** - Build and test without certificates
3. **Community contributions** - Easier for contributors to test PRs
4. **Personal builds** - Users can build custom versions for themselves

## Notes

- This doesn't replace `package_app.sh` - that remains the official build script
- Distribution builds still require proper Developer ID signing
- All limitations are clearly documented in README and script comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)