### PR TITLE
Fix launch crash from missing SwiftPM resource bundle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -86,9 +86,6 @@ let package = Package(
                     "CodexBarCore",
                 ],
                 path: "Sources/CodexBar",
-                resources: [
-                    .process("Resources"),
-                ],
                 swiftSettings: [
                     // Opt into Swift 6 strict concurrency (approachable migration path).
                     .enableUpcomingFeature("StrictConcurrency"),

--- a/Sources/CodexBar/ProviderBrandIcon.swift
+++ b/Sources/CodexBar/ProviderBrandIcon.swift
@@ -4,26 +4,11 @@ import CodexBarCore
 enum ProviderBrandIcon {
     private static let size = NSSize(width: 16, height: 16)
 
-    /// Lazy-loaded resource bundle for provider icons.
-    private static let resourceBundle: Bundle? = {
-        // SwiftPM creates a CodexBar_CodexBar.bundle for resources in the CodexBar target.
-        if let bundleURL = Bundle.main.url(forResource: "CodexBar_CodexBar", withExtension: "bundle"),
-           let bundle = Bundle(url: bundleURL)
-        {
-            return bundle
-        }
-        // Fallback to main bundle for development/testing.
-        return Bundle.main
-    }()
-
     static func image(for provider: UsageProvider) -> NSImage? {
         let baseName = ProviderDescriptorRegistry.descriptor(for: provider).branding.iconResourceName
-        guard let bundle = self.resourceBundle,
-              let url = bundle.url(forResource: baseName, withExtension: "svg"),
+        guard let url = Bundle.main.url(forResource: baseName, withExtension: "svg"),
               let image = NSImage(contentsOf: url)
-        else {
-            return nil
-        }
+        else { return nil }
 
         image.size = self.size
         image.isTemplate = true


### PR DESCRIPTION
## Summary
- Avoid SwiftPM-generated resource bundle accessor for CodexBar to prevent launch-time crash.
- Load provider icons from the main app bundle resources.

## Commands
- brew install swiftformat swiftlint
- swiftformat Sources Tests
- swiftlint --strict
- ./Scripts/compile_and_run.sh

## Screenshots
- N/A (no UI changes)

## Issue
- N/A