### PR TITLE
Fix missing menu bar icon on macOS 26 (RenderBox shader failure)

### DIFF
--- a/Sources/CodexBar/PreferencesProviderSidebarView.swift
+++ b/Sources/CodexBar/PreferencesProviderSidebarView.swift
@@ -35,7 +35,7 @@ struct ProviderSidebarListView: View {
         .scrollContentBackground(.hidden)
         .background(
             RoundedRectangle(cornerRadius: ProviderSettingsMetrics.sidebarCornerRadius, style: .continuous)
-                .fill(.regularMaterial))
+                .fill(Color(nsColor: .controlBackgroundColor).opacity(0.8)))
         .overlay(
             RoundedRectangle(cornerRadius: ProviderSettingsMetrics.sidebarCornerRadius, style: .continuous)
                 .stroke(Color(nsColor: .separatorColor).opacity(0.7), lineWidth: 1))

--- a/Sources/CodexBar/UsageProgressBar.swift
+++ b/Sources/CodexBar/UsageProgressBar.swift
@@ -61,7 +61,6 @@ struct UsageProgressBar: View {
             if self.isHighlighted {
                 bar
                     .compositingGroup()
-                    .drawingGroup()
             } else if needsPunchCompositing {
                 bar
                     .compositingGroup()


### PR DESCRIPTION
Fixes #668, likely also #645.

## Problem

On some macOS 26 machines, the menu bar icon never shows up. Process runs, notifications work, no icon.

RenderBox fails to compile Metal shaders for two SwiftUI modifiers, logs `precondition failure: <private>`, and silently corrupts rendering state so the NSStatusItem never appears.

Symbolicated crash:
```
RB::non_fatal_precondition_failure(...)
  ← RB::FunctionLibrary::FunctionLibrary(RB::Device&, RB::CustomShader::Library const&)
    ← RB::CustomShader::Function::function(...)
      ← RB::CustomEffect::render(...)
```

## Changes

- Replace `.regularMaterial` with `Color(nsColor: .controlBackgroundColor).opacity(0.8)` in provider sidebar (triggers blur/vibrancy shader)
- Drop `.drawingGroup()` from highlighted progress bar (forces Metal offscreen rendering). `.compositingGroup()` alone is enough.

## Verification

- `swift build -c debug` passes
- `pnpm check` passes (0 lint violations in 620 files)
- `swift test` was not fully run (suite takes >5min, timed out in CI-less local env)
- Tested on affected machine (macOS 26.2, M1 Pro): menu bar icon appears, no renderbox faults in logs

## Commands run

```
swift build -c debug
pnpm check
./Scripts/package_app.sh debug
codesign --force --deep -s - CodexBar.app
open CodexBar.app
log show --predicate 'process == "CodexBar" AND subsystem == "com.apple.renderbox"' --last 30s --style compact
```