### PR TITLE
fix: handle errSecInteractionNotAllowed in KeychainCacheStore to prevent cache self-destruction on wake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Providers & Usage
 - Gemini: discover OAuth config in fnm/Homebrew/bundled CLI layouts so expired-token refresh keeps working (#723). Thanks @Leechael!
 
+### Fixes
+- Keychain cache: preserve cached credentials when macOS temporarily denies keychain UI after wake, avoiding repeated prompts (#594). Thanks @josepe98!
+
 ## 0.21 — 2026-04-18
 
 ### Highlights

--- a/Sources/CodexBarCore/KeychainCacheStore.swift
+++ b/Sources/CodexBarCore/KeychainCacheStore.swift
@@ -46,13 +46,14 @@ public enum KeychainCacheStore {
             return testResult
         }
         #if os(macOS)
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.serviceName,
             kSecAttrAccount as String: key.account,
             kSecMatchLimit as String: kSecMatchLimitOne,
             kSecReturnData as String: true,
         ]
+        KeychainNoUIQuery.apply(to: &query)
 
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
@@ -69,6 +70,12 @@ public enum KeychainCacheStore {
             }
             return .found(decoded)
         case errSecItemNotFound:
+            return .missing
+        case errSecInteractionNotAllowed:
+            // Keychain is temporarily locked (e.g. immediately after wake from sleep).
+            // The cache entry is valid — treat as missing so the caller falls through
+            // gracefully rather than deleting a perfectly good cache entry.
+            self.log.info("Keychain cache temporarily locked (\(key.account)), will retry on next access")
             return .missing
         default:
             self.log.error("Keychain cache read failed (\(key.account)): \(status)")

--- a/Sources/CodexBarCore/KeychainCacheStore.swift
+++ b/Sources/CodexBarCore/KeychainCacheStore.swift
@@ -69,17 +69,8 @@ public enum KeychainCacheStore {
                 return .invalid
             }
             return .found(decoded)
-        case errSecItemNotFound:
-            return .missing
-        case errSecInteractionNotAllowed:
-            // Keychain is temporarily locked (e.g. immediately after wake from sleep).
-            // The cache entry is valid — treat as missing so the caller falls through
-            // gracefully rather than deleting a perfectly good cache entry.
-            self.log.info("Keychain cache temporarily locked (\(key.account)), will retry on next access")
-            return .missing
         default:
-            self.log.error("Keychain cache read failed (\(key.account)): \(status)")
-            return .invalid
+            return self.loadResultForKeychainReadFailure(status: status, key: key)
         }
         #else
         return .missing
@@ -210,6 +201,25 @@ public enum KeychainCacheStore {
         decoder.dateDecodingStrategy = .iso8601
         return decoder
     }
+
+    #if os(macOS)
+    static func loadResultForKeychainReadFailure<Entry>(
+        status: OSStatus,
+        key: Key) -> LoadResult<Entry>
+    {
+        switch status {
+        case errSecItemNotFound:
+            return .missing
+        case errSecInteractionNotAllowed:
+            // Keychain is temporarily locked, e.g. immediately after wake from sleep.
+            self.log.info("Keychain cache temporarily locked (\(key.account)), will retry on next access")
+            return .missing
+        default:
+            self.log.error("Keychain cache read failed (\(key.account)): \(status)")
+            return .invalid
+        }
+    }
+    #endif
 
     private static func loadFromTestStore<Entry: Codable>(
         key: Key,

--- a/Tests/CodexBarTests/KeychainCacheStoreTests.swift
+++ b/Tests/CodexBarTests/KeychainCacheStoreTests.swift
@@ -68,4 +68,21 @@ struct KeychainCacheStoreTests {
             #expect(Bool(false), "Expected keychain cache entry to be cleared")
         }
     }
+
+    #if os(macOS)
+    @Test
+    func `interaction not allowed is treated as temporarily missing`() {
+        let key = KeychainCacheStore.Key(category: "test", identifier: UUID().uuidString)
+        let result: KeychainCacheStore.LoadResult<TestEntry> = KeychainCacheStore.loadResultForKeychainReadFailure(
+            status: errSecInteractionNotAllowed,
+            key: key)
+
+        switch result {
+        case .missing:
+            #expect(true)
+        case .found, .invalid:
+            #expect(Bool(false), "Expected temporary keychain lock to preserve cache")
+        }
+    }
+    #endif
 }


### PR DESCRIPTION
## Problem

When the Mac wakes from sleep, the keychain is briefly locked. During this window, `KeychainCacheStore.load` calls `SecItemCopyMatching` and gets back `errSecInteractionNotAllowed` (-25308). This falls into the `default` case, returns `.invalid`, and the caller deletes the cache entry:

```swift
// In Repository.loadRecord
case .invalid:
    KeychainCacheStore.clear(key: ClaudeOAuthCredentialsStore.cacheKey)  // cache wiped
```

The cache entry was perfectly valid — it was just temporarily inaccessible. Deleting it forces a fresh read of `"Claude Code-credentials"` on the next access, which triggers a keychain prompt. This is why users see repeated password prompts after wake from sleep even after clicking "Always Allow".

## Fix

Two small changes to `KeychainCacheStore.load`:

1. Apply `KeychainNoUIQuery` to the load query — consistent with how other no-UI reads are performed elsewhere in the codebase, and ensures the call fails fast with `errSecInteractionNotAllowed` rather than blocking.

2. Add an explicit `case errSecInteractionNotAllowed` that returns `.missing` instead of `.invalid`. The entry is valid but temporarily inaccessible — the caller should fall through gracefully and retry on next access, not destroy the cache.

## Context

`errSecInteractionNotAllowed` is already handled explicitly in `ClaudeOAuthCredentials.swift` and `KeychainAccessPreflight.swift`, but was missed in `KeychainCacheStore` itself. The `KeychainNoUIQuery` helper exists precisely for this purpose but wasn't applied to cache reads.

Note: I'm a user who hit this bug (repeated prompts after wake) and traced it to this specific code path.