### PR TITLE
Consider usageBarsShowUsed in smart menu updates

### DIFF
--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -120,9 +120,11 @@ extension StatusItemController {
 
         let hasTokenAccountSwitcher = menu.items.contains { $0.view is TokenAccountSwitcherView }
         let switcherProvidersMatch = enabledProviders == self.lastSwitcherProviders
+        let switcherUsageBarsShowUsedMatch = self.settings.usageBarsShowUsed == self.lastSwitcherUsageBarsShowUsed
         let canSmartUpdate = self.shouldMergeIcons &&
             enabledProviders.count > 1 &&
             switcherProvidersMatch &&
+            switcherUsageBarsShowUsedMatch &&
             tokenAccountDisplay == nil &&
             !hasTokenAccountSwitcher &&
             !menu.items.isEmpty &&
@@ -154,6 +156,7 @@ extension StatusItemController {
         // Track which providers the switcher was built with for smart update detection
         if self.shouldMergeIcons, enabledProviders.count > 1 {
             self.lastSwitcherProviders = enabledProviders
+            self.lastSwitcherUsageBarsShowUsed = self.settings.usageBarsShowUsed
         }
         self.addTokenAccountSwitcherIfNeeded(to: menu, display: tokenAccountDisplay)
         let menuContext = MenuCardContext(

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -81,6 +81,10 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     private var lastProviderOrder: [UsageProvider]
     private var lastMergeIcons: Bool
     private var lastSwitcherShowsIcons: Bool
+    private var lastObservedUsageBarsShowUsed: Bool
+    /// Tracks which `usageBarsShowUsed` mode the provider switcher was built with.
+    /// Used to decide whether we can "smart update" menu content without rebuilding the switcher.
+    var lastSwitcherUsageBarsShowUsed: Bool
     /// Tracks which providers the merged menu's switcher was built with, to detect when it needs full rebuild.
     var lastSwitcherProviders: [UsageProvider] = []
     let loginLogger = CodexBarLog.logger(LogCategories.login)
@@ -152,6 +156,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.lastProviderOrder = settings.providerOrder
         self.lastMergeIcons = settings.mergeIcons
         self.lastSwitcherShowsIcons = settings.switcherShowsIcons
+        self.lastObservedUsageBarsShowUsed = settings.usageBarsShowUsed
+        self.lastSwitcherUsageBarsShowUsed = settings.usageBarsShowUsed
         self.statusBar = statusBar
         let item = statusBar.statusItem(withLength: NSStatusItem.variableLength)
         // Ensure the icon is rendered at 1:1 without resampling (crisper edges for template images).
@@ -289,6 +295,11 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         let showsIcons = self.settings.switcherShowsIcons
         if showsIcons != self.lastSwitcherShowsIcons {
             self.lastSwitcherShowsIcons = showsIcons
+            shouldRefresh = true
+        }
+        let usageBarsShowUsed = self.settings.usageBarsShowUsed
+        if usageBarsShowUsed != self.lastObservedUsageBarsShowUsed {
+            self.lastObservedUsageBarsShowUsed = usageBarsShowUsed
             shouldRefresh = true
         }
         return shouldRefresh


### PR DESCRIPTION
Fix provider switcher progress to update immediately when “Show usage as used” changes by treating the setting as a switcher rebuild trigger. Split cached state between “last observed” and “switcher built with” to keep smart menu updates safe and avoid stale tab indicators.

Fixes #304 