### PR TITLE
Publish macOS CLI tarballs in release workflow

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,4 +1,4 @@
-name: Release Linux CLI
+name: Release CLI
 
 on:
   release:
@@ -9,15 +9,31 @@ permissions:
   contents: write
 
 jobs:
-  build-linux-cli:
+  build-cli:
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: linux-x64
             runs-on: ubuntu-24.04
+            platform: linux
+            arch: x86_64
+            static-swift-stdlib: true
           - name: linux-arm64
             runs-on: ubuntu-24.04-arm
+            platform: linux
+            arch: aarch64
+            static-swift-stdlib: true
+          - name: macos-arm64
+            runs-on: macos-14
+            platform: macos
+            arch: arm64
+            static-swift-stdlib: false
+          - name: macos-x64
+            runs-on: macos-13
+            platform: macos
+            arch: x86_64
+            static-swift-stdlib: false
     runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v6
@@ -27,15 +43,25 @@ jobs:
           set -euo pipefail
           uname -a
           uname -m
+          swift --version
 
-      - name: Setup Swift 6.2.1
+      - name: Setup Swift 6.2.1 (Linux)
+        if: matrix.platform == 'linux'
         uses: swift-actions/setup-swift@v3
         with:
           swift-version: "6.2.1"
           skip-verify-signature: true
 
       - name: Build CodexBarCLI (release)
-        run: swift build -c release --product CodexBarCLI --static-swift-stdlib
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          BUILD_ARGS=(swift build -c release --product CodexBarCLI)
+          if [[ "${{ matrix.static-swift-stdlib }}" == "true" ]]; then
+            BUILD_ARGS+=(--static-swift-stdlib)
+          fi
+          "${BUILD_ARGS[@]}"
 
       - name: Package
         id: pkg
@@ -49,20 +75,19 @@ jobs:
             exit 1
           fi
 
-          ARCH="$(uname -m)"
-          case "$ARCH" in
-            x86_64) ARCH="x86_64" ;;
-            aarch64|arm64) ARCH="aarch64" ;;
-          esac
+          SHOW_BIN_ARGS=(swift build -c release --product CodexBarCLI --show-bin-path)
+          if [[ "${{ matrix.static-swift-stdlib }}" == "true" ]]; then
+            SHOW_BIN_ARGS+=(--static-swift-stdlib)
+          fi
 
-          BIN_DIR="$(swift build -c release --product CodexBarCLI --static-swift-stdlib --show-bin-path)"
+          BIN_DIR="$("${SHOW_BIN_ARGS[@]}")"
           OUT_DIR="$(mktemp -d)"
           install -m 0755 "$BIN_DIR/CodexBarCLI" "$OUT_DIR/CodexBarCLI"
           ln -s "CodexBarCLI" "$OUT_DIR/codexbar"
 
-          ASSET="CodexBarCLI-${TAG}-linux-${ARCH}.tar.gz"
+          ASSET="CodexBarCLI-${TAG}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz"
           (cd "$OUT_DIR" && tar czf "$ASSET" CodexBarCLI codexbar)
-          sha256sum "$OUT_DIR/$ASSET" > "$OUT_DIR/$ASSET.sha256"
+          shasum -a 256 "$OUT_DIR/$ASSET" > "$OUT_DIR/$ASSET.sha256"
 
           echo "out_dir=$OUT_DIR" >> "$GITHUB_OUTPUT"
           echo "asset=$ASSET" >> "$GITHUB_OUTPUT"
@@ -83,7 +108,7 @@ jobs:
         if: github.event_name != 'release'
         uses: actions/upload-artifact@v6
         with:
-          name: codexbar-linux-cli-${{ matrix.name }}
+          name: codexbar-cli-${{ matrix.name }}
           path: |
             ${{ steps.pkg.outputs.out_dir }}/${{ steps.pkg.outputs.asset }}
             ${{ steps.pkg.outputs.out_dir }}/${{ steps.pkg.outputs.asset }}.sha256

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -45,8 +45,7 @@ jobs:
           uname -m
           swift --version
 
-      - name: Setup Swift 6.2.1 (Linux)
-        if: matrix.platform == 'linux'
+      - name: Setup Swift 6.2.1
         uses: swift-actions/setup-swift@v3
         with:
           swift-version: "6.2.1"

--- a/README.md
+++ b/README.md
@@ -17,11 +17,15 @@ Download: <https://github.com/steipete/CodexBar/releases>
 brew install --cask steipete/tap/codexbar
 ```
 
-### Linux (CLI only)
+### CLI (macOS/Linux)
+Homebrew formula (Linux today):
 ```bash
 brew install steipete/tap/codexbar
 ```
-Or download `CodexBarCLI-v<tag>-linux-<arch>.tar.gz` from GitHub Releases.
+Or download release tarballs from GitHub Releases:
+- macOS: `CodexBarCLI-v<tag>-macos-arm64.tar.gz`, `CodexBarCLI-v<tag>-macos-x86_64.tar.gz`
+- Linux: `CodexBarCLI-v<tag>-linux-aarch64.tar.gz`, `CodexBarCLI-v<tag>-linux-x86_64.tar.gz`
+
 Linux support via Omarchy: community Waybar module and TUI, driven by the `codexbar` executable.
 
 ### First run
@@ -63,7 +67,7 @@ The menu bar icon is a tiny two-bar meter:
 - Provider status polling with incident badges in the menu and icon overlay.
 - Merge Icons mode to combine providers into one status item + switcher, with an optional Overview tab for up to three providers.
 - Refresh cadence presets (manual, 1m, 2m, 5m, 15m).
-- Bundled CLI (`codexbar`) for scripts and CI (including `codexbar cost --provider codex|claude` for local cost usage); Linux CLI builds available.
+- Bundled CLI (`codexbar`) for scripts and CI (including `codexbar cost --provider codex|claude` for local cost usage); macOS and Linux CLI builds available.
 - WidgetKit widget mirrors the menu card snapshot.
 - Privacy-first: on-device parsing by default; browser cookies are opt-in and reused (no passwords stored).
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,13 +16,15 @@ Use it when you need usage numbers in scripts, CI, or dashboards without UI.
 - From the repo: `./bin/install-codexbar-cli.sh` (same symlink targets).
 - Manual: `ln -sf "/Applications/CodexBar.app/Contents/Helpers/CodexBarCLI" /usr/local/bin/codexbar`.
 
-### Linux install
-- Homebrew (Linuxbrew, Linux only): `brew install steipete/tap/codexbar`.
-- Download `CodexBarCLI-v<tag>-linux-<arch>.tar.gz` from GitHub Releases (x86_64 + aarch64).
-- Extract; run `./codexbar` (symlink) or `./CodexBarCLI`.
+### Release tarball install (macOS/Linux)
+- Homebrew formula (Linux today): `brew install steipete/tap/codexbar`.
+- Download release tarballs from GitHub Releases:
+  - macOS: `CodexBarCLI-v<tag>-macos-arm64.tar.gz`, `CodexBarCLI-v<tag>-macos-x86_64.tar.gz`
+  - Linux: `CodexBarCLI-v<tag>-linux-aarch64.tar.gz`, `CodexBarCLI-v<tag>-linux-x86_64.tar.gz`
+- Extract and run `./codexbar` (symlink) or `./CodexBarCLI`.
 
 ```
-tar -xzf CodexBarCLI-v0.17.0-linux-x86_64.tar.gz
+tar -xzf CodexBarCLI-v0.17.0-macos-x86_64.tar.gz
 ./codexbar --version
 ./codexbar usage --format json --pretty
 ```

--- a/docs/releasing-homebrew.md
+++ b/docs/releasing-homebrew.md
@@ -22,12 +22,14 @@ In `../homebrew-tap`, add/update the cask at `Casks/codexbar.rb`:
 - Update `sha256` to match that zip.
 - Keep `depends_on arch: :arm64` and `depends_on macos: ">= :sonoma"` (CodexBar is macOS 14+).
 
-## 2b) Update the Homebrew tap formula (Linux CLI)
+## 2b) Update the Homebrew tap formula (CLI)
 In `../homebrew-tap`, add/update the formula at `Formula/codexbar.rb`:
 - `url` points at the GitHub release assets:
-  - `.../releases/download/v<version>/CodexBarCLI-v<version>-linux-aarch64.tar.gz`
-  - `.../releases/download/v<version>/CodexBarCLI-v<version>-linux-x86_64.tar.gz`
-- Update both `sha256` values to match those tarballs.
+  - macOS: `.../releases/download/v<version>/CodexBarCLI-v<version>-macos-arm64.tar.gz`
+  - macOS: `.../releases/download/v<version>/CodexBarCLI-v<version>-macos-x86_64.tar.gz`
+  - Linux: `.../releases/download/v<version>/CodexBarCLI-v<version>-linux-aarch64.tar.gz`
+  - Linux: `.../releases/download/v<version>/CodexBarCLI-v<version>-linux-x86_64.tar.gz`
+- Update all `sha256` values to match those tarballs.
 
 ## 3) Verify install
 ```sh


### PR DESCRIPTION
## Summary

- Expand `.github/workflows/release-cli.yml` from Linux-only to a cross-platform CLI release workflow.
- Keep existing Linux assets and add two macOS CLI tarballs on release:
  - `CodexBarCLI-v<tag>-macos-arm64.tar.gz`
  - `CodexBarCLI-v<tag>-macos-x86_64.tar.gz`
- Preserve static Swift stdlib packaging for Linux only.
- Update CLI-related docs (`README.md`, `docs/cli.md`, `docs/releasing-homebrew.md`) to reflect the new macOS + Linux CLI asset matrix.

## Why

Intel macOS users can run `CodexBarCLI`, but release assets currently only publish Linux CLI tarballs. Publishing macOS CLI tarballs closes that distribution gap and makes downstream package automation (including Homebrew formula updates) straightforward.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-cli.yml")'`
- `swift build -c release --product CodexBarCLI`
- `./.build/release/CodexBarCLI --version`

## Follow-up

Homebrew tap formula updates are still required to consume the new macOS CLI tarballs.
