### PR TITLE
Add Moonshot provider (official platform API)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,4 @@
 - Keep provider data siloed: when rendering usage or account info for a provider (Claude vs Codex), never display identity/plan fields sourced from a different provider.***
 - Claude CLI status line is custom + user-configurable; never rely on it for usage parsing.
 - Cookie imports: default Chrome-only when possible to avoid other browser prompts; override via browser list when needed.
+- Moonshot provider: official Moonshot uses `GET /v1/users/me/balance` on `api.moonshot.ai` or `api.moonshot.cn`, exposes a Region picker, shows balance-only/no-limit semantics, and must stay distinct from the third-party Kimi K2 provider tracked in issue #473.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.21 — Unreleased
 
 ### Highlights
+- Moonshot: add an official Moonshot platform provider with International/China region selection, config/env API-key support, and balance-only display semantics distinct from Kimi K2 (#473).
 - z.ai: preserve weekly and 5-hour token quotas together, surface the 5-hour lane correctly across the menu/menu bar, and add regression coverage (#662). Thanks to @takumi3488 for the original fix and investigation.
 - Cursor: fix a crash in the usage fetch path and add regression coverage (#663). Thanks @anirudhvee for the report and validation!
 - Antigravity: accept localhost TLS challenges when probing the local language server so usage/account info loads again instead of reporting `no working API port found` (#693, fixes #692). Thanks @anirudhvee!
@@ -13,6 +14,7 @@
 - Codex: make OpenAI web extras opt-in for fresh installs, preserve working legacy setups on upgrade, add an OpenAI web battery-saver toggle, and keep account-scoped dashboard state aligned during refreshes and account switches (#529). Thanks @cbrane!
 
 ### Providers & Usage
+- Moonshot: add the official balance endpoint provider for `api.moonshot.ai` / `api.moonshot.cn`, store API keys in `~/.codexbar/config.json`, and keep Kimi K2 untouched so official Moonshot credentials are no longer conflated with the third-party Kimi K2 service (#473).
 - z.ai: preserve both weekly and 5-hour token quotas, keep the existing 2-limit behavior unchanged, and render the 5-hour quota as a tertiary row in provider snapshots and CLI/menu cards (#662). Credit to @takumi3488 for the original fix and investigation.
 - Cursor: fix the usage fetch path so failed or cancelled requests no longer crash, and add Linux build and regression test coverage fixes (#663).
 - Antigravity: scope insecure localhost trust handling to `127.0.0.1` / `localhost`, keep localhost requests cancellable, and restore local quota/account probing on builds that previously failed TLS challenge handling (#693, fixes #692). Thanks @anirudhvee!

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# Repository Notes
+
+## Build, Test, Run
+- Dev loop: `./Scripts/compile_and_run.sh`
+- Quick verification: `swiftformat Sources Tests`, `swiftlint --strict`, `swift build`, `swift test`
+- Package app: `./Scripts/package_app.sh`
+
+## Coding Conventions
+- SwiftFormat and SwiftLint are required; keep explicit `self`.
+- Prefer small typed structs/enums and existing provider patterns over new abstractions.
+- Reuse shared provider settings descriptors instead of adding custom provider-only UI.
+
+## Provider Notes
+- Keep provider identity and plan data siloed by provider.
+- Moonshot is the official Moonshot platform provider and is separate from Kimi K2.
+- Moonshot uses `GET /v1/users/me/balance` on `api.moonshot.ai` or `api.moonshot.cn`, exposes a Region picker, and renders balance-only/no-limit semantics.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CodexBar 🎚️ - May your tokens never run out.
 
-Tiny macOS 14+ menu bar app that keeps your Codex, Claude, Cursor, Gemini, Antigravity, Droid (Factory), Copilot, z.ai, Kiro, Vertex AI, Augment, Amp, JetBrains AI, OpenRouter, and Perplexity limits visible (session + weekly where available) and shows when each window resets. One status item per provider (or Merge Icons mode with a provider switcher and optional Overview tab); enable what you use from Settings. No Dock icon, minimal UI, dynamic bar icons in the menu bar.
+Tiny macOS 14+ menu bar app that keeps your Codex, Claude, Cursor, Gemini, Antigravity, Droid (Factory), Copilot, z.ai, Kiro, Vertex AI, Augment, Amp, JetBrains AI, Moonshot, OpenRouter, and Perplexity limits visible (session + weekly where available) and shows when each window resets. One status item per provider (or Merge Icons mode with a provider switcher and optional Overview tab); enable what you use from Settings. No Dock icon, minimal UI, dynamic bar icons in the menu bar.
 
 <img src="codexbar.png" alt="CodexBar menu screenshot" width="520" />
 
@@ -41,6 +41,7 @@ Linux support via Omarchy: community Waybar module and TUI, driven by the `codex
 - [z.ai](docs/zai.md) — API token (Keychain) for quota + MCP windows.
 - [Kimi](docs/kimi.md) — Auth token (JWT from `kimi-auth` cookie) for weekly quota + 5‑hour rate limit.
 - [Kimi K2](docs/kimi-k2.md) — API key for credit-based usage totals.
+- [Moonshot](docs/moonshot.md) — Official Moonshot platform API balance via `api.moonshot.ai` or `api.moonshot.cn`.
 - [Kiro](docs/kiro.md) — CLI-based usage via `kiro-cli /usage` command; monthly credits + bonus credits.
 - [Vertex AI](docs/vertexai.md) — Google Cloud gcloud OAuth with token cost tracking from local Claude logs.
 - [Augment](docs/augment.md) — Browser cookie-based authentication with automatic session keepalive; credits tracking and usage monitoring.

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -788,6 +788,10 @@ extension UsageMenuCardView.Model {
             return notes
         }
 
+        if input.provider == .moonshot, input.snapshot != nil {
+            return ["No limit set"]
+        }
+
         guard input.provider == .openrouter,
               let openRouter = input.snapshot?.openRouterUsage
         else {

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -63,7 +63,7 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
         else {
             return nil
         }
-        guard provider == .openrouter else {
+        guard provider == .openrouter || provider == .moonshot else {
             return (label: "Plan", value: rawPlan)
         }
 

--- a/Sources/CodexBar/Providers/Moonshot/MoonshotProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Moonshot/MoonshotProviderImplementation.swift
@@ -1,0 +1,72 @@
+import AppKit
+import CodexBarCore
+import CodexBarMacroSupport
+import Foundation
+import SwiftUI
+
+@ProviderImplementationRegistration
+struct MoonshotProviderImplementation: ProviderImplementation {
+    let id: UsageProvider = .moonshot
+
+    @MainActor
+    func observeSettings(_ settings: SettingsStore) {
+        _ = settings.moonshotAPIToken
+        _ = settings.moonshotRegion
+    }
+
+    @MainActor
+    func settingsSnapshot(context: ProviderSettingsSnapshotContext) -> ProviderSettingsSnapshotContribution? {
+        _ = context
+        return .moonshot(context.settings.moonshotSettingsSnapshot())
+    }
+
+    @MainActor
+    func settingsPickers(context: ProviderSettingsContext) -> [ProviderSettingsPickerDescriptor] {
+        let binding = Binding(
+            get: { context.settings.moonshotRegion.rawValue },
+            set: { raw in
+                context.settings.moonshotRegion = MoonshotRegion(rawValue: raw) ?? .international
+            })
+        let options = MoonshotRegion.allCases.map {
+            ProviderSettingsPickerOption(id: $0.rawValue, title: $0.displayName)
+        }
+
+        return [
+            ProviderSettingsPickerDescriptor(
+                id: "moonshot-region",
+                title: "Region",
+                subtitle: "Choose the official Moonshot API host for your account.",
+                binding: binding,
+                options: options,
+                isVisible: nil,
+                onChange: nil),
+        ]
+    }
+
+    @MainActor
+    func settingsFields(context: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {
+        [
+            ProviderSettingsFieldDescriptor(
+                id: "moonshot-api-key",
+                title: "API key",
+                subtitle: "Stored in ~/.codexbar/config.json. Generate one in the Moonshot console.",
+                kind: .secure,
+                placeholder: "Paste API key…",
+                binding: context.stringBinding(\.moonshotAPIToken),
+                actions: [
+                    ProviderSettingsActionDescriptor(
+                        id: "moonshot-open-api-keys",
+                        title: "Open API Keys",
+                        style: .link,
+                        isVisible: nil,
+                        perform: {
+                            if let url = URL(string: "https://platform.moonshot.ai/console/api-keys") {
+                                NSWorkspace.shared.open(url)
+                            }
+                        }),
+                ],
+                isVisible: nil,
+                onActivate: { context.settings.ensureMoonshotAPITokenLoaded() }),
+        ]
+    }
+}

--- a/Sources/CodexBar/Providers/Moonshot/MoonshotSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Moonshot/MoonshotSettingsStore.swift
@@ -1,0 +1,34 @@
+import CodexBarCore
+import Foundation
+
+extension SettingsStore {
+    var moonshotAPIToken: String {
+        get { self.configSnapshot.providerConfig(for: .moonshot)?.sanitizedAPIKey ?? "" }
+        set {
+            self.updateProviderConfig(provider: .moonshot) { entry in
+                entry.apiKey = self.normalizedConfigValue(newValue)
+            }
+            self.logSecretUpdate(provider: .moonshot, field: "apiKey", value: newValue)
+        }
+    }
+
+    var moonshotRegion: MoonshotRegion {
+        get {
+            let raw = self.configSnapshot.providerConfig(for: .moonshot)?.region
+            return MoonshotRegion(rawValue: raw ?? "") ?? .international
+        }
+        set {
+            self.updateProviderConfig(provider: .moonshot) { entry in
+                entry.region = newValue.rawValue
+            }
+        }
+    }
+
+    func ensureMoonshotAPITokenLoaded() {}
+}
+
+extension SettingsStore {
+    func moonshotSettingsSnapshot() -> ProviderSettingsSnapshot.MoonshotProviderSettings {
+        ProviderSettingsSnapshot.MoonshotProviderSettings(region: self.moonshotRegion)
+    }
+}

--- a/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
@@ -32,6 +32,7 @@ enum ProviderImplementationRegistry {
         case .augment: AugmentProviderImplementation()
         case .jetbrains: JetBrainsProviderImplementation()
         case .kimik2: KimiK2ProviderImplementation()
+        case .moonshot: MoonshotProviderImplementation()
         case .amp: AmpProviderImplementation()
         case .ollama: OllamaProviderImplementation()
         case .synthetic: SyntheticProviderImplementation()

--- a/Sources/CodexBar/Resources/ProviderIcon-moonshot.svg
+++ b/Sources/CodexBar/Resources/ProviderIcon-moonshot.svg
@@ -1,0 +1,4 @@
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg" fill="currentColor" stroke="currentColor">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M232 120a136 136 0 1 0 0 272a136 136 0 1 0 0-272ZM292 88a136 136 0 1 1 0 272a136 136 0 1 1 0-272Z"/>
+<path d="M354 120L372 164L416 182L372 200L354 244L336 200L292 182L336 164L354 120Z" stroke-width="18" stroke-linejoin="round"/>
+</svg>

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -635,6 +635,9 @@ extension StatusItemController {
         provider: UsageProvider,
         snapshot: UsageSnapshot?) -> Bool
     {
+        if provider == .moonshot {
+            return snapshot != nil
+        }
         guard provider == .openrouter,
               let openRouterUsage = snapshot?.openRouterUsage
         else {

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -777,6 +777,7 @@ extension UsageStore {
                 .kiro: "Kiro debug log not yet implemented",
                 .kimi: "Kimi debug log not yet implemented",
                 .kimik2: "Kimi K2 debug log not yet implemented",
+                .moonshot: "Moonshot debug log not yet implemented",
                 .jetbrains: "JetBrains AI debug log not yet implemented",
             ]
             let buildText = {
@@ -851,7 +852,7 @@ extension UsageStore {
                     let source = resolution?.source.rawValue ?? "none"
                     return "WARP_API_KEY=\(hasAny ? "present" : "missing") source=\(source)"
                 case .gemini, .antigravity, .opencode, .opencodego, .factory, .copilot, .vertexai, .kilo, .kiro, .kimi,
-                     .kimik2, .jetbrains, .perplexity:
+                     .kimik2, .moonshot, .jetbrains, .perplexity:
                     return unimplementedDebugLogMessages[provider] ?? "Debug log not yet implemented"
                 }
             }

--- a/Sources/CodexBarCLI/TokenAccountCLI.swift
+++ b/Sources/CodexBarCLI/TokenAccountCLI.swift
@@ -170,6 +170,10 @@ struct TokenAccountCLIContext {
         case .zai:
             return self.makeSnapshot(
                 zai: ProviderSettingsSnapshot.ZaiProviderSettings(apiRegion: self.resolveZaiRegion(config)))
+        case .moonshot:
+            return self.makeSnapshot(
+                moonshot: ProviderSettingsSnapshot.MoonshotProviderSettings(
+                    region: self.resolveMoonshotRegion(config)))
         case .kilo:
             return self.makeSnapshot(
                 kilo: ProviderSettingsSnapshot.KiloProviderSettings(
@@ -201,6 +205,7 @@ struct TokenAccountCLIContext {
         factory: ProviderSettingsSnapshot.FactoryProviderSettings? = nil,
         minimax: ProviderSettingsSnapshot.MiniMaxProviderSettings? = nil,
         zai: ProviderSettingsSnapshot.ZaiProviderSettings? = nil,
+        moonshot: ProviderSettingsSnapshot.MoonshotProviderSettings? = nil,
         kilo: ProviderSettingsSnapshot.KiloProviderSettings? = nil,
         kimi: ProviderSettingsSnapshot.KimiProviderSettings? = nil,
         augment: ProviderSettingsSnapshot.AugmentProviderSettings? = nil,
@@ -219,6 +224,7 @@ struct TokenAccountCLIContext {
             factory: factory,
             minimax: minimax,
             zai: zai,
+            moonshot: moonshot,
             kilo: kilo,
             kimi: kimi,
             augment: augment,
@@ -359,6 +365,15 @@ struct TokenAccountCLIContext {
             return .global
         }
         return MiniMaxAPIRegion(rawValue: raw) ?? .global
+    }
+
+    private func resolveMoonshotRegion(_ config: ProviderConfig?) -> MoonshotRegion {
+        guard let raw = config?.region?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty
+        else {
+            return .international
+        }
+        return MoonshotRegion(rawValue: raw) ?? .international
     }
 
     private func resolveAlibabaCodingPlanRegion(_ config: ProviderConfig?) -> AlibabaCodingPlanAPIRegion {

--- a/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
@@ -154,6 +154,15 @@ public enum CodexBarConfigValidator {
                         code: "invalid_region",
                         message: "Region \(region) is not a valid Alibaba Coding Plan region."))
                 }
+            case .moonshot:
+                if MoonshotRegion(rawValue: region) == nil {
+                    issues.append(CodexBarConfigIssue(
+                        severity: .error,
+                        provider: provider,
+                        field: "region",
+                        code: "invalid_region",
+                        message: "Region \(region) is not a valid Moonshot region."))
+                }
             default:
                 issues.append(CodexBarConfigIssue(
                     severity: .warning,

--- a/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
+++ b/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
@@ -23,6 +23,10 @@ public enum ProviderConfigEnvironment {
             if let key = KimiK2SettingsReader.apiKeyEnvironmentKeys.first {
                 env[key] = apiKey
             }
+        case .moonshot:
+            if let key = MoonshotSettingsReader.apiKeyEnvironmentKeys.first {
+                env[key] = apiKey
+            }
         case .synthetic:
             env[SyntheticSettingsReader.apiKeyKey] = apiKey
         case .warp:

--- a/Sources/CodexBarCore/Logging/LogCategories.swift
+++ b/Sources/CodexBarCore/Logging/LogCategories.swift
@@ -37,6 +37,7 @@ public enum LogCategories {
     public static let minimaxCookieStore = "minimax-cookie-store"
     public static let minimaxUsage = "minimax-usage"
     public static let minimaxWeb = "minimax-web"
+    public static let moonshotUsage = "moonshot-usage"
     public static let notifications = "notifications"
     public static let openAIWeb = "openai-web"
     public static let openAIWebview = "openai-webview"

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderDescriptor.swift
@@ -1,0 +1,70 @@
+import CodexBarMacroSupport
+import Foundation
+
+@ProviderDescriptorRegistration
+@ProviderDescriptorDefinition
+public enum MoonshotProviderDescriptor {
+    static func makeDescriptor() -> ProviderDescriptor {
+        ProviderDescriptor(
+            id: .moonshot,
+            metadata: ProviderMetadata(
+                id: .moonshot,
+                displayName: "Moonshot",
+                sessionLabel: "Balance",
+                weeklyLabel: "Balance",
+                opusLabel: nil,
+                supportsOpus: false,
+                supportsCredits: false,
+                creditsHint: "",
+                toggleTitle: "Show Moonshot usage",
+                cliName: "moonshot",
+                defaultEnabled: false,
+                isPrimaryProvider: false,
+                usesAccountFallback: false,
+                browserCookieOrder: nil,
+                dashboardURL: "https://platform.moonshot.ai/console/info",
+                statusPageURL: nil),
+            branding: ProviderBranding(
+                iconStyle: .moonshot,
+                iconResourceName: "ProviderIcon-moonshot",
+                color: ProviderColor(red: 32 / 255, green: 93 / 255, blue: 235 / 255)),
+            tokenCost: ProviderTokenCostConfig(
+                supportsTokenCost: false,
+                noDataMessage: { "Moonshot cost summary is not available." }),
+            fetchPlan: ProviderFetchPlan(
+                sourceModes: [.auto, .api],
+                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [MoonshotAPIFetchStrategy()] })),
+            cli: ProviderCLIConfig(
+                name: "moonshot",
+                aliases: [],
+                versionDetector: nil))
+    }
+}
+
+struct MoonshotAPIFetchStrategy: ProviderFetchStrategy {
+    let id: String = "moonshot.api"
+    let kind: ProviderFetchKind = .apiToken
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        Self.resolveToken(environment: context.env) != nil
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        guard let apiKey = Self.resolveToken(environment: context.env) else {
+            throw MoonshotUsageError.missingCredentials
+        }
+        let region = context.settings?.moonshot?.region ?? MoonshotSettingsReader.region(environment: context.env)
+        let usage = try await MoonshotUsageFetcher.fetchUsage(apiKey: apiKey, region: region)
+        return self.makeResult(
+            usage: usage.toUsageSnapshot(),
+            sourceLabel: "api")
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+
+    private static func resolveToken(environment: [String: String]) -> String? {
+        ProviderTokenResolver.moonshotToken(environment: environment)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotRegion.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotRegion.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public enum MoonshotRegion: String, CaseIterable, Sendable {
+    case international
+    case china
+
+    private static let balancePath = "v1/users/me/balance"
+
+    public var displayName: String {
+        switch self {
+        case .international:
+            "International (api.moonshot.ai)"
+        case .china:
+            "China (api.moonshot.cn)"
+        }
+    }
+
+    public var apiBaseURLString: String {
+        switch self {
+        case .international:
+            "https://api.moonshot.ai"
+        case .china:
+            "https://api.moonshot.cn"
+        }
+    }
+
+    public var balanceURL: URL {
+        URL(string: self.apiBaseURLString)!.appendingPathComponent(Self.balancePath)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotSettingsReader.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+public struct MoonshotSettingsReader: Sendable {
+    public static let apiKeyEnvironmentKeys = [
+        "MOONSHOT_API_KEY",
+        "MOONSHOT_KEY",
+    ]
+    public static let regionEnvironmentKey = "MOONSHOT_REGION"
+
+    public static func apiKey(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
+    {
+        for key in self.apiKeyEnvironmentKeys {
+            guard let raw = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !raw.isEmpty
+            else {
+                continue
+            }
+            let cleaned = Self.cleaned(raw)
+            if !cleaned.isEmpty {
+                return cleaned
+            }
+        }
+        return nil
+    }
+
+    public static func region(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> MoonshotRegion
+    {
+        guard let raw = environment[self.regionEnvironmentKey] else {
+            return .international
+        }
+        let cleaned = Self.cleaned(raw).lowercased()
+        return MoonshotRegion(rawValue: cleaned) ?? .international
+    }
+
+    private static func cleaned(_ raw: String) -> String {
+        var value = raw
+        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
+            (value.hasPrefix("'") && value.hasSuffix("'"))
+        {
+            value.removeFirst()
+            value.removeLast()
+        }
+        return value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotUsageFetcher.swift
@@ -1,0 +1,156 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public struct MoonshotUsageSnapshot: Sendable {
+    public let summary: MoonshotUsageSummary
+
+    public init(summary: MoonshotUsageSummary) {
+        self.summary = summary
+    }
+
+    public func toUsageSnapshot() -> UsageSnapshot {
+        self.summary.toUsageSnapshot()
+    }
+}
+
+public struct MoonshotUsageSummary: Sendable {
+    public let availableBalance: Double
+    public let voucherBalance: Double
+    public let cashBalance: Double
+    public let updatedAt: Date
+
+    public init(availableBalance: Double, voucherBalance: Double, cashBalance: Double, updatedAt: Date) {
+        self.availableBalance = availableBalance
+        self.voucherBalance = voucherBalance
+        self.cashBalance = cashBalance
+        self.updatedAt = updatedAt
+    }
+
+    public func toUsageSnapshot() -> UsageSnapshot {
+        let balance = UsageFormatter.usdString(self.availableBalance)
+        let loginMethod: String
+        if self.cashBalance < 0 {
+            let deficit = UsageFormatter.usdString(abs(self.cashBalance))
+            loginMethod = "Balance: \(balance) · \(deficit) in deficit"
+        } else {
+            loginMethod = "Balance: \(balance)"
+        }
+        let identity = ProviderIdentitySnapshot(
+            providerID: .moonshot,
+            accountEmail: nil,
+            accountOrganization: nil,
+            loginMethod: loginMethod)
+        return UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            providerCost: nil,
+            updatedAt: self.updatedAt,
+            identity: identity)
+    }
+}
+
+public enum MoonshotUsageError: LocalizedError, Sendable {
+    case missingCredentials
+    case networkError(String)
+    case apiError(String)
+    case parseFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingCredentials:
+            "Missing Moonshot API key."
+        case let .networkError(message):
+            "Moonshot network error: \(message)"
+        case let .apiError(message):
+            "Moonshot API error: \(message)"
+        case let .parseFailed(message):
+            "Failed to parse Moonshot response: \(message)"
+        }
+    }
+}
+
+public struct MoonshotUsageFetcher: Sendable {
+    private static let log = CodexBarLog.logger(LogCategories.moonshotUsage)
+
+    public static func fetchUsage(
+        apiKey: String,
+        region: MoonshotRegion = .international,
+        session: URLSession = .shared) async throws -> MoonshotUsageSnapshot
+    {
+        let cleaned = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else {
+            throw MoonshotUsageError.missingCredentials
+        }
+
+        var request = URLRequest(url: self.resolveBalanceURL(region: region))
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(cleaned)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw MoonshotUsageError.networkError("Invalid response")
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? "HTTP \(httpResponse.statusCode)"
+            Self.log.error("Moonshot API returned \(httpResponse.statusCode): \(body)")
+            throw MoonshotUsageError.apiError(body)
+        }
+
+        let summary = try self.parseSummary(data: data)
+        return MoonshotUsageSnapshot(summary: summary)
+    }
+
+    public static func resolveBalanceURL(region: MoonshotRegion) -> URL {
+        region.balanceURL
+    }
+
+    static func _parseSummaryForTesting(_ data: Data) throws -> MoonshotUsageSummary {
+        try self.parseSummary(data: data)
+    }
+
+    private static func parseSummary(data: Data) throws -> MoonshotUsageSummary {
+        guard let json = try? JSONSerialization.jsonObject(with: data),
+              let dictionary = json as? [String: Any]
+        else {
+            throw MoonshotUsageError.parseFailed("Root JSON is not an object.")
+        }
+
+        guard let payload = dictionary["data"] as? [String: Any] else {
+            throw MoonshotUsageError.parseFailed("Missing data object.")
+        }
+        guard let availableBalance = self.double(from: payload["available_balance"]) else {
+            throw MoonshotUsageError.parseFailed("Missing available_balance.")
+        }
+        guard let voucherBalance = self.double(from: payload["voucher_balance"]) else {
+            throw MoonshotUsageError.parseFailed("Missing voucher_balance.")
+        }
+        guard let cashBalance = self.double(from: payload["cash_balance"]) else {
+            throw MoonshotUsageError.parseFailed("Missing cash_balance.")
+        }
+
+        return MoonshotUsageSummary(
+            availableBalance: availableBalance,
+            voucherBalance: voucherBalance,
+            cashBalance: cashBalance,
+            updatedAt: Date())
+    }
+
+    private static func double(from raw: Any?) -> Double? {
+        if let value = raw as? Double {
+            return value
+        }
+        if let value = raw as? Int {
+            return Double(value)
+        }
+        if let value = raw as? String {
+            return Double(value)
+        }
+        return nil
+    }
+}

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -72,6 +72,7 @@ public enum ProviderDescriptorRegistry {
         .augment: AugmentProviderDescriptor.descriptor,
         .jetbrains: JetBrainsProviderDescriptor.descriptor,
         .kimik2: KimiK2ProviderDescriptor.descriptor,
+        .moonshot: MoonshotProviderDescriptor.descriptor,
         .amp: AmpProviderDescriptor.descriptor,
         .ollama: OllamaProviderDescriptor.descriptor,
         .synthetic: SyntheticProviderDescriptor.descriptor,

--- a/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
@@ -13,6 +13,7 @@ public struct ProviderSettingsSnapshot: Sendable {
         factory: FactoryProviderSettings? = nil,
         minimax: MiniMaxProviderSettings? = nil,
         zai: ZaiProviderSettings? = nil,
+        moonshot: MoonshotProviderSettings? = nil,
         copilot: CopilotProviderSettings? = nil,
         kilo: KiloProviderSettings? = nil,
         kimi: KimiProviderSettings? = nil,
@@ -34,6 +35,7 @@ public struct ProviderSettingsSnapshot: Sendable {
             factory: factory,
             minimax: minimax,
             zai: zai,
+            moonshot: moonshot,
             copilot: copilot,
             kilo: kilo,
             kimi: kimi,
@@ -160,6 +162,14 @@ public struct ProviderSettingsSnapshot: Sendable {
         }
     }
 
+    public struct MoonshotProviderSettings: Sendable {
+        public let region: MoonshotRegion
+
+        public init(region: MoonshotRegion = .international) {
+            self.region = region
+        }
+    }
+
     public struct CopilotProviderSettings: Sendable {
         public init() {}
     }
@@ -243,6 +253,7 @@ public struct ProviderSettingsSnapshot: Sendable {
     public let factory: FactoryProviderSettings?
     public let minimax: MiniMaxProviderSettings?
     public let zai: ZaiProviderSettings?
+    public let moonshot: MoonshotProviderSettings?
     public let copilot: CopilotProviderSettings?
     public let kilo: KiloProviderSettings?
     public let kimi: KimiProviderSettings?
@@ -268,6 +279,7 @@ public struct ProviderSettingsSnapshot: Sendable {
         factory: FactoryProviderSettings?,
         minimax: MiniMaxProviderSettings?,
         zai: ZaiProviderSettings?,
+        moonshot: MoonshotProviderSettings?,
         copilot: CopilotProviderSettings?,
         kilo: KiloProviderSettings?,
         kimi: KimiProviderSettings?,
@@ -288,6 +300,7 @@ public struct ProviderSettingsSnapshot: Sendable {
         self.factory = factory
         self.minimax = minimax
         self.zai = zai
+        self.moonshot = moonshot
         self.copilot = copilot
         self.kilo = kilo
         self.kimi = kimi
@@ -309,6 +322,7 @@ public enum ProviderSettingsSnapshotContribution: Sendable {
     case factory(ProviderSettingsSnapshot.FactoryProviderSettings)
     case minimax(ProviderSettingsSnapshot.MiniMaxProviderSettings)
     case zai(ProviderSettingsSnapshot.ZaiProviderSettings)
+    case moonshot(ProviderSettingsSnapshot.MoonshotProviderSettings)
     case copilot(ProviderSettingsSnapshot.CopilotProviderSettings)
     case kilo(ProviderSettingsSnapshot.KiloProviderSettings)
     case kimi(ProviderSettingsSnapshot.KimiProviderSettings)
@@ -331,6 +345,7 @@ public struct ProviderSettingsSnapshotBuilder: Sendable {
     public var factory: ProviderSettingsSnapshot.FactoryProviderSettings?
     public var minimax: ProviderSettingsSnapshot.MiniMaxProviderSettings?
     public var zai: ProviderSettingsSnapshot.ZaiProviderSettings?
+    public var moonshot: ProviderSettingsSnapshot.MoonshotProviderSettings?
     public var copilot: ProviderSettingsSnapshot.CopilotProviderSettings?
     public var kilo: ProviderSettingsSnapshot.KiloProviderSettings?
     public var kimi: ProviderSettingsSnapshot.KimiProviderSettings?
@@ -356,6 +371,7 @@ public struct ProviderSettingsSnapshotBuilder: Sendable {
         case let .factory(value): self.factory = value
         case let .minimax(value): self.minimax = value
         case let .zai(value): self.zai = value
+        case let .moonshot(value): self.moonshot = value
         case let .copilot(value): self.copilot = value
         case let .kilo(value): self.kilo = value
         case let .kimi(value): self.kimi = value
@@ -380,6 +396,7 @@ public struct ProviderSettingsSnapshotBuilder: Sendable {
             factory: self.factory,
             minimax: self.minimax,
             zai: self.zai,
+            moonshot: self.moonshot,
             copilot: self.copilot,
             kilo: self.kilo,
             kimi: self.kimi,

--- a/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
+++ b/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
@@ -50,6 +50,10 @@ public enum ProviderTokenResolver {
         self.kimiK2Resolution(environment: environment)?.token
     }
 
+    public static func moonshotToken(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        self.moonshotResolution(environment: environment)?.token
+    }
+
     public static func kiloToken(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         authFileURL: URL? = nil) -> String?
@@ -130,6 +134,12 @@ public enum ProviderTokenResolver {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
     {
         self.resolveEnv(KimiK2SettingsReader.apiKey(environment: environment))
+    }
+
+    public static func moonshotResolution(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
+    {
+        self.resolveEnv(MoonshotSettingsReader.apiKey(environment: environment))
     }
 
     public static func kiloResolution(

--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -22,6 +22,7 @@ public enum UsageProvider: String, CaseIterable, Sendable, Codable {
     case augment
     case jetbrains
     case kimik2
+    case moonshot
     case amp
     case ollama
     case synthetic
@@ -53,6 +54,7 @@ public enum IconStyle: Sendable, CaseIterable {
     case augment
     case jetbrains
     case amp
+    case moonshot
     case ollama
     case synthetic
     case warp

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
@@ -235,6 +235,7 @@ enum CostUsageScanner {
             return self.loadClaudeDaily(provider: .vertexai, range: range, now: now, options: filtered)
         case .zai, .gemini, .antigravity, .cursor, .opencode, .opencodego, .alibaba, .factory, .copilot,
              .minimax, .kilo, .kiro, .kimi,
+             .moonshot,
              .kimik2, .augment, .jetbrains, .amp, .ollama, .synthetic, .openrouter, .warp, .perplexity:
             return emptyReport
         }

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -70,6 +70,7 @@ enum ProviderChoice: String, AppEnum {
         case .jetbrains: return nil // JetBrains not yet supported in widgets
         case .kimi: return nil // Kimi not yet supported in widgets
         case .kimik2: return nil // Kimi K2 not yet supported in widgets
+        case .moonshot: return nil // Moonshot not yet supported in widgets
         case .amp: return nil // Amp not yet supported in widgets
         case .ollama: return nil // Ollama not yet supported in widgets
         case .synthetic: return nil // Synthetic not yet supported in widgets

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -276,6 +276,7 @@ private struct ProviderSwitchChip: View {
         case .jetbrains: "JetBrains"
         case .kimi: "Kimi"
         case .kimik2: "Kimi K2"
+        case .moonshot: "Moonshot"
         case .amp: "Amp"
         case .ollama: "Ollama"
         case .synthetic: "Synthetic"
@@ -629,6 +630,8 @@ enum WidgetColors {
             Color(red: 254 / 255, green: 96 / 255, blue: 60 / 255) // Kimi orange
         case .kimik2:
             Color(red: 76 / 255, green: 0 / 255, blue: 255 / 255) // Kimi K2 purple
+        case .moonshot:
+            Color(red: 32 / 255, green: 93 / 255, blue: 235 / 255) // Moonshot blue
         case .amp:
             Color(red: 220 / 255, green: 38 / 255, blue: 38 / 255) // Amp red
         case .ollama:

--- a/Tests/CodexBarTests/MenuCardModelTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelTests.swift
@@ -387,6 +387,44 @@ struct MenuCardModelTests {
     }
 
     @Test
+    func `moonshot model shows balance note without quota bars`() throws {
+        let now = Date()
+        let metadata = try #require(ProviderDefaults.metadata[.moonshot])
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .moonshot,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "Balance: $49.58"))
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .moonshot,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.metrics.isEmpty)
+        #expect(model.usageNotes == ["No limit set"])
+    }
+
+    @Test
     func `hides email when personal info hidden`() throws {
         let now = Date()
         let identity = ProviderIdentitySnapshot(

--- a/Tests/CodexBarTests/MoonshotSettingsReaderTests.swift
+++ b/Tests/CodexBarTests/MoonshotSettingsReaderTests.swift
@@ -1,0 +1,46 @@
+import CodexBarCore
+import Testing
+
+struct MoonshotSettingsReaderTests {
+    @Test
+    func `api key prefers MOONSHOT API KEY`() {
+        let env = [
+            "MOONSHOT_API_KEY": "primary-token",
+            "MOONSHOT_KEY": "fallback-token",
+        ]
+
+        #expect(MoonshotSettingsReader.apiKey(environment: env) == "primary-token")
+    }
+
+    @Test
+    func `api key strips quotes`() {
+        let env = ["MOONSHOT_KEY": "\"quoted-token\""]
+
+        #expect(MoonshotSettingsReader.apiKey(environment: env) == "quoted-token")
+    }
+
+    @Test
+    func `region parses china`() {
+        let env = ["MOONSHOT_REGION": "china"]
+
+        #expect(MoonshotSettingsReader.region(environment: env) == .china)
+    }
+
+    @Test
+    func `region defaults to international for unknown values`() {
+        let env = ["MOONSHOT_REGION": "moon"]
+
+        #expect(MoonshotSettingsReader.region(environment: env) == .international)
+    }
+}
+
+struct MoonshotProviderTokenResolverTests {
+    @Test
+    func `resolves from environment`() {
+        let env = ["MOONSHOT_API_KEY": "env-token"]
+        let resolution = ProviderTokenResolver.moonshotResolution(environment: env)
+
+        #expect(resolution?.token == "env-token")
+        #expect(resolution?.source == .environment)
+    }
+}

--- a/Tests/CodexBarTests/MoonshotUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/MoonshotUsageFetcherTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct MoonshotUsageFetcherTests {
+    @Test
+    func `parses documented response`() throws {
+        let json = """
+        {
+          "code": 0,
+          "data": {
+            "available_balance": 49.58,
+            "voucher_balance": 50.00,
+            "cash_balance": 12.34
+          },
+          "scode": "0x0",
+          "status": true
+        }
+        """
+
+        let summary = try MoonshotUsageFetcher._parseSummaryForTesting(Data(json.utf8))
+
+        #expect(summary.availableBalance == 49.58)
+        #expect(summary.voucherBalance == 50.00)
+        #expect(summary.cashBalance == 12.34)
+
+        let usage = MoonshotUsageSnapshot(summary: summary).toUsageSnapshot()
+        #expect(usage.primary == nil)
+        #expect(usage.secondary == nil)
+        #expect(usage.loginMethod(for: .moonshot) == "Balance: $49.58")
+    }
+
+    @Test
+    func `negative cash balance is surfaced as deficit`() throws {
+        let json = """
+        {
+          "code": 0,
+          "data": {
+            "available_balance": 49.58,
+            "voucher_balance": 50.00,
+            "cash_balance": -0.42
+          },
+          "scode": "0x0",
+          "status": true
+        }
+        """
+
+        let summary = try MoonshotUsageFetcher._parseSummaryForTesting(Data(json.utf8))
+        let usage = MoonshotUsageSnapshot(summary: summary).toUsageSnapshot()
+
+        #expect(summary.cashBalance == -0.42)
+        #expect(usage.loginMethod(for: .moonshot)?.contains("in deficit") == true)
+    }
+
+    @Test
+    func `invalid root returns parse error`() {
+        let json = """
+        [{ "available_balance": 1 }]
+        """
+
+        #expect {
+            _ = try MoonshotUsageFetcher._parseSummaryForTesting(Data(json.utf8))
+        } throws: { error in
+            guard case let MoonshotUsageError.parseFailed(message) = error else { return false }
+            return message == "Root JSON is not an object."
+        }
+    }
+
+    @Test
+    func `international host uses moonshot ai`() {
+        let url = MoonshotUsageFetcher.resolveBalanceURL(region: .international)
+
+        #expect(url.absoluteString == "https://api.moonshot.ai/v1/users/me/balance")
+    }
+
+    @Test
+    func `china host uses moonshot cn`() {
+        let url = MoonshotUsageFetcher.resolveBalanceURL(region: .china)
+
+        #expect(url.absoluteString == "https://api.moonshot.cn/v1/users/me/balance")
+    }
+}

--- a/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
+++ b/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
@@ -40,6 +40,17 @@ struct ProviderConfigEnvironmentTests {
     }
 
     @Test
+    func `applies API key override for moonshot`() {
+        let config = ProviderConfig(id: .moonshot, apiKey: "moon-token")
+        let env = ProviderConfigEnvironment.applyAPIKeyOverride(
+            base: [:],
+            provider: .moonshot,
+            config: config)
+
+        #expect(env[MoonshotSettingsReader.apiKeyEnvironmentKeys.first ?? ""] == "moon-token")
+    }
+
+    @Test
     func `applies API key override for kilo`() {
         let config = ProviderConfig(id: .kilo, apiKey: "kilo-token")
         let env = ProviderConfigEnvironment.applyAPIKeyOverride(

--- a/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
+++ b/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
@@ -117,6 +117,14 @@ struct ProvidersPaneCoverageTests {
     }
 
     @Test
+    func `provider detail plan row formats moonshot as balance`() {
+        let row = ProviderDetailView<EmptyView>.planRow(provider: .moonshot, planText: "Balance: $49.58")
+
+        #expect(row?.label == "Balance")
+        #expect(row?.value == "$49.58")
+    }
+
+    @Test
     func `provider detail plan row keeps plan label for non open router`() {
         let row = ProviderDetailView<EmptyView>.planRow(provider: .codex, planText: "Pro")
 

--- a/Tests/CodexBarTests/StatusItemControllerMenuTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerMenuTests.swift
@@ -149,4 +149,21 @@ struct StatusItemControllerMenuTests {
             snapshot: snapshot))
         #expect(snapshot.primary?.usedPercent == 10)
     }
+
+    @Test
+    func `moonshot brand fallback enabled for balance only snapshots`() {
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .moonshot,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "Balance: $49.58"))
+
+        #expect(StatusItemController.shouldUseOpenRouterBrandFallback(
+            provider: .moonshot,
+            snapshot: snapshot))
+    }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,7 +54,7 @@ See `docs/configuration.md` for the schema.
     - `web` (macOS only): web-only; no CLI fallback.
     - `cli`: CLI-only (Codex RPC → PTY fallback; Claude PTY).
     - `oauth`: Claude OAuth only (debug); no fallback. Not supported for Codex.
-    - `api`: API key flow when the provider supports it (z.ai, Gemini, Copilot, Kilo, Kimi K2, MiniMax, Warp, OpenRouter, Synthetic).
+    - `api`: API key flow when the provider supports it (z.ai, Gemini, Copilot, Kilo, Kimi K2, Moonshot, MiniMax, Warp, OpenRouter, Synthetic).
     - Output `source` reflects the strategy actually used (`openai-web`, `web`, `oauth`, `api`, `local`, or provider CLI label).
     - Codex web: OpenAI web dashboard (usage limits, credits remaining, code review remaining, usage breakdown).
         - `--web-timeout <seconds>` (default: 60)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,7 +72,7 @@ All provider fields are optional unless noted.
 
 ## Provider IDs
 Current IDs (see `Sources/CodexBarCore/Providers/Providers.swift`):
-`codex`, `claude`, `cursor`, `opencode`, `factory`, `gemini`, `antigravity`, `copilot`, `zai`, `minimax`, `kimi`, `kilo`, `kiro`, `vertexai`, `augment`, `jetbrains`, `kimik2`, `amp`, `ollama`, `synthetic`, `warp`, `openrouter`.
+`codex`, `claude`, `cursor`, `opencode`, `factory`, `gemini`, `antigravity`, `copilot`, `zai`, `minimax`, `kimi`, `kilo`, `kiro`, `vertexai`, `augment`, `jetbrains`, `kimik2`, `moonshot`, `amp`, `ollama`, `synthetic`, `warp`, `openrouter`.
 
 ## Ordering
 The order of `providers` controls display/order in the app and CLI. Reorder the array to change ordering.

--- a/docs/moonshot.md
+++ b/docs/moonshot.md
@@ -1,0 +1,55 @@
+---
+summary: "Moonshot provider data sources: official API key + balance endpoint."
+read_when:
+  - Adding or tweaking Moonshot balance parsing
+  - Updating Moonshot API key or region handling
+  - Documenting the official Moonshot provider
+---
+
+# Moonshot provider
+
+Moonshot is API-only. CodexBar calls the official Moonshot balance endpoint and shows the available USD balance for the selected region.
+This provider is intentionally separate from Kimi K2, which points at the third-party `kimi-k2.ai` service instead of Moonshot's official platform.
+
+Official docs: <https://platform.moonshot.ai/docs/api/balance>
+
+## Data sources + configuration
+
+1. **API key** stored in `~/.codexbar/config.json` or supplied via `MOONSHOT_API_KEY` / `MOONSHOT_KEY`.
+   CodexBar stores the key in config after you paste it in Preferences → Providers → Moonshot.
+2. **Region** stored in `~/.codexbar/config.json` (`providerConfig.moonshot.region`) or supplied via `MOONSHOT_REGION`.
+   Supported values: `international` and `china`. Default: `international`.
+3. **Balance endpoint**
+   - International: `GET https://api.moonshot.ai/v1/users/me/balance`
+   - China: `GET https://api.moonshot.cn/v1/users/me/balance`
+   - Request headers: `Authorization: Bearer <api key>`, `Accept: application/json`
+
+## Response format
+
+Moonshot documents a stable JSON object:
+
+```json
+{
+  "code": 0,
+  "data": {
+    "available_balance": 49.58,
+    "voucher_balance": 50.0,
+    "cash_balance": -0.42
+  }
+}
+```
+
+CodexBar displays:
+- `Balance: $X.XX`
+- `No limit set`
+- `cash_balance` deficits as `... in deficit` when the cash portion is negative
+
+There is no session window, weekly window, or reset timestamp for Moonshot.
+
+## Key files
+
+- `Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderDescriptor.swift`
+- `Sources/CodexBarCore/Providers/Moonshot/MoonshotUsageFetcher.swift`
+- `Sources/CodexBarCore/Providers/Moonshot/MoonshotSettingsReader.swift`
+- `Sources/CodexBar/Providers/Moonshot/MoonshotProviderImplementation.swift`
+- `Sources/CodexBar/Providers/Moonshot/MoonshotSettingsStore.swift`

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,5 +1,5 @@
 ---
-summary: "Provider data sources and parsing overview (Codex, Claude, Gemini, Antigravity, Cursor, OpenCode, Alibaba Coding Plan, Droid/Factory, z.ai, Copilot, Kimi, Kilo, Kimi K2, Kiro, Warp, Vertex AI, Augment, Amp, Ollama, JetBrains AI, OpenRouter)."
+summary: "Provider data sources and parsing overview (Codex, Claude, Gemini, Antigravity, Cursor, OpenCode, Alibaba Coding Plan, Droid/Factory, z.ai, Copilot, Kimi, Kilo, Kimi K2, Moonshot, Kiro, Warp, Vertex AI, Augment, Amp, Ollama, JetBrains AI, OpenRouter)."
 read_when:
   - Adding or modifying provider fetch/parsing
   - Adjusting provider labels, toggles, or metadata
@@ -32,6 +32,7 @@ until the session is invalid, to avoid repeated Keychain prompts.
 | Kilo | API token (`KILO_API_KEY`) → usage API (`api`); auto falls back to CLI session auth (`cli`). |
 | Copilot | API token (device flow/env) → copilot_internal API (`api`). |
 | Kimi K2 | API key (Keychain/env) → credit endpoint (`api`). |
+| Moonshot | Official API key (config/env) + region selector → balance endpoint (`api`). |
 | Kiro | CLI command via `kiro-cli chat --no-interactive "/usage"` (`cli`). |
 | Vertex AI | Google ADC OAuth (gcloud) → Cloud Monitoring quota usage (`oauth`). |
 | JetBrains AI | Local XML quota file (`local`). |
@@ -90,6 +91,14 @@ until the session is invalid, to avoid repeated Keychain prompts.
 - Shows credit usage based on consumed/remaining totals.
 - Status: none yet.
 - Details: `docs/kimi-k2.md`.
+
+## Moonshot
+- API key from `~/.codexbar/config.json` (`providerConfig.moonshot.apiKey`) or `MOONSHOT_API_KEY` / `MOONSHOT_KEY`.
+- Region from config (`providerConfig.moonshot.region`) or `MOONSHOT_REGION`; supported values: `international`, `china`.
+- Balance endpoint: `https://api.moonshot.ai/v1/users/me/balance` or `https://api.moonshot.cn/v1/users/me/balance`.
+- Shows balance-only UI (`Balance: $X.XX`, `No limit set`) and surfaces negative `cash_balance` as `in deficit`.
+- Distinct from Kimi K2, which targets the third-party `kimi-k2.ai` endpoint.
+- Details: `docs/moonshot.md`.
 
 ## Gemini
 - OAuth-backed quota API (`retrieveUserQuota`) using Gemini CLI credentials.


### PR DESCRIPTION
## Summary
- add a new Moonshot provider that uses the official Moonshot balance endpoint instead of the third-party Kimi K2 service
- support International and China regions via config/env + a settings picker
- document the provider and add focused parser/settings/UI regression tests

## Details
- adds `Sources/CodexBarCore/Providers/Moonshot/` and `Sources/CodexBar/Providers/Moonshot/`
- keeps Kimi K2 untouched; this only addresses the official Moonshot provider path discussed in #473
- stores Moonshot API keys in `~/.codexbar/config.json` and honors `MOONSHOT_API_KEY` / `MOONSHOT_KEY`
- honors `MOONSHOT_REGION` and persists a `region` value in provider config
- shows Moonshot as a balance-only provider (`Balance: $X.XX`, `No limit set`) and surfaces negative cash balance as `in deficit`

## Verification
- `swift build --target CodexBarCore`
- `swift build --target CodexBarCLI`
- `swift build --target CodexBarWidget`
- `swift run CodexBarCLI --help` (confirms `moonshot` is registered as a provider)
- `MOONSHOT_API_KEY=moonshot-invalid-key MOONSHOT_REGION=international swift run --skip-build CodexBarCLI usage --provider moonshot --format json` (confirms a clean Moonshot API error path on invalid auth)

## Environment blockers in this session
- `swift build --target CodexBar` fails in the upstream `KeyboardShortcuts` dependency because `PreviewsMacros` is unavailable in this Command Line Tools-only environment
- `./Scripts/lint.sh lint` crashes inside `swiftlint` because SourceKit/Xcode is unavailable here
- no real Moonshot API key was available in the environment, so I could not run the live success-path smoke test or capture screenshots
