### PR TITLE
feat: support Edge browser cookie import for Codex provider

### DIFF
--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
@@ -287,7 +287,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
             }
             for source in sources {
                 let cookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
-                if cookies.isEmpty {
+                guard !cookies.isEmpty else {
                     log("\(source.label) produced 0 HTTPCookies.")
                     continue
                 }

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
@@ -267,19 +267,21 @@ public struct OpenAIDashboardBrowserCookieImporter {
         }
     }
 
-    private func tryChrome(
+    /// Generic cookie loader for any non-Safari browser (Chrome, Edge, Firefox, Brave, Arc, etc.).
+    /// SweetCookieKit handles engine-specific decryption internally.
+    private func tryBrowser(
+        _ browser: Browser,
         targetEmail: String?,
         allowAnyAccount: Bool,
         log: @escaping (String) -> Void,
         diagnostics: inout ImportDiagnostics) async -> ImportResult?
     {
-        // Chrome fallback: may trigger Keychain prompt. Only do this if Safari didn't match.
         do {
             let query = BrowserCookieQuery(domains: Self.cookieDomains)
-            let chromeSources = try Self.cookieClient.records(
+            let sources = try Self.cookieClient.records(
                 matching: query,
-                in: .chrome)
-            for source in chromeSources {
+                in: browser)
+            for source in sources {
                 let cookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
                 if cookies.isEmpty {
                     log("\(source.label) produced 0 HTTPCookies.")
@@ -304,55 +306,10 @@ public struct OpenAIDashboardBrowserCookieImporter {
             if let hint = error.accessDeniedHint {
                 diagnostics.accessDeniedHints.append(hint)
             }
-            log("Chrome cookie load failed: \(error.localizedDescription)")
+            log("\(browser.rawValue) cookie load failed: \(error.localizedDescription)")
             return nil
         } catch {
-            log("Chrome cookie load failed: \(error.localizedDescription)")
-            return nil
-        }
-    }
-
-    private func tryFirefox(
-        targetEmail: String?,
-        allowAnyAccount: Bool,
-        log: @escaping (String) -> Void,
-        diagnostics: inout ImportDiagnostics) async -> ImportResult?
-    {
-        // Firefox fallback: no Keychain, but still only after Safari/Chrome.
-        do {
-            let query = BrowserCookieQuery(domains: Self.cookieDomains)
-            let firefoxSources = try Self.cookieClient.records(
-                matching: query,
-                in: .firefox)
-            for source in firefoxSources {
-                let cookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
-                if cookies.isEmpty {
-                    log("\(source.label) produced 0 HTTPCookies.")
-                    continue
-                }
-                diagnostics.foundAnyCookies = true
-                log("Loaded \(cookies.count) cookies from \(source.label) (\(self.cookieSummary(cookies)))")
-                let candidate = Candidate(label: source.label, cookies: cookies)
-                if let match = await self.applyCandidate(
-                    candidate,
-                    targetEmail: targetEmail,
-                    allowAnyAccount: allowAnyAccount,
-                    log: log,
-                    diagnostics: &diagnostics)
-                {
-                    return match
-                }
-            }
-            return nil
-        } catch let error as BrowserCookieError {
-            BrowserCookieAccessGate.recordIfNeeded(error)
-            if let hint = error.accessDeniedHint {
-                diagnostics.accessDeniedHints.append(hint)
-            }
-            log("Firefox cookie load failed: \(error.localizedDescription)")
-            return nil
-        } catch {
-            log("Firefox cookie load failed: \(error.localizedDescription)")
+            log("\(browser.rawValue) cookie load failed: \(error.localizedDescription)")
             return nil
         }
     }
@@ -371,20 +328,15 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 allowAnyAccount: allowAnyAccount,
                 log: log,
                 diagnostics: &diagnostics)
-        case .chrome:
-            await self.tryChrome(
-                targetEmail: targetEmail,
-                allowAnyAccount: allowAnyAccount,
-                log: log,
-                diagnostics: &diagnostics)
-        case .firefox:
-            await self.tryFirefox(
-                targetEmail: targetEmail,
-                allowAnyAccount: allowAnyAccount,
-                log: log,
-                diagnostics: &diagnostics)
         default:
-            nil
+            // All non-Safari browsers (Chrome, Edge, Firefox, Brave, Arc, etc.)
+            // share the same cookie loading path via SweetCookieKit.
+            await self.tryBrowser(
+                source,
+                targetEmail: targetEmail,
+                allowAnyAccount: allowAnyAccount,
+                log: log,
+                diagnostics: &diagnostics)
         }
     }
 

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
@@ -281,6 +281,10 @@ public struct OpenAIDashboardBrowserCookieImporter {
             let sources = try Self.cookieClient.records(
                 matching: query,
                 in: browser)
+            guard !sources.isEmpty else {
+                log("\(browser.displayName) contained 0 matching records.")
+                return nil
+            }
             for source in sources {
                 let cookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
                 if cookies.isEmpty {
@@ -306,10 +310,10 @@ public struct OpenAIDashboardBrowserCookieImporter {
             if let hint = error.accessDeniedHint {
                 diagnostics.accessDeniedHints.append(hint)
             }
-            log("\(browser.rawValue) cookie load failed: \(error.localizedDescription)")
+            log("\(browser.displayName) cookie load failed: \(error.localizedDescription)")
             return nil
         } catch {
-            log("\(browser.rawValue) cookie load failed: \(error.localizedDescription)")
+            log("\(browser.displayName) cookie load failed: \(error.localizedDescription)")
             return nil
         }
     }


### PR DESCRIPTION
## Summary

- Replace hardcoded Safari/Chrome/Firefox switch in `OpenAIDashboardBrowserCookieImporter.trySource` with a generic `tryBrowser` method that handles any non-Safari browser
- Edge (and all other Chromium-based browsers like Brave, Arc, Vivaldi) were silently ignored because `default: nil` dropped them — now they route through the same cookie loading path via SweetCookieKit
- Net code reduction: 62 lines removed, 14 added

## Context

SweetCookieKit already has full Edge support (enum, profile paths, keychain labels, decryption). Other providers (MiniMax, Augment, Kimi) already iterate all browsers generically. The Codex/OpenAI web cookie importer was the only place still using a closed browser list.

Closes #372

## Test plan

- [x] `swift build` passes
- [x] `swift test` passes — 8 pre-existing Claude OAuth keychain test failures are unrelated (they depend on real keychain credentials not present in dev environments, same failures on `main`)
- [x] `swiftformat` and `swiftlint --strict` pass
- [ ] Manual: install Edge on macOS, sign into chatgpt.com, verify CodexBar picks up Codex session cookies from Edge

No new unit tests added: the original `tryChrome`/`tryFirefox` had no unit tests either, as `trySource` depends on real browser cookie stores and Keychain access. The existing `OpenAIDashboardBrowserCookieImporterTests` only covers error message formatting.