### PR TITLE
Fix status overlay showing for disabled providers in merged mode

### DIFF
--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -226,7 +226,7 @@ extension StatusItemController {
         let tilt: CGFloat = style == .combined ? 0 : self.tiltAmount(for: primaryProvider) * .pi / 28
 
         let statusIndicator: ProviderStatusIndicator = {
-            for provider in UsageProvider.allCases {
+            for provider in self.store.enabledProviders() {
                 let indicator = self.store.statusIndicator(for: provider)
                 if indicator.hasIssue { return indicator }
             }


### PR DESCRIPTION
When Merge Icons and Check provider status are both enabled, the status overlay (white circle) was incorrectly appearing even when no enabled provider had issues. This happened because the code was iterating over all providers instead of just enabled ones.

Now only enabled providers are checked for status issues in merged mode.