### PR TITLE
Generalize provider usage bucket groups

### DIFF
--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -52,9 +52,24 @@ struct UsageMenuCardView: View {
         }
 
         struct MetricGroup: Identifiable {
+            enum Kind {
+                case builtInPrimary
+                case providerBucket
+            }
+
             let id: String
             let title: String?
+            let kind: Kind
             let metrics: [Metric]
+
+            var internalID: String {
+                switch self.kind {
+                case .builtInPrimary:
+                    "builtInPrimary"
+                case .providerBucket:
+                    "providerBucket:\(self.id)"
+                }
+            }
         }
 
         enum SubtitleStyle {
@@ -98,6 +113,7 @@ struct UsageMenuCardView: View {
     let model: Model
     let width: CGFloat
     @Environment(\.menuItemHighlighted) private var isHighlighted
+    private static let builtInPrimaryMetricGroupID = "__builtInPrimary"
 
     static func popupMetricTitle(provider: UsageProvider, metric: Model.Metric) -> String {
         if provider == .openrouter, metric.id == "primary" {
@@ -111,7 +127,11 @@ struct UsageMenuCardView: View {
         var groups: [Model.MetricGroup] = []
         let primaryMetrics = metrics.filter { $0.groupID == nil }
         if !primaryMetrics.isEmpty {
-            groups.append(.init(id: "primary", title: nil, metrics: primaryMetrics))
+            groups.append(.init(
+                id: self.builtInPrimaryMetricGroupID,
+                title: nil,
+                kind: .builtInPrimary,
+                metrics: primaryMetrics))
         }
 
         var supplementalGroups: [String: [Model.Metric]] = [:]
@@ -126,18 +146,30 @@ struct UsageMenuCardView: View {
 
         for groupID in supplementalOrder {
             guard let metrics = supplementalGroups[groupID], !metrics.isEmpty else { continue }
-            groups.append(.init(id: groupID, title: metrics.first?.groupTitle, metrics: metrics))
+            groups.append(.init(
+                id: groupID,
+                title: metrics.first?.groupTitle,
+                kind: .providerBucket,
+                metrics: metrics))
         }
 
         return groups
     }
 
     static func primaryMetricGroup(metrics: [Model.Metric]) -> Model.MetricGroup? {
-        self.metricGroups(metrics: metrics).first { $0.id == "primary" }
+        self.metricGroups(metrics: metrics).first { $0.kind == .builtInPrimary }
     }
 
     static func supplementalMetricGroups(metrics: [Model.Metric]) -> [Model.MetricGroup] {
-        self.metricGroups(metrics: metrics).filter { $0.id != "primary" }
+        self.metricGroups(metrics: metrics).filter { $0.kind == .providerBucket }
+    }
+
+    static func emptyPrimaryMetricGroup() -> Model.MetricGroup {
+        .init(
+            id: self.builtInPrimaryMetricGroupID,
+            title: nil,
+            kind: .builtInPrimary,
+            metrics: [])
     }
 
     static func displayMetricTitle(provider: UsageProvider, metric: Model.Metric) -> String {
@@ -173,7 +205,7 @@ struct UsageMenuCardView: View {
                 VStack(alignment: .leading, spacing: 12) {
                     if hasUsage {
                         VStack(alignment: .leading, spacing: 12) {
-                            ForEach(Array(metricGroups.enumerated()), id: \.element.id) { index, group in
+                            ForEach(Array(metricGroups.enumerated()), id: \.element.internalID) { index, group in
                                 if index > 0 {
                                     Divider()
                                 }
@@ -505,7 +537,7 @@ struct UsageMenuCardUsageSectionView: View {
                         .font(.subheadline)
                 }
             } else {
-                ForEach(Array(metricGroups.enumerated()), id: \.element.id) { index, group in
+                ForEach(Array(metricGroups.enumerated()), id: \.element.internalID) { index, group in
                     if index > 0 {
                         Divider()
                     }

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -2,6 +2,14 @@ import AppKit
 import CodexBarCore
 import SwiftUI
 
+extension View {
+    fileprivate func menuCardSectionTitleStyle() -> some View {
+        self
+            .font(.body)
+            .fontWeight(.medium)
+    }
+}
+
 /// SwiftUI card used inside the NSMenu to mirror Apple's rich menu panels.
 struct UsageMenuCardView: View {
     struct Model {
@@ -27,6 +35,8 @@ struct UsageMenuCardView: View {
         struct Metric: Identifiable {
             let id: String
             let title: String
+            let groupID: String?
+            let groupTitle: String?
             let percent: Double
             let percentStyle: PercentStyle
             let resetText: String?
@@ -39,6 +49,12 @@ struct UsageMenuCardView: View {
             var percentLabel: String {
                 String(format: "%.0f%% %@", self.percent, self.percentStyle.labelSuffix)
             }
+        }
+
+        struct MetricGroup: Identifiable {
+            let id: String
+            let title: String?
+            let metrics: [Metric]
         }
 
         enum SubtitleStyle {
@@ -90,6 +106,47 @@ struct UsageMenuCardView: View {
         return metric.title
     }
 
+    static func metricGroups(metrics: [Model.Metric]) -> [Model.MetricGroup] {
+        guard !metrics.isEmpty else { return [] }
+        var groups: [Model.MetricGroup] = []
+        let primaryMetrics = metrics.filter { $0.groupID == nil }
+        if !primaryMetrics.isEmpty {
+            groups.append(.init(id: "primary", title: nil, metrics: primaryMetrics))
+        }
+
+        var supplementalGroups: [String: [Model.Metric]] = [:]
+        var supplementalOrder: [String] = []
+        for metric in metrics {
+            guard let groupID = metric.groupID else { continue }
+            if supplementalGroups[groupID] == nil {
+                supplementalOrder.append(groupID)
+            }
+            supplementalGroups[groupID, default: []].append(metric)
+        }
+
+        for groupID in supplementalOrder {
+            guard let metrics = supplementalGroups[groupID], !metrics.isEmpty else { continue }
+            groups.append(.init(id: groupID, title: metrics.first?.groupTitle, metrics: metrics))
+        }
+
+        return groups
+    }
+
+    static func primaryMetricGroup(metrics: [Model.Metric]) -> Model.MetricGroup? {
+        self.metricGroups(metrics: metrics).first { $0.id == "primary" }
+    }
+
+    static func supplementalMetricGroups(metrics: [Model.Metric]) -> [Model.MetricGroup] {
+        self.metricGroups(metrics: metrics).filter { $0.id != "primary" }
+    }
+
+    static func displayMetricTitle(provider: UsageProvider, metric: Model.Metric) -> String {
+        if provider == .openrouter, metric.id == "primary" {
+            return "API key limit"
+        }
+        return metric.title
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             UsageMenuCardHeaderView(model: self.model)
@@ -111,15 +168,29 @@ struct UsageMenuCardView: View {
                 let hasCredits = self.model.creditsText != nil
                 let hasProviderCost = self.model.providerCost != nil
                 let hasCost = self.model.tokenUsage != nil || hasProviderCost
+                let metricGroups = Self.metricGroups(metrics: self.model.metrics)
 
                 VStack(alignment: .leading, spacing: 12) {
                     if hasUsage {
                         VStack(alignment: .leading, spacing: 12) {
-                            ForEach(self.model.metrics, id: \.id) { metric in
-                                MetricRow(
-                                    metric: metric,
-                                    title: Self.popupMetricTitle(provider: self.model.provider, metric: metric),
-                                    progressColor: self.model.progressColor)
+                            ForEach(Array(metricGroups.enumerated()), id: \.element.id) { index, group in
+                                if index > 0 {
+                                    Divider()
+                                }
+                                VStack(alignment: .leading, spacing: 12) {
+                                    if let title = group.title {
+                                        Text(title)
+                                            .menuCardSectionTitleStyle()
+                                    }
+                                    ForEach(group.metrics, id: \.id) { metric in
+                                        MetricRow(
+                                            metric: metric,
+                                            title: Self.displayMetricTitle(
+                                                provider: self.model.provider,
+                                                metric: metric),
+                                            progressColor: self.model.progressColor)
+                                    }
+                                }
                             }
                             if !self.model.usageNotes.isEmpty {
                                 UsageNotesContent(notes: self.model.usageNotes)
@@ -301,8 +372,7 @@ private struct ProviderCostContent: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(self.section.title)
-                .font(.body)
-                .fontWeight(.medium)
+                .menuCardSectionTitleStyle()
             UsageProgressBar(
                 percent: self.section.percentUsed,
                 tint: self.progressColor,
@@ -328,8 +398,7 @@ private struct MetricRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(self.title)
-                .font(.body)
-                .fontWeight(.medium)
+                .menuCardSectionTitleStyle()
             UsageProgressBar(
                 percent: self.metric.percent,
                 tint: self.progressColor,
@@ -425,6 +494,7 @@ struct UsageMenuCardUsageSectionView: View {
     @Environment(\.menuItemHighlighted) private var isHighlighted
 
     var body: some View {
+        let metricGroups = UsageMenuCardView.metricGroups(metrics: self.model.metrics)
         VStack(alignment: .leading, spacing: 12) {
             if self.model.metrics.isEmpty {
                 if !self.model.usageNotes.isEmpty {
@@ -435,11 +505,24 @@ struct UsageMenuCardUsageSectionView: View {
                         .font(.subheadline)
                 }
             } else {
-                ForEach(self.model.metrics, id: \.id) { metric in
-                    MetricRow(
-                        metric: metric,
-                        title: UsageMenuCardView.popupMetricTitle(provider: self.model.provider, metric: metric),
-                        progressColor: self.model.progressColor)
+                ForEach(Array(metricGroups.enumerated()), id: \.element.id) { index, group in
+                    if index > 0 {
+                        Divider()
+                    }
+                    VStack(alignment: .leading, spacing: 12) {
+                        if let title = group.title {
+                            Text(title)
+                                .menuCardSectionTitleStyle()
+                        }
+                        ForEach(group.metrics, id: \.id) { metric in
+                            MetricRow(
+                                metric: metric,
+                                title: UsageMenuCardView.displayMetricTitle(
+                                    provider: self.model.provider,
+                                    metric: metric),
+                                progressColor: self.model.progressColor)
+                        }
+                    }
                 }
                 if !self.model.usageNotes.isEmpty {
                     UsageNotesContent(notes: self.model.usageNotes)
@@ -451,6 +534,52 @@ struct UsageMenuCardUsageSectionView: View {
         }
         .padding(.horizontal, 16)
         .padding(.top, 10)
+        .padding(.bottom, self.bottomPadding)
+        .frame(width: self.width, alignment: .leading)
+    }
+}
+
+struct UsageMenuCardMetricGroupSectionView: View {
+    let provider: UsageProvider
+    let group: UsageMenuCardView.Model.MetricGroup
+    let usageNotes: [String]
+    let placeholder: String?
+    let topPadding: CGFloat
+    let bottomPadding: CGFloat
+    let width: CGFloat
+    let progressColor: Color
+    @Environment(\.menuItemHighlighted) private var isHighlighted
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let title = self.group.title {
+                Text(title)
+                    .menuCardSectionTitleStyle()
+            }
+            if self.group.metrics.isEmpty {
+                if !self.usageNotes.isEmpty {
+                    UsageNotesContent(notes: self.usageNotes)
+                } else if let placeholder = self.placeholder {
+                    Text(placeholder)
+                        .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                        .font(.subheadline)
+                }
+            } else {
+                ForEach(self.group.metrics, id: \.id) { metric in
+                    MetricRow(
+                        metric: metric,
+                        title: UsageMenuCardView.displayMetricTitle(
+                            provider: self.provider,
+                            metric: metric),
+                        progressColor: self.progressColor)
+                }
+                if !self.usageNotes.isEmpty {
+                    UsageNotesContent(notes: self.usageNotes)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, self.topPadding)
         .padding(.bottom, self.bottomPadding)
         .frame(width: self.width, alignment: .leading)
     }
@@ -508,8 +637,7 @@ private struct CreditsBarContent: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             Text("Credits")
-                .font(.body)
-                .fontWeight(.medium)
+                .menuCardSectionTitleStyle()
             if let percentLeft {
                 UsageProgressBar(
                     percent: percentLeft,
@@ -924,6 +1052,8 @@ extension UsageMenuCardView.Model {
             metrics.append(Metric(
                 id: "primary",
                 title: input.metadata.sessionLabel,
+                groupID: nil,
+                groupTitle: nil,
                 percent: Self.clamped(
                     input.usageBarsShowUsed ? primary.usedPercent : primary.remainingPercent),
                 percentStyle: percentStyle,
@@ -961,6 +1091,8 @@ extension UsageMenuCardView.Model {
             metrics.append(Metric(
                 id: "secondary",
                 title: input.metadata.weeklyLabel,
+                groupID: nil,
+                groupTitle: nil,
                 percent: Self.clamped(input.usageBarsShowUsed ? weekly.usedPercent : weekly.remainingPercent),
                 percentStyle: percentStyle,
                 resetText: weeklyResetText,
@@ -986,6 +1118,8 @@ extension UsageMenuCardView.Model {
             metrics.append(Metric(
                 id: "tertiary",
                 title: input.metadata.opusLabel ?? "Sonnet",
+                groupID: nil,
+                groupTitle: nil,
                 percent: Self.clamped(input.usageBarsShowUsed ? opus.usedPercent : opus.remainingPercent),
                 percentStyle: percentStyle,
                 resetText: Self.resetText(for: opus, style: input.resetTimeDisplayStyle, now: input.now),
@@ -995,12 +1129,32 @@ extension UsageMenuCardView.Model {
                 pacePercent: nil,
                 paceOnTop: true))
         }
+        for bucketGroup in snapshot.usageBucketGroups {
+            for bucket in bucketGroup.buckets {
+                metrics.append(Metric(
+                    id: bucket.id,
+                    title: bucket.title,
+                    groupID: bucketGroup.id,
+                    groupTitle: bucketGroup.title,
+                    percent: Self.clamped(
+                        input.usageBarsShowUsed ? bucket.window.usedPercent : bucket.window.remainingPercent),
+                    percentStyle: percentStyle,
+                    resetText: Self.resetText(for: bucket.window, style: input.resetTimeDisplayStyle, now: input.now),
+                    detailText: nil,
+                    detailLeftText: nil,
+                    detailRightText: nil,
+                    pacePercent: nil,
+                    paceOnTop: true))
+            }
+        }
 
         if input.provider == .codex, let remaining = input.dashboard?.codeReviewRemainingPercent {
             let percent = input.usageBarsShowUsed ? (100 - remaining) : remaining
             metrics.append(Metric(
                 id: "code-review",
                 title: "Code review",
+                groupID: nil,
+                groupTitle: nil,
                 percent: Self.clamped(percent),
                 percentStyle: percentStyle,
                 resetText: nil,

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -179,6 +179,11 @@ struct MenuDescriptor {
                     resetStyle: resetStyle,
                     showUsed: settings.usageBarsShowUsed)
             }
+            Self.appendUsageBucketGroupEntries(
+                entries: &entries,
+                snapshot: snap,
+                resetStyle: resetStyle,
+                showUsed: settings.usageBarsShowUsed)
 
             if let cost = snap.providerCost {
                 if cost.currencyCode == "Quota" {
@@ -405,6 +410,30 @@ struct MenuDescriptor {
             return true
         }
         return false
+    }
+
+    private static func appendUsageBucketGroupEntries(
+        entries: inout [Entry],
+        snapshot: UsageSnapshot,
+        resetStyle: ResetTimeDisplayStyle,
+        showUsed: Bool)
+    {
+        for group in snapshot.usageBucketGroups {
+            guard !group.buckets.isEmpty else { continue }
+            if entries.count > 1 {
+                entries.append(.divider)
+            }
+            entries.append(.text(group.title, .headline))
+
+            for bucket in group.buckets {
+                self.appendRateWindow(
+                    entries: &entries,
+                    title: bucket.title,
+                    window: bucket.window,
+                    resetStyle: resetStyle,
+                    showUsed: showUsed)
+            }
+        }
     }
 
     private static func appendRateWindow(

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -439,7 +439,9 @@ extension StatusItemController {
         }
 
         guard let model = self.menuCardModel(for: context.selectedProvider) else { return false }
-        if context.openAIContext.hasOpenAIWebMenuItems {
+        let supplementalMetricGroups = UsageMenuCardView.supplementalMetricGroups(metrics: model.metrics)
+        let shouldRenderSectionedCard = context.openAIContext.hasOpenAIWebMenuItems || !supplementalMetricGroups.isEmpty
+        if shouldRenderSectionedCard {
             let webItems = OpenAIWebMenuItems(
                 hasUsageBreakdown: context.openAIContext.hasUsageBreakdown,
                 hasCreditsHistory: context.openAIContext.hasCreditsHistory,
@@ -450,7 +452,10 @@ extension StatusItemController {
                 provider: context.currentProvider,
                 width: context.menuWidth,
                 webItems: webItems)
-            return true
+            if !context.openAIContext.hasOpenAIWebMenuItems {
+                menu.addItem(.separator())
+            }
+            return context.openAIContext.hasOpenAIWebMenuItems
         }
 
         menu.addItem(self.makeMenuCardItem(
@@ -841,7 +846,10 @@ extension StatusItemController {
         width: CGFloat,
         webItems: OpenAIWebMenuItems)
     {
-        let hasUsageBlock = !model.metrics.isEmpty || model.placeholder != nil
+        let primaryMetricGroup = UsageMenuCardView.primaryMetricGroup(metrics: model.metrics)
+        let supplementalMetricGroups = UsageMenuCardView.supplementalMetricGroups(metrics: model.metrics)
+        let hasUsageBlock = primaryMetricGroup != nil || !model.usageNotes.isEmpty || model.placeholder != nil
+        let hasSupplementalUsageBlocks = !supplementalMetricGroups.isEmpty
         let hasCredits = model.creditsText != nil
         let hasExtraUsage = model.providerCost != nil
         let hasCost = model.tokenUsage != nil
@@ -852,16 +860,20 @@ extension StatusItemController {
 
         let headerView = UsageMenuCardHeaderSectionView(
             model: model,
-            showDivider: hasUsageBlock,
+            showDivider: hasUsageBlock || hasSupplementalUsageBlocks,
             width: width)
         menu.addItem(self.makeMenuCardItem(headerView, id: "menuCardHeader", width: width))
 
         if hasUsageBlock {
-            let usageView = UsageMenuCardUsageSectionView(
-                model: model,
-                showBottomDivider: false,
+            let usageView = UsageMenuCardMetricGroupSectionView(
+                provider: provider,
+                group: primaryMetricGroup ?? .init(id: "primary", title: nil, metrics: []),
+                usageNotes: model.usageNotes,
+                placeholder: model.placeholder,
+                topPadding: 10,
                 bottomPadding: usageBottomPadding,
-                width: width)
+                width: width,
+                progressColor: model.progressColor)
             let usageSubmenu = self.makeUsageSubmenu(
                 provider: provider,
                 snapshot: self.store.snapshot(for: provider),
@@ -873,14 +885,30 @@ extension StatusItemController {
                 submenu: usageSubmenu))
         }
 
+        for (index, supplementalMetricGroup) in supplementalMetricGroups.enumerated() {
+            if hasUsageBlock || index > 0 {
+                menu.addItem(.separator())
+            }
+            let supplementalView = UsageMenuCardMetricGroupSectionView(
+                provider: provider,
+                group: supplementalMetricGroup,
+                usageNotes: [],
+                placeholder: nil,
+                topPadding: sectionSpacing,
+                bottomPadding: bottomPadding,
+                width: width,
+                progressColor: model.progressColor)
+            menu.addItem(self.makeMenuCardItem(
+                supplementalView,
+                id: "menuCardUsageGroup-\(supplementalMetricGroup.id)",
+                width: width))
+        }
+
         if hasCredits || hasExtraUsage || hasCost {
             menu.addItem(.separator())
         }
 
         if hasCredits {
-            if hasExtraUsage || hasCost {
-                menu.addItem(.separator())
-            }
             let creditsView = UsageMenuCardCreditsSectionView(
                 model: model,
                 showBottomDivider: false,
@@ -897,10 +925,10 @@ extension StatusItemController {
                 menu.addItem(self.makeBuyCreditsItem())
             }
         }
+        if hasCredits, hasExtraUsage || hasCost {
+            menu.addItem(.separator())
+        }
         if hasExtraUsage {
-            if hasCredits {
-                menu.addItem(.separator())
-            }
             let extraUsageView = UsageMenuCardExtraUsageSectionView(
                 model: model,
                 topPadding: sectionSpacing,
@@ -911,10 +939,10 @@ extension StatusItemController {
                 id: "menuCardExtraUsage",
                 width: width))
         }
+        if hasExtraUsage, hasCost {
+            menu.addItem(.separator())
+        }
         if hasCost {
-            if hasCredits || hasExtraUsage {
-                menu.addItem(.separator())
-            }
             let costView = UsageMenuCardCostSectionView(
                 model: model,
                 topPadding: sectionSpacing,

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -867,7 +867,7 @@ extension StatusItemController {
         if hasUsageBlock {
             let usageView = UsageMenuCardMetricGroupSectionView(
                 provider: provider,
-                group: primaryMetricGroup ?? .init(id: "primary", title: nil, metrics: []),
+                group: primaryMetricGroup ?? UsageMenuCardView.emptyPrimaryMetricGroup(),
                 usageNotes: model.usageNotes,
                 placeholder: model.placeholder,
                 topPadding: 10,

--- a/Sources/CodexBarCLI/CLIRenderer.swift
+++ b/Sources/CodexBarCLI/CLIRenderer.swift
@@ -33,6 +33,7 @@ enum CLIRenderer {
             now: now,
             lines: &lines)
         self.appendTertiaryLines(snapshot: snapshot, metadata: meta, context: context, now: now, lines: &lines)
+        self.appendUsageBucketGroupLines(snapshot: snapshot, context: context, now: now, lines: &lines)
         self.appendCreditsLine(provider: provider, credits: credits, useColor: context.useColor, lines: &lines)
         self.appendIdentityAndNotes(
             provider: provider,
@@ -117,6 +118,24 @@ enum CLIRenderer {
         lines.append(self.rateLine(title: metadata.opusLabel ?? "Sonnet", window: opus, useColor: context.useColor))
         if let reset = self.resetLine(for: opus, style: context.resetStyle, now: now) {
             lines.append(self.subtleLine(reset, useColor: context.useColor))
+        }
+    }
+
+    private static func appendUsageBucketGroupLines(
+        snapshot: UsageSnapshot,
+        context: RenderContext,
+        now: Date,
+        lines: inout [String])
+    {
+        for group in snapshot.usageBucketGroups {
+            guard !group.buckets.isEmpty else { continue }
+            lines.append(group.title)
+            for bucket in group.buckets {
+                lines.append(self.rateLine(title: bucket.title, window: bucket.window, useColor: context.useColor))
+                if let reset = self.resetLine(for: bucket.window, style: context.resetStyle, now: now) {
+                    lines.append(self.subtleLine(reset, useColor: context.useColor))
+                }
+            }
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
@@ -6,11 +6,13 @@ import FoundationNetworking
 public struct CodexUsageResponse: Decodable, Sendable {
     public let planType: PlanType?
     public let rateLimit: RateLimitDetails?
+    public let additionalRateLimits: [AdditionalRateLimit]?
     public let credits: CreditDetails?
 
     enum CodingKeys: String, CodingKey {
         case planType = "plan_type"
         case rateLimit = "rate_limit"
+        case additionalRateLimits = "additional_rate_limits"
         case credits
     }
 
@@ -91,6 +93,18 @@ public struct CodexUsageResponse: Decodable, Sendable {
             case usedPercent = "used_percent"
             case resetAt = "reset_at"
             case limitWindowSeconds = "limit_window_seconds"
+        }
+    }
+
+    public struct AdditionalRateLimit: Decodable, Sendable {
+        public let limitName: String?
+        public let meteredFeature: String?
+        public let rateLimit: RateLimitDetails?
+
+        enum CodingKeys: String, CodingKey {
+            case limitName = "limit_name"
+            case meteredFeature = "metered_feature"
+            case rateLimit = "rate_limit"
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -164,6 +164,7 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
     private static func mapUsage(_ response: CodexUsageResponse, credentials: CodexOAuthCredentials) -> UsageSnapshot {
         let primary = Self.makeWindow(response.rateLimit?.primaryWindow)
         let secondary = Self.makeWindow(response.rateLimit?.secondaryWindow)
+        let usageBucketGroups = Self.makeUsageBucketGroups(response.additionalRateLimits)
 
         let identity = ProviderIdentitySnapshot(
             providerID: .codex,
@@ -175,6 +176,7 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
             primary: primary ?? RateWindow(usedPercent: 0, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
             secondary: secondary,
             tertiary: nil,
+            usageBucketGroups: usageBucketGroups,
             updatedAt: Date(),
             identity: identity)
     }
@@ -193,6 +195,36 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
             windowMinutes: window.limitWindowSeconds / 60,
             resetsAt: resetDate,
             resetDescription: resetDescription)
+    }
+
+    private static func makeUsageBucketGroups(
+        _ rateLimits: [CodexUsageResponse.AdditionalRateLimit]?) -> [UsageBucketGroupSnapshot]
+    {
+        guard let sparkRateLimit = rateLimits?.first(where: self.isSparkRateLimit) else { return [] }
+        let session = self.makeWindow(sparkRateLimit.rateLimit?.primaryWindow)
+        let weekly = self.makeWindow(sparkRateLimit.rateLimit?.secondaryWindow)
+        var buckets: [UsageBucketSnapshot] = []
+        if let session {
+            buckets.append(UsageBucketSnapshot(id: "codex.spark.session", title: "Session", window: session))
+        }
+        if let weekly {
+            buckets.append(UsageBucketSnapshot(id: "codex.spark.weekly", title: "Weekly", window: weekly))
+        }
+        guard !buckets.isEmpty else { return [] }
+        return [UsageBucketGroupSnapshot(
+            id: "codex.spark",
+            title: "GPT-5.3-Codex-Spark",
+            buckets: buckets)]
+    }
+
+    private static func isSparkRateLimit(_ rateLimit: CodexUsageResponse.AdditionalRateLimit) -> Bool {
+        let limitName = rateLimit.limitName?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if limitName == "gpt-5.3-codex-spark" {
+            return true
+        }
+
+        let meteredFeature = rateLimit.meteredFeature?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return meteredFeature == "codex_bengalfox"
     }
 
     private static func resolveAccountEmail(from credentials: CodexOAuthCredentials) -> String? {

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -19,6 +19,30 @@ public struct RateWindow: Codable, Equatable, Sendable {
     }
 }
 
+public struct UsageBucketSnapshot: Codable, Equatable, Sendable {
+    public let id: String
+    public let title: String
+    public let window: RateWindow
+
+    public init(id: String, title: String, window: RateWindow) {
+        self.id = id
+        self.title = title
+        self.window = window
+    }
+}
+
+public struct UsageBucketGroupSnapshot: Codable, Equatable, Sendable {
+    public let id: String
+    public let title: String
+    public let buckets: [UsageBucketSnapshot]
+
+    public init(id: String, title: String, buckets: [UsageBucketSnapshot]) {
+        self.id = id
+        self.title = title
+        self.buckets = buckets
+    }
+}
+
 public struct ProviderIdentitySnapshot: Codable, Sendable {
     public let providerID: UsageProvider?
     public let accountEmail: String?
@@ -51,6 +75,7 @@ public struct UsageSnapshot: Codable, Sendable {
     public let primary: RateWindow?
     public let secondary: RateWindow?
     public let tertiary: RateWindow?
+    public let usageBucketGroups: [UsageBucketGroupSnapshot]
     public let providerCost: ProviderCostSnapshot?
     public let zaiUsage: ZaiUsageSnapshot?
     public let minimaxUsage: MiniMaxUsageSnapshot?
@@ -63,6 +88,7 @@ public struct UsageSnapshot: Codable, Sendable {
         case primary
         case secondary
         case tertiary
+        case usageBucketGroups
         case providerCost
         case openRouterUsage
         case updatedAt
@@ -76,6 +102,7 @@ public struct UsageSnapshot: Codable, Sendable {
         primary: RateWindow?,
         secondary: RateWindow?,
         tertiary: RateWindow? = nil,
+        usageBucketGroups: [UsageBucketGroupSnapshot] = [],
         providerCost: ProviderCostSnapshot? = nil,
         zaiUsage: ZaiUsageSnapshot? = nil,
         minimaxUsage: MiniMaxUsageSnapshot? = nil,
@@ -87,6 +114,7 @@ public struct UsageSnapshot: Codable, Sendable {
         self.primary = primary
         self.secondary = secondary
         self.tertiary = tertiary
+        self.usageBucketGroups = Self.normalizedUsageBucketGroups(usageBucketGroups)
         self.providerCost = providerCost
         self.zaiUsage = zaiUsage
         self.minimaxUsage = minimaxUsage
@@ -101,6 +129,10 @@ public struct UsageSnapshot: Codable, Sendable {
         self.primary = try container.decodeIfPresent(RateWindow.self, forKey: .primary)
         self.secondary = try container.decodeIfPresent(RateWindow.self, forKey: .secondary)
         self.tertiary = try container.decodeIfPresent(RateWindow.self, forKey: .tertiary)
+        let decodedUsageBucketGroups = try container.decodeIfPresent(
+            [UsageBucketGroupSnapshot].self,
+            forKey: .usageBucketGroups) ?? []
+        self.usageBucketGroups = Self.normalizedUsageBucketGroups(decodedUsageBucketGroups)
         self.providerCost = try container.decodeIfPresent(ProviderCostSnapshot.self, forKey: .providerCost)
         self.zaiUsage = nil // Not persisted, fetched fresh each time
         self.minimaxUsage = nil // Not persisted, fetched fresh each time
@@ -131,6 +163,7 @@ public struct UsageSnapshot: Codable, Sendable {
         try container.encode(self.primary, forKey: .primary)
         try container.encode(self.secondary, forKey: .secondary)
         try container.encode(self.tertiary, forKey: .tertiary)
+        try container.encode(self.usageBucketGroups, forKey: .usageBucketGroups)
         try container.encodeIfPresent(self.providerCost, forKey: .providerCost)
         try container.encodeIfPresent(self.openRouterUsage, forKey: .openRouterUsage)
         try container.encode(self.updatedAt, forKey: .updatedAt)
@@ -184,6 +217,7 @@ public struct UsageSnapshot: Codable, Sendable {
             primary: self.primary,
             secondary: self.secondary,
             tertiary: self.tertiary,
+            usageBucketGroups: self.usageBucketGroups,
             providerCost: self.providerCost,
             zaiUsage: self.zaiUsage,
             minimaxUsage: self.minimaxUsage,
@@ -198,6 +232,16 @@ public struct UsageSnapshot: Codable, Sendable {
         let scopedIdentity = identity.scoped(to: provider)
         if scopedIdentity.providerID == identity.providerID { return self }
         return self.withIdentity(scopedIdentity)
+    }
+
+    private static func normalizedUsageBucketGroups(
+        _ groups: [UsageBucketGroupSnapshot]) -> [UsageBucketGroupSnapshot]
+    {
+        groups.compactMap { group in
+            let buckets = group.buckets.filter { !$0.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            guard !buckets.isEmpty else { return nil }
+            return UsageBucketGroupSnapshot(id: group.id, title: group.title, buckets: buckets)
+        }
     }
 }
 

--- a/Tests/CodexBarTests/CLISnapshotTests.swift
+++ b/Tests/CodexBarTests/CLISnapshotTests.swift
@@ -44,6 +44,66 @@ struct CLISnapshotTests {
     }
 
     @Test
+    func rendersSparkSectionForCodexWhenLiveSparkUsageExists() {
+        let now = Date(timeIntervalSince1970: 0)
+        let snap = UsageSnapshot(
+            primary: .init(
+                usedPercent: 12,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: "today at 3:00 PM"),
+            secondary: .init(
+                usedPercent: 25,
+                windowMinutes: 10080,
+                resetsAt: nil,
+                resetDescription: "Fri at 9:00 AM"),
+            usageBucketGroups: [
+                UsageBucketGroupSnapshot(
+                    id: "codex.spark",
+                    title: "GPT-5.3-Codex-Spark",
+                    buckets: [
+                        UsageBucketSnapshot(
+                            id: "codex.spark.session",
+                            title: "Session",
+                            window: .init(
+                                usedPercent: 3,
+                                windowMinutes: 300,
+                                resetsAt: now.addingTimeInterval(900),
+                                resetDescription: nil)),
+                        UsageBucketSnapshot(
+                            id: "codex.spark.weekly",
+                            title: "Weekly",
+                            window: .init(
+                                usedPercent: 17,
+                                windowMinutes: 10080,
+                                resetsAt: now.addingTimeInterval(1200),
+                                resetDescription: nil)),
+                    ]),
+            ],
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "user@example.com",
+                accountOrganization: nil,
+                loginMethod: nil))
+
+        let output = CLIRenderer.renderText(
+            provider: .codex,
+            snapshot: snap,
+            credits: nil,
+            context: RenderContext(
+                header: "Codex 1.2.3 (oauth)",
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown))
+
+        #expect(output.contains("GPT-5.3-Codex-Spark"))
+        #expect(output.contains("Session: 97% left"))
+        #expect(output.contains("Weekly: 83% left"))
+        #expect(output.contains("Plan:") == false)
+    }
+
+    @Test
     func rendersTextSnapshotForClaudeWithoutWeekly() {
         let snap = UsageSnapshot(
             primary: .init(usedPercent: 2, windowMinutes: nil, resetsAt: nil, resetDescription: "3pm (Europe/Vienna)"),
@@ -246,6 +306,47 @@ struct CLISnapshotTests {
     }
 
     @Test
+    func usageSnapshotRoundTripsUsageBucketGroups() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = UsageSnapshot(
+            primary: .init(usedPercent: 50, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            usageBucketGroups: [
+                UsageBucketGroupSnapshot(
+                    id: "codex.spark",
+                    title: "GPT-5.3-Codex-Spark",
+                    buckets: [
+                        UsageBucketSnapshot(
+                            id: "codex.spark.session",
+                            title: "Session",
+                            window: .init(
+                                usedPercent: 3,
+                                windowMinutes: 300,
+                                resetsAt: now.addingTimeInterval(900),
+                                resetDescription: nil)),
+                    ]),
+                UsageBucketGroupSnapshot(
+                    id: "empty.group",
+                    title: "Empty",
+                    buckets: []),
+            ],
+            updatedAt: now)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .secondsSince1970
+        let data = try encoder.encode(snapshot)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        let decoded = try decoder.decode(UsageSnapshot.self, from: data)
+
+        #expect(decoded.usageBucketGroups.count == 1)
+        #expect(decoded.usageBucketGroups.first?.id == "codex.spark")
+        #expect(decoded.usageBucketGroups.first?.buckets.map(\.id) == ["codex.spark.session"])
+    }
+
+    @Test
     func rendersJSONPayload() throws {
         let snap = UsageSnapshot(
             primary: .init(usedPercent: 50, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
@@ -282,6 +383,7 @@ struct CLISnapshotTests {
         #expect(json.contains("status.example.com"))
         #expect(json.contains("\"primary\""))
         #expect(json.contains("\"windowMinutes\":300"))
+        #expect(json.contains("\"usageBucketGroups\":[]"))
         #expect(json.contains("1700000000"))
     }
 
@@ -302,6 +404,7 @@ struct CLISnapshotTests {
         }
 
         #expect(json.contains("\"secondary\":null"))
+        #expect(json.contains("\"usageBucketGroups\":[]"))
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexOAuthTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthTests.swift
@@ -100,6 +100,100 @@ struct CodexOAuthTests {
     }
 
     @Test
+    func mapsCodexSparkWindowsFromOAuthAdditionalRateLimits() throws {
+        let json = """
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 22,
+              "reset_at": 1766948068,
+              "limit_window_seconds": 18000
+            },
+            "secondary_window": {
+              "used_percent": 43,
+              "reset_at": 1767407914,
+              "limit_window_seconds": 604800
+            }
+          },
+          "additional_rate_limits": [
+            {
+              "limit_name": "GPT-5.3-Codex-Spark",
+              "metered_feature": "codex_bengalfox",
+              "rate_limit": {
+                "primary_window": {
+                  "used_percent": 3,
+                  "reset_at": 1766948068,
+                  "limit_window_seconds": 18000
+                },
+                "secondary_window": {
+                  "used_percent": 17,
+                  "reset_at": 1767407914,
+                  "limit_window_seconds": 604800
+                }
+              }
+            }
+          ]
+        }
+        """
+        let creds = CodexOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: nil,
+            accountId: nil,
+            lastRefresh: Date())
+        let snapshot = try CodexOAuthFetchStrategy._mapUsageForTesting(Data(json.utf8), credentials: creds)
+        #expect(snapshot.primary?.usedPercent == 22)
+        #expect(snapshot.secondary?.usedPercent == 43)
+        #expect(snapshot.usageBucketGroups.count == 1)
+        let sparkGroup = try #require(snapshot.usageBucketGroups.first)
+        #expect(sparkGroup.id == "codex.spark")
+        #expect(sparkGroup.title == "GPT-5.3-Codex-Spark")
+        #expect(sparkGroup.buckets.map(\.id) == ["codex.spark.session", "codex.spark.weekly"])
+        #expect(sparkGroup.buckets.map(\.title) == ["Session", "Weekly"])
+        #expect(sparkGroup.buckets.first?.window.usedPercent == 3)
+        #expect(sparkGroup.buckets.first?.window.windowMinutes == 300)
+        #expect(sparkGroup.buckets.last?.window.usedPercent == 17)
+        #expect(sparkGroup.buckets.last?.window.windowMinutes == 10080)
+    }
+
+    @Test
+    func ignoresUnrelatedOAuthAdditionalRateLimitsWhenSparkAbsent() throws {
+        let json = """
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 22,
+              "reset_at": 1766948068,
+              "limit_window_seconds": 18000
+            }
+          },
+          "additional_rate_limits": [
+            {
+              "limit_name": "Something else",
+              "metered_feature": "codex_something_else",
+              "rate_limit": {
+                "secondary_window": {
+                  "used_percent": 88,
+                  "reset_at": 1767407914,
+                  "limit_window_seconds": 604800
+                }
+              }
+            }
+          ]
+        }
+        """
+        let creds = CodexOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: nil,
+            accountId: nil,
+            lastRefresh: Date())
+        let snapshot = try CodexOAuthFetchStrategy._mapUsageForTesting(Data(json.utf8), credentials: creds)
+        #expect(snapshot.primary?.usedPercent == 22)
+        #expect(snapshot.usageBucketGroups.isEmpty)
+    }
+
+    @Test
     func resolvesChatGPTUsageURLFromConfig() {
         let config = "chatgpt_base_url = \"https://chatgpt.com/backend-api/\"\n"
         let url = CodexOAuthUsageFetcher._resolveUsageURLForTesting(configContents: config)

--- a/Tests/CodexBarTests/MenuCardModelSparkTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelSparkTests.swift
@@ -1,0 +1,123 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite
+struct MenuCardModelSparkTests {
+    @Test
+    func showsSparkSessionAndWeeklyMetricsWhenCodexSparkUsagePresent() throws {
+        let now = Date()
+        let metadata = try #require(ProviderDefaults.metadata[.codex])
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 22,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(3000),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 40,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(6000),
+                resetDescription: nil),
+            usageBucketGroups: [
+                UsageBucketGroupSnapshot(
+                    id: "codex.spark",
+                    title: "GPT-5.3-Codex-Spark",
+                    buckets: [
+                        UsageBucketSnapshot(
+                            id: "codex.spark.session",
+                            title: "Session",
+                            window: RateWindow(
+                                usedPercent: 3,
+                                windowMinutes: 300,
+                                resetsAt: now.addingTimeInterval(5400),
+                                resetDescription: nil)),
+                        UsageBucketSnapshot(
+                            id: "codex.spark.weekly",
+                            title: "Weekly",
+                            window: RateWindow(
+                                usedPercent: 17,
+                                windowMinutes: 10080,
+                                resetsAt: now.addingTimeInterval(7200),
+                                resetDescription: nil)),
+                    ]),
+            ],
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "codex@example.com",
+                accountOrganization: nil,
+                loginMethod: nil))
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .codex,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: "codex@example.com", plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.metrics.count == 4)
+        #expect(model.metrics.contains { $0.id == "codex.spark.session" && $0.title == "Session" && $0.percent == 97 })
+        #expect(model.metrics.contains { $0.id == "codex.spark.weekly" && $0.title == "Weekly" && $0.percent == 83 })
+
+        let groups = UsageMenuCardView.metricGroups(metrics: model.metrics)
+        #expect(groups.count == 2)
+        let sparkGroup = try #require(groups.last)
+        #expect(sparkGroup.id == "codex.spark")
+        #expect(sparkGroup.title == "GPT-5.3-Codex-Spark")
+        #expect(sparkGroup.metrics.map(\.id) == ["codex.spark.session", "codex.spark.weekly"])
+    }
+
+    @Test
+    func doesNotCreateSupplementalGroupWithoutUsageBucketGroups() throws {
+        let now = Date()
+        let metadata = try #require(ProviderDefaults.metadata[.codex])
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 22, windowMinutes: 300, resetsAt: now, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 40, windowMinutes: 10080, resetsAt: now, resetDescription: nil),
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "codex@example.com",
+                accountOrganization: nil,
+                loginMethod: "Pro"))
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .codex,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: "codex@example.com", plan: "Pro"),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(UsageMenuCardView.metricGroups(metrics: model.metrics).count == 1)
+        #expect(model.metrics.contains { $0.groupID != nil } == false)
+    }
+}

--- a/Tests/CodexBarTests/MenuCardModelSparkTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelSparkTests.swift
@@ -120,4 +120,114 @@ struct MenuCardModelSparkTests {
         #expect(UsageMenuCardView.metricGroups(metrics: model.metrics).count == 1)
         #expect(model.metrics.contains { $0.groupID != nil } == false)
     }
+
+    @Test
+    func preservesProviderOwnedPrimaryBucketGroupAlongsideBuiltInPrimaryGroup() throws {
+        let now = Date()
+        let metadata = try #require(ProviderDefaults.metadata[.codex])
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 22, windowMinutes: 300, resetsAt: now, resetDescription: nil),
+            secondary: nil,
+            usageBucketGroups: [
+                UsageBucketGroupSnapshot(
+                    id: "primary",
+                    title: "Provider Primary",
+                    buckets: [
+                        UsageBucketSnapshot(
+                            id: "primary.session",
+                            title: "Session",
+                            window: RateWindow(
+                                usedPercent: 3,
+                                windowMinutes: 300,
+                                resetsAt: now.addingTimeInterval(5400),
+                                resetDescription: nil)),
+                    ]),
+            ],
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "codex@example.com",
+                accountOrganization: nil,
+                loginMethod: nil))
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .codex,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: "codex@example.com", plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        let groups = UsageMenuCardView.metricGroups(metrics: model.metrics)
+        #expect(groups.count == 2)
+        #expect(groups.map(\.kind) == [.builtInPrimary, .providerBucket])
+        #expect(groups.contains { $0.id == "primary" && $0.kind == .providerBucket })
+        #expect(UsageMenuCardView.primaryMetricGroup(metrics: model.metrics)?.kind == .builtInPrimary)
+        #expect(UsageMenuCardView.supplementalMetricGroups(metrics: model.metrics).map(\.id) == ["primary"])
+    }
+
+    @Test
+    func keepsInternalViewIdentityUniqueWhenProviderGroupMatchesBuiltInSentinel() throws {
+        let now = Date()
+        let metadata = try #require(ProviderDefaults.metadata[.codex])
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 22, windowMinutes: 300, resetsAt: now, resetDescription: nil),
+            secondary: nil,
+            usageBucketGroups: [
+                UsageBucketGroupSnapshot(
+                    id: "__builtInPrimary",
+                    title: "Provider Sentinel",
+                    buckets: [
+                        UsageBucketSnapshot(
+                            id: "__builtInPrimary.session",
+                            title: "Session",
+                            window: RateWindow(
+                                usedPercent: 3,
+                                windowMinutes: 300,
+                                resetsAt: now.addingTimeInterval(5400),
+                                resetDescription: nil)),
+                    ]),
+            ],
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "codex@example.com",
+                accountOrganization: nil,
+                loginMethod: nil))
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .codex,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: "codex@example.com", plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        let groups = UsageMenuCardView.metricGroups(metrics: model.metrics)
+        #expect(groups.map(\.internalID) == ["builtInPrimary", "providerBucket:__builtInPrimary"])
+    }
 }

--- a/Tests/CodexBarTests/MenuDescriptorSparkTests.swift
+++ b/Tests/CodexBarTests/MenuDescriptorSparkTests.swift
@@ -1,0 +1,144 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite
+struct MenuDescriptorSparkTests {
+    @Test
+    func codexUsageSectionSeparatesSparkRowsWhenLiveSparkUsageExists() throws {
+        let suite = "MenuDescriptorSparkTests-live-spark"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.usageBarsShowUsed = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let now = Date()
+        store._setSnapshotForTesting(UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: now, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 20, windowMinutes: 10080, resetsAt: now, resetDescription: nil),
+            usageBucketGroups: [
+                UsageBucketGroupSnapshot(
+                    id: "codex.spark",
+                    title: "GPT-5.3-Codex-Spark",
+                    buckets: [
+                        UsageBucketSnapshot(
+                            id: "codex.spark.session",
+                            title: "Session",
+                            window: RateWindow(
+                                usedPercent: 3,
+                                windowMinutes: 300,
+                                resetsAt: now,
+                                resetDescription: nil)),
+                        UsageBucketSnapshot(
+                            id: "codex.spark.weekly",
+                            title: "Weekly",
+                            window: RateWindow(
+                                usedPercent: 17,
+                                windowMinutes: 10080,
+                                resetsAt: now,
+                                resetDescription: nil)),
+                    ]),
+            ],
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "codex@example.com",
+                accountOrganization: nil,
+                loginMethod: nil)), provider: .codex)
+
+        let descriptor = MenuDescriptor.build(
+            provider: .codex,
+            store: store,
+            settings: settings,
+            account: AccountInfo(email: "codex@example.com", plan: nil),
+            updateReady: false,
+            includeContextualActions: false)
+
+        let textLines = descriptor.sections
+            .flatMap(\.entries)
+            .compactMap { entry -> String? in
+                guard case let .text(text, _) = entry else { return nil }
+                return text
+            }
+
+        #expect(textLines.contains("GPT-5.3-Codex-Spark"))
+        #expect(textLines.contains("Session: 97% left"))
+        #expect(textLines.contains("Weekly: 83% left"))
+    }
+
+    @Test
+    func codexSparkOnlyUsageSectionDoesNotInsertLeadingDivider() throws {
+        let suite = "MenuDescriptorSparkTests-spark-only"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.usageBarsShowUsed = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let now = Date()
+        store._setSnapshotForTesting(UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            usageBucketGroups: [
+                UsageBucketGroupSnapshot(
+                    id: "codex.spark",
+                    title: "GPT-5.3-Codex-Spark",
+                    buckets: [
+                        UsageBucketSnapshot(
+                            id: "codex.spark.session",
+                            title: "Session",
+                            window: RateWindow(
+                                usedPercent: 3,
+                                windowMinutes: 300,
+                                resetsAt: now,
+                                resetDescription: nil)),
+                    ]),
+            ],
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "codex@example.com",
+                accountOrganization: nil,
+                loginMethod: nil)), provider: .codex)
+
+        let descriptor = MenuDescriptor.build(
+            provider: .codex,
+            store: store,
+            settings: settings,
+            account: AccountInfo(email: "codex@example.com", plan: nil),
+            updateReady: false,
+            includeContextualActions: false)
+
+        let entries = try #require(descriptor.sections.first?.entries)
+        #expect(entries.count >= 3)
+        #expect({
+            guard case .text("Codex", .headline) = entries[0] else { return false }
+            return true
+        }())
+        #expect({
+            guard case .text("GPT-5.3-Codex-Spark", .headline) = entries[1] else { return false }
+            return true
+        }())
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -19,6 +19,18 @@ private func makeCodexSparkUsageBucketGroup() -> UsageBucketGroupSnapshot {
         ])
 }
 
+private func makeProviderPrimaryUsageBucketGroup() -> UsageBucketGroupSnapshot {
+    UsageBucketGroupSnapshot(
+        id: "primary",
+        title: "Provider Primary",
+        buckets: [
+            UsageBucketSnapshot(
+                id: "primary.session",
+                title: "Session",
+                window: RateWindow(usedPercent: 3, windowMinutes: 300, resetsAt: Date(), resetDescription: nil)),
+        ])
+}
+
 @MainActor
 @Suite
 struct StatusMenuTests {
@@ -751,6 +763,52 @@ struct StatusMenuTests {
         let separatorIndex = sparkIndex + 1
         #expect(separatorIndex < menu.items.count)
         #expect(menu.items[separatorIndex].isSeparatorItem)
+    }
+
+    @Test
+    func providerOwnedPrimaryBucketGroupStillRendersAsSupplementalSection() throws {
+        StatusItemController.menuCardRenderingEnabled = true
+        StatusItemController.menuRefreshEnabled = false
+        defer { self.disableMenuCardsForTesting() }
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store._setSnapshotForTesting(UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: Date(), resetDescription: nil),
+            secondary: nil,
+            usageBucketGroups: [makeProviderPrimaryUsageBucketGroup()],
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "codex@example.com",
+                accountOrganization: nil,
+                loginMethod: nil)), provider: .codex)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        let ids = self.representedIDs(in: menu)
+        let usageIndex = try #require(ids.firstIndex(of: "menuCardUsage"))
+        let providerPrimaryIndex = try #require(ids.firstIndex(of: "menuCardUsageGroup-primary"))
+
+        #expect(usageIndex < providerPrimaryIndex)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -3,6 +3,22 @@ import CodexBarCore
 import Testing
 @testable import CodexBar
 
+private func makeCodexSparkUsageBucketGroup() -> UsageBucketGroupSnapshot {
+    UsageBucketGroupSnapshot(
+        id: "codex.spark",
+        title: "GPT-5.3-Codex-Spark",
+        buckets: [
+            UsageBucketSnapshot(
+                id: "codex.spark.session",
+                title: "Session",
+                window: RateWindow(usedPercent: 3, windowMinutes: 300, resetsAt: Date(), resetDescription: nil)),
+            UsageBucketSnapshot(
+                id: "codex.spark.weekly",
+                title: "Weekly",
+                window: RateWindow(usedPercent: 17, windowMinutes: 10080, resetsAt: Date(), resetDescription: nil)),
+        ])
+}
+
 @MainActor
 @Suite
 struct StatusMenuTests {
@@ -632,6 +648,109 @@ struct StatusMenuTests {
         #expect(creditsIndex != nil)
         #expect(costIndex != nil)
         #expect(try #require(creditsIndex) < costIndex!)
+    }
+
+    @Test
+    func codexMenuCardSeparatesSparkSectionWhenLiveSparkUsageExists() throws {
+        StatusItemController.menuCardRenderingEnabled = true
+        StatusItemController.menuRefreshEnabled = false
+        defer { self.disableMenuCardsForTesting() }
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: false)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store._setSnapshotForTesting(UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: Date(), resetDescription: nil),
+            secondary: RateWindow(usedPercent: 20, windowMinutes: 10080, resetsAt: Date(), resetDescription: nil),
+            usageBucketGroups: [makeCodexSparkUsageBucketGroup()],
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "codex@example.com",
+                accountOrganization: nil,
+                loginMethod: nil)), provider: .codex)
+        store.credits = CreditsSnapshot(remaining: 42, events: [], updatedAt: Date())
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        let ids = self.representedIDs(in: menu)
+        let usageIndex = try #require(ids.firstIndex(of: "menuCardUsage"))
+        let sparkIndex = try #require(ids.firstIndex(of: "menuCardUsageGroup-codex.spark"))
+        let creditsIndex = try #require(ids.firstIndex(of: "menuCardCredits"))
+
+        #expect(usageIndex < sparkIndex)
+        #expect(sparkIndex < creditsIndex)
+    }
+
+    @Test
+    func codexSparkOnlyMenuCardKeepsSeparatorBeforeActions() throws {
+        StatusItemController.menuCardRenderingEnabled = true
+        StatusItemController.menuRefreshEnabled = false
+        defer { self.disableMenuCardsForTesting() }
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: false)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store._setSnapshotForTesting(UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: Date(), resetDescription: nil),
+            secondary: RateWindow(usedPercent: 20, windowMinutes: 10080, resetsAt: Date(), resetDescription: nil),
+            usageBucketGroups: [makeCodexSparkUsageBucketGroup()],
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "codex@example.com",
+                accountOrganization: nil,
+                loginMethod: nil)), provider: .codex)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+
+        let sparkIndex = try #require(menu.items.firstIndex {
+            ($0.representedObject as? String) == "menuCardUsageGroup-codex.spark"
+        })
+        let separatorIndex = sparkIndex + 1
+        #expect(separatorIndex < menu.items.count)
+        #expect(menu.items[separatorIndex].isSeparatorItem)
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR adds a generic provider-owned bucket-group mechanism for extra live rate-limit sections and uses Codex OAuth Spark data as the first implementation.

The goal is to support provider-specific rate-limit buckets without widening the existing `primary` / `secondary` / `tertiary` model or adding more one-off snapshot fields.

Why this approach:
- It keeps the current `primary` / `secondary` / `tertiary` model intact, so existing menu bar ranking, pace logic, and provider behavior stay stable.
- It gives providers one reusable path for extra rate-limit sections through snapshot data instead of more provider-specific fields.
- It keeps provider-specific detection in the provider mapping layer while making presentation data-driven in shared renderers.
- It matches the repo’s preference for typed snapshot data over provider-specific UI branching or metadata flags.

What changed:
- Added `UsageBucketGroupSnapshot` and `UsageBucketSnapshot` to `UsageSnapshot` as `usageBucketGroups`.
- Mapped Codex OAuth `additional_rate_limits` into a generic bucket group:
  - group id: `codex.spark`
  - group title: `GPT-5.3-Codex-Spark`
  - bucket ids: `codex.spark.session`, `codex.spark.weekly`
- Updated the menu descriptor, menu card, status menu, and CLI renderer to display extra bucket groups generically.
- Added regression coverage for OAuth decoding, snapshot round-tripping, CLI rendering, menu rendering, and status menu ordering/separators.

What intentionally did not change:
- No scanner, pricing, or history code.
- No changes to the existing `primary` / `secondary` / `tertiary` semantics.
- No new provider metadata booleans or provider-specific rendering branches for extra buckets.

## Verification
- `swift test`
- `pnpm check`
- `./Scripts/compile_and_run.sh`
