### PR TITLE
[proposal] browser detection before keychain access

### DIFF
--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -27,8 +27,9 @@ struct CodexBarApp: App {
         let preferencesSelection = PreferencesSelection()
         let settings = SettingsStore()
         let fetcher = UsageFetcher()
+        let browserDetection = BrowserDetection()
         let account = fetcher.loadAccountInfo()
-        let store = UsageStore(fetcher: fetcher, settings: settings)
+        let store = UsageStore(fetcher: fetcher, browserDetection: browserDetection, settings: settings)
         self.preferencesSelection = preferencesSelection
         _settings = State(wrappedValue: settings)
         _store = State(wrappedValue: store)
@@ -268,8 +269,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Defensive fallback: this should not be hit in normal app lifecycle.
         let fallbackSettings = SettingsStore()
         let fetcher = UsageFetcher()
+        let browserDetection = BrowserDetection()
         let fallbackAccount = fetcher.loadAccountInfo()
-        let fallbackStore = UsageStore(fetcher: fetcher, settings: fallbackSettings)
+        let fallbackStore = UsageStore(fetcher: fetcher, browserDetection: browserDetection, settings: fallbackSettings)
         self.statusController = StatusItemController.factory(
             fallbackStore,
             fallbackSettings,

--- a/Sources/CodexBar/CursorLoginRunner.swift
+++ b/Sources/CodexBar/CursorLoginRunner.swift
@@ -25,6 +25,7 @@ final class CursorLoginRunner: NSObject {
         let email: String?
     }
 
+    private let browserDetection: BrowserDetection
     private var webView: WKWebView?
     private var window: NSWindow?
     private var continuation: CheckedContinuation<Result, Never>?
@@ -33,6 +34,11 @@ final class CursorLoginRunner: NSObject {
 
     private static let dashboardURL = URL(string: "https://cursor.com/dashboard")!
     private static let loginURLPattern = "authenticator.cursor.sh"
+
+    init(browserDetection: BrowserDetection) {
+        self.browserDetection = browserDetection
+        super.init()
+    }
 
     /// Runs the Cursor login flow in a browser window.
     /// Returns the result after the user completes login or cancels.
@@ -117,7 +123,7 @@ final class CursorLoginRunner: NSObject {
 
     private func fetchUserEmail() async -> String? {
         do {
-            let probe = CursorStatusProbe()
+            let probe = CursorStatusProbe(browserDetection: self.browserDetection)
             let snapshot = try await probe.fetch()
             return snapshot.accountEmail
         } catch {

--- a/Sources/CodexBar/PreferencesDebugPane.swift
+++ b/Sources/CodexBar/PreferencesDebugPane.swift
@@ -157,9 +157,10 @@ struct DebugPane: View {
                     }
 
                     ScrollView {
-                        Text(self.store.openAIDashboardCookieImportDebugLog?.isEmpty == false
-                            ? (self.store.openAIDashboardCookieImportDebugLog ?? "")
-                            : "No log yet. Update OpenAI cookies in Providers → Codex to run an import.")
+                        Text(
+                            self.store.openAIDashboardCookieImportDebugLog?.isEmpty == false
+                                ? (self.store.openAIDashboardCookieImportDebugLog ?? "")
+                                : "No log yet. Update OpenAI cookies in Providers → Codex to run an import.")
                             .font(.system(.footnote, design: .monospaced))
                             .textSelection(.enabled)
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -290,9 +291,10 @@ struct DebugPane: View {
                         Text("Effective PATH")
                             .font(.callout.weight(.semibold))
                         ScrollView {
-                            Text(self.store.pathDebugInfo.effectivePATH.isEmpty
-                                ? "Unavailable"
-                                : self.store.pathDebugInfo.effectivePATH)
+                            Text(
+                                self.store.pathDebugInfo.effectivePATH.isEmpty
+                                    ? "Unavailable"
+                                    : self.store.pathDebugInfo.effectivePATH)
                                 .font(.system(.footnote, design: .monospaced))
                                 .textSelection(.enabled)
                                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/CodexBar/ProviderRegistry.swift
+++ b/Sources/CodexBar/ProviderRegistry.swift
@@ -21,7 +21,8 @@ struct ProviderRegistry {
         settings: SettingsStore,
         metadata: [UsageProvider: ProviderMetadata],
         codexFetcher: UsageFetcher,
-        claudeFetcher: any ClaudeUsageFetching) -> [UsageProvider: ProviderSpec]
+        claudeFetcher: any ClaudeUsageFetching,
+        browserDetection: BrowserDetection) -> [UsageProvider: ProviderSpec]
     {
         var specs: [UsageProvider: ProviderSpec] = [:]
         specs.reserveCapacity(UsageProvider.allCases.count)
@@ -84,7 +85,8 @@ struct ProviderRegistry {
                         env: ProcessInfo.processInfo.environment,
                         settings: snapshot,
                         fetcher: codexFetcher,
-                        claudeFetcher: claudeFetcher)
+                        claudeFetcher: claudeFetcher,
+                        browserDetection: browserDetection)
                     return await descriptor.fetchOutcome(context: context)
                 })
             specs[provider] = spec

--- a/Sources/CodexBar/Providers/Cursor/CursorLoginFlow.swift
+++ b/Sources/CodexBar/Providers/Cursor/CursorLoginFlow.swift
@@ -3,7 +3,7 @@ import CodexBarCore
 @MainActor
 extension StatusItemController {
     func runCursorLoginFlow() async {
-        let cursorRunner = CursorLoginRunner()
+        let cursorRunner = CursorLoginRunner(browserDetection: self.store.browserDetection)
         let phaseHandler: @Sendable (CursorLoginRunner.Phase) -> Void = { [weak self] phase in
             Task { @MainActor in
                 switch phase {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1465,8 +1465,9 @@ private final class ProviderSwitcherView: NSView {
                self.segments.indices.contains(index)
             {
                 let font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
-                let titleWidth = ceil((self.segments[index].title as NSString).size(withAttributes: [.font: font])
-                    .width)
+                let titleWidth = ceil(
+                    (self.segments[index].title as NSString).size(withAttributes: [.font: font])
+                        .width)
                 let contentPadding: CGFloat = 4 + 4
                 let extraSlack: CGFloat = 1
                 desiredWidths.append(ceil(titleWidth + contentPadding + extraSlack))

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -233,6 +233,7 @@ final class UsageStore {
     @ObservationIgnored private let codexFetcher: UsageFetcher
     @ObservationIgnored private let claudeFetcher: any ClaudeUsageFetching
     @ObservationIgnored private let costUsageFetcher: CostUsageFetcher
+    @ObservationIgnored let browserDetection: BrowserDetection
     @ObservationIgnored private let registry: ProviderRegistry
     @ObservationIgnored private let settings: SettingsStore
     @ObservationIgnored private let sessionQuotaNotifier: SessionQuotaNotifier
@@ -254,29 +255,34 @@ final class UsageStore {
 
     init(
         fetcher: UsageFetcher,
-        claudeFetcher: any ClaudeUsageFetching = ClaudeUsageFetcher(),
+        browserDetection: BrowserDetection,
+        claudeFetcher: (any ClaudeUsageFetching)? = nil,
         costUsageFetcher: CostUsageFetcher = CostUsageFetcher(),
         settings: SettingsStore,
         registry: ProviderRegistry = .shared,
         sessionQuotaNotifier: SessionQuotaNotifier = SessionQuotaNotifier())
     {
         self.codexFetcher = fetcher
-        self.claudeFetcher = claudeFetcher
+        self.browserDetection = browserDetection
+        self.claudeFetcher = claudeFetcher ?? ClaudeUsageFetcher(browserDetection: browserDetection)
         self.costUsageFetcher = costUsageFetcher
         self.settings = settings
         self.registry = registry
         self.sessionQuotaNotifier = sessionQuotaNotifier
         self.providerMetadata = registry.metadata
         self
-            .failureGates = Dictionary(uniqueKeysWithValues: UsageProvider.allCases
+            .failureGates = Dictionary(
+                uniqueKeysWithValues: UsageProvider.allCases
+                    .map { ($0, ConsecutiveFailureGate()) })
+        self.tokenFailureGates = Dictionary(
+            uniqueKeysWithValues: UsageProvider.allCases
                 .map { ($0, ConsecutiveFailureGate()) })
-        self.tokenFailureGates = Dictionary(uniqueKeysWithValues: UsageProvider.allCases
-            .map { ($0, ConsecutiveFailureGate()) })
         self.providerSpecs = registry.specs(
             settings: settings,
             metadata: self.providerMetadata,
             codexFetcher: fetcher,
-            claudeFetcher: claudeFetcher)
+            claudeFetcher: self.claudeFetcher,
+            browserDetection: browserDetection)
         self.bindSettings()
         self.detectVersions()
         self.refreshPathDebugInfo()
@@ -960,8 +966,9 @@ extension UsageStore {
                 now.timeIntervalSince(lastAttempt) > 300
             } else {
                 self.openAIDashboardRequiresLogin &&
-                    (lastEmail?.lowercased() != normalizedTarget?.lowercased() || now
-                        .timeIntervalSince(lastAttempt) > 300)
+                    (
+                        lastEmail?.lowercased() != normalizedTarget?.lowercased() || now
+                            .timeIntervalSince(lastAttempt) > 300)
             }
         }
 
@@ -979,7 +986,7 @@ extension UsageStore {
                 self.logOpenAIWeb(message)
             }
 
-            let importer = OpenAIDashboardBrowserCookieImporter()
+            let importer = OpenAIDashboardBrowserCookieImporter(browserDetection: self.browserDetection)
             let result: OpenAIDashboardBrowserCookieImporter.ImportResult
             switch cookieSource {
             case .manual:
@@ -1240,7 +1247,7 @@ extension UsageStore {
             let hasKey = if let manualHeader {
                 ClaudeWebAPIFetcher.hasSessionKey(cookieHeader: manualHeader)
             } else {
-                ClaudeWebAPIFetcher.hasSessionKey { msg in lines.append(msg) }
+                ClaudeWebAPIFetcher.hasSessionKey(browserDetection: self.browserDetection) { msg in lines.append(msg) }
             }
             let hasOAuthCredentials = (try? ClaudeOAuthCredentialsStore.load()) != nil
 
@@ -1264,7 +1271,8 @@ extension UsageStore {
                 return lines.joined(separator: "\n")
             case .web:
                 do {
-                    let web = try await ClaudeWebAPIFetcher.fetchUsage { msg in lines.append(msg) }
+                    let web = try await ClaudeWebAPIFetcher
+                        .fetchUsage(browserDetection: self.browserDetection) { msg in lines.append(msg) }
                     lines.append("")
                     lines.append("Web API summary:")
 

--- a/Sources/CodexBarClaudeWebProbe/main.swift
+++ b/Sources/CodexBarClaudeWebProbe/main.swift
@@ -27,6 +27,7 @@ enum CodexBarClaudeWebProbe {
         do {
             let results = try await ClaudeWebAPIFetcher.probeEndpoints(
                 endpoints,
+                browserDetection: BrowserDetection(),
                 includePreview: includePreview)
             for result in results {
                 Self.printResult(result)

--- a/Sources/CodexBarCore/BrowserDetection.swift
+++ b/Sources/CodexBarCore/BrowserDetection.swift
@@ -1,0 +1,223 @@
+import Foundation
+#if os(macOS)
+import SweetCookieKit
+
+/// Detects which browsers are installed to avoid unnecessary keychain prompts.
+public final class BrowserDetection: Sendable {
+    private nonisolated(unsafe) var cache: [Browser: CachedResult] = [:]
+
+    private struct CachedResult {
+        let isInstalled: Bool
+        let timestamp: Date
+    }
+
+    public init() {}
+
+    public func isInstalled(_ browser: Browser) -> Bool {
+        // Safari is always available on macOS
+        if browser == .safari {
+            return true
+        }
+
+        if let cached = self.cache[browser] {
+            return cached.isInstalled
+        }
+
+        let result = self.detectInstallation(for: browser)
+        self.cache[browser] = CachedResult(isInstalled: result, timestamp: Date())
+        return result
+    }
+
+    public func filterInstalled(_ browsers: [Browser]) -> [Browser] {
+        browsers.filter { self.isInstalled($0) }
+    }
+
+    func clearCache() {
+        self.cache.removeAll()
+    }
+
+    // MARK: - Detection Logic
+
+    private func detectInstallation(for browser: Browser) -> Bool {
+        let homeDir = FileManager.default.homeDirectoryForCurrentUser.path
+        let fm = FileManager.default
+
+        // 1. Check application bundle paths
+        let appPaths = self.applicationPaths(for: browser)
+        for path in appPaths where fm.fileExists(atPath: path) {
+            return true
+        }
+
+        // 2. Check profile directory (indicates past usage)
+        if let profilePath = self.profilePath(for: browser, homeDirectory: homeDir) {
+            if fm.fileExists(atPath: profilePath) {
+                // For Chromium-based browsers, verify actual profile data exists
+                if self.requiresProfileValidation(browser) {
+                    return self.hasValidProfile(at: profilePath, fileManager: fm)
+                }
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private func applicationPaths(for browser: Browser) -> [String] {
+        let homeDir = FileManager.default.homeDirectoryForCurrentUser.path
+        guard let appName = self.applicationName(for: browser) else { return [] }
+
+        return [
+            "/Applications/\(appName).app",
+            "\(homeDir)/Applications/\(appName).app",
+        ]
+    }
+
+    private func applicationName(for browser: Browser) -> String? {
+        switch browser {
+        case .safari:
+            return "Safari"
+        case .chrome:
+            return "Google Chrome"
+        case .chromeBeta:
+            return "Google Chrome Beta"
+        case .chromeCanary:
+            return "Google Chrome Canary"
+        case .arc:
+            return "Arc"
+        case .arcBeta:
+            return "Arc Beta"
+        case .arcCanary:
+            return "Arc Canary"
+        case .brave:
+            return "Brave Browser"
+        case .braveBeta:
+            return "Brave Browser Beta"
+        case .braveNightly:
+            return "Brave Browser Nightly"
+        case .edge:
+            return "Microsoft Edge"
+        case .edgeBeta:
+            return "Microsoft Edge Beta"
+        case .edgeCanary:
+            return "Microsoft Edge Canary"
+        case .vivaldi:
+            return "Vivaldi"
+        case .chromium:
+            return "Chromium"
+        case .firefox:
+            return "Firefox"
+        case .chatgptAtlas:
+            return "ChatGPT Atlas"
+        case .helium:
+            return "Helium"
+        @unknown default:
+            return nil
+        }
+    }
+
+    private func profilePath(for browser: Browser, homeDirectory: String) -> String? {
+        switch browser {
+        case .safari:
+            return "\(homeDirectory)/Library/Cookies/Cookies.binarycookies"
+        case .chrome:
+            return "\(homeDirectory)/Library/Application Support/Google/Chrome"
+        case .chromeBeta:
+            return "\(homeDirectory)/Library/Application Support/Google/Chrome Beta"
+        case .chromeCanary:
+            return "\(homeDirectory)/Library/Application Support/Google/Chrome Canary"
+        case .arc:
+            return "\(homeDirectory)/Library/Application Support/Arc/User Data"
+        case .arcBeta:
+            return "\(homeDirectory)/Library/Application Support/Arc Beta/User Data"
+        case .arcCanary:
+            return "\(homeDirectory)/Library/Application Support/Arc Canary/User Data"
+        case .brave:
+            return "\(homeDirectory)/Library/Application Support/BraveSoftware/Brave-Browser"
+        case .braveBeta:
+            return "\(homeDirectory)/Library/Application Support/BraveSoftware/Brave-Browser-Beta"
+        case .braveNightly:
+            return "\(homeDirectory)/Library/Application Support/BraveSoftware/Brave-Browser-Nightly"
+        case .edge:
+            return "\(homeDirectory)/Library/Application Support/Microsoft Edge"
+        case .edgeBeta:
+            return "\(homeDirectory)/Library/Application Support/Microsoft Edge Beta"
+        case .edgeCanary:
+            return "\(homeDirectory)/Library/Application Support/Microsoft Edge Canary"
+        case .vivaldi:
+            return "\(homeDirectory)/Library/Application Support/Vivaldi"
+        case .chromium:
+            return "\(homeDirectory)/Library/Application Support/Chromium"
+        case .firefox:
+            return "\(homeDirectory)/Library/Application Support/Firefox/Profiles"
+        case .chatgptAtlas:
+            return "\(homeDirectory)/Library/Application Support/ChatGPT Atlas"
+        case .helium:
+            return "\(homeDirectory)/Library/Application Support/net.imput.helium"
+        @unknown default:
+            return nil
+        }
+    }
+
+    private func requiresProfileValidation(_ browser: Browser) -> Bool {
+        // Chromium-based browsers should have Default/ or Profile*/ subdirectories
+        switch browser {
+        case .chrome, .chromeBeta, .chromeCanary,
+             .arc, .arcBeta, .arcCanary,
+             .brave, .braveBeta, .braveNightly,
+             .edge, .edgeBeta, .edgeCanary,
+             .vivaldi, .chromium, .chatgptAtlas:
+            return true
+        case .firefox:
+            // Firefox should have at least one *.default* directory
+            return true
+        case .helium:
+            // Helium doesn't use the Default/Profile* pattern
+            return false
+        case .safari:
+            return false
+        @unknown default:
+            return false
+        }
+    }
+
+    private func hasValidProfile(at profilePath: String, fileManager: FileManager) -> Bool {
+        guard let contents = try? fileManager.contentsOfDirectory(atPath: profilePath) else {
+            return false
+        }
+
+        // Check for Default/ or Profile*/ subdirectories for Chromium browsers
+        let hasProfile = contents.contains { name in
+            name == "Default" || name.hasPrefix("Profile ") || name.hasPrefix("user-")
+        }
+
+        // For Firefox, check for .default directories
+        if !hasProfile {
+            let hasFirefoxProfile = contents.contains { name in
+                name.contains(".default")
+            }
+            return hasFirefoxProfile
+        }
+
+        return hasProfile
+    }
+}
+
+#else
+
+// MARK: - Non-macOS stub
+
+public actor BrowserDetection {
+    public init() {}
+
+    public func isInstalled(_ browser: Browser) -> Bool {
+        true
+    }
+
+    public func filterInstalled(_ browsers: [Browser]) -> [Browser] {
+        browsers
+    }
+
+    public func clearCache() {}
+}
+
+#endif

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
@@ -65,7 +65,11 @@ public struct OpenAIDashboardBrowserCookieImporter {
         }
     }
 
-    public init() {}
+    public init(browserDetection: BrowserDetection) {
+        self.browserDetection = browserDetection
+    }
+
+    private let browserDetection: BrowserDetection
 
     private struct ImportDiagnostics {
         var mismatches: [FoundAccount] = []
@@ -110,7 +114,9 @@ public struct OpenAIDashboardBrowserCookieImporter {
 
         var diagnostics = ImportDiagnostics()
 
-        for browserSource in Self.cookieImportOrder {
+        // Filter to only installed browsers to avoid unnecessary keychain prompts
+        let installedBrowsers = self.browserDetection.filterInstalled(Self.cookieImportOrder)
+        for browserSource in installedBrowsers {
             if let match = await self.trySource(
                 browserSource,
                 targetEmail: normalizedTarget,

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardScrapeScript.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardScrapeScript.swift
@@ -553,6 +553,6 @@ let openAIDashboardScrapeScript = """
         didScrollToCredits
       };
     })();
-    
+
 """
 #endif

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -37,7 +37,9 @@ public enum ClaudeProviderDescriptor {
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "claude",
-                versionDetector: { ClaudeUsageFetcher().detectVersion() }))
+                versionDetector: { browserDetection in
+                    ClaudeUsageFetcher(browserDetection: browserDetection).detectVersion()
+                }))
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {
@@ -47,11 +49,20 @@ public enum ClaudeProviderDescriptor {
             case .oauth:
                 return [ClaudeOAuthFetchStrategy()]
             case .web:
-                return [ClaudeWebFetchStrategy()]
+                return [ClaudeWebFetchStrategy(browserDetection: context.browserDetection)]
             case .cli:
-                return [ClaudeCLIFetchStrategy(useWebExtras: false, manualCookieHeader: nil)]
+                return [ClaudeCLIFetchStrategy(
+                    useWebExtras: false,
+                    manualCookieHeader: nil,
+                    browserDetection: context.browserDetection)]
             case .auto:
-                return [ClaudeWebFetchStrategy(), ClaudeCLIFetchStrategy(useWebExtras: false, manualCookieHeader: nil)]
+                return [
+                    ClaudeWebFetchStrategy(browserDetection: context.browserDetection),
+                    ClaudeCLIFetchStrategy(
+                        useWebExtras: false,
+                        manualCookieHeader: nil,
+                        browserDetection: context.browserDetection),
+                ]
             }
         case .app:
             let webExtrasEnabled = context.settings?.claude?.webExtrasEnabled ?? false
@@ -60,18 +71,20 @@ public enum ClaudeProviderDescriptor {
             case .oauth:
                 return [ClaudeOAuthFetchStrategy()]
             case .web:
-                return [ClaudeWebFetchStrategy()]
+                return [ClaudeWebFetchStrategy(browserDetection: context.browserDetection)]
             case .cli:
                 return [ClaudeCLIFetchStrategy(
                     useWebExtras: webExtrasEnabled,
-                    manualCookieHeader: manualCookieHeader)]
+                    manualCookieHeader: manualCookieHeader,
+                    browserDetection: context.browserDetection)]
             case .auto:
                 return [
                     ClaudeOAuthFetchStrategy(),
-                    ClaudeWebFetchStrategy(),
+                    ClaudeWebFetchStrategy(browserDetection: context.browserDetection),
                     ClaudeCLIFetchStrategy(
                         useWebExtras: webExtrasEnabled,
-                        manualCookieHeader: manualCookieHeader),
+                        manualCookieHeader: manualCookieHeader,
+                        browserDetection: context.browserDetection),
                 ]
             }
         }
@@ -118,7 +131,10 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        let fetcher = ClaudeUsageFetcher(dataSource: .oauth, useWebExtras: false)
+        let fetcher = ClaudeUsageFetcher(
+            browserDetection: context.browserDetection,
+            dataSource: .oauth,
+            useWebExtras: false)
         let usage = try await fetcher.loadLatestUsage(model: "sonnet")
         return self.makeResult(
             usage: Self.snapshot(from: usage),
@@ -148,17 +164,19 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
 struct ClaudeWebFetchStrategy: ProviderFetchStrategy {
     let id: String = "claude.web"
     let kind: ProviderFetchKind = .web
+    let browserDetection: BrowserDetection
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
         if let header = Self.manualCookieHeader(from: context) {
             return ClaudeWebAPIFetcher.hasSessionKey(cookieHeader: header)
         }
         guard context.settings?.claude?.cookieSource != .off else { return false }
-        return ClaudeWebAPIFetcher.hasSessionKey()
+        return ClaudeWebAPIFetcher.hasSessionKey(browserDetection: self.browserDetection)
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
         let fetcher = ClaudeUsageFetcher(
+            browserDetection: browserDetection,
             dataSource: .web,
             useWebExtras: false,
             manualCookieHeader: Self.manualCookieHeader(from: context))
@@ -185,11 +203,13 @@ struct ClaudeCLIFetchStrategy: ProviderFetchStrategy {
     let kind: ProviderFetchKind = .cli
     let useWebExtras: Bool
     let manualCookieHeader: String?
+    let browserDetection: BrowserDetection
 
     func isAvailable(_: ProviderFetchContext) async -> Bool { true }
 
     func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
         let fetcher = ClaudeUsageFetcher(
+            browserDetection: browserDetection,
             dataSource: .cli,
             useWebExtras: self.useWebExtras,
             manualCookieHeader: self.manualCookieHeader)

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -36,7 +36,7 @@ public enum CodexProviderDescriptor {
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "codex",
-                versionDetector: { ProviderVersionDetector.codexVersion() }))
+                versionDetector: { _ in ProviderVersionDetector.codexVersion() }))
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {

--- a/Sources/CodexBarCore/Providers/Cursor/CursorProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorProviderDescriptor.swift
@@ -51,7 +51,7 @@ struct CursorStatusFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        let probe = CursorStatusProbe()
+        let probe = CursorStatusProbe(browserDetection: context.browserDetection)
         let manual = Self.manualCookieHeader(from: context)
         let snap = try await probe.fetch(cookieHeaderOverride: manual)
         return self.makeResult(

--- a/Sources/CodexBarCore/Providers/Factory/FactoryLocalStorageImporter.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryLocalStorageImporter.swift
@@ -13,12 +13,15 @@ enum FactoryLocalStorageImporter {
         let sourceLabel: String
     }
 
-    static func importWorkOSTokens(logger: ((String) -> Void)? = nil) -> [TokenInfo] {
+    static func importWorkOSTokens(
+        browserDetection: BrowserDetection,
+        logger: ((String) -> Void)? = nil) -> [TokenInfo]
+    {
         let log: (String) -> Void = { msg in logger?("[factory-storage] \(msg)") }
         var tokens: [TokenInfo] = []
 
         let safariCandidates = self.safariLocalStorageCandidates()
-        let chromeCandidates = self.chromeLocalStorageCandidates()
+        let chromeCandidates = self.chromeLocalStorageCandidates(browserDetection: browserDetection)
         if !safariCandidates.isEmpty {
             log("Safari local storage candidates: \(safariCandidates.count)")
         }
@@ -72,7 +75,7 @@ enum FactoryLocalStorageImporter {
         let kind: LocalStorageSourceKind
     }
 
-    private static func chromeLocalStorageCandidates() -> [LocalStorageCandidate] {
+    private static func chromeLocalStorageCandidates(browserDetection: BrowserDetection) -> [LocalStorageCandidate] {
         let browsers: [Browser] = [
             .chrome,
             .chromeBeta,
@@ -84,8 +87,12 @@ enum FactoryLocalStorageImporter {
             .chromium,
             .helium,
         ]
+
+        // Filter to only installed browsers to avoid unnecessary filesystem access
+        let installedBrowsers = browserDetection.filterInstalled(browsers)
+
         let roots = ChromiumProfileLocator
-            .roots(for: browsers, homeDirectories: BrowserCookieClient.defaultHomeDirectories())
+            .roots(for: installedBrowsers, homeDirectories: BrowserCookieClient.defaultHomeDirectories())
             .map { (url: $0.url, labelPrefix: $0.labelPrefix) }
 
         var candidates: [LocalStorageCandidate] = []

--- a/Sources/CodexBarCore/Providers/Factory/FactoryProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryProviderDescriptor.swift
@@ -51,7 +51,7 @@ struct FactoryStatusFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        let probe = FactoryStatusProbe()
+        let probe = FactoryStatusProbe(browserDetection: context.browserDetection)
         let manual = Self.manualCookieHeader(from: context)
         let snap = try await probe.fetch(cookieHeaderOverride: manual)
         return self.makeResult(

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiProviderDescriptor.swift
@@ -37,7 +37,7 @@ public enum GeminiProviderDescriptor {
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [GeminiStatusFetchStrategy()] })),
             cli: ProviderCLIConfig(
                 name: "gemini",
-                versionDetector: { ProviderVersionDetector.geminiVersion() }))
+                versionDetector: { _ in ProviderVersionDetector.geminiVersion() }))
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Kiro/KiroProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroProviderDescriptor.swift
@@ -37,7 +37,7 @@ public enum KiroProviderDescriptor {
             cli: ProviderCLIConfig(
                 name: "kiro",
                 aliases: ["kiro-cli"],
-                versionDetector: { KiroStatusProbe.detectVersion() }))
+                versionDetector: { _ in KiroStatusProbe.detectVersion() }))
     }
 }
 

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxCookieImporter.swift
@@ -25,9 +25,15 @@ public enum MiniMaxCookieImporter {
         }
     }
 
-    public static func importSessions(logger: ((String) -> Void)? = nil) throws -> [SessionInfo] {
+    public static func importSessions(
+        browserDetection: BrowserDetection,
+        logger: ((String) -> Void)? = nil) throws -> [SessionInfo]
+    {
         var sessions: [SessionInfo] = []
-        for browserSource in minimaxCookieImportOrder {
+
+        // Filter to only installed browsers to avoid unnecessary keychain prompts
+        let installedBrowsers = browserDetection.filterInstalled(minimaxCookieImportOrder)
+        for browserSource in installedBrowsers {
             do {
                 let perSource = try self.importSessions(from: browserSource, logger: logger)
                 sessions.append(contentsOf: perSource)
@@ -78,17 +84,20 @@ public enum MiniMaxCookieImporter {
         return sessions
     }
 
-    public static func importSession(logger: ((String) -> Void)? = nil) throws -> SessionInfo {
-        let sessions = try self.importSessions(logger: logger)
+    public static func importSession(
+        browserDetection: BrowserDetection,
+        logger: ((String) -> Void)? = nil) throws -> SessionInfo
+    {
+        let sessions = try self.importSessions(browserDetection: browserDetection, logger: logger)
         guard let first = sessions.first else {
             throw MiniMaxCookieImportError.noCookies
         }
         return first
     }
 
-    public static func hasSession(logger: ((String) -> Void)? = nil) -> Bool {
+    public static func hasSession(browserDetection: BrowserDetection, logger: ((String) -> Void)? = nil) -> Bool {
         do {
-            return try !self.importSessions(logger: logger).isEmpty
+            return try !self.importSessions(browserDetection: browserDetection, logger: logger).isEmpty
         } catch {
             return false
         }

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxLocalStorageImporter.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxLocalStorageImporter.swift
@@ -11,11 +11,14 @@ enum MiniMaxLocalStorageImporter {
         let sourceLabel: String
     }
 
-    static func importAccessTokens(logger: ((String) -> Void)? = nil) -> [TokenInfo] {
+    static func importAccessTokens(
+        browserDetection: BrowserDetection,
+        logger: ((String) -> Void)? = nil) -> [TokenInfo]
+    {
         let log: (String) -> Void = { msg in logger?("[minimax-storage] \(msg)") }
         var tokens: [TokenInfo] = []
 
-        let chromeCandidates = self.chromeLocalStorageCandidates()
+        let chromeCandidates = self.chromeLocalStorageCandidates(browserDetection: browserDetection)
         if !chromeCandidates.isEmpty {
             log("Chrome local storage candidates: \(chromeCandidates.count)")
         }
@@ -37,7 +40,7 @@ enum MiniMaxLocalStorageImporter {
         }
 
         if tokens.isEmpty {
-            let sessionCandidates = self.chromeSessionStorageCandidates()
+            let sessionCandidates = self.chromeSessionStorageCandidates(browserDetection: browserDetection)
             if !sessionCandidates.isEmpty {
                 log("Chrome session storage candidates: \(sessionCandidates.count)")
             }
@@ -54,7 +57,7 @@ enum MiniMaxLocalStorageImporter {
         }
 
         if tokens.isEmpty {
-            let indexedCandidates = self.chromeIndexedDBCandidates()
+            let indexedCandidates = self.chromeIndexedDBCandidates(browserDetection: browserDetection)
             if !indexedCandidates.isEmpty {
                 log("Chrome IndexedDB candidates: \(indexedCandidates.count)")
             }
@@ -77,11 +80,14 @@ enum MiniMaxLocalStorageImporter {
         return tokens
     }
 
-    static func importGroupIDs(logger: ((String) -> Void)? = nil) -> [String: String] {
+    static func importGroupIDs(
+        browserDetection: BrowserDetection,
+        logger: ((String) -> Void)? = nil) -> [String: String]
+    {
         let log: (String) -> Void = { msg in logger?("[minimax-storage] \(msg)") }
         var results: [String: String] = [:]
 
-        let chromeCandidates = self.chromeLocalStorageCandidates()
+        let chromeCandidates = self.chromeLocalStorageCandidates(browserDetection: browserDetection)
         if !chromeCandidates.isEmpty {
             log("Chrome local storage candidates: \(chromeCandidates.count)")
         }
@@ -119,7 +125,7 @@ enum MiniMaxLocalStorageImporter {
         let url: URL
     }
 
-    private static func chromeLocalStorageCandidates() -> [LocalStorageCandidate] {
+    private static func chromeLocalStorageCandidates(browserDetection: BrowserDetection) -> [LocalStorageCandidate] {
         let browsers: [Browser] = [
             .chrome,
             .chromeBeta,
@@ -138,8 +144,12 @@ enum MiniMaxLocalStorageImporter {
             .chromium,
             .helium,
         ]
+
+        // Filter to only installed browsers to avoid unnecessary filesystem access
+        let installedBrowsers = browserDetection.filterInstalled(browsers)
+
         let roots = ChromiumProfileLocator
-            .roots(for: browsers, homeDirectories: BrowserCookieClient.defaultHomeDirectories())
+            .roots(for: installedBrowsers, homeDirectories: BrowserCookieClient.defaultHomeDirectories())
             .map { (url: $0.url, labelPrefix: $0.labelPrefix) }
 
         var candidates: [LocalStorageCandidate] = []
@@ -175,7 +185,8 @@ enum MiniMaxLocalStorageImporter {
         }
     }
 
-    private static func chromeSessionStorageCandidates() -> [SessionStorageCandidate] {
+    private static func chromeSessionStorageCandidates(browserDetection: BrowserDetection)
+    -> [SessionStorageCandidate] {
         let browsers: [Browser] = [
             .chrome,
             .chromeBeta,
@@ -194,8 +205,12 @@ enum MiniMaxLocalStorageImporter {
             .chromium,
             .helium,
         ]
+
+        // Filter to only installed browsers to avoid unnecessary filesystem access
+        let installedBrowsers = browserDetection.filterInstalled(browsers)
+
         let roots = ChromiumProfileLocator
-            .roots(for: browsers, homeDirectories: BrowserCookieClient.defaultHomeDirectories())
+            .roots(for: installedBrowsers, homeDirectories: BrowserCookieClient.defaultHomeDirectories())
             .map { (url: $0.url, labelPrefix: $0.labelPrefix) }
 
         var candidates: [SessionStorageCandidate] = []
@@ -231,7 +246,7 @@ enum MiniMaxLocalStorageImporter {
         }
     }
 
-    private static func chromeIndexedDBCandidates() -> [IndexedDBCandidate] {
+    private static func chromeIndexedDBCandidates(browserDetection: BrowserDetection) -> [IndexedDBCandidate] {
         let browsers: [Browser] = [
             .chrome,
             .chromeBeta,
@@ -250,8 +265,12 @@ enum MiniMaxLocalStorageImporter {
             .chromium,
             .helium,
         ]
+
+        // Filter to only installed browsers to avoid unnecessary filesystem access
+        let installedBrowsers = browserDetection.filterInstalled(browsers)
+
         let roots = ChromiumProfileLocator
-            .roots(for: browsers, homeDirectories: BrowserCookieClient.defaultHomeDirectories())
+            .roots(for: installedBrowsers, homeDirectories: BrowserCookieClient.defaultHomeDirectories())
             .map { (url: $0.url, labelPrefix: $0.labelPrefix) }
 
         var candidates: [IndexedDBCandidate] = []

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxProviderDescriptor.swift
@@ -51,7 +51,7 @@ struct MiniMaxCodingPlanFetchStrategy: ProviderFetchStrategy {
             return true
         }
         #if os(macOS)
-        return MiniMaxCookieImporter.hasSession()
+        return MiniMaxCookieImporter.hasSession(browserDetection: context.browserDetection)
         #else
         return false
         #endif
@@ -70,12 +70,17 @@ struct MiniMaxCodingPlanFetchStrategy: ProviderFetchStrategy {
         }
 
         #if os(macOS)
-        let sessions = (try? MiniMaxCookieImporter.importSessions()) ?? []
+        let sessions = (try? MiniMaxCookieImporter.importSessions(
+            browserDetection: context.browserDetection)) ?? []
         guard !sessions.isEmpty else { throw MiniMaxSettingsError.missingCookie }
 
         let tokenLog: (String) -> Void = { msg in Self.log.debug(msg) }
-        let accessTokens = MiniMaxLocalStorageImporter.importAccessTokens(logger: tokenLog)
-        let groupIDs = MiniMaxLocalStorageImporter.importGroupIDs(logger: tokenLog)
+        let accessTokens = MiniMaxLocalStorageImporter.importAccessTokens(
+            browserDetection: context.browserDetection,
+            logger: tokenLog)
+        let groupIDs = MiniMaxLocalStorageImporter.importGroupIDs(
+            browserDetection: context.browserDetection,
+            logger: tokenLog)
         var tokensByLabel: [String: [String]] = [:]
         var groupIDByLabel: [String: String] = [:]
         for token in accessTokens {

--- a/Sources/CodexBarCore/Providers/ProviderCLIConfig.swift
+++ b/Sources/CodexBarCore/Providers/ProviderCLIConfig.swift
@@ -3,12 +3,12 @@ import Foundation
 public struct ProviderCLIConfig: Sendable {
     public let name: String
     public let aliases: [String]
-    public let versionDetector: (@Sendable () -> String?)?
+    public let versionDetector: (@Sendable (BrowserDetection) -> String?)?
 
     public init(
         name: String,
         aliases: [String] = [],
-        versionDetector: (@Sendable () -> String?)?)
+        versionDetector: (@Sendable (BrowserDetection) -> String?)?)
     {
         self.name = name
         self.aliases = aliases

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -27,6 +27,7 @@ public struct ProviderFetchContext: Sendable {
     public let settings: ProviderSettingsSnapshot?
     public let fetcher: UsageFetcher
     public let claudeFetcher: any ClaudeUsageFetching
+    public let browserDetection: BrowserDetection
 
     public init(
         runtime: ProviderRuntime,
@@ -38,7 +39,8 @@ public struct ProviderFetchContext: Sendable {
         env: [String: String],
         settings: ProviderSettingsSnapshot?,
         fetcher: UsageFetcher,
-        claudeFetcher: any ClaudeUsageFetching)
+        claudeFetcher: any ClaudeUsageFetching,
+        browserDetection: BrowserDetection)
     {
         self.runtime = runtime
         self.sourceMode = sourceMode
@@ -50,6 +52,7 @@ public struct ProviderFetchContext: Sendable {
         self.settings = settings
         self.fetcher = fetcher
         self.claudeFetcher = claudeFetcher
+        self.browserDetection = browserDetection
     }
 }
 

--- a/Tests/CodexBarTests/AppDelegateTests.swift
+++ b/Tests/CodexBarTests/AppDelegateTests.swift
@@ -20,7 +20,7 @@ struct AppDelegateTests {
 
         let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
         let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, settings: settings)
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
         let account = fetcher.loadAccountInfo()
 
         // configure should not eagerly construct the status controller

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -1,0 +1,152 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+#if os(macOS)
+import SweetCookieKit
+
+@Suite
+struct BrowserDetectionTests {
+    @Test
+    func test_safariAlwaysInstalled() async {
+        let isInstalled = await BrowserDetection().isInstalled(.safari)
+        #expect(isInstalled == true)
+    }
+
+    @Test
+    func test_filterInstalledIncludesSafari() async {
+        let browsers: [Browser] = [.safari, .chrome, .firefox]
+        let installed = await BrowserDetection().filterInstalled(browsers)
+        #expect(installed.contains(.safari))
+    }
+
+    @Test
+    func test_cacheWorks() async {
+        let detection = BrowserDetection()
+        // First call should detect
+        let first = await detection.isInstalled(.safari)
+
+        // Second call should use cache (same result)
+        let second = await detection.isInstalled(.safari)
+
+        #expect(first == second)
+    }
+
+    @Test
+    func test_cacheConsistency() async {
+        let detection = BrowserDetection()
+        _ = await detection.isInstalled(.safari)
+
+        // Second call should return consistent result
+        let result = await detection.isInstalled(.safari)
+        #expect(result == true)
+    }
+
+    @Test
+    func test_syncWrapperWorks() {
+        let isInstalled = BrowserDetection().isInstalled(.safari)
+        #expect(isInstalled == true)
+    }
+
+    @Test
+    func test_syncFilterWorks() {
+        let browsers: [Browser] = [.safari, .chrome, .firefox]
+        let installed = BrowserDetection().filterInstalled(browsers)
+        #expect(installed.contains(.safari))
+    }
+
+    @Test
+    func test_filterPreservesOrder() async {
+        let browsers: [Browser] = [.firefox, .safari, .chrome]
+        let installed = await BrowserDetection().filterInstalled(browsers)
+
+        // Safari should still be present
+        #expect(installed.contains(.safari))
+
+        // Order should be preserved (safari should not be first if firefox is installed)
+        if let safariIndex = installed.firstIndex(of: .safari),
+           let firefoxIndex = installed.firstIndex(of: .firefox)
+        {
+            #expect(firefoxIndex < safariIndex)
+        }
+    }
+
+    @Test
+    func test_emptyListReturnsEmpty() async {
+        let browsers: [Browser] = []
+        let installed = await BrowserDetection().filterInstalled(browsers)
+        #expect(installed.isEmpty)
+    }
+
+    @Test
+    func test_applicationPathsGeneration() async {
+        // Test that we generate correct paths
+        // We can't test actual installation without knowing the test environment,
+        // but we can verify the detection doesn't crash
+        let browsers: [Browser] = [
+            .chrome, .chromeBeta, .chromeCanary,
+            .arc, .arcBeta, .arcCanary,
+            .brave, .braveBeta, .braveNightly,
+            .edge, .edgeBeta, .edgeCanary,
+            .vivaldi, .chromium, .firefox,
+            .chatgptAtlas, .helium,
+        ]
+
+        for browser in browsers {
+            let isInstalled = await BrowserDetection().isInstalled(browser)
+            // Just verify it returns a boolean without crashing
+            #expect(isInstalled == true || isInstalled == false)
+        }
+    }
+
+    @Test
+    func test_detectionDoesNotThrow() async {
+        // Verify that detection handles missing browsers gracefully
+        let unlikelyBrowsers: [Browser] = [
+            .chromeBeta, .chromeCanary,
+            .arcBeta, .arcCanary,
+            .braveBeta, .braveNightly,
+            .edgeBeta, .edgeCanary,
+        ]
+
+        for browser in unlikelyBrowsers {
+            let result = await BrowserDetection().isInstalled(browser)
+            // Should return false for most test environments, but shouldn't crash
+            #expect(result == true || result == false)
+        }
+    }
+
+    @Test
+    func test_profileValidationForChromiumBrowsers() async {
+        // Chromium browsers should check for Default/Profile directories
+        // This test verifies the detection doesn't crash when profile dirs are missing
+        let chromiumBrowsers: [Browser] = [
+            .chrome, .arc, .brave, .edge, .vivaldi, .chromium, .chatgptAtlas,
+        ]
+
+        for browser in chromiumBrowsers {
+            let result = await BrowserDetection().isInstalled(browser)
+            #expect(result == true || result == false)
+        }
+    }
+}
+
+#else
+
+@Suite
+struct BrowserDetectionTests {
+    @Test
+    func test_nonMacOSReturnsNoBrowsers() async {
+        let isInstalled = await BrowserDetection().isInstalled(Browser())
+        #expect(isInstalled == false)
+    }
+
+    @Test
+    func test_nonMacOSFilterReturnsEmpty() async {
+        let browsers = [Browser(), Browser()]
+        let installed = await BrowserDetection().filterInstalled(browsers)
+        #expect(installed.isEmpty)
+    }
+}
+
+#endif

--- a/Tests/CodexBarTests/CLIWebFallbackTests.swift
+++ b/Tests/CodexBarTests/CLIWebFallbackTests.swift
@@ -5,7 +5,8 @@ import Testing
 @Suite
 struct CLIWebFallbackTests {
     private func makeContext(sourceMode: ProviderSourceMode = .auto) -> ProviderFetchContext {
-        ProviderFetchContext(
+        let browserDetection = BrowserDetection()
+        return ProviderFetchContext(
             runtime: .cli,
             sourceMode: sourceMode,
             includeCredits: true,
@@ -15,7 +16,8 @@ struct CLIWebFallbackTests {
             env: [:],
             settings: nil,
             fetcher: UsageFetcher(),
-            claudeFetcher: ClaudeUsageFetcher())
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+            browserDetection: browserDetection)
     }
 
     @Test
@@ -51,7 +53,7 @@ struct CLIWebFallbackTests {
     @Test
     func claudeFallsBackWhenNoSessionKey() {
         let context = self.makeContext()
-        let strategy = ClaudeWebFetchStrategy()
+        let strategy = ClaudeWebFetchStrategy(browserDetection: BrowserDetection())
         #expect(strategy.shouldFallback(on: ClaudeWebAPIFetcher.FetchError.noSessionKeyFound, context: context))
         #expect(strategy.shouldFallback(on: ClaudeWebAPIFetcher.FetchError.unauthorized, context: context))
     }

--- a/Tests/CodexBarTests/ClaudeUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeUsageTests.swift
@@ -109,7 +109,7 @@ struct ClaudeUsageTests {
         guard ProcessInfo.processInfo.environment["LIVE_CLAUDE_FETCH"] == "1" else {
             return
         }
-        let fetcher = ClaudeUsageFetcher(dataSource: .cli)
+        let fetcher = ClaudeUsageFetcher(browserDetection: BrowserDetection(), dataSource: .cli)
         do {
             let snap = try await fetcher.loadLatestUsage()
             let opusUsed = snap.opus?.usedPercent ?? -1
@@ -167,7 +167,7 @@ struct ClaudeUsageTests {
         guard ProcessInfo.processInfo.environment["LIVE_CLAUDE_WEB_FETCH"] == "1" else {
             return
         }
-        let fetcher = ClaudeUsageFetcher(dataSource: .web)
+        let fetcher = ClaudeUsageFetcher(browserDetection: BrowserDetection(), dataSource: .web)
         let snap = try await fetcher.loadLatestUsage()
         let weeklyUsed = snap.secondary?.usedPercent ?? -1
         let opusUsed = snap.opus?.usedPercent ?? -1
@@ -185,7 +185,7 @@ struct ClaudeUsageTests {
     @Test
     func claudeWebAPIHasSessionKeyCheck() {
         // Quick check that hasSessionKey returns a boolean (doesn't crash)
-        let hasKey = ClaudeWebAPIFetcher.hasSessionKey()
+        let hasKey = ClaudeWebAPIFetcher.hasSessionKey(browserDetection: BrowserDetection())
         // We can't assert the value since it depends on the test environment
         #expect(hasKey == true || hasKey == false)
     }
@@ -356,9 +356,10 @@ struct ClaudeUsageTests {
     @Test
     func claudeUsageFetcherInitWithDataSources() {
         // Verify we can create fetchers with both configurations
-        let defaultFetcher = ClaudeUsageFetcher()
-        let webFetcher = ClaudeUsageFetcher(dataSource: .web)
-        let cliFetcher = ClaudeUsageFetcher(dataSource: .cli)
+        let browserDetection = BrowserDetection()
+        let defaultFetcher = ClaudeUsageFetcher(browserDetection: browserDetection)
+        let webFetcher = ClaudeUsageFetcher(browserDetection: browserDetection, dataSource: .web)
+        let cliFetcher = ClaudeUsageFetcher(browserDetection: browserDetection, dataSource: .cli)
         // Both should be valid instances (no crashes)
         let defaultVersion = defaultFetcher.detectVersion()
         let webVersion = webFetcher.detectVersion()

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -121,7 +121,7 @@ struct CursorStatusProbeTests {
 
     @Test
     func prefersPlanRatioOverPercentField() {
-        let snapshot = CursorStatusProbe()
+        let snapshot = CursorStatusProbe(browserDetection: BrowserDetection())
             .parseUsageSummary(
                 CursorUsageSummary(
                     billingCycleStart: nil,
@@ -150,7 +150,7 @@ struct CursorStatusProbeTests {
 
     @Test
     func usesPercentFieldWhenLimitMissing() {
-        let snapshot = CursorStatusProbe()
+        let snapshot = CursorStatusProbe(browserDetection: BrowserDetection())
             .parseUsageSummary(
                 CursorUsageSummary(
                     billingCycleStart: nil,

--- a/Tests/CodexBarTests/GeminiStatusProbeTests.swift
+++ b/Tests/CodexBarTests/GeminiStatusProbeTests.swift
@@ -76,7 +76,8 @@ struct GeminiStatusProbeTests {
     @Test
     func stripsANSICodesBeforeParsing() throws {
         // swiftlint:disable:next line_length
-        let output = "\u{1B}[32m│\u{1B}[0m  gemini-2.5-flash                                                -       75.5% (Resets in 18h)  │"
+        let output =
+            "\u{1B}[32m│\u{1B}[0m  gemini-2.5-flash                                                -       75.5% (Resets in 18h)  │"
         let snap = try GeminiStatusProbe.parse(text: output)
         #expect(snap.dailyPercentLeft == 75.5)
     }

--- a/Tests/CodexBarTests/OpenAIWebAccountSwitchTests.swift
+++ b/Tests/CodexBarTests/OpenAIWebAccountSwitchTests.swift
@@ -11,7 +11,7 @@ struct OpenAIWebAccountSwitchTests {
         let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
         settings.refreshFrequency = .manual
 
-        let store = UsageStore(fetcher: UsageFetcher(), settings: settings)
+        let store = UsageStore(fetcher: UsageFetcher(), browserDetection: BrowserDetection(), settings: settings)
 
         store.handleOpenAIWebTargetEmailChangeIfNeeded(targetEmail: "a@example.com")
         store.openAIDashboard = OpenAIDashboardSnapshot(
@@ -34,7 +34,7 @@ struct OpenAIWebAccountSwitchTests {
         let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
         settings.refreshFrequency = .manual
 
-        let store = UsageStore(fetcher: UsageFetcher(), settings: settings)
+        let store = UsageStore(fetcher: UsageFetcher(), browserDetection: BrowserDetection(), settings: settings)
 
         store.handleOpenAIWebTargetEmailChangeIfNeeded(targetEmail: "a@example.com")
         let dash = OpenAIDashboardSnapshot(

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -12,7 +12,10 @@ struct ProviderSettingsDescriptorTests {
         let defaults = UserDefaults(suiteName: "ProviderSettingsDescriptorTests-unique")!
         defaults.removePersistentDomain(forName: "ProviderSettingsDescriptorTests-unique")
         let settings = SettingsStore(userDefaults: defaults, zaiTokenStore: NoopZaiTokenStore())
-        let store = UsageStore(fetcher: UsageFetcher(environment: [:]), settings: settings)
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(),
+            settings: settings)
 
         var statusByID: [String: String] = [:]
         var lastRunAtByID: [String: Date] = [:]
@@ -78,7 +81,10 @@ struct ProviderSettingsDescriptorTests {
         let defaults = UserDefaults(suiteName: "ProviderSettingsDescriptorTests-codex")!
         defaults.removePersistentDomain(forName: "ProviderSettingsDescriptorTests-codex")
         let settings = SettingsStore(userDefaults: defaults, zaiTokenStore: NoopZaiTokenStore())
-        let store = UsageStore(fetcher: UsageFetcher(environment: [:]), settings: settings)
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(),
+            settings: settings)
 
         let context = ProviderSettingsContext(
             provider: .codex,
@@ -110,7 +116,10 @@ struct ProviderSettingsDescriptorTests {
         let defaults = UserDefaults(suiteName: "ProviderSettingsDescriptorTests-claude")!
         defaults.removePersistentDomain(forName: "ProviderSettingsDescriptorTests-claude")
         let settings = SettingsStore(userDefaults: defaults, zaiTokenStore: NoopZaiTokenStore())
-        let store = UsageStore(fetcher: UsageFetcher(environment: [:]), settings: settings)
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(),
+            settings: settings)
 
         let context = ProviderSettingsContext(
             provider: .claude,

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -26,7 +26,7 @@ struct StatusItemAnimationTests {
         }
 
         let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, settings: settings)
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
         let controller = StatusItemController(
             store: store,
             settings: settings,
@@ -65,7 +65,7 @@ struct StatusItemAnimationTests {
         }
 
         let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, settings: settings)
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
 
         // Seed with data so init doesn't start the animation driver.
         let snapshot = UsageSnapshot(

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -32,7 +32,7 @@ struct StatusMenuTests {
         }
 
         let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, settings: settings)
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
         let controller = StatusItemController(
             store: store,
             settings: settings,
@@ -75,7 +75,7 @@ struct StatusMenuTests {
         }
 
         let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, settings: settings)
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
         store.openAIDashboard = OpenAIDashboardSnapshot(
             signedInEmail: "user@example.com",
             codeReviewRemainingPercent: 100,
@@ -119,7 +119,7 @@ struct StatusMenuTests {
         }
 
         let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, settings: settings)
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
 
         let calendar = Calendar(identifier: .gregorian)
         var components = DateComponents()
@@ -152,10 +152,12 @@ struct StatusMenuTests {
         controller.menuWillOpen(menu)
         let usageItem = menu.items.first { ($0.representedObject as? String) == "menuCardUsage" }
         let creditsItem = menu.items.first { ($0.representedObject as? String) == "menuCardCredits" }
-        #expect(usageItem?.submenu?.items
-            .contains { ($0.representedObject as? String) == "usageBreakdownChart" } == true)
-        #expect(creditsItem?.submenu?.items
-            .contains { ($0.representedObject as? String) == "creditsHistoryChart" } == true)
+        #expect(
+            usageItem?.submenu?.items
+                .contains { ($0.representedObject as? String) == "usageBreakdownChart" } == true)
+        #expect(
+            creditsItem?.submenu?.items
+                .contains { ($0.representedObject as? String) == "creditsHistoryChart" } == true)
     }
 
     @Test
@@ -179,7 +181,7 @@ struct StatusMenuTests {
         }
 
         let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, settings: settings)
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
         store.credits = CreditsSnapshot(remaining: 100, events: [], updatedAt: Date())
         store.openAIDashboard = OpenAIDashboardSnapshot(
             signedInEmail: "user@example.com",
@@ -245,7 +247,7 @@ struct StatusMenuTests {
         }
 
         let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, settings: settings)
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
         let identity = ProviderIdentitySnapshot(
             providerID: .claude,
             accountEmail: "user@example.com",
@@ -316,7 +318,7 @@ struct StatusMenuTests {
         }
 
         let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, settings: settings)
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
         store._setErrorForTesting("No Vertex AI usage data found for the current project.", provider: .vertexai)
         store._setTokenSnapshotForTesting(CostUsageTokenSnapshot(
             sessionTokens: 10,

--- a/Tests/CodexBarTests/TTYIntegrationTests.swift
+++ b/Tests/CodexBarTests/TTYIntegrationTests.swift
@@ -28,7 +28,7 @@ struct TTYIntegrationTests {
             return
         }
 
-        let fetcher = ClaudeUsageFetcher(dataSource: .cli)
+        let fetcher = ClaudeUsageFetcher(browserDetection: BrowserDetection(), dataSource: .cli)
 
         var shouldAssert = true
         do {


### PR DESCRIPTION
To be up front: There's a ton of constructor injection here. It feels kind of funky. No worries if this PR should be closed in favor of some other approach (or if we don't want to check for browsers at all). It was cheap enough to experiment, and I figured its easy enough to share from there.

#### What
There were a few new Keychain permission prompts that were bothering me + getting in the way of using CodexBar (because it would prompt every time I clicked on the menu bar icon!)

I thought about allowing permission - but I use Safari + don't have Chrome installed, so there's nothing in the keychains for CodexBar to find.

So, the next best thing I came up with was to change behavior to look for presence of browsers before trying to access keychain - disk i/o is cheaper than stealing attention is.

#### Building + Testing
built via running `./Scripts/compile_and_run.sh` a million times. 

I'm on Xcode 26.2 so I had to bump swift-syntax locally. I don't think it'll make much of a difference, but, wanted to note that in case it's interesting for anyone.
```
-        .package(url: "https://github.com/apple/swift-syntax", from: "600.0.0"),
+        .package(url: "https://github.com/apple/swift-syntax", branch: "release/6.2"),
```

I didn't install Chromium or Arc to test, but it does the right thing with Safari + Firefox + I'm not seeing keychain requests anymore.

#### Claude session
```
> /model
  ⎿  Set model to opus (claude-opus-4-1-20250805)

> i'd like to make a plan: if i don't have a given browser installed (Safari, Firefox, Chrome, Arc, Chromium, Brave, etc) we should not try to read cookies from macOS keychain. we shouldn't act on the plan yet.
  ⎿  <Claude does stuff>

> save the plan to disk as MINIMIZE_PERMISSIONS.md, ensuring there is a detailed checklist of browsers + detection methods we can follow (looking in /Applications, ~/Applications, app bundle + preference existence, caches, etc)
  ⎿  <Claude does stuff, file saved to disk. attached below>

> /model
⎿  Set model to Default (Sonnet 4.5 · Smartest model for daily use)

> /clear
> read AGENTS.md README.md and MINIMIZE_PERMISSIONS.md
  ⎿  <Claude does stuff>

> i'd like to implement the plan as described by MINIMIZE_PERMISSIONS.md. what would that look like?
  ⎿  <Claude does stuff>

> this looks pretty good, but minimize singleton usage. Inject the browser detector as much as possible, and only use `__shared__` at a high level such as in `CLIEntry`, `*Probe.swift` classes, and so on.
  ⎿  <Claude does stuff>

> Remove TTL expiry
  ⎿  <Claude does stuff>
```

#### MINIMIZE_PERMISSIONS.md
```
# Minimize Keychain Permissions: Browser Detection Plan

## Problem Statement

CodexBar currently attempts to read cookies from all browsers in the configured order, triggering macOS Keychain prompts for "Chrome Safe Storage" even when Chrome/Arc/Brave/etc aren't installed. This creates unnecessary permission prompts and user confusion.

## Solution Overview

Implement browser installation detection to skip cookie reading attempts for browsers that aren't installed, thereby avoiding unnecessary keychain access prompts.

## Browser Detection Methods

### Detection Priority Order
1. **Application Bundle Check** - Most reliable, check for .app bundle
2. **Profile Directory Check** - Indicates browser was used at least once
3. **Preferences/Cache Check** - Additional validation for edge cases

## Browser Detection Checklist

### Safari
- **Status**: Always available on macOS (no check needed)
- **Cookie Location**: `~/Library/Cookies/Cookies.binarycookies`
- **Note**: Skip detection, always attempt cookie read

### Google Chrome
- **Application Paths**:
  - [ ] `/Applications/Google Chrome.app`
  - [ ] `~/Applications/Google Chrome.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/Google/Chrome/`
  - [ ] Check for at least one profile: `Default/` or `Profile */`
- **Additional Validation**:
  - [ ] `~/Library/Application Support/Google/Chrome/Local State` (file exists)
  - [ ] `~/Library/Caches/Google/Chrome/` (directory exists)
- **Cookie Location**: `~/Library/Application Support/Google/Chrome/*/Cookies`
- **Keychain Service**: "Chrome Safe Storage"

### Google Chrome Beta
- **Application Paths**:
  - [ ] `/Applications/Google Chrome Beta.app`
  - [ ] `~/Applications/Google Chrome Beta.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/Google/Chrome Beta/`
- **Cookie Location**: `~/Library/Application Support/Google/Chrome Beta/*/Cookies`

### Google Chrome Canary
- **Application Paths**:
  - [ ] `/Applications/Google Chrome Canary.app`
  - [ ] `~/Applications/Google Chrome Canary.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/Google/Chrome Canary/`
- **Cookie Location**: `~/Library/Application Support/Google/Chrome Canary/*/Cookies`

### Arc
- **Application Paths**:
  - [ ] `/Applications/Arc.app`
  - [ ] `~/Applications/Arc.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/Arc/`
  - [ ] Check for user profiles: `User Data/Default/` or `User Data/Profile */`
- **Additional Validation**:
  - [ ] `~/Library/Application Support/Arc/User Data/Local State`
  - [ ] `~/Library/Caches/Arc/` (directory exists)
- **Cookie Location**: `~/Library/Application Support/Arc/User Data/*/Cookies`
- **Keychain Service**: "Arc Safe Storage"

### Brave Browser
- **Application Paths**:
  - [ ] `/Applications/Brave Browser.app`
  - [ ] `~/Applications/Brave Browser.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/BraveSoftware/Brave-Browser/`
  - [ ] Check for profiles: `Default/` or `Profile */`
- **Additional Validation**:
  - [ ] `~/Library/Application Support/BraveSoftware/Brave-Browser/Local State`
  - [ ] `~/Library/Caches/BraveSoftware/Brave-Browser/`
- **Cookie Location**: `~/Library/Application Support/BraveSoftware/Brave-Browser/*/Cookies`
- **Keychain Service**: "Brave Safe Storage"

### Brave Browser Beta
- **Application Paths**:
  - [ ] `/Applications/Brave Browser Beta.app`
  - [ ] `~/Applications/Brave Browser Beta.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/BraveSoftware/Brave-Browser-Beta/`
- **Cookie Location**: `~/Library/Application Support/BraveSoftware/Brave-Browser-Beta/*/Cookies`

### Brave Browser Nightly
- **Application Paths**:
  - [ ] `/Applications/Brave Browser Nightly.app`
  - [ ] `~/Applications/Brave Browser Nightly.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/BraveSoftware/Brave-Browser-Nightly/`
- **Cookie Location**: `~/Library/Application Support/BraveSoftware/Brave-Browser-Nightly/*/Cookies`

### Microsoft Edge
- **Application Paths**:
  - [ ] `/Applications/Microsoft Edge.app`
  - [ ] `~/Applications/Microsoft Edge.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/Microsoft Edge/`
  - [ ] Check for profiles: `Default/` or `Profile */`
- **Additional Validation**:
  - [ ] `~/Library/Application Support/Microsoft Edge/Local State`
  - [ ] `~/Library/Caches/Microsoft Edge/`
- **Cookie Location**: `~/Library/Application Support/Microsoft Edge/*/Cookies`
- **Keychain Service**: "Microsoft Edge Safe Storage"

### Microsoft Edge Beta
- **Application Paths**:
  - [ ] `/Applications/Microsoft Edge Beta.app`
  - [ ] `~/Applications/Microsoft Edge Beta.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/Microsoft Edge Beta/`
- **Cookie Location**: `~/Library/Application Support/Microsoft Edge Beta/*/Cookies`

### Microsoft Edge Canary
- **Application Paths**:
  - [ ] `/Applications/Microsoft Edge Canary.app`
  - [ ] `~/Applications/Microsoft Edge Canary.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/Microsoft Edge Canary/`
- **Cookie Location**: `~/Library/Application Support/Microsoft Edge Canary/*/Cookies`

### Vivaldi
- **Application Paths**:
  - [ ] `/Applications/Vivaldi.app`
  - [ ] `~/Applications/Vivaldi.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/Vivaldi/`
  - [ ] Check for profiles: `Default/` or `Profile */`
- **Additional Validation**:
  - [ ] `~/Library/Application Support/Vivaldi/Local State`
  - [ ] `~/Library/Caches/Vivaldi/`
- **Cookie Location**: `~/Library/Application Support/Vivaldi/*/Cookies`
- **Keychain Service**: "Vivaldi Safe Storage"

### Opera
- **Application Paths**:
  - [ ] `/Applications/Opera.app`
  - [ ] `~/Applications/Opera.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/com.operasoftware.Opera/`
- **Cookie Location**: `~/Library/Application Support/com.operasoftware.Opera/Cookies`
- **Keychain Service**: "Opera Safe Storage"

### Chromium
- **Application Paths**:
  - [ ] `/Applications/Chromium.app`
  - [ ] `~/Applications/Chromium.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/Chromium/`
- **Cookie Location**: `~/Library/Application Support/Chromium/*/Cookies`
- **Keychain Service**: "Chromium Safe Storage"

### Firefox
- **Application Paths**:
  - [ ] `/Applications/Firefox.app`
  - [ ] `~/Applications/Firefox.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/Firefox/`
  - [ ] `~/Library/Application Support/Firefox/Profiles/` (must contain at least one *.default* directory)
- **Additional Validation**:
  - [ ] `~/Library/Application Support/Firefox/profiles.ini` (file exists)
  - [ ] `~/Library/Caches/Firefox/`
- **Cookie Location**: `~/Library/Application Support/Firefox/Profiles/*/cookies.sqlite`
- **Note**: No keychain access required (SQLite database)

### ChatGPT Atlas
- **Application Paths**:
  - [ ] `/Applications/ChatGPT Atlas.app`
  - [ ] `~/Applications/ChatGPT Atlas.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/ChatGPT Atlas/`
- **Cookie Location**: `~/Library/Application Support/ChatGPT Atlas/*/Cookies`
- **Keychain Service**: "ChatGPT Atlas Safe Storage"

### Helium
- **Application Paths**:
  - [ ] `/Applications/Helium.app`
  - [ ] `~/Applications/Helium.app`
- **Profile Directory**:
  - [ ] `~/Library/Application Support/net.imput.helium/` (note: no "User Data" subdirectory)
- **Cookie Location**: `~/Library/Application Support/net.imput.helium/*/Cookies`
- **Keychain Service**: "Helium Safe Storage"

## Implementation Checklist

### Phase 1: Create Browser Detection Module
- [ ] Create `Sources/CodexBarCore/BrowserDetection.swift`
- [ ] Implement `BrowserDetection` enum with static methods
- [ ] Add `isInstalled(_ browser: Browser) -> Bool` method
- [ ] Add `installedBrowsers(from: [Browser]) -> [Browser]` convenience method
- [ ] Implement caching to avoid repeated filesystem checks
- [ ] Add detailed logging for debugging

### Phase 2: Update Cookie Import Points
- [ ] Update `OpenAIDashboardBrowserCookieImporter.swift`
  - [ ] Filter browser list before Safari attempt
  - [ ] Filter browser list before Chrome attempt
  - [ ] Filter browser list before Firefox attempt
  - [ ] Add logging for skipped browsers
- [ ] Update `FactoryStatusProbe.swift` (FactoryCookieImporter)
  - [ ] Filter browsers in `importSessions(from:)`
  - [ ] Add detection before WorkOS cookie attempts
- [ ] Update `CursorStatusProbe.swift` (CursorCookieImporter)
  - [ ] Filter browsers before cookie import
- [ ] Update `ClaudeWebAPIFetcher.swift`
  - [ ] Filter browsers in cookie import logic
- [ ] Update `MiniMaxCookieImporter.swift`
  - [ ] Filter browsers before attempting reads
- [ ] Update `MiniMaxLocalStorageImporter.swift`
  - [ ] Check browser existence before ChromiumProfileLocator calls

### Phase 3: Testing
- [ ] Test with only Safari installed
- [ ] Test with Safari + Chrome
- [ ] Test with Safari + Arc
- [ ] Test with Safari + Firefox
- [ ] Test with all browsers installed
- [ ] Test with Chrome installed but no profile created
- [ ] Test with browser in ~/Applications instead of /Applications
- [ ] Verify no keychain prompts for uninstalled browsers
- [ ] Verify successful cookie reads for installed browsers
- [ ] Check performance impact of detection

### Phase 4: Documentation
- [ ] Update provider documentation with detection behavior
- [ ] Add debug logging to show which browsers were detected
- [ ] Document caching behavior and TTL
- [ ] Add troubleshooting guide for edge cases

## Detection Algorithm

func isInstalled(_ browser: Browser) -> Bool {
    // 1. Check cache first (5-minute TTL)
    if let cached = cache[browser], cached.age < 5.minutes {
        return cached.value
    }

    // 2. Check application bundle (most reliable)
    let appPaths = [
        "/Applications/\(browser.appName).app",
        "\(FileManager.default.homeDirectoryForCurrentUser.path)/Applications/\(browser.appName).app"
    ]
    for path in appPaths {
        if FileManager.default.fileExists(atPath: path) {
            cache[browser] = (true, Date())
            return true
        }
    }

    // 3. Check profile directory (indicates past usage)
    if let profilePath = browser.profilePath {
        let fullPath = FileManager.default.homeDirectoryForCurrentUser
            .appendingPathComponent(profilePath.replacingOccurrences(of: "~/", with: ""))
        if FileManager.default.fileExists(atPath: fullPath.path) {
            // Verify it has actual profile data
            if browser.requiresProfileValidation {
                // Check for Default/ or Profile*/ subdirectories
                let contents = try? FileManager.default.contentsOfDirectory(atPath: fullPath.path)
                let hasProfile = contents?.contains { name in
                    name == "Default" || name.hasPrefix("Profile ")
                } ?? false
                if hasProfile {
                    cache[browser] = (true, Date())
                    return true
                }
            } else {
                cache[browser] = (true, Date())
                return true
            }
        }
    }

    // 4. Browser not found
    cache[browser] = (false, Date())
    return false
}

## Expected Outcomes

1. **Reduced Permission Prompts**: Users only see keychain prompts for browsers they actually have installed
2. **Improved Performance**: Skip unnecessary cookie read attempts for non-existent browsers
3. **Better User Experience**: No confusion about "Chrome Safe Storage" prompts when Chrome isn't installed
4. **Clearer Diagnostics**: Logs clearly show which browsers were detected and which were skipped
5. **Graceful Degradation**: System continues to work even if detection fails (conservative approach)

## Rollback Plan

If browser detection causes issues:
1. Add a UserDefaults flag to disable browser detection
2. Default to current behavior (attempt all browsers)
3. Allow per-browser override in advanced settings
4. Provide debug command to force-clear detection cache

## Future Enhancements

1. **Smart Ordering**: Prioritize recently-used browsers based on profile modification times
2. **Lazy Detection**: Only check when actually needed, not at startup
3. **User Preferences**: Allow users to explicitly disable certain browsers
4. **Background Updates**: Periodically refresh browser detection cache
5. **Custom Browser Support**: Allow users to add custom Chromium-based browsers
```