### PR TITLE
fix(cursor): use breakdown.total for accurate usage limits

### DIFF
--- a/Sources/CodexBar/PreferencesDebugPane.swift
+++ b/Sources/CodexBar/PreferencesDebugPane.swift
@@ -59,14 +59,15 @@ struct DebugPane: View {
 
                 SettingsSection(
                     title: "Probe logs",
-                    caption: "Fetch the latest PTY scrape for Codex or Claude; Copy keeps the full text.")
+                    caption: "Fetch the latest probe output for debugging; Copy keeps the full text.")
                 {
                     Picker("Provider", selection: self.$currentLogProvider) {
                         Text("Codex").tag(UsageProvider.codex)
                         Text("Claude").tag(UsageProvider.claude)
+                        Text("Cursor").tag(UsageProvider.cursor)
                     }
                     .pickerStyle(.segmented)
-                    .frame(width: 240)
+                    .frame(width: 320)
 
                     HStack(spacing: 12) {
                         Button { self.loadLog(self.currentLogProvider) } label: {

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -440,6 +440,11 @@ public struct CursorStatusProbe: Sendable {
         self.timeout = timeout
     }
 
+    /// Fetch Cursor usage with manual cookie header (for debugging).
+    public func fetchWithManualCookies(_ cookieHeader: String) async throws -> CursorStatusSnapshot {
+        try await self.fetchWithCookieHeader(cookieHeader)
+    }
+
     /// Fetch Cursor usage using browser cookies with fallback to stored session.
     public func fetch(cookieHeaderOverride: String? = nil, logger: ((String) -> Void)? = nil)
         async throws -> CursorStatusSnapshot
@@ -485,13 +490,13 @@ public struct CursorStatusProbe: Sendable {
         async let usageSummaryTask = self.fetchUsageSummary(cookieHeader: cookieHeader)
         async let userInfoTask = self.fetchUserInfo(cookieHeader: cookieHeader)
 
-        let usageSummary = try await usageSummaryTask
+        let (usageSummary, rawJSON) = try await usageSummaryTask
         let userInfo = try? await userInfoTask
 
-        return self.parseUsageSummary(usageSummary, userInfo: userInfo)
+        return self.parseUsageSummary(usageSummary, userInfo: userInfo, rawJSON: rawJSON)
     }
 
-    private func fetchUsageSummary(cookieHeader: String) async throws -> CursorUsageSummary {
+    private func fetchUsageSummary(cookieHeader: String) async throws -> (CursorUsageSummary, String) {
         let url = self.baseURL.appendingPathComponent("/api/usage-summary")
         var request = URLRequest(url: url)
         request.timeoutInterval = self.timeout
@@ -512,11 +517,13 @@ public struct CursorStatusProbe: Sendable {
             throw CursorStatusProbeError.networkError("HTTP \(httpResponse.statusCode)")
         }
 
+        let rawJSON = String(data: data, encoding: .utf8) ?? "<binary>"
+
         do {
             let decoder = JSONDecoder()
-            return try decoder.decode(CursorUsageSummary.self, from: data)
+            let summary = try decoder.decode(CursorUsageSummary.self, from: data)
+            return (summary, rawJSON)
         } catch {
-            let rawJSON = String(data: data, encoding: .utf8) ?? "<binary>"
             throw CursorStatusProbeError
                 .parseFailed("JSON decode failed: \(error.localizedDescription). Raw: \(rawJSON.prefix(200))")
         }
@@ -539,7 +546,7 @@ public struct CursorStatusProbe: Sendable {
         return try decoder.decode(CursorUserInfo.self, from: data)
     }
 
-    func parseUsageSummary(_ summary: CursorUsageSummary, userInfo: CursorUserInfo?) -> CursorStatusSnapshot {
+    func parseUsageSummary(_ summary: CursorUsageSummary, userInfo: CursorUserInfo?, rawJSON: String?) -> CursorStatusSnapshot {
         // Parse billing cycle end date
         let billingCycleEnd: Date? = summary.billingCycleEnd.flatMap { dateString in
             let formatter = ISO8601DateFormatter()
@@ -548,8 +555,9 @@ public struct CursorStatusProbe: Sendable {
         }
 
         // Convert cents to USD (plan percent derives from raw values to avoid percent unit mismatches).
+        // Use breakdown.total if available (includes bonus credits), otherwise fall back to limit.
         let planUsedRaw = Double(summary.individualUsage?.plan?.used ?? 0)
-        let planLimitRaw = Double(summary.individualUsage?.plan?.limit ?? 0)
+        let planLimitRaw = Double(summary.individualUsage?.plan?.breakdown?.total ?? summary.individualUsage?.plan?.limit ?? 0)
         let planUsed = planUsedRaw / 100.0
         let planLimit = planLimitRaw / 100.0
         let planPercentUsed: Double = if planLimitRaw > 0 {
@@ -578,7 +586,7 @@ public struct CursorStatusProbe: Sendable {
             membershipType: summary.membershipType,
             accountEmail: userInfo?.email,
             accountName: userInfo?.name,
-            rawJSON: nil)
+            rawJSON: rawJSON)
     }
 }
 

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -243,19 +243,19 @@ private struct RPCCreditsSnapshot: Decodable, Encodable {
     let balance: String?
 }
 
-private enum RPCWireError: Error, CustomStringConvertible {
+private enum RPCWireError: Error, LocalizedError {
     case startFailed(String)
     case requestFailed(String)
     case malformed(String)
 
-    var description: String {
+    var errorDescription: String? {
         switch self {
         case let .startFailed(message):
-            "Failed to start codex app-server: \(message)"
+            "Codex not running. Try running a Codex command first. (\(message))"
         case let .requestFailed(message):
-            "RPC request failed: \(message)"
+            "Codex connection failed: \(message)"
         case let .malformed(message):
-            "Malformed response: \(message)"
+            "Codex returned invalid data: \(message)"
         }
     }
 }


### PR DESCRIPTION
Cursor API returns bonus credits in breakdown.total field, which includes both the base plan limit and any bonus credits awarded.

Previously, the code only used the 'limit' field, causing incorrect usage percentages for users with bonus credits. For example, a user with 00 base + 6.88 bonus would show 100% used when they still had 6.88 remaining.

Changes:
- Use breakdown.total when available (includes bonus credits)
- Fall back to limit if breakdown is not present
- Add rawJSON capture for debugging
- Add Cursor to debug pane for easier troubleshooting
- Add fetchWithManualCookies method for testing

Fixes usage calculation for Cursor Ultra and other plans with bonus credits.