### PR TITLE
Add Ubuntu dashboard frontend

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,9 +58,18 @@ let package = Package(
                 swiftSettings: [
                     .enableUpcomingFeature("StrictConcurrency"),
                 ]),
+            .executableTarget(
+                name: "CodexBarLinux",
+                dependencies: [
+                    "CodexBarCore",
+                ],
+                path: "Sources/CodexBarLinux",
+                swiftSettings: [
+                    .enableUpcomingFeature("StrictConcurrency"),
+                ]),
             .testTarget(
                 name: "CodexBarLinuxTests",
-                dependencies: ["CodexBarCore", "CodexBarCLI"],
+                dependencies: ["CodexBarCore", "CodexBarCLI", "CodexBarLinux"],
                 path: "TestsLinux",
                 swiftSettings: [
                     .enableUpcomingFeature("StrictConcurrency"),

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ brew install steipete/tap/codexbar
 Or download `CodexBarCLI-v<tag>-linux-<arch>.tar.gz` from GitHub Releases.
 Linux support via Omarchy: community Waybar module and TUI, driven by the `codexbar` executable.
 
+### Ubuntu dashboard (from source)
+```bash
+./bin/install-codexbar-linux.sh
+codexbar-linux launch
+```
+This installs a lightweight browser-based Ubuntu frontend backed by `CodexBarCLI`.
+If Swift is missing, the installer bootstraps it via Swiftly first.
+Details: [docs/linux.md](docs/linux.md)
+
 ### First run
 - Open Settings → Providers and enable what you use.
 - Install/sign in to the provider sources you rely on (e.g. `codex`, `claude`, `gemini`, browser cookies, or OAuth; Antigravity requires the Antigravity app running).
@@ -94,6 +103,7 @@ Wondering if CodexBar scans your disk? It doesn’t crawl your filesystem; it re
 - Provider authoring: [docs/provider.md](docs/provider.md)
 - UI & icon notes: [docs/ui.md](docs/ui.md)
 - CLI reference: [docs/cli.md](docs/cli.md)
+- Linux frontend: [docs/linux.md](docs/linux.md)
 - Architecture: [docs/architecture.md](docs/architecture.md)
 - Refresh loop: [docs/refresh-loop.md](docs/refresh-loop.md)
 - Status polling: [docs/status.md](docs/status.md)

--- a/Sources/CodexBarLinux/LinuxDashboardModels.swift
+++ b/Sources/CodexBarLinux/LinuxDashboardModels.swift
@@ -1,0 +1,154 @@
+import CodexBarCore
+import Foundation
+
+struct LinuxProviderPayload: Decodable, Sendable {
+    let provider: String
+    let account: String?
+    let version: String?
+    let source: String
+    let status: LinuxProviderStatusPayload?
+    let usage: UsageSnapshot?
+    let credits: CreditsSnapshot?
+    let antigravityPlanInfo: AntigravityPlanInfoSummary?
+    let openaiDashboard: OpenAIDashboardSnapshot?
+    let error: LinuxProviderErrorPayload?
+
+    var resolvedProvider: UsageProvider? {
+        UsageProvider(rawValue: self.provider)
+    }
+
+    var metadata: ProviderMetadata? {
+        guard let provider = self.resolvedProvider else { return nil }
+        return ProviderDescriptorRegistry.descriptor(for: provider).metadata
+    }
+
+    var displayName: String {
+        self.metadata?.displayName ?? self.provider.capitalized
+    }
+
+    var updatedAt: Date? {
+        if let usage = self.usage { return usage.updatedAt }
+        if let credits = self.credits { return credits.updatedAt }
+        if let openaiDashboard = self.openaiDashboard { return openaiDashboard.updatedAt }
+        if let status = self.status { return status.updatedAt }
+        return nil
+    }
+
+    var statusURL: String? {
+        if let status = self.status { return status.url }
+        if let metadata = self.metadata {
+            return metadata.statusLinkURL ?? metadata.statusPageURL
+        }
+        return nil
+    }
+
+    var dashboardURL: String? {
+        self.metadata?.dashboardURL ?? self.metadata?.subscriptionDashboardURL
+    }
+
+    var identityLines: [String] {
+        guard let usage = self.usage else { return [] }
+        let identity = usage.identity(for: self.resolvedProvider ?? .codex) ?? usage.identity
+
+        var lines: [String] = []
+        if let account = self.account, !account.isEmpty {
+            lines.append("Cuenta: \(account)")
+        } else if let email = identity?.accountEmail, !email.isEmpty {
+            lines.append("Cuenta: \(email)")
+        }
+        if let organization = identity?.accountOrganization, !organization.isEmpty {
+            lines.append("Org: \(organization)")
+        }
+        if let loginMethod = identity?.loginMethod, !loginMethod.isEmpty {
+            lines.append("Plan: \(loginMethod)")
+        }
+        return lines
+    }
+}
+
+struct LinuxProviderStatusPayload: Decodable, Sendable {
+    let indicator: String
+    let description: String?
+    let updatedAt: Date?
+    let url: String
+}
+
+struct LinuxProviderErrorPayload: Decodable, Sendable {
+    let code: Int32
+    let message: String
+    let kind: String?
+}
+
+struct LinuxDashboardSnapshot: Sendable {
+    let generatedAt: Date
+    let providers: [LinuxProviderPayload]
+
+    var healthyProviderCount: Int {
+        self.providers.filter { $0.error == nil }.count
+    }
+
+    var failedProviderCount: Int {
+        self.providers.filter { $0.error != nil }.count
+    }
+
+    var headline: String {
+        if self.providers.isEmpty {
+            return "No hay providers configurados todavia"
+        }
+        if self.failedProviderCount > 0 {
+            return "\(self.healthyProviderCount) providers activos, \(self.failedProviderCount) con error"
+        }
+        return "\(self.providers.count) providers activos"
+    }
+
+    var topSummary: String {
+        let leading = self.providers
+            .compactMap { payload -> String? in
+                guard let primary = payload.usage?.primary else { return nil }
+                let label = payload.metadata?.cliName ?? payload.provider
+                return "\(label) \(Int(primary.remainingPercent.rounded()))%"
+            }
+            .prefix(3)
+        if leading.isEmpty { return "Esperando datos de uso" }
+        return leading.joined(separator: " | ")
+    }
+
+    var waybarText: String {
+        if self.failedProviderCount > 0 {
+            return "CB !\(self.failedProviderCount)"
+        }
+        let leading = self.providers.compactMap { payload -> String? in
+            guard let primary = payload.usage?.primary else { return nil }
+            let label = payload.metadata?.cliName ?? payload.provider
+            return "\(label):\(Int(primary.remainingPercent.rounded()))%"
+        }
+        if leading.isEmpty { return "CB idle" }
+        return "CB " + leading.prefix(2).joined(separator: " ")
+    }
+
+    var waybarTooltip: String {
+        let rows = self.providers.map { payload -> String in
+            if let error = payload.error {
+                return "\(payload.displayName): error \(error.message)"
+            }
+            if let primary = payload.usage?.primary {
+                return "\(payload.displayName): \(Int(primary.remainingPercent.rounded()))% restante"
+            }
+            if let credits = payload.credits {
+                return "\(payload.displayName): \(UsageFormatter.creditsString(from: credits.remaining))"
+            }
+            return "\(payload.displayName): sin datos"
+        }
+        return rows.joined(separator: "\n")
+    }
+
+    var waybarClass: String {
+        self.failedProviderCount > 0 ? "error" : "ok"
+    }
+}
+
+struct LinuxWaybarPayload: Encodable {
+    let text: String
+    let tooltip: String
+    let `class`: String
+}

--- a/Sources/CodexBarLinux/LinuxDashboardPayloadCodec.swift
+++ b/Sources/CodexBarLinux/LinuxDashboardPayloadCodec.swift
@@ -1,0 +1,56 @@
+import CodexBarCore
+import Foundation
+
+enum LinuxDashboardPayloadCodec {
+    static func decodePayloads(_ rawJSON: String) throws -> [LinuxProviderPayload] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let data = rawJSON.data(using: .utf8) else {
+            throw LinuxDashboardPayloadCodecError.decodeFailed("No se pudo leer la salida JSON.")
+        }
+        do {
+            return try decoder.decode([LinuxProviderPayload].self, from: data)
+        } catch {
+            throw LinuxDashboardPayloadCodecError.decodeFailed(
+                "No se pudo decodificar JSON del CLI: \(error.localizedDescription)")
+        }
+    }
+
+    static func errorPayload(from error: SubprocessRunnerError) -> String {
+        let message = error.localizedDescription
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: "\\n")
+        return """
+        [
+          {
+            "provider": "cli",
+            "account": null,
+            "version": null,
+            "source": "cli",
+            "status": null,
+            "usage": null,
+            "credits": null,
+            "antigravityPlanInfo": null,
+            "openaiDashboard": null,
+            "error": {
+              "code": 1,
+              "message": "\(message)",
+              "kind": "runtime"
+            }
+          }
+        ]
+        """
+    }
+}
+
+enum LinuxDashboardPayloadCodecError: LocalizedError {
+    case decodeFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .decodeFailed(message):
+            return message
+        }
+    }
+}

--- a/Sources/CodexBarLinux/LinuxDashboardRenderer.swift
+++ b/Sources/CodexBarLinux/LinuxDashboardRenderer.swift
@@ -1,0 +1,440 @@
+import CodexBarCore
+import Foundation
+
+enum LinuxDashboardRenderer {
+    static func renderHTML(
+        snapshot: LinuxDashboardSnapshot,
+        refreshSeconds: Int,
+        outputDirectory: URL) -> String
+    {
+        let generated = Self.timestampFormatter.string(from: snapshot.generatedAt)
+        let cards = snapshot.providers
+            .sorted { lhs, rhs in
+                if (lhs.error != nil) != (rhs.error != nil) {
+                    return lhs.error != nil
+                }
+                return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+            }
+            .map(Self.renderCard)
+            .joined(separator: "\n")
+
+        let outputPath = Self.escapeHTML(outputDirectory.path)
+        let summary = Self.escapeHTML(snapshot.topSummary)
+        let headline = Self.escapeHTML(snapshot.headline)
+
+        return """
+        <!doctype html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <meta http-equiv="refresh" content="\(max(10, refreshSeconds))">
+          <title>CodexBar Linux</title>
+          <style>
+            :root {
+              --bg: #f4efe4;
+              --panel: rgba(255, 252, 245, 0.84);
+              --panel-strong: rgba(255, 248, 237, 0.96);
+              --ink: #1f1b16;
+              --muted: #685f53;
+              --line: rgba(73, 54, 31, 0.14);
+              --accent: #a5441d;
+              --accent-soft: rgba(165, 68, 29, 0.14);
+              --ok: #1f7a45;
+              --warn: #9f5b00;
+              --error: #a11d33;
+              --shadow: 0 18px 50px rgba(84, 55, 26, 0.14);
+              --radius: 22px;
+              --radius-sm: 14px;
+              --font-sans: "Avenir Next", "Segoe UI", "Liberation Sans", sans-serif;
+              --font-serif: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif;
+            }
+            * { box-sizing: border-box; }
+            body {
+              margin: 0;
+              font-family: var(--font-sans);
+              color: var(--ink);
+              background:
+                radial-gradient(circle at top left, rgba(255,255,255,0.75), transparent 28%),
+                radial-gradient(circle at right 20%, rgba(236, 182, 133, 0.24), transparent 18%),
+                linear-gradient(160deg, #f8f2e7 0%, #f0e5d2 42%, #eadbc4 100%);
+              min-height: 100vh;
+            }
+            .shell {
+              max-width: 1200px;
+              margin: 0 auto;
+              padding: 40px 20px 56px;
+            }
+            .hero {
+              background: linear-gradient(135deg, rgba(255,255,255,0.72), rgba(255,245,231,0.92));
+              border: 1px solid var(--line);
+              border-radius: 30px;
+              box-shadow: var(--shadow);
+              padding: 28px;
+              position: relative;
+              overflow: hidden;
+            }
+            .hero::after {
+              content: "";
+              position: absolute;
+              inset: auto -10% -35% 52%;
+              height: 220px;
+              background: radial-gradient(circle, rgba(165,68,29,0.18), transparent 66%);
+              pointer-events: none;
+            }
+            .eyebrow {
+              font-size: 12px;
+              letter-spacing: 0.24em;
+              text-transform: uppercase;
+              color: var(--muted);
+              margin-bottom: 10px;
+            }
+            h1 {
+              margin: 0;
+              font-family: var(--font-serif);
+              font-size: clamp(34px, 6vw, 58px);
+              line-height: 0.95;
+            }
+            .summary {
+              margin: 14px 0 18px;
+              color: var(--muted);
+              font-size: 18px;
+            }
+            .meta {
+              display: flex;
+              flex-wrap: wrap;
+              gap: 10px;
+              color: var(--muted);
+              font-size: 14px;
+            }
+            .chip {
+              border: 1px solid var(--line);
+              background: rgba(255,255,255,0.62);
+              border-radius: 999px;
+              padding: 8px 12px;
+            }
+            .grid {
+              display: grid;
+              grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+              gap: 18px;
+              margin-top: 24px;
+            }
+            .card {
+              background: var(--panel);
+              border: 1px solid var(--line);
+              border-radius: var(--radius);
+              padding: 18px;
+              box-shadow: 0 10px 30px rgba(97, 64, 34, 0.08);
+              backdrop-filter: blur(8px);
+            }
+            .card.error {
+              border-color: rgba(161,29,51,0.28);
+              background: linear-gradient(180deg, rgba(255,249,249,0.96), rgba(255,239,241,0.96));
+            }
+            .card-head {
+              display: flex;
+              justify-content: space-between;
+              gap: 12px;
+              align-items: flex-start;
+              margin-bottom: 16px;
+            }
+            .title {
+              margin: 0;
+              font-size: 22px;
+              font-weight: 700;
+            }
+            .subtitle {
+              margin-top: 4px;
+              color: var(--muted);
+              font-size: 13px;
+            }
+            .badges {
+              display: flex;
+              flex-wrap: wrap;
+              gap: 8px;
+              justify-content: flex-end;
+            }
+            .badge {
+              padding: 7px 10px;
+              border-radius: 999px;
+              font-size: 12px;
+              font-weight: 700;
+              letter-spacing: 0.02em;
+              border: 1px solid transparent;
+              background: rgba(31, 27, 22, 0.08);
+            }
+            .badge.source {
+              background: var(--accent-soft);
+              color: var(--accent);
+            }
+            .badge.ok { background: rgba(31,122,69,0.12); color: var(--ok); }
+            .badge.warn { background: rgba(159,91,0,0.12); color: var(--warn); }
+            .badge.error { background: rgba(161,29,51,0.12); color: var(--error); }
+            .lane {
+              margin-top: 14px;
+              padding: 12px 13px;
+              border-radius: var(--radius-sm);
+              background: var(--panel-strong);
+              border: 1px solid rgba(73,54,31,0.08);
+            }
+            .lane-top {
+              display: flex;
+              justify-content: space-between;
+              gap: 10px;
+              align-items: baseline;
+            }
+            .lane-label {
+              font-size: 13px;
+              text-transform: uppercase;
+              letter-spacing: 0.12em;
+              color: var(--muted);
+            }
+            .lane-value {
+              font-weight: 700;
+              font-size: 15px;
+            }
+            .bar {
+              height: 9px;
+              border-radius: 999px;
+              background: rgba(31, 27, 22, 0.08);
+              overflow: hidden;
+              margin: 10px 0 8px;
+            }
+            .fill {
+              height: 100%;
+              background: linear-gradient(90deg, #d96a2d 0%, #a5441d 100%);
+              border-radius: inherit;
+            }
+            .lane-meta {
+              font-size: 13px;
+              color: var(--muted);
+            }
+            .stack {
+              display: grid;
+              gap: 8px;
+              margin-top: 14px;
+            }
+            .stack-row {
+              font-size: 14px;
+              color: var(--muted);
+            }
+            .actions {
+              display: flex;
+              flex-wrap: wrap;
+              gap: 10px;
+              margin-top: 16px;
+            }
+            .link {
+              display: inline-flex;
+              align-items: center;
+              gap: 6px;
+              border-radius: 999px;
+              padding: 9px 12px;
+              text-decoration: none;
+              color: var(--ink);
+              background: rgba(255,255,255,0.7);
+              border: 1px solid var(--line);
+            }
+            .error-copy {
+              color: var(--error);
+              font-weight: 600;
+              line-height: 1.5;
+              margin-top: 8px;
+            }
+            @media (max-width: 720px) {
+              .shell { padding: 18px 12px 32px; }
+              .hero { padding: 20px; }
+              .card-head { flex-direction: column; }
+              .badges { justify-content: flex-start; }
+            }
+          </style>
+        </head>
+        <body>
+          <main class="shell">
+            <section class="hero">
+              <div class="eyebrow">Ubuntu Dashboard</div>
+              <h1>CodexBar Linux</h1>
+              <p class="summary">\(headline)<br>\(summary)</p>
+              <div class="meta">
+                <span class="chip">Actualizado \(generated)</span>
+                <span class="chip">Refresco automatico cada \(refreshSeconds)s</span>
+                <span class="chip">Salida en \(outputPath)</span>
+              </div>
+            </section>
+            <section class="grid">
+              \(cards.isEmpty ? "<article class=\"card\"><p>No hay datos todavia. Lanza providers en la configuracion y espera el siguiente refresh.</p></article>" : cards)
+            </section>
+          </main>
+        </body>
+        </html>
+        """
+    }
+
+    static func renderFailureHTML(
+        message: String,
+        refreshSeconds: Int,
+        outputDirectory: URL) -> String
+    {
+        let snapshot = LinuxDashboardSnapshot(generatedAt: Date(), providers: [])
+        let base = Self.renderHTML(snapshot: snapshot, refreshSeconds: refreshSeconds, outputDirectory: outputDirectory)
+        let escaped = Self.escapeHTML(message)
+        return base.replacingOccurrences(
+            of: "</section>\n            <section class=\"grid\">",
+            with: """
+            <div class="actions">
+              <span class="chip">Sin backend disponible</span>
+            </div>
+            </section>
+            <section class="grid">
+              <article class="card error">
+                <div class="card-head">
+                  <div>
+                    <h2 class="title">No se pudo actualizar CodexBar Linux</h2>
+                    <div class="subtitle">El frontend Linux depende de CodexBarCLI</div>
+                  </div>
+                  <div class="badges">
+                    <span class="badge error">backend error</span>
+                  </div>
+                </div>
+                <div class="error-copy">\(escaped)</div>
+              </article>
+            """)
+    }
+
+    private static func renderCard(_ payload: LinuxProviderPayload) -> String {
+        let subtitleBits = [payload.version, payload.account].compactMap(\.self)
+        let subtitle = subtitleBits.isEmpty ? "Sin cuenta asociada" : subtitleBits.joined(separator: " | ")
+        let cardClass = payload.error == nil ? "card" : "card error"
+        let badges = [
+            "<span class=\"badge source\">\(Self.escapeHTML(payload.source))</span>",
+            Self.renderStatusBadge(payload),
+        ].compactMap(\.self).joined(separator: "\n")
+
+        var body: [String] = []
+        if let error = payload.error {
+            body.append("<div class=\"error-copy\">\(Self.escapeHTML(error.message))</div>")
+        }
+        if let metadata = payload.metadata {
+            if let primary = payload.usage?.primary {
+                body.append(Self.renderLane(label: metadata.sessionLabel, window: primary))
+            }
+            if let secondary = payload.usage?.secondary {
+                body.append(Self.renderLane(label: metadata.weeklyLabel, window: secondary))
+            }
+            if let tertiary = payload.usage?.tertiary {
+                let label = metadata.opusLabel ?? "Extra"
+                body.append(Self.renderLane(label: label, window: tertiary))
+            }
+        } else if let primary = payload.usage?.primary {
+            body.append(Self.renderLane(label: "Usage", window: primary))
+        }
+
+        if let credits = payload.credits {
+            let value = Self.escapeHTML(UsageFormatter.creditsString(from: credits.remaining))
+            body.append("""
+            <div class="lane">
+              <div class="lane-top">
+                <span class="lane-label">Creditos</span>
+                <span class="lane-value">\(value)</span>
+              </div>
+            </div>
+            """)
+        }
+
+        let stackLines = payload.identityLines.map { "<div class=\"stack-row\">\(Self.escapeHTML($0))</div>" }
+        if !stackLines.isEmpty {
+            body.append("<div class=\"stack\">\(stackLines.joined(separator: ""))</div>")
+        }
+
+        let actionLinks = [
+            payload.dashboardURL.map { url in
+                "<a class=\"link\" href=\"\(Self.escapeAttribute(url))\">Dashboard</a>"
+            },
+            payload.statusURL.map { url in
+                "<a class=\"link\" href=\"\(Self.escapeAttribute(url))\">Status</a>"
+            },
+        ].compactMap(\.self)
+        if !actionLinks.isEmpty {
+            body.append("<div class=\"actions\">\(actionLinks.joined(separator: ""))</div>")
+        }
+
+        if body.isEmpty {
+            body.append("<div class=\"stack-row\">Sin datos de uso todavia.</div>")
+        }
+
+        return """
+        <article class="\(cardClass)">
+          <div class="card-head">
+            <div>
+              <h2 class="title">\(Self.escapeHTML(payload.displayName))</h2>
+              <div class="subtitle">\(Self.escapeHTML(subtitle))</div>
+            </div>
+            <div class="badges">
+              \(badges)
+            </div>
+          </div>
+          \(body.joined(separator: "\n"))
+        </article>
+        """
+    }
+
+    private static func renderStatusBadge(_ payload: LinuxProviderPayload) -> String? {
+        if payload.error != nil {
+            return "<span class=\"badge error\">error</span>"
+        }
+        guard let status = payload.status else {
+            return "<span class=\"badge ok\">ok</span>"
+        }
+        let indicator = status.indicator.lowercased()
+        let cssClass: String
+        switch indicator {
+        case "none":
+            cssClass = "ok"
+        case "minor", "unknown", "maintenance":
+            cssClass = "warn"
+        default:
+            cssClass = "error"
+        }
+        let copy = status.description?.isEmpty == false ? status.description! : indicator
+        return "<span class=\"badge \(cssClass)\">\(Self.escapeHTML(copy))</span>"
+    }
+
+    private static func renderLane(label: String, window: RateWindow) -> String {
+        let remaining = Int(window.remainingPercent.rounded())
+        let width = max(0, min(100, remaining))
+        let usageLine = UsageFormatter.usageLine(
+            remaining: window.remainingPercent,
+            used: window.usedPercent,
+            showUsed: false)
+        let resetLine = UsageFormatter.resetLine(for: window, style: .countdown) ?? "Sin reset reportado"
+        return """
+        <div class="lane">
+          <div class="lane-top">
+            <span class="lane-label">\(Self.escapeHTML(label))</span>
+            <span class="lane-value">\(Self.escapeHTML(usageLine))</span>
+          </div>
+          <div class="bar"><div class="fill" style="width: \(width)%"></div></div>
+          <div class="lane-meta">\(Self.escapeHTML(resetLine))</div>
+        </div>
+        """
+    }
+
+    private static func escapeHTML(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+            .replacingOccurrences(of: "\"", with: "&quot;")
+    }
+
+    private static func escapeAttribute(_ text: String) -> String {
+        Self.escapeHTML(text).replacingOccurrences(of: "'", with: "&#39;")
+    }
+
+    private static let timestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .medium
+        return formatter
+    }()
+}

--- a/Sources/CodexBarLinux/main.swift
+++ b/Sources/CodexBarLinux/main.swift
@@ -1,0 +1,512 @@
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+import CodexBarCore
+import Foundation
+
+@main
+enum CodexBarLinuxMain {
+    static func main() async {
+        do {
+            let options = try LinuxDashboardOptions.parse(arguments: Array(CommandLine.arguments.dropFirst()))
+            if options.showHelp {
+                Self.printHelp()
+                exit(0)
+            }
+
+            let app = LinuxDashboardApp(options: options)
+            try await app.run()
+            exit(0)
+        } catch {
+            fputs("CodexBarLinux error: \(error.localizedDescription)\n", stderr)
+            exit(1)
+        }
+    }
+
+    private static func printHelp() {
+        print(
+            """
+            CodexBarLinux - lightweight Ubuntu dashboard for CodexBarCLI
+
+            Usage:
+              CodexBarLinux [launch|serve|refresh|open|stop] [options]
+
+            Commands:
+              launch   Render once, start the background refresher, and open the dashboard
+              serve    Run the refresher loop in the foreground
+              refresh  Fetch once and rewrite the dashboard files
+              open     Open the generated dashboard in the default browser
+              stop     Stop the background refresher
+
+            Options:
+              --interval <seconds>    Refresh interval (default: 60)
+              --output-dir <path>     Dashboard output directory
+              --cli-path <path>       Absolute path to codexbar/CodexBarCLI
+              --provider <id>         Forwarded to CodexBarCLI --provider
+              --source <mode>         Forwarded to CodexBarCLI --source
+              --status                Include provider status checks
+              --no-open               Do not launch the browser
+              -h, --help              Show this help
+            """)
+    }
+}
+
+private enum LinuxDashboardCommand: String {
+    case launch
+    case serve
+    case refresh
+    case open
+    case stop
+}
+
+private struct LinuxDashboardOptions {
+    var command: LinuxDashboardCommand = .launch
+    var intervalSeconds: Int = 60
+    var outputDirectory: URL = LinuxDashboardPaths.defaultOutputDirectory()
+    var cliPath: String?
+    var provider: String?
+    var source: String?
+    var includeStatus: Bool = false
+    var noOpen: Bool = false
+    var showHelp: Bool = false
+
+    static func parse(arguments: [String]) throws -> LinuxDashboardOptions {
+        var options = LinuxDashboardOptions()
+        var index = 0
+
+        if let first = arguments.first,
+           !first.hasPrefix("-"),
+           let command = LinuxDashboardCommand(rawValue: first)
+        {
+            options.command = command
+            index += 1
+        }
+
+        while index < arguments.count {
+            let arg = arguments[index]
+            switch arg {
+            case "-h", "--help":
+                options.showHelp = true
+            case "--interval":
+                index += 1
+                options.intervalSeconds = try Self.parseInt(arguments, index: index, flag: arg)
+            case "--output-dir":
+                index += 1
+                options.outputDirectory = URL(
+                    fileURLWithPath: try Self.parseString(arguments, index: index, flag: arg),
+                    isDirectory: true)
+            case "--cli-path":
+                index += 1
+                options.cliPath = try Self.parseString(arguments, index: index, flag: arg)
+            case "--provider":
+                index += 1
+                options.provider = try Self.parseString(arguments, index: index, flag: arg)
+            case "--source":
+                index += 1
+                options.source = try Self.parseString(arguments, index: index, flag: arg)
+            case "--status":
+                options.includeStatus = true
+            case "--no-open":
+                options.noOpen = true
+            default:
+                throw LinuxDashboardError.usage("Unknown argument '\(arg)'")
+            }
+            index += 1
+        }
+
+        if options.intervalSeconds < 10 {
+            throw LinuxDashboardError.usage("--interval must be at least 10 seconds")
+        }
+
+        return options
+    }
+
+    private static func parseString(_ arguments: [String], index: Int, flag: String) throws -> String {
+        guard arguments.indices.contains(index) else {
+            throw LinuxDashboardError.usage("Missing value for \(flag)")
+        }
+        return arguments[index]
+    }
+
+    private static func parseInt(_ arguments: [String], index: Int, flag: String) throws -> Int {
+        let raw = try Self.parseString(arguments, index: index, flag: flag)
+        guard let value = Int(raw) else {
+            throw LinuxDashboardError.usage("Invalid integer for \(flag): \(raw)")
+        }
+        return value
+    }
+}
+
+private enum LinuxDashboardError: LocalizedError {
+    case usage(String)
+    case cliNotFound
+    case process(String)
+    case decode(String)
+    case io(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .usage(message): return message
+        case .cliNotFound:
+            return "CodexBarCLI no encontrado. Instala el CLI o usa --cli-path."
+        case let .process(message): return message
+        case let .decode(message): return message
+        case let .io(message): return message
+        }
+    }
+}
+
+private enum LinuxDashboardPaths {
+    static func defaultOutputDirectory() -> URL {
+        let environment = ProcessInfo.processInfo.environment
+        if let stateHome = environment["XDG_STATE_HOME"], !stateHome.isEmpty {
+            return URL(fileURLWithPath: stateHome, isDirectory: true)
+                .appendingPathComponent("codexbar-linux", isDirectory: true)
+        }
+        return URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent(".local", isDirectory: true)
+            .appendingPathComponent("state", isDirectory: true)
+            .appendingPathComponent("codexbar-linux", isDirectory: true)
+    }
+
+    static func indexHTML(in directory: URL) -> URL {
+        directory.appendingPathComponent("index.html")
+    }
+
+    static func snapshotJSON(in directory: URL) -> URL {
+        directory.appendingPathComponent("snapshot.json")
+    }
+
+    static func waybarJSON(in directory: URL) -> URL {
+        directory.appendingPathComponent("waybar.json")
+    }
+
+    static func pidFile(in directory: URL) -> URL {
+        directory.appendingPathComponent("codexbar-linux.pid")
+    }
+
+    static func logFile(in directory: URL) -> URL {
+        directory.appendingPathComponent("codexbar-linux.log")
+    }
+}
+
+private final class LinuxDashboardApp {
+    private let options: LinuxDashboardOptions
+    private let fileManager: FileManager
+
+    init(options: LinuxDashboardOptions, fileManager: FileManager = .default) {
+        self.options = options
+        self.fileManager = fileManager
+    }
+
+    func run() async throws {
+        try self.ensureOutputDirectory()
+        switch self.options.command {
+        case .launch:
+            try await self.launch()
+        case .serve:
+            try await self.serve()
+        case .refresh:
+            try await self.refreshOnce()
+        case .open:
+            try self.openDashboard()
+        case .stop:
+            try self.stop()
+        }
+    }
+
+    private func launch() async throws {
+        try await self.refreshOnce()
+        if self.currentDaemonPID() == nil {
+            try self.spawnDetachedServer()
+        }
+        if !self.options.noOpen {
+            try self.openDashboard()
+        }
+    }
+
+    private func serve() async throws {
+        try Self.installSignalHandlers()
+        let pidURL = LinuxDashboardPaths.pidFile(in: self.options.outputDirectory)
+        let pid = getpid()
+        if let current = self.currentDaemonPID(), current != pid {
+            throw LinuxDashboardError.process("CodexBarLinux ya se esta ejecutando con PID \(current).")
+        }
+
+        try self.writeText("\(pid)\n", to: pidURL)
+        defer {
+            try? self.fileManager.removeItem(at: pidURL)
+        }
+
+        repeat {
+            do {
+                try await self.refreshOnce()
+            } catch {
+                let failureHTML = LinuxDashboardRenderer.renderFailureHTML(
+                    message: error.localizedDescription,
+                    refreshSeconds: self.options.intervalSeconds,
+                    outputDirectory: self.options.outputDirectory)
+                try? self.writeText(failureHTML, to: LinuxDashboardPaths.indexHTML(in: self.options.outputDirectory))
+                try? self.writeWaybarError(message: error.localizedDescription)
+            }
+
+            if linuxDashboardShouldStop != 0 { break }
+            Thread.sleep(forTimeInterval: TimeInterval(self.options.intervalSeconds))
+        } while linuxDashboardShouldStop == 0
+    }
+
+    private func refreshOnce() async throws {
+        let fetch = try await LinuxDashboardBackend.fetch(options: self.options)
+        let snapshot = LinuxDashboardSnapshot(generatedAt: Date(), providers: fetch.providers)
+
+        let html = LinuxDashboardRenderer.renderHTML(
+            snapshot: snapshot,
+            refreshSeconds: self.options.intervalSeconds,
+            outputDirectory: self.options.outputDirectory)
+        try self.writeText(fetch.rawJSON, to: LinuxDashboardPaths.snapshotJSON(in: self.options.outputDirectory))
+        try self.writeText(html, to: LinuxDashboardPaths.indexHTML(in: self.options.outputDirectory))
+        try self.writeWaybarSnapshot(snapshot)
+    }
+
+    private func openDashboard() throws {
+        let target = LinuxDashboardPaths.indexHTML(in: self.options.outputDirectory).path
+        let launchers: [[String]] = [
+            ["/usr/bin/xdg-open", target],
+            ["/usr/bin/gio", "open", target],
+        ]
+
+        for launcher in launchers where self.fileManager.isExecutableFile(atPath: launcher[0]) {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: launcher[0])
+            process.arguments = Array(launcher.dropFirst())
+            process.standardOutput = nil
+            process.standardError = nil
+            process.standardInput = nil
+            do {
+                try process.run()
+                return
+            } catch {
+                continue
+            }
+        }
+
+        throw LinuxDashboardError.process("No se pudo abrir el navegador. Abre manualmente \(target)")
+    }
+
+    private func stop() throws {
+        let pidURL = LinuxDashboardPaths.pidFile(in: self.options.outputDirectory)
+        guard let pidString = try? String(contentsOf: pidURL).trimmingCharacters(in: .whitespacesAndNewlines),
+              let pid = Int32(pidString)
+        else {
+            throw LinuxDashboardError.process("No hay un proceso CodexBarLinux registrado.")
+        }
+
+        if kill(pid, SIGTERM) != 0 {
+            if errno == ESRCH {
+                try? self.fileManager.removeItem(at: pidURL)
+                throw LinuxDashboardError.process("El PID \(pid) ya no existe.")
+            }
+            throw LinuxDashboardError.process("No se pudo detener el PID \(pid).")
+        }
+    }
+
+    private func currentDaemonPID() -> pid_t? {
+        let pidURL = LinuxDashboardPaths.pidFile(in: self.options.outputDirectory)
+        guard let pidString = try? String(contentsOf: pidURL).trimmingCharacters(in: .whitespacesAndNewlines),
+              let rawPID = Int32(pidString)
+        else {
+            return nil
+        }
+        let pid = pid_t(rawPID)
+
+        if kill(pid, 0) == 0 {
+            return pid
+        }
+
+        try? self.fileManager.removeItem(at: pidURL)
+        return nil
+    }
+
+    private func spawnDetachedServer() throws {
+        let executable = try Self.currentExecutableURL()
+        let logURL = LinuxDashboardPaths.logFile(in: self.options.outputDirectory)
+        if !self.fileManager.fileExists(atPath: logURL.path) {
+            self.fileManager.createFile(atPath: logURL.path, contents: Data())
+        }
+
+        let logHandle = try FileHandle(forWritingTo: logURL)
+        logHandle.seekToEndOfFile()
+
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = self.detachedServeArguments()
+        process.standardOutput = logHandle
+        process.standardError = logHandle
+        process.standardInput = nil
+        try process.run()
+    }
+
+    private func detachedServeArguments() -> [String] {
+        var arguments = ["serve", "--interval", "\(self.options.intervalSeconds)", "--no-open"]
+        arguments += ["--output-dir", self.options.outputDirectory.path]
+        if let cliPath = self.options.cliPath {
+            arguments += ["--cli-path", cliPath]
+        }
+        if let provider = self.options.provider {
+            arguments += ["--provider", provider]
+        }
+        if let source = self.options.source {
+            arguments += ["--source", source]
+        }
+        if self.options.includeStatus {
+            arguments.append("--status")
+        }
+        return arguments
+    }
+
+    private func ensureOutputDirectory() throws {
+        try self.fileManager.createDirectory(at: self.options.outputDirectory, withIntermediateDirectories: true)
+    }
+
+    private func writeText(_ value: String, to url: URL) throws {
+        do {
+            try value.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            throw LinuxDashboardError.io("No se pudo escribir \(url.path): \(error.localizedDescription)")
+        }
+    }
+
+    private func writeWaybarSnapshot(_ snapshot: LinuxDashboardSnapshot) throws {
+        let payload = LinuxWaybarPayload(
+            text: snapshot.waybarText,
+            tooltip: snapshot.waybarTooltip,
+            class: snapshot.waybarClass)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(payload)
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw LinuxDashboardError.io("No se pudo serializar waybar.json")
+        }
+        try self.writeText(text, to: LinuxDashboardPaths.waybarJSON(in: self.options.outputDirectory))
+    }
+
+    private func writeWaybarError(message: String) throws {
+        let payload = LinuxWaybarPayload(text: "CB !", tooltip: message, class: "error")
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(payload)
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw LinuxDashboardError.io("No se pudo serializar waybar.json")
+        }
+        try self.writeText(text, to: LinuxDashboardPaths.waybarJSON(in: self.options.outputDirectory))
+    }
+
+    fileprivate static func currentExecutableURL() throws -> URL {
+        #if os(Linux)
+        let path = try FileManager.default.destinationOfSymbolicLink(atPath: "/proc/self/exe")
+        return URL(fileURLWithPath: path)
+        #else
+        if let url = Bundle.main.executableURL {
+            return url
+        }
+        throw LinuxDashboardError.process("No se pudo resolver el ejecutable actual.")
+        #endif
+    }
+
+    private static func installSignalHandlers() throws {
+        signal(SIGINT, linuxDashboardHandleSignal)
+        signal(SIGTERM, linuxDashboardHandleSignal)
+    }
+}
+
+private enum LinuxDashboardBackend {
+    static func fetch(options: LinuxDashboardOptions) async throws -> (rawJSON: String, providers: [LinuxProviderPayload]) {
+        let binary = try self.resolveCLIBinary(explicitPath: options.cliPath)
+        var arguments = ["--format", "json", "--pretty", "--json-only"]
+        if let provider = options.provider {
+            arguments += ["--provider", provider]
+        }
+        if let source = options.source {
+            arguments += ["--source", source]
+        }
+        if options.includeStatus {
+            arguments.append("--status")
+        }
+
+        let environment = ProcessInfo.processInfo.environment
+        let result: SubprocessResult
+        do {
+            result = try await SubprocessRunner.run(
+                binary: binary,
+                arguments: arguments,
+                environment: environment,
+                timeout: 120,
+                label: "codexbar-linux-refresh")
+        } catch let error as SubprocessRunnerError {
+            if case let .nonZeroExit(_, _) = error {
+                let payload = LinuxDashboardPayloadCodec.errorPayload(from: error)
+                if let payloads = try? LinuxDashboardPayloadCodec.decodePayloads(payload) {
+                    return (payload, payloads)
+                }
+            }
+            throw error
+        }
+
+        let trimmed = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw LinuxDashboardError.process("CodexBarCLI no devolvio JSON.")
+        }
+
+        return (trimmed, try LinuxDashboardPayloadCodec.decodePayloads(trimmed))
+    }
+
+    private static func resolveCLIBinary(explicitPath: String?) throws -> String {
+        let fileManager = FileManager.default
+        if let explicitPath, fileManager.isExecutableFile(atPath: explicitPath) {
+            return explicitPath
+        }
+
+        if let currentExecutable = try? LinuxDashboardApp.currentExecutableURL() {
+            let directory = currentExecutable.deletingLastPathComponent()
+            let localCandidates = [
+                directory.appendingPathComponent("CodexBarCLI").path,
+                directory.appendingPathComponent("codexbar").path,
+            ]
+            for candidate in localCandidates where fileManager.isExecutableFile(atPath: candidate) {
+                return candidate
+            }
+        }
+
+        if let existingPATH = ProcessInfo.processInfo.environment["PATH"] {
+            for directory in existingPATH.split(separator: ":").map(String.init) where !directory.isEmpty {
+                for name in ["codexbar", "CodexBarCLI"] {
+                    let candidate = URL(fileURLWithPath: directory, isDirectory: true)
+                        .appendingPathComponent(name)
+                        .path
+                    if fileManager.isExecutableFile(atPath: candidate) {
+                        return candidate
+                    }
+                }
+            }
+        }
+
+        let env = ProcessInfo.processInfo.environment
+        let pathCandidates = [
+            ShellCommandLocator.commandV("codexbar", env["SHELL"], 1.0, fileManager),
+            ShellCommandLocator.commandV("CodexBarCLI", env["SHELL"], 1.0, fileManager),
+        ].compactMap(\.self)
+        for candidate in pathCandidates where fileManager.isExecutableFile(atPath: candidate) {
+            return candidate
+        }
+
+        throw LinuxDashboardError.cliNotFound
+    }
+}
+
+nonisolated(unsafe) private var linuxDashboardShouldStop: sig_atomic_t = 0
+
+private func linuxDashboardHandleSignal(_: Int32) -> Void {
+    linuxDashboardShouldStop = 1
+}

--- a/TestsLinux/CodexBarLinuxRendererTests.swift
+++ b/TestsLinux/CodexBarLinuxRendererTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+@testable import CodexBarLinux
+
+struct CodexBarLinuxRendererTests {
+    @Test
+    func renderer_buildsDashboardCardsAndWaybarSummary() throws {
+        let json = """
+        [
+          {
+            "provider": "codex",
+            "account": "user@example.com",
+            "version": "1.2.3",
+            "source": "codex-cli",
+            "status": null,
+            "usage": {
+              "primary": {
+                "usedPercent": 25,
+                "windowMinutes": 300,
+                "resetsAt": "2026-03-25T12:00:00Z",
+                "resetDescription": null
+              },
+              "secondary": {
+                "usedPercent": 40,
+                "windowMinutes": 10080,
+                "resetsAt": "2026-03-30T12:00:00Z",
+                "resetDescription": null
+              },
+              "tertiary": null,
+              "updatedAt": "2026-03-25T10:00:00Z",
+              "identity": {
+                "providerID": "codex",
+                "accountEmail": "user@example.com",
+                "accountOrganization": null,
+                "loginMethod": "plus"
+              },
+              "accountEmail": "user@example.com",
+              "accountOrganization": null,
+              "loginMethod": "plus"
+            },
+            "credits": {
+              "remaining": 112.4,
+              "events": [],
+              "updatedAt": "2026-03-25T10:00:00Z"
+            },
+            "antigravityPlanInfo": null,
+            "openaiDashboard": null,
+            "error": null
+          },
+          {
+            "provider": "claude",
+            "account": null,
+            "version": null,
+            "source": "web",
+            "status": null,
+            "usage": null,
+            "credits": null,
+            "antigravityPlanInfo": null,
+            "openaiDashboard": null,
+            "error": {
+              "code": 1,
+              "message": "Missing cookies",
+              "kind": "runtime"
+            }
+          }
+        ]
+        """
+
+        let payloads = try LinuxDashboardPayloadCodec.decodePayloads(json)
+        let snapshot = LinuxDashboardSnapshot(
+            generatedAt: Date(timeIntervalSince1970: 1_774_445_200),
+            providers: payloads)
+
+        let html = LinuxDashboardRenderer.renderHTML(
+            snapshot: snapshot,
+            refreshSeconds: 60,
+            outputDirectory: URL(fileURLWithPath: "/tmp/codexbar-linux", isDirectory: true))
+
+        #expect(html.contains("CodexBar Linux"))
+        #expect(html.contains("Codex"))
+        #expect(html.contains("75% left"))
+        #expect(html.contains("112.4 left"))
+        #expect(html.contains("Missing cookies"))
+        #expect(snapshot.waybarText == "CB !1")
+        #expect(snapshot.waybarTooltip.contains("Codex: 75% restante"))
+    }
+
+    @Test
+    func backend_decodesCliErrorPayload() throws {
+        let raw = LinuxDashboardPayloadCodec.errorPayload(
+            from: .nonZeroExit(code: 3, stderr: "selected source requires web support"))
+        let payloads = try LinuxDashboardPayloadCodec.decodePayloads(raw)
+
+        #expect(payloads.count == 1)
+        #expect(payloads[0].provider == "cli")
+        #expect(payloads[0].error?.message.contains("selected source requires web support") == true)
+    }
+}

--- a/bin/install-codexbar-linux.sh
+++ b/bin/install-codexbar-linux.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+SWIFTLY_VERSION="1.1.1"
+SWIFTLY_HOME_DIR="${SWIFTLY_HOME_DIR:-$HOME/.local/share/swiftly}"
+SWIFTLY_ENV_SH="${SWIFTLY_HOME_DIR}/env.sh"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "This installer is intended for Linux/Ubuntu only." >&2
+  exit 1
+fi
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+bootstrap_swift() {
+  local arch tmp_dir archive
+  arch="$(uname -m)"
+  tmp_dir="$(mktemp -d)"
+  archive="${tmp_dir}/swiftly-${SWIFTLY_VERSION}-${arch}.tar.gz"
+
+  echo "Swift toolchain not found. Bootstrapping via Swiftly ${SWIFTLY_VERSION}..."
+  need_cmd curl
+  need_cmd tar
+
+  curl -fL "https://download.swift.org/swiftly/linux/swiftly-${SWIFTLY_VERSION}-${arch}.tar.gz" -o "$archive"
+  tar -zxf "$archive" -C "$tmp_dir"
+
+  (
+    cd "$tmp_dir"
+    ./swiftly init --quiet-shell-followup
+  )
+
+  if [[ -f "$SWIFTLY_ENV_SH" ]]; then
+    # shellcheck disable=SC1090
+    source "$SWIFTLY_ENV_SH"
+    hash -r
+  fi
+
+  if ! command -v swift >/dev/null 2>&1; then
+    echo "Swiftly finished but 'swift' is still not on PATH." >&2
+    echo "Source ${SWIFTLY_ENV_SH} and retry." >&2
+    exit 1
+  fi
+
+  rm -rf "$tmp_dir"
+}
+
+if ! command -v swift >/dev/null 2>&1; then
+  bootstrap_swift
+fi
+
+if [[ -f "$SWIFTLY_ENV_SH" ]]; then
+  # shellcheck disable=SC1090
+  source "$SWIFTLY_ENV_SH"
+  hash -r
+fi
+
+cd "$ROOT_DIR"
+
+swift build -c release --product CodexBarCLI
+swift build -c release --product CodexBarLinux
+
+BIN_DIR="${HOME}/.local/bin"
+APP_DIR="${XDG_DATA_HOME:-$HOME/.local/share}"
+APP_DIR="${APP_DIR%/}"
+DESKTOP_DIR="${APP_DIR}/applications"
+ICON_DIR="${APP_DIR}/icons/hicolor/512x512/apps"
+
+mkdir -p "$BIN_DIR" "$DESKTOP_DIR" "$ICON_DIR"
+
+install -m 755 ".build/release/CodexBarCLI" "${BIN_DIR}/CodexBarCLI"
+install -m 755 ".build/release/CodexBarLinux" "${BIN_DIR}/CodexBarLinux"
+ln -sf "${BIN_DIR}/CodexBarCLI" "${BIN_DIR}/codexbar"
+ln -sf "${BIN_DIR}/CodexBarLinux" "${BIN_DIR}/codexbar-linux"
+install -m 644 "codexbar.png" "${ICON_DIR}/codexbar-linux.png"
+
+cat > "${DESKTOP_DIR}/codexbar-linux.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=CodexBar Linux
+Comment=Ubuntu dashboard for CodexBar providers
+Exec=${BIN_DIR}/codexbar-linux launch
+Icon=codexbar-linux
+Terminal=false
+Categories=Utility;Development;
+EOF
+
+update-desktop-database "${DESKTOP_DIR}" >/dev/null 2>&1 || true
+gtk-update-icon-cache "${APP_DIR}/icons/hicolor" >/dev/null 2>&1 || true
+
+echo "Installed:"
+echo "  ${BIN_DIR}/codexbar"
+echo "  ${BIN_DIR}/codexbar-linux"
+echo
+echo "Try:"
+echo "  codexbar --format json --pretty"
+echo "  codexbar-linux launch"
+echo "  codexbar-linux stop"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,6 +12,7 @@ read_when:
 - `Sources/CodexBar`: state + UI (UsageStore, SettingsStore, StatusItemController, menus, icon rendering).
 - `Sources/CodexBarWidget`: WidgetKit extension wired to the shared snapshot.
 - `Sources/CodexBarCLI`: bundled CLI for `codexbar` usage/status output.
+- `Sources/CodexBarLinux`: Linux frontend that refreshes `CodexBarCLI` JSON into a local dashboard + Waybar artifact.
 - `Sources/CodexBarMacros`: SwiftSyntax macros for provider registration.
 - `Sources/CodexBarMacroSupport`: shared macro support used by app/core/CLI targets.
 - `Sources/CodexBarClaudeWatchdog`: helper process for stable Claude CLI PTY sessions.

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -1,0 +1,96 @@
+---
+summary: "Ubuntu/Linux dashboard frontend built on top of CodexBarCLI."
+read_when:
+  - "You want to install CodexBar on Ubuntu."
+  - "You are extending or debugging the Linux frontend."
+---
+
+# CodexBar Linux
+
+CodexBar Linux is a lightweight Ubuntu-friendly frontend that sits on top of `CodexBarCLI`.
+It does not try to recreate the macOS menu bar app.
+Instead, it runs a local refresher loop, writes dashboard artifacts to disk, and opens a browser dashboard.
+
+## What it installs
+- `codexbar`: the existing CLI backend
+- `codexbar-linux`: the Linux frontend
+- `~/.local/share/applications/codexbar-linux.desktop`: desktop launcher
+
+## Install from source
+
+```bash
+./bin/install-codexbar-linux.sh
+```
+
+If `swift` is missing, the installer bootstraps the official Swift toolchain via `swiftly` first.
+Then it builds `CodexBarCLI` and `CodexBarLinux` in release mode and installs them into `~/.local/bin`.
+
+## Quick start
+
+```bash
+codexbar --format json --pretty
+codexbar-linux launch
+```
+
+`codexbar-linux launch` does three things:
+- fetches the latest provider data through `codexbar`
+- starts a background refresh loop
+- opens the generated dashboard in your default browser
+
+Stop it with:
+
+```bash
+codexbar-linux stop
+```
+
+## Files written by the frontend
+
+By default the Linux frontend writes to:
+
+```bash
+~/.local/state/codexbar-linux
+```
+
+Or `$XDG_STATE_HOME/codexbar-linux` when `XDG_STATE_HOME` is set.
+
+Files:
+- `index.html`: browser dashboard
+- `snapshot.json`: latest raw CLI JSON
+- `waybar.json`: small JSON payload for custom Waybar modules
+- `codexbar-linux.log`: background refresher log
+- `codexbar-linux.pid`: running refresher PID
+
+## Commands
+
+```bash
+codexbar-linux launch
+codexbar-linux serve
+codexbar-linux refresh
+codexbar-linux open
+codexbar-linux stop
+```
+
+Useful flags:
+- `--interval 60`
+- `--provider codex`
+- `--source cli`
+- `--status`
+- `--cli-path /absolute/path/to/CodexBarCLI`
+- `--output-dir /tmp/codexbar-linux`
+
+## Waybar integration
+
+`waybar.json` is rewritten on every refresh. A minimal custom module can read it, for example:
+
+```json
+{
+  "custom/codexbar": {
+    "exec": "cat ~/.local/state/codexbar-linux/waybar.json",
+    "return-type": "json",
+    "interval": 5
+  }
+}
+```
+
+The frontend is still browser-based, so this is not an AppIndicator tray port.
+It is meant to be dependency-free and easy to install on plain Ubuntu.


### PR DESCRIPTION
## Summary
- add a new `CodexBarLinux` executable that turns `CodexBarCLI` JSON into a lightweight Ubuntu browser dashboard
- add a Linux installer that installs both `CodexBarCLI` and `CodexBarLinux`, bootstrapping Swift via Swiftly when needed
- document the Linux frontend and add Linux-focused renderer and payload tests

## What This Adds
- local dashboard artifacts in `~/.local/state/codexbar-linux` (HTML, raw snapshot JSON, Waybar JSON, log, PID)
- `codexbar-linux` commands for `launch`, `serve`, `refresh`, `open`, and `stop`
- a Waybar-friendly JSON output file without introducing GTK or AppIndicator dependencies

## Notes
- this is intentionally not a direct port of the macOS menubar UI
- the Linux frontend reuses the CLI as the supported backend contract instead of trying to move AppKit or SwiftUI code across platforms
- the installer now bootstraps Swift with Swiftly when `swift` is not already installed

## Validation
- `bash -n bin/install-codexbar-linux.sh`
- attempted `./Scripts/compile_and_run.sh`, but the environment used for authoring did not have `swift` installed
- attempted `pnpm check`, but the Linux SwiftFormat portable download did not contain the expected binary, so lint could not complete in this environment