### PR TITLE
Fix session conflicts: clear stale cache and detect login redirects (#323)

### DIFF
--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
@@ -261,6 +261,9 @@ public struct AmpUsageFetcher: Sendable {
             if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
                 throw AmpUsageError.invalidCredentials
             }
+            if diagnostics.detectedLoginRedirect {
+                throw AmpUsageError.invalidCredentials
+            }
             throw AmpUsageError.networkError("HTTP \(httpResponse.statusCode)")
         }
 
@@ -277,6 +280,7 @@ public struct AmpUsageFetcher: Sendable {
         private let cookieHeader: String
         private let logger: ((String) -> Void)?
         var redirects: [String] = []
+        private(set) var detectedLoginRedirect = false
 
         init(cookieHeader: String, logger: ((String) -> Void)?) {
             self.cookieHeader = cookieHeader
@@ -299,6 +303,7 @@ public struct AmpUsageFetcher: Sendable {
                 if let logger {
                     logger("[amp] Detected login redirect, aborting (invalid session)")
                 }
+                self.detectedLoginRedirect = true
                 completionHandler(nil)
                 return
             }

--- a/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
@@ -651,6 +651,7 @@ public struct FactoryStatusProbe: Sendable {
             } catch {
                 if case FactoryStatusProbeError.notLoggedIn = error {
                     CookieHeaderCache.clear(provider: .factory)
+                    await FactorySessionStore.shared.clearSession()
                 }
                 lastError = error
             }


### PR DESCRIPTION
## Summary

This PR fixes session-related edge cases that caused stale account data and redirect loops.

- **Factory**: Clears `FactorySessionStore` when cached cookie headers fail authentication (401/403), ensuring account changes are reflected correctly.
- **Amp**: Detects login-page redirects in `RedirectDiagnostics` and aborts early, preventing infinite redirect loops when sessions are invalid.

## Root cause

Cached session data was not cleared when authentication failed, allowing stale account state to persist.
Additionally, Amp login redirects were not recognized as terminal failures, leading to repeated redirects.

## Test plan

- [ ] Factory: Log in with Account A, then Account B in the browser. Refresh CodexBar and verify Account B is shown.
- [ ] Amp: Clear browser session cookies and confirm CodexBar shows a clear error instead of entering a redirect loop.

Fixes #323
