### PR TITLE
Port CodexBar usage display scaffold to iOS + WidgetKit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,10 @@ let package = Package(
     platforms: [
         .macOS(.v14),
     ],
+    products: [
+        .library(name: "CodexBarCore", targets: ["CodexBarCore"]),
+        .library(name: "CodexBariOSShared", targets: ["CodexBariOSShared"]),
+    ],
     dependencies: [
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.8.1"),
         .package(url: "https://github.com/steipete/Commander", from: "0.2.1"),
@@ -48,6 +52,13 @@ let package = Package(
                 dependencies: [
                     "CodexBarMacros",
                 ]),
+            .target(
+                name: "CodexBariOSShared",
+                dependencies: [],
+                path: "Sources/CodexBariOSShared",
+                swiftSettings: [
+                    .enableUpcomingFeature("StrictConcurrency"),
+                ]),
             .executableTarget(
                 name: "CodexBarCLI",
                 dependencies: [
@@ -60,7 +71,7 @@ let package = Package(
                 ]),
             .testTarget(
                 name: "CodexBarLinuxTests",
-                dependencies: ["CodexBarCore", "CodexBarCLI"],
+                dependencies: ["CodexBarCore", "CodexBarCLI", "CodexBariOSShared"],
                 path: "TestsLinux",
                 swiftSettings: [
                     .enableUpcomingFeature("StrictConcurrency"),

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Wondering if CodexBar scans your disk? It doesn’t crawl your filesystem; it re
 - Status polling: [docs/status.md](docs/status.md)
 - Sparkle updates: [docs/sparkle.md](docs/sparkle.md)
 - Release checklist: [docs/RELEASING.md](docs/RELEASING.md)
+- iOS app/widget scaffold: [ios/README.md](ios/README.md)
 
 ## Getting started (dev)
 - Clone the repo and open it in Xcode or run the scripts directly.

--- a/Sources/CodexBariOSShared/iOSWidgetSnapshot.swift
+++ b/Sources/CodexBariOSShared/iOSWidgetSnapshot.swift
@@ -1,0 +1,297 @@
+import Foundation
+
+public struct iOSWidgetSnapshot: Codable, Equatable, Sendable {
+    public struct ProviderEntry: Codable, Equatable, Sendable {
+        public let providerID: String
+        public let updatedAt: Date
+        public let primary: RateWindow?
+        public let secondary: RateWindow?
+        public let tertiary: RateWindow?
+        public let creditsRemaining: Double?
+        public let codeReviewRemainingPercent: Double?
+        public let tokenUsage: TokenUsageSummary?
+        public let dailyUsage: [DailyUsagePoint]
+
+        public init(
+            providerID: String,
+            updatedAt: Date,
+            primary: RateWindow?,
+            secondary: RateWindow?,
+            tertiary: RateWindow?,
+            creditsRemaining: Double?,
+            codeReviewRemainingPercent: Double?,
+            tokenUsage: TokenUsageSummary?,
+            dailyUsage: [DailyUsagePoint])
+        {
+            self.providerID = providerID
+            self.updatedAt = updatedAt
+            self.primary = primary
+            self.secondary = secondary
+            self.tertiary = tertiary
+            self.creditsRemaining = creditsRemaining
+            self.codeReviewRemainingPercent = codeReviewRemainingPercent
+            self.tokenUsage = tokenUsage
+            self.dailyUsage = dailyUsage
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case providerID = "provider"
+            case updatedAt
+            case primary
+            case secondary
+            case tertiary
+            case creditsRemaining
+            case codeReviewRemainingPercent
+            case tokenUsage
+            case dailyUsage
+        }
+    }
+
+    public struct RateWindow: Codable, Equatable, Sendable {
+        public let usedPercent: Double
+        public let windowMinutes: Int?
+        public let resetsAt: Date?
+        public let resetDescription: String?
+
+        public init(usedPercent: Double, windowMinutes: Int?, resetsAt: Date?, resetDescription: String?) {
+            self.usedPercent = usedPercent
+            self.windowMinutes = windowMinutes
+            self.resetsAt = resetsAt
+            self.resetDescription = resetDescription
+        }
+
+        public var remainingPercent: Double {
+            max(0, 100 - self.usedPercent)
+        }
+    }
+
+    public struct TokenUsageSummary: Codable, Equatable, Sendable {
+        public let sessionCostUSD: Double?
+        public let sessionTokens: Int?
+        public let last30DaysCostUSD: Double?
+        public let last30DaysTokens: Int?
+
+        public init(
+            sessionCostUSD: Double?,
+            sessionTokens: Int?,
+            last30DaysCostUSD: Double?,
+            last30DaysTokens: Int?)
+        {
+            self.sessionCostUSD = sessionCostUSD
+            self.sessionTokens = sessionTokens
+            self.last30DaysCostUSD = last30DaysCostUSD
+            self.last30DaysTokens = last30DaysTokens
+        }
+    }
+
+    public struct DailyUsagePoint: Codable, Equatable, Sendable {
+        public let dayKey: String
+        public let totalTokens: Int?
+        public let costUSD: Double?
+
+        public init(dayKey: String, totalTokens: Int?, costUSD: Double?) {
+            self.dayKey = dayKey
+            self.totalTokens = totalTokens
+            self.costUSD = costUSD
+        }
+    }
+
+    public struct ProviderSummary: Equatable, Sendable {
+        public let providerID: String
+        public let displayName: String
+        public let updatedAt: Date
+        public let sessionRemainingPercent: Double?
+        public let weeklyRemainingPercent: Double?
+        public let creditsRemaining: Double?
+        public let codeReviewRemainingPercent: Double?
+        public let todayCostUSD: Double?
+        public let last30DaysCostUSD: Double?
+        public let todayTokens: Int?
+        public let last30DaysTokens: Int?
+    }
+
+    public let entries: [ProviderEntry]
+    public let enabledProviderIDs: [String]
+    public let generatedAt: Date
+
+    public init(entries: [ProviderEntry], enabledProviderIDs: [String], generatedAt: Date) {
+        self.entries = entries
+        self.enabledProviderIDs = enabledProviderIDs
+        self.generatedAt = generatedAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case entries
+        case enabledProviderIDs = "enabledProviders"
+        case generatedAt
+    }
+
+    public var providerSummaries: [ProviderSummary] {
+        self.entries.map { entry in
+            ProviderSummary(
+                providerID: entry.providerID,
+                displayName: iOSProviderCatalog.displayName(for: entry.providerID),
+                updatedAt: entry.updatedAt,
+                sessionRemainingPercent: entry.primary?.remainingPercent,
+                weeklyRemainingPercent: entry.secondary?.remainingPercent,
+                creditsRemaining: entry.creditsRemaining,
+                codeReviewRemainingPercent: entry.codeReviewRemainingPercent,
+                todayCostUSD: entry.tokenUsage?.sessionCostUSD,
+                last30DaysCostUSD: entry.tokenUsage?.last30DaysCostUSD,
+                todayTokens: entry.tokenUsage?.sessionTokens,
+                last30DaysTokens: entry.tokenUsage?.last30DaysTokens)
+        }
+    }
+
+    public var availableProviderIDs: [String] {
+        let source = self.enabledProviderIDs.isEmpty ? self.entries.map(\.providerID) : self.enabledProviderIDs
+        var seen: Set<String> = []
+        return source.filter { seen.insert($0).inserted }
+    }
+
+    public func selectedProviderID(preferred: String?) -> String? {
+        let available = self.availableProviderIDs
+        guard !available.isEmpty else { return nil }
+        if let preferred, available.contains(preferred) {
+            return preferred
+        }
+        return available.first
+    }
+
+    public static func decode(from data: Data) throws -> iOSWidgetSnapshot {
+        try self.decoder.decode(iOSWidgetSnapshot.self, from: data)
+    }
+
+    public func encode() throws -> Data {
+        try Self.encoder.encode(self)
+    }
+
+    private static var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    private static var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}
+
+public enum iOSWidgetSnapshotStore {
+    public static let appGroupID = "group.com.steipete.codexbar"
+    private static let filename = "widget-snapshot.json"
+    private static let selectedProviderKey = "widgetSelectedProvider"
+
+    public static func load(bundleID: String? = Bundle.main.bundleIdentifier) -> iOSWidgetSnapshot? {
+        guard let url = self.snapshotURL(bundleID: bundleID) else { return nil }
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? iOSWidgetSnapshot.decode(from: data)
+    }
+
+    public static func save(_ snapshot: iOSWidgetSnapshot, bundleID: String? = Bundle.main.bundleIdentifier) {
+        guard let url = self.snapshotURL(bundleID: bundleID) else { return }
+        guard let data = try? snapshot.encode() else { return }
+        try? data.write(to: url, options: [.atomic])
+    }
+
+    public static func loadSelectedProviderID(bundleID: String? = Bundle.main.bundleIdentifier) -> String? {
+        guard let defaults = self.sharedDefaults(bundleID: bundleID) else { return nil }
+        return defaults.string(forKey: self.selectedProviderKey)
+    }
+
+    public static func saveSelectedProviderID(_ providerID: String, bundleID: String? = Bundle.main.bundleIdentifier) {
+        guard let defaults = self.sharedDefaults(bundleID: bundleID) else { return }
+        defaults.set(providerID, forKey: self.selectedProviderKey)
+    }
+
+    private static func sharedDefaults(bundleID: String?) -> UserDefaults? {
+        guard let groupID = self.groupID(for: bundleID) else { return nil }
+        return UserDefaults(suiteName: groupID)
+    }
+
+    private static func snapshotURL(bundleID: String?) -> URL? {
+        let fm = FileManager.default
+        if let groupID = self.groupID(for: bundleID),
+           let container = fm.containerURL(forSecurityApplicationGroupIdentifier: groupID)
+        {
+            return container.appendingPathComponent(self.filename, isDirectory: false)
+        }
+
+        let base = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fm.temporaryDirectory
+        let dir = base.appendingPathComponent("CodexBar", isDirectory: true)
+        try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent(self.filename, isDirectory: false)
+    }
+
+    private static func groupID(for bundleID: String?) -> String? {
+        guard let bundleID, !bundleID.isEmpty else { return self.appGroupID }
+        if bundleID.contains(".debug") {
+            return "group.com.steipete.codexbar.debug"
+        }
+        return self.appGroupID
+    }
+}
+
+public enum iOSProviderCatalog {
+    public static func displayName(for providerID: String) -> String {
+        self.metadata[providerID] ?? providerID.capitalized
+    }
+
+    private static let metadata: [String: String] = [
+        "codex": "Codex",
+        "claude": "Claude",
+        "gemini": "Gemini",
+        "antigravity": "Antigravity",
+        "cursor": "Cursor",
+        "opencode": "OpenCode",
+        "zai": "z.ai",
+        "factory": "Droid",
+        "copilot": "Copilot",
+        "minimax": "MiniMax",
+        "vertexai": "Vertex AI",
+        "kiro": "Kiro",
+        "augment": "Augment",
+        "jetbrains": "JetBrains",
+        "kimi": "Kimi",
+        "kimik2": "Kimi K2",
+        "amp": "Amp",
+        "synthetic": "Synthetic",
+    ]
+}
+
+public enum iOSWidgetPreviewData {
+    public static func snapshot() -> iOSWidgetSnapshot {
+        iOSWidgetSnapshot(
+            entries: [
+                .init(
+                    providerID: "codex",
+                    updatedAt: Date(),
+                    primary: .init(usedPercent: 32, windowMinutes: 300, resetsAt: nil, resetDescription: "Resets in 3h"),
+                    secondary: .init(
+                        usedPercent: 58,
+                        windowMinutes: 10_080,
+                        resetsAt: nil,
+                        resetDescription: "Resets in 4d"),
+                    tertiary: nil,
+                    creditsRemaining: 1243.4,
+                    codeReviewRemainingPercent: 77,
+                    tokenUsage: .init(
+                        sessionCostUSD: 12.4,
+                        sessionTokens: 420_000,
+                        last30DaysCostUSD: 923.8,
+                        last30DaysTokens: 12_400_000),
+                    dailyUsage: [
+                        .init(dayKey: "2026-02-02", totalTokens: 120_000, costUSD: 15.2),
+                        .init(dayKey: "2026-02-03", totalTokens: 80_000, costUSD: 10.1),
+                        .init(dayKey: "2026-02-04", totalTokens: 140_000, costUSD: 17.9),
+                        .init(dayKey: "2026-02-05", totalTokens: 90_000, costUSD: 11.4),
+                        .init(dayKey: "2026-02-06", totalTokens: 160_000, costUSD: 19.8),
+                    ]),
+            ],
+            enabledProviderIDs: ["codex"],
+            generatedAt: Date())
+    }
+}

--- a/TestsLinux/iOSWidgetSnapshotTests.swift
+++ b/TestsLinux/iOSWidgetSnapshotTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import CodexBariOSShared
+
+@Suite
+struct iOSWidgetSnapshotTests {
+    @Test
+    func decodeSnapshotAndComputeSummaries() throws {
+        let json = """
+        {
+          "entries": [
+            {
+              "provider": "codex",
+              "updatedAt": "2026-02-08T12:00:00Z",
+              "primary": {"usedPercent": 25, "windowMinutes": 300, "resetsAt": null, "resetDescription": "Resets in 3h"},
+              "secondary": {"usedPercent": 50, "windowMinutes": 10080, "resetsAt": null, "resetDescription": "Resets in 4d"},
+              "tertiary": null,
+              "creditsRemaining": 123.4,
+              "codeReviewRemainingPercent": 80,
+              "tokenUsage": {"sessionCostUSD": 1.2, "sessionTokens": 1200, "last30DaysCostUSD": 45.6, "last30DaysTokens": 32000},
+              "dailyUsage": []
+            }
+          ],
+          "enabledProviders": ["codex"],
+          "generatedAt": "2026-02-08T12:00:00Z"
+        }
+        """
+
+        let data = try #require(json.data(using: .utf8))
+        let snapshot = try iOSWidgetSnapshot.decode(from: data)
+        let summaries = snapshot.providerSummaries
+
+        #expect(summaries.count == 1)
+        #expect(summaries[0].providerID == "codex")
+        #expect(summaries[0].sessionRemainingPercent == 75)
+        #expect(summaries[0].weeklyRemainingPercent == 50)
+        #expect(summaries[0].creditsRemaining == 123.4)
+    }
+
+    @Test
+    func selectedProviderFallsBackToFirstAvailable() {
+        let snapshot = iOSWidgetSnapshot(
+            entries: [
+                .init(
+                    providerID: "claude",
+                    updatedAt: Date(),
+                    primary: nil,
+                    secondary: nil,
+                    tertiary: nil,
+                    creditsRemaining: nil,
+                    codeReviewRemainingPercent: nil,
+                    tokenUsage: nil,
+                    dailyUsage: []),
+            ],
+            enabledProviderIDs: ["claude"],
+            generatedAt: Date())
+
+        let selected = snapshot.selectedProviderID(preferred: "codex")
+        #expect(selected == "claude")
+    }
+}

--- a/ios/CodexBariOSApp/CodexBariOSApp.entitlements
+++ b/ios/CodexBariOSApp/CodexBariOSApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.steipete.codexbar</string>
+    </array>
+</dict>
+</plist>

--- a/ios/CodexBariOSApp/Info.plist
+++ b/ios/CodexBariOSApp/Info.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>CodexBar</string>
+    <key>UIApplicationSceneManifest</key>
+    <dict>
+        <key>UIApplicationSupportsMultipleScenes</key>
+        <false/>
+    </dict>
+    <key>UILaunchScreen</key>
+    <dict/>
+</dict>
+</plist>

--- a/ios/CodexBariOSApp/Sources/CodexBariOSApp.swift
+++ b/ios/CodexBariOSApp/Sources/CodexBariOSApp.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+@main
+struct CodexBariOSApp: App {
+    @State private var viewModel = UsageDashboardViewModel()
+
+    var body: some Scene {
+        WindowGroup {
+            UsageDashboardView(viewModel: self.viewModel)
+        }
+    }
+}

--- a/ios/CodexBariOSApp/Sources/UsageDashboardView.swift
+++ b/ios/CodexBariOSApp/Sources/UsageDashboardView.swift
@@ -1,0 +1,223 @@
+import CodexBariOSShared
+import SwiftUI
+
+struct UsageDashboardView: View {
+    @Bindable var viewModel: UsageDashboardViewModel
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if let snapshot = self.viewModel.snapshot,
+                   let summary = self.viewModel.selectedSummary
+                {
+                    self.snapshotContent(snapshot: snapshot, summary: summary)
+                } else {
+                    self.emptyState
+                }
+            }
+            .navigationTitle("CodexBar")
+            .toolbar {
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    Button("Import JSON") {
+                        self.viewModel.showingImportSheet = true
+                    }
+                    Button("Refresh") {
+                        self.viewModel.loadSnapshot()
+                    }
+                }
+            }
+        }
+        .sheet(isPresented: self.$viewModel.showingImportSheet) {
+            SnapshotImportSheet(viewModel: self.viewModel)
+        }
+        .task {
+            self.viewModel.loadSnapshot()
+        }
+    }
+
+    private func snapshotContent(
+        snapshot: iOSWidgetSnapshot,
+        summary: iOSWidgetSnapshot.ProviderSummary) -> some View
+    {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                let available = snapshot.availableProviderIDs
+                if available.count > 1 {
+                    Picker("Provider", selection: Binding(
+                        get: { self.viewModel.selectedProviderID ?? available.first ?? summary.providerID },
+                        set: { self.viewModel.selectProvider($0) }))
+                    {
+                        ForEach(available, id: \.self) { providerID in
+                            Text(iOSProviderCatalog.displayName(for: providerID))
+                                .tag(providerID)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text(summary.displayName)
+                        .font(.title2.weight(.semibold))
+                    Text("Updated \(Self.relativeDate(summary.updatedAt))")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+
+                    UsageBarRow(title: "Session", percentLeft: summary.sessionRemainingPercent, tint: .teal)
+                    UsageBarRow(title: "Weekly", percentLeft: summary.weeklyRemainingPercent, tint: .orange)
+
+                    if let codeReview = summary.codeReviewRemainingPercent {
+                        UsageBarRow(title: "Code review", percentLeft: codeReview, tint: .blue)
+                    }
+
+                    Divider()
+
+                    ValueRow(title: "Credits", value: summary.creditsRemaining.map(Self.decimal) ?? "—")
+                    ValueRow(title: "Today cost", value: summary.todayCostUSD.map(Self.usd) ?? "—")
+                    ValueRow(title: "30d cost", value: summary.last30DaysCostUSD.map(Self.usd) ?? "—")
+                    ValueRow(
+                        title: "Today tokens",
+                        value: summary.todayTokens.map(Self.integer) ?? "—")
+                    ValueRow(
+                        title: "30d tokens",
+                        value: summary.last30DaysTokens.map(Self.integer) ?? "—")
+                }
+                .padding(16)
+                .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 14))
+            }
+            .padding()
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Text("No usage snapshot yet")
+                .font(.headline)
+            Text("Import `widget-snapshot.json` or load sample data to preview iOS cards and widgets.")
+                .font(.subheadline)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+            Button("Load Sample Data") {
+                self.viewModel.loadSampleData()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding(24)
+    }
+
+    private static func relativeDate(_ value: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        return formatter.localizedString(for: value, relativeTo: Date())
+    }
+
+    private static func usd(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = "USD"
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: value)) ?? String(format: "$%.2f", value)
+    }
+
+    private static func decimal(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.2f", value)
+    }
+
+    private static func integer(_ value: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+}
+
+private struct UsageBarRow: View {
+    let title: String
+    let percentLeft: Double?
+    let tint: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(self.title)
+                    .font(.footnote.weight(.medium))
+                Spacer()
+                Text(self.percentLeft.map { String(format: "%.0f%%", $0) } ?? "—")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            GeometryReader { proxy in
+                let ratio = max(0, min(100, self.percentLeft ?? 0)) / 100
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.primary.opacity(0.12))
+                    Capsule().fill(self.tint).frame(width: proxy.size.width * ratio)
+                }
+            }
+            .frame(height: 7)
+        }
+    }
+}
+
+private struct ValueRow: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(self.title)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(self.value)
+                .font(.subheadline.weight(.medium))
+        }
+    }
+}
+
+private struct SnapshotImportSheet: View {
+    @Bindable var viewModel: UsageDashboardViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Paste snapshot JSON")
+                    .font(.headline)
+                Text("Expected format is `widget-snapshot.json` from CodexBar.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                TextEditor(text: self.$viewModel.importJSON)
+                    .font(.system(.footnote, design: .monospaced))
+                    .frame(minHeight: 260)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(.quaternary, lineWidth: 1))
+                if let error = self.viewModel.importErrorMessage {
+                    Text(error)
+                        .font(.footnote)
+                        .foregroundStyle(.red)
+                }
+                Spacer()
+            }
+            .padding()
+            .navigationTitle("Import")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") {
+                        self.dismiss()
+                    }
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Save") {
+                        self.viewModel.importSnapshotFromJSON()
+                    }
+                    .fontWeight(.semibold)
+                }
+            }
+        }
+    }
+}

--- a/ios/CodexBariOSApp/Sources/UsageDashboardViewModel.swift
+++ b/ios/CodexBariOSApp/Sources/UsageDashboardViewModel.swift
@@ -1,0 +1,58 @@
+import CodexBariOSShared
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class UsageDashboardViewModel {
+    var snapshot: iOSWidgetSnapshot?
+    var selectedProviderID: String?
+    var importJSON = ""
+    var importErrorMessage: String?
+    var showingImportSheet = false
+
+    var selectedSummary: iOSWidgetSnapshot.ProviderSummary? {
+        guard let snapshot else { return nil }
+        let selected = snapshot.selectedProviderID(preferred: self.selectedProviderID)
+        return snapshot.providerSummaries.first { $0.providerID == selected }
+    }
+
+    func loadSnapshot() {
+        let snapshot = iOSWidgetSnapshotStore.load()
+        let storedProvider = iOSWidgetSnapshotStore.loadSelectedProviderID()
+        self.snapshot = snapshot
+        self.selectedProviderID = snapshot?.selectedProviderID(preferred: storedProvider ?? self.selectedProviderID)
+        self.importErrorMessage = nil
+    }
+
+    func loadSampleData() {
+        let sample = iOSWidgetPreviewData.snapshot()
+        iOSWidgetSnapshotStore.save(sample)
+        self.snapshot = sample
+        self.selectedProviderID = sample.selectedProviderID(preferred: self.selectedProviderID)
+        self.importErrorMessage = nil
+    }
+
+    func selectProvider(_ providerID: String) {
+        self.selectedProviderID = providerID
+        iOSWidgetSnapshotStore.saveSelectedProviderID(providerID)
+    }
+
+    func importSnapshotFromJSON() {
+        guard let data = self.importJSON.data(using: .utf8) else {
+            self.importErrorMessage = "Could not parse pasted text as UTF-8."
+            return
+        }
+        do {
+            let snapshot = try iOSWidgetSnapshot.decode(from: data)
+            iOSWidgetSnapshotStore.save(snapshot)
+            self.snapshot = snapshot
+            self.selectedProviderID = snapshot.selectedProviderID(preferred: self.selectedProviderID)
+            self.importErrorMessage = nil
+            self.showingImportSheet = false
+            self.importJSON = ""
+        } catch {
+            self.importErrorMessage = "Invalid snapshot JSON: \(error.localizedDescription)"
+        }
+    }
+}

--- a/ios/CodexBariOSWidget/CodexBariOSWidget.entitlements
+++ b/ios/CodexBariOSWidget/CodexBariOSWidget.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.application-groups</key>
+    <array>
+        <string>group.com.steipete.codexbar</string>
+    </array>
+</dict>
+</plist>

--- a/ios/CodexBariOSWidget/Info.plist
+++ b/ios/CodexBariOSWidget/Info.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDisplayName</key>
+    <string>CodexBar Widget</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.widgetkit-extension</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>$(PRODUCT_MODULE_NAME).CodexBariOSWidgetBundle</string>
+    </dict>
+</dict>
+</plist>

--- a/ios/CodexBariOSWidget/Sources/CodexBariOSWidget.swift
+++ b/ios/CodexBariOSWidget/Sources/CodexBariOSWidget.swift
@@ -1,0 +1,228 @@
+import AppIntents
+import CodexBariOSShared
+import SwiftUI
+import WidgetKit
+
+enum ProviderChoice: String, AppEnum {
+    case codex
+    case claude
+    case gemini
+    case cursor
+    case copilot
+    case minimax
+    case opencode
+    case zai
+
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Provider")
+
+    static let caseDisplayRepresentations: [ProviderChoice: DisplayRepresentation] = [
+        .codex: .init(title: "Codex"),
+        .claude: .init(title: "Claude"),
+        .gemini: .init(title: "Gemini"),
+        .cursor: .init(title: "Cursor"),
+        .copilot: .init(title: "Copilot"),
+        .minimax: .init(title: "MiniMax"),
+        .opencode: .init(title: "OpenCode"),
+        .zai: .init(title: "z.ai"),
+    ]
+}
+
+struct ProviderSelectionIntent: AppIntent, WidgetConfigurationIntent {
+    static let title: LocalizedStringResource = "Provider"
+    static let description = IntentDescription("Select which provider appears in the widget.")
+
+    @Parameter(title: "Provider")
+    var provider: ProviderChoice
+
+    init() {
+        self.provider = .codex
+    }
+}
+
+struct CodexBariOSWidgetEntry: TimelineEntry {
+    let date: Date
+    let providerID: String
+    let snapshot: iOSWidgetSnapshot
+}
+
+struct CodexBariOSWidgetTimelineProvider: AppIntentTimelineProvider {
+    func placeholder(in _: Context) -> CodexBariOSWidgetEntry {
+        CodexBariOSWidgetEntry(
+            date: Date(),
+            providerID: "codex",
+            snapshot: iOSWidgetPreviewData.snapshot())
+    }
+
+    func snapshot(for configuration: ProviderSelectionIntent, in _: Context) async -> CodexBariOSWidgetEntry {
+        let snapshot = iOSWidgetSnapshotStore.load() ?? iOSWidgetPreviewData.snapshot()
+        return CodexBariOSWidgetEntry(
+            date: Date(),
+            providerID: snapshot.selectedProviderID(preferred: configuration.provider.rawValue) ?? "codex",
+            snapshot: snapshot)
+    }
+
+    func timeline(
+        for configuration: ProviderSelectionIntent,
+        in _: Context) async -> Timeline<CodexBariOSWidgetEntry>
+    {
+        let snapshot = iOSWidgetSnapshotStore.load() ?? iOSWidgetPreviewData.snapshot()
+        let entry = CodexBariOSWidgetEntry(
+            date: Date(),
+            providerID: snapshot.selectedProviderID(preferred: configuration.provider.rawValue) ?? "codex",
+            snapshot: snapshot)
+        let refreshDate = Date().addingTimeInterval(30 * 60)
+        return Timeline(entries: [entry], policy: .after(refreshDate))
+    }
+}
+
+struct CodexBariOSUsageWidget: Widget {
+    private let kind = "CodexBariOSUsageWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: self.kind,
+            intent: ProviderSelectionIntent.self,
+            provider: CodexBariOSWidgetTimelineProvider())
+        { entry in
+            CodexBariOSUsageWidgetView(entry: entry)
+        }
+        .configurationDisplayName("CodexBar Usage")
+        .description("Session and weekly usage for your selected provider.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+private struct CodexBariOSUsageWidgetView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: CodexBariOSWidgetEntry
+
+    private var summary: iOSWidgetSnapshot.ProviderSummary? {
+        self.entry.snapshot.providerSummaries.first { $0.providerID == self.entry.providerID }
+    }
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.02)
+            if let summary {
+                self.content(summary: summary)
+            } else {
+                self.emptyState
+            }
+        }
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+
+    @ViewBuilder
+    private func content(summary: iOSWidgetSnapshot.ProviderSummary) -> some View {
+        switch self.family {
+        case .systemSmall:
+            VStack(alignment: .leading, spacing: 8) {
+                self.header(summary: summary)
+                UsageBarRow(title: "Session", percentLeft: summary.sessionRemainingPercent)
+                UsageBarRow(title: "Weekly", percentLeft: summary.weeklyRemainingPercent)
+                if let credits = summary.creditsRemaining {
+                    ValueLine(title: "Credits", value: Self.decimal(credits))
+                }
+            }
+            .padding(12)
+        default:
+            VStack(alignment: .leading, spacing: 10) {
+                self.header(summary: summary)
+                UsageBarRow(title: "Session", percentLeft: summary.sessionRemainingPercent)
+                UsageBarRow(title: "Weekly", percentLeft: summary.weeklyRemainingPercent)
+                ValueLine(title: "Today", value: summary.todayCostUSD.map(Self.usd) ?? "—")
+                ValueLine(title: "30d", value: summary.last30DaysCostUSD.map(Self.usd) ?? "—")
+                if let credits = summary.creditsRemaining {
+                    ValueLine(title: "Credits", value: Self.decimal(credits))
+                }
+            }
+            .padding(12)
+        }
+    }
+
+    private func header(summary: iOSWidgetSnapshot.ProviderSummary) -> some View {
+        HStack {
+            Text(summary.displayName)
+                .font(.body.weight(.semibold))
+            Spacer()
+            Text(Self.relative(summary.updatedAt))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Open CodexBar")
+                .font(.body.weight(.semibold))
+            Text("Import a widget snapshot in the app first.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(12)
+    }
+
+    private static func relative(_ value: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        return formatter.localizedString(for: value, relativeTo: Date())
+    }
+
+    private static func usd(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = "USD"
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: value)) ?? String(format: "$%.2f", value)
+    }
+
+    private static func decimal(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 2
+        formatter.minimumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.2f", value)
+    }
+}
+
+private struct UsageBarRow: View {
+    let title: String
+    let percentLeft: Double?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(self.title)
+                    .font(.caption)
+                Spacer()
+                Text(self.percentLeft.map { String(format: "%.0f%%", $0) } ?? "—")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            GeometryReader { proxy in
+                let ratio = max(0, min(100, self.percentLeft ?? 0)) / 100
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.primary.opacity(0.12))
+                    Capsule().fill(Color.accentColor).frame(width: proxy.size.width * ratio)
+                }
+            }
+            .frame(height: 6)
+        }
+    }
+}
+
+private struct ValueLine: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(self.title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(self.value)
+                .font(.caption)
+        }
+    }
+}

--- a/ios/CodexBariOSWidget/Sources/CodexBariOSWidgetBundle.swift
+++ b/ios/CodexBariOSWidget/Sources/CodexBariOSWidgetBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct CodexBariOSWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        CodexBariOSUsageWidget()
+    }
+}

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,55 @@
+# CodexBar iOS Port Scaffold
+
+This folder contains a practical iOS app + widget scaffold for CodexBar usage display.
+
+## What is included
+
+- `CodexBariOSApp` (SwiftUI app)
+- `CodexBariOSWidgetExtension` (WidgetKit extension)
+- Shared snapshot model module from this package: `CodexBariOSShared`
+- `project.yml` for [XcodeGen](https://github.com/yonaskolb/XcodeGen)
+
+## Quick start
+
+1. Install XcodeGen:
+
+```bash
+brew install xcodegen
+```
+
+2. Generate the iOS Xcode project:
+
+```bash
+cd ios
+xcodegen generate
+open CodexBariOS.xcodeproj
+```
+
+3. In Xcode:
+- Set your Team for app + widget targets.
+- Update bundle IDs if needed.
+- Keep the same App Group in both entitlements:
+  - `group.com.steipete.codexbar`
+
+4. Build and run on iOS 17+ (simulator or device).
+
+## Data flow
+
+The iOS app and widget read/write `widget-snapshot.json` via App Group container using:
+
+- `iOSWidgetSnapshot`
+- `iOSWidgetSnapshotStore`
+
+The expected JSON schema matches CodexBar's widget snapshot format (`provider`, `primary`, `secondary`, token usage, etc.).
+
+## Current behavior
+
+- If no snapshot exists, app can load sample data.
+- You can paste/import snapshot JSON directly in the app.
+- Widget renders the selected provider from snapshot data.
+
+## Next steps for deeper parity
+
+- Add direct provider fetch flows on iOS (OAuth/API-token providers first).
+- Add secure iOS settings UI for provider credentials.
+- Add background refresh tasks that periodically persist fresh snapshots.

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -1,0 +1,50 @@
+name: CodexBariOS
+options:
+  createIntermediateGroups: true
+configs:
+  Debug: debug
+  Release: release
+packages:
+  CodexBar:
+    path: ..
+targets:
+  CodexBariOSApp:
+    type: application
+    platform: iOS
+    deploymentTarget: "17.0"
+    sources:
+      - path: CodexBariOSApp/Sources
+    info:
+      path: CodexBariOSApp/Info.plist
+    entitlements:
+      path: CodexBariOSApp/CodexBariOSApp.entitlements
+    dependencies:
+      - package: CodexBar
+        product: CodexBariOSShared
+      - target: CodexBariOSWidgetExtension
+        embed: true
+        codeSign: false
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.steipete.codexbar.ios
+        TARGETED_DEVICE_FAMILY: "1,2"
+        SWIFT_STRICT_CONCURRENCY: complete
+  CodexBariOSWidgetExtension:
+    type: app-extension
+    platform: iOS
+    deploymentTarget: "17.0"
+    sources:
+      - path: CodexBariOSWidget/Sources
+    info:
+      path: CodexBariOSWidget/Info.plist
+    entitlements:
+      path: CodexBariOSWidget/CodexBariOSWidget.entitlements
+    dependencies:
+      - package: CodexBar
+        product: CodexBariOSShared
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.steipete.codexbar.ios.widget
+        APPLICATION_EXTENSION_API_ONLY: YES
+        TARGETED_DEVICE_FAMILY: "1,2"
+        SWIFT_STRICT_CONCURRENCY: complete


### PR DESCRIPTION
## Summary
- add a new shared CodexBariOSShared Swift package module for iOS-compatible widget snapshot decoding, provider summaries, and App Group persistence
- add a full iOS scaffold (ios/) with a SwiftUI app target and WidgetKit extension target (via XcodeGen) to display CodexBar usage
- add tests for snapshot decoding and provider fallback selection
- link iOS scaffold docs from the main README

## Test Plan
- run: swift test --filter iOSWidgetSnapshotTests
- result: 2 tests passed
