### PR TITLE
Harden Codex cost scanner fork and refresh handling

### DIFF
--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageCache.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageCache.swift
@@ -4,7 +4,7 @@ enum CostUsageCacheIO {
     private static func artifactVersion(for provider: UsageProvider) -> Int {
         switch provider {
         case .codex:
-            3
+            4
         case .claude, .vertexai:
             2
         default:

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageCache.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageCache.swift
@@ -4,7 +4,7 @@ enum CostUsageCacheIO {
     private static func artifactVersion(for provider: UsageProvider) -> Int {
         switch provider {
         case .codex:
-            2
+            3
         case .claude, .vertexai:
             2
         default:
@@ -77,6 +77,7 @@ struct CostUsageFileUsage: Codable {
     var lastModel: String?
     var lastTotals: CostUsageCodexTotals?
     var sessionId: String?
+    var forkedFromId: String?
     var claudeRows: [CostUsageScanner.ClaudeUsageRow]?
 }
 

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner+Timestamp.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner+Timestamp.swift
@@ -26,6 +26,10 @@ private enum CostUsageTimestampParser {
 }
 
 extension CostUsageScanner {
+    static func dateFromTimestamp(_ text: String) -> Date? {
+        CostUsageTimestampParser.parseISO(text)
+    }
+
     static func dayKeyFromTimestamp(_ text: String) -> String? {
         let bytes = Array(text.utf8)
         guard bytes.count >= 20 else { return nil }

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+// swiftlint:disable type_body_length
 enum CostUsageScanner {
     private static let log = CodexBarLog.logger(LogCategories.tokenCost)
 
@@ -53,14 +54,22 @@ enum CostUsageScanner {
         let totals: CostUsageCodexTotals
     }
 
+    private struct CodexScanResources {
+        let fileIndex: CodexSessionFileIndex
+        let inheritedResolver: CodexInheritedTotalsResolver
+    }
+
     private final class CodexSessionFileIndex {
         private let files: [URL]
+        private let roots: [URL]
         private var nextUnindexedFile = 0
         private var fileURLBySessionId: [String: URL] = [:]
         private var missingSessionIds: Set<String> = []
 
-        init(files: [URL]) {
+        init(files: [URL], roots: [URL], cachedSessionFiles: [String: URL] = [:]) {
             self.files = files
+            self.roots = roots
+            self.fileURLBySessionId = cachedSessionFiles
         }
 
         func remember(fileURL: URL, sessionId: String?) {
@@ -88,6 +97,28 @@ enum CostUsageScanner {
                 }
             }
 
+            for root in self.roots {
+                guard let enumerator = FileManager.default.enumerator(
+                    at: root,
+                    includingPropertiesForKeys: [.isRegularFileKey],
+                    options: [.skipsHiddenFiles, .skipsPackageDescendants])
+                else { continue }
+
+                while let fileURL = enumerator.nextObject() as? URL {
+                    guard fileURL.pathExtension.lowercased() == "jsonl" else { continue }
+                    if self.files.contains(where: { $0.path == fileURL.path }) {
+                        continue
+                    }
+                    guard let indexedSessionId = CostUsageScanner.parseCodexSessionIdentifier(fileURL: fileURL) else {
+                        continue
+                    }
+                    self.fileURLBySessionId[indexedSessionId] = fileURL
+                    if indexedSessionId == sessionId {
+                        return fileURL
+                    }
+                }
+            }
+
             self.missingSessionIds.insert(sessionId)
             return nil
         }
@@ -112,11 +143,10 @@ enum CostUsageScanner {
             let snapshots = self.snapshots(for: sessionId)
             var inherited: CostUsageCodexTotals?
             for snapshot in snapshots {
-                let isAtOrBefore: Bool
-                if let snapshotDate = snapshot.date, let cutoffDate {
-                    isAtOrBefore = snapshotDate <= cutoffDate
+                let isAtOrBefore: Bool = if let snapshotDate = snapshot.date, let cutoffDate {
+                    snapshotDate <= cutoffDate
                 } else {
-                    isAtOrBefore = snapshot.timestamp <= cutoffTimestamp
+                    snapshot.timestamp <= cutoffTimestamp
                 }
                 if isAtOrBefore {
                     inherited = snapshot.totals
@@ -273,8 +303,8 @@ enum CostUsageScanner {
         root: URL,
         scanSinceKey: String,
         scanUntilKey: String,
-        includeRecursive: Bool
-    ) -> [URL] {
+        includeRecursive: Bool) -> [URL]
+    {
         let partitioned = self.listCodexSessionFilesByDatePartition(
             root: root,
             scanSinceKey: scanSinceKey,
@@ -288,6 +318,71 @@ enum CostUsageScanner {
             out.append(item)
         }
         return out
+    }
+
+    private static func cachedCodexSessionFiles(
+        cache: CostUsageCache,
+        range: CostUsageDayRange,
+        roots: [URL]) -> [URL]
+    {
+        cache.files.compactMap { path, usage in
+            let hasRelevantDay = usage.days.keys.contains {
+                CostUsageDayRange.isInRange(dayKey: $0, since: range.scanSinceKey, until: range.scanUntilKey)
+            }
+            guard hasRelevantDay else { return nil }
+            guard FileManager.default.fileExists(atPath: path) else { return nil }
+            let fileURL = URL(fileURLWithPath: path)
+            guard Self.isWithinCodexRoots(fileURL: fileURL, roots: roots) else { return nil }
+            return fileURL
+        }
+    }
+
+    private static func cachedCodexSessionIndex(cache: CostUsageCache, roots: [URL]) -> [String: URL] {
+        var out: [String: URL] = [:]
+        for (path, usage) in cache.files {
+            guard let sessionId = usage.sessionId, !sessionId.isEmpty else { continue }
+            guard FileManager.default.fileExists(atPath: path) else { continue }
+            let fileURL = URL(fileURLWithPath: path)
+            guard Self.isWithinCodexRoots(fileURL: fileURL, roots: roots) else { continue }
+            out[sessionId] = fileURL
+        }
+        return out
+    }
+
+    private static func codexRootsFingerprint(_ roots: [URL]) -> [String: Int64] {
+        var out: [String: Int64] = [:]
+        for root in roots {
+            out[root.standardizedFileURL.path] = 0
+        }
+        return out
+    }
+
+    private static func listCodexRecentlyModifiedFiles(root: URL, modifiedSince: Date) -> [URL] {
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants])
+        else { return [] }
+
+        var out: [URL] = []
+        while let fileURL = enumerator.nextObject() as? URL {
+            guard fileURL.pathExtension.lowercased() == "jsonl" else { continue }
+            let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .contentModificationDateKey])
+            guard values?.isRegularFile == true else { continue }
+            guard let modifiedAt = values?.contentModificationDate, modifiedAt >= modifiedSince else { continue }
+            out.append(fileURL)
+        }
+        return out
+    }
+
+    private static func isWithinCodexRoots(fileURL: URL, roots: [URL]) -> Bool {
+        let filePath = fileURL.standardizedFileURL.path
+        return roots.contains { root in
+            let rootPath = root.standardizedFileURL.path
+            if filePath == rootPath { return true }
+            let prefix = rootPath.hasSuffix("/") ? rootPath : rootPath + "/"
+            return filePath.hasPrefix(prefix)
+        }
     }
 
     private static func listCodexSessionFilesByDatePartition(
@@ -381,7 +476,17 @@ enum CostUsageScanner {
         return String(describing: identifier)
     }
 
+    private struct CodexSessionMetadata {
+        let sessionId: String?
+        let forkedFromId: String?
+        let forkTimestamp: String?
+    }
+
     private static func parseCodexSessionIdentifier(fileURL: URL) -> String? {
+        self.parseCodexSessionMetadata(fileURL: fileURL)?.sessionId
+    }
+
+    private static func parseCodexSessionMetadata(fileURL: URL) -> CodexSessionMetadata? {
         let handle: FileHandle
         do {
             handle = try FileHandle(forReadingFrom: fileURL)
@@ -396,17 +501,24 @@ enum CostUsageScanner {
         var buffer = Data()
         let newline = Data([0x0A])
 
-        func parseSessionIdentifier(from lineData: Data) -> String? {
+        func parseSessionMetadata(from lineData: Data) -> CodexSessionMetadata? {
             guard !lineData.isEmpty else { return nil }
             guard let obj = (try? JSONSerialization.jsonObject(with: lineData)) as? [String: Any] else { return nil }
             guard obj["type"] as? String == "session_meta" else { return nil }
             let payload = obj["payload"] as? [String: Any]
-            return payload?["session_id"] as? String
-                ?? payload?["sessionId"] as? String
-                ?? payload?["id"] as? String
-                ?? obj["session_id"] as? String
-                ?? obj["sessionId"] as? String
-                ?? obj["id"] as? String
+            return CodexSessionMetadata(
+                sessionId: payload?["session_id"] as? String
+                    ?? payload?["sessionId"] as? String
+                    ?? payload?["id"] as? String
+                    ?? obj["session_id"] as? String
+                    ?? obj["sessionId"] as? String
+                    ?? obj["id"] as? String,
+                forkedFromId: payload?["forked_from_id"] as? String
+                    ?? payload?["forkedFromId"] as? String
+                    ?? payload?["parent_session_id"] as? String
+                    ?? payload?["parentSessionId"] as? String,
+                forkTimestamp: payload?["timestamp"] as? String
+                    ?? obj["timestamp"] as? String)
         }
 
         do {
@@ -415,8 +527,8 @@ enum CostUsageScanner {
                 while let newlineRange = buffer.range(of: newline) {
                     let lineData = buffer.subdata(in: 0..<newlineRange.lowerBound)
                     buffer.removeSubrange(0..<newlineRange.upperBound)
-                    if let sessionId = parseSessionIdentifier(from: lineData) {
-                        return sessionId
+                    if let metadata = parseSessionMetadata(from: lineData) {
+                        return metadata
                     }
                 }
             }
@@ -427,16 +539,16 @@ enum CostUsageScanner {
             return nil
         }
 
-        if let sessionId = parseSessionIdentifier(from: buffer) {
-            return sessionId
+        if let metadata = parseSessionMetadata(from: buffer) {
+            return metadata
         }
         return nil
     }
 
     private static func parseCodexTokenSnapshots(fileURL: URL) -> (
         sessionId: String?,
-        snapshots: [CodexTimestampedTotals]
-    ) {
+        snapshots: [CodexTimestampedTotals])
+    {
         var sessionId: String?
         var previousTotals: CostUsageCodexTotals?
         var snapshots: [CodexTimestampedTotals] = []
@@ -447,7 +559,8 @@ enum CostUsageScanner {
             if date == nil, !warnedAboutUnparsedTimestamp {
                 warnedAboutUnparsedTimestamp = true
                 self.log.warning(
-                    "Codex cost usage could not parse parent token snapshot timestamp; falling back to lexical comparison",
+                    "Codex cost usage could not parse parent token snapshot timestamp; "
+                        + "falling back to lexical comparison",
                     metadata: ["path": fileURL.path, "timestamp": timestamp])
             }
             return date
@@ -460,7 +573,8 @@ enum CostUsageScanner {
                 prefixBytes: 512 * 1024,
                 onLine: { line in
                     guard !line.bytes.isEmpty, !line.wasTruncated else { return }
-                    guard let obj = (try? JSONSerialization.jsonObject(with: line.bytes)) as? [String: Any] else { return }
+                    guard let obj = (try? JSONSerialization.jsonObject(with: line.bytes)) as? [String: Any]
+                    else { return }
 
                     if obj["type"] as? String == "session_meta" {
                         let payload = obj["payload"] as? [String: Any]
@@ -518,6 +632,7 @@ enum CostUsageScanner {
         return (sessionId, snapshots)
     }
 
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
     static func parseCodexFile(
         fileURL: URL,
         range: CostUsageDayRange,
@@ -531,6 +646,7 @@ enum CostUsageScanner {
         var sessionId: String?
         var forkedFromId: String?
         var inheritedTotals: CostUsageCodexTotals?
+        var remainingInheritedTotals: CostUsageCodexTotals?
 
         var days: [String: [String: [Int]]] = [:]
 
@@ -551,6 +667,20 @@ enum CostUsageScanner {
         let maxLineBytes = 256 * 1024
         let prefixBytes = 32 * 1024
 
+        if startOffset == 0,
+           let metadata = Self.parseCodexSessionMetadata(fileURL: fileURL)
+        {
+            sessionId = metadata.sessionId
+            forkedFromId = metadata.forkedFromId
+            if let forkedFromId = metadata.forkedFromId,
+               inheritedTotals == nil
+            {
+                let forkedAt = metadata.forkTimestamp ?? ""
+                inheritedTotals = inheritedTotalsResolver?(forkedFromId, forkedAt)
+                remainingInheritedTotals = inheritedTotals
+            }
+        }
+
         let parsedBytes: Int64
         do {
             parsedBytes = try CostUsageJsonl.scan(
@@ -559,124 +689,155 @@ enum CostUsageScanner {
                 maxLineBytes: maxLineBytes,
                 prefixBytes: prefixBytes,
                 onLine: { line in
-                guard !line.bytes.isEmpty else { return }
-                guard !line.wasTruncated else { return }
+                    guard !line.bytes.isEmpty else { return }
+                    guard !line.wasTruncated else { return }
 
-                guard
-                    line.bytes.containsAscii(#""type":"event_msg""#)
-                    || line.bytes.containsAscii(#""type":"turn_context""#)
-                    || line.bytes.containsAscii(#""type":"session_meta""#)
-                else { return }
+                    guard
+                        line.bytes.containsAscii(#""type":"event_msg""#)
+                        || line.bytes.containsAscii(#""type":"turn_context""#)
+                        || line.bytes.containsAscii(#""type":"session_meta""#)
+                    else { return }
 
-                if line.bytes.containsAscii(#""type":"event_msg""#), !line.bytes.containsAscii(#""token_count""#) {
-                    return
-                }
-
-                guard
-                    let obj = (try? JSONSerialization.jsonObject(with: line.bytes)) as? [String: Any],
-                    let type = obj["type"] as? String
-                else { return }
-
-                if type == "session_meta" {
-                    let payload = obj["payload"] as? [String: Any]
-                    if sessionId == nil {
-                        sessionId = payload?["session_id"] as? String
-                            ?? payload?["sessionId"] as? String
-                            ?? payload?["id"] as? String
-                            ?? obj["session_id"] as? String
-                            ?? obj["sessionId"] as? String
-                            ?? obj["id"] as? String
+                    if line.bytes.containsAscii(#""type":"event_msg""#), !line.bytes.containsAscii(#""token_count""#) {
+                        return
                     }
-                    if forkedFromId == nil {
-                        forkedFromId = payload?["forked_from_id"] as? String
-                            ?? payload?["forkedFromId"] as? String
-                            ?? payload?["parent_session_id"] as? String
-                            ?? payload?["parentSessionId"] as? String
-                    }
-                    if inheritedTotals == nil, let forkedFromId {
-                        let forkedAt = payload?["timestamp"] as? String
-                            ?? obj["timestamp"] as? String
-                            ?? ""
-                        inheritedTotals = inheritedTotalsResolver?(forkedFromId, forkedAt)
-                    }
-                    return
-                }
 
-                guard let tsText = obj["timestamp"] as? String else { return }
-                guard let dayKey = Self.dayKeyFromTimestamp(tsText) ?? Self.dayKeyFromParsedISO(tsText) else { return }
+                    guard
+                        let obj = (try? JSONSerialization.jsonObject(with: line.bytes)) as? [String: Any],
+                        let type = obj["type"] as? String
+                    else { return }
 
-                if type == "turn_context" {
-                    if let payload = obj["payload"] as? [String: Any] {
-                        if let model = payload["model"] as? String {
-                            currentModel = model
-                        } else if let info = payload["info"] as? [String: Any], let model = info["model"] as? String {
-                            currentModel = model
+                    if type == "session_meta" {
+                        let payload = obj["payload"] as? [String: Any]
+                        if sessionId == nil {
+                            sessionId = payload?["session_id"] as? String
+                                ?? payload?["sessionId"] as? String
+                                ?? payload?["id"] as? String
+                                ?? obj["session_id"] as? String
+                                ?? obj["sessionId"] as? String
+                                ?? obj["id"] as? String
                         }
+                        if forkedFromId == nil {
+                            forkedFromId = payload?["forked_from_id"] as? String
+                                ?? payload?["forkedFromId"] as? String
+                                ?? payload?["parent_session_id"] as? String
+                                ?? payload?["parentSessionId"] as? String
+                        }
+                        if inheritedTotals == nil, let forkedFromId {
+                            let forkedAt = payload?["timestamp"] as? String
+                                ?? obj["timestamp"] as? String
+                                ?? ""
+                            inheritedTotals = inheritedTotalsResolver?(forkedFromId, forkedAt)
+                            remainingInheritedTotals = inheritedTotals
+                        }
+                        return
                     }
-                    return
-                }
 
-                guard type == "event_msg" else { return }
-                guard let payload = obj["payload"] as? [String: Any] else { return }
-                guard (payload["type"] as? String) == "token_count" else { return }
+                    guard let tsText = obj["timestamp"] as? String else { return }
+                    guard let dayKey = Self.dayKeyFromTimestamp(tsText) ?? Self.dayKeyFromParsedISO(tsText)
+                    else { return }
 
-                let info = payload["info"] as? [String: Any]
-                let modelFromInfo = info?["model"] as? String
-                    ?? info?["model_name"] as? String
-                    ?? payload["model"] as? String
-                    ?? obj["model"] as? String
-                let model = modelFromInfo ?? currentModel ?? "gpt-5"
+                    if type == "turn_context" {
+                        if let payload = obj["payload"] as? [String: Any] {
+                            if let model = payload["model"] as? String {
+                                currentModel = model
+                            } else if let info = payload["info"] as? [String: Any],
+                                      let model = info["model"] as? String
+                            {
+                                currentModel = model
+                            }
+                        }
+                        return
+                    }
 
-                func toInt(_ v: Any?) -> Int {
-                    if let n = v as? NSNumber { return n.intValue }
-                    return 0
-                }
+                    guard type == "event_msg" else { return }
+                    guard let payload = obj["payload"] as? [String: Any] else { return }
+                    guard (payload["type"] as? String) == "token_count" else { return }
 
-                let total = (info?["total_token_usage"] as? [String: Any])
-                let last = (info?["last_token_usage"] as? [String: Any])
+                    let info = payload["info"] as? [String: Any]
+                    let modelFromInfo = info?["model"] as? String
+                        ?? info?["model_name"] as? String
+                        ?? payload["model"] as? String
+                        ?? obj["model"] as? String
+                    let model = modelFromInfo ?? currentModel ?? "gpt-5"
 
-                var deltaInput = 0
-                var deltaCached = 0
-                var deltaOutput = 0
+                    func toInt(_ v: Any?) -> Int {
+                        if let n = v as? NSNumber { return n.intValue }
+                        return 0
+                    }
 
-                if let total {
-                    let rawTotals = CostUsageCodexTotals(
-                        input: toInt(total["input_tokens"]),
-                        cached: toInt(total["cached_input_tokens"] ?? total["cache_read_input_tokens"]),
-                        output: toInt(total["output_tokens"]))
+                    let total = (info?["total_token_usage"] as? [String: Any])
+                    let last = (info?["last_token_usage"] as? [String: Any])
 
-                    let currentTotals: CostUsageCodexTotals
-                    if let inheritedTotals {
-                        currentTotals = CostUsageCodexTotals(
-                            input: max(0, rawTotals.input - inheritedTotals.input),
-                            cached: max(0, rawTotals.cached - inheritedTotals.cached),
-                            output: max(0, rawTotals.output - inheritedTotals.output))
+                    var deltaInput = 0
+                    var deltaCached = 0
+                    var deltaOutput = 0
+
+                    func adjustedLastDelta(_ rawDelta: CostUsageCodexTotals) -> CostUsageCodexTotals {
+                        guard var remaining = remainingInheritedTotals else { return rawDelta }
+
+                        let adjusted = CostUsageCodexTotals(
+                            input: max(0, rawDelta.input - remaining.input),
+                            cached: max(0, rawDelta.cached - remaining.cached),
+                            output: max(0, rawDelta.output - remaining.output))
+
+                        remaining.input = max(0, remaining.input - rawDelta.input)
+                        remaining.cached = max(0, remaining.cached - rawDelta.cached)
+                        remaining.output = max(0, remaining.output - rawDelta.output)
+                        remainingInheritedTotals = if remaining.input == 0, remaining.cached == 0,
+                                                      remaining.output == 0
+                        {
+                            nil
+                        } else {
+                            remaining
+                        }
+
+                        return adjusted
+                    }
+
+                    if let total {
+                        let rawTotals = CostUsageCodexTotals(
+                            input: toInt(total["input_tokens"]),
+                            cached: toInt(total["cached_input_tokens"] ?? total["cache_read_input_tokens"]),
+                            output: toInt(total["output_tokens"]))
+
+                        let currentTotals: CostUsageCodexTotals = if let inheritedTotals {
+                            CostUsageCodexTotals(
+                                input: max(0, rawTotals.input - inheritedTotals.input),
+                                cached: max(0, rawTotals.cached - inheritedTotals.cached),
+                                output: max(0, rawTotals.output - inheritedTotals.output))
+                        } else {
+                            rawTotals
+                        }
+
+                        let prev = previousTotals ?? .init(input: 0, cached: 0, output: 0)
+                        deltaInput = max(0, currentTotals.input - prev.input)
+                        deltaCached = max(0, currentTotals.cached - prev.cached)
+                        deltaOutput = max(0, currentTotals.output - prev.output)
+                        previousTotals = currentTotals
+                        remainingInheritedTotals = nil
+                    } else if let last {
+                        let rawDelta = CostUsageCodexTotals(
+                            input: max(0, toInt(last["input_tokens"])),
+                            cached: max(0, toInt(last["cached_input_tokens"] ?? last["cache_read_input_tokens"])),
+                            output: max(0, toInt(last["output_tokens"])))
+                        let adjustedDelta = adjustedLastDelta(rawDelta)
+                        deltaInput = adjustedDelta.input
+                        deltaCached = adjustedDelta.cached
+                        deltaOutput = adjustedDelta.output
+                        let prev = previousTotals ?? .init(input: 0, cached: 0, output: 0)
+                        previousTotals = CostUsageCodexTotals(
+                            input: prev.input + deltaInput,
+                            cached: prev.cached + deltaCached,
+                            output: prev.output + deltaOutput)
                     } else {
-                        currentTotals = rawTotals
+                        return
                     }
 
-                    let prev = previousTotals ?? .init(input: 0, cached: 0, output: 0)
-                    deltaInput = max(0, currentTotals.input - prev.input)
-                    deltaCached = max(0, currentTotals.cached - prev.cached)
-                    deltaOutput = max(0, currentTotals.output - prev.output)
-                    previousTotals = currentTotals
-                } else if let last {
-                    deltaInput = max(0, toInt(last["input_tokens"]))
-                    deltaCached = max(0, toInt(last["cached_input_tokens"] ?? last["cache_read_input_tokens"]))
-                    deltaOutput = max(0, toInt(last["output_tokens"]))
-                    let prev = previousTotals ?? .init(input: 0, cached: 0, output: 0)
-                    previousTotals = CostUsageCodexTotals(
-                        input: prev.input + deltaInput,
-                        cached: prev.cached + deltaCached,
-                        output: prev.output + deltaOutput)
-                } else {
-                    return
-                }
-
-                if deltaInput == 0, deltaCached == 0, deltaOutput == 0 { return }
-                let cachedClamp = min(deltaCached, deltaInput)
-                add(dayKey: dayKey, model: model, input: deltaInput, cached: cachedClamp, output: deltaOutput)
-            })
+                    if deltaInput == 0, deltaCached == 0, deltaOutput == 0 { return }
+                    let cachedClamp = min(deltaCached, deltaInput)
+                    add(dayKey: dayKey, model: model, input: deltaInput, cached: cachedClamp, output: deltaOutput)
+                })
         } catch {
             self.log.warning(
                 "Codex cost usage failed while scanning session file",
@@ -698,8 +859,7 @@ enum CostUsageScanner {
         range: CostUsageDayRange,
         cache: inout CostUsageCache,
         state: inout CodexScanState,
-        fileIndex: CodexSessionFileIndex,
-        inheritedResolver: CodexInheritedTotalsResolver)
+        resources: CodexScanResources)
     {
         let path = fileURL.path
         let attrs = (try? FileManager.default.attributesOfItem(atPath: path)) ?? [:]
@@ -776,7 +936,7 @@ enum CostUsageScanner {
                     forkedFromId: delta.forkedFromId ?? cached.forkedFromId)
                 if let sessionId {
                     state.seenSessionIds.insert(sessionId)
-                    fileIndex.remember(fileURL: fileURL, sessionId: sessionId)
+                    resources.fileIndex.remember(fileURL: fileURL, sessionId: sessionId)
                 }
                 if let fileId {
                     state.seenFileIds.insert(fileId)
@@ -792,7 +952,7 @@ enum CostUsageScanner {
         let parsed = Self.parseCodexFile(
             fileURL: fileURL,
             range: range,
-            inheritedTotalsResolver: inheritedResolver.inheritedTotals(for:atOrBefore:))
+            inheritedTotalsResolver: resources.inheritedResolver.inheritedTotals(for:atOrBefore:))
         let sessionId = parsed.sessionId ?? cached?.sessionId
         if let sessionId, state.seenSessionIds.contains(sessionId) {
             cache.files.removeValue(forKey: path)
@@ -812,7 +972,7 @@ enum CostUsageScanner {
         Self.applyFileDays(cache: &cache, fileDays: usage.days, sign: 1)
         if let sessionId {
             state.seenSessionIds.insert(sessionId)
-            fileIndex.remember(fileURL: fileURL, sessionId: sessionId)
+            resources.fileIndex.remember(fileURL: fileURL, sessionId: sessionId)
         }
         if let fileId {
             state.seenFileIds.insert(fileId)
@@ -835,6 +995,12 @@ enum CostUsageScanner {
             }
 
             let roots = self.codexSessionsRoots(options: options)
+            let includeRecursive = options.forceRescan
+            let rootsFingerprint = Self.codexRootsFingerprint(roots)
+            let rootsChanged = cache.roots != nil && cache.roots != rootsFingerprint
+            let shouldRunColdCacheLookback = cache.files.isEmpty || rootsChanged
+            let coldCacheLookbackStart = Self.parseDayKey(range.scanSinceKey)
+                .map { Calendar.current.startOfDay(for: $0) }
             var seenPaths: Set<String> = []
             var files: [URL] = []
             for root in roots {
@@ -842,25 +1008,51 @@ enum CostUsageScanner {
                     root: root,
                     scanSinceKey: range.scanSinceKey,
                     scanUntilKey: range.scanUntilKey,
-                    includeRecursive: true)
+                    includeRecursive: includeRecursive)
                 for fileURL in rootFiles.sorted(by: { $0.path < $1.path }) where !seenPaths.contains(fileURL.path) {
                     seenPaths.insert(fileURL.path)
                     files.append(fileURL)
                 }
+
+                if !includeRecursive, shouldRunColdCacheLookback, let coldCacheLookbackStart {
+                    let recentlyModifiedFiles = Self.listCodexRecentlyModifiedFiles(
+                        root: root,
+                        modifiedSince: coldCacheLookbackStart)
+                    for fileURL in recentlyModifiedFiles.sorted(by: { $0.path < $1.path })
+                        where !seenPaths.contains(fileURL.path)
+                    {
+                        seenPaths.insert(fileURL.path)
+                        files.append(fileURL)
+                    }
+                }
             }
+
+            for fileURL in Self.cachedCodexSessionFiles(cache: cache, range: range, roots: roots)
+                .sorted(by: { $0.path < $1.path })
+                where !seenPaths.contains(fileURL.path)
+            {
+                seenPaths.insert(fileURL.path)
+                files.append(fileURL)
+            }
+
             let filePathsInScan = Set(files.map(\.path))
 
             var scanState = CodexScanState()
-            let fileIndex = CodexSessionFileIndex(files: files)
+            let fileIndex = CodexSessionFileIndex(
+                files: files,
+                roots: includeRecursive ? [] : roots,
+                cachedSessionFiles: Self.cachedCodexSessionIndex(cache: cache, roots: roots))
             let inheritedResolver = CodexInheritedTotalsResolver(fileIndex: fileIndex)
+            let resources = CodexScanResources(
+                fileIndex: fileIndex,
+                inheritedResolver: inheritedResolver)
             for fileURL in files {
                 Self.scanCodexFile(
                     fileURL: fileURL,
                     range: range,
                     cache: &cache,
                     state: &scanState,
-                    fileIndex: fileIndex,
-                    inheritedResolver: inheritedResolver)
+                    resources: resources)
             }
 
             for key in cache.files.keys where !filePathsInScan.contains(key) {
@@ -871,6 +1063,7 @@ enum CostUsageScanner {
             }
 
             Self.pruneDays(cache: &cache, sinceKey: range.scanSinceKey, untilKey: range.scanUntilKey)
+            cache.roots = rootsFingerprint
             cache.lastScanUnixMs = nowMs
             CostUsageCacheIO.save(provider: .codex, cache: cache, cacheRoot: options.cacheRoot)
         }
@@ -1090,6 +1283,8 @@ enum CostUsageScanner {
         return comps.date
     }
 }
+
+// swiftlint:enable type_body_length
 
 extension Data {
     func containsAscii(_ needle: String) -> Bool {

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 enum CostUsageScanner {
+    private static let log = CodexBarLog.logger(LogCategories.tokenCost)
+
     enum ClaudeLogProviderFilter {
         case all
         case vertexAIOnly
@@ -37,11 +39,121 @@ enum CostUsageScanner {
         let lastModel: String?
         let lastTotals: CostUsageCodexTotals?
         let sessionId: String?
+        let forkedFromId: String?
     }
 
     private struct CodexScanState {
         var seenSessionIds: Set<String> = []
         var seenFileIds: Set<String> = []
+    }
+
+    private struct CodexTimestampedTotals {
+        let timestamp: String
+        let date: Date?
+        let totals: CostUsageCodexTotals
+    }
+
+    private final class CodexSessionFileIndex {
+        private let files: [URL]
+        private var nextUnindexedFile = 0
+        private var fileURLBySessionId: [String: URL] = [:]
+        private var missingSessionIds: Set<String> = []
+
+        init(files: [URL]) {
+            self.files = files
+        }
+
+        func remember(fileURL: URL, sessionId: String?) {
+            guard let sessionId, !sessionId.isEmpty else { return }
+            self.fileURLBySessionId[sessionId] = fileURL
+        }
+
+        func fileURL(for sessionId: String) -> URL? {
+            if let cached = self.fileURLBySessionId[sessionId] {
+                return cached
+            }
+            if self.missingSessionIds.contains(sessionId) {
+                return nil
+            }
+
+            while self.nextUnindexedFile < self.files.count {
+                let fileURL = self.files[self.nextUnindexedFile]
+                self.nextUnindexedFile += 1
+                guard let indexedSessionId = CostUsageScanner.parseCodexSessionIdentifier(fileURL: fileURL) else {
+                    continue
+                }
+                self.fileURLBySessionId[indexedSessionId] = fileURL
+                if indexedSessionId == sessionId {
+                    return fileURL
+                }
+            }
+
+            self.missingSessionIds.insert(sessionId)
+            return nil
+        }
+    }
+
+    private final class CodexInheritedTotalsResolver {
+        private let fileIndex: CodexSessionFileIndex
+        private var snapshotsBySessionId: [String: [CodexTimestampedTotals]] = [:]
+
+        init(fileIndex: CodexSessionFileIndex) {
+            self.fileIndex = fileIndex
+        }
+
+        func inheritedTotals(for sessionId: String, atOrBefore cutoffTimestamp: String) -> CostUsageCodexTotals? {
+            guard !cutoffTimestamp.isEmpty else { return nil }
+            let cutoffDate = CostUsageScanner.dateFromTimestamp(cutoffTimestamp)
+            if cutoffDate == nil {
+                CostUsageScanner.log.warning(
+                    "Codex cost usage could not parse fork timestamp; falling back to lexical comparison",
+                    metadata: ["sessionId": sessionId, "timestamp": cutoffTimestamp])
+            }
+            let snapshots = self.snapshots(for: sessionId)
+            var inherited: CostUsageCodexTotals?
+            for snapshot in snapshots {
+                let isAtOrBefore: Bool
+                if let snapshotDate = snapshot.date, let cutoffDate {
+                    isAtOrBefore = snapshotDate <= cutoffDate
+                } else {
+                    isAtOrBefore = snapshot.timestamp <= cutoffTimestamp
+                }
+                if isAtOrBefore {
+                    inherited = snapshot.totals
+                }
+            }
+            return inherited
+        }
+
+        private func snapshots(for sessionId: String) -> [CodexTimestampedTotals] {
+            if let cached = self.snapshotsBySessionId[sessionId] {
+                return cached
+            }
+            guard let fileURL = self.fileIndex.fileURL(for: sessionId) else {
+                CostUsageScanner.log.warning(
+                    "Codex cost usage parent session file not found",
+                    metadata: ["sessionId": sessionId])
+                return []
+            }
+            let parsed = CostUsageScanner.parseCodexTokenSnapshots(fileURL: fileURL)
+            guard let parsedSessionId = parsed.sessionId else {
+                CostUsageScanner.log.warning(
+                    "Codex cost usage parent session missing session metadata",
+                    metadata: ["sessionId": sessionId, "path": fileURL.path])
+                return []
+            }
+            if parsedSessionId != sessionId {
+                CostUsageScanner.log.warning(
+                    "Codex cost usage parent session resolved to mismatched session id",
+                    metadata: [
+                        "requestedSessionId": sessionId,
+                        "resolvedSessionId": parsedSessionId,
+                        "path": fileURL.path,
+                    ])
+            }
+            self.snapshotsBySessionId[parsedSessionId] = parsed.snapshots
+            return self.snapshotsBySessionId[sessionId] ?? []
+        }
     }
 
     struct ClaudeParseResult {
@@ -157,15 +269,21 @@ enum CostUsageScanner {
             .appendingPathComponent("archived_sessions", isDirectory: true)
     }
 
-    private static func listCodexSessionFiles(root: URL, scanSinceKey: String, scanUntilKey: String) -> [URL] {
+    private static func listCodexSessionFiles(
+        root: URL,
+        scanSinceKey: String,
+        scanUntilKey: String,
+        includeRecursive: Bool
+    ) -> [URL] {
         let partitioned = self.listCodexSessionFilesByDatePartition(
             root: root,
             scanSinceKey: scanSinceKey,
             scanUntilKey: scanUntilKey)
         let flat = self.listCodexSessionFilesFlat(root: root, scanSinceKey: scanSinceKey, scanUntilKey: scanUntilKey)
+        let recursive = includeRecursive ? self.listCodexSessionFilesRecursive(root: root) : []
         var seen: Set<String> = []
         var out: [URL] = []
-        for item in partitioned + flat where !seen.contains(item.path) {
+        for item in partitioned + flat + recursive where !seen.contains(item.path) {
             seen.insert(item.path)
             out.append(item)
         }
@@ -228,6 +346,22 @@ enum CostUsageScanner {
         return out
     }
 
+    private static func listCodexSessionFilesRecursive(root: URL) -> [URL] {
+        guard FileManager.default.fileExists(atPath: root.path) else { return [] }
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles, .skipsPackageDescendants])
+        else { return [] }
+
+        var out: [URL] = []
+        while let item = enumerator.nextObject() as? URL {
+            guard item.pathExtension.lowercased() == "jsonl" else { continue }
+            out.append(item)
+        }
+        return out
+    }
+
     private static let codexFilenameDateRegex = try? NSRegularExpression(pattern: "(\\d{4}-\\d{2}-\\d{2})")
 
     private static func dayKeyFromFilename(_ filename: String) -> String? {
@@ -247,16 +381,156 @@ enum CostUsageScanner {
         return String(describing: identifier)
     }
 
+    private static func parseCodexSessionIdentifier(fileURL: URL) -> String? {
+        let handle: FileHandle
+        do {
+            handle = try FileHandle(forReadingFrom: fileURL)
+        } catch {
+            self.log.warning(
+                "Codex cost usage failed to open session file for session id parsing",
+                metadata: ["path": fileURL.path, "error": error.localizedDescription])
+            return nil
+        }
+        defer { try? handle.close() }
+
+        var buffer = Data()
+        let newline = Data([0x0A])
+
+        func parseSessionIdentifier(from lineData: Data) -> String? {
+            guard !lineData.isEmpty else { return nil }
+            guard let obj = (try? JSONSerialization.jsonObject(with: lineData)) as? [String: Any] else { return nil }
+            guard obj["type"] as? String == "session_meta" else { return nil }
+            let payload = obj["payload"] as? [String: Any]
+            return payload?["session_id"] as? String
+                ?? payload?["sessionId"] as? String
+                ?? payload?["id"] as? String
+                ?? obj["session_id"] as? String
+                ?? obj["sessionId"] as? String
+                ?? obj["id"] as? String
+        }
+
+        do {
+            while let chunk = try handle.read(upToCount: 64 * 1024), !chunk.isEmpty {
+                buffer.append(chunk)
+                while let newlineRange = buffer.range(of: newline) {
+                    let lineData = buffer.subdata(in: 0..<newlineRange.lowerBound)
+                    buffer.removeSubrange(0..<newlineRange.upperBound)
+                    if let sessionId = parseSessionIdentifier(from: lineData) {
+                        return sessionId
+                    }
+                }
+            }
+        } catch {
+            self.log.warning(
+                "Codex cost usage failed while reading session file for session id parsing",
+                metadata: ["path": fileURL.path, "error": error.localizedDescription])
+            return nil
+        }
+
+        if let sessionId = parseSessionIdentifier(from: buffer) {
+            return sessionId
+        }
+        return nil
+    }
+
+    private static func parseCodexTokenSnapshots(fileURL: URL) -> (
+        sessionId: String?,
+        snapshots: [CodexTimestampedTotals]
+    ) {
+        var sessionId: String?
+        var previousTotals: CostUsageCodexTotals?
+        var snapshots: [CodexTimestampedTotals] = []
+        var warnedAboutUnparsedTimestamp = false
+
+        func parsedSnapshotDate(timestamp: String) -> Date? {
+            let date = Self.dateFromTimestamp(timestamp)
+            if date == nil, !warnedAboutUnparsedTimestamp {
+                warnedAboutUnparsedTimestamp = true
+                self.log.warning(
+                    "Codex cost usage could not parse parent token snapshot timestamp; falling back to lexical comparison",
+                    metadata: ["path": fileURL.path, "timestamp": timestamp])
+            }
+            return date
+        }
+
+        do {
+            _ = try CostUsageJsonl.scan(
+                fileURL: fileURL,
+                maxLineBytes: 512 * 1024,
+                prefixBytes: 512 * 1024,
+                onLine: { line in
+                    guard !line.bytes.isEmpty, !line.wasTruncated else { return }
+                    guard let obj = (try? JSONSerialization.jsonObject(with: line.bytes)) as? [String: Any] else { return }
+
+                    if obj["type"] as? String == "session_meta" {
+                        let payload = obj["payload"] as? [String: Any]
+                        if sessionId == nil {
+                            sessionId = payload?["session_id"] as? String
+                                ?? payload?["sessionId"] as? String
+                                ?? payload?["id"] as? String
+                                ?? obj["session_id"] as? String
+                                ?? obj["sessionId"] as? String
+                                ?? obj["id"] as? String
+                        }
+                        return
+                    }
+
+                    guard obj["type"] as? String == "event_msg" else { return }
+                    guard let payload = obj["payload"] as? [String: Any] else { return }
+                    guard payload["type"] as? String == "token_count" else { return }
+                    guard let info = payload["info"] as? [String: Any] else { return }
+                    guard let timestamp = obj["timestamp"] as? String else { return }
+
+                    func toInt(_ value: Any?) -> Int {
+                        if let number = value as? NSNumber { return number.intValue }
+                        return 0
+                    }
+
+                    if let total = info["total_token_usage"] as? [String: Any] {
+                        let next = CostUsageCodexTotals(
+                            input: toInt(total["input_tokens"]),
+                            cached: toInt(total["cached_input_tokens"] ?? total["cache_read_input_tokens"]),
+                            output: toInt(total["output_tokens"]))
+                        previousTotals = next
+                        snapshots.append(CodexTimestampedTotals(
+                            timestamp: timestamp,
+                            date: parsedSnapshotDate(timestamp: timestamp),
+                            totals: next))
+                    } else if let last = info["last_token_usage"] as? [String: Any] {
+                        let base = previousTotals ?? .init(input: 0, cached: 0, output: 0)
+                        let next = CostUsageCodexTotals(
+                            input: base.input + toInt(last["input_tokens"]),
+                            cached: base.cached + toInt(last["cached_input_tokens"] ?? last["cache_read_input_tokens"]),
+                            output: base.output + toInt(last["output_tokens"]))
+                        previousTotals = next
+                        snapshots.append(CodexTimestampedTotals(
+                            timestamp: timestamp,
+                            date: parsedSnapshotDate(timestamp: timestamp),
+                            totals: next))
+                    }
+                })
+        } catch {
+            self.log.warning(
+                "Codex cost usage failed while scanning parent token snapshots",
+                metadata: ["path": fileURL.path, "error": error.localizedDescription])
+        }
+
+        return (sessionId, snapshots)
+    }
+
     static func parseCodexFile(
         fileURL: URL,
         range: CostUsageDayRange,
         startOffset: Int64 = 0,
         initialModel: String? = nil,
-        initialTotals: CostUsageCodexTotals? = nil) -> CodexParseResult
+        initialTotals: CostUsageCodexTotals? = nil,
+        inheritedTotalsResolver: ((String, String) -> CostUsageCodexTotals?)? = nil) -> CodexParseResult
     {
         var currentModel = initialModel
         var previousTotals = initialTotals
         var sessionId: String?
+        var forkedFromId: String?
+        var inheritedTotals: CostUsageCodexTotals?
 
         var days: [String: [String: [Int]]] = [:]
 
@@ -277,12 +551,14 @@ enum CostUsageScanner {
         let maxLineBytes = 256 * 1024
         let prefixBytes = 32 * 1024
 
-        let parsedBytes = (try? CostUsageJsonl.scan(
-            fileURL: fileURL,
-            offset: startOffset,
-            maxLineBytes: maxLineBytes,
-            prefixBytes: prefixBytes,
-            onLine: { line in
+        let parsedBytes: Int64
+        do {
+            parsedBytes = try CostUsageJsonl.scan(
+                fileURL: fileURL,
+                offset: startOffset,
+                maxLineBytes: maxLineBytes,
+                prefixBytes: prefixBytes,
+                onLine: { line in
                 guard !line.bytes.isEmpty else { return }
                 guard !line.wasTruncated else { return }
 
@@ -302,14 +578,26 @@ enum CostUsageScanner {
                 else { return }
 
                 if type == "session_meta" {
+                    let payload = obj["payload"] as? [String: Any]
                     if sessionId == nil {
-                        let payload = obj["payload"] as? [String: Any]
                         sessionId = payload?["session_id"] as? String
                             ?? payload?["sessionId"] as? String
                             ?? payload?["id"] as? String
                             ?? obj["session_id"] as? String
                             ?? obj["sessionId"] as? String
                             ?? obj["id"] as? String
+                    }
+                    if forkedFromId == nil {
+                        forkedFromId = payload?["forked_from_id"] as? String
+                            ?? payload?["forkedFromId"] as? String
+                            ?? payload?["parent_session_id"] as? String
+                            ?? payload?["parentSessionId"] as? String
+                    }
+                    if inheritedTotals == nil, let forkedFromId {
+                        let forkedAt = payload?["timestamp"] as? String
+                            ?? obj["timestamp"] as? String
+                            ?? ""
+                        inheritedTotals = inheritedTotalsResolver?(forkedFromId, forkedAt)
                     }
                     return
                 }
@@ -352,19 +640,35 @@ enum CostUsageScanner {
                 var deltaOutput = 0
 
                 if let total {
-                    let input = toInt(total["input_tokens"])
-                    let cached = toInt(total["cached_input_tokens"] ?? total["cache_read_input_tokens"])
-                    let output = toInt(total["output_tokens"])
+                    let rawTotals = CostUsageCodexTotals(
+                        input: toInt(total["input_tokens"]),
+                        cached: toInt(total["cached_input_tokens"] ?? total["cache_read_input_tokens"]),
+                        output: toInt(total["output_tokens"]))
 
-                    let prev = previousTotals
-                    deltaInput = max(0, input - (prev?.input ?? 0))
-                    deltaCached = max(0, cached - (prev?.cached ?? 0))
-                    deltaOutput = max(0, output - (prev?.output ?? 0))
-                    previousTotals = CostUsageCodexTotals(input: input, cached: cached, output: output)
+                    let currentTotals: CostUsageCodexTotals
+                    if let inheritedTotals {
+                        currentTotals = CostUsageCodexTotals(
+                            input: max(0, rawTotals.input - inheritedTotals.input),
+                            cached: max(0, rawTotals.cached - inheritedTotals.cached),
+                            output: max(0, rawTotals.output - inheritedTotals.output))
+                    } else {
+                        currentTotals = rawTotals
+                    }
+
+                    let prev = previousTotals ?? .init(input: 0, cached: 0, output: 0)
+                    deltaInput = max(0, currentTotals.input - prev.input)
+                    deltaCached = max(0, currentTotals.cached - prev.cached)
+                    deltaOutput = max(0, currentTotals.output - prev.output)
+                    previousTotals = currentTotals
                 } else if let last {
                     deltaInput = max(0, toInt(last["input_tokens"]))
                     deltaCached = max(0, toInt(last["cached_input_tokens"] ?? last["cache_read_input_tokens"]))
                     deltaOutput = max(0, toInt(last["output_tokens"]))
+                    let prev = previousTotals ?? .init(input: 0, cached: 0, output: 0)
+                    previousTotals = CostUsageCodexTotals(
+                        input: prev.input + deltaInput,
+                        cached: prev.cached + deltaCached,
+                        output: prev.output + deltaOutput)
                 } else {
                     return
                 }
@@ -372,21 +676,30 @@ enum CostUsageScanner {
                 if deltaInput == 0, deltaCached == 0, deltaOutput == 0 { return }
                 let cachedClamp = min(deltaCached, deltaInput)
                 add(dayKey: dayKey, model: model, input: deltaInput, cached: cachedClamp, output: deltaOutput)
-            })) ?? startOffset
+            })
+        } catch {
+            self.log.warning(
+                "Codex cost usage failed while scanning session file",
+                metadata: ["path": fileURL.path, "error": error.localizedDescription])
+            parsedBytes = startOffset
+        }
 
         return CodexParseResult(
             days: days,
             parsedBytes: parsedBytes,
             lastModel: currentModel,
             lastTotals: previousTotals,
-            sessionId: sessionId)
+            sessionId: sessionId,
+            forkedFromId: forkedFromId)
     }
 
     private static func scanCodexFile(
         fileURL: URL,
         range: CostUsageDayRange,
         cache: inout CostUsageCache,
-        state: inout CodexScanState)
+        state: inout CodexScanState,
+        fileIndex: CodexSessionFileIndex,
+        inheritedResolver: CodexInheritedTotalsResolver)
     {
         let path = fileURL.path
         let attrs = (try? FileManager.default.attributesOfItem(atPath: path)) ?? [:]
@@ -432,6 +745,7 @@ enum CostUsageScanner {
             let startOffset = cached.parsedBytes ?? cached.size
             let canIncremental = size > cached.size && startOffset > 0 && startOffset <= size
                 && cached.lastTotals != nil
+                && cached.forkedFromId == nil
             if canIncremental {
                 let delta = Self.parseCodexFile(
                     fileURL: fileURL,
@@ -458,9 +772,11 @@ enum CostUsageScanner {
                     parsedBytes: delta.parsedBytes,
                     lastModel: delta.lastModel,
                     lastTotals: delta.lastTotals,
-                    sessionId: sessionId)
+                    sessionId: sessionId,
+                    forkedFromId: delta.forkedFromId ?? cached.forkedFromId)
                 if let sessionId {
                     state.seenSessionIds.insert(sessionId)
+                    fileIndex.remember(fileURL: fileURL, sessionId: sessionId)
                 }
                 if let fileId {
                     state.seenFileIds.insert(fileId)
@@ -473,7 +789,10 @@ enum CostUsageScanner {
             Self.applyFileDays(cache: &cache, fileDays: cached.days, sign: -1)
         }
 
-        let parsed = Self.parseCodexFile(fileURL: fileURL, range: range)
+        let parsed = Self.parseCodexFile(
+            fileURL: fileURL,
+            range: range,
+            inheritedTotalsResolver: inheritedResolver.inheritedTotals(for:atOrBefore:))
         let sessionId = parsed.sessionId ?? cached?.sessionId
         if let sessionId, state.seenSessionIds.contains(sessionId) {
             cache.files.removeValue(forKey: path)
@@ -487,11 +806,13 @@ enum CostUsageScanner {
             parsedBytes: parsed.parsedBytes,
             lastModel: parsed.lastModel,
             lastTotals: parsed.lastTotals,
-            sessionId: sessionId)
+            sessionId: sessionId,
+            forkedFromId: parsed.forkedFromId)
         cache.files[path] = usage
         Self.applyFileDays(cache: &cache, fileDays: usage.days, sign: 1)
         if let sessionId {
             state.seenSessionIds.insert(sessionId)
+            fileIndex.remember(fileURL: fileURL, sessionId: sessionId)
         }
         if let fileId {
             state.seenFileIds.insert(fileId)
@@ -503,34 +824,43 @@ enum CostUsageScanner {
         let nowMs = Int64(now.timeIntervalSince1970 * 1000)
 
         let refreshMs = Int64(max(0, options.refreshMinIntervalSeconds) * 1000)
-        let shouldRefresh = refreshMs == 0 || cache.lastScanUnixMs == 0 || nowMs - cache.lastScanUnixMs > refreshMs
-
-        let roots = self.codexSessionsRoots(options: options)
-        var seenPaths: Set<String> = []
-        var files: [URL] = []
-        for root in roots {
-            let rootFiles = Self.listCodexSessionFiles(
-                root: root,
-                scanSinceKey: range.scanSinceKey,
-                scanUntilKey: range.scanUntilKey)
-            for fileURL in rootFiles.sorted(by: { $0.path < $1.path }) where !seenPaths.contains(fileURL.path) {
-                seenPaths.insert(fileURL.path)
-                files.append(fileURL)
-            }
-        }
-        let filePathsInScan = Set(files.map(\.path))
+        let shouldRefresh = options.forceRescan
+            || refreshMs == 0
+            || cache.lastScanUnixMs == 0
+            || nowMs - cache.lastScanUnixMs > refreshMs
 
         if shouldRefresh {
             if options.forceRescan {
                 cache = CostUsageCache()
             }
+
+            let roots = self.codexSessionsRoots(options: options)
+            var seenPaths: Set<String> = []
+            var files: [URL] = []
+            for root in roots {
+                let rootFiles = Self.listCodexSessionFiles(
+                    root: root,
+                    scanSinceKey: range.scanSinceKey,
+                    scanUntilKey: range.scanUntilKey,
+                    includeRecursive: true)
+                for fileURL in rootFiles.sorted(by: { $0.path < $1.path }) where !seenPaths.contains(fileURL.path) {
+                    seenPaths.insert(fileURL.path)
+                    files.append(fileURL)
+                }
+            }
+            let filePathsInScan = Set(files.map(\.path))
+
             var scanState = CodexScanState()
+            let fileIndex = CodexSessionFileIndex(files: files)
+            let inheritedResolver = CodexInheritedTotalsResolver(fileIndex: fileIndex)
             for fileURL in files {
                 Self.scanCodexFile(
                     fileURL: fileURL,
                     range: range,
                     cache: &cache,
-                    state: &scanState)
+                    state: &scanState,
+                    fileIndex: fileIndex,
+                    inheritedResolver: inheritedResolver)
             }
 
             for key in cache.files.keys where !filePathsInScan.contains(key) {
@@ -643,6 +973,7 @@ enum CostUsageScanner {
         lastModel: String? = nil,
         lastTotals: CostUsageCodexTotals? = nil,
         sessionId: String? = nil,
+        forkedFromId: String? = nil,
         claudeRows: [ClaudeUsageRow]? = nil) -> CostUsageFileUsage
     {
         CostUsageFileUsage(
@@ -653,6 +984,7 @@ enum CostUsageScanner {
             lastModel: lastModel,
             lastTotals: lastTotals,
             sessionId: sessionId,
+            forkedFromId: forkedFromId,
             claudeRows: claudeRows)
     }
 

--- a/Tests/CodexBarTests/CostUsageCacheTests.swift
+++ b/Tests/CodexBarTests/CostUsageCacheTests.swift
@@ -10,7 +10,7 @@ struct CostUsageCacheTests {
         let codexURL = CostUsageCacheIO.cacheFileURL(provider: .codex, cacheRoot: root)
         let claudeURL = CostUsageCacheIO.cacheFileURL(provider: .claude, cacheRoot: root)
 
-        #expect(codexURL.lastPathComponent == "codex-v2.json")
+        #expect(codexURL.lastPathComponent == "codex-v4.json")
         #expect(claudeURL.lastPathComponent == "claude-v2.json")
     }
 }

--- a/Tests/CodexBarTests/CostUsageScannerBreakdownTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerBreakdownTests.swift
@@ -167,6 +167,906 @@ struct CostUsageScannerBreakdownTests {
     }
 
     @Test
+    func `codex daily report includes long lived sessions stored under older date partitions`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let fileDay = try env.makeLocalNoon(year: 2026, month: 2, day: 27)
+        let reportDay = try env.makeLocalNoon(year: 2026, month: 3, day: 11)
+        let model = "openai/gpt-5.2-codex"
+
+        _ = try env.writeCodexSessionFile(
+            day: fileDay,
+            filename: "rollout-2026-02-27T11-29-28-cross-day.jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "session_meta",
+                    "payload": [
+                        "id": "cross-day-session",
+                    ],
+                ],
+                [
+                    "type": "turn_context",
+                    "timestamp": env.isoString(for: reportDay),
+                    "payload": [
+                        "model": model,
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": env.isoString(for: reportDay.addingTimeInterval(1)),
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 100,
+                                "cached_input_tokens": 20,
+                                "output_tokens": 10,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+            ]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+        options.forceRescan = true
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: reportDay,
+            until: reportDay,
+            now: reportDay,
+            options: options)
+
+        #expect(report.data.count == 1)
+        #expect(report.data[0].inputTokens == 100)
+        #expect(report.data[0].outputTokens == 10)
+        #expect(report.data[0].totalTokens == 110)
+    }
+
+    @Test
+    func `codex forked child subtracts parent totals at fork timestamp`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let parentDay = try env.makeLocalNoon(year: 2026, month: 2, day: 27)
+        let childDay = try env.makeLocalNoon(year: 2026, month: 3, day: 11)
+        let parentTs0 = env.isoString(for: parentDay)
+        let parentTs1 = env.isoString(for: parentDay.addingTimeInterval(1))
+        let parentTs2 = env.isoString(for: parentDay.addingTimeInterval(2))
+        let parentTs3 = env.isoString(for: parentDay.addingTimeInterval(3))
+        let childForkTs = env.isoString(for: parentDay.addingTimeInterval(2.5))
+        let childTs1 = env.isoString(for: childDay.addingTimeInterval(1))
+        let childTs2 = env.isoString(for: childDay.addingTimeInterval(2))
+
+        let model = "openai/gpt-5.2-codex"
+        let parentSessionId = "sess-parent"
+        let childSessionId = "sess-child"
+
+        _ = try env.writeCodexSessionFile(
+            day: parentDay,
+            filename: "rollout-2026-02-27T11-29-28-\(parentSessionId).jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "session_meta",
+                    "payload": [
+                        "id": parentSessionId,
+                    ],
+                ],
+                [
+                    "type": "turn_context",
+                    "timestamp": parentTs0,
+                    "payload": [
+                        "model": model,
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": parentTs1,
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 10,
+                                "cached_input_tokens": 2,
+                                "output_tokens": 1,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": parentTs2,
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 20,
+                                "cached_input_tokens": 5,
+                                "output_tokens": 2,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": parentTs3,
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 30,
+                                "cached_input_tokens": 8,
+                                "output_tokens": 3,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+            ]))
+
+        _ = try env.writeCodexSessionFile(
+            day: childDay,
+            filename: "rollout-2026-03-11T11-30-27-\(childSessionId).jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "session_meta",
+                    "payload": [
+                        "id": childSessionId,
+                        "forked_from_id": parentSessionId,
+                        "timestamp": childForkTs,
+                    ],
+                ],
+                [
+                    "type": "turn_context",
+                    "timestamp": childDay.ISO8601Format(),
+                    "payload": [
+                        "model": model,
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": childTs1,
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 20,
+                                "cached_input_tokens": 5,
+                                "output_tokens": 2,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": childTs2,
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 27,
+                                "cached_input_tokens": 7,
+                                "output_tokens": 4,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+            ]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+        options.forceRescan = true
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: childDay,
+            until: childDay,
+            now: childDay,
+            options: options)
+
+        let expectedCost = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.2-codex",
+            inputTokens: 7,
+            cachedInputTokens: 2,
+            outputTokens: 2)
+
+        #expect(report.data.count == 1)
+        #expect(report.data[0].inputTokens == 7)
+        #expect(report.data[0].outputTokens == 2)
+        #expect(report.data[0].totalTokens == 9)
+        #expect(abs((report.data[0].costUSD ?? 0) - (expectedCost ?? 0)) < 0.000001)
+    }
+
+    @Test
+    func `codex forked child ignores replayed parent prefix sequence`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let parentDay = try env.makeLocalNoon(year: 2026, month: 2, day: 27)
+        let childDay = try env.makeLocalNoon(year: 2026, month: 3, day: 11)
+        let model = "openai/gpt-5.2-codex"
+        let parentSessionId = "sess-parent-prefix"
+        let childSessionId = "sess-child-prefix"
+        let forkTs = env.isoString(for: parentDay.addingTimeInterval(5))
+
+        let parentEvents: [[String: Any]] = [
+            [
+                "type": "session_meta",
+                "payload": [
+                    "id": parentSessionId,
+                ],
+            ],
+            [
+                "type": "turn_context",
+                "timestamp": env.isoString(for: parentDay),
+                "payload": [
+                    "model": model,
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: parentDay.addingTimeInterval(1)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 10,
+                            "cached_input_tokens": 2,
+                            "output_tokens": 1,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: parentDay.addingTimeInterval(2)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 20,
+                            "cached_input_tokens": 5,
+                            "output_tokens": 2,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: parentDay.addingTimeInterval(3)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 30,
+                            "cached_input_tokens": 8,
+                            "output_tokens": 3,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+        ]
+        _ = try env.writeCodexSessionFile(
+            day: parentDay,
+            filename: "rollout-2026-02-27T11-29-28-\(parentSessionId).jsonl",
+            contents: env.jsonl(parentEvents))
+
+        let childEvents: [[String: Any]] = [
+            [
+                "type": "session_meta",
+                "payload": [
+                    "id": childSessionId,
+                    "forked_from_id": parentSessionId,
+                    "timestamp": forkTs,
+                ],
+            ],
+            [
+                "type": "turn_context",
+                "timestamp": env.isoString(for: childDay),
+                "payload": [
+                    "model": model,
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: childDay.addingTimeInterval(1)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 10,
+                            "cached_input_tokens": 2,
+                            "output_tokens": 1,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: childDay.addingTimeInterval(2)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 20,
+                            "cached_input_tokens": 5,
+                            "output_tokens": 2,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: childDay.addingTimeInterval(3)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 30,
+                            "cached_input_tokens": 8,
+                            "output_tokens": 3,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: childDay.addingTimeInterval(4)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 30,
+                            "cached_input_tokens": 8,
+                            "output_tokens": 3,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: childDay.addingTimeInterval(5)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 35,
+                            "cached_input_tokens": 9,
+                            "output_tokens": 4,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: childDay.addingTimeInterval(6)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 42,
+                            "cached_input_tokens": 11,
+                            "output_tokens": 5,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+        ]
+        _ = try env.writeCodexSessionFile(
+            day: childDay,
+            filename: "rollout-2026-03-11T11-30-27-\(childSessionId).jsonl",
+            contents: env.jsonl(childEvents))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+        options.forceRescan = true
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: childDay,
+            until: childDay,
+            now: childDay,
+            options: options)
+
+        let expectedCost = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.2-codex",
+            inputTokens: 12,
+            cachedInputTokens: 3,
+            outputTokens: 2)
+
+        #expect(report.data.count == 1)
+        #expect(report.data[0].inputTokens == 12)
+        #expect(report.data[0].outputTokens == 2)
+        #expect(report.data[0].totalTokens == 14)
+        #expect(abs((report.data[0].costUSD ?? 0) - (expectedCost ?? 0)) < 0.000001)
+    }
+
+    @Test
+    func `codex forked child resolves parent when parent session file is a symlink`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let parentDay = try env.makeLocalNoon(year: 2026, month: 2, day: 27)
+        let childDay = try env.makeLocalNoon(year: 2026, month: 3, day: 11)
+        let model = "openai/gpt-5.2-codex"
+        let parentSessionId = "sess-parent-symlink"
+        let childSessionId = "sess-child-symlink"
+        let forkTs = env.isoString(for: parentDay.addingTimeInterval(3))
+
+        let parentContents = try env.jsonl([
+            [
+                "type": "session_meta",
+                "payload": [
+                    "id": parentSessionId,
+                ],
+            ],
+            [
+                "type": "turn_context",
+                "timestamp": env.isoString(for: parentDay),
+                "payload": [
+                    "model": model,
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: parentDay.addingTimeInterval(1)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 10,
+                            "cached_input_tokens": 2,
+                            "output_tokens": 1,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: parentDay.addingTimeInterval(2)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 20,
+                            "cached_input_tokens": 5,
+                            "output_tokens": 2,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+        ])
+
+        let parentTarget = env.root.appendingPathComponent("parent-target.jsonl", isDirectory: false)
+        try parentContents.write(to: parentTarget, atomically: true, encoding: .utf8)
+
+        let comps = Calendar.current.dateComponents([.year, .month, .day], from: parentDay)
+        let parentDir = env.codexSessionsRoot
+            .appendingPathComponent(String(format: "%04d", comps.year ?? 1970), isDirectory: true)
+            .appendingPathComponent(String(format: "%02d", comps.month ?? 1), isDirectory: true)
+            .appendingPathComponent(String(format: "%02d", comps.day ?? 1), isDirectory: true)
+        try FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)
+        let parentLink = parentDir.appendingPathComponent("rollout-2026-02-27T11-29-28-\(parentSessionId).jsonl", isDirectory: false)
+        try FileManager.default.createSymbolicLink(at: parentLink, withDestinationURL: parentTarget)
+
+        _ = try env.writeCodexSessionFile(
+            day: childDay,
+            filename: "rollout-2026-03-11T11-30-27-\(childSessionId).jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "session_meta",
+                    "payload": [
+                        "id": childSessionId,
+                        "forked_from_id": parentSessionId,
+                        "timestamp": forkTs,
+                    ],
+                ],
+                [
+                    "type": "turn_context",
+                    "timestamp": env.isoString(for: childDay),
+                    "payload": [
+                        "model": model,
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": env.isoString(for: childDay.addingTimeInterval(1)),
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 20,
+                                "cached_input_tokens": 5,
+                                "output_tokens": 2,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": env.isoString(for: childDay.addingTimeInterval(2)),
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 27,
+                                "cached_input_tokens": 7,
+                                "output_tokens": 4,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+            ]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+        options.forceRescan = true
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: childDay,
+            until: childDay,
+            now: childDay,
+            options: options)
+
+        let expectedCost = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.2-codex",
+            inputTokens: 7,
+            cachedInputTokens: 2,
+            outputTokens: 2)
+
+        #expect(report.data.count == 1)
+        #expect(report.data[0].inputTokens == 7)
+        #expect(report.data[0].outputTokens == 2)
+        #expect(report.data[0].totalTokens == 9)
+        #expect(abs((report.data[0].costUSD ?? 0) - (expectedCost ?? 0)) < 0.000001)
+    }
+
+    @Test
+    func `codex forked child resolves parent by exact session meta id`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let parentDay = try env.makeLocalNoon(year: 2026, month: 2, day: 27)
+        let childDay = try env.makeLocalNoon(year: 2026, month: 3, day: 11)
+        let model = "openai/gpt-5.2-codex"
+        let wantedParentSessionId = "sess-parent-exact"
+        let wrongParentSessionId = "sess-parent-exact-extra"
+        let childSessionId = "sess-child-exact"
+        let forkTs = env.isoString(for: parentDay.addingTimeInterval(3))
+
+        _ = try env.writeCodexSessionFile(
+            day: parentDay,
+            filename: "rollout-2026-02-27T11-29-28-\(wrongParentSessionId).jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "session_meta",
+                    "payload": [
+                        "id": wrongParentSessionId,
+                    ],
+                ],
+                [
+                    "type": "turn_context",
+                    "timestamp": env.isoString(for: parentDay),
+                    "payload": [
+                        "model": model,
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": env.isoString(for: parentDay.addingTimeInterval(1)),
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 1000,
+                                "cached_input_tokens": 100,
+                                "output_tokens": 100,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+            ]))
+
+        _ = try env.writeCodexSessionFile(
+            day: parentDay,
+            filename: "rollout-2026-02-27T11-29-29-\(wantedParentSessionId).jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "session_meta",
+                    "payload": [
+                        "id": wantedParentSessionId,
+                    ],
+                ],
+                [
+                    "type": "turn_context",
+                    "timestamp": env.isoString(for: parentDay),
+                    "payload": [
+                        "model": model,
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": env.isoString(for: parentDay.addingTimeInterval(1)),
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 20,
+                                "cached_input_tokens": 5,
+                                "output_tokens": 2,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": env.isoString(for: parentDay.addingTimeInterval(2)),
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 30,
+                                "cached_input_tokens": 8,
+                                "output_tokens": 3,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+            ]))
+
+        _ = try env.writeCodexSessionFile(
+            day: childDay,
+            filename: "rollout-2026-03-11T11-30-27-\(childSessionId).jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "session_meta",
+                    "payload": [
+                        "id": childSessionId,
+                        "forked_from_id": wantedParentSessionId,
+                        "timestamp": forkTs,
+                    ],
+                ],
+                [
+                    "type": "turn_context",
+                    "timestamp": env.isoString(for: childDay),
+                    "payload": [
+                        "model": model,
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": env.isoString(for: childDay.addingTimeInterval(1)),
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 35,
+                                "cached_input_tokens": 9,
+                                "output_tokens": 4,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": env.isoString(for: childDay.addingTimeInterval(2)),
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 42,
+                                "cached_input_tokens": 11,
+                                "output_tokens": 5,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+            ]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+        options.forceRescan = true
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: childDay,
+            until: childDay,
+            now: childDay,
+            options: options)
+
+        let expectedCost = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.2-codex",
+            inputTokens: 12,
+            cachedInputTokens: 3,
+            outputTokens: 2)
+
+        #expect(report.data.count == 1)
+        #expect(report.data[0].inputTokens == 12)
+        #expect(report.data[0].outputTokens == 2)
+        #expect(report.data[0].totalTokens == 14)
+        #expect(abs((report.data[0].costUSD ?? 0) - (expectedCost ?? 0)) < 0.000001)
+    }
+
+    @Test
+    func `codex forked child compares parent snapshots by parsed timestamp`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let parentDay = try env.makeLocalNoon(year: 2026, month: 2, day: 27)
+        let childDay = try env.makeLocalNoon(year: 2026, month: 3, day: 11)
+        let model = "openai/gpt-5.2-codex"
+        let parentSessionId = "sess-parent-timestamp"
+        let childSessionId = "sess-child-timestamp"
+
+        _ = try env.writeCodexSessionFile(
+            day: parentDay,
+            filename: "rollout-2026-02-27T11-29-28-\(parentSessionId).jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "session_meta",
+                    "payload": [
+                        "id": parentSessionId,
+                    ],
+                ],
+                [
+                    "type": "turn_context",
+                    "timestamp": "2026-02-27T23:59:58Z",
+                    "payload": [
+                        "model": model,
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": "2026-02-27T23:59:59Z",
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 20,
+                                "cached_input_tokens": 5,
+                                "output_tokens": 2,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": "2026-02-28T00:00:01Z",
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 100,
+                                "cached_input_tokens": 20,
+                                "output_tokens": 10,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+            ]))
+
+        _ = try env.writeCodexSessionFile(
+            day: childDay,
+            filename: "rollout-2026-03-11T11-30-27-\(childSessionId).jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "session_meta",
+                    "payload": [
+                        "id": childSessionId,
+                        "forked_from_id": parentSessionId,
+                        "timestamp": "2026-02-28T08:00:00+08:00",
+                    ],
+                ],
+                [
+                    "type": "turn_context",
+                    "timestamp": env.isoString(for: childDay),
+                    "payload": [
+                        "model": model,
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": env.isoString(for: childDay.addingTimeInterval(1)),
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 25,
+                                "cached_input_tokens": 7,
+                                "output_tokens": 4,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": env.isoString(for: childDay.addingTimeInterval(2)),
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 30,
+                                "cached_input_tokens": 10,
+                                "output_tokens": 6,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+            ]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+        options.forceRescan = true
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: childDay,
+            until: childDay,
+            now: childDay,
+            options: options)
+
+        let expectedCost = CostUsagePricing.codexCostUSD(
+            model: model,
+            inputTokens: 10,
+            cachedInputTokens: 5,
+            outputTokens: 4)
+
+        #expect(report.data.count == 1)
+        #expect(report.data[0].inputTokens == 10)
+        #expect(report.data[0].outputTokens == 4)
+        #expect(report.data[0].totalTokens == 14)
+        #expect(abs((report.data[0].costUSD ?? 0) - (expectedCost ?? 0)) < 0.000001)
+    }
+
+    @Test
     func `claude daily report parses usage and caches`() throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }

--- a/Tests/CodexBarTests/CostUsageScannerBreakdownTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerBreakdownTests.swift
@@ -2,6 +2,8 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
+// swiftlint:disable file_length
+// swiftlint:disable type_body_length
 struct CostUsageScannerBreakdownTests {
     @Test
     func `codex daily report parses token counts and caches`() throws {
@@ -214,7 +216,6 @@ struct CostUsageScannerBreakdownTests {
             claudeProjectsRoots: nil,
             cacheRoot: env.cacheRoot)
         options.refreshMinIntervalSeconds = 0
-        options.forceRescan = true
 
         let report = CostUsageScanner.loadDailyReport(
             provider: .codex,
@@ -391,6 +392,168 @@ struct CostUsageScannerBreakdownTests {
     }
 
     @Test
+    func `codex forked child subtracts inherited replay from last token usage`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let parentDay = try env.makeLocalNoon(year: 2026, month: 2, day: 27)
+        let childDay = try env.makeLocalNoon(year: 2026, month: 3, day: 11)
+        let parentTs0 = env.isoString(for: parentDay)
+        let parentTs1 = env.isoString(for: parentDay.addingTimeInterval(1))
+        let parentTs2 = env.isoString(for: parentDay.addingTimeInterval(2))
+        let childTs1 = env.isoString(for: childDay.addingTimeInterval(1))
+        let childTs2 = env.isoString(for: childDay.addingTimeInterval(2))
+        let childTs3 = env.isoString(for: childDay.addingTimeInterval(3))
+
+        let model = "openai/gpt-5.2-codex"
+        let parentSessionId = "sess-parent-last"
+        let childSessionId = "sess-child-last"
+        let forkTs = env.isoString(for: parentDay.addingTimeInterval(2.5))
+
+        _ = try env.writeCodexSessionFile(
+            day: parentDay,
+            filename: "rollout-2026-02-27T11-29-28-\(parentSessionId).jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "session_meta",
+                    "payload": [
+                        "id": parentSessionId,
+                    ],
+                ],
+                [
+                    "type": "turn_context",
+                    "timestamp": parentTs0,
+                    "payload": [
+                        "model": model,
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": parentTs1,
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 10,
+                                "cached_input_tokens": 2,
+                                "output_tokens": 1,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": parentTs2,
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "total_token_usage": [
+                                "input_tokens": 20,
+                                "cached_input_tokens": 5,
+                                "output_tokens": 2,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+            ]))
+
+        _ = try env.writeCodexSessionFile(
+            day: childDay,
+            filename: "rollout-2026-03-11T11-30-27-\(childSessionId).jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "session_meta",
+                    "payload": [
+                        "id": childSessionId,
+                        "forked_from_id": parentSessionId,
+                        "timestamp": forkTs,
+                    ],
+                ],
+                [
+                    "type": "turn_context",
+                    "timestamp": childDay.ISO8601Format(),
+                    "payload": [
+                        "model": model,
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": childTs1,
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "last_token_usage": [
+                                "input_tokens": 10,
+                                "cached_input_tokens": 2,
+                                "output_tokens": 1,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": childTs2,
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "last_token_usage": [
+                                "input_tokens": 10,
+                                "cached_input_tokens": 3,
+                                "output_tokens": 1,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": childTs3,
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "last_token_usage": [
+                                "input_tokens": 7,
+                                "cached_input_tokens": 2,
+                                "output_tokens": 2,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+            ]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+        options.forceRescan = true
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: childDay,
+            until: childDay,
+            now: childDay,
+            options: options)
+
+        let expectedCost = CostUsagePricing.codexCostUSD(
+            model: model,
+            inputTokens: 7,
+            cachedInputTokens: 2,
+            outputTokens: 2)
+
+        #expect(report.data.count == 1)
+        #expect(report.data[0].inputTokens == 7)
+        #expect(report.data[0].outputTokens == 2)
+        #expect(report.data[0].totalTokens == 9)
+        #expect(abs((report.data[0].costUSD ?? 0) - (expectedCost ?? 0)) < 0.000001)
+    }
+
+    @Test
+    // swiftlint:disable:next function_body_length
     func `codex forked child ignores replayed parent prefix sequence`() throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }
@@ -607,6 +770,208 @@ struct CostUsageScannerBreakdownTests {
     }
 
     @Test
+    // swiftlint:disable:next function_body_length
+    func `codex forked child subtracts inherited replay even when session meta appears late`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let parentDay = try env.makeLocalNoon(year: 2026, month: 2, day: 27)
+        let childDay = try env.makeLocalNoon(year: 2026, month: 3, day: 11)
+        let model = "openai/gpt-5.2-codex"
+        let parentSessionId = "sess-parent-late-meta"
+        let childSessionId = "sess-child-late-meta"
+        let forkTs = env.isoString(for: parentDay.addingTimeInterval(5))
+
+        let parentEvents: [[String: Any]] = [
+            [
+                "type": "session_meta",
+                "payload": [
+                    "id": parentSessionId,
+                ],
+            ],
+            [
+                "type": "turn_context",
+                "timestamp": env.isoString(for: parentDay),
+                "payload": [
+                    "model": model,
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: parentDay.addingTimeInterval(1)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 10,
+                            "cached_input_tokens": 2,
+                            "output_tokens": 1,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: parentDay.addingTimeInterval(2)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 20,
+                            "cached_input_tokens": 5,
+                            "output_tokens": 2,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: parentDay.addingTimeInterval(3)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 30,
+                            "cached_input_tokens": 8,
+                            "output_tokens": 3,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+        ]
+        _ = try env.writeCodexSessionFile(
+            day: parentDay,
+            filename: "rollout-2026-02-27T11-29-28-\(parentSessionId).jsonl",
+            contents: env.jsonl(parentEvents))
+
+        let childEvents: [[String: Any]] = [
+            [
+                "type": "turn_context",
+                "timestamp": env.isoString(for: childDay),
+                "payload": [
+                    "model": model,
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: childDay.addingTimeInterval(1)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 10,
+                            "cached_input_tokens": 2,
+                            "output_tokens": 1,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: childDay.addingTimeInterval(2)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 20,
+                            "cached_input_tokens": 5,
+                            "output_tokens": 2,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: childDay.addingTimeInterval(3)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 30,
+                            "cached_input_tokens": 8,
+                            "output_tokens": 3,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+            [
+                "type": "session_meta",
+                "payload": [
+                    "id": childSessionId,
+                    "forked_from_id": parentSessionId,
+                    "timestamp": forkTs,
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: childDay.addingTimeInterval(4)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 35,
+                            "cached_input_tokens": 9,
+                            "output_tokens": 4,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+            [
+                "type": "event_msg",
+                "timestamp": env.isoString(for: childDay.addingTimeInterval(5)),
+                "payload": [
+                    "type": "token_count",
+                    "info": [
+                        "total_token_usage": [
+                            "input_tokens": 42,
+                            "cached_input_tokens": 11,
+                            "output_tokens": 5,
+                        ],
+                        "model": model,
+                    ],
+                ],
+            ],
+        ]
+        _ = try env.writeCodexSessionFile(
+            day: childDay,
+            filename: "rollout-2026-03-11T11-30-27-\(childSessionId).jsonl",
+            contents: env.jsonl(childEvents))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+        options.forceRescan = true
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: childDay,
+            until: childDay,
+            now: childDay,
+            options: options)
+
+        let expectedCost = CostUsagePricing.codexCostUSD(
+            model: "gpt-5.2-codex",
+            inputTokens: 12,
+            cachedInputTokens: 3,
+            outputTokens: 2)
+
+        #expect(report.data.count == 1)
+        #expect(report.data[0].inputTokens == 12)
+        #expect(report.data[0].outputTokens == 2)
+        #expect(report.data[0].totalTokens == 14)
+        #expect(abs((report.data[0].costUSD ?? 0) - (expectedCost ?? 0)) < 0.000001)
+    }
+
+    @Test
     func `codex forked child resolves parent when parent session file is a symlink`() throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }
@@ -673,7 +1038,9 @@ struct CostUsageScannerBreakdownTests {
             .appendingPathComponent(String(format: "%02d", comps.month ?? 1), isDirectory: true)
             .appendingPathComponent(String(format: "%02d", comps.day ?? 1), isDirectory: true)
         try FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)
-        let parentLink = parentDir.appendingPathComponent("rollout-2026-02-27T11-29-28-\(parentSessionId).jsonl", isDirectory: false)
+        let parentLink = parentDir.appendingPathComponent(
+            "rollout-2026-02-27T11-29-28-\(parentSessionId).jsonl",
+            isDirectory: false)
         try FileManager.default.createSymbolicLink(at: parentLink, withDestinationURL: parentTarget)
 
         _ = try env.writeCodexSessionFile(
@@ -755,6 +1122,7 @@ struct CostUsageScannerBreakdownTests {
     }
 
     @Test
+    // swiftlint:disable:next function_body_length
     func `codex forked child resolves parent by exact session meta id`() throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }
@@ -1067,6 +1435,212 @@ struct CostUsageScannerBreakdownTests {
     }
 
     @Test
+    func `codex first refresh keeps unrelated archived sessions out of cache`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let reportDay = try env.makeLocalNoon(year: 2026, month: 3, day: 11)
+        let archivedDay = try env.makeLocalNoon(year: 2025, month: 1, day: 1)
+        let model = "openai/gpt-5.2-codex"
+
+        _ = try env.writeCodexSessionFile(
+            day: reportDay,
+            filename: "rollout-2026-03-11T11-30-27-session-recent.jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "turn_context",
+                    "timestamp": env.isoString(for: reportDay),
+                    "payload": [
+                        "model": model,
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": env.isoString(for: reportDay.addingTimeInterval(1)),
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "last_token_usage": [
+                                "input_tokens": 7,
+                                "cached_input_tokens": 2,
+                                "output_tokens": 2,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+            ]))
+
+        let archivedURL = try env.writeCodexArchivedSessionFile(
+            filename: "rollout-2025-01-01T12-00-00-session-archived.jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "turn_context",
+                    "timestamp": env.isoString(for: archivedDay),
+                    "payload": [
+                        "model": model,
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": env.isoString(for: archivedDay.addingTimeInterval(1)),
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "last_token_usage": [
+                                "input_tokens": 100,
+                                "cached_input_tokens": 10,
+                                "output_tokens": 5,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+            ]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: reportDay,
+            until: reportDay,
+            now: reportDay,
+            options: options)
+
+        let cache = CostUsageCacheIO.load(provider: .codex, cacheRoot: env.cacheRoot)
+
+        #expect(report.data.count == 1)
+        #expect(cache.files.keys.contains { $0.hasSuffix("session-recent.jsonl") })
+        #expect(!cache.files.keys.contains(archivedURL.path))
+    }
+
+    @Test
+    func `codex root switch reloads long lived sessions from older partitions`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        func writeSessionFile(
+            root: URL,
+            day: Date,
+            filename: String,
+            contents: String) throws -> URL
+        {
+            let comps = Calendar.current.dateComponents([.year, .month, .day], from: day)
+            let dir = root
+                .appendingPathComponent(String(format: "%04d", comps.year ?? 1970), isDirectory: true)
+                .appendingPathComponent(String(format: "%02d", comps.month ?? 1), isDirectory: true)
+                .appendingPathComponent(String(format: "%02d", comps.day ?? 1), isDirectory: true)
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let url = dir.appendingPathComponent(filename, isDirectory: false)
+            try contents.write(to: url, atomically: true, encoding: .utf8)
+            return url
+        }
+
+        let fileDay = try env.makeLocalNoon(year: 2026, month: 2, day: 27)
+        let reportDay = try env.makeLocalNoon(year: 2026, month: 3, day: 11)
+        let model = "openai/gpt-5.2-codex"
+        let otherSessionsRoot = env.root
+            .appendingPathComponent("other-codex-home", isDirectory: true)
+            .appendingPathComponent("sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: otherSessionsRoot, withIntermediateDirectories: true)
+
+        let oldRootURL = try env.writeCodexSessionFile(
+            day: reportDay,
+            filename: "rollout-2026-03-11T11-30-27-session-old-root.jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "turn_context",
+                    "timestamp": env.isoString(for: reportDay),
+                    "payload": [
+                        "model": model,
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": env.isoString(for: reportDay.addingTimeInterval(1)),
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "last_token_usage": [
+                                "input_tokens": 7,
+                                "cached_input_tokens": 2,
+                                "output_tokens": 2,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+            ]))
+
+        _ = try writeSessionFile(
+            root: otherSessionsRoot,
+            day: fileDay,
+            filename: "rollout-2026-02-27T11-30-27-session-new-root.jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "turn_context",
+                    "timestamp": env.isoString(for: reportDay),
+                    "payload": [
+                        "model": model,
+                    ],
+                ],
+                [
+                    "type": "event_msg",
+                    "timestamp": env.isoString(for: reportDay.addingTimeInterval(1)),
+                    "payload": [
+                        "type": "token_count",
+                        "info": [
+                            "last_token_usage": [
+                                "input_tokens": 10,
+                                "cached_input_tokens": 5,
+                                "output_tokens": 4,
+                            ],
+                            "model": model,
+                        ],
+                    ],
+                ],
+            ]))
+
+        var firstOptions = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        firstOptions.refreshMinIntervalSeconds = 0
+
+        _ = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: reportDay,
+            until: reportDay,
+            now: reportDay,
+            options: firstOptions)
+
+        var secondOptions = CostUsageScanner.Options(
+            codexSessionsRoot: otherSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        secondOptions.refreshMinIntervalSeconds = 0
+
+        let secondReport = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: reportDay,
+            until: reportDay,
+            now: reportDay,
+            options: secondOptions)
+
+        let cache = CostUsageCacheIO.load(provider: .codex, cacheRoot: env.cacheRoot)
+
+        #expect(secondReport.data.count == 1)
+        #expect(secondReport.data[0].inputTokens == 10)
+        #expect(secondReport.data[0].outputTokens == 4)
+        #expect(secondReport.data[0].totalTokens == 14)
+        #expect(!cache.files.keys.contains(oldRootURL.path))
+    }
+
+    @Test
     func `claude daily report parses usage and caches`() throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }
@@ -1241,3 +1815,5 @@ struct CostUsageScannerBreakdownTests {
         #expect(report.data[0].modelBreakdowns?.map(\.totalTokens) == [110, 40, 30, 15])
     }
 }
+
+// swiftlint:enable type_body_length


### PR DESCRIPTION
## Summary

Tighten the Codex cost scanner around fork inheritance, cold-cache discovery, and sessions-root changes.

This keeps the fork replay fix from `#680`, but also addresses follow-on edge cases in incremental parsing, cache reuse, and long-lived session discovery.

Supersedes #680.

Thanks to @xx205 for the original fix and test coverage that made this follow-up much easier.

## Validation

- `pnpm check`
- `swift test --filter CostUsageScannerBreakdownTests --filter CostUsageScannerTests`
- `./Scripts/compile_and_run.sh`