### PR TITLE
fix: use Data Protection keychain to eliminate repeated permission prompts

### DIFF
--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -138,6 +138,9 @@ APP_GROUP_ID="group.com.steipete.codexbar"
 if [[ "$BUNDLE_ID" == *".debug"* ]]; then
   APP_GROUP_ID="group.com.steipete.codexbar.debug"
 fi
+# Keychain access group for the Data Protection keychain.
+# Must match DataProtectionKeychain.accessGroup in Swift code.
+KEYCHAIN_GROUP="Y5PE65HELJ.com.steipete.codexbar"
 ENTITLEMENTS_DIR="$ROOT/.build/entitlements"
 APP_ENTITLEMENTS="${ENTITLEMENTS_DIR}/CodexBar.entitlements"
 WIDGET_ENTITLEMENTS="${ENTITLEMENTS_DIR}/CodexBarWidget.entitlements"
@@ -155,6 +158,14 @@ cat > "$APP_ENTITLEMENTS" <<PLIST
     <array>
         <string>${APP_GROUP_ID}</string>
     </array>
+    $(if [[ "$SIGNING_MODE" != "adhoc" && "$ALLOW_LLDB" != "1" ]]; then
+    cat <<INNER
+    <key>keychain-access-groups</key>
+    <array>
+        <string>${KEYCHAIN_GROUP}</string>
+    </array>
+INNER
+    fi)
     $(if [[ "$ALLOW_LLDB" == "1" ]]; then echo "    <key>com.apple.security.get-task-allow</key><true/>"; fi)
 </dict>
 </plist>

--- a/Sources/CodexBar/CookieHeaderStore.swift
+++ b/Sources/CodexBar/CookieHeaderStore.swift
@@ -61,13 +61,14 @@ struct KeychainCookieHeaderStore: CookieHeaderStoring {
         }
         Self.cacheLock.unlock()
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
             kSecMatchLimit as String: kSecMatchLimitOne,
             kSecReturnData as String: true,
         ]
+        DataProtectionKeychain.apply(to: &query)
 
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
@@ -130,11 +131,12 @@ struct KeychainCookieHeaderStore: CookieHeaderStoring {
         }
 
         let data = raw.data(using: .utf8)!
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let attributes: [String: Any] = [
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
@@ -171,11 +173,12 @@ struct KeychainCookieHeaderStore: CookieHeaderStoring {
 
     private func deleteIfPresent() throws {
         guard !KeychainAccessGate.isDisabled else { return }
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let status = SecItemDelete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             // Invalidate cache

--- a/Sources/CodexBar/CopilotTokenStore.swift
+++ b/Sources/CodexBar/CopilotTokenStore.swift
@@ -33,13 +33,14 @@ struct KeychainCopilotTokenStore: CopilotTokenStoring {
             return nil
         }
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
             kSecMatchLimit as String: kSecMatchLimitOne,
             kSecReturnData as String: true,
         ]
+        DataProtectionKeychain.apply(to: &query)
 
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
@@ -81,11 +82,12 @@ struct KeychainCopilotTokenStore: CopilotTokenStoring {
         }
 
         let data = cleaned!.data(using: .utf8)!
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let attributes: [String: Any] = [
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
@@ -113,11 +115,12 @@ struct KeychainCopilotTokenStore: CopilotTokenStoring {
 
     private func deleteTokenIfPresent() throws {
         guard !KeychainAccessGate.isDisabled else { return }
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let status = SecItemDelete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             return

--- a/Sources/CodexBar/HiddenWindowView.swift
+++ b/Sources/CodexBar/HiddenWindowView.swift
@@ -12,9 +12,10 @@ struct HiddenWindowView: View {
                 }
             }
             .task {
-                // Migrate keychain items to reduce permission prompts during development (runs off main thread)
+                // Migrate keychain items (runs off main thread)
                 await Task.detached(priority: .userInitiated) {
                     KeychainMigration.migrateIfNeeded()
+                    KeychainMigration.migrateToDataProtectionIfNeeded()
                 }.value
             }
             .onAppear {

--- a/Sources/CodexBar/KeychainMigration.swift
+++ b/Sources/CodexBar/KeychainMigration.swift
@@ -2,11 +2,16 @@ import CodexBarCore
 import Foundation
 import Security
 
-/// Migrates keychain items to use kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
-/// to prevent permission prompts on every rebuild during development.
+/// Migrates keychain items from the legacy login keychain to the Data Protection
+/// keychain so that access is validated by team ID rather than binary hash.
+///
+/// V1 changed the accessibility level (still legacy keychain).
+/// V2 moves items into the Data Protection keychain with a team-scoped access
+/// group, eliminating permission prompts after Sparkle binary updates.
 enum KeychainMigration {
     private static let log = CodexBarLog.logger(LogCategories.keychainMigration)
     private static let migrationKey = "KeychainMigrationV1Completed"
+    private static let migrationV2Key = "KeychainMigrationV2DPCompleted"
 
     struct MigrationItem: Hashable {
         let service: String
@@ -140,9 +145,122 @@ enum KeychainMigration {
         return true
     }
 
+    // MARK: - V2: Legacy → Data Protection keychain
+
+    /// Move items from the legacy login keychain into the Data Protection
+    /// keychain. This is the migration that actually fixes the repeated-prompt
+    /// problem: the DP keychain validates by team ID, not binary hash.
+    static func migrateToDataProtectionIfNeeded() {
+        guard !KeychainAccessGate.isDisabled else {
+            self.log.info("Keychain access disabled; skipping DP migration")
+            return
+        }
+
+        guard !UserDefaults.standard.bool(forKey: self.migrationV2Key) else {
+            self.log.debug("Data Protection keychain migration already completed, skipping")
+            return
+        }
+
+        self.log.info("Starting Data Protection keychain migration")
+
+        var migratedCount = 0
+        var errorCount = 0
+
+        for item in self.itemsToMigrate {
+            do {
+                if try self.migrateItemToDP(item) {
+                    migratedCount += 1
+                }
+            } catch {
+                errorCount += 1
+                self.log.error("DP migration failed for \(item.label): \(String(describing: error))")
+            }
+        }
+
+        self.log.info("DP migration complete: \(migratedCount) migrated, \(errorCount) errors")
+        UserDefaults.standard.set(true, forKey: self.migrationV2Key)
+    }
+
+    /// Read an item from the legacy keychain and write it to the Data
+    /// Protection keychain, then remove the legacy copy.
+    private static func migrateItemToDP(_ item: MigrationItem) throws -> Bool {
+        // Check if already present in DP keychain
+        var dpCheckQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: item.service,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnAttributes as String: true,
+        ]
+        DataProtectionKeychain.apply(to: &dpCheckQuery)
+        if let account = item.account {
+            dpCheckQuery[kSecAttrAccount as String] = account
+        }
+        if SecItemCopyMatching(dpCheckQuery as CFDictionary, nil) == errSecSuccess {
+            self.log.debug("\(item.label) already in DP keychain")
+            return false
+        }
+
+        // Read from legacy keychain
+        var legacyQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: item.service,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnData as String: true,
+        ]
+        if let account = item.account {
+            legacyQuery[kSecAttrAccount as String] = account
+        }
+
+        var result: CFTypeRef?
+        let readStatus = SecItemCopyMatching(legacyQuery as CFDictionary, &result)
+        if readStatus == errSecItemNotFound {
+            return false
+        }
+        guard readStatus == errSecSuccess,
+              let data = result as? Data
+        else {
+            throw KeychainMigrationError.readFailed(readStatus)
+        }
+
+        // Write to DP keychain
+        var addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: item.service,
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        DataProtectionKeychain.apply(to: &addQuery)
+        if let account = item.account {
+            addQuery[kSecAttrAccount as String] = account
+        }
+
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            throw KeychainMigrationError.addFailed(addStatus)
+        }
+
+        // Remove legacy copy
+        var deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: item.service,
+        ]
+        if let account = item.account {
+            deleteQuery[kSecAttrAccount as String] = account
+        }
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        self.log.info("Migrated \(item.label) to Data Protection keychain")
+        return true
+    }
+
     /// Reset migration flag (for testing)
     static func resetMigrationFlag() {
         UserDefaults.standard.removeObject(forKey: self.migrationKey)
+    }
+
+    /// Reset V2 migration flag (for testing)
+    static func resetMigrationV2Flag() {
+        UserDefaults.standard.removeObject(forKey: self.migrationV2Key)
     }
 }
 

--- a/Sources/CodexBar/KimiK2TokenStore.swift
+++ b/Sources/CodexBar/KimiK2TokenStore.swift
@@ -29,13 +29,14 @@ struct KeychainKimiK2TokenStore: KimiK2TokenStoring {
 
     func loadToken() throws -> String? {
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
             kSecMatchLimit as String: kSecMatchLimitOne,
             kSecReturnData as String: true,
         ]
+        DataProtectionKeychain.apply(to: &query)
 
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
@@ -73,11 +74,12 @@ struct KeychainKimiK2TokenStore: KimiK2TokenStoring {
         }
 
         let data = cleaned!.data(using: .utf8)!
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let attributes: [String: Any] = [
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
@@ -104,11 +106,12 @@ struct KeychainKimiK2TokenStore: KimiK2TokenStoring {
     }
 
     private func deleteTokenIfPresent() throws {
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let status = SecItemDelete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             return

--- a/Sources/CodexBar/KimiTokenStore.swift
+++ b/Sources/CodexBar/KimiTokenStore.swift
@@ -33,13 +33,14 @@ struct KeychainKimiTokenStore: KimiTokenStoring {
             return nil
         }
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
             kSecMatchLimit as String: kSecMatchLimitOne,
             kSecReturnData as String: true,
         ]
+        DataProtectionKeychain.apply(to: &query)
 
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
@@ -81,11 +82,12 @@ struct KeychainKimiTokenStore: KimiTokenStoring {
         }
 
         let data = cleaned!.data(using: .utf8)!
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let attributes: [String: Any] = [
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
@@ -113,11 +115,12 @@ struct KeychainKimiTokenStore: KimiTokenStoring {
 
     private func deleteTokenIfPresent() throws {
         guard !KeychainAccessGate.isDisabled else { return }
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let status = SecItemDelete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             return

--- a/Sources/CodexBar/MiniMaxAPITokenStore.swift
+++ b/Sources/CodexBar/MiniMaxAPITokenStore.swift
@@ -33,13 +33,14 @@ struct KeychainMiniMaxAPITokenStore: MiniMaxAPITokenStoring {
             return nil
         }
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
             kSecMatchLimit as String: kSecMatchLimitOne,
             kSecReturnData as String: true,
         ]
+        DataProtectionKeychain.apply(to: &query)
 
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
@@ -81,11 +82,12 @@ struct KeychainMiniMaxAPITokenStore: MiniMaxAPITokenStoring {
         }
 
         let data = cleaned!.data(using: .utf8)!
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let attributes: [String: Any] = [
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
@@ -113,11 +115,12 @@ struct KeychainMiniMaxAPITokenStore: MiniMaxAPITokenStoring {
 
     private func deleteIfPresent() throws {
         guard !KeychainAccessGate.isDisabled else { return }
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let status = SecItemDelete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             return

--- a/Sources/CodexBar/MiniMaxCookieStore.swift
+++ b/Sources/CodexBar/MiniMaxCookieStore.swift
@@ -33,13 +33,14 @@ struct KeychainMiniMaxCookieStore: MiniMaxCookieStoring {
             return nil
         }
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
             kSecMatchLimit as String: kSecMatchLimitOne,
             kSecReturnData as String: true,
         ]
+        DataProtectionKeychain.apply(to: &query)
 
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
@@ -86,11 +87,12 @@ struct KeychainMiniMaxCookieStore: MiniMaxCookieStoring {
         }
 
         let data = raw.data(using: .utf8)!
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let attributes: [String: Any] = [
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
@@ -118,11 +120,12 @@ struct KeychainMiniMaxCookieStore: MiniMaxCookieStoring {
 
     private func deleteIfPresent() throws {
         guard !KeychainAccessGate.isDisabled else { return }
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let status = SecItemDelete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             return

--- a/Sources/CodexBar/SyntheticTokenStore.swift
+++ b/Sources/CodexBar/SyntheticTokenStore.swift
@@ -33,13 +33,14 @@ struct KeychainSyntheticTokenStore: SyntheticTokenStoring {
             return nil
         }
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
             kSecMatchLimit as String: kSecMatchLimitOne,
             kSecReturnData as String: true,
         ]
+        DataProtectionKeychain.apply(to: &query)
 
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
@@ -81,11 +82,12 @@ struct KeychainSyntheticTokenStore: SyntheticTokenStoring {
         }
 
         let data = cleaned!.data(using: .utf8)!
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let attributes: [String: Any] = [
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
@@ -113,11 +115,12 @@ struct KeychainSyntheticTokenStore: SyntheticTokenStoring {
 
     private func deleteTokenIfPresent() throws {
         guard !KeychainAccessGate.isDisabled else { return }
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let status = SecItemDelete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             return

--- a/Sources/CodexBar/ZaiTokenStore.swift
+++ b/Sources/CodexBar/ZaiTokenStore.swift
@@ -50,13 +50,14 @@ struct KeychainZaiTokenStore: ZaiTokenStoring {
         }
         Self.cacheLock.unlock()
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
             kSecMatchLimit as String: kSecMatchLimitOne,
             kSecReturnData as String: true,
         ]
+        DataProtectionKeychain.apply(to: &query)
 
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
@@ -113,11 +114,12 @@ struct KeychainZaiTokenStore: ZaiTokenStoring {
         }
 
         let data = cleaned!.data(using: .utf8)!
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let attributes: [String: Any] = [
             kSecValueData as String: data,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
@@ -156,11 +158,12 @@ struct KeychainZaiTokenStore: ZaiTokenStoring {
 
     private func deleteTokenIfPresent() throws {
         guard !KeychainAccessGate.isDisabled else { return }
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
         ]
+        DataProtectionKeychain.apply(to: &query)
         let status = SecItemDelete(query as CFDictionary)
         if status == errSecSuccess || status == errSecItemNotFound {
             // Invalidate cache

--- a/Sources/CodexBarCore/DataProtectionKeychain.swift
+++ b/Sources/CodexBarCore/DataProtectionKeychain.swift
@@ -1,0 +1,39 @@
+import Foundation
+#if os(macOS)
+import Security
+#endif
+
+/// Helpers for using the macOS Data Protection keychain instead of the legacy
+/// login keychain.
+///
+/// The legacy login keychain validates "Always Allow" grants against the
+/// binary's **code directory hash**. Every Sparkle update replaces the binary,
+/// changing the hash and invalidating all prior grants — causing repeated
+/// permission prompts.
+///
+/// The Data Protection keychain (`kSecUseDataProtectionKeychain`) with a
+/// team-scoped `keychain-access-groups` entitlement validates access by
+/// **Developer ID team** instead. Items survive binary updates as long as the
+/// signing team stays the same.
+public enum DataProtectionKeychain {
+    /// Keychain access group matching the `keychain-access-groups` entitlement.
+    /// Format: `<TeamID>.<identifier>`.
+    public static let accessGroup = "Y5PE65HELJ.com.steipete.codexbar"
+
+    #if os(macOS)
+    /// Add Data Protection keychain attributes to a query dictionary.
+    ///
+    /// Call this on every `SecItem*` query for CodexBar-owned items so they
+    /// route through the Data Protection keychain instead of the legacy login
+    /// keychain. This eliminates permission prompts after Sparkle updates.
+    ///
+    /// For ad-hoc builds without the `keychain-access-groups` entitlement the
+    /// attributes are still added; `SecItem*` calls will fall back gracefully
+    /// (the entitlement is only enforced for Data Protection keychain items
+    /// that specify an access group).
+    public static func apply(to query: inout [String: Any]) {
+        query[kSecUseDataProtectionKeychain as String] = true
+        query[kSecAttrAccessGroup as String] = accessGroup
+    }
+    #endif
+}


### PR DESCRIPTION
## Summary

- Switch CodexBar-owned Keychain items from the legacy login keychain to the **Data Protection keychain** (`kSecUseDataProtectionKeychain`) with a team-scoped `keychain-access-groups` entitlement
- The legacy keychain validates "Always Allow" by binary hash — every Sparkle update invalidates prior grants, causing ~10 prompts daily
- The DP keychain validates by **Developer ID team**, so grants survive binary updates permanently
- Includes V2 migration that transparently moves existing items from legacy → DP keychain on first launch

## What changed (12 files)

- **`DataProtectionKeychain.swift`** (new) — helper to add DP keychain attributes to query dicts
- **8 token/cookie stores** — add `DataProtectionKeychain.apply(to:)` to all `SecItem*` queries
- **`KeychainMigration.swift`** — add V2 migration: legacy → DP keychain (one-time, transparent)
- **`HiddenWindowView.swift`** — wire V2 migration at startup
- **`package_app.sh`** — add `keychain-access-groups` entitlement for Developer ID builds

## What this doesn't fix

- Chrome Safe Storage prompts (Chrome's item, Chrome's ACL)
- Claude CLI credential prompts (Claude CLI's item)
- `KeychainCacheStore` is left on the legacy keychain intentionally — it's an ephemeral internal cache, not user-facing

## Test plan

- [x] `swift build` passes
- [x] All 1040 tests pass (0 regressions)
- [ ] Verify entitlement appears in Developer ID signed build: `codesign -d --entitlements - CodexBar.app`
- [ ] After install + migration, tokens accessible without Keychain prompt
- [ ] After simulated Sparkle update (re-sign + replace binary), no new prompts

Fixes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)