### PR TITLE
fix: recognize Ollama __Secure-session cookies

### DIFF
--- a/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
@@ -9,6 +9,7 @@ import SweetCookieKit
 
 private let ollamaSessionCookieNames: Set<String> = [
     "session",
+    "__Secure-session",
     "ollama_session",
     "__Host-ollama_session",
     "__Secure-next-auth.session-token",

--- a/Tests/CodexBarTests/OllamaUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageFetcherTests.swift
@@ -62,6 +62,14 @@ struct OllamaUsageFetcherTests {
     }
 
     @Test
+    func `manual mode accepts secure session cookie header`() throws {
+        let resolved = try OllamaUsageFetcher.resolveManualCookieHeader(
+            override: "__Secure-session=abc; theme=dark",
+            manualCookieMode: true)
+        #expect(resolved?.contains("__Secure-session=abc") == true)
+    }
+
+    @Test
     func `retry policy retries only for auth errors`() {
         #expect(OllamaUsageFetcher.shouldRetryWithNextCookieCandidate(after: OllamaUsageError.invalidCredentials))
         #expect(OllamaUsageFetcher.shouldRetryWithNextCookieCandidate(after: OllamaUsageError.notLoggedIn))
@@ -122,6 +130,16 @@ struct OllamaUsageFetcherTests {
 
         let selected = try OllamaCookieImporter.selectSessionInfo(from: [candidate])
         #expect(selected.sourceLabel == "Profile C")
+    }
+
+    @Test
+    func `cookie selector accepts secure session cookie`() throws {
+        let candidate = OllamaCookieImporter.SessionInfo(
+            cookies: [Self.makeCookie(name: "__Secure-session", value: "auth")],
+            sourceLabel: "Profile D")
+
+        let selected = try OllamaCookieImporter.selectSessionInfo(from: [candidate])
+        #expect(selected.sourceLabel == "Profile D")
     }
 
     @Test


### PR DESCRIPTION
Fixes #704

## Summary

- recognize `__Secure-session` as a valid Ollama session cookie
- add focused Ollama cookie recognition tests

## Validation

- `swift test --filter OllamaUsageFetcherTests`
- `./Scripts/compile_and_run.sh`
- verified Ollama web usage loads locally in the CLI and the menu bar
