### PR TITLE
Preserve CodexBar keychain caches by default

### DIFF
--- a/Scripts/compile_and_run.sh
+++ b/Scripts/compile_and_run.sh
@@ -20,6 +20,14 @@ SIGNING_MODE="${CODEXBAR_SIGNING:-}"
 log()  { printf '%s\n' "$*"; }
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
+delete_keychain_service_items() {
+  local service="$1"
+  security delete-generic-password -s "${service}" >/dev/null 2>&1 || true
+  while security delete-generic-password -s "${service}" >/dev/null 2>&1; do
+    :
+  done
+}
+
 has_signing_identity() {
   local identity="${1:-}"
   if [[ -z "${identity}" ]]; then
@@ -180,12 +188,11 @@ kill_claude_probes
 # 2.5) Delete keychain entries to avoid permission prompts with adhoc signing
 # (adhoc signature changes on every build, making old keychain entries inaccessible)
 if [[ "${SIGNING_MODE:-adhoc}" == "adhoc" ]]; then
-  log "==> Clearing keychain entries (adhoc signing)"
-  security delete-generic-password -s "com.steipete.CodexBar" 2>/dev/null || true
-  # Clear all keychain items for the app to avoid multiple prompts
-  while security delete-generic-password -s "com.steipete.CodexBar" 2>/dev/null; do
-    :
-  done
+  log "==> Clearing CodexBar keychain entries (adhoc signing)"
+  # Clear both the legacy keychain store and the current cache service. Leaving CodexBar-owned caches behind causes
+  # fresh adhoc-signed builds to re-open stale ACLs and repeatedly prompt for keychain access/password approval.
+  delete_keychain_service_items "com.steipete.CodexBar"
+  delete_keychain_service_items "com.steipete.codexbar.cache"
 fi
 
 # 3) Package (release build happens inside package_app.sh).

--- a/Scripts/compile_and_run.sh
+++ b/Scripts/compile_and_run.sh
@@ -16,6 +16,7 @@ RUN_TESTS=0
 DEBUG_LLDB=0
 RELEASE_ARCHES=""
 SIGNING_MODE="${CODEXBAR_SIGNING:-}"
+CLEAR_ADHOC_KEYCHAIN=0
 
 log()  { printf '%s\n' "$*"; }
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
@@ -160,10 +161,11 @@ for arg in "$@"; do
     --wait|-w) WAIT_FOR_LOCK=1 ;;
     --test|-t) RUN_TESTS=1 ;;
     --debug-lldb) DEBUG_LLDB=1 ;;
+    --clear-adhoc-keychain) CLEAR_ADHOC_KEYCHAIN=1 ;;
     --release-universal) RELEASE_ARCHES="arm64 x86_64" ;;
     --release-arches=*) RELEASE_ARCHES="${arg#*=}" ;;
     --help|-h)
-      log "Usage: $(basename "$0") [--wait] [--test] [--debug-lldb] [--release-universal] [--release-arches=\"arm64 x86_64\"]"
+      log "Usage: $(basename "$0") [--wait] [--test] [--debug-lldb] [--clear-adhoc-keychain] [--release-universal] [--release-arches=\"arm64 x86_64\"]"
       exit 0
       ;;
     *)
@@ -172,6 +174,9 @@ for arg in "$@"; do
 done
 
 resolve_signing_mode
+if [[ "${CLEAR_ADHOC_KEYCHAIN}" == "1" && "${SIGNING_MODE}" != "adhoc" ]]; then
+  fail "--clear-adhoc-keychain is only supported when using adhoc signing."
+fi
 if [[ "${SIGNING_MODE}" == "adhoc" ]]; then
   log "==> Signing: adhoc (set APP_IDENTITY or install a dev cert to avoid keychain prompts)"
 else
@@ -185,14 +190,16 @@ log "==> Killing existing CodexBar instances"
 kill_all_codexbar
 kill_claude_probes
 
-# 2.5) Delete keychain entries to avoid permission prompts with adhoc signing
+# 2.5) Optionally delete keychain entries to avoid permission prompts with adhoc signing
 # (adhoc signature changes on every build, making old keychain entries inaccessible)
-if [[ "${SIGNING_MODE:-adhoc}" == "adhoc" ]]; then
+if [[ "${SIGNING_MODE:-adhoc}" == "adhoc" && "${CLEAR_ADHOC_KEYCHAIN}" == "1" ]]; then
   log "==> Clearing CodexBar keychain entries (adhoc signing)"
-  # Clear both the legacy keychain store and the current cache service. Leaving CodexBar-owned caches behind causes
-  # fresh adhoc-signed builds to re-open stale ACLs and repeatedly prompt for keychain access/password approval.
+  # Clear both the legacy keychain store and the current cache service when developers explicitly want a clean reset
+  # of CodexBar-owned keychain state for ad-hoc builds.
   delete_keychain_service_items "com.steipete.CodexBar"
   delete_keychain_service_items "com.steipete.codexbar.cache"
+elif [[ "${SIGNING_MODE:-adhoc}" == "adhoc" ]]; then
+  log "==> Preserving CodexBar keychain entries (pass --clear-adhoc-keychain to reset adhoc keychain state)"
 fi
 
 # 3) Package (release build happens inside package_app.sh).

--- a/docs/DEVELOPMENT_SETUP.md
+++ b/docs/DEVELOPMENT_SETUP.md
@@ -15,6 +15,9 @@ When developing CodexBar, you may see frequent keychain permission prompts like:
 > **CodexBar wants to access key "Claude Code-credentials" in your keychain.**
 
 This happens because each rebuild creates a new code signature, and macOS treats it as a "different" app.
+That can affect both CodexBar-owned entries (`com.steipete.CodexBar`, `com.steipete.codexbar.cache`) and
+third-party items such as `Claude Code-credentials`, so an ad-hoc-signed rebuild can keep re-triggering
+password/keychain approval dialogs even after you previously chose **Always Allow**.
 
 ### Quick Fix (Temporary)
 
@@ -100,6 +103,11 @@ This script:
 4. Packages the app with `./Scripts/package_app.sh`
 5. Launches `CodexBar.app`
 6. Verifies it stays running
+
+When the script falls back to ad-hoc signing, it also clears CodexBar-owned keychain services before relaunching so
+the new build does not inherit stale ACLs from the previous app identity.
+This reduces repeat prompts for CodexBar-managed cache entries, but third-party keychain items still need stable
+signing if you want macOS to remember **Always Allow** across rebuilds.
 
 ### Quick Build (No Tests)
 

--- a/docs/DEVELOPMENT_SETUP.md
+++ b/docs/DEVELOPMENT_SETUP.md
@@ -104,10 +104,12 @@ This script:
 5. Launches `CodexBar.app`
 6. Verifies it stays running
 
-When the script falls back to ad-hoc signing, it also clears CodexBar-owned keychain services before relaunching so
-the new build does not inherit stale ACLs from the previous app identity.
-This reduces repeat prompts for CodexBar-managed cache entries, but third-party keychain items still need stable
-signing if you want macOS to remember **Always Allow** across rebuilds.
+When the script falls back to ad-hoc signing, it preserves CodexBar-owned keychain state by default.
+That means you may still see keychain prompts for existing CodexBar cache entries, but allowing those prompts keeps the
+cached browser/OAuth state available across normal rebuilds.
+If you want a clean reset of CodexBar-owned keychain state for an ad-hoc build, run
+`./Scripts/compile_and_run.sh --clear-adhoc-keychain` before relaunching.
+Third-party keychain items still need stable signing if you want macOS to remember **Always Allow** across rebuilds.
 
 ### Quick Build (No Tests)
 


### PR DESCRIPTION
## Summary
- preserve CodexBar-owned keychain entries during normal ad-hoc rebuilds
- add `--clear-adhoc-keychain` for explicit reset runs
- update the development setup docs to explain the default and reset paths

Supersedes #673.

Thanks @magnaprog for the original investigation and first pass here.