### PR TITLE
docs: use repo-relative workspace paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@
 ## Build, Test, Run
 - Dev loop: `./Scripts/compile_and_run.sh` kills old instances, runs `swift build` + `swift test`, packages, relaunches `CodexBar.app`, and confirms it stays running.
 - Quick build/test: `swift build` (debug) or `swift build -c release`; `swift test` for the full XCTest suite.
-- Package locally: `./Scripts/package_app.sh` to refresh `CodexBar.app`, then restart with `pkill -x CodexBar || pkill -f CodexBar.app || true; cd /Users/steipete/Projects/codexbar && open -n /Users/steipete/Projects/codexbar/CodexBar.app`.
+- Package locally: `./Scripts/package_app.sh` to refresh `CodexBar.app`, then restart with `pkill -x CodexBar || pkill -f CodexBar.app || true; ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT" && open -n "$ROOT/CodexBar.app"`.
 - Release flow: `./Scripts/sign-and-notarize.sh` (arm64 notarized zip) and `./Scripts/make_appcast.sh <zip> <feed-url>`; follow validation steps in `docs/RELEASING.md`.
 
 ## Coding Style & Naming
@@ -28,7 +28,7 @@
 ## Agent Notes
 - Use the provided scripts and package manager (SwiftPM); avoid adding dependencies or tooling without confirmation.
 - Validate behavior against the freshly built bundle; restart via the pkill+open command above to avoid running stale binaries.
-- To guarantee the right bundle is running after a rebuild, use: `pkill -x CodexBar || pkill -f CodexBar.app || true; cd /Users/steipete/Projects/codexbar && open -n /Users/steipete/Projects/codexbar/CodexBar.app`.
+- To guarantee the right bundle is running after a rebuild, use: `pkill -x CodexBar || pkill -f CodexBar.app || true; ROOT="$(git rev-parse --show-toplevel)"; cd "$ROOT" && open -n "$ROOT/CodexBar.app"`.
 - After any code change that affects the app, always rebuild with `Scripts/package_app.sh` and restart the app using the command above before validating behavior.
 - If you edited code, run `scripts/compile_and_run.sh` before handoff; it kills old instances, builds, tests, packages, relaunches, and verifies the app stays running.
 - Per user request: after every edit (code or docs), rebuild and restart using `./Scripts/compile_and_run.sh` so the running app reflects the latest changes.

--- a/docs/FORK_QUICK_START.md
+++ b/docs/FORK_QUICK_START.md
@@ -52,7 +52,8 @@ swiftlint --strict
 
 # Restart app after rebuild
 pkill -x CodexBar || pkill -f CodexBar.app || true
-cd /Users/steipete/Projects/codexbar && open -n /Users/steipete/Projects/codexbar/CodexBar.app
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT" && open -n "$ROOT/CodexBar.app"
 ```
 
 ### Release


### PR DESCRIPTION
## Summary
- replace user-specific absolute workspace paths in docs with repo-relative paths
- keep AGENTS/quick-start instructions multi-user friendly

## Changes
- AGENTS.md: update clone/workspace examples to use relative patterns
- docs/FORK_QUICK_START.md: remove hardcoded  examples in favor of repo-root/sibling references

## Why
Absolute paths tied to one macOS username break multi-user setups and shared checkouts.