### PR TITLE
Improve Codex pricing and cost history

### DIFF
--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -9,14 +9,27 @@ struct CostHistoryChartMenuView: View {
     private struct Point: Identifiable {
         let id: String
         let date: Date
-        let costUSD: Double
+        let displayCostUSD: Double
+        let actualCostUSD: Double?
         let totalTokens: Int?
+        let hasUsage: Bool
+        let isPlaceholder: Bool
 
-        init(date: Date, costUSD: Double, totalTokens: Int?) {
+        init(
+            date: Date,
+            displayCostUSD: Double,
+            actualCostUSD: Double?,
+            totalTokens: Int?,
+            hasUsage: Bool,
+            isPlaceholder: Bool = false)
+        {
             self.date = date
-            self.costUSD = costUSD
+            self.displayCostUSD = displayCostUSD
+            self.actualCostUSD = actualCostUSD
             self.totalTokens = totalTokens
-            self.id = "\(Int(date.timeIntervalSince1970))-\(costUSD)"
+            self.hasUsage = hasUsage
+            self.isPlaceholder = isPlaceholder
+            self.id = "\(Int(date.timeIntervalSince1970))-\(displayCostUSD)-\(isPlaceholder)-\(hasUsage)"
         }
     }
 
@@ -25,6 +38,16 @@ struct CostHistoryChartMenuView: View {
     private let totalCostUSD: Double?
     private let width: CGFloat
     @State private var selectedDateKey: String?
+
+    private struct DetailModelLine: Identifiable {
+        let id: String
+        let text: String
+    }
+
+    private struct DetailContent {
+        let primary: String
+        let models: [DetailModelLine]
+    }
 
     init(provider: UsageProvider, daily: [DailyEntry], totalCostUSD: Double?, width: CGFloat) {
         self.provider = provider
@@ -45,15 +68,16 @@ struct CostHistoryChartMenuView: View {
                     ForEach(model.points) { point in
                         BarMark(
                             x: .value("Day", point.date, unit: .day),
-                            y: .value("Cost", point.costUSD))
-                            .foregroundStyle(model.barColor)
+                            y: .value("Cost", point.displayCostUSD))
+                            .foregroundStyle(point.isPlaceholder ? Color.clear : model.barColor)
                     }
                     if let peak = Self.peakPoint(model: model) {
-                        let capStart = max(peak.costUSD - Self.capHeight(maxValue: model.maxCostUSD), 0)
+                        let peakCostUSD = peak.actualCostUSD ?? 0
+                        let capStart = max(peakCostUSD - Self.capHeight(maxValue: model.maxCostUSD), 0)
                         BarMark(
                             x: .value("Day", peak.date, unit: .day),
                             yStart: .value("Cap start", capStart),
-                            yEnd: .value("Cap end", peak.costUSD))
+                            yEnd: .value("Cap end", peakCostUSD))
                             .foregroundStyle(Color(nsColor: .systemYellow))
                     }
                 }
@@ -68,7 +92,8 @@ struct CostHistoryChartMenuView: View {
                     }
                 }
                 .chartLegend(.hidden)
-                .frame(height: 130)
+                .chartYScale(domain: 0...model.chartMaxCostUSD)
+                .frame(maxWidth: .infinity, minHeight: 130, maxHeight: 130)
                 .chartOverlay { proxy in
                     GeometryReader { geo in
                         ZStack(alignment: .topLeading) {
@@ -88,21 +113,27 @@ struct CostHistoryChartMenuView: View {
                     }
                 }
 
-                let detail = self.detailLines(model: model)
+                let detail = self.detailContent(model: model)
                 VStack(alignment: .leading, spacing: 0) {
                     Text(detail.primary)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                         .truncationMode(.tail)
-                        .frame(height: 16, alignment: .leading)
-                    Text(detail.secondary ?? " ")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .frame(height: 16, alignment: .leading)
-                        .opacity(detail.secondary == nil ? 0 : 1)
+                        .frame(maxWidth: .infinity, minHeight: 16, maxHeight: 16, alignment: .leading)
+                    VStack(alignment: .leading, spacing: 2) {
+                        ForEach(0..<model.maxDetailLineCount, id: \.self) { index in
+                            let line = index < detail.models.count ? detail.models[index] : nil
+                            Text(line?.text ?? " ")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .opacity(line == nil ? 0 : 1)
+                        }
+                    }
+                    .padding(.top, 6)
                 }
             }
 
@@ -110,11 +141,12 @@ struct CostHistoryChartMenuView: View {
                 Text("Total (30d): \(UsageFormatter.usdString(total))")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
-        .frame(minWidth: self.width, maxWidth: .infinity, alignment: .leading)
+        .frame(width: self.width, alignment: .leading)
     }
 
     private struct Model {
@@ -126,6 +158,9 @@ struct CostHistoryChartMenuView: View {
         let barColor: Color
         let peakKey: String?
         let maxCostUSD: Double
+        let minimumVisibleCostUSD: Double
+        let chartMaxCostUSD: Double
+        let maxDetailLineCount: Int
     }
 
     private static let selectionBandColor = Color(nsColor: .labelColor).opacity(0.1)
@@ -136,34 +171,72 @@ struct CostHistoryChartMenuView: View {
 
     private static func makeModel(provider: UsageProvider, daily: [DailyEntry]) -> Model {
         let sorted = daily.sorted { lhs, rhs in lhs.date < rhs.date }
-        var points: [Point] = []
-        points.reserveCapacity(sorted.count)
-
-        var pointsByKey: [String: Point] = [:]
-        pointsByKey.reserveCapacity(sorted.count)
-
         var entriesByKey: [String: DailyEntry] = [:]
         entriesByKey.reserveCapacity(sorted.count)
 
+        for entry in sorted {
+            entriesByKey[entry.date] = entry
+        }
+
+        let dayRange = Self.contiguousDayKeys(from: sorted)
+
+        var points: [Point] = []
+        points.reserveCapacity(dayRange.count)
+
+        var pointsByKey: [String: Point] = [:]
+        pointsByKey.reserveCapacity(dayRange.count)
+
         var dateKeys: [(key: String, date: Date)] = []
-        dateKeys.reserveCapacity(sorted.count)
+        dateKeys.reserveCapacity(dayRange.count)
 
         var peak: (key: String, costUSD: Double)?
         var maxCostUSD: Double = 0
+        var maxDetailLineCount = 1
+
         for entry in sorted {
-            guard let costUSD = entry.costUSD, costUSD > 0 else { continue }
-            guard let date = self.dateFromDayKey(entry.date) else { continue }
-            let point = Point(date: date, costUSD: costUSD, totalTokens: entry.totalTokens)
-            points.append(point)
-            pointsByKey[entry.date] = point
-            entriesByKey[entry.date] = entry
-            dateKeys.append((entry.date, date))
-            if let cur = peak {
-                if costUSD > cur.costUSD { peak = (entry.date, costUSD) }
-            } else {
-                peak = (entry.date, costUSD)
+            if let costUSD = entry.costUSD, costUSD > 0 {
+                maxCostUSD = max(maxCostUSD, costUSD)
             }
-            maxCostUSD = max(maxCostUSD, costUSD)
+        }
+
+        let minimumVisibleCostUSD: Double = if maxCostUSD > 0 {
+            maxCostUSD * 0.01
+        } else if sorted.contains(where: Self.hasUsage(entry:)) {
+            1
+        } else {
+            0
+        }
+
+        for item in dayRange {
+            let entry = entriesByKey[item.key]
+            let actualCostUSD = entry.flatMap(\.costUSD).map { max(0, $0) }
+            let hasUsage = entry.map { Self.hasUsage(entry: $0) } ?? false
+            let displayCostUSD = if hasUsage {
+                max(actualCostUSD ?? 0.0, minimumVisibleCostUSD)
+            } else {
+                0.0
+            }
+            let point = Point(
+                date: item.date,
+                displayCostUSD: displayCostUSD,
+                actualCostUSD: actualCostUSD,
+                totalTokens: entry?.totalTokens,
+                hasUsage: hasUsage,
+                isPlaceholder: entry == nil)
+            points.append(point)
+            pointsByKey[item.key] = point
+            dateKeys.append((item.key, item.date))
+            if let entry {
+                maxDetailLineCount = max(maxDetailLineCount, Self.detailLineCount(for: entry))
+            }
+
+            if let actualCostUSD, actualCostUSD > 0 {
+                if let cur = peak {
+                    if actualCostUSD > cur.costUSD { peak = (item.key, actualCostUSD) }
+                } else {
+                    peak = (item.key, actualCostUSD)
+                }
+            }
         }
 
         let axisDates: [Date] = {
@@ -171,6 +244,8 @@ struct CostHistoryChartMenuView: View {
             if Calendar.current.isDate(first, inSameDayAs: last) { return [first] }
             return [first, last]
         }()
+
+        let chartMaxCostUSD = max(maxCostUSD, minimumVisibleCostUSD * 8, 1)
 
         let barColor = Self.barColor(for: provider)
         return Model(
@@ -181,7 +256,10 @@ struct CostHistoryChartMenuView: View {
             axisDates: axisDates,
             barColor: barColor,
             peakKey: peak?.key,
-            maxCostUSD: maxCostUSD)
+            maxCostUSD: maxCostUSD,
+            minimumVisibleCostUSD: minimumVisibleCostUSD,
+            chartMaxCostUSD: chartMaxCostUSD,
+            maxDetailLineCount: maxDetailLineCount)
     }
 
     private static func barColor(for provider: UsageProvider) -> Color {
@@ -206,9 +284,52 @@ struct CostHistoryChartMenuView: View {
         return comps.date
     }
 
+    private static func contiguousDayKeys(from sorted: [DailyEntry]) -> [(key: String, date: Date)] {
+        guard let firstEntry = sorted.first,
+              let lastEntry = sorted.last,
+              let firstDate = self.dateFromDayKey(firstEntry.date),
+              let lastDate = self.dateFromDayKey(lastEntry.date)
+        else {
+            return []
+        }
+
+        var days: [(key: String, date: Date)] = []
+        var current = firstDate
+        let calendar = Calendar.current
+
+        while current <= lastDate {
+            let comps = calendar.dateComponents([.year, .month, .day], from: current)
+            let key = String(format: "%04d-%02d-%02d", comps.year ?? 1970, comps.month ?? 1, comps.day ?? 1)
+            days.append((key, current))
+            guard let next = calendar.date(byAdding: .day, value: 1, to: current) else { break }
+            current = next
+        }
+
+        return days
+    }
+
     private static func peakPoint(model: Model) -> Point? {
         guard let key = model.peakKey else { return nil }
         return model.pointsByDateKey[key]
+    }
+
+    private static func detailLineCount(for entry: DailyEntry) -> Int {
+        guard let breakdown = entry.modelBreakdowns, !breakdown.isEmpty else { return 1 }
+        return breakdown.count
+    }
+
+    private static func hasUsage(entry: DailyEntry) -> Bool {
+        if let totalTokens = entry.totalTokens, totalTokens > 0 {
+            return true
+        }
+        if (entry.inputTokens ?? 0) > 0
+            || (entry.outputTokens ?? 0) > 0
+            || (entry.cacheCreationTokens ?? 0) > 0
+            || (entry.cacheReadTokens ?? 0) > 0
+        {
+            return true
+        }
+        return false
     }
 
     private func selectionBandRect(model: Model, proxy: ChartProxy, geo: GeometryProxy) -> CGRect? {
@@ -286,41 +407,70 @@ struct CostHistoryChartMenuView: View {
         return best?.key
     }
 
-    private func detailLines(model: Model) -> (primary: String, secondary: String?) {
+    private func detailContent(model: Model) -> DetailContent {
         guard let key = self.selectedDateKey,
               let point = model.pointsByDateKey[key],
               let date = Self.dateFromDayKey(key)
         else {
-            return ("Hover a bar for details", nil)
+            return DetailContent(primary: "Hover a bar for details", models: [])
+        }
+
+        guard !point.isPlaceholder else {
+            let dayLabel = date.formatted(.dateTime.month(.abbreviated).day())
+            return DetailContent(primary: "\(dayLabel): No cost data", models: [])
         }
 
         let dayLabel = date.formatted(.dateTime.month(.abbreviated).day())
-        let cost = UsageFormatter.usdString(point.costUSD)
-        if let tokens = point.totalTokens {
-            let primary = "\(dayLabel): \(cost) · \(UsageFormatter.tokenCountString(tokens)) tokens"
-            let secondary = self.topModelsText(key: key, model: model)
-            return (primary, secondary)
+        let partial = self.hasUnpricedModels(key: key, model: model) ? " partial" : ""
+        let models = self.topModelLines(key: key, model: model)
+        let primary = if let actualCostUSD = point.actualCostUSD, actualCostUSD > 0 {
+            "\(dayLabel): \(UsageFormatter.usdString(actualCostUSD))\(partial)"
+        } else if point.hasUsage {
+            "\(dayLabel): No priced cost data"
+        } else {
+            "\(dayLabel): No cost data"
         }
-        let primary = "\(dayLabel): \(cost)"
-        let secondary = self.topModelsText(key: key, model: model)
-        return (primary, secondary)
+
+        if let tokens = point.totalTokens {
+            return DetailContent(
+                primary: "\(primary) · \(UsageFormatter.tokenCountString(tokens)) tokens",
+                models: models)
+        }
+        return DetailContent(primary: primary, models: models)
     }
 
-    private func topModelsText(key: String, model: Model) -> String? {
-        guard let entry = model.entriesByDateKey[key] else { return nil }
-        guard let breakdown = entry.modelBreakdowns, !breakdown.isEmpty else { return nil }
+    private func hasUnpricedModels(key: String, model: Model) -> Bool {
+        guard let entry = model.entriesByDateKey[key],
+              let breakdown = entry.modelBreakdowns
+        else {
+            return false
+        }
+        return breakdown.contains { $0.costUSD == nil }
+    }
+
+    private func topModelLines(key: String, model: Model) -> [DetailModelLine] {
+        guard let entry = model.entriesByDateKey[key] else { return [] }
+        guard let breakdown = entry.modelBreakdowns, !breakdown.isEmpty else { return [] }
         let parts = breakdown
-            .compactMap { item -> (name: String, costUSD: Double)? in
-                guard let costUSD = item.costUSD, costUSD > 0 else { return nil }
-                return (UsageFormatter.modelDisplayName(item.modelName), costUSD)
+            .map { item in
+                (
+                    name: UsageFormatter.modelDisplayName(item.modelName),
+                    costUSD: item.costUSD,
+                    totalTokens: item.totalTokens)
             }
             .sorted { lhs, rhs in
-                if lhs.costUSD == rhs.costUSD { return lhs.name < rhs.name }
-                return lhs.costUSD > rhs.costUSD
+                lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
             }
-            .prefix(3)
-            .map { "\($0.name) \(UsageFormatter.usdString($0.costUSD))" }
-        guard !parts.isEmpty else { return nil }
-        return "Top: \(parts.joined(separator: " · "))"
+            .map { item in
+                let tokensSuffix = item.totalTokens.map { " · \(UsageFormatter.tokenCountString($0)) tokens" } ?? ""
+                if let costUSD = item.costUSD, costUSD > 0 {
+                    return DetailModelLine(
+                        id: item.name,
+                        text: "\(item.name): \(UsageFormatter.usdString(costUSD))\(tokensSuffix)")
+                }
+                let suffix = item.name == "GPT-5.3 Spark" ? "Research Preview" : "unpriced"
+                return DetailModelLine(id: item.name, text: "\(item.name): \(suffix)\(tokensSuffix)")
+            }
+        return Array(parts)
     }
 }

--- a/Sources/CodexBarCLI/CLICostCommand.swift
+++ b/Sources/CodexBarCLI/CLICostCommand.swift
@@ -117,7 +117,10 @@ extension CodexBarCLI {
                 costUSD: entry.costUSD,
                 modelsUsed: entry.modelsUsed,
                 modelBreakdowns: entry.modelBreakdowns?.map { breakdown in
-                    CostModelBreakdownPayload(modelName: breakdown.modelName, costUSD: breakdown.costUSD)
+                    CostModelBreakdownPayload(
+                        modelName: breakdown.modelName,
+                        costUSD: breakdown.costUSD,
+                        totalTokens: breakdown.totalTokens)
                 })
         } ?? []
 
@@ -272,10 +275,12 @@ struct CostDailyEntryPayload: Encodable {
 struct CostModelBreakdownPayload: Encodable {
     let modelName: String
     let costUSD: Double?
+    let totalTokens: Int?
 
     private enum CodingKeys: String, CodingKey {
         case modelName
         case costUSD = "cost"
+        case totalTokens
     }
 }
 

--- a/Sources/CodexBarCore/CostUsageModels.swift
+++ b/Sources/CodexBarCore/CostUsageModels.swift
@@ -29,11 +29,13 @@ public struct CostUsageDailyReport: Sendable, Decodable {
     public struct ModelBreakdown: Sendable, Decodable, Equatable {
         public let modelName: String
         public let costUSD: Double?
+        public let totalTokens: Int?
 
         private enum CodingKeys: String, CodingKey {
             case modelName
             case costUSD
             case cost
+            case totalTokens
         }
 
         public init(from decoder: Decoder) throws {
@@ -42,11 +44,13 @@ public struct CostUsageDailyReport: Sendable, Decodable {
             self.costUSD =
                 try container.decodeIfPresent(Double.self, forKey: .costUSD)
                 ?? container.decodeIfPresent(Double.self, forKey: .cost)
+            self.totalTokens = try container.decodeIfPresent(Int.self, forKey: .totalTokens)
         }
 
-        public init(modelName: String, costUSD: Double?) {
+        public init(modelName: String, costUSD: Double?, totalTokens: Int? = nil) {
             self.modelName = modelName
             self.costUSD = costUSD
+            self.totalTokens = totalTokens
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
@@ -6,11 +6,15 @@ import FoundationNetworking
 public struct CodexUsageResponse: Decodable, Sendable {
     public let planType: PlanType?
     public let rateLimit: RateLimitDetails?
+    public let codeReviewRateLimit: RateLimitDetails?
+    public let additionalRateLimits: [AdditionalRateLimit]?
     public let credits: CreditDetails?
 
     enum CodingKeys: String, CodingKey {
         case planType = "plan_type"
         case rateLimit = "rate_limit"
+        case codeReviewRateLimit = "code_review_rate_limit"
+        case additionalRateLimits = "additional_rate_limits"
         case credits
     }
 
@@ -91,6 +95,18 @@ public struct CodexUsageResponse: Decodable, Sendable {
             case usedPercent = "used_percent"
             case resetAt = "reset_at"
             case limitWindowSeconds = "limit_window_seconds"
+        }
+    }
+
+    public struct AdditionalRateLimit: Decodable, Sendable {
+        public let limitName: String?
+        public let meteredFeature: String?
+        public let rateLimit: RateLimitDetails?
+
+        enum CodingKeys: String, CodingKey {
+            case limitName = "limit_name"
+            case meteredFeature = "metered_feature"
+            case rateLimit = "rate_limit"
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -12,8 +12,8 @@ public enum CodexProviderDescriptor {
                 displayName: "Codex",
                 sessionLabel: "Session",
                 weeklyLabel: "Weekly",
-                opusLabel: nil,
-                supportsOpus: false,
+                opusLabel: "Spark",
+                supportsOpus: true,
                 supportsCredits: true,
                 creditsHint: "Credits unavailable; keep Codex running to refresh.",
                 toggleTitle: "Show Codex usage",
@@ -164,6 +164,7 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
     private static func mapUsage(_ response: CodexUsageResponse, credentials: CodexOAuthCredentials) -> UsageSnapshot {
         let primary = Self.makeWindow(response.rateLimit?.primaryWindow)
         let secondary = Self.makeWindow(response.rateLimit?.secondaryWindow)
+        let tertiary = Self.makeSparkWindow(response.additionalRateLimits)
 
         let identity = ProviderIdentitySnapshot(
             providerID: .codex,
@@ -174,7 +175,7 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
         return UsageSnapshot(
             primary: primary ?? RateWindow(usedPercent: 0, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
             secondary: secondary,
-            tertiary: nil,
+            tertiary: tertiary,
             updatedAt: Date(),
             identity: identity)
     }
@@ -193,6 +194,22 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
             windowMinutes: window.limitWindowSeconds / 60,
             resetsAt: resetDate,
             resetDescription: resetDescription)
+    }
+
+    private static func makeSparkWindow(_ rateLimits: [CodexUsageResponse.AdditionalRateLimit]?) -> RateWindow? {
+        guard let sparkRateLimit = rateLimits?.first(where: self.isSparkRateLimit) else { return nil }
+        return self.makeWindow(sparkRateLimit.rateLimit?.secondaryWindow)
+            ?? self.makeWindow(sparkRateLimit.rateLimit?.primaryWindow)
+    }
+
+    private static func isSparkRateLimit(_ rateLimit: CodexUsageResponse.AdditionalRateLimit) -> Bool {
+        let limitName = rateLimit.limitName?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if limitName == "gpt-5.3-codex-spark" {
+            return true
+        }
+
+        let meteredFeature = rateLimit.meteredFeature?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return meteredFeature == "codex_bengalfox"
     }
 
     private static func resolveAccountEmail(from credentials: CodexOAuthCredentials) -> String? {

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -6,6 +6,8 @@ public enum ResetTimeDisplayStyle: String, Codable, Sendable {
 }
 
 public enum UsageFormatter {
+    private static let gptModelRegex = try? NSRegularExpression(pattern: #"^gpt-([0-9.]+)(?:-(.+))?$"#)
+
     public static func usageLine(remaining: Double, used: Double, showUsed: Bool) -> String {
         let percent = showUsed ? used : remaining
         let clamped = min(100, max(0, percent))
@@ -186,6 +188,10 @@ public enum UsageFormatter {
         var cleaned = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else { return raw }
 
+        if cleaned.lowercased() == "unknown" {
+            return "Unknown model"
+        }
+
         let patterns = [
             #"(?:-|\s)\d{8}$"#,
             #"(?:-|\s)\d{4}-\d{2}-\d{2}$"#,
@@ -203,7 +209,43 @@ public enum UsageFormatter {
             cleaned.removeSubrange(trailing)
         }
 
+        let lower = cleaned.lowercased()
+        if lower.hasPrefix("gpt-5") {
+            return self.gptModelDisplayName(from: lower) ?? cleaned
+        }
+
         return cleaned.isEmpty ? raw : cleaned
+    }
+
+    private static func gptModelDisplayName(from raw: String) -> String? {
+        guard let regex = self.gptModelRegex else { return nil }
+        let range = NSRange(raw.startIndex..<raw.endIndex, in: raw)
+        guard let match = regex.firstMatch(in: raw, range: range) else { return nil }
+        guard let versionRange = Range(match.range(at: 1), in: raw) else { return nil }
+
+        let version = raw[versionRange]
+        guard let suffixRange = Range(match.range(at: 2), in: raw) else {
+            return "GPT-\(version)"
+        }
+
+        let suffix = String(raw[suffixRange])
+        switch suffix {
+        case "codex":
+            return "GPT-\(version) Codex"
+        case "codex-max":
+            return "GPT-\(version) Codex Max"
+        case "codex-mini":
+            return "GPT-\(version) Codex Mini"
+        case "codex-spark":
+            return "GPT-\(version) Spark"
+        default:
+            let words = suffix.split(separator: "-").map { part in
+                let text = String(part)
+                if text.uppercased() == "GPT" { return "GPT" }
+                return String(text.prefix(1)).uppercased() + String(text.dropFirst())
+            }
+            return "GPT-\(version) \(words.joined(separator: " "))"
+        }
     }
 
     /// Cleans a provider plan string: strip ANSI/bracket noise, drop boilerplate words, collapse whitespace, and

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageCache.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageCache.swift
@@ -1,6 +1,15 @@
 import Foundation
 
 enum CostUsageCacheIO {
+    private static func cacheVersion(for provider: UsageProvider) -> Int {
+        switch provider {
+        case .codex:
+            4
+        default:
+            1
+        }
+    }
+
     private static func defaultCacheRoot() -> URL {
         let root = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         return root.appendingPathComponent("CodexBar", isDirectory: true)
@@ -8,22 +17,24 @@ enum CostUsageCacheIO {
 
     static func cacheFileURL(provider: UsageProvider, cacheRoot: URL? = nil) -> URL {
         let root = cacheRoot ?? self.defaultCacheRoot()
+        let version = self.cacheVersion(for: provider)
         return root
             .appendingPathComponent("cost-usage", isDirectory: true)
-            .appendingPathComponent("\(provider.rawValue)-v1.json", isDirectory: false)
+            .appendingPathComponent("\(provider.rawValue)-v\(version).json", isDirectory: false)
     }
 
     static func load(provider: UsageProvider, cacheRoot: URL? = nil) -> CostUsageCache {
         let url = self.cacheFileURL(provider: provider, cacheRoot: cacheRoot)
-        if let decoded = self.loadCache(at: url) { return decoded }
+        let version = self.cacheVersion(for: provider)
+        if let decoded = self.loadCache(at: url, version: version) { return decoded }
         return CostUsageCache()
     }
 
-    private static func loadCache(at url: URL) -> CostUsageCache? {
+    private static func loadCache(at url: URL, version: Int) -> CostUsageCache? {
         guard let data = try? Data(contentsOf: url) else { return nil }
         guard let decoded = try? JSONDecoder().decode(CostUsageCache.self, from: data)
         else { return nil }
-        guard decoded.version == 1 else { return nil }
+        guard decoded.version == version else { return nil }
         return decoded
     }
 
@@ -33,7 +44,9 @@ enum CostUsageCacheIO {
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
 
         let tmp = dir.appendingPathComponent(".tmp-\(UUID().uuidString).json", isDirectory: false)
-        let data = (try? JSONEncoder().encode(cache)) ?? Data()
+        var cacheToSave = cache
+        cacheToSave.version = self.cacheVersion(for: provider)
+        let data = (try? JSONEncoder().encode(cacheToSave)) ?? Data()
         do {
             try data.write(to: tmp, options: [.atomic])
             _ = try FileManager.default.replaceItemAt(url, withItemAt: tmp)

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageJsonl.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageJsonl.swift
@@ -32,13 +32,16 @@ enum CostUsageJsonl {
         func appendSegment(_ segment: Data.SubSequence) {
             guard !segment.isEmpty else { return }
             lineBytes += segment.count
-            guard !truncated else { return }
+            if !truncated {
+                let remainingPrefix = max(0, prefixBytes - current.count)
+                if remainingPrefix > 0 {
+                    current.append(contentsOf: segment.prefix(remainingPrefix))
+                }
+            }
             if lineBytes > maxLineBytes || lineBytes > prefixBytes {
                 truncated = true
-                current.removeAll(keepingCapacity: true)
                 return
             }
-            current.append(contentsOf: segment)
         }
 
         func flushLine() {

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
@@ -4,7 +4,7 @@ enum CostUsagePricing {
     struct CodexPricing: Sendable {
         let inputCostPerToken: Double
         let outputCostPerToken: Double
-        let cacheReadInputCostPerToken: Double
+        let cacheReadInputCostPerToken: Double?
     }
 
     struct ClaudePricing: Sendable {
@@ -25,15 +25,63 @@ enum CostUsagePricing {
             inputCostPerToken: 1.25e-6,
             outputCostPerToken: 1e-5,
             cacheReadInputCostPerToken: 1.25e-7),
+        "gpt-5-chat": CodexPricing(
+            inputCostPerToken: 1.25e-6,
+            outputCostPerToken: 1e-5,
+            cacheReadInputCostPerToken: 1.25e-7),
+        "gpt-5-chat-latest": CodexPricing(
+            inputCostPerToken: 1.25e-6,
+            outputCostPerToken: 1e-5,
+            cacheReadInputCostPerToken: 1.25e-7),
         "gpt-5-codex": CodexPricing(
             inputCostPerToken: 1.25e-6,
             outputCostPerToken: 1e-5,
             cacheReadInputCostPerToken: 1.25e-7),
+        "gpt-5-codex-mini": CodexPricing(
+            inputCostPerToken: 2.5e-7,
+            outputCostPerToken: 2e-6,
+            cacheReadInputCostPerToken: 2.5e-8),
+        "gpt-5-mini": CodexPricing(
+            inputCostPerToken: 2.5e-7,
+            outputCostPerToken: 2e-6,
+            cacheReadInputCostPerToken: 2.5e-8),
+        "gpt-5-nano": CodexPricing(
+            inputCostPerToken: 5e-8,
+            outputCostPerToken: 4e-7,
+            cacheReadInputCostPerToken: 5e-9),
+        "gpt-5-pro": CodexPricing(
+            inputCostPerToken: 1.5e-5,
+            outputCostPerToken: 1.2e-4,
+            cacheReadInputCostPerToken: nil),
         "gpt-5.1": CodexPricing(
             inputCostPerToken: 1.25e-6,
             outputCostPerToken: 1e-5,
             cacheReadInputCostPerToken: 1.25e-7),
+        "gpt-5.1-chat-latest": CodexPricing(
+            inputCostPerToken: 1.25e-6,
+            outputCostPerToken: 1e-5,
+            cacheReadInputCostPerToken: 1.25e-7),
+        "gpt-5.1-codex": CodexPricing(
+            inputCostPerToken: 1.25e-6,
+            outputCostPerToken: 1e-5,
+            cacheReadInputCostPerToken: 1.25e-7),
+        "gpt-5.1-codex-max": CodexPricing(
+            inputCostPerToken: 1.25e-6,
+            outputCostPerToken: 1e-5,
+            cacheReadInputCostPerToken: 1.25e-7),
+        "gpt-5.1-codex-mini": CodexPricing(
+            inputCostPerToken: 2.5e-7,
+            outputCostPerToken: 2e-6,
+            cacheReadInputCostPerToken: 2.5e-8),
         "gpt-5.2": CodexPricing(
+            inputCostPerToken: 1.75e-6,
+            outputCostPerToken: 1.4e-5,
+            cacheReadInputCostPerToken: 1.75e-7),
+        "gpt-5.2-chat": CodexPricing(
+            inputCostPerToken: 1.75e-6,
+            outputCostPerToken: 1.4e-5,
+            cacheReadInputCostPerToken: 1.75e-7),
+        "gpt-5.2-chat-latest": CodexPricing(
             inputCostPerToken: 1.75e-6,
             outputCostPerToken: 1.4e-5,
             cacheReadInputCostPerToken: 1.75e-7),
@@ -41,6 +89,10 @@ enum CostUsagePricing {
             inputCostPerToken: 1.75e-6,
             outputCostPerToken: 1.4e-5,
             cacheReadInputCostPerToken: 1.75e-7),
+        "gpt-5.2-pro": CodexPricing(
+            inputCostPerToken: 2.1e-5,
+            outputCostPerToken: 1.68e-4,
+            cacheReadInputCostPerToken: nil),
         "gpt-5.3": CodexPricing(
             inputCostPerToken: 1.75e-6,
             outputCostPerToken: 1.4e-5,
@@ -49,6 +101,18 @@ enum CostUsagePricing {
             inputCostPerToken: 1.75e-6,
             outputCostPerToken: 1.4e-5,
             cacheReadInputCostPerToken: 1.75e-7),
+        "gpt-5.4": CodexPricing(
+            inputCostPerToken: 2.5e-6,
+            outputCostPerToken: 1.5e-5,
+            cacheReadInputCostPerToken: 2.5e-7),
+        "gpt-5.4-codex": CodexPricing(
+            inputCostPerToken: 2.5e-6,
+            outputCostPerToken: 1.5e-5,
+            cacheReadInputCostPerToken: 2.5e-7),
+        "gpt-5.4-pro": CodexPricing(
+            inputCostPerToken: 3e-5,
+            outputCostPerToken: 1.8e-4,
+            cacheReadInputCostPerToken: nil),
     ]
 
     private static let claude: [String: ClaudePricing] = [
@@ -165,13 +229,30 @@ enum CostUsagePricing {
     ]
 
     static func normalizeCodexModel(_ raw: String) -> String {
-        var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.hasPrefix("openai/") {
-            trimmed = String(trimmed.dropFirst("openai/".count))
+        let trimmed = self.displayCodexModel(raw)
+        if self.codex[trimmed] != nil {
+            return trimmed
+        }
+        if trimmed == "gpt-5.3-codex-spark" {
+            return trimmed
+        }
+        if trimmed.hasSuffix("-fast") {
+            let base = String(trimmed.dropLast("-fast".count))
+            if self.codex[base] != nil {
+                return base
+            }
         }
         if let codexRange = trimmed.range(of: "-codex") {
             let base = String(trimmed[..<codexRange.lowerBound])
             if self.codex[base] != nil { return base }
+        }
+        return trimmed
+    }
+
+    static func displayCodexModel(_ raw: String) -> String {
+        var trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("openai/") {
+            trimmed = String(trimmed.dropFirst("openai/".count))
         }
         return trimmed
     }
@@ -210,8 +291,11 @@ enum CostUsagePricing {
         guard let pricing = self.codex[key] else { return nil }
         let cached = min(max(0, cachedInputTokens), max(0, inputTokens))
         let nonCached = max(0, inputTokens - cached)
+        if cached > 0, pricing.cacheReadInputCostPerToken == nil {
+            return nil
+        }
         return Double(nonCached) * pricing.inputCostPerToken
-            + Double(cached) * pricing.cacheReadInputCostPerToken
+            + Double(cached) * (pricing.cacheReadInputCostPerToken ?? 0)
             + Double(max(0, outputTokens)) * pricing.outputCostPerToken
     }
 

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner+Claude.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner+Claude.swift
@@ -528,15 +528,19 @@ extension CostUsageScanner {
                         cacheReadInputTokens: cacheRead,
                         cacheCreationInputTokens: cacheCreate,
                         outputTokens: output)
-                breakdown.append(CostUsageDailyReport.ModelBreakdown(modelName: model, costUSD: cost))
+                breakdown.append(CostUsageDailyReport.ModelBreakdown(
+                    modelName: model,
+                    costUSD: cost,
+                    totalTokens: input + cacheRead + cacheCreate + output))
                 if let cost {
                     dayCost += cost
                     dayCostSeen = true
                 }
             }
 
-            breakdown.sort { lhs, rhs in (rhs.costUSD ?? -1) < (lhs.costUSD ?? -1) }
-            let top = Array(breakdown.prefix(3))
+            breakdown.sort {
+                $0.modelName.localizedStandardCompare($1.modelName) == .orderedAscending
+            }
 
             let dayTotal = dayInput + dayCacheRead + dayCacheCreate + dayOutput
             let entryCost = dayCostSeen ? dayCost : nil
@@ -549,7 +553,7 @@ extension CostUsageScanner {
                 totalTokens: dayTotal,
                 costUSD: entryCost,
                 modelsUsed: modelNames,
-                modelBreakdowns: top))
+                modelBreakdowns: breakdown))
 
             totalInput += dayInput
             totalOutput += dayOutput

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 enum CostUsageScanner {
+    private static let codexSessionMetaModelRegex = try? NSRegularExpression(
+        pattern: #"GPT-([0-9]+(?:\.[0-9]+)?)(?:\s+(Codex|Mini|Nano|Pro))?(?:\s+(Max|Mini|Spark))?"#,
+        options: [.caseInsensitive])
+    private static let codexTurnContextModelRegex = try? NSRegularExpression(
+        pattern: #""model":"([^"]+)""#,
+        options: [])
+
     enum ClaudeLogProviderFilter: Sendable {
         case all
         case vertexAIOnly
@@ -241,14 +248,14 @@ enum CostUsageScanner {
         func add(dayKey: String, model: String, input: Int, cached: Int, output: Int) {
             guard CostUsageDayRange.isInRange(dayKey: dayKey, since: range.scanSinceKey, until: range.scanUntilKey)
             else { return }
-            let normModel = CostUsagePricing.normalizeCodexModel(model)
+            let displayModel = CostUsagePricing.displayCodexModel(model)
 
             var dayModels = days[dayKey] ?? [:]
-            var packed = dayModels[normModel] ?? [0, 0, 0]
+            var packed = dayModels[displayModel] ?? [0, 0, 0]
             packed[0] = (packed[safe: 0] ?? 0) + input
             packed[1] = (packed[safe: 1] ?? 0) + cached
             packed[2] = (packed[safe: 2] ?? 0) + output
-            dayModels[normModel] = packed
+            dayModels[displayModel] = packed
             days[dayKey] = dayModels
         }
 
@@ -262,7 +269,13 @@ enum CostUsageScanner {
             prefixBytes: prefixBytes,
             onLine: { line in
                 guard !line.bytes.isEmpty else { return }
-                guard !line.wasTruncated else { return }
+
+                if line.wasTruncated {
+                    Self.updateCodexStateFromTruncatedLine(
+                        line: line,
+                        currentModel: &currentModel)
+                    return
+                }
 
                 guard
                     line.bytes.containsAscii(#""type":"event_msg""#)
@@ -280,14 +293,17 @@ enum CostUsageScanner {
                 else { return }
 
                 if type == "session_meta" {
+                    let payload = obj["payload"] as? [String: Any]
                     if sessionId == nil {
-                        let payload = obj["payload"] as? [String: Any]
                         sessionId = payload?["session_id"] as? String
                             ?? payload?["sessionId"] as? String
                             ?? payload?["id"] as? String
                             ?? obj["session_id"] as? String
                             ?? obj["sessionId"] as? String
                             ?? obj["id"] as? String
+                    }
+                    if currentModel == nil {
+                        currentModel = Self.codexModelFromSessionMeta(payload: payload)
                     }
                     return
                 }
@@ -315,7 +331,10 @@ enum CostUsageScanner {
                     ?? info?["model_name"] as? String
                     ?? payload["model"] as? String
                     ?? obj["model"] as? String
-                let model = modelFromInfo ?? currentModel ?? "gpt-5"
+                let model = modelFromInfo
+                    ?? currentModel
+                    ?? Self.codexModelFromRateLimits(payload: payload, info: info)
+                    ?? "unknown"
 
                 func toInt(_ v: Any?) -> Int {
                     if let n = v as? NSNumber { return n.intValue }
@@ -358,6 +377,92 @@ enum CostUsageScanner {
             lastModel: currentModel,
             lastTotals: previousTotals,
             sessionId: sessionId)
+    }
+
+    private static func updateCodexStateFromTruncatedLine(line: CostUsageJsonl.Line, currentModel: inout String?) {
+        guard line.bytes.containsAscii(#""type":"turn_context""#) || line.bytes.containsAscii(#""type":"session_meta""#)
+        else {
+            return
+        }
+
+        if currentModel == nil {
+            currentModel = self.codexModelFromTruncatedLinePrefix(line.bytes)
+        }
+    }
+
+    private static func codexModelFromTruncatedLinePrefix(_ bytes: Data) -> String? {
+        guard let text = String(data: bytes, encoding: .utf8) else { return nil }
+
+        if let regex = self.codexTurnContextModelRegex {
+            let range = NSRange(text.startIndex..<text.endIndex, in: text)
+            if let match = regex.firstMatch(in: text, range: range),
+               let modelRange = Range(match.range(at: 1), in: text)
+            {
+                return String(text[modelRange])
+            }
+        }
+
+        return Self.codexModelFromInstructions(text)
+    }
+
+    private static func codexModelFromSessionMeta(payload: [String: Any]?) -> String? {
+        guard let payload else { return nil }
+
+        if let model = payload["model"] as? String {
+            return model
+        }
+
+        if let baseInstructions = (payload["base_instructions"] as? [String: Any])?["text"] as? String {
+            return Self.codexModelFromInstructions(baseInstructions)
+        }
+
+        return nil
+    }
+
+    private static func codexModelFromInstructions(_ text: String) -> String? {
+        guard let regex = self.codexSessionMetaModelRegex else { return nil }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, range: range) else { return nil }
+        guard let versionRange = Range(match.range(at: 1), in: text) else { return nil }
+
+        let version = text[versionRange].lowercased()
+        var model = "gpt-\(version)"
+
+        let primaryTier = Range(match.range(at: 2), in: text).map { text[$0].lowercased() }
+        let secondaryTier = Range(match.range(at: 3), in: text).map { text[$0].lowercased() }
+
+        switch primaryTier {
+        case "codex":
+            model += "-codex"
+            if let secondaryTier {
+                model += "-\(secondaryTier)"
+            }
+        case "mini", "nano", "pro":
+            model += "-\(primaryTier!)"
+        default:
+            break
+        }
+
+        return model
+    }
+
+    private static func codexModelFromRateLimits(payload: [String: Any], info: [String: Any]?) -> String? {
+        let rateLimits = payload["rate_limits"] as? [String: Any]
+            ?? info?["rate_limits"] as? [String: Any]
+
+        if let limitName = rateLimits?["limit_name"] as? String,
+           limitName.caseInsensitiveCompare("GPT-5.3-Codex-Spark") == .orderedSame
+        {
+            return "gpt-5.3-codex-spark"
+        }
+
+        if let meteredFeature = rateLimits?["metered_feature"] as? String,
+           meteredFeature.localizedCaseInsensitiveContains("spark")
+        {
+            return "gpt-5.3-codex-spark"
+        }
+
+        return nil
     }
 
     private static func scanCodexFile(
@@ -536,6 +641,7 @@ enum CostUsageScanner {
         var totalTokens = 0
         var totalCost: Double = 0
         var costSeen = false
+        var hasUnknownCost = false
 
         let dayKeys = cache.days.keys.sorted().filter {
             CostUsageDayRange.isInRange(dayKey: $0, since: range.sinceKey, until: range.untilKey)
@@ -551,6 +657,7 @@ enum CostUsageScanner {
             var breakdown: [CostUsageDailyReport.ModelBreakdown] = []
             var dayCost: Double = 0
             var dayCostSeen = false
+            var dayHasUnknownCost = false
 
             for model in modelNames {
                 let packed = models[model] ?? [0, 0, 0]
@@ -566,15 +673,21 @@ enum CostUsageScanner {
                     inputTokens: input,
                     cachedInputTokens: cached,
                     outputTokens: output)
-                breakdown.append(CostUsageDailyReport.ModelBreakdown(modelName: model, costUSD: cost))
+                breakdown.append(CostUsageDailyReport.ModelBreakdown(
+                    modelName: model,
+                    costUSD: cost,
+                    totalTokens: input + output))
                 if let cost {
                     dayCost += cost
                     dayCostSeen = true
+                } else if input > 0 || cached > 0 || output > 0 {
+                    dayHasUnknownCost = true
                 }
             }
 
-            breakdown.sort { lhs, rhs in (rhs.costUSD ?? -1) < (lhs.costUSD ?? -1) }
-            let top = Array(breakdown.prefix(3))
+            breakdown.sort {
+                $0.modelName.localizedStandardCompare($1.modelName) == .orderedAscending
+            }
 
             let dayTotal = dayInput + dayOutput
             let entryCost = dayCostSeen ? dayCost : nil
@@ -585,11 +698,14 @@ enum CostUsageScanner {
                 totalTokens: dayTotal,
                 costUSD: entryCost,
                 modelsUsed: modelNames,
-                modelBreakdowns: top))
+                modelBreakdowns: breakdown))
 
             totalInput += dayInput
             totalOutput += dayOutput
             totalTokens += dayTotal
+            if dayHasUnknownCost {
+                hasUnknownCost = true
+            }
             if let entryCost {
                 totalCost += entryCost
                 costSeen = true
@@ -602,7 +718,7 @@ enum CostUsageScanner {
                 totalInputTokens: totalInput,
                 totalOutputTokens: totalOutput,
                 totalTokens: totalTokens,
-                totalCostUSD: costSeen ? totalCost : nil)
+                totalCostUSD: costSeen && !hasUnknownCost ? totalCost : nil)
 
         return CostUsageDailyReport(data: entries, summary: summary)
     }

--- a/Tests/CodexBarTests/CLICostTests.swift
+++ b/Tests/CodexBarTests/CLICostTests.swift
@@ -57,7 +57,10 @@ struct CLICostTests {
                     costUSD: 0.01,
                     modelsUsed: ["claude-sonnet-4-20250514"],
                     modelBreakdowns: [
-                        CostModelBreakdownPayload(modelName: "claude-sonnet-4-20250514", costUSD: 0.01),
+                        CostModelBreakdownPayload(
+                            modelName: "claude-sonnet-4-20250514",
+                            costUSD: 0.01,
+                            totalTokens: 15),
                     ]),
             ],
             totals: CostTotalsPayload(

--- a/Tests/CodexBarTests/CodexOAuthTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthTests.swift
@@ -100,6 +100,100 @@ struct CodexOAuthTests {
     }
 
     @Test
+    func mapsSparkWindowFromOAuthAdditionalRateLimits() throws {
+        let json = """
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 22,
+              "reset_at": 1766948068,
+              "limit_window_seconds": 18000
+            },
+            "secondary_window": {
+              "used_percent": 43,
+              "reset_at": 1767407914,
+              "limit_window_seconds": 604800
+            }
+          },
+          "code_review_rate_limit": {
+            "primary_window": {
+              "used_percent": 5,
+              "reset_at": 1766948068,
+              "limit_window_seconds": 604800
+            }
+          },
+          "additional_rate_limits": [
+            {
+              "limit_name": "GPT-5.3-Codex-Spark",
+              "metered_feature": "codex_bengalfox",
+              "rate_limit": {
+                "primary_window": {
+                  "used_percent": 3,
+                  "reset_at": 1766948068,
+                  "limit_window_seconds": 18000
+                },
+                "secondary_window": {
+                  "used_percent": 17,
+                  "reset_at": 1767407914,
+                  "limit_window_seconds": 604800
+                }
+              }
+            }
+          ]
+        }
+        """
+        let creds = CodexOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: nil,
+            accountId: nil,
+            lastRefresh: Date())
+        let snapshot = try CodexOAuthFetchStrategy._mapUsageForTesting(Data(json.utf8), credentials: creds)
+        #expect(snapshot.primary?.usedPercent == 22)
+        #expect(snapshot.secondary?.usedPercent == 43)
+        #expect(snapshot.tertiary?.usedPercent == 17)
+        #expect(snapshot.tertiary?.windowMinutes == 10080)
+        #expect(snapshot.tertiary?.resetsAt != nil)
+    }
+
+    @Test
+    func ignoresUnrelatedAdditionalRateLimitsWhenSparkAbsent() throws {
+        let json = """
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 22,
+              "reset_at": 1766948068,
+              "limit_window_seconds": 18000
+            }
+          },
+          "additional_rate_limits": [
+            {
+              "limit_name": "Something else",
+              "metered_feature": "codex_something_else",
+              "rate_limit": {
+                "secondary_window": {
+                  "used_percent": 88,
+                  "reset_at": 1767407914,
+                  "limit_window_seconds": 604800
+                }
+              }
+            }
+          ]
+        }
+        """
+        let creds = CodexOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: nil,
+            accountId: nil,
+            lastRefresh: Date())
+        let snapshot = try CodexOAuthFetchStrategy._mapUsageForTesting(Data(json.utf8), credentials: creds)
+        #expect(snapshot.primary?.usedPercent == 22)
+        #expect(snapshot.tertiary == nil)
+    }
+
+    @Test
     func resolvesChatGPTUsageURLFromConfig() {
         let config = "chatgpt_base_url = \"https://chatgpt.com/backend-api/\"\n"
         let url = CodexOAuthUsageFetcher._resolveUsageURLForTesting(configContents: config)

--- a/Tests/CodexBarTests/CostUsagePricingTests.swift
+++ b/Tests/CodexBarTests/CostUsagePricingTests.swift
@@ -5,10 +5,18 @@ import Testing
 struct CostUsagePricingTests {
     @Test
     func normalizesCodexModelVariants() {
-        #expect(CostUsagePricing.normalizeCodexModel("openai/gpt-5-codex") == "gpt-5")
-        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.2-codex") == "gpt-5.2")
-        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.1-codex-max") == "gpt-5.1")
+        #expect(CostUsagePricing.normalizeCodexModel("openai/gpt-5-codex") == "gpt-5-codex")
+        #expect(CostUsagePricing.normalizeCodexModel("gpt-5-codex-mini") == "gpt-5-codex-mini")
+        #expect(CostUsagePricing.normalizeCodexModel("gpt-5-chat") == "gpt-5-chat")
+        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.2-codex") == "gpt-5.2-codex")
+        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.2-chat") == "gpt-5.2-chat")
+        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.2-pro") == "gpt-5.2-pro")
+        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.1-codex-max") == "gpt-5.1-codex-max")
+        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.1-codex-mini") == "gpt-5.1-codex-mini")
         #expect(CostUsagePricing.normalizeCodexModel("gpt-5.3-codex-max") == "gpt-5.3")
+        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.4-codex") == "gpt-5.4-codex")
+        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.4-pro") == "gpt-5.4-pro")
+        #expect(CostUsagePricing.normalizeCodexModel("openai/gpt-5.3-codex-spark") == "gpt-5.3-codex-spark")
     }
 
     @Test
@@ -29,6 +37,85 @@ struct CostUsagePricingTests {
             cachedInputTokens: 10,
             outputTokens: 5)
         #expect(cost != nil)
+    }
+
+    @Test
+    func codexCostSupportsGpt54Codex() {
+        let cost = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.4-codex",
+            inputTokens: 100,
+            cachedInputTokens: 10,
+            outputTokens: 5)
+        #expect(cost != nil)
+    }
+
+    @Test
+    func codexCostSupportsGpt5MiniAndChatAliases() {
+        #expect(CostUsagePricing.codexCostUSD(
+            model: "gpt-5-codex-mini",
+            inputTokens: 100,
+            cachedInputTokens: 10,
+            outputTokens: 5) != nil)
+        #expect(CostUsagePricing.codexCostUSD(
+            model: "gpt-5-chat",
+            inputTokens: 100,
+            cachedInputTokens: 10,
+            outputTokens: 5) != nil)
+        #expect(CostUsagePricing.codexCostUSD(
+            model: "gpt-5.2-chat",
+            inputTokens: 100,
+            cachedInputTokens: 10,
+            outputTokens: 5) != nil)
+    }
+
+    @Test
+    func codexCostSupportsGpt52ProWithoutCachedReads() {
+        let cost = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.2-pro",
+            inputTokens: 100,
+            cachedInputTokens: 0,
+            outputTokens: 5)
+        #expect(cost != nil)
+    }
+
+    @Test
+    func codexCostReturnsNilForGpt52ProCachedReads() {
+        let cost = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.2-pro",
+            inputTokens: 100,
+            cachedInputTokens: 10,
+            outputTokens: 5)
+        #expect(cost == nil)
+    }
+
+    @Test
+    func codexCostSupportsGpt54ProWithoutCachedReads() {
+        let cost = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.4-pro",
+            inputTokens: 100,
+            cachedInputTokens: 0,
+            outputTokens: 5)
+        #expect(cost != nil)
+    }
+
+    @Test
+    func codexCostReturnsNilForGpt54ProCachedReads() {
+        let cost = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.4-pro",
+            inputTokens: 100,
+            cachedInputTokens: 10,
+            outputTokens: 5)
+        #expect(cost == nil)
+    }
+
+    @Test
+    func codexCostReturnsNilForGpt53CodexSparkPreview() {
+        let cost = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.3-codex-spark",
+            inputTokens: 100,
+            cachedInputTokens: 10,
+            outputTokens: 5)
+        #expect(cost == nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/CostUsageScannerTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerTests.swift
@@ -56,7 +56,10 @@ struct CostUsageScannerTests {
             now: day,
             options: options)
         #expect(first.data.count == 1)
-        #expect(first.data[0].modelsUsed == ["gpt-5.2"])
+        #expect(first.data[0].modelsUsed == ["gpt-5.2-codex"])
+        #expect(first.data[0].modelBreakdowns?.contains {
+            $0.modelName == "gpt-5.2-codex" && $0.costUSD != nil && $0.totalTokens == 110
+        } == true)
         #expect(first.data[0].totalTokens == 110)
         #expect((first.data[0].costUSD ?? 0) > 0)
 
@@ -475,7 +478,7 @@ struct CostUsageScannerTests {
         let iso2 = env.isoString(for: day.addingTimeInterval(2))
 
         let model = "openai/gpt-5.2-codex"
-        let normalized = CostUsagePricing.normalizeCodexModel(model)
+        let displayModel = CostUsagePricing.displayCodexModel(model)
         let turnContext: [String: Any] = [
             "type": "turn_context",
             "timestamp": iso0,
@@ -536,7 +539,7 @@ struct CostUsageScannerTests {
             initialModel: first.lastModel,
             initialTotals: first.lastTotals)
         let dayKey = CostUsageScanner.CostUsageDayRange.dayKey(from: day)
-        let packed = delta.days[dayKey]?[normalized] ?? []
+        let packed = delta.days[dayKey]?[displayModel] ?? []
         #expect(packed.count >= 3)
         #expect(packed[0] == 60)
         #expect(packed[1] == 20)
@@ -889,8 +892,494 @@ struct CostUsageScannerTests {
         #expect(scanned.count == 2)
         #expect(String(data: scanned[0].bytes, encoding: .utf8) == "ok")
         #expect(scanned[0].wasTruncated == false)
-        #expect(scanned[1].bytes.isEmpty)
+        #expect(scanned[1].bytes.count == 64)
         #expect(scanned[1].wasTruncated == true)
+    }
+}
+
+extension CostUsageScannerTests {
+    @Test
+    func codexDailyReportRecoversModelFromSessionMetaInstructions() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2025, month: 12, day: 24)
+        let iso0 = env.isoString(for: day)
+        let iso1 = env.isoString(for: day.addingTimeInterval(1))
+
+        let sessionMeta: [String: Any] = [
+            "type": "session_meta",
+            "timestamp": iso0,
+            "payload": [
+                "id": "sess-meta-model",
+                "base_instructions": [
+                    "text": "You are GPT-5.2 running in the Codex CLI.",
+                ],
+            ],
+        ]
+        let tokenCountWithoutModel: [String: Any] = [
+            "type": "event_msg",
+            "timestamp": iso1,
+            "payload": [
+                "type": "token_count",
+                "info": [
+                    "total_token_usage": [
+                        "input_tokens": 100,
+                        "cached_input_tokens": 20,
+                        "output_tokens": 10,
+                    ],
+                ],
+            ],
+        ]
+
+        _ = try env.writeCodexSessionFile(
+            day: day,
+            filename: "session-meta-model.jsonl",
+            contents: env.jsonl([sessionMeta, tokenCountWithoutModel]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: day,
+            until: day,
+            now: day,
+            options: options)
+        let entry = try #require(report.data.first)
+        #expect(entry.modelsUsed == ["gpt-5.2"])
+        #expect(entry.modelBreakdowns?.contains {
+            $0.modelName == "gpt-5.2" && $0.costUSD != nil && $0.totalTokens == 110
+        } == true)
+    }
+
+    @Test
+    func codexDailyReportRecoversPlainGpt5FromSessionMetaInstructions() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2025, month: 12, day: 27)
+        let iso0 = env.isoString(for: day)
+        let iso1 = env.isoString(for: day.addingTimeInterval(1))
+
+        let sessionMeta: [String: Any] = [
+            "type": "session_meta",
+            "timestamp": iso0,
+            "payload": [
+                "id": "sess-meta-gpt5",
+                "base_instructions": [
+                    "text": "You are Codex, a coding agent based on GPT-5.",
+                ],
+            ],
+        ]
+        let tokenCountWithoutModel: [String: Any] = [
+            "type": "event_msg",
+            "timestamp": iso1,
+            "payload": [
+                "type": "token_count",
+                "info": [
+                    "total_token_usage": [
+                        "input_tokens": 100,
+                        "cached_input_tokens": 20,
+                        "output_tokens": 10,
+                    ],
+                ],
+            ],
+        ]
+
+        _ = try env.writeCodexSessionFile(
+            day: day,
+            filename: "session-meta-gpt5.jsonl",
+            contents: env.jsonl([sessionMeta, tokenCountWithoutModel]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: day,
+            until: day,
+            now: day,
+            options: options)
+        let entry = try #require(report.data.first)
+        #expect(entry.modelsUsed == ["gpt-5"])
+        #expect(entry.modelBreakdowns?.contains {
+            $0.modelName == "gpt-5" && $0.costUSD != nil && $0.totalTokens == 110
+        } == true)
+    }
+
+    @Test
+    func codexDailyReportRecoversGpt52ProFromSessionMetaInstructions() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2025, month: 12, day: 28)
+        let iso0 = env.isoString(for: day)
+        let iso1 = env.isoString(for: day.addingTimeInterval(1))
+
+        let sessionMeta: [String: Any] = [
+            "type": "session_meta",
+            "timestamp": iso0,
+            "payload": [
+                "id": "sess-meta-gpt52-pro",
+                "base_instructions": [
+                    "text": "You are Codex, a coding agent based on GPT-5.2 Pro.",
+                ],
+            ],
+        ]
+        let tokenCountWithoutModel: [String: Any] = [
+            "type": "event_msg",
+            "timestamp": iso1,
+            "payload": [
+                "type": "token_count",
+                "info": [
+                    "last_token_usage": [
+                        "input_tokens": 100,
+                        "cached_input_tokens": 0,
+                        "output_tokens": 10,
+                    ],
+                ],
+            ],
+        ]
+
+        _ = try env.writeCodexSessionFile(
+            day: day,
+            filename: "session-meta-gpt52-pro.jsonl",
+            contents: env.jsonl([sessionMeta, tokenCountWithoutModel]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: day,
+            until: day,
+            now: day,
+            options: options)
+        let entry = try #require(report.data.first)
+        #expect(entry.modelsUsed == ["gpt-5.2-pro"])
+        #expect(entry.modelBreakdowns?.contains {
+            $0.modelName == "gpt-5.2-pro" && $0.costUSD != nil && $0.totalTokens == 110
+        } == true)
+    }
+
+    @Test
+    func codexDailyReportRecoversModelFromTruncatedTurnContextPrefix() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2025, month: 12, day: 26)
+        let iso0 = env.isoString(for: day)
+        let iso1 = env.isoString(for: day.addingTimeInterval(1))
+        let largeText = String(repeating: "x", count: Int(4e4))
+
+        let turnContext = [
+            #"{"type":"turn_context","timestamp":""#,
+            iso0,
+            #"","payload":{"model":"gpt-5.3-codex","user_instructions":""#,
+            largeText,
+            #""}}"#,
+        ].joined()
+        let tokenCountWithoutModel: [String: Any] = [
+            "type": "event_msg",
+            "timestamp": iso1,
+            "payload": [
+                "type": "token_count",
+                "info": [
+                    "total_token_usage": [
+                        "input_tokens": 100,
+                        "cached_input_tokens": 20,
+                        "output_tokens": 10,
+                    ],
+                ],
+            ],
+        ]
+
+        _ = try env.writeCodexSessionFile(
+            day: day,
+            filename: "session-truncated-turn-context.jsonl",
+            contents: turnContext + "\n" + env.jsonl([tokenCountWithoutModel]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: day,
+            until: day,
+            now: day,
+            options: options)
+        let entry = try #require(report.data.first)
+        #expect(entry.modelsUsed == ["gpt-5.3-codex"])
+        #expect(entry.modelBreakdowns?.contains {
+            $0.modelName == "gpt-5.3-codex" && $0.costUSD != nil && $0.totalTokens == 110
+        } == true)
+    }
+
+    @Test
+    func codexDailyReportUsesUnknownModelWhenMetadataIsMissing() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2025, month: 12, day: 24)
+        let iso0 = env.isoString(for: day)
+
+        let tokenCountWithoutModel: [String: Any] = [
+            "type": "event_msg",
+            "timestamp": iso0,
+            "payload": [
+                "type": "token_count",
+                "info": [
+                    "total_token_usage": [
+                        "input_tokens": 100,
+                        "cached_input_tokens": 20,
+                        "output_tokens": 10,
+                    ],
+                ],
+            ],
+        ]
+
+        _ = try env.writeCodexSessionFile(
+            day: day,
+            filename: "session-unknown-model.jsonl",
+            contents: env.jsonl([tokenCountWithoutModel]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: day,
+            until: day,
+            now: day,
+            options: options)
+        let entry = try #require(report.data.first)
+        #expect(entry.modelsUsed == ["unknown"])
+        #expect(entry.modelBreakdowns?.contains {
+            $0.modelName == "unknown" && $0.costUSD == nil && $0.totalTokens == 110
+        } == true)
+    }
+
+    @Test
+    func codexDailyReportRecoversSparkFromRateLimitMetadata() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2025, month: 12, day: 25)
+        let iso0 = env.isoString(for: day)
+
+        let tokenCountWithoutModel: [String: Any] = [
+            "type": "event_msg",
+            "timestamp": iso0,
+            "payload": [
+                "type": "token_count",
+                "info": [
+                    "total_token_usage": [
+                        "input_tokens": 80,
+                        "cached_input_tokens": 10,
+                        "output_tokens": 8,
+                    ],
+                ],
+                "rate_limits": [
+                    "limit_name": "GPT-5.3-Codex-Spark",
+                ],
+            ],
+        ]
+
+        _ = try env.writeCodexSessionFile(
+            day: day,
+            filename: "session-spark-rate-limit.jsonl",
+            contents: env.jsonl([tokenCountWithoutModel]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: day,
+            until: day,
+            now: day,
+            options: options)
+        let entry = try #require(report.data.first)
+        #expect(entry.modelsUsed == ["gpt-5.3-codex-spark"])
+        #expect(entry.modelBreakdowns?.contains {
+            $0.modelName == "gpt-5.3-codex-spark" && $0.costUSD == nil && $0.totalTokens == 88
+        } == true)
+    }
+
+    @Test
+    func codexDailyReportKeepsSparkBreakdownDistinct() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2025, month: 12, day: 21)
+        let iso0 = env.isoString(for: day)
+        let iso1 = env.isoString(for: day.addingTimeInterval(1))
+        let iso2 = env.isoString(for: day.addingTimeInterval(2))
+        let iso3 = env.isoString(for: day.addingTimeInterval(3))
+
+        let standardModel = "openai/gpt-5.3-codex"
+        let sparkModel = "openai/gpt-5.3-codex-spark"
+        let turnContextStandard: [String: Any] = [
+            "type": "turn_context",
+            "timestamp": iso0,
+            "payload": [
+                "model": standardModel,
+            ],
+        ]
+        let standardTokenCount: [String: Any] = [
+            "type": "event_msg",
+            "timestamp": iso1,
+            "payload": [
+                "type": "token_count",
+                "info": [
+                    "total_token_usage": [
+                        "input_tokens": 100,
+                        "cached_input_tokens": 20,
+                        "output_tokens": 10,
+                    ],
+                    "model": standardModel,
+                ],
+            ],
+        ]
+        _ = try env.writeCodexSessionFile(
+            day: day,
+            filename: "session-standard.jsonl",
+            contents: env.jsonl([turnContextStandard, standardTokenCount]))
+
+        let turnContextSpark: [String: Any] = [
+            "type": "turn_context",
+            "timestamp": iso2,
+            "payload": [
+                "model": sparkModel,
+            ],
+        ]
+        let sparkTokenCount: [String: Any] = [
+            "type": "event_msg",
+            "timestamp": iso3,
+            "payload": [
+                "type": "token_count",
+                "info": [
+                    "total_token_usage": [
+                        "input_tokens": 60,
+                        "cached_input_tokens": 10,
+                        "output_tokens": 6,
+                    ],
+                    "model": sparkModel,
+                ],
+            ],
+        ]
+
+        _ = try env.writeCodexSessionFile(
+            day: day,
+            filename: "session-spark.jsonl",
+            contents: env.jsonl([turnContextSpark, sparkTokenCount]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: day,
+            until: day,
+            now: day,
+            options: options)
+        let entry = try #require(report.data.first)
+        #expect(entry.costUSD != nil)
+        #expect(entry.modelsUsed == ["gpt-5.3-codex", "gpt-5.3-codex-spark"])
+        #expect(entry.modelBreakdowns?.count == 2)
+        #expect(entry.modelBreakdowns?.contains {
+            $0.modelName == "gpt-5.3-codex" && $0.costUSD != nil && $0.totalTokens == 110
+        } == true)
+        #expect(entry.modelBreakdowns?.contains {
+            $0.modelName == "gpt-5.3-codex-spark" && $0.costUSD == nil && $0.totalTokens == 66
+        } == true)
+        #expect(report.summary?.totalCostUSD == nil)
+    }
+
+    @Test
+    func codexDailyReportKeepsAllModelBreakdownsForBusyDays() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2025, month: 12, day: 23)
+        let models = [
+            "openai/gpt-5.1-codex",
+            "openai/gpt-5.2-codex",
+            "openai/gpt-5.3-codex",
+            "openai/gpt-5.4",
+        ]
+
+        for (index, model) in models.enumerated() {
+            let timestamp = env.isoString(for: day.addingTimeInterval(TimeInterval(index)))
+            let tokenCount: [String: Any] = [
+                "type": "event_msg",
+                "timestamp": timestamp,
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "last_token_usage": [
+                            "input_tokens": 100 + index,
+                            "cached_input_tokens": 10,
+                            "output_tokens": 10,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ]
+
+            _ = try env.writeCodexSessionFile(
+                day: day,
+                filename: "session-\(index).jsonl",
+                contents: env.jsonl([tokenCount]))
+        }
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: day,
+            until: day,
+            now: day,
+            options: options)
+        let entry = try #require(report.data.first)
+        #expect(entry.modelsUsed == [
+            "gpt-5.1-codex",
+            "gpt-5.2-codex",
+            "gpt-5.3-codex",
+            "gpt-5.4",
+        ])
+        #expect(entry.modelBreakdowns?.map(\.modelName) == [
+            "gpt-5.1-codex",
+            "gpt-5.2-codex",
+            "gpt-5.3-codex",
+            "gpt-5.4",
+        ])
     }
 }
 

--- a/Tests/CodexBarTests/MenuCardModelTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelTests.swift
@@ -840,3 +840,57 @@ struct MenuCardModelTests {
         #expect(primary.detailText == "10/100 credits")
     }
 }
+
+extension MenuCardModelTests {
+    @Test
+    func showsSparkMetricWhenCodexTertiaryWindowPresent() throws {
+        let now = Date()
+        let identity = ProviderIdentitySnapshot(
+            providerID: .codex,
+            accountEmail: "codex@example.com",
+            accountOrganization: nil,
+            loginMethod: "Plus Plan")
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 22,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(3000),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 40,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(6000),
+                resetDescription: nil),
+            tertiary: RateWindow(
+                usedPercent: 17,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(7200),
+                resetDescription: nil),
+            updatedAt: now,
+            identity: identity)
+        let metadata = try #require(ProviderDefaults.metadata[.codex])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .codex,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: "codex@example.com", plan: "Plus Plan"),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.metrics.count == 3)
+        #expect(model.metrics.contains { $0.title == "Spark" && $0.percent == 83 })
+    }
+}

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -99,6 +99,14 @@ struct UsageFormatterTests {
         #expect(UsageFormatter.modelDisplayName("gpt-4o-2024-08-06") == "gpt-4o")
         #expect(UsageFormatter.modelDisplayName("Claude Opus 4.5 2025 1101") == "Claude Opus 4.5")
         #expect(UsageFormatter.modelDisplayName("claude-sonnet-4-5") == "claude-sonnet-4-5")
+        #expect(UsageFormatter.modelDisplayName("gpt-5.4") == "GPT-5.4")
+        #expect(UsageFormatter.modelDisplayName("gpt-5-mini") == "GPT-5 Mini")
+        #expect(UsageFormatter.modelDisplayName("gpt-5-nano") == "GPT-5 Nano")
+        #expect(UsageFormatter.modelDisplayName("gpt-5.2-pro") == "GPT-5.2 Pro")
+        #expect(UsageFormatter.modelDisplayName("gpt-5.2-codex") == "GPT-5.2 Codex")
+        #expect(UsageFormatter.modelDisplayName("gpt-5.1-codex-max") == "GPT-5.1 Codex Max")
+        #expect(UsageFormatter.modelDisplayName("gpt-5.3-codex-spark") == "GPT-5.3 Spark")
+        #expect(UsageFormatter.modelDisplayName("unknown") == "Unknown model")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add current GPT-5 family pricing and model normalization for Codex local cost scanning, including GPT-5.4 and GPT-5.4 Pro
- surface GPT-5.3 Codex Spark as a separate OAuth bucket and preserve distinct model labels in cost history
- improve Codex cost chart rendering with empty-day backfill, vertical per-model details, token totals, and better unknown-model recovery from session metadata

## Verification
- swift test --filter CostUsagePricingTests
- swift test --filter CostUsageScannerTests
- swift test --filter UsageFormatterTests
- swift test --filter CodexOAuthTests
- swift test --filter CLICostTests
- pnpm check
- ./Scripts/compile_and_run.sh