### PR TITLE
fix: make Kimi resetTime optional to handle API response without it

### DIFF
--- a/Sources/CodexBarCore/Providers/Kimi/KimiModels.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiModels.swift
@@ -12,11 +12,11 @@ struct KimiUsage: Codable {
 
 public struct KimiUsageDetail: Codable, Sendable {
     public let limit: String
-    public let used: String? // Optional because rate limit detail doesn't have this
+    public let used: String?
     public let remaining: String?
-    public let resetTime: String
+    public let resetTime: String?
 
-    public init(limit: String, used: String?, remaining: String?, resetTime: String) {
+    public init(limit: String, used: String?, remaining: String?, resetTime: String?) {
         self.limit = limit
         self.used = used
         self.remaining = remaining

--- a/Sources/CodexBarCore/Providers/Kimi/KimiUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiUsageSnapshot.swift
@@ -11,8 +11,8 @@ public struct KimiUsageSnapshot: Sendable {
         self.updatedAt = updatedAt
     }
 
-    private static func parseDate(_ dateString: String) -> Date? {
-        // Handle ISO 8601 format like: 2026-01-09T15:23:13.716839300Z
+    private static func parseDate(_ dateString: String?) -> Date? {
+        guard let dateString else { return nil }
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         if let date = formatter.date(from: dateString) {


### PR DESCRIPTION
## Summary

Fixes a JSON decoding error when the Kimi API returns usage details without the `resetTime` field. The error message was: "The data couldn't be read because it is missing."

## Problem

The `KimiUsageDetail` model defined `resetTime` as a required `String` field, but the Kimi API sometimes returns usage details without this field (e.g., when the weekly quota detail doesn't include a reset time). This caused JSON decoding to fail with:

```
[kimi] fetch strategies:
  - kimi.web (web) available error=The data couldn't be read because it is missing.
Error: No available fetch strategy for kimi.
```

## Solution

1. Changed `resetTime` in `KimiUsageDetail` from `String` to `String?`
2. Updated `parseDate(_:)` method in `KimiUsageSnapshot` to accept `String?` and return `nil` when the input is `nil`

## Testing

- [x] Built and tested locally with `./Scripts/compile_and_run.sh`
- [x] CLI command `swift run CodexBarCLI usage --provider kimi` now works correctly
- [x] All existing Kimi tests pass
- [x] SwiftLint passes with no violations

## Example Output

```
== Kimi (web) ==
Weekly: 79% left [=========---]
Resets 21/100 requests
Rate Limit: 69% left [========----]
Resets in 1h 5m
```

## Files Changed

- `Sources/CodexBarCore/Providers/Kimi/KimiModels.swift` - Make `resetTime` optional
- `Sources/CodexBarCore/Providers/Kimi/KimiUsageSnapshot.swift` - Handle optional `resetTime` in date parsing