### PR TITLE
Fix Claude CLI well-known path fallback precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 ### Highlights
 - z.ai: preserve weekly and 5-hour token quotas together, surface the 5-hour lane correctly across the menu/menu bar, and add regression coverage (#662). Thanks to @takumi3488 for the original fix and investigation.
 - Cursor: fix a crash in the usage fetch path and add regression coverage (#663). Thanks @anirudhvee for the report and validation!
+- Claude: preserve normal CLI fallback precedence across well-known install paths so Finder-launched apps still prefer user-managed and native Homebrew binaries when multiple installs exist.
 
 ### Providers & Usage
 - z.ai: preserve both weekly and 5-hour token quotas, keep the existing 2-limit behavior unchanged, and render the 5-hour quota as a tertiary row in provider snapshots and CLI/menu cards (#662). Credit to @takumi3488 for the original fix and investigation.
 - Cursor: fix the usage fetch path so failed or cancelled requests no longer crash, and add Linux build and regression test coverage fixes (#663).
+- Claude: preserve normal CLI fallback precedence across well-known install paths so Finder-launched apps prefer `~/.claude/bin/claude`, then Homebrew, before the bundled `cmux.app` binary when shell-based resolution is unavailable.
 
 ### Menu & Settings
 - z.ai: fix menu bar selection when both weekly and 5-hour quotas are present (#662).

--- a/Sources/CodexBarCore/PathEnvironment.swift
+++ b/Sources/CodexBarCore/PathEnvironment.swift
@@ -52,8 +52,20 @@ public enum BinaryLocator {
             loginPATH: loginPATH,
             commandV: commandV,
             aliasResolver: aliasResolver,
+            wellKnownPaths: self.claudeWellKnownPaths(home: home),
             fileManager: fileManager,
             home: home)
+    }
+
+    /// Well-known installation paths for the Claude CLI binary.
+    /// Covers the macOS Terminal installer (cmux.app), ~/.claude/bin, and Homebrew.
+    static func claudeWellKnownPaths(home: String) -> [String] {
+        [
+            "/Applications/cmux.app/Contents/Resources/bin/claude",
+            "\(home)/.claude/bin/claude",
+            "/usr/local/bin/claude",
+            "/opt/homebrew/bin/claude",
+        ]
     }
 
     public static func resolveCodexBinary(
@@ -124,6 +136,7 @@ public enum BinaryLocator {
         loginPATH: [String]?,
         commandV: (String, String?, TimeInterval, FileManager) -> String?,
         aliasResolver: (String, String?, TimeInterval, FileManager, String) -> String?,
+        wellKnownPaths: [String] = [],
         fileManager: FileManager,
         home: String) -> String?
     {
@@ -164,7 +177,14 @@ public enum BinaryLocator {
             return aliasHit
         }
 
-        // 5) Minimal fallback
+        // 5) Well-known installation paths (e.g. cmux.app bundle, ~/.claude/bin)
+        // macOS apps launched from Finder may not inherit the user's shell PATH,
+        // so check common install locations that the shell-based lookups above may miss.
+        for candidate in wellKnownPaths where fileManager.isExecutableFile(atPath: candidate) {
+            return candidate
+        }
+
+        // 6) Minimal fallback
         let fallback = ["/usr/bin", "/bin", "/usr/sbin", "/sbin"]
         if let pathHit = self.find(name, in: fallback, fileManager: fileManager) {
             return pathHit

--- a/Sources/CodexBarCore/PathEnvironment.swift
+++ b/Sources/CodexBarCore/PathEnvironment.swift
@@ -61,10 +61,10 @@ public enum BinaryLocator {
     /// Covers the macOS Terminal installer (cmux.app), ~/.claude/bin, and Homebrew.
     static func claudeWellKnownPaths(home: String) -> [String] {
         [
-            "/Applications/cmux.app/Contents/Resources/bin/claude",
             "\(home)/.claude/bin/claude",
-            "/usr/local/bin/claude",
             "/opt/homebrew/bin/claude",
+            "/usr/local/bin/claude",
+            "/Applications/cmux.app/Contents/Resources/bin/claude",
         ]
     }
 

--- a/Tests/CodexBarTests/PathBuilderTests.swift
+++ b/Tests/CodexBarTests/PathBuilderTests.swift
@@ -211,6 +211,56 @@ struct PathBuilderTests {
     }
 
     @Test
+    func `resolves claude from well-known cmux path when shell lookups fail`() {
+        let cmuxPath = "/Applications/cmux.app/Contents/Resources/bin/claude"
+        let fm = MockFileManager(executables: [cmuxPath])
+        let commandV: (String, String?, TimeInterval, FileManager) -> String? = { _, _, _, _ in nil }
+        let aliasResolver: (String, String?, TimeInterval, FileManager, String) -> String? = { _, _, _, _, _ in nil }
+
+        let resolved = BinaryLocator.resolveClaudeBinary(
+            env: ["SHELL": "/bin/zsh"],
+            loginPATH: nil,
+            commandV: commandV,
+            aliasResolver: aliasResolver,
+            fileManager: fm,
+            home: "/Users/test")
+        #expect(resolved == cmuxPath)
+    }
+
+    @Test
+    func `resolves claude from well-known home dir path`() {
+        let homePath = "/Users/test/.claude/bin/claude"
+        let fm = MockFileManager(executables: [homePath])
+        let commandV: (String, String?, TimeInterval, FileManager) -> String? = { _, _, _, _ in nil }
+        let aliasResolver: (String, String?, TimeInterval, FileManager, String) -> String? = { _, _, _, _, _ in nil }
+
+        let resolved = BinaryLocator.resolveClaudeBinary(
+            env: ["SHELL": "/bin/zsh"],
+            loginPATH: nil,
+            commandV: commandV,
+            aliasResolver: aliasResolver,
+            fileManager: fm,
+            home: "/Users/test")
+        #expect(resolved == homePath)
+    }
+
+    @Test
+    func `prefers shell PATH over well-known paths`() {
+        let shellPath = "/custom/bin/claude"
+        let cmuxPath = "/Applications/cmux.app/Contents/Resources/bin/claude"
+        let fm = MockFileManager(executables: [shellPath, cmuxPath])
+        let commandV: (String, String?, TimeInterval, FileManager) -> String? = { _, _, _, _ in shellPath }
+
+        let resolved = BinaryLocator.resolveClaudeBinary(
+            env: ["SHELL": "/bin/zsh"],
+            loginPATH: nil,
+            commandV: commandV,
+            fileManager: fm,
+            home: "/Users/test")
+        #expect(resolved == shellPath)
+    }
+
+    @Test
     func `skips alias when command V resolves`() {
         let path = "/shell/bin/claude"
         let fm = MockFileManager(executables: [path])

--- a/Tests/CodexBarTests/PathBuilderTests.swift
+++ b/Tests/CodexBarTests/PathBuilderTests.swift
@@ -245,6 +245,43 @@ struct PathBuilderTests {
     }
 
     @Test
+    func `prefers user managed well-known path over cmux path`() {
+        let homePath = "/Users/test/.claude/bin/claude"
+        let cmuxPath = "/Applications/cmux.app/Contents/Resources/bin/claude"
+        let fm = MockFileManager(executables: [homePath, cmuxPath])
+        let commandV: (String, String?, TimeInterval, FileManager) -> String? = { _, _, _, _ in nil }
+        let aliasResolver: (String, String?, TimeInterval, FileManager, String) -> String? = { _, _, _, _, _ in nil }
+
+        let resolved = BinaryLocator.resolveClaudeBinary(
+            env: ["SHELL": "/bin/zsh"],
+            loginPATH: nil,
+            commandV: commandV,
+            aliasResolver: aliasResolver,
+            fileManager: fm,
+            home: "/Users/test")
+        #expect(resolved == homePath)
+    }
+
+    @Test
+    func `prefers homebrew arm path over usr local fallback`() {
+        let fm = MockFileManager(executables: [
+            "/opt/homebrew/bin/claude",
+            "/usr/local/bin/claude",
+        ])
+        let commandV: (String, String?, TimeInterval, FileManager) -> String? = { _, _, _, _ in nil }
+        let aliasResolver: (String, String?, TimeInterval, FileManager, String) -> String? = { _, _, _, _, _ in nil }
+
+        let resolved = BinaryLocator.resolveClaudeBinary(
+            env: ["SHELL": "/bin/zsh"],
+            loginPATH: nil,
+            commandV: commandV,
+            aliasResolver: aliasResolver,
+            fileManager: fm,
+            home: "/Users/test")
+        #expect(resolved == "/opt/homebrew/bin/claude")
+    }
+
+    @Test
     func `prefers shell PATH over well-known paths`() {
         let shellPath = "/custom/bin/claude"
         let cmuxPath = "/Applications/cmux.app/Contents/Resources/bin/claude"


### PR DESCRIPTION
Preserves the Claude CLI well-known path fallback from #640 while keeping normal precedence when multiple installs exist.

- add well-known Claude CLI fallback locations for Finder-launched apps
- prefer `~/.claude/bin/claude` and native Homebrew installs before the bundled `cmux.app` binary in fallback mode
- add regression coverage for the fallback ordering

Supersedes #640.

Thanks @claw-explorer for the original PR and investigation.