### PR TITLE
Fix MiniMax API fetch region

### DIFF
--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxAPIRegion.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxAPIRegion.swift
@@ -26,6 +26,15 @@ public enum MiniMaxAPIRegion: String, CaseIterable, Sendable {
         }
     }
 
+    public var apiBaseURLString: String {
+        switch self {
+        case .global:
+            "https://api.minimax.io"
+        case .chinaMainland:
+            "https://api.minimaxi.com"
+        }
+    }
+
     public var codingPlanURL: URL {
         var components = URLComponents(string: self.baseURLString)!
         components.path = "/" + Self.codingPlanPath
@@ -41,5 +50,9 @@ public enum MiniMaxAPIRegion: String, CaseIterable, Sendable {
 
     public var remainsURL: URL {
         URL(string: self.baseURLString)!.appendingPathComponent(Self.remainsPath)
+    }
+
+    public var apiRemainsURL: URL {
+        URL(string: self.apiBaseURLString)!.appendingPathComponent(Self.remainsPath)
     }
 }

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxProviderDescriptor.swift
@@ -86,7 +86,8 @@ struct MiniMaxAPIFetchStrategy: ProviderFetchStrategy {
         guard let apiToken = ProviderTokenResolver.minimaxToken(environment: context.env) else {
             throw MiniMaxAPISettingsError.missingToken
         }
-        let usage = try await MiniMaxUsageFetcher.fetchUsage(apiToken: apiToken)
+        let region = context.settings?.minimax?.apiRegion ?? .global
+        let usage = try await MiniMaxUsageFetcher.fetchUsage(apiToken: apiToken, region: region)
         return self.makeResult(
             usage: usage.toUsageSnapshot(),
             sourceLabel: "api")

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -8,7 +8,6 @@ public struct MiniMaxUsageFetcher: Sendable {
     private static let codingPlanPath = "user-center/payment/coding-plan"
     private static let codingPlanQuery = "cycle_type=3"
     private static let codingPlanRemainsPath = "v1/api/openplatform/coding_plan/remains"
-    private static let apiRemainsURL = URL(string: "https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains")!
     private struct RemainsContext: Sendable {
         let authorizationToken: String?
         let groupID: String?
@@ -51,6 +50,7 @@ public struct MiniMaxUsageFetcher: Sendable {
 
     public static func fetchUsage(
         apiToken: String,
+        region: MiniMaxAPIRegion = .global,
         now: Date = Date()) async throws -> MiniMaxUsageSnapshot
     {
         let cleaned = apiToken.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -58,7 +58,7 @@ public struct MiniMaxUsageFetcher: Sendable {
             throw MiniMaxUsageError.invalidCredentials
         }
 
-        var request = URLRequest(url: self.apiRemainsURL)
+        var request = URLRequest(url: region.apiRemainsURL)
         request.httpMethod = "GET"
         request.setValue("Bearer \(cleaned)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "accept")


### PR DESCRIPTION
## Problem
MiniMax API usage fetches always target `api.minimaxi.com`, even when the provider is configured for the global (.io) stack. For `sk-cp-` keys tied to `.io`, this results in `MiniMax credentials are invalid or expired.` In the UI, MiniMax shows `minimax.api (api) available error=MiniMax credentials are invalid or expired.` and `minimax.web (web) unavailable`, which then surfaces `No available fetch strategy for minimax.`

## Investigation
- `MiniMaxUsageFetcher` hard-coded `https://api.minimaxi.com/v1/api/openplatform/coding_plan/remains`.
- The MiniMax region setting is used for web requests but not the API token path.
- With a `.io` key, the API request is sent to the `.com` host and fails authentication.

Example (debug pane):
- `minimax.api (api) available error=MiniMax credentials are invalid or expired.`
- `minimax.web (web) unavailable`
- Menu card: `No available fetch strategy for minimax.`

## Proposed solution
- Add region-aware API base URLs (`api.minimax.io` vs `api.minimaxi.com`).
- Use the region’s API base when fetching coding plan remains.
- Pass the MiniMax region from settings into the API fetch strategy.

## Changes
- `MiniMaxAPIRegion` adds `apiBaseURLString` and `apiRemainsURL`.
- `MiniMaxUsageFetcher.fetchUsage(apiToken:)` now uses `region.apiRemainsURL`.
- `MiniMaxAPIFetchStrategy` passes the configured region into the API fetcher.

## Testing
- `./Scripts/compile_and_run.sh` failed on this machine due to Swift toolchain/SDK mismatch (`SwiftBridging` redefinition; SDK built with a different Swift version).
- `pnpm check` failed because `swiftformat` is not installed on PATH.
