### PR TITLE
Add universal binary support (Intel + Apple Silicon)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@
 - Dev loop: `./Scripts/compile_and_run.sh` kills old instances, runs `swift build` + `swift test`, packages, relaunches `CodexBar.app`, and confirms it stays running.
 - Quick build/test: `swift build` (debug) or `swift build -c release`; `swift test` for the full XCTest suite.
 - Package locally: `./Scripts/package_app.sh` to refresh `CodexBar.app`, then restart with `pkill -x CodexBar || pkill -f CodexBar.app || true; cd /Users/steipete/Projects/codexbar && open -n /Users/steipete/Projects/codexbar/CodexBar.app`.
-- Release flow: `./Scripts/sign-and-notarize.sh` (arm64 notarized zip) and `./Scripts/make_appcast.sh <zip> <feed-url>`; follow validation steps in `docs/RELEASING.md`.
+- Release flow: `./Scripts/sign-and-notarize.sh` (universal arm64 + x86_64 notarized zip) and `./Scripts/make_appcast.sh <zip> <feed-url>`; follow validation steps in `docs/RELEASING.md`.
+- Build universal binary for testing: `ARCHES="arm64 x86_64" ./Scripts/package_app.sh` or use `./Scripts/compile_and_run.sh --release-universal`.
 
 ## Coding Style & Naming
 - Enforce SwiftFormat/SwiftLint: run `swiftformat Sources Tests` and `swiftlint --strict`. 4-space indent, 120-char lines, explicit `self` is intentional—do not remove.

--- a/Scripts/sign-and-notarize.sh
+++ b/Scripts/sign-and-notarize.sh
@@ -30,8 +30,8 @@ fi
 echo "$APP_STORE_CONNECT_API_KEY_P8" | sed 's/\\n/\n/g' > /tmp/codexbar-api-key.p8
 trap 'rm -f /tmp/codexbar-api-key.p8 /tmp/${APP_NAME}Notarize.zip' EXIT
 
-# Allow building a universal binary if ARCHES is provided; default to arm64 per release policy.
-ARCHES_VALUE=${ARCHES:-"arm64"}
+# Allow building a universal binary if ARCHES is provided; default to universal (arm64 + x86_64) for Intel + Apple Silicon support.
+ARCHES_VALUE=${ARCHES:-"arm64 x86_64"}
 ARCH_LIST=( ${ARCHES_VALUE} )
 for ARCH in "${ARCH_LIST[@]}"; do
   swift build -c release --arch "$ARCH"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -36,12 +36,13 @@ SwiftPM-only; package/sign/notarize manually (no Xcode project). Sparkle feed is
 ```
 Uses Xcode’s `ictool` + transparent padding + iconset → Icon.icns.
 
-## Build, sign, notarize (arm64)
+## Build, sign, notarize (universal: arm64 + x86_64)
 ```
 ./Scripts/sign-and-notarize.sh
 ```
 What it does:
-- `swift build -c release --arch arm64`
+- `swift build -c release --arch arm64` and `swift build -c release --arch x86_64`
+- Creates a universal binary using `lipo` that supports both Intel and Apple Silicon Macs
 - Packages `CodexBar.app` with Info.plist and Icon.icns
 - Embeds Sparkle.framework, Updater, Autoupdate, XPCs
 - Codesigns **everything** with runtime + timestamp (deep) and adds rpath


### PR DESCRIPTION
Adds universal binary support to enable Intel (x86_64) and Apple Silicon (arm64) Mac compatibility.

The creator mentioned they couldn't test on Intel, so this change defaults the release build to create universal binaries that work on both architectures.

## Changes
- Updated `Scripts/sign-and-notarize.sh` to default to `arm64 x86_64` instead of `arm64` only
- Updated `docs/RELEASING.md` to document universal binary support
- Updated `AGENTS.md` release flow notes

## Testing
- Built universal binary on Intel Mac (x86_64)
- Verified both architectures present: `lipo -archs CodexBar.app/Contents/MacOS/CodexBar` shows `arm64 x86_64`
- Tested app execution on Intel Mac

## Commands Runsh
ARCHES="arm64 x86_64" ./Scripts/package_app.sh release
lipo -archs CodexBar.app/Contents/MacOS/CodexBar