### PR TITLE
Allow --source auto on Linux

### DIFF
--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -95,7 +95,7 @@ extension CodexBarCLI {
         }
 
         #if !os(macOS)
-        if parsedSourceMode?.usesWeb == true {
+        if parsedSourceMode == .web {
             Self.exit(
                 code: .failure,
                 message: "Error: --source web/auto is only supported on macOS.",
@@ -243,7 +243,7 @@ extension CodexBarCLI {
             account: account)
 
         #if !os(macOS)
-        if effectiveSourceMode.usesWeb {
+        if effectiveSourceMode == .web {
             return Self.webSourceUnsupportedOutput(
                 provider: provider,
                 account: account,

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -13,7 +13,7 @@ public enum ProviderSourceMode: String, CaseIterable, Sendable, Codable {
     case api
 
     public var usesWeb: Bool {
-        self == .auto || self == .web
+        self == .web
     }
 }
 

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -13,7 +13,7 @@ public enum ProviderSourceMode: String, CaseIterable, Sendable, Codable {
     case api
 
     public var usesWeb: Bool {
-        self == .web
+        self == .auto || self == .web
     }
 }
 

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -124,4 +124,13 @@ struct CLIEntryTests {
         #expect(!CodexBarCLI.shouldUseColor(noColor: true, format: .text))
         #expect(!CodexBarCLI.shouldUseColor(noColor: false, format: .json))
     }
+
+    #if !os(macOS)
+    @Test
+    func sourceModeUsesWebOnlyForWeb() {
+        #expect(ProviderSourceMode.web.usesWeb)
+        #expect(!ProviderSourceMode.auto.usesWeb)
+        #expect(!ProviderSourceMode.api.usesWeb)
+    }
+    #endif
 }

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -127,9 +127,9 @@ struct CLIEntryTests {
 
     #if !os(macOS)
     @Test
-    func sourceModeUsesWebOnlyForWeb() {
+    func sourceModeUsesWebIncludesAuto() {
         #expect(ProviderSourceMode.web.usesWeb)
-        #expect(!ProviderSourceMode.auto.usesWeb)
+        #expect(ProviderSourceMode.auto.usesWeb)
         #expect(!ProviderSourceMode.api.usesWeb)
     }
     #endif

--- a/docs/kimi.md
+++ b/docs/kimi.md
@@ -16,10 +16,11 @@ Tracks usage for [Kimi For Coding](https://www.kimi.com/code) in CodexBar.
 - Shows current 5-hour rate limit usage
 - Automatic and manual authentication methods
 - Automatic refresh countdown
+- Headless-friendly auth via env var (no GUI required)
 
 ## Setup
 
-Choose one of two authentication methods:
+Choose one of the authentication methods:
 
 ### Method 1: Automatic Browser Import (Recommended)
 
@@ -50,6 +51,15 @@ Alternatively, set the `KIMI_AUTH_TOKEN` environment variable:
 
 ```bash
 export KIMI_AUTH_TOKEN="jwt-token-here"
+```
+
+This is the recommended approach for CLI/headless usage.
+
+With `KIMI_AUTH_TOKEN` set, the default `codexbar usage --provider kimi` (`--source auto`) will fetch usage via Kimi's HTTP endpoint.
+
+```bash
+export KIMI_AUTH_TOKEN="<paste kimi-auth cookie here>"
+codexbar usage --provider kimi
 ```
 
 ## Authentication Priority


### PR DESCRIPTION
## What
- Treat `--source auto` as non-web so Linux doesn’t error out by default.
- Keep `--source web` macOS-only behavior unchanged.
- Add a small non-macOS test for `ProviderSourceMode.usesWeb`.
- Document Kimi CLI usage with `KIMI_AUTH_TOKEN` (auto mode).

## Why
On Linux, the CLI defaults to `--source auto`, but it was gated as a web-only mode and aborted before providers could use env/api/cli strategies (e.g., Kimi via `KIMI_AUTH_TOKEN`).

## Testing
- `swift test`