### PR TITLE
Clear ad-hoc keychain caches

### DIFF
--- a/Scripts/compile_and_run.sh
+++ b/Scripts/compile_and_run.sh
@@ -20,6 +20,14 @@ SIGNING_MODE="${CODEXBAR_SIGNING:-}"
 log()  { printf '%s\n' "$*"; }
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
+delete_keychain_service_items() {
+  local service="$1"
+  security delete-generic-password -s "${service}" >/dev/null 2>&1 || true
+  while security delete-generic-password -s "${service}" >/dev/null 2>&1; do
+    :
+  done
+}
+
 has_signing_identity() {
   local identity="${1:-}"
   if [[ -z "${identity}" ]]; then
@@ -180,12 +188,11 @@ kill_claude_probes
 # 2.5) Delete keychain entries to avoid permission prompts with adhoc signing
 # (adhoc signature changes on every build, making old keychain entries inaccessible)
 if [[ "${SIGNING_MODE:-adhoc}" == "adhoc" ]]; then
-  log "==> Clearing keychain entries (adhoc signing)"
-  security delete-generic-password -s "com.steipete.CodexBar" 2>/dev/null || true
-  # Clear all keychain items for the app to avoid multiple prompts
-  while security delete-generic-password -s "com.steipete.CodexBar" 2>/dev/null; do
-    :
-  done
+  log "==> Clearing CodexBar keychain entries (adhoc signing)"
+  # Clear both the legacy keychain store and the current cache service. Leaving CodexBar-owned caches behind causes
+  # fresh adhoc-signed builds to re-open stale ACLs and repeatedly prompt for keychain access/password approval.
+  delete_keychain_service_items "com.steipete.CodexBar"
+  delete_keychain_service_items "com.steipete.codexbar.cache"
 fi
 
 # 3) Package (release build happens inside package_app.sh).

--- a/docs/DEVELOPMENT_SETUP.md
+++ b/docs/DEVELOPMENT_SETUP.md
@@ -15,6 +15,9 @@ When developing CodexBar, you may see frequent keychain permission prompts like:
 > **CodexBar wants to access key "Claude Code-credentials" in your keychain.**
 
 This happens because each rebuild creates a new code signature, and macOS treats it as a "different" app.
+That can affect both CodexBar-owned entries (`com.steipete.CodexBar`, `com.steipete.codexbar.cache`) and
+third-party items such as `Claude Code-credentials`, so an ad-hoc-signed rebuild can keep re-triggering
+password/keychain approval dialogs even after you previously chose **Always Allow**.
 
 ### Quick Fix (Temporary)
 
@@ -100,6 +103,11 @@ This script:
 4. Packages the app with `./Scripts/package_app.sh`
 5. Launches `CodexBar.app`
 6. Verifies it stays running
+
+When the script falls back to ad-hoc signing, it also clears CodexBar-owned keychain services before relaunching so
+the new build does not inherit stale ACLs from the previous app identity.
+This reduces repeat prompts for CodexBar-managed cache entries, but third-party keychain items still need stable
+signing if you want macOS to remember **Always Allow** across rebuilds.
 
 ### Quick Build (No Tests)
 


### PR DESCRIPTION
## Summary

- Clear both CodexBar-owned keychain services during ad-hoc rebuilds: `com.steipete.CodexBar` and `com.steipete.codexbar.cache`
- Silence `security delete-generic-password` output in the rebuild log
- Update the development setup doc to explain what this change covers and what still requires stable signing

## Why

`./Scripts/compile_and_run.sh` was only clearing the legacy keychain service.
The current runtime cache under `com.steipete.codexbar.cache` was left behind, so a fresh ad-hoc-signed build could still run into stale ACLs and prompt again.

This change is limited to CodexBar-owned keychain entries.
Third-party items such as `Claude Code-credentials` still need stable signing if you want macOS to keep the `Always Allow` grant across rebuilds.

## Validation

- `./Scripts/lint.sh lint`
- `bash -n Scripts/compile_and_run.sh`
- `./Scripts/compile_and_run.sh --test` reaches the updated keychain-clearing path, then stops because this environment has Swift 6.0.0 while the package requires Swift tools 6.2

## Platform check

The app target in this repo is macOS-only, and the keychain cache path is guarded behind `#if os(macOS)`.
I did not find the same issue in the non-macOS code paths in this package.
