### PR TITLE
normalized spacing in menu popup

### DIFF
--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -166,8 +166,8 @@ struct UsageMenuCardView: View {
             }
         }
         .padding(.horizontal, 16)
-        .padding(.top, 2)
-        .padding(.bottom, 2)
+        .padding(.top, 8)
+        .padding(.bottom, 6)
         .frame(width: self.width, alignment: .leading)
     }
 
@@ -363,21 +363,14 @@ private struct MetricRow: View {
 
 struct UsageMenuCardHeaderSectionView: View {
     let model: UsageMenuCardView.Model
-    let showDivider: Bool
     let width: CGFloat
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            UsageMenuCardHeaderView(model: self.model)
-
-            if self.showDivider {
-                Divider()
-            }
-        }
-        .padding(.horizontal, 16)
-        .padding(.top, 2)
-        .padding(.bottom, self.model.subtitleStyle == .error ? 2 : 0)
-        .frame(width: self.width, alignment: .leading)
+        UsageMenuCardHeaderView(model: self.model)
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+            .padding(.bottom, 8)
+            .frame(width: self.width, alignment: .leading)
     }
 }
 
@@ -408,7 +401,7 @@ struct UsageMenuCardUsageSectionView: View {
             }
         }
         .padding(.horizontal, 16)
-        .padding(.top, 10)
+        .padding(.top, 8)
         .padding(.bottom, self.bottomPadding)
         .frame(width: self.width, alignment: .leading)
     }

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -292,7 +292,6 @@ extension StatusItemController {
                     UsageMenuCardView(model: model, width: context.menuWidth),
                     id: "menuCard",
                     width: context.menuWidth))
-                menu.addItem(.separator())
             } else {
                 for (index, model) in cards.enumerated() {
                     menu.addItem(self.makeMenuCardItem(
@@ -302,9 +301,6 @@ extension StatusItemController {
                     if index < cards.count - 1 {
                         menu.addItem(.separator())
                     }
-                }
-                if !cards.isEmpty {
-                    menu.addItem(.separator())
                 }
             }
             return false
@@ -332,7 +328,6 @@ extension StatusItemController {
         if context.currentProvider == .codex, model.creditsText != nil {
             menu.addItem(self.makeBuyCreditsItem())
         }
-        menu.addItem(.separator())
         return false
     }
 
@@ -355,7 +350,6 @@ extension StatusItemController {
                 _ = self.addCostHistorySubmenu(to: menu, provider: currentProvider)
             }
         }
-        menu.addItem(.separator())
     }
 
     private func addActionableSections(_ sections: [MenuDescriptor.Section], to menu: NSMenu) {
@@ -366,6 +360,9 @@ extension StatusItemController {
             }
         }
         for (index, section) in actionableSections.enumerated() {
+            // Add a separator before each section group with a spacer for consistent padding
+            menu.addItem(.separator())
+            self.addMenuSpacer(to: menu, height: 4)
             for entry in section.entries {
                 switch entry {
                 case let .text(text, style):
@@ -404,10 +401,17 @@ extension StatusItemController {
                     menu.addItem(.separator())
                 }
             }
-            if index < actionableSections.count - 1 {
-                menu.addItem(.separator())
-            }
+            // Add trailing spacer after each section group for consistent padding
+            self.addMenuSpacer(to: menu, height: 4)
         }
+    }
+
+    private func addMenuSpacer(to menu: NSMenu, height: CGFloat) {
+        let spacerView = NSView(frame: NSRect(x: 0, y: 0, width: 1, height: height))
+        let spacerItem = NSMenuItem()
+        spacerItem.view = spacerView
+        spacerItem.isEnabled = false
+        menu.addItem(spacerItem)
     }
 
     func makeMenu(for provider: UsageProvider?) -> NSMenu {
@@ -658,22 +662,20 @@ extension StatusItemController {
         let hasCredits = model.creditsText != nil
         let hasExtraUsage = model.providerCost != nil
         let hasCost = model.tokenUsage != nil
-        let bottomPadding = CGFloat(hasCredits ? 4 : 6)
-        let sectionSpacing = CGFloat(6)
-        let usageBottomPadding = bottomPadding
-        let creditsBottomPadding = bottomPadding
+        let sectionPadding = CGFloat(6)
+        let sectionSpacing = CGFloat(8)
 
         let headerView = UsageMenuCardHeaderSectionView(
             model: model,
-            showDivider: hasUsageBlock,
             width: width)
         menu.addItem(self.makeMenuCardItem(headerView, id: "menuCardHeader", width: width))
 
         if hasUsageBlock {
+            menu.addItem(.separator())
             let usageView = UsageMenuCardUsageSectionView(
                 model: model,
                 showBottomDivider: false,
-                bottomPadding: usageBottomPadding,
+                bottomPadding: sectionPadding,
                 width: width)
             let usageSubmenu = self.makeUsageSubmenu(
                 provider: provider,
@@ -686,19 +688,13 @@ extension StatusItemController {
                 submenu: usageSubmenu))
         }
 
-        if hasCredits || hasExtraUsage || hasCost {
-            menu.addItem(.separator())
-        }
-
         if hasCredits {
-            if hasExtraUsage || hasCost {
-                menu.addItem(.separator())
-            }
+            menu.addItem(.separator())
             let creditsView = UsageMenuCardCreditsSectionView(
                 model: model,
                 showBottomDivider: false,
                 topPadding: sectionSpacing,
-                bottomPadding: creditsBottomPadding,
+                bottomPadding: sectionPadding,
                 width: width)
             let creditsSubmenu = webItems.hasCreditsHistory ? self.makeCreditsHistorySubmenu() : nil
             menu.addItem(self.makeMenuCardItem(
@@ -711,13 +707,11 @@ extension StatusItemController {
             }
         }
         if hasExtraUsage {
-            if hasCredits {
-                menu.addItem(.separator())
-            }
+            menu.addItem(.separator())
             let extraUsageView = UsageMenuCardExtraUsageSectionView(
                 model: model,
                 topPadding: sectionSpacing,
-                bottomPadding: bottomPadding,
+                bottomPadding: sectionPadding,
                 width: width)
             menu.addItem(self.makeMenuCardItem(
                 extraUsageView,
@@ -725,13 +719,11 @@ extension StatusItemController {
                 width: width))
         }
         if hasCost {
-            if hasCredits || hasExtraUsage {
-                menu.addItem(.separator())
-            }
+            menu.addItem(.separator())
             let costView = UsageMenuCardCostSectionView(
                 model: model,
                 topPadding: sectionSpacing,
-                bottomPadding: bottomPadding,
+                bottomPadding: sectionPadding,
                 width: width)
             let costSubmenu = webItems.hasCostHistory ? self.makeCostHistorySubmenu(provider: provider) : nil
             menu.addItem(self.makeMenuCardItem(
@@ -891,7 +883,7 @@ extension StatusItemController {
                         RoundedRectangle(cornerRadius: 6, style: .continuous)
                             .fill(MenuHighlightStyle.selectionBackground(true))
                             .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
+                            .padding(.vertical, 1)
                     }
                 }
                 .overlay(alignment: .topTrailing) {


### PR DESCRIPTION
   Fixes inconsistent padding throughout the CodexBar menu popup.

## Changes

Before:
<img width="250" height="52" alt="before" src="https://github.com/user-attachments/assets/8061ebd5-e5a8-47cc-ae59-1fb2efc383ba" /><br />
After:
<img width="250" height="61" alt="after" src="https://github.com/user-attachments/assets/c6e68b3c-73ae-468f-a3f2-51c15693a17d" /><br />

 ## Summary

 This PR fixes inconsistent padding and spacing throughout the CodexBar menu popup.

 Changes Made

 ## Header Section Padding

 ✅ Increase top/bottom padding so the highlighted provider header has proper breathing room
 ✅ Move divider out of the header view into a separate menu separator
 ✅ Remove showDivider parameter from UsageMenuCardHeaderSectionView

 These changes fix:
 - Cramped "Claude / Updated ..." header area
 - Blue selection highlight overlapping the divider line below the header

 ## Card Section Spacing

 ✅ Unify all card sections to consistent padding values (8pt top, 6pt bottom)
 ✅ Remove conditional 4/6pt bottom padding logic
 ✅ Fix double separators when both credits and extra usage sections are present

 Problem: Sections used different padding values depending on which other sections were visible, and a logic error added two consecutive separators when
 credits + extra usage were both present.

 Solution: Each section now uses the same sectionSpacing and sectionPadding values, and each section adds exactly one separator before itself.

 ## Action Item Section Spacing

 ✅ Add spacers above and below each action group to match card section spacing
 ✅ Consolidate separator ownership so each section manages its own leading separator

 Problem: The action item groups (Add Account...Status Page, Settings...Quit) had tighter padding than the card sections above them, and relied on trailing separators from previous sections.

 Solution: Added 4px spacers above and below each action group for symmetric padding around divider lines.

 ## Testing

 - Built and tested locally
 - Verified header highlight no longer overlaps divider
 - Confirmed consistent spacing across all menu sections
 - No regressions in menu card rendering or submenu behavior

## Files Modified

```
 ┌──────────────────────────────────────────────────┬───────────────────────────────────────────────────────────────────┐
 │ File                                             │ Changes                                                           │
 ├──────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
 │ Sources/CodexBar/MenuCardView.swift              │ Header padding, removed showDivider, unified section padding      │
 ├──────────────────────────────────────────────────┼───────────────────────────────────────────────────────────────────┤
 │ Sources/CodexBar/StatusItemController+Menu.swift │ Separator logic, spacers, unified padding values, highlight inset │
 └──────────────────────────────────────────────────┴───────────────────────────────────────────────────────────────────┘
```
 ## Impact

 - Fixes cramped header padding in the menu popup
 - Fixes highlight overlapping divider line
 - Fixes inconsistent spacing between all menu sections
 - No breaking changes