### PR TITLE
fix: handle null usage response from Claude API

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -413,7 +413,9 @@ public enum ClaudeWebAPIFetcher {
         }
 
         // Parse five_hour (session) usage
-        var sessionPercent: Double?
+        // Note: The API may return null for all fields when there's no usage data yet
+        // or when the user has unlimited/no rate limits. Treat null as 0% usage.
+        var sessionPercent: Double = 0.0
         var sessionResets: Date?
         if let fiveHour = json["five_hour"] as? [String: Any] {
             if let utilization = fiveHour["utilization"] as? Int {
@@ -422,10 +424,6 @@ public enum ClaudeWebAPIFetcher {
             if let resetsAt = fiveHour["resets_at"] as? String {
                 sessionResets = self.parseISO8601Date(resetsAt)
             }
-        }
-        guard let sessionPercent else {
-            // If we can't parse session utilization, treat this as a failure so callers can fall back to the CLI.
-            throw FetchError.invalidResponse
         }
 
         // Parse seven_day (weekly) usage

--- a/Tests/CodexBarTests/ClaudeUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeUsageTests.swift
@@ -222,6 +222,29 @@ struct ClaudeUsageTests {
     }
 
     @Test
+    func parsesClaudeWebAPIUsageResponseWhenAllFieldsNull() throws {
+        // Claude Max and similar unlimited plans may return null for all usage fields
+        let json = """
+        {
+          "five_hour": null,
+          "seven_day": null,
+          "seven_day_oauth_apps": null,
+          "seven_day_opus": null,
+          "seven_day_sonnet": null,
+          "iguana_necktie": null,
+          "extra_usage": null
+        }
+        """
+        let data = Data(json.utf8)
+        let parsed = try ClaudeWebAPIFetcher._parseUsageResponseForTesting(data)
+        #expect(parsed.sessionPercentUsed == 0.0)
+        #expect(parsed.weeklyPercentUsed == nil)
+        #expect(parsed.opusPercentUsed == nil)
+        #expect(parsed.sessionResetsAt == nil)
+        #expect(parsed.weeklyResetsAt == nil)
+    }
+
+    @Test
     func parsesClaudeWebAPIOverageSpendLimit() {
         let json = """
         {


### PR DESCRIPTION
The Claude API now returns null values for all usage fields (five_hour, seven_day, etc.) for certain account types like Claude Max that have unlimited/no rate limits.

Previously, the parser would throw `invalidResponse` when it couldn't find a valid `utilization` value in the `five_hour` object, causing the CLI to fail with "Invalid response from Claude API."

This change treats null usage responses as 0% used (100% remaining) instead of failing, allowing users with Claude Max and similar plans to see their usage status correctly.

Also adds a test case for the null response scenario.