### PR TITLE
fix: use case-insensitive matching for JetBrains IDE directories

### DIFF
--- a/Sources/CodexBarCore/Providers/JetBrains/JetBrainsIDEDetector.swift
+++ b/Sources/CodexBarCore/Providers/JetBrains/JetBrainsIDEDetector.swift
@@ -103,7 +103,10 @@ public enum JetBrainsIDEDetector {
     }
 
     private static func parseIDEDirectory(dirname: String, basePath: String) -> JetBrainsIDEInfo? {
-        for (prefix, displayName) in self.idePatterns where dirname.hasPrefix(prefix) {
+        let dirnameLower = dirname.lowercased()
+        for (prefix, displayName) in self.idePatterns {
+            let prefixLower = prefix.lowercased()
+            guard dirnameLower.hasPrefix(prefixLower) else { continue }
             let versionPart = String(dirname.dropFirst(prefix.count))
             let version = versionPart.isEmpty ? "Unknown" : versionPart
             let idePath = "\(basePath)/\(dirname)"


### PR DESCRIPTION
## Summary
- Fixes case-sensitivity issue when detecting JetBrains IDE directories

JetBrains Toolbox may create IDE directories with varying case, such as `Webstorm` instead of `WebStorm`. This change makes the directory name matching case-insensitive so all IDE installations are detected regardless of directory name casing.

Fixes #199

## Test plan
- [x] Verified fix compiles successfully with `swift build --target CodexBarCore`
- [ ] Manual testing: User with `Webstorm` (lowercase 's') directory should now see their WebStorm installation detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)