### PR TITLE
Handle Codex Pro Lite plan responses and OAuth fallback edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,12 @@
 ## 0.21 — Unreleased
 
 ### Highlights
-- z.ai: preserve weekly and 5-hour token quotas together, surface the 5-hour lane correctly across the menu/menu bar, and add regression coverage (#662). Thanks to @takumi3488 for the original fix and investigation.
 - Cursor: fix a crash in the usage fetch path and add regression coverage (#663). Thanks @anirudhvee for the report and validation!
-- Antigravity: accept localhost TLS challenges when probing the local language server so usage/account info loads again instead of reporting `no working API port found` (#693, fixes #692). Thanks @anirudhvee!
-- Codex: recognize the new Pro $100 plan in OAuth, OpenAI web, menu, and CLI rendering, and preserve CLI fallback when partial OAuth payloads lose the 5-hour session lane (#691, #709).
+- z.ai: preserve weekly and 5-hour token quotas together, surface the 5-hour lane correctly across the menu/menu bar, and add regression coverage (#662). Thanks to @takumi3488 for the original fix and investigation.
+- Codex: recognize the new Pro $100 plan in OAuth, OpenAI web, menu, and CLI rendering, and preserve CLI fallback when partial OAuth payloads lose the 5-hour session lane (#691, #709). Thanks @ImLukeF!
 - Codex: fix local cost scanner overcounting and cross-day undercounting across forked sessions, cold-cache refreshes, and sessions-root changes (#698). Thanks @xx205!
 - Codex: add Microsoft Edge as a browser-cookie import option for the Codex provider while preserving the contributor-branch workflow from the original PR (#694). Thanks @Astro-Han!
 - Menu bar: fix missing icons on affected macOS 26 systems by avoiding RenderBox-triggering SwiftUI effects (#677). Thanks @andrzejchm!
-- Claude: preserve normal CLI fallback precedence across well-known install paths so Finder-launched apps still prefer user-managed and native Homebrew binaries when multiple installs exist.
 - Codex: make OpenAI web extras opt-in for fresh installs, preserve working legacy setups on upgrade, add an OpenAI web battery-saver toggle, and keep account-scoped dashboard state aligned during refreshes and account switches (#529). Thanks @cbrane!
 
 ### Providers & Usage
@@ -21,7 +19,7 @@
 - Ollama: recognize `__Secure-session` cookies during manual cookie entry and browser-cookie import so authenticated usage fetching continues to work with the newer cookie name (#707). Thanks @anirudhvee!
 - OpenCode: enable weekly pace visualization for the app and CLI so weekly bars show reserve percentage, expected-usage markers, and "Lasts until reset" details like Codex and Claude (#639). Thanks @Zachary!
 - Cost: tighten the local Codex cost scanner around fork inheritance, cold-cache discovery, incremental parsing, and sessions-root changes so replayed sessions no longer overcount or slip usage across day boundaries (#698). Thanks @xx205!
-- Claude: preserve normal CLI fallback precedence across well-known install paths so Finder-launched apps prefer `~/.claude/bin/claude`, then Homebrew, before the bundled `cmux.app` binary when shell-based resolution is unavailable.
+- Claude: preserve normal CLI fallback precedence across well-known install paths so Finder-launched apps still prefer user-managed and native Homebrew binaries when multiple installs exist.
 - Codex: support Microsoft Edge in browser-cookie import for the Codex provider while keeping the contributor branch untouched in the superseding integration path (#694). Thanks @Astro-Han!
 - OpenCode / OpenCode Go: treat serialized `_server` auth/account-context failures as invalid credentials so cached browser cookies are cleared and retried instead of surfacing a misleading HTTP 500.
 - Codex: make OpenAI web extras opt-in by default, preserve legacy implicit-auto cookie setups during upgrade inference, add battery-saver gating for non-forced dashboard refreshes, and preserve provider/dashboard state for enabled providers that are temporarily unavailable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - z.ai: preserve weekly and 5-hour token quotas together, surface the 5-hour lane correctly across the menu/menu bar, and add regression coverage (#662). Thanks to @takumi3488 for the original fix and investigation.
 - Cursor: fix a crash in the usage fetch path and add regression coverage (#663). Thanks @anirudhvee for the report and validation!
 - Antigravity: accept localhost TLS challenges when probing the local language server so usage/account info loads again instead of reporting `no working API port found` (#693, fixes #692). Thanks @anirudhvee!
+- Codex: recognize the new Pro $100 plan in OAuth, OpenAI web, menu, and CLI rendering, and preserve CLI fallback when partial OAuth payloads lose the 5-hour session lane (#691, #709).
 - Codex: fix local cost scanner overcounting and cross-day undercounting across forked sessions, cold-cache refreshes, and sessions-root changes (#698). Thanks @xx205!
 - Codex: add Microsoft Edge as a browser-cookie import option for the Codex provider while preserving the contributor-branch workflow from the original PR (#694). Thanks @Astro-Han!
 - Menu bar: fix missing icons on affected macOS 26 systems by avoiding RenderBox-triggering SwiftUI effects (#677). Thanks @andrzejchm!
@@ -16,6 +17,7 @@
 - z.ai: preserve both weekly and 5-hour token quotas, keep the existing 2-limit behavior unchanged, and render the 5-hour quota as a tertiary row in provider snapshots and CLI/menu cards (#662). Credit to @takumi3488 for the original fix and investigation.
 - Cursor: fix the usage fetch path so failed or cancelled requests no longer crash, and add Linux build and regression test coverage fixes (#663).
 - Antigravity: scope insecure localhost trust handling to `127.0.0.1` / `localhost`, keep localhost requests cancellable, and restore local quota/account probing on builds that previously failed TLS challenge handling (#693, fixes #692). Thanks @anirudhvee!
+- Codex: render the new Pro $100 plan consistently across OAuth, OpenAI web, menu, and CLI surfaces, tolerate newer Codex OAuth payload variants like `prolite`, and only fall back to the CLI in auto mode when OAuth decode damage actually drops the session lane (#691, #709).
 - OpenCode: enable weekly pace visualization for the app and CLI so weekly bars show reserve percentage, expected-usage markers, and "Lasts until reset" details like Codex and Claude (#639). Thanks @Zachary!
 - Cost: tighten the local Codex cost scanner around fork inheritance, cold-cache discovery, incremental parsing, and sessions-root changes so replayed sessions no longer overcount or slip usage across day boundaries (#698). Thanks @xx205!
 - Claude: preserve normal CLI fallback precedence across well-known install paths so Finder-launched apps prefer `~/.claude/bin/claude`, then Homebrew, before the bundled `cmux.app` binary when shell-based resolution is unavailable.

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -840,7 +840,7 @@ extension UsageMenuCardView.Model {
     }
 
     private static func planDisplay(_ text: String) -> String {
-        let cleaned = UsageFormatter.cleanPlanName(text)
+        let cleaned = CodexPlanFormatting.displayName(text) ?? UsageFormatter.cleanPlanName(text)
         return cleaned.isEmpty ? text : cleaned
     }
 

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -477,7 +477,7 @@ struct MenuDescriptor {
 
 private enum AccountFormatter {
     static func plan(_ text: String) -> String {
-        let cleaned = UsageFormatter.cleanPlanName(text)
+        let cleaned = CodexPlanFormatting.displayName(text) ?? UsageFormatter.cleanPlanName(text)
         return cleaned.isEmpty ? text : cleaned
     }
 

--- a/Sources/CodexBarCLI/CLIRenderer.swift
+++ b/Sources/CodexBarCLI/CLIRenderer.swift
@@ -153,7 +153,12 @@ enum CLIRenderer {
                 lines.append(self.labelValueLine("Activity", value: detail, useColor: context.useColor))
             }
         } else if let plan = snapshot.loginMethod(for: provider), !plan.isEmpty {
-            lines.append(self.labelValueLine("Plan", value: plan.capitalized, useColor: context.useColor))
+            let displayPlan = if provider == .codex {
+                CodexPlanFormatting.displayName(plan) ?? plan
+            } else {
+                plan.capitalized
+            }
+            lines.append(self.labelValueLine("Plan", value: displayPlan, useColor: context.useColor))
         }
 
         for note in context.notes {

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardParser.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardParser.swift
@@ -492,7 +492,7 @@ public enum OpenAIDashboardParser {
             "essential",
         ]
         guard allowed.contains(where: { lower.contains($0) }) else { return nil }
-        return UsageFormatter.cleanPlanName(trimmed)
+        return CodexPlanFormatting.displayName(trimmed) ?? UsageFormatter.cleanPlanName(trimmed)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
@@ -14,6 +14,13 @@ public struct CodexUsageResponse: Decodable, Sendable {
         case credits
     }
 
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.planType = try? container.decodeIfPresent(PlanType.self, forKey: .planType)
+        self.rateLimit = try? container.decodeIfPresent(RateLimitDetails.self, forKey: .rateLimit)
+        self.credits = try? container.decodeIfPresent(CreditDetails.self, forKey: .credits)
+    }
+
     public enum PlanType: Sendable, Decodable, Equatable {
         case guest
         case free
@@ -75,10 +82,45 @@ public struct CodexUsageResponse: Decodable, Sendable {
     public struct RateLimitDetails: Decodable, Sendable {
         public let primaryWindow: WindowSnapshot?
         public let secondaryWindow: WindowSnapshot?
+        let primaryWindowDecodeFailed: Bool
+        let secondaryWindowDecodeFailed: Bool
 
         enum CodingKeys: String, CodingKey {
             case primaryWindow = "primary_window"
             case secondaryWindow = "secondary_window"
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let primaryHadValue = Self.hasNonNilValue(container: container, key: .primaryWindow)
+            do {
+                self.primaryWindow = try container.decodeIfPresent(WindowSnapshot.self, forKey: .primaryWindow)
+                self.primaryWindowDecodeFailed = false
+            } catch {
+                self.primaryWindow = nil
+                self.primaryWindowDecodeFailed = primaryHadValue
+            }
+
+            let secondaryHadValue = Self.hasNonNilValue(container: container, key: .secondaryWindow)
+            do {
+                self.secondaryWindow = try container.decodeIfPresent(WindowSnapshot.self, forKey: .secondaryWindow)
+                self.secondaryWindowDecodeFailed = false
+            } catch {
+                self.secondaryWindow = nil
+                self.secondaryWindowDecodeFailed = secondaryHadValue
+            }
+        }
+
+        private static func hasNonNilValue(
+            container: KeyedDecodingContainer<CodingKeys>,
+            key: CodingKeys) -> Bool
+        {
+            guard container.contains(key) else { return false }
+            return (try? container.decodeNil(forKey: key)) == false
+        }
+
+        var hasWindowDecodeFailure: Bool {
+            self.primaryWindowDecodeFailed || self.secondaryWindowDecodeFailed
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexPlanFormatting.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexPlanFormatting.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+public enum CodexPlanFormatting {
+    private static let exactDisplayNames: [String: String] = [
+        "prolite": "Pro Lite",
+        "pro_lite": "Pro Lite",
+        "pro-lite": "Pro Lite",
+        "pro lite": "Pro Lite",
+    ]
+
+    private static let uppercaseWords: Set<String> = [
+        "cbp",
+        "k12",
+    ]
+
+    public static func displayName(_ raw: String?) -> String? {
+        guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            return nil
+        }
+
+        let lower = raw.lowercased()
+        if let exact = Self.exactDisplayNames[lower] {
+            return exact
+        }
+
+        let cleaned = UsageFormatter.cleanPlanName(raw)
+        let candidate = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !candidate.isEmpty else { return raw }
+
+        let components = candidate
+            .split(whereSeparator: { $0 == "_" || $0 == "-" || $0.isWhitespace })
+            .map(String.init)
+            .filter { !$0.isEmpty }
+
+        guard !components.isEmpty else { return candidate }
+
+        let formatted = components.map(Self.wordDisplayName).joined(separator: " ")
+        return formatted.isEmpty ? candidate : formatted
+    }
+
+    private static func wordDisplayName(_ raw: String) -> String {
+        let lower = raw.lowercased()
+        if let exact = Self.exactDisplayNames[lower] {
+            return exact
+        }
+        if Self.uppercaseWords.contains(lower) {
+            return lower.uppercased()
+        }
+        if raw == raw.uppercased(), raw.contains(where: \.isLetter) {
+            return raw
+        }
+        if let first = raw.first, first.isLowercase {
+            return raw.prefix(1).uppercased() + raw.dropFirst()
+        }
+        return raw
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -174,12 +174,19 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
         sourceMode: ProviderSourceMode) throws -> ProviderFetchResult
     {
         let credits = Self.mapCredits(usageResponse.credits)
-
-        if let reconciled = CodexReconciledState.fromOAuth(
+        let reconciled = CodexReconciledState.fromOAuth(
             response: usageResponse,
             credentials: credentials,
             updatedAt: updatedAt)
+
+        if sourceMode == .auto,
+           usageResponse.rateLimit?.hasWindowDecodeFailure == true,
+           reconciled?.session == nil
         {
+            throw UsageError.noRateLimitsFound
+        }
+
+        if let reconciled {
             return CodexOAuthFetchStrategy().makeResult(
                 usage: reconciled.toUsageSnapshot(),
                 credits: credits,

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -324,6 +324,20 @@ private struct RPCCreditsSnapshot: Decodable, Encodable {
     let balance: String?
 }
 
+private struct RPCRateLimitsErrorBody: Decodable {
+    let email: String?
+    let planType: String?
+    let rateLimit: CodexUsageResponse.RateLimitDetails?
+    let credits: CodexUsageResponse.CreditDetails?
+
+    enum CodingKeys: String, CodingKey {
+        case email
+        case planType = "plan_type"
+        case rateLimit = "rate_limit"
+        case credits
+    }
+}
+
 private enum RPCWireError: Error, LocalizedError {
     case startFailed(String)
     case requestFailed(String)
@@ -566,33 +580,40 @@ public struct UsageFetcher: Sendable {
     }
 
     private func loadRPCUsage() async throws -> UsageSnapshot {
-        let rpc = try CodexRPCClient(environment: self.environment)
-        defer { rpc.shutdown() }
+        do {
+            let rpc = try CodexRPCClient(environment: self.environment)
+            defer { rpc.shutdown() }
 
-        try await rpc.initialize(clientName: "codexbar", clientVersion: "0.5.4")
-        // The app-server answers on a single stdout stream, so keep requests
-        // serialized to avoid starving one reader when multiple awaiters race
-        // for the same pipe.
-        let limits = try await rpc.fetchRateLimits().rateLimits
-        let account = try? await rpc.fetchAccount()
+            try await rpc.initialize(clientName: "codexbar", clientVersion: "0.5.4")
+            // The app-server answers on a single stdout stream, so keep requests
+            // serialized to avoid starving one reader when multiple awaiters race
+            // for the same pipe.
+            let limits = try await rpc.fetchRateLimits().rateLimits
+            let account = try? await rpc.fetchAccount()
 
-        let identity = ProviderIdentitySnapshot(
-            providerID: .codex,
-            accountEmail: account?.account.flatMap { details in
-                if case let .chatgpt(email, _) = details { email } else { nil }
-            },
-            accountOrganization: nil,
-            loginMethod: account?.account.flatMap { details in
-                if case let .chatgpt(_, plan) = details { plan } else { nil }
-            })
-        guard let state = CodexReconciledState.fromCLI(
-            primary: Self.makeWindow(from: limits.primary),
-            secondary: Self.makeWindow(from: limits.secondary),
-            identity: identity)
-        else {
-            throw UsageError.noRateLimitsFound
+            let identity = ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: account?.account.flatMap { details in
+                    if case let .chatgpt(email, _) = details { email } else { nil }
+                },
+                accountOrganization: nil,
+                loginMethod: account?.account.flatMap { details in
+                    if case let .chatgpt(_, plan) = details { plan } else { nil }
+                })
+            guard let state = CodexReconciledState.fromCLI(
+                primary: Self.makeWindow(from: limits.primary),
+                secondary: Self.makeWindow(from: limits.secondary),
+                identity: identity)
+            else {
+                throw UsageError.noRateLimitsFound
+            }
+            return state.toUsageSnapshot()
+        } catch {
+            if let snapshot = Self.recoverUsageFromRPCError(error) {
+                return snapshot
+            }
+            throw error
         }
-        return state.toUsageSnapshot()
     }
 
     private func loadTTYUsage(keepCLISessionsAlive: Bool) async throws -> UsageSnapshot {
@@ -625,13 +646,20 @@ public struct UsageFetcher: Sendable {
     }
 
     private func loadRPCCredits() async throws -> CreditsSnapshot {
-        let rpc = try CodexRPCClient(environment: self.environment)
-        defer { rpc.shutdown() }
-        try await rpc.initialize(clientName: "codexbar", clientVersion: "0.5.4")
-        let limits = try await rpc.fetchRateLimits().rateLimits
-        guard let credits = limits.credits else { throw UsageError.noRateLimitsFound }
-        let remaining = Self.parseCredits(credits.balance)
-        return CreditsSnapshot(remaining: remaining, events: [], updatedAt: Date())
+        do {
+            let rpc = try CodexRPCClient(environment: self.environment)
+            defer { rpc.shutdown() }
+            try await rpc.initialize(clientName: "codexbar", clientVersion: "0.5.4")
+            let limits = try await rpc.fetchRateLimits().rateLimits
+            guard let credits = limits.credits else { throw UsageError.noRateLimitsFound }
+            let remaining = Self.parseCredits(credits.balance)
+            return CreditsSnapshot(remaining: remaining, events: [], updatedAt: Date())
+        } catch {
+            if let credits = Self.recoverCreditsFromRPCError(error) {
+                return credits
+            }
+            throw error
+        }
     }
 
     private func loadTTYCredits(keepCLISessionsAlive: Bool) async throws -> CreditsSnapshot {
@@ -712,6 +740,16 @@ public struct UsageFetcher: Sendable {
             resetDescription: resetDescription)
     }
 
+    private static func makeWindow(from response: CodexUsageResponse.WindowSnapshot?) -> RateWindow? {
+        guard let response else { return nil }
+        let resetsAtDate = Date(timeIntervalSince1970: TimeInterval(response.resetAt))
+        return RateWindow(
+            usedPercent: Double(response.usedPercent),
+            windowMinutes: response.limitWindowSeconds / 60,
+            resetsAt: resetsAtDate,
+            resetDescription: UsageFormatter.resetDescription(from: resetsAtDate))
+    }
+
     private static func makeTTYWindow(
         percentLeft: Int?,
         windowMinutes: Int,
@@ -729,6 +767,80 @@ public struct UsageFetcher: Sendable {
     private static func parseCredits(_ balance: String?) -> Double {
         guard let balance, let val = Double(balance) else { return 0 }
         return val
+    }
+
+    private static func recoverUsageFromRPCError(_ error: Error) -> UsageSnapshot? {
+        guard let body = self.decodeRateLimitsErrorBody(from: error) else { return nil }
+        let identity = ProviderIdentitySnapshot(
+            providerID: .codex,
+            accountEmail: self.normalizedCodexAccountField(body.email),
+            accountOrganization: nil,
+            loginMethod: self.normalizedCodexAccountField(body.planType))
+        guard let state = CodexReconciledState.fromCLI(
+            primary: self.makeWindow(from: body.rateLimit?.primaryWindow),
+            secondary: self.makeWindow(from: body.rateLimit?.secondaryWindow),
+            identity: identity)
+        else {
+            return nil
+        }
+        return state.toUsageSnapshot()
+    }
+
+    private static func recoverCreditsFromRPCError(_ error: Error) -> CreditsSnapshot? {
+        guard let credits = self.decodeRateLimitsErrorBody(from: error)?.credits else { return nil }
+        guard let remaining = credits.balance else { return nil }
+        return CreditsSnapshot(remaining: remaining, events: [], updatedAt: Date())
+    }
+
+    private static func decodeRateLimitsErrorBody(from error: Error) -> RPCRateLimitsErrorBody? {
+        guard case let RPCWireError.requestFailed(message) = error else { return nil }
+        guard let json = self.extractJSONObject(after: "body=", in: message) else { return nil }
+        guard let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(RPCRateLimitsErrorBody.self, from: data)
+    }
+
+    private static func extractJSONObject(after marker: String, in text: String) -> String? {
+        guard let markerRange = text.range(of: marker) else { return nil }
+        let suffix = text[markerRange.upperBound...]
+        guard let start = suffix.firstIndex(of: "{") else { return nil }
+
+        var depth = 0
+        var inString = false
+        var isEscaped = false
+        var endIndex: String.Index?
+
+        for index in suffix[start...].indices {
+            let character = suffix[index]
+
+            if inString {
+                if isEscaped {
+                    isEscaped = false
+                } else if character == "\\" {
+                    isEscaped = true
+                } else if character == "\"" {
+                    inString = false
+                }
+                continue
+            }
+
+            switch character {
+            case "\"":
+                inString = true
+            case "{":
+                depth += 1
+            case "}":
+                depth -= 1
+                if depth == 0 {
+                    endIndex = index
+                    break
+                }
+            default:
+                break
+            }
+        }
+
+        guard let endIndex else { return nil }
+        return String(suffix[start...endIndex])
     }
 
     private static func normalizedCodexAccountField(_ value: String?) -> String? {
@@ -788,6 +900,14 @@ extension UsageFetcher {
             throw UsageError.noRateLimitsFound
         }
         return state.toUsageSnapshot()
+    }
+
+    public static func _recoverCodexRPCUsageFromErrorForTesting(_ message: String) -> UsageSnapshot? {
+        self.recoverUsageFromRPCError(RPCWireError.requestFailed(message))
+    }
+
+    public static func _recoverCodexRPCCreditsFromErrorForTesting(_ message: String) -> CreditsSnapshot? {
+        self.recoverCreditsFromRPCError(RPCWireError.requestFailed(message))
     }
 
     private static func makeTestingWindow(

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -783,6 +783,11 @@ public struct UsageFetcher: Sendable {
         else {
             return nil
         }
+        if body.rateLimit?.hasWindowDecodeFailure == true,
+           state.session == nil
+        {
+            return nil
+        }
         return state.toUsageSnapshot()
     }
 

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -807,7 +807,6 @@ public struct UsageFetcher: Sendable {
         var depth = 0
         var inString = false
         var isEscaped = false
-        var endIndex: String.Index?
 
         for index in suffix[start...].indices {
             let character = suffix[index]
@@ -831,16 +830,14 @@ public struct UsageFetcher: Sendable {
             case "}":
                 depth -= 1
                 if depth == 0 {
-                    endIndex = index
-                    break
+                    return String(suffix[start...index])
                 }
             default:
                 break
             }
         }
 
-        guard let endIndex else { return nil }
-        return String(suffix[start...endIndex])
+        return nil
     }
 
     private static func normalizedCodexAccountField(_ value: String?) -> String? {

--- a/Tests/CodexBarTests/CLISnapshotTests.swift
+++ b/Tests/CodexBarTests/CLISnapshotTests.swift
@@ -43,6 +43,34 @@ struct CLISnapshotTests {
     }
 
     @Test
+    func `renders Codex prolite plan with spaced display name`() {
+        let identity = ProviderIdentitySnapshot(
+            providerID: .codex,
+            accountEmail: "user@example.com",
+            accountOrganization: nil,
+            loginMethod: "prolite")
+        let snap = UsageSnapshot(
+            primary: .init(usedPercent: 12, windowMinutes: 300, resetsAt: nil, resetDescription: "today at 3:00 PM"),
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: Date(timeIntervalSince1970: 0),
+            identity: identity)
+
+        let output = CLIRenderer.renderText(
+            provider: .codex,
+            snapshot: snap,
+            credits: nil,
+            context: RenderContext(
+                header: "Codex 1.2.3 (codex-cli)",
+                status: nil,
+                useColor: false,
+                resetStyle: .absolute))
+
+        #expect(output.contains("Plan: Pro Lite"))
+        #expect(!output.contains("Plan: Prolite"))
+    }
+
+    @Test
     func `renders text snapshot for claude without weekly`() {
         let snap = UsageSnapshot(
             primary: .init(usedPercent: 2, windowMinutes: nil, resetsAt: nil, resetDescription: "3pm (Europe/Vienna)"),

--- a/Tests/CodexBarTests/CodexOAuthTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthTests.swift
@@ -88,6 +88,33 @@ struct CodexOAuthTests {
     }
 
     @Test
+    func `decodes prolite plan type without failing usage mapping`() throws {
+        let json = """
+        {
+          "plan_type": "prolite",
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 12,
+              "reset_at": 1766948068,
+              "limit_window_seconds": 18000
+            }
+          }
+        }
+        """
+        let response = try CodexOAuthUsageFetcher._decodeUsageResponseForTesting(Data(json.utf8))
+        #expect(response.planType?.rawValue == "prolite")
+
+        let creds = CodexOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: nil,
+            accountId: nil,
+            lastRefresh: Date())
+        let mapped = try CodexOAuthFetchStrategy._mapUsageForTesting(Data(json.utf8), credentials: creds)
+        #expect(mapped?.primary?.usedPercent == 12)
+    }
+
+    @Test
     func `maps usage windows from O auth`() throws {
         let json = """
         {
@@ -280,6 +307,239 @@ struct CodexOAuthTests {
             lastRefresh: Date())
         let snapshot = try CodexOAuthFetchStrategy._mapUsageForTesting(Data(json.utf8), credentials: creds)
         #expect(snapshot == nil)
+    }
+
+    @Test
+    func `keeps valid window when secondary window is malformed`() throws {
+        let json = """
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 18,
+              "reset_at": 1766948068,
+              "limit_window_seconds": 18000
+            },
+            "secondary_window": {
+              "used_percent": "bad",
+              "reset_at": 1767407914,
+              "limit_window_seconds": 604800
+            }
+          }
+        }
+        """
+        let creds = CodexOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: nil,
+            accountId: nil,
+            lastRefresh: Date())
+        let snapshot = try CodexOAuthFetchStrategy._mapUsageForTesting(Data(json.utf8), credentials: creds)
+        #expect(snapshot?.primary?.usedPercent == 18)
+        #expect(snapshot?.secondary == nil)
+    }
+
+    @Test
+    func `auto mode falls back when primary window is malformed but weekly window survives`() throws {
+        let json = """
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": "bad",
+              "reset_at": 1766948068,
+              "limit_window_seconds": 18000
+            },
+            "secondary_window": {
+              "used_percent": 43,
+              "reset_at": 1767407914,
+              "limit_window_seconds": 604800
+            }
+          }
+        }
+        """
+        let creds = CodexOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: nil,
+            accountId: nil,
+            lastRefresh: Date())
+
+        #expect(throws: UsageError.noRateLimitsFound) {
+            _ = try CodexOAuthFetchStrategy._mapResultForTesting(
+                Data(json.utf8),
+                credentials: creds,
+                sourceMode: .auto)
+        }
+    }
+
+    @Test
+    func `explicit oauth keeps weekly window when primary window is malformed`() throws {
+        let json = """
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": "bad",
+              "reset_at": 1766948068,
+              "limit_window_seconds": 18000
+            },
+            "secondary_window": {
+              "used_percent": 43,
+              "reset_at": 1767407914,
+              "limit_window_seconds": 604800
+            }
+          }
+        }
+        """
+        let creds = CodexOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: nil,
+            accountId: nil,
+            lastRefresh: Date())
+
+        let result = try CodexOAuthFetchStrategy._mapResultForTesting(
+            Data(json.utf8),
+            credentials: creds,
+            sourceMode: .oauth)
+
+        #expect(result.usage.primary == nil)
+        #expect(result.usage.secondary?.usedPercent == 43)
+        #expect(result.usage.secondary?.windowMinutes == 10080)
+    }
+
+    @Test
+    func `auto mode preserves reversed session window when primary window is malformed`() throws {
+        let json = """
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": "bad",
+              "reset_at": 1767407914,
+              "limit_window_seconds": 604800
+            },
+            "secondary_window": {
+              "used_percent": 18,
+              "reset_at": 1766948068,
+              "limit_window_seconds": 18000
+            }
+          }
+        }
+        """
+        let creds = CodexOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: nil,
+            accountId: nil,
+            lastRefresh: Date())
+
+        let result = try CodexOAuthFetchStrategy._mapResultForTesting(
+            Data(json.utf8),
+            credentials: creds,
+            sourceMode: .auto)
+
+        #expect(result.usage.primary?.usedPercent == 18)
+        #expect(result.usage.primary?.windowMinutes == 300)
+        #expect(result.usage.secondary == nil)
+    }
+
+    @Test
+    func `auto mode falls back when reversed session window is malformed in secondary`() throws {
+        let json = """
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 43,
+              "reset_at": 1767407914,
+              "limit_window_seconds": 604800
+            },
+            "secondary_window": {
+              "used_percent": "bad",
+              "reset_at": 1766948068,
+              "limit_window_seconds": 18000
+            }
+          }
+        }
+        """
+        let creds = CodexOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: nil,
+            accountId: nil,
+            lastRefresh: Date())
+
+        #expect(throws: UsageError.noRateLimitsFound) {
+            _ = try CodexOAuthFetchStrategy._mapResultForTesting(
+                Data(json.utf8),
+                credentials: creds,
+                sourceMode: .auto)
+        }
+    }
+
+    @Test
+    func `explicit oauth keeps weekly window when reversed session window is malformed`() throws {
+        let json = """
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 43,
+              "reset_at": 1767407914,
+              "limit_window_seconds": 604800
+            },
+            "secondary_window": {
+              "used_percent": "bad",
+              "reset_at": 1766948068,
+              "limit_window_seconds": 18000
+            }
+          }
+        }
+        """
+        let creds = CodexOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: nil,
+            accountId: nil,
+            lastRefresh: Date())
+
+        let result = try CodexOAuthFetchStrategy._mapResultForTesting(
+            Data(json.utf8),
+            credentials: creds,
+            sourceMode: .oauth)
+
+        #expect(result.usage.primary == nil)
+        #expect(result.usage.secondary?.usedPercent == 43)
+        #expect(result.usage.secondary?.windowMinutes == 10080)
+    }
+
+    @Test
+    func `ignores malformed credits payload while keeping usage`() throws {
+        let json = """
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 22,
+              "reset_at": 1766948068,
+              "limit_window_seconds": 18000
+            }
+          },
+          "credits": {
+            "has_credits": false,
+            "unlimited": false,
+            "balance": []
+          }
+        }
+        """
+        let response = try CodexOAuthUsageFetcher._decodeUsageResponseForTesting(Data(json.utf8))
+        #expect(response.credits?.hasCredits == false)
+        #expect(response.credits?.unlimited == false)
+        #expect(response.credits?.balance == nil)
+
+        let creds = CodexOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: nil,
+            accountId: nil,
+            lastRefresh: Date())
+        let snapshot = try CodexOAuthFetchStrategy._mapUsageForTesting(Data(json.utf8), credentials: creds)
+        #expect(snapshot?.primary?.usedPercent == 22)
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexPlanFormattingTests.swift
+++ b/Tests/CodexBarTests/CodexPlanFormattingTests.swift
@@ -1,0 +1,37 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct CodexPlanFormattingTests {
+    @Test
+    func `maps prolite aliases to Pro Lite`() {
+        #expect(CodexPlanFormatting.displayName("prolite") == "Pro Lite")
+        #expect(CodexPlanFormatting.displayName("pro_lite") == "Pro Lite")
+        #expect(CodexPlanFormatting.displayName("pro-lite") == "Pro Lite")
+        #expect(CodexPlanFormatting.displayName("pro lite") == "Pro Lite")
+    }
+
+    @Test
+    func `returns nil for empty plan values`() {
+        #expect(CodexPlanFormatting.displayName(nil) == nil)
+        #expect(CodexPlanFormatting.displayName("") == nil)
+        #expect(CodexPlanFormatting.displayName("   ") == nil)
+    }
+
+    @Test
+    func `humanizes machine style plan identifiers`() {
+        #expect(
+            CodexPlanFormatting.displayName("enterprise_cbp_usage_based")
+                == "Enterprise CBP Usage Based")
+        #expect(
+            CodexPlanFormatting.displayName("self_serve_business_usage_based")
+                == "Self Serve Business Usage Based")
+        #expect(CodexPlanFormatting.displayName("k12") == "K12")
+    }
+
+    @Test
+    func `preserves already readable plan text`() {
+        #expect(CodexPlanFormatting.displayName("Enterprise") == "Enterprise")
+        #expect(CodexPlanFormatting.displayName("Pro Lite") == "Pro Lite")
+    }
+}

--- a/Tests/CodexBarTests/CodexPresentationCharacterizationTests.swift
+++ b/Tests/CodexBarTests/CodexPresentationCharacterizationTests.swift
@@ -96,6 +96,42 @@ struct CodexPresentationCharacterizationTests {
     }
 
     @Test
+    func `Codex menu humanizes prolite plan from snapshot identity`() {
+        let settings = self.makeSettingsStore(suite: "CodexPresentationCharacterizationTests-prolite")
+        settings.statusChecksEnabled = false
+
+        let fetcher = UsageFetcher(environment: [:])
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 12, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date(),
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "codex@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "prolite")),
+            provider: .codex)
+
+        let descriptor = MenuDescriptor.build(
+            provider: .codex,
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updateReady: false,
+            includeContextualActions: false)
+
+        let lines = self.textLines(from: descriptor)
+        #expect(lines.contains("Plan: Pro Lite"))
+        #expect(!lines.contains("Plan: Prolite"))
+    }
+
+    @Test
     func `Codex menu prefers snapshot identity over conflicting fallback account info`() throws {
         let settings = self.makeSettingsStore(suite: "CodexPresentationCharacterizationTests-snapshot-precedence")
         settings.statusChecksEnabled = false

--- a/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
+++ b/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
@@ -24,8 +24,16 @@ struct CodexUsageFetcherFallbackTests {
     }
 
     @Test
+    func `CLI usage does not partially recover malformed RPC body without session lane`() {
+        let snapshot = UsageFetcher._recoverCodexRPCUsageFromErrorForTesting(
+            Self.partialDecodeBodyMessage)
+
+        #expect(snapshot == nil)
+    }
+
+    @Test
     func `CLI usage falls back from RPC decode mismatch to TTY status`() async throws {
-        let stubCLIPath = try self.makeDecodeMismatchStubCodexCLI()
+        let stubCLIPath = try self.makeDecodeMismatchStubCodexCLI(message: Self.decodeMismatchMessage)
         defer { try? FileManager.default.removeItem(atPath: stubCLIPath) }
 
         let fetcher = UsageFetcher(environment: ["CODEX_CLI_PATH": stubCLIPath])
@@ -39,13 +47,27 @@ struct CodexUsageFetcherFallbackTests {
 
     @Test
     func `CLI credits fall back from RPC decode mismatch to TTY status`() async throws {
-        let stubCLIPath = try self.makeDecodeMismatchStubCodexCLI()
+        let stubCLIPath = try self.makeDecodeMismatchStubCodexCLI(message: Self.decodeMismatchMessage)
         defer { try? FileManager.default.removeItem(atPath: stubCLIPath) }
 
         let fetcher = UsageFetcher(environment: ["CODEX_CLI_PATH": stubCLIPath])
         let credits = try await fetcher.loadLatestCredits()
 
         #expect(credits.remaining == 42)
+    }
+
+    @Test
+    func `CLI usage falls back to TTY when RPC body recovery misses session lane`() async throws {
+        let stubCLIPath = try self.makeDecodeMismatchStubCodexCLI(message: Self.partialDecodeBodyMessage)
+        defer { try? FileManager.default.removeItem(atPath: stubCLIPath) }
+
+        let fetcher = UsageFetcher(environment: ["CODEX_CLI_PATH": stubCLIPath])
+        let snapshot = try await fetcher.loadLatestUsage()
+
+        #expect(snapshot.primary?.usedPercent == 12)
+        #expect(snapshot.primary?.windowMinutes == 300)
+        #expect(snapshot.secondary?.usedPercent == 25)
+        #expect(snapshot.secondary?.windowMinutes == 10080)
     }
 
     private static let decodeMismatchBodyMessage = """
@@ -81,7 +103,39 @@ struct CodexUsageFetcherFallbackTests {
     }
     """
 
-    private func makeDecodeMismatchStubCodexCLI() throws -> String {
+    private static let decodeMismatchMessage = """
+    failed to fetch codex rate limits: Decode error for https://chatgpt.com/backend-api/wham/usage:
+    unknown variant `prolite`, expected one of `guest`, `free`, `go`, `plus`, `pro`
+    """
+
+    private static let partialDecodeBodyMessage = """
+    failed to fetch codex rate limits: Decode error for https://chatgpt.com/backend-api/wham/usage:
+    unknown variant `prolite`, expected one of `guest`, `free`, `go`, `plus`, `pro`;
+    content-type=application/json; body={
+      "email": "prolite-test@example.com",
+      "plan_type": "prolite",
+      "rate_limit": {
+        "allowed": true,
+        "limit_reached": false,
+        "primary_window": {
+          "used_percent": "oops",
+          "limit_window_seconds": 18000,
+          "reset_at": 1776216359
+        },
+        "secondary_window": {
+          "used_percent": 19,
+          "limit_window_seconds": 604800,
+          "reset_after_seconds": 187681,
+          "reset_at": 1776395384
+        }
+      }
+    }
+    """
+
+    private func makeDecodeMismatchStubCodexCLI(
+        message: String = Self.decodeMismatchBodyMessage)
+        throws -> String
+    {
         let script = """
         #!/usr/bin/python3
         import json
@@ -104,7 +158,7 @@ struct CodexUsageFetcherFallbackTests {
                     payload = {
                         "id": identifier,
                         "error": {
-                            "message": "failed to fetch codex rate limits: Decode error for https://chatgpt.com/backend-api/wham/usage: unknown variant `prolite`"
+                            "message": '''\(message)'''
                         }
                     }
                 elif method == "account/read":

--- a/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
+++ b/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
@@ -12,7 +12,7 @@ struct CodexUsageFetcherFallbackTests {
         #expect(snapshot?.primary?.windowMinutes == 300)
         #expect(snapshot?.secondary?.usedPercent == 19)
         #expect(snapshot?.secondary?.windowMinutes == 10080)
-        #expect(snapshot?.accountEmail(for: UsageProvider.codex) == "lukeforn@gmail.com")
+        #expect(snapshot?.accountEmail(for: UsageProvider.codex) == "prolite-test@example.com")
         #expect(snapshot?.loginMethod(for: UsageProvider.codex) == "prolite")
     }
 
@@ -52,9 +52,9 @@ struct CodexUsageFetcherFallbackTests {
     failed to fetch codex rate limits: Decode error for https://chatgpt.com/backend-api/wham/usage:
     unknown variant `prolite`, expected one of `guest`, `free`, `go`, `plus`, `pro`;
     content-type=application/json; body={
-      "user_id": "user-HjRmNJhdtyqaGzIB98OrOdJw",
-      "account_id": "user-HjRmNJhdtyqaGzIB98OrOdJw",
-      "email": "lukeforn@gmail.com",
+      "user_id": "user-TEST",
+      "account_id": "account-TEST",
+      "email": "prolite-test@example.com",
       "plan_type": "prolite",
       "rate_limit": {
         "allowed": true,

--- a/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
+++ b/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
@@ -4,6 +4,26 @@ import Testing
 
 struct CodexUsageFetcherFallbackTests {
     @Test
+    func `CLI usage recovers from RPC decode mismatch body payload`() {
+        let snapshot = UsageFetcher._recoverCodexRPCUsageFromErrorForTesting(
+            Self.decodeMismatchBodyMessage)
+
+        #expect(snapshot?.primary?.usedPercent == 4)
+        #expect(snapshot?.primary?.windowMinutes == 300)
+        #expect(snapshot?.secondary?.usedPercent == 19)
+        #expect(snapshot?.secondary?.windowMinutes == 10080)
+        #expect(snapshot?.accountEmail(for: UsageProvider.codex) == "lukeforn@gmail.com")
+        #expect(snapshot?.loginMethod(for: UsageProvider.codex) == "prolite")
+    }
+
+    @Test
+    func `CLI credits recover from RPC decode mismatch body payload`() {
+        let credits = UsageFetcher._recoverCodexRPCCreditsFromErrorForTesting(Self.decodeMismatchBodyMessage)
+
+        #expect(credits?.remaining == 0)
+    }
+
+    @Test
     func `CLI usage falls back from RPC decode mismatch to TTY status`() async throws {
         let stubCLIPath = try self.makeDecodeMismatchStubCodexCLI()
         defer { try? FileManager.default.removeItem(atPath: stubCLIPath) }
@@ -27,6 +47,39 @@ struct CodexUsageFetcherFallbackTests {
 
         #expect(credits.remaining == 42)
     }
+
+    private static let decodeMismatchBodyMessage = """
+    failed to fetch codex rate limits: Decode error for https://chatgpt.com/backend-api/wham/usage:
+    unknown variant `prolite`, expected one of `guest`, `free`, `go`, `plus`, `pro`;
+    content-type=application/json; body={
+      "user_id": "user-HjRmNJhdtyqaGzIB98OrOdJw",
+      "account_id": "user-HjRmNJhdtyqaGzIB98OrOdJw",
+      "email": "lukeforn@gmail.com",
+      "plan_type": "prolite",
+      "rate_limit": {
+        "allowed": true,
+        "limit_reached": false,
+        "primary_window": {
+          "used_percent": 4,
+          "limit_window_seconds": 18000,
+          "reset_after_seconds": 8657,
+          "reset_at": 1776216359
+        },
+        "secondary_window": {
+          "used_percent": 19,
+          "limit_window_seconds": 604800,
+          "reset_after_seconds": 187681,
+          "reset_at": 1776395384
+        }
+      },
+      "credits": {
+        "has_credits": false,
+        "unlimited": false,
+        "overage_limit_reached": false,
+        "balance": "0E-10"
+      }
+    }
+    """
 
     private func makeDecodeMismatchStubCodexCLI() throws -> String {
         let script = """

--- a/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
+++ b/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
@@ -1,0 +1,87 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct CodexUsageFetcherFallbackTests {
+    @Test
+    func `CLI usage falls back from RPC decode mismatch to TTY status`() async throws {
+        let stubCLIPath = try self.makeDecodeMismatchStubCodexCLI()
+        defer { try? FileManager.default.removeItem(atPath: stubCLIPath) }
+
+        let fetcher = UsageFetcher(environment: ["CODEX_CLI_PATH": stubCLIPath])
+        let snapshot = try await fetcher.loadLatestUsage()
+
+        #expect(snapshot.primary?.usedPercent == 12)
+        #expect(snapshot.primary?.windowMinutes == 300)
+        #expect(snapshot.secondary?.usedPercent == 25)
+        #expect(snapshot.secondary?.windowMinutes == 10080)
+    }
+
+    @Test
+    func `CLI credits fall back from RPC decode mismatch to TTY status`() async throws {
+        let stubCLIPath = try self.makeDecodeMismatchStubCodexCLI()
+        defer { try? FileManager.default.removeItem(atPath: stubCLIPath) }
+
+        let fetcher = UsageFetcher(environment: ["CODEX_CLI_PATH": stubCLIPath])
+        let credits = try await fetcher.loadLatestCredits()
+
+        #expect(credits.remaining == 42)
+    }
+
+    private func makeDecodeMismatchStubCodexCLI() throws -> String {
+        let script = """
+        #!/usr/bin/python3
+        import json
+        import sys
+
+        args = sys.argv[1:]
+        if "app-server" in args:
+            for line in sys.stdin:
+                if not line.strip():
+                    continue
+                message = json.loads(line)
+                method = message.get("method")
+                if method == "initialized":
+                    continue
+
+                identifier = message.get("id")
+                if method == "initialize":
+                    payload = {"id": identifier, "result": {}}
+                elif method == "account/rateLimits/read":
+                    payload = {
+                        "id": identifier,
+                        "error": {
+                            "message": "failed to fetch codex rate limits: Decode error for https://chatgpt.com/backend-api/wham/usage: unknown variant `prolite`"
+                        }
+                    }
+                elif method == "account/read":
+                    payload = {
+                        "id": identifier,
+                        "result": {
+                            "account": {
+                                "type": "chatgpt",
+                                "email": "stub@example.com",
+                                "planType": "prolite"
+                            },
+                            "requiresOpenaiAuth": False
+                        }
+                    }
+                else:
+                    payload = {"id": identifier, "result": {}}
+
+                print(json.dumps(payload), flush=True)
+        else:
+            for line in sys.stdin:
+                if "/status" in line:
+                    break
+            print("Credits: 42 credits", flush=True)
+            print("5h limit: [#####] 88% left", flush=True)
+            print("Weekly limit: [##] 75% left", flush=True)
+        """
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-fallback-stub-\(UUID().uuidString)", isDirectory: false)
+        try Data(script.utf8).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url.path
+    }
+}

--- a/Tests/CodexBarTests/CodexUserFacingErrorTests.swift
+++ b/Tests/CodexBarTests/CodexUserFacingErrorTests.swift
@@ -28,6 +28,17 @@ struct CodexUserFacingErrorTests {
     }
 
     @Test
+    func `decode mismatch codex error is sanitized`() {
+        let store = self.makeUsageStore(suite: "CodexUserFacingErrorTests-decode-mismatch")
+        store.errors[.codex] =
+            "Codex connection failed: failed to fetch codex rate limits: "
+                + "Decode error for https://chatgpt.com/backend-api/wham/usage: "
+                + "unknown variant `prolite`, expected one of `guest`, `free`, `go`, `plus`, `pro`"
+
+        #expect(store.userFacingError(for: .codex) == "Codex usage is temporarily unavailable. Try refreshing.")
+    }
+
+    @Test
     func `cached credits failure preserves cached suffix while sanitizing body`() {
         let store = self.makeUsageStore(suite: "CodexUserFacingErrorTests-cached-credits")
         store.lastCreditsError =

--- a/Tests/CodexBarTests/OpenAIDashboardParserTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardParserTests.swift
@@ -99,6 +99,20 @@ struct OpenAIDashboardParserTests {
     }
 
     @Test
+    func `parses prolite plan from client bootstrap`() {
+        let html = """
+        <html>
+        <body>
+        <script type="application/json" id="client-bootstrap">
+        {"session":{"user":{"email":"user@example.com"}},"planType":"prolite"}
+        </script>
+        </body>
+        </html>
+        """
+        #expect(OpenAIDashboardParser.parsePlanFromHTML(html: html) == "Pro Lite")
+    }
+
+    @Test
     func `parses credit events from table rows`() {
         let rows: [[String]] = [
             ["Dec 18, 2025", "CLI", "397.205 credits"],


### PR DESCRIPTION
Fixes #691 and #709.

Codex started returning new `plan_type` values like `prolite`, which left a few different paths in CodexBar out of sync. This change teaches the Codex-specific surfaces to render those plan values consistently as `Pro Lite` without pushing provider-specific behavior into the shared formatter.

It also makes the OAuth usage decoder more tolerant of optional payload drift, but keeps `auto` mode honest about when that partial decode is no longer good enough. If OAuth loses the 5h/session lane because a window payload is malformed, we now fall back to the CLI. If a valid session lane still survives after reconciliation, including the reversed weekly/session shape, we keep the OAuth result instead of discarding usable data.

The test coverage here is intentionally broad because the blast radius crosses a few boundaries: OAuth decoding, dashboard parsing, menu and CLI rendering, user-facing error sanitization, and the CLI fallback path when Codex RPC chokes on newer plan variants.