### PR TITLE
Avoid false signed-out detection on MiniMax coding-plan shell pages

### DIFF
--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -320,8 +320,27 @@ public struct MiniMaxUsageFetcher: Sendable {
     }
 
     private static func looksSignedOut(html: String) -> Bool {
-        let lower = html.lowercased()
+        let lower = self.visibleText(from: html).lowercased()
         return lower.contains("sign in") || lower.contains("log in") || lower.contains("登录") || lower.contains("登入")
+    }
+
+    private static func visibleText(from html: String) -> String {
+        let patterns = [
+            #"(?is)<script\b[^>]*>.*?</script>"#,
+            #"(?is)<style\b[^>]*>.*?</style>"#,
+            #"(?is)<!--.*?-->"#,
+            #"<[^>]+>"#,
+            #"\s+"#,
+        ]
+
+        return patterns.enumerated().reduce(html) { result, item in
+            let replacement = item.offset == patterns.count - 1 ? " " : ""
+            return result.replacingOccurrences(
+                of: item.element,
+                with: replacement,
+                options: .regularExpression)
+        }
+        .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 

--- a/Tests/CodexBarTests/MiniMaxProviderTests.swift
+++ b/Tests/CodexBarTests/MiniMaxProviderTests.swift
@@ -318,3 +318,124 @@ struct MiniMaxAPIRegionTests {
         #expect(origin.absoluteString == "https://api.minimaxi.com")
     }
 }
+
+@Suite(.serialized)
+struct MiniMaxWebFetchTests {
+    @Test
+    func ignoresLoginStringsInsideScriptDataAndFallsBackToRemainsAPI() async throws {
+        let registered = URLProtocol.registerClass(MiniMaxWebFetchStubURLProtocol.self)
+        defer {
+            if registered {
+                URLProtocol.unregisterClass(MiniMaxWebFetchStubURLProtocol.self)
+            }
+            MiniMaxWebFetchStubURLProtocol.handler = nil
+            MiniMaxWebFetchStubURLProtocol.requests = []
+        }
+
+        MiniMaxWebFetchStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            switch url.path {
+            case "/user-center/payment/coding-plan":
+                let html = """
+                <html>
+                  <body><div id="__next"></div></body>
+                  <script id="__NEXT_DATA__" type="application/json">
+                    {"props":{"pageProps":{"_nextI18Next":{"initialI18nStore":{"zh":{"common":{"landing_common_login":"登录"}}}}}}
+                  </script>
+                </html>
+                """
+                return Self.makeHTMLResponse(url: url, body: html)
+            case "/v1/api/openplatform/coding_plan/remains":
+                let start = 1_700_000_000_000
+                let end = start + 5 * 60 * 60 * 1000
+                let body = """
+                {
+                  "base_resp": { "status_code": 0 },
+                  "current_subscribe_title": "Tag",
+                  "model_remains": [
+                    {
+                      "current_interval_total_count": 1000,
+                      "current_interval_usage_count": 1000,
+                      "start_time": \(start),
+                      "end_time": \(end),
+                      "remains_time": 240000
+                    }
+                  ]
+                }
+                """
+                return Self.makeJSONResponse(url: url, body: body)
+            default:
+                return Self.makeHTMLResponse(url: url, body: "", statusCode: 404)
+            }
+        }
+
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = try await MiniMaxUsageFetcher.fetchUsage(
+            cookieHeader: "HERTZ-SESSION=test-session",
+            region: .chinaMainland,
+            now: now)
+
+        #expect(snapshot.planName == "Tag")
+        #expect(MiniMaxWebFetchStubURLProtocol.requests.count == 2)
+        #expect(MiniMaxWebFetchStubURLProtocol.requests.first?.url?.path == "/user-center/payment/coding-plan")
+        #expect(MiniMaxWebFetchStubURLProtocol.requests.last?.url?.path == "/v1/api/openplatform/coding_plan/remains")
+    }
+
+    private static func makeHTMLResponse(
+        url: URL,
+        body: String,
+        statusCode: Int = 200) -> (HTTPURLResponse, Data)
+    {
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "text/html; charset=utf-8"])!
+        return (response, Data(body.utf8))
+    }
+
+    private static func makeJSONResponse(
+        url: URL,
+        body: String,
+        statusCode: Int = 200) -> (HTTPURLResponse, Data)
+    {
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": "application/json"])!
+        return (response, Data(body.utf8))
+    }
+}
+
+final class MiniMaxWebFetchStubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var requests: [URLRequest] = []
+
+    override static func canInit(with request: URLRequest) -> Bool {
+        guard let host = request.url?.host else { return false }
+        return host == "platform.minimaxi.com" || host == "platform.minimax.io"
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.requests.append(self.request)
+        guard let handler = Self.handler else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(self.request)
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            self.client?.urlProtocol(self, didLoad: data)
+            self.client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            self.client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}


### PR DESCRIPTION
## Summary
- fix the existing MiniMax web fetch path so shell pages are not misclassified as signed out just because login strings appear inside script/style payloads
- strip non-visible HTML content before checking for `sign in` / `log in` / `登录` / `登入`
- add a MiniMax web fetch regression test that exercises the fallback from a `__NEXT_DATA__` shell page to the remains API

## Scope
This PR does not add MiniMax support as a new provider.
It fixes the MiniMax web-fetch path that already exists in the current upstream codebase.

## Why
MiniMax's current Coding Plan page can return an SSR shell where login-related translation strings live inside `__NEXT_DATA__`, even though the page is not actually the sign-in screen. The previous raw-string check saw `登录` in the script payload and returned `invalidCredentials` before the fetcher could fall back to `coding_plan/remains`.

## Validation
- reproduced locally with a live MiniMax web session and confirmed the old logic returned `MiniMax credentials are invalid or expired`
- verified the patched local build successfully reports MiniMax usage again from the web source
- attempted `swift test --disable-experimental-prebuilts --filter MiniMax` on a clean local checkout; that run is currently blocked here by an unrelated `KeyboardShortcuts` `#Preview` macro build issue, not by this diff
