### PR TITLE
Fix OpenCode Go Usage Dashboard link to open workspace-specific URL

### DIFF
--- a/Sources/CodexBar/Providers/OpenCodeGo/OpenCodeGoSettingsStore.swift
+++ b/Sources/CodexBar/Providers/OpenCodeGo/OpenCodeGoSettingsStore.swift
@@ -33,6 +33,14 @@ extension SettingsStore {
         }
     }
 
+    var opencodegoDashboardURL: URL? {
+        let workspaceID = self.opencodegoWorkspaceID
+        if !workspaceID.isEmpty {
+            return URL(string: "https://opencode.ai/workspace/\(workspaceID)/go")
+        }
+        return URL(string: "https://opencode.ai")
+    }
+
     func ensureOpenCodeGoCookieLoaded() {}
 }
 

--- a/Sources/CodexBar/Providers/OpenCodeGo/OpenCodeGoSettingsStore.swift
+++ b/Sources/CodexBar/Providers/OpenCodeGo/OpenCodeGoSettingsStore.swift
@@ -34,8 +34,8 @@ extension SettingsStore {
     }
 
     var opencodegoDashboardURL: URL? {
-        let workspaceID = self.opencodegoWorkspaceID
-        if !workspaceID.isEmpty {
+        let workspaceID = OpenCodeGoUsageFetcher.normalizeWorkspaceID(self.opencodegoWorkspaceID)
+        if let workspaceID {
             return URL(string: "https://opencode.ai/workspace/\(workspaceID)/go")
         }
         return URL(string: "https://opencode.ai")

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -44,6 +44,10 @@ extension StatusItemController {
             return self.settings.alibabaCodingPlanAPIRegion.dashboardURL
         }
 
+        if provider == .opencodego {
+            return self.settings.opencodegoDashboardURL
+        }
+
         let meta = self.store.metadata(for: provider)
         let urlString: String? = if provider == .claude, self.store.isClaudeSubscription() {
             meta.subscriptionDashboardURL ?? meta.dashboardURL

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -147,7 +147,7 @@ public struct OpenCodeGoUsageFetcher: Sendable {
         return ids[0]
     }
 
-    private static func normalizeWorkspaceID(_ raw: String?) -> String? {
+    static func normalizeWorkspaceID(_ raw: String?) -> String? {
         guard let raw else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.hasPrefix("wrk_"), trimmed.count > 4 {

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -147,7 +147,7 @@ public struct OpenCodeGoUsageFetcher: Sendable {
         return ids[0]
     }
 
-    static func normalizeWorkspaceID(_ raw: String?) -> String? {
+    public static func normalizeWorkspaceID(_ raw: String?) -> String? {
         guard let raw else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.hasPrefix("wrk_"), trimmed.count > 4 {


### PR DESCRIPTION
## Summary

**Problem:** When clicking "Usage Dashboard" for OpenCode Go, the app always opens `https://opencode.ai/` instead of the workspace-specific usage page at `https://opencode.ai/workspace/{workspace_id}/go`.

**Fix:** Added a computed property `opencodegoDashboardURL` in `OpenCodeGoSettingsStore.swift` that constructs the correct workspace-specific URL when a `workspaceID` is configured. Updated `StatusItemController+Actions.swift` to use this URL for the OpenCode Go provider.

**Files changed:**
- `Sources/CodexBar/Providers/OpenCodeGo/OpenCodeGoSettingsStore.swift` - Added `opencodegoDashboardURL` property
- `Sources/CodexBar/StatusItemController+Actions.swift` - Added special handling for `.opencodego` in `dashboardURL(for:)`