### PR TITLE
Stop persisting selected menu provider on merged menu open

### DIFF
--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -539,7 +539,7 @@ extension StatusItemController {
 
     private func menuProvider(for menu: NSMenu) -> UsageProvider? {
         if self.shouldMergeIcons {
-            return self.selectedMenuProvider ?? self.resolvedMenuProvider()
+            return self.resolvedMenuProvider()
         }
         if let provider = self.menuProviders[ObjectIdentifier(menu)] {
             return provider

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -52,9 +52,9 @@ extension StatusItemController {
 
         var provider: UsageProvider?
         if self.shouldMergeIcons {
-            self.selectedMenuProvider = self.resolvedMenuProvider()
-            self.lastMenuProvider = self.selectedMenuProvider ?? .codex
-            provider = self.selectedMenuProvider
+            let resolvedProvider = self.resolvedMenuProvider()
+            self.lastMenuProvider = resolvedProvider ?? .codex
+            provider = resolvedProvider
         } else {
             if let menuProvider = self.menuProviders[ObjectIdentifier(menu)] {
                 self.lastMenuProvider = menuProvider

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -117,6 +117,73 @@ struct StatusMenuTests {
     }
 
     @Test
+    func mergedMenuRefreshUsesResolvedEnabledProviderWhenPersistedSelectionIsDisabled() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: false)
+        }
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+        if let geminiMeta = registry.metadata[.gemini] {
+            settings.setProviderEnabled(provider: .gemini, metadata: geminiMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let event = CreditEvent(date: Date(), service: "CLI", creditsUsed: 1)
+        let breakdown = OpenAIDashboardSnapshot.makeDailyBreakdown(from: [event], maxDays: 30)
+        store.openAIDashboard = OpenAIDashboardSnapshot(
+            signedInEmail: "user@example.com",
+            codeReviewRemainingPercent: 100,
+            creditEvents: [event],
+            dailyBreakdown: breakdown,
+            usageBreakdown: breakdown,
+            creditsPurchaseURL: nil,
+            updatedAt: Date())
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+
+        let expectedResolved = store.enabledProviders().first ?? .codex
+        #expect(store.enabledProviders().count > 1)
+        #expect(controller.shouldMergeIcons == true)
+
+        func hasOpenAIWebSubmenus(_ menu: NSMenu) -> Bool {
+            let usageItem = menu.items.first { ($0.representedObject as? String) == "menuCardUsage" }
+            let creditsItem = menu.items.first { ($0.representedObject as? String) == "menuCardCredits" }
+            let hasUsageBreakdown = usageItem?.submenu?.items
+                .contains { ($0.representedObject as? String) == "usageBreakdownChart" } == true
+            let hasCreditsHistory = creditsItem?.submenu?.items
+                .contains { ($0.representedObject as? String) == "creditsHistoryChart" } == true
+            return hasUsageBreakdown || hasCreditsHistory
+        }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+
+        #expect(controller.lastMenuProvider == expectedResolved)
+        #expect(settings.selectedMenuProvider == .codex)
+        #expect(hasOpenAIWebSubmenus(menu) == false)
+
+        controller.menuContentVersion &+= 1
+        controller.refreshOpenMenusIfNeeded()
+
+        #expect(hasOpenAIWebSubmenus(menu) == false)
+    }
+
+    @Test
     func providerToggleUpdatesStatusItemVisibility() {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()


### PR DESCRIPTION
## Summary
- stop writing `SettingsStore.selectedMenuProvider` from merged menu open (`menuWillOpen`)
- keep persistence only for explicit user selection in `ProviderSwitcherView.onSelect`
- add one regression test that covers `mergeIcons = true` + `selectedMenuProvider = nil`

## Why
Opening the merged menu should not be treated as a settings mutation.

Previously, opening the menu could write `selectedMenuProvider` and trigger settings observation paths (`UsageStore.observeSettingsChanges()` / controller settings observation), which can kick off a background refresh at open time. Since `ProviderInteractionContext.current` defaults to `.background`, that refresh can race user-initiated refresh behavior and break `onlyOnUserAction` semantics.

This change makes menu open read-only for provider resolution while preserving explicit persistence on user selection.

## Scope
- no Claude OAuth/keychain behavior changes
- no new logging
- only these files changed:
  - `Sources/CodexBar/StatusItemController+Menu.swift`
  - `Tests/CodexBarTests/StatusMenuTests.swift`

## Testing
- `swift test` (pass)
- `./Scripts/compile_and_run.sh` (pass)
