### PR TITLE
Feature: Hide menu item if under a threshold

### DIFF
--- a/Sources/CodexBar/PreferencesDisplayPane.swift
+++ b/Sources/CodexBar/PreferencesDisplayPane.swift
@@ -52,6 +52,45 @@ struct DisplayPane: View {
                     }
                     .disabled(!self.settings.menuBarShowsBrandIconWithPercent)
                     .opacity(self.settings.menuBarShowsBrandIconWithPercent ? 1 : 0.5)
+
+                    VStack(alignment: .leading, spacing: 10) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Toggle(isOn: self.$settings.hideStatusItemBelowThreshold) {
+                                Text("Hide status item below threshold")
+                                    .font(.body)
+                            }
+                            .toggleStyle(.checkbox)
+
+                            Text("Only show status items when session usage exceeds the threshold.")
+                                .font(.footnote)
+                                .foregroundStyle(.tertiary)
+                                .fixedSize(horizontal: false, vertical: true)
+
+                            if self.settings.hideStatusItemBelowThreshold {
+                                HStack(spacing: 8) {
+                                    Text("Threshold:")
+                                        .font(.footnote)
+                                        .foregroundStyle(.secondary)
+
+                                    TextField(
+                                        "80",
+                                        value: Binding(
+                                            get: { self.settings.statusItemThresholdPercent },
+                                            set: { self.settings.statusItemThresholdPercent = max(0, min(100, $0)) }
+                                        ),
+                                        format: .number
+                                    )
+                                        .textFieldStyle(.roundedBorder)
+                                        .frame(width: 60)
+
+                                    Text("%")
+                                        .font(.footnote)
+                                        .foregroundStyle(.secondary)
+                                }
+                                .padding(.leading, 20)
+                            }
+                        }
+                    }
                 }
 
                 Divider()

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -75,6 +75,23 @@ extension SettingsStore {
         }
     }
 
+    var hideStatusItemBelowThreshold: Bool {
+        get { self.defaultsState.hideStatusItemBelowThreshold }
+        set {
+            self.defaultsState.hideStatusItemBelowThreshold = newValue
+            self.userDefaults.set(newValue, forKey: "hideStatusItemBelowThreshold")
+        }
+    }
+
+    var statusItemThresholdPercent: Int {
+        get { self.defaultsState.statusItemThresholdPercent }
+        set {
+            let clamped = max(0, min(100, newValue))
+            self.defaultsState.statusItemThresholdPercent = clamped
+            self.userDefaults.set(clamped, forKey: "statusItemThresholdPercent")
+        }
+    }
+
     var usageBarsShowUsed: Bool {
         get { self.defaultsState.usageBarsShowUsed }
         set {

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -9,6 +9,8 @@ extension SettingsStore {
         _ = self.debugDisableKeychainAccess
         _ = self.statusChecksEnabled
         _ = self.sessionQuotaNotificationsEnabled
+        _ = self.hideStatusItemBelowThreshold
+        _ = self.statusItemThresholdPercent
         _ = self.usageBarsShowUsed
         _ = self.resetTimesShowAbsolute
         _ = self.menuBarShowsBrandIconWithPercent

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -115,6 +115,11 @@ final class SettingsStore {
         copilotTokenStore: any CopilotTokenStoring = KeychainCopilotTokenStore(),
         tokenAccountStore: any ProviderTokenAccountStoring = FileTokenAccountStore())
     {
+        // Register defaults first, before any properties are initialized or accessed
+        userDefaults.register(defaults: [
+            "hideStatusItemBelowThreshold": false,
+            "statusItemThresholdPercent": 80,
+        ])
         let legacyStores = CodexBarConfigMigrator.LegacyStores(
             zaiTokenStore: zaiTokenStore,
             syntheticTokenStore: syntheticTokenStore,
@@ -178,6 +183,11 @@ extension SettingsStore {
         if sessionQuotaDefault == nil {
             userDefaults.set(true, forKey: "sessionQuotaNotificationsEnabled")
         }
+        let hideStatusItemBelowThreshold = userDefaults.bool(forKey: "hideStatusItemBelowThreshold")
+        let statusItemThresholdPercent = max(
+            0,
+            min(100, userDefaults.integer(forKey: "statusItemThresholdPercent"))
+        )
         let usageBarsShowUsed = userDefaults.object(forKey: "usageBarsShowUsed") as? Bool ?? false
         let resetTimesShowAbsolute = userDefaults.object(forKey: "resetTimesShowAbsolute") as? Bool ?? false
         let menuBarShowsBrandIconWithPercent = userDefaults.object(
@@ -220,6 +230,8 @@ extension SettingsStore {
             debugLoadingPatternRaw: debugLoadingPatternRaw,
             statusChecksEnabled: statusChecksEnabled,
             sessionQuotaNotificationsEnabled: sessionQuotaNotificationsEnabled,
+            hideStatusItemBelowThreshold: hideStatusItemBelowThreshold,
+            statusItemThresholdPercent: statusItemThresholdPercent,
             usageBarsShowUsed: usageBarsShowUsed,
             resetTimesShowAbsolute: resetTimesShowAbsolute,
             menuBarShowsBrandIconWithPercent: menuBarShowsBrandIconWithPercent,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -9,6 +9,8 @@ struct SettingsDefaultsState: Sendable {
     var debugLoadingPatternRaw: String?
     var statusChecksEnabled: Bool
     var sessionQuotaNotificationsEnabled: Bool
+    var hideStatusItemBelowThreshold: Bool
+    var statusItemThresholdPercent: Int
     var usageBarsShowUsed: Bool
     var resetTimesShowAbsolute: Bool
     var menuBarShowsBrandIconWithPercent: Bool

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -43,6 +43,8 @@ extension StatusItemController {
         if self.isHostedSubviewMenu(menu) {
             self.refreshHostedSubviewHeights(in: menu)
             self.openMenus[ObjectIdentifier(menu)] = menu
+            self.scheduleOpenMenuRefresh(for: menu)
+            self.updateVisibility()
             // Removed redundant async refresh - single pass is sufficient after initial layout
             return
         }
@@ -75,6 +77,7 @@ extension StatusItemController {
         self.openMenus[ObjectIdentifier(menu)] = menu
         // Only schedule refresh after menu is registered as open - refreshNow is called async
         self.scheduleOpenMenuRefresh(for: menu)
+        self.updateVisibility()
     }
 
     func menuDidClose(_ menu: NSMenu) {
@@ -93,6 +96,7 @@ extension StatusItemController {
         for menuItem in menu.items {
             (menuItem.view as? MenuCardHighlighting)?.setHighlighted(false)
         }
+        self.updateVisibility()
     }
 
     func menu(_ menu: NSMenu, willHighlight item: NSMenuItem?) {

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -274,4 +274,96 @@ struct SettingsStoreTests {
 
         #expect(storeB.orderedProviders().first == .antigravity)
     }
+
+    @Test
+    func defaultsHideStatusItemBelowThresholdToFalse() {
+        let suite = "SettingsStoreTests-hideStatusItem"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let store = SettingsStore(userDefaults: defaults, zaiTokenStore: NoopZaiTokenStore())
+
+        #expect(store.hideStatusItemBelowThreshold == false)
+    }
+
+    @Test
+    func defaultsStatusItemThresholdPercentTo80() {
+        let suite = "SettingsStoreTests-thresholdPercent"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+
+        let store = SettingsStore(userDefaults: defaults, zaiTokenStore: NoopZaiTokenStore())
+
+        #expect(store.statusItemThresholdPercent == 80)
+    }
+
+    @Test
+    func persistsHideStatusItemBelowThresholdAcrossInstances() {
+        let suite = "SettingsStoreTests-hideStatusItemPersist"
+        let defaultsA = UserDefaults(suiteName: suite)!
+        defaultsA.removePersistentDomain(forName: suite)
+        let storeA = SettingsStore(userDefaults: defaultsA, zaiTokenStore: NoopZaiTokenStore())
+
+        storeA.hideStatusItemBelowThreshold = true
+
+        let defaultsB = UserDefaults(suiteName: suite)!
+        let storeB = SettingsStore(userDefaults: defaultsB, zaiTokenStore: NoopZaiTokenStore())
+
+        #expect(storeB.hideStatusItemBelowThreshold == true)
+    }
+
+    @Test
+    func persistsStatusItemThresholdPercentAcrossInstances() {
+        let suite = "SettingsStoreTests-thresholdPercentPersist"
+        let defaultsA = UserDefaults(suiteName: suite)!
+        defaultsA.removePersistentDomain(forName: suite)
+        let storeA = SettingsStore(userDefaults: defaultsA, zaiTokenStore: NoopZaiTokenStore())
+
+        storeA.statusItemThresholdPercent = 90
+
+        let defaultsB = UserDefaults(suiteName: suite)!
+        let storeB = SettingsStore(userDefaults: defaultsB, zaiTokenStore: NoopZaiTokenStore())
+
+        #expect(storeB.statusItemThresholdPercent == 90)
+    }
+
+    @Test
+    func statusItemThresholdPercentClampsValueAbove100() {
+        let suite = "SettingsStoreTests-thresholdClampHigh"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let store = SettingsStore(userDefaults: defaults, zaiTokenStore: NoopZaiTokenStore())
+
+        store.statusItemThresholdPercent = 150
+
+        #expect(store.statusItemThresholdPercent == 100)
+        #expect(defaults.integer(forKey: "statusItemThresholdPercent") == 100)
+    }
+
+    @Test
+    func statusItemThresholdPercentClampsValueBelow0() {
+        let suite = "SettingsStoreTests-thresholdClampLow"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let store = SettingsStore(userDefaults: defaults, zaiTokenStore: NoopZaiTokenStore())
+
+        store.statusItemThresholdPercent = -10
+
+        #expect(store.statusItemThresholdPercent == 0)
+        #expect(defaults.integer(forKey: "statusItemThresholdPercent") == 0)
+    }
+
+    @Test
+    func statusItemThresholdPercentAcceptsBoundaryValues() {
+        let suite = "SettingsStoreTests-thresholdBoundary"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let store = SettingsStore(userDefaults: defaults, zaiTokenStore: NoopZaiTokenStore())
+
+        store.statusItemThresholdPercent = 0
+        #expect(store.statusItemThresholdPercent == 0)
+
+        store.statusItemThresholdPercent = 100
+        #expect(store.statusItemThresholdPercent == 100)
+    }
 }

--- a/Tests/CodexBarTests/StatusItemVisibilityTests.swift
+++ b/Tests/CodexBarTests/StatusItemVisibilityTests.swift
@@ -1,0 +1,528 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite
+struct StatusItemVisibilityTests {
+    @Test
+    func statusItemVisibleWhenThresholdDisabled() {
+        let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.hideStatusItemBelowThreshold = false
+        settings.statusItemThresholdPercent = 80
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection())
+
+        // Usage at 50% (below 80% threshold), but threshold is disabled
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 50, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setErrorForTesting(nil, provider: .codex)
+
+        #expect(controller.isVisible(.codex) == true)
+    }
+
+    @Test
+    func statusItemHiddenWhenBelowThreshold() {
+        let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.hideStatusItemBelowThreshold = true
+        settings.statusItemThresholdPercent = 80
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection())
+
+        // Cancel the launch visibility task to immediately apply threshold
+        controller.launchVisibilityTask?.cancel()
+
+        // Usage at 50% (below 80% threshold)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 50, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setErrorForTesting(nil, provider: .codex)
+
+        #expect(controller.isVisible(.codex) == false)
+    }
+
+    @Test
+    func statusItemVisibleWhenAboveThreshold() {
+        let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.hideStatusItemBelowThreshold = true
+        settings.statusItemThresholdPercent = 80
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection())
+
+        // Cancel the launch visibility task to immediately apply threshold
+        controller.launchVisibilityTask?.cancel()
+
+        // Usage at 90% (above 80% threshold)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 90, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setErrorForTesting(nil, provider: .codex)
+
+        #expect(controller.isVisible(.codex) == true)
+    }
+
+    @Test
+    func statusItemHiddenWhenProviderDisabled() {
+        let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.hideStatusItemBelowThreshold = true
+        settings.statusItemThresholdPercent = 80
+
+        let registry = ProviderRegistry.shared
+        // Enable claude so codex isn't the fallback when disabled
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+        // Disable codex
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: false)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection())
+
+        // Cancel the launch visibility task to immediately apply threshold
+        controller.launchVisibilityTask?.cancel()
+
+        // Usage at 50% (below 80% threshold), provider disabled
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 50, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setErrorForTesting(nil, provider: .codex)
+
+        // Should be hidden because provider is disabled (not because of threshold)
+        #expect(controller.isVisible(.codex) == false)
+    }
+
+    @Test
+    func statusItemVisibleWhenNoSnapshot() {
+        let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.hideStatusItemBelowThreshold = true
+        settings.statusItemThresholdPercent = 80
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection())
+
+        // Cancel the launch visibility task to immediately apply threshold
+        controller.launchVisibilityTask?.cancel()
+
+        // No snapshot available
+        store._setSnapshotForTesting(nil, provider: .codex)
+        store._setErrorForTesting(nil, provider: .codex)
+
+        // Should be visible when no data is available (default to visible)
+        #expect(controller.isVisible(.codex) == true)
+    }
+
+    @Test
+    func statusItemVisibleWhenMenuOpen() {
+        let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.hideStatusItemBelowThreshold = true
+        settings.statusItemThresholdPercent = 80
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection())
+
+        // Cancel the launch visibility task to immediately apply threshold
+        controller.launchVisibilityTask?.cancel()
+
+        // Usage at 50% (below 80% threshold)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 50, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setErrorForTesting(nil, provider: .codex)
+
+        // Simulate a menu being open
+        let menu = NSMenu()
+        controller.openMenus[ObjectIdentifier(menu)] = menu
+
+        // Should be visible while menu is open, even though below threshold
+        #expect(controller.isVisible(.codex) == true)
+    }
+
+    @Test
+    func mergedIconVisibleWhenThresholdDisabled() {
+        let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.hideStatusItemBelowThreshold = false
+        settings.statusItemThresholdPercent = 80
+        settings.mergeIcons = true
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection())
+
+        // Both providers at 50% (below 80% threshold), but threshold is disabled
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 50, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .codex)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        #expect(controller.statusItem.isVisible == true)
+    }
+
+    @Test
+    func mergedIconHiddenWhenAllProvidersBelowThreshold() {
+        let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.hideStatusItemBelowThreshold = true
+        settings.statusItemThresholdPercent = 80
+        settings.mergeIcons = true
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection())
+
+        // Cancel the launch visibility task to immediately apply threshold
+        controller.launchVisibilityTask?.cancel()
+
+        // Both providers at 50% (below 80% threshold)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 50, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .codex)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        controller.updateVisibility()
+
+        #expect(controller.statusItem.isVisible == false)
+    }
+
+    @Test
+    func mergedIconVisibleWhenOneProviderAboveThreshold() {
+        let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.hideStatusItemBelowThreshold = true
+        settings.statusItemThresholdPercent = 80
+        settings.mergeIcons = true
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection())
+
+        // Cancel the launch visibility task to immediately apply threshold
+        controller.launchVisibilityTask?.cancel()
+
+        // Codex at 50% (below), Claude at 90% (above)
+        let lowSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 50, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        let highSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 90, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(lowSnapshot, provider: .codex)
+        store._setSnapshotForTesting(highSnapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .codex)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        controller.updateVisibility()
+
+        #expect(controller.statusItem.isVisible == true)
+    }
+
+    @Test
+    func mergedIconVisibleWhenMenuOpenEvenIfAllBelowThreshold() {
+        let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.hideStatusItemBelowThreshold = true
+        settings.statusItemThresholdPercent = 80
+        settings.mergeIcons = true
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection())
+
+        // Cancel the launch visibility task to immediately apply threshold
+        controller.launchVisibilityTask?.cancel()
+
+        // Both providers at 50% (below 80% threshold)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 50, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .codex)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        // Simulate a menu being open
+        let menu = NSMenu()
+        controller.openMenus[ObjectIdentifier(menu)] = menu
+
+        controller.updateVisibility()
+
+        #expect(controller.statusItem.isVisible == true)
+    }
+
+    @Test
+    func mergedIconVisibleWhenAllProvidersAboveThreshold() {
+        let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.hideStatusItemBelowThreshold = true
+        settings.statusItemThresholdPercent = 80
+        settings.mergeIcons = true
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection())
+
+        // Cancel the launch visibility task to immediately apply threshold
+        controller.launchVisibilityTask?.cancel()
+
+        // Both providers at 90% (above 80% threshold)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 90, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .codex)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        controller.updateVisibility()
+
+        #expect(controller.statusItem.isVisible == true)
+    }
+
+    @Test
+    func mergedIconVisibleWhenNoProvidersEnabledAndThresholdDisabled() {
+        let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.hideStatusItemBelowThreshold = false
+        settings.statusItemThresholdPercent = 80
+        settings.mergeIcons = true
+
+        let registry = ProviderRegistry.shared
+        // Disable all providers
+        for provider in UsageProvider.allCases {
+            if let metadata = registry.metadata[provider] {
+                settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: false)
+            }
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection())
+
+        controller.launchVisibilityTask?.cancel()
+        controller.updateVisibility()
+
+        // Should be visible because threshold setting is disabled
+        #expect(controller.statusItem.isVisible == true)
+    }
+
+    @Test
+    func mergedIconHiddenWhenNoProvidersEnabledAndThresholdEnabled() {
+        let settings = SettingsStore(zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.hideStatusItemBelowThreshold = true
+        settings.statusItemThresholdPercent = 80
+        settings.mergeIcons = true
+
+        let registry = ProviderRegistry.shared
+        // Disable all providers
+        for provider in UsageProvider.allCases {
+            if let metadata = registry.metadata[provider] {
+                settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: false)
+            }
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection())
+
+        controller.launchVisibilityTask?.cancel()
+        controller.updateVisibility()
+
+        // Should be hidden because threshold setting is enabled
+        #expect(controller.statusItem.isVisible == false)
+    }
+}


### PR DESCRIPTION
**what**
I usually hit a keyboard shortcut to open up CodexBar and check on whats going on - so having it in the Menu Bar all the time is a bit much. Unless I want to check (or am about to hit a limit) I don't really need to see the status item. So, might as well hide it?

**other implicit behavior**
I kept the status item showing on app launch for 15s to confirm the app opened - which, anecdotally, is just long enough for me to check on the status of things, tab away, and forget about things for a few minutes at a time.

**visuals**
While CodexBar is open to show details, the status item will also stay visible.

Video of CodexCode showing and hiding in response to the key combo
https://github.com/user-attachments/assets/09dd8096-2313-43b4-a209-36846eb865a6

There's a menubar animation when it shows and hides. Claude claims its from macOS, and I think that's true. But, It's a bit weird to see all the time. I did a quick pass of "what if I hide the view within the status item instead of the status item itself?" but that looked worse.

Here's a screenshot of the settings page to configure all this:
<img width="608" height="772" alt="Screenshot 2026-01-19 at 11 56 37" src="https://github.com/user-attachments/assets/1bc1184f-bfac-4173-a17b-832df1008d6c" />

I'm not totally sold on this page - and happy to change anything based on feedback, but here's whats on my list of things that are questionable:
1. I went with a textfield, but a slider at 5% intervals might make more sense? 
2. The spacing between 'Only show status item when…' and the threshold text entry feels like it's a bit too tight?

**implementation notes**
Although I had Claude do the first pass of things, there were enough "ehhhh…" that I spent some time talking it through most of the implementation to be a bit more idiomatic. Some examples of Opus falling short:
1. insisting on validating text in the `didSet` of the data store instead of a `Binding` and clamping in a `set`
2. didn't want to acknowledge `userDefaults.register(defaults:)` existing without API docs being thrown at it (but to be fair… most people forget about this API as well 🙈)
3. couldn't figure out how to get the tests to run in under 15 seconds w/r/t/ the app launch dismissal