### PR TITLE
Fix Claude keychain prompt on token rotation via security CLI fallback

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+TestingOverrides.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+TestingOverrides.swift
@@ -20,6 +20,8 @@ extension ClaudeOAuthCredentialsStore {
 
     @TaskLocal static var taskKeychainAccessOverride: Bool?
     @TaskLocal static var taskCredentialsFileFingerprintStoreOverride: CredentialsFileFingerprintStore?
+    @TaskLocal static var taskSecurityCLIKeychainReadEnabledOverride: Bool?
+    @TaskLocal static var taskSecurityCLIKeychainDataOverride: Data?
 
     static func withKeychainAccessOverrideForTesting<T>(
         _ disabled: Bool?,
@@ -35,6 +37,42 @@ extension ClaudeOAuthCredentialsStore {
         operation: () async throws -> T) async rethrows -> T
     {
         try await self.$taskKeychainAccessOverride.withValue(disabled) {
+            try await operation()
+        }
+    }
+
+    static func withSecurityCLIKeychainReadEnabledOverrideForTesting<T>(
+        _ enabled: Bool?,
+        operation: () throws -> T) rethrows -> T
+    {
+        try self.$taskSecurityCLIKeychainReadEnabledOverride.withValue(enabled) {
+            try operation()
+        }
+    }
+
+    static func withSecurityCLIKeychainReadEnabledOverrideForTesting<T>(
+        _ enabled: Bool?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$taskSecurityCLIKeychainReadEnabledOverride.withValue(enabled) {
+            try await operation()
+        }
+    }
+
+    static func withSecurityCLIKeychainDataOverrideForTesting<T>(
+        _ data: Data?,
+        operation: () throws -> T) rethrows -> T
+    {
+        try self.$taskSecurityCLIKeychainDataOverride.withValue(data) {
+            try operation()
+        }
+    }
+
+    static func withSecurityCLIKeychainDataOverrideForTesting<T>(
+        _ data: Data?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$taskSecurityCLIKeychainDataOverride.withValue(data) {
             try await operation()
         }
     }


### PR DESCRIPTION
## Problem

When Claude CLI rotates your OAuth token, it **deletes and recreates** the `"Claude Code-credentials"` keychain item. This wipes any existing ACL entries — including the "Always Allow" grant previously given to CodexBar. Every subsequent `SecItemCopyMatching` call from CodexBar against the new item triggers a fresh keychain prompt, causing repeated password dialogs every time the token rotates (~every hour).

PR #364 addressed this by only accessing the keychain on user interaction, which hid the symptom but didn't fix the root cause.

## Fix

Before touching Security.framework, we now try reading the keychain item via `/usr/bin/security find-generic-password -s "Claude Code-credentials" -w`. This system binary reads the item **without going through the per-app ACL check**, so no prompt is ever shown — even after token rotation creates a fresh keychain item.

Hooks added in three places:
- `loadFromClaudeKeychainNonInteractive()` — background sync path
- `loadFromClaudeKeychain()` — interactive load path  
- `syncFromClaudeKeychainWithoutPrompt()` — post-rotation sync (most critical)

**Enabled by default.** Can be disabled via:
- `CODEXBAR_CLAUDE_USE_SECURITY_CLI_KEYCHAIN_READ=0` env var
- `defaults write com.steipete.codexbar claudeOAuthDisableSecurityCLIKeychainRead -bool YES`

## Security

- `/usr/bin/security` runs as the same user — no privilege escalation
- Scoped to one specific keychain item (`-s "Claude Code-credentials"`)
- CodexBar is not sandboxed so this doesn't grant any new capabilities
- Read-only operation — cannot write or modify keychain items

## Tests

Two new tests added:
- `loadFromClaudeKeychain_usesSecurityCLIPathWhenEnabled`
- `syncFromClaudeKeychainWithoutPrompt_usesSecurityCLIPathWhenEnabled`

