### PR TITLE
feat(opencode): support multiple browsers for cookie import

### DIFF
--- a/Sources/CodexBarCore/Providers/OpenCode/OpenCodeCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/OpenCode/OpenCodeCookieImporter.swift
@@ -27,10 +27,11 @@ public enum OpenCodeCookieImporter {
     public static func importSession(
         browserDetection: BrowserDetection,
         preferredBrowsers: [Browser]? = nil,
+        excludeBrowsers: [Browser] = [],
         logger: ((String) -> Void)? = nil) throws -> SessionInfo
     {
         let log: (String) -> Void = { msg in logger?("[opencode-cookie] \(msg)") }
-        let browsersToTry = preferredBrowsers ?? opencodeCookieImportOrder
+        let browsersToTry = (preferredBrowsers ?? opencodeCookieImportOrder).filter { !excludeBrowsers.contains($0) }
         let installedBrowsers = browsersToTry.cookieImportCandidates(using: browserDetection)
 
         for browserSource in installedBrowsers {
@@ -66,12 +67,14 @@ public enum OpenCodeCookieImporter {
     public static func hasSession(
         browserDetection: BrowserDetection,
         preferredBrowsers: [Browser]? = nil,
+        excludeBrowsers: [Browser] = [],
         logger: ((String) -> Void)? = nil) -> Bool
     {
         do {
             _ = try self.importSession(
                 browserDetection: browserDetection,
                 preferredBrowsers: preferredBrowsers,
+                excludeBrowsers: excludeBrowsers,
                 logger: logger)
             return true
         } catch {

--- a/Sources/CodexBarCore/Providers/OpenCode/OpenCodeCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/OpenCode/OpenCodeCookieImporter.swift
@@ -26,13 +26,12 @@ public enum OpenCodeCookieImporter {
 
     public static func importSession(
         browserDetection: BrowserDetection,
-        preferredBrowsers: [Browser] = [.chrome],
+        preferredBrowsers: [Browser]? = nil,
         logger: ((String) -> Void)? = nil) throws -> SessionInfo
     {
         let log: (String) -> Void = { msg in logger?("[opencode-cookie] \(msg)") }
-        let installedBrowsers = preferredBrowsers.isEmpty
-            ? opencodeCookieImportOrder.cookieImportCandidates(using: browserDetection)
-            : preferredBrowsers.cookieImportCandidates(using: browserDetection)
+        let browsersToTry = preferredBrowsers ?? opencodeCookieImportOrder
+        let installedBrowsers = browsersToTry.cookieImportCandidates(using: browserDetection)
 
         for browserSource in installedBrowsers {
             do {
@@ -66,7 +65,7 @@ public enum OpenCodeCookieImporter {
 
     public static func hasSession(
         browserDetection: BrowserDetection,
-        preferredBrowsers: [Browser] = [.chrome],
+        preferredBrowsers: [Browser]? = nil,
         logger: ((String) -> Void)? = nil) -> Bool
     {
         do {


### PR DESCRIPTION
## Summary

Previously OpenCode only attempted to import cookies from Chrome, hardcoded as `preferredBrowsers: [.chrome]`. This caused issues for users who use other browsers like Edge, Safari, or Firefox.

Now uses the default browser import order (Safari → Chrome → Edge → Brave → Arc → ...) when no preferred browsers are specified, allowing users to authenticate with OpenCode in any supported browser.

## Changes

- Modified `OpenCodeCookieImporter.swift` to use the default browser import order instead of hardcoded Chrome
- Changed `preferredBrowsers` parameter from `[.chrome]` (required) to `nil` (optional), which defaults to trying all available browsers in the standard order

## Testing

- Verified that Edge is already supported in SweetCookieKit (BrowserCatalog.swift shows Edge with `chromiumProfileRelativePath: "Microsoft Edge"`)
- The fix uses `Browser.defaultImportOrder` which includes: Safari → Chrome → Edge → Brave → Arc → Dia → ChatGPT Atlas → Chromium → Helium → Vivaldi → Firefox → Zen → Chrome Beta → Chrome Canary → Arc Beta → Arc Canary → Brave Beta → Brave Nightly → Edge Beta → Edge Canary

## Related Issue

Fixes: Users with Edge/Safari/Firefox cannot use OpenCode provider - "No OpenCode session cookies found in browsers" error