### PR TITLE
Add Abacus AI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CodexBar 🎚️ - May your tokens never run out.
 
-Tiny macOS 14+ menu bar app that keeps your Codex, Claude, Cursor, Gemini, Antigravity, Droid (Factory), Copilot, z.ai, Kiro, Vertex AI, Augment, Amp, JetBrains AI, OpenRouter, and Perplexity limits visible (session + weekly where available) and shows when each window resets. One status item per provider (or Merge Icons mode with a provider switcher and optional Overview tab); enable what you use from Settings. No Dock icon, minimal UI, dynamic bar icons in the menu bar.
+Tiny macOS 14+ menu bar app that keeps your Codex, Claude, Cursor, Gemini, Antigravity, Droid (Factory), Copilot, z.ai, Kiro, Vertex AI, Augment, Amp, JetBrains AI, OpenRouter, Perplexity, and Abacus AI limits visible (session + weekly where available) and shows when each window resets. One status item per provider (or Merge Icons mode with a provider switcher and optional Overview tab); enable what you use from Settings. No Dock icon, minimal UI, dynamic bar icons in the menu bar.
 
 <img src="codexbar.png" alt="CodexBar menu screenshot" width="520" />
 
@@ -47,6 +47,7 @@ Linux support via Omarchy: community Waybar module and TUI, driven by the `codex
 - [Amp](docs/amp.md) — Browser cookie-based authentication with Amp Free usage tracking.
 - [JetBrains AI](docs/jetbrains.md) — Local XML-based quota from JetBrains IDE configuration; monthly credits tracking.
 - [OpenRouter](docs/openrouter.md) — API token for credit-based usage tracking across multiple AI providers.
+- [Abacus AI](docs/abacus.md) — Browser cookie auth for ChatLLM/RouteLLM compute credit tracking.
 - Open to new providers: [provider authoring guide](docs/provider.md).
 
 ## Icon & Screenshot

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1068,6 +1068,9 @@ extension UsageMenuCardView.Model {
             {
                 primaryDetailText = detail
             }
+            if primary.resetsAt == nil {
+                primaryResetText = nil
+            }
             if let pace = input.weeklyPace {
                 let paceDetail = Self.weeklyPaceDetail(
                     window: primary,

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1057,6 +1057,31 @@ extension UsageMenuCardView.Model {
         if input.provider == .warp || input.provider == .kilo, primary.resetsAt == nil {
             primaryResetText = nil
         }
+        // Abacus: show credits as detail, compute pace on the primary monthly window
+        var primaryDetailLeft: String?
+        var primaryDetailRight: String?
+        var primaryPacePercent: Double?
+        var primaryPaceOnTop = true
+        if input.provider == .abacus {
+            if let detail = primary.resetDescription,
+               !detail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                primaryDetailText = detail
+            }
+            if let pace = input.weeklyPace {
+                let paceDetail = Self.weeklyPaceDetail(
+                    window: primary,
+                    now: input.now,
+                    pace: pace,
+                    showUsed: input.usageBarsShowUsed)
+                if let paceDetail {
+                    primaryDetailLeft = paceDetail.leftLabel
+                    primaryDetailRight = paceDetail.rightLabel
+                    primaryPacePercent = paceDetail.pacePercent
+                    primaryPaceOnTop = paceDetail.paceOnTop
+                }
+            }
+        }
         return Metric(
             id: "primary",
             title: input.metadata.sessionLabel,
@@ -1065,10 +1090,10 @@ extension UsageMenuCardView.Model {
             percentStyle: percentStyle,
             resetText: primaryResetText,
             detailText: primaryDetailText,
-            detailLeftText: nil,
-            detailRightText: nil,
-            pacePercent: nil,
-            paceOnTop: true)
+            detailLeftText: primaryDetailLeft,
+            detailRightText: primaryDetailRight,
+            pacePercent: primaryPacePercent,
+            paceOnTop: primaryPaceOnTop)
     }
 
     private static func secondaryMetric(

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -170,8 +170,9 @@ struct MenuDescriptor {
                     entries.append(.text(detail, .secondary))
                 }
                 if provider == .abacus,
-                   let paceSummary = UsagePaceText.weeklySummary(provider: provider, window: primary)
+                   let pace = store.weeklyPace(provider: provider, window: primary)
                 {
+                    let paceSummary = UsagePaceText.weeklySummary(pace: pace)
                     entries.append(.text(paceSummary, .secondary))
                 }
             }

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -146,9 +146,9 @@ struct MenuDescriptor {
         if let snap = store.snapshot(for: provider) {
             let resetStyle = settings.resetTimeDisplayStyle
             if let primary = snap.primary {
-                let primaryWindow = if provider == .warp || provider == .kilo {
-                    // Warp/Kilo primary uses resetDescription for non-reset detail (e.g., "Unlimited", "X/Y credits").
-                    // Avoid rendering it as a "Resets ..." line.
+                let primaryWindow = if provider == .warp || provider == .kilo || provider == .abacus {
+                    // Warp/Kilo/Abacus primary uses resetDescription for non-reset detail
+                    // (e.g., "Unlimited", "X/Y credits"). Avoid rendering it as a "Resets ..." line.
                     RateWindow(
                         usedPercent: primary.usedPercent,
                         windowMinutes: primary.windowMinutes,
@@ -163,11 +163,16 @@ struct MenuDescriptor {
                     window: primaryWindow,
                     resetStyle: resetStyle,
                     showUsed: settings.usageBarsShowUsed)
-                if provider == .warp || provider == .kilo,
+                if provider == .warp || provider == .kilo || provider == .abacus,
                    let detail = primary.resetDescription?.trimmingCharacters(in: .whitespacesAndNewlines),
                    !detail.isEmpty
                 {
                     entries.append(.text(detail, .secondary))
+                }
+                if provider == .abacus,
+                   let paceSummary = UsagePaceText.weeklySummary(provider: provider, window: primary)
+                {
+                    entries.append(.text(paceSummary, .secondary))
                 }
             }
             if let weekly = snap.secondary {

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -452,6 +452,14 @@ struct ProvidersPane: View {
                     id: MenuBarMetricPreference.primary.rawValue,
                     title: "Primary (API key limit)"),
             ]
+        } else if provider == .abacus {
+            let metadata = self.store.metadata(for: provider)
+            options = [
+                ProviderSettingsPickerOption(id: MenuBarMetricPreference.automatic.rawValue, title: "Automatic"),
+                ProviderSettingsPickerOption(
+                    id: MenuBarMetricPreference.primary.rawValue,
+                    title: "Primary (\(metadata.sessionLabel))"),
+            ]
         } else {
             let metadata = self.store.metadata(for: provider)
             let snapshot = self.store.snapshot(for: provider)
@@ -540,7 +548,9 @@ struct ProvidersPane: View {
         {
             self.store.weeklyPace(provider: provider, window: weekly, now: now)
         } else {
-            snapshot?.secondary.flatMap { window in
+            // Abacus uses primary for monthly credits (no secondary window)
+            let paceWindow = provider == .abacus ? snapshot?.primary : snapshot?.secondary
+            paceWindow.flatMap { window in
                 self.store.weeklyPace(provider: provider, window: window, now: now)
             }
         }

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -543,13 +543,13 @@ struct ProvidersPane: View {
             tokenError = nil
         }
 
+        // Abacus uses primary for monthly credits (no secondary window)
+        let paceWindow = provider == .abacus ? snapshot?.primary : snapshot?.secondary
         let weeklyPace = if let codexProjection,
                             let weekly = codexProjection.rateWindow(for: .weekly)
         {
             self.store.weeklyPace(provider: provider, window: weekly, now: now)
         } else {
-            // Abacus uses primary for monthly credits (no secondary window)
-            let paceWindow = provider == .abacus ? snapshot?.primary : snapshot?.secondary
             paceWindow.flatMap { window in
                 self.store.weeklyPace(provider: provider, window: window, now: now)
             }

--- a/Sources/CodexBar/Providers/Abacus/AbacusProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Abacus/AbacusProviderImplementation.swift
@@ -88,7 +88,7 @@ struct AbacusProviderImplementation: ProviderImplementation {
                         style: .link,
                         isVisible: nil,
                         perform: {
-                            if let url = URL(string: "https://apps.abacus.ai/compute-points") {
+                            if let url = URL(string: "https://apps.abacus.ai/chatllm/admin/compute-points-usage") {
                                 NSWorkspace.shared.open(url)
                             }
                         }),

--- a/Sources/CodexBar/Providers/Abacus/AbacusProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Abacus/AbacusProviderImplementation.swift
@@ -71,7 +71,29 @@ struct AbacusProviderImplementation: ProviderImplementation {
     }
 
     @MainActor
-    func settingsFields(context _: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {
-        []
+    func settingsFields(context: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {
+        [
+            ProviderSettingsFieldDescriptor(
+                id: "abacus-cookie",
+                title: "",
+                subtitle: "",
+                kind: .secure,
+                placeholder: "Cookie: \u{2026}\n\nor paste a cURL capture from the Abacus AI dashboard",
+                binding: context.stringBinding(\.abacusCookieHeader),
+                actions: [
+                    ProviderSettingsActionDescriptor(
+                        id: "abacus-open-dashboard",
+                        title: "Open Dashboard",
+                        style: .link,
+                        isVisible: nil,
+                        perform: {
+                            if let url = URL(string: "https://apps.abacus.ai/compute-points") {
+                                NSWorkspace.shared.open(url)
+                            }
+                        }),
+                ],
+                isVisible: { context.settings.abacusCookieSource == .manual },
+                onActivate: nil),
+        ]
     }
 }

--- a/Sources/CodexBar/Providers/Abacus/AbacusProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Abacus/AbacusProviderImplementation.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CodexBarCore
 import CodexBarMacroSupport
 import Foundation

--- a/Sources/CodexBar/Providers/Abacus/AbacusProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Abacus/AbacusProviderImplementation.swift
@@ -1,0 +1,77 @@
+import CodexBarCore
+import CodexBarMacroSupport
+import Foundation
+import SwiftUI
+
+@ProviderImplementationRegistration
+struct AbacusProviderImplementation: ProviderImplementation {
+    let id: UsageProvider = .abacus
+
+    @MainActor
+    func observeSettings(_ settings: SettingsStore) {
+        _ = settings.abacusCookieSource
+        _ = settings.abacusCookieHeader
+    }
+
+    @MainActor
+    func settingsSnapshot(context: ProviderSettingsSnapshotContext) -> ProviderSettingsSnapshotContribution? {
+        .abacus(context.settings.abacusSettingsSnapshot(tokenOverride: context.tokenOverride))
+    }
+
+    @MainActor
+    func tokenAccountsVisibility(context: ProviderSettingsContext, support: TokenAccountSupport) -> Bool {
+        guard support.requiresManualCookieSource else { return true }
+        if !context.settings.tokenAccounts(for: context.provider).isEmpty { return true }
+        return context.settings.abacusCookieSource == .manual
+    }
+
+    @MainActor
+    func applyTokenAccountCookieSource(settings: SettingsStore) {
+        if settings.abacusCookieSource != .manual {
+            settings.abacusCookieSource = .manual
+        }
+    }
+
+    @MainActor
+    func settingsPickers(context: ProviderSettingsContext) -> [ProviderSettingsPickerDescriptor] {
+        let cookieBinding = Binding(
+            get: { context.settings.abacusCookieSource.rawValue },
+            set: { raw in
+                context.settings.abacusCookieSource = ProviderCookieSource(rawValue: raw) ?? .auto
+            })
+        let cookieOptions = ProviderCookieSourceUI.options(
+            allowsOff: false,
+            keychainDisabled: context.settings.debugDisableKeychainAccess)
+
+        let cookieSubtitle: () -> String? = {
+            ProviderCookieSourceUI.subtitle(
+                source: context.settings.abacusCookieSource,
+                keychainDisabled: context.settings.debugDisableKeychainAccess,
+                auto: "Automatic imports browser cookies.",
+                manual: "Paste a Cookie header or cURL capture from the Abacus AI dashboard.",
+                off: "Abacus AI cookies are disabled.")
+        }
+
+        return [
+            ProviderSettingsPickerDescriptor(
+                id: "abacus-cookie-source",
+                title: "Cookie source",
+                subtitle: "Automatic imports browser cookies.",
+                dynamicSubtitle: cookieSubtitle,
+                binding: cookieBinding,
+                options: cookieOptions,
+                isVisible: nil,
+                onChange: nil,
+                trailingText: {
+                    guard let entry = CookieHeaderCache.load(provider: .abacus) else { return nil }
+                    let when = entry.storedAt.relativeDescription()
+                    return "Cached: \(entry.sourceLabel) • \(when)"
+                }),
+        ]
+    }
+
+    @MainActor
+    func settingsFields(context _: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {
+        []
+    }
+}

--- a/Sources/CodexBar/Providers/Abacus/AbacusSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Abacus/AbacusSettingsStore.swift
@@ -1,0 +1,61 @@
+import CodexBarCore
+import Foundation
+
+extension SettingsStore {
+    var abacusCookieHeader: String {
+        get { self.configSnapshot.providerConfig(for: .abacus)?.sanitizedCookieHeader ?? "" }
+        set {
+            self.updateProviderConfig(provider: .abacus) { entry in
+                entry.cookieHeader = self.normalizedConfigValue(newValue)
+            }
+            self.logSecretUpdate(provider: .abacus, field: "cookieHeader", value: newValue)
+        }
+    }
+
+    var abacusCookieSource: ProviderCookieSource {
+        get { self.resolvedCookieSource(provider: .abacus, fallback: .auto) }
+        set {
+            self.updateProviderConfig(provider: .abacus) { entry in
+                entry.cookieSource = newValue
+            }
+            self.logProviderModeChange(provider: .abacus, field: "cookieSource", value: newValue.rawValue)
+        }
+    }
+}
+
+extension SettingsStore {
+    func abacusSettingsSnapshot(tokenOverride: TokenAccountOverride?) -> ProviderSettingsSnapshot
+    .AbacusProviderSettings {
+        ProviderSettingsSnapshot.AbacusProviderSettings(
+            cookieSource: self.abacusSnapshotCookieSource(tokenOverride: tokenOverride),
+            manualCookieHeader: self.abacusSnapshotCookieHeader(tokenOverride: tokenOverride))
+    }
+
+    private func abacusSnapshotCookieHeader(tokenOverride: TokenAccountOverride?) -> String {
+        let fallback = self.abacusCookieHeader
+        guard let support = TokenAccountSupportCatalog.support(for: .abacus),
+              case .cookieHeader = support.injection
+        else {
+            return fallback
+        }
+        guard let account = ProviderTokenAccountSelection.selectedAccount(
+            provider: .abacus,
+            settings: self,
+            override: tokenOverride)
+        else {
+            return fallback
+        }
+        return TokenAccountSupportCatalog.normalizedCookieHeader(account.token, support: support)
+    }
+
+    private func abacusSnapshotCookieSource(tokenOverride _: TokenAccountOverride?) -> ProviderCookieSource {
+        let fallback = self.abacusCookieSource
+        guard let support = TokenAccountSupportCatalog.support(for: .abacus),
+              support.requiresManualCookieSource
+        else {
+            return fallback
+        }
+        if self.tokenAccounts(for: .abacus).isEmpty { return fallback }
+        return .manual
+    }
+}

--- a/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
@@ -38,6 +38,7 @@ enum ProviderImplementationRegistry {
         case .openrouter: OpenRouterProviderImplementation()
         case .warp: WarpProviderImplementation()
         case .perplexity: PerplexityProviderImplementation()
+        case .abacus: AbacusProviderImplementation()
         }
     }
 

--- a/Sources/CodexBar/Resources/ProviderIcon-abacus.svg
+++ b/Sources/CodexBar/Resources/ProviderIcon-abacus.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <!-- Abacus AI logo: stylized vertical lines with dots -->
+    <g transform="translate(15, 10)">
+        <!-- Vertical lines -->
+        <rect x="0" y="0" width="4" height="80" rx="2" fill="white"/>
+        <rect x="17.5" y="0" width="4" height="80" rx="2" fill="white"/>
+        <rect x="35" y="0" width="4" height="80" rx="2" fill="white"/>
+        <rect x="52.5" y="0" width="4" height="80" rx="2" fill="white"/>
+        <rect x="66" y="0" width="4" height="80" rx="2" fill="white"/>
+        <!-- Dots on the lines (beads on an abacus) -->
+        <circle cx="2" cy="20" r="7" fill="white"/>
+        <circle cx="19.5" cy="45" r="7" fill="white"/>
+        <circle cx="37" cy="30" r="7" fill="white"/>
+        <circle cx="54.5" cy="60" r="7" fill="white"/>
+        <circle cx="68" cy="40" r="7" fill="white"/>
+    </g>
+</svg>

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -486,6 +486,7 @@ extension StatusItemController {
         case .pace, .both:
             let weeklyWindow = codexProjection?.rateWindow(for: .weekly)
                 ?? snapshot?.secondary
+                // Abacus has no secondary window; pace is computed on primary monthly credits
                 ?? (provider == .abacus ? snapshot?.primary : nil)
             pace = weeklyWindow.flatMap { window in
                 self.store.weeklyPace(provider: provider, window: window, now: now)

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -484,7 +484,9 @@ extension StatusItemController {
         case .percent:
             pace = nil
         case .pace, .both:
-            let weeklyWindow = codexProjection?.rateWindow(for: .weekly) ?? snapshot?.secondary
+            let weeklyWindow = codexProjection?.rateWindow(for: .weekly)
+                ?? snapshot?.secondary
+                ?? (self.store.supportsWeeklyPace(for: provider) ? snapshot?.primary : nil)
             pace = weeklyWindow.flatMap { window in
                 self.store.weeklyPace(provider: provider, window: window, now: now)
             }

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -486,7 +486,7 @@ extension StatusItemController {
         case .pace, .both:
             let weeklyWindow = codexProjection?.rateWindow(for: .weekly)
                 ?? snapshot?.secondary
-                ?? (self.store.supportsWeeklyPace(for: provider) ? snapshot?.primary : nil)
+                ?? (provider == .abacus ? snapshot?.primary : nil)
             pace = weeklyWindow.flatMap { window in
                 self.store.weeklyPace(provider: provider, window: window, now: now)
             }

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1408,13 +1408,13 @@ extension StatusItemController {
 
         let sourceLabel = snapshotOverride == nil ? self.store.sourceLabel(for: target) : nil
         let kiloAutoMode = target == .kilo && self.settings.kiloUsageDataSource == .auto
+        // Abacus uses primary for monthly credits (no secondary window)
+        let paceWindow = target == .abacus ? snapshot?.primary : snapshot?.secondary
         let weeklyPace = if let codexProjection,
                             let weekly = codexProjection.rateWindow(for: .weekly)
         {
             self.store.weeklyPace(provider: target, window: weekly, now: now)
         } else {
-            // Abacus uses primary for monthly credits (no secondary window)
-            let paceWindow = target == .abacus ? snapshot?.primary : snapshot?.secondary
             paceWindow.flatMap { window in
                 self.store.weeklyPace(provider: target, window: window, now: now)
             }

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1413,7 +1413,9 @@ extension StatusItemController {
         {
             self.store.weeklyPace(provider: target, window: weekly, now: now)
         } else {
-            snapshot?.secondary.flatMap { window in
+            // Abacus uses primary for monthly credits (no secondary window)
+            let paceWindow = target == .abacus ? snapshot?.primary : snapshot?.secondary
+            paceWindow.flatMap { window in
                 self.store.weeklyPace(provider: target, window: window, now: now)
             }
         }

--- a/Sources/CodexBar/UsageStore+HistoricalPace.swift
+++ b/Sources/CodexBar/UsageStore+HistoricalPace.swift
@@ -5,7 +5,7 @@ import Foundation
 extension UsageStore {
     func supportsWeeklyPace(for provider: UsageProvider) -> Bool {
         switch provider {
-        case .codex, .claude, .opencode:
+        case .codex, .claude, .opencode, .abacus:
             true
         default:
             false

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -851,7 +851,7 @@ extension UsageStore {
                     let source = resolution?.source.rawValue ?? "none"
                     return "WARP_API_KEY=\(hasAny ? "present" : "missing") source=\(source)"
                 case .gemini, .antigravity, .opencode, .opencodego, .factory, .copilot, .vertexai, .kilo, .kiro, .kimi,
-                     .kimik2, .jetbrains, .perplexity:
+                     .kimik2, .jetbrains, .perplexity, .abacus:
                     return unimplementedDebugLogMessages[provider] ?? "Debug log not yet implemented"
                 }
             }

--- a/Sources/CodexBarCLI/TokenAccountCLI.swift
+++ b/Sources/CodexBarCLI/TokenAccountCLI.swift
@@ -186,6 +186,13 @@ struct TokenAccountCLIContext {
                 perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings(
                     cookieSource: cookieSource,
                     manualCookieHeader: cookieHeader))
+        case .abacus:
+            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
+            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
+            return self.makeSnapshot(
+                abacus: ProviderSettingsSnapshot.AbacusProviderSettings(
+                    cookieSource: cookieSource,
+                    manualCookieHeader: cookieHeader))
         case .gemini, .antigravity, .copilot, .kiro, .vertexai, .kimik2, .synthetic, .openrouter, .warp:
             return nil
         }
@@ -207,7 +214,8 @@ struct TokenAccountCLIContext {
         amp: ProviderSettingsSnapshot.AmpProviderSettings? = nil,
         ollama: ProviderSettingsSnapshot.OllamaProviderSettings? = nil,
         jetbrains: ProviderSettingsSnapshot.JetBrainsProviderSettings? = nil,
-        perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings? = nil) -> ProviderSettingsSnapshot
+        perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings? = nil,
+        abacus: ProviderSettingsSnapshot.AbacusProviderSettings? = nil) -> ProviderSettingsSnapshot
     {
         ProviderSettingsSnapshot.make(
             codex: codex,
@@ -225,7 +233,8 @@ struct TokenAccountCLIContext {
             amp: amp,
             ollama: ollama,
             jetbrains: jetbrains,
-            perplexity: perplexity)
+            perplexity: perplexity,
+            abacus: abacus)
     }
 
     private func makeCodexSettingsSnapshot(account: ProviderTokenAccount?) ->

--- a/Sources/CodexBarCore/Logging/LogCategories.swift
+++ b/Sources/CodexBarCore/Logging/LogCategories.swift
@@ -1,4 +1,5 @@
 public enum LogCategories {
+    public static let abacusUsage = "abacus-usage"
     public static let amp = "amp"
     public static let antigravity = "antigravity"
     public static let app = "app"

--- a/Sources/CodexBarCore/Logging/LogCategories.swift
+++ b/Sources/CodexBarCore/Logging/LogCategories.swift
@@ -1,4 +1,5 @@
 public enum LogCategories {
+    public static let abacusCookie = "abacus-cookie"
     public static let abacusUsage = "abacus-usage"
     public static let amp = "amp"
     public static let antigravity = "antigravity"

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusCookieImporter.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+#if os(macOS)
+import SweetCookieKit
+
+public enum AbacusCookieImporter {
+    private static let log = CodexBarLog.logger(LogCategories.abacusCookie)
+    private static let cookieClient = BrowserCookieClient()
+    private static let cookieDomains = ["abacus.ai", "apps.abacus.ai"]
+    private static let cookieImportOrder: BrowserCookieImportOrder =
+        ProviderDefaults.metadata[.abacus]?.browserCookieOrder ?? Browser.defaultImportOrder
+
+    /// Exact cookie names known to carry Abacus session state.
+    /// CSRF tokens are deliberately excluded — they are present in anonymous
+    /// jars and do not indicate an authenticated session.
+    private static let knownSessionCookieNames: Set<String> = [
+        "sessionid", "session_id", "session_token",
+        "auth_token", "access_token",
+    ]
+
+    /// Substrings that indicate a session or auth cookie (applied only when
+    /// no exact-name match is found). Deliberately excludes overly broad
+    /// patterns like "id" and "token" that match analytics/CSRF cookies.
+    private static let sessionCookieSubstrings = ["session", "auth", "sid", "jwt"]
+
+    /// Cookie name prefixes that indicate a non-session cookie even when a
+    /// substring match would otherwise accept it (e.g. "csrftoken").
+    private static let excludedCookiePrefixes = ["csrf", "_ga", "_gid", "tracking", "analytics"]
+
+    public struct SessionInfo: Sendable {
+        public let cookies: [HTTPCookie]
+        public let sourceLabel: String
+
+        public var cookieHeader: String {
+            self.cookies.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
+        }
+    }
+
+    /// Returns all candidate sessions across browsers/profiles, ordered by
+    /// import priority.  Callers should try each in turn so that a stale
+    /// session in the first source doesn't block a valid one further down.
+    public static func importSessions(
+        browserDetection: BrowserDetection = BrowserDetection(),
+        logger: ((String) -> Void)? = nil) throws -> [SessionInfo]
+    {
+        var candidates: [SessionInfo] = []
+        let installedBrowsers = self.cookieImportOrder.cookieImportCandidates(using: browserDetection)
+
+        for browserSource in installedBrowsers {
+            do {
+                let query = BrowserCookieQuery(domains: self.cookieDomains)
+                let sources = try Self.cookieClient.codexBarRecords(
+                    matching: query,
+                    in: browserSource,
+                    logger: { msg in self.emit(msg, logger: logger) })
+                for source in sources where !source.records.isEmpty {
+                    let httpCookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
+                    guard !httpCookies.isEmpty else { continue }
+
+                    guard Self.containsSessionCookie(httpCookies) else {
+                        self.emit(
+                            "Skipping \(source.label): no session cookie found",
+                            logger: logger)
+                        continue
+                    }
+
+                    self.emit(
+                        "Found \(httpCookies.count) session cookies in \(source.label)",
+                        logger: logger)
+                    candidates.append(SessionInfo(cookies: httpCookies, sourceLabel: source.label))
+                }
+            } catch {
+                BrowserCookieAccessGate.recordIfNeeded(error)
+                self.emit(
+                    "\(browserSource.displayName) cookie import failed: \(error.localizedDescription)",
+                    logger: logger)
+            }
+        }
+
+        guard !candidates.isEmpty else {
+            throw AbacusUsageError.noSessionCookie
+        }
+        return candidates
+    }
+
+    /// Cheap check for whether any browser has an Abacus session cookie,
+    /// used by the fetch strategy's `isAvailable()`.
+    public static func hasSession(
+        browserDetection: BrowserDetection = BrowserDetection(),
+        logger: ((String) -> Void)? = nil) -> Bool
+    {
+        do {
+            return try !self.importSessions(browserDetection: browserDetection, logger: logger).isEmpty
+        } catch {
+            return false
+        }
+    }
+
+    /// Returns `true` if the cookie set contains at least one cookie whose name
+    /// indicates session or authentication state.  Checks exact known names
+    /// first, then falls back to conservative substring matching.
+    private static func containsSessionCookie(_ cookies: [HTTPCookie]) -> Bool {
+        cookies.contains { cookie in
+            let lower = cookie.name.lowercased()
+            if self.knownSessionCookieNames.contains(lower) { return true }
+            if self.excludedCookiePrefixes.contains(where: { lower.hasPrefix($0) }) { return false }
+            return self.sessionCookieSubstrings.contains { lower.contains($0) }
+        }
+    }
+
+    private static func emit(_ message: String, logger: ((String) -> Void)?) {
+        logger?("[abacus-cookie] \(message)")
+        self.log.debug(message)
+    }
+}
+#endif

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusCookieImporter.swift
@@ -46,12 +46,19 @@ public enum AbacusCookieImporter {
     /// Returns all candidate sessions across browsers/profiles, ordered by
     /// import priority.  Callers should try each in turn so that a stale
     /// session in the first source doesn't block a valid one further down.
+    ///
+    /// Defaults to Chrome-only per AGENTS.md guideline. Pass an empty
+    /// `preferredBrowsers` list to fall back to the full descriptor-defined
+    /// import order (Safari, Firefox, etc.) when Chrome has no cookies.
     public static func importSessions(
         browserDetection: BrowserDetection = BrowserDetection(),
+        preferredBrowsers: [Browser] = [.chrome],
         logger: ((String) -> Void)? = nil) throws -> [SessionInfo]
     {
         var candidates: [SessionInfo] = []
-        let installedBrowsers = self.cookieImportOrder.cookieImportCandidates(using: browserDetection)
+        let installedBrowsers = preferredBrowsers.isEmpty
+            ? self.cookieImportOrder.cookieImportCandidates(using: browserDetection)
+            : preferredBrowsers.cookieImportCandidates(using: browserDetection)
 
         for browserSource in installedBrowsers {
             do {
@@ -94,10 +101,14 @@ public enum AbacusCookieImporter {
     /// used by the fetch strategy's `isAvailable()`.
     public static func hasSession(
         browserDetection: BrowserDetection = BrowserDetection(),
+        preferredBrowsers: [Browser] = [.chrome],
         logger: ((String) -> Void)? = nil) -> Bool
     {
         do {
-            return try !self.importSessions(browserDetection: browserDetection, logger: logger).isEmpty
+            return try !self.importSessions(
+                browserDetection: browserDetection,
+                preferredBrowsers: preferredBrowsers,
+                logger: logger).isEmpty
         } catch {
             return false
         }

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusCookieImporter.swift
@@ -3,6 +3,8 @@ import Foundation
 #if os(macOS)
 import SweetCookieKit
 
+// MARK: - Abacus Cookie Importer
+
 public enum AbacusCookieImporter {
     private static let log = CodexBarLog.logger(LogCategories.abacusCookie)
     private static let cookieClient = BrowserCookieClient()
@@ -30,6 +32,11 @@ public enum AbacusCookieImporter {
     public struct SessionInfo: Sendable {
         public let cookies: [HTTPCookie]
         public let sourceLabel: String
+
+        public init(cookies: [HTTPCookie], sourceLabel: String) {
+            self.cookies = cookies
+            self.sourceLabel = sourceLabel
+        }
 
         public var cookieHeader: String {
             self.cookies.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
@@ -25,7 +25,7 @@ public enum AbacusProviderDescriptor {
                 defaultEnabled: false,
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
-                browserCookieOrder: ProviderBrowserCookieDefaults.defaultImportOrder,
+                browserCookieOrder: [.chrome],
                 dashboardURL: "https://apps.abacus.ai/chatllm/admin/compute-points-usage",
                 statusPageURL: nil,
                 statusLinkURL: nil),

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
@@ -48,6 +48,8 @@ public enum AbacusProviderDescriptor {
     }
 }
 
+// MARK: - Fetch Strategy
+
 struct AbacusWebFetchStrategy: ProviderFetchStrategy {
     let id: String = "abacus.web"
     let kind: ProviderFetchKind = .web

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
@@ -25,7 +25,7 @@ public enum AbacusProviderDescriptor {
                 defaultEnabled: false,
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
-                browserCookieOrder: [.chrome],
+                browserCookieOrder: ProviderBrowserCookieDefaults.defaultImportOrder,
                 dashboardURL: "https://apps.abacus.ai/chatllm/admin/compute-points-usage",
                 statusPageURL: nil,
                 statusLinkURL: nil),
@@ -61,7 +61,13 @@ struct AbacusWebFetchStrategy: ProviderFetchStrategy {
         }
         if CookieHeaderCache.load(provider: .abacus) != nil { return true }
         #if os(macOS)
-        return AbacusCookieImporter.hasSession(browserDetection: context.browserDetection)
+        // Try Chrome first, then any installed browser as fallback.
+        if AbacusCookieImporter.hasSession(browserDetection: context.browserDetection) {
+            return true
+        }
+        return AbacusCookieImporter.hasSession(
+            browserDetection: context.browserDetection,
+            preferredBrowsers: [])
         #else
         return false
         #endif

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
@@ -27,7 +27,7 @@ public enum AbacusProviderDescriptor {
                 usesAccountFallback: false,
                 browserCookieOrder: ProviderBrowserCookieDefaults.defaultImportOrder,
                 dashboardURL: "https://apps.abacus.ai/chatllm/admin/compute-points-usage",
-                statusPageURL: "https://status.abacus.ai",
+                statusPageURL: nil,
                 statusLinkURL: nil),
             branding: ProviderBranding(
                 iconStyle: .abacus,

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
@@ -54,7 +54,15 @@ struct AbacusWebFetchStrategy: ProviderFetchStrategy {
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
         guard context.settings?.abacus?.cookieSource != .off else { return false }
-        return true
+        if context.settings?.abacus?.cookieSource == .manual {
+            return CookieHeaderNormalizer.normalize(context.settings?.abacus?.manualCookieHeader) != nil
+        }
+        if CookieHeaderCache.load(provider: .abacus) != nil { return true }
+        #if os(macOS)
+        return AbacusCookieImporter.hasSession(browserDetection: context.browserDetection)
+        #else
+        return false
+        #endif
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusProviderDescriptor.swift
@@ -1,0 +1,79 @@
+import CodexBarMacroSupport
+import Foundation
+
+#if os(macOS)
+import SweetCookieKit
+#endif
+
+@ProviderDescriptorRegistration
+@ProviderDescriptorDefinition
+public enum AbacusProviderDescriptor {
+    static func makeDescriptor() -> ProviderDescriptor {
+        ProviderDescriptor(
+            id: .abacus,
+            metadata: ProviderMetadata(
+                id: .abacus,
+                displayName: "Abacus AI",
+                sessionLabel: "Credits",
+                weeklyLabel: "Weekly",
+                opusLabel: nil,
+                supportsOpus: false,
+                supportsCredits: true,
+                creditsHint: "Abacus AI compute credits for ChatLLM/RouteLLM usage.",
+                toggleTitle: "Show Abacus AI usage",
+                cliName: "abacusai",
+                defaultEnabled: false,
+                isPrimaryProvider: false,
+                usesAccountFallback: false,
+                browserCookieOrder: ProviderBrowserCookieDefaults.defaultImportOrder,
+                dashboardURL: "https://apps.abacus.ai/chatllm/admin/compute-points-usage",
+                statusPageURL: "https://status.abacus.ai",
+                statusLinkURL: nil),
+            branding: ProviderBranding(
+                iconStyle: .abacus,
+                iconResourceName: "ProviderIcon-abacus",
+                color: ProviderColor(red: 56 / 255, green: 189 / 255, blue: 248 / 255)),
+            tokenCost: ProviderTokenCostConfig(
+                supportsTokenCost: false,
+                noDataMessage: { "Abacus AI cost summary is not supported." }),
+            fetchPlan: ProviderFetchPlan(
+                sourceModes: [.auto, .web],
+                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in
+                    [AbacusWebFetchStrategy()]
+                })),
+            cli: ProviderCLIConfig(
+                name: "abacusai",
+                aliases: ["abacus-ai"],
+                versionDetector: nil))
+    }
+}
+
+struct AbacusWebFetchStrategy: ProviderFetchStrategy {
+    let id: String = "abacus.web"
+    let kind: ProviderFetchKind = .web
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        guard context.settings?.abacus?.cookieSource != .off else { return false }
+        return true
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        let manual = Self.manualCookieHeader(from: context)
+        let logger: ((String) -> Void)? = context.verbose
+            ? { msg in CodexBarLog.logger(LogCategories.abacusUsage).verbose(msg) }
+            : nil
+        let snap = try await AbacusUsageFetcher.fetchUsage(cookieHeaderOverride: manual, logger: logger)
+        return self.makeResult(
+            usage: snap.toUsageSnapshot(),
+            sourceLabel: "web")
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+
+    private static func manualCookieHeader(from context: ProviderFetchContext) -> String? {
+        guard context.settings?.abacus?.cookieSource == .manual else { return nil }
+        return CookieHeaderNormalizer.normalize(context.settings?.abacus?.manualCookieHeader)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageError.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageError.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-public enum AbacusUsageError: LocalizedError, Sendable {
+// MARK: - Abacus Usage Error
+
+public enum AbacusUsageError: LocalizedError, Sendable, Equatable {
     case noSessionCookie
     case sessionExpired
     case networkError(String)
@@ -9,18 +11,17 @@ public enum AbacusUsageError: LocalizedError, Sendable {
 
     /// Whether this error indicates an authentication/session problem that
     /// should trigger cache eviction and candidate fallthrough.
+    /// Parse failures are deterministic — retrying with another session
+    /// produces the same result, so they are NOT recoverable.
     public var isRecoverable: Bool {
         switch self {
-        case .unauthorized, .sessionExpired, .parseFailed: true
+        case .unauthorized, .sessionExpired: true
         default: false
         }
     }
 
     public var isAuthRelated: Bool {
-        switch self {
-        case .unauthorized, .sessionExpired: true
-        default: false
-        }
+        self.isRecoverable
     }
 
     public var errorDescription: String? {
@@ -41,6 +42,6 @@ public enum AbacusUsageError: LocalizedError, Sendable {
 
 #if !os(macOS)
 extension AbacusUsageError {
-    static let notSupported = AbacusUsageError.networkError("Abacus AI is only supported on macOS.")
+    public static let notSupported = AbacusUsageError.networkError("Abacus AI is only supported on macOS.")
 }
 #endif

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageError.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageError.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+public enum AbacusUsageError: LocalizedError, Sendable {
+    case noSessionCookie
+    case sessionExpired
+    case networkError(String)
+    case parseFailed(String)
+    case unauthorized
+
+    /// Whether this error indicates an authentication/session problem that
+    /// should trigger cache eviction and candidate fallthrough.
+    public var isRecoverable: Bool {
+        switch self {
+        case .unauthorized, .sessionExpired, .parseFailed: true
+        default: false
+        }
+    }
+
+    public var isAuthRelated: Bool {
+        switch self {
+        case .unauthorized, .sessionExpired: true
+        default: false
+        }
+    }
+
+    public var errorDescription: String? {
+        switch self {
+        case .noSessionCookie:
+            "No Abacus AI session found. Please log in to apps.abacus.ai in your browser."
+        case .sessionExpired:
+            "Abacus AI session expired. Please log in again."
+        case let .networkError(msg):
+            "Abacus AI API error: \(msg)"
+        case let .parseFailed(msg):
+            "Could not parse Abacus AI usage: \(msg)"
+        case .unauthorized:
+            "Unauthorized. Please log in to Abacus AI."
+        }
+    }
+}
+
+#if !os(macOS)
+extension AbacusUsageError {
+    static let notSupported = AbacusUsageError.networkError("Abacus AI is only supported on macOS.")
+}
+#endif

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -3,184 +3,10 @@ import Foundation
 #if os(macOS)
 import SweetCookieKit
 
-private let abacusCookieImportOrder: BrowserCookieImportOrder =
-    ProviderDefaults.metadata[.abacus]?.browserCookieOrder ?? Browser.defaultImportOrder
-
-// MARK: - Abacus Cookie Importer
-
-public enum AbacusCookieImporter {
-    private static let cookieClient = BrowserCookieClient()
-    private static let cookieDomains = ["abacus.ai", "apps.abacus.ai"]
-
-    /// Exact cookie names known to carry Abacus session state.
-    /// CSRF tokens are deliberately excluded — they are present in anonymous
-    /// jars and do not indicate an authenticated session.
-    private static let knownSessionCookieNames: Set<String> = [
-        "sessionid", "session_id", "session_token",
-        "auth_token", "access_token",
-    ]
-
-    /// Substrings that indicate a session or auth cookie (applied only when
-    /// no exact-name match is found). Deliberately excludes overly broad
-    /// patterns like "id" and "token" that match analytics/CSRF cookies.
-    private static let sessionCookieSubstrings = ["session", "auth", "sid", "jwt"]
-
-    /// Cookie name prefixes that indicate a non-session cookie even when a
-    /// substring match would otherwise accept it (e.g. "csrftoken").
-    private static let excludedCookiePrefixes = ["csrf", "_ga", "_gid", "tracking", "analytics"]
-
-    public struct SessionInfo: Sendable {
-        public let cookies: [HTTPCookie]
-        public let sourceLabel: String
-
-        public var cookieHeader: String {
-            self.cookies.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
-        }
-    }
-
-    /// Returns all candidate sessions across browsers/profiles, ordered by
-    /// import priority.  Callers should try each in turn so that a stale
-    /// session in the first source doesn't block a valid one further down.
-    public static func importSessions(logger: ((String) -> Void)? = nil) throws -> [SessionInfo] {
-        let log: (String) -> Void = { msg in logger?("[abacus-cookie] \(msg)") }
-        var candidates: [SessionInfo] = []
-
-        for browserSource in abacusCookieImportOrder {
-            do {
-                let query = BrowserCookieQuery(domains: cookieDomains)
-                let sources = try Self.cookieClient.codexBarRecords(
-                    matching: query,
-                    in: browserSource,
-                    logger: log)
-                for source in sources where !source.records.isEmpty {
-                    let httpCookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
-                    guard !httpCookies.isEmpty else { continue }
-
-                    guard Self.containsSessionCookie(httpCookies) else {
-                        let cookieNames = httpCookies.map(\.name).joined(separator: ", ")
-                        log("Skipping \(source.label): no session cookie found among [\(cookieNames)]")
-                        continue
-                    }
-
-                    let cookieNames = httpCookies.map(\.name).joined(separator: ", ")
-                    log("Found \(httpCookies.count) cookies in \(source.label): \(cookieNames)")
-                    candidates.append(SessionInfo(cookies: httpCookies, sourceLabel: source.label))
-                }
-            } catch {
-                BrowserCookieAccessGate.recordIfNeeded(error)
-                log("\(browserSource.displayName) cookie import failed: \(error.localizedDescription)")
-            }
-        }
-
-        if candidates.isEmpty {
-            throw AbacusUsageError.noSessionCookie
-        }
-        return candidates
-    }
-
-    /// Returns `true` if the cookie set contains at least one cookie whose name
-    /// indicates session or authentication state.  Checks exact known names
-    /// first, then falls back to conservative substring matching.
-    private static func containsSessionCookie(_ cookies: [HTTPCookie]) -> Bool {
-        cookies.contains { cookie in
-            let lower = cookie.name.lowercased()
-            if self.knownSessionCookieNames.contains(lower) { return true }
-            if self.excludedCookiePrefixes.contains(where: { lower.hasPrefix($0) }) { return false }
-            return self.sessionCookieSubstrings.contains { lower.contains($0) }
-        }
-    }
-}
-
-// MARK: - Abacus Usage Snapshot
-
-public struct AbacusUsageSnapshot: Sendable {
-    public let creditsUsed: Double?
-    public let creditsTotal: Double?
-    public let resetsAt: Date?
-    public let planName: String?
-
-    public func toUsageSnapshot() -> UsageSnapshot {
-        let percentUsed: Double = if let used = self.creditsUsed, let total = self.creditsTotal, total > 0 {
-            (used / total) * 100.0
-        } else {
-            0
-        }
-
-        let resetDesc: String? = if let used = self.creditsUsed, let total = self.creditsTotal {
-            "\(Self.formatCredits(used)) / \(Self.formatCredits(total)) credits"
-        } else {
-            nil
-        }
-
-        // Use windowMinutes matching the monthly billing cycle so pace calculation works.
-        // Approximate 1 month as 30 days.
-        let windowMinutes = 30 * 24 * 60
-
-        let primary = RateWindow(
-            usedPercent: percentUsed,
-            windowMinutes: windowMinutes,
-            resetsAt: self.resetsAt,
-            resetDescription: resetDesc)
-
-        let identity = ProviderIdentitySnapshot(
-            providerID: .abacus,
-            accountEmail: nil,
-            accountOrganization: nil,
-            loginMethod: self.planName)
-
-        return UsageSnapshot(
-            primary: primary,
-            secondary: nil,
-            tertiary: nil,
-            providerCost: nil,
-            updatedAt: Date(),
-            identity: identity)
-    }
-
-    private static func formatCredits(_ value: Double) -> String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = value >= 1000 ? 0 : 1
-        formatter.groupingSeparator = ","
-        return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.0f", value)
-    }
-}
-
-// MARK: - Abacus Usage Error
-
-public enum AbacusUsageError: LocalizedError, Sendable {
-    case noSessionCookie
-    case sessionExpired
-    case networkError(String)
-    case parseFailed(String)
-    case unauthorized
-
-    var isAuthRelated: Bool {
-        switch self {
-        case .unauthorized, .sessionExpired: true
-        default: false
-        }
-    }
-
-    public var errorDescription: String? {
-        switch self {
-        case .noSessionCookie:
-            "No Abacus AI session found. Please log in to apps.abacus.ai in \(abacusCookieImportOrder.loginHint)."
-        case .sessionExpired:
-            "Abacus AI session expired. Please log in again."
-        case let .networkError(msg):
-            "Abacus AI API error: \(msg)"
-        case let .parseFailed(msg):
-            "Could not parse Abacus AI usage: \(msg)"
-        case .unauthorized:
-            "Unauthorized. Please log in to Abacus AI."
-        }
-    }
-}
-
 // MARK: - Abacus Usage Fetcher
 
 public enum AbacusUsageFetcher {
+    private static let log = CodexBarLog.logger(LogCategories.abacusUsage)
     private static let computePointsURL =
         URL(string: "https://apps.abacus.ai/api/_getOrganizationComputePoints")!
     private static let billingInfoURL =
@@ -191,61 +17,65 @@ public enum AbacusUsageFetcher {
         timeout: TimeInterval = 15.0,
         logger: ((String) -> Void)? = nil) async throws -> AbacusUsageSnapshot
     {
-        let log: (String) -> Void = { msg in logger?("[abacus] \(msg)") }
-
+        // Manual cookie header — no fallback, errors propagate directly
         if let override = CookieHeaderNormalizer.normalize(cookieHeaderOverride) {
-            log("Using manual cookie header")
-            return try await Self.fetchWithCookieHeader(override, timeout: timeout)
+            self.emit("Using manual cookie header", logger: logger)
+            return try await self.fetchWithCookieHeader(override, timeout: timeout, logger: logger)
         }
 
+        // Cached cookie header — clear on recoverable errors and fall through
         if let cached = CookieHeaderCache.load(provider: .abacus),
            !cached.cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         {
-            log("Using cached cookie header from \(cached.sourceLabel)")
+            self.emit("Using cached cookie header from \(cached.sourceLabel)", logger: logger)
             do {
-                return try await Self.fetchWithCookieHeader(cached.cookieHeader, timeout: timeout)
-            } catch let error as AbacusUsageError {
-                switch error {
-                case .unauthorized, .sessionExpired:
-                    CookieHeaderCache.clear(provider: .abacus)
-                default:
-                    throw error
-                }
+                return try await Self.fetchWithCookieHeader(
+                    cached.cookieHeader, timeout: timeout, logger: logger)
+            } catch let error as AbacusUsageError where error.isRecoverable {
+                CookieHeaderCache.clear(provider: .abacus)
+                self.emit(
+                    "Cached cookie failed (\(error.localizedDescription)); cleared, trying fresh import",
+                    logger: logger)
             }
         }
 
+        // Fresh browser import — try each candidate, fall through on recoverable errors
         let sessions: [AbacusCookieImporter.SessionInfo]
         do {
-            sessions = try AbacusCookieImporter.importSessions(logger: log)
+            sessions = try AbacusCookieImporter.importSessions(logger: logger)
         } catch {
             BrowserCookieAccessGate.recordIfNeeded(error)
-            log("Browser cookie import failed: \(error.localizedDescription)")
+            self.emit("Browser cookie import failed: \(error.localizedDescription)", logger: logger)
             throw AbacusUsageError.noSessionCookie
         }
 
-        // Try each candidate; fall through on auth errors so a stale session
-        // in the first source doesn't block a valid one further down.
+        var lastError: AbacusUsageError = .noSessionCookie
         for session in sessions {
-            log("Trying cookies from \(session.sourceLabel)")
+            self.emit("Trying cookies from \(session.sourceLabel)", logger: logger)
             do {
-                let snapshot = try await Self.fetchWithCookieHeader(session.cookieHeader, timeout: timeout)
+                let snapshot = try await Self.fetchWithCookieHeader(
+                    session.cookieHeader, timeout: timeout, logger: logger)
                 CookieHeaderCache.store(
                     provider: .abacus,
                     cookieHeader: session.cookieHeader,
                     sourceLabel: session.sourceLabel)
                 return snapshot
-            } catch let error as AbacusUsageError where error.isAuthRelated {
-                log("\(session.sourceLabel): \(error.localizedDescription), trying next source")
+            } catch let error as AbacusUsageError where error.isRecoverable {
+                self.emit(
+                    "\(session.sourceLabel): \(error.localizedDescription), trying next source",
+                    logger: logger)
+                lastError = error
                 continue
             }
         }
 
-        throw AbacusUsageError.noSessionCookie
+        throw lastError
     }
 
     private static func fetchWithCookieHeader(
         _ cookieHeader: String,
-        timeout: TimeInterval) async throws -> AbacusUsageSnapshot
+        timeout: TimeInterval,
+        logger: ((String) -> Void)? = nil) async throws -> AbacusUsageSnapshot
     {
         // Fetch compute points (GET) and billing info (POST) concurrently
         async let computePoints = Self.fetchJSON(
@@ -260,10 +90,13 @@ public enum AbacusUsageFetcher {
         } catch let error as AbacusUsageError where error.isAuthRelated {
             throw error
         } catch {
+            self.emit(
+                "Billing info fetch failed: \(error.localizedDescription); credits shown without plan/reset",
+                logger: logger)
             biResult = [:]
         }
 
-        return Self.parseResults(computePoints: cpResult, billingInfo: biResult)
+        return try Self.parseResults(computePoints: cpResult, billingInfo: biResult)
     }
 
     private static func fetchJSON(
@@ -290,12 +123,21 @@ public enum AbacusUsageFetcher {
         }
 
         guard httpResponse.statusCode == 200 else {
-            let body = String(data: data, encoding: .utf8) ?? ""
+            let body = String(data: data.prefix(200), encoding: .utf8) ?? ""
             throw AbacusUsageError.networkError("HTTP \(httpResponse.statusCode): \(body)")
         }
 
-        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            throw AbacusUsageError.parseFailed("Invalid JSON from \(url.lastPathComponent)")
+        let parsed: Any
+        do {
+            parsed = try JSONSerialization.jsonObject(with: data)
+        } catch {
+            let preview = String(data: data.prefix(200), encoding: .utf8) ?? "<non-UTF8>"
+            throw AbacusUsageError.parseFailed(
+                "\(url.lastPathComponent): \(error.localizedDescription) — preview: \(preview)")
+        }
+
+        guard let root = parsed as? [String: Any] else {
+            throw AbacusUsageError.parseFailed("\(url.lastPathComponent): top-level JSON is not a dictionary")
         }
 
         guard root["success"] as? Bool == true,
@@ -316,21 +158,25 @@ public enum AbacusUsageFetcher {
     // MARK: - Parsing
 
     private static func parseResults(
-        computePoints: [String: Any], billingInfo: [String: Any]) -> AbacusUsageSnapshot
+        computePoints: [String: Any], billingInfo: [String: Any]) throws -> AbacusUsageSnapshot
     {
-        // _getOrganizationComputePoints returns values already in credits (no division needed)
         let totalCredits = Self.double(from: computePoints["totalComputePoints"])
         let creditsLeft = Self.double(from: computePoints["computePointsLeft"])
+
+        guard totalCredits != nil || creditsLeft != nil else {
+            let keys = computePoints.keys.sorted().joined(separator: ", ")
+            throw AbacusUsageError.parseFailed(
+                "Missing credit fields in compute points response. Keys: [\(keys)]")
+        }
+
         let creditsUsed: Double? = if let total = totalCredits, let left = creditsLeft {
             total - left
         } else {
             nil
         }
 
-        // _getBillingInfo returns the exact next billing date and plan tier
         let nextBillingDate = billingInfo["nextBillingDate"] as? String
         let currentTier = billingInfo["currentTier"] as? String
-
         let resetsAt = Self.parseDate(nextBillingDate)
 
         return AbacusUsageSnapshot(
@@ -355,33 +201,16 @@ public enum AbacusUsageFetcher {
         formatter.formatOptions = [.withInternetDateTime]
         return formatter.date(from: isoString)
     }
+
+    private static func emit(_ message: String, logger: ((String) -> Void)?) {
+        logger?("[abacus] \(message)")
+        self.log.debug(message)
+    }
 }
 
 #else
 
 // MARK: - Abacus (Unsupported)
-
-public enum AbacusUsageError: LocalizedError, Sendable {
-    case notSupported
-
-    public var errorDescription: String? {
-        "Abacus AI is only supported on macOS."
-    }
-}
-
-public struct AbacusUsageSnapshot: Sendable {
-    public init() {}
-
-    public func toUsageSnapshot() -> UsageSnapshot {
-        UsageSnapshot(
-            primary: RateWindow(usedPercent: 0, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
-            secondary: nil,
-            tertiary: nil,
-            providerCost: nil,
-            updatedAt: Date(),
-            identity: nil)
-    }
-}
 
 public enum AbacusUsageFetcher {
     public static func fetchUsage(

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -163,17 +163,13 @@ public enum AbacusUsageFetcher {
         let totalCredits = Self.double(from: computePoints["totalComputePoints"])
         let creditsLeft = Self.double(from: computePoints["computePointsLeft"])
 
-        guard totalCredits != nil || creditsLeft != nil else {
+        guard let totalCredits, let creditsLeft else {
             let keys = computePoints.keys.sorted().joined(separator: ", ")
             throw AbacusUsageError.parseFailed(
                 "Missing credit fields in compute points response. Keys: [\(keys)]")
         }
 
-        let creditsUsed: Double? = if let total = totalCredits, let left = creditsLeft {
-            total - left
-        } else {
-            nil
-        }
+        let creditsUsed = totalCredits - creditsLeft
 
         let nextBillingDate = billingInfo["nextBillingDate"] as? String
         let currentTier = billingInfo["currentTier"] as? String

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -152,8 +152,10 @@ public enum AbacusUsageFetcher {
             let errorMsg = (root["error"] as? String ?? "Unknown error").lowercased()
             if errorMsg.contains("expired") || errorMsg.contains("session")
                 || errorMsg.contains("login") || errorMsg.contains("authenticate")
+                || errorMsg.contains("unauthorized") || errorMsg.contains("unauthenticated")
+                || errorMsg.contains("forbidden")
             {
-                throw AbacusUsageError.sessionExpired
+                throw AbacusUsageError.unauthorized
             }
             throw AbacusUsageError.parseFailed("\(url.lastPathComponent): \(errorMsg)")
         }

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -86,8 +86,8 @@ public struct AbacusUsageSnapshot: Sendable {
 
         let identity = ProviderIdentitySnapshot(
             providerID: .abacus,
-            accountEmail: nil,
-            accountOrganization: nil,
+            accountEmail: self.accountEmail,
+            accountOrganization: self.accountOrganization,
             loginMethod: self.planName)
 
         return UsageSnapshot(

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -43,14 +43,24 @@ public enum AbacusUsageFetcher {
             }
         }
 
-        // Fresh browser import — try each candidate, fall through on recoverable errors
+        // Fresh browser import — try Chrome first (AGENTS.md default), then broaden
+        // to all browsers if Chrome yields no session cookies.
         let sessions: [AbacusCookieImporter.SessionInfo]
         do {
             sessions = try AbacusCookieImporter.importSessions(logger: logger)
         } catch {
             BrowserCookieAccessGate.recordIfNeeded(error)
-            self.emit("Browser cookie import failed: \(error.localizedDescription)", logger: logger)
-            throw AbacusUsageError.noSessionCookie
+            self.emit(
+                "Chrome cookie import failed: \(error.localizedDescription); falling back to all browsers",
+                logger: logger)
+            do {
+                sessions = try AbacusCookieImporter.importSessions(
+                    preferredBrowsers: [], logger: logger)
+            } catch {
+                BrowserCookieAccessGate.recordIfNeeded(error)
+                self.emit("Browser cookie import failed: \(error.localizedDescription)", logger: logger)
+                throw AbacusUsageError.noSessionCookie
+            }
         }
 
         var lastError: AbacusUsageError = .noSessionCookie

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -13,10 +13,11 @@ public enum AbacusCookieImporter {
     private static let cookieDomains = ["abacus.ai", "apps.abacus.ai"]
 
     /// Exact cookie names known to carry Abacus session state.
+    /// CSRF tokens are deliberately excluded — they are present in anonymous
+    /// jars and do not indicate an authenticated session.
     private static let knownSessionCookieNames: Set<String> = [
         "sessionid", "session_id", "session_token",
         "auth_token", "access_token",
-        "csrftoken", "csrf_token",
     ]
 
     /// Substrings that indicate a session or auth cookie (applied only when
@@ -143,6 +144,13 @@ public enum AbacusUsageError: LocalizedError, Sendable {
     case parseFailed(String)
     case unauthorized
 
+    var isAuthRelated: Bool {
+        switch self {
+        case .unauthorized, .sessionExpired: true
+        default: false
+        }
+    }
+
     public var errorDescription: String? {
         switch self {
         case .noSessionCookie:
@@ -225,7 +233,14 @@ public enum AbacusUsageFetcher {
             url: self.billingInfoURL, method: "POST", cookieHeader: cookieHeader, timeout: timeout)
 
         let cpResult = try await computePoints
-        let biResult = await (try? billingInfo) ?? [:]
+        let biResult: [String: Any]
+        do {
+            biResult = try await billingInfo
+        } catch let error as AbacusUsageError where error.isAuthRelated {
+            throw error
+        } catch {
+            biResult = [:]
+        }
 
         return Self.parseResults(computePoints: cpResult, billingInfo: biResult)
     }

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -39,7 +39,7 @@ public enum AbacusCookieImporter {
         for browserSource in abacusCookieImportOrder {
             do {
                 let query = BrowserCookieQuery(domains: cookieDomains)
-                let sources = try Self.cookieClient.records(
+                let sources = try Self.cookieClient.codexBarRecords(
                     matching: query,
                     in: browserSource,
                     logger: log)
@@ -265,7 +265,12 @@ public enum AbacusUsageFetcher {
         guard root["success"] as? Bool == true,
               let result = root["result"] as? [String: Any]
         else {
-            let errorMsg = root["error"] as? String ?? "Unknown error"
+            let errorMsg = (root["error"] as? String ?? "Unknown error").lowercased()
+            if errorMsg.contains("expired") || errorMsg.contains("session")
+                || errorMsg.contains("login") || errorMsg.contains("authenticate")
+            {
+                throw AbacusUsageError.sessionExpired
+            }
             throw AbacusUsageError.parseFailed("\(url.lastPathComponent): \(errorMsg)")
         }
 

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -54,12 +54,8 @@ public enum AbacusCookieImporter {
 public struct AbacusUsageSnapshot: Sendable {
     public let creditsUsed: Double?
     public let creditsTotal: Double?
-    public let last24HoursUsage: Double?
-    public let last7DaysUsage: Double?
     public let resetsAt: Date?
     public let planName: String?
-    public let accountEmail: String?
-    public let accountOrganization: String?
 
     public func toUsageSnapshot() -> UsageSnapshot {
         let percentUsed: Double = if let used = self.creditsUsed, let total = self.creditsTotal, total > 0 {
@@ -86,8 +82,8 @@ public struct AbacusUsageSnapshot: Sendable {
 
         let identity = ProviderIdentitySnapshot(
             providerID: .abacus,
-            accountEmail: self.accountEmail,
-            accountOrganization: self.accountOrganization,
+            accountEmail: nil,
+            accountOrganization: nil,
             loginMethod: self.planName)
 
         return UsageSnapshot(
@@ -136,7 +132,10 @@ public enum AbacusUsageError: LocalizedError, Sendable {
 // MARK: - Abacus Usage Fetcher
 
 public enum AbacusUsageFetcher {
-    private static let apiURL = URL(string: "https://apps.abacus.ai/api/v0/describeUser")!
+    private static let computePointsURL =
+        URL(string: "https://apps.abacus.ai/api/_getOrganizationComputePoints")!
+    private static let billingInfoURL =
+        URL(string: "https://apps.abacus.ai/api/_getBillingInfo")!
 
     public static func fetchUsage(
         cookieHeaderOverride: String? = nil,
@@ -187,18 +186,35 @@ public enum AbacusUsageFetcher {
         _ cookieHeader: String,
         timeout: TimeInterval) async throws -> AbacusUsageSnapshot
     {
-        var request = URLRequest(url: apiURL)
-        request.httpMethod = "POST"
+        // Fetch compute points (GET) and billing info (POST) concurrently
+        async let computePoints = Self.fetchJSON(
+            url: computePointsURL, method: "GET", cookieHeader: cookieHeader, timeout: timeout)
+        async let billingInfo = Self.fetchJSON(
+            url: billingInfoURL, method: "POST", cookieHeader: cookieHeader, timeout: timeout)
+
+        let cpResult = try await computePoints
+        let biResult = (try? await billingInfo) ?? [:]
+
+        return Self.parseResults(computePoints: cpResult, billingInfo: biResult)
+    }
+
+    private static func fetchJSON(
+        url: URL, method: String, cookieHeader: String, timeout: TimeInterval
+    ) async throws -> [String: Any] {
+        var request = URLRequest(url: url)
+        request.httpMethod = method
         request.timeoutInterval = timeout
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
-        request.httpBody = "{}".data(using: .utf8)
+        if method == "POST" {
+            request.httpBody = "{}".data(using: .utf8)
+        }
 
         let (data, response) = try await URLSession.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
-            throw AbacusUsageError.networkError("Invalid response")
+            throw AbacusUsageError.networkError("Invalid response from \(url.lastPathComponent)")
         }
 
         if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
@@ -210,55 +226,45 @@ public enum AbacusUsageFetcher {
             throw AbacusUsageError.networkError("HTTP \(httpResponse.statusCode): \(body)")
         }
 
-        return try Self.parseResponse(data)
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AbacusUsageError.parseFailed("Invalid JSON from \(url.lastPathComponent)")
+        }
+
+        guard root["success"] as? Bool == true,
+              let result = root["result"] as? [String: Any]
+        else {
+            let errorMsg = root["error"] as? String ?? "Unknown error"
+            throw AbacusUsageError.parseFailed("\(url.lastPathComponent): \(errorMsg)")
+        }
+
+        return result
     }
 
-    // MARK: - Manual JSON Parsing (resilient, no Codable)
+    // MARK: - Parsing
 
-    private static func parseResponse(_ data: Data) throws -> AbacusUsageSnapshot {
-        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            throw AbacusUsageError.parseFailed("Invalid JSON")
+    private static func parseResults(
+        computePoints: [String: Any], billingInfo: [String: Any]
+    ) -> AbacusUsageSnapshot {
+        // _getOrganizationComputePoints returns values already in credits (no division needed)
+        let totalCredits = Self.double(from: computePoints["totalComputePoints"])
+        let creditsLeft = Self.double(from: computePoints["computePointsLeft"])
+        let creditsUsed: Double? = if let total = totalCredits, let left = creditsLeft {
+            total - left
+        } else {
+            nil
         }
 
-        guard root["success"] as? Bool == true else {
-            let errorMsg = root["error"] as? String ?? "Unknown error"
-            throw AbacusUsageError.parseFailed("API returned error: \(errorMsg)")
-        }
+        // _getBillingInfo returns the exact next billing date and plan tier
+        let nextBillingDate = billingInfo["nextBillingDate"] as? String
+        let currentTier = billingInfo["currentTier"] as? String
 
-        guard let result = root["result"] as? [String: Any] else {
-            throw AbacusUsageError.parseFailed("Missing 'result' object")
-        }
-
-        let email = result["email"] as? String
-        let organization = (result["organization"] as? [String: Any])
-        let orgName = organization?["name"] as? String
-        let subscriptionTier = organization?["subscriptionTier"] as? String
-        let lastBilledAt = organization?["lastBilledAt"] as? String
-
-        let computePointInfo = organization?["computePointInfo"] as? [String: Any]
-        let currMonthAvailPoints = Self.double(from: computePointInfo?["currMonthAvailPoints"])
-        let currMonthUsage = Self.double(from: computePointInfo?["currMonthUsage"])
-        let last24HoursUsage = Self.double(from: computePointInfo?["last24HoursUsage"])
-        let last7DaysUsage = Self.double(from: computePointInfo?["last7DaysUsage"])
-
-        // Divide all point values by 100 (centi-credits)
-        let creditsUsed = currMonthUsage.map { $0 / 100.0 }
-        let creditsTotal = currMonthAvailPoints.map { $0 / 100.0 }
-        let daily = last24HoursUsage.map { $0 / 100.0 }
-        let weekly = last7DaysUsage.map { $0 / 100.0 }
-
-        // Compute reset date: lastBilledAt + 1 calendar month
-        let resetsAt: Date? = Self.computeResetDate(from: lastBilledAt)
+        let resetsAt = Self.parseDate(nextBillingDate)
 
         return AbacusUsageSnapshot(
             creditsUsed: creditsUsed,
-            creditsTotal: creditsTotal,
-            last24HoursUsage: daily,
-            last7DaysUsage: weekly,
+            creditsTotal: totalCredits,
             resetsAt: resetsAt,
-            planName: subscriptionTier,
-            accountEmail: email,
-            accountOrganization: orgName)
+            planName: currentTier)
     }
 
     private static func double(from value: Any?) -> Double? {
@@ -268,17 +274,13 @@ public enum AbacusUsageFetcher {
         return nil
     }
 
-    private static func computeResetDate(from isoString: String?) -> Date? {
+    private static func parseDate(_ isoString: String?) -> Date? {
         guard let isoString else { return nil }
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        var date = formatter.date(from: isoString)
-        if date == nil {
-            formatter.formatOptions = [.withInternetDateTime]
-            date = formatter.date(from: isoString)
-        }
-        guard let billedAt = date else { return nil }
-        return Calendar.current.date(byAdding: .month, value: 1, to: billedAt)
+        if let date = formatter.date(from: isoString) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: isoString)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -12,8 +12,17 @@ public enum AbacusCookieImporter {
     private static let cookieClient = BrowserCookieClient()
     private static let cookieDomains = ["abacus.ai", "apps.abacus.ai"]
 
-    /// Cookie name prefixes/substrings that indicate a session or auth cookie.
-    private static let sessionCookiePatterns = ["session", "sess", "auth", "token", "sid", "jwt", "id"]
+    /// Exact cookie names known to carry Abacus session state.
+    private static let knownSessionCookieNames: Set<String> = [
+        "sessionid", "session_id", "session_token",
+        "auth_token", "access_token",
+        "csrftoken", "csrf_token",
+    ]
+
+    /// Substrings that indicate a session or auth cookie (applied only when
+    /// no exact-name match is found). Deliberately excludes overly broad
+    /// patterns like "id" that match analytics/tracking cookies.
+    private static let sessionCookieSubstrings = ["session", "auth", "token", "sid", "jwt"]
 
     public struct SessionInfo: Sendable {
         public let cookies: [HTTPCookie]
@@ -59,11 +68,13 @@ public enum AbacusCookieImporter {
     }
 
     /// Returns `true` if the cookie set contains at least one cookie whose name
-    /// suggests it carries session or authentication state.
+    /// indicates session or authentication state.  Checks exact known names
+    /// first, then falls back to conservative substring matching.
     private static func containsSessionCookie(_ cookies: [HTTPCookie]) -> Bool {
         cookies.contains { cookie in
             let lower = cookie.name.lowercased()
-            return sessionCookiePatterns.contains { lower.contains($0) }
+            if self.knownSessionCookieNames.contains(lower) { return true }
+            return self.sessionCookieSubstrings.contains { lower.contains($0) }
         }
     }
 }
@@ -209,19 +220,19 @@ public enum AbacusUsageFetcher {
     {
         // Fetch compute points (GET) and billing info (POST) concurrently
         async let computePoints = Self.fetchJSON(
-            url: computePointsURL, method: "GET", cookieHeader: cookieHeader, timeout: timeout)
+            url: self.computePointsURL, method: "GET", cookieHeader: cookieHeader, timeout: timeout)
         async let billingInfo = Self.fetchJSON(
-            url: billingInfoURL, method: "POST", cookieHeader: cookieHeader, timeout: timeout)
+            url: self.billingInfoURL, method: "POST", cookieHeader: cookieHeader, timeout: timeout)
 
         let cpResult = try await computePoints
-        let biResult = (try? await billingInfo) ?? [:]
+        let biResult = await (try? billingInfo) ?? [:]
 
         return Self.parseResults(computePoints: cpResult, billingInfo: biResult)
     }
 
     private static func fetchJSON(
-        url: URL, method: String, cookieHeader: String, timeout: TimeInterval
-    ) async throws -> [String: Any] {
+        url: URL, method: String, cookieHeader: String, timeout: TimeInterval) async throws -> [String: Any]
+    {
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.timeoutInterval = timeout
@@ -264,8 +275,8 @@ public enum AbacusUsageFetcher {
     // MARK: - Parsing
 
     private static func parseResults(
-        computePoints: [String: Any], billingInfo: [String: Any]
-    ) -> AbacusUsageSnapshot {
+        computePoints: [String: Any], billingInfo: [String: Any]) -> AbacusUsageSnapshot
+    {
         // _getOrganizationComputePoints returns values already in credits (no division needed)
         let totalCredits = Self.double(from: computePoints["totalComputePoints"])
         let creditsLeft = Self.double(from: computePoints["computePointsLeft"])

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -74,31 +74,25 @@ public struct AbacusUsageSnapshot: Sendable {
             nil
         }
 
+        // Use windowMinutes matching the monthly billing cycle so pace calculation works.
+        // Approximate 1 month as 30 days.
+        let windowMinutes = 30 * 24 * 60
+
         let primary = RateWindow(
             usedPercent: percentUsed,
-            windowMinutes: nil,
+            windowMinutes: windowMinutes,
             resetsAt: self.resetsAt,
             resetDescription: resetDesc)
 
-        let secondary: RateWindow? = if let weekly = self.last7DaysUsage {
-            RateWindow(
-                usedPercent: 0,
-                windowMinutes: 7 * 24 * 60,
-                resetsAt: nil,
-                resetDescription: "\(Self.formatCredits(weekly)) credits (7 days)")
-        } else {
-            nil
-        }
-
         let identity = ProviderIdentitySnapshot(
             providerID: .abacus,
-            accountEmail: self.accountEmail,
-            accountOrganization: self.accountOrganization,
+            accountEmail: nil,
+            accountOrganization: nil,
             loginMethod: self.planName)
 
         return UsageSnapshot(
             primary: primary,
-            secondary: secondary,
+            secondary: nil,
             tertiary: nil,
             providerCost: nil,
             updatedAt: Date(),
@@ -106,11 +100,11 @@ public struct AbacusUsageSnapshot: Sendable {
     }
 
     private static func formatCredits(_ value: Double) -> String {
-        if value >= 1000 {
-            let formatted = String(format: "%,.0f", value)
-            return formatted
-        }
-        return String(format: "%.1f", value)
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = value >= 1000 ? 0 : 1
+        formatter.groupingSeparator = ","
+        return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.0f", value)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -22,8 +22,12 @@ public enum AbacusCookieImporter {
 
     /// Substrings that indicate a session or auth cookie (applied only when
     /// no exact-name match is found). Deliberately excludes overly broad
-    /// patterns like "id" that match analytics/tracking cookies.
-    private static let sessionCookieSubstrings = ["session", "auth", "token", "sid", "jwt"]
+    /// patterns like "id" and "token" that match analytics/CSRF cookies.
+    private static let sessionCookieSubstrings = ["session", "auth", "sid", "jwt"]
+
+    /// Cookie name prefixes that indicate a non-session cookie even when a
+    /// substring match would otherwise accept it (e.g. "csrftoken").
+    private static let excludedCookiePrefixes = ["csrf", "_ga", "_gid", "tracking", "analytics"]
 
     public struct SessionInfo: Sendable {
         public let cookies: [HTTPCookie]
@@ -34,8 +38,12 @@ public enum AbacusCookieImporter {
         }
     }
 
-    public static func importSession(logger: ((String) -> Void)? = nil) throws -> SessionInfo {
+    /// Returns all candidate sessions across browsers/profiles, ordered by
+    /// import priority.  Callers should try each in turn so that a stale
+    /// session in the first source doesn't block a valid one further down.
+    public static func importSessions(logger: ((String) -> Void)? = nil) throws -> [SessionInfo] {
         let log: (String) -> Void = { msg in logger?("[abacus-cookie] \(msg)") }
+        var candidates: [SessionInfo] = []
 
         for browserSource in abacusCookieImportOrder {
             do {
@@ -48,7 +56,6 @@ public enum AbacusCookieImporter {
                     let httpCookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
                     guard !httpCookies.isEmpty else { continue }
 
-                    // Only accept cookie sets that contain at least one session/auth cookie
                     guard Self.containsSessionCookie(httpCookies) else {
                         let cookieNames = httpCookies.map(\.name).joined(separator: ", ")
                         log("Skipping \(source.label): no session cookie found among [\(cookieNames)]")
@@ -57,7 +64,7 @@ public enum AbacusCookieImporter {
 
                     let cookieNames = httpCookies.map(\.name).joined(separator: ", ")
                     log("Found \(httpCookies.count) cookies in \(source.label): \(cookieNames)")
-                    return SessionInfo(cookies: httpCookies, sourceLabel: source.label)
+                    candidates.append(SessionInfo(cookies: httpCookies, sourceLabel: source.label))
                 }
             } catch {
                 BrowserCookieAccessGate.recordIfNeeded(error)
@@ -65,7 +72,10 @@ public enum AbacusCookieImporter {
             }
         }
 
-        throw AbacusUsageError.noSessionCookie
+        if candidates.isEmpty {
+            throw AbacusUsageError.noSessionCookie
+        }
+        return candidates
     }
 
     /// Returns `true` if the cookie set contains at least one cookie whose name
@@ -75,6 +85,7 @@ public enum AbacusCookieImporter {
         cookies.contains { cookie in
             let lower = cookie.name.lowercased()
             if self.knownSessionCookieNames.contains(lower) { return true }
+            if self.excludedCookiePrefixes.contains(where: { lower.hasPrefix($0) }) { return false }
             return self.sessionCookieSubstrings.contains { lower.contains($0) }
         }
     }
@@ -203,23 +214,33 @@ public enum AbacusUsageFetcher {
             }
         }
 
-        let session: AbacusCookieImporter.SessionInfo
+        let sessions: [AbacusCookieImporter.SessionInfo]
         do {
-            session = try AbacusCookieImporter.importSession(logger: log)
-            log("Using cookies from \(session.sourceLabel)")
+            sessions = try AbacusCookieImporter.importSessions(logger: log)
         } catch {
             BrowserCookieAccessGate.recordIfNeeded(error)
             log("Browser cookie import failed: \(error.localizedDescription)")
             throw AbacusUsageError.noSessionCookie
         }
 
-        // API errors after a successful cookie import must propagate directly
-        let snapshot = try await Self.fetchWithCookieHeader(session.cookieHeader, timeout: timeout)
-        CookieHeaderCache.store(
-            provider: .abacus,
-            cookieHeader: session.cookieHeader,
-            sourceLabel: session.sourceLabel)
-        return snapshot
+        // Try each candidate; fall through on auth errors so a stale session
+        // in the first source doesn't block a valid one further down.
+        for session in sessions {
+            log("Trying cookies from \(session.sourceLabel)")
+            do {
+                let snapshot = try await Self.fetchWithCookieHeader(session.cookieHeader, timeout: timeout)
+                CookieHeaderCache.store(
+                    provider: .abacus,
+                    cookieHeader: session.cookieHeader,
+                    sourceLabel: session.sourceLabel)
+                return snapshot
+            } catch let error as AbacusUsageError where error.isAuthRelated {
+                log("\(session.sourceLabel): \(error.localizedDescription), trying next source")
+                continue
+            }
+        }
+
+        throw AbacusUsageError.noSessionCookie
     }
 
     private static func fetchWithCookieHeader(

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -119,11 +119,14 @@ public enum AbacusUsageFetcher {
         timeout: TimeInterval,
         logger: ((String) -> Void)? = nil) async throws -> AbacusUsageSnapshot
     {
-        // Fetch compute points (GET) and billing info (POST) concurrently
+        // Fetch compute points (required, full timeout) and billing info
+        // (optional, shorter budget) concurrently. Billing is bounded so a
+        // slow/flaky billing endpoint can't delay credit rendering.
+        let billingBudget = min(timeout, 5.0)
         async let computePoints = self.fetchJSON(
             url: self.computePointsURL, method: "GET", cookieHeader: cookieHeader, timeout: timeout)
         async let billingInfo = self.fetchJSON(
-            url: self.billingInfoURL, method: "POST", cookieHeader: cookieHeader, timeout: timeout)
+            url: self.billingInfoURL, method: "POST", cookieHeader: cookieHeader, timeout: billingBudget)
 
         let cpResult = try await computePoints
         let biResult: [String: Any]

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -1,0 +1,327 @@
+import Foundation
+
+#if os(macOS)
+import SweetCookieKit
+
+private let abacusCookieImportOrder: BrowserCookieImportOrder =
+    ProviderDefaults.metadata[.abacus]?.browserCookieOrder ?? Browser.defaultImportOrder
+
+// MARK: - Abacus Cookie Importer
+
+public enum AbacusCookieImporter {
+    private static let cookieClient = BrowserCookieClient()
+    private static let cookieDomains = ["abacus.ai", "apps.abacus.ai"]
+
+    public struct SessionInfo: Sendable {
+        public let cookies: [HTTPCookie]
+        public let sourceLabel: String
+
+        public var cookieHeader: String {
+            self.cookies.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
+        }
+    }
+
+    public static func importSession(logger: ((String) -> Void)? = nil) throws -> SessionInfo {
+        let log: (String) -> Void = { msg in logger?("[abacus-cookie] \(msg)") }
+
+        for browserSource in abacusCookieImportOrder {
+            do {
+                let query = BrowserCookieQuery(domains: cookieDomains)
+                let sources = try Self.cookieClient.records(
+                    matching: query,
+                    in: browserSource,
+                    logger: log)
+                for source in sources where !source.records.isEmpty {
+                    let httpCookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
+                    if !httpCookies.isEmpty {
+                        let cookieNames = httpCookies.map(\.name).joined(separator: ", ")
+                        log("Found \(httpCookies.count) cookies in \(source.label): \(cookieNames)")
+                        return SessionInfo(cookies: httpCookies, sourceLabel: source.label)
+                    }
+                }
+            } catch {
+                BrowserCookieAccessGate.recordIfNeeded(error)
+                log("\(browserSource.displayName) cookie import failed: \(error.localizedDescription)")
+            }
+        }
+
+        throw AbacusUsageError.noSessionCookie
+    }
+}
+
+// MARK: - Abacus Usage Snapshot
+
+public struct AbacusUsageSnapshot: Sendable {
+    public let creditsUsed: Double?
+    public let creditsTotal: Double?
+    public let last24HoursUsage: Double?
+    public let last7DaysUsage: Double?
+    public let resetsAt: Date?
+    public let planName: String?
+    public let accountEmail: String?
+    public let accountOrganization: String?
+
+    public func toUsageSnapshot() -> UsageSnapshot {
+        let percentUsed: Double = if let used = self.creditsUsed, let total = self.creditsTotal, total > 0 {
+            (used / total) * 100.0
+        } else {
+            0
+        }
+
+        let resetDesc: String? = if let used = self.creditsUsed, let total = self.creditsTotal {
+            "\(Self.formatCredits(used)) / \(Self.formatCredits(total)) credits"
+        } else {
+            nil
+        }
+
+        let primary = RateWindow(
+            usedPercent: percentUsed,
+            windowMinutes: nil,
+            resetsAt: self.resetsAt,
+            resetDescription: resetDesc)
+
+        let secondary: RateWindow? = if let weekly = self.last7DaysUsage {
+            RateWindow(
+                usedPercent: 0,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: "\(Self.formatCredits(weekly)) credits (7 days)")
+        } else {
+            nil
+        }
+
+        let identity = ProviderIdentitySnapshot(
+            providerID: .abacus,
+            accountEmail: self.accountEmail,
+            accountOrganization: self.accountOrganization,
+            loginMethod: self.planName)
+
+        return UsageSnapshot(
+            primary: primary,
+            secondary: secondary,
+            tertiary: nil,
+            providerCost: nil,
+            updatedAt: Date(),
+            identity: identity)
+    }
+
+    private static func formatCredits(_ value: Double) -> String {
+        if value >= 1000 {
+            let formatted = String(format: "%,.0f", value)
+            return formatted
+        }
+        return String(format: "%.1f", value)
+    }
+}
+
+// MARK: - Abacus Usage Error
+
+public enum AbacusUsageError: LocalizedError, Sendable {
+    case noSessionCookie
+    case sessionExpired
+    case networkError(String)
+    case parseFailed(String)
+    case unauthorized
+
+    public var errorDescription: String? {
+        switch self {
+        case .noSessionCookie:
+            "No Abacus AI session found. Please log in to apps.abacus.ai in \(abacusCookieImportOrder.loginHint)."
+        case .sessionExpired:
+            "Abacus AI session expired. Please log in again."
+        case let .networkError(msg):
+            "Abacus AI API error: \(msg)"
+        case let .parseFailed(msg):
+            "Could not parse Abacus AI usage: \(msg)"
+        case .unauthorized:
+            "Unauthorized. Please log in to Abacus AI."
+        }
+    }
+}
+
+// MARK: - Abacus Usage Fetcher
+
+public enum AbacusUsageFetcher {
+    private static let apiURL = URL(string: "https://apps.abacus.ai/api/v0/describeUser")!
+
+    public static func fetchUsage(
+        cookieHeaderOverride: String? = nil,
+        timeout: TimeInterval = 15.0,
+        logger: ((String) -> Void)? = nil) async throws -> AbacusUsageSnapshot
+    {
+        let log: (String) -> Void = { msg in logger?("[abacus] \(msg)") }
+
+        if let override = CookieHeaderNormalizer.normalize(cookieHeaderOverride) {
+            log("Using manual cookie header")
+            return try await Self.fetchWithCookieHeader(override, timeout: timeout)
+        }
+
+        if let cached = CookieHeaderCache.load(provider: .abacus),
+           !cached.cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            log("Using cached cookie header from \(cached.sourceLabel)")
+            do {
+                return try await Self.fetchWithCookieHeader(cached.cookieHeader, timeout: timeout)
+            } catch let error as AbacusUsageError {
+                switch error {
+                case .unauthorized, .sessionExpired:
+                    CookieHeaderCache.clear(provider: .abacus)
+                default:
+                    throw error
+                }
+            }
+        }
+
+        do {
+            let session = try AbacusCookieImporter.importSession(logger: log)
+            log("Using cookies from \(session.sourceLabel)")
+            let snapshot = try await Self.fetchWithCookieHeader(session.cookieHeader, timeout: timeout)
+            CookieHeaderCache.store(
+                provider: .abacus,
+                cookieHeader: session.cookieHeader,
+                sourceLabel: session.sourceLabel)
+            return snapshot
+        } catch {
+            BrowserCookieAccessGate.recordIfNeeded(error)
+            log("Browser cookie import failed: \(error.localizedDescription)")
+        }
+
+        throw AbacusUsageError.noSessionCookie
+    }
+
+    private static func fetchWithCookieHeader(
+        _ cookieHeader: String,
+        timeout: TimeInterval) async throws -> AbacusUsageSnapshot
+    {
+        var request = URLRequest(url: apiURL)
+        request.httpMethod = "POST"
+        request.timeoutInterval = timeout
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.httpBody = "{}".data(using: .utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AbacusUsageError.networkError("Invalid response")
+        }
+
+        if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+            throw AbacusUsageError.unauthorized
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw AbacusUsageError.networkError("HTTP \(httpResponse.statusCode): \(body)")
+        }
+
+        return try Self.parseResponse(data)
+    }
+
+    // MARK: - Manual JSON Parsing (resilient, no Codable)
+
+    private static func parseResponse(_ data: Data) throws -> AbacusUsageSnapshot {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AbacusUsageError.parseFailed("Invalid JSON")
+        }
+
+        guard root["success"] as? Bool == true else {
+            let errorMsg = root["error"] as? String ?? "Unknown error"
+            throw AbacusUsageError.parseFailed("API returned error: \(errorMsg)")
+        }
+
+        guard let result = root["result"] as? [String: Any] else {
+            throw AbacusUsageError.parseFailed("Missing 'result' object")
+        }
+
+        let email = result["email"] as? String
+        let organization = (result["organization"] as? [String: Any])
+        let orgName = organization?["name"] as? String
+        let subscriptionTier = organization?["subscriptionTier"] as? String
+        let lastBilledAt = organization?["lastBilledAt"] as? String
+
+        let computePointInfo = organization?["computePointInfo"] as? [String: Any]
+        let currMonthAvailPoints = Self.double(from: computePointInfo?["currMonthAvailPoints"])
+        let currMonthUsage = Self.double(from: computePointInfo?["currMonthUsage"])
+        let last24HoursUsage = Self.double(from: computePointInfo?["last24HoursUsage"])
+        let last7DaysUsage = Self.double(from: computePointInfo?["last7DaysUsage"])
+
+        // Divide all point values by 100 (centi-credits)
+        let creditsUsed = currMonthUsage.map { $0 / 100.0 }
+        let creditsTotal = currMonthAvailPoints.map { $0 / 100.0 }
+        let daily = last24HoursUsage.map { $0 / 100.0 }
+        let weekly = last7DaysUsage.map { $0 / 100.0 }
+
+        // Compute reset date: lastBilledAt + 1 calendar month
+        let resetsAt: Date? = Self.computeResetDate(from: lastBilledAt)
+
+        return AbacusUsageSnapshot(
+            creditsUsed: creditsUsed,
+            creditsTotal: creditsTotal,
+            last24HoursUsage: daily,
+            last7DaysUsage: weekly,
+            resetsAt: resetsAt,
+            planName: subscriptionTier,
+            accountEmail: email,
+            accountOrganization: orgName)
+    }
+
+    private static func double(from value: Any?) -> Double? {
+        if let d = value as? Double { return d }
+        if let i = value as? Int { return Double(i) }
+        if let n = value as? NSNumber { return n.doubleValue }
+        return nil
+    }
+
+    private static func computeResetDate(from isoString: String?) -> Date? {
+        guard let isoString else { return nil }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var date = formatter.date(from: isoString)
+        if date == nil {
+            formatter.formatOptions = [.withInternetDateTime]
+            date = formatter.date(from: isoString)
+        }
+        guard let billedAt = date else { return nil }
+        return Calendar.current.date(byAdding: .month, value: 1, to: billedAt)
+    }
+}
+
+#else
+
+// MARK: - Abacus (Unsupported)
+
+public enum AbacusUsageError: LocalizedError, Sendable {
+    case notSupported
+
+    public var errorDescription: String? {
+        "Abacus AI is only supported on macOS."
+    }
+}
+
+public struct AbacusUsageSnapshot: Sendable {
+    public init() {}
+
+    public func toUsageSnapshot() -> UsageSnapshot {
+        UsageSnapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            providerCost: nil,
+            updatedAt: Date(),
+            identity: nil)
+    }
+}
+
+public enum AbacusUsageFetcher {
+    public static func fetchUsage(
+        cookieHeaderOverride _: String? = nil,
+        timeout _: TimeInterval = 15.0,
+        logger _: ((String) -> Void)? = nil) async throws -> AbacusUsageSnapshot
+    {
+        throw AbacusUsageError.notSupported
+    }
+}
+
+#endif

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 #if os(macOS)
 import SweetCookieKit
 
@@ -29,7 +33,7 @@ public enum AbacusUsageFetcher {
         {
             self.emit("Using cached cookie header from \(cached.sourceLabel)", logger: logger)
             do {
-                return try await Self.fetchWithCookieHeader(
+                return try await self.fetchWithCookieHeader(
                     cached.cookieHeader, timeout: timeout, logger: logger)
             } catch let error as AbacusUsageError where error.isRecoverable {
                 CookieHeaderCache.clear(provider: .abacus)
@@ -53,7 +57,7 @@ public enum AbacusUsageFetcher {
         for session in sessions {
             self.emit("Trying cookies from \(session.sourceLabel)", logger: logger)
             do {
-                let snapshot = try await Self.fetchWithCookieHeader(
+                let snapshot = try await self.fetchWithCookieHeader(
                     session.cookieHeader, timeout: timeout, logger: logger)
                 CookieHeaderCache.store(
                     provider: .abacus,
@@ -72,15 +76,17 @@ public enum AbacusUsageFetcher {
         throw lastError
     }
 
+    // MARK: - API Requests
+
     private static func fetchWithCookieHeader(
         _ cookieHeader: String,
         timeout: TimeInterval,
         logger: ((String) -> Void)? = nil) async throws -> AbacusUsageSnapshot
     {
         // Fetch compute points (GET) and billing info (POST) concurrently
-        async let computePoints = Self.fetchJSON(
+        async let computePoints = self.fetchJSON(
             url: self.computePointsURL, method: "GET", cookieHeader: cookieHeader, timeout: timeout)
-        async let billingInfo = Self.fetchJSON(
+        async let billingInfo = self.fetchJSON(
             url: self.billingInfoURL, method: "POST", cookieHeader: cookieHeader, timeout: timeout)
 
         let cpResult = try await computePoints
@@ -96,7 +102,7 @@ public enum AbacusUsageFetcher {
             biResult = [:]
         }
 
-        return try Self.parseResults(computePoints: cpResult, billingInfo: biResult)
+        return try self.parseResults(computePoints: cpResult, billingInfo: biResult)
     }
 
     private static func fetchJSON(
@@ -160,8 +166,8 @@ public enum AbacusUsageFetcher {
     private static func parseResults(
         computePoints: [String: Any], billingInfo: [String: Any]) throws -> AbacusUsageSnapshot
     {
-        let totalCredits = Self.double(from: computePoints["totalComputePoints"])
-        let creditsLeft = Self.double(from: computePoints["computePointsLeft"])
+        let totalCredits = self.double(from: computePoints["totalComputePoints"])
+        let creditsLeft = self.double(from: computePoints["computePointsLeft"])
 
         guard let totalCredits, let creditsLeft else {
             let keys = computePoints.keys.sorted().joined(separator: ", ")
@@ -173,7 +179,7 @@ public enum AbacusUsageFetcher {
 
         let nextBillingDate = billingInfo["nextBillingDate"] as? String
         let currentTier = billingInfo["currentTier"] as? String
-        let resetsAt = Self.parseDate(nextBillingDate)
+        let resetsAt = self.parseDate(nextBillingDate)
 
         return AbacusUsageSnapshot(
             creditsUsed: creditsUsed,
@@ -197,6 +203,8 @@ public enum AbacusUsageFetcher {
         formatter.formatOptions = [.withInternetDateTime]
         return formatter.date(from: isoString)
     }
+
+    // MARK: - Logging
 
     private static func emit(_ message: String, logger: ((String) -> Void)?) {
         logger?("[abacus] \(message)")

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -12,6 +12,9 @@ public enum AbacusCookieImporter {
     private static let cookieClient = BrowserCookieClient()
     private static let cookieDomains = ["abacus.ai", "apps.abacus.ai"]
 
+    /// Cookie name prefixes/substrings that indicate a session or auth cookie.
+    private static let sessionCookiePatterns = ["session", "sess", "auth", "token", "sid", "jwt", "id"]
+
     public struct SessionInfo: Sendable {
         public let cookies: [HTTPCookie]
         public let sourceLabel: String
@@ -33,11 +36,18 @@ public enum AbacusCookieImporter {
                     logger: log)
                 for source in sources where !source.records.isEmpty {
                     let httpCookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
-                    if !httpCookies.isEmpty {
+                    guard !httpCookies.isEmpty else { continue }
+
+                    // Only accept cookie sets that contain at least one session/auth cookie
+                    guard Self.containsSessionCookie(httpCookies) else {
                         let cookieNames = httpCookies.map(\.name).joined(separator: ", ")
-                        log("Found \(httpCookies.count) cookies in \(source.label): \(cookieNames)")
-                        return SessionInfo(cookies: httpCookies, sourceLabel: source.label)
+                        log("Skipping \(source.label): no session cookie found among [\(cookieNames)]")
+                        continue
                     }
+
+                    let cookieNames = httpCookies.map(\.name).joined(separator: ", ")
+                    log("Found \(httpCookies.count) cookies in \(source.label): \(cookieNames)")
+                    return SessionInfo(cookies: httpCookies, sourceLabel: source.label)
                 }
             } catch {
                 BrowserCookieAccessGate.recordIfNeeded(error)
@@ -46,6 +56,15 @@ public enum AbacusCookieImporter {
         }
 
         throw AbacusUsageError.noSessionCookie
+    }
+
+    /// Returns `true` if the cookie set contains at least one cookie whose name
+    /// suggests it carries session or authentication state.
+    private static func containsSessionCookie(_ cookies: [HTTPCookie]) -> Bool {
+        cookies.contains { cookie in
+            let lower = cookie.name.lowercased()
+            return sessionCookiePatterns.contains { lower.contains($0) }
+        }
     }
 }
 
@@ -165,21 +184,23 @@ public enum AbacusUsageFetcher {
             }
         }
 
+        let session: AbacusCookieImporter.SessionInfo
         do {
-            let session = try AbacusCookieImporter.importSession(logger: log)
+            session = try AbacusCookieImporter.importSession(logger: log)
             log("Using cookies from \(session.sourceLabel)")
-            let snapshot = try await Self.fetchWithCookieHeader(session.cookieHeader, timeout: timeout)
-            CookieHeaderCache.store(
-                provider: .abacus,
-                cookieHeader: session.cookieHeader,
-                sourceLabel: session.sourceLabel)
-            return snapshot
         } catch {
             BrowserCookieAccessGate.recordIfNeeded(error)
             log("Browser cookie import failed: \(error.localizedDescription)")
+            throw AbacusUsageError.noSessionCookie
         }
 
-        throw AbacusUsageError.noSessionCookie
+        // API errors after a successful cookie import must propagate directly
+        let snapshot = try await Self.fetchWithCookieHeader(session.cookieHeader, timeout: timeout)
+        CookieHeaderCache.store(
+            provider: .abacus,
+            cookieHeader: session.cookieHeader,
+            sourceLabel: session.sourceLabel)
+        return snapshot
     }
 
     private static func fetchWithCookieHeader(

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -44,26 +44,53 @@ public enum AbacusUsageFetcher {
         }
 
         // Fresh browser import — try Chrome first (AGENTS.md default), then broaden
-        // to all browsers if Chrome yields no session cookies.
-        let sessions: [AbacusCookieImporter.SessionInfo]
-        do {
-            sessions = try AbacusCookieImporter.importSessions(logger: logger)
-        } catch {
-            BrowserCookieAccessGate.recordIfNeeded(error)
-            self.emit(
-                "Chrome cookie import failed: \(error.localizedDescription); falling back to all browsers",
-                logger: logger)
-            do {
-                sessions = try AbacusCookieImporter.importSessions(
-                    preferredBrowsers: [], logger: logger)
-            } catch {
-                BrowserCookieAccessGate.recordIfNeeded(error)
-                self.emit("Browser cookie import failed: \(error.localizedDescription)", logger: logger)
-                throw AbacusUsageError.noSessionCookie
-            }
+        // to all browsers if Chrome has no sessions OR if all Chrome sessions fail
+        // with recoverable errors (expired/unauthorized cookies).
+        var lastError: AbacusUsageError = .noSessionCookie
+        if let snapshot = try await self.tryFetchFromBrowsers(
+            preferredBrowsers: [.chrome],
+            label: "Chrome",
+            timeout: timeout,
+            logger: logger,
+            lastError: &lastError)
+        {
+            return snapshot
         }
 
-        var lastError: AbacusUsageError = .noSessionCookie
+        self.emit("Chrome sessions exhausted; falling back to all browsers", logger: logger)
+        if let snapshot = try await self.tryFetchFromBrowsers(
+            preferredBrowsers: [],
+            label: "all browsers",
+            timeout: timeout,
+            logger: logger,
+            lastError: &lastError)
+        {
+            return snapshot
+        }
+
+        throw lastError
+    }
+
+    /// Tries to import sessions from `preferredBrowsers` and fetch usage.  Returns
+    /// the snapshot on success, nil if no sessions were available or all failed
+    /// with recoverable errors. Non-recoverable errors are rethrown directly.
+    private static func tryFetchFromBrowsers(
+        preferredBrowsers: [Browser],
+        label: String,
+        timeout: TimeInterval,
+        logger: ((String) -> Void)?,
+        lastError: inout AbacusUsageError) async throws -> AbacusUsageSnapshot?
+    {
+        let sessions: [AbacusCookieImporter.SessionInfo]
+        do {
+            sessions = try AbacusCookieImporter.importSessions(
+                preferredBrowsers: preferredBrowsers, logger: logger)
+        } catch {
+            BrowserCookieAccessGate.recordIfNeeded(error)
+            self.emit("\(label) cookie import failed: \(error.localizedDescription)", logger: logger)
+            return nil
+        }
+
         for session in sessions {
             self.emit("Trying cookies from \(session.sourceLabel)", logger: logger)
             do {
@@ -82,8 +109,7 @@ public enum AbacusUsageFetcher {
                 continue
             }
         }
-
-        throw lastError
+        return nil
     }
 
     // MARK: - API Requests

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageSnapshot.swift
@@ -31,9 +31,15 @@ public struct AbacusUsageSnapshot: Sendable {
             nil
         }
 
-        // Use windowMinutes matching the monthly billing cycle so pace calculation works.
-        // Approximate 1 month as 30 days.
-        let windowMinutes = 30 * 24 * 60
+        // Derive window from actual billing cycle when possible.
+        // Assume the cycle started one calendar month before resetsAt.
+        let windowMinutes: Int = if let resetDate = self.resetsAt,
+                                    let cycleStart = Calendar.current.date(byAdding: .month, value: -1, to: resetDate)
+        {
+            max(1, Int(resetDate.timeIntervalSince(cycleStart) / 60))
+        } else {
+            30 * 24 * 60
+        }
 
         let primary = RateWindow(
             usedPercent: percentUsed,

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageSnapshot.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public struct AbacusUsageSnapshot: Sendable {
+    public let creditsUsed: Double?
+    public let creditsTotal: Double?
+    public let resetsAt: Date?
+    public let planName: String?
+
+    public init(
+        creditsUsed: Double? = nil,
+        creditsTotal: Double? = nil,
+        resetsAt: Date? = nil,
+        planName: String? = nil)
+    {
+        self.creditsUsed = creditsUsed
+        self.creditsTotal = creditsTotal
+        self.resetsAt = resetsAt
+        self.planName = planName
+    }
+
+    public func toUsageSnapshot() -> UsageSnapshot {
+        let percentUsed: Double = if let used = self.creditsUsed, let total = self.creditsTotal, total > 0 {
+            (used / total) * 100.0
+        } else {
+            0
+        }
+
+        let resetDesc: String? = if let used = self.creditsUsed, let total = self.creditsTotal {
+            "\(Self.formatCredits(used)) / \(Self.formatCredits(total)) credits"
+        } else {
+            nil
+        }
+
+        // Use windowMinutes matching the monthly billing cycle so pace calculation works.
+        // Approximate 1 month as 30 days.
+        let windowMinutes = 30 * 24 * 60
+
+        let primary = RateWindow(
+            usedPercent: percentUsed,
+            windowMinutes: windowMinutes,
+            resetsAt: self.resetsAt,
+            resetDescription: resetDesc)
+
+        let identity = ProviderIdentitySnapshot(
+            providerID: .abacus,
+            accountEmail: nil,
+            accountOrganization: nil,
+            loginMethod: self.planName)
+
+        return UsageSnapshot(
+            primary: primary,
+            secondary: nil,
+            tertiary: nil,
+            providerCost: nil,
+            updatedAt: Date(),
+            identity: identity)
+    }
+
+    private static let creditFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.locale = Locale(identifier: "en_US")
+        return formatter
+    }()
+
+    private static func formatCredits(_ value: Double) -> String {
+        self.creditFormatter.maximumFractionDigits = value >= 1000 ? 0 : 1
+        return self.creditFormatter.string(from: NSNumber(value: value)) ?? String(format: "%.0f", value)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageSnapshot.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// MARK: - Abacus Usage Snapshot
+
 public struct AbacusUsageSnapshot: Sendable {
     public let creditsUsed: Double?
     public let creditsTotal: Double?
@@ -62,15 +64,14 @@ public struct AbacusUsageSnapshot: Sendable {
             identity: identity)
     }
 
-    private static let creditFormatter: NumberFormatter = {
+    // MARK: - Formatting
+
+    /// Thread-safe credit formatting — allocates per call to avoid shared mutable state.
+    private static func formatCredits(_ value: Double) -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         formatter.locale = Locale(identifier: "en_US")
-        return formatter
-    }()
-
-    private static func formatCredits(_ value: Double) -> String {
-        self.creditFormatter.maximumFractionDigits = value >= 1000 ? 0 : 1
-        return self.creditFormatter.string(from: NSNumber(value: value)) ?? String(format: "%.0f", value)
+        formatter.maximumFractionDigits = value >= 1000 ? 0 : 1
+        return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.0f", value)
     }
 }

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -78,6 +78,7 @@ public enum ProviderDescriptorRegistry {
         .openrouter: OpenRouterProviderDescriptor.descriptor,
         .warp: WarpProviderDescriptor.descriptor,
         .perplexity: PerplexityProviderDescriptor.descriptor,
+        .abacus: AbacusProviderDescriptor.descriptor,
     ]
     private static let bootstrap: Void = {
         for provider in UsageProvider.allCases {

--- a/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
@@ -20,7 +20,8 @@ public struct ProviderSettingsSnapshot: Sendable {
         amp: AmpProviderSettings? = nil,
         ollama: OllamaProviderSettings? = nil,
         jetbrains: JetBrainsProviderSettings? = nil,
-        perplexity: PerplexityProviderSettings? = nil) -> ProviderSettingsSnapshot
+        perplexity: PerplexityProviderSettings? = nil,
+        abacus: AbacusProviderSettings? = nil) -> ProviderSettingsSnapshot
     {
         ProviderSettingsSnapshot(
             debugMenuEnabled: debugMenuEnabled,
@@ -41,7 +42,8 @@ public struct ProviderSettingsSnapshot: Sendable {
             amp: amp,
             ollama: ollama,
             jetbrains: jetbrains,
-            perplexity: perplexity)
+            perplexity: perplexity,
+            abacus: abacus)
     }
 
     public struct CodexProviderSettings: Sendable {
@@ -232,6 +234,16 @@ public struct ProviderSettingsSnapshot: Sendable {
         }
     }
 
+    public struct AbacusProviderSettings: Sendable {
+        public let cookieSource: ProviderCookieSource
+        public let manualCookieHeader: String?
+
+        public init(cookieSource: ProviderCookieSource, manualCookieHeader: String?) {
+            self.cookieSource = cookieSource
+            self.manualCookieHeader = manualCookieHeader
+        }
+    }
+
     public let debugMenuEnabled: Bool
     public let debugKeepCLISessionsAlive: Bool
     public let codex: CodexProviderSettings?
@@ -251,6 +263,7 @@ public struct ProviderSettingsSnapshot: Sendable {
     public let ollama: OllamaProviderSettings?
     public let jetbrains: JetBrainsProviderSettings?
     public let perplexity: PerplexityProviderSettings?
+    public let abacus: AbacusProviderSettings?
 
     public var jetbrainsIDEBasePath: String? {
         self.jetbrains?.ideBasePath
@@ -275,7 +288,8 @@ public struct ProviderSettingsSnapshot: Sendable {
         amp: AmpProviderSettings?,
         ollama: OllamaProviderSettings?,
         jetbrains: JetBrainsProviderSettings? = nil,
-        perplexity: PerplexityProviderSettings? = nil)
+        perplexity: PerplexityProviderSettings? = nil,
+        abacus: AbacusProviderSettings? = nil)
     {
         self.debugMenuEnabled = debugMenuEnabled
         self.debugKeepCLISessionsAlive = debugKeepCLISessionsAlive
@@ -296,6 +310,7 @@ public struct ProviderSettingsSnapshot: Sendable {
         self.ollama = ollama
         self.jetbrains = jetbrains
         self.perplexity = perplexity
+        self.abacus = abacus
     }
 }
 
@@ -317,6 +332,7 @@ public enum ProviderSettingsSnapshotContribution: Sendable {
     case ollama(ProviderSettingsSnapshot.OllamaProviderSettings)
     case jetbrains(ProviderSettingsSnapshot.JetBrainsProviderSettings)
     case perplexity(ProviderSettingsSnapshot.PerplexityProviderSettings)
+    case abacus(ProviderSettingsSnapshot.AbacusProviderSettings)
 }
 
 public struct ProviderSettingsSnapshotBuilder: Sendable {
@@ -339,6 +355,7 @@ public struct ProviderSettingsSnapshotBuilder: Sendable {
     public var ollama: ProviderSettingsSnapshot.OllamaProviderSettings?
     public var jetbrains: ProviderSettingsSnapshot.JetBrainsProviderSettings?
     public var perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings?
+    public var abacus: ProviderSettingsSnapshot.AbacusProviderSettings?
 
     public init(debugMenuEnabled: Bool = false, debugKeepCLISessionsAlive: Bool = false) {
         self.debugMenuEnabled = debugMenuEnabled
@@ -364,6 +381,7 @@ public struct ProviderSettingsSnapshotBuilder: Sendable {
         case let .ollama(value): self.ollama = value
         case let .jetbrains(value): self.jetbrains = value
         case let .perplexity(value): self.perplexity = value
+        case let .abacus(value): self.abacus = value
         }
     }
 
@@ -387,6 +405,7 @@ public struct ProviderSettingsSnapshotBuilder: Sendable {
             amp: self.amp,
             ollama: self.ollama,
             jetbrains: self.jetbrains,
-            perplexity: self.perplexity)
+            perplexity: self.perplexity,
+            abacus: self.abacus)
     }
 }

--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -28,6 +28,7 @@ public enum UsageProvider: String, CaseIterable, Sendable, Codable {
     case warp
     case openrouter
     case perplexity
+    case abacus
 }
 
 // swiftformat:enable sortDeclarations
@@ -58,6 +59,7 @@ public enum IconStyle: Sendable, CaseIterable {
     case warp
     case openrouter
     case perplexity
+    case abacus
     case combined
 }
 

--- a/Sources/CodexBarCore/TokenAccountSupportCatalog+Data.swift
+++ b/Sources/CodexBarCore/TokenAccountSupportCatalog+Data.swift
@@ -65,5 +65,12 @@ extension TokenAccountSupportCatalog {
             injection: .cookieHeader,
             requiresManualCookieSource: true,
             cookieName: nil),
+        .abacus: TokenAccountSupport(
+            title: "Session tokens",
+            subtitle: "Store multiple Abacus AI Cookie headers.",
+            placeholder: "Cookie: …",
+            injection: .cookieHeader,
+            requiresManualCookieSource: true,
+            cookieName: nil),
     ]
 }

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
@@ -235,7 +235,7 @@ enum CostUsageScanner {
             return self.loadClaudeDaily(provider: .vertexai, range: range, now: now, options: filtered)
         case .zai, .gemini, .antigravity, .cursor, .opencode, .opencodego, .alibaba, .factory, .copilot,
              .minimax, .kilo, .kiro, .kimi,
-             .kimik2, .augment, .jetbrains, .amp, .ollama, .synthetic, .openrouter, .warp, .perplexity:
+             .kimik2, .augment, .jetbrains, .amp, .ollama, .synthetic, .openrouter, .warp, .perplexity, .abacus:
             return emptyReport
         }
     }

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -76,6 +76,7 @@ enum ProviderChoice: String, AppEnum {
         case .openrouter: return nil // OpenRouter not yet supported in widgets
         case .warp: return nil // Warp not yet supported in widgets
         case .perplexity: return nil // Perplexity not yet supported in widgets
+        case .abacus: return nil // Abacus AI not yet supported in widgets
         }
     }
 }

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -282,6 +282,7 @@ private struct ProviderSwitchChip: View {
         case .openrouter: "OpenRouter"
         case .warp: "Warp"
         case .perplexity: "Pplx"
+        case .abacus: "Abacus"
         }
     }
 }
@@ -641,6 +642,8 @@ enum WidgetColors {
             Color(red: 147 / 255, green: 139 / 255, blue: 180 / 255)
         case .perplexity:
             Color(red: 32 / 255, green: 178 / 255, blue: 170 / 255) // Perplexity teal
+        case .abacus:
+            Color(red: 56 / 255, green: 189 / 255, blue: 248 / 255)
         }
     }
 }

--- a/Tests/CodexBarTests/AbacusProviderTests.swift
+++ b/Tests/CodexBarTests/AbacusProviderTests.swift
@@ -234,3 +234,42 @@ struct AbacusErrorTests {
         #expect(error.errorDescription?.contains("log in") == true)
     }
 }
+
+// MARK: - Error Classification Tests
+
+struct AbacusErrorClassificationTests {
+    @Test
+    func `unauthorized is recoverable and auth related`() {
+        let error = AbacusUsageError.unauthorized
+        #expect(error.isRecoverable == true)
+        #expect(error.isAuthRelated == true)
+    }
+
+    @Test
+    func `sessionExpired is recoverable and auth related`() {
+        let error = AbacusUsageError.sessionExpired
+        #expect(error.isRecoverable == true)
+        #expect(error.isAuthRelated == true)
+    }
+
+    @Test
+    func `parseFailed is not recoverable`() {
+        let error = AbacusUsageError.parseFailed("bad json")
+        #expect(error.isRecoverable == false)
+        #expect(error.isAuthRelated == false)
+    }
+
+    @Test
+    func `networkError is not recoverable`() {
+        let error = AbacusUsageError.networkError("timeout")
+        #expect(error.isRecoverable == false)
+        #expect(error.isAuthRelated == false)
+    }
+
+    @Test
+    func `noSessionCookie is not recoverable`() {
+        let error = AbacusUsageError.noSessionCookie
+        #expect(error.isRecoverable == false)
+        #expect(error.isAuthRelated == false)
+    }
+}

--- a/Tests/CodexBarTests/AbacusProviderTests.swift
+++ b/Tests/CodexBarTests/AbacusProviderTests.swift
@@ -1,0 +1,233 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+// MARK: - Descriptor Tests
+
+struct AbacusDescriptorTests {
+    @Test
+    func `descriptor has correct identity`() {
+        let descriptor = AbacusProviderDescriptor.descriptor
+        #expect(descriptor.id == .abacus)
+        #expect(descriptor.metadata.displayName == "Abacus AI")
+        #expect(descriptor.metadata.cliName == "abacusai")
+    }
+
+    @Test
+    func `descriptor supports credits not opus`() {
+        let meta = AbacusProviderDescriptor.descriptor.metadata
+        #expect(meta.supportsCredits == true)
+        #expect(meta.supportsOpus == false)
+    }
+
+    @Test
+    func `descriptor is not primary provider`() {
+        let meta = AbacusProviderDescriptor.descriptor.metadata
+        #expect(meta.isPrimaryProvider == false)
+        #expect(meta.defaultEnabled == false)
+    }
+
+    @Test
+    func `descriptor supports auto and web source modes`() {
+        let descriptor = AbacusProviderDescriptor.descriptor
+        #expect(descriptor.fetchPlan.sourceModes.contains(.auto))
+        #expect(descriptor.fetchPlan.sourceModes.contains(.web))
+    }
+
+    @Test
+    func `descriptor has no version detector`() {
+        let descriptor = AbacusProviderDescriptor.descriptor
+        #expect(descriptor.cli.versionDetector == nil)
+    }
+
+    @Test
+    func `descriptor does not support token cost`() {
+        let descriptor = AbacusProviderDescriptor.descriptor
+        #expect(descriptor.tokenCost.supportsTokenCost == false)
+    }
+
+    @Test
+    func `cli aliases include abacus-ai`() {
+        let descriptor = AbacusProviderDescriptor.descriptor
+        #expect(descriptor.cli.aliases.contains("abacus-ai"))
+    }
+
+    @Test
+    func `dashboard url points to compute points page`() {
+        let meta = AbacusProviderDescriptor.descriptor.metadata
+        #expect(meta.dashboardURL?.contains("compute-points") == true)
+    }
+}
+
+// MARK: - Usage Snapshot Conversion Tests
+
+struct AbacusUsageSnapshotTests {
+    @Test
+    func `converts full snapshot to usage snapshot`() {
+        let resetDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = AbacusUsageSnapshot(
+            creditsUsed: 250,
+            creditsTotal: 1000,
+            resetsAt: resetDate,
+            planName: "Pro")
+
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(usage.primary != nil)
+        #expect(abs((usage.primary?.usedPercent ?? 0) - 25.0) < 0.01)
+        #expect(usage.primary?.resetDescription == "250 / 1,000 credits")
+        #expect(usage.primary?.resetsAt == resetDate)
+        #expect(usage.primary?.windowMinutes == 30 * 24 * 60)
+        #expect(usage.secondary == nil)
+        #expect(usage.tertiary == nil)
+        #expect(usage.identity?.providerID == .abacus)
+        #expect(usage.identity?.loginMethod == "Pro")
+    }
+
+    @Test
+    func `handles zero usage`() {
+        let snapshot = AbacusUsageSnapshot(
+            creditsUsed: 0,
+            creditsTotal: 500,
+            resetsAt: nil,
+            planName: "Basic")
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.usedPercent == 0.0)
+        #expect(usage.primary?.resetDescription == "0 / 500 credits")
+    }
+
+    @Test
+    func `handles full usage`() {
+        let snapshot = AbacusUsageSnapshot(
+            creditsUsed: 1000,
+            creditsTotal: 1000,
+            resetsAt: nil,
+            planName: nil)
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(abs((usage.primary?.usedPercent ?? 0) - 100.0) < 0.01)
+        #expect(usage.primary?.resetDescription == "1,000 / 1,000 credits")
+    }
+
+    @Test
+    func `handles nil credits gracefully`() {
+        let snapshot = AbacusUsageSnapshot(
+            creditsUsed: nil,
+            creditsTotal: nil,
+            resetsAt: nil,
+            planName: nil)
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.usedPercent == 0.0)
+        #expect(usage.primary?.resetDescription == nil)
+    }
+
+    @Test
+    func `handles nil total with non-nil used`() {
+        let snapshot = AbacusUsageSnapshot(
+            creditsUsed: 100,
+            creditsTotal: nil,
+            resetsAt: nil,
+            planName: nil)
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.usedPercent == 0.0)
+    }
+
+    @Test
+    func `handles zero total credits`() {
+        let snapshot = AbacusUsageSnapshot(
+            creditsUsed: 0,
+            creditsTotal: 0,
+            resetsAt: nil,
+            planName: nil)
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.usedPercent == 0.0)
+    }
+
+    @Test
+    func `formats large credit values with comma grouping`() {
+        let snapshot = AbacusUsageSnapshot(
+            creditsUsed: 12345,
+            creditsTotal: 50000,
+            resetsAt: nil,
+            planName: nil)
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.resetDescription == "12,345 / 50,000 credits")
+    }
+
+    @Test
+    func `formats fractional credit values`() {
+        let snapshot = AbacusUsageSnapshot(
+            creditsUsed: 42.5,
+            creditsTotal: 100,
+            resetsAt: nil,
+            planName: nil)
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.resetDescription == "42.5 / 100 credits")
+    }
+
+    @Test
+    func `window minutes represents monthly cycle`() {
+        let snapshot = AbacusUsageSnapshot(
+            creditsUsed: 0,
+            creditsTotal: 100,
+            resetsAt: nil,
+            planName: nil)
+
+        let usage = snapshot.toUsageSnapshot()
+        // 30 days * 24 hours * 60 minutes = 43200
+        #expect(usage.primary?.windowMinutes == 43200)
+    }
+
+    @Test
+    func `identity has no email or organization`() {
+        let snapshot = AbacusUsageSnapshot(
+            creditsUsed: 0,
+            creditsTotal: 100,
+            resetsAt: nil,
+            planName: "Pro")
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.identity?.accountEmail == nil)
+        #expect(usage.identity?.accountOrganization == nil)
+    }
+}
+
+// MARK: - Error Description Tests
+
+struct AbacusErrorTests {
+    @Test
+    func `noSessionCookie error mentions login`() {
+        let error = AbacusUsageError.noSessionCookie
+        #expect(error.errorDescription?.contains("log in") == true)
+    }
+
+    @Test
+    func `sessionExpired error mentions expired`() {
+        let error = AbacusUsageError.sessionExpired
+        #expect(error.errorDescription?.contains("expired") == true)
+    }
+
+    @Test
+    func `networkError includes message`() {
+        let error = AbacusUsageError.networkError("HTTP 500")
+        #expect(error.errorDescription?.contains("HTTP 500") == true)
+    }
+
+    @Test
+    func `parseFailed includes message`() {
+        let error = AbacusUsageError.parseFailed("Invalid JSON")
+        #expect(error.errorDescription?.contains("Invalid JSON") == true)
+    }
+
+    @Test
+    func `unauthorized error mentions login`() {
+        let error = AbacusUsageError.unauthorized
+        #expect(error.errorDescription?.contains("log in") == true)
+    }
+}

--- a/Tests/CodexBarTests/AbacusProviderTests.swift
+++ b/Tests/CodexBarTests/AbacusProviderTests.swift
@@ -63,7 +63,7 @@ struct AbacusDescriptorTests {
 
 struct AbacusUsageSnapshotTests {
     @Test
-    func `converts full snapshot to usage snapshot`() {
+    func `converts full snapshot to usage snapshot`() throws {
         let resetDate = Date(timeIntervalSince1970: 1_700_000_000)
         let snapshot = AbacusUsageSnapshot(
             creditsUsed: 250,
@@ -77,7 +77,10 @@ struct AbacusUsageSnapshotTests {
         #expect(abs((usage.primary?.usedPercent ?? 0) - 25.0) < 0.01)
         #expect(usage.primary?.resetDescription == "250 / 1,000 credits")
         #expect(usage.primary?.resetsAt == resetDate)
-        #expect(usage.primary?.windowMinutes == 30 * 24 * 60)
+        // Window derived from actual billing cycle (1 calendar month before resetDate)
+        let cycleStart = try #require(Calendar.current.date(byAdding: .month, value: -1, to: resetDate))
+        let expectedMinutes = Int(resetDate.timeIntervalSince(cycleStart) / 60)
+        #expect(usage.primary?.windowMinutes == expectedMinutes)
         #expect(usage.secondary == nil)
         #expect(usage.tertiary == nil)
         #expect(usage.identity?.providerID == .abacus)

--- a/docs/abacus.md
+++ b/docs/abacus.md
@@ -1,0 +1,67 @@
+---
+summary: "Abacus AI provider: browser cookie auth for ChatLLM/RouteLLM compute credit tracking."
+read_when:
+  - Adding or modifying the Abacus AI provider
+  - Debugging Abacus cookie imports or API responses
+  - Adjusting Abacus usage display or credit formatting
+---
+
+# Abacus AI Provider
+
+The Abacus AI provider tracks ChatLLM/RouteLLM compute credit usage via browser cookie authentication.
+
+## Features
+
+- **Monthly credit gauge**: Shows credits used vs. plan total with pace tick indicator.
+- **Reserve/deficit estimate**: Projected credit usage through the billing cycle.
+- **Reset timing**: Displays the next billing date from the Abacus billing API.
+- **Subscription tiers**: Detects Basic and Pro plans.
+- **Cookie auth**: Automatic browser cookie import (Safari, Chrome, Firefox) or manual cookie header.
+
+## Setup
+
+1. Open **Settings → Providers**
+2. Enable **Abacus AI**
+3. Log in to [apps.abacus.ai](https://apps.abacus.ai) in your browser
+4. Cookie import happens automatically on the next refresh
+
+### Manual cookie mode
+
+1. In **Settings → Providers → Abacus AI**, set Cookie source to **Manual**
+2. Open your browser DevTools on `apps.abacus.ai`, copy the `Cookie:` header from any API request
+3. Paste the header into the cookie field in CodexBar
+
+## How it works
+
+Two API endpoints are fetched concurrently using browser session cookies:
+
+- `GET https://apps.abacus.ai/api/_getOrganizationComputePoints` — returns `totalComputePoints` and `computePointsLeft` (values are in credit units, no conversion needed).
+- `POST https://apps.abacus.ai/api/_getBillingInfo` — returns `nextBillingDate` (ISO 8601) and `currentTier` (plan name).
+
+Cookie domains: `abacus.ai`, `apps.abacus.ai`. Session cookies are validated before use (anonymous/marketing-only cookie sets are skipped). Valid cookies are cached in Keychain and reused until the session expires.
+
+The billing cycle window is set to 30 days for pace calculation.
+
+## CLI
+
+```bash
+codexbar usage --provider abacusai --verbose
+```
+
+## Troubleshooting
+
+### "No Abacus AI session found"
+
+Log in to [apps.abacus.ai](https://apps.abacus.ai) in a supported browser (Safari, Chrome, Firefox), then refresh CodexBar.
+
+### "Abacus AI session expired"
+
+Re-login to Abacus AI. The cached cookie will be cleared automatically and a fresh one imported on the next refresh.
+
+### "Unauthorized"
+
+Your session cookies may be invalid. Log out and back in to Abacus AI, or paste a fresh `Cookie:` header in manual mode.
+
+### Credits show 0
+
+Verify that your Abacus AI account has an active subscription with compute credits allocated.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,5 +1,5 @@
 ---
-summary: "Provider data sources and parsing overview (Codex, Claude, Gemini, Antigravity, Cursor, OpenCode, Alibaba Coding Plan, Droid/Factory, z.ai, Copilot, Kimi, Kilo, Kimi K2, Kiro, Warp, Vertex AI, Augment, Amp, Ollama, JetBrains AI, OpenRouter)."
+summary: "Provider data sources and parsing overview (Codex, Claude, Gemini, Antigravity, Cursor, OpenCode, Alibaba Coding Plan, Droid/Factory, z.ai, Copilot, Kimi, Kilo, Kimi K2, Kiro, Warp, Vertex AI, Augment, Amp, Ollama, JetBrains AI, OpenRouter, Abacus AI)."
 read_when:
   - Adding or modifying provider fetch/parsing
   - Adjusting provider labels, toggles, or metadata
@@ -39,6 +39,7 @@ until the session is invalid, to avoid repeated Keychain prompts.
 | Warp | API token (config/env) → GraphQL request limits (`api`). |
 | Ollama | Web settings page via browser cookies (`web`). |
 | OpenRouter | API token (config, overrides env) → credits API (`api`). |
+| Abacus AI | Browser cookies → compute points + billing API (`web`). |
 
 ## Codex
 - Web dashboard (optional, off by default): `https://chatgpt.com/codex/settings/usage` via WebView + browser cookies.
@@ -182,5 +183,13 @@ until the session is invalid, to avoid repeated Keychain prompts.
 - Override base URL with `OPENROUTER_API_URL` env var.
 - Status: `https://status.openrouter.ai` (link only, no auto-polling yet).
 - Details: `docs/openrouter.md`.
+
+## Abacus AI
+- Browser cookies (`abacus.ai`, `apps.abacus.ai`) via automatic import or manual header.
+- `GET https://apps.abacus.ai/api/_getOrganizationComputePoints` (credits used/total).
+- `POST https://apps.abacus.ai/api/_getBillingInfo` (next billing date, subscription tier).
+- Shows monthly credit gauge with pace tick and reserve/deficit estimate.
+- Status: none yet.
+- Details: `docs/abacus.md`.
 
 See also: `docs/provider.md` for architecture notes.


### PR DESCRIPTION
## Summary
- Add Abacus AI as a new cookie-based provider for tracking ChatLLM/RouteLLM compute credit usage
- Fetches credit usage from `_getOrganizationComputePoints` (GET) and billing cycle from `_getBillingInfo` (POST), both called concurrently
- Shows monthly credit gauge with pace tick, reserve/deficit estimate, and reset date
- Cookie auth via SweetCookieKit browser import (Safari, Chrome, etc.) with manual override option
- Supports Basic and Pro subscription tiers

## New files
- `AbacusProviderDescriptor.swift` — provider metadata, branding (cyan), web-only fetch strategy
- `AbacusUsageFetcher.swift` — cookie importer, API fetcher, JSON parsing
- `AbacusProviderImplementation.swift` — settings UI (cookie source picker)
- `AbacusSettingsStore.swift` — settings persistence
- `ProviderIcon-abacus.svg` — provider icon
- `docs/abacus.md` — provider documentation (setup, API details, troubleshooting)

## Modified files
- `Providers.swift` — `.abacus` enum case
- `ProviderSettingsSnapshot.swift` — `AbacusProviderSettings`
- `ProviderDescriptor.swift`, `ProviderImplementationRegistry.swift` — registration
- `MenuCardView.swift`, `MenuDescriptor.swift` — Abacus-specific display (pace tick, credit detail)
- `UsagePaceText.swift` — enable pace calculation for Abacus
- `docs/providers.md` — added Abacus AI to strategy table and detailed provider section
- `README.md` — added Abacus AI to provider list
- Exhaustive switch updates in CLI, widget, store, and scanner files

## Test plan
- [x] Enable Abacus AI in preferences, verify cookie import from Safari
- [x] Verify credit values match the Abacus dashboard
- [x] Verify reset date matches billing cycle (nextBillingDate from API)
- [x] Verify pace tick and reserve/deficit text display correctly
- [x] Test with expired cookies — should re-import from browser
- [x] Run `codexbar usage --provider abacusai --verbose` to verify CLI output