### PR TITLE
Handle cancelled OpenAI navigation without early success completion

### DIFF
--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardNavigationDelegate.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardNavigationDelegate.swift
@@ -19,18 +19,12 @@ final class NavigationDelegate: NSObject, WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        if Self.shouldIgnoreNavigationError(error) {
-            self.completeOnce(.success(()))
-            return
-        }
+        if Self.shouldIgnoreNavigationError(error) { return }
         self.completeOnce(.failure(error))
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        if Self.shouldIgnoreNavigationError(error) {
-            self.completeOnce(.success(()))
-            return
-        }
+        if Self.shouldIgnoreNavigationError(error) { return }
         self.completeOnce(.failure(error))
     }
 

--- a/Tests/CodexBarTests/OpenAIDashboardNavigationDelegateTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardNavigationDelegateTests.swift
@@ -18,17 +18,44 @@ struct OpenAIDashboardNavigationDelegateTests {
     }
 
     @MainActor
-    @Test("cancelled failures complete with success")
-    func cancelledFailureCompletesWithSuccess() {
+    @Test("cancelled failure is ignored until finish")
+    func cancelledFailureIsIgnoredUntilFinish() {
         let webView = WKWebView()
         var result: Result<Void, Error>?
         let delegate = NavigationDelegate { result = $0 }
 
         delegate.webView(webView, didFail: nil, withError: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled))
+        #expect(result == nil)
+        delegate.webView(webView, didFinish: nil)
 
         switch result {
         case .success?:
             #expect(Bool(true))
+        default:
+            #expect(Bool(false))
+        }
+    }
+
+    @MainActor
+    @Test("cancelled provisional failure is ignored until real failure")
+    func cancelledProvisionalFailureIsIgnoredUntilRealFailure() {
+        let webView = WKWebView()
+        var result: Result<Void, Error>?
+        let delegate = NavigationDelegate { result = $0 }
+
+        delegate.webView(
+            webView,
+            didFailProvisionalNavigation: nil,
+            withError: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled))
+        #expect(result == nil)
+
+        let timeout = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)
+        delegate.webView(webView, didFailProvisionalNavigation: nil, withError: timeout)
+
+        switch result {
+        case let .failure(error as NSError)?:
+            #expect(error.domain == NSURLErrorDomain)
+            #expect(error.code == NSURLErrorTimedOut)
         default:
             #expect(Bool(false))
         }


### PR DESCRIPTION
Supersedes #409.

Carries forward @spirosrap's fix to ignore NSURLErrorCancelled (-999) for OpenAI dashboard navigation, while avoiding early terminal success on cancellation.

- Ignore cancelled navigation callbacks without completing the continuation early.
- Keep non-cancelled failures as hard failures.
- Add tests that prove cancelled callbacks are non-terminal and later finish/failure drives completion.

Thanks @spirosrap for the original fix and test groundwork.
