### PR TITLE
Add GPT-5.3 Codex pricing support

### DIFF
--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
@@ -41,6 +41,14 @@ enum CostUsagePricing {
             inputCostPerToken: 1.75e-6,
             outputCostPerToken: 1.4e-5,
             cacheReadInputCostPerToken: 1.75e-7),
+        "gpt-5.3": CodexPricing(
+            inputCostPerToken: 1.75e-6,
+            outputCostPerToken: 1.4e-5,
+            cacheReadInputCostPerToken: 1.75e-7),
+        "gpt-5.3-codex": CodexPricing(
+            inputCostPerToken: 1.75e-6,
+            outputCostPerToken: 1.4e-5,
+            cacheReadInputCostPerToken: 1.75e-7),
     ]
 
     private static let claude: [String: ClaudePricing] = [

--- a/Tests/CodexBarTests/CostUsagePricingTests.swift
+++ b/Tests/CodexBarTests/CostUsagePricingTests.swift
@@ -7,6 +7,7 @@ struct CostUsagePricingTests {
     func normalizesCodexModelVariants() {
         #expect(CostUsagePricing.normalizeCodexModel("openai/gpt-5-codex") == "gpt-5")
         #expect(CostUsagePricing.normalizeCodexModel("gpt-5.2-codex") == "gpt-5.2")
+        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.3-codex") == "gpt-5.3")
         #expect(CostUsagePricing.normalizeCodexModel("gpt-5.1-codex-max") == "gpt-5.1")
     }
 
@@ -14,6 +15,16 @@ struct CostUsagePricingTests {
     func codexCostSupportsGpt51CodexMax() {
         let cost = CostUsagePricing.codexCostUSD(
             model: "gpt-5.1-codex-max",
+            inputTokens: 100,
+            cachedInputTokens: 10,
+            outputTokens: 5)
+        #expect(cost != nil)
+    }
+
+    @Test
+    func codexCostSupportsGpt53Codex() {
+        let cost = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.3-codex",
             inputTokens: 100,
             cachedInputTokens: 10,
             outputTokens: 5)


### PR DESCRIPTION
## Summary
- add `gpt-5.3` and `gpt-5.3-codex` entries to Codex cost pricing
- ensure `gpt-5.3-codex` normalizes to `gpt-5.3`
- add a pricing test to prevent regressions

## Validation
- `pnpm check`
- `./Scripts/compile_and_run.sh`
- `swift test --filter CostUsagePricingTests`

## Context
This fixes missing cost history bars for `gpt-5.3-codex` sessions. The model usage was present in local Codex session logs but excluded from cost history because pricing was missing.
