### PR TITLE
Copilot Provider Update

### DIFF
--- a/Sources/CodexBar/PreferencesProviderSettingsRows.swift
+++ b/Sources/CodexBar/PreferencesProviderSettingsRows.swift
@@ -196,6 +196,13 @@ struct ProviderSettingsFieldRowView: View {
                     }
                 }
             }
+
+            if let footer = self.field.footerText, !footer.isEmpty {
+                Text(footer)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 }

--- a/Sources/CodexBar/Providers/Copilot/CopilotProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Copilot/CopilotProviderImplementation.swift
@@ -31,6 +31,7 @@ struct CopilotProviderImplementation: ProviderImplementation {
                 id: "copilot-api-token",
                 title: "GitHub Login",
                 subtitle: "Requires authentication via GitHub Device Flow.",
+                footerText: "Device code is copied to your clipboard — paste with ⌘V.",
                 kind: .secure,
                 placeholder: "Sign in via button below",
                 binding: context.stringBinding(\.copilotAPIToken),

--- a/Sources/CodexBar/Providers/Shared/ProviderSettingsDescriptors.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderSettingsDescriptors.swift
@@ -76,6 +76,7 @@ struct ProviderSettingsFieldDescriptor: Identifiable {
     let id: String
     let title: String
     let subtitle: String
+    var footerText: String? = nil
     let kind: Kind
     let placeholder: String?
     let binding: Binding<String>


### PR DESCRIPTION
Added clear information of the automatic copy/paste of device codes which maybe missed due to window load. This should make things slightly clearer for those onboarding for the first time. 

Footer Added: Device code is copied to your clipboard — paste with ⌘V.