### PR TITLE
fix: detect Claude CLI at well-known install paths (cmux.app, ~/.claude/bin)

### DIFF
--- a/Sources/CodexBarCore/PathEnvironment.swift
+++ b/Sources/CodexBarCore/PathEnvironment.swift
@@ -52,8 +52,20 @@ public enum BinaryLocator {
             loginPATH: loginPATH,
             commandV: commandV,
             aliasResolver: aliasResolver,
+            wellKnownPaths: self.claudeWellKnownPaths(home: home),
             fileManager: fileManager,
             home: home)
+    }
+
+    /// Well-known installation paths for the Claude CLI binary.
+    /// Covers the macOS Terminal installer (cmux.app), ~/.claude/bin, and Homebrew.
+    static func claudeWellKnownPaths(home: String) -> [String] {
+        [
+            "/Applications/cmux.app/Contents/Resources/bin/claude",
+            "\(home)/.claude/bin/claude",
+            "/usr/local/bin/claude",
+            "/opt/homebrew/bin/claude",
+        ]
     }
 
     public static func resolveCodexBinary(
@@ -124,6 +136,7 @@ public enum BinaryLocator {
         loginPATH: [String]?,
         commandV: (String, String?, TimeInterval, FileManager) -> String?,
         aliasResolver: (String, String?, TimeInterval, FileManager, String) -> String?,
+        wellKnownPaths: [String] = [],
         fileManager: FileManager,
         home: String) -> String?
     {
@@ -164,7 +177,14 @@ public enum BinaryLocator {
             return aliasHit
         }
 
-        // 5) Minimal fallback
+        // 5) Well-known installation paths (e.g. cmux.app bundle, ~/.claude/bin)
+        // macOS apps launched from Finder may not inherit the user's shell PATH,
+        // so check common install locations that the shell-based lookups above may miss.
+        for candidate in wellKnownPaths where fileManager.isExecutableFile(atPath: candidate) {
+            return candidate
+        }
+
+        // 6) Minimal fallback
         let fallback = ["/usr/bin", "/bin", "/usr/sbin", "/sbin"]
         if let pathHit = self.find(name, in: fallback, fileManager: fileManager) {
             return pathHit

--- a/Tests/CodexBarTests/PathBuilderTests.swift
+++ b/Tests/CodexBarTests/PathBuilderTests.swift
@@ -211,6 +211,56 @@ struct PathBuilderTests {
     }
 
     @Test
+    func `resolves claude from well-known cmux path when shell lookups fail`() {
+        let cmuxPath = "/Applications/cmux.app/Contents/Resources/bin/claude"
+        let fm = MockFileManager(executables: [cmuxPath])
+        let commandV: (String, String?, TimeInterval, FileManager) -> String? = { _, _, _, _ in nil }
+        let aliasResolver: (String, String?, TimeInterval, FileManager, String) -> String? = { _, _, _, _, _ in nil }
+
+        let resolved = BinaryLocator.resolveClaudeBinary(
+            env: ["SHELL": "/bin/zsh"],
+            loginPATH: nil,
+            commandV: commandV,
+            aliasResolver: aliasResolver,
+            fileManager: fm,
+            home: "/Users/test")
+        #expect(resolved == cmuxPath)
+    }
+
+    @Test
+    func `resolves claude from well-known home dir path`() {
+        let homePath = "/Users/test/.claude/bin/claude"
+        let fm = MockFileManager(executables: [homePath])
+        let commandV: (String, String?, TimeInterval, FileManager) -> String? = { _, _, _, _ in nil }
+        let aliasResolver: (String, String?, TimeInterval, FileManager, String) -> String? = { _, _, _, _, _ in nil }
+
+        let resolved = BinaryLocator.resolveClaudeBinary(
+            env: ["SHELL": "/bin/zsh"],
+            loginPATH: nil,
+            commandV: commandV,
+            aliasResolver: aliasResolver,
+            fileManager: fm,
+            home: "/Users/test")
+        #expect(resolved == homePath)
+    }
+
+    @Test
+    func `prefers shell PATH over well-known paths`() {
+        let shellPath = "/custom/bin/claude"
+        let cmuxPath = "/Applications/cmux.app/Contents/Resources/bin/claude"
+        let fm = MockFileManager(executables: [shellPath, cmuxPath])
+        let commandV: (String, String?, TimeInterval, FileManager) -> String? = { _, _, _, _ in shellPath }
+
+        let resolved = BinaryLocator.resolveClaudeBinary(
+            env: ["SHELL": "/bin/zsh"],
+            loginPATH: nil,
+            commandV: commandV,
+            fileManager: fm,
+            home: "/Users/test")
+        #expect(resolved == shellPath)
+    }
+
+    @Test
     func `skips alias when command V resolves`() {
         let path = "/shell/bin/claude"
         let fm = MockFileManager(executables: [path])


### PR DESCRIPTION
## Problem

CodexBar shows "Claude CLI is not installed" even when Claude Code is installed and fully functional (fixes #599).

This happens because macOS apps launched from Finder don't inherit the user's shell `$PATH`. The existing resolution chain tries login shell capture, environment PATH, interactive shell lookup, and alias resolution—but all of these can fail when the Claude CLI is installed via the macOS Terminal installer to a non-standard location like `/Applications/cmux.app/Contents/Resources/bin/claude`.

## Solution

Adds a **well-known paths** fallback step to `BinaryLocator.resolveBinary()` that checks common Claude CLI installation locations before the minimal system-path lookup:

| Path | Source |
|------|--------|
| `/Applications/cmux.app/Contents/Resources/bin/claude` | macOS Terminal installer |
| `~/.claude/bin/claude` | Manual/script install |
| `/usr/local/bin/claude` | Homebrew (Intel) |
| `/opt/homebrew/bin/claude` | Homebrew (Apple Silicon) |

The well-known paths are only checked **after** all dynamic resolution methods fail, so they never override a user's preferred installation or explicit `CLAUDE_CLI_PATH` override.

## Changes

- **`PathEnvironment.swift`**: Added `wellKnownPaths` parameter to `resolveBinary()` and `claudeWellKnownPaths(home:)` static method
- **`PathBuilderTests.swift`**: Added 3 tests verifying well-known path resolution and priority ordering

## Testing

- ✅ Well-known cmux.app path resolves when all shell lookups fail
- ✅ Well-known `~/.claude/bin` path resolves when all shell lookups fail
- ✅ Shell PATH is still preferred over well-known paths (priority preserved)

Fixes #599