### PR TITLE
Fix: respect `never` prompt mode regardless of keychain read strategy

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthKeychainPromptMode.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthKeychainPromptMode.swift
@@ -40,10 +40,15 @@ public enum ClaudeOAuthKeychainPromptPreference {
         readStrategy: ClaudeOAuthKeychainReadStrategy = ClaudeOAuthKeychainReadStrategyPreference.current())
         -> ClaudeOAuthKeychainPromptMode
     {
+        let stored = self.storedMode(userDefaults: userDefaults)
+        // Always honor an explicit opt-out. When set to `.never`, no Security.framework keychain queries
+        // should run — including fingerprint/sync probes — regardless of the read strategy. This prevents
+        // macOS XARA partition-check dialogs that `kSecUseAuthenticationUIFail` cannot suppress.
+        if stored == .never { return .never }
         guard self.isApplicable(readStrategy: readStrategy) else {
             return .always
         }
-        return self.storedMode(userDefaults: userDefaults)
+        return stored
     }
 
     public static func securityFrameworkFallbackMode(


### PR DESCRIPTION
## Summary

- `effectiveMode()` now checks for `.never` before the read-strategy guard
- An explicit opt-out via `claudeOAuthKeychainPromptMode = never` is always honored, regardless of `claudeOAuthKeychainReadStrategy`

## Problem

When `claudeOAuthKeychainReadStrategy` is set to `securityCLIExperimental`, `effectiveMode()` unconditionally returns `.always` — silently overriding a user's `claudeOAuthKeychainPromptMode = never` preference. This allows Security.framework fingerprint/sync queries to run, which trigger unavoidable macOS XARA (Cross-Application Resource Access) partition-check dialogs every ~2 minutes.

The XARA prompts occur because Claude Code resets the `Claude Code-credentials` keychain entry's ACL partition list to `apple-tool:` only on every token refresh, removing CodexBar's `teamid:Y5PE65HELJ` authorization. These XARA prompts **cannot** be suppressed by `kSecUseAuthenticationUIFail` or `LAContext.interactionNotAllowed`.

## Change

```diff
 public static func effectiveMode(...) -> ClaudeOAuthKeychainPromptMode {
+    let stored = self.storedMode(userDefaults: userDefaults)
+    // Always honor an explicit opt-out. When set to `.never`, no Security.framework
+    // keychain queries should run — including fingerprint/sync probes — regardless
+    // of the read strategy. This prevents macOS XARA partition-check dialogs that
+    // `kSecUseAuthenticationUIFail` cannot suppress.
+    if stored == .never { return .never }
     guard self.isApplicable(readStrategy: readStrategy) else {
         return .always
     }
-    return self.storedMode(userDefaults: userDefaults)
+    return stored
 }
```

## Test plan

- [ ] Set `claudeOAuthKeychainPromptMode = never` + `claudeOAuthKeychainReadStrategy = securityCLIExperimental` → verify no keychain prompts appear
- [ ] Set `claudeOAuthKeychainPromptMode = onlyOnUserAction` + `securityCLIExperimental` → verify existing behavior unchanged (`.always` effective mode)
- [ ] Set `claudeOAuthKeychainPromptMode = never` + `securityFramework` → verify `.never` is returned
- [ ] Verify `~/.claude/.credentials.json` is used as primary credential source when keychain access is disabled

Fixes #458
Related: #84, #186