### PR TITLE
Fix missing task cancellation and legacy keychain fingerprint mismatch

### DIFF
--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -492,6 +492,7 @@ final class UsageStore {
         self.timerTask?.cancel()
         self.tokenTimerTask?.cancel()
         self.tokenRefreshSequenceTask?.cancel()
+        self.pathDebugRefreshTask?.cancel()
     }
 
     enum SessionQuotaWindowSource: String {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -1067,8 +1067,17 @@ public enum ClaudeOAuthCredentialsStore {
                 promptMode: promptMode),
                 !data.isEmpty
             {
-                // Same as above: store fingerprint after interactive read to avoid background "sync" reads.
-                self.saveClaudeKeychainFingerprint(self.currentClaudeKeychainFingerprintWithoutPrompt())
+                // Build fingerprint from the legacy candidate directly rather than using
+                // currentClaudeKeychainFingerprintWithoutPrompt(), which prefers the newest
+                // candidate and may return a fingerprint for a different keychain item.
+                if let legacyCandidate = self.claudeKeychainLegacyCandidateWithoutPrompt(
+                    promptMode: promptMode)
+                {
+                    self.saveClaudeKeychainFingerprint(ClaudeKeychainFingerprint(
+                        modifiedAt: legacyCandidate.modifiedAt.map { Int($0.timeIntervalSince1970) },
+                        createdAt: legacyCandidate.createdAt.map { Int($0.timeIntervalSince1970) },
+                        persistentRefHash: Self.sha256Prefix(legacyCandidate.persistentRef)))
+                }
                 return data
             }
         } catch let error as ClaudeOAuthCredentialsError {
@@ -1592,7 +1601,19 @@ extension ClaudeOAuthCredentialsStore {
            let creds = try? ClaudeOAuthCredentials.parse(data: legacyData),
            !creds.isExpired
         {
-            self.saveClaudeKeychainFingerprint(self.currentClaudeKeychainFingerprintWithoutPrompt())
+            // Build fingerprint from the legacy candidate directly, matching the candidate
+            // path above. currentClaudeKeychainFingerprintWithoutPrompt() prefers the newest
+            // candidate and may return a fingerprint for a different keychain item, causing
+            // stale comparisons on subsequent background sync checks.
+            if let legacyCandidate = self.claudeKeychainLegacyCandidateWithoutPrompt(
+                promptMode: fallbackPromptMode)
+            {
+                let legacyFingerprint = ClaudeKeychainFingerprint(
+                    modifiedAt: legacyCandidate.modifiedAt.map { Int($0.timeIntervalSince1970) },
+                    createdAt: legacyCandidate.createdAt.map { Int($0.timeIntervalSince1970) },
+                    persistentRefHash: Self.sha256Prefix(legacyCandidate.persistentRef))
+                self.saveClaudeKeychainFingerprint(legacyFingerprint)
+            }
             self.writeMemoryCache(
                 record: ClaudeOAuthCredentialRecord(credentials: creds, owner: .claudeCLI, source: .memoryCache),
                 timestamp: now)


### PR DESCRIPTION
## Summary

- **Cancel `pathDebugRefreshTask` in `UsageStore.deinit`** — this task was missing from the deinit cleanup, causing it to continue running after deallocation (the `[weak self]` prevents crashes but the task does unnecessary background work)
- **Fix legacy keychain fingerprint mismatch in `ClaudeOAuthCredentials`** — two call sites (`loadFromClaudeKeychainUsingSecurityFramework` and `syncFromClaudeKeychainWithoutPrompt`) used `currentClaudeKeychainFingerprintWithoutPrompt()` after a successful legacy data read. This function prefers the newest *candidate* and may return a fingerprint for a different keychain item than the one actually read via the legacy service-level query. Now builds the fingerprint from `claudeKeychainLegacyCandidateWithoutPrompt()` directly, matching the pattern already used in the candidate path

## Context

The fingerprint mismatch caused `syncWithClaudeKeychainIfChanged` to see a "changed" fingerprint on subsequent checks, triggering unnecessary keychain re-reads. This is related to #340 — while not the root cause (which is Claude Code's delete+recreate ACL wipe), it reduced the effectiveness of the cache layer that mitigates the repeated prompts.

## Test plan

- [x] `swift build` passes cleanly
- [ ] Verify `pathDebugRefreshTask` is properly canceled on store deallocation
- [ ] Verify legacy keychain recovery path stores correct fingerprint, preventing unnecessary background sync re-reads

🤖 Generated with [Claude Code](https://claude.com/claude-code)