### PR TITLE
fix: add x86_64 CI verification and fix cross-compilation macro errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,27 @@ jobs:
       - name: Swift Test
         run: swift test --no-parallel
 
+      - name: Compile for x86_64
+        run: |
+          set -euo pipefail
+          # KeyboardShortcuts 2.x added #Preview blocks in Recorder.swift that use
+          # PreviewsMacros — a plugin unavailable in command-line swift build.
+          # Strip them before building (same patch applied in package_app.sh).
+          recorder=".build/checkouts/KeyboardShortcuts/Sources/KeyboardShortcuts/Recorder.swift"
+          if [[ -f "$recorder" ]] && grep -q '#Preview' "$recorder"; then
+            chmod +w "$recorder"
+            perl -0777 -i -pe 's/\n#Preview \{[^}]*\}//g' "$recorder"
+          fi
+          swift build -c release --arch x86_64 --product CodexBar
+          swift build -c release --arch x86_64 --product CodexBarCLI
+          swift build -c release --arch x86_64 --product CodexBarClaudeWatchdog
+
+      - name: Build + package universal binary (ad-hoc signed)
+        run: |
+          set -euo pipefail
+          ARCHES="arm64 x86_64" CODEXBAR_SIGNING=adhoc ./Scripts/package_app.sh release
+          lipo -archs CodexBar.app/Contents/MacOS/CodexBar
+
   build-linux-cli:
     strategy:
       fail-fast: false

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -34,6 +34,31 @@ if [[ ${#ARCH_LIST[@]} -eq 0 ]]; then
   esac
 fi
 
+patch_keyboard_shortcuts_recorder() {
+  local recorder_path="$ROOT/.build/checkouts/KeyboardShortcuts/Sources/KeyboardShortcuts/Recorder.swift"
+  if [[ ! -f "$recorder_path" ]]; then
+    return 0
+  fi
+  if ! grep -q '#Preview' "$recorder_path"; then
+    return 0
+  fi
+
+  chmod +w "$recorder_path" || true
+  python3 - "$recorder_path" <<'PY'
+import sys, re
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text()
+
+# Remove #Preview { ... } blocks — they use PreviewsMacros which is unavailable
+# when cross-compiling and are not needed for release builds.
+patched = re.sub(r'\n#Preview \{[^}]*\}', '', text, flags=re.DOTALL)
+if patched != text:
+    path.write_text(patched)
+PY
+}
+
 patch_keyboard_shortcuts() {
   local util_path="$ROOT/.build/checkouts/KeyboardShortcuts/Sources/KeyboardShortcuts/Utilities.swift"
   if [[ ! -f "$util_path" ]]; then
@@ -103,6 +128,7 @@ if [[ ! -f "$KEYBOARD_SHORTCUTS_UTIL" ]]; then
   swift build -c "$CONF" --arch "${ARCH_LIST[0]}"
 fi
 patch_keyboard_shortcuts
+patch_keyboard_shortcuts_recorder
 
 for ARCH in "${ARCH_LIST[@]}"; do
   swift build -c "$CONF" --arch "$ARCH"

--- a/Sources/CodexBar/MenuHighlightStyle.swift
+++ b/Sources/CodexBar/MenuHighlightStyle.swift
@@ -1,7 +1,14 @@
 import SwiftUI
 
+private struct MenuItemHighlightedKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+
 extension EnvironmentValues {
-    @Entry var menuItemHighlighted: Bool = false
+    var menuItemHighlighted: Bool {
+        get { self[MenuItemHighlightedKey.self] }
+        set { self[MenuItemHighlightedKey.self] = newValue }
+    }
 }
 
 enum MenuHighlightStyle {


### PR DESCRIPTION
## Summary

PR #331 made `package_app.sh` default to universal binaries — great for Intel users. However, CI only ran `swift test` on the arm64 runner, so x86_64-breaking regressions could still merge silently and corrupt those universal release builds.

This PR closes that gap and fixes two existing x86_64 compilation failures that were already present.

## Why

Without an x86_64 build step in CI, the universal binary guarantee is only as good as the last time someone manually verified it. These failures were invisible on arm64 and would have shipped in the next release.

## Changes

**`.github/workflows/ci.yml`**
- Added a `swift build -c release --arch x86_64` step (cross-compiles all three products from the arm64 runner — catches arm64-only APIs and conditional code)
- Added a `package_app.sh release` step with `CODEXBAR_SIGNING=adhoc` that verifies the output binary contains both slices via `lipo -archs`

**`Sources/CodexBar/MenuHighlightStyle.swift`**
- Replaced `@Entry` macro with the explicit `EnvironmentKey` pattern — `SwiftUIMacros.EntryMacro` is unavailable when cross-compiling to x86_64. Functionally identical on arm64.

**`Scripts/package_app.sh`**
- Added `patch_keyboard_shortcuts_recorder()`, parallel to the existing `patch_keyboard_shortcuts()`, that strips `#Preview` blocks from `KeyboardShortcuts/Recorder.swift` before the build loop — `PreviewsMacros` is similarly unavailable during x86_64 cross-compilation. No runtime impact on either architecture.

## Testing

Verified locally on an Apple Silicon Mac:

```bash
ARCHES="arm64 x86_64" CODEXBAR_SIGNING=adhoc ./Scripts/package_app.sh release
lipo -archs CodexBar.app/Contents/MacOS/CodexBar
# x86_64 arm64
```

The app also launched and ran correctly from the resulting bundle.