### PR TITLE
fix(opencode): handle null subscription responses without POST retry

### DIFF
--- a/Tests/CodexBarTests/OpenCodeUsageFetcherErrorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeUsageFetcherErrorTests.swift
@@ -70,6 +70,138 @@ struct OpenCodeUsageFetcherErrorTests {
         }
     }
 
+    @Test
+    func subscriptionGetNullSkipsPostAndReturnsGracefulError() async throws {
+        let registered = URLProtocol.registerClass(OpenCodeStubURLProtocol.self)
+        defer {
+            if registered {
+                URLProtocol.unregisterClass(OpenCodeStubURLProtocol.self)
+            }
+            OpenCodeStubURLProtocol.handler = nil
+        }
+
+        var methods: [String] = []
+        var urls: [URL] = []
+        var queries: [String] = []
+        var contentTypes: [String] = []
+        OpenCodeStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            methods.append(request.httpMethod ?? "GET")
+            urls.append(url)
+            queries.append(url.query ?? "")
+            contentTypes.append(request.value(forHTTPHeaderField: "Content-Type") ?? "")
+
+            if request.httpMethod?.uppercased() == "GET" {
+                return Self.makeResponse(url: url, body: "null", statusCode: 200, contentType: "application/json")
+            }
+
+            let body = #"{"status":500,"unhandled":true,"message":"HTTPError"}"#
+            return Self.makeResponse(url: url, body: body, statusCode: 500, contentType: "application/json")
+        }
+
+        do {
+            _ = try await OpenCodeUsageFetcher.fetchUsage(
+                cookieHeader: "auth=test",
+                timeout: 2,
+                workspaceIDOverride: "wrk_TEST123")
+            Issue.record("Expected OpenCodeUsageError.apiError")
+        } catch let error as OpenCodeUsageError {
+            switch error {
+            case let .apiError(message):
+                #expect(message.contains("No subscription usage data"))
+                #expect(message.contains("wrk_TEST123"))
+            default:
+                Issue.record("Expected apiError, got: \(error)")
+            }
+        }
+
+        #expect(methods == ["GET"])
+        #expect(queries[0].contains("id="))
+        #expect(queries[0].contains("wrk_TEST123"))
+        #expect(urls[0].path == "/_server")
+        #expect(contentTypes[0].isEmpty)
+    }
+
+    @Test
+    func subscriptionGetPayloadDoesNotFallbackToPost() async throws {
+        let registered = URLProtocol.registerClass(OpenCodeStubURLProtocol.self)
+        defer {
+            if registered {
+                URLProtocol.unregisterClass(OpenCodeStubURLProtocol.self)
+            }
+            OpenCodeStubURLProtocol.handler = nil
+        }
+
+        var methods: [String] = []
+        OpenCodeStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            methods.append(request.httpMethod ?? "GET")
+
+            let body = """
+            {
+              "rollingUsage": { "usagePercent": 17, "resetInSec": 600 },
+              "weeklyUsage": { "usagePercent": 75, "resetInSec": 7200 }
+            }
+            """
+            return Self.makeResponse(url: url, body: body, statusCode: 200, contentType: "application/json")
+        }
+
+        let snapshot = try await OpenCodeUsageFetcher.fetchUsage(
+            cookieHeader: "auth=test",
+            timeout: 2,
+            workspaceIDOverride: "wrk_TEST123")
+
+        #expect(snapshot.rollingUsagePercent == 17)
+        #expect(snapshot.weeklyUsagePercent == 75)
+        #expect(methods == ["GET"])
+    }
+
+    @Test
+    func subscriptionGetMissingFieldsFallsBackToPost() async throws {
+        let registered = URLProtocol.registerClass(OpenCodeStubURLProtocol.self)
+        defer {
+            if registered {
+                URLProtocol.unregisterClass(OpenCodeStubURLProtocol.self)
+            }
+            OpenCodeStubURLProtocol.handler = nil
+        }
+
+        var methods: [String] = []
+        OpenCodeStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            methods.append(request.httpMethod ?? "GET")
+
+            if request.httpMethod?.uppercased() == "GET" {
+                return Self.makeResponse(
+                    url: url,
+                    body: #"{"ok":true}"#,
+                    statusCode: 200,
+                    contentType: "application/json")
+            }
+
+            let body = """
+            {
+              "rollingUsage": { "usagePercent": 22, "resetInSec": 300 },
+              "weeklyUsage": { "usagePercent": 44, "resetInSec": 3600 }
+            }
+            """
+            return Self.makeResponse(
+                url: url,
+                body: body,
+                statusCode: 200,
+                contentType: "application/json")
+        }
+
+        let snapshot = try await OpenCodeUsageFetcher.fetchUsage(
+            cookieHeader: "auth=test",
+            timeout: 2,
+            workspaceIDOverride: "wrk_TEST123")
+
+        #expect(snapshot.rollingUsagePercent == 22)
+        #expect(snapshot.weeklyUsagePercent == 44)
+        #expect(methods == ["GET", "POST"])
+    }
+
     private static func makeResponse(
         url: URL,
         body: String,


### PR DESCRIPTION
## Summary
- detect explicit `null` from OpenCode subscription GET responses
- skip POST fallback for explicit `null` payloads to avoid the known `HTTP 500: HTTPError` path
- return a clearer provider error message that includes workspace id context
- keep existing GET->POST fallback for non-null malformed payloads

## Why
Some workspaces return `null` for subscription usage via GET. The prior behavior retried with POST and surfaced a generic 500, which obscured the actual failure mode.

## Tests
- `swift test --filter OpenCodeUsageFetcherErrorTests`
- `pnpm check`
- `./Scripts/compile_and_run.sh`

## Notes
This PR improves failure handling and messaging. It does not add free-tier percentage tracking because there is no confirmed public endpoint that exposes free-tier quota state as `{used, limit, reset}`.

Refs #273
