### PR TITLE
Add Linux native tray MVP executable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Build CodexBarCLI (release, static Swift stdlib)
         run: swift build -c release --product CodexBarCLI --static-swift-stdlib
 
+      - name: Build CodexBarLinuxTray (release)
+        run: swift build -c release --product CodexBarLinuxTray
+
       - name: Swift Test (Linux only)
         run: swift test --parallel
 
@@ -83,3 +86,15 @@ jobs:
           fi
           "$BIN" usage --provider codex --web 2>&1 | tee /tmp/codexbarcli-stderr.txt >/dev/null || true
           grep -q "macOS" /tmp/codexbarcli-stderr.txt
+
+      - name: Smoke test CodexBarLinuxTray
+        shell: bash
+        run: |
+          set -euo pipefail
+          BIN_DIR="$(swift build -c release --product CodexBarLinuxTray --show-bin-path)"
+          BIN="$BIN_DIR/CodexBarLinuxTray"
+          timeout 5s env CODEXBAR_TRAY_STDOUT_ONLY=1 "$BIN" || rc=$?
+          if [[ "${rc:-0}" -ne 0 && "${rc:-0}" -ne 124 ]]; then
+            echo "CodexBarLinuxTray exited unexpectedly: ${rc}"
+            exit "${rc}"
+          fi

--- a/Package.swift
+++ b/Package.swift
@@ -120,5 +120,17 @@ let package = Package(
             ]))
         #endif
 
+        #if os(Linux)
+        targets.append(.executableTarget(
+            name: "CodexBarLinuxTray",
+            dependencies: [
+                "CodexBarCore",
+            ],
+            path: "Sources/CodexBarLinuxTray",
+            swiftSettings: [
+                .enableUpcomingFeature("StrictConcurrency"),
+            ]))
+        #endif
+
         return targets
     }())

--- a/README.md
+++ b/README.md
@@ -17,12 +17,18 @@ Download: <https://github.com/steipete/CodexBar/releases>
 brew install --cask steipete/tap/codexbar
 ```
 
-### Linux (CLI only)
+### Linux (CLI + native tray MVP)
 ```bash
 brew install steipete/tap/codexbar
 ```
 Or download `CodexBarCLI-v<tag>-linux-<arch>.tar.gz` from GitHub Releases.
 Linux support via Omarchy: community Waybar module and TUI, driven by the `codexbar` executable.
+
+Build native tray MVP from source:
+```bash
+swift build -c release --product CodexBarLinuxTray
+./.build/release/CodexBarLinuxTray
+```
 
 ### First run
 - Open Settings → Providers and enable what you use.
@@ -63,6 +69,7 @@ The menu bar icon is a tiny two-bar meter:
 - Merge Icons mode to combine providers into one status item + switcher.
 - Refresh cadence presets (manual, 1m, 2m, 5m, 15m).
 - Bundled CLI (`codexbar`) for scripts and CI (including `codexbar cost --provider codex|claude` for local cost usage); Linux CLI builds available.
+- Linux tray host executable (`CodexBarLinuxTray`) for native tray + tooltip refresh view.
 - WidgetKit widget mirrors the menu card snapshot.
 - Privacy-first: on-device parsing by default; browser cookies are opt-in and reused (no passwords stored).
 
@@ -92,6 +99,7 @@ Wondering if CodexBar scans your disk? It doesn’t crawl your filesystem; it re
 - Providers overview: [docs/providers.md](docs/providers.md)
 - Provider authoring: [docs/provider.md](docs/provider.md)
 - UI & icon notes: [docs/ui.md](docs/ui.md)
+- Linux tray notes: [docs/linux-tray.md](docs/linux-tray.md)
 - CLI reference: [docs/cli.md](docs/cli.md)
 - Architecture: [docs/architecture.md](docs/architecture.md)
 - Refresh loop: [docs/refresh-loop.md](docs/refresh-loop.md)

--- a/Sources/CodexBarCore/Credentials/CredentialStore.swift
+++ b/Sources/CodexBarCore/Credentials/CredentialStore.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+public struct ProviderCredentialKey: Hashable, Sendable {
+    public let provider: UsageProvider
+
+    public init(provider: UsageProvider) {
+        self.provider = provider
+    }
+}
+
+public protocol ProviderCredentialStore: Sendable {
+    func apiKey(for key: ProviderCredentialKey) -> String?
+}
+
+public struct EnvironmentProviderCredentialStore: ProviderCredentialStore {
+    private let env: [String: String]
+
+    public init(env: [String: String] = ProcessInfo.processInfo.environment) {
+        self.env = env
+    }
+
+    public func apiKey(for key: ProviderCredentialKey) -> String? {
+        let names = Self.environmentNames(for: key.provider)
+        for name in names {
+            if let value = self.env[name]?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private static func environmentNames(for provider: UsageProvider) -> [String] {
+        switch provider {
+        case .zai:
+            [ZaiSettingsReader.apiTokenKey]
+        case .copilot:
+            ["COPILOT_API_TOKEN"]
+        case .minimax:
+            [MiniMaxAPISettingsReader.apiTokenKey]
+        case .kimik2:
+            KimiK2SettingsReader.apiKeyEnvironmentKeys
+        case .synthetic:
+            [SyntheticSettingsReader.apiKeyKey]
+        case .warp:
+            WarpSettingsReader.apiKeyEnvironmentKeys
+        default:
+            []
+        }
+    }
+}
+
+public struct FileProviderCredentialStore: ProviderCredentialStore {
+    public let fileURL: URL
+    private let fileManager: FileManager
+    private let decoder: JSONDecoder
+
+    public init(
+        fileURL: URL = Self.defaultURL(),
+        fileManager: FileManager = .default,
+        decoder: JSONDecoder = JSONDecoder())
+    {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+        self.decoder = decoder
+    }
+
+    public func apiKey(for key: ProviderCredentialKey) -> String? {
+        guard let map = self.loadMap() else { return nil }
+        guard let value = map[key.provider.rawValue]?.trimmingCharacters(in: .whitespacesAndNewlines) else { return nil }
+        return value.isEmpty ? nil : value
+    }
+
+    public static func defaultURL(home: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
+        home
+            .appendingPathComponent(".codexbar", isDirectory: true)
+            .appendingPathComponent("credentials.json")
+    }
+
+    private func loadMap() -> [String: String]? {
+        guard self.fileManager.fileExists(atPath: self.fileURL.path) else { return nil }
+        guard let data = try? Data(contentsOf: self.fileURL) else { return nil }
+        return try? self.decoder.decode([String: String].self, from: data)
+    }
+}
+
+public struct CompositeProviderCredentialStore: ProviderCredentialStore {
+    private let stores: [any ProviderCredentialStore]
+
+    public init(stores: [any ProviderCredentialStore]) {
+        self.stores = stores
+    }
+
+    public func apiKey(for key: ProviderCredentialKey) -> String? {
+        for store in self.stores {
+            if let value = store.apiKey(for: key), !value.isEmpty {
+                return value
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/CodexBarLinuxTray/LinuxTrayConfig.swift
+++ b/Sources/CodexBarLinuxTray/LinuxTrayConfig.swift
@@ -1,0 +1,84 @@
+import CodexBarCore
+import Foundation
+
+struct LinuxTrayRuntimeConfig: Codable, Sendable {
+    var refreshSeconds: Int
+    var staleAfterRefreshes: Int
+    var iconName: String
+
+    static let `default` = LinuxTrayRuntimeConfig(
+        refreshSeconds: 120,
+        staleAfterRefreshes: 3,
+        iconName: "utilities-terminal")
+
+    var normalized: LinuxTrayRuntimeConfig {
+        LinuxTrayRuntimeConfig(
+            refreshSeconds: max(30, self.refreshSeconds),
+            staleAfterRefreshes: max(2, self.staleAfterRefreshes),
+            iconName: self.iconName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? Self.default.iconName
+                : self.iconName)
+    }
+}
+
+struct LinuxTrayRuntimeConfigStore {
+    let fileURL: URL
+
+    init(fileURL: URL = Self.defaultURL()) {
+        self.fileURL = fileURL
+    }
+
+    func load() -> LinuxTrayRuntimeConfig {
+        guard let data = try? Data(contentsOf: self.fileURL),
+              let decoded = try? JSONDecoder().decode(LinuxTrayRuntimeConfig.self, from: data)
+        else {
+            return .default
+        }
+        return decoded.normalized
+    }
+
+    static func defaultURL(home: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
+        home
+            .appendingPathComponent(".codexbar", isDirectory: true)
+            .appendingPathComponent("linux-tray.json")
+    }
+}
+
+struct ProviderRuntimeSettings: Sendable {
+    let sourceMode: ProviderSourceMode
+    let env: [String: String]
+}
+
+struct ProviderRuntimeResolver {
+    let credentials: any ProviderCredentialStore
+    let baseEnv: [String: String]
+
+    init(
+        credentials: any ProviderCredentialStore,
+        baseEnv: [String: String] = ProcessInfo.processInfo.environment)
+    {
+        self.credentials = credentials
+        self.baseEnv = baseEnv
+    }
+
+    func resolve(provider: UsageProvider, providerConfig: ProviderConfig?) -> ProviderRuntimeSettings {
+        let preferred = providerConfig?.source ?? .auto
+        let sourceMode = preferred.usesWeb ? .cli : preferred
+
+        var env = ProviderConfigEnvironment.applyAPIKeyOverride(
+            base: self.baseEnv,
+            provider: provider,
+            config: providerConfig)
+        let configHasAPIKey = providerConfig?.sanitizedAPIKey != nil
+        if !configHasAPIKey,
+           let apiKey = self.credentials.apiKey(for: .init(provider: provider))
+        {
+            env = ProviderConfigEnvironment.applyAPIKeyOverride(
+                base: env,
+                provider: provider,
+                config: ProviderConfig(id: provider, apiKey: apiKey))
+        }
+
+        return ProviderRuntimeSettings(sourceMode: sourceMode, env: env)
+    }
+}

--- a/Sources/CodexBarLinuxTray/LinuxTrayHost.swift
+++ b/Sources/CodexBarLinuxTray/LinuxTrayHost.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+protocol LinuxTrayHost: Sendable {
+    func start(onActivate: (@Sendable () -> Void)?) async
+    func update(summary: String, tooltip: String, iconName: String) async
+    func stop() async
+}
+
+actor ZenityTrayHost: LinuxTrayHost {
+    private var process: Process?
+    private var stdinPipe: Pipe?
+    private var stdoutTask: Task<Void, Never>?
+    private var onActivate: (@Sendable () -> Void)?
+    private var activeIconName = "utilities-terminal"
+
+    func start(onActivate: (@Sendable () -> Void)?) async {
+        self.onActivate = onActivate
+        await self.ensureStarted()
+    }
+
+    func update(summary: String, tooltip: String, iconName: String) async {
+        self.activeIconName = iconName
+        await self.ensureStarted()
+        self.sendLine("icon:\(self.escapeLine(iconName))")
+        self.sendLine("message:\(self.escapeLine(summary))")
+        self.sendLine("tooltip:\(self.escapeLine(tooltip))")
+        self.sendLine("visible:true")
+    }
+
+    func stop() async {
+        self.stdoutTask?.cancel()
+        self.stdoutTask = nil
+        self.process?.terminate()
+        self.process = nil
+        self.stdinPipe = nil
+    }
+
+    private func ensureStarted() async {
+        if let process = self.process, process.isRunning { return }
+        self.stdoutTask?.cancel()
+        self.stdoutTask = nil
+
+        let process = Process()
+        let input = Pipe()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/zenity")
+        process.arguments = [
+            "--notification",
+            "--listen",
+            "--text=CodexBar",
+            "--icon-name=\(self.activeIconName)",
+        ]
+        process.standardInput = input
+        process.standardOutput = output
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            self.process = process
+            self.stdinPipe = input
+            self.stdoutTask = Task.detached(priority: .utility) { [weak self] in
+                await self?.readEvents(from: output.fileHandleForReading)
+            }
+        } catch {
+            self.process = nil
+            self.stdinPipe = nil
+        }
+    }
+
+    private func readEvents(from handle: FileHandle) async {
+        while !Task.isCancelled {
+            let data = handle.availableData
+            if data.isEmpty { return }
+            guard let line = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                !line.isEmpty
+            else {
+                continue
+            }
+
+            // zenity emits a line when the tray icon is activated.
+            self.onActivate?()
+            if line == "quit" {
+                return
+            }
+        }
+    }
+
+    private func sendLine(_ line: String) {
+        guard let writer = self.stdinPipe?.fileHandleForWriting else { return }
+        guard let data = "\(line)\n".data(using: .utf8) else { return }
+        writer.write(data)
+    }
+
+    private func escapeLine(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+    }
+}
+
+actor StdoutTrayHost: LinuxTrayHost {
+    func start(onActivate: (@Sendable () -> Void)?) async {
+        _ = onActivate
+    }
+
+    func update(summary: String, tooltip: String, iconName: String) async {
+        print("[\(iconName)] \(summary)\n\(tooltip)\n")
+    }
+
+    func stop() async {}
+}

--- a/Sources/CodexBarLinuxTray/main.swift
+++ b/Sources/CodexBarLinuxTray/main.swift
@@ -1,0 +1,208 @@
+import CodexBarCore
+import Dispatch
+import Foundation
+
+private struct ProviderRenderState: Sendable {
+    let provider: UsageProvider
+    let displayName: String
+    let usage: UsageSnapshot?
+    let credits: CreditsSnapshot?
+    let error: String?
+    let fetchedAt: Date
+}
+
+private final class LinuxTrayCoordinator: @unchecked Sendable {
+    private let configStore = CodexBarConfigStore()
+    private let runtimeConfigStore = LinuxTrayRuntimeConfigStore()
+    private let fetcher = UsageFetcher()
+    private let browserDetection = BrowserDetection()
+    private let claudeFetcher: ClaudeUsageFetcher
+    private let runtimeResolver: ProviderRuntimeResolver
+    private let host: any LinuxTrayHost
+
+    private var refreshToken: UInt64 = 0
+    private var latestStates: [UsageProvider: ProviderRenderState] = [:]
+    private var latestRefreshAt: Date?
+    private var latestRuntimeConfig = LinuxTrayRuntimeConfig.default
+    private var isRefreshing = false
+
+    init(host: any LinuxTrayHost) {
+        self.host = host
+        self.claudeFetcher = ClaudeUsageFetcher(browserDetection: self.browserDetection)
+        self.runtimeResolver = ProviderRuntimeResolver(
+            credentials: CompositeProviderCredentialStore(stores: [
+                EnvironmentProviderCredentialStore(),
+                FileProviderCredentialStore(),
+            ]))
+    }
+
+    func run() async {
+        await self.host.start(onActivate: { [weak self] in
+            Task { await self?.refreshNow() }
+        })
+
+        await self.refreshNow()
+        while true {
+            self.latestRuntimeConfig = self.runtimeConfigStore.load()
+            let wait = UInt64(self.latestRuntimeConfig.refreshSeconds) * 1_000_000_000
+            try? await Task.sleep(nanoseconds: wait)
+            await self.refreshNow()
+        }
+    }
+
+    private func refreshNow() async {
+        guard !self.isRefreshing else { return }
+        self.isRefreshing = true
+        defer { self.isRefreshing = false }
+
+        self.latestRuntimeConfig = self.runtimeConfigStore.load()
+        self.refreshToken &+= 1
+        let generation = self.refreshToken
+
+        let config = (try? self.configStore.loadOrCreateDefault()) ?? CodexBarConfig.makeDefault()
+        let metadata = ProviderDescriptorRegistry.metadata
+        let providers = config.enabledProviders(metadata: metadata)
+
+        let states = await self.fetchStates(providers: providers, config: config, metadata: metadata)
+        if generation != self.refreshToken { return }
+
+        self.latestStates = Dictionary(uniqueKeysWithValues: states.map { ($0.provider, $0) })
+        self.latestRefreshAt = Date()
+
+        let snapshot = WidgetSnapshot(
+            entries: states.map { state in
+                WidgetSnapshot.ProviderEntry(
+                    provider: state.provider,
+                    updatedAt: state.usage?.updatedAt ?? state.fetchedAt,
+                    primary: state.usage?.primary,
+                    secondary: state.usage?.secondary,
+                    tertiary: state.usage?.tertiary,
+                    creditsRemaining: state.credits?.remaining,
+                    codeReviewRemainingPercent: nil,
+                    tokenUsage: nil,
+                    dailyUsage: [])
+            },
+            enabledProviders: providers,
+            generatedAt: Date())
+        WidgetSnapshotStore.save(snapshot)
+
+        let rendered = self.render(states: states, generatedAt: snapshot.generatedAt)
+        await self.host.update(
+            summary: rendered.summary,
+            tooltip: rendered.tooltip,
+            iconName: self.latestRuntimeConfig.iconName)
+    }
+
+    private func fetchStates(
+        providers: [UsageProvider],
+        config: CodexBarConfig,
+        metadata: [UsageProvider: ProviderMetadata]) async -> [ProviderRenderState]
+    {
+        await withTaskGroup(of: ProviderRenderState.self, returning: [ProviderRenderState].self) { group in
+            for provider in providers {
+                group.addTask {
+                    let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
+                    let settings = config.providerConfig(for: provider)
+                    let runtime = self.runtimeResolver.resolve(provider: provider, providerConfig: settings)
+                    let context = ProviderFetchContext(
+                        runtime: .app,
+                        sourceMode: runtime.sourceMode,
+                        includeCredits: true,
+                        webTimeout: 60,
+                        webDebugDumpHTML: false,
+                        verbose: false,
+                        env: runtime.env,
+                        settings: nil,
+                        fetcher: self.fetcher,
+                        claudeFetcher: self.claudeFetcher,
+                        browserDetection: self.browserDetection)
+                    let outcome = await descriptor.fetchOutcome(context: context)
+                    switch outcome.result {
+                    case let .success(result):
+                        return ProviderRenderState(
+                            provider: provider,
+                            displayName: metadata[provider]?.displayName ?? provider.rawValue.capitalized,
+                            usage: result.usage.scoped(to: provider),
+                            credits: result.credits,
+                            error: nil,
+                            fetchedAt: Date())
+                    case let .failure(error):
+                        return ProviderRenderState(
+                            provider: provider,
+                            displayName: metadata[provider]?.displayName ?? provider.rawValue.capitalized,
+                            usage: nil,
+                            credits: nil,
+                            error: UsageFormatter.truncatedSingleLine(error.localizedDescription, max: 120),
+                            fetchedAt: Date())
+                    }
+                }
+            }
+
+            var values: [ProviderRenderState] = []
+            values.reserveCapacity(providers.count)
+            for await state in group {
+                values.append(state)
+            }
+            let indexMap = Dictionary(uniqueKeysWithValues: providers.enumerated().map { ($1, $0) })
+            values.sort { (indexMap[$0.provider] ?? 0) < (indexMap[$1.provider] ?? 0) }
+            return values
+        }
+    }
+
+    private func render(states: [ProviderRenderState], generatedAt: Date) -> (summary: String, tooltip: String) {
+        let errorCount = states.filter { $0.error != nil }.count
+        let hasStaleData: Bool
+        if let last = self.latestRefreshAt {
+            let staleInterval = TimeInterval(self.latestRuntimeConfig.refreshSeconds * self.latestRuntimeConfig.staleAfterRefreshes)
+            hasStaleData = Date().timeIntervalSince(last) > staleInterval
+        } else {
+            hasStaleData = true
+        }
+
+        let primary = states.first?.usage?.primary?.remainingPercent
+        var summary = "CodexBar"
+        if let primary {
+            summary += String(format: " %.0f%%", max(0, primary))
+        }
+        if errorCount > 0 {
+            summary += " !\(errorCount)"
+        } else if hasStaleData {
+            summary += " stale"
+        }
+
+        var lines: [String] = states.map { state in
+            if let usage = state.usage {
+                let session = usage.primary.map { String(format: "%.0f%%", max(0, $0.remainingPercent)) } ?? "--"
+                let weekly = usage.secondary.map { String(format: "%.0f%%", max(0, $0.remainingPercent)) } ?? "--"
+                let reset = usage.primary.flatMap {
+                    UsageFormatter.resetLine(for: $0, style: .countdown)
+                } ?? "Reset unknown"
+                var row = "\(state.displayName): session \(session), weekly \(weekly), \(reset)"
+                if let credits = state.credits?.remaining {
+                    row += ", credits \(UsageFormatter.creditsString(from: credits))"
+                }
+                return row
+            }
+            return "\(state.displayName): error - \(state.error ?? "unknown")"
+        }
+        if lines.isEmpty {
+            lines = ["No enabled providers. Edit ~/.codexbar/config.json to enable one."]
+        }
+        lines.append(UsageFormatter.updatedString(from: generatedAt))
+        lines.append("Click tray icon to refresh now.")
+        return (summary, lines.joined(separator: "\n"))
+    }
+}
+
+private let hasZenity = ProcessInfo.processInfo.environment["CODEXBAR_TRAY_STDOUT_ONLY"] != "1"
+    && FileManager.default.isExecutableFile(atPath: "/usr/bin/zenity")
+private let host: any LinuxTrayHost = hasZenity ? ZenityTrayHost() : StdoutTrayHost()
+private let coordinator = LinuxTrayCoordinator(host: host)
+private let completion = DispatchSemaphore(value: 0)
+
+Task {
+    await coordinator.run()
+    completion.signal()
+}
+
+completion.wait()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,7 @@ read_when:
 - `Sources/CodexBar`: state + UI (UsageStore, SettingsStore, StatusItemController, menus, icon rendering).
 - `Sources/CodexBarWidget`: WidgetKit extension wired to the shared snapshot.
 - `Sources/CodexBarCLI`: bundled CLI for `codexbar` usage/status output.
+- `Sources/CodexBarLinuxTray` (Linux only): native tray host loop built on `CodexBarCore`, writing `WidgetSnapshotStore`.
 - `Sources/CodexBarMacros`: SwiftSyntax macros for provider registration.
 - `Sources/CodexBarMacroSupport`: shared macro support used by app/core/CLI targets.
 - `Sources/CodexBarClaudeWatchdog`: helper process for stable Claude CLI PTY sessions.
@@ -20,6 +21,7 @@ read_when:
 ## Entry points
 - `CodexBarApp`: SwiftUI keepalive + Settings scene.
 - `AppDelegate`: wires status controller, Sparkle updater, notifications.
+- `CodexBarLinuxTray`: Linux tray process that refreshes provider usage and updates the tray indicator.
 
 ## Data flow
 - Background refresh → `UsageFetcher`/provider probes → `UsageStore` → menu/icon/widgets.
@@ -28,5 +30,14 @@ read_when:
 ## Concurrency & platform
 - Swift 6 strict concurrency enabled; prefer Sendable state and explicit MainActor hops.
 - macOS 14+ targeting; avoid deprecated APIs when refactoring.
+- Linux tray runtime follows the same provider registry/fetch pipeline and stores snapshot output through
+  `WidgetSnapshotStore`.
+
+## Platform boundaries
+- macOS host layer: `Sources/CodexBar/StatusItemController*.swift`, `Sources/CodexBar/CodexbarApp.swift`.
+- Shared cross-platform logic: `Sources/CodexBarCore` provider descriptors, fetch strategies, formatting,
+  config store, and widget snapshot models.
+- Linux host layer: `Sources/CodexBarLinuxTray` for tray lifecycle, refresh scheduling, and Linux-specific
+  runtime config.
 
 See also: `docs/providers.md`, `docs/refresh-loop.md`, `docs/ui.md`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,6 +20,8 @@ Use it when you need usage numbers in scripts, CI, or dashboards without UI.
 - Homebrew (Linuxbrew, Linux only): `brew install steipete/tap/codexbar`.
 - Download `CodexBarCLI-v<tag>-linux-<arch>.tar.gz` from GitHub Releases (x86_64 + aarch64).
 - Extract; run `./codexbar` (symlink) or `./CodexBarCLI`.
+- Native tray MVP from source: `swift build -c release --product CodexBarLinuxTray && ./.build/release/CodexBarLinuxTray`.
+- Headless mode for CI: set `CODEXBAR_TRAY_STDOUT_ONLY=1`.
 
 ```
 tar -xzf CodexBarCLI-v0.17.0-linux-x86_64.tar.gz

--- a/docs/linux-tray.md
+++ b/docs/linux-tray.md
@@ -1,0 +1,60 @@
+---
+summary: "Linux tray executable details, runtime config, and limitations."
+read_when:
+  - Running CodexBar as a native Linux tray process
+  - Debugging Linux tray refresh/runtime behavior
+  - Packaging Linux tray binaries
+---
+
+# Linux tray (MVP)
+
+`CodexBarLinuxTray` is a Linux-only executable target that reuses `CodexBarCore` provider descriptors and
+fetch pipelines, then publishes the current state to the tray and `WidgetSnapshotStore`.
+
+## Build and run
+
+```bash
+swift build -c debug --product CodexBarLinuxTray
+./.build/debug/CodexBarLinuxTray
+```
+
+CI/non-GUI mode:
+
+```bash
+CODEXBAR_TRAY_STDOUT_ONLY=1 ./.build/debug/CodexBarLinuxTray
+```
+
+## Data + config
+
+- Providers, source mode, and API key overrides come from `~/.codexbar/config.json`.
+- Linux tray runtime settings come from `~/.codexbar/linux-tray.json`.
+- Credentials fallback file (optional): `~/.codexbar/credentials.json`.
+  - Shape: `{ "provider-id": "api-key" }`
+  - Used only when `config.json` has no `apiKey` for a provider.
+
+## Runtime settings
+
+`~/.codexbar/linux-tray.json`:
+
+```json
+{
+  "refreshSeconds": 120,
+  "staleAfterRefreshes": 3,
+  "iconName": "utilities-terminal"
+}
+```
+
+- `refreshSeconds`: periodic refresh interval (minimum `30`).
+- `staleAfterRefreshes`: stale threshold multiplier for status text.
+- `iconName`: icon passed to `zenity --notification`.
+
+## Tray backend
+
+- Preferred backend: `zenity --notification --listen` for native tray presence.
+- Fallback backend: stdout host (for headless/CI and environments without `zenity`).
+
+## Current limitations
+
+- Linux tray currently uses click-to-refresh with tooltip details.
+- Provider toggles and advanced settings are still managed via `~/.codexbar/config.json`.
+- `web/auto` provider source modes are downgraded to `cli` on Linux.


### PR DESCRIPTION
## Summary
- add Linux-only `CodexBarLinuxTray` executable target in `Package.swift`
- implement tray refresh loop wired to `CodexBarCore` provider fetch pipelines and `WidgetSnapshotStore`
- add Linux tray runtime/docs and Linux CI build + smoke checks

## Notes
- This branch currently includes the credential-store abstractions from #385.
- Tray backend uses `zenity --notification --listen` with stdout fallback for headless environments.

## Test plan
- [x] `swift build -c debug --product CodexBarLinuxTray`
- [x] `timeout 8s ./.build/debug/CodexBarLinuxTray`
- [x] `swift build -c debug`
- [x] `swift test`

Made with [Cursor](https://cursor.com)