### PR TITLE
Introduce vertical cost detail list

### DIFF
--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -371,7 +371,12 @@ struct CostHistoryChartMenuView: View {
                 let lCost = lhs.costUSD ?? -1
                 let rCost = rhs.costUSD ?? -1
                 if lCost != rCost { return lCost > rCost }
-                return lhs.modelName < rhs.modelName
+
+                let lTokens = lhs.totalTokens ?? -1
+                let rTokens = rhs.totalTokens ?? -1
+                if lTokens != rTokens { return lTokens > rTokens }
+
+                return lhs.modelName > rhs.modelName
             }
             .prefix(Self.maxVisibleDetailLines)
             .enumerated()

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -20,6 +20,18 @@ struct CostHistoryChartMenuView: View {
         }
     }
 
+    private struct DetailRow: Identifiable {
+        let id: String
+        let title: String
+        let subtitle: String?
+        let accentColor: Color
+    }
+
+    private struct DetailContent {
+        let primary: String
+        let rows: [DetailRow]
+    }
+
     private let provider: UsageProvider
     private let daily: [DailyEntry]
     private let totalCostUSD: Double?
@@ -88,22 +100,48 @@ struct CostHistoryChartMenuView: View {
                     }
                 }
 
-                let detail = self.detailLines(model: model)
-                VStack(alignment: .leading, spacing: 0) {
+                let detail = self.detailContent(model: model)
+                VStack(alignment: .leading, spacing: Self.detailSpacing) {
                     Text(detail.primary)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                         .truncationMode(.tail)
-                        .frame(height: 16, alignment: .leading)
-                    Text(detail.secondary ?? " ")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                        .frame(height: 16, alignment: .leading)
-                        .opacity(detail.secondary == nil ? 0 : 1)
+                        .frame(height: Self.detailPrimaryLineHeight, alignment: .leading)
+                    ForEach(detail.rows) { row in
+                        HStack(alignment: .top, spacing: 8) {
+                            Rectangle()
+                                .fill(row.accentColor)
+                                .frame(width: 2, height: row.subtitle == nil ? 14 : Self.detailRowHeight)
+                                .padding(.top, 1)
+
+                            VStack(alignment: .leading, spacing: 1) {
+                                Text(row.title)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                                if let subtitle = row.subtitle {
+                                    Text(subtitle)
+                                        .font(.caption2)
+                                        .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                                        .lineLimit(1)
+                                        .truncationMode(.tail)
+                                }
+                            }
+                        }
+                        .frame(height: Self.detailRowHeight, alignment: .leading)
+                    }
+                    ForEach(0..<max(model.maxRenderedBreakdownRows - detail.rows.count, 0), id: \.self) { _ in
+                        Text(" ")
+                            .font(.caption)
+                            .frame(height: Self.detailRowHeight, alignment: .leading)
+                            .opacity(0)
+                    }
                 }
+                .frame(
+                    height: Self.detailBlockHeight(maxBreakdownRows: model.maxRenderedBreakdownRows),
+                    alignment: .topLeading)
             }
 
             if let total = self.totalCostUSD {
@@ -126,9 +164,14 @@ struct CostHistoryChartMenuView: View {
         let barColor: Color
         let peakKey: String?
         let maxCostUSD: Double
+        let maxRenderedBreakdownRows: Int
     }
 
     private static let selectionBandColor = Color(nsColor: .labelColor).opacity(0.1)
+    private static let maxVisibleDetailLines = 4
+    private static let detailPrimaryLineHeight: CGFloat = 16
+    private static let detailRowHeight: CGFloat = 24
+    private static let detailSpacing: CGFloat = 6
 
     private static func capHeight(maxValue: Double) -> Double {
         maxValue * 0.05
@@ -150,6 +193,7 @@ struct CostHistoryChartMenuView: View {
 
         var peak: (key: String, costUSD: Double)?
         var maxCostUSD: Double = 0
+        var maxRenderedBreakdownRows = 0
         for entry in sorted {
             guard let costUSD = entry.costUSD, costUSD >= 0 else { continue }
             guard let date = self.dateFromDayKey(entry.date) else { continue }
@@ -158,6 +202,7 @@ struct CostHistoryChartMenuView: View {
             pointsByKey[entry.date] = point
             entriesByKey[entry.date] = entry
             dateKeys.append((entry.date, date))
+            maxRenderedBreakdownRows = max(maxRenderedBreakdownRows, Self.renderedBreakdownRowCount(for: entry))
             if let cur = peak {
                 if costUSD > cur.costUSD { peak = (entry.date, costUSD) }
             } else {
@@ -181,7 +226,8 @@ struct CostHistoryChartMenuView: View {
             axisDates: axisDates,
             barColor: barColor,
             peakKey: maxCostUSD > 0 ? peak?.key : nil,
-            maxCostUSD: maxCostUSD)
+            maxCostUSD: maxCostUSD,
+            maxRenderedBreakdownRows: maxRenderedBreakdownRows)
     }
 
     private static func barColor(for provider: UsageProvider) -> Color {
@@ -209,6 +255,18 @@ struct CostHistoryChartMenuView: View {
     private static func peakPoint(model: Model) -> Point? {
         guard let key = model.peakKey else { return nil }
         return model.pointsByDateKey[key]
+    }
+
+    private static func renderedBreakdownRowCount(for entry: DailyEntry) -> Int {
+        guard let breakdown = entry.modelBreakdowns, !breakdown.isEmpty else { return 0 }
+        return min(breakdown.count, self.maxVisibleDetailLines)
+    }
+
+    private static func detailBlockHeight(maxBreakdownRows: Int) -> CGFloat {
+        guard maxBreakdownRows > 0 else { return self.detailPrimaryLineHeight }
+        return self.detailPrimaryLineHeight +
+            (CGFloat(maxBreakdownRows) * self.detailRowHeight) +
+            (CGFloat(maxBreakdownRows) * self.detailSpacing)
     }
 
     private func selectionBandRect(model: Model, proxy: ChartProxy, geo: GeometryProxy) -> CGRect? {
@@ -286,41 +344,51 @@ struct CostHistoryChartMenuView: View {
         return best?.key
     }
 
-    private func detailLines(model: Model) -> (primary: String, secondary: String?) {
+    private func detailContent(model: Model) -> DetailContent {
         guard let key = self.selectedDateKey,
               let point = model.pointsByDateKey[key],
               let date = Self.dateFromDayKey(key)
         else {
-            return ("Hover a bar for details", nil)
+            return DetailContent(primary: "Hover a bar for details", rows: [])
         }
 
         let dayLabel = date.formatted(.dateTime.month(.abbreviated).day())
         let cost = UsageFormatter.usdString(point.costUSD)
-        if let tokens = point.totalTokens {
-            let primary = "\(dayLabel): \(cost) · \(UsageFormatter.tokenCountString(tokens)) tokens"
-            let secondary = self.topModelsText(key: key, model: model)
-            return (primary, secondary)
+        let primary = if let tokens = point.totalTokens {
+            "\(dayLabel): \(cost) · \(UsageFormatter.tokenCountString(tokens)) tokens"
+        } else {
+            "\(dayLabel): \(cost)"
         }
-        let primary = "\(dayLabel): \(cost)"
-        let secondary = self.topModelsText(key: key, model: model)
-        return (primary, secondary)
+        return DetailContent(primary: primary, rows: self.breakdownRows(key: key, model: model))
     }
 
-    private func topModelsText(key: String, model: Model) -> String? {
-        guard let entry = model.entriesByDateKey[key] else { return nil }
-        guard let breakdown = entry.modelBreakdowns, !breakdown.isEmpty else { return nil }
-        let parts = breakdown
-            .compactMap { item -> String? in
-                let name = UsageFormatter.modelDisplayName(item.modelName)
-                guard let detail = UsageFormatter.modelCostDetail(
-                    item.modelName,
-                    costUSD: item.costUSD,
-                    totalTokens: item.totalTokens)
-                else { return nil }
-                return "\(name) \(detail)"
+    private func breakdownRows(key: String, model: Model) -> [DetailRow] {
+        guard let entry = model.entriesByDateKey[key] else { return [] }
+        guard let breakdown = entry.modelBreakdowns, !breakdown.isEmpty else { return [] }
+
+        return breakdown
+            .sorted { lhs, rhs in
+                let lCost = lhs.costUSD ?? -1
+                let rCost = rhs.costUSD ?? -1
+                if lCost != rCost { return lCost > rCost }
+                return lhs.modelName < rhs.modelName
             }
-            .prefix(3)
-        guard !parts.isEmpty else { return nil }
-        return "Top: \(parts.joined(separator: " · "))"
+            .prefix(Self.maxVisibleDetailLines)
+            .enumerated()
+            .map { index, item in
+                DetailRow(
+                    id: "\(item.modelName)-\(index)",
+                    title: UsageFormatter.modelDisplayName(item.modelName),
+                    subtitle: UsageFormatter.modelCostDetail(
+                        item.modelName,
+                        costUSD: item.costUSD,
+                        totalTokens: item.totalTokens),
+                    accentColor: model.barColor.opacity(Self.breakdownAccentOpacity(for: index)))
+            }
+    }
+
+    private static func breakdownAccentOpacity(for index: Int) -> Double {
+        let opacity = 0.75 - (Double(index) * 0.12)
+        return max(0.3, opacity)
     }
 }


### PR DESCRIPTION
## Summary
This PR now focuses only on the cost chart hover UI change: it replaces the single secondary detail line with a vertical per-model list in the chart detail area.

The branch intentionally keeps `main`'s current data behavior. There are no scanner, decoding, CLI payload, or model-shape changes in this version.

## What changed
- `CostHistoryChartMenuView` now shows a stacked detail block under the chart.
- The selected day still renders the existing primary summary line for date, cost, and tokens when available.
- Model breakdowns render as a vertical list with accent bars and per-row cost detail.
- The list is capped at four visible rows.
- The menu reserves detail height based on the busiest loaded day so hover movement does not resize the menu.

## What did not change
- No changes to `CostUsageModels`.
- No changes to the cost scanners.
- No changes to decoding or CLI payloads.
- No pricing or total-cost behavior changes.

## Verification
- [x] `pnpm check`
- [x] `swift test`
- [x] `./Scripts/compile_and_run.sh`

<img width="661" height="735" alt="Screenshot 2026-03-17 at 3 13 45 PM" src="https://github.com/user-attachments/assets/490e823a-d274-470d-96dd-76b57fd74bda" />