### PR TITLE
Update copyright year to 2026

### DIFF
--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -191,7 +191,7 @@ cat > "$APP/Contents/Info.plist" <<PLIST
     <key>LSMinimumSystemVersion</key><string>14.0</string>
     <key>LSUIElement</key><true/>
     <key>CFBundleIconFile</key><string>Icon</string>
-    <key>NSHumanReadableCopyright</key><string>© 2025 Peter Steinberger. MIT License.</string>
+    <key>NSHumanReadableCopyright</key><string>© 2026 Peter Steinberger. MIT License.</string>
     <key>SUFeedURL</key><string>${FEED_URL}</string>
     <key>SUPublicEDKey</key><string>AGCY8w5vHirVfGGDGc8Szc5iuOqupZSh9pMj/Qs67XI=</string>
     <key>SUEnableAutomaticChecks</key><${AUTO_CHECKS}/>

--- a/Sources/CodexBar/PreferencesAboutPane.swift
+++ b/Sources/CodexBar/PreferencesAboutPane.swift
@@ -109,7 +109,7 @@ struct AboutPane: View {
                     .foregroundStyle(.secondary)
             }
 
-            Text("© 2025 Peter Steinberger. MIT License.")
+            Text("© 2026 Peter Steinberger. MIT License.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .padding(.top, 4)


### PR DESCRIPTION
## Summary
- update the packaged app copyright year from 2025 to 2026
- update the About pane copyright year from 2025 to 2026