### PR TITLE
Fix Gemini OAuth: resolve multi-level symlink chain

### DIFF
--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
@@ -451,11 +451,22 @@ public struct GeminiStatusProbe: Sendable {
             return nil
         }
 
+        guard let content = Self.resolveOAuthFileContent(from: geminiPath) else {
+            return nil
+        }
+        return self.parseOAuthCredentials(from: content)
+    }
+
+    /// Resolve the full symlink chain starting from `binaryPath`, then search each
+    /// intermediate directory for the Gemini CLI oauth2.js file.
+    /// Returns the file content if found, or `nil`.
+    /// Visible to tests via `@testable import`.
+    static func resolveOAuthFileContent(from binaryPath: String) -> String? {
         // Resolve symlinks recursively, collecting all intermediate paths
         // (e.g. /usr/local/bin/gemini → /opt/homebrew/bin/gemini → ../Cellar/.../bin/gemini → ...)
         let fm = FileManager.default
-        var candidates: [String] = [geminiPath]
-        var current = geminiPath
+        var candidates: [String] = [binaryPath]
+        var current = binaryPath
         var visited: Set<String> = []
         while true {
             let canonical = (current as NSString).standardizingPath
@@ -500,7 +511,7 @@ public struct GeminiStatusProbe: Sendable {
 
             for path in possiblePaths {
                 if let content = try? String(contentsOfFile: path, encoding: .utf8) {
-                    return self.parseOAuthCredentials(from: content)
+                    return content
                 }
             }
         }

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
@@ -451,43 +451,57 @@ public struct GeminiStatusProbe: Sendable {
             return nil
         }
 
-        // Resolve symlinks to find the actual installation
+        // Resolve symlinks recursively, collecting all intermediate paths
+        // (e.g. /usr/local/bin/gemini → /opt/homebrew/bin/gemini → ../Cellar/.../bin/gemini → ...)
         let fm = FileManager.default
-        var realPath = geminiPath
-        if let resolved = try? fm.destinationOfSymbolicLink(atPath: geminiPath) {
+        var candidates: [String] = [geminiPath]
+        var current = geminiPath
+        var visited: Set<String> = []
+        while true {
+            let canonical = (current as NSString).standardizingPath
+            if visited.contains(canonical) { break }
+            visited.insert(canonical)
+            guard let resolved = try? fm.destinationOfSymbolicLink(atPath: current) else { break }
             if resolved.hasPrefix("/") {
-                realPath = resolved
+                current = resolved
             } else {
-                realPath = (geminiPath as NSString).deletingLastPathComponent + "/" + resolved
+                current = ((current as NSString).deletingLastPathComponent as NSString)
+                    .appendingPathComponent(resolved)
             }
+            current = (current as NSString).standardizingPath
+            candidates.append(current)
         }
 
         // Navigate from bin/gemini to the oauth2.js file
-        // Homebrew path: .../libexec/lib/node_modules/@google/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js
-        // Bun/npm path: .../node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js (sibling package)
-        let binDir = (realPath as NSString).deletingLastPathComponent
-        let baseDir = (binDir as NSString).deletingLastPathComponent
-
+        // Try from each resolved path in the symlink chain (deepest first)
         let oauthSubpath =
             "node_modules/@google/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js"
         let nixShareSubpath =
             "share/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js"
         let oauthFile = "dist/src/code_assist/oauth2.js"
-        let possiblePaths = [
-            // Homebrew nested structure
-            "\(baseDir)/libexec/lib/\(oauthSubpath)",
-            "\(baseDir)/lib/\(oauthSubpath)",
-            // Nix package layout
-            "\(baseDir)/\(nixShareSubpath)",
-            // Bun/npm sibling structure: gemini-cli-core is a sibling to gemini-cli
-            "\(baseDir)/../gemini-cli-core/\(oauthFile)",
-            // npm nested inside gemini-cli
-            "\(baseDir)/node_modules/@google/gemini-cli-core/\(oauthFile)",
-        ]
 
-        for path in possiblePaths {
-            if let content = try? String(contentsOfFile: path, encoding: .utf8) {
-                return self.parseOAuthCredentials(from: content)
+        for candidate in candidates.reversed() {
+            let binDir = (candidate as NSString).deletingLastPathComponent
+            let baseDir = (binDir as NSString).deletingLastPathComponent
+
+            let possiblePaths = [
+                // Homebrew nested structure
+                "\(baseDir)/libexec/lib/\(oauthSubpath)",
+                "\(baseDir)/lib/\(oauthSubpath)",
+                // Nix package layout
+                "\(baseDir)/\(nixShareSubpath)",
+                // Bun/npm sibling structure
+                "\(baseDir)/../gemini-cli-core/\(oauthFile)",
+                // npm nested inside gemini-cli
+                "\(baseDir)/node_modules/@google/gemini-cli-core/\(oauthFile)",
+                // Direct node_modules lookup from candidate
+                "\(binDir)/node_modules/@google/gemini-cli-core/\(oauthFile)",
+            ]
+
+            for path in possiblePaths {
+                if let content = try? String(contentsOfFile: path, encoding: .utf8) {
+                    return self.parseOAuthCredentials(from: content)
+                }
             }
         }
 

--- a/Tests/CodexBarTests/GeminiOAuthSymlinkTests.swift
+++ b/Tests/CodexBarTests/GeminiOAuthSymlinkTests.swift
@@ -1,0 +1,175 @@
+@testable import CodexBarCore
+import Foundation
+import Testing
+
+/// Regression tests for multi-level symlink resolution when locating
+/// Gemini CLI's oauth2.js file.
+///
+/// See: https://github.com/steipete/CodexBar/pull/497
+///
+/// On some setups (e.g. Apple Silicon with `/usr/local/bin/gemini` →
+/// `/opt/homebrew/bin/gemini` → `../Cellar/…/bin/gemini` → …), the
+/// previous single-level `destinationOfSymbolicLink` call resolved too
+/// shallowly, producing a wrong base path and silently failing to find
+/// the OAuth credentials file.
+@Suite
+struct GeminiOAuthSymlinkTests {
+    /// Sample oauth2.js content used by all tests.
+    private static let sampleOAuth2JS = """
+        const OAUTH_CLIENT_ID = 'test-client-id.apps.googleusercontent.com';
+        const OAUTH_CLIENT_SECRET = 'test-client-secret';
+        """
+
+    // MARK: - Helpers
+
+    /// Build a temporary directory tree that mimics a Homebrew Cellar layout
+    /// and return the path to the top-level "entry" symlink.
+    ///
+    /// Layout created:
+    /// ```
+    ///   <root>/
+    ///     usr/local/bin/gemini  → <root>/opt/homebrew/bin/gemini       (level 0 — optional)
+    ///     opt/homebrew/bin/gemini → ../Cellar/gemini-cli/0.32.1/bin/gemini  (level 1)
+    ///     opt/homebrew/Cellar/gemini-cli/0.32.1/
+    ///       bin/gemini → ../libexec/bin/gemini                         (level 2)
+    ///       libexec/bin/gemini  (regular file — final target)
+    ///       libexec/lib/node_modules/@google/gemini-cli/
+    ///         node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js
+    /// ```
+    private static func makeBrewLayout(
+        root: URL,
+        includeExtraSymlink: Bool) throws -> String
+    {
+        let fm = FileManager.default
+
+        // Cellar paths
+        let cellarBase = root.appendingPathComponent(
+            "opt/homebrew/Cellar/gemini-cli/0.32.1", isDirectory: true)
+        let cellarBin = cellarBase.appendingPathComponent("bin", isDirectory: true)
+        let libexecBin = cellarBase.appendingPathComponent("libexec/bin", isDirectory: true)
+        let oauthDir = cellarBase.appendingPathComponent(
+            "libexec/lib/node_modules/@google/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/code_assist",
+            isDirectory: true)
+
+        // Create directories
+        try fm.createDirectory(at: cellarBin, withIntermediateDirectories: true)
+        try fm.createDirectory(at: libexecBin, withIntermediateDirectories: true)
+        try fm.createDirectory(at: oauthDir, withIntermediateDirectories: true)
+
+        // Write the oauth2.js file
+        let oauthFile = oauthDir.appendingPathComponent("oauth2.js")
+        try Self.sampleOAuth2JS.write(to: oauthFile, atomically: true, encoding: .utf8)
+
+        // Final target: libexec/bin/gemini (regular file)
+        let finalBinary = libexecBin.appendingPathComponent("gemini")
+        try "#!/usr/bin/env node\n".write(to: finalBinary, atomically: true, encoding: .utf8)
+
+        // Level 2 symlink: Cellar/…/bin/gemini → ../libexec/bin/gemini
+        let cellarBinGemini = cellarBin.appendingPathComponent("gemini")
+        try fm.createSymbolicLink(
+            atPath: cellarBinGemini.path,
+            withDestinationPath: "../libexec/bin/gemini")
+
+        // Level 1 symlink: opt/homebrew/bin/gemini → ../Cellar/gemini-cli/0.32.1/bin/gemini
+        let homebrewBin = root.appendingPathComponent("opt/homebrew/bin", isDirectory: true)
+        try fm.createDirectory(at: homebrewBin, withIntermediateDirectories: true)
+        let homebrewBinGemini = homebrewBin.appendingPathComponent("gemini")
+        try fm.createSymbolicLink(
+            atPath: homebrewBinGemini.path,
+            withDestinationPath: "../Cellar/gemini-cli/0.32.1/bin/gemini")
+
+        if includeExtraSymlink {
+            // Level 0 symlink: usr/local/bin/gemini → <absolute>/opt/homebrew/bin/gemini
+            let usrLocalBin = root.appendingPathComponent("usr/local/bin", isDirectory: true)
+            try fm.createDirectory(at: usrLocalBin, withIntermediateDirectories: true)
+            let usrLocalBinGemini = usrLocalBin.appendingPathComponent("gemini")
+            try fm.createSymbolicLink(
+                atPath: usrLocalBinGemini.path,
+                withDestinationPath: homebrewBinGemini.path)
+            return usrLocalBinGemini.path
+        } else {
+            return homebrewBinGemini.path
+        }
+    }
+
+    // MARK: - Tests
+
+    /// Standard 2-level Homebrew symlink chain (no extra symlink).
+    /// The old code handled this correctly; this test guards against regressions.
+    @Test
+    func findsOAuthWithStandardHomebrewChain() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GeminiSymlinkTest-standard-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let entryPath = try Self.makeBrewLayout(root: root, includeExtraSymlink: false)
+        let content = GeminiStatusProbe.resolveOAuthFileContent(from: entryPath)
+
+        #expect(content != nil, "Should find oauth2.js through standard 2-level Homebrew symlink chain")
+        #expect(content?.contains("OAUTH_CLIENT_ID") == true)
+        #expect(content?.contains("test-client-id") == true)
+    }
+
+    /// Multi-level symlink chain with an extra `/usr/local/bin` symlink.
+    /// This is the scenario that caused the original bug — the old single-level
+    /// `destinationOfSymbolicLink` resolved to `/opt/homebrew/bin/gemini` and
+    /// computed `baseDir = /opt/homebrew`, missing the Cellar path entirely.
+    @Test
+    func findsOAuthWithExtraSymlinkLevel() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GeminiSymlinkTest-extra-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let entryPath = try Self.makeBrewLayout(root: root, includeExtraSymlink: true)
+        let content = GeminiStatusProbe.resolveOAuthFileContent(from: entryPath)
+
+        #expect(content != nil, "Should find oauth2.js through 3-level symlink chain (the bug scenario)")
+        #expect(content?.contains("OAUTH_CLIENT_ID") == true)
+        #expect(content?.contains("test-client-id") == true)
+    }
+
+    /// When the binary path is not a symlink at all (e.g. direct npm install),
+    /// the resolver should still search relative to that path.
+    @Test
+    func handlesNonSymlinkBinary() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GeminiSymlinkTest-direct-\(UUID().uuidString)")
+        let fm = FileManager.default
+        defer { try? fm.removeItem(at: root) }
+
+        // Create: root/bin/gemini (regular file) + root/lib/node_modules/…/oauth2.js
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        try fm.createDirectory(at: binDir, withIntermediateDirectories: true)
+        let binary = binDir.appendingPathComponent("gemini")
+        try "#!/usr/bin/env node\n".write(to: binary, atomically: true, encoding: .utf8)
+
+        let oauthDir = root.appendingPathComponent(
+            "lib/node_modules/@google/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/code_assist",
+            isDirectory: true)
+        try fm.createDirectory(at: oauthDir, withIntermediateDirectories: true)
+        try Self.sampleOAuth2JS.write(
+            to: oauthDir.appendingPathComponent("oauth2.js"),
+            atomically: true,
+            encoding: .utf8)
+
+        let content = GeminiStatusProbe.resolveOAuthFileContent(from: binary.path)
+        #expect(content != nil, "Should find oauth2.js from non-symlinked binary")
+    }
+
+    /// Returns nil gracefully when no oauth2.js exists anywhere in the chain.
+    @Test
+    func returnsNilWhenOAuthFileMissing() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("GeminiSymlinkTest-missing-\(UUID().uuidString)")
+        let fm = FileManager.default
+        defer { try? fm.removeItem(at: root) }
+
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        try fm.createDirectory(at: binDir, withIntermediateDirectories: true)
+        let binary = binDir.appendingPathComponent("gemini")
+        try "#!/usr/bin/env node\n".write(to: binary, atomically: true, encoding: .utf8)
+
+        let content = GeminiStatusProbe.resolveOAuthFileContent(from: binary.path)
+        #expect(content == nil, "Should return nil when oauth2.js does not exist")
+    }
+}


### PR DESCRIPTION
## Summary

- **Bug**: Homebrew-installed `gemini` CLI has a 4-level symlink chain: `/usr/local/bin/gemini` → `/opt/homebrew/bin/gemini` → `../Cellar/gemini-cli/0.32.1/bin/gemini` → `../libexec/bin/gemini`. CodexBar only resolves one level using `destinationOfSymbolicLink`, so it lands at `/opt/homebrew/bin/` which lacks the `libexec/` tree containing `oauth2.js`. This causes Gemini OAuth credential detection to fail silently.
- **Fix**: Recursive symlink resolution that walks the entire chain, collecting all intermediate paths. It then tries each resolved directory (deepest first) to locate the OAuth credentials file, ensuring the correct `libexec/` path is found regardless of how many symlink levels Homebrew uses.

## Test plan

- [x] Tested with Homebrew gemini-cli 0.32.1 on macOS (4-level symlink chain)
- [x] Verified OAuth credentials are correctly located at the deepest resolved path
- [x] Confirmed backward compatibility with direct (non-symlinked) gemini installations