### PR TITLE
Fix Factory usage percentage by preferring API usedRatio

### DIFF
--- a/Tests/CodexBarTests/FactoryStatusProbeFetchTests.swift
+++ b/Tests/CodexBarTests/FactoryStatusProbeFetchTests.swift
@@ -44,12 +44,14 @@ struct FactoryStatusProbeFetchTests {
                     "standard": {
                       "userTokens": 100,
                       "orgTotalTokensUsed": 250,
-                      "totalAllowance": 1000
+                      "totalAllowance": 1000,
+                      "usedRatio": 0.10
                     },
                     "premium": {
                       "userTokens": 10,
                       "orgTotalTokensUsed": 20,
-                      "totalAllowance": 100
+                      "totalAllowance": 100,
+                      "usedRatio": 0.10
                     }
                   },
                   "userId": "user-1"
@@ -65,9 +67,16 @@ struct FactoryStatusProbeFetchTests {
 
         #expect(snapshot.standardUserTokens == 100)
         #expect(snapshot.standardAllowance == 1000)
+        #expect(snapshot.standardUsedRatio == 0.10)
         #expect(snapshot.premiumUserTokens == 10)
+        #expect(snapshot.premiumUsedRatio == 0.10)
         #expect(snapshot.userId == "user-1")
         #expect(snapshot.planName == "Team")
+
+        // Verify usedRatio is used in percentage calculation (0.10 * 100 = 10%)
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.usedPercent == 10)
+        #expect(usage.secondary?.usedPercent == 10)
     }
 
     private static func makeResponse(

--- a/Tests/CodexBarTests/FactoryStatusProbeTests.swift
+++ b/Tests/CodexBarTests/FactoryStatusProbeTests.swift
@@ -54,6 +54,115 @@ struct FactoryStatusSnapshotTests {
 
         #expect(usage.primary?.usedPercent == 50)
     }
+
+    @Test
+    func prefersAPIUsedRatioOverCalculation() {
+        // Simulates Factory Max plan where totalAllowance may be missing/zero
+        // but usedRatio is provided by the API (72,311,737 / 200,000,000 ≈ 0.3616)
+        let snapshot = FactoryStatusSnapshot(
+            standardUserTokens: 72_311_737,
+            standardOrgTokens: 72_311_737,
+            standardAllowance: 0, // API may not return allowance
+            standardUsedRatio: 0.3615586850, // API provides correct ratio
+            premiumUserTokens: 0,
+            premiumOrgTokens: 0,
+            premiumAllowance: 0,
+            premiumUsedRatio: 0.0,
+            periodStart: nil,
+            periodEnd: nil,
+            planName: "Max",
+            tier: nil,
+            organizationName: nil,
+            accountEmail: nil,
+            userId: nil,
+            rawJSON: nil)
+
+        let usage = snapshot.toUsageSnapshot()
+
+        // Should use API ratio (36.16%) instead of falling back to 0%
+        #expect(usage.primary?.usedPercent ?? 0 > 36)
+        #expect(usage.primary?.usedPercent ?? 0 < 37)
+    }
+
+    @Test
+    func fallsBackToCalculationWhenAPIRatioMissing() {
+        let snapshot = FactoryStatusSnapshot(
+            standardUserTokens: 50_000_000,
+            standardOrgTokens: 0,
+            standardAllowance: 100_000_000,
+            standardUsedRatio: nil, // No API ratio provided
+            premiumUserTokens: 0,
+            premiumOrgTokens: 0,
+            premiumAllowance: 0,
+            premiumUsedRatio: nil,
+            periodStart: nil,
+            periodEnd: nil,
+            planName: nil,
+            tier: nil,
+            organizationName: nil,
+            accountEmail: nil,
+            userId: nil,
+            rawJSON: nil)
+
+        let usage = snapshot.toUsageSnapshot()
+
+        // Should calculate: 50M / 100M = 50%
+        #expect(usage.primary?.usedPercent == 50)
+    }
+
+    @Test
+    func fallsBackWhenAPIRatioIsInvalid() {
+        // Test with out-of-range ratio (> 1.0) - should fall back to calculation
+        let snapshot = FactoryStatusSnapshot(
+            standardUserTokens: 50_000_000,
+            standardOrgTokens: 0,
+            standardAllowance: 100_000_000,
+            standardUsedRatio: 1.5, // Invalid: > 1.0
+            premiumUserTokens: 0,
+            premiumOrgTokens: 0,
+            premiumAllowance: 0,
+            premiumUsedRatio: -0.5, // Invalid: < 0
+            periodStart: nil,
+            periodEnd: nil,
+            planName: nil,
+            tier: nil,
+            organizationName: nil,
+            accountEmail: nil,
+            userId: nil,
+            rawJSON: nil)
+
+        let usage = snapshot.toUsageSnapshot()
+
+        // Should fall back to calculation: 50M / 100M = 50%
+        #expect(usage.primary?.usedPercent == 50)
+    }
+
+    @Test
+    func clampsSlightlyOutOfRangeRatios() {
+        // Test with ratio slightly > 1.0 due to floating point (should clamp, not fall back)
+        let snapshot = FactoryStatusSnapshot(
+            standardUserTokens: 100_000_000,
+            standardOrgTokens: 0,
+            standardAllowance: 100_000_000,
+            standardUsedRatio: 1.0005, // Slightly over due to rounding
+            premiumUserTokens: 0,
+            premiumOrgTokens: 0,
+            premiumAllowance: 0,
+            premiumUsedRatio: nil,
+            periodStart: nil,
+            periodEnd: nil,
+            planName: nil,
+            tier: nil,
+            organizationName: nil,
+            accountEmail: nil,
+            userId: nil,
+            rawJSON: nil)
+
+        let usage = snapshot.toUsageSnapshot()
+
+        // Should clamp to 100% (not fall back)
+        #expect(usage.primary?.usedPercent == 100)
+    }
 }
 
 @Suite


### PR DESCRIPTION
**Problem**: Factory usage shows incorrect percentages when `totalAllowance` is missing/zero/sentinel in the API response, causing 0% used to display regardless of actual usage.

**Fix**: Use API-provided `usedRatio` field when valid (0-1 range), falling back to `used/allowance` calculation otherwise.

**Changes**:
- Add `standardUsedRatio`/`premiumUsedRatio` to `FactoryStatusSnapshot`
- Pass through from API in `buildSnapshot`  
- Prefer API ratio in `calculateUsagePercent` with floating-point tolerance

**Tests**: 8 Factory tests pass (added 4 new)