### PR TITLE
Ignore cancelled OpenAI dashboard navigation errors (-999)

### DIFF
--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardNavigationDelegate.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardNavigationDelegate.swift
@@ -20,6 +20,7 @@ final class NavigationDelegate: NSObject, WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         if Self.shouldIgnoreNavigationError(error) {
+            self.completeOnce(.success(()))
             return
         }
         self.completeOnce(.failure(error))
@@ -27,6 +28,7 @@ final class NavigationDelegate: NSObject, WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         if Self.shouldIgnoreNavigationError(error) {
+            self.completeOnce(.success(()))
             return
         }
         self.completeOnce(.failure(error))

--- a/Tests/CodexBarTests/OpenAIDashboardNavigationDelegateTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardNavigationDelegateTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import WebKit
 @testable import CodexBarCore
 
 @Suite
@@ -14,5 +15,22 @@ struct OpenAIDashboardNavigationDelegateTests {
     func doesNotIgnoreOtherURLErrors() {
         let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
         #expect(!NavigationDelegate.shouldIgnoreNavigationError(error))
+    }
+
+    @MainActor
+    @Test("cancelled failures complete with success")
+    func cancelledFailureCompletesWithSuccess() {
+        let webView = WKWebView()
+        var result: Result<Void, Error>?
+        let delegate = NavigationDelegate { result = $0 }
+
+        delegate.webView(webView, didFail: nil, withError: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled))
+
+        switch result {
+        case .success?:
+            #expect(Bool(true))
+        default:
+            #expect(Bool(false))
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ignore `NSURLErrorCancelled` (`-999`) in OpenAI dashboard WKWebView navigation delegate callbacks
- keep treating all other navigation errors as failures
- add focused tests for ignored vs non-ignored navigation errors
- mark helper as `nonisolated` so tests can call it without actor isolation issues

## Why
`WKWebView` can emit `NSURLErrorCancelled` during expected navigation transitions. Treating that as a hard failure surfaces a misleading error in Codex/OpenAI credits fetch.

Fixes #262