### PR TITLE
Fix Cursor subscription/plan bug (minimal, JSON fix)

### DIFF
--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -690,10 +690,9 @@ public struct CursorStatusProbe: Sendable {
         }
 
         // Convert cents to USD (plan percent derives from raw values to avoid percent unit mismatches).
-        // Use breakdown.total if available (includes bonus credits), otherwise fall back to limit.
+        // Use plan.limit directly - breakdown.total represents total *used* credits, not the limit.
         let planUsedRaw = Double(summary.individualUsage?.plan?.used ?? 0)
-        let planLimitRaw = Double(summary.individualUsage?.plan?.breakdown?.total ?? summary.individualUsage?.plan?
-            .limit ?? 0)
+        let planLimitRaw = Double(summary.individualUsage?.plan?.limit ?? 0)
         let planUsed = planUsedRaw / 100.0
         let planLimit = planLimitRaw / 100.0
         let planPercentUsed: Double = if planLimitRaw > 0 {


### PR DESCRIPTION
Ultra-minimal fix for long-standing bug (it never worked).

More focused than #225 so hopefully is easier to merge. I tested this myself locally, it's a precision change.

## Before
<img width="872" height="1189" alt="cursor-before" src="https://github.com/user-attachments/assets/945766f5-ffee-46f3-b2fc-0ec22d867537" />

## After
<img width="894" height="1189" alt="cursor-after" src="https://github.com/user-attachments/assets/2504b379-7ca7-4447-b589-ac6274b501a6" />

## Summary
- Fixes Cursor usage always showing 100% used (0% left) regardless of actual usage
- `breakdown.total` represents total *used* credits, not the plan limit

## Test plan
- [x] Verified locally with Cursor Ultra account showing correct ~48% left

🤖 Generated with [Claude Code](https://claude.com/claude-code)
^ sorry @steipete 😂