### PR TITLE
Wrap long status blurbs in menu

### DIFF
--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -543,7 +543,7 @@ extension StatusItemController {
     }
 
     private func makeWrappedSecondaryTextItem(text: String, width: CGFloat) -> NSMenuItem {
-        let item = NSMenuItem()
+        let item = NSMenuItem(title: text, action: nil, keyEquivalent: "")
         let view = self.makeWrappedSecondaryTextView(text: text)
         let height = self.menuTextItemHeight(for: view, width: width)
         view.frame = NSRect(origin: .zero, size: NSSize(width: width, height: height))

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -451,7 +451,7 @@ struct StatusMenuTests {
         let statusItem = menu.items.first(where: { $0.toolTip == statusText })
         #expect(statusItem != nil)
         #expect(statusItem?.view != nil)
-        #expect(statusItem?.title.isEmpty == true)
+        #expect(statusItem?.title == statusText)
         #expect(statusItem?.view?.frame.width == 310)
     }
 


### PR DESCRIPTION
## Summary
- Wrap secondary status blurbs in the menu actions section using a view-backed text row so long error messages can wrap instead of widening the menu.
- Add a StatusMenu test that verifies the status blurb is rendered as a fixed-width custom view.

## Verification
- `pnpm check`
- `./Scripts/compile_and_run.sh`
- `swift test` (hit an existing `swiftpm-testing-helper` / AppKit `SIGSEGV` during runner drawing; crash report captured at `~/Library/Logs/DiagnosticReports/swiftpm-testing-helper-2026-03-16-233445.ips`)