### PR TITLE
fix: add claude opus 4.6 pricing

### DIFF
--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
@@ -64,6 +64,16 @@ enum CostUsagePricing {
             outputCostPerTokenAboveThreshold: nil,
             cacheCreationInputCostPerTokenAboveThreshold: nil,
             cacheReadInputCostPerTokenAboveThreshold: nil),
+        "claude-opus-4-6-20260205": ClaudePricing(
+            inputCostPerToken: 5e-6,
+            outputCostPerToken: 2.5e-5,
+            cacheCreationInputCostPerToken: 6.25e-6,
+            cacheReadInputCostPerToken: 5e-7,
+            thresholdTokens: nil,
+            inputCostPerTokenAboveThreshold: nil,
+            outputCostPerTokenAboveThreshold: nil,
+            cacheCreationInputCostPerTokenAboveThreshold: nil,
+            cacheReadInputCostPerTokenAboveThreshold: nil),
         "claude-sonnet-4-5": ClaudePricing(
             inputCostPerToken: 3e-6,
             outputCostPerToken: 1.5e-5,


### PR DESCRIPTION
Added the pricing for the 4.6 opus model, so it correctly tracks usd consumed

<img width="314" height="240" alt="image" src="https://github.com/user-attachments/assets/410de421-9f9c-4cc7-9ca9-0d88a657f4cc" />
