### PR TITLE
fix(claude): enrich OAuth identity via CLI probe when API returns no email

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -291,25 +291,30 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
 
     /// The OAuth usage endpoint does not return account identity (email/org).
     /// When identity is missing, attempt a best-effort CLI status probe to fill it in.
+    ///
+    /// Skipped when the OAuth token came from an environment variable, since the
+    /// CLI may be logged into a different account than the env-backed token.
     static func enrichIdentityIfNeeded(
         usage: ClaudeUsageSnapshot,
         environment: [String: String]) async -> ClaudeUsageSnapshot
     {
         guard usage.accountEmail == nil else { return usage }
 
+        // When the OAuth token is provided via env var, the local CLI session
+        // may belong to a different account. Merging would show the wrong identity.
+        let hasEnvToken = !(environment[ClaudeOAuthCredentialsStore.environmentTokenKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+        guard !hasEnvToken else { return usage }
+
         let identity: ClaudeAccountIdentity?
         #if DEBUG
         if let override = Self.identityProbeOverride {
             identity = override
         } else {
-            identity = try? await ClaudeStatusProbe.fetchIdentity(
-                timeout: 5,
-                environment: environment)
+            identity = await Self.probeIdentityViaCLI(environment: environment)
         }
         #else
-        identity = try? await ClaudeStatusProbe.fetchIdentity(
-            timeout: 5,
-            environment: environment)
+        identity = await Self.probeIdentityViaCLI(environment: environment)
         #endif
 
         guard let identity else { return usage }
@@ -323,6 +328,18 @@ struct ClaudeOAuthFetchStrategy: ProviderFetchStrategy {
             accountOrganization: identity.accountOrganization,
             loginMethod: usage.loginMethod ?? identity.loginMethod,
             rawText: usage.rawText)
+    }
+
+    /// Run `claude /status` to scrape account identity, then reset the PTY session
+    /// so we don't leave a background `claude` process resident.
+    private static func probeIdentityViaCLI(
+        environment: [String: String]) async -> ClaudeAccountIdentity?
+    {
+        let identity = try? await ClaudeStatusProbe.fetchIdentity(
+            timeout: 5,
+            environment: environment)
+        await ClaudeCLISession.shared.reset()
+        return identity
     }
 
     func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {

--- a/Tests/CodexBarTests/ClaudeOAuthIdentityEnrichmentTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthIdentityEnrichmentTests.swift
@@ -96,5 +96,25 @@ struct ClaudeOAuthIdentityEnrichmentTests {
         #expect(enriched.accountEmail == "user@example.com")
         #expect(enriched.loginMethod == "Claude Pro")
     }
+
+    @Test
+    func `skips probe when OAuth token came from env var`() async {
+        let usage = self.makeUsage(accountEmail: nil)
+        let identity = ClaudeAccountIdentity(
+            accountEmail: "cli@example.com",
+            accountOrganization: nil,
+            loginMethod: nil)
+
+        let env = [ClaudeOAuthCredentialsStore.environmentTokenKey: "sk-ant-oat-env-token"]
+        let enriched = await ClaudeOAuthFetchStrategy.$identityProbeOverride
+            .withValue(.some(identity)) {
+                await ClaudeOAuthFetchStrategy.enrichIdentityIfNeeded(
+                    usage: usage,
+                    environment: env)
+            }
+
+        // Should NOT merge CLI identity when token is env-backed
+        #expect(enriched.accountEmail == nil)
+    }
 }
 #endif


### PR DESCRIPTION
## Summary

- When OAuth is the active Claude data source, the account email is never shown in the menu bar because the OAuth usage API (`api.anthropic.com/api/oauth/usage`) does not return identity fields
- After a successful OAuth usage fetch, if `accountEmail` is nil, perform a best-effort CLI identity probe via `ClaudeStatusProbe.fetchIdentity()` (5s timeout) and merge the result into the snapshot
- If the probe fails or CLI is unavailable, the snapshot is returned unchanged — no impact on the existing flow

Fixes #567

## Changes

**`ClaudeProviderDescriptor.swift`** — `ClaudeOAuthFetchStrategy`:
- Add `enrichIdentityIfNeeded(usage:environment:)` that probes `claude /status` when OAuth returns nil email
- Call it in `fetch()` after `loadLatestUsage()` succeeds
- Add `@TaskLocal identityProbeOverride` for testability (`#if DEBUG`)

**`ClaudeOAuthIdentityEnrichmentTests.swift`** (new):
- Verifies email is merged when OAuth returns nil and probe succeeds
- Verifies existing email is preserved (no override)
- Verifies graceful handling when probe fails (nil identity)
- Verifies OAuth `loginMethod` takes precedence over probe `loginMethod`

## Test plan

- [x] `swift build` succeeds
- [x] All 4 new tests pass (`swift test --filter ClaudeOAuthIdentityEnrichmentTests`)
- [x] All 17 existing `ClaudeOAuthTests` pass
- [x] All 11 existing `ClaudeOAuthFetchStrategyAvailabilityTests` pass (10 pass; 1 pre-existing environment-dependent failure on main)
- [ ] Manual: enable Claude with Usage source = OAuth, verify email appears in menu bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)