### PR TITLE
Add OpenCode provider integration

### DIFF
--- a/Sources/CodexBar/IconRenderer.swift
+++ b/Sources/CodexBar/IconRenderer.swift
@@ -715,6 +715,7 @@ enum IconRenderer {
         case .kiro: 9
         case .vertexai: 10
         case .augment: 11
+        case .opencode: 12
         case .combined: 99
         }
     }

--- a/Sources/CodexBar/Providers/OpenCode/OpenCodeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/OpenCode/OpenCodeProviderImplementation.swift
@@ -1,0 +1,8 @@
+import CodexBarCore
+import CodexBarMacroSupport
+import Foundation
+
+@ProviderImplementationRegistration
+struct OpenCodeProviderImplementation: ProviderImplementation {
+    let id: UsageProvider = .opencode
+}

--- a/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
@@ -22,6 +22,7 @@ enum ProviderImplementationRegistry {
         _ = ProviderImplementationRegistry.register(CopilotProviderImplementation())
         _ = ProviderImplementationRegistry.register(KiroProviderImplementation())
         _ = ProviderImplementationRegistry.register(VertexAIProviderImplementation())
+        _ = ProviderImplementationRegistry.register(OpenCodeProviderImplementation())
     }()
 
     private static func ensureBootstrapped() {

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -235,6 +235,7 @@ final class UsageStore {
     var antigravityVersion: String?
     var cursorVersion: String?
     var kiroVersion: String?
+    var opencodeVersion: String?
     var isRefreshing = false
     private(set) var refreshingProviders: Set<UsageProvider> = []
     var debugForceAnimation = false
@@ -350,6 +351,7 @@ final class UsageStore {
         case .vertexai: nil
         case .kiro: self.kiroVersion
         case .augment: nil
+        case .opencode: self.opencodeVersion
         }
     }
 
@@ -1312,6 +1314,10 @@ extension UsageStore {
             case .augment:
                 let text = await self.debugAugmentLog()
                 await MainActor.run { self.probeLogs[.augment] = text }
+                return text
+            case .opencode:
+                let text = "OpenCode debug log not yet implemented"
+                await MainActor.run { self.probeLogs[.opencode] = text }
                 return text
             }
         }.value

--- a/Sources/CodexBarCore/Providers/OpenCode/OpenCodeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenCode/OpenCodeProviderDescriptor.swift
@@ -1,0 +1,78 @@
+import CodexBarMacroSupport
+import Foundation
+
+@ProviderDescriptorRegistration
+@ProviderDescriptorDefinition
+public enum OpenCodeProviderDescriptor {
+    static func makeDescriptor() -> ProviderDescriptor {
+        ProviderDescriptor(
+            id: .opencode,
+            metadata: ProviderMetadata(
+                id: .opencode,
+                displayName: "OpenCode",
+                sessionLabel: "Cost",
+                weeklyLabel: "Avg/Day",
+                opusLabel: nil,
+                supportsOpus: false,
+                supportsCredits: false,
+                creditsHint: "",
+                toggleTitle: "Show OpenCode usage",
+                cliName: "opencode",
+                defaultEnabled: false,
+                isPrimaryProvider: false,
+                usesAccountFallback: false,
+                dashboardURL: "https://opencode.ai",
+                statusPageURL: nil,
+                statusLinkURL: "https://opencode.ai"),
+            branding: ProviderBranding(
+                iconStyle: .opencode,
+                iconResourceName: "ProviderIcon-opencode",
+                // OpenCode brand color - teal/cyan
+                color: ProviderColor(red: 0 / 255, green: 200 / 255, blue: 200 / 255)),
+            tokenCost: ProviderTokenCostConfig(
+                supportsTokenCost: true,
+                noDataMessage: { "OpenCode cost tracking requires usage data. Run some sessions first." }),
+            fetchPlan: ProviderFetchPlan(
+                sourceModes: [.auto, .cli],
+                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [OpenCodeCLIFetchStrategy()] })),
+            cli: ProviderCLIConfig(
+                name: "opencode",
+                aliases: [],
+                versionDetector: { _ in OpenCodeStatusProbe.detectVersion() }))
+    }
+}
+
+struct OpenCodeCLIFetchStrategy: ProviderFetchStrategy {
+    let id: String = "opencode.cli"
+    let kind: ProviderFetchKind = .cli
+
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
+        // Check if opencode binary exists
+        let possiblePaths = [
+            "\(NSHomeDirectory())/.opencode/bin/opencode",
+            "\(NSHomeDirectory())/.local/share/opencode/bin/opencode",
+            "/usr/local/bin/opencode",
+            "/opt/homebrew/bin/opencode",
+        ]
+
+        for path in possiblePaths {
+            if FileManager.default.fileExists(atPath: path) {
+                return true
+            }
+        }
+
+        return TTYCommandRunner.which("opencode") != nil
+    }
+
+    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+        let probe = OpenCodeStatusProbe()
+        let snap = try await probe.fetch()
+        return self.makeResult(
+            usage: snap.toUsageSnapshot(),
+            sourceLabel: "cli")
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+}

--- a/Sources/CodexBarCore/Providers/OpenCode/OpenCodeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/OpenCode/OpenCodeStatusProbe.swift
@@ -1,0 +1,335 @@
+import Foundation
+
+public struct OpenCodeUsageSnapshot: Sendable {
+    public let totalCost: Double
+    public let avgCostPerDay: Double
+    public let totalSessions: Int
+    public let totalMessages: Int
+    public let days: Int
+    public let inputTokens: Int
+    public let outputTokens: Int
+    public let cacheReadTokens: Int
+    public let cacheWriteTokens: Int
+    public let updatedAt: Date
+
+    public func toUsageSnapshot() -> UsageSnapshot {
+        // Primary: Show cost as a "percentage" where 100% = $100 spent
+        // This gives a visual indication of spending
+        let costPercent = min(100, (self.totalCost / 100.0) * 100)
+
+        let primary = RateWindow(
+            usedPercent: costPercent,
+            windowMinutes: nil,
+            resetsAt: nil,
+            resetDescription: String(format: "$%.2f total", self.totalCost))
+
+        // Secondary: Show average cost per day as a percentage where 100% = $10/day
+        let avgPercent = min(100, (self.avgCostPerDay / 10.0) * 100)
+        let secondary = RateWindow(
+            usedPercent: avgPercent,
+            windowMinutes: nil,
+            resetsAt: nil,
+            resetDescription: String(format: "$%.2f/day", self.avgCostPerDay))
+
+        let identity = ProviderIdentitySnapshot(
+            providerID: .opencode,
+            accountEmail: nil,
+            accountOrganization: "\(self.totalSessions) sessions",
+            loginMethod: nil)
+
+        return UsageSnapshot(
+            primary: primary,
+            secondary: secondary,
+            tertiary: nil,
+            providerCost: nil,
+            zaiUsage: nil,
+            updatedAt: self.updatedAt,
+            identity: identity)
+    }
+}
+
+public enum OpenCodeStatusProbeError: LocalizedError, Sendable {
+    case cliNotFound
+    case cliFailed(String)
+    case parseError(String)
+    case timeout
+    case noData
+
+    public var errorDescription: String? {
+        switch self {
+        case .cliNotFound:
+            "opencode not found. Install it from https://opencode.ai"
+        case let .cliFailed(message):
+            message
+        case let .parseError(msg):
+            "Failed to parse OpenCode stats: \(msg)"
+        case .timeout:
+            "OpenCode CLI timed out."
+        case .noData:
+            "No usage data available. Run some OpenCode sessions first."
+        }
+    }
+}
+
+public struct OpenCodeStatusProbe: Sendable {
+    public init() {}
+
+    private static let logger = CodexBarLog.logger("opencode")
+
+    public static func detectVersion() -> String? {
+        guard let binary = Self.findBinary() else { return nil }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binary)
+        process.arguments = ["--version"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            guard let output = String(data: data, encoding: .utf8) else { return nil }
+            let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        } catch {
+            self.logger.debug("opencode version detection failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private static func findBinary() -> String? {
+        // Check common locations for opencode
+        let possiblePaths = [
+            "\(NSHomeDirectory())/.opencode/bin/opencode",
+            "\(NSHomeDirectory())/.local/share/opencode/bin/opencode",
+            "/usr/local/bin/opencode",
+            "/opt/homebrew/bin/opencode",
+        ]
+
+        for path in possiblePaths {
+            if FileManager.default.fileExists(atPath: path) {
+                return path
+            }
+        }
+
+        // Fall back to PATH lookup
+        return TTYCommandRunner.which("opencode")
+    }
+
+    public func fetch() async throws -> OpenCodeUsageSnapshot {
+        let output = try await self.runStatsCommand()
+        return try self.parse(output: output)
+    }
+
+    private struct OpenCodeCLIResult: Sendable {
+        let stdout: String
+        let stderr: String
+        let terminationStatus: Int32
+    }
+
+    private func runStatsCommand() async throws -> String {
+        let result = try await self.runCommand(arguments: ["stats"], timeout: 15.0)
+        let trimmedStdout = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedStderr = result.stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if result.terminationStatus != 0 {
+            let message = trimmedStderr.isEmpty ? trimmedStdout : trimmedStderr
+            throw OpenCodeStatusProbeError.cliFailed(
+                message.isEmpty ? "OpenCode CLI failed with status \(result.terminationStatus)." : message)
+        }
+
+        if trimmedStdout.isEmpty {
+            throw OpenCodeStatusProbeError.noData
+        }
+
+        return result.stdout
+    }
+
+    private func runCommand(arguments: [String], timeout: TimeInterval) async throws -> OpenCodeCLIResult {
+        guard let binary = Self.findBinary() else {
+            throw OpenCodeStatusProbeError.cliNotFound
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binary)
+        process.arguments = arguments
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        process.standardInput = FileHandle.nullDevice
+
+        var env = ProcessInfo.processInfo.environment
+        env["TERM"] = "dumb" // Disable color output for easier parsing
+        env["NO_COLOR"] = "1"
+        process.environment = env
+
+        return try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global().async {
+                do {
+                    try process.run()
+                } catch {
+                    continuation.resume(throwing: error)
+                    return
+                }
+
+                let deadline = Date().addingTimeInterval(timeout)
+                while process.isRunning, Date() < deadline {
+                    Thread.sleep(forTimeInterval: 0.1)
+                }
+
+                if process.isRunning {
+                    process.terminate()
+                    process.waitUntilExit()
+                    continuation.resume(throwing: OpenCodeStatusProbeError.timeout)
+                    return
+                }
+
+                let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+                let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+                let stdoutOutput = String(data: stdoutData, encoding: .utf8) ?? ""
+                let stderrOutput = String(data: stderrData, encoding: .utf8) ?? ""
+                continuation.resume(returning: OpenCodeCLIResult(
+                    stdout: stdoutOutput,
+                    stderr: stderrOutput,
+                    terminationStatus: process.terminationStatus))
+            }
+        }
+    }
+
+    func parse(output: String) throws -> OpenCodeUsageSnapshot {
+        let stripped = Self.stripANSI(output)
+        let trimmed = stripped.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if trimmed.isEmpty {
+            throw OpenCodeStatusProbeError.parseError("Empty output from opencode stats.")
+        }
+
+        var totalCost: Double = 0
+        var avgCostPerDay: Double = 0
+        var sessions: Int = 0
+        var messages: Int = 0
+        var days: Int = 0
+        var inputTokens: Int = 0
+        var outputTokens: Int = 0
+        var cacheRead: Int = 0
+        var cacheWrite: Int = 0
+
+        // Parse Sessions count
+        if let match = stripped.range(of: #"Sessions\s+(\d+)"#, options: .regularExpression) {
+            let str = String(stripped[match])
+            if let numMatch = str.range(of: #"\d+"#, options: .regularExpression) {
+                sessions = Int(String(str[numMatch])) ?? 0
+            }
+        }
+
+        // Parse Messages count
+        if let match = stripped.range(of: #"Messages\s+(\d+)"#, options: .regularExpression) {
+            let str = String(stripped[match])
+            if let numMatch = str.range(of: #"\d+"#, options: .regularExpression) {
+                messages = Int(String(str[numMatch])) ?? 0
+            }
+        }
+
+        // Parse Days count
+        if let match = stripped.range(of: #"Days\s+(\d+)"#, options: .regularExpression) {
+            let str = String(stripped[match])
+            if let numMatch = str.range(of: #"\d+"#, options: .regularExpression) {
+                days = Int(String(str[numMatch])) ?? 0
+            }
+        }
+
+        // Parse Total Cost: $X.XX
+        if let match = stripped.range(of: #"Total Cost\s+\$(\d+\.?\d*)"#, options: .regularExpression) {
+            let str = String(stripped[match])
+            if let numMatch = str.range(of: #"\d+\.?\d*"#, options: .regularExpression) {
+                totalCost = Double(String(str[numMatch])) ?? 0
+            }
+        }
+
+        // Parse Avg Cost/Day: $X.XX
+        if let match = stripped.range(of: #"Avg Cost/Day\s+\$(\d+\.?\d*)"#, options: .regularExpression) {
+            let str = String(stripped[match])
+            if let numMatch = str.range(of: #"\d+\.?\d*"#, options: .regularExpression) {
+                avgCostPerDay = Double(String(str[numMatch])) ?? 0
+            }
+        }
+
+        // Parse Input tokens (handles K, M suffixes)
+        if let match = stripped.range(of: #"Input\s+([\d.]+)([KMB]?)"#, options: .regularExpression) {
+            inputTokens = Self.parseTokenCount(String(stripped[match]))
+        }
+
+        // Parse Output tokens
+        if let match = stripped.range(of: #"Output\s+([\d.]+)([KMB]?)"#, options: .regularExpression) {
+            outputTokens = Self.parseTokenCount(String(stripped[match]))
+        }
+
+        // Parse Cache Read tokens
+        if let match = stripped.range(of: #"Cache Read\s+([\d.]+)([KMB]?)"#, options: .regularExpression) {
+            cacheRead = Self.parseTokenCount(String(stripped[match]))
+        }
+
+        // Parse Cache Write tokens
+        if let match = stripped.range(of: #"Cache Write\s+([\d.]+)([KMB]?)"#, options: .regularExpression) {
+            cacheWrite = Self.parseTokenCount(String(stripped[match]))
+        }
+
+        // Require at least some data to be parsed
+        if sessions == 0, totalCost == 0 {
+            throw OpenCodeStatusProbeError.noData
+        }
+
+        return OpenCodeUsageSnapshot(
+            totalCost: totalCost,
+            avgCostPerDay: avgCostPerDay,
+            totalSessions: sessions,
+            totalMessages: messages,
+            days: days,
+            inputTokens: inputTokens,
+            outputTokens: outputTokens,
+            cacheReadTokens: cacheRead,
+            cacheWriteTokens: cacheWrite,
+            updatedAt: Date())
+    }
+
+    private static func parseTokenCount(_ str: String) -> Int {
+        // Extract number and optional suffix (K, M, B)
+        let pattern = #"([\d.]+)\s*([KMB]?)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []),
+              let match = regex.firstMatch(in: str, options: [], range: NSRange(str.startIndex..., in: str))
+        else {
+            return 0
+        }
+
+        guard let numberRange = Range(match.range(at: 1), in: str),
+              let number = Double(String(str[numberRange]))
+        else {
+            return 0
+        }
+
+        var multiplier: Double = 1
+        if let suffixRange = Range(match.range(at: 2), in: str) {
+            let suffix = String(str[suffixRange]).uppercased()
+            switch suffix {
+            case "K": multiplier = 1_000
+            case "M": multiplier = 1_000_000
+            case "B": multiplier = 1_000_000_000
+            default: break
+            }
+        }
+
+        return Int(number * multiplier)
+    }
+
+    private static func stripANSI(_ text: String) -> String {
+        let pattern = #"\x1B\[[0-9;?]*[A-Za-z]|\x1B\].*?\x07|\x1B\[[0-9;]*m"#
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
+            return text
+        }
+        let range = NSRange(text.startIndex..., in: text)
+        return regex.stringByReplacingMatches(in: text, options: [], range: range, withTemplate: "")
+    }
+}

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -65,6 +65,7 @@ public enum ProviderDescriptorRegistry {
         _ = ProviderDescriptorRegistry.register(CopilotProviderDescriptor.descriptor)
         _ = ProviderDescriptorRegistry.register(VertexAIProviderDescriptor.descriptor)
         _ = ProviderDescriptorRegistry.register(KiroProviderDescriptor.descriptor)
+        _ = ProviderDescriptorRegistry.register(OpenCodeProviderDescriptor.descriptor)
     }()
 
     private static func ensureBootstrapped() {

--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -15,6 +15,7 @@ public enum UsageProvider: String, CaseIterable, Sendable, Codable {
     case kiro
     case vertexai
     case augment
+    case opencode
 }
 
 // swiftformat:enable sortDeclarations
@@ -32,6 +33,7 @@ public enum IconStyle: Sendable {
     case kiro
     case vertexai
     case augment
+    case opencode
     case combined
 }
 

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
@@ -81,6 +81,8 @@ enum CostUsageScanner {
             return CostUsageDailyReport(data: [], summary: nil)
         case .augment:
             return CostUsageDailyReport(data: [], summary: nil)
+        case .opencode:
+            return CostUsageDailyReport(data: [], summary: nil)
         }
     }
 

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -50,6 +50,7 @@ enum ProviderChoice: String, AppEnum {
         case .vertexai: return nil // Vertex AI not yet supported in widgets
         case .kiro: return nil // Kiro not yet supported in widgets
         case .augment: return nil // Augment not yet supported in widgets
+        case .opencode: return nil // OpenCode not yet supported in widgets
         }
     }
 }

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -269,6 +269,7 @@ private struct ProviderSwitchChip: View {
         case .vertexai: "Vertex"
         case .kiro: "Kiro"
         case .augment: "Augment"
+        case .opencode: "OpenCode"
         }
     }
 }
@@ -587,6 +588,8 @@ enum WidgetColors {
             Color(red: 255 / 255, green: 153 / 255, blue: 0 / 255) // AWS orange
         case .augment:
             Color(red: 99 / 255, green: 102 / 255, blue: 241 / 255) // Augment purple
+        case .opencode:
+            Color(red: 0 / 255, green: 200 / 255, blue: 200 / 255) // OpenCode teal
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds support for [OpenCode](https://opencode.ai), an open-source terminal-based AI coding assistant
- Parses `opencode stats` CLI output to display cost and token usage statistics
- OpenCode tracks local cost/usage rather than quotas, so shows total cost and avg cost/day

## Changes
- Added `opencode` to `UsageProvider` enum and `IconStyle`
- Created `OpenCodeStatusProbe` to parse CLI output
- Created `OpenCodeProviderDescriptor` with metadata and CLI fetch strategy
- Registered provider in descriptor and implementation registries
- Added exhaustive switch cases in widgets, UsageStore, and CostUsageScanner

## Test plan
- [x] Build succeeds with Swift 6.2
- [ ] Install OpenCode and verify the provider appears in settings
- [ ] Enable OpenCode provider and verify usage data is fetched
- [ ] Verify menu bar shows correct cost statistics

🤖 Generated with [Claude Code](https://claude.com/claude-code)