### PR TITLE
RAT-111: split Claude usage fetcher responsibilities

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -58,19 +58,63 @@ public enum ClaudeUsageError: LocalizedError, Sendable {
 }
 
 public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
-    private let environment: [String: String]
-    private let runtime: ProviderRuntime
-    private let dataSource: ClaudeUsageDataSource
-    private let oauthKeychainPromptCooldownEnabled: Bool
-    private let allowBackgroundDelegatedRefresh: Bool
-    private let allowStartupBootstrapPrompt: Bool
-    private let useWebExtras: Bool
-    private let manualCookieHeader: String?
-    private let keepCLISessionsAlive: Bool
-    private let browserDetection: BrowserDetection
+    private struct Configuration: Sendable {
+        let environment: [String: String]
+        let runtime: ProviderRuntime
+        let dataSource: ClaudeUsageDataSource
+        let oauthKeychainPromptCooldownEnabled: Bool
+        let allowBackgroundDelegatedRefresh: Bool
+        let allowStartupBootstrapPrompt: Bool
+        let useWebExtras: Bool
+        let manualCookieHeader: String?
+        let keepCLISessionsAlive: Bool
+        let browserDetection: BrowserDetection
+    }
+
+    private let configuration: Configuration
     private static let log = CodexBarLog.logger(LogCategories.claudeUsage)
     private static var isClaudeOAuthFlowDebugEnabled: Bool {
         ProcessInfo.processInfo.environment["CODEXBAR_DEBUG_CLAUDE_OAUTH_FLOW"] == "1"
+    }
+
+    private var environment: [String: String] {
+        self.configuration.environment
+    }
+
+    private var runtime: ProviderRuntime {
+        self.configuration.runtime
+    }
+
+    private var dataSource: ClaudeUsageDataSource {
+        self.configuration.dataSource
+    }
+
+    private var oauthKeychainPromptCooldownEnabled: Bool {
+        self.configuration.oauthKeychainPromptCooldownEnabled
+    }
+
+    private var allowBackgroundDelegatedRefresh: Bool {
+        self.configuration.allowBackgroundDelegatedRefresh
+    }
+
+    private var allowStartupBootstrapPrompt: Bool {
+        self.configuration.allowStartupBootstrapPrompt
+    }
+
+    private var useWebExtras: Bool {
+        self.configuration.useWebExtras
+    }
+
+    private var manualCookieHeader: String? {
+        self.configuration.manualCookieHeader
+    }
+
+    private var keepCLISessionsAlive: Bool {
+        self.configuration.keepCLISessionsAlive
+    }
+
+    private var browserDetection: BrowserDetection {
+        self.configuration.browserDetection
     }
 
     private struct ClaudeOAuthKeychainPromptPolicy: Sendable {
@@ -164,18 +208,319 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         manualCookieHeader: String? = nil,
         keepCLISessionsAlive: Bool = false)
     {
-        self.browserDetection = browserDetection
-        self.environment = environment
-        self.runtime = runtime
-        self.dataSource = dataSource
-        self.oauthKeychainPromptCooldownEnabled = oauthKeychainPromptCooldownEnabled
-        self.allowBackgroundDelegatedRefresh = allowBackgroundDelegatedRefresh
-        self.allowStartupBootstrapPrompt = allowStartupBootstrapPrompt
-        self.useWebExtras = useWebExtras
-        self.manualCookieHeader = manualCookieHeader
-        self.keepCLISessionsAlive = keepCLISessionsAlive
+        self.configuration = Configuration(
+            environment: environment,
+            runtime: runtime,
+            dataSource: dataSource,
+            oauthKeychainPromptCooldownEnabled: oauthKeychainPromptCooldownEnabled,
+            allowBackgroundDelegatedRefresh: allowBackgroundDelegatedRefresh,
+            allowStartupBootstrapPrompt: allowStartupBootstrapPrompt,
+            useWebExtras: useWebExtras,
+            manualCookieHeader: manualCookieHeader,
+            keepCLISessionsAlive: keepCLISessionsAlive,
+            browserDetection: browserDetection)
     }
 
+    private struct OAuthExecutor: Sendable {
+        let fetcher: ClaudeUsageFetcher
+
+        func load(allowDelegatedRetry: Bool) async throws -> ClaudeUsageSnapshot {
+            do {
+                let promptPolicy = ClaudeUsageFetcher.currentClaudeOAuthKeychainPromptPolicy()
+
+                #if DEBUG
+                let hasCache = ClaudeUsageFetcher.hasCachedCredentialsOverride
+                    ?? ClaudeOAuthCredentialsStore.hasCachedCredentials(environment: self.fetcher.environment)
+                #else
+                let hasCache = ClaudeOAuthCredentialsStore.hasCachedCredentials(environment: self.fetcher.environment)
+                #endif
+
+                let startupBootstrapOverride = self.shouldAllowStartupBootstrapPrompt(
+                    policy: promptPolicy,
+                    hasCache: hasCache)
+                let allowKeychainPrompt = (promptPolicy.canPromptNow || startupBootstrapOverride) && !hasCache
+                ClaudeUsageFetcher.logOAuthBootstrapPromptDecision(
+                    allowKeychainPrompt: allowKeychainPrompt,
+                    policy: promptPolicy,
+                    hasCache: hasCache,
+                    startupBootstrapOverride: startupBootstrapOverride)
+
+                let credentials = try await ClaudeOAuthCredentialsStore.$allowBackgroundPromptBootstrap
+                    .withValue(startupBootstrapOverride) {
+                        try await ClaudeUsageFetcher.loadOAuthCredentials(
+                            environment: self.fetcher.environment,
+                            allowKeychainPrompt: allowKeychainPrompt,
+                            respectKeychainPromptCooldown: promptPolicy.shouldRespectKeychainPromptCooldown)
+                    }
+
+                try self.validateRequiredOAuthScope(credentials)
+                let usage = try await ClaudeUsageFetcher.fetchOAuthUsage(accessToken: credentials.accessToken)
+                return try ClaudeUsageFetcher.mapOAuthUsage(usage, credentials: credentials)
+            } catch let error as CancellationError {
+                throw error
+            } catch let error as ClaudeUsageError {
+                throw error
+            } catch let error as ClaudeOAuthCredentialsError {
+                if case .refreshDelegatedToClaudeCLI = error {
+                    return try await self.loadAfterDelegatedRefresh(allowDelegatedRetry: allowDelegatedRetry)
+                }
+                throw ClaudeUsageError.oauthFailed(error.localizedDescription)
+            } catch let error as ClaudeOAuthFetchError {
+                ClaudeOAuthCredentialsStore.invalidateCache()
+                if case let .serverError(statusCode, body) = error,
+                   statusCode == 403,
+                   body?.contains("user:profile") ?? false
+                {
+                    throw ClaudeUsageError.oauthFailed(
+                        "Claude OAuth token does not meet scope requirement 'user:profile'. "
+                            + "Run `claude setup-token` to re-generate credentials, or switch Claude Source to "
+                            + "Web/CLI.")
+                }
+                throw ClaudeUsageError.oauthFailed(error.localizedDescription)
+            } catch {
+                throw ClaudeUsageError.oauthFailed(error.localizedDescription)
+            }
+        }
+
+        private func shouldAllowStartupBootstrapPrompt(
+            policy: ClaudeOAuthKeychainPromptPolicy,
+            hasCache: Bool) -> Bool
+        {
+            guard policy.isApplicable else { return false }
+            guard self.fetcher.allowStartupBootstrapPrompt else { return false }
+            guard !hasCache else { return false }
+            guard policy.mode == .onlyOnUserAction else { return false }
+            guard policy.interaction == .background else { return false }
+            return ProviderRefreshContext.current == .startup
+        }
+
+        private func loadAfterDelegatedRefresh(allowDelegatedRetry: Bool) async throws -> ClaudeUsageSnapshot {
+            guard allowDelegatedRetry else {
+                throw ClaudeUsageError.oauthFailed(
+                    "Claude OAuth token expired and delegated Claude CLI refresh did not recover. "
+                        + "Run `claude login`, then retry.")
+            }
+
+            try Task.checkCancellation()
+
+            let delegatedPromptPolicy = ClaudeUsageFetcher.currentClaudeOAuthKeychainPromptPolicy()
+            try ClaudeUsageFetcher.assertDelegatedRefreshAllowedInCurrentInteraction(
+                policy: delegatedPromptPolicy,
+                allowBackgroundDelegatedRefresh: self.fetcher.allowBackgroundDelegatedRefresh)
+
+            let delegatedOutcome = await ClaudeUsageFetcher.attemptDelegatedRefresh(
+                environment: self.fetcher.environment)
+            ClaudeUsageFetcher.log.info(
+                "Claude OAuth delegated refresh attempted",
+                metadata: [
+                    "outcome": ClaudeUsageFetcher.delegatedRefreshOutcomeLabel(delegatedOutcome),
+                ])
+
+            do {
+                if self.fetcher.oauthKeychainPromptCooldownEnabled {
+                    switch delegatedOutcome {
+                    case .skippedByCooldown, .cliUnavailable:
+                        throw ClaudeUsageError.oauthFailed(
+                            "Claude OAuth token expired; delegated refresh is unavailable (outcome="
+                                + "\(ClaudeUsageFetcher.delegatedRefreshOutcomeLabel(delegatedOutcome))).")
+                    case .attemptedSucceeded, .attemptedFailed:
+                        break
+                    }
+                }
+
+                try Task.checkCancellation()
+
+                _ = ClaudeOAuthCredentialsStore.invalidateCacheIfCredentialsFileChanged()
+
+                let didSyncSilently = delegatedOutcome == .attemptedSucceeded
+                    && ClaudeOAuthCredentialsStore.syncFromClaudeKeychainWithoutPrompt(now: Date())
+
+                let promptPolicy = ClaudeUsageFetcher.currentClaudeOAuthKeychainPromptPolicy()
+                ClaudeUsageFetcher.logDeferredBackgroundDelegatedRecoveryIfNeeded(
+                    delegatedOutcome: delegatedOutcome,
+                    didSyncSilently: didSyncSilently,
+                    policy: promptPolicy)
+                let retryAllowKeychainPrompt = promptPolicy.canPromptNow && !didSyncSilently
+                if retryAllowKeychainPrompt {
+                    ClaudeUsageFetcher.log.info(
+                        "Claude OAuth keychain prompt allowed (post-delegation retry)",
+                        metadata: [
+                            "interaction": promptPolicy.interactionLabel,
+                            "promptMode": promptPolicy.mode.rawValue,
+                            "promptPolicyApplicable": "\(promptPolicy.isApplicable)",
+                            "delegatedOutcome": ClaudeUsageFetcher.delegatedRefreshOutcomeLabel(delegatedOutcome),
+                            "didSyncSilently": "\(didSyncSilently)",
+                        ])
+                }
+                if ClaudeUsageFetcher.isClaudeOAuthFlowDebugEnabled {
+                    ClaudeUsageFetcher.log.debug(
+                        "Claude OAuth credential load (post-delegation retry start)",
+                        metadata: [
+                            "cooldownEnabled": "\(self.fetcher.oauthKeychainPromptCooldownEnabled)",
+                            "didSyncSilently": "\(didSyncSilently)",
+                            "allowKeychainPrompt": "\(retryAllowKeychainPrompt)",
+                            "delegatedOutcome": ClaudeUsageFetcher.delegatedRefreshOutcomeLabel(delegatedOutcome),
+                            "interaction": promptPolicy.interactionLabel,
+                            "promptMode": promptPolicy.mode.rawValue,
+                            "promptPolicyApplicable": "\(promptPolicy.isApplicable)",
+                        ])
+                }
+
+                let refreshedCredentials = try await ClaudeUsageFetcher.loadOAuthCredentials(
+                    environment: self.fetcher.environment,
+                    allowKeychainPrompt: retryAllowKeychainPrompt,
+                    respectKeychainPromptCooldown: promptPolicy.shouldRespectKeychainPromptCooldown)
+                if ClaudeUsageFetcher.isClaudeOAuthFlowDebugEnabled {
+                    ClaudeUsageFetcher.log.debug(
+                        "Claude OAuth credential load (post-delegation retry)",
+                        metadata: [
+                            "cooldownEnabled": "\(self.fetcher.oauthKeychainPromptCooldownEnabled)",
+                            "didSyncSilently": "\(didSyncSilently)",
+                            "allowKeychainPrompt": "\(retryAllowKeychainPrompt)",
+                            "delegatedOutcome": ClaudeUsageFetcher.delegatedRefreshOutcomeLabel(delegatedOutcome),
+                            "interaction": promptPolicy.interactionLabel,
+                            "promptMode": promptPolicy.mode.rawValue,
+                            "promptPolicyApplicable": "\(promptPolicy.isApplicable)",
+                        ])
+                }
+
+                try self.validateRequiredOAuthScope(refreshedCredentials)
+                let usage = try await ClaudeUsageFetcher.fetchOAuthUsage(
+                    accessToken: refreshedCredentials.accessToken)
+                return try ClaudeUsageFetcher.mapOAuthUsage(usage, credentials: refreshedCredentials)
+            } catch {
+                ClaudeUsageFetcher.log.debug(
+                    "Claude OAuth post-delegation retry failed",
+                    metadata: ClaudeUsageFetcher.delegatedRetryFailureMetadata(
+                        error: error,
+                        oauthKeychainPromptCooldownEnabled: self.fetcher.oauthKeychainPromptCooldownEnabled,
+                        delegatedOutcome: delegatedOutcome))
+                throw ClaudeUsageError.oauthFailed(
+                    ClaudeUsageFetcher.delegatedRefreshFailureMessage(
+                        for: delegatedOutcome,
+                        retryError: error))
+            }
+        }
+
+        private func validateRequiredOAuthScope(_ credentials: ClaudeOAuthCredentials) throws {
+            guard credentials.scopes.contains("user:profile") else {
+                let scopes = credentials.scopes.joined(separator: ", ")
+                let detail = scopes.isEmpty
+                    ? "Claude OAuth token missing 'user:profile' scope."
+                    : "Claude OAuth token missing 'user:profile' scope (has: \(scopes))."
+                throw ClaudeUsageError.oauthFailed(
+                    detail + " Run `claude setup-token` to re-generate credentials, or switch Claude Source to "
+                        + "Web/CLI.")
+            }
+        }
+    }
+
+    private struct StepExecutor: Sendable {
+        let fetcher: ClaudeUsageFetcher
+
+        func loadLatestUsage(model: String) async throws -> ClaudeUsageSnapshot {
+            switch self.fetcher.dataSource {
+            case .auto:
+                return try await self.executeAuto(model: model)
+            case .oauth:
+                var snapshot = try await self.fetcher.loadViaOAuth(allowDelegatedRetry: true)
+                snapshot = await self.fetcher.applyWebExtrasIfNeeded(to: snapshot)
+                return snapshot
+            case .web:
+                return try await self.fetcher.loadViaWebAPI()
+            case .cli:
+                do {
+                    var snapshot = try await self.fetcher.loadViaPTY(model: model, timeout: 10)
+                    snapshot = await self.fetcher.applyWebExtrasIfNeeded(to: snapshot)
+                    return snapshot
+                } catch {
+                    var snapshot = try await self.fetcher.loadViaPTY(model: model, timeout: 24)
+                    snapshot = await self.fetcher.applyWebExtrasIfNeeded(to: snapshot)
+                    return snapshot
+                }
+            }
+        }
+
+        private func executeAuto(model: String) async throws -> ClaudeUsageSnapshot {
+            let plan = await self.makeAutoFetchPlan()
+            self.logAutoPlan(plan)
+
+            let executionSteps = plan.executionSteps
+            for (index, step) in executionSteps.enumerated() {
+                do {
+                    return try await self.execute(step: step, model: model)
+                } catch {
+                    if index < executionSteps.count - 1 {
+                        ClaudeUsageFetcher.log.debug(
+                            "Claude planner step failed; falling back to next step",
+                            metadata: [
+                                "step": step.dataSource.rawValue,
+                                "reason": step.inclusionReason.rawValue,
+                                "errorType": String(describing: type(of: error)),
+                            ])
+                        continue
+                    }
+                    throw error
+                }
+            }
+            throw ClaudeUsageError.parseFailed("Claude planner produced no executable steps.")
+        }
+
+        private func makeAutoFetchPlan() async -> ClaudeFetchPlan {
+            let hasWebSession =
+                if let header = self.fetcher.manualCookieHeader {
+                    ClaudeWebAPIFetcher.hasSessionKey(cookieHeader: header)
+                } else {
+                    ClaudeWebAPIFetcher.hasSessionKey(browserDetection: self.fetcher.browserDetection)
+                }
+            let hasCLI = ClaudeCLIResolver.isAvailable(environment: self.fetcher.environment)
+            return ClaudeSourcePlanner.resolve(input: ClaudeSourcePlanningInput(
+                runtime: self.fetcher.runtime,
+                selectedDataSource: .auto,
+                webExtrasEnabled: self.fetcher.useWebExtras,
+                hasWebSession: hasWebSession,
+                hasCLI: hasCLI,
+                hasOAuthCredentials: ClaudeOAuthPlanningAvailability.isAvailable(
+                    runtime: self.fetcher.runtime,
+                    sourceMode: .auto,
+                    environment: self.fetcher.environment)))
+        }
+
+        private func logAutoPlan(_ plan: ClaudeFetchPlan) {
+            var metadata: [String: String] = [
+                "plannerOrder": plan.orderLabel,
+                "selected": plan.preferredStep?.dataSource.rawValue ?? "none",
+                "noSourceAvailable": "\(plan.isNoSourceAvailable)",
+                "webExtrasEnabled": "\(self.fetcher.useWebExtras)",
+                "oauthReadStrategy": ClaudeOAuthKeychainReadStrategyPreference.current().rawValue,
+            ]
+            for (index, step) in plan.orderedSteps.enumerated() {
+                metadata["step\(index)"] =
+                    "\(step.dataSource.rawValue):\(step.inclusionReason.rawValue):\(step.isPlausiblyAvailable)"
+            }
+            ClaudeUsageFetcher.log.debug("Claude auto source planner", metadata: metadata)
+        }
+
+        private func execute(step: ClaudeFetchPlanStep, model: String) async throws -> ClaudeUsageSnapshot {
+            switch step.dataSource {
+            case .oauth:
+                var snapshot = try await self.fetcher.loadViaOAuth(allowDelegatedRetry: true)
+                snapshot = await self.fetcher.applyWebExtrasIfNeeded(to: snapshot)
+                return snapshot
+            case .web:
+                return try await self.fetcher.loadViaWebAPI()
+            case .cli:
+                var snapshot = try await self.fetcher.loadViaPTY(model: model, timeout: 10)
+                snapshot = await self.fetcher.applyWebExtrasIfNeeded(to: snapshot)
+                return snapshot
+            case .auto:
+                throw ClaudeUsageError.parseFailed("Planner emitted invalid auto execution step.")
+            }
+        }
+    }
+}
+
+extension ClaudeUsageFetcher {
     // MARK: - Parsing helpers
 
     public static func parse(json: Data) -> ClaudeUsageSnapshot? {
@@ -298,19 +643,13 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         }
     }
 
-    // MARK: - OAuth API path
-
-    private func shouldAllowStartupBootstrapPrompt(
-        policy: ClaudeOAuthKeychainPromptPolicy,
-        hasCache: Bool) -> Bool
-    {
-        guard policy.isApplicable else { return false }
-        guard self.allowStartupBootstrapPrompt else { return false }
-        guard !hasCache else { return false }
-        guard policy.mode == .onlyOnUserAction else { return false }
-        guard policy.interaction == .background else { return false }
-        return ProviderRefreshContext.current == .startup
+    public func loadLatestUsage(model: String = "sonnet") async throws -> ClaudeUsageSnapshot {
+        try await StepExecutor(fetcher: self).loadLatestUsage(model: model)
     }
+}
+
+extension ClaudeUsageFetcher {
+    // MARK: - OAuth API path
 
     private static func logOAuthBootstrapPromptDecision(
         allowKeychainPrompt: Bool,
@@ -349,188 +688,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
     }
 
     private func loadViaOAuth(allowDelegatedRetry: Bool) async throws -> ClaudeUsageSnapshot {
-        do {
-            let promptPolicy = Self.currentClaudeOAuthKeychainPromptPolicy()
-
-            // Allow keychain prompt when no cached credentials exist (bootstrap case)
-            #if DEBUG
-            let hasCache = Self.hasCachedCredentialsOverride
-                ?? ClaudeOAuthCredentialsStore.hasCachedCredentials(environment: self.environment)
-            #else
-            let hasCache = ClaudeOAuthCredentialsStore.hasCachedCredentials(environment: self.environment)
-            #endif
-            let startupBootstrapOverride = self.shouldAllowStartupBootstrapPrompt(
-                policy: promptPolicy,
-                hasCache: hasCache)
-            // Note: `hasCachedCredentials` intentionally returns true for expired Claude-CLI-owned creds, because the
-            // repair path is delegated refresh via Claude CLI (followed by a silent re-sync) rather than immediately
-            // prompting on the initial load.
-            let allowKeychainPrompt = (promptPolicy.canPromptNow || startupBootstrapOverride) && !hasCache
-            Self.logOAuthBootstrapPromptDecision(
-                allowKeychainPrompt: allowKeychainPrompt,
-                policy: promptPolicy,
-                hasCache: hasCache,
-                startupBootstrapOverride: startupBootstrapOverride)
-            // Ownership-aware credential loading:
-            // - Claude CLI-owned credentials delegate refresh to Claude CLI.
-            // - CodexBar-owned credentials use direct token-endpoint refresh.
-            let creds = try await ClaudeOAuthCredentialsStore.$allowBackgroundPromptBootstrap
-                .withValue(startupBootstrapOverride) {
-                    try await Self.loadOAuthCredentials(
-                        environment: self.environment,
-                        allowKeychainPrompt: allowKeychainPrompt,
-                        respectKeychainPromptCooldown: promptPolicy.shouldRespectKeychainPromptCooldown)
-                }
-            // The usage endpoint requires user:profile scope.
-            if !creds.scopes.contains("user:profile") {
-                throw ClaudeUsageError.oauthFailed(
-                    "Claude OAuth token missing 'user:profile' scope (has: \(creds.scopes.joined(separator: ", "))). "
-                        + "Run `claude setup-token` to re-generate credentials, or switch Claude Source to Web/CLI.")
-            }
-            let usage = try await Self.fetchOAuthUsage(accessToken: creds.accessToken)
-            return try Self.mapOAuthUsage(usage, credentials: creds)
-        } catch let error as CancellationError {
-            throw error
-        } catch let error as ClaudeUsageError {
-            throw error
-        } catch let error as ClaudeOAuthCredentialsError {
-            if case .refreshDelegatedToClaudeCLI = error {
-                return try await self.loadViaOAuthAfterDelegatedRefresh(allowDelegatedRetry: allowDelegatedRetry)
-            }
-            throw ClaudeUsageError.oauthFailed(error.localizedDescription)
-        } catch let error as ClaudeOAuthFetchError {
-            ClaudeOAuthCredentialsStore.invalidateCache()
-            if case let .serverError(statusCode, body) = error,
-               statusCode == 403,
-               body?.contains("user:profile") ?? false
-            {
-                throw ClaudeUsageError.oauthFailed(
-                    "Claude OAuth token does not meet scope requirement 'user:profile'. "
-                        + "Run `claude setup-token` to re-generate credentials, or switch Claude Source to Web/CLI.")
-            }
-            throw ClaudeUsageError.oauthFailed(error.localizedDescription)
-        } catch {
-            throw ClaudeUsageError.oauthFailed(error.localizedDescription)
-        }
-    }
-
-    private func loadViaOAuthAfterDelegatedRefresh(allowDelegatedRetry: Bool) async throws -> ClaudeUsageSnapshot {
-        guard allowDelegatedRetry else {
-            throw ClaudeUsageError.oauthFailed(
-                "Claude OAuth token expired and delegated Claude CLI refresh did not recover. "
-                    + "Run `claude login`, then retry.")
-        }
-
-        try Task.checkCancellation()
-
-        let delegatedPromptPolicy = Self.currentClaudeOAuthKeychainPromptPolicy()
-        try Self.assertDelegatedRefreshAllowedInCurrentInteraction(
-            policy: delegatedPromptPolicy,
-            allowBackgroundDelegatedRefresh: self.allowBackgroundDelegatedRefresh)
-
-        let delegatedOutcome = await Self.attemptDelegatedRefresh(environment: self.environment)
-        Self.log.info(
-            "Claude OAuth delegated refresh attempted",
-            metadata: [
-                "outcome": Self.delegatedRefreshOutcomeLabel(delegatedOutcome),
-            ])
-
-        do {
-            // In Auto mode, avoid forcing interactive Keychain prompts or blocking the fallback chain when
-            // delegation cannot run.
-            if self.oauthKeychainPromptCooldownEnabled {
-                switch delegatedOutcome {
-                case .skippedByCooldown, .cliUnavailable:
-                    throw ClaudeUsageError.oauthFailed(
-                        "Claude OAuth token expired; delegated refresh is unavailable (outcome="
-                            + "\(Self.delegatedRefreshOutcomeLabel(delegatedOutcome))).")
-                case .attemptedSucceeded:
-                    break
-                case .attemptedFailed:
-                    // Delegation ran but didn't observe a keychain change. We'll attempt a non-interactive reload
-                    // below (allowKeychainPrompt=false) and then allow the Auto chain to fall back.
-                    break
-                }
-            }
-
-            try Task.checkCancellation()
-
-            // After delegated refresh, reload credentials and retry OAuth once.
-            // In OAuth mode we allow an interactive Keychain prompt here; in Auto mode we keep it silent to avoid
-            // bypassing the prompt cooldown and to let the fallback chain proceed.
-            _ = ClaudeOAuthCredentialsStore.invalidateCacheIfCredentialsFileChanged()
-
-            let didSyncSilently = delegatedOutcome == .attemptedSucceeded
-                && ClaudeOAuthCredentialsStore.syncFromClaudeKeychainWithoutPrompt(now: Date())
-
-            let promptPolicy = Self.currentClaudeOAuthKeychainPromptPolicy()
-            Self.logDeferredBackgroundDelegatedRecoveryIfNeeded(
-                delegatedOutcome: delegatedOutcome,
-                didSyncSilently: didSyncSilently,
-                policy: promptPolicy)
-            let retryAllowKeychainPrompt = promptPolicy.canPromptNow && !didSyncSilently
-            if retryAllowKeychainPrompt {
-                Self.log.info(
-                    "Claude OAuth keychain prompt allowed (post-delegation retry)",
-                    metadata: [
-                        "interaction": promptPolicy.interactionLabel,
-                        "promptMode": promptPolicy.mode.rawValue,
-                        "promptPolicyApplicable": "\(promptPolicy.isApplicable)",
-                        "delegatedOutcome": Self.delegatedRefreshOutcomeLabel(delegatedOutcome),
-                        "didSyncSilently": "\(didSyncSilently)",
-                    ])
-            }
-            if Self.isClaudeOAuthFlowDebugEnabled {
-                Self.log.debug(
-                    "Claude OAuth credential load (post-delegation retry start)",
-                    metadata: [
-                        "cooldownEnabled": "\(self.oauthKeychainPromptCooldownEnabled)",
-                        "didSyncSilently": "\(didSyncSilently)",
-                        "allowKeychainPrompt": "\(retryAllowKeychainPrompt)",
-                        "delegatedOutcome": Self.delegatedRefreshOutcomeLabel(delegatedOutcome),
-                        "interaction": promptPolicy.interactionLabel,
-                        "promptMode": promptPolicy.mode.rawValue,
-                        "promptPolicyApplicable": "\(promptPolicy.isApplicable)",
-                    ])
-            }
-            let refreshedCreds = try await Self.loadOAuthCredentials(
-                environment: self.environment,
-                allowKeychainPrompt: retryAllowKeychainPrompt,
-                respectKeychainPromptCooldown: promptPolicy.shouldRespectKeychainPromptCooldown)
-            if Self.isClaudeOAuthFlowDebugEnabled {
-                Self.log.debug(
-                    "Claude OAuth credential load (post-delegation retry)",
-                    metadata: [
-                        "cooldownEnabled": "\(self.oauthKeychainPromptCooldownEnabled)",
-                        "didSyncSilently": "\(didSyncSilently)",
-                        "allowKeychainPrompt": "\(retryAllowKeychainPrompt)",
-                        "delegatedOutcome": Self.delegatedRefreshOutcomeLabel(delegatedOutcome),
-                        "interaction": promptPolicy.interactionLabel,
-                        "promptMode": promptPolicy.mode.rawValue,
-                        "promptPolicyApplicable": "\(promptPolicy.isApplicable)",
-                    ])
-            }
-
-            if !refreshedCreds.scopes.contains("user:profile") {
-                let scopes = refreshedCreds.scopes.joined(separator: ", ")
-                throw ClaudeUsageError.oauthFailed(
-                    "Claude OAuth token missing 'user:profile' scope (has: \(scopes)). "
-                        + "Run `claude setup-token` to re-generate credentials, "
-                        + "or switch Claude Source to Web/CLI.")
-            }
-
-            let usage = try await Self.fetchOAuthUsage(accessToken: refreshedCreds.accessToken)
-            return try Self.mapOAuthUsage(usage, credentials: refreshedCreds)
-        } catch {
-            Self.log.debug(
-                "Claude OAuth post-delegation retry failed",
-                metadata: Self.delegatedRetryFailureMetadata(
-                    error: error,
-                    oauthKeychainPromptCooldownEnabled: self.oauthKeychainPromptCooldownEnabled,
-                    delegatedOutcome: delegatedOutcome))
-            throw ClaudeUsageError.oauthFailed(
-                Self.delegatedRefreshFailureMessage(for: delegatedOutcome, retryError: error))
-        }
+        try await OAuthExecutor(fetcher: self).load(allowDelegatedRetry: allowDelegatedRetry)
     }
 
     private static func loadOAuthCredentials(
@@ -575,8 +733,8 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             environment: environment)
     }
 
-    private static func delegatedRefreshOutcomeLabel(_ outcome: ClaudeOAuthDelegatedRefreshCoordinator
-        .Outcome) -> String
+    private static func delegatedRefreshOutcomeLabel(
+        _ outcome: ClaudeOAuthDelegatedRefreshCoordinator.Outcome) -> String
     {
         switch outcome {
         case .skippedByCooldown:
@@ -704,8 +862,9 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             updatedAt: Date())
     }
 
-    private static func normalizeClaudeExtraUsageAmounts(used: Double, limit: Double) -> (
-        used: Double, limit: Double)
+    private static func normalizeClaudeExtraUsageAmounts(
+        used: Double,
+        limit: Double) -> (used: Double, limit: Double)
     {
         // Claude's OAuth API returns values in cents (minor units), same as the Web API.
         // Always convert to dollars (major units) for display consistency.
@@ -770,9 +929,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
 
     // MARK: - PTY-based probe (no tmux)
 
-    private func loadViaPTY(model: String, timeout: TimeInterval = 10) async throws
-        -> ClaudeUsageSnapshot
-    {
+    private func loadViaPTY(model: String, timeout: TimeInterval = 10) async throws -> ClaudeUsageSnapshot {
         guard let claudeBinary = ClaudeCLIResolver.resolvedBinaryPath(environment: self.environment) else {
             throw ClaudeUsageError.claudeNotInstalled
         }
@@ -814,9 +971,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             rawText: snap.rawText)
     }
 
-    private func applyWebExtrasIfNeeded(to snapshot: ClaudeUsageSnapshot) async
-        -> ClaudeUsageSnapshot
-    {
+    private func applyWebExtrasIfNeeded(to snapshot: ClaudeUsageSnapshot) async -> ClaudeUsageSnapshot {
         guard self.useWebExtras, self.dataSource != .web else { return snapshot }
         do {
             let webData: ClaudeWebAPIFetcher.WebUsageData =
@@ -881,100 +1036,6 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         guard task.terminationStatus == 0 else { return nil }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         return String(data: data, encoding: .utf8)
-    }
-}
-
-extension ClaudeUsageFetcher {
-    private func makeAutoFetchPlan() async -> ClaudeFetchPlan {
-        let hasWebSession =
-            if let header = self.manualCookieHeader {
-                ClaudeWebAPIFetcher.hasSessionKey(cookieHeader: header)
-            } else {
-                ClaudeWebAPIFetcher.hasSessionKey(browserDetection: self.browserDetection)
-            }
-        let hasCLI = ClaudeCLIResolver.isAvailable(environment: self.environment)
-        return ClaudeSourcePlanner.resolve(input: ClaudeSourcePlanningInput(
-            runtime: self.runtime,
-            selectedDataSource: .auto,
-            webExtrasEnabled: self.useWebExtras,
-            hasWebSession: hasWebSession,
-            hasCLI: hasCLI,
-            hasOAuthCredentials: ClaudeOAuthPlanningAvailability.isAvailable(
-                runtime: self.runtime,
-                sourceMode: .auto,
-                environment: self.environment)))
-    }
-
-    private func execute(step: ClaudeFetchPlanStep, model: String) async throws -> ClaudeUsageSnapshot {
-        switch step.dataSource {
-        case .oauth:
-            var snapshot = try await self.loadViaOAuth(allowDelegatedRetry: true)
-            snapshot = await self.applyWebExtrasIfNeeded(to: snapshot)
-            return snapshot
-        case .web:
-            return try await self.loadViaWebAPI()
-        case .cli:
-            var snapshot = try await self.loadViaPTY(model: model, timeout: 10)
-            snapshot = await self.applyWebExtrasIfNeeded(to: snapshot)
-            return snapshot
-        case .auto:
-            throw ClaudeUsageError.parseFailed("Planner emitted invalid auto execution step.")
-        }
-    }
-
-    public func loadLatestUsage(model: String = "sonnet") async throws -> ClaudeUsageSnapshot {
-        switch self.dataSource {
-        case .auto:
-            let plan = await self.makeAutoFetchPlan()
-            var planMetadata: [String: String] = [
-                "plannerOrder": plan.orderLabel,
-                "selected": plan.preferredStep?.dataSource.rawValue ?? "none",
-                "noSourceAvailable": "\(plan.isNoSourceAvailable)",
-                "webExtrasEnabled": "\(self.useWebExtras)",
-                "oauthReadStrategy": ClaudeOAuthKeychainReadStrategyPreference.current().rawValue,
-            ]
-            for (index, step) in plan.orderedSteps.enumerated() {
-                planMetadata["step\(index)"] =
-                    "\(step.dataSource.rawValue):\(step.inclusionReason.rawValue):\(step.isPlausiblyAvailable)"
-            }
-            Self.log.debug("Claude auto source planner", metadata: planMetadata)
-
-            let executionSteps = plan.executionSteps
-            for (index, step) in executionSteps.enumerated() {
-                do {
-                    return try await self.execute(step: step, model: model)
-                } catch {
-                    if index < executionSteps.count - 1 {
-                        Self.log.debug(
-                            "Claude planner step failed; falling back to next step",
-                            metadata: [
-                                "step": step.dataSource.rawValue,
-                                "reason": step.inclusionReason.rawValue,
-                                "errorType": String(describing: type(of: error)),
-                            ])
-                        continue
-                    }
-                    throw error
-                }
-            }
-            throw ClaudeUsageError.parseFailed("Claude planner produced no executable steps.")
-        case .oauth:
-            var snap = try await self.loadViaOAuth(allowDelegatedRetry: true)
-            snap = await self.applyWebExtrasIfNeeded(to: snap)
-            return snap
-        case .web:
-            return try await self.loadViaWebAPI()
-        case .cli:
-            do {
-                var snap = try await self.loadViaPTY(model: model, timeout: 10)
-                snap = await self.applyWebExtrasIfNeeded(to: snap)
-                return snap
-            } catch {
-                var snap = try await self.loadViaPTY(model: model, timeout: 24)
-                snap = await self.applyWebExtrasIfNeeded(to: snap)
-                return snap
-            }
-        }
     }
 
     private static func oauthCredentialProbeErrorLabel(_ error: Error) -> String {

--- a/Tests/CodexBarTests/ClaudeUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeUsageTests.swift
@@ -1201,13 +1201,15 @@ struct ClaudeAutoFetcherCharacterizationTests {
             manualCookieHeader: "foo=bar")
 
         await self.withNoOAuthCredentials {
-            do {
-                _ = try await fetcher.loadLatestUsage(model: "sonnet")
-                Issue.record("Expected app auto no-source fetch to fail.")
-            } catch let error as ClaudeUsageError {
-                #expect(error.localizedDescription.contains("Claude planner produced no executable steps."))
-            } catch {
-                Issue.record("Unexpected error: \(error)")
+            await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/definitely/missing/claude") {
+                do {
+                    _ = try await fetcher.loadLatestUsage(model: "sonnet")
+                    Issue.record("Expected app auto no-source fetch to fail.")
+                } catch let error as ClaudeUsageError {
+                    #expect(error.localizedDescription.contains("Claude planner produced no executable steps."))
+                } catch {
+                    Issue.record("Unexpected error: \(error)")
+                }
             }
         }
     }
@@ -1222,13 +1224,15 @@ struct ClaudeAutoFetcherCharacterizationTests {
             manualCookieHeader: "foo=bar")
 
         await self.withNoOAuthCredentials {
-            do {
-                _ = try await fetcher.loadLatestUsage(model: "sonnet")
-                Issue.record("Expected CLI auto no-source fetch to fail.")
-            } catch let error as ClaudeUsageError {
-                #expect(error.localizedDescription.contains("Claude planner produced no executable steps."))
-            } catch {
-                Issue.record("Unexpected error: \(error)")
+            await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/definitely/missing/claude") {
+                do {
+                    _ = try await fetcher.loadLatestUsage(model: "sonnet")
+                    Issue.record("Expected CLI auto no-source fetch to fail.")
+                } catch let error as ClaudeUsageError {
+                    #expect(error.localizedDescription.contains("Claude planner produced no executable steps."))
+                } catch {
+                    Issue.record("Unexpected error: \(error)")
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- split `ClaudeUsageFetcher` internals into fetcher-local execution helpers while keeping the public facade unchanged
- keep planner-input assembly fetcher-local and thin, delegating directly to `ClaudeSourcePlanner`
- tighten the auto no-source tests so they are deterministic on machines where `claude` is on `PATH`

## Validation
- `swift build`
- `pnpm check`
- `swift test --filter ClaudeUsageTests`
- `swift test --filter 'ClaudeOAuthDelegatedRefreshRecoveryTests|ClaudeOAuthCredentialsStorePromptPolicyTests|ClaudeOAuthKeychainAccessGateTests|ClaudeDebugDiagnosticsTests|ClaudeBaselineCharacterizationTests|ClaudeUsageDelegatedRefreshEnvironmentTests'`
- `./Scripts/compile_and_run.sh`

## Residual baseline risk
- full `swift test` still hits pre-existing/baseline-sensitive failures recorded in the Gate E/F artifacts:
  - `HistoricalUsagePaceTests.partialDayCredits_areNotUndercountedAtAsOfTime()`
  - `HistoricalUsagePaceTests.gregorianDayParsing_isStableForYYYYMMDD()`
  - `ClaudeOAuthCredentialsStoreSecurityCLITests.experimentalReader_nonInteractiveBackgroundLoad_stillExecutesSecurityCLIRead()` in full-suite context only
  - `OpenAIDashboardNavigationDelegateTests` timeout case in full-suite context only
