### PR TITLE
Show Cursor plan usage in dollars

### DIFF
--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -35,9 +35,13 @@ struct UsageMenuCardView: View {
             let detailRightText: String?
             let pacePercent: Double?
             let paceOnTop: Bool
+            let customLabel: String?
 
             var percentLabel: String {
-                String(format: "%.0f%% %@", self.percent, self.percentStyle.labelSuffix)
+                if let customLabel {
+                    return customLabel
+                }
+                return String(format: "%.0f%% %@", self.percent, self.percentStyle.labelSuffix)
             }
         }
 
@@ -806,7 +810,14 @@ extension UsageMenuCardView.Model {
         let zaiUsage = input.provider == .zai ? snapshot.zaiUsage : nil
         let zaiTokenDetail = Self.zaiLimitDetailText(limit: zaiUsage?.tokenLimit)
         let zaiTimeDetail = Self.zaiLimitDetailText(limit: zaiUsage?.timeLimit)
-        let openRouterQuotaDetail = Self.openRouterQuotaDetail(provider: input.provider, snapshot: snapshot)
+        let openRouterQuotaDetail = Self.openRouterQuotaDetail(
+            provider: input.provider,
+            snapshot: snapshot,
+            showUsed: input.usageBarsShowUsed)
+        let cursorPlanUsageDetail = Self.cursorPlanUsageDetail(
+            provider: input.provider,
+            snapshot: snapshot,
+            showUsed: input.usageBarsShowUsed)
         if let primary = snapshot.primary {
             var primaryDetailText: String? = input.provider == .zai ? zaiTokenDetail : nil
             var primaryResetText = Self.resetText(for: primary, style: input.resetTimeDisplayStyle, now: input.now)
@@ -824,18 +835,33 @@ extension UsageMenuCardView.Model {
             if input.provider == .warp, primary.resetsAt == nil {
                 primaryResetText = nil
             }
+            // For Cursor, show dollar-based bar instead of percentage
+            var primaryPercent = Self.clamped(
+                input.usageBarsShowUsed ? primary.usedPercent : primary.remainingPercent)
+            var primaryCustomLabel: String?
+            if input.provider == .cursor {
+                if let cost = snapshot.cursorPlanCost,
+                   cost.limit > 0
+                {
+                    let usedPercent = (cost.used / cost.limit) * 100
+                    primaryPercent = Self.clamped(input.usageBarsShowUsed ? usedPercent : (100 - usedPercent))
+                    primaryCustomLabel = cursorPlanUsageDetail
+                } else {
+                    primaryCustomLabel = "Usage unavailable"
+                }
+            }
             metrics.append(Metric(
                 id: "primary",
                 title: input.metadata.sessionLabel,
-                percent: Self.clamped(
-                    input.usageBarsShowUsed ? primary.usedPercent : primary.remainingPercent),
+                percent: primaryPercent,
                 percentStyle: percentStyle,
                 resetText: primaryResetText,
                 detailText: primaryDetailText,
                 detailLeftText: nil,
                 detailRightText: nil,
                 pacePercent: nil,
-                paceOnTop: true))
+                paceOnTop: true,
+                customLabel: primaryCustomLabel))
         }
         if let weekly = snapshot.secondary {
             let paceDetail = Self.weeklyPaceDetail(
@@ -862,7 +888,8 @@ extension UsageMenuCardView.Model {
                 detailLeftText: paceDetail?.leftLabel,
                 detailRightText: paceDetail?.rightLabel,
                 pacePercent: paceDetail?.pacePercent,
-                paceOnTop: paceDetail?.paceOnTop ?? true))
+                paceOnTop: paceDetail?.paceOnTop ?? true,
+                customLabel: nil))
         }
         if input.metadata.supportsOpus, let opus = snapshot.tertiary {
             metrics.append(Metric(
@@ -875,7 +902,8 @@ extension UsageMenuCardView.Model {
                 detailLeftText: nil,
                 detailRightText: nil,
                 pacePercent: nil,
-                paceOnTop: true))
+                paceOnTop: true,
+                customLabel: nil))
         }
 
         if input.provider == .codex, let remaining = input.dashboard?.codeReviewRemainingPercent {
@@ -890,7 +918,8 @@ extension UsageMenuCardView.Model {
                 detailLeftText: nil,
                 detailRightText: nil,
                 pacePercent: nil,
-                paceOnTop: true))
+                paceOnTop: true,
+                customLabel: nil))
         }
         return metrics
     }
@@ -911,7 +940,11 @@ extension UsageMenuCardView.Model {
         return nil
     }
 
-    private static func openRouterQuotaDetail(provider: UsageProvider, snapshot: UsageSnapshot) -> String? {
+    private static func openRouterQuotaDetail(
+        provider: UsageProvider,
+        snapshot: UsageSnapshot,
+        showUsed: Bool) -> String?
+    {
         guard provider == .openrouter,
               let usage = snapshot.openRouterUsage,
               usage.hasValidKeyQuota,
@@ -921,9 +954,41 @@ extension UsageMenuCardView.Model {
             return nil
         }
 
-        let remaining = UsageFormatter.usdString(keyRemaining)
         let limit = UsageFormatter.usdString(keyLimit)
-        return "\(remaining)/\(limit) left"
+        if showUsed {
+            let used = UsageFormatter.usdString(keyLimit - keyRemaining)
+            return "\(used)/\(limit) used"
+        } else {
+            let remaining = UsageFormatter.usdString(keyRemaining)
+            return "\(remaining)/\(limit) left"
+        }
+    }
+
+    private static func cursorPlanUsageDetail(
+        provider: UsageProvider,
+        snapshot: UsageSnapshot,
+        showUsed: Bool) -> String?
+    {
+        guard provider == .cursor,
+              let cost = snapshot.cursorPlanCost,
+              cost.limit > 0
+        else {
+            return nil
+        }
+
+        let limit = UsageFormatter.currencyString(cost.limit, currencyCode: cost.currencyCode)
+        if cost.used > cost.limit {
+            let overLimit = UsageFormatter.currencyString(cost.used - cost.limit, currencyCode: cost.currencyCode)
+            return "\(overLimit) over limit"
+        }
+
+        if showUsed {
+            let used = UsageFormatter.currencyString(cost.used, currencyCode: cost.currencyCode)
+            return "\(used) / \(limit) used"
+        } else {
+            let remaining = UsageFormatter.currencyString(cost.limit - cost.used, currencyCode: cost.currencyCode)
+            return "\(remaining) / \(limit) left"
+        }
     }
 
     private struct PaceDetail {

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -441,6 +441,10 @@ extension StatusItemController {
     }
 
     func menuBarDisplayText(for provider: UsageProvider, snapshot: UsageSnapshot?) -> String? {
+        if provider == .cursor {
+            return self.cursorMenuBarDollarText(snapshot: snapshot)
+        }
+
         let percentWindow = self.menuBarPercentWindow(for: provider, snapshot: snapshot)
         let displayText = MenuBarDisplayText.displayText(
             mode: self.settings.menuBarDisplayMode,
@@ -469,6 +473,24 @@ extension StatusItemController {
 
     private func menuBarPercentWindow(for provider: UsageProvider, snapshot: UsageSnapshot?) -> RateWindow? {
         self.menuBarMetricWindow(for: provider, snapshot: snapshot)
+    }
+
+    private func cursorMenuBarDollarText(snapshot: UsageSnapshot?) -> String? {
+        guard let cost = snapshot?.cursorPlanCost, cost.limit > 0 else { return nil }
+
+        let limit = UsageFormatter.currencyString(cost.limit, currencyCode: cost.currencyCode)
+        if cost.used > cost.limit {
+            let overLimit = UsageFormatter.currencyString(cost.used - cost.limit, currencyCode: cost.currencyCode)
+            return "\(overLimit) over"
+        }
+
+        if self.settings.usageBarsShowUsed {
+            let used = UsageFormatter.currencyString(cost.used, currencyCode: cost.currencyCode)
+            return "\(used)/\(limit)"
+        } else {
+            let remaining = UsageFormatter.currencyString(cost.limit - cost.used, currencyCode: cost.currencyCode)
+            return "\(remaining)/\(limit)"
+        }
     }
 
     private func primaryProviderForUnifiedIcon() -> UsageProvider {

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -280,6 +280,18 @@ public struct CursorStatusSnapshot: Sendable {
             nil
         }
 
+        let cursorPlanCost: ProviderCostSnapshot? = if self.planLimitUSD > 0 {
+            ProviderCostSnapshot(
+                used: self.planUsedUSD,
+                limit: self.planLimitUSD,
+                currencyCode: "USD",
+                period: "monthly",
+                resetsAt: self.billingCycleEnd,
+                updatedAt: Date())
+        } else {
+            nil
+        }
+
         // Provider cost snapshot for on-demand usage
         let providerCost: ProviderCostSnapshot? = if resolvedOnDemandUsed > 0 {
             ProviderCostSnapshot(
@@ -312,6 +324,7 @@ public struct CursorStatusSnapshot: Sendable {
             secondary: secondary,
             tertiary: nil,
             providerCost: providerCost,
+            cursorPlanCost: cursorPlanCost,
             cursorRequests: cursorRequests,
             updatedAt: Date(),
             identity: identity)
@@ -695,10 +708,9 @@ public struct CursorStatusProbe: Sendable {
         let planLimitRaw = Double(summary.individualUsage?.plan?.limit ?? 0)
         let planUsed = planUsedRaw / 100.0
         let planLimit = planLimitRaw / 100.0
+        // Cursor plan display is dollar-first. If limit is missing, do not fall back to percent-only fields.
         let planPercentUsed: Double = if planLimitRaw > 0 {
             (planUsedRaw / planLimitRaw) * 100
-        } else if let totalPercentUsed = summary.individualUsage?.plan?.totalPercentUsed {
-            totalPercentUsed <= 1 ? totalPercentUsed * 100 : totalPercentUsed
         } else {
             0
         }

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -52,6 +52,7 @@ public struct UsageSnapshot: Codable, Sendable {
     public let secondary: RateWindow?
     public let tertiary: RateWindow?
     public let providerCost: ProviderCostSnapshot?
+    public let cursorPlanCost: ProviderCostSnapshot?
     public let zaiUsage: ZaiUsageSnapshot?
     public let minimaxUsage: MiniMaxUsageSnapshot?
     public let openRouterUsage: OpenRouterUsageSnapshot?
@@ -64,6 +65,7 @@ public struct UsageSnapshot: Codable, Sendable {
         case secondary
         case tertiary
         case providerCost
+        case cursorPlanCost
         case openRouterUsage
         case updatedAt
         case identity
@@ -77,6 +79,7 @@ public struct UsageSnapshot: Codable, Sendable {
         secondary: RateWindow?,
         tertiary: RateWindow? = nil,
         providerCost: ProviderCostSnapshot? = nil,
+        cursorPlanCost: ProviderCostSnapshot? = nil,
         zaiUsage: ZaiUsageSnapshot? = nil,
         minimaxUsage: MiniMaxUsageSnapshot? = nil,
         openRouterUsage: OpenRouterUsageSnapshot? = nil,
@@ -88,6 +91,7 @@ public struct UsageSnapshot: Codable, Sendable {
         self.secondary = secondary
         self.tertiary = tertiary
         self.providerCost = providerCost
+        self.cursorPlanCost = cursorPlanCost
         self.zaiUsage = zaiUsage
         self.minimaxUsage = minimaxUsage
         self.openRouterUsage = openRouterUsage
@@ -102,6 +106,7 @@ public struct UsageSnapshot: Codable, Sendable {
         self.secondary = try container.decodeIfPresent(RateWindow.self, forKey: .secondary)
         self.tertiary = try container.decodeIfPresent(RateWindow.self, forKey: .tertiary)
         self.providerCost = try container.decodeIfPresent(ProviderCostSnapshot.self, forKey: .providerCost)
+        self.cursorPlanCost = try container.decodeIfPresent(ProviderCostSnapshot.self, forKey: .cursorPlanCost)
         self.zaiUsage = nil // Not persisted, fetched fresh each time
         self.minimaxUsage = nil // Not persisted, fetched fresh each time
         self.openRouterUsage = try container.decodeIfPresent(OpenRouterUsageSnapshot.self, forKey: .openRouterUsage)
@@ -132,6 +137,7 @@ public struct UsageSnapshot: Codable, Sendable {
         try container.encode(self.secondary, forKey: .secondary)
         try container.encode(self.tertiary, forKey: .tertiary)
         try container.encodeIfPresent(self.providerCost, forKey: .providerCost)
+        try container.encodeIfPresent(self.cursorPlanCost, forKey: .cursorPlanCost)
         try container.encodeIfPresent(self.openRouterUsage, forKey: .openRouterUsage)
         try container.encode(self.updatedAt, forKey: .updatedAt)
         try container.encodeIfPresent(self.identity, forKey: .identity)
@@ -185,6 +191,7 @@ public struct UsageSnapshot: Codable, Sendable {
             secondary: self.secondary,
             tertiary: self.tertiary,
             providerCost: self.providerCost,
+            cursorPlanCost: self.cursorPlanCost,
             zaiUsage: self.zaiUsage,
             minimaxUsage: self.minimaxUsage,
             openRouterUsage: self.openRouterUsage,

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -150,7 +150,7 @@ struct CursorStatusProbeTests {
     }
 
     @Test
-    func usesPercentFieldWhenLimitMissing() {
+    func keepsPlanPercentAtZeroWhenLimitMissing() {
         let snapshot = CursorStatusProbe(browserDetection: BrowserDetection(cacheTTL: 0))
             .parseUsageSummary(
                 CursorUsageSummary(
@@ -176,7 +176,7 @@ struct CursorStatusProbeTests {
                 userInfo: nil,
                 rawJSON: nil)
 
-        #expect(snapshot.planPercentUsed == 50.0)
+        #expect(snapshot.planPercentUsed == 0)
     }
 
     @Test
@@ -203,6 +203,9 @@ struct CursorStatusProbeTests {
         #expect(usageSnapshot.secondary != nil)
         // Uses individual on-demand values (what users see in their dashboard)
         #expect(usageSnapshot.secondary?.usedPercent == 5.0)
+        #expect(usageSnapshot.cursorPlanCost?.used == 22.5)
+        #expect(usageSnapshot.cursorPlanCost?.limit == 50.0)
+        #expect(usageSnapshot.cursorPlanCost?.currencyCode == "USD")
         #expect(usageSnapshot.providerCost?.used == 5.0)
         #expect(usageSnapshot.providerCost?.limit == 100.0)
         #expect(usageSnapshot.providerCost?.currencyCode == "USD")
@@ -283,6 +286,8 @@ struct CursorStatusProbeTests {
         #expect(usageSnapshot.providerCost != nil)
         #expect(usageSnapshot.providerCost?.used == 10.0)
         #expect(usageSnapshot.providerCost?.limit == 0.0)
+        #expect(usageSnapshot.cursorPlanCost?.used == 25.0)
+        #expect(usageSnapshot.cursorPlanCost?.limit == 50.0)
         // Secondary should be nil when no on-demand limit
         #expect(usageSnapshot.secondary == nil)
     }
@@ -318,6 +323,7 @@ struct CursorStatusProbeTests {
         #expect(usageSnapshot.cursorRequests?.limit == 500)
         #expect(usageSnapshot.cursorRequests?.usedPercent == 100.0)
         #expect(usageSnapshot.cursorRequests?.remainingPercent == 0.0)
+        #expect(usageSnapshot.cursorPlanCost == nil)
 
         // Primary RateWindow should use request-based percentage for legacy plans
         #expect(usageSnapshot.primary?.usedPercent == 100.0)
@@ -404,6 +410,8 @@ struct CursorStatusProbeTests {
 
         let usageSnapshot = snapshot.toUsageSnapshot()
         #expect(usageSnapshot.cursorRequests == nil)
+        #expect(usageSnapshot.cursorPlanCost?.used == 25.0)
+        #expect(usageSnapshot.cursorPlanCost?.limit == 50.0)
     }
 
     // MARK: - Session Store Serialization

--- a/Tests/CodexBarTests/MenuCardModelTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelTests.swift
@@ -127,6 +127,260 @@ struct MenuCardModelTests {
     }
 
     @Test
+    func cursorPrimaryMetricShowsPlanDollarUsageDetail() throws {
+        let now = Date()
+        let identity = ProviderIdentitySnapshot(
+            providerID: .cursor,
+            accountEmail: "cursor@example.com",
+            accountOrganization: nil,
+            loginMethod: "Cursor Ultra")
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 5,
+                windowMinutes: nil,
+                resetsAt: now.addingTimeInterval(86400),
+                resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            cursorPlanCost: ProviderCostSnapshot(
+                used: 20,
+                limit: 400,
+                currencyCode: "USD",
+                period: "monthly",
+                resetsAt: now.addingTimeInterval(86400),
+                updatedAt: now),
+            updatedAt: now,
+            identity: identity)
+        let metadata = try #require(ProviderDefaults.metadata[.cursor])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .cursor,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: "cursor@example.com", plan: "Cursor Ultra"),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: true,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        let primary = try #require(model.metrics.first)
+        #expect(primary.customLabel == "$20.00 / $400.00 used")
+        #expect(primary.detailText == nil)
+    }
+
+    @Test
+    func cursorPrimaryMetricShowsUnavailableLabelWhenPlanCostMissing() throws {
+        let now = Date()
+        let identity = ProviderIdentitySnapshot(
+            providerID: .cursor,
+            accountEmail: "cursor@example.com",
+            accountOrganization: nil,
+            loginMethod: "Cursor Ultra")
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 5,
+                windowMinutes: nil,
+                resetsAt: now.addingTimeInterval(86400),
+                resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            cursorPlanCost: nil,
+            updatedAt: now,
+            identity: identity)
+        let metadata = try #require(ProviderDefaults.metadata[.cursor])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .cursor,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: "cursor@example.com", plan: "Cursor Ultra"),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: true,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        let primary = try #require(model.metrics.first)
+        #expect(primary.customLabel == "Usage unavailable")
+        #expect(primary.percentLabel == "Usage unavailable")
+    }
+
+    @Test
+    func cursorPrimaryMetricShowsOverLimitLabelWhenShowingUsed() throws {
+        let now = Date()
+        let identity = ProviderIdentitySnapshot(
+            providerID: .cursor,
+            accountEmail: "cursor@example.com",
+            accountOrganization: nil,
+            loginMethod: "Cursor Pro")
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 200,
+                windowMinutes: nil,
+                resetsAt: now.addingTimeInterval(86400),
+                resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            cursorPlanCost: ProviderCostSnapshot(
+                used: 400,
+                limit: 200,
+                currencyCode: "USD",
+                period: "monthly",
+                resetsAt: now.addingTimeInterval(86400),
+                updatedAt: now),
+            updatedAt: now,
+            identity: identity)
+        let metadata = try #require(ProviderDefaults.metadata[.cursor])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .cursor,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: "cursor@example.com", plan: "Cursor Pro"),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: true,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        let primary = try #require(model.metrics.first)
+        #expect(primary.customLabel == "$200.00 over limit")
+        #expect(primary.detailText == nil)
+        #expect(primary.percent == 100)
+    }
+
+    @Test
+    func cursorPrimaryMetricShowsRemainingDollarUsageDetail() throws {
+        let now = Date()
+        let identity = ProviderIdentitySnapshot(
+            providerID: .cursor,
+            accountEmail: "cursor@example.com",
+            accountOrganization: nil,
+            loginMethod: "Cursor Ultra")
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 5,
+                windowMinutes: nil,
+                resetsAt: now.addingTimeInterval(86400),
+                resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            cursorPlanCost: ProviderCostSnapshot(
+                used: 20,
+                limit: 400,
+                currencyCode: "USD",
+                period: "monthly",
+                resetsAt: now.addingTimeInterval(86400),
+                updatedAt: now),
+            updatedAt: now,
+            identity: identity)
+        let metadata = try #require(ProviderDefaults.metadata[.cursor])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .cursor,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: "cursor@example.com", plan: "Cursor Ultra"),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        let primary = try #require(model.metrics.first)
+        #expect(primary.customLabel == "$380.00 / $400.00 left")
+    }
+
+    @Test
+    func cursorPrimaryMetricShowsOverLimitLabelWhenShowingRemaining() throws {
+        let now = Date()
+        let identity = ProviderIdentitySnapshot(
+            providerID: .cursor,
+            accountEmail: "cursor@example.com",
+            accountOrganization: nil,
+            loginMethod: "Cursor Pro")
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 200,
+                windowMinutes: nil,
+                resetsAt: now.addingTimeInterval(86400),
+                resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            cursorPlanCost: ProviderCostSnapshot(
+                used: 22,
+                limit: 20,
+                currencyCode: "USD",
+                period: "monthly",
+                resetsAt: now.addingTimeInterval(86400),
+                updatedAt: now),
+            updatedAt: now,
+            identity: identity)
+        let metadata = try #require(ProviderDefaults.metadata[.cursor])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .cursor,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: "cursor@example.com", plan: "Cursor Pro"),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        let primary = try #require(model.metrics.first)
+        #expect(primary.customLabel == "$2.00 over limit")
+        #expect(primary.percent == 0)
+    }
+
+    @Test
     func showsCodeReviewMetricWhenDashboardPresent() throws {
         let now = Date()
         let identity = ProviderIdentitySnapshot(

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -427,6 +427,98 @@ struct StatusItemAnimationTests {
     }
 
     @Test
+    func menuBarDisplayTextUsesCursorDollarsInsteadOfPercent() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-cursor-dollars"),
+            zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .cursor
+        settings.menuBarDisplayMode = .both
+        settings.usageBarsShowUsed = true
+        settings.setMenuBarMetricPreference(.primary, for: .cursor)
+
+        let registry = ProviderRegistry.shared
+        if let cursorMeta = registry.metadata[.cursor] {
+            settings.setProviderEnabled(provider: .cursor, metadata: cursorMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 1, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            cursorPlanCost: ProviderCostSnapshot(
+                used: 20,
+                limit: 400,
+                currencyCode: "USD",
+                period: "monthly",
+                resetsAt: nil,
+                updatedAt: Date()),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .cursor)
+        store._setErrorForTesting(nil, provider: .cursor)
+
+        let displayText = controller.menuBarDisplayText(for: .cursor, snapshot: snapshot)
+
+        #expect(displayText == "$20.00/$400.00")
+    }
+
+    @Test
+    func menuBarDisplayTextHidesCursorTextWhenDollarDataMissing() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-cursor-no-dollars"),
+            zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .cursor
+        settings.menuBarDisplayMode = .percent
+        settings.usageBarsShowUsed = true
+        settings.setMenuBarMetricPreference(.primary, for: .cursor)
+
+        let registry = ProviderRegistry.shared
+        if let cursorMeta = registry.metadata[.cursor] {
+            settings.setProviderEnabled(provider: .cursor, metadata: cursorMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 40, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            cursorPlanCost: nil,
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .cursor)
+        store._setErrorForTesting(nil, provider: .cursor)
+
+        let displayText = controller.menuBarDisplayText(for: .cursor, snapshot: snapshot)
+
+        #expect(displayText == nil)
+    }
+
+    @Test
     func menuBarDisplayTextUsesCreditsWhenCodexWeeklyIsExhausted() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "StatusItemAnimationTests-credits-fallback"),


### PR DESCRIPTION
## Summary
- show Cursor primary usage labels in dollars (used/left and over-limit) instead of percentage text in menu cards
- show dollar text for Cursor in the menu bar brand+text mode, with no percent fallback
- persist cursorPlanCost in UsageSnapshot so dollar labels survive serialization
- keep Cursor parser dollar-first by avoiding percent-only fallback when plan limit is missing

## Tests
- swift test --filter MenuCardModelTests --filter CursorStatusProbeTests --filter StatusItemAnimationTests
- pnpm check
- ./Scripts/compile_and_run.sh

Refs: https://github.com/steipete/CodexBar/issues/398#issuecomment-3935146412
Fixes #398
