### PR TITLE
Add new OpenAI model pricing and remove -codex suffix stripping

### DIFF
--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageCache.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageCache.swift
@@ -10,7 +10,7 @@ enum CostUsageCacheIO {
         let root = cacheRoot ?? self.defaultCacheRoot()
         return root
             .appendingPathComponent("cost-usage", isDirectory: true)
-            .appendingPathComponent("\(provider.rawValue)-v1.json", isDirectory: false)
+            .appendingPathComponent("\(provider.rawValue)-v2.json", isDirectory: false)
     }
 
     static func load(provider: UsageProvider, cacheRoot: URL? = nil) -> CostUsageCache {

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
@@ -33,11 +33,27 @@ enum CostUsagePricing {
             inputCostPerToken: 1.25e-6,
             outputCostPerToken: 1e-5,
             cacheReadInputCostPerToken: 1.25e-7),
+        "gpt-5.1-codex": CodexPricing(
+            inputCostPerToken: 1.25e-6,
+            outputCostPerToken: 1e-5,
+            cacheReadInputCostPerToken: 1.25e-7),
+        "gpt-5.1-codex-mini": CodexPricing(
+            inputCostPerToken: 2.5e-7,
+            outputCostPerToken: 2e-6,
+            cacheReadInputCostPerToken: 2.5e-8),
+        "gpt-5.1-codex-max": CodexPricing(
+            inputCostPerToken: 1.25e-6,
+            outputCostPerToken: 1e-5,
+            cacheReadInputCostPerToken: 1.25e-7),
         "gpt-5.2": CodexPricing(
             inputCostPerToken: 1.75e-6,
             outputCostPerToken: 1.4e-5,
             cacheReadInputCostPerToken: 1.75e-7),
         "gpt-5.2-codex": CodexPricing(
+            inputCostPerToken: 1.75e-6,
+            outputCostPerToken: 1.4e-5,
+            cacheReadInputCostPerToken: 1.75e-7),
+        "gpt-5.3-codex": CodexPricing(
             inputCostPerToken: 1.75e-6,
             outputCostPerToken: 1.4e-5,
             cacheReadInputCostPerToken: 1.75e-7),
@@ -160,10 +176,6 @@ enum CostUsagePricing {
         var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.hasPrefix("openai/") {
             trimmed = String(trimmed.dropFirst("openai/".count))
-        }
-        if let codexRange = trimmed.range(of: "-codex") {
-            let base = String(trimmed[..<codexRange.lowerBound])
-            if self.codex[base] != nil { return base }
         }
         return trimmed
     }

--- a/Tests/CodexBarTests/CostUsagePricingTests.swift
+++ b/Tests/CodexBarTests/CostUsagePricingTests.swift
@@ -5,9 +5,7 @@ import Testing
 struct CostUsagePricingTests {
     @Test
     func normalizesCodexModelVariants() {
-        #expect(CostUsagePricing.normalizeCodexModel("openai/gpt-5-codex") == "gpt-5")
-        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.2-codex") == "gpt-5.2")
-        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.1-codex-max") == "gpt-5.1")
+        #expect(CostUsagePricing.normalizeCodexModel("openai/gpt-5-codex") == "gpt-5-codex")
     }
 
     @Test


### PR DESCRIPTION
- Add pricing for gpt-5.1-codex, gpt-5.1-codex-max, gpt-5.1-codex-mini, gpt-5.3-codex
- Fix prev PR's mistake in pricing
- Remove -codex suffix fallback in normalizeCodexModel to ensure exact pricing lookups for bug and consistency with adding gpt-5.1-codex-mini