### PR TITLE
Fix script path casing and host-only SwiftPM packaging fallback

### DIFF
--- a/Scripts/compile_and_run.sh
+++ b/Scripts/compile_and_run.sh
@@ -201,12 +201,12 @@ if [[ -n "${RELEASE_ARCHES}" ]]; then
   ARCHES_VALUE="${RELEASE_ARCHES}"
 fi
 if [[ "${DEBUG_LLDB}" == "1" ]]; then
-  run_step "package app" env CODEXBAR_ALLOW_LLDB=1 ARCHES="${ARCHES_VALUE}" "${ROOT_DIR}/scripts/package_app.sh" debug
+  run_step "package app" env CODEXBAR_ALLOW_LLDB=1 ARCHES="${ARCHES_VALUE}" "${ROOT_DIR}/Scripts/package_app.sh" debug
 else
   if [[ -n "${SIGNING_MODE}" ]]; then
-    run_step "package app" env CODEXBAR_SIGNING="${SIGNING_MODE}" ARCHES="${ARCHES_VALUE}" "${ROOT_DIR}/scripts/package_app.sh"
+    run_step "package app" env CODEXBAR_SIGNING="${SIGNING_MODE}" ARCHES="${ARCHES_VALUE}" "${ROOT_DIR}/Scripts/package_app.sh"
   else
-    run_step "package app" env ARCHES="${ARCHES_VALUE}" "${ROOT_DIR}/scripts/package_app.sh"
+    run_step "package app" env ARCHES="${ARCHES_VALUE}" "${ROOT_DIR}/Scripts/package_app.sh"
   fi
 fi
 

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -210,6 +210,21 @@ build_product_path() {
   esac
 }
 
+# Resolve path to built binary; some SwiftPM versions use .build/$CONF/ when building for host only.
+resolve_binary_path() {
+  local name="$1"
+  local arch="$2"
+  local candidate
+  candidate=$(build_product_path "$name" "$arch")
+  if [[ -f "$candidate" ]]; then
+    echo "$candidate"
+    return
+  fi
+  if [[ "$arch" == "arm64" || "$arch" == "x86_64" ]] && [[ -f ".build/$CONF/$name" ]]; then
+    echo ".build/$CONF/$name"
+  fi
+}
+
 verify_binary_arches() {
   local binary="$1"; shift
   local expected=("$@")
@@ -236,9 +251,9 @@ install_binary() {
   local binaries=()
   for arch in "${ARCH_LIST[@]}"; do
     local src
-    src=$(build_product_path "$name" "$arch")
-    if [[ ! -f "$src" ]]; then
-      echo "ERROR: Missing ${name} build for ${arch} at ${src}" >&2
+    src=$(resolve_binary_path "$name" "$arch")
+    if [[ -z "$src" || ! -f "$src" ]]; then
+      echo "ERROR: Missing ${name} build for ${arch} at $(build_product_path "$name" "$arch")" >&2
       exit 1
     fi
     binaries+=("$src")
@@ -254,14 +269,14 @@ install_binary() {
 
 install_binary "CodexBar" "$APP/Contents/MacOS/CodexBar"
 # Ship CodexBarCLI alongside the app for easy symlinking.
-if [[ -f "$(build_product_path "CodexBarCLI" "${ARCH_LIST[0]}")" ]]; then
+if [[ -n "$(resolve_binary_path "CodexBarCLI" "${ARCH_LIST[0]}")" ]]; then
   install_binary "CodexBarCLI" "$APP/Contents/Helpers/CodexBarCLI"
 fi
 # Watchdog helper: ensures `claude` probes die when CodexBar crashes/gets killed.
-if [[ -f "$(build_product_path "CodexBarClaudeWatchdog" "${ARCH_LIST[0]}")" ]]; then
+if [[ -n "$(resolve_binary_path "CodexBarClaudeWatchdog" "${ARCH_LIST[0]}")" ]]; then
   install_binary "CodexBarClaudeWatchdog" "$APP/Contents/Helpers/CodexBarClaudeWatchdog"
 fi
-if [[ -f "$(build_product_path "CodexBarWidget" "${ARCH_LIST[0]}")" ]]; then
+if [[ -n "$(resolve_binary_path "CodexBarWidget" "${ARCH_LIST[0]}")" ]]; then
   WIDGET_APP="$APP/Contents/PlugIns/CodexBarWidget.appex"
   mkdir -p "$WIDGET_APP/Contents/MacOS" "$WIDGET_APP/Contents/Resources"
   cat > "$WIDGET_APP/Contents/Info.plist" <<PLIST
@@ -334,7 +349,8 @@ if [[ ! -f "$APP/Contents/Resources/Icon-classic.icns" ]]; then
 fi
 
 # SwiftPM resource bundles (e.g. KeyboardShortcuts) are emitted next to the built binary.
-PREFERRED_BUILD_DIR="$(dirname "$(build_product_path "CodexBar" "${ARCH_LIST[0]}")")"
+CODEXBAR_BINARY="$(resolve_binary_path "CodexBar" "${ARCH_LIST[0]}")"
+PREFERRED_BUILD_DIR="$(dirname "${CODEXBAR_BINARY:-$(build_product_path "CodexBar" "${ARCH_LIST[0]}")}")"
 shopt -s nullglob
 SWIFTPM_BUNDLES=("${PREFERRED_BUILD_DIR}/"*.bundle)
 shopt -u nullglob


### PR DESCRIPTION
## Summary
- Keep only the script-related parts of #275.
- Fix path casing in `Scripts/compile_and_run.sh` (`Scripts/package_app.sh` instead of `scripts/package_app.sh`).
- Make `Scripts/package_app.sh` resilient to host-only SwiftPM output layout by resolving binaries from either arch-specific or `.build/$CONF/` paths.

## Not Included
- Excludes the logging/test bootstrap change from #275 (`Sources/CodexBarCore/Logging/CodexBarLog.swift`).

## Attribution
- Partial cherry-pick of original work by @julerex from commit `ed76573b601a6f152167ecee758a080c66d83c82` in #275. Thanks @julerex !

## Validation
- `./Scripts/compile_and_run.sh`
- `pnpm check`
