### PR TITLE
Universal binary support (Intel + Apple Silicon)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@
 - Dev loop: `./Scripts/compile_and_run.sh` kills old instances, runs `swift build` + `swift test`, packages, relaunches `CodexBar.app`, and confirms it stays running.
 - Quick build/test: `swift build` (debug) or `swift build -c release`; `swift test` for the full XCTest suite.
 - Package locally: `./Scripts/package_app.sh` to refresh `CodexBar.app`, then restart with `pkill -x CodexBar || pkill -f CodexBar.app || true; cd /Users/steipete/Projects/codexbar && open -n /Users/steipete/Projects/codexbar/CodexBar.app`.
-- Release flow: `./Scripts/sign-and-notarize.sh` (arm64 notarized zip) and `./Scripts/make_appcast.sh <zip> <feed-url>`; follow validation steps in `docs/RELEASING.md`.
+- Release flow: `./Scripts/sign-and-notarize.sh` (universal arm64 + x86_64 notarized zip) and `./Scripts/make_appcast.sh <zip> <feed-url>`; follow validation steps in `docs/RELEASING.md`.
+- Build universal binary for testing: `ARCHES="arm64 x86_64" ./Scripts/package_app.sh` or use `./Scripts/compile_and_run.sh --release-universal`.
 
 ## Coding Style & Naming
 - Enforce SwiftFormat/SwiftLint: run `swiftformat Sources Tests` and `swiftlint --strict`. 4-space indent, 120-char lines, explicit `self` is intentional—do not remove.

--- a/Scripts/sign-and-notarize.sh
+++ b/Scripts/sign-and-notarize.sh
@@ -30,8 +30,8 @@ fi
 echo "$APP_STORE_CONNECT_API_KEY_P8" | sed 's/\\n/\n/g' > /tmp/codexbar-api-key.p8
 trap 'rm -f /tmp/codexbar-api-key.p8 /tmp/${APP_NAME}Notarize.zip' EXIT
 
-# Allow building a universal binary if ARCHES is provided; default to arm64 per release policy.
-ARCHES_VALUE=${ARCHES:-"arm64"}
+# Allow building a universal binary if ARCHES is provided; default to universal (arm64 + x86_64) for Intel + Apple Silicon support.
+ARCHES_VALUE=${ARCHES:-"arm64 x86_64"}
 ARCH_LIST=( ${ARCHES_VALUE} )
 for ARCH in "${ARCH_LIST[@]}"; do
   swift build -c release --arch "$ARCH"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -36,12 +36,13 @@ SwiftPM-only; package/sign/notarize manually (no Xcode project). Sparkle feed is
 ```
 Uses Xcode’s `ictool` + transparent padding + iconset → Icon.icns.
 
-## Build, sign, notarize (arm64)
+## Build, sign, notarize (universal: arm64 + x86_64)
 ```
 ./Scripts/sign-and-notarize.sh
 ```
 What it does:
-- `swift build -c release --arch arm64`
+- `swift build -c release --arch arm64` and `swift build -c release --arch x86_64`
+- Creates a universal binary using `lipo` that supports both Intel and Apple Silicon Macs
 - Packages `CodexBar.app` with Info.plist and Icon.icns
 - Embeds Sparkle.framework, Updater, Autoupdate, XPCs
 - Codesigns **everything** with runtime + timestamp (deep) and adds rpath

--- a/test_universal.sh
+++ b/test_universal.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Quick test script to verify universal binary support
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+cd "$ROOT"
+
+echo "=== Testing Universal Binary Support ==="
+echo ""
+
+# Step 1: Build for both architectures
+echo "Step 1: Building universal binary (arm64 + x86_64)..."
+echo "This will take several minutes (building for both architectures)..."
+ARCHES="arm64 x86_64" ./Scripts/package_app.sh release
+
+# Step 2: Check the architectures in the built binary
+echo ""
+echo "Step 2: Verifying architectures in CodexBar binary..."
+BINARY="$ROOT/CodexBar.app/Contents/MacOS/CodexBar"
+if [[ ! -f "$BINARY" ]]; then
+    echo "ERROR: CodexBar binary not found at $BINARY"
+    exit 1
+fi
+
+ARCHES_IN_BINARY=$(lipo -archs "$BINARY")
+echo "Architectures found: $ARCHES_IN_BINARY"
+
+# Step 3: Verify both architectures are present
+if [[ "$ARCHES_IN_BINARY" == *"arm64"* ]] && [[ "$ARCHES_IN_BINARY" == *"x86_64"* ]]; then
+    echo "✅ SUCCESS: Binary contains both arm64 and x86_64"
+else
+    echo "❌ FAILED: Binary missing required architectures"
+    echo "   Expected: arm64 x86_64"
+    echo "   Got: $ARCHES_IN_BINARY"
+    exit 1
+fi
+
+# Step 4: Check file info
+echo ""
+echo "Step 3: Binary file information:"
+file "$BINARY"
+
+# Step 5: Verify it's a universal binary
+echo ""
+echo "Step 4: Detailed architecture info:"
+lipo -detailed_info "$BINARY" | grep -E "(architecture|cputype|cpusubtype)" | head -6
+
+# Step 6: Test that it can run (on current architecture)
+echo ""
+echo "Step 5: Testing binary execution (should work on $(uname -m))..."
+if "$BINARY" --help >/dev/null 2>&1; then
+    echo "✅ Binary executes successfully"
+else
+    echo "⚠️  Binary execution test inconclusive (may need GUI context)"
+fi
+
+echo ""
+echo "=== Test Complete ==="
+echo ""
+echo "To test the app:"
+echo "  open $ROOT/CodexBar.app"
+echo ""
+echo "To verify on an Apple Silicon Mac, transfer the app and run:"
+echo "  lipo -archs /path/to/CodexBar.app/Contents/MacOS/CodexBar"


### PR DESCRIPTION
Makes universal binary (Intel + Apple Silicon) the default for release builds.

The creator mentioned they couldn't test on Intel, so this change defaults the release build to create universal binaries that work on both architectures. This ensures Intel Mac users can use CodexBar without needing to manually specify architectures.

## Changes
- Updated `Scripts/sign-and-notarize.sh` to default to `arm64 x86_64` instead of `arm64` only
- Updated `docs/RELEASING.md` to document universal binary support
- Updated `AGENTS.md` release flow notes
- Added `test_universal.sh` script to verify universal binary builds (can be run on Apple Silicon to verify both architectures are present without needing Intel hardware)

## Testing
- Built universal binary on Intel Mac (x86_64)
- Verified both architectures present: `lipo -archs CodexBar.app/Contents/MacOS/CodexBar` shows `arm64 x86_64`
- Tested app execution on Intel Mac
- Test script can be run on Apple Silicon to verify build without needing Intel hardware

## Commands Run
ARCHES="arm64 x86_64" ./Scripts/package_app.sh release
lipo -archs CodexBar.app/Contents/MacOS/CodexBar
./test_universal.sh
