### PR TITLE
fix(parsing): handle European decimal separator in number parsing

### DIFF
--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardParser.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardParser.swift
@@ -140,10 +140,9 @@ public enum OpenAIDashboardParser {
 
     private static func parseCreditsUsed(_ text: String) -> Double {
         let cleaned = text
-            .replacingOccurrences(of: ",", with: "")
             .replacingOccurrences(of: "credits", with: "", options: .caseInsensitive)
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        return Double(cleaned) ?? 0
+        return TextParsing.parseLocalizedNumber(cleaned) ?? 0
     }
 
     // MARK: - Private

--- a/Sources/CodexBarCore/TextParsing.swift
+++ b/Sources/CodexBarCore/TextParsing.swift
@@ -10,14 +10,66 @@ public enum TextParsing {
         return regex.stringByReplacingMatches(in: text, options: [], range: range, withTemplate: "")
     }
 
+    /// Parses a number string with automatic locale detection.
+    ///
+    /// Handles both US format (1,234.56) and European format (1.234,56) by detecting
+    /// which separator is the decimal point based on position and digit count.
+    public static func parseLocalizedNumber(_ raw: String) -> Double? {
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+
+        let hasDot = trimmed.contains(".")
+        let hasComma = trimmed.contains(",")
+
+        if hasDot && hasComma {
+            // Both separators present: the last one is the decimal separator
+            guard let lastDot = trimmed.lastIndex(of: "."),
+                  let lastComma = trimmed.lastIndex(of: ",")
+            else {
+                return nil
+            }
+
+            if lastDot > lastComma {
+                // US format: 1,234.56
+                let cleaned = trimmed.replacingOccurrences(of: ",", with: "")
+                return Double(cleaned)
+            } else {
+                // European format: 1.234,56
+                let cleaned = trimmed
+                    .replacingOccurrences(of: ".", with: "")
+                    .replacingOccurrences(of: ",", with: ".")
+                return Double(cleaned)
+            }
+        } else if hasComma {
+            // Only comma - check digits after comma to determine if decimal or thousands
+            if let commaIndex = trimmed.lastIndex(of: ",") {
+                let afterComma = trimmed[trimmed.index(after: commaIndex)...]
+                let digitCount = afterComma.filter(\.isNumber).count
+
+                if digitCount <= 2 {
+                    // European decimal: "20,00" or "20,5"
+                    let cleaned = trimmed.replacingOccurrences(of: ",", with: ".")
+                    return Double(cleaned)
+                } else {
+                    // US thousands: "1,000" or "1,234,567"
+                    let cleaned = trimmed.replacingOccurrences(of: ",", with: "")
+                    return Double(cleaned)
+                }
+            }
+            return nil
+        } else {
+            // No comma (may have dot or no separator) - parse directly
+            return Double(trimmed)
+        }
+    }
+
     public static func firstNumber(pattern: String, text: String) -> Double? {
         guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return nil }
         let range = NSRange(text.startIndex..<text.endIndex, in: text)
         guard let match = regex.firstMatch(in: text, options: [], range: range),
               match.numberOfRanges >= 2,
               let r = Range(match.range(at: 1), in: text) else { return nil }
-        let raw = text[r].replacingOccurrences(of: ",", with: "")
-        return Double(raw)
+        return parseLocalizedNumber(String(text[r]))
     }
 
     public static func firstInt(pattern: String, text: String) -> Int? {

--- a/Tests/CodexBarTests/TextParsingTests.swift
+++ b/Tests/CodexBarTests/TextParsingTests.swift
@@ -9,4 +9,94 @@ struct TextParsingTests {
         let stripped = TextParsing.stripANSICodes(input)
         #expect(stripped == "hello")
     }
+
+    // MARK: - parseLocalizedNumber tests
+
+    @Test
+    func parseLocalizedNumberHandlesUSDecimal() {
+        #expect(TextParsing.parseLocalizedNumber("20.00") == 20.0)
+        #expect(TextParsing.parseLocalizedNumber("1234.56") == 1234.56)
+        #expect(TextParsing.parseLocalizedNumber("0.99") == 0.99)
+    }
+
+    @Test
+    func parseLocalizedNumberHandlesEuropeanDecimal() {
+        // European format: comma as decimal separator
+        #expect(TextParsing.parseLocalizedNumber("20,00") == 20.0)
+        #expect(TextParsing.parseLocalizedNumber("20,5") == 20.5)
+        #expect(TextParsing.parseLocalizedNumber("0,99") == 0.99)
+    }
+
+    @Test
+    func parseLocalizedNumberHandlesUSThousands() {
+        // US format: comma as thousands separator
+        #expect(TextParsing.parseLocalizedNumber("1,000") == 1000.0)
+        #expect(TextParsing.parseLocalizedNumber("1,234,567") == 1234567.0)
+    }
+
+    @Test
+    func parseLocalizedNumberHandlesUSThousandsWithDecimal() {
+        // US format: comma thousands + dot decimal
+        #expect(TextParsing.parseLocalizedNumber("1,234.56") == 1234.56)
+        #expect(TextParsing.parseLocalizedNumber("1,000,000.99") == 1000000.99)
+    }
+
+    @Test
+    func parseLocalizedNumberHandlesEuropeanThousandsWithDecimal() {
+        // European format: dot thousands + comma decimal
+        #expect(TextParsing.parseLocalizedNumber("1.234,56") == 1234.56)
+        #expect(TextParsing.parseLocalizedNumber("1.000.000,99") == 1000000.99)
+    }
+
+    @Test
+    func parseLocalizedNumberHandlesPlainIntegers() {
+        #expect(TextParsing.parseLocalizedNumber("100") == 100.0)
+        #expect(TextParsing.parseLocalizedNumber("0") == 0.0)
+        #expect(TextParsing.parseLocalizedNumber("999999") == 999999.0)
+    }
+
+    @Test
+    func parseLocalizedNumberHandlesWhitespace() {
+        #expect(TextParsing.parseLocalizedNumber("  20,00  ") == 20.0)
+        #expect(TextParsing.parseLocalizedNumber(" 1,234.56 ") == 1234.56)
+    }
+
+    @Test
+    func parseLocalizedNumberReturnsNilForEmpty() {
+        #expect(TextParsing.parseLocalizedNumber("") == nil)
+        #expect(TextParsing.parseLocalizedNumber("   ") == nil)
+    }
+
+    @Test
+    func parseLocalizedNumberReturnsNilForInvalid() {
+        #expect(TextParsing.parseLocalizedNumber("abc") == nil)
+        #expect(TextParsing.parseLocalizedNumber("12.34.56") == nil)
+    }
+
+    // MARK: - firstNumber regression tests
+
+    @Test
+    func firstNumberParsesEuropeanCredits() {
+        // The bug: "Credits: 20,00" was being parsed as 2000.00
+        let text = "Credits remaining: 20,00"
+        let pattern = #"credits\s*remaining[^0-9]*([0-9][0-9.,]*)"#
+        let result = TextParsing.firstNumber(pattern: pattern, text: text)
+        #expect(result == 20.0)
+    }
+
+    @Test
+    func firstNumberParsesUSCredits() {
+        let text = "Credits remaining: 1,234.56"
+        let pattern = #"credits\s*remaining[^0-9]*([0-9][0-9.,]*)"#
+        let result = TextParsing.firstNumber(pattern: pattern, text: text)
+        #expect(result == 1234.56)
+    }
+
+    @Test
+    func firstNumberParsesEuropeanLargeCredits() {
+        let text = "Credits remaining: 1.234,56"
+        let pattern = #"credits\s*remaining[^0-9]*([0-9][0-9.,]*)"#
+        let result = TextParsing.firstNumber(pattern: pattern, text: text)
+        #expect(result == 1234.56)
+    }
 }


### PR DESCRIPTION
## Summary

- Fix parsing of European-format numbers where comma is the decimal separator
- Numbers like `20,00` were incorrectly parsed as `2000.00`, breaking usage display for European locale users
- Prevents hearts skipping a beat by showing that 10 euro's were spent instead of 1000.

<img width="312" height="75" alt="Untitled" src="https://github.com/user-attachments/assets/8139f05f-3bf1-4def-8f77-1ee8b372e6a3" />

## Changes

- Add `parseLocalizedNumber()` function with heuristic-based format detection:
  - Both separators present → last one is the decimal separator
  - Only comma with ≤2 digits after → European decimal (`20,00` → `20.0`)
  - Only comma with 3+ digits after → US thousands (`1,000` → `1000`)
- Update `firstNumber()` and `parseCreditsUsed()` to use the new function
- Add 13 comprehensive tests covering US, European, and mixed formats

## Test plan

- [x] All 358 existing tests pass
- [x] New tests cover: US decimal, European decimal, US thousands, European thousands with decimal, plain integers, whitespace handling, empty/invalid inputs
- [x] Regression tests verify `"Credits remaining: 20,00"` parses as `20.0` (not `2000.0`)