### PR TITLE
feat: make cost summary refresh interval configurable

### DIFF
--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -43,7 +43,7 @@ struct GeneralPane: View {
                                 .fixedSize(horizontal: false, vertical: true)
 
                             if self.settings.costUsageEnabled {
-                                Text("Auto-refresh: hourly · Timeout: 10m")
+                                Text("Auto-refresh: \(self.costRefreshLabel) · Timeout: 10m")
                                     .font(.footnote)
                                     .foregroundStyle(.tertiary)
 
@@ -112,6 +112,15 @@ struct GeneralPane: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 20)
             .padding(.vertical, 12)
+        }
+    }
+
+    private var costRefreshLabel: String {
+        switch self.settings.refreshFrequency {
+        case .manual:
+            return "off"
+        default:
+            return self.settings.refreshFrequency.label
         }
     }
 


### PR DESCRIPTION
Replace the hardcoded 1-hour (3600s) cost summary refresh interval with the user-configurable refresh cadence setting. The cost summary now refreshes on the same schedule as provider usage (1m, 2m, 5m, 15m, 30m).

Changes:
- Remove hardcoded tokenFetchTTL constant from UsageStore
- Update startTokenTimer() to use settings.refreshFrequency.seconds
- Restart token timer when settings change (like provider timer)
- Update UI text from "Auto-refresh: hourly" to show actual interval

Note: The CostUsageScanner already has internal 60-second caching, so no additional floor is needed at the app level.