### PR TITLE
fix: add gpt-5.4 codex pricing

### DIFF
--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
@@ -41,6 +41,14 @@ enum CostUsagePricing {
             inputCostPerToken: 1.75e-6,
             outputCostPerToken: 1.4e-5,
             cacheReadInputCostPerToken: 1.75e-7),
+        "gpt-5.4": CodexPricing(
+            inputCostPerToken: 2.5e-6,
+            outputCostPerToken: 1.5e-5,
+            cacheReadInputCostPerToken: 2.5e-7),
+        "gpt-5.4-codex": CodexPricing(
+            inputCostPerToken: 2.5e-6,
+            outputCostPerToken: 1.5e-5,
+            cacheReadInputCostPerToken: 2.5e-7),
     ]
 
     private static let claude: [String: ClaudePricing] = [

--- a/Tests/CodexBarTests/CostUsagePricingTests.swift
+++ b/Tests/CodexBarTests/CostUsagePricingTests.swift
@@ -8,6 +8,7 @@ struct CostUsagePricingTests {
         #expect(CostUsagePricing.normalizeCodexModel("openai/gpt-5-codex") == "gpt-5")
         #expect(CostUsagePricing.normalizeCodexModel("gpt-5.2-codex") == "gpt-5.2")
         #expect(CostUsagePricing.normalizeCodexModel("gpt-5.1-codex-max") == "gpt-5.1")
+        #expect(CostUsagePricing.normalizeCodexModel("gpt-5.4-codex") == "gpt-5.4")
     }
 
     @Test
@@ -18,6 +19,17 @@ struct CostUsagePricingTests {
             cachedInputTokens: 10,
             outputTokens: 5)
         #expect(cost != nil)
+    }
+
+    @Test
+    func codexCostSupportsGpt54() {
+        let cost = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.4",
+            inputTokens: 1_000_000,
+            cachedInputTokens: 200_000,
+            outputTokens: 50_000)
+        #expect(cost != nil)
+        #expect(cost == 2.8)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add Codex pricing entries for `gpt-5.4` and `gpt-5.4-codex`
- make Codex cost calculations work for current GPT-5.4 usage logs
- add regression coverage for GPT-5.4 normalization and cost calculation

## Why
CodexBar was already parsing and summing GPT-5.4 token usage, but the pricing table did not include GPT-5.4. That made large GPT-5.4 token totals appear alongside implausibly small USD totals.

## Testing
- `swift test --filter CostUsagePricingTests`

## Before / After

**Before**

<img width="645" height="225" alt="Before pricing fix" src="https://github.com/user-attachments/assets/4a9cf6b5-e8d8-4cfa-84c3-18e78909525b" />

**After**

<img width="650" height="247" alt="After pricing fix" src="https://github.com/user-attachments/assets/3c61d294-7bbb-41fe-a3f2-d18db22e7d98" />

Closes #602
