### PR TITLE
Fix MiniMax CN region: Open Coding Plan buttons use region-aware URL

### DIFF
--- a/Sources/CodexBar/Providers/MiniMax/MiniMaxProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/MiniMax/MiniMaxProviderImplementation.swift
@@ -126,11 +126,7 @@ struct MiniMaxProviderImplementation: ProviderImplementation {
                         style: .link,
                         isVisible: nil,
                         perform: {
-                            if let url = URL(
-                                string: "https://platform.minimax.io/user-center/payment/coding-plan?cycle_type=3")
-                            {
-                                NSWorkspace.shared.open(url)
-                            }
+                            NSWorkspace.shared.open(context.settings.minimaxAPIRegion.codingPlanURL)
                         }),
                 ],
                 isVisible: nil,
@@ -149,11 +145,7 @@ struct MiniMaxProviderImplementation: ProviderImplementation {
                         style: .link,
                         isVisible: nil,
                         perform: {
-                            if let url = URL(
-                                string: "https://platform.minimax.io/user-center/payment/coding-plan?cycle_type=3")
-                            {
-                                NSWorkspace.shared.open(url)
-                            }
+                            NSWorkspace.shared.open(context.settings.minimaxAPIRegion.codingPlanURL)
                         }),
                 ],
                 isVisible: {


### PR DESCRIPTION
## Summary

Both "Open Coding Plan" buttons in MiniMax settings were hardcoded to the global URL (`platform.minimax.io`) instead of using the region-aware `codingPlanURL` property. When a user selects the China mainland region (`platform.minimaxi.com`), the buttons still opened the global site.

## Changes

**`Sources/CodexBar/Providers/MiniMax/MiniMaxProviderImplementation.swift`**
- Replaced hardcoded `https://platform.minimax.io/user-center/payment/coding-plan?cycle_type=3` with `context.settings.minimaxAPIRegion.codingPlanURL` in both the API token and cookie settings actions.

## Testing

- `swift build` ✅
- `swift test` — all 807 tests passed ✅

Closes #378