### PR TITLE
Fix z.ai API schema changes - handle missing token limit fields

### DIFF
--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -807,10 +807,17 @@ extension UsageMenuCardView.Model {
 
     private static func zaiLimitDetailText(limit: ZaiLimitEntry?) -> String? {
         guard let limit else { return nil }
-        let currentStr = UsageFormatter.tokenCountString(limit.currentValue)
-        let usageStr = UsageFormatter.tokenCountString(limit.usage)
-        let remainingStr = UsageFormatter.tokenCountString(limit.remaining)
-        return "\(currentStr) / \(usageStr) (\(remainingStr) remaining)"
+        
+        if let currentValue = limit.currentValue,
+           let usage = limit.usage,
+           let remaining = limit.remaining {
+            let currentStr = UsageFormatter.tokenCountString(currentValue)
+            let usageStr = UsageFormatter.tokenCountString(usage)
+            let remainingStr = UsageFormatter.tokenCountString(remaining)
+            return "\(currentStr) / \(usageStr) (\(remainingStr) remaining)"
+        }
+        
+        return nil
     }
 
     private struct PaceDetail {

--- a/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
@@ -22,9 +22,9 @@ public struct ZaiLimitEntry: Sendable {
     public let type: ZaiLimitType
     public let unit: ZaiLimitUnit
     public let number: Int
-    public let usage: Int
-    public let currentValue: Int
-    public let remaining: Int
+    public let usage: Int?
+    public let currentValue: Int?
+    public let remaining: Int?
     public let percentage: Double
     public let usageDetails: [ZaiUsageDetail]
     public let nextResetTime: Date?
@@ -33,9 +33,9 @@ public struct ZaiLimitEntry: Sendable {
         type: ZaiLimitType,
         unit: ZaiLimitUnit,
         number: Int,
-        usage: Int,
-        currentValue: Int,
-        remaining: Int,
+        usage: Int?,
+        currentValue: Int?,
+        remaining: Int?,
         percentage: Double,
         usageDetails: [ZaiUsageDetail],
         nextResetTime: Date?)
@@ -93,12 +93,17 @@ extension ZaiLimitEntry {
     }
 
     private var computedUsedPercent: Double? {
-        guard self.usage > 0 else { return nil }
-        let limit = max(0, self.usage)
+        guard let usage = self.usage else {
+            return nil
+        }
+        guard usage > 0 else { return nil }
+        let limit = max(0, usage)
         guard limit > 0 else { return nil }
 
-        let usedFromRemaining = limit - self.remaining
-        let used = max(0, min(limit, max(usedFromRemaining, self.currentValue)))
+        let remaining = self.remaining ?? 0
+        let currentValue = self.currentValue ?? 0
+        let usedFromRemaining = limit - remaining
+        let used = max(0, min(limit, max(usedFromRemaining, currentValue)))
         let percent = (Double(used) / Double(limit)) * 100
         return min(100, max(0, percent))
     }
@@ -225,9 +230,9 @@ private struct ZaiLimitRaw: Codable {
     let type: String
     let unit: Int
     let number: Int
-    let usage: Int
-    let currentValue: Int
-    let remaining: Int
+    let usage: Int?
+    let currentValue: Int?
+    let remaining: Int?
     let percentage: Int
     let usageDetails: [ZaiUsageDetail]?
     let nextResetTime: Int?

--- a/Tests/CodexBarTests/ZaiProviderTests.swift
+++ b/Tests/CodexBarTests/ZaiProviderTests.swift
@@ -71,6 +71,34 @@ struct ZaiUsageSnapshotTests {
         #expect(usage.secondary?.resetDescription == "30 days window")
         #expect(usage.zaiUsage?.tokenLimit?.usage == 100)
     }
+
+    @Test
+    func mapsUsageSnapshotWindowsWithMissingFields() {
+        let reset = Date(timeIntervalSince1970: 123)
+        let tokenLimit = ZaiLimitEntry(
+            type: .tokensLimit,
+            unit: .hours,
+            number: 5,
+            usage: nil,
+            currentValue: nil,
+            remaining: nil,
+            percentage: 25,
+            usageDetails: [],
+            nextResetTime: reset)
+        let snapshot = ZaiUsageSnapshot(
+            tokenLimit: tokenLimit,
+            timeLimit: nil,
+            planName: nil,
+            updatedAt: reset)
+
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(usage.primary?.usedPercent == 25)
+        #expect(usage.primary?.windowMinutes == 300)
+        #expect(usage.primary?.resetsAt == reset)
+        #expect(usage.primary?.resetDescription == "5 hours window")
+        #expect(usage.zaiUsage?.tokenLimit?.usage == nil)
+    }
 }
 
 @Suite
@@ -117,6 +145,7 @@ struct ZaiUsageParsingTests {
         #expect(snapshot.planName == "Pro")
         #expect(snapshot.tokenLimit?.usage == 40_000_000)
         #expect(snapshot.timeLimit?.usageDetails.first?.modelCode == "search-prime")
+        #expect(snapshot.tokenLimit?.percentage == 34.0)
     }
 
     @Test
@@ -163,6 +192,52 @@ struct ZaiUsageParsingTests {
         #expect(snapshot.planName == "Pro")
         #expect(snapshot.tokenLimit == nil)
         #expect(snapshot.timeLimit == nil)
+    }
+
+    @Test
+    func parsesNewSchemaWithMissingTokenLimitFields() throws {
+        let json = """
+        {
+          "code": 200,
+          "msg": "Operation successful",
+          "data": {
+            "limits": [
+              {
+                "type": "TIME_LIMIT",
+                "unit": 5,
+                "number": 1,
+                "usage": 100,
+                "currentValue": 0,
+                "remaining": 100,
+                "percentage": 0,
+                "usageDetails": [
+                  { "modelCode": "search-prime", "usage": 0 },
+                  { "modelCode": "web-reader", "usage": 1 },
+                  { "modelCode": "zread", "usage": 0 }
+                ]
+              },
+              {
+                "type": "TOKENS_LIMIT",
+                "unit": 3,
+                "number": 5,
+                "percentage": 1,
+                "nextResetTime": 1770724088678
+              }
+            ]
+          },
+          "success": true
+        }
+        """
+
+        let snapshot = try ZaiUsageFetcher.parseUsageSnapshot(from: Data(json.utf8))
+
+        #expect(snapshot.tokenLimit?.percentage == 1.0)
+        #expect(snapshot.tokenLimit?.usage == nil)
+        #expect(snapshot.tokenLimit?.currentValue == nil)
+        #expect(snapshot.tokenLimit?.remaining == nil)
+        #expect(snapshot.tokenLimit?.usedPercent == 1.0)
+        #expect(snapshot.tokenLimit?.windowMinutes == 300)
+        #expect(snapshot.timeLimit?.usage == 100)
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes parsing error for z.ai provider when API omits token limit detail fields.

## Problem
The z.ai API has changed `TOKENS_LIMIT` response schema. The `usage`, `currentValue`, and `remaining` fields are now omitted from responses for coding plan users. This caused JSON decoding to fail with:
> "Failed to parse z.ai response: The data couldn't be read because it is missing."

## Solution
Made the affected fields optional in both `ZaiLimitEntry` and `ZaiLimitRaw` structs:
- Fields default to `nil` when not present in API response
- `computedUsedPercent` uses `percentage` directly when fields are missing
- UI gracefully handles missing fields by not showing token count details
- Added comprehensive test coverage for new schema

## Changes
- **ZaiUsageStats.swift**: Make `usage`, `currentValue`, `remaining` optional
- **MenuCardView.swift**: Update `zaiLimitDetailText()` to handle optional fields
- **ZaiProviderTests.swift**: Add tests for new API schema

## Backward Compatibility
Still works with old API responses that include all fields. Tests verify both schemas work correctly.

## Testing
- ✅ All 15 Zai provider tests pass
- ✅ App compiles and runs successfully
- ✅ Handles both old and new API response formats

Related to: https://github.com/steipete/CodexBar/issues (z.ai API schema changes)