### PR TITLE
[Feature] Add separate progress bars status item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ debug_*.swift
 .vscode/
 .codex/environments/
 .swiftpm-cache/
+output.log
 
 # Debug/analysis docs
 docs/*-analysis.md

--- a/Sources/CodexBar/PreferencesDisplayPane.swift
+++ b/Sources/CodexBar/PreferencesDisplayPane.swift
@@ -22,6 +22,12 @@ struct DisplayPane: View {
                         subtitle: "Use a single menu bar icon with a provider switcher.",
                         binding: self.$settings.mergeIcons)
                     PreferenceToggleRow(
+                        title: "Show separate progress bars",
+                        subtitle: "Display an additional status item showing only progress bars (no icon or text).",
+                        binding: self.$settings.menuBarShowsSeparateBars)
+                        .disabled(!self.settings.mergeIcons)
+                        .opacity(self.settings.mergeIcons ? 1 : 0.5)
+                    PreferenceToggleRow(
                         title: "Switcher shows icons",
                         subtitle: "Show provider icons in the switcher (otherwise show a weekly progress line).",
                         binding: self.$settings.switcherShowsIcons)

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -125,6 +125,14 @@ extension SettingsStore {
         }
     }
 
+    var menuBarShowsSeparateBars: Bool {
+        get { self.defaultsState.menuBarShowsSeparateBars }
+        set {
+            self.defaultsState.menuBarShowsSeparateBars = newValue
+            self.userDefaults.set(newValue, forKey: "menuBarShowsSeparateBars")
+        }
+    }
+
     private var menuBarDisplayModeRaw: String? {
         get { self.defaultsState.menuBarDisplayModeRaw }
         set {

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -188,6 +188,7 @@ extension SettingsStore {
         let resetTimesShowAbsolute = userDefaults.object(forKey: "resetTimesShowAbsolute") as? Bool ?? false
         let menuBarShowsBrandIconWithPercent = userDefaults.object(
             forKey: "menuBarShowsBrandIconWithPercent") as? Bool ?? false
+        let menuBarShowsSeparateBars = userDefaults.object(forKey: "menuBarShowsSeparateBars") as? Bool ?? false
         let menuBarDisplayModeRaw = userDefaults.string(forKey: "menuBarDisplayMode")
             ?? MenuBarDisplayMode.percent.rawValue
         let historicalTrackingEnabled = userDefaults.object(forKey: "historicalTrackingEnabled") as? Bool ?? false
@@ -238,6 +239,7 @@ extension SettingsStore {
             usageBarsShowUsed: usageBarsShowUsed,
             resetTimesShowAbsolute: resetTimesShowAbsolute,
             menuBarShowsBrandIconWithPercent: menuBarShowsBrandIconWithPercent,
+            menuBarShowsSeparateBars: menuBarShowsSeparateBars,
             menuBarDisplayModeRaw: menuBarDisplayModeRaw,
             historicalTrackingEnabled: historicalTrackingEnabled,
             showAllTokenAccountsInMenu: showAllTokenAccountsInMenu,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -14,6 +14,7 @@ struct SettingsDefaultsState: Sendable {
     var usageBarsShowUsed: Bool
     var resetTimesShowAbsolute: Bool
     var menuBarShowsBrandIconWithPercent: Bool
+    var menuBarShowsSeparateBars: Bool
     var menuBarDisplayModeRaw: String?
     var historicalTrackingEnabled: Bool
     var showAllTokenAccountsInMenu: Bool

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -161,6 +161,7 @@ extension StatusItemController {
         if mergeIcons {
             let phase: Double? = self.needsMenuBarIconAnimation() ? self.animationPhase : nil
             self.applyIcon(phase: phase)
+            self.applySeparateBarsIcon(phase: phase)
         }
     }
 
@@ -313,6 +314,99 @@ extension StatusItemController {
                 primaryRemaining: primary,
                 weeklyRemaining: weekly,
                 creditsRemaining: credits,
+                stale: stale,
+                style: style,
+                blink: blink,
+                wiggle: wiggle,
+                tilt: tilt,
+                statusIndicator: statusIndicator)
+            self.setButtonImage(image, for: button)
+        }
+    }
+    
+    /// Applies an icon showing only dual progress bars (no brand icon, no text) to the separate bars status item.
+    func applySeparateBarsIcon(phase: Double?) {
+        guard self.settings.menuBarShowsSeparateBars,
+              let button = self.separateBarsStatusItem?.button
+        else { return }
+        
+        let primaryProvider = self.primaryProviderForUnifiedIcon()
+        
+        // Force a refresh when the provider changes to avoid rendering artifacts
+        let providerChanged = self.lastSeparateBarsProvider != primaryProvider
+        if providerChanged {
+            // Clear the old image to force a clean render
+            button.image = nil
+            self.lastSeparateBarsProvider = primaryProvider
+        }
+        
+        let showUsed = self.settings.usageBarsShowUsed
+        let snapshot = self.store.snapshot(for: primaryProvider)
+        
+        var primary = showUsed ? snapshot?.primary?.usedPercent : snapshot?.primary?.remainingPercent
+        var weekly = showUsed ? snapshot?.secondary?.usedPercent : snapshot?.secondary?.remainingPercent
+        if showUsed,
+           primaryProvider == .warp,
+           let remaining = snapshot?.secondary?.remainingPercent,
+           remaining <= 0
+        {
+            weekly = 0
+        }
+        if showUsed,
+           primaryProvider == .warp,
+           let remaining = snapshot?.secondary?.remainingPercent,
+           remaining > 0,
+           weekly == 0
+        {
+            weekly = Self.loadingPercentEpsilon
+        }
+        var stale = self.store.isStale(provider: primaryProvider)
+        var morphProgress: Double?
+        
+        let needsAnimation = self.needsMenuBarIconAnimation()
+        if let phase, needsAnimation {
+            var pattern = self.animationPattern
+            if pattern == .unbraid {
+                morphProgress = pattern.value(phase: phase) / 100
+                primary = nil
+                weekly = nil
+                stale = false
+            } else {
+                primary = max(pattern.value(phase: phase), Self.loadingPercentEpsilon)
+                weekly = max(pattern.value(phase: phase + pattern.secondaryOffset), Self.loadingPercentEpsilon)
+                stale = false
+            }
+        }
+        
+        let style: IconStyle = self.store.style(for: primaryProvider)
+        let isLoading = phase != nil && self.shouldAnimate(provider: primaryProvider)
+        let blink: CGFloat = {
+            guard isLoading, style == .warp, let phase else {
+                return self.blinkAmount(for: primaryProvider)
+            }
+            let normalized = (sin(phase * 3) + 1) / 2
+            return CGFloat(max(0, min(normalized, 1)))
+        }()
+        let wiggle = self.wiggleAmount(for: primaryProvider)
+        let tilt = self.tiltAmount(for: primaryProvider) * .pi / 28
+        
+        let statusIndicator: ProviderStatusIndicator = {
+            for provider in self.store.enabledProviders() {
+                let indicator = self.store.statusIndicator(for: provider)
+                if indicator.hasIssue { return indicator }
+            }
+            return .none
+        }()
+        
+        self.setButtonTitle(nil, for: button)
+        if let morphProgress {
+            let image = IconRenderer.makeMorphIcon(progress: morphProgress, style: style)
+            self.setButtonImage(image, for: button)
+        } else {
+            let image = IconRenderer.makeIcon(
+                primaryRemaining: primary,
+                weeklyRemaining: weekly,
+                creditsRemaining: nil,
                 stale: stale,
                 style: style,
                 blink: blink,
@@ -581,6 +675,7 @@ extension StatusItemController {
             self.animationPhase = 0
             if self.shouldMergeIcons {
                 self.applyIcon(phase: nil)
+                self.applySeparateBarsIcon(phase: nil)
             } else {
                 UsageProvider.allCases.forEach { self.applyIcon(for: $0, phase: nil) }
             }
@@ -591,6 +686,7 @@ extension StatusItemController {
         self.animationPhase += 0.045 // half-speed animation
         if self.shouldMergeIcons {
             self.applyIcon(phase: self.animationPhase)
+            self.applySeparateBarsIcon(phase: self.animationPhase)
         } else {
             UsageProvider.allCases.forEach { self.applyIcon(for: $0, phase: self.animationPhase) }
         }

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -36,6 +36,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     private let statusBar: NSStatusBar
     var statusItem: NSStatusItem
     var statusItems: [UsageProvider: NSStatusItem] = [:]
+    var separateBarsStatusItem: NSStatusItem?  // Optional separate status item showing only progress bars
     var lastMenuProvider: UsageProvider?
     var menuProviders: [ObjectIdentifier: UsageProvider] = [:]
     var menuContentVersion: Int = 0
@@ -85,6 +86,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     /// Tracks which `usageBarsShowUsed` mode the provider switcher was built with.
     /// Used to decide whether we can "smart update" menu content without rebuilding the switcher.
     var lastSwitcherUsageBarsShowUsed: Bool
+    /// Tracks the last provider used for the separate bars status item, to detect when it changes.
+    var lastSeparateBarsProvider: UsageProvider?
     /// Tracks whether the merged-menu switcher was built with the Overview tab visible.
     /// Used to force switcher rebuilds when Overview availability toggles.
     var lastSwitcherIncludesOverview: Bool = false
@@ -338,6 +341,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         let phase: Double? = self.needsMenuBarIconAnimation() ? self.animationPhase : nil
         if self.shouldMergeIcons {
             self.applyIcon(phase: phase)
+            self.applySeparateBarsIcon(phase: phase)
             self.attachMenus()
         } else {
             UsageProvider.allCases.forEach { self.applyIcon(for: $0, phase: phase) }
@@ -362,6 +366,19 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         let anyEnabled = !self.store.enabledProviders().isEmpty
         let force = self.store.debugForceAnimation
         let mergeIcons = self.shouldMergeIcons
+        let showsSeparateBars = self.settings.menuBarShowsSeparateBars && mergeIcons
+        
+        // Update separate bars status item visibility
+        if showsSeparateBars {
+            if self.separateBarsStatusItem == nil {
+                self.separateBarsStatusItem = self.statusBar.statusItem(withLength: NSStatusItem.variableLength)
+                self.separateBarsStatusItem?.button?.imageScaling = .scaleNone
+            }
+            self.separateBarsStatusItem?.isVisible = anyEnabled || force
+        } else {
+            self.separateBarsStatusItem?.isVisible = false
+        }
+        
         if mergeIcons {
             self.statusItem.isVisible = anyEnabled || force
             for item in self.statusItems.values {


### PR DESCRIPTION
## Summary

Adds a new display option to show dual progress bars as a separate menu bar status item, independent from the provider icon.

## Changes

- New toggle 'Show separate progress bars' in Display settings (only visible when 'Merge Icons' is enabled)
- Creates a second status item showing only the dual progress bars (no icon, no text)
- Both status items update with the same provider data
- Users can drag to reposition the bars independently in macOS menu bar
- Fixed rendering artifacts when provider changes

## Use Cases

- Keep progress bars visible at all times while the icon changes
- Minimalist view: show only bars in one area, only icon in another
- Redundancy: quick glance at bars from one position, detailed info from clicking the icon

## Testing

- Verified bars render correctly without artifacts when provider changes
- Tested toggle on/off behavior
- Confirmed independent positioning in menu bar

## Note

This is a feature request implementation, not a bug fix.