### PR TITLE
feat(proxy): add provider proxy settings

### DIFF
--- a/Sources/CodexBar/NetworkProxyPasswordStore.swift
+++ b/Sources/CodexBar/NetworkProxyPasswordStore.swift
@@ -1,0 +1,43 @@
+import CodexBarCore
+import Foundation
+
+protocol NetworkProxyPasswordStoring: Sendable {
+    func loadPassword() throws -> String?
+    func storePassword(_ password: String?) throws
+}
+
+enum NetworkProxyPasswordStoreError: LocalizedError {
+    case keychainUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .keychainUnavailable:
+            "Network proxy password store is unavailable."
+        }
+    }
+}
+
+struct KeychainNetworkProxyPasswordStore: NetworkProxyPasswordStoring {
+    private static let key = KeychainCacheStore.Key(
+        category: "network-proxy",
+        identifier: "password")
+
+    func loadPassword() throws -> String? {
+        switch KeychainCacheStore.load(key: Self.key, as: String.self) {
+        case let .found(value):
+            value
+        case .missing:
+            nil
+        case .invalid:
+            throw NetworkProxyPasswordStoreError.keychainUnavailable
+        }
+    }
+
+    func storePassword(_ password: String?) throws {
+        if let password, !password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            KeychainCacheStore.store(key: Self.key, entry: password)
+        } else {
+            KeychainCacheStore.clear(key: Self.key)
+        }
+    }
+}

--- a/Sources/CodexBar/NetworkProxyPasswordStore.swift
+++ b/Sources/CodexBar/NetworkProxyPasswordStore.swift
@@ -25,9 +25,11 @@ struct KeychainNetworkProxyPasswordStore: NetworkProxyPasswordStoring {
     func loadPassword() throws -> String? {
         switch KeychainCacheStore.load(key: Self.key, as: String.self) {
         case let .found(value):
-            value
+            return value
         case .missing:
-            nil
+            return nil
+        case .temporarilyUnavailable:
+            throw NetworkProxyPasswordStoreError.keychainUnavailable
         case .invalid:
             throw NetworkProxyPasswordStoreError.keychainUnavailable
         }

--- a/Sources/CodexBar/PreferencesAdvancedPane.swift
+++ b/Sources/CodexBar/PreferencesAdvancedPane.swift
@@ -1,3 +1,4 @@
+import CodexBarCore
 import KeyboardShortcuts
 import SwiftUI
 
@@ -51,6 +52,84 @@ struct AdvancedPane: View {
                     Text(L("install_cli_subtitle"))
                         .font(.footnote)
                         .foregroundStyle(.tertiary)
+                }
+
+                Divider()
+
+                SettingsSection(
+                    title: "Network proxy",
+                    caption: "Routes provider HTTP requests through an HTTP or SOCKS5 proxy.")
+                {
+                    VStack(alignment: .leading, spacing: 10) {
+                        PreferenceToggleRow(
+                            title: "Enable proxy",
+                            subtitle: "Applies to provider requests made by the app.",
+                            binding: self.$settings.networkProxyEnabled)
+
+                        HStack(alignment: .top, spacing: 12) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text("Scheme")
+                                    .font(.body)
+                                Text("Select HTTP for standard proxies or SOCKS5 for tunneling.")
+                                    .font(.footnote)
+                                    .foregroundStyle(.tertiary)
+                            }
+                            Spacer()
+                            Picker("Proxy scheme", selection: self.$settings.networkProxyScheme) {
+                                ForEach(NetworkProxyScheme.allCases, id: \.self) { scheme in
+                                    Text(scheme.displayName).tag(scheme)
+                                }
+                            }
+                            .labelsHidden()
+                            .pickerStyle(.menu)
+                            .frame(maxWidth: 200)
+                        }
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack(spacing: 12) {
+                                Text("Host")
+                                    .frame(width: 88, alignment: .leading)
+                                TextField("proxy.example.com", text: self.$settings.networkProxyHost)
+                                    .textFieldStyle(.roundedBorder)
+                            }
+                            HStack(spacing: 12) {
+                                Text("Port")
+                                    .frame(width: 88, alignment: .leading)
+                                TextField("8080", text: self.$settings.networkProxyPort)
+                                    .textFieldStyle(.roundedBorder)
+                                    .frame(maxWidth: 120)
+                            }
+                            HStack(spacing: 12) {
+                                Text("Username")
+                                    .frame(width: 88, alignment: .leading)
+                                TextField("optional", text: self.$settings.networkProxyUsername)
+                                    .textFieldStyle(.roundedBorder)
+                            }
+                            HStack(spacing: 12) {
+                                Text("Password")
+                                    .frame(width: 88, alignment: .leading)
+                                SecureField("stored in Keychain", text: self.$settings.networkProxyPassword)
+                                    .textFieldStyle(.roundedBorder)
+                            }
+                        }
+
+                        Text("Leave host empty to disable the proxy. Password is stored in Keychain.")
+                            .font(.footnote)
+                            .foregroundStyle(.tertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        Label {
+                            Text(self.settings.networkProxyStatusText)
+                                .font(.footnote)
+                                .foregroundStyle(self.settings.networkProxyStatusIsActive ? .secondary : .tertiary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        } icon: {
+                            Image(systemName: self.settings.networkProxyStatusIsActive
+                                ? "checkmark.circle.fill"
+                                : "exclamationmark.triangle.fill")
+                            .foregroundStyle(self.settings.networkProxyStatusIsActive ? .green : .orange)
+                        }
+                    }
                 }
 
                 Divider()

--- a/Sources/CodexBar/ProviderRegistry.swift
+++ b/Sources/CodexBar/ProviderRegistry.swift
@@ -58,6 +58,7 @@ struct ProviderRegistry {
                         env: env,
                         settings: snapshot,
                         fetcher: fetcher,
+                        httpClient: ProviderHTTPClient.shared,
                         claudeFetcher: claudeFetcher,
                         browserDetection: browserDetection)
                 })

--- a/Sources/CodexBar/ProviderRegistry.swift
+++ b/Sources/CodexBar/ProviderRegistry.swift
@@ -58,7 +58,6 @@ struct ProviderRegistry {
                         env: env,
                         settings: snapshot,
                         fetcher: fetcher,
-                        httpClient: ProviderHTTPClient.shared,
                         claudeFetcher: claudeFetcher,
                         browserDetection: browserDetection)
                 })

--- a/Sources/CodexBar/SettingsStore+ConfigPersistence.swift
+++ b/Sources/CodexBar/SettingsStore+ConfigPersistence.swift
@@ -34,7 +34,7 @@ private struct ConfigChangeContext {
 }
 
 extension SettingsStore {
-    private func updateConfig(reason: String, mutate: (inout CodexBarConfig) -> Void) {
+    func updateConfig(reason: String, mutate: (inout CodexBarConfig) -> Void) {
         guard !self.configLoading else { return }
         var config = self.config
         mutate(&config)

--- a/Sources/CodexBar/SettingsStore+NetworkProxy.swift
+++ b/Sources/CodexBar/SettingsStore+NetworkProxy.swift
@@ -1,0 +1,106 @@
+import CodexBarCore
+import Foundation
+
+extension SettingsStore {
+    var networkProxyEnabled: Bool {
+        get { self.config.networkProxy?.enabled ?? false }
+        set {
+            self.updateNetworkProxyConfiguration { proxy in
+                proxy.enabled = newValue
+            }
+        }
+    }
+
+    var networkProxyScheme: NetworkProxyScheme {
+        get { self.config.networkProxy?.scheme ?? .http }
+        set {
+            self.updateNetworkProxyConfiguration { proxy in
+                proxy.scheme = newValue
+            }
+        }
+    }
+
+    var networkProxyHost: String {
+        get { self.config.networkProxy?.host ?? "" }
+        set {
+            self.updateNetworkProxyConfiguration { proxy in
+                proxy.host = newValue
+            }
+        }
+    }
+
+    var networkProxyPort: String {
+        get { self.config.networkProxy?.port ?? "" }
+        set {
+            self.updateNetworkProxyConfiguration { proxy in
+                proxy.port = newValue
+            }
+        }
+    }
+
+    var networkProxyUsername: String {
+        get { self.config.networkProxy?.username ?? "" }
+        set {
+            self.updateNetworkProxyConfiguration { proxy in
+                proxy.username = newValue
+            }
+        }
+    }
+
+    var networkProxyPassword: String {
+        get { (try? self.networkProxyPasswordStore.loadPassword()) ?? "" }
+        set {
+            do {
+                try self.networkProxyPasswordStore.storePassword(newValue)
+            } catch {
+                CodexBarLog.logger(LogCategories.configStore).error("Failed to persist proxy password: \(error)")
+            }
+            self.syncProviderHTTPClientConfiguration()
+        }
+    }
+
+    func updateNetworkProxyConfiguration(mutate: (inout NetworkProxyConfiguration) -> Void) {
+        self.updateConfig(reason: "network-proxy") { config in
+            var proxy = config.networkProxy ?? NetworkProxyConfiguration(
+                enabled: false,
+                scheme: .http,
+                host: "",
+                port: "",
+                username: "")
+            mutate(&proxy)
+            config.networkProxy = proxy
+        }
+        self.syncProviderHTTPClientConfiguration()
+    }
+
+    func activeNetworkProxyConfiguration() -> NetworkProxyConfiguration? {
+        guard let proxy = self.config.networkProxy, proxy.isActive else { return nil }
+        return proxy
+    }
+
+    var networkProxyStatusText: String {
+        guard let proxy = self.config.networkProxy else {
+            return "Proxy is off."
+        }
+        if !proxy.enabled {
+            return "Proxy is configured but disabled."
+        }
+        let host = proxy.trimmedHost
+        guard !host.isEmpty else {
+            return "Proxy is enabled, but the host is missing."
+        }
+        guard let port = proxy.resolvedPort else {
+            return "Proxy is enabled, but the port must be between 1 and 65535."
+        }
+        return "Proxy is active and will route provider requests through \(host):\(port)."
+    }
+
+    var networkProxyStatusIsActive: Bool {
+        self.activeNetworkProxyConfiguration() != nil
+    }
+
+    func syncProviderHTTPClientConfiguration() {
+        let password = (try? self.networkProxyPasswordStore.loadPassword()) ?? nil
+        ProviderHTTPClient.shared.update(proxy: self.activeNetworkProxyConfiguration(), password: password)
+    }
+}

--- a/Sources/CodexBar/SettingsStore+NetworkProxy.swift
+++ b/Sources/CodexBar/SettingsStore+NetworkProxy.swift
@@ -50,12 +50,15 @@ extension SettingsStore {
     var networkProxyPassword: String {
         get { (try? self.networkProxyPasswordStore.loadPassword()) ?? "" }
         set {
+            let trimmedPassword = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
             do {
                 try self.networkProxyPasswordStore.storePassword(newValue)
             } catch {
                 CodexBarLog.logger(LogCategories.configStore).error("Failed to persist proxy password: \(error)")
             }
-            self.syncProviderHTTPClientConfiguration()
+            ProviderHTTPClient.shared.update(
+                proxy: self.activeNetworkProxyConfiguration(),
+                password: trimmedPassword.isEmpty ? nil : trimmedPassword)
         }
     }
 
@@ -100,7 +103,13 @@ extension SettingsStore {
     }
 
     func syncProviderHTTPClientConfiguration() {
-        let password = (try? self.networkProxyPasswordStore.loadPassword()) ?? nil
-        ProviderHTTPClient.shared.update(proxy: self.activeNetworkProxyConfiguration(), password: password)
+        do {
+            let password = try self.networkProxyPasswordStore.loadPassword()
+            ProviderHTTPClient.shared.update(proxy: self.activeNetworkProxyConfiguration(), password: password)
+        } catch {
+            ProviderHTTPClient.shared.update(
+                proxy: self.activeNetworkProxyConfiguration(),
+                password: ProviderHTTPClient.shared.currentPassword())
+        }
     }
 }

--- a/Sources/CodexBar/SettingsStore+NetworkProxy.swift
+++ b/Sources/CodexBar/SettingsStore+NetworkProxy.swift
@@ -59,6 +59,7 @@ extension SettingsStore {
             ProviderHTTPClient.shared.update(
                 proxy: self.activeNetworkProxyConfiguration(),
                 password: trimmedPassword.isEmpty ? nil : trimmedPassword)
+            self.cancelNetworkProxyPasswordRetry()
         }
     }
 
@@ -73,6 +74,7 @@ extension SettingsStore {
             mutate(&proxy)
             config.networkProxy = proxy
         }
+        self.cancelNetworkProxyPasswordRetry()
         self.syncProviderHTTPClientConfiguration()
     }
 
@@ -106,10 +108,36 @@ extension SettingsStore {
         do {
             let password = try self.networkProxyPasswordStore.loadPassword()
             ProviderHTTPClient.shared.update(proxy: self.activeNetworkProxyConfiguration(), password: password)
+            self.cancelNetworkProxyPasswordRetry()
         } catch {
+            let proxy = self.activeNetworkProxyConfiguration()
             ProviderHTTPClient.shared.update(
-                proxy: self.activeNetworkProxyConfiguration(),
+                proxy: proxy,
                 password: ProviderHTTPClient.shared.currentPassword())
+            if proxy != nil {
+                self.scheduleNetworkProxyPasswordRetry()
+            } else {
+                self.cancelNetworkProxyPasswordRetry()
+            }
         }
+    }
+
+    private func scheduleNetworkProxyPasswordRetry() {
+        guard self.networkProxyPasswordRetryTask == nil else { return }
+        guard self.networkProxyPasswordRetryAttempt < Self.networkProxyPasswordRetryDelays.count else { return }
+        let delay = Self.networkProxyPasswordRetryDelays[self.networkProxyPasswordRetryAttempt]
+        self.networkProxyPasswordRetryAttempt += 1
+        self.networkProxyPasswordRetryTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: delay)
+            guard !Task.isCancelled else { return }
+            self?.networkProxyPasswordRetryTask = nil
+            self?.syncProviderHTTPClientConfiguration()
+        }
+    }
+
+    private func cancelNetworkProxyPasswordRetry() {
+        self.networkProxyPasswordRetryTask?.cancel()
+        self.networkProxyPasswordRetryTask = nil
+        self.networkProxyPasswordRetryAttempt = 0
     }
 }

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -81,6 +81,7 @@ final class SettingsStore {
     @ObservationIgnored var configPersistTask: Task<Void, Never>?
     @ObservationIgnored var configLoading = false
     @ObservationIgnored var tokenAccountsLoaded = false
+    @ObservationIgnored let networkProxyPasswordStore: any NetworkProxyPasswordStoring
     var defaultsState: SettingsDefaultsState
     var configRevision: Int = 0
     var providerOrder: [UsageProvider] = []
@@ -124,7 +125,8 @@ final class SettingsStore {
             account: "amp-cookie",
             promptKind: .ampCookie),
         copilotTokenStore: any CopilotTokenStoring = KeychainCopilotTokenStore(),
-        tokenAccountStore: any ProviderTokenAccountStoring = FileTokenAccountStore())
+        tokenAccountStore: any ProviderTokenAccountStoring = FileTokenAccountStore(),
+        networkProxyPasswordStore: any NetworkProxyPasswordStoring = KeychainNetworkProxyPasswordStore())
     {
         let appGroupID = AppGroupSupport.currentGroupID()
         let appGroupMigration: AppGroupSupport.MigrationResult
@@ -172,10 +174,12 @@ final class SettingsStore {
         self.userDefaults = userDefaults
         self.configStore = configStore
         self.config = config
+        self.networkProxyPasswordStore = networkProxyPasswordStore
         self.configLoading = true
         self.defaultsState = Self.loadDefaultsState(userDefaults: userDefaults)
         self.updateProviderState(config: config)
         self.configLoading = false
+        self.syncProviderHTTPClientConfiguration()
         CodexBarLog.setFileLoggingEnabled(self.debugFileLoggingEnabled)
         userDefaults.removeObject(forKey: "showCodexUsage")
         userDefaults.removeObject(forKey: "showClaudeUsage")
@@ -431,6 +435,7 @@ extension SettingsStore {
             enablement[provider] = config.providerConfig(for: provider)?.enabled ?? defaultEnabled
         }
         self.providerEnablement = enablement
+        self.syncProviderHTTPClientConfiguration()
     }
 
     func orderedProviders() -> [UsageProvider] {

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -81,11 +81,20 @@ final class SettingsStore {
     @ObservationIgnored var configPersistTask: Task<Void, Never>?
     @ObservationIgnored var configLoading = false
     @ObservationIgnored var tokenAccountsLoaded = false
+    @ObservationIgnored var networkProxyPasswordRetryTask: Task<Void, Never>?
+    @ObservationIgnored var networkProxyPasswordRetryAttempt = 0
     @ObservationIgnored let networkProxyPasswordStore: any NetworkProxyPasswordStoring
     var defaultsState: SettingsDefaultsState
     var configRevision: Int = 0
     var providerOrder: [UsageProvider] = []
     var providerEnablement: [UsageProvider: Bool] = [:]
+    static var networkProxyPasswordRetryDelays: [Duration] = [
+        .seconds(1),
+        .seconds(2),
+        .seconds(5),
+        .seconds(10),
+        .seconds(30),
+    ]
 
     static func shouldBridgeSharedDefaults(for userDefaults: UserDefaults) -> Bool {
         if !self.isRunningTests { return true }

--- a/Sources/CodexBar/UsageStore+Status.swift
+++ b/Sources/CodexBar/UsageStore+Status.swift
@@ -1,3 +1,4 @@
+import CodexBarCore
 import Foundation
 
 extension UsageStore {
@@ -6,7 +7,7 @@ extension UsageStore {
         var request = URLRequest(url: apiURL)
         request.timeoutInterval = 10
 
-        let (data, _) = try await URLSession.shared.data(for: request, delegate: nil)
+        let (data, _) = try await ProviderHTTPClient.shared.data(for: request)
 
         struct Response: Decodable {
             struct Status: Decodable {
@@ -52,7 +53,7 @@ extension UsageStore {
         }
         var request = URLRequest(url: url)
         request.timeoutInterval = 10
-        let (data, _) = try await URLSession.shared.data(for: request, delegate: nil)
+        let (data, _) = try await ProviderHTTPClient.shared.data(for: request)
         return try Self.parseGoogleWorkspaceStatus(data: data, productID: productID)
     }
 

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -153,7 +153,6 @@ extension UsageStore {
             env: env,
             settings: snapshot,
             fetcher: fetcher,
-            httpClient: ProviderHTTPClient.shared,
             claudeFetcher: self.claudeFetcher,
             browserDetection: self.browserDetection)
     }

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -153,6 +153,7 @@ extension UsageStore {
             env: env,
             settings: snapshot,
             fetcher: fetcher,
+            httpClient: ProviderHTTPClient.shared,
             claudeFetcher: self.claudeFetcher,
             browserDetection: self.browserDetection)
     }

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -5,10 +5,16 @@ public struct CodexBarConfig: Codable, Sendable {
 
     public var version: Int
     public var providers: [ProviderConfig]
+    public var networkProxy: NetworkProxyConfiguration?
 
-    public init(version: Int = Self.currentVersion, providers: [ProviderConfig]) {
+    public init(
+        version: Int = Self.currentVersion,
+        providers: [ProviderConfig],
+        networkProxy: NetworkProxyConfiguration? = nil)
+    {
         self.version = version
         self.providers = providers
+        self.networkProxy = networkProxy
     }
 
     public static func makeDefault(
@@ -19,7 +25,7 @@ public struct CodexBarConfig: Codable, Sendable {
                 id: provider,
                 enabled: metadata[provider]?.defaultEnabled)
         }
-        return CodexBarConfig(version: Self.currentVersion, providers: providers)
+        return CodexBarConfig(version: Self.currentVersion, providers: providers, networkProxy: nil)
     }
 
     public func normalized(
@@ -43,7 +49,8 @@ public struct CodexBarConfig: Codable, Sendable {
 
         return CodexBarConfig(
             version: Self.currentVersion,
-            providers: normalized)
+            providers: normalized,
+            networkProxy: self.networkProxy)
     }
 
     public func orderedProviders() -> [UsageProvider] {

--- a/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
@@ -44,6 +44,10 @@ public enum CodexBarConfigValidator {
             self.validateProvider(entry, issues: &issues)
         }
 
+        if let proxy = config.networkProxy {
+            self.validateNetworkProxy(proxy, issues: &issues)
+        }
+
         return issues
     }
 
@@ -198,6 +202,31 @@ public enum CodexBarConfigValidator {
                 field: "tokenAccounts",
                 code: "token_accounts_unused",
                 message: "tokenAccounts are set but \(provider.rawValue) does not support token accounts."))
+        }
+    }
+
+    private static func validateNetworkProxy(
+        _ proxy: NetworkProxyConfiguration,
+        issues: inout [CodexBarConfigIssue])
+    {
+        guard proxy.enabled else { return }
+
+        if proxy.trimmedHost.isEmpty {
+            issues.append(CodexBarConfigIssue(
+                severity: .error,
+                provider: nil,
+                field: "networkProxy.host",
+                code: "proxy_host_missing",
+                message: "Network proxy host is required when proxy is enabled."))
+        }
+
+        if proxy.resolvedPort == nil {
+            issues.append(CodexBarConfigIssue(
+                severity: .error,
+                provider: nil,
+                field: "networkProxy.port",
+                code: "proxy_port_invalid",
+                message: "Network proxy port must be a number between 1 and 65535."))
         }
     }
 }

--- a/Sources/CodexBarCore/Config/NetworkProxyConfiguration.swift
+++ b/Sources/CodexBarCore/Config/NetworkProxyConfiguration.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+public enum NetworkProxyScheme: String, CaseIterable, Codable, Sendable {
+    case http
+    case socks5
+
+    public var displayName: String {
+        switch self {
+        case .http: "HTTP"
+        case .socks5: "SOCKS5"
+        }
+    }
+}
+
+public struct NetworkProxyConfiguration: Codable, Sendable, Equatable {
+    public var enabled: Bool
+    public var scheme: NetworkProxyScheme
+    public var host: String
+    public var port: String
+    public var username: String
+
+    public init(
+        enabled: Bool,
+        scheme: NetworkProxyScheme,
+        host: String,
+        port: String,
+        username: String)
+    {
+        self.enabled = enabled
+        self.scheme = scheme
+        self.host = host
+        self.port = port
+        self.username = username
+    }
+
+    public var trimmedHost: String {
+        self.host.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public var trimmedPort: String {
+        self.port.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public var trimmedUsername: String {
+        self.username.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public var resolvedPort: Int? {
+        guard let port = Int(self.trimmedPort), (1...65535).contains(port) else { return nil }
+        return port
+    }
+
+    public var isActive: Bool {
+        self.enabled && !self.trimmedHost.isEmpty && self.resolvedPort != nil
+    }
+}

--- a/Sources/CodexBarCore/ProviderHTTPClient.swift
+++ b/Sources/CodexBarCore/ProviderHTTPClient.swift
@@ -1,0 +1,78 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public final class ProviderHTTPClient: @unchecked Sendable {
+    public static let shared = ProviderHTTPClient()
+
+    private let queue = DispatchQueue(label: "com.steipete.CodexBar.provider-http-client")
+    private var session: URLSession
+    private var proxy: NetworkProxyConfiguration?
+    private var password: String?
+
+    public init() {
+        self.proxy = nil
+        self.password = nil
+        self.session = URLSession(configuration: Self.makeSessionConfiguration(proxy: nil, password: nil))
+    }
+
+    public func update(proxy: NetworkProxyConfiguration?, password: String?) {
+        let configuration = Self.makeSessionConfiguration(proxy: proxy, password: password)
+        let session = URLSession(configuration: configuration)
+        self.queue.sync {
+            self.proxy = proxy
+            self.password = password
+            self.session = session
+        }
+    }
+
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let session = self.queue.sync { self.session }
+        return try await session.data(for: request)
+    }
+
+    public func currentProxyConfiguration() -> NetworkProxyConfiguration? {
+        self.queue.sync { self.proxy }
+    }
+
+    public static func makeSessionConfiguration(
+        proxy: NetworkProxyConfiguration?,
+        password: String?) -> URLSessionConfiguration
+    {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.timeoutIntervalForRequest = 60
+        configuration.timeoutIntervalForResource = 60
+
+        guard let proxy, proxy.isActive, let port = proxy.resolvedPort else {
+            return configuration
+        }
+
+        let trimmedPassword = password?.trimmingCharacters(in: .whitespacesAndNewlines)
+        var proxyDictionary: [String: Any] = [:]
+        switch proxy.scheme {
+        case .http:
+            proxyDictionary[kCFNetworkProxiesHTTPEnable as String] = 1
+            proxyDictionary[kCFNetworkProxiesHTTPProxy as String] = proxy.trimmedHost
+            proxyDictionary[kCFNetworkProxiesHTTPPort as String] = port
+            proxyDictionary[kCFNetworkProxiesHTTPSEnable as String] = 1
+            proxyDictionary[kCFNetworkProxiesHTTPSProxy as String] = proxy.trimmedHost
+            proxyDictionary[kCFNetworkProxiesHTTPSPort as String] = port
+        case .socks5:
+            proxyDictionary[kCFNetworkProxiesSOCKSEnable as String] = 1
+            proxyDictionary[kCFNetworkProxiesSOCKSProxy as String] = proxy.trimmedHost
+            proxyDictionary[kCFNetworkProxiesSOCKSPort as String] = port
+        }
+
+        if !proxy.trimmedUsername.isEmpty {
+            proxyDictionary[kCFProxyUsernameKey as String] = proxy.trimmedUsername
+        }
+        if let trimmedPassword, !trimmedPassword.isEmpty {
+            proxyDictionary[kCFProxyPasswordKey as String] = trimmedPassword
+        }
+
+        configuration.connectionProxyDictionary = proxyDictionary
+        return configuration
+    }
+}

--- a/Sources/CodexBarCore/ProviderHTTPClient.swift
+++ b/Sources/CodexBarCore/ProviderHTTPClient.swift
@@ -53,26 +53,44 @@ public final class ProviderHTTPClient: @unchecked Sendable {
         var proxyDictionary: [String: Any] = [:]
         switch proxy.scheme {
         case .http:
-            proxyDictionary[kCFNetworkProxiesHTTPEnable as String] = 1
-            proxyDictionary[kCFNetworkProxiesHTTPProxy as String] = proxy.trimmedHost
-            proxyDictionary[kCFNetworkProxiesHTTPPort as String] = port
-            proxyDictionary[kCFNetworkProxiesHTTPSEnable as String] = 1
-            proxyDictionary[kCFNetworkProxiesHTTPSProxy as String] = proxy.trimmedHost
-            proxyDictionary[kCFNetworkProxiesHTTPSPort as String] = port
+            proxyDictionary[ProxyDictionaryKey.httpEnable] = 1
+            proxyDictionary[ProxyDictionaryKey.httpProxy] = proxy.trimmedHost
+            proxyDictionary[ProxyDictionaryKey.httpPort] = port
+            proxyDictionary[ProxyDictionaryKey.httpsEnable] = 1
+            proxyDictionary[ProxyDictionaryKey.httpsProxy] = proxy.trimmedHost
+            proxyDictionary[ProxyDictionaryKey.httpsPort] = port
         case .socks5:
-            proxyDictionary[kCFNetworkProxiesSOCKSEnable as String] = 1
-            proxyDictionary[kCFNetworkProxiesSOCKSProxy as String] = proxy.trimmedHost
-            proxyDictionary[kCFNetworkProxiesSOCKSPort as String] = port
+            proxyDictionary[ProxyDictionaryKey.socksEnable] = 1
+            proxyDictionary[ProxyDictionaryKey.socksProxy] = proxy.trimmedHost
+            proxyDictionary[ProxyDictionaryKey.socksPort] = port
         }
 
         if !proxy.trimmedUsername.isEmpty {
-            proxyDictionary[kCFProxyUsernameKey as String] = proxy.trimmedUsername
+            proxyDictionary[proxy.scheme == .http ? ProxyDictionaryKey.httpUser : ProxyDictionaryKey.socksUser] =
+                proxy.trimmedUsername
         }
         if let trimmedPassword, !trimmedPassword.isEmpty {
-            proxyDictionary[kCFProxyPasswordKey as String] = trimmedPassword
+            proxyDictionary[proxy.scheme == .http ? ProxyDictionaryKey.httpPassword : ProxyDictionaryKey.socksPassword] =
+                trimmedPassword
         }
 
         configuration.connectionProxyDictionary = proxyDictionary
         return configuration
     }
+}
+
+private enum ProxyDictionaryKey {
+    static let httpEnable = "HTTPEnable"
+    static let httpProxy = "HTTPProxy"
+    static let httpPort = "HTTPPort"
+    static let httpsEnable = "HTTPSEnable"
+    static let httpsProxy = "HTTPSProxy"
+    static let httpsPort = "HTTPSPort"
+    static let socksEnable = "SOCKSEnable"
+    static let socksProxy = "SOCKSProxy"
+    static let socksPort = "SOCKSPort"
+    static let httpUser = "HTTPUser"
+    static let httpPassword = "HTTPPassword"
+    static let socksUser = "SOCKSUser"
+    static let socksPassword = "SOCKSPassword"
 }

--- a/Sources/CodexBarCore/ProviderHTTPClient.swift
+++ b/Sources/CodexBarCore/ProviderHTTPClient.swift
@@ -36,6 +36,10 @@ public final class ProviderHTTPClient: @unchecked Sendable {
         self.queue.sync { self.proxy }
     }
 
+    public func currentPassword() -> String? {
+        self.queue.sync { self.password }
+    }
+
     public static func makeSessionConfiguration(
         proxy: NetworkProxyConfiguration?,
         password: String?) -> URLSessionConfiguration

--- a/Sources/CodexBarCore/ProviderHTTPClient.swift
+++ b/Sources/CodexBarCore/ProviderHTTPClient.swift
@@ -20,11 +20,14 @@ public final class ProviderHTTPClient: @unchecked Sendable {
     public func update(proxy: NetworkProxyConfiguration?, password: String?) {
         let configuration = Self.makeSessionConfiguration(proxy: proxy, password: password)
         let session = URLSession(configuration: configuration)
-        self.queue.sync {
+        let oldSession = self.queue.sync {
+            let oldSession = self.session
             self.proxy = proxy
             self.password = password
             self.session = session
+            return oldSession
         }
+        oldSession.finishTasksAndInvalidate()
     }
 
     public func data(for request: URLRequest) async throws -> (Data, URLResponse) {

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanUsageFetcher.swift
@@ -108,7 +108,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         request.setValue(region.gatewayBaseURLString, forHTTPHeaderField: "Origin")
         request.setValue(region.dashboardURL.absoluteString, forHTTPHeaderField: "Referer")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw AlibabaCodingPlanUsageError.networkError("Invalid response")
         }
@@ -158,7 +158,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         request.setValue(region.gatewayBaseURLString, forHTTPHeaderField: "Origin")
         request.setValue(region.consoleRefererURL.absoluteString, forHTTPHeaderField: "Referer")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw AlibabaCodingPlanUsageError.networkError("Invalid response")
         }
@@ -338,7 +338,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
             "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             forHTTPHeaderField: "Accept")
 
-        if let (data, response) = try? await URLSession.shared.data(for: request),
+        if let (data, response) = try? await ProviderHTTPClient.shared.data(for: request),
            let httpResponse = response as? HTTPURLResponse,
            httpResponse.statusCode == 200,
            let html = String(data: data, encoding: .utf8),
@@ -404,7 +404,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
             .absoluteString + "/"
         request.setValue(referer, forHTTPHeaderField: "Referer")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             return nil
         }

--- a/Sources/CodexBarCore/Providers/Augment/AugmentSessionKeepalive.swift
+++ b/Sources/CodexBarCore/Providers/Augment/AugmentSessionKeepalive.swift
@@ -377,7 +377,7 @@ public final class AugmentSessionKeepalive {
             request.setValue("https://app.augmentcode.com", forHTTPHeaderField: "Referer")
 
             do {
-                let (data, response) = try await URLSession.shared.data(for: request)
+                let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
                 guard let httpResponse = response as? HTTPURLResponse else {
                     self.log("   ✗ Invalid response type")

--- a/Sources/CodexBarCore/Providers/Augment/AugmentStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Augment/AugmentStatusProbe.swift
@@ -497,7 +497,7 @@ public struct AugmentStatusProbe: Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw AugmentStatusProbeError.networkError("Invalid response")
@@ -535,7 +535,7 @@ public struct AugmentStatusProbe: Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw AugmentStatusProbeError.networkError("Invalid response")

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -1011,7 +1011,7 @@ public enum ClaudeOAuthCredentialsStore {
             ]
             request.httpBody = (components.percentEncodedQuery ?? "").data(using: .utf8)
 
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
             guard let http = response as? HTTPURLResponse else {
                 throw ClaudeOAuthCredentialsError.refreshFailed("Invalid response")

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthUsageFetcher.swift
@@ -52,7 +52,7 @@ enum ClaudeOAuthUsageFetcher {
         request.setValue(Self.claudeCodeUserAgent(), forHTTPHeaderField: "User-Agent")
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             guard let http = response as? HTTPURLResponse else {
                 throw ClaudeOAuthFetchError.invalidResponse
             }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -270,7 +270,7 @@ public enum ClaudeWebAPIFetcher {
             request.timeoutInterval = 20
 
             do {
-                let (data, response) = try await URLSession.shared.data(for: request)
+                let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
                 let http = response as? HTTPURLResponse
                 let contentType = http?.allHeaderFields["Content-Type"] as? String
                 let truncated = data.prefix(Self.maxProbeBytes)
@@ -405,7 +405,7 @@ public enum ClaudeWebAPIFetcher {
         request.httpMethod = "GET"
         request.timeoutInterval = 15
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FetchError.invalidResponse
@@ -435,7 +435,7 @@ public enum ClaudeWebAPIFetcher {
         request.httpMethod = "GET"
         request.timeoutInterval = 15
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FetchError.invalidResponse
@@ -554,7 +554,7 @@ public enum ClaudeWebAPIFetcher {
         request.timeoutInterval = 15
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else { return nil }
             logger?("Overage API status: \(httpResponse.statusCode)")
             guard httpResponse.statusCode == 200 else { return nil }
@@ -701,7 +701,7 @@ public enum ClaudeWebAPIFetcher {
         request.timeoutInterval = 15
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else { return nil }
             logger?("Account API status: \(httpResponse.statusCode)")
             guard httpResponse.statusCode == 200 else { return nil }

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
@@ -209,7 +209,7 @@ public enum CodexOAuthUsageFetcher {
         }
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             guard let http = response as? HTTPURLResponse else {
                 throw CodexOAuthFetchError.invalidResponse
             }

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexTokenRefresher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexTokenRefresher.swift
@@ -49,7 +49,7 @@ public enum CodexTokenRefresher {
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             guard let http = response as? HTTPURLResponse else {
                 throw RefreshError.invalidResponse("No HTTP response")
             }

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotDeviceFlow.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotDeviceFlow.swift
@@ -98,7 +98,7 @@ public struct CopilotDeviceFlow: Sendable {
         ]
         postRequest.httpBody = Self.formURLEncodedBody(body)
 
-        let (data, response) = try await URLSession.shared.data(for: postRequest)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: postRequest)
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             throw URLError(.badServerResponse)
@@ -127,7 +127,7 @@ public struct CopilotDeviceFlow: Sendable {
             try await Task.sleep(nanoseconds: UInt64(interval) * 1_000_000_000)
             try Task.checkCancellation()
 
-            let (data, _) = try await URLSession.shared.data(for: request)
+            let (data, _) = try await ProviderHTTPClient.shared.data(for: request)
 
             // Check for error in JSON
             if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
@@ -107,7 +107,7 @@ public struct CopilotUsageFetcher: Sendable {
         request.setValue("token \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw URLError(.badServerResponse)
         }

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
@@ -49,7 +49,7 @@ public struct CopilotUsageFetcher: Sendable {
         request.setValue("token \(self.token)", forHTTPHeaderField: "Authorization")
         self.addCommonHeaders(to: &request)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw URLError(.badServerResponse)

--- a/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
@@ -1296,7 +1296,7 @@ public struct FactoryStatusProbe: Sendable {
             request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
         }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FactoryStatusProbeError.networkError("Invalid response")
@@ -1354,7 +1354,14 @@ public struct FactoryStatusProbe: Sendable {
             request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
         }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        // Build request body
+        var body: [String: Any] = ["useCache": true]
+        if let userId {
+            body["userId"] = userId
+        }
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FactoryStatusProbeError.networkError("Invalid response")
@@ -1488,7 +1495,7 @@ public struct FactoryStatusProbe: Sendable {
         }
         request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FactoryStatusProbeError.networkError("Invalid WorkOS response")
         }
@@ -1558,7 +1565,7 @@ public struct FactoryStatusProbe: Sendable {
         }
         request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FactoryStatusProbeError.networkError("Invalid WorkOS response")
         }

--- a/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
@@ -1354,13 +1354,6 @@ public struct FactoryStatusProbe: Sendable {
             request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
         }
 
-        // Build request body
-        var body: [String: Any] = ["useCache": true]
-        if let userId {
-            body["userId"] = userId
-        }
-        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
-
         let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {

--- a/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
@@ -1259,7 +1259,7 @@ public struct FactoryStatusProbe: Sendable {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await URLSession.shared.data(for: request)
+            (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         } catch {
             return nil
         }

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
@@ -147,7 +147,7 @@ public struct GeminiStatusProbe: Sendable {
         timeout: TimeInterval = 10.0,
         homeDirectory: String = NSHomeDirectory(),
         dataLoader: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = { request in
-            try await URLSession.shared.data(for: request)
+            try await ProviderHTTPClient.shared.data(for: request)
         })
     {
         self.timeout = timeout

--- a/Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift
@@ -275,7 +275,7 @@ public struct KiloUsageFetcher: Sendable {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await URLSession.shared.data(for: request)
+            (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         } catch {
             throw KiloUsageError.networkError(error.localizedDescription)
         }

--- a/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
@@ -46,7 +46,7 @@ public struct KimiUsageFetcher: Sendable {
         let requestBody = ["scope": ["FEATURE_CODING"]]
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw KimiAPIError.networkError("Invalid response")
         }

--- a/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
@@ -123,7 +123,7 @@ public struct KimiK2UsageFetcher: Sendable {
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw KimiK2UsageError.networkError("Invalid response")

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -146,7 +146,7 @@ public struct MiniMaxUsageFetcher: Sendable {
             self.resolveCodingPlanRefererURL(region: region, environment: environment).absoluteString,
             forHTTPHeaderField: "referer")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw MiniMaxUsageError.networkError("Invalid response")
         }
@@ -209,7 +209,7 @@ public struct MiniMaxUsageFetcher: Sendable {
             self.resolveCodingPlanRefererURL(region: region, environment: environment).absoluteString,
             forHTTPHeaderField: "referer")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw MiniMaxUsageError.networkError("Invalid response")
         }

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterUsageStats.swift
@@ -216,7 +216,7 @@ public struct OpenRouterUsageFetcher: Sendable {
         let title = Self.sanitizedHeaderValue(environment[self.clientTitleEnvKey]) ?? Self.defaultClientTitle
         request.setValue(title, forHTTPHeaderField: "X-Title")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw OpenRouterUsageError.networkError("Invalid response")
@@ -323,7 +323,7 @@ public struct OpenRouterUsageFetcher: Sendable {
         request.timeoutInterval = timeoutSeconds
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200

--- a/Sources/CodexBarCore/Providers/Perplexity/PerplexityUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Perplexity/PerplexityUsageFetcher.swift
@@ -43,7 +43,7 @@ public struct PerplexityUsageFetcher: Sendable {
             "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw PerplexityAPIError.networkError("Invalid response")
         }

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -27,6 +27,7 @@ public struct ProviderFetchContext: Sendable {
     public let env: [String: String]
     public let settings: ProviderSettingsSnapshot?
     public let fetcher: UsageFetcher
+    public let httpClient: ProviderHTTPClient
     public let claudeFetcher: any ClaudeUsageFetching
     public let browserDetection: BrowserDetection
 
@@ -40,6 +41,7 @@ public struct ProviderFetchContext: Sendable {
         env: [String: String],
         settings: ProviderSettingsSnapshot?,
         fetcher: UsageFetcher,
+        httpClient: ProviderHTTPClient = .shared,
         claudeFetcher: any ClaudeUsageFetching,
         browserDetection: BrowserDetection)
     {
@@ -52,6 +54,7 @@ public struct ProviderFetchContext: Sendable {
         self.env = env
         self.settings = settings
         self.fetcher = fetcher
+        self.httpClient = httpClient
         self.claudeFetcher = claudeFetcher
         self.browserDetection = browserDetection
     }

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -27,7 +27,6 @@ public struct ProviderFetchContext: Sendable {
     public let env: [String: String]
     public let settings: ProviderSettingsSnapshot?
     public let fetcher: UsageFetcher
-    public let httpClient: ProviderHTTPClient
     public let claudeFetcher: any ClaudeUsageFetching
     public let browserDetection: BrowserDetection
 
@@ -41,7 +40,6 @@ public struct ProviderFetchContext: Sendable {
         env: [String: String],
         settings: ProviderSettingsSnapshot?,
         fetcher: UsageFetcher,
-        httpClient: ProviderHTTPClient = .shared,
         claudeFetcher: any ClaudeUsageFetching,
         browserDetection: BrowserDetection)
     {
@@ -54,7 +52,6 @@ public struct ProviderFetchContext: Sendable {
         self.env = env
         self.settings = settings
         self.fetcher = fetcher
-        self.httpClient = httpClient
         self.claudeFetcher = claudeFetcher
         self.browserDetection = browserDetection
     }

--- a/Sources/CodexBarCore/Providers/Synthetic/SyntheticUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Synthetic/SyntheticUsageStats.swift
@@ -104,7 +104,7 @@ public struct SyntheticUsageFetcher: Sendable {
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw SyntheticUsageError.networkError("Invalid response")

--- a/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAITokenRefresher.swift
+++ b/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAITokenRefresher.swift
@@ -49,7 +49,7 @@ public enum VertexAITokenRefresher {
         request.httpBody = bodyString.data(using: .utf8)
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             guard let http = response as? HTTPURLResponse else {
                 throw RefreshError.invalidResponse("No HTTP response")
             }

--- a/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAIUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAIUsageFetcher.swift
@@ -219,7 +219,7 @@ public enum VertexAIUsageFetcher {
             let response: URLResponse
 
             do {
-                (data, response) = try await URLSession.shared.data(for: request)
+                (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             } catch {
                 throw VertexAIFetchError.networkError(error)
             }

--- a/Sources/CodexBarCore/Providers/Warp/WarpUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Warp/WarpUsageFetcher.swift
@@ -206,7 +206,7 @@ public struct WarpUsageFetcher: Sendable {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw WarpUsageError.networkError("Invalid response")

--- a/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
@@ -316,7 +316,7 @@ public struct ZaiUsageFetcher: Sendable {
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "authorization")
         request.setValue("application/json", forHTTPHeaderField: "accept")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ZaiUsageError.networkError("Invalid response")

--- a/Tests/CodexBarTests/FactoryStatusProbeFetchTests.swift
+++ b/Tests/CodexBarTests/FactoryStatusProbeFetchTests.swift
@@ -101,6 +101,12 @@ struct FactoryStatusProbeFetchTests {
             "GET api.factory.ai/api/billing/limits",
             "GET api.factory.ai/api/organization/subscription/usage?useCache=true",
         ])
+        let usageRequest = try #require(FactoryStubURLProtocol.requests.first {
+            $0.url?.path == "/api/organization/subscription/usage"
+        })
+        #expect(usageRequest.httpMethod == "GET")
+        #expect(usageRequest.httpBody == nil)
+        #expect(usageRequest.httpBodyStream == nil)
         await FactorySessionStore.shared.clearSession()
     }
 

--- a/Tests/CodexBarTests/NetworkProxyTests.swift
+++ b/Tests/CodexBarTests/NetworkProxyTests.swift
@@ -1,0 +1,169 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@Suite(.serialized)
+@MainActor
+struct NetworkProxyTests {
+    @Test
+    func `proxy settings persist without password in config file`() throws {
+        let suite = "NetworkProxyTests-persist"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        let proxyPasswordStore = InMemoryProxyPasswordStore()
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            kimiK2TokenStore: InMemoryKimiK2TokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore(),
+            networkProxyPasswordStore: proxyPasswordStore)
+
+        settings.networkProxyEnabled = true
+        #expect(settings.networkProxyEnabled == true)
+        settings.networkProxyScheme = .socks5
+        #expect(settings.networkProxyScheme == .socks5)
+        settings.networkProxyHost = "proxy.example.com"
+        #expect(settings.networkProxyHost == "proxy.example.com")
+        settings.networkProxyPort = "1080"
+        #expect(settings.networkProxyPort == "1080")
+        settings.networkProxyUsername = "alice"
+        #expect(settings.networkProxyUsername == "alice")
+        settings.networkProxyPassword = "secret"
+        #expect(settings.networkProxyPassword == "secret")
+
+        let saved = try configStore.load()
+        let proxy = try #require(saved?.networkProxy)
+        #expect(proxy.enabled == true)
+        #expect(proxy.scheme == .socks5)
+        #expect(proxy.host == "proxy.example.com")
+        #expect(proxy.port == "1080")
+        #expect(proxy.username == "alice")
+        #expect(String(data: try Data(contentsOf: configStore.fileURL), encoding: .utf8)?.contains("secret") == false)
+
+        let reloaded = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            kimiK2TokenStore: InMemoryKimiK2TokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore(),
+            networkProxyPasswordStore: proxyPasswordStore)
+
+        #expect(reloaded.networkProxyEnabled == true)
+        #expect(reloaded.networkProxyScheme == .socks5)
+        #expect(reloaded.networkProxyHost == "proxy.example.com")
+        #expect(reloaded.networkProxyPort == "1080")
+        #expect(reloaded.networkProxyUsername == "alice")
+        #expect(reloaded.networkProxyPassword == "secret")
+    }
+
+    @Test
+    func `http proxy session configuration includes auth and host`() throws {
+        let proxy = NetworkProxyConfiguration(
+            enabled: true,
+            scheme: .http,
+            host: "proxy.example.com",
+            port: "8080",
+            username: "alice")
+
+        let configuration = ProviderHTTPClient.makeSessionConfiguration(
+            proxy: proxy,
+            password: "secret")
+
+        let dictionary = try #require(configuration.connectionProxyDictionary as? [String: Any])
+        #expect(dictionary[kCFNetworkProxiesHTTPEnable as String] as? Int == 1)
+        #expect(dictionary[kCFNetworkProxiesHTTPProxy as String] as? String == "proxy.example.com")
+        #expect(dictionary[kCFNetworkProxiesHTTPPort as String] as? Int == 8080)
+        #expect(dictionary[kCFNetworkProxiesHTTPSEnable as String] as? Int == 1)
+        #expect(dictionary[kCFNetworkProxiesHTTPSProxy as String] as? String == "proxy.example.com")
+        #expect(dictionary[kCFNetworkProxiesHTTPSPort as String] as? Int == 8080)
+        #expect(dictionary[kCFProxyUsernameKey as String] as? String == "alice")
+        #expect(dictionary[kCFProxyPasswordKey as String] as? String == "secret")
+    }
+
+    @Test
+    func `socks5 proxy session configuration includes auth and host`() throws {
+        let proxy = NetworkProxyConfiguration(
+            enabled: true,
+            scheme: .socks5,
+            host: "proxy.example.com",
+            port: "1080",
+            username: "alice")
+
+        let configuration = ProviderHTTPClient.makeSessionConfiguration(
+            proxy: proxy,
+            password: "secret")
+
+        let dictionary = try #require(configuration.connectionProxyDictionary as? [String: Any])
+        #expect(dictionary[kCFNetworkProxiesSOCKSEnable as String] as? Int == 1)
+        #expect(dictionary[kCFNetworkProxiesSOCKSProxy as String] as? String == "proxy.example.com")
+        #expect(dictionary[kCFNetworkProxiesSOCKSPort as String] as? Int == 1080)
+        #expect(dictionary[kCFProxyUsernameKey as String] as? String == "alice")
+        #expect(dictionary[kCFProxyPasswordKey as String] as? String == "secret")
+    }
+
+    @Test
+    func `proxy status text reflects active and inactive states`() throws {
+        let suite = "NetworkProxyTests-status"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            kimiK2TokenStore: InMemoryKimiK2TokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore(),
+            networkProxyPasswordStore: InMemoryProxyPasswordStore())
+
+        #expect(settings.networkProxyStatusText == "Proxy is off.")
+        #expect(settings.networkProxyStatusIsActive == false)
+
+        settings.networkProxyEnabled = true
+        settings.networkProxyHost = "proxy.example.com"
+        settings.networkProxyPort = "1080"
+
+        #expect(settings.networkProxyStatusIsActive == true)
+        #expect(
+            settings.networkProxyStatusText
+                == "Proxy is active and will route provider requests through proxy.example.com:1080.")
+    }
+}

--- a/Tests/CodexBarTests/NetworkProxyTests.swift
+++ b/Tests/CodexBarTests/NetworkProxyTests.swift
@@ -101,14 +101,14 @@ struct NetworkProxyTests {
             password: "secret")
 
         let dictionary = try #require(configuration.connectionProxyDictionary as? [String: Any])
-        #expect(dictionary[kCFNetworkProxiesHTTPEnable as String] as? Int == 1)
-        #expect(dictionary[kCFNetworkProxiesHTTPProxy as String] as? String == "proxy.example.com")
-        #expect(dictionary[kCFNetworkProxiesHTTPPort as String] as? Int == 8080)
-        #expect(dictionary[kCFNetworkProxiesHTTPSEnable as String] as? Int == 1)
-        #expect(dictionary[kCFNetworkProxiesHTTPSProxy as String] as? String == "proxy.example.com")
-        #expect(dictionary[kCFNetworkProxiesHTTPSPort as String] as? Int == 8080)
-        #expect(dictionary[kCFProxyUsernameKey as String] as? String == "alice")
-        #expect(dictionary[kCFProxyPasswordKey as String] as? String == "secret")
+        #expect(dictionary["HTTPEnable"] as? Int == 1)
+        #expect(dictionary["HTTPProxy"] as? String == "proxy.example.com")
+        #expect(dictionary["HTTPPort"] as? Int == 8080)
+        #expect(dictionary["HTTPSEnable"] as? Int == 1)
+        #expect(dictionary["HTTPSProxy"] as? String == "proxy.example.com")
+        #expect(dictionary["HTTPSPort"] as? Int == 8080)
+        #expect(dictionary["HTTPUser"] as? String == "alice")
+        #expect(dictionary["HTTPPassword"] as? String == "secret")
     }
 
     @Test
@@ -125,11 +125,11 @@ struct NetworkProxyTests {
             password: "secret")
 
         let dictionary = try #require(configuration.connectionProxyDictionary as? [String: Any])
-        #expect(dictionary[kCFNetworkProxiesSOCKSEnable as String] as? Int == 1)
-        #expect(dictionary[kCFNetworkProxiesSOCKSProxy as String] as? String == "proxy.example.com")
-        #expect(dictionary[kCFNetworkProxiesSOCKSPort as String] as? Int == 1080)
-        #expect(dictionary[kCFProxyUsernameKey as String] as? String == "alice")
-        #expect(dictionary[kCFProxyPasswordKey as String] as? String == "secret")
+        #expect(dictionary["SOCKSEnable"] as? Int == 1)
+        #expect(dictionary["SOCKSProxy"] as? String == "proxy.example.com")
+        #expect(dictionary["SOCKSPort"] as? Int == 1080)
+        #expect(dictionary["SOCKSUser"] as? String == "alice")
+        #expect(dictionary["SOCKSPassword"] as? String == "secret")
     }
 
     @Test

--- a/Tests/CodexBarTests/NetworkProxyTests.swift
+++ b/Tests/CodexBarTests/NetworkProxyTests.swift
@@ -6,6 +6,27 @@ import Testing
 import Security
 #endif
 
+final class FailingOnLoadProxyPasswordStore: NetworkProxyPasswordStoring, @unchecked Sendable {
+    var value: String?
+    var shouldFailOnLoad = false
+
+    init(value: String? = nil) {
+        self.value = value
+    }
+
+    func loadPassword() throws -> String? {
+        if self.shouldFailOnLoad {
+            struct LoadFailure: Error {}
+            throw LoadFailure()
+        }
+        return self.value
+    }
+
+    func storePassword(_ password: String?) throws {
+        self.value = password
+    }
+}
+
 @Suite(.serialized)
 @MainActor
 struct NetworkProxyTests {
@@ -168,6 +189,51 @@ struct NetworkProxyTests {
         #expect(
             settings.networkProxyStatusText
                 == "Proxy is active and will route provider requests through proxy.example.com:1080.")
+    }
+
+    @Test
+    func `proxy auth stays cached when password load fails during sync`() throws {
+        ProviderHTTPClient.shared.update(proxy: nil, password: nil)
+        defer { ProviderHTTPClient.shared.update(proxy: nil, password: nil) }
+
+        let suite = "NetworkProxyTests-sync-password-cache"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let passwordStore = FailingOnLoadProxyPasswordStore()
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            kimiK2TokenStore: InMemoryKimiK2TokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore(),
+            networkProxyPasswordStore: passwordStore)
+
+        settings.networkProxyEnabled = true
+        settings.networkProxyHost = "proxy.example.com"
+        settings.networkProxyPort = "8080"
+        settings.networkProxyUsername = "alice"
+        settings.networkProxyPassword = "secret"
+
+        #expect(ProviderHTTPClient.shared.currentPassword() == "secret")
+        #expect(ProviderHTTPClient.shared.currentProxyConfiguration()?.host == "proxy.example.com")
+
+        passwordStore.shouldFailOnLoad = true
+        settings.networkProxyHost = "proxy2.example.com"
+
+        #expect(ProviderHTTPClient.shared.currentPassword() == "secret")
+        #expect(ProviderHTTPClient.shared.currentProxyConfiguration()?.host == "proxy2.example.com")
     }
 
     #if os(macOS)

--- a/Tests/CodexBarTests/NetworkProxyTests.swift
+++ b/Tests/CodexBarTests/NetworkProxyTests.swift
@@ -2,6 +2,9 @@ import CodexBarCore
 import Foundation
 import Testing
 @testable import CodexBar
+#if os(macOS)
+import Security
+#endif
 
 @Suite(.serialized)
 @MainActor
@@ -166,4 +169,22 @@ struct NetworkProxyTests {
             settings.networkProxyStatusText
                 == "Proxy is active and will route provider requests through proxy.example.com:1080.")
     }
+
+    #if os(macOS)
+    @Test
+    func `temporary keychain unavailability is treated as proxy password store failure`() {
+        let store = KeychainNetworkProxyPasswordStore()
+
+        KeychainCacheStore.withLoadFailureStatusOverrideForTesting(errSecInteractionNotAllowed) {
+            do {
+                _ = try store.loadPassword()
+                #expect(Bool(false), "Expected proxy password load to fail")
+            } catch NetworkProxyPasswordStoreError.keychainUnavailable {
+                #expect(true)
+            } catch {
+                #expect(Bool(false), "Expected keychainUnavailable, got \(error)")
+            }
+        }
+    }
+    #endif
 }

--- a/Tests/CodexBarTests/NetworkProxyTests.swift
+++ b/Tests/CodexBarTests/NetworkProxyTests.swift
@@ -236,6 +236,62 @@ struct NetworkProxyTests {
         #expect(ProviderHTTPClient.shared.currentProxyConfiguration()?.host == "proxy2.example.com")
     }
 
+    @Test
+    func `proxy password load is retried after startup keychain failure`() async throws {
+        ProviderHTTPClient.shared.update(proxy: nil, password: nil)
+        let originalDelays = SettingsStore.networkProxyPasswordRetryDelays
+        SettingsStore.networkProxyPasswordRetryDelays = [.milliseconds(5)]
+        defer {
+            ProviderHTTPClient.shared.update(proxy: nil, password: nil)
+            SettingsStore.networkProxyPasswordRetryDelays = originalDelays
+        }
+
+        let suite = "NetworkProxyTests-startup-password-retry"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        try configStore.save(CodexBarConfig(
+            providers: [],
+            networkProxy: NetworkProxyConfiguration(
+                enabled: true,
+                scheme: .http,
+                host: "proxy.example.com",
+                port: "8080",
+                username: "alice")))
+        let passwordStore = FailingOnLoadProxyPasswordStore(value: "secret")
+        passwordStore.shouldFailOnLoad = true
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            kimiK2TokenStore: InMemoryKimiK2TokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore(),
+            networkProxyPasswordStore: passwordStore)
+        _ = settings
+
+        #expect(ProviderHTTPClient.shared.currentProxyConfiguration()?.host == "proxy.example.com")
+        #expect(ProviderHTTPClient.shared.currentPassword() == nil)
+
+        passwordStore.shouldFailOnLoad = false
+        try await Task.sleep(for: .milliseconds(30))
+
+        #expect(ProviderHTTPClient.shared.currentPassword() == "secret")
+        #expect(ProviderHTTPClient.shared.currentProxyConfiguration()?.host == "proxy.example.com")
+    }
+
     #if os(macOS)
     @Test
     func `temporary keychain unavailability is treated as proxy password store failure`() {

--- a/Tests/CodexBarTests/TestStores.swift
+++ b/Tests/CodexBarTests/TestStores.swift
@@ -21,6 +21,22 @@ final class InMemoryCookieHeaderStore: CookieHeaderStoring, @unchecked Sendable 
     }
 }
 
+final class InMemoryProxyPasswordStore: NetworkProxyPasswordStoring, @unchecked Sendable {
+    var value: String?
+
+    init(value: String? = nil) {
+        self.value = value
+    }
+
+    func loadPassword() throws -> String? {
+        self.value
+    }
+
+    func storePassword(_ password: String?) throws {
+        self.value = password
+    }
+}
+
 final class InMemoryMiniMaxCookieStore: MiniMaxCookieStoring, @unchecked Sendable {
     var value: String?
 


### PR DESCRIPTION
## Summary
Add a global proxy setting for provider network traffic in `Advanced` settings. Supports `HTTP` and `SOCKS5`, with `host`, `port`, `username`, and password stored in Keychain.

## What changed
- Added `networkProxy` to app config and validation for host/port
- Added a shared proxy-aware HTTP client for provider requests
- Routed provider fetches through that client, including custom-session call sites
- Added Keychain-backed storage for the proxy password
- Added Advanced settings UI for enabling and configuring the proxy
- Added status text so users can see whether the proxy is actually active

## Scope
- Applies only to provider HTTP requests inside the app
- Does not change browser cookie import, PTY, or CLI behavior
- Does not add PAC, bypass lists, or per-provider proxy overrides

## Testing
- `./Scripts/compile_and_run.sh`
- `swift test --filter NetworkProxyTests -q`

## Prior art
This is a narrower follow-up to the closed proxy attempt in #597, which replaced `URLSession.shared` directly and did not keep the password out of plain config.

## Dependency
This PR also relies on SweetCookieKit's Yandex Browser support: https://github.com/steipete/SweetCookieKit/pull/9
