### PR TITLE
Fix Gecko cookie profile detection for uppercase .Default directories

### DIFF
--- a/Sources/CodexBarCore/BrowserDetection.swift
+++ b/Sources/CodexBarCore/BrowserDetection.swift
@@ -214,7 +214,7 @@ public final class BrowserDetection: Sendable {
 
         if browser.usesGeckoProfileStore {
             return contents.contains { name in
-                name.contains(".default")
+                name.range(of: ".default", options: [.caseInsensitive]) != nil
             }
         }
 
@@ -225,7 +225,7 @@ public final class BrowserDetection: Sendable {
         guard let contents = self.directoryContents(profilePath) else { return false }
 
         if browser.usesGeckoProfileStore {
-            for name in contents where name.contains(".default") {
+            for name in contents where name.range(of: ".default", options: [.caseInsensitive]) != nil {
                 let cookieDB = "\(profilePath)/\(name)/cookies.sqlite"
                 if self.fileExists(cookieDB) {
                     return true

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -112,6 +112,28 @@ struct BrowserDetectionTests {
         FileManager.default.createFile(atPath: profile.appendingPathComponent("cookies.sqlite").path, contents: Data())
         #expect(detection.isCookieSourceAvailable(.firefox) == true)
     }
+
+    @Test
+    func zenAcceptsUppercaseDefaultProfileDir() throws {
+        let temp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let profiles = temp
+            .appendingPathComponent("Library")
+            .appendingPathComponent("Application Support")
+            .appendingPathComponent("zen")
+            .appendingPathComponent("Profiles")
+        try FileManager.default.createDirectory(at: profiles, withIntermediateDirectories: true)
+
+        let detection = BrowserDetection(homeDirectory: temp.path, cacheTTL: 0)
+        #expect(detection.isCookieSourceAvailable(.zen) == false)
+
+        let profile = profiles.appendingPathComponent("abc.Default (release)")
+        try FileManager.default.createDirectory(at: profile, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: profile.appendingPathComponent("cookies.sqlite").path, contents: Data())
+        #expect(detection.isCookieSourceAvailable(.zen) == true)
+    }
 }
 
 #else


### PR DESCRIPTION
## Summary
- match Gecko profile directory names case-insensitively when checking for `*.default*`
- apply this to both profile availability checks and `cookies.sqlite` detection
- add regression test for Zen profile directory names like `abc.Default (release)`

## Why
Some Firefox/Zen installs use uppercase `Default` in profile directory names. Current matching only checked lowercase `.default`, which can skip valid cookie stores and block cookie import.

## Validation
- `pnpm check`
- `./Scripts/compile_and_run.sh`
- manual local verification: `CodexBarCLI usage --provider cursor --source auto ...` imported cookies successfully from `Zen e6wtnxlb.Default (release)`
- `swift test --filter BrowserDetectionTests`

## Note
`swift test` (full suite) currently crashes in existing `ProviderVersionDetector` teardown path (`NSConcreteTask terminationStatus: task still running`) on current main; unrelated to this change.