### PR TITLE
fix: handle Antigravity localhost TLS challenges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Highlights
 - z.ai: preserve weekly and 5-hour token quotas together, surface the 5-hour lane correctly across the menu/menu bar, and add regression coverage (#662). Thanks to @takumi3488 for the original fix and investigation.
 - Cursor: fix a crash in the usage fetch path and add regression coverage (#663). Thanks @anirudhvee for the report and validation!
+- Antigravity: accept localhost TLS challenges when probing the local language server so usage/account info loads again instead of reporting `no working API port found` (#693, fixes #692). Thanks @anirudhvee!
 - Menu bar: fix missing icons on affected macOS 26 systems by avoiding RenderBox-triggering SwiftUI effects (#677). Thanks @andrzejchm!
 - Claude: preserve normal CLI fallback precedence across well-known install paths so Finder-launched apps still prefer user-managed and native Homebrew binaries when multiple installs exist.
 - Codex: make OpenAI web extras opt-in for fresh installs, preserve working legacy setups on upgrade, add an OpenAI web battery-saver toggle, and keep account-scoped dashboard state aligned during refreshes and account switches (#529). Thanks @cbrane!
@@ -12,6 +13,7 @@
 ### Providers & Usage
 - z.ai: preserve both weekly and 5-hour token quotas, keep the existing 2-limit behavior unchanged, and render the 5-hour quota as a tertiary row in provider snapshots and CLI/menu cards (#662). Credit to @takumi3488 for the original fix and investigation.
 - Cursor: fix the usage fetch path so failed or cancelled requests no longer crash, and add Linux build and regression test coverage fixes (#663).
+- Antigravity: scope insecure localhost trust handling to `127.0.0.1` / `localhost`, keep localhost requests cancellable, and restore local quota/account probing on builds that previously failed TLS challenge handling (#693, fixes #692). Thanks @anirudhvee!
 - Claude: preserve normal CLI fallback precedence across well-known install paths so Finder-launched apps prefer `~/.claude/bin/claude`, then Homebrew, before the bundled `cmux.app` binary when shell-based resolution is unavailable.
 - OpenCode / OpenCode Go: treat serialized `_server` auth/account-context failures as invalid credentials so cached browser cookies are cleared and retried instead of surfacing a misleading HTTP 500.
 - Codex: make OpenAI web extras opt-in by default, preserve legacy implicit-auto cookie setups during upgrade inference, add battery-saver gating for non-forced dashboard refreshes, and preserve provider/dashboard state for enabled providers that are temporarily unavailable.

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -663,19 +663,25 @@ enum LocalhostTrustPolicy {
 
 private final class LocalhostSessionDelegate: NSObject, URLSessionDelegate, URLSessionTaskDelegate {
     func data(for request: URLRequest, session: URLSession) async throws -> (Data, URLResponse) {
-        try await withCheckedThrowingContinuation { continuation in
-            let task = session.dataTask(with: request) { data, response, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
+        let state = LocalhostSessionTaskState()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let task = session.dataTask(with: request) { data, response, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    guard let data, let response else {
+                        continuation.resume(throwing: AntigravityStatusProbeError.apiError("Invalid response"))
+                        return
+                    }
+                    continuation.resume(returning: (data, response))
                 }
-                guard let data, let response else {
-                    continuation.resume(throwing: AntigravityStatusProbeError.apiError("Invalid response"))
-                    return
-                }
-                continuation.resume(returning: (data, response))
+                state.setTask(task)
+                task.resume()
             }
-            task.resume()
+        } onCancel: {
+            state.cancel()
         }
     }
 
@@ -716,6 +722,31 @@ private final class LocalhostSessionDelegate: NSObject, URLSessionDelegate, URLS
         }
         completionHandler(.useCredential, URLCredential(trust: trust))
         #endif
+    }
+}
+
+private final class LocalhostSessionTaskState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var task: URLSessionDataTask?
+    private var isCancelled = false
+
+    func setTask(_ task: URLSessionDataTask) {
+        self.lock.lock()
+        self.task = task
+        let shouldCancel = self.isCancelled
+        self.lock.unlock()
+
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func cancel() {
+        self.lock.lock()
+        self.isCancelled = true
+        let task = self.task
+        self.lock.unlock()
+        task?.cancel()
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -630,10 +630,13 @@ public struct AntigravityStatusProbe: Sendable {
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = context.timeout
         config.timeoutIntervalForResource = context.timeout
-        let session = URLSession(configuration: config, delegate: InsecureSessionDelegate(), delegateQueue: nil)
+        config.waitsForConnectivity = false
+
+        let delegate = LocalhostSessionDelegate()
+        let session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
         defer { session.invalidateAndCancel() }
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await delegate.data(for: request, session: session)
         guard let http = response as? HTTPURLResponse else {
             throw AntigravityStatusProbeError.apiError("Invalid response")
         }
@@ -645,34 +648,73 @@ public struct AntigravityStatusProbe: Sendable {
     }
 }
 
-private final class InsecureSessionDelegate: NSObject {}
+enum LocalhostTrustPolicy {
+    static func shouldAcceptServerTrust(
+        host: String,
+        authenticationMethod: String,
+        hasServerTrust: Bool) -> Bool
+    {
+        guard authenticationMethod == NSURLAuthenticationMethodServerTrust else { return false }
+        let normalizedHost = host.lowercased()
+        guard normalizedHost == "127.0.0.1" || normalizedHost == "localhost" else { return false }
+        return hasServerTrust
+    }
+}
 
-extension InsecureSessionDelegate: URLSessionTaskDelegate {}
+private final class LocalhostSessionDelegate: NSObject, URLSessionDelegate, URLSessionTaskDelegate {
+    func data(for request: URLRequest, session: URLSession) async throws -> (Data, URLResponse) {
+        try await withCheckedThrowingContinuation { continuation in
+            let task = session.dataTask(with: request) { data, response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                guard let data, let response else {
+                    continuation.resume(throwing: AntigravityStatusProbeError.apiError("Invalid response"))
+                    return
+                }
+                continuation.resume(returning: (data, response))
+            }
+            task.resume()
+        }
+    }
 
-extension InsecureSessionDelegate {
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
+    {
+        self.handle(challenge, completionHandler: completionHandler)
+    }
+
     func urlSession(
         _ session: URLSession,
         task: URLSessionTask,
         didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping @MainActor @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
     {
-        let result = self.challengeResult(challenge)
-        Task { @MainActor in
-            completionHandler(result.disposition, result.credential)
-        }
+        self.handle(challenge, completionHandler: completionHandler)
     }
 
-    private func challengeResult(_ challenge: URLAuthenticationChallenge) -> (
-        disposition: URLSession.AuthChallengeDisposition,
-        credential: URLCredential?)
+    private func handle(
+        _ challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
     {
         #if canImport(FoundationNetworking)
-        return (.performDefaultHandling, nil)
+        completionHandler(.performDefaultHandling, nil)
         #else
-        if let trust = challenge.protectionSpace.serverTrust {
-            return (.useCredential, URLCredential(trust: trust))
+        let protectionSpace = challenge.protectionSpace
+        let trust = protectionSpace.serverTrust
+        guard LocalhostTrustPolicy.shouldAcceptServerTrust(
+            host: protectionSpace.host,
+            authenticationMethod: protectionSpace.authenticationMethod,
+            hasServerTrust: trust != nil),
+            let trust
+        else {
+            completionHandler(.performDefaultHandling, nil)
+            return
         }
-        return (.performDefaultHandling, nil)
+        completionHandler(.useCredential, URLCredential(trust: trust))
         #endif
     }
 }

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -1,8 +1,38 @@
-import CodexBarCore
+@testable import CodexBarCore
 import Foundation
 import Testing
 
 struct AntigravityStatusProbeTests {
+    @Test
+    func `localhost trust policy only accepts local server trust challenges`() {
+        #expect(
+            LocalhostTrustPolicy.shouldAcceptServerTrust(
+                host: "127.0.0.1",
+                authenticationMethod: NSURLAuthenticationMethodServerTrust,
+                hasServerTrust: true))
+        #expect(
+            LocalhostTrustPolicy.shouldAcceptServerTrust(
+                host: "LOCALHOST",
+                authenticationMethod: NSURLAuthenticationMethodServerTrust,
+                hasServerTrust: true))
+
+        #expect(
+            !LocalhostTrustPolicy.shouldAcceptServerTrust(
+                host: "cursor.com",
+                authenticationMethod: NSURLAuthenticationMethodServerTrust,
+                hasServerTrust: true))
+        #expect(
+            !LocalhostTrustPolicy.shouldAcceptServerTrust(
+                host: "127.0.0.1",
+                authenticationMethod: NSURLAuthenticationMethodHTTPBasic,
+                hasServerTrust: true))
+        #expect(
+            !LocalhostTrustPolicy.shouldAcceptServerTrust(
+                host: "127.0.0.1",
+                authenticationMethod: NSURLAuthenticationMethodServerTrust,
+                hasServerTrust: false))
+    }
+
     @Test
     func `parses user status response`() throws {
         let json = """

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -1,6 +1,6 @@
-@testable import CodexBarCore
 import Foundation
 import Testing
+@testable import CodexBarCore
 
 struct AntigravityStatusProbeTests {
     @Test


### PR DESCRIPTION
Fixes #692

## Summary

- handle Antigravity localhost TLS auth challenges explicitly in `AntigravityStatusProbe`
- limit the trust override to `127.0.0.1` / `localhost`
- add a focused regression test for the localhost trust policy

## Validation

- `swift test --filter AntigravityStatusProbeTests`
- `./Scripts/compile_and_run.sh`
- verified the rebuilt app shows Antigravity account/quota info locally instead of `Antigravity port detection failed: no working API port found`
