### PR TITLE
Remove Intel support claims on website

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
         <div class="copy" data-animate="2">
           <div class="badges" aria-label="Highlights">
             <span class="badge">macOS 14+</span>
-            <span class="badge">Apple Silicon + Intel</span>
+            <span class="badge">Apple Silicon only</span>
             <span class="badge">Free &amp; open source</span>
             <span class="badge">No passwords stored</span>
           </div>
@@ -57,7 +57,7 @@
               </p>
             </div>
           </div>
-          <p class="requirement">Requirements: macOS 14+ (Apple Silicon + Intel).</p>
+          <p class="requirement">Requirements: macOS 14+ (Apple Silicon only).</p>
           <div class="cta">
             <a class="btn primary" href="https://github.com/steipete/CodexBar/releases/latest">Download latest</a>
             <a class="btn" href="https://github.com/steipete/CodexBar">View on GitHub</a>


### PR DESCRIPTION
This PR fixes #231 by changing the website to remove claims of Intel support. The current Homebrew setup does not support Intel Macs and while there are some PRs trying to add such support (#331, #457, #544), these PRs don't appear to be moving to acceptance and @steipete has [said he would prefer this not be added in favor of Intel users manual compiling themselves](https://github.com/steipete/CodexBar/issues/52#issuecomment-3691444010).

It doesn't make sense to advertise Intel support for CodexBar to users when it's not officially supported and there's ample evidence that this wording has led to wasted time from many Intel users trying to install via Homebrew: #231, #300, #563, #572