### PR TITLE
feat: add 2x usage indicator for Claude and Codex promotions

### DIFF
--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -686,11 +686,20 @@ extension UsageMenuCardView.Model {
     }
 
     static func make(_ input: Input) -> UsageMenuCardView.Model {
-        let planText = Self.plan(
-            for: input.provider,
-            snapshot: input.snapshot,
-            account: input.account,
-            metadata: input.metadata)
+        let planText: String? = {
+            let base = Self.plan(
+                for: input.provider,
+                snapshot: input.snapshot,
+                account: input.account,
+                metadata: input.metadata)
+            guard let promo = PromotionStatus.check(provider: input.provider, now: input.now) else {
+                return base
+            }
+            if let plan = base {
+                return "\(plan) · \(promo.badge)"
+            }
+            return promo.badge
+        }()
         let metrics = Self.metrics(input: input)
         let usageNotes = Self.usageNotes(input: input)
         let creditsText: String? = if input.provider == .openrouter {

--- a/Sources/CodexBarCore/PromotionStatus.swift
+++ b/Sources/CodexBarCore/PromotionStatus.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+public enum PromotionStatus: Sendable {
+    public struct Result: Sendable {
+        public let is2x: Bool
+        public let badge: String
+    }
+
+    /// Returns `nil` if no promotion applies to this provider at the given time.
+    public static func check(provider: UsageProvider, now: Date = Date()) -> Result? {
+        switch provider {
+        case .claude:
+            return checkClaude(now: now)
+        case .codex:
+            return checkCodex(now: now)
+        default:
+            return nil
+        }
+    }
+
+    // MARK: - Claude Spring Break (March 13–27, 2026)
+
+    private static func checkClaude(now: Date) -> Result? {
+        let et = TimeZone(identifier: "America/New_York")!
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = et
+
+        // Promo window: March 13, 2026 00:00 ET → March 28, 2026 00:00 ET
+        // (March 27 11:59 PM PT ≈ March 28 ~03:00 AM ET)
+        let start = cal.date(from: DateComponents(year: 2026, month: 3, day: 13))!
+        let end = cal.date(from: DateComponents(year: 2026, month: 3, day: 28))!
+
+        guard now >= start, now < end else { return nil }
+
+        let comps = cal.dateComponents([.weekday, .hour], from: now)
+        let weekday = comps.weekday! // 1 = Sun, 7 = Sat
+        let hour = comps.hour!
+
+        let isWeekend = weekday == 1 || weekday == 7
+        let isPeak = !isWeekend && hour >= 8 && hour < 14
+
+        if isPeak {
+            return Result(is2x: false, badge: "Peak")
+        }
+        return Result(is2x: true, badge: "⚡ 2×")
+    }
+
+    // MARK: - Codex 2× (until April 2, 2026)
+
+    private static func checkCodex(now: Date) -> Result? {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "America/New_York")!
+        let end = cal.date(from: DateComponents(year: 2026, month: 4, day: 2))!
+        guard now < end else { return nil }
+        return Result(is2x: true, badge: "⚡ 2×")
+    }
+}


### PR DESCRIPTION
## Summary

- Add `PromotionStatus.swift` with pure-function logic to determine if Claude or Codex is in 2x mode based on current date/time
- Append promotion badge (`⚡ 2×` or `Peak`) to plan text in the menu card header
- Claude Spring Break (Mar 13–27, 2026): 2x during off-peak/weekends, "Peak" during weekday 8AM–2PM ET
- Codex: 2x 24/7 until April 2, 2026. No external API calls needed

## Test plan

- [ ] `swift build` compiles successfully
- [ ] Open Claude menu card during off-peak → verify `Pro · ⚡ 2×` appears
- [ ] Open Claude menu card during peak hours → verify `Pro · Peak` appears
- [ ] Open Codex menu card → verify `⚡ 2×` appears next to plan
- [ ] After promo dates, verify badges disappear and plan text is unchanged
- [ ] Unit test `PromotionStatus.check` with fixed dates covering boundary cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)