### PR TITLE
Enable usage pace visualization for OpenCode provider

### DIFF
--- a/Sources/CodexBar/UsageStore+HistoricalPace.swift
+++ b/Sources/CodexBar/UsageStore+HistoricalPace.swift
@@ -14,7 +14,7 @@ extension UsageStore {
     }
 
     func weeklyPace(provider: UsageProvider, window: RateWindow, now: Date = .init()) -> UsagePace? {
-        guard provider == .codex || provider == .claude else { return nil }
+        guard provider == .codex || provider == .claude || provider == .opencode else { return nil }
         guard window.remainingPercent > 0 else { return nil }
         let resolved: UsagePace?
         if provider == .codex, self.settings.historicalTrackingEnabled {

--- a/Sources/CodexBarCLI/CLIRenderer.swift
+++ b/Sources/CodexBarCLI/CLIRenderer.swift
@@ -295,7 +295,7 @@ enum CLIRenderer {
         useColor: Bool,
         now: Date) -> String?
     {
-        guard provider == .codex || provider == .claude else { return nil }
+        guard provider == .codex || provider == .claude || provider == .opencode else { return nil }
         guard window.remainingPercent > 0 else { return nil }
         guard let pace = UsagePace.weekly(window: window, now: now, defaultWindowMinutes: 10080) else { return nil }
         guard pace.expectedUsedPercent >= Self.paceMinimumExpectedPercent else { return nil }


### PR DESCRIPTION
## Summary
- Add OpenCode (`.opencode`) to the provider allowlists in `weeklyPace()` (SwiftUI) and `paceLine()` (CLI)
- OpenCode's weekly rate window already provides `usedPercent`, `windowMinutes`, and `resetsAt` — the pace pipeline just wasn't enabled for it
- Now shows "X% in reserve" / "X% in deficit", expected-usage marker, and "Lasts until reset" / "Runs out in ..." on the weekly bar, matching the existing Codex and Claude experience

## Test plan
- [x] `swift build` passes
- [x] `./Scripts/compile_and_run.sh` builds, packages, and relaunches successfully
- [x] Visually confirmed pace labels appear on the OpenCode weekly usage bar