### PR TITLE
fix: make assignedDate and quotaResetDate optional in CopilotUsageModels

### DIFF
--- a/Sources/CodexBarCore/CopilotUsageModels.swift
+++ b/Sources/CodexBarCore/CopilotUsageModels.swift
@@ -27,8 +27,8 @@ public struct CopilotUsageResponse: Sendable, Decodable {
 
     public let quotaSnapshots: QuotaSnapshots
     public let copilotPlan: String
-    public let assignedDate: String
-    public let quotaResetDate: String
+    public let assignedDate: String?
+    public let quotaResetDate: String?
 
     private enum CodingKeys: String, CodingKey {
         case quotaSnapshots = "quota_snapshots"


### PR DESCRIPTION
## Problem

The Copilot tab in CodexBar shows **"The data couldn't be read because it is missing"** for users on trial/free Copilot plans.

## Root Cause

GitHub's `/copilot_internal/user` API returns `null` for `assigned_date` and `quota_reset_date` fields on trial/free plans. However, `CopilotUsageModels.swift` declares these as non-optional `String`, causing a `DecodingError.valueNotFound` during JSON decoding.

## Fix

Change `assignedDate: String` to `String?` and `quotaResetDate: String` to `String?` to handle null values gracefully.

## Testing

Verified locally with a GitHub Copilot Individual (trial) account. Copilot usage now displays correctly:

```
== Copilot (api) ==
Premium: 80% left [=========---]
Chat: 100% left [============]
Plan: Individual
```

Fixes #162
