### PR TITLE
feat: "Hide personal info" toggle in menu (aka streamer mode)

### DIFF
--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -60,17 +60,32 @@ struct MenuDescriptor {
         switch provider {
         case .codex?:
             sections.append(Self.usageSection(for: .codex, store: store, settings: settings))
-            if let accountSection = Self.accountSection(for: .codex, store: store, account: account) {
+            if let accountSection = Self.accountSection(
+                for: .codex,
+                store: store,
+                settings: settings,
+                account: account)
+            {
                 sections.append(accountSection)
             }
         case .claude?:
             sections.append(Self.usageSection(for: .claude, store: store, settings: settings))
-            if let accountSection = Self.accountSection(for: .claude, store: store, account: account) {
+            if let accountSection = Self.accountSection(
+                for: .claude,
+                store: store,
+                settings: settings,
+                account: account)
+            {
                 sections.append(accountSection)
             }
         case let provider?:
             sections.append(Self.usageSection(for: provider, store: store, settings: settings))
-            if let accountSection = Self.accountSection(for: provider, store: store, account: account) {
+            if let accountSection = Self.accountSection(
+                for: provider,
+                store: store,
+                settings: settings,
+                account: account)
+            {
                 sections.append(accountSection)
             }
         case nil:
@@ -82,7 +97,11 @@ struct MenuDescriptor {
             }
             if addedUsage {
                 if let accountProvider = Self.accountProviderForCombined(store: store),
-                   let accountSection = Self.accountSection(for: accountProvider, store: store, account: account)
+                   let accountSection = Self.accountSection(
+                       for: accountProvider,
+                       store: store,
+                       settings: settings,
+                       account: account)
                 {
                     sections.append(accountSection)
                 }
@@ -186,6 +205,7 @@ struct MenuDescriptor {
     private static func accountSection(
         for provider: UsageProvider,
         store: UsageStore,
+        settings: SettingsStore,
         account: AccountInfo) -> Section?
     {
         let snapshot = store.snapshot(for: provider)
@@ -194,7 +214,8 @@ struct MenuDescriptor {
             provider: provider,
             snapshot: snapshot,
             metadata: metadata,
-            fallback: account)
+            fallback: account,
+            hidePersonalInfo: settings.hidePersonalInfo)
         guard !entries.isEmpty else { return nil }
         return Section(entries: entries)
     }
@@ -203,16 +224,18 @@ struct MenuDescriptor {
         provider: UsageProvider,
         snapshot: UsageSnapshot?,
         metadata: ProviderMetadata,
-        fallback: AccountInfo) -> [Entry]
+        fallback: AccountInfo,
+        hidePersonalInfo: Bool) -> [Entry]
     {
         var entries: [Entry] = []
         let emailText = snapshot?.accountEmail(for: provider)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let planText = snapshot?.loginMethod(for: provider)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let redactedEmail = PersonalInfoRedactor.redactEmail(emailText, isEnabled: hidePersonalInfo)
 
         if let emailText, !emailText.isEmpty {
-            entries.append(.text("Account: \(emailText)", .secondary))
+            entries.append(.text("Account: \(redactedEmail)", .secondary))
         }
         if let planText, !planText.isEmpty {
             entries.append(.text("Plan: \(AccountFormatter.plan(planText))", .secondary))
@@ -220,7 +243,8 @@ struct MenuDescriptor {
 
         if metadata.usesAccountFallback {
             if emailText?.isEmpty ?? true, let fallbackEmail = fallback.email, !fallbackEmail.isEmpty {
-                entries.append(.text("Account: \(fallbackEmail)", .secondary))
+                let redacted = PersonalInfoRedactor.redactEmail(fallbackEmail, isEnabled: hidePersonalInfo)
+                entries.append(.text("Account: \(redacted)", .secondary))
             }
             if planText?.isEmpty ?? true, let fallbackPlan = fallback.plan, !fallbackPlan.isEmpty {
                 entries.append(.text("Plan: \(AccountFormatter.plan(fallbackPlan))", .secondary))

--- a/Sources/CodexBar/PersonalInfoRedactor.swift
+++ b/Sources/CodexBar/PersonalInfoRedactor.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+enum PersonalInfoRedactor {
+    static let emailPlaceholder = "Hidden"
+
+    private static let emailRegex: NSRegularExpression = {
+        let pattern = #"[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}"#
+        return (try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]))
+            ?? (try! NSRegularExpression(pattern: "$^", options: []))
+    }()
+
+    static func redactEmail(_ email: String?, isEnabled: Bool) -> String {
+        guard let email, !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return "" }
+        guard isEnabled else { return email }
+        return Self.emailPlaceholder
+    }
+
+    static func redactEmails(in text: String?, isEnabled: Bool) -> String? {
+        guard let text else { return nil }
+        guard isEnabled else { return text }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return Self.emailRegex.stringByReplacingMatches(
+            in: text,
+            options: [],
+            range: range,
+            withTemplate: Self.emailPlaceholder)
+    }
+}

--- a/Sources/CodexBar/PreferencesAdvancedPane.swift
+++ b/Sources/CodexBar/PreferencesAdvancedPane.swift
@@ -50,6 +50,10 @@ struct AdvancedPane: View {
                         subtitle: "Show Codex Credits and Claude Extra usage sections in the menu.",
                         binding: self.$settings.showOptionalCreditsAndExtraUsage)
                     PreferenceToggleRow(
+                        title: "Hide personal information",
+                        subtitle: "Obscure email addresses in the menu bar and menu UI.",
+                        binding: self.$settings.hidePersonalInfo)
+                    PreferenceToggleRow(
                         title: "Merge Icons",
                         subtitle: "Use a single menu bar icon with a provider switcher.",
                         binding: self.$settings.mergeIcons)

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -102,6 +102,11 @@ final class SettingsStore {
         didSet { self.userDefaults.set(self.costUsageEnabled, forKey: "tokenCostUsageEnabled") }
     }
 
+    /// Optional: hide personal info (emails) in menu bar + menu content.
+    var hidePersonalInfo: Bool {
+        didSet { self.userDefaults.set(self.hidePersonalInfo, forKey: "hidePersonalInfo") }
+    }
+
     var randomBlinkEnabled: Bool {
         didSet { self.userDefaults.set(self.randomBlinkEnabled, forKey: "randomBlinkEnabled") }
     }
@@ -344,6 +349,7 @@ final class SettingsStore {
         _ = self.resetTimesShowAbsolute
         _ = self.menuBarShowsBrandIconWithPercent
         _ = self.costUsageEnabled
+        _ = self.hidePersonalInfo
         _ = self.randomBlinkEnabled
         _ = self.claudeWebExtrasEnabled
         _ = self.showOptionalCreditsAndExtraUsage
@@ -467,6 +473,7 @@ final class SettingsStore {
         self.menuBarShowsBrandIconWithPercent = userDefaults.object(
             forKey: "menuBarShowsBrandIconWithPercent") as? Bool ?? false
         self.costUsageEnabled = userDefaults.object(forKey: "tokenCostUsageEnabled") as? Bool ?? false
+        self.hidePersonalInfo = userDefaults.object(forKey: "hidePersonalInfo") as? Bool ?? false
         self.randomBlinkEnabled = userDefaults.object(forKey: "randomBlinkEnabled") as? Bool ?? false
         self.claudeWebExtrasEnabled = userDefaults.object(forKey: "claudeWebExtrasEnabled") as? Bool ?? false
         let creditsExtrasDefault = userDefaults.object(forKey: "showOptionalCreditsAndExtraUsage") as? Bool

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -884,6 +884,7 @@ extension StatusItemController {
             resetTimeDisplayStyle: self.settings.resetTimeDisplayStyle,
             tokenCostUsageEnabled: self.settings.isCostUsageEffectivelyEnabled(for: target),
             showOptionalCreditsAndExtraUsage: self.settings.showOptionalCreditsAndExtraUsage,
+            hidePersonalInfo: self.settings.hidePersonalInfo,
             now: Date())
         return UsageMenuCardView.Model.make(input)
     }

--- a/Tests/CodexBarTests/MenuCardModelTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelTests.swift
@@ -56,6 +56,7 @@ struct MenuCardModelTests {
             resetTimeDisplayStyle: .countdown,
             tokenCostUsageEnabled: false,
             showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
             now: now))
 
         #expect(model.providerName == "Codex")
@@ -116,6 +117,7 @@ struct MenuCardModelTests {
             resetTimeDisplayStyle: .countdown,
             tokenCostUsageEnabled: false,
             showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
             now: now))
 
         #expect(model.metrics.first?.title == "Session")
@@ -165,6 +167,7 @@ struct MenuCardModelTests {
             resetTimeDisplayStyle: .countdown,
             tokenCostUsageEnabled: false,
             showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
             now: now))
 
         #expect(model.metrics.contains { $0.title == "Code review" && $0.percent == 73 })
@@ -206,6 +209,7 @@ struct MenuCardModelTests {
             resetTimeDisplayStyle: .countdown,
             tokenCostUsageEnabled: false,
             showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
             now: now))
 
         #expect(model.metrics.count == 1)
@@ -233,6 +237,7 @@ struct MenuCardModelTests {
             resetTimeDisplayStyle: .countdown,
             tokenCostUsageEnabled: false,
             showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
             now: Date()))
 
         #expect(model.subtitleStyle == .error)
@@ -273,6 +278,7 @@ struct MenuCardModelTests {
             resetTimeDisplayStyle: .countdown,
             tokenCostUsageEnabled: true,
             showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
             now: now))
 
         #expect(model.tokenUsage?.monthLine.contains("456") == true)
@@ -299,6 +305,7 @@ struct MenuCardModelTests {
             resetTimeDisplayStyle: .countdown,
             tokenCostUsageEnabled: false,
             showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
             now: Date()))
 
         #expect(model.planText == nil)
@@ -338,6 +345,7 @@ struct MenuCardModelTests {
             resetTimeDisplayStyle: .countdown,
             tokenCostUsageEnabled: false,
             showOptionalCreditsAndExtraUsage: false,
+            hidePersonalInfo: false,
             now: now))
 
         #expect(model.creditsText == nil)
@@ -377,8 +385,49 @@ struct MenuCardModelTests {
             resetTimeDisplayStyle: .countdown,
             tokenCostUsageEnabled: false,
             showOptionalCreditsAndExtraUsage: false,
+            hidePersonalInfo: false,
             now: now))
 
         #expect(model.providerCost == nil)
+    }
+
+    @Test
+    func hidesEmailWhenPersonalInfoHidden() {
+        let now = Date()
+        let identity = ProviderIdentitySnapshot(
+            providerID: .codex,
+            accountEmail: "codex@example.com",
+            accountOrganization: nil,
+            loginMethod: nil)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: now,
+            identity: identity)
+        let metadata = ProviderDefaults.metadata[.codex]!
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .codex,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: "codex@example.com", plan: nil),
+            isRefreshing: false,
+            lastError: "OpenAI dashboard signed in as codex@example.com.",
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: true,
+            now: now))
+
+        #expect(model.email == "Hidden")
+        #expect(model.subtitleText.contains("codex@example.com") == false)
     }
 }


### PR DESCRIPTION
I want to use this when I make content. I don't want to leak my email. I asked Codex to fix it.

## Summary
- add a Hide personal information toggle in Advanced > Display
- redact email addresses across menu card header, account rows, and error/hint strings
- add shared redaction helper + test coverage

Written by Codex as I know that's your preference

## Testing
- ./Scripts/compile_and_run.sh (user confirmed)

## Screenshots
<img width="377" height="139" alt="image" src="https://github.com/user-attachments/assets/26f0cda1-651c-4aed-aed6-ea52a64c3a40" />
<img width="536" height="502" alt="image" src="https://github.com/user-attachments/assets/037030e3-73f1-4cd0-992c-f9df800dfe22" />

