### PR TITLE
Add GPT-5.4 mini and nano pricing

### DIFF
--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
@@ -97,6 +97,16 @@ enum CostUsagePricing {
             outputCostPerToken: 1.5e-5,
             cacheReadInputCostPerToken: 2.5e-7,
             displayLabel: nil),
+        "gpt-5.4-mini": CodexPricing(
+            inputCostPerToken: 7.5e-7,
+            outputCostPerToken: 4.5e-6,
+            cacheReadInputCostPerToken: 7.5e-8,
+            displayLabel: nil),
+        "gpt-5.4-nano": CodexPricing(
+            inputCostPerToken: 2e-7,
+            outputCostPerToken: 1.25e-6,
+            cacheReadInputCostPerToken: 2e-8,
+            displayLabel: nil),
         "gpt-5.4-pro": CodexPricing(
             inputCostPerToken: 3e-5,
             outputCostPerToken: 1.8e-4,

--- a/Tests/CodexBarTests/CostUsagePricingTests.swift
+++ b/Tests/CodexBarTests/CostUsagePricingTests.swift
@@ -8,6 +8,8 @@ struct CostUsagePricingTests {
         #expect(CostUsagePricing.normalizeCodexModel("gpt-5.2-codex") == "gpt-5.2-codex")
         #expect(CostUsagePricing.normalizeCodexModel("gpt-5.1-codex-max") == "gpt-5.1-codex-max")
         #expect(CostUsagePricing.normalizeCodexModel("gpt-5.4-pro-2026-03-05") == "gpt-5.4-pro")
+        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.4-mini-2026-03-17") == "gpt-5.4-mini")
+        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.4-nano-2026-03-17") == "gpt-5.4-nano")
         #expect(CostUsagePricing.normalizeCodexModel("gpt-5.3-codex-2026-03-05") == "gpt-5.3-codex")
         #expect(CostUsagePricing.normalizeCodexModel("gpt-5.3-codex-spark") == "gpt-5.3-codex-spark")
     }
@@ -30,6 +32,23 @@ struct CostUsagePricingTests {
             cachedInputTokens: 10,
             outputTokens: 5)
         #expect(cost != nil)
+    }
+
+    @Test
+    func `codex cost supports gpt54 mini and nano`() {
+        let mini = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.4-mini-2026-03-17",
+            inputTokens: 100,
+            cachedInputTokens: 10,
+            outputTokens: 5)
+        let nano = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.4-nano",
+            inputTokens: 100,
+            cachedInputTokens: 10,
+            outputTokens: 5)
+
+        #expect(mini != nil)
+        #expect(nano != nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add GPT-5.4 mini and GPT-5.4 nano to the Codex pricing catalog.
- Normalize dated snapshot variants to the new base model IDs.

## Validation
- swift test --filter CostUsagePricingTests
- ./Scripts/compile_and_run.sh
- pnpm check