### PR TITLE
feat: add Helium browser support for storage importers

### DIFF
--- a/Sources/CodexBarCore/Providers/Factory/FactoryLocalStorageImporter.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryLocalStorageImporter.swift
@@ -90,6 +90,7 @@ enum FactoryLocalStorageImporter {
                         .appendingPathComponent("host"),
                     "ChatGPT Atlas"),
                 (appSupport.appendingPathComponent("Chromium"), "Chromium"),
+                (appSupport.appendingPathComponent("Helium").appendingPathComponent("User Data"), "Helium"),
             ]
         }
 

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxLocalStorageImporter.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxLocalStorageImporter.swift
@@ -151,6 +151,7 @@ enum MiniMaxLocalStorageImporter {
                         .appendingPathComponent("host"),
                     "ChatGPT Atlas"),
                 (appSupport.appendingPathComponent("Chromium"), "Chromium"),
+                (appSupport.appendingPathComponent("Helium").appendingPathComponent("User Data"), "Helium"),
             ]
         }
 
@@ -219,6 +220,7 @@ enum MiniMaxLocalStorageImporter {
                         .appendingPathComponent("host"),
                     "ChatGPT Atlas"),
                 (appSupport.appendingPathComponent("Chromium"), "Chromium"),
+                (appSupport.appendingPathComponent("Helium").appendingPathComponent("User Data"), "Helium"),
             ]
         }
 
@@ -287,6 +289,7 @@ enum MiniMaxLocalStorageImporter {
                         .appendingPathComponent("host"),
                     "ChatGPT Atlas"),
                 (appSupport.appendingPathComponent("Chromium"), "Chromium"),
+                (appSupport.appendingPathComponent("Helium").appendingPathComponent("User Data"), "Helium"),
             ]
         }
 


### PR DESCRIPTION
## Summary

This PR adds support for the Helium browser (a Chromium-based browser) to extract tokens and session data from local storage, session storage, and IndexedDB.

## Changes

- **MiniMaxLocalStorageImporter**: Added Helium paths to:
  - `chromeLocalStorageCandidates()` for local storage
  - `chromeSessionStorageCandidates()` for session storage  
  - `chromeIndexedDBCandidates()` for IndexedDB

- **FactoryLocalStorageImporter**: Added Helium paths to:
  - `chromeLocalStorageCandidates()` for local storage

## Technical Details

Helium follows the standard Chromium User Data directory structure:
```
~/Library/Application Support/Helium/User Data/[Profile]/
```

This enables CodexBar to access:
- Local Storage: `~/Library/Application Support/Helium/User Data/[Profile]/Local Storage/leveldb/`
- Session Storage: `~/Library/Application Support/Helium/User Data/[Profile]/Session Storage/`
- IndexedDB: `~/Library/Application Support/Helium/User Data/[Profile]/IndexedDB/`

## Note

Full cookie support via `BrowserCookieClient` requires adding Helium to the SweetCookieKit package separately, as that functionality is handled by the external dependency.

## Test Plan

- [ ] Verify Helium browser is detected when installed
- [ ] Confirm tokens are extracted from Helium's local storage for MiniMax provider
- [ ] Confirm tokens are extracted from Helium's local storage for Factory provider
- [ ] Test with multiple Helium profiles if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)