### PR TITLE
fix(claude): sync OAuth cache on keychain changes

### DIFF
--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -1251,7 +1251,9 @@ extension UsageStore {
                 ClaudeWebAPIFetcher.hasSessionKey(browserDetection: self.browserDetection) { msg in lines.append(msg) }
             }
             // Don't prompt for keychain access during debug dump
-            let hasOAuthCredentials = (try? ClaudeOAuthCredentialsStore.load(allowKeychainPrompt: false)) != nil
+            let hasOAuthCredentials = (try? ClaudeOAuthCredentialsStore.load(
+                allowKeychainPrompt: false,
+                respectKeychainPromptCooldown: true)) != nil
             let hasClaudeBinary = BinaryLocator.resolveClaudeBinary(
                 env: ProcessInfo.processInfo.environment,
                 loginPATH: LoginShellPathCache.shared.current) != nil

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -145,7 +145,8 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
         // - Claude Code has stored OAuth creds in Keychain and we may be able to bootstrap (one prompt max).
         if let creds = try? ClaudeOAuthCredentialsStore.load(
             environment: context.env,
-            allowKeychainPrompt: false)
+            allowKeychainPrompt: false,
+            respectKeychainPromptCooldown: true)
         {
             let hasRequiredScope = creds.scopes.contains("user:profile")
             if hasRequiredScope {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -230,7 +230,8 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         case .auto:
             let oauthCreds = try? ClaudeOAuthCredentialsStore.load(
                 environment: self.environment,
-                allowKeychainPrompt: false)
+                allowKeychainPrompt: false,
+                respectKeychainPromptCooldown: true)
             let hasOAuthCredentials = oauthCreds?.scopes.contains("user:profile") ?? false
             let hasWebSession =
                 if let header = self.manualCookieHeader {


### PR DESCRIPTION
Addresses the Claude OAuth cache/keychain mismatch case by re-detecting Claude keychain changes *non-interactively* on cache hits and syncing CodexBar's cached OAuth credentials when the access token changed.

- Adds a no-UI Claude keychain fingerprint + 60s throttle to avoid repeated keychain touches
- Respects the existing keychain prompt cooldown gate in Auto mode
- Syncs CodexBar's in-memory + keychain cache when Claude keychain token changes
- Adds focused unit tests for sync/no-sync behavior

Repro this fixes: create a newer `Claude Code-credentials` item with a different token; CodexBar used to keep serving `com.steipete.codexbar.cache` until expiry; now it syncs.

Commands run:
- swiftformat Sources Tests
- swiftlint --strict
- pnpm check
- ./Scripts/compile_and_run.sh
