### PR TITLE
fix(antigravity): display userTier.name instead of planInfo for plan display

### DIFF
--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -228,7 +228,8 @@ public struct AntigravityStatusProbe: Sendable {
         let modelConfigs = userStatus.cascadeModelConfigData?.clientModelConfigs ?? []
         let models = modelConfigs.compactMap(Self.quotaFromConfig(_:))
         let email = userStatus.email
-        let planName = userStatus.planStatus?.planInfo?.preferredName
+        // Prefer userTier.name (actual subscription tier) over planInfo (shows "Pro" for Ultra users)
+        let planName = userStatus.userTier?.name ?? userStatus.planStatus?.planInfo?.preferredName
 
         return AntigravityStatusSnapshot(
             modelQuotas: models,
@@ -586,6 +587,13 @@ private struct UserStatus: Decodable {
     let email: String?
     let planStatus: PlanStatus?
     let cascadeModelConfigData: ModelConfigData?
+    let userTier: UserTier?
+}
+
+private struct UserTier: Decodable {
+    let id: String?
+    let name: String?
+    let description: String?
 }
 
 private struct PlanStatus: Decodable {


### PR DESCRIPTION
## Summary

Fixes #216

The Antigravity API returns two plan identifiers:
- `planInfo.planName`: Shows "Pro" for all paid users  
- `userTier.name`: Shows actual subscription tier (e.g., "Google AI Ultra")

This change prefers `userTier.name` when available, falling back to `planInfo.preferredName` for backwards compatibility.

## Changes

1. Added `UserTier` struct to parse the `userTier` field from the API response
2. Updated plan name logic to prefer `userTier.name` over `planInfo.preferredName`

## Testing

- Users on Google AI Ultra will now see "Google AI Ultra" instead of "Pro"
- Users without `userTier` in their response will still fall back to `planInfo`