### PR TITLE
Cache reset times in-memory to preserve pace/deficit/reserve display

### DIFF
--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -14,6 +14,7 @@ extension UsageStore {
             self.refreshingProviders.remove(provider)
             await MainActor.run {
                 self.snapshots.removeValue(forKey: provider)
+                self.lastKnownResetTimes.removeValue(forKey: provider)
                 self.errors[provider] = nil
                 self.lastSourceLabels.removeValue(forKey: provider)
                 self.lastFetchAttempts.removeValue(forKey: provider)
@@ -60,6 +61,7 @@ extension UsageStore {
         {
             await MainActor.run {
                 self.snapshots.removeValue(forKey: .claude)
+                self.lastKnownResetTimes.removeValue(forKey: .claude)
                 self.errors[.claude] = nil
                 self.lastSourceLabels.removeValue(forKey: .claude)
                 self.lastFetchAttempts.removeValue(forKey: .claude)
@@ -80,7 +82,9 @@ extension UsageStore {
             let scoped = result.usage.scoped(to: provider)
             await MainActor.run {
                 self.handleSessionQuotaTransition(provider: provider, snapshot: scoped)
-                self.snapshots[provider] = scoped
+                let backfilled = scoped.backfillingResetTimes(from: self.lastKnownResetTimes[provider])
+                self.lastKnownResetTimes[provider] = backfilled
+                self.snapshots[provider] = backfilled
                 self.lastSourceLabels[provider] = result.sourceLabel
                 self.errors[provider] = nil
                 self.failureGates[provider]?.recordSuccess()

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -181,7 +181,9 @@ extension UsageStore {
             }
             await MainActor.run {
                 self.handleSessionQuotaTransition(provider: provider, snapshot: labeled)
-                self.snapshots[provider] = labeled
+                let backfilled = labeled.backfillingResetTimes(from: self.lastKnownResetTimes[provider])
+                self.lastKnownResetTimes[provider] = backfilled
+                self.snapshots[provider] = backfilled
                 self.lastSourceLabels[provider] = result.sourceLabel
                 self.errors[provider] = nil
                 self.failureGates[provider]?.recordSuccess()

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -153,6 +153,7 @@ final class UsageStore {
     @ObservationIgnored let planUtilizationHistoryStore: PlanUtilizationHistoryStore
     @ObservationIgnored var codexHistoricalDataset: CodexHistoricalDataset?
     @ObservationIgnored var codexHistoricalDatasetAccountKey: String?
+    @ObservationIgnored var lastKnownResetTimes: [UsageProvider: UsageSnapshot] = [:]
     @ObservationIgnored var lastKnownSessionRemaining: [UsageProvider: Double] = [:]
     @ObservationIgnored var lastKnownSessionWindowSource: [UsageProvider: SessionQuotaWindowSource] = [:]
     @ObservationIgnored var lastTokenFetchAt: [UsageProvider: Date] = [:]

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -17,6 +17,16 @@ public struct RateWindow: Codable, Equatable, Sendable {
     public var remainingPercent: Double {
         max(0, 100 - self.usedPercent)
     }
+
+    public func backfillingResetTime(from cached: RateWindow?, now: Date = .init()) -> RateWindow {
+        if self.resetsAt != nil { return self }
+        guard let cachedReset = cached?.resetsAt, cachedReset > now else { return self }
+        return RateWindow(
+            usedPercent: self.usedPercent,
+            windowMinutes: self.windowMinutes ?? cached?.windowMinutes,
+            resetsAt: cachedReset,
+            resetDescription: self.resetDescription ?? cached?.resetDescription)
+    }
 }
 
 public struct ProviderIdentitySnapshot: Codable, Sendable {
@@ -236,6 +246,38 @@ public struct UsageSnapshot: Codable, Sendable {
         let usableFallback = fallbackWindows.filter { $0.remainingPercent > 0 }
         let exhaustedFallback = fallbackWindows.filter { $0.remainingPercent <= 0 }
         return usableFallback + exhaustedFallback
+    }
+
+    public func backfillingResetTimes(from cached: UsageSnapshot?, now: Date = .init()) -> UsageSnapshot {
+        guard let cached else { return self }
+        if !Self.identitiesMatch(self.identity, cached.identity) { return self }
+        let bp = self.primary?.backfillingResetTime(from: cached.primary, now: now)
+        let bs = self.secondary?.backfillingResetTime(from: cached.secondary, now: now)
+        let bt = self.tertiary?.backfillingResetTime(from: cached.tertiary, now: now)
+        if bp?.resetsAt == self.primary?.resetsAt,
+           bs?.resetsAt == self.secondary?.resetsAt,
+           bt?.resetsAt == self.tertiary?.resetsAt
+        { return self }
+        return UsageSnapshot(
+            primary: bp,
+            secondary: bs,
+            tertiary: bt,
+            providerCost: self.providerCost,
+            zaiUsage: self.zaiUsage,
+            minimaxUsage: self.minimaxUsage,
+            openRouterUsage: self.openRouterUsage,
+            cursorRequests: self.cursorRequests,
+            updatedAt: self.updatedAt,
+            identity: self.identity)
+    }
+
+    private static func identitiesMatch(_ a: ProviderIdentitySnapshot?, _ b: ProviderIdentitySnapshot?) -> Bool {
+        if a == nil, b == nil { return true }
+        if a == nil || b == nil { return false }
+        if let emailA = a?.accountEmail, let emailB = b?.accountEmail, !emailA.isEmpty, !emailB.isEmpty {
+            return emailA == emailB
+        }
+        return true
     }
 }
 

--- a/Tests/CodexBarTests/ResetTimeBackfillTests.swift
+++ b/Tests/CodexBarTests/ResetTimeBackfillTests.swift
@@ -1,0 +1,125 @@
+import CodexBarCore
+import Foundation
+import XCTest
+
+final class ResetTimeBackfillTests: XCTestCase {
+    func test_backfillsNilResetFromCache() {
+        let future = Date().addingTimeInterval(3600)
+        let cached = RateWindow(usedPercent: 50, windowMinutes: 300, resetsAt: future, resetDescription: "in 1h")
+        let fresh = RateWindow(usedPercent: 60, windowMinutes: 300, resetsAt: nil, resetDescription: nil)
+
+        let result = fresh.backfillingResetTime(from: cached)
+
+        XCTAssertEqual(result.usedPercent, 60)
+        XCTAssertEqual(result.resetsAt, future)
+        XCTAssertEqual(result.resetDescription, "in 1h")
+    }
+
+    func test_doesNotBackfillWhenFreshHasReset() {
+        let future1 = Date().addingTimeInterval(3600)
+        let future2 = Date().addingTimeInterval(7200)
+        let cached = RateWindow(usedPercent: 50, windowMinutes: 300, resetsAt: future1, resetDescription: nil)
+        let fresh = RateWindow(usedPercent: 60, windowMinutes: 300, resetsAt: future2, resetDescription: nil)
+
+        let result = fresh.backfillingResetTime(from: cached)
+
+        XCTAssertEqual(result.resetsAt, future2)
+    }
+
+    func test_doesNotBackfillExpiredCachedReset() {
+        let past = Date().addingTimeInterval(-60)
+        let cached = RateWindow(usedPercent: 50, windowMinutes: 300, resetsAt: past, resetDescription: nil)
+        let fresh = RateWindow(usedPercent: 60, windowMinutes: 300, resetsAt: nil, resetDescription: nil)
+
+        let result = fresh.backfillingResetTime(from: cached)
+
+        XCTAssertNil(result.resetsAt)
+    }
+
+    func test_backfillsWindowMinutesFromCache() {
+        let future = Date().addingTimeInterval(3600)
+        let cached = RateWindow(usedPercent: 50, windowMinutes: 300, resetsAt: future, resetDescription: nil)
+        let fresh = RateWindow(usedPercent: 60, windowMinutes: nil, resetsAt: nil, resetDescription: nil)
+
+        let result = fresh.backfillingResetTime(from: cached)
+
+        XCTAssertEqual(result.windowMinutes, 300)
+    }
+
+    func test_snapshotBackfillsPrimaryAndSecondary() {
+        let future = Date().addingTimeInterval(3600)
+        let cachedPrimary = RateWindow(usedPercent: 50, windowMinutes: 300, resetsAt: future, resetDescription: nil)
+        let cachedSecondary = RateWindow(
+            usedPercent: 30, windowMinutes: 10080, resetsAt: future, resetDescription: nil)
+        let cached = UsageSnapshot(
+            primary: cachedPrimary, secondary: cachedSecondary, updatedAt: Date().addingTimeInterval(-300))
+
+        let freshPrimary = RateWindow(usedPercent: 55, windowMinutes: 300, resetsAt: nil, resetDescription: nil)
+        let freshSecondary = RateWindow(usedPercent: 35, windowMinutes: 10080, resetsAt: nil, resetDescription: nil)
+        let fresh = UsageSnapshot(primary: freshPrimary, secondary: freshSecondary, updatedAt: Date())
+
+        let result = fresh.backfillingResetTimes(from: cached)
+
+        XCTAssertEqual(result.primary?.resetsAt, future)
+        XCTAssertEqual(result.secondary?.resetsAt, future)
+        XCTAssertEqual(result.primary?.usedPercent, 55)
+        XCTAssertEqual(result.secondary?.usedPercent, 35)
+    }
+
+    func test_snapshotSkipsBackfillOnAccountChange() {
+        let future = Date().addingTimeInterval(3600)
+        let oldIdentity = ProviderIdentitySnapshot(
+            providerID: .claude, accountEmail: "old@example.com", accountOrganization: nil, loginMethod: nil)
+        let newIdentity = ProviderIdentitySnapshot(
+            providerID: .claude, accountEmail: "new@example.com", accountOrganization: nil, loginMethod: nil)
+
+        let cached = UsageSnapshot(
+            primary: RateWindow(usedPercent: 50, windowMinutes: 300, resetsAt: future, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date().addingTimeInterval(-300),
+            identity: oldIdentity)
+
+        let fresh = UsageSnapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date(),
+            identity: newIdentity)
+
+        let result = fresh.backfillingResetTimes(from: cached)
+
+        XCTAssertNil(result.primary?.resetsAt, "Should not backfill across different accounts")
+    }
+
+    func test_snapshotBackfillsWhenIdentityMatches() {
+        let future = Date().addingTimeInterval(3600)
+        let identity = ProviderIdentitySnapshot(
+            providerID: .claude, accountEmail: "same@example.com", accountOrganization: nil, loginMethod: nil)
+
+        let cached = UsageSnapshot(
+            primary: RateWindow(usedPercent: 50, windowMinutes: 300, resetsAt: future, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date().addingTimeInterval(-300),
+            identity: identity)
+
+        let fresh = UsageSnapshot(
+            primary: RateWindow(usedPercent: 60, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date(),
+            identity: identity)
+
+        let result = fresh.backfillingResetTimes(from: cached)
+
+        XCTAssertEqual(result.primary?.resetsAt, future)
+    }
+
+    func test_snapshotNoOpWhenNoCachedData() {
+        let fresh = UsageSnapshot(
+            primary: RateWindow(usedPercent: 55, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        let result = fresh.backfillingResetTimes(from: nil)
+
+        XCTAssertNil(result.primary?.resetsAt)
+    }
+}


### PR DESCRIPTION
## Problem

When Claude usage is fetched via a non-cookie auth path (e.g. OAuth), `resetsAt` can come back as `nil`. This causes the pace/deficit/reserve display to disappear until the next cookie-based fetch, which may prompt the user for keychain access.

## Fix

Add a dedicated in-memory reset time cache (`lastKnownResetTimes`) on `UsageStore`, separate from the snapshots dict (which gets cleared on fetch failures and provider disable).

When a fresh fetch returns `nil` for `resetsAt`:
- Backfill from the cached value if it hasn't expired (still in the future)
- Also backfills `windowMinutes` and `resetDescription` when missing
- **Identity-aware**: skips backfill when account email changes between cached and fresh snapshots
- Applied in both the main refresh path and the token-account refresh path
- Cache cleared on credential file changes and provider disable/re-enable

## Changes

- `RateWindow.backfillingResetTime(from:)` — backfill a single rate window
- `UsageSnapshot.backfillingResetTimes(from:)` — backfill primary/secondary/tertiary with identity check
- `UsageStore.lastKnownResetTimes` — dedicated cache dict that survives snapshot clears
- `UsageStore+Refresh.swift` — apply backfill in main refresh path; clear cache on credential changes and provider disable
- `UsageStore+TokenAccounts.swift` — apply backfill in token-account refresh path
- 8 new tests covering backfill, expiry, account switch, same-account, and no-op cases

## Testing

- `swift build` ✅
- `swift test` — all 803+ tests pass ✅
- New `ResetTimeBackfillTests` — 8/8 pass ✅

Related: #232, #84