### PR TITLE
fix: correct Claude CLI package name in setup message

### DIFF
--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -230,7 +230,7 @@ extension StatusItemController {
         case .missingBinary:
             self.presentLoginAlert(
                 title: "Claude CLI not found",
-                message: "Install the Claude CLI (npm i -g @anthropic-ai/claude-cli) and try again.")
+                message: "Install the Claude CLI (npm i -g @anthropic-ai/claude-code) and try again.")
         case let .launchFailed(message):
             self.presentLoginAlert(title: "Could not start claude /login", message: message)
         case .timedOut:


### PR DESCRIPTION
Show the message to setup @anthropic-ai/claude-code instead of @anthropic-ai/claude-cli

> npm error 404 Not Found - GET https://registry.npmjs.org/@anthropic-ai%2fclaude-cli - Not found