### PR TITLE
Fix typo with Kilo dashboard link

### DIFF
--- a/Sources/CodexBarCore/Providers/Kilo/KiloProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloProviderDescriptor.swift
@@ -22,7 +22,7 @@ public enum KiloProviderDescriptor {
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
                 browserCookieOrder: nil,
-                dashboardURL: "https://app.kilo.ai/account/usage",
+                dashboardURL: "https://app.kilo.ai/usage",
                 statusPageURL: nil),
             branding: ProviderBranding(
                 iconStyle: .kilo,

--- a/Tests/CodexBarTests/KiloSettingsReaderTests.swift
+++ b/Tests/CodexBarTests/KiloSettingsReaderTests.swift
@@ -22,7 +22,7 @@ struct KiloSettingsReaderTests {
     @Test
     func `descriptor uses app kilo AI dashboard`() {
         let descriptor = ProviderDescriptorRegistry.descriptor(for: .kilo)
-        #expect(descriptor.metadata.dashboardURL == "https://app.kilo.ai/account/usage")
+        #expect(descriptor.metadata.dashboardURL == "https://app.kilo.ai/usage")
     }
 
     @Test


### PR DESCRIPTION
The correct Kilo dashboard link is https://app.kilo.ai/usage