### PR TITLE
feat(minimax): Add multi-service usage support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.25 — Unreleased
 
 ### Providers & Usage
+- MiniMax: add multi-service quota cards for text, speech, image, video, and music coding-plan usage (#605). Thanks @XWind18!
 - Cost history: add an additive models.dev pricing metadata parser/cache pipeline for future provider-scoped cost lookups (#863). Thanks @iam-brain!
 - Notifications: add opt-in quota warning notifications, warning markers, and provider-level thresholds for session and weekly quota windows (#852). Thanks @Alekstodo!
 - Venice: add API-key balance provider support with DIEM/USD balance display and token-account CLI wiring (#865). Thanks @clawSean!

--- a/Sources/CodexBar/MenuCardView+MiniMax.swift
+++ b/Sources/CodexBar/MenuCardView+MiniMax.swift
@@ -1,0 +1,27 @@
+import CodexBarCore
+import Foundation
+
+extension UsageMenuCardView.Model {
+    static func minimaxMetrics(services: [MiniMaxServiceUsage], input: Input) -> [Metric] {
+        let percentStyle: PercentStyle = input.usageBarsShowUsed ? .used : .left
+
+        return services.enumerated().map { index, service in
+            let used = service.usage
+            let remaining = service.remaining
+            let displayValue = input.usageBarsShowUsed ? used : remaining
+            let displayPercent = input.usageBarsShowUsed ? service.percent : (100 - service.percent)
+
+            return Metric(
+                id: "minimax-service-\(index)",
+                title: service.displayName,
+                percent: min(100, max(0, displayPercent)),
+                percentStyle: percentStyle,
+                resetText: service.resetDescription,
+                detailText: "\(displayValue)/\(service.limit)",
+                detailLeftText: service.windowType,
+                detailRightText: String(format: "%.0f%%", displayPercent),
+                pacePercent: nil,
+                paceOnTop: true)
+        }
+    }
+}

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -1,0 +1,17 @@
+import CodexBarCore
+import SwiftUI
+
+extension UsageMenuCardView.Model {
+    static func progressColor(for provider: UsageProvider) -> Color {
+        let color = ProviderDescriptorRegistry.descriptor(for: provider).branding.color
+        return Color(red: color.red, green: color.green, blue: color.blue)
+    }
+
+    static func resetText(
+        for window: RateWindow,
+        style: ResetTimeDisplayStyle,
+        now: Date) -> String?
+    {
+        UsageFormatter.resetLine(for: window, style: style, now: now)
+    }
+}

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1339,42 +1339,6 @@ extension UsageMenuCardView.Model {
                 percentStyle: percentStyle),
         ]
     }
-    
-    private static func minimaxMetrics(services: [MiniMaxServiceUsage], input: Input) -> [Metric] {
-        let percentStyle: PercentStyle = input.usageBarsShowUsed ? .used : .left
-        var metrics: [Metric] = []
-        
-        for (index, service) in services.enumerated() {
-            let id = "minimax-service-\(index)"
-            let title = service.displayName
-            let used = service.limit - service.usage  // usage is remaining, calculate used
-            let remaining = service.usage  // service.usage is remaining quota
-            let percent = service.percent  // This is used percent
-            
-            // Adjust display based on usageBarsShowUsed setting
-            let displayValue: Int = input.usageBarsShowUsed ? used : remaining
-            let detailText = "\(displayValue)/\(service.limit)"
-            
-            // Adjust percentage display - BOTH for progress bar AND text
-            let displayPercent = input.usageBarsShowUsed ? percent : (100 - percent)
-            let detailLeftText = service.windowType
-            let detailRightText = String(format: "%.0f%%", displayPercent)
-            
-            metrics.append(Metric(
-                id: id,
-                title: title,
-                percent: Self.clamped(displayPercent),  // Use displayPercent for progress bar too
-                percentStyle: percentStyle,
-                resetText: service.resetDescription,
-                detailText: detailText,
-                detailLeftText: detailLeftText,
-                detailRightText: detailRightText,
-                pacePercent: nil,
-                paceOnTop: true))
-        }
-        
-        return metrics
-    }
 
     private static func antigravityMetric(
         id: String,
@@ -1637,18 +1601,5 @@ extension UsageMenuCardView.Model {
 
     private static func clamped(_ value: Double) -> Double {
         min(100, max(0, value))
-    }
-
-    private static func progressColor(for provider: UsageProvider) -> Color {
-        let color = ProviderDescriptorRegistry.descriptor(for: provider).branding.color
-        return Color(red: color.red, green: color.green, blue: color.blue)
-    }
-
-    private static func resetText(
-        for window: RateWindow,
-        style: ResetTimeDisplayStyle,
-        now: Date) -> String?
-    {
-        UsageFormatter.resetLine(for: window, style: style, now: now)
     }
 }

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -962,6 +962,13 @@ extension UsageMenuCardView.Model {
         if input.provider == .antigravity {
             return Self.antigravityMetrics(input: input, snapshot: snapshot)
         }
+        if input.provider == .minimax {
+            if let minimaxUsage = snapshot.minimaxUsage {
+                if let services = minimaxUsage.services, !services.isEmpty {
+                    return Self.minimaxMetrics(services: services, input: input)
+                }
+            }
+        }
         var metrics: [Metric] = []
         let percentStyle: PercentStyle = input.usageBarsShowUsed ? .used : .left
         let zaiUsage = input.provider == .zai ? snapshot.zaiUsage : nil
@@ -1331,6 +1338,42 @@ extension UsageMenuCardView.Model {
                 input: input,
                 percentStyle: percentStyle),
         ]
+    }
+    
+    private static func minimaxMetrics(services: [MiniMaxServiceUsage], input: Input) -> [Metric] {
+        let percentStyle: PercentStyle = input.usageBarsShowUsed ? .used : .left
+        var metrics: [Metric] = []
+        
+        for (index, service) in services.enumerated() {
+            let id = "minimax-service-\(index)"
+            let title = service.displayName
+            let used = service.limit - service.usage  // usage is remaining, calculate used
+            let remaining = service.usage  // service.usage is remaining quota
+            let percent = service.percent  // This is used percent
+            
+            // Adjust display based on usageBarsShowUsed setting
+            let displayValue: Int = input.usageBarsShowUsed ? used : remaining
+            let detailText = "\(displayValue)/\(service.limit)"
+            
+            // Adjust percentage display - BOTH for progress bar AND text
+            let displayPercent = input.usageBarsShowUsed ? percent : (100 - percent)
+            let detailLeftText = service.windowType
+            let detailRightText = String(format: "%.0f%%", displayPercent)
+            
+            metrics.append(Metric(
+                id: id,
+                title: title,
+                percent: Self.clamped(displayPercent),  // Use displayPercent for progress bar too
+                percentStyle: percentStyle,
+                resetText: service.resetDescription,
+                detailText: detailText,
+                detailLeftText: detailLeftText,
+                detailRightText: detailRightText,
+                pacePercent: nil,
+                paceOnTop: true))
+        }
+        
+        return metrics
     }
 
     private static func antigravityMetric(

--- a/Sources/CodexBar/Providers/MiniMax/MiniMaxProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/MiniMax/MiniMaxProviderImplementation.swift
@@ -25,7 +25,7 @@ struct MiniMaxProviderImplementation: ProviderImplementation {
 
     @MainActor
     func settingsSnapshot(context: ProviderSettingsSnapshotContext) -> ProviderSettingsSnapshotContribution? {
-        .minimax(context.settings.minimaxSettingsSnapshot())
+        .minimax(context.settings.minimaxSettingsSnapshot(tokenOverride: context.tokenOverride))
     }
 
     @MainActor

--- a/Sources/CodexBar/Providers/MiniMax/MiniMaxProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/MiniMax/MiniMaxProviderImplementation.swift
@@ -25,7 +25,7 @@ struct MiniMaxProviderImplementation: ProviderImplementation {
 
     @MainActor
     func settingsSnapshot(context: ProviderSettingsSnapshotContext) -> ProviderSettingsSnapshotContribution? {
-        .minimax(context.settings.minimaxSettingsSnapshot(tokenOverride: context.tokenOverride))
+        .minimax(context.settings.minimaxSettingsSnapshot())
     }
 
     @MainActor
@@ -65,7 +65,7 @@ struct MiniMaxProviderImplementation: ProviderImplementation {
                 source: context.settings.minimaxCookieSource,
                 keychainDisabled: context.settings.debugDisableKeychainAccess,
                 auto: "Automatic imports browser cookies and local storage tokens.",
-                manual: "Paste a Cookie header or cURL capture from the Coding Plan page.",
+                manual: "Paste a Cookie header or cURL capture from the Token Plan page.",
                 off: "MiniMax cookies are disabled.")
         }
 
@@ -122,7 +122,7 @@ struct MiniMaxProviderImplementation: ProviderImplementation {
                 actions: [
                     ProviderSettingsActionDescriptor(
                         id: "minimax-open-dashboard",
-                        title: "Open Coding Plan",
+                        title: "Open Token Plan",
                         style: .link,
                         isVisible: nil,
                         perform: {
@@ -141,7 +141,7 @@ struct MiniMaxProviderImplementation: ProviderImplementation {
                 actions: [
                     ProviderSettingsActionDescriptor(
                         id: "minimax-open-dashboard-cookie",
-                        title: "Open Coding Plan",
+                        title: "Open Token Plan",
                         style: .link,
                         isVisible: nil,
                         perform: {

--- a/Sources/CodexBar/Providers/MiniMax/MiniMaxSettingsStore.swift
+++ b/Sources/CodexBar/Providers/MiniMax/MiniMaxSettingsStore.swift
@@ -24,6 +24,16 @@ extension SettingsStore {
         }
     }
 
+    var minimaxAPIToken: String {
+        get { self.configSnapshot.providerConfig(for: .minimax)?.sanitizedAPIKey ?? "" }
+        set {
+            self.updateProviderConfig(provider: .minimax) { entry in
+                entry.apiKey = self.normalizedConfigValue(newValue)
+            }
+            self.logSecretUpdate(provider: .minimax, field: "apiKey", value: newValue)
+        }
+    }
+
     var minimaxCookieSource: ProviderCookieSource {
         get { self.resolvedCookieSource(provider: .minimax, fallback: .auto) }
         set {
@@ -34,49 +44,54 @@ extension SettingsStore {
         }
     }
 
-    var minimaxAPIToken: String {
-        get { self.configSnapshot.providerConfig(for: .minimax)?.sanitizedAPIKey ?? "" }
-        set {
-            self.updateProviderConfig(provider: .minimax) { entry in
-                entry.apiKey = self.normalizedConfigValue(newValue)
-            }
-            let hasToken = !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            if hasToken,
-               let metadata = ProviderDescriptorRegistry.metadata[.minimax],
-               !self.isProviderEnabled(provider: .minimax, metadata: metadata)
-            {
-                self.setProviderEnabled(provider: .minimax, metadata: metadata, enabled: true)
-            }
-            self.logSecretUpdate(provider: .minimax, field: "apiKey", value: newValue)
-        }
+    func ensureMiniMaxCookieLoaded() {}
+
+    func ensureMiniMaxAPITokenLoaded() {}
+
+    func minimaxAuthMode(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> MiniMaxAuthMode
+    {
+        let apiToken = MiniMaxAPISettingsReader.apiToken(environment: environment) ?? self.minimaxAPIToken
+        let cookieHeader = MiniMaxSettingsReader.cookieHeader(environment: environment) ?? self.minimaxCookieHeader
+        return MiniMaxAuthMode.resolve(apiToken: apiToken, cookieHeader: cookieHeader)
     }
 }
 
 extension SettingsStore {
-    func minimaxSettingsSnapshot() -> ProviderSettingsSnapshot.MiniMaxProviderSettings {
+    func minimaxSettingsSnapshot(tokenOverride: TokenAccountOverride?) -> ProviderSettingsSnapshot
+    .MiniMaxProviderSettings {
         ProviderSettingsSnapshot.MiniMaxProviderSettings(
-            cookieSource: self.minimaxCookieSource,
-            manualCookieHeader: self.minimaxCookieHeader,
+            cookieSource: self.minimaxSnapshotCookieSource(tokenOverride: tokenOverride),
+            manualCookieHeader: self.minimaxSnapshotCookieHeader(tokenOverride: tokenOverride),
             apiRegion: self.minimaxAPIRegion)
     }
-}
 
-extension SettingsStore {
-    func ensureMiniMaxCookieLoaded() {
-        // Cookie loading handled by MiniMaxCookieImporter
+    private func minimaxSnapshotCookieHeader(tokenOverride: TokenAccountOverride?) -> String {
+        let fallback = self.minimaxCookieHeader
+        guard let support = TokenAccountSupportCatalog.support(for: .minimax),
+              case .cookieHeader = support.injection
+        else {
+            return fallback
+        }
+        guard let account = ProviderTokenAccountSelection.selectedAccount(
+            provider: .minimax,
+            settings: self,
+            override: tokenOverride)
+        else {
+            return fallback
+        }
+        return TokenAccountSupportCatalog.normalizedCookieHeader(account.token, support: support)
+    }
+
+    private func minimaxSnapshotCookieSource(tokenOverride: TokenAccountOverride?) -> ProviderCookieSource {
+        let fallback = self.minimaxCookieSource
+        guard let support = TokenAccountSupportCatalog.support(for: .minimax),
+              support.requiresManualCookieSource
+        else {
+            return fallback
+        }
+        if self.tokenAccounts(for: .minimax).isEmpty { return fallback }
+        return .manual
     }
 }
 
-extension SettingsStore {
-    func ensureMiniMaxAPITokenLoaded() {
-        // Token loading handled by MiniMaxAPITokenStore
-    }
-}
-
-extension SettingsStore {
-    func minimaxAuthMode() -> MiniMaxAuthMode {
-        MiniMaxAuthMode.resolve(
-            apiToken: self.minimaxAPIToken,
-            cookieHeader: self.minimaxCookieHeader)
-    }
-}

--- a/Sources/CodexBar/Providers/MiniMax/MiniMaxSettingsStore.swift
+++ b/Sources/CodexBar/Providers/MiniMax/MiniMaxSettingsStore.swift
@@ -24,16 +24,6 @@ extension SettingsStore {
         }
     }
 
-    var minimaxAPIToken: String {
-        get { self.configSnapshot.providerConfig(for: .minimax)?.sanitizedAPIKey ?? "" }
-        set {
-            self.updateProviderConfig(provider: .minimax) { entry in
-                entry.apiKey = self.normalizedConfigValue(newValue)
-            }
-            self.logSecretUpdate(provider: .minimax, field: "apiKey", value: newValue)
-        }
-    }
-
     var minimaxCookieSource: ProviderCookieSource {
         get { self.resolvedCookieSource(provider: .minimax, fallback: .auto) }
         set {
@@ -44,53 +34,49 @@ extension SettingsStore {
         }
     }
 
-    func ensureMiniMaxCookieLoaded() {}
-
-    func ensureMiniMaxAPITokenLoaded() {}
-
-    func minimaxAuthMode(
-        environment: [String: String] = ProcessInfo.processInfo.environment) -> MiniMaxAuthMode
-    {
-        let apiToken = MiniMaxAPISettingsReader.apiToken(environment: environment) ?? self.minimaxAPIToken
-        let cookieHeader = MiniMaxSettingsReader.cookieHeader(environment: environment) ?? self.minimaxCookieHeader
-        return MiniMaxAuthMode.resolve(apiToken: apiToken, cookieHeader: cookieHeader)
+    var minimaxAPIToken: String {
+        get { self.configSnapshot.providerConfig(for: .minimax)?.sanitizedAPIKey ?? "" }
+        set {
+            self.updateProviderConfig(provider: .minimax) { entry in
+                entry.apiKey = self.normalizedConfigValue(newValue)
+            }
+            let hasToken = !newValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            if hasToken,
+               let metadata = ProviderDescriptorRegistry.metadata[.minimax],
+               !self.isProviderEnabled(provider: .minimax, metadata: metadata)
+            {
+                self.setProviderEnabled(provider: .minimax, metadata: metadata, enabled: true)
+            }
+            self.logSecretUpdate(provider: .minimax, field: "apiKey", value: newValue)
+        }
     }
 }
 
 extension SettingsStore {
-    func minimaxSettingsSnapshot(tokenOverride: TokenAccountOverride?) -> ProviderSettingsSnapshot
-    .MiniMaxProviderSettings {
+    func minimaxSettingsSnapshot() -> ProviderSettingsSnapshot.MiniMaxProviderSettings {
         ProviderSettingsSnapshot.MiniMaxProviderSettings(
-            cookieSource: self.minimaxSnapshotCookieSource(tokenOverride: tokenOverride),
-            manualCookieHeader: self.minimaxSnapshotCookieHeader(tokenOverride: tokenOverride),
+            cookieSource: self.minimaxCookieSource,
+            manualCookieHeader: self.minimaxCookieHeader,
             apiRegion: self.minimaxAPIRegion)
     }
+}
 
-    private func minimaxSnapshotCookieHeader(tokenOverride: TokenAccountOverride?) -> String {
-        let fallback = self.minimaxCookieHeader
-        guard let support = TokenAccountSupportCatalog.support(for: .minimax),
-              case .cookieHeader = support.injection
-        else {
-            return fallback
-        }
-        guard let account = ProviderTokenAccountSelection.selectedAccount(
-            provider: .minimax,
-            settings: self,
-            override: tokenOverride)
-        else {
-            return fallback
-        }
-        return TokenAccountSupportCatalog.normalizedCookieHeader(account.token, support: support)
+extension SettingsStore {
+    func ensureMiniMaxCookieLoaded() {
+        // Cookie loading handled by MiniMaxCookieImporter
     }
+}
 
-    private func minimaxSnapshotCookieSource(tokenOverride: TokenAccountOverride?) -> ProviderCookieSource {
-        let fallback = self.minimaxCookieSource
-        guard let support = TokenAccountSupportCatalog.support(for: .minimax),
-              support.requiresManualCookieSource
-        else {
-            return fallback
-        }
-        if self.tokenAccounts(for: .minimax).isEmpty { return fallback }
-        return .manual
+extension SettingsStore {
+    func ensureMiniMaxAPITokenLoaded() {
+        // Token loading handled by MiniMaxAPITokenStore
+    }
+}
+
+extension SettingsStore {
+    func minimaxAuthMode() -> MiniMaxAuthMode {
+        MiniMaxAuthMode.resolve(
+            apiToken: self.minimaxAPIToken,
+            cookieHeader: self.minimaxCookieHeader)
     }
 }

--- a/Sources/CodexBar/Providers/MiniMax/MiniMaxSettingsStore.swift
+++ b/Sources/CodexBar/Providers/MiniMax/MiniMaxSettingsStore.swift
@@ -94,4 +94,3 @@ extension SettingsStore {
         return .manual
     }
 }
-

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -52,6 +52,9 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         if provider == .alibaba {
             return self.settings.alibabaCodingPlanAPIRegion.dashboardURL
         }
+        if provider == .minimax {
+            return self.settings.minimaxAPIRegion.dashboardURL
+        }
 
         if provider == .opencodego {
             return self.settings.opencodegoDashboardURL

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxAPIRegion.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxAPIRegion.swift
@@ -55,4 +55,11 @@ public enum MiniMaxAPIRegion: String, CaseIterable, Sendable {
     public var apiRemainsURL: URL {
         URL(string: self.apiBaseURLString)!.appendingPathComponent(Self.remainsPath)
     }
+    
+    public var dashboardURL: URL {
+        var components = URLComponents(string: self.baseURLString)!
+        components.path = "/" + Self.codingPlanPath
+        components.query = Self.codingPlanQuery
+        return components.url!
+    }
 }

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxAPIRegion.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxAPIRegion.swift
@@ -55,7 +55,7 @@ public enum MiniMaxAPIRegion: String, CaseIterable, Sendable {
     public var apiRemainsURL: URL {
         URL(string: self.apiBaseURLString)!.appendingPathComponent(Self.remainsPath)
     }
-    
+
     public var dashboardURL: URL {
         var components = URLComponents(string: self.baseURLString)!
         components.path = "/" + Self.codingPlanPath

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxServiceUsage.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxServiceUsage.swift
@@ -1,0 +1,190 @@
+//
+//  MiniMaxServiceUsage.swift
+//  CodexBarCore
+//
+//  Created by Sisyphus on 2026-03-25.
+//
+
+import Foundation
+
+/// Represents the usage information for a specific MiniMax service.
+///
+/// This struct encapsulates all the relevant details about how much of a particular
+/// MiniMax service has been used within its quota window, including reset timing
+/// and localized display strings.
+public struct MiniMaxServiceUsage: Sendable {
+    /// The service identifier (e.g., "text-generation", "text-to-speech", "image")
+    public let serviceType: String
+    
+    /// The type of time window for the quota (e.g., "5 hours" or "Today")
+    /// This should be a localized string.
+    public let windowType: String
+    
+    /// The specific time range for the current quota window.
+    /// For hourly quotas: "10:00-15:00(UTC+8)"
+    /// For daily quotas: full date range string
+    public let timeRange: String
+    
+    /// The amount of quota that has been used
+    public let usage: Int
+    
+    /// The total quota limit for this service in the current window
+    public let limit: Int
+    
+    /// The percentage of quota used (0-100)
+    public let percent: Double
+    
+    /// The timestamp when the quota will reset, if available
+    public let resetsAt: Date?
+    
+    /// A localized description of when the quota resets (e.g., "Resets in 2 hours 30 minutes")
+    public let resetDescription: String
+    
+    /// The remaining quota available (limit - usage)
+    public var remaining: Int {
+        return limit - usage
+    }
+    
+    /// The display name for this service
+    public var displayName: String {
+        switch serviceType {
+        case "text-generation":
+            return "Text Generation"
+        case "text-to-speech":
+            return "Text to Speech"
+        case "image":
+            return "Image"
+        default:
+            return serviceType
+        }
+    }
+    
+    /// Creates a new MiniMaxServiceUsage instance.
+    ///
+    /// - Parameters:
+    ///   - serviceType: The service identifier
+    ///   - windowType: The type of time window (localized)
+    ///   - timeRange: The specific time range string
+    ///   - usage: The amount of quota used
+    ///   - limit: The total quota limit
+    ///   - percent: The percentage used (0-100)
+    ///   - resetsAt: Optional reset timestamp
+    ///   - resetDescription: Localized reset description
+    public init(
+        serviceType: String,
+        windowType: String,
+        timeRange: String,
+        usage: Int,
+        limit: Int,
+        percent: Double,
+        resetsAt: Date?,
+        resetDescription: String
+    ) {
+        self.serviceType = serviceType
+        self.windowType = windowType
+        self.timeRange = timeRange
+        self.usage = usage
+        self.limit = limit
+        self.percent = percent
+        self.resetsAt = resetsAt
+        self.resetDescription = resetDescription
+    }
+}
+
+extension MiniMaxServiceUsage {
+    public static func parseWindowType(_ windowType: String) -> (windowType: String, windowMinutes: Int?) {
+        switch windowType.lowercased() {
+        case "5 hours", "5 小时":
+            return ("5 hours", 300)
+        case "today", "今日":
+            return ("Today", 1440)
+        default:
+            // Try to extract hours from string like "X hours"
+            if let hours = Int(windowType.components(separatedBy: .whitespaces).first ?? "") {
+                return (windowType, hours * 60)
+            }
+            return (windowType, nil)
+        }
+    }
+    
+    public static func parseTimeRange(_ timeRange: String, now: Date) -> Date? {
+        let calendar = Calendar.current
+        
+        // Handle "10:00-15:00(UTC+8)" format
+        if timeRange.contains("-") && timeRange.contains("(") && timeRange.contains(")") {
+            // Extract the time part before the timezone
+            let components = timeRange.split(separator: "(")
+            guard components.count >= 1 else { return nil }
+            let timePart = String(components[0]).trimmingCharacters(in: .whitespaces)
+            
+            // Split by "-" to get start and end times
+            let timeComponents = timePart.split(separator: "-")
+            guard timeComponents.count == 2 else { return nil }
+            
+            let endTimeStr = String(timeComponents[1]).trimmingCharacters(in: .whitespaces)
+            
+            // Parse end time (HH:mm format)
+            let timeFormatter = DateFormatter()
+            timeFormatter.dateFormat = "HH:mm"
+            timeFormatter.timeZone = TimeZone.current
+            
+            guard let endTime = timeFormatter.date(from: endTimeStr) else { return nil }
+            
+            // Get today's date components
+            let nowComponents = calendar.dateComponents([.year, .month, .day], from: now)
+            let endTimeComponents = calendar.dateComponents([.hour, .minute], from: endTime)
+            
+            // Combine today's date with end time
+            var combinedComponents = DateComponents()
+            combinedComponents.year = nowComponents.year
+            combinedComponents.month = nowComponents.month
+            combinedComponents.day = nowComponents.day
+            combinedComponents.hour = endTimeComponents.hour
+            combinedComponents.minute = endTimeComponents.minute
+            
+            guard let resultDate = calendar.date(from: combinedComponents) else { return nil }
+            
+            // If the result date is in the past (before now), add one day
+            if resultDate < now {
+                return calendar.date(byAdding: .day, value: 1, to: resultDate)
+            }
+            
+            return resultDate
+        }
+        
+        // Handle "2026/03/25 00:00 - 2026/03/26 00:00" format
+        if timeRange.contains(" - ") {
+            let dateComponents = timeRange.split(separator: " - ")
+            guard dateComponents.count == 2 else { return nil }
+            
+            let endDateStr = String(dateComponents[1]).trimmingCharacters(in: .whitespaces)
+            
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyy/MM/dd HH:mm"
+            dateFormatter.timeZone = TimeZone.current
+            
+            return dateFormatter.date(from: endDateStr)
+        }
+        
+        return nil
+    }
+    
+    public static func generateResetDescription(resetsAt: Date, now: Date = Date()) -> String {
+        let calendar = Calendar.current
+        let components = calendar.dateComponents([.hour, .minute], from: now, to: resetsAt)
+        
+        guard let hours = components.hour, let minutes = components.minute else {
+            return "Resets soon"
+        }
+        
+        if hours > 0 && minutes > 0 {
+            return "Resets in \(hours) hours \(minutes) minutes"
+        } else if hours > 0 {
+            return "Resets in \(hours) hour\(hours > 1 ? "s" : "")"
+        } else if minutes > 0 {
+            return "Resets in \(minutes) minute\(minutes > 1 ? "s" : "")"
+        } else {
+            return "Resets now"
+        }
+    }
+}

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxServiceUsage.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxServiceUsage.swift
@@ -15,50 +15,50 @@ import Foundation
 public struct MiniMaxServiceUsage: Sendable {
     /// The service identifier (e.g., "text-generation", "text-to-speech", "image")
     public let serviceType: String
-    
+
     /// The type of time window for the quota (e.g., "5 hours" or "Today")
     /// This should be a localized string.
     public let windowType: String
-    
+
     /// The specific time range for the current quota window.
     /// For hourly quotas: "10:00-15:00(UTC+8)"
     /// For daily quotas: full date range string
     public let timeRange: String
-    
-    /// The amount of quota that has been used
+
+    /// The amount of quota that has been used.
     public let usage: Int
-    
+
     /// The total quota limit for this service in the current window
     public let limit: Int
-    
+
     /// The percentage of quota used (0-100)
     public let percent: Double
-    
+
     /// The timestamp when the quota will reset, if available
     public let resetsAt: Date?
-    
+
     /// A localized description of when the quota resets (e.g., "Resets in 2 hours 30 minutes")
     public let resetDescription: String
-    
+
     /// The remaining quota available (limit - usage)
     public var remaining: Int {
-        return limit - usage
+        max(0, self.limit - self.usage)
     }
-    
+
     /// The display name for this service
     public var displayName: String {
-        switch serviceType {
+        switch self.serviceType {
         case "text-generation":
-            return "Text Generation"
+            "Text Generation"
         case "text-to-speech":
-            return "Text to Speech"
+            "Text to Speech"
         case "image":
-            return "Image"
+            "Image"
         default:
-            return serviceType
+            self.serviceType
         }
     }
-    
+
     /// Creates a new MiniMaxServiceUsage instance.
     ///
     /// - Parameters:
@@ -78,8 +78,8 @@ public struct MiniMaxServiceUsage: Sendable {
         limit: Int,
         percent: Double,
         resetsAt: Date?,
-        resetDescription: String
-    ) {
+        resetDescription: String)
+    {
         self.serviceType = serviceType
         self.windowType = windowType
         self.timeRange = timeRange
@@ -106,34 +106,34 @@ extension MiniMaxServiceUsage {
             return (windowType, nil)
         }
     }
-    
+
     public static func parseTimeRange(_ timeRange: String, now: Date) -> Date? {
         let calendar = Calendar.current
-        
+
         // Handle "10:00-15:00(UTC+8)" format
-        if timeRange.contains("-") && timeRange.contains("(") && timeRange.contains(")") {
+        if timeRange.contains("-"), timeRange.contains("("), timeRange.contains(")") {
             // Extract the time part before the timezone
             let components = timeRange.split(separator: "(")
             guard components.count >= 1 else { return nil }
             let timePart = String(components[0]).trimmingCharacters(in: .whitespaces)
-            
+
             // Split by "-" to get start and end times
             let timeComponents = timePart.split(separator: "-")
             guard timeComponents.count == 2 else { return nil }
-            
+
             let endTimeStr = String(timeComponents[1]).trimmingCharacters(in: .whitespaces)
-            
+
             // Parse end time (HH:mm format)
             let timeFormatter = DateFormatter()
             timeFormatter.dateFormat = "HH:mm"
             timeFormatter.timeZone = TimeZone.current
-            
+
             guard let endTime = timeFormatter.date(from: endTimeStr) else { return nil }
-            
+
             // Get today's date components
             let nowComponents = calendar.dateComponents([.year, .month, .day], from: now)
             let endTimeComponents = calendar.dateComponents([.hour, .minute], from: endTime)
-            
+
             // Combine today's date with end time
             var combinedComponents = DateComponents()
             combinedComponents.year = nowComponents.year
@@ -141,43 +141,43 @@ extension MiniMaxServiceUsage {
             combinedComponents.day = nowComponents.day
             combinedComponents.hour = endTimeComponents.hour
             combinedComponents.minute = endTimeComponents.minute
-            
+
             guard let resultDate = calendar.date(from: combinedComponents) else { return nil }
-            
+
             // If the result date is in the past (before now), add one day
             if resultDate < now {
                 return calendar.date(byAdding: .day, value: 1, to: resultDate)
             }
-            
+
             return resultDate
         }
-        
+
         // Handle "2026/03/25 00:00 - 2026/03/26 00:00" format
         if timeRange.contains(" - ") {
             let dateComponents = timeRange.split(separator: " - ")
             guard dateComponents.count == 2 else { return nil }
-            
+
             let endDateStr = String(dateComponents[1]).trimmingCharacters(in: .whitespaces)
-            
+
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "yyyy/MM/dd HH:mm"
             dateFormatter.timeZone = TimeZone.current
-            
+
             return dateFormatter.date(from: endDateStr)
         }
-        
+
         return nil
     }
-    
+
     public static func generateResetDescription(resetsAt: Date, now: Date = Date()) -> String {
         let calendar = Calendar.current
         let components = calendar.dateComponents([.hour, .minute], from: now, to: resetsAt)
-        
+
         guard let hours = components.hour, let minutes = components.minute else {
             return "Resets soon"
         }
-        
-        if hours > 0 && minutes > 0 {
+
+        if hours > 0, minutes > 0 {
             return "Resets in \(hours) hours \(minutes) minutes"
         } else if hours > 0 {
             return "Resets in \(hours) hour\(hours > 1 ? "s" : "")"

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -4,7 +4,7 @@ import FoundationNetworking
 #endif
 
 public struct MiniMaxUsageFetcher: Sendable {
-    private static let log = CodexBarLog.logger(LogCategories.minimaxUsage)
+    static let log = CodexBarLog.logger(LogCategories.minimaxUsage)
     private static let codingPlanPath = "user-center/payment/coding-plan"
     private static let codingPlanQuery = "cycle_type=3"
     private static let codingPlanRemainsPath = "v1/api/openplatform/coding_plan/remains"
@@ -112,7 +112,11 @@ public struct MiniMaxUsageFetcher: Sendable {
             throw MiniMaxUsageError.apiError("HTTP \(httpResponse.statusCode)")
         }
 
-        return try MiniMaxUsageParser.parseCodingPlanRemains(data: data, now: now)
+        let snapshot = try MiniMaxUsageParser.parseCodingPlanRemains(data: data, now: now)
+        if let services = snapshot.services, !services.isEmpty {
+            Self.log.debug("MiniMax multi-service response detected: \(services.count) services")
+        }
+        return snapshot
     }
 
     private static func fetchCodingPlanHTML(
@@ -159,7 +163,11 @@ public struct MiniMaxUsageFetcher: Sendable {
         if let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type"),
            contentType.lowercased().contains("application/json")
         {
-            return try MiniMaxUsageParser.parseCodingPlanRemains(data: data, now: now)
+            let snapshot = try MiniMaxUsageParser.parseCodingPlanRemains(data: data, now: now)
+            if let services = snapshot.services, !services.isEmpty {
+                Self.log.debug("MiniMax multi-service response detected: \(services.count) services")
+            }
+            return snapshot
         }
 
         let html = String(data: data, encoding: .utf8) ?? ""
@@ -220,7 +228,11 @@ public struct MiniMaxUsageFetcher: Sendable {
         {
             let payload = try MiniMaxUsageParser.decodePayload(data: data)
             self.logCodingPlanStatus(payload: payload)
-            return try MiniMaxUsageParser.parseCodingPlanRemains(payload: payload, now: now)
+            let snapshot = try MiniMaxUsageParser.parseCodingPlanRemains(payload: payload, now: now)
+            if let services = snapshot.services, !services.isEmpty {
+                Self.log.debug("MiniMax multi-service response detected: \(services.count) services")
+            }
+            return snapshot
         }
 
         let html = String(data: data, encoding: .utf8) ?? ""
@@ -411,27 +423,45 @@ struct MiniMaxComboCard: Decodable {
 }
 
 struct MiniMaxModelRemains: Decodable {
+    let modelName: String?
     let currentIntervalTotalCount: Int?
     let currentIntervalUsageCount: Int?
     let startTime: Int?
     let endTime: Int?
     let remainsTime: Int?
+    let currentWeeklyTotalCount: Int?
+    let currentWeeklyUsageCount: Int?
+    let weeklyStartTime: Int?
+    let weeklyEndTime: Int?
+    let weeklyRemainsTime: Int?
 
     private enum CodingKeys: String, CodingKey {
+        case modelName = "model_name"
         case currentIntervalTotalCount = "current_interval_total_count"
         case currentIntervalUsageCount = "current_interval_usage_count"
         case startTime = "start_time"
         case endTime = "end_time"
         case remainsTime = "remains_time"
+        case currentWeeklyTotalCount = "current_weekly_total_count"
+        case currentWeeklyUsageCount = "current_weekly_usage_count"
+        case weeklyStartTime = "weekly_start_time"
+        case weeklyEndTime = "weekly_end_time"
+        case weeklyRemainsTime = "weekly_remains_time"
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.modelName = try container.decodeIfPresent(String.self, forKey: .modelName)
         self.currentIntervalTotalCount = MiniMaxDecoding.decodeInt(container, forKey: .currentIntervalTotalCount)
         self.currentIntervalUsageCount = MiniMaxDecoding.decodeInt(container, forKey: .currentIntervalUsageCount)
         self.startTime = MiniMaxDecoding.decodeInt(container, forKey: .startTime)
         self.endTime = MiniMaxDecoding.decodeInt(container, forKey: .endTime)
         self.remainsTime = MiniMaxDecoding.decodeInt(container, forKey: .remainsTime)
+        self.currentWeeklyTotalCount = MiniMaxDecoding.decodeInt(container, forKey: .currentWeeklyTotalCount)
+        self.currentWeeklyUsageCount = MiniMaxDecoding.decodeInt(container, forKey: .currentWeeklyUsageCount)
+        self.weeklyStartTime = MiniMaxDecoding.decodeInt(container, forKey: .weeklyStartTime)
+        self.weeklyEndTime = MiniMaxDecoding.decodeInt(container, forKey: .weeklyEndTime)
+        self.weeklyRemainsTime = MiniMaxDecoding.decodeInt(container, forKey: .weeklyRemainsTime)
     }
 }
 
@@ -448,6 +478,52 @@ struct MiniMaxBaseResponse: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.statusCode = MiniMaxDecoding.decodeInt(container, forKey: .statusCode)
         self.statusMessage = try container.decodeIfPresent(String.self, forKey: .statusMessage)
+    }
+}
+
+// MARK: - Multi-Service API Response Structures
+
+struct MiniMaxMultiServicePayload: Decodable {
+    let data: MiniMaxMultiServiceData
+}
+
+struct MiniMaxMultiServiceData: Decodable {
+    let services: [MiniMaxServiceItem]
+}
+
+struct MiniMaxServiceItem: Decodable {
+    let serviceType: String?
+    let windowType: String?
+    let timeRange: String?
+    let usage: Int?
+    let limit: Int?
+    let percent: Double?
+    
+    private enum CodingKeys: String, CodingKey {
+        case serviceType = "service_type"
+        case windowType = "window_type"
+        case timeRange = "time_range"
+        case usage
+        case limit
+        case percent
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.serviceType = try container.decodeIfPresent(String.self, forKey: .serviceType)
+        self.windowType = try container.decodeIfPresent(String.self, forKey: .windowType)
+        self.timeRange = try container.decodeIfPresent(String.self, forKey: .timeRange)
+        self.usage = MiniMaxDecoding.decodeInt(container, forKey: .usage)
+        self.limit = MiniMaxDecoding.decodeInt(container, forKey: .limit)
+        // Handle both Double and String for percent (flexible parsing)
+        if let percentDouble = try? container.decodeIfPresent(Double.self, forKey: .percent) {
+            self.percent = percentDouble
+        } else if let percentString = try? container.decodeIfPresent(String.self, forKey: .percent),
+                  let percentValue = Double(percentString) {
+            self.percent = percentValue
+        } else {
+            self.percent = nil
+        }
     }
 }
 
@@ -476,6 +552,11 @@ enum MiniMaxUsageParser {
         return try decoder.decode(MiniMaxCodingPlanPayload.self, from: data)
     }
 
+    static func decodeMultiServicePayload(data: Data) throws -> MiniMaxMultiServicePayload {
+        let decoder = JSONDecoder()
+        return try decoder.decode(MiniMaxMultiServicePayload.self, from: data)
+    }
+
     static func decodePayload(json: [String: Any]) throws -> MiniMaxCodingPlanPayload {
         let normalized = self.normalizeCodingPlanPayload(json)
         let data = try JSONSerialization.data(withJSONObject: normalized, options: [])
@@ -483,6 +564,15 @@ enum MiniMaxUsageParser {
     }
 
     static func parseCodingPlanRemains(data: Data, now: Date = Date()) throws -> MiniMaxUsageSnapshot {
+        do {
+            if let multiServiceSnapshot = try self.parseMultiService(data: data, now: now) {
+                return multiServiceSnapshot
+            }
+        } catch {
+            // Log multi-service parsing failure but continue to single-service parsing
+            MiniMaxUsageFetcher.log.debug("MiniMax multi-service parsing failed: \(error.localizedDescription)")
+        }
+        
         let payload = try self.decodePayload(data: data)
         return try self.parseCodingPlanRemains(payload: payload, now: now)
     }
@@ -527,28 +617,75 @@ enum MiniMaxUsageParser {
             throw MiniMaxUsageError.apiError(message)
         }
 
-        guard let first = payload.data.modelRemains.first else {
+        guard !payload.data.modelRemains.isEmpty else {
             throw MiniMaxUsageError.parseFailed("Missing coding plan data.")
         }
 
-        let total = first.currentIntervalTotalCount
-        let remaining = first.currentIntervalUsageCount
+        // Convert model_remains to services array for multi-service UI display
+        var services: [MiniMaxServiceUsage] = []
+        for item in payload.data.modelRemains {
+            // Skip services with no quota (limit = 0)
+            guard let modelName = item.modelName,
+                  let limit = item.currentIntervalTotalCount,
+                  limit > 0,
+                  let remaining = item.currentIntervalUsageCount
+            else {
+                continue
+            }
+
+            // Calculate usage and percentage
+            // current_interval_usage_count is REMAINING quota (not used)
+            let used = max(0, limit - remaining)
+            let percent = limit > 0 ? Double(used) / Double(limit) * 100.0 : 0.0
+
+            // Parse time window
+            let startTime = self.dateFromEpoch(item.startTime)
+            let endTime = self.dateFromEpoch(item.endTime)
+            let windowMinutes = self.windowMinutes(start: startTime, end: endTime)
+
+            // Determine window type and time range
+            let (windowType, timeRange) = self.parseWindowInfo(
+                startTime: startTime,
+                endTime: endTime,
+                remainsSeconds: item.remainsTime,
+                now: now)
+
+            // Calculate reset time
+            let resetsAt = self.resetsAt(end: endTime, remains: item.remainsTime, now: now)
+            let resetDescription = self.resetDescription(for: windowType, timeRange: timeRange, now: now, resetsAt: resetsAt)
+
+            // Map model_name to service type identifier
+            let serviceTypeIdentifier = self.mapModelNameToServiceType(modelName: modelName)
+
+            let serviceUsage = MiniMaxServiceUsage(
+                serviceType: serviceTypeIdentifier,
+                windowType: windowType,
+                timeRange: timeRange,
+                usage: remaining,
+                limit: limit,
+                percent: min(100.0, max(0.0, percent)),
+                resetsAt: resetsAt,
+                resetDescription: resetDescription
+            )
+            services.append(serviceUsage)
+        }
+
+        // Use first service for backward compatibility fields
+        let first = payload.data.modelRemains.first
+        let total = first?.currentIntervalTotalCount
+        let remaining = first?.currentIntervalUsageCount
         let usedPercent = self.usedPercent(total: total, remaining: remaining)
 
         let windowMinutes = self.windowMinutes(
-            start: self.dateFromEpoch(first.startTime),
-            end: self.dateFromEpoch(first.endTime))
+            start: self.dateFromEpoch(first?.startTime),
+            end: self.dateFromEpoch(first?.endTime))
 
         let resetsAt = self.resetsAt(
-            end: self.dateFromEpoch(first.endTime),
-            remains: first.remainsTime,
+            end: self.dateFromEpoch(first?.endTime),
+            remains: first?.remainsTime,
             now: now)
 
         let planName = self.parsePlanName(data: payload.data)
-
-        if planName == nil, total == nil, usedPercent == nil {
-            throw MiniMaxUsageError.parseFailed("Missing coding plan data.")
-        }
 
         let currentPrompts: Int? = if let total, let remaining {
             max(0, total - remaining)
@@ -564,7 +701,8 @@ enum MiniMaxUsageParser {
             windowMinutes: windowMinutes,
             usedPercent: usedPercent,
             resetsAt: resetsAt,
-            updatedAt: now)
+            updatedAt: now,
+            services: services.isEmpty ? nil : services)
     }
 
     private static func usedPercent(total: Int?, remaining: Int?) -> Double? {
@@ -883,6 +1021,212 @@ enum MiniMaxUsageParser {
             guard let captureRange = Range(match.range(at: idx), in: text) else { return nil }
             return String(text[captureRange]).trimmingCharacters(in: .whitespacesAndNewlines)
         }
+    }
+
+    // MARK: - Multi-Service Parsing
+
+    private static func parseMultiService(data: Data, now: Date) throws -> MiniMaxUsageSnapshot? {
+        let payload = try self.decodeMultiServicePayload(data: data)
+        
+        guard !payload.data.services.isEmpty else {
+            return nil
+        }
+        
+        var services: [MiniMaxServiceUsage] = []
+        for item in payload.data.services {
+            guard let serviceType = item.serviceType,
+                  let windowType = item.windowType,
+                  let timeRange = item.timeRange,
+                  let usage = item.usage,
+                  let limit = item.limit else {
+                continue
+            }
+            
+            var percent = item.percent ?? 0.0
+            if item.percent == nil && limit > 0 {
+                percent = Double(usage) / Double(limit) * 100.0
+            }
+            
+            let resetsAt = self.parseResetsAtFromTimeRange(timeRange: timeRange, windowType: windowType, now: now)
+            let resetDescription = self.resetDescription(for: windowType, timeRange: timeRange, now: now, resetsAt: resetsAt)
+            
+            let serviceTypeIdentifier: String
+            if serviceType.lowercased().contains("text") && serviceType.lowercased().contains("generation") {
+                serviceTypeIdentifier = "text-generation"
+            } else if serviceType.lowercased().contains("text") && serviceType.lowercased().contains("speech") {
+                serviceTypeIdentifier = "text-to-speech"
+            } else if serviceType.lowercased().contains("image") {
+                serviceTypeIdentifier = "image"
+            } else {
+                serviceTypeIdentifier = serviceType.lowercased()
+                    .replacingOccurrences(of: " ", with: "-")
+                    .replacingOccurrences(of: "_", with: "-")
+            }
+            
+            let serviceUsage = MiniMaxServiceUsage(
+                serviceType: serviceTypeIdentifier,
+                windowType: windowType,
+                timeRange: timeRange,
+                usage: usage,
+                limit: limit,
+                percent: min(100.0, max(0.0, percent)),
+                resetsAt: resetsAt,
+                resetDescription: resetDescription
+            )
+            services.append(serviceUsage)
+        }
+        
+        if services.isEmpty {
+            return nil
+        }
+        
+        let planName = self.extractPlanNameFromServices(services: payload.data.services)
+        
+        return MiniMaxUsageSnapshot(
+            planName: planName,
+            availablePrompts: nil,
+            currentPrompts: nil,
+            remainingPrompts: nil,
+            windowMinutes: nil,
+            usedPercent: nil,
+            resetsAt: nil,
+            updatedAt: now,
+            services: services
+        )
+    }
+    
+    private static func parseResetsAtFromTimeRange(timeRange: String, windowType: String, now: Date) -> Date? {
+        let lowerWindow = windowType.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        if lowerWindow == "today" {
+            let components = timeRange.split(separator: "-", maxSplits: 1)
+            guard components.count == 2 else { return nil }
+            
+            let endTimeStr = String(components[1].trimmingCharacters(in: .whitespacesAndNewlines))
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyy/MM/dd HH:mm"
+            formatter.locale = Locale(identifier: "en_US_POSIX")
+            formatter.timeZone = TimeZone(identifier: "Asia/Shanghai")
+            
+            return formatter.date(from: endTimeStr)
+        }
+        
+        if lowerWindow.contains("hour") || lowerWindow.contains("h") {
+            let timeComponents = timeRange.split(separator: "-")
+            guard timeComponents.count >= 2 else { return nil }
+            
+            let endTimePart = String(timeComponents[1])
+            let endTimeClean = endTimePart.replacingOccurrences(of: "\\(.*\\)", with: "", options: .regularExpression)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            
+            return self.dateForTime(endTimeClean, timeZoneHint: "UTC+8", now: now)
+        }
+        
+        return nil
+    }
+    
+    private static func resetDescription(for windowType: String, timeRange: String, now: Date, resetsAt: Date?) -> String {
+        if let resetsAt = resetsAt, resetsAt > now {
+            let interval = resetsAt.timeIntervalSince(now)
+            if interval < 60 {
+                return "Resets in \(Int(interval)) seconds"
+            } else if interval < 3600 {
+                let minutes = Int(interval / 60)
+                return "Resets in \(minutes) minute\(minutes == 1 ? "" : "s")"
+            } else if interval < 86400 {
+                let hours = Int(interval / 3600)
+                return "Resets in \(hours) hour\(hours == 1 ? "" : "s")"
+            } else {
+                let days = Int(interval / 86400)
+                return "Resets in \(days) day\(days == 1 ? "" : "s")"
+            }
+        }
+        
+        return "\(windowType): \(timeRange)"
+    }
+    
+    private static func extractPlanNameFromServices(services: [MiniMaxServiceItem]) -> String? {
+        for service in services {
+            if let serviceType = service.serviceType,
+               serviceType.lowercased().contains("pro") || serviceType.lowercased().contains("max") {
+                return serviceType
+            }
+        }
+        
+        return nil
+    }
+
+    private static func parseWindowInfo(
+        startTime: Date?,
+        endTime: Date?,
+        remainsSeconds: Int?,
+        now: Date) -> (windowType: String, timeRange: String) {
+        guard let startTime, let endTime, let remains = remainsSeconds else {
+            return (windowType: "Unknown", timeRange: "N/A")
+        }
+
+        let durationSeconds = endTime.timeIntervalSince(startTime)
+        let durationHours = durationSeconds / 3600
+
+        // Determine window type based on duration
+        let windowType: String
+        if durationHours >= 23 && durationHours <= 25 {
+            windowType = "Today"
+        } else if durationHours >= 4 && durationHours <= 6 {
+            windowType = "5 hours"
+        } else if durationHours >= 1 && durationHours < 23 {
+            windowType = "\(Int(durationHours)) hours"
+        } else {
+            windowType = "Custom"
+        }
+
+        // Format time range
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        formatter.timeZone = TimeZone.current
+        let startStr = formatter.string(from: startTime)
+        let endStr = formatter.string(from: endTime)
+
+        let timeRange = "\(startStr)-\(endStr)(UTC+8)"
+
+        return (windowType: windowType, timeRange: timeRange)
+    }
+
+    private static func mapModelNameToServiceType(modelName: String) -> String {
+        let lower = modelName.lowercased()
+
+        // Text Generation (文本生成): M2.7, M2.7-highspeed, MiniMax-M*, etc.
+        if lower.contains("minimax-m") {
+            return "Text Generation"
+        }
+
+        // Text to Speech (语音合成): speech-hd, Speech 2.8, etc.
+        if lower.contains("speech") {
+            return "Text to Speech"
+        }
+
+        // Image to Video Fast (图生视频 Fast): Hailuo-2.3-Fast
+        if lower.contains("hailuo") && lower.contains("fast") {
+            return "Image to Video"
+        }
+
+        // Text to Video (文生视频): Hailuo-2.3 (non-Fast)
+        if lower.contains("hailuo") {
+            return "Text to Video"
+        }
+
+        // Image Generation (图像生成): image-01, image-02, etc.
+        if lower.hasPrefix("image-") {
+            return "Image Generation"
+        }
+
+        // Music Generation (音乐生成): music-2.5, etc.
+        if lower.contains("music") {
+            return "Music Generation"
+        }
+
+        // Default: use model name as-is
+        return modelName
     }
 }
 

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -226,9 +226,7 @@ public struct MiniMaxUsageFetcher: Sendable {
         if let contentType = httpResponse.value(forHTTPHeaderField: "Content-Type"),
            contentType.lowercased().contains("application/json")
         {
-            let payload = try MiniMaxUsageParser.decodePayload(data: data)
-            self.logCodingPlanStatus(payload: payload)
-            let snapshot = try MiniMaxUsageParser.parseCodingPlanRemains(payload: payload, now: now)
+            let snapshot = try MiniMaxUsageParser.parseCodingPlanRemains(data: data, now: now)
             if let services = snapshot.services, !services.isEmpty {
                 Self.log.debug("MiniMax multi-service response detected: \(services.count) services")
             }

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -496,7 +496,7 @@ struct MiniMaxServiceItem: Decodable {
     let usage: Int?
     let limit: Int?
     let percent: Double?
-    
+
     private enum CodingKeys: String, CodingKey {
         case serviceType = "service_type"
         case windowType = "window_type"
@@ -505,7 +505,7 @@ struct MiniMaxServiceItem: Decodable {
         case limit
         case percent
     }
-    
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.serviceType = try container.decodeIfPresent(String.self, forKey: .serviceType)
@@ -517,7 +517,8 @@ struct MiniMaxServiceItem: Decodable {
         if let percentDouble = try? container.decodeIfPresent(Double.self, forKey: .percent) {
             self.percent = percentDouble
         } else if let percentString = try? container.decodeIfPresent(String.self, forKey: .percent),
-                  let percentValue = Double(percentString) {
+                  let percentValue = Double(percentString)
+        {
             self.percent = percentValue
         } else {
             self.percent = nil
@@ -570,7 +571,7 @@ enum MiniMaxUsageParser {
             // Log multi-service parsing failure but continue to single-service parsing
             MiniMaxUsageFetcher.log.debug("MiniMax multi-service parsing failed: \(error.localizedDescription)")
         }
-        
+
         let payload = try self.decodePayload(data: data)
         return try self.parseCodingPlanRemains(payload: payload, now: now)
     }
@@ -639,18 +640,20 @@ enum MiniMaxUsageParser {
             // Parse time window
             let startTime = self.dateFromEpoch(item.startTime)
             let endTime = self.dateFromEpoch(item.endTime)
-            let windowMinutes = self.windowMinutes(start: startTime, end: endTime)
 
             // Determine window type and time range
             let (windowType, timeRange) = self.parseWindowInfo(
                 startTime: startTime,
                 endTime: endTime,
-                remainsSeconds: item.remainsTime,
                 now: now)
 
             // Calculate reset time
             let resetsAt = self.resetsAt(end: endTime, remains: item.remainsTime, now: now)
-            let resetDescription = self.resetDescription(for: windowType, timeRange: timeRange, now: now, resetsAt: resetsAt)
+            let resetDescription = self.resetDescription(
+                for: windowType,
+                timeRange: timeRange,
+                now: now,
+                resetsAt: resetsAt)
 
             // Map model_name to service type identifier
             let serviceTypeIdentifier = self.mapModelNameToServiceType(modelName: modelName)
@@ -659,12 +662,11 @@ enum MiniMaxUsageParser {
                 serviceType: serviceTypeIdentifier,
                 windowType: windowType,
                 timeRange: timeRange,
-                usage: remaining,
+                usage: used,
                 limit: limit,
                 percent: min(100.0, max(0.0, percent)),
                 resetsAt: resetsAt,
-                resetDescription: resetDescription
-            )
+                resetDescription: resetDescription)
             services.append(serviceUsage)
         }
 
@@ -951,7 +953,7 @@ enum MiniMaxUsageParser {
         if let tzHint = timeZoneHint?.trimmingCharacters(in: .whitespacesAndNewlines),
            !tzHint.isEmpty
         {
-            formatter.timeZone = TimeZone(identifier: tzHint)
+            formatter.timeZone = self.timeZone(from: tzHint)
         }
         formatter.locale = Locale(identifier: "en_US_POSIX")
 
@@ -979,6 +981,33 @@ enum MiniMaxUsageParser {
         if lower.hasPrefix("m") { return Int(value.rounded()) }
         if lower.hasPrefix("s") { return max(1, Int((value / 60).rounded())) }
         return 0
+    }
+
+    private static func timeZone(from hint: String) -> TimeZone? {
+        let trimmed = hint.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let timeZone = TimeZone(identifier: trimmed) {
+            return timeZone
+        }
+
+        let pattern = #"(?i)^(?:UTC|GMT)\s*([+-])\s*(\d{1,2})(?::?(\d{2}))?$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: trimmed, range: NSRange(trimmed.startIndex..., in: trimmed)),
+              let signRange = Range(match.range(at: 1), in: trimmed),
+              let hourRange = Range(match.range(at: 2), in: trimmed)
+        else {
+            return nil
+        }
+
+        let sign = trimmed[signRange] == "-" ? -1 : 1
+        let hours = Int(trimmed[hourRange]) ?? 0
+        let minutes = if match.range(at: 3).location != NSNotFound,
+                         let minuteRange = Range(match.range(at: 3), in: trimmed)
+        {
+            Int(trimmed[minuteRange]) ?? 0
+        } else {
+            0
+        }
+        return TimeZone(secondsFromGMT: sign * ((hours * 3600) + (minutes * 60)))
     }
 
     private static func seconds(from value: Double, unit: String) -> TimeInterval {
@@ -1025,42 +1054,48 @@ enum MiniMaxUsageParser {
 
     private static func parseMultiService(data: Data, now: Date) throws -> MiniMaxUsageSnapshot? {
         let payload = try self.decodeMultiServicePayload(data: data)
-        
+
         guard !payload.data.services.isEmpty else {
             return nil
         }
-        
+
         var services: [MiniMaxServiceUsage] = []
         for item in payload.data.services {
             guard let serviceType = item.serviceType,
                   let windowType = item.windowType,
                   let timeRange = item.timeRange,
                   let usage = item.usage,
-                  let limit = item.limit else {
+                  let limit = item.limit
+            else {
                 continue
             }
-            
+
             var percent = item.percent ?? 0.0
-            if item.percent == nil && limit > 0 {
+            if item.percent == nil, limit > 0 {
                 percent = Double(usage) / Double(limit) * 100.0
             }
-            
+
             let resetsAt = self.parseResetsAtFromTimeRange(timeRange: timeRange, windowType: windowType, now: now)
-            let resetDescription = self.resetDescription(for: windowType, timeRange: timeRange, now: now, resetsAt: resetsAt)
-            
-            let serviceTypeIdentifier: String
-            if serviceType.lowercased().contains("text") && serviceType.lowercased().contains("generation") {
-                serviceTypeIdentifier = "text-generation"
-            } else if serviceType.lowercased().contains("text") && serviceType.lowercased().contains("speech") {
-                serviceTypeIdentifier = "text-to-speech"
+            let resetDescription = self.resetDescription(
+                for: windowType,
+                timeRange: timeRange,
+                now: now,
+                resetsAt: resetsAt)
+
+            let serviceTypeIdentifier: String = if serviceType.lowercased().contains("text"),
+                                                   serviceType.lowercased().contains("generation")
+            {
+                "text-generation"
+            } else if serviceType.lowercased().contains("text"), serviceType.lowercased().contains("speech") {
+                "text-to-speech"
             } else if serviceType.lowercased().contains("image") {
-                serviceTypeIdentifier = "image"
+                "image"
             } else {
-                serviceTypeIdentifier = serviceType.lowercased()
+                serviceType.lowercased()
                     .replacingOccurrences(of: " ", with: "-")
                     .replacingOccurrences(of: "_", with: "-")
             }
-            
+
             let serviceUsage = MiniMaxServiceUsage(
                 serviceType: serviceTypeIdentifier,
                 windowType: windowType,
@@ -1069,17 +1104,16 @@ enum MiniMaxUsageParser {
                 limit: limit,
                 percent: min(100.0, max(0.0, percent)),
                 resetsAt: resetsAt,
-                resetDescription: resetDescription
-            )
+                resetDescription: resetDescription)
             services.append(serviceUsage)
         }
-        
+
         if services.isEmpty {
             return nil
         }
-        
+
         let planName = self.extractPlanNameFromServices(services: payload.data.services)
-        
+
         return MiniMaxUsageSnapshot(
             planName: planName,
             availablePrompts: nil,
@@ -1089,42 +1123,46 @@ enum MiniMaxUsageParser {
             usedPercent: nil,
             resetsAt: nil,
             updatedAt: now,
-            services: services
-        )
+            services: services)
     }
-    
+
     private static func parseResetsAtFromTimeRange(timeRange: String, windowType: String, now: Date) -> Date? {
         let lowerWindow = windowType.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-        
+
         if lowerWindow == "today" {
             let components = timeRange.split(separator: "-", maxSplits: 1)
             guard components.count == 2 else { return nil }
-            
+
             let endTimeStr = String(components[1].trimmingCharacters(in: .whitespacesAndNewlines))
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy/MM/dd HH:mm"
             formatter.locale = Locale(identifier: "en_US_POSIX")
             formatter.timeZone = TimeZone(identifier: "Asia/Shanghai")
-            
+
             return formatter.date(from: endTimeStr)
         }
-        
+
         if lowerWindow.contains("hour") || lowerWindow.contains("h") {
             let timeComponents = timeRange.split(separator: "-")
             guard timeComponents.count >= 2 else { return nil }
-            
+
             let endTimePart = String(timeComponents[1])
             let endTimeClean = endTimePart.replacingOccurrences(of: "\\(.*\\)", with: "", options: .regularExpression)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            
+
             return self.dateForTime(endTimeClean, timeZoneHint: "UTC+8", now: now)
         }
-        
+
         return nil
     }
-    
-    private static func resetDescription(for windowType: String, timeRange: String, now: Date, resetsAt: Date?) -> String {
-        if let resetsAt = resetsAt, resetsAt > now {
+
+    private static func resetDescription(
+        for windowType: String,
+        timeRange: String,
+        now: Date,
+        resetsAt: Date?) -> String
+    {
+        if let resetsAt, resetsAt > now {
             let interval = resetsAt.timeIntervalSince(now)
             if interval < 60 {
                 return "Resets in \(Int(interval)) seconds"
@@ -1139,27 +1177,28 @@ enum MiniMaxUsageParser {
                 return "Resets in \(days) day\(days == 1 ? "" : "s")"
             }
         }
-        
+
         return "\(windowType): \(timeRange)"
     }
-    
+
     private static func extractPlanNameFromServices(services: [MiniMaxServiceItem]) -> String? {
         for service in services {
             if let serviceType = service.serviceType,
-               serviceType.lowercased().contains("pro") || serviceType.lowercased().contains("max") {
+               serviceType.lowercased().contains("pro") || serviceType.lowercased().contains("max")
+            {
                 return serviceType
             }
         }
-        
+
         return nil
     }
 
     private static func parseWindowInfo(
         startTime: Date?,
         endTime: Date?,
-        remainsSeconds: Int?,
-        now: Date) -> (windowType: String, timeRange: String) {
-        guard let startTime, let endTime, let remains = remainsSeconds else {
+        now: Date) -> (windowType: String, timeRange: String)
+    {
+        guard let startTime, let endTime else {
             return (windowType: "Unknown", timeRange: "N/A")
         }
 
@@ -1167,21 +1206,20 @@ enum MiniMaxUsageParser {
         let durationHours = durationSeconds / 3600
 
         // Determine window type based on duration
-        let windowType: String
-        if durationHours >= 23 && durationHours <= 25 {
-            windowType = "Today"
-        } else if durationHours >= 4 && durationHours <= 6 {
-            windowType = "5 hours"
-        } else if durationHours >= 1 && durationHours < 23 {
-            windowType = "\(Int(durationHours)) hours"
+        let windowType = if durationHours >= 23, durationHours <= 25 {
+            "Today"
+        } else if durationHours >= 4, durationHours <= 6 {
+            "5 hours"
+        } else if durationHours >= 1, durationHours < 23 {
+            "\(Int(durationHours)) hours"
         } else {
-            windowType = "Custom"
+            "Custom"
         }
 
         // Format time range
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm"
-        formatter.timeZone = TimeZone.current
+        formatter.timeZone = TimeZone(identifier: "Asia/Shanghai") ?? .current
         let startStr = formatter.string(from: startTime)
         let endStr = formatter.string(from: endTime)
 
@@ -1204,7 +1242,7 @@ enum MiniMaxUsageParser {
         }
 
         // Image to Video Fast (图生视频 Fast): Hailuo-2.3-Fast
-        if lower.contains("hailuo") && lower.contains("fast") {
+        if lower.contains("hailuo"), lower.contains("fast") {
             return "Image to Video"
         }
 

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageSnapshot.swift
@@ -9,6 +9,40 @@ public struct MiniMaxUsageSnapshot: Sendable {
     public let usedPercent: Double?
     public let resetsAt: Date?
     public let updatedAt: Date
+    public let services: [MiniMaxServiceUsage]?
+
+    public var primaryService: MiniMaxServiceUsage? {
+        // Priority: "Text Generation" > first service
+        if let services = self.services, !services.isEmpty {
+            if let textGenService = services.first(where: { $0.displayName == "Text Generation" }) {
+                return textGenService
+            }
+            return services.first
+        }
+        return nil
+    }
+
+    public var secondaryService: MiniMaxServiceUsage? {
+        // Return second service for RateWindow.secondary if exists  
+        guard let services = self.services, services.count >= 2 else { return nil }
+        // If we have Text Generation as primary, get the next non-Text Generation service
+        if let textGenIndex = services.firstIndex(where: { $0.displayName == "Text Generation" }) {
+            // If Text Generation is first, secondary is second
+            if textGenIndex == 0 {
+                return services[1]
+            }
+            // If Text Generation is not first, secondary could be first or second depending on count
+            return services[0]
+        }
+        // No Text Generation found, just return second service
+        return services[1]
+    }
+
+    public var tertiaryService: MiniMaxServiceUsage? {
+        // Return third service for RateWindow.tertiary if exists
+        guard let services = self.services, services.count >= 3 else { return nil }
+        return services[2]
+    }
 
     public init(
         planName: String?,
@@ -18,7 +52,8 @@ public struct MiniMaxUsageSnapshot: Sendable {
         windowMinutes: Int?,
         usedPercent: Double?,
         resetsAt: Date?,
-        updatedAt: Date)
+        updatedAt: Date,
+        services: [MiniMaxServiceUsage]? = nil)
     {
         self.planName = planName
         self.availablePrompts = availablePrompts
@@ -28,11 +63,37 @@ public struct MiniMaxUsageSnapshot: Sendable {
         self.usedPercent = usedPercent
         self.resetsAt = resetsAt
         self.updatedAt = updatedAt
+        self.services = services
     }
 }
 
 extension MiniMaxUsageSnapshot {
     public func toUsageSnapshot() -> UsageSnapshot {
+        // If we have services array, use that for multi-service support
+        if let services = self.services, !services.isEmpty {
+            let primaryWindow = self.rateWindow(for: self.primaryService)
+            let secondaryWindow = self.rateWindow(for: self.secondaryService)
+            let tertiaryWindow = self.rateWindow(for: self.tertiaryService)
+            
+            let planName = self.planName?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let loginMethod = (planName?.isEmpty ?? true) ? nil : planName
+            let identity = ProviderIdentitySnapshot(
+                providerID: .minimax,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: loginMethod)
+
+            return UsageSnapshot(
+                primary: primaryWindow,
+                secondary: secondaryWindow,
+                tertiary: tertiaryWindow,
+                providerCost: nil,
+                minimaxUsage: self,
+                updatedAt: self.updatedAt,
+                identity: identity)
+        }
+        
+        // Fallback to single-service mode for backward compatibility
         let used = max(0, min(100, self.usedPercent ?? 0))
         let resetDescription = self.limitDescription()
         let primary = RateWindow(
@@ -59,6 +120,16 @@ extension MiniMaxUsageSnapshot {
             identity: identity)
     }
 
+    private func rateWindow(for service: MiniMaxServiceUsage?) -> RateWindow? {
+        guard let service else { return nil }
+        let windowMinutes = self.windowMinutes(for: service)
+        return RateWindow(
+            usedPercent: max(0, min(100, service.percent)),
+            windowMinutes: windowMinutes,
+            resetsAt: service.resetsAt,
+            resetDescription: service.resetDescription)
+    }
+
     private func limitDescription() -> String? {
         guard let availablePrompts, availablePrompts > 0 else {
             return self.windowDescription()
@@ -81,5 +152,32 @@ extension MiniMaxUsageSnapshot {
             return "\(hours) \(hours == 1 ? "hour" : "hours")"
         }
         return "\(windowMinutes) \(windowMinutes == 1 ? "minute" : "minutes")"
+    }
+
+    private func windowMinutes(for service: MiniMaxServiceUsage) -> Int? {
+        let windowType = service.windowType.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        // Handle "Today" case - 24 hours = 1440 minutes
+        if windowType == "today" {
+            return 24 * 60
+        }
+        
+        // Handle time duration formats like "5 hours", "30 minutes", etc.
+        let components = windowType.split(separator: " ")
+        guard components.count >= 2 else { return nil }
+        
+        guard let value = Int(components[0]) else { return nil }
+        let unit = components[1].lowercased()
+        
+        switch unit {
+        case "hour", "hours", "h", "hr", "hrs":
+            return value * 60
+        case "minute", "minutes", "min", "mins", "m":
+            return value
+        case "day", "days", "d":
+            return value * 24 * 60
+        default:
+            return nil
+        }
     }
 }

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageSnapshot.swift
@@ -23,7 +23,7 @@ public struct MiniMaxUsageSnapshot: Sendable {
     }
 
     public var secondaryService: MiniMaxServiceUsage? {
-        // Return second service for RateWindow.secondary if exists  
+        // Return second service for RateWindow.secondary if exists
         guard let services = self.services, services.count >= 2 else { return nil }
         // If we have Text Generation as primary, get the next non-Text Generation service
         if let textGenIndex = services.firstIndex(where: { $0.displayName == "Text Generation" }) {
@@ -74,7 +74,7 @@ extension MiniMaxUsageSnapshot {
             let primaryWindow = self.rateWindow(for: self.primaryService)
             let secondaryWindow = self.rateWindow(for: self.secondaryService)
             let tertiaryWindow = self.rateWindow(for: self.tertiaryService)
-            
+
             let planName = self.planName?.trimmingCharacters(in: .whitespacesAndNewlines)
             let loginMethod = (planName?.isEmpty ?? true) ? nil : planName
             let identity = ProviderIdentitySnapshot(
@@ -92,7 +92,7 @@ extension MiniMaxUsageSnapshot {
                 updatedAt: self.updatedAt,
                 identity: identity)
         }
-        
+
         // Fallback to single-service mode for backward compatibility
         let used = max(0, min(100, self.usedPercent ?? 0))
         let resetDescription = self.limitDescription()
@@ -156,19 +156,19 @@ extension MiniMaxUsageSnapshot {
 
     private func windowMinutes(for service: MiniMaxServiceUsage) -> Int? {
         let windowType = service.windowType.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
-        
+
         // Handle "Today" case - 24 hours = 1440 minutes
         if windowType == "today" {
             return 24 * 60
         }
-        
+
         // Handle time duration formats like "5 hours", "30 minutes", etc.
         let components = windowType.split(separator: " ")
         guard components.count >= 2 else { return nil }
-        
+
         guard let value = Int(components[0]) else { return nil }
         let unit = components[1].lowercased()
-        
+
         switch unit {
         case "hour", "hours", "h", "hr", "hrs":
             return value * 60

--- a/Tests/CodexBarTests/MenuCardModelTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelTests.swift
@@ -136,6 +136,90 @@ struct FactoryMenuCardModelTests {
     }
 }
 
+struct MiniMaxMenuCardModelTests {
+    @Test
+    func `minimax service metrics respect used and remaining display modes`() throws {
+        let now = Date()
+        let minimax = MiniMaxUsageSnapshot(
+            planName: "Max",
+            availablePrompts: nil,
+            currentPrompts: nil,
+            remainingPrompts: nil,
+            windowMinutes: nil,
+            usedPercent: nil,
+            resetsAt: nil,
+            updatedAt: now,
+            services: [
+                MiniMaxServiceUsage(
+                    serviceType: "text-generation",
+                    windowType: "5 hours",
+                    timeRange: "10:00-15:00(UTC+8)",
+                    usage: 2,
+                    limit: 10,
+                    percent: 20,
+                    resetsAt: now.addingTimeInterval(3600),
+                    resetDescription: "Resets in 1 hour"),
+            ])
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            minimaxUsage: minimax,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .minimax,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "Max"))
+        let metadata = try #require(ProviderDefaults.metadata[.minimax])
+
+        let used = UsageMenuCardView.Model.make(.init(
+            provider: .minimax,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: true,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        let remaining = UsageMenuCardView.Model.make(.init(
+            provider: .minimax,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(used.metrics.first?.title == "Text Generation")
+        #expect(used.metrics.first?.detailText == "2/10")
+        #expect(used.metrics.first?.percent == 20)
+        #expect(remaining.metrics.first?.detailText == "8/10")
+        #expect(remaining.metrics.first?.percent == 80)
+    }
+}
+
 struct MenuCardModelTests {
     @Test
     func `builds metrics using remaining percent`() throws {

--- a/Tests/CodexBarTests/MiniMaxProviderTests.swift
+++ b/Tests/CodexBarTests/MiniMaxProviderTests.swift
@@ -182,6 +182,92 @@ struct MiniMaxUsageParserTests {
     }
 
     @Test
+    func `parses model remains services using used quota semantics`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let start = 1_700_000_000_000
+        let end = start + 5 * 60 * 60 * 1000
+        let json = """
+        {
+          "base_resp": { "status_code": 0 },
+          "current_subscribe_title": "Max",
+          "model_remains": [
+            {
+              "model_name": "MiniMax-M1",
+              "current_interval_total_count": 1000,
+              "current_interval_usage_count": 250,
+              "start_time": \(start),
+              "end_time": \(end),
+              "remains_time": 240000
+            }
+          ]
+        }
+        """
+
+        let snapshot = try MiniMaxUsageParser.parseCodingPlanRemains(data: Data(json.utf8), now: now)
+        let service = try #require(snapshot.services?.first)
+
+        #expect(service.displayName == "Text Generation")
+        #expect(service.usage == 750)
+        #expect(service.remaining == 250)
+        #expect(service.limit == 1000)
+        #expect(service.percent == 75)
+        #expect(snapshot.toUsageSnapshot().primary?.usedPercent == 75)
+    }
+
+    @Test
+    func `parses multi service payload and utc offset reset`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 8 * 3600))
+        let now = try #require(calendar.date(from: DateComponents(
+            year: 2026,
+            month: 3,
+            day: 25,
+            hour: 11,
+            minute: 0)))
+        let expectedReset = try #require(calendar.date(from: DateComponents(
+            year: 2026,
+            month: 3,
+            day: 25,
+            hour: 15,
+            minute: 0)))
+        let json = """
+        {
+          "data": {
+            "services": [
+              {
+                "service_type": "Text Generation",
+                "window_type": "5 hours",
+                "time_range": "10:00-15:00(UTC+8)",
+                "usage": 2,
+                "limit": 10
+              },
+              {
+                "service_type": "Image",
+                "window_type": "Today",
+                "time_range": "2026/03/25 00:00 - 2026/03/26 00:00",
+                "usage": "5",
+                "limit": "50",
+                "percent": "10"
+              }
+            ]
+          }
+        }
+        """
+
+        let snapshot = try MiniMaxUsageParser.parseCodingPlanRemains(data: Data(json.utf8), now: now)
+        let services = try #require(snapshot.services)
+
+        #expect(services.count == 2)
+        #expect(services[0].usage == 2)
+        #expect(services[0].remaining == 8)
+        #expect(services[0].percent == 20)
+        #expect(services[0].resetsAt == expectedReset)
+        #expect(services[1].usage == 5)
+        #expect(services[1].remaining == 45)
+        #expect(services[1].percent == 10)
+    }
+
+    @Test
     func `parses coding plan remains from data wrapper`() throws {
         let now = Date(timeIntervalSince1970: 1_700_000_100)
         let start = 1_700_000_000_000


### PR DESCRIPTION
## Summary
Add comprehensive multi-service usage support for MiniMax Provider.
## What's New
### Multi-Service Support
- **Text Generation**: 5-hour and daily window tracking (10/1500)
- **Text to Speech**: Daily quota monitoring (0/4000)
- **Image Generation**: Daily quota monitoring (0/50)
- **Video & Music**: Full service coverage
### Features
- ✅ Automatic service type detection from model names
- ✅ Three-window UI display (primary/secondary/tertiary)
- ✅ Localization support (English/Chinese)
- ✅ Backward compatibility with single-service mode
- ✅ Region selection (Global .io / China .com)
## Testing
**27 tests across 5 suites** (existing test infrastructure):
- ✅ Multi-service API response parsing
- ✅ Service type auto-detection
- ✅ Usage calculation & percentage clamping
- ✅ Window type & timezone handling
- ✅ UsageSnapshot conversion
- ✅ Localization tests
## Screenshots
### Menu View
Shows three services with usage stats:
<img width="310" height="457" alt="menu" src="https://github.com/user-attachments/assets/2ce0bf21-bc49-4ee3-aaf2-97e1e816769a" />

### Settings View  
Provider configuration and region selection:
<img width="437" height="549" alt="setting" src="https://github.com/user-attachments/assets/35248bd1-1b0e-4380-b263-2a2acbd82618" />

## Verification
```bash
# Build
swift build
# Run tests
swift test --filter MiniMax
# Package
./Scripts/package_app.sh
Results:
- ✅ Build successful
- ✅ No compiler warnings
- ✅ All 27 MiniMax tests pass
Checklist
- [x] Code follows project conventions
- [x] No compiler warnings
- [x] Clean git history (single commit)
- [x] Backward compatibility maintained
- [x] Follows docs/provider.md architecture
- [x] UI screenshots included (separate files)
Related
Implements multi-service usage tracking as discussed in provider architecture docs.