### PR TITLE
Refine reset time display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Menu & Menu Bar
 - Menu: opening OpenAI web submenus triggers a refresh when the data is stale.
 - Menu: fix usage line labels to honor “Show usage as used”.
+- Menu: tighten absolute reset timestamps and move the toggle into Display settings.
 - Debug: add a toggle to keep Codex/Claude CLI sessions alive between probes.
 - Debug: add a button to reset CLI probe sessions.
 - App icon: use the classic icon on macOS 15 and earlier while keeping Liquid Glass for macOS 26+ (#178). Thanks @zerone0x!

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -779,6 +779,7 @@ extension UsageMenuCardView.Model {
             let paceDetail = Self.weeklyPaceDetail(
                 provider: input.provider,
                 window: weekly,
+                resetStyle: input.resetTimeDisplayStyle,
                 now: input.now,
                 showUsed: input.usageBarsShowUsed)
             metrics.append(Metric(
@@ -842,10 +843,15 @@ extension UsageMenuCardView.Model {
     private static func weeklyPaceDetail(
         provider: UsageProvider,
         window: RateWindow,
+        resetStyle: ResetTimeDisplayStyle,
         now: Date,
         showUsed: Bool) -> PaceDetail?
     {
-        guard let detail = UsagePaceText.weeklyDetail(provider: provider, window: window, now: now) else { return nil }
+        guard let detail = UsagePaceText.weeklyDetail(
+            provider: provider,
+            window: window,
+            resetStyle: resetStyle,
+            now: now) else { return nil }
         let expectedUsed = detail.expectedUsedPercent
         let actualUsed = window.usedPercent
         let expectedPercent = showUsed ? expectedUsed : (100 - expectedUsed)

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -129,7 +129,10 @@ struct MenuDescriptor {
                     window: weekly,
                     resetStyle: resetStyle,
                     showUsed: settings.usageBarsShowUsed)
-                if let paceSummary = UsagePaceText.weeklySummary(provider: provider, window: weekly) {
+                if let paceSummary = UsagePaceText.weeklySummary(
+                    provider: provider,
+                    window: weekly,
+                    resetStyle: resetStyle) {
                     entries.append(.text(paceSummary, .secondary))
                 }
             }

--- a/Sources/CodexBar/PreferencesAdvancedPane.swift
+++ b/Sources/CodexBar/PreferencesAdvancedPane.swift
@@ -53,8 +53,6 @@ struct AdvancedPane: View {
                         .foregroundStyle(.tertiary)
                 }
 
-                Divider()
-
                 SettingsSection(contentSpacing: 10) {
                     PreferenceToggleRow(
                         title: "Show Debug Settings",

--- a/Sources/CodexBar/PreferencesDisplayPane.swift
+++ b/Sources/CodexBar/PreferencesDisplayPane.swift
@@ -66,8 +66,8 @@ struct DisplayPane: View {
                         subtitle: "Progress bars fill as you consume quota (instead of showing remaining).",
                         binding: self.$settings.usageBarsShowUsed)
                     PreferenceToggleRow(
-                        title: "Show reset time as clock",
-                        subtitle: "Display reset times as absolute clock values instead of countdowns.",
+                        title: "Show reset date/time",
+                        subtitle: "Display reset times as absolute date + time values instead of countdowns.",
                         binding: self.$settings.resetTimesShowAbsolute)
                     PreferenceToggleRow(
                         title: "Show credits + extra usage",

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -972,7 +972,7 @@ extension StatusItemController {
         }
         if let resetTime = timeLimit.nextResetTime {
             let reset = self.settings.resetTimeDisplayStyle == .absolute
-                ? UsageFormatter.resetDescription(from: resetTime)
+                ? UsageFormatter.resetAbsoluteDescription(from: resetTime)
                 : UsageFormatter.resetCountdownDescription(from: resetTime)
             let item = NSMenuItem(title: "Resets: \(reset)", action: nil, keyEquivalent: "")
             item.isEnabled = false

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -47,6 +47,19 @@ public enum UsageFormatter {
         return date.formatted(date: .abbreviated, time: .shortened)
     }
 
+    public static func resetAbsoluteDescription(from date: Date, now: Date = .init()) -> String {
+        let calendar = Calendar.current
+        if calendar.isDate(date, inSameDayAs: now) {
+            return date.formatted(date: .omitted, time: .shortened)
+        }
+        if let weekAhead = calendar.date(byAdding: .day, value: 7, to: now), date < weekAhead {
+            let weekday = date.formatted(.dateTime.weekday(.abbreviated))
+            let time = date.formatted(date: .omitted, time: .shortened)
+            return "\(weekday) \(time)"
+        }
+        return date.formatted(.dateTime.month(.abbreviated).day().hour().minute())
+    }
+
     public static func resetLine(
         for window: RateWindow,
         style: ResetTimeDisplayStyle,
@@ -55,8 +68,9 @@ public enum UsageFormatter {
         if let date = window.resetsAt {
             let text = style == .countdown
                 ? self.resetCountdownDescription(from: date, now: now)
-                : self.resetDescription(from: date, now: now)
-            return "Resets \(text)"
+                : self.resetAbsoluteDescription(from: date, now: now)
+            let prefix = style == .countdown ? "Resets " : "Resets at "
+            return "\(prefix)\(text)"
         }
 
         if let desc = window.resetDescription {

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -81,6 +81,26 @@ struct UsageFormatterTests {
     }
 
     @Test
+    func resetLineUsesAbsoluteWhenResetsAtIsAvailable() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+        let reset = now.addingTimeInterval(60 * 60)
+        let window = RateWindow(usedPercent: 0, windowMinutes: nil, resetsAt: reset, resetDescription: nil)
+        let text = UsageFormatter.resetLine(for: window, style: .absolute, now: now)
+        #expect(text?.hasPrefix("Resets at ") == true)
+    }
+
+    @Test
+    func resetAbsoluteDescriptionOmitsYear() {
+        let now = Date(timeIntervalSince1970: 1_785_000_000) // Jan 2026-ish
+        let sameDay = now.addingTimeInterval(3 * 3600)
+        let later = now.addingTimeInterval(15 * 24 * 3600)
+        let sameDayText = UsageFormatter.resetAbsoluteDescription(from: sameDay, now: now)
+        let laterText = UsageFormatter.resetAbsoluteDescription(from: later, now: now)
+        #expect(!sameDayText.contains("2026"))
+        #expect(!laterText.contains("2026"))
+    }
+
+    @Test
     func resetLineFallsBackToProvidedDescription() {
         let window = RateWindow(
             usedPercent: 0,

--- a/Tests/CodexBarTests/UsagePaceTextTests.swift
+++ b/Tests/CodexBarTests/UsagePaceTextTests.swift
@@ -50,6 +50,20 @@ struct UsagePaceTextTests {
     }
 
     @Test
+    func weeklyPaceDetail_usesAbsoluteResetStyle() {
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 50,
+            windowMinutes: 10080,
+            resetsAt: now.addingTimeInterval(4 * 24 * 3600),
+            resetDescription: nil)
+
+        let detail = UsagePaceText.weeklyDetail(provider: .codex, window: window, resetStyle: .absolute, now: now)
+
+        #expect(detail?.rightLabel?.hasPrefix("Runs out at ") == true)
+    }
+
+    @Test
     func weeklyPaceDetail_hidesWhenResetIsMissing() {
         let now = Date(timeIntervalSince1970: 0)
         let window = RateWindow(


### PR DESCRIPTION
## Summary
- Shorten absolute reset timestamps (time-only today, weekday+time within 7 days, month/day+time otherwise), including runs-out copy.
- Move the reset date/time toggle to Display → Menu content.
- Update tests + changelog.

## Testing
- `./Scripts/compile_and_run.sh`
- `swift test`

## Screenshots
- Not provided (text-only change).

## Notes
- `pnpm check` fails locally because `swiftformat`/`swiftlint` are not installed.

## Issue
- Closes #249
