### PR TITLE
fix(polling): Prevent hanging providers from permanently blocking background usage refresh

### DIFF
--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -55,7 +55,11 @@ extension UsageStore {
                 await descriptor.fetchOutcome(context: fetchContext)
             }
             group.addTask {
-                try? await Task.sleep(for: .seconds(30))
+                do {
+                    try await Task.sleep(for: .seconds(30))
+                } catch {
+                    return nil
+                }
                 self.providerLogger.warning("Provider refresh timed out", metadata: ["provider": provider.rawValue])
                 return nil
             }

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -45,14 +45,29 @@ extension UsageStore {
         let fetchContext = spec.makeFetchContext()
         let descriptor = spec.descriptor
         // Keep provider fetch work off MainActor so slow keychain/process reads don't stall menu/UI responsiveness.
+        // We use a withTaskGroup with a 30-second timeout leg to ensure that a single hanging provider 
+        // does not block the entire refresh task group permanently.
         let outcome = await withTaskGroup(
-            of: ProviderFetchOutcome.self,
+            of: ProviderFetchOutcome?.self,
             returning: ProviderFetchOutcome.self)
         { group in
             group.addTask {
                 await descriptor.fetchOutcome(context: fetchContext)
             }
-            return await group.next()!
+            group.addTask {
+                try? await Task.sleep(for: .seconds(30))
+                self.providerLogger.warning("Provider refresh timed out", metadata: ["provider": provider.rawValue])
+                return nil
+            }
+            let first = await group.next()
+            group.cancelAll()
+            if let first, let outcome = first {
+                return outcome
+            } else {
+                return ProviderFetchOutcome(
+                    result: .failure(SubprocessRunnerError.timedOut("\(provider.rawValue) fetch")),
+                    attempts: [])
+            }
         }
         if provider == .claude,
            ClaudeOAuthCredentialsStore.invalidateCacheIfCredentialsFileChanged()

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -494,7 +494,18 @@ final class UsageStore {
         self.timerTask = Task.detached(priority: .utility) { [weak self] in
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(wait))
-                await self?.refresh()
+                // We use a 60-second window to allow all providers ample time to finish under normal conditions.
+                guard let store = self else { return }
+                try? await withThrowingTaskGroup(of: Void.self) { group in
+                    group.addTask { await store.refresh() }
+                    group.addTask {
+                        try await Task.sleep(for: .seconds(60))
+                        store.providerLogger.error("GLOBAL REFRESH HANG DETECTED: reached 60s safety timeout")
+                        throw SubprocessRunnerError.timedOut("global refresh")
+                    }
+                    _ = try await group.next()
+                    group.cancelAll()
+                }
             }
         }
     }

--- a/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
+++ b/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
@@ -59,111 +59,123 @@ public enum SubprocessRunner {
         process.arguments = arguments
         process.environment = environment
 
+        var processGroup: pid_t? = nil
+        var exitCodeTask: Task<Int32, Never>? = nil
+
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
         process.standardInput = nil
 
+        // Create asynchronous tasks to read from stdout and stderr.
+        // Using readToEnd() in a separate task ensures we capture all output without blocking the main execution.
         let stdoutTask = Task<Data, Never> {
-            stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+            (try? stdoutPipe.fileHandleForReading.readToEnd()) ?? Data()
         }
         let stderrTask = Task<Data, Never> {
-            stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            (try? stderrPipe.fileHandleForReading.readToEnd()) ?? Data()
         }
 
-        do {
-            try process.run()
-        } catch {
-            stdoutTask.cancel()
-            stderrTask.cancel()
-            stdoutPipe.fileHandleForReading.closeFile()
-            stderrPipe.fileHandleForReading.closeFile()
-            throw SubprocessRunnerError.launchFailed(error.localizedDescription)
-        }
-
-        var processGroup: pid_t?
-        let pid = process.processIdentifier
-        if setpgid(pid, pid) == 0 {
-            processGroup = pid
-        }
-
-        let exitCodeTask = Task<Int32, Never> {
-            process.waitUntilExit()
-            return process.terminationStatus
-        }
-
-        do {
-            let exitCode = try await withThrowingTaskGroup(of: Int32.self) { group in
-                group.addTask { await exitCodeTask.value }
-                group.addTask {
-                    try await Task.sleep(for: .seconds(timeout))
-                    throw SubprocessRunnerError.timedOut(label)
-                }
-                let code = try await group.next()!
-                group.cancelAll()
-                return code
-            }
-
-            let stdoutData = await stdoutTask.value
-            let stderrData = await stderrTask.value
-            let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
-            let stderr = String(data: stderrData, encoding: .utf8) ?? ""
-
-            if exitCode != 0 {
-                let duration = Date().timeIntervalSince(start)
-                self.log.warning(
-                    "Subprocess failed",
-                    metadata: [
-                        "label": label,
-                        "binary": binaryName,
-                        "status": "\(exitCode)",
-                        "duration_ms": "\(Int(duration * 1000))",
-                    ])
-                throw SubprocessRunnerError.nonZeroExit(code: exitCode, stderr: stderr)
-            }
-
-            let duration = Date().timeIntervalSince(start)
-            self.log.debug(
-                "Subprocess exit",
-                metadata: [
-                    "label": label,
-                    "binary": binaryName,
-                    "status": "\(exitCode)",
-                    "duration_ms": "\(Int(duration * 1000))",
-                ])
-            return SubprocessResult(stdout: stdout, stderr: stderr)
-        } catch {
-            let duration = Date().timeIntervalSince(start)
-            self.log.warning(
-                "Subprocess error",
-                metadata: [
-                    "label": label,
-                    "binary": binaryName,
-                    "duration_ms": "\(Int(duration * 1000))",
-                ])
+        defer {
+            // CRITICAL: Ensure the process is actually killed on exit/error/timeout.
             if process.isRunning {
+                self.log.debug("Subprocess cleanup: terminating running process", metadata: ["label": label])
                 process.terminate()
                 if let pgid = processGroup {
                     kill(-pgid, SIGTERM)
                 }
+                
+                // Give it a brief window to exit gracefully before SIGKILL.
                 let killDeadline = Date().addingTimeInterval(0.4)
                 while process.isRunning, Date() < killDeadline {
                     usleep(50000)
                 }
+                
                 if process.isRunning {
+                    self.log.warning("Subprocess cleanup: process resisted SIGTERM, sending SIGKILL", metadata: ["label": label])
                     if let pgid = processGroup {
                         kill(-pgid, SIGKILL)
                     }
                     kill(process.processIdentifier, SIGKILL)
                 }
             }
-            exitCodeTask.cancel()
+            
+            // Cancel tasks to avoid leaking resources.
+            exitCodeTask?.cancel()
             stdoutTask.cancel()
             stderrTask.cancel()
-            stdoutPipe.fileHandleForReading.closeFile()
-            stderrPipe.fileHandleForReading.closeFile()
-            throw error
+            
+            // Ensure pipes are closed on exit to unblock any pending read operations.
+            try? stdoutPipe.fileHandleForReading.close()
+            try? stderrPipe.fileHandleForReading.close()
         }
+
+        do {
+            try process.run()
+        } catch {
+            self.log.error("Subprocess launch failed", metadata: ["label": label, "error": error.localizedDescription])
+            throw SubprocessRunnerError.launchFailed(error.localizedDescription)
+        }
+
+        let pid = process.processIdentifier
+        if setpgid(pid, pid) == 0 {
+            processGroup = pid
+        }
+
+        // Wait for the process to exit or the timeout to fire.
+        let task = Task<Int32, Never> {
+            process.waitUntilExit()
+            return process.terminationStatus
+        }
+        exitCodeTask = task
+
+        let exitCode = try await withThrowingTaskGroup(of: Int32.self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                try await Task.sleep(for: .seconds(timeout))
+                self.log.warning("Subprocess timed out", metadata: ["label": label, "timeout": "\(timeout)"])
+                throw SubprocessRunnerError.timedOut(label)
+            }
+            let code = try await group.next()!
+            group.cancelAll()
+            return code
+        }
+
+        // IMPORTANT: We close the pipes BEFORE awaiting the reading tasks.
+        // readToEnd() can block indefinitely if the underlying process is dead but the pipe is still "open" 
+        // in a zombie state or if a child process inherited it. Closing the handle explicitly triggers EOF 
+        // in the reading task, allowing stdoutTask.value to complete.
+        try? stdoutPipe.fileHandleForReading.close()
+        try? stderrPipe.fileHandleForReading.close()
+
+        let stdoutData = await stdoutTask.value
+        let stderrData = await stderrTask.value
+        let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
+        let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+
+        if exitCode != 0 {
+            let duration = Date().timeIntervalSince(start)
+            self.log.warning(
+                "Subprocess failed",
+                metadata: [
+                    "label": label,
+                    "binary": binaryName,
+                    "status": "\(exitCode)",
+                    "duration_ms": "\(Int(duration * 1000))",
+                ])
+            throw SubprocessRunnerError.nonZeroExit(code: exitCode, stderr: stderr)
+        }
+
+        let duration = Date().timeIntervalSince(start)
+        self.log.debug(
+            "Subprocess exit",
+            metadata: [
+                "label": label,
+                "binary": binaryName,
+                "status": "\(exitCode)",
+                "duration_ms": "\(Int(duration * 1000))",
+            ])
+        return SubprocessResult(stdout: stdout, stderr: stderr)
     }
 }


### PR DESCRIPTION
## Summary
This PR prevents hanging usage providers from permanently blocking the background usage refresh loop.

### What was happening
- The background usage poller could permanently freeze if a provider request or subprocess blocked indefinitely (e.g., due to a network blackhole or a hanging CLI command).
- This caused CodexBar to stop updating usage data entirely until restarted.

### Root cause
- The `UsageStore` polling loop lacked a global timeout safety net.
- `UsageStore+Refresh` awaited provider `fetchOutcome()` indefinitely.
- `SubprocessRunner` pipes were awaited before being closed, meaning inherited file handles from zombie child processes could block stdout/stderr reads safely.

## What changed
1. **Global Polling Timeout**
- Added a 60-second task group timeout to the background polling loop in `UsageStore.swift`.

2. **Per-Provider Refresh Timeout**
- Added a 30-second task group timeout per provider in `UsageStore+Refresh.swift`.

3. **Subprocess Hardening**
- Improved `SubprocessRunner.swift` with guaranteed execution of cleanup via a `defer` block.
- Implemented aggressive `SIGKILL` enforcement to murder processes resisting `SIGTERM`.
- Explicitly closed stdout/stderr pipes *before* awaiting their read tasks to unblock hanging `readToEnd()` calls.

## Before / After
### Before
- Permanent background thread hang if Antigravity stalled, or if network requests were blackholed.

### After
- The system gracefully recovers and logs a warning if any provider takes longer than 30 seconds.
- Background polling loop cleanly restarts even if a fetch hangs.

## Validation
- Monitored background polling logs ensuring hanging fetching operations correctly encounter `SubprocessRunnerError.timedOut`.
- Zombie processes correctly terminated via `defer` cleanup loops.

## Notes
Fixes #189
