### PR TITLE
Add GPT-5.3 Codex pricing

### DIFF
--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
@@ -41,6 +41,14 @@ enum CostUsagePricing {
             inputCostPerToken: 1.75e-6,
             outputCostPerToken: 1.4e-5,
             cacheReadInputCostPerToken: 1.75e-7),
+        "gpt-5.3": CodexPricing(
+            inputCostPerToken: 1.75e-6,
+            outputCostPerToken: 1.4e-5,
+            cacheReadInputCostPerToken: 1.75e-7),
+        "gpt-5.3-codex": CodexPricing(
+            inputCostPerToken: 1.75e-6,
+            outputCostPerToken: 1.4e-5,
+            cacheReadInputCostPerToken: 1.75e-7),
     ]
 
     private static let claude: [String: ClaudePricing] = [

--- a/Tests/CodexBarTests/CostUsagePricingTests.swift
+++ b/Tests/CodexBarTests/CostUsagePricingTests.swift
@@ -8,12 +8,23 @@ struct CostUsagePricingTests {
         #expect(CostUsagePricing.normalizeCodexModel("openai/gpt-5-codex") == "gpt-5")
         #expect(CostUsagePricing.normalizeCodexModel("gpt-5.2-codex") == "gpt-5.2")
         #expect(CostUsagePricing.normalizeCodexModel("gpt-5.1-codex-max") == "gpt-5.1")
+        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.3-codex-max") == "gpt-5.3")
     }
 
     @Test
     func codexCostSupportsGpt51CodexMax() {
         let cost = CostUsagePricing.codexCostUSD(
             model: "gpt-5.1-codex-max",
+            inputTokens: 100,
+            cachedInputTokens: 10,
+            outputTokens: 5)
+        #expect(cost != nil)
+    }
+
+    @Test
+    func codexCostSupportsGpt53CodexMax() {
+        let cost = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.3-codex-max",
             inputTokens: 100,
             cachedInputTokens: 10,
             outputTokens: 5)


### PR DESCRIPTION
## Summary
- add Codex pricing entries for `gpt-5.3` and `gpt-5.3-codex`
- keep existing token pricing behavior consistent for GPT-5.2-tier models
- add regression tests for `gpt-5.3-codex-max` normalization and cost support

fixes https://github.com/steipete/CodexBar/issues/389

before
<img width="604" height="216" alt="Screenshot 2026-02-20 at 1 49 35 PM" src="https://github.com/user-attachments/assets/dc36c8e0-b1cc-4b9c-9439-41e67548225c" />


after
<img width="620" height="220" alt="Screenshot 2026-02-20 at 1 59 46 PM" src="https://github.com/user-attachments/assets/8e4c6c81-05ab-4474-9fe2-9007fd36d607" />



## Validation
- `pnpm check`
- `./Scripts/compile_and_run.sh`
- `swift test -q --filter CostUsagePricingTests`
- `swift test -q` *(fails on unrelated existing test: `ClaudeOAuthDelegatedRefreshCoordinatorTests.experimentalStrategy_observesSecurityCLIChangeAfterTouch`)*