### PR TITLE
Fix extra usage values shown 100x wrong due to double cent-to-dollar conversion

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -706,7 +706,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             period: "Monthly",
             resetsAt: nil,
             updatedAt: Date())
-        return Self.rescaleClaudeExtraUsageCostIfNeeded(snapshot, loginMethod: loginMethod)
+        return snapshot
     }
 
     private static func normalizeClaudeExtraUsageAmounts(used: Double, limit: Double) -> (
@@ -714,38 +714,8 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
     {
         // Claude's OAuth API returns values in cents (minor units), same as the Web API.
         // Always convert to dollars (major units) for display consistency.
-        // This removes the fragile heuristic that could fail on non-whole cent values
-        // (e.g., 5472.50 cents would not be detected as needing conversion).
         // See: ClaudeWebAPIFetcher.swift which always divides by 100.
         (used: used / 100.0, limit: limit / 100.0)
-    }
-
-    /// Some non-enterprise plans report extra usage amounts 100x too high.
-    /// Scale down again when limits are implausible.
-    private static func rescaleClaudeExtraUsageCostIfNeeded(
-        _ cost: ProviderCostSnapshot?,
-        loginMethod: String?) -> ProviderCostSnapshot?
-    {
-        guard let cost else { return nil }
-        guard let threshold = Self.extraUsageRescaleThreshold(for: loginMethod) else { return cost }
-        guard cost.limit >= threshold else { return cost }
-
-        return ProviderCostSnapshot(
-            used: cost.used / 100.0,
-            limit: cost.limit / 100.0,
-            currencyCode: cost.currencyCode,
-            period: cost.period,
-            resetsAt: cost.resetsAt,
-            updatedAt: cost.updatedAt)
-    }
-
-    private static func extraUsageRescaleThreshold(for loginMethod: String?) -> Double? {
-        let normalized =
-            loginMethod?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .lowercased() ?? ""
-        if normalized.contains("enterprise") { return nil }
-        return 1000
     }
 
     private static func inferPlan(rateLimitTier: String?) -> String? {
@@ -793,15 +763,11 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                 resetDescription: webData.weeklyResetsAt.map { Self.formatResetDate($0) })
         }
 
-        let providerCost = Self.rescaleClaudeExtraUsageCostIfNeeded(
-            webData.extraUsageCost,
-            loginMethod: webData.loginMethod)
-
         return ClaudeUsageSnapshot(
             primary: primary,
             secondary: secondary,
             opus: opus,
-            providerCost: providerCost,
+            providerCost: webData.extraUsageCost,
             updatedAt: Date(),
             accountEmail: webData.accountEmail,
             accountOrganization: webData.accountOrganization,
@@ -881,14 +847,11 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
                 }
             // Only merge cost extras; keep identity fields from the primary data source.
             if snapshot.providerCost == nil, let extra = webData.extraUsageCost {
-                let normalizedExtra = Self.rescaleClaudeExtraUsageCostIfNeeded(
-                    extra,
-                    loginMethod: snapshot.loginMethod ?? webData.loginMethod)
                 return ClaudeUsageSnapshot(
                     primary: snapshot.primary,
                     secondary: snapshot.secondary,
                     opus: snapshot.opus,
-                    providerCost: normalizedExtra,
+                    providerCost: extra,
                     updatedAt: snapshot.updatedAt,
                     accountEmail: snapshot.accountEmail,
                     accountOrganization: snapshot.accountOrganization,
@@ -1076,13 +1039,5 @@ extension ClaudeUsageFetcher {
         return try Self.mapOAuthUsage(usage, credentials: creds)
     }
 
-    public static func _rescaleExtraUsageForTesting(
-        _ cost: ProviderCostSnapshot?,
-        snapshotLoginMethod: String?,
-        webLoginMethod: String?) -> ProviderCostSnapshot?
-    {
-        let loginMethod = snapshotLoginMethod ?? webLoginMethod
-        return Self.rescaleClaudeExtraUsageCostIfNeeded(cost, loginMethod: loginMethod)
-    }
 }
 #endif

--- a/Tests/CodexBarTests/ClaudeOAuthTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthTests.swift
@@ -122,7 +122,7 @@ struct ClaudeOAuthTests {
     }
 
     @Test
-    func rescalesOAuthExtraUsageWhenLimitIsImplausiblyHigh() throws {
+    func normalizesHighLimitOAuthExtraUsage() throws {
         let json = """
         {
           "five_hour": { "utilization": 1, "resets_at": "2025-12-25T12:00:00.000Z" },
@@ -138,12 +138,12 @@ struct ClaudeOAuthTests {
             Data(json.utf8),
             rateLimitTier: "claude_pro")
         #expect(snap.providerCost?.currencyCode == "USD")
-        #expect(snap.providerCost?.limit == 20)
-        #expect(snap.providerCost?.used == 2.22)
+        #expect(snap.providerCost?.limit == 2000)
+        #expect(snap.providerCost?.used == 222)
     }
 
     @Test
-    func rescalesOAuthExtraUsageWhenPlanMissing() throws {
+    func normalizesOAuthExtraUsageCentsToMajorUnits() throws {
         let json = """
         {
           "five_hour": { "utilization": 1, "resets_at": "2025-12-25T12:00:00.000Z" },
@@ -157,46 +157,8 @@ struct ClaudeOAuthTests {
         """
         let snap = try ClaudeUsageFetcher._mapOAuthUsageForTesting(Data(json.utf8))
         #expect(snap.providerCost?.currencyCode == "USD")
-        #expect(snap.providerCost?.limit == 20)
-        #expect(snap.providerCost?.used == 2.22)
-    }
-
-    @Test
-    func doesNotRescaleOAuthExtraUsageForEnterprisePlans() throws {
-        let json = """
-        {
-          "five_hour": { "utilization": 1, "resets_at": "2025-12-25T12:00:00.000Z" },
-          "extra_usage": {
-            "is_enabled": true,
-            "monthly_limit": 200000,
-            "used_credits": 22200,
-            "currency": "USD"
-          }
-        }
-        """
-        let snap = try ClaudeUsageFetcher._mapOAuthUsageForTesting(
-            Data(json.utf8),
-            rateLimitTier: "claude_enterprise")
-        #expect(snap.providerCost?.currencyCode == "USD")
         #expect(snap.providerCost?.limit == 2000)
         #expect(snap.providerCost?.used == 222)
-    }
-
-    @Test
-    func rescalesWebExtraUsageWhenSnapshotPlanMissing() {
-        let cost = ProviderCostSnapshot(
-            used: 222,
-            limit: 2000,
-            currencyCode: "USD",
-            period: "Monthly",
-            resetsAt: nil,
-            updatedAt: Date())
-        let rescaled = ClaudeUsageFetcher._rescaleExtraUsageForTesting(
-            cost,
-            snapshotLoginMethod: nil,
-            webLoginMethod: "Claude Pro")
-        #expect(rescaled?.limit == 20)
-        #expect(rescaled?.used == 2.22)
     }
 
     @Test


### PR DESCRIPTION
Both the OAuth path (`normalizeClaudeExtraUsageAmounts`) and the Web path (`parseOverageSpendLimit`) already divide the raw API response by 100 to go from cents to dollars. But `rescaleClaudeExtraUsageCostIfNeeded` was dividing by 100 *again* whenever the post-normalization limit came out >= $1000 — so any Max/Team user with a high extra-usage cap got their values squished by another 100x.

Removed the rescale function entirely since the upstream conversion handles it correctly for every plan type now. Updated tests to match.

## What changed

- Deleted `rescaleClaudeExtraUsageCostIfNeeded` and `extraUsageRescaleThreshold`
- Removed the 3 call sites (OAuth, Web, fallback web merge) that fed into it
- Removed the `_rescaleExtraUsageForTesting` test hook
- Updated `ClaudeOAuthTests` to expect the correct post-normalization values instead of the double-divided ones

Fixes #227