### PR TITLE
fix: persist refresh interval to UserDefaults on first launch

### DIFF
--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -157,8 +157,12 @@ final class SettingsStore {
 
 extension SettingsStore {
     private static func loadDefaultsState(userDefaults: UserDefaults) -> SettingsDefaultsState {
-        let refreshRaw = userDefaults.string(forKey: "refreshFrequency") ?? RefreshFrequency.fiveMinutes.rawValue
-        let refreshFrequency = RefreshFrequency(rawValue: refreshRaw) ?? .fiveMinutes
+        let refreshDefault = userDefaults.string(forKey: "refreshFrequency")
+            .flatMap(RefreshFrequency.init(rawValue:))
+        let refreshFrequency = refreshDefault ?? .fiveMinutes
+        if refreshDefault == nil {
+            userDefaults.set(refreshFrequency.rawValue, forKey: "refreshFrequency")
+        }
         let launchAtLogin = userDefaults.object(forKey: "launchAtLogin") as? Bool ?? false
         let debugMenuEnabled = userDefaults.object(forKey: "debugMenuEnabled") as? Bool ?? false
         let debugDisableKeychainAccess: Bool = {

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -21,6 +21,25 @@ struct SettingsStoreTests {
 
         #expect(store.refreshFrequency == .fiveMinutes)
         #expect(store.refreshFrequency.seconds == 300)
+        #expect(defaults.string(forKey: "refreshFrequency") == RefreshFrequency.fiveMinutes.rawValue)
+    }
+
+    @Test
+    func `repairs unrecognized refresh frequency raw value`() throws {
+        let suite = "SettingsStoreTests-invalid-refresh"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set("legacyValue", forKey: "refreshFrequency")
+        let configStore = testConfigStore(suiteName: suite)
+
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        #expect(store.refreshFrequency == .fiveMinutes)
+        #expect(defaults.string(forKey: "refreshFrequency") == RefreshFrequency.fiveMinutes.rawValue)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Write the resolved `refreshFrequency` value to UserDefaults when the key is absent or contains an unrecognized raw value, matching the pattern used by `sessionQuotaNotificationsEnabled` and other settings
- Add test coverage for both the first-launch write-back and invalid raw value repair scenarios

Closes #506

## Test plan

- [x] `swift build` passes
- [x] `swift test` — all SettingsStore tests pass (923 total, 7 pre-existing OAuth/keychain environment failures unrelated to this change)
- [x] Manual: launch CodexBar, verify `defaults read com.steipete.codexbar | grep refreshFrequency` shows the key
- [x] Manual: change refresh cadence in Settings, quit and relaunch, verify the setting persists