### PR TITLE
fix: use tier-aware effective budget for Cursor usage percentage

### DIFF
--- a/Sources/CodexBar/Providers/Cursor/CursorProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Cursor/CursorProviderImplementation.swift
@@ -90,13 +90,18 @@ struct CursorProviderImplementation: ProviderImplementation {
 
     @MainActor
     func appendUsageMenuEntries(context: ProviderMenuUsageContext, entries: inout [ProviderMenuEntry]) {
+        // Show on-demand usage separately
         guard let cost = context.snapshot?.providerCost, cost.currencyCode != "Quota" else { return }
-        let used = UsageFormatter.currencyString(cost.used, currencyCode: cost.currencyCode)
-        if cost.limit > 0 {
-            let limitStr = UsageFormatter.currencyString(cost.limit, currencyCode: cost.currencyCode)
-            entries.append(.text("On-Demand: \(used) / \(limitStr)", .primary))
-        } else {
-            entries.append(.text("On-Demand: \(used)", .primary))
+
+        // Only show on-demand if there's actual usage
+        if cost.used > 0 {
+            let used = UsageFormatter.currencyString(cost.used, currencyCode: cost.currencyCode)
+            if cost.limit > 0 {
+                let limitStr = UsageFormatter.currencyString(cost.limit, currencyCode: cost.currencyCode)
+                entries.append(.text("On-Demand: \(used) / \(limitStr)", .primary))
+            } else {
+                entries.append(.text("On-Demand: \(used)", .primary))
+            }
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Cursor/CursorEffectiveUsage.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorEffectiveUsage.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Effective usage snapshot for Cursor plans with tier-aware budget calculations.
+/// This provides accurate usage percentages for higher-tier plans (Pro+, Ultra)
+/// that have effective budgets much larger than their nominal prices.
+public struct CursorEffectiveUsage: Codable, Sendable {
+    /// Total usage (plan + on-demand) in USD
+    public let totalUsedUSD: Double
+    /// Effective budget (tier budget + on-demand limit) in USD
+    public let effectiveBudgetUSD: Double
+    /// Plan tier for display purposes
+    public let planTier: CursorPlanTier
+    /// Whether on-demand usage has started (plan allowance exhausted)
+    public let isPlanExhausted: Bool
+    /// On-demand usage in USD (for separate display when plan is exhausted)
+    public let onDemandUsedUSD: Double
+    /// On-demand limit in USD (nil if unlimited)
+    public let onDemandLimitUSD: Double?
+
+    public init(
+        totalUsedUSD: Double,
+        effectiveBudgetUSD: Double,
+        planTier: CursorPlanTier,
+        isPlanExhausted: Bool,
+        onDemandUsedUSD: Double,
+        onDemandLimitUSD: Double?)
+    {
+        self.totalUsedUSD = totalUsedUSD
+        self.effectiveBudgetUSD = effectiveBudgetUSD
+        self.planTier = planTier
+        self.isPlanExhausted = isPlanExhausted
+        self.onDemandUsedUSD = onDemandUsedUSD
+        self.onDemandLimitUSD = onDemandLimitUSD
+    }
+
+    /// Effective percentage used based on total usage / effective budget
+    public var effectivePercentUsed: Double {
+        guard self.effectiveBudgetUSD > 0 else { return 0 }
+        return min((self.totalUsedUSD / self.effectiveBudgetUSD) * 100, 100)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Cursor/CursorPlanTier.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorPlanTier.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Represents Cursor subscription plan tiers with their effective usage budgets.
+///
+/// Higher-tier plans provide more effective capacity than their nominal price suggests.
+/// For example, Ultra ($200/mo) provides approximately 20x the value of a baseline Pro plan,
+/// meaning users can consume ~$800 worth of API usage before hitting limits.
+public enum CursorPlanTier: String, Codable, Sendable {
+    case hobby
+    case pro
+    case proPlus
+    case ultra
+    case team
+    case enterprise
+    case unknown
+
+    /// Initialize plan tier from the API's membership type string.
+    /// - Parameter membershipType: The membership type from Cursor's API (e.g., "pro", "pro+", "ultra")
+    public init(membershipType: String?) {
+        switch membershipType?.lowercased() {
+        case "hobby":
+            self = .hobby
+        case "pro":
+            self = .pro
+        case "pro+", "pro_plus", "proplus":
+            self = .proPlus
+        case "ultra":
+            self = .ultra
+        case "team":
+            self = .team
+        case "enterprise":
+            self = .enterprise
+        default:
+            self = .unknown
+        }
+    }
+
+    /// Effective budget in USD based on plan tier.
+    ///
+    /// These values approximate the actual usage capacity provided by each tier,
+    /// calibrated against a ~$40 Pro baseline:
+    /// - Pro ($20/mo) provides ~$40 effective (1x baseline)
+    /// - Pro+ ($60/mo) provides ~$120 effective (3x baseline)
+    /// - Ultra ($200/mo) provides ~$800 effective (20x baseline)
+    public var effectiveBudgetUSD: Double {
+        switch self {
+        case .hobby:
+            return 20
+        case .pro:
+            return 40
+        case .proPlus:
+            return 120 // 3x baseline
+        case .ultra:
+            return 800 // 20x baseline
+        case .team:
+            return 60
+        case .enterprise, .unknown:
+            return 40 // Conservative default
+        }
+    }
+
+    /// Display name for the plan tier.
+    public var displayName: String {
+        switch self {
+        case .hobby:
+            return "Hobby"
+        case .pro:
+            return "Pro"
+        case .proPlus:
+            return "Pro+"
+        case .ultra:
+            return "Ultra"
+        case .team:
+            return "Team"
+        case .enterprise:
+            return "Enterprise"
+        case .unknown:
+            return "Unknown"
+        }
+    }
+}

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -55,6 +55,7 @@ public struct UsageSnapshot: Codable, Sendable {
     public let zaiUsage: ZaiUsageSnapshot?
     public let minimaxUsage: MiniMaxUsageSnapshot?
     public let cursorRequests: CursorRequestUsage?
+    public let cursorEffectiveUsage: CursorEffectiveUsage?
     public let updatedAt: Date
     public let identity: ProviderIdentitySnapshot?
 
@@ -78,6 +79,7 @@ public struct UsageSnapshot: Codable, Sendable {
         zaiUsage: ZaiUsageSnapshot? = nil,
         minimaxUsage: MiniMaxUsageSnapshot? = nil,
         cursorRequests: CursorRequestUsage? = nil,
+        cursorEffectiveUsage: CursorEffectiveUsage? = nil,
         updatedAt: Date,
         identity: ProviderIdentitySnapshot? = nil)
     {
@@ -88,6 +90,7 @@ public struct UsageSnapshot: Codable, Sendable {
         self.zaiUsage = zaiUsage
         self.minimaxUsage = minimaxUsage
         self.cursorRequests = cursorRequests
+        self.cursorEffectiveUsage = cursorEffectiveUsage
         self.updatedAt = updatedAt
         self.identity = identity
     }
@@ -101,6 +104,7 @@ public struct UsageSnapshot: Codable, Sendable {
         self.zaiUsage = nil // Not persisted, fetched fresh each time
         self.minimaxUsage = nil // Not persisted, fetched fresh each time
         self.cursorRequests = nil // Not persisted, fetched fresh each time
+        self.cursorEffectiveUsage = nil // Not persisted, fetched fresh each time
         self.updatedAt = try container.decode(Date.self, forKey: .updatedAt)
         if let identity = try container.decodeIfPresent(ProviderIdentitySnapshot.self, forKey: .identity) {
             self.identity = identity
@@ -184,6 +188,7 @@ public struct UsageSnapshot: Codable, Sendable {
             zaiUsage: self.zaiUsage,
             minimaxUsage: self.minimaxUsage,
             cursorRequests: self.cursorRequests,
+            cursorEffectiveUsage: self.cursorEffectiveUsage,
             updatedAt: self.updatedAt,
             identity: scopedIdentity)
     }


### PR DESCRIPTION
## Summary
- Fixes usage percentage display for Pro+/Ultra Cursor plans
- Higher-tier plans now show percentage against effective capacity, not nominal limit

## Problem
Cursor Pro+/Ultra users saw misleading usage percentages. For example, an Ultra user ($200/mo) with $300 usage would see the Plan bar at 0% left, even though Ultra provides ~$800 effective capacity.

Reference: https://x.com/steipete/status/2014620261715226833

## Solution
Introduced plan-tier-aware effective budgets:

| Plan | Nominal | Effective Budget |
|------|---------|-----------------|
| Pro | $20/mo | $40 |
| Pro+ | $60/mo | $120 (3x) |
| Ultra | $200/mo | $800 (20x) |

The Plan progress bar now calculates percentage as `totalUsed / (tierEffectiveBudget + onDemandLimit)`.

## Changes
- Add `CursorPlanTier` enum with effective budget values
- Add `CursorEffectiveUsage` struct for tier-aware usage data
- Update `CursorStatusSnapshot` with plan tier detection and effective percentage calculation
- Update progress bar to use effective percentage for non-legacy plans
- Add comprehensive tests

## Testing
- All 24 `CursorStatusProbeTests` pass
- Manual verification with Ultra account shows correct percentage

Fixes #154