### PR TITLE
Build universal binary by default for Intel Mac support

### DIFF
--- a/Scripts/compile_and_run.sh
+++ b/Scripts/compile_and_run.sh
@@ -195,8 +195,8 @@ fi
 if [[ "${DEBUG_LLDB}" == "1" && -n "${RELEASE_ARCHES}" ]]; then
   fail "--release-arches is only supported for release packaging"
 fi
-HOST_ARCH="$(uname -m)"
-ARCHES_VALUE="${HOST_ARCH}"
+# Build universal binary by default (arm64 + x86_64)
+ARCHES_VALUE="arm64 x86_64"
 if [[ -n "${RELEASE_ARCHES}" ]]; then
   ARCHES_VALUE="${RELEASE_ARCHES}"
 fi

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -23,15 +23,10 @@ if [[ "${CODEXBAR_FORCE_CLEAN:-0}" == "1" ]]; then
   swift package clean >/dev/null 2>&1 || true
 fi
 
-# Build for host architecture by default; allow overriding via ARCHES (e.g., "arm64 x86_64" for universal).
+# Build universal binary by default (arm64 + x86_64); allow overriding via ARCHES.
 ARCH_LIST=( ${ARCHES:-} )
 if [[ ${#ARCH_LIST[@]} -eq 0 ]]; then
-  HOST_ARCH=$(uname -m)
-  case "$HOST_ARCH" in
-    arm64) ARCH_LIST=(arm64) ;;
-    x86_64) ARCH_LIST=(x86_64) ;;
-    *) ARCH_LIST=("$HOST_ARCH") ;;
-  esac
+  ARCH_LIST=(arm64 x86_64)
 fi
 
 patch_keyboard_shortcuts() {


### PR DESCRIPTION
Body:
 Summary
Changes the default build behavior to create universal binaries (arm64 + x86_64) instead of host-architecture-only builds, enabling Intel Mac support out of the box.
 Changes
- Modified `Scripts/package_app.sh`: Default `ARCH_LIST` to `arm64 x86_64` instead of host architecture detection
- Modified `Scripts/compile_and_run.sh`: Default `ARCHES_VALUE` to "arm64 x86_64" instead of `uname -m`
 Why
Previously, the build scripts only compiled for the host architecture, which meant:
- Building on Apple Silicon Macs produced arm64-only binaries
- Building on Intel Macs produced x86_64-only binaries
This change ensures that both architectures are always included in the build, making the app work on both Intel and Apple Silicon Macs regardless of where it was built.
 Backward Compatibility
Users can still override this behavior via the `ARCHES` environment variable:
ARCHES="arm64" ./Scripts/package_app.sh      # Apple Silicon only
ARCHES="x86_64" ./Scripts/package_app.sh     # Intel only
Testing
- Verified that lipo -archs CodexBar.app/Contents/MacOS/CodexBar outputs: x86_64 arm64
- Build completes successfully with ./Scripts/compile_and_run.sh