### PR TITLE
Add time-until-reset countdown to menu bar

### DIFF
--- a/Sources/CodexBar/MenuBarDisplayText.swift
+++ b/Sources/CodexBar/MenuBarDisplayText.swift
@@ -2,6 +2,20 @@ import CodexBarCore
 import Foundation
 
 enum MenuBarDisplayText {
+    /// Returns a compact countdown string (e.g. "28m" or "2h 5m") until the next quota reset.
+    /// Returns nil if `resetsAt` is nil or already in the past.
+    static func timeUntilResetText(resetsAt: Date?, now: Date = .init()) -> String? {
+        guard let resetsAt, resetsAt > now else { return nil }
+        let totalSeconds = Int(resetsAt.timeIntervalSince(now))
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        if hours > 0 {
+            return "\(hours)h \(minutes)m"
+        } else {
+            return minutes > 0 ? "\(minutes)m" : "<1m"
+        }
+    }
+
     static func percentText(window: RateWindow?, showUsed: Bool) -> String? {
         guard let window else { return nil }
         let percent = showUsed ? window.usedPercent : window.remainingPercent

--- a/Sources/CodexBar/PreferencesDisplayPane.swift
+++ b/Sources/CodexBar/PreferencesDisplayPane.swift
@@ -37,6 +37,12 @@ struct DisplayPane: View {
                         title: "Menu bar shows percent",
                         subtitle: "Replace critter bars with provider branding icons and a percentage.",
                         binding: self.$settings.menuBarShowsBrandIconWithPercent)
+                    PreferenceToggleRow(
+                        title: "Show time until reset",
+                        subtitle: "Display a countdown (e.g. \"28m\") next to the percentage in the menu bar.",
+                        binding: self.$settings.menuBarShowsTimeUntilReset)
+                        .disabled(!self.settings.menuBarShowsBrandIconWithPercent)
+                        .opacity(self.settings.menuBarShowsBrandIconWithPercent ? 1 : 0.5)
                     HStack(alignment: .top, spacing: 12) {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("Display mode")

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -117,6 +117,14 @@ extension SettingsStore {
         }
     }
 
+    var menuBarShowsTimeUntilReset: Bool {
+        get { self.defaultsState.menuBarShowsTimeUntilReset }
+        set {
+            self.defaultsState.menuBarShowsTimeUntilReset = newValue
+            self.userDefaults.set(newValue, forKey: "menuBarShowsTimeUntilReset")
+        }
+    }
+
     var menuBarShowsBrandIconWithPercent: Bool {
         get { self.defaultsState.menuBarShowsBrandIconWithPercent }
         set {

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -186,6 +186,7 @@ extension SettingsStore {
         }
         let usageBarsShowUsed = userDefaults.object(forKey: "usageBarsShowUsed") as? Bool ?? false
         let resetTimesShowAbsolute = userDefaults.object(forKey: "resetTimesShowAbsolute") as? Bool ?? false
+        let menuBarShowsTimeUntilReset = userDefaults.object(forKey: "menuBarShowsTimeUntilReset") as? Bool ?? false
         let menuBarShowsBrandIconWithPercent = userDefaults.object(
             forKey: "menuBarShowsBrandIconWithPercent") as? Bool ?? false
         let menuBarDisplayModeRaw = userDefaults.string(forKey: "menuBarDisplayMode")
@@ -236,6 +237,7 @@ extension SettingsStore {
             sessionQuotaNotificationsEnabled: sessionQuotaNotificationsEnabled,
             usageBarsShowUsed: usageBarsShowUsed,
             resetTimesShowAbsolute: resetTimesShowAbsolute,
+            menuBarShowsTimeUntilReset: menuBarShowsTimeUntilReset,
             menuBarShowsBrandIconWithPercent: menuBarShowsBrandIconWithPercent,
             menuBarDisplayModeRaw: menuBarDisplayModeRaw,
             showAllTokenAccountsInMenu: showAllTokenAccountsInMenu,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -13,6 +13,7 @@ struct SettingsDefaultsState: Sendable {
     var sessionQuotaNotificationsEnabled: Bool
     var usageBarsShowUsed: Bool
     var resetTimesShowAbsolute: Bool
+    var menuBarShowsTimeUntilReset: Bool
     var menuBarShowsBrandIconWithPercent: Bool
     var menuBarDisplayModeRaw: String?
     var showAllTokenAccountsInMenu: Bool

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -464,7 +464,19 @@ extension StatusItemController {
                 .replacingOccurrences(of: " left", with: "")
         }
 
-        return displayText
+        guard let base = displayText else { return displayText }
+
+        if self.settings.menuBarShowsTimeUntilReset {
+            // Pick the nearest upcoming reset across primary and secondary windows.
+            let now = Date()
+            let dates = [snapshot?.primary?.resetsAt, snapshot?.secondary?.resetsAt].compactMap { $0 }
+            let nearest = dates.filter { $0 > now }.min()
+            if let countdown = MenuBarDisplayText.timeUntilResetText(resetsAt: nearest, now: now) {
+                return "\(base) · \(countdown)"
+            }
+        }
+
+        return base
     }
 
     private func menuBarPercentWindow(for provider: UsageProvider, snapshot: UsageSnapshot?) -> RateWindow? {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -92,6 +92,9 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var lastSwitcherProviders: [UsageProvider] = []
     /// Tracks which switcher tab state was used for the current merged-menu switcher instance.
     var lastMergedSwitcherSelection: ProviderSwitcherSelection?
+    /// Fires every 60 seconds to keep the time-until-reset countdown current in the menu bar.
+    private var countdownRefreshTimer: Timer?
+
     let loginLogger = CodexBarLog.logger(LogCategories.login)
     var selectedMenuProvider: UsageProvider? {
         get { self.settings.selectedMenuProvider }
@@ -195,6 +198,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.observeDebugForceAnimation()
         self.observeSettingsChanges()
         self.observeUpdaterChanges()
+        self.updateCountdownTimer()
     }
 
     private func observeStoreChanges() {
@@ -320,8 +324,24 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         }
         self.updateVisibility()
         self.updateIcons()
+        self.updateCountdownTimer()
         if shouldRefreshOpenMenus {
             self.refreshOpenMenusIfNeeded()
+        }
+    }
+
+    /// Starts a 60-second repeating timer when the countdown feature is active, stops it otherwise.
+    private func updateCountdownTimer() {
+        let needsTimer = self.settings.menuBarShowsTimeUntilReset &&
+            self.settings.menuBarShowsBrandIconWithPercent
+        if needsTimer, self.countdownRefreshTimer == nil {
+            self.countdownRefreshTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) {
+                [weak self] _ in
+                Task { @MainActor [weak self] in self?.updateIcons() }
+            }
+        } else if !needsTimer, self.countdownRefreshTimer != nil {
+            self.countdownRefreshTimer?.invalidate()
+            self.countdownRefreshTimer = nil
         }
     }
 


### PR DESCRIPTION
## Summary

Adds a **time-until-reset countdown** directly in the menu bar, so you can see how long until your quota resets without having to click the icon.

**Before:** click the icon → scroll down to find "Resets in 28m"
**After:** menu bar already shows `72% · 28m`

## Settings

New toggle in **Settings → Display → Menu bar**:

> **Show time until reset** — Display a countdown (e.g. "28m") next to the percentage in the menu bar.

The toggle is disabled/faded when "Menu bar shows percent" is off, since the countdown only appears in text mode.

## Countdown format

| Time remaining | Display |
|---|---|
| Hours + minutes | `2h 5m` |
| Under an hour | `28m` |
| Under a minute | `<1m` |
| Past or unknown | *(hidden)* |

Picks the nearest upcoming reset across both the primary and secondary quota windows.

## Implementation

- `MenuBarDisplayText.timeUntilResetText()` — pure formatter, testable in isolation
- `StatusItemController` starts a 60-second `Timer` when the feature is on, so the label ticks down every minute without waiting for a data refresh; timer is torn down when disabled
- Persisted via `UserDefaults` key `menuBarShowsTimeUntilReset`, default `false`

## Test plan

- [ ] Enable "Menu bar shows percent" + "Show time until reset" → see e.g. `72% · 28m`
- [ ] Wait ~1 minute → countdown decrements automatically
- [ ] Disable toggle → only `72%` shown
- [ ] Disable "Menu bar shows percent" → countdown toggle is greyed out