### PR TITLE
Enable security CLI keychain read by default

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthKeychainReadStrategy.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthKeychainReadStrategy.swift
@@ -21,7 +21,7 @@ public enum ClaudeOAuthKeychainReadStrategyPreference {
         {
             return strategy
         }
-        return .securityFramework
+        return .securityCLIExperimental
     }
 
     #if DEBUG


### PR DESCRIPTION
## Problem

PR #388 added the security CLI keychain read path to fix the repeated keychain prompt after token rotation — great fix! However, the default strategy is still `.securityFramework`, meaning users have to manually opt in via:

```
defaults write com.steipete.codexbar claudeOAuthKeychainReadStrategy securityCLIExperimental
```

Most users will never know this setting exists, so they'll continue seeing the keychain prompt every time Claude CLI rotates their token.

## Fix

Change the default from `.securityFramework` to `.securityCLIExperimental` so the fix is active for all users out of the box. One line change.

Users who want to revert to the old Security.framework path can do so via:

```
defaults write com.steipete.codexbar claudeOAuthKeychainReadStrategy securityFramework
```

## Why this is safe

The security CLI path in #388 is well-tested and handles all failure cases (timeout, binary unavailable, non-zero exit) by falling back gracefully. Making it the default is a low-risk change with a high impact — it actually fixes the keychain prompt for all users rather than just those who discover the hidden setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)