### PR TITLE
Fix token account override being overwritten by config apiKey

### DIFF
--- a/Sources/CodexBar/ProviderRegistry.swift
+++ b/Sources/CodexBar/ProviderRegistry.swift
@@ -98,6 +98,7 @@ struct ProviderRegistry {
             settings: settings,
             override: tokenOverride)
         var env = base
+        // If token account is selected, use its token instead of config's apiKey
         if let account, let override = TokenAccountSupportCatalog.envOverride(
             for: provider,
             token: account.token)
@@ -105,6 +106,7 @@ struct ProviderRegistry {
             for (key, value) in override {
                 env[key] = value
             }
+            return env
         }
         return ProviderConfigEnvironment.applyAPIKeyOverride(
             base: env,

--- a/Sources/CodexBarCLI/TokenAccountCLI.swift
+++ b/Sources/CodexBarCLI/TokenAccountCLI.swift
@@ -185,12 +185,14 @@ struct TokenAccountCLIContext {
         account: ProviderTokenAccount?) -> [String: String]
     {
         var env = base
+        // If token account is selected, use its token instead of config's apiKey
         if let account,
            let override = TokenAccountSupportCatalog.envOverride(for: provider, token: account.token)
         {
             for (key, value) in override {
                 env[key] = value
             }
+            return env
         }
         let providerConfig = self.providerConfig(for: provider)
         env = ProviderConfigEnvironment.applyAPIKeyOverride(


### PR DESCRIPTION
## Summary

When a token account is selected, the environment override for the token was being applied first, but then `ProviderConfigEnvironment.applyAPIKeyOverride()` was called afterward, which would overwrite the token account's value with the config's root `apiKey`.

This caused issues when:
1. A user has both a root `apiKey` and token accounts configured
2. The root `apiKey` is invalid or doesn't have a plan
3. The token account's token is valid

The fix returns early after applying the token account override, preventing the config's `apiKey` from overwriting it.

## Changes
- `ProviderRegistry.makeEnvironment` (app): Return early after applying token account override
- `TokenAccountCLIContext.environment` (CLI): Same fix

## Test Plan
- [x] Tested with ZAI provider having both root `apiKey` (invalid) and token account (valid)
- [x] Before fix: Shows "Failed to parse z.ai response: Missing data"
- [x] After fix: Shows correct usage limits from token account