### PR TITLE
Fix dashboard day keys and flaky tests

### DIFF
--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardScrapeScript.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardScrapeScript.swift
@@ -203,6 +203,12 @@ let openAIDashboardScrapeScript = """
       };
       const dayKeyFromPayload = (payload) => {
         if (!payload || typeof payload !== 'object') return null;
+        const localDayKeyForDate = (date) => {
+          const year = date.getFullYear();
+          const month = String(date.getMonth() + 1).padStart(2, '0');
+          const day = String(date.getDate()).padStart(2, '0');
+          return `${year}-${month}-${day}`;
+        };
         const keys = ['day', 'date', 'name', 'label', 'x', 'time', 'timestamp'];
         for (const k of keys) {
           const v = payload[k];
@@ -215,7 +221,7 @@ let openAIDashboardScrapeScript = """
           if (typeof v === 'number' && Number.isFinite(v) && (k === 'timestamp' || k === 'time' || k === 'x')) {
             try {
               const d = new Date(v);
-              if (!isNaN(d.getTime())) return d.toISOString().slice(0, 10);
+              if (!isNaN(d.getTime())) return localDayKeyForDate(d);
             } catch {}
           }
         }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+TestingOverrides.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials+TestingOverrides.swift
@@ -187,6 +187,10 @@ extension ClaudeOAuthCredentialsStore {
         }
     }
 
+    static func currentSecurityCLIReadOverrideForTesting() -> SecurityCLIReadOverride? {
+        self.taskSecurityCLIReadOverride ?? self.securityCLIReadOverride
+    }
+
     static func withSecurityCLIReadAccountOverrideForTesting<T>(
         _ account: String?,
         operation: () throws -> T) rethrows -> T

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthDelegatedRefreshCoordinator.swift
@@ -55,12 +55,25 @@ public enum ClaudeOAuthDelegatedRefreshCoordinator {
         // Detached to avoid inheriting the caller's executor context (e.g. MainActor) and cancellation state.
         let readStrategy = ClaudeOAuthKeychainReadStrategyPreference.current()
         let keychainAccessDisabled = KeychainAccessGate.isDisabled
+        #if DEBUG
+        let securityCLIReadOverride = ClaudeOAuthCredentialsStore.currentSecurityCLIReadOverrideForTesting()
+        #endif
         let task = Task.detached(priority: .utility) {
+            #if DEBUG
+            return await ClaudeOAuthCredentialsStore.withSecurityCLIReadOverrideForTesting(securityCLIReadOverride) {
+                await self.performAttempt(
+                    now: now,
+                    timeout: timeout,
+                    readStrategy: readStrategy,
+                    keychainAccessDisabled: keychainAccessDisabled)
+            }
+            #else
             await self.performAttempt(
                 now: now,
                 timeout: timeout,
                 readStrategy: readStrategy,
                 keychainAccessDisabled: keychainAccessDisabled)
+            #endif
         }
         self.inFlightAttemptID = attemptID
         self.inFlightTask = task

--- a/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshCoordinatorTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthDelegatedRefreshCoordinatorTests.swift
@@ -255,11 +255,11 @@ struct ClaudeOAuthDelegatedRefreshCoordinatorTests {
             let securityData = self.makeCredentialsData(
                 accessToken: "security-token-a",
                 expiresAt: Date(timeIntervalSinceNow: 3600))
-            ClaudeOAuthCredentialsStore.setSecurityCLIReadOverrideForTesting(.data(securityData))
-            defer { ClaudeOAuthCredentialsStore.setSecurityCLIReadOverrideForTesting(nil) }
-            let outcome = await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
-                now: Date(timeIntervalSince1970: 60000),
-                timeout: 0.1)
+            let outcome = await ClaudeOAuthCredentialsStore.withSecurityCLIReadOverrideForTesting(.data(securityData)) {
+                await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
+                    now: Date(timeIntervalSince1970: 60000),
+                    timeout: 0.1)
+            }
 
             guard case .attemptedFailed = outcome else {
                 Issue.record("Expected .attemptedFailed outcome")
@@ -325,12 +325,13 @@ struct ClaudeOAuthDelegatedRefreshCoordinatorTests {
             ClaudeOAuthDelegatedRefreshCoordinator.setTouchAuthPathOverrideForTesting { _ in
                 dataBox.store(afterData)
             }
-            ClaudeOAuthCredentialsStore.setSecurityCLIReadOverrideForTesting(.dynamic { _ in dataBox.load() })
-            defer { ClaudeOAuthCredentialsStore.setSecurityCLIReadOverrideForTesting(nil) }
-
-            let outcome = await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
-                now: Date(timeIntervalSince1970: 61000),
-                timeout: 0.1)
+            let outcome = await ClaudeOAuthCredentialsStore.withSecurityCLIReadOverrideForTesting(.dynamic { _ in
+                dataBox.load()
+            }) {
+                await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
+                    now: Date(timeIntervalSince1970: 61000),
+                    timeout: 0.1)
+            }
 
             #expect(outcome == .attemptedSucceeded)
             #expect(fingerprintCounter.count < 1)
@@ -390,12 +391,13 @@ struct ClaudeOAuthDelegatedRefreshCoordinatorTests {
             ClaudeOAuthDelegatedRefreshCoordinator.setTouchAuthPathOverrideForTesting { _ in
                 dataBox.store(afterData)
             }
-            ClaudeOAuthCredentialsStore.setSecurityCLIReadOverrideForTesting(.dynamic { _ in dataBox.load() })
-            defer { ClaudeOAuthCredentialsStore.setSecurityCLIReadOverrideForTesting(nil) }
-
-            let outcome = await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
-                now: Date(timeIntervalSince1970: 61500),
-                timeout: 0.1)
+            let outcome = await ClaudeOAuthCredentialsStore.withSecurityCLIReadOverrideForTesting(.dynamic { _ in
+                dataBox.load()
+            }) {
+                await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
+                    now: Date(timeIntervalSince1970: 61500),
+                    timeout: 0.1)
+            }
 
             guard case .attemptedFailed = outcome else {
                 Issue.record("Expected .attemptedFailed outcome when baseline is unavailable")
@@ -428,15 +430,15 @@ struct ClaudeOAuthDelegatedRefreshCoordinatorTests {
                 expiresAt: Date(timeIntervalSinceNow: 3600))
             ClaudeOAuthDelegatedRefreshCoordinator.setCLIAvailableOverrideForTesting(true)
             ClaudeOAuthDelegatedRefreshCoordinator.setTouchAuthPathOverrideForTesting { _ in }
-            ClaudeOAuthCredentialsStore.setSecurityCLIReadOverrideForTesting(.dynamic { _ in
+            let outcome = await ClaudeOAuthCredentialsStore.withSecurityCLIReadOverrideForTesting(.dynamic { _ in
                 securityReadCounter.increment()
                 return securityData
-            })
-            defer { ClaudeOAuthCredentialsStore.setSecurityCLIReadOverrideForTesting(nil) }
-            let outcome = await KeychainAccessGate.withTaskOverrideForTesting(true) {
-                await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
-                    now: Date(timeIntervalSince1970: 62000),
-                    timeout: 0.1)
+            }) {
+                await KeychainAccessGate.withTaskOverrideForTesting(true) {
+                    await ClaudeOAuthDelegatedRefreshCoordinator.attempt(
+                        now: Date(timeIntervalSince1970: 62000),
+                        timeout: 0.1)
+                }
             }
 
             guard case .attemptedFailed = outcome else {

--- a/Tests/CodexBarTests/HistoricalUsagePaceTestSupport.swift
+++ b/Tests/CodexBarTests/HistoricalUsagePaceTestSupport.swift
@@ -4,15 +4,7 @@ import Testing
 @testable import CodexBar
 
 extension HistoricalUsagePaceTests {
-    private static let utcTimeZone: TimeZone = {
-        if let zone = TimeZone(identifier: "UTC") {
-            return zone
-        }
-        if let zone = TimeZone(secondsFromGMT: 0) {
-            return zone
-        }
-        return TimeZone.current
-    }()
+    private static let dashboardTimeZone: TimeZone = .current
 
     static func linearCurve(end: Double) -> [Double] {
         let clampedEnd = max(0, min(100, end))
@@ -45,10 +37,10 @@ extension HistoricalUsagePaceTests {
         overridesByDayOffset: [Int: Double] = [:]) -> [OpenAIDashboardDailyBreakdown]
     {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = Self.utcTimeZone
+        calendar.timeZone = Self.dashboardTimeZone
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = Self.utcTimeZone
+        formatter.timeZone = Self.dashboardTimeZone
         formatter.dateFormat = "yyyy-MM-dd"
 
         let endDay = calendar.startOfDay(for: endDate)
@@ -65,10 +57,10 @@ extension HistoricalUsagePaceTests {
 
     static func gregorianDate(year: Int, month: Int, day: Int, hour: Int) -> Date {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = Self.utcTimeZone
+        calendar.timeZone = Self.dashboardTimeZone
         var components = DateComponents()
         components.calendar = calendar
-        components.timeZone = Self.utcTimeZone
+        components.timeZone = Self.dashboardTimeZone
         components.year = year
         components.month = month
         components.day = day
@@ -91,10 +83,10 @@ extension HistoricalUsagePaceTests {
             return nil
         }
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = Self.utcTimeZone
+        calendar.timeZone = Self.dashboardTimeZone
         var dateComponents = DateComponents()
         dateComponents.calendar = calendar
-        dateComponents.timeZone = Self.utcTimeZone
+        dateComponents.timeZone = Self.dashboardTimeZone
         dateComponents.year = year
         dateComponents.month = month
         dateComponents.day = day

--- a/Tests/CodexBarTests/OpenAIDashboardNavigationDelegateTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardNavigationDelegateTests.swift
@@ -61,17 +61,25 @@ struct OpenAIDashboardNavigationDelegateTests {
         }
     }
 
-    @MainActor
     @Test("navigation timeout fails with timed out error")
     func navigationTimeoutFailsWithTimedOutError() async {
-        var result: Result<Void, Error>?
-        let delegate = NavigationDelegate { result = $0 }
+        final class DelegateBox: @unchecked Sendable {
+            var delegate: NavigationDelegate?
+        }
 
-        delegate.armTimeout(seconds: 0.01)
-        try? await Task.sleep(for: .milliseconds(30))
+        let result = await withCheckedContinuation { (continuation: CheckedContinuation<Result<Void, Error>, Never>) in
+            Task { @MainActor in
+                let box = DelegateBox()
+                box.delegate = NavigationDelegate { result in
+                    continuation.resume(returning: result)
+                    box.delegate = nil
+                }
+                box.delegate?.armTimeout(seconds: 0.01)
+            }
+        }
 
         switch result {
-        case let .failure(error as URLError)?:
+        case let .failure(error as URLError):
             #expect(error.code == .timedOut)
         default:
             #expect(Bool(false))


### PR DESCRIPTION
Keep dashboard usage day keys local and harden the flaky async Claude/OpenAI Web tests.\n\nValidation: pnpm check, swift test.