### PR TITLE
Fix preferences sidebar clipping and window sizing on macOS Tahoe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Copilot: open the complete device-login verification URL when available so the browser flow carries the user code (#739). Thanks @skhe!
 - Alibaba: update the China mainland Coding Plan endpoint and browser-cookie domain while keeping older domains as fallbacks (#712). Thanks @hezhongtang!
 
+### Menu & Settings
+- Settings: fix provider-sidebar clipping on macOS Tahoe and resize the Preferences window when switching tabs (#580). Thanks @chadneal!
+
 ### Fixes
 - Keychain cache: preserve cached credentials when macOS temporarily denies keychain UI after wake, avoiding repeated prompts (#594). Thanks @josepe98!
 

--- a/Scripts/compile_and_run.sh
+++ b/Scripts/compile_and_run.sh
@@ -29,6 +29,27 @@ delete_keychain_service_items() {
   done
 }
 
+# Ensure Swift >= 5.5 (required for --arch flag in swift build)
+ensure_swift_version() {
+  local swift_ver
+  swift_ver=$(swift --version 2>&1 | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
+  local major minor
+  major=$(echo "$swift_ver" | cut -d. -f1)
+  minor=$(echo "$swift_ver" | cut -d. -f2)
+  if [[ "${major:-0}" -ge 6 ]] || { [[ "${major:-0}" -eq 5 ]] && [[ "${minor:-0}" -ge 5 ]]; }; then
+    return 0
+  fi
+  # Try Xcode toolchain
+  local xcrun_swift
+  xcrun_swift=$(xcrun --find swift 2>/dev/null || true)
+  if [[ -n "$xcrun_swift" && -x "$xcrun_swift" ]]; then
+    log "WARN: PATH swift is v${swift_ver}; switching to Xcode toolchain at $(dirname "$xcrun_swift")"
+    export PATH="$(dirname "$xcrun_swift"):$PATH"
+    return 0
+  fi
+  fail "Swift >= 5.5 required (found ${swift_ver:-none}). Install Xcode or update swiftly."
+}
+
 has_signing_identity() {
   local identity="${1:-}"
   if [[ -z "${identity}" ]]; then
@@ -173,6 +194,7 @@ for arg in "$@"; do
   esac
 done
 
+ensure_swift_version
 resolve_signing_mode
 if [[ "${CLEAR_ADHOC_KEYCHAIN}" == "1" && "${SIGNING_MODE}" != "adhoc" ]]; then
   fail "--clear-adhoc-keychain is only supported when using adhoc signing."

--- a/Scripts/compile_and_run.sh
+++ b/Scripts/compile_and_run.sh
@@ -31,8 +31,14 @@ delete_keychain_service_items() {
 
 # Ensure Swift >= 5.5 (required for --arch flag in swift build)
 ensure_swift_version() {
+  local swift_output
   local swift_ver
-  swift_ver=$(swift --version 2>&1 | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
+  swift_output=$(swift --version 2>&1 || true)
+  if [[ "$swift_output" =~ (Apple[[:space:]]+)?Swift[[:space:]]+version[[:space:]]+([0-9]+)\.([0-9]+)(\.[0-9]+)? ]]; then
+    swift_ver="${BASH_REMATCH[2]}.${BASH_REMATCH[3]}${BASH_REMATCH[4]}"
+  else
+    fail "Swift >= 5.5 required (found ${swift_output:-none}). Install Xcode or update swiftly."
+  fi
   local major minor
   major=$(echo "$swift_ver" | cut -d. -f1)
   minor=$(echo "$swift_ver" | cut -d. -f2)

--- a/Sources/CodexBar/PreferencesProviderSidebarView.swift
+++ b/Sources/CodexBar/PreferencesProviderSidebarView.swift
@@ -13,26 +13,33 @@ struct ProviderSidebarListView: View {
     @State private var draggingProvider: UsageProvider?
 
     var body: some View {
-        List(selection: self.$selection) {
-            ForEach(self.providers, id: \.self) { provider in
-                ProviderSidebarRowView(
-                    provider: provider,
-                    store: self.store,
-                    isEnabled: self.isEnabled(provider),
-                    subtitle: self.subtitle(provider),
-                    draggingProvider: self.$draggingProvider)
-                    .tag(provider)
-                    .onDrop(
-                        of: [UTType.plainText],
-                        delegate: ProviderSidebarDropDelegate(
-                            item: provider,
-                            providers: self.providers,
-                            dragging: self.$draggingProvider,
-                            moveProviders: self.moveProviders))
+        ScrollView {
+            VStack(spacing: 0) {
+                ForEach(self.providers, id: \.self) { provider in
+                    ProviderSidebarRowView(
+                        provider: provider,
+                        store: self.store,
+                        isEnabled: self.isEnabled(provider),
+                        subtitle: self.subtitle(provider),
+                        draggingProvider: self.$draggingProvider)
+                        .padding(.horizontal, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .fill(self.selection == provider ? Color(nsColor: .selectedContentBackgroundColor) : Color.clear)
+                                .padding(.horizontal, 4))
+                        .contentShape(Rectangle())
+                        .onTapGesture { self.selection = provider }
+                        .onDrop(
+                            of: [UTType.plainText],
+                            delegate: ProviderSidebarDropDelegate(
+                                item: provider,
+                                providers: self.providers,
+                                dragging: self.$draggingProvider,
+                                moveProviders: self.moveProviders))
+                }
             }
+            .padding(.vertical, 4)
         }
-        .listStyle(.sidebar)
-        .scrollContentBackground(.hidden)
         .background(
             RoundedRectangle(cornerRadius: ProviderSettingsMetrics.sidebarCornerRadius, style: .continuous)
                 .fill(Color(nsColor: .controlBackgroundColor).opacity(0.8)))

--- a/Sources/CodexBar/PreferencesProviderSidebarView.swift
+++ b/Sources/CodexBar/PreferencesProviderSidebarView.swift
@@ -25,7 +25,10 @@ struct ProviderSidebarListView: View {
                         .padding(.horizontal, 8)
                         .background(
                             RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .fill(self.selection == provider ? Color(nsColor: .selectedContentBackgroundColor) : Color.clear)
+                                .fill(
+                                    self.selection == provider
+                                        ? Color(nsColor: .selectedContentBackgroundColor)
+                                        : Color.clear)
                                 .padding(.horizontal, 4))
                         .contentShape(Rectangle())
                         .onTapGesture { self.selection = provider }

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -1,7 +1,7 @@
 import AppKit
 import SwiftUI
 
-enum PreferencesTab: String, Hashable {
+enum PreferencesTab: String, CaseIterable, Hashable {
     case general
     case providers
     case display
@@ -12,6 +12,17 @@ enum PreferencesTab: String, Hashable {
     static let defaultWidth: CGFloat = 496
     static let providersWidth: CGFloat = 720
     static let windowHeight: CGFloat = 580
+
+    var title: String {
+        switch self {
+        case .general: "General"
+        case .providers: "Providers"
+        case .display: "Display"
+        case .advanced: "Advanced"
+        case .about: "About"
+        case .debug: "Debug"
+        }
+    }
 
     var preferredWidth: CGFloat {
         self == .providers ? PreferencesTab.providersWidth : PreferencesTab.defaultWidth
@@ -110,6 +121,24 @@ struct PreferencesView: View {
         } else {
             change()
         }
+        Self.resizeSettingsWindow(width: tab.preferredWidth, height: tab.preferredHeight, animate: animate)
+    }
+
+    private static let settingsWindowIdentifier = "com_apple_SwiftUI_Settings_window"
+    private static let knownTabTitles = Set(PreferencesTab.allCases.map(\.title))
+
+    private static func resizeSettingsWindow(width: CGFloat, height: CGFloat, animate: Bool) {
+        guard let window = NSApp.windows.first(where: {
+            $0.identifier?.rawValue == settingsWindowIdentifier
+                || knownTabTitles.contains($0.title)
+        }) else { return }
+        let toolbarHeight = window.frame.height - window.contentLayoutRect.height
+        guard toolbarHeight > 0 else { return }
+        let newSize = NSSize(width: width, height: height + toolbarHeight)
+        var frame = window.frame
+        frame.origin.y += frame.size.height - newSize.height
+        frame.size = newSize
+        window.setFrame(frame, display: true, animate: animate)
     }
 
     private func ensureValidTabSelection() {


### PR DESCRIPTION
## Summary
- Fix provider sidebar clipping on macOS Tahoe where `.listStyle(.sidebar)` internal insets pushed content beyond the 240px frame, hiding provider names, icons, and reorder handles
- Replace `List` with `ScrollView`+`VStack` for full control over sidebar layout without system-imposed insets
- Add direct `NSWindow.setFrame` resizing since SwiftUI's `.windowResizability(.contentSize)` doesn't propagate frame changes on Tahoe
- Add `PreferencesTab.title` and `CaseIterable` to derive window-finder tab titles from the enum instead of hardcoded strings
- Use system `selectedContentBackgroundColor` for sidebar selection highlight
- Add `ensure_swift_version()` to `compile_and_run.sh` for Xcode toolchain fallback

## Test plan
- [ ] Open Settings → Providers tab: all provider names, icons, reorder handles, and checkboxes visible
- [ ] Click providers to verify selection works and highlights correctly
- [ ] Drag to reorder providers
- [ ] Switch between General/Providers tabs: window animates to correct width
- [ ] Verify on macOS Tahoe (Darwin 25.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)