### PR TITLE
feat: support Edge browser cookie import for Codex provider

### DIFF
--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
@@ -290,20 +290,26 @@ public struct OpenAIDashboardBrowserCookieImporter {
         }
     }
 
-    private func tryChrome(
+    /// Generic cookie loader for any non-Safari browser (Chrome, Edge, Firefox, Brave, Arc, etc.).
+    /// SweetCookieKit handles engine-specific decryption internally.
+    private func tryBrowser(
+        _ browser: Browser,
         context: ImportContext,
         log: @escaping (String) -> Void,
         diagnostics: inout ImportDiagnostics) async -> ImportResult?
     {
-        // Chrome fallback: may trigger Keychain prompt. Only do this if Safari didn't match.
         do {
             let query = BrowserCookieQuery(domains: Self.cookieDomains)
-            let chromeSources = try Self.cookieClient.codexBarRecords(
+            let sources = try Self.cookieClient.codexBarRecords(
                 matching: query,
-                in: .chrome)
-            for source in chromeSources {
+                in: browser)
+            guard !sources.isEmpty else {
+                log("\(browser.displayName) contained 0 matching records.")
+                return nil
+            }
+            for source in sources {
                 let cookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
-                if cookies.isEmpty {
+                guard !cookies.isEmpty else {
                     log("\(source.label) produced 0 HTTPCookies.")
                     continue
                 }
@@ -325,53 +331,10 @@ public struct OpenAIDashboardBrowserCookieImporter {
             if let hint = error.accessDeniedHint {
                 diagnostics.accessDeniedHints.append(hint)
             }
-            log("Chrome cookie load failed: \(error.localizedDescription)")
+            log("\(browser.displayName) cookie load failed: \(error.localizedDescription)")
             return nil
         } catch {
-            log("Chrome cookie load failed: \(error.localizedDescription)")
-            return nil
-        }
-    }
-
-    private func tryFirefox(
-        context: ImportContext,
-        log: @escaping (String) -> Void,
-        diagnostics: inout ImportDiagnostics) async -> ImportResult?
-    {
-        // Firefox fallback: no Keychain, but still only after Safari/Chrome.
-        do {
-            let query = BrowserCookieQuery(domains: Self.cookieDomains)
-            let firefoxSources = try Self.cookieClient.codexBarRecords(
-                matching: query,
-                in: .firefox)
-            for source in firefoxSources {
-                let cookies = BrowserCookieClient.makeHTTPCookies(source.records, origin: query.origin)
-                if cookies.isEmpty {
-                    log("\(source.label) produced 0 HTTPCookies.")
-                    continue
-                }
-                diagnostics.foundAnyCookies = true
-                log("Loaded \(cookies.count) cookies from \(source.label) (\(self.cookieSummary(cookies)))")
-                let candidate = Candidate(label: source.label, cookies: cookies)
-                if let match = await self.applyCandidate(
-                    candidate,
-                    context: context,
-                    log: log,
-                    diagnostics: &diagnostics)
-                {
-                    return match
-                }
-            }
-            return nil
-        } catch let error as BrowserCookieError {
-            BrowserCookieAccessGate.recordIfNeeded(error)
-            if let hint = error.accessDeniedHint {
-                diagnostics.accessDeniedHints.append(hint)
-            }
-            log("Firefox cookie load failed: \(error.localizedDescription)")
-            return nil
-        } catch {
-            log("Firefox cookie load failed: \(error.localizedDescription)")
+            log("\(browser.displayName) cookie load failed: \(error.localizedDescription)")
             return nil
         }
     }
@@ -388,18 +351,14 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 context: context,
                 log: log,
                 diagnostics: &diagnostics)
-        case .chrome:
-            await self.tryChrome(
-                context: context,
-                log: log,
-                diagnostics: &diagnostics)
-        case .firefox:
-            await self.tryFirefox(
-                context: context,
-                log: log,
-                diagnostics: &diagnostics)
         default:
-            nil
+            // All non-Safari browsers (Chrome, Edge, Firefox, Brave, Arc, etc.)
+            // share the same cookie loading path via SweetCookieKit.
+            await self.tryBrowser(
+                source,
+                context: context,
+                log: log,
+                diagnostics: &diagnostics)
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -630,10 +630,15 @@ public struct AntigravityStatusProbe: Sendable {
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = context.timeout
         config.timeoutIntervalForResource = context.timeout
-        let session = URLSession(configuration: config, delegate: InsecureSessionDelegate(), delegateQueue: nil)
+        #if !os(Linux)
+        config.waitsForConnectivity = false
+        #endif
+
+        let delegate = LocalhostSessionDelegate()
+        let session = URLSession(configuration: config, delegate: delegate, delegateQueue: nil)
         defer { session.invalidateAndCancel() }
 
-        let (data, response) = try await session.data(for: request)
+        let (data, response) = try await delegate.data(for: request, session: session)
         guard let http = response as? HTTPURLResponse else {
             throw AntigravityStatusProbeError.apiError("Invalid response")
         }
@@ -645,35 +650,104 @@ public struct AntigravityStatusProbe: Sendable {
     }
 }
 
-private final class InsecureSessionDelegate: NSObject {}
+enum LocalhostTrustPolicy {
+    static func shouldAcceptServerTrust(host: String, hasServerTrust: Bool) -> Bool {
+        let normalizedHost = host.lowercased()
+        guard normalizedHost == "127.0.0.1" || normalizedHost == "localhost" else { return false }
+        return hasServerTrust
+    }
+}
 
-extension InsecureSessionDelegate: URLSessionTaskDelegate {}
+private final class LocalhostSessionDelegate: NSObject {
+    func data(for request: URLRequest, session: URLSession) async throws -> (Data, URLResponse) {
+        let state = LocalhostSessionTaskState()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let task = session.dataTask(with: request) { data, response, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    guard let data, let response else {
+                        continuation.resume(throwing: AntigravityStatusProbeError.apiError("Invalid response"))
+                        return
+                    }
+                    continuation.resume(returning: (data, response))
+                }
+                state.setTask(task)
+                task.resume()
+            }
+        } onCancel: {
+            state.cancel()
+        }
+    }
+}
 
-extension InsecureSessionDelegate {
+extension LocalhostSessionDelegate: URLSessionDelegate {
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
+    {
+        let result = self.challengeResult(challenge)
+        completionHandler(result.disposition, result.credential)
+    }
+}
+
+extension LocalhostSessionDelegate: URLSessionTaskDelegate {
     func urlSession(
         _ session: URLSession,
         task: URLSessionTask,
         didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping @MainActor @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
+        completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
     {
         let result = self.challengeResult(challenge)
-        Task { @MainActor in
-            completionHandler(result.disposition, result.credential)
-        }
+        completionHandler(result.disposition, result.credential)
     }
 
     private func challengeResult(_ challenge: URLAuthenticationChallenge) -> (
         disposition: URLSession.AuthChallengeDisposition,
         credential: URLCredential?)
     {
-        #if canImport(FoundationNetworking)
+        #if os(Linux)
         return (.performDefaultHandling, nil)
         #else
-        if let trust = challenge.protectionSpace.serverTrust {
-            return (.useCredential, URLCredential(trust: trust))
+        let protectionSpace = challenge.protectionSpace
+        let trust = protectionSpace.serverTrust
+        guard LocalhostTrustPolicy.shouldAcceptServerTrust(
+            host: protectionSpace.host,
+            hasServerTrust: trust != nil),
+            let trust
+        else {
+            return (.performDefaultHandling, nil)
         }
-        return (.performDefaultHandling, nil)
+        return (.useCredential, URLCredential(trust: trust))
         #endif
+    }
+}
+
+private final class LocalhostSessionTaskState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var task: URLSessionDataTask?
+    private var isCancelled = false
+
+    func setTask(_ task: URLSessionDataTask) {
+        self.lock.lock()
+        self.task = task
+        let shouldCancel = self.isCancelled
+        self.lock.unlock()
+
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func cancel() {
+        self.lock.lock()
+        self.isCancelled = true
+        let task = self.task
+        self.lock.unlock()
+        task?.cancel()
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -21,7 +21,8 @@ public enum CodexProviderDescriptor {
                 defaultEnabled: true,
                 isPrimaryProvider: true,
                 usesAccountFallback: true,
-                browserCookieOrder: ProviderBrowserCookieDefaults.defaultImportOrder,
+                browserCookieOrder: ProviderBrowserCookieDefaults.codexCookieImportOrder
+                    ?? ProviderBrowserCookieDefaults.defaultImportOrder,
                 dashboardURL: "https://chatgpt.com/codex/settings/usage",
                 statusPageURL: "https://status.openai.com/"),
             branding: ProviderBranding(

--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -151,4 +151,15 @@ public enum ProviderBrowserCookieDefaults {
         nil
         #endif
     }
+
+    /// Preserve the legacy Codex prompt behavior: prefer Safari/Chrome/Firefox before
+    /// probing additional Chromium variants that may trigger Safe Storage prompts.
+    public static var codexCookieImportOrder: BrowserCookieImportOrder? {
+        #if os(macOS)
+        let preferredPrefix: [Browser] = [.safari, .chrome, .firefox]
+        return preferredPrefix + Browser.defaultImportOrder.filter { !preferredPrefix.contains($0) }
+        #else
+        nil
+        #endif
+    }
 }

--- a/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
+++ b/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
@@ -5,6 +5,12 @@ import Testing
 struct BrowserCookieOrderStatusStringTests {
     #if os(macOS)
     @Test
+    func `codex cookie import order keeps firefox ahead of extra chromium browsers`() {
+        let order = ProviderDefaults.metadata[.codex]?.browserCookieOrder ?? Browser.defaultImportOrder
+        #expect(Array(order.prefix(3)) == [.safari, .chrome, .firefox])
+    }
+
+    @Test
     func `cursor no session includes browser login hint`() {
         let order = ProviderDefaults.metadata[.cursor]?.browserCookieOrder ?? Browser.defaultImportOrder
         let message = CursorStatusProbeError.noSessionCookie.errorDescription ?? ""


### PR DESCRIPTION
Supersedes #521.

Builds on @Astro-Han's original Edge cookie import work while keeping the contributor branch untouched.

Thanks @Astro-Han for the original implementation.