### PR TITLE
feat: add Claude warming service to keep usage window advancing

### DIFF
--- a/Sources/CodexBar/MenuContent.swift
+++ b/Sources/CodexBar/MenuContent.swift
@@ -128,6 +128,8 @@ struct MenuContent: View {
             self.actions.quit()
         case let .copyError(message):
             self.actions.copyError(message)
+        case .claudeWarmingPingNow:
+            self.actions.claudeWarmingPingNow()
         }
     }
 }
@@ -145,6 +147,7 @@ struct MenuActions {
     let openAbout: () -> Void
     let quit: () -> Void
     let copyError: (String) -> Void
+    let claudeWarmingPingNow: () -> Void
 }
 
 @MainActor

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -64,6 +64,7 @@ struct MenuDescriptor {
         case about
         case quit
         case copyError(String)
+        case claudeWarmingPingNow
     }
 
     var sections: [Section]
@@ -502,6 +503,7 @@ extension MenuDescriptor.MenuAction {
         case .openTerminal: MenuDescriptor.MenuActionSystemImage.openTerminal.rawValue
         case .loginToProvider: MenuDescriptor.MenuActionSystemImage.loginToProvider.rawValue
         case .copyError: MenuDescriptor.MenuActionSystemImage.copyError.rawValue
+        case .claudeWarmingPingNow: MenuDescriptor.MenuActionSystemImage.refresh.rawValue
         }
     }
 }

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -18,6 +18,10 @@ struct ClaudeProviderImplementation: ProviderImplementation {
         }
     }
 
+    func makeRuntime() -> (any ProviderRuntime)? {
+        ClaudeWarmingRuntime()
+    }
+
     @MainActor
     func observeSettings(_ settings: SettingsStore) {
         _ = settings.claudeUsageDataSource
@@ -26,6 +30,7 @@ struct ClaudeProviderImplementation: ProviderImplementation {
         _ = settings.claudeOAuthKeychainPromptMode
         _ = settings.claudeOAuthKeychainReadStrategy
         _ = settings.claudeWebExtrasEnabled
+        _ = settings.claudeWarmingEnabled
     }
 
     @MainActor
@@ -77,12 +82,29 @@ struct ClaudeProviderImplementation: ProviderImplementation {
                 context.settings.claudeOAuthPromptFreeCredentialsEnabled = enabled
             })
 
+        let warmingBinding = Binding(
+            get: { context.settings.claudeWarmingEnabled },
+            set: { enabled in
+                context.settings.claudeWarmingEnabled = enabled
+            })
+
         return [
             ProviderSettingsToggleDescriptor(
                 id: "claude-oauth-prompt-free-credentials",
                 title: "Avoid Keychain prompts",
                 subtitle: subtitle,
                 binding: promptFreeBinding,
+                statusText: nil,
+                actions: [],
+                isVisible: nil,
+                onChange: nil,
+                onAppDidBecomeActive: nil,
+                onAppearWhenEnabled: nil),
+            ProviderSettingsToggleDescriptor(
+                id: "claude-warming",
+                title: "Enable Claude Warming",
+                subtitle: "Pings Claude CLI hourly to keep the 5-hour usage window advancing, so it resets sooner when you start working.",
+                binding: warmingBinding,
                 statusText: nil,
                 actions: [],
                 isVisible: nil,
@@ -210,6 +232,31 @@ struct ClaudeProviderImplementation: ProviderImplementation {
             let used = UsageFormatter.currencyString(cost.used, currencyCode: cost.currencyCode)
             let limit = UsageFormatter.currencyString(cost.limit, currencyCode: cost.currencyCode)
             entries.append(.text("Extra usage: \(used) / \(limit)", .primary))
+        }
+
+        if context.settings.claudeWarmingEnabled,
+           let runtime = context.store.providerRuntimes[.claude] as? ClaudeWarmingRuntime,
+           let service = runtime.warmingService
+        {
+            if let lastPing = service.lastPingTime {
+                let time = ClaudeWarmingService.formatTime(lastPing)
+                entries.append(.text("Warmer: Last ping \(time) (\(service.lastPingMessage))", .secondary))
+            }
+            if let resetAt = service.windowResetsAt {
+                if Date() > resetAt {
+                    entries.append(.text("Warmer: Window expired", .secondary))
+                } else {
+                    let time = ClaudeWarmingService.formatTime(resetAt)
+                    entries.append(.text("Warmer: Window resets ~\(time)", .secondary))
+                }
+            }
+        }
+    }
+
+    @MainActor
+    func appendActionMenuEntries(context: ProviderMenuActionContext, entries: inout [ProviderMenuEntry]) {
+        if context.settings.claudeWarmingEnabled {
+            entries.append(.action("Ping Now", .claudeWarmingPingNow))
         }
     }
 

--- a/Sources/CodexBar/Providers/Claude/ClaudeWarmingRuntime.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeWarmingRuntime.swift
@@ -23,6 +23,7 @@ final class ClaudeWarmingRuntime: ProviderRuntime {
 
     private func updateWarmingState(context: ProviderRuntimeContext) {
         let shouldRun = context.settings.claudeWarmingEnabled
+            && context.store.isEnabled(.claude)
         if shouldRun {
             if warmingService == nil {
                 warmingService = ClaudeWarmingService()

--- a/Sources/CodexBar/Providers/Claude/ClaudeWarmingRuntime.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeWarmingRuntime.swift
@@ -1,0 +1,37 @@
+import CodexBarCore
+import Foundation
+
+@MainActor
+final class ClaudeWarmingRuntime: ProviderRuntime {
+    let id: UsageProvider = .claude
+    private(set) var warmingService: ClaudeWarmingService?
+
+    func start(context: ProviderRuntimeContext) {
+        if warmingService == nil {
+            warmingService = ClaudeWarmingService()
+        }
+        updateWarmingState(context: context)
+    }
+
+    func stop(context _: ProviderRuntimeContext) {
+        warmingService?.stop()
+    }
+
+    func settingsDidChange(context: ProviderRuntimeContext) {
+        updateWarmingState(context: context)
+    }
+
+    private func updateWarmingState(context: ProviderRuntimeContext) {
+        let shouldRun = context.settings.claudeWarmingEnabled
+        if shouldRun {
+            if warmingService == nil {
+                warmingService = ClaudeWarmingService()
+            }
+            if let service = warmingService, !service.isRunning {
+                service.start()
+            }
+        } else {
+            warmingService?.stop()
+        }
+    }
+}

--- a/Sources/CodexBar/Providers/Claude/ClaudeWarmingService.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeWarmingService.swift
@@ -1,0 +1,144 @@
+import CodexBarCore
+import Foundation
+
+@MainActor
+final class ClaudeWarmingService {
+    private static let log = CodexBarLog.logger(LogCategories.claudeWarming)
+    private static let pingInterval: TimeInterval = 3600
+    private static let windowDuration: TimeInterval = 5 * 3600
+    private static let windowStartTimeKey = "claudeWarmingWindowStartTime"
+    private static let authFailurePatterns = ["not logged in", "login", "unauthorized", "auth error"]
+
+    private var timer: Timer?
+    private(set) var lastPingTime: Date?
+    private(set) var lastPingSuccess: Bool = true
+    private(set) var lastPingMessage: String = ""
+    private(set) var windowStartTime: Date? {
+        didSet {
+            if let t = windowStartTime {
+                UserDefaults.standard.set(t, forKey: Self.windowStartTimeKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Self.windowStartTimeKey)
+            }
+        }
+    }
+
+    var onStatusChanged: (() -> Void)?
+
+    var windowResetsAt: Date? {
+        guard let start = windowStartTime else { return nil }
+        return start.addingTimeInterval(Self.windowDuration)
+    }
+
+    var nextPingTime: Date? {
+        guard let last = lastPingTime else { return nil }
+        return last.addingTimeInterval(Self.pingInterval)
+    }
+
+    init() {
+        if let saved = UserDefaults.standard.object(forKey: Self.windowStartTimeKey) as? Date {
+            if Date().timeIntervalSince(saved) < Self.windowDuration {
+                windowStartTime = saved
+            }
+        }
+    }
+
+    func start() {
+        guard timer == nil else { return }
+        Self.log.info("Warming service started")
+
+        Task { await self.ping() }
+
+        timer = Timer.scheduledTimer(withTimeInterval: Self.pingInterval, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor in
+                await self.ping()
+            }
+        }
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+        Self.log.info("Warming service stopped")
+    }
+
+    func pingNow() {
+        Task { await self.ping() }
+    }
+
+    var isRunning: Bool {
+        timer != nil
+    }
+
+    private func ping() async {
+        guard let claudePath = ClaudeCLIResolver.resolvedBinaryPath() else {
+            lastPingTime = Date()
+            lastPingSuccess = false
+            lastPingMessage = "CLI not found"
+            Self.log.warning("Claude CLI not found, skipping ping")
+            onStatusChanged?()
+            return
+        }
+
+        let (output, exitCode) = await runClaude(at: claudePath)
+        lastPingTime = Date()
+
+        let isAuthFailure = exitCode != 0 || Self.authFailurePatterns.contains { pattern in
+            output.localizedCaseInsensitiveContains(pattern)
+        }
+
+        if isAuthFailure {
+            lastPingSuccess = false
+            lastPingMessage = "Auth failure"
+            Self.log.warning(
+                "Ping auth failure",
+                metadata: ["exitCode": "\(exitCode)", "response": "\(output.prefix(200))"])
+        } else {
+            lastPingSuccess = true
+            lastPingMessage = "OK"
+            Self.log.info(
+                "Ping succeeded",
+                metadata: ["exitCode": "\(exitCode)", "responseLength": "\(output.count)"])
+
+            if let resetAt = windowResetsAt, Date() > resetAt {
+                windowStartTime = Date()
+            } else if windowStartTime == nil {
+                windowStartTime = Date()
+            }
+        }
+
+        onStatusChanged?()
+    }
+
+    private func runClaude(at path: String) async -> (String, Int32) {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .utility).async {
+                let process = Process()
+                let pipe = Pipe()
+
+                process.executableURL = URL(fileURLWithPath: path)
+                process.arguments = ["-p", ".", "--model", "haiku"]
+                process.standardOutput = pipe
+                process.standardError = pipe
+                process.environment = ProcessInfo.processInfo.environment
+
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                    let output = String(data: data, encoding: .utf8) ?? ""
+                    continuation.resume(returning: (output, process.terminationStatus))
+                } catch {
+                    continuation.resume(returning: ("Process launch failed: \(error)", 1))
+                }
+            }
+        }
+    }
+
+    static func formatTime(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "h:mm a"
+        return f.string(from: date)
+    }
+}

--- a/Sources/CodexBar/Providers/Claude/ClaudeWarmingService.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeWarmingService.swift
@@ -111,6 +111,8 @@ final class ClaudeWarmingService {
         onStatusChanged?()
     }
 
+    private static let processTimeout: TimeInterval = 60
+
     private func runClaude(at path: String) async -> (String, Int32) {
         await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .utility).async {
@@ -125,12 +127,30 @@ final class ClaudeWarmingService {
 
                 do {
                     try process.run()
-                    process.waitUntilExit()
-                    let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                    let output = String(data: data, encoding: .utf8) ?? ""
-                    continuation.resume(returning: (output, process.terminationStatus))
                 } catch {
                     continuation.resume(returning: ("Process launch failed: \(error)", 1))
+                    return
+                }
+
+                let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+                timer.schedule(deadline: .now() + Self.processTimeout)
+                timer.setEventHandler {
+                    if process.isRunning {
+                        process.terminate()
+                    }
+                }
+                timer.resume()
+
+                process.waitUntilExit()
+                timer.cancel()
+
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                let output = String(data: data, encoding: .utf8) ?? ""
+
+                if process.terminationReason == .uncaughtSignal {
+                    continuation.resume(returning: ("Process timed out after \(Int(Self.processTimeout))s", 1))
+                } else {
+                    continuation.resume(returning: (output, process.terminationStatus))
                 }
             }
         }

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -233,6 +233,17 @@ extension SettingsStore {
         }
     }
 
+    var claudeWarmingEnabled: Bool {
+        get { self.defaultsState.claudeWarmingEnabled }
+        set {
+            self.defaultsState.claudeWarmingEnabled = newValue
+            self.userDefaults.set(newValue, forKey: "claudeWarmingEnabled")
+            CodexBarLog.logger(LogCategories.settings).info(
+                "Claude warming updated",
+                metadata: ["enabled": newValue ? "1" : "0"])
+        }
+    }
+
     var claudeWebExtrasEnabled: Bool {
         get { self.claudeWebExtrasEnabledRaw }
         set { self.claudeWebExtrasEnabledRaw = newValue }

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -243,6 +243,7 @@ extension SettingsStore {
         let menuBarShowsHighestUsage = userDefaults.object(forKey: "menuBarShowsHighestUsage") as? Bool ?? false
         let claudeOAuthKeychainPromptModeRaw = userDefaults.string(forKey: "claudeOAuthKeychainPromptMode")
         let claudeOAuthKeychainReadStrategyRaw = userDefaults.string(forKey: "claudeOAuthKeychainReadStrategy")
+        let claudeWarmingEnabled = userDefaults.object(forKey: "claudeWarmingEnabled") as? Bool ?? false
         let claudeWebExtrasEnabledRaw = userDefaults.object(forKey: "claudeWebExtrasEnabled") as? Bool ?? false
         let creditsExtrasDefault = userDefaults.object(forKey: "showOptionalCreditsAndExtraUsage") as? Bool
         let showOptionalCreditsAndExtraUsage = creditsExtrasDefault ?? true
@@ -287,6 +288,7 @@ extension SettingsStore {
             menuBarShowsHighestUsage: menuBarShowsHighestUsage,
             claudeOAuthKeychainPromptModeRaw: claudeOAuthKeychainPromptModeRaw,
             claudeOAuthKeychainReadStrategyRaw: claudeOAuthKeychainReadStrategyRaw,
+            claudeWarmingEnabled: claudeWarmingEnabled,
             claudeWebExtrasEnabledRaw: claudeWebExtrasEnabledRaw,
             showOptionalCreditsAndExtraUsage: showOptionalCreditsAndExtraUsage,
             openAIWebAccessEnabled: openAIWebAccessEnabled,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -24,6 +24,7 @@ struct SettingsDefaultsState {
     var menuBarShowsHighestUsage: Bool
     var claudeOAuthKeychainPromptModeRaw: String?
     var claudeOAuthKeychainReadStrategyRaw: String?
+    var claudeWarmingEnabled: Bool
     var claudeWebExtrasEnabledRaw: Bool
     var showOptionalCreditsAndExtraUsage: Bool
     var openAIWebAccessEnabled: Bool

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -221,6 +221,12 @@ extension StatusItemController {
         }
     }
 
+    @objc func claudeWarmingPingNow() {
+        if let runtime = self.store.providerRuntimes[.claude] as? ClaudeWarmingRuntime {
+            runtime.warmingService?.pingNow()
+        }
+    }
+
     private static func openTerminal(command: String) {
         let escaped = command
             .replacingOccurrences(of: "\\\\", with: "\\\\\\\\")

--- a/Sources/CodexBar/StatusItemController+MenuActionMapping.swift
+++ b/Sources/CodexBar/StatusItemController+MenuActionMapping.swift
@@ -18,6 +18,7 @@ extension StatusItemController {
         case .about: (#selector(self.showSettingsAbout), nil)
         case .quit: (#selector(self.quit), nil)
         case let .copyError(message): (#selector(self.copyError(_:)), message)
+        case .claudeWarmingPingNow: (#selector(self.claudeWarmingPingNow), nil)
         }
     }
 

--- a/Sources/CodexBarCore/Logging/LogCategories.swift
+++ b/Sources/CodexBarCore/Logging/LogCategories.swift
@@ -9,6 +9,7 @@ public enum LogCategories {
     public static let claudeCLI = "claude-cli"
     public static let claudeProbe = "claude-probe"
     public static let claudeUsage = "claude-usage"
+    public static let claudeWarming = "claude-warming"
     public static let codexRPC = "codex-rpc"
     public static let configMigration = "config-migration"
     public static let configStore = "config-store"


### PR DESCRIPTION
## Summary

- add a background warming service that pings Claude CLI hourly (`claude -p "." --model haiku`) to keep the 5-hour rolling usage window advancing
- integrate as a `ProviderRuntime` under the Claude provider with a settings toggle ("Enable Claude Warming")
- show warming status (last ping time, window reset time) in the Claude usage menu
- add a "Ping Now" menu action for manual pings

### How it works

Claude Code (Max plan) enforces a rolling 5-hour usage window that starts from your first API call. By making lightweight pings every hour in the background, the window may already be 1–4 hours elapsed by the time you start actual work, meaning it resets sooner — effectively giving you access to fresh quota faster.

### Files

| File | Change |
|------|--------|
| `ClaudeWarmingService.swift` | **new** — core ping logic, window tracking, auth failure detection |
| `ClaudeWarmingRuntime.swift` | **new** — `ProviderRuntime` that starts/stops the service based on settings |
| `ClaudeProviderImplementation.swift` | add `makeRuntime()`, settings toggle, warming menu entries |
| `SettingsStoreState.swift` / `SettingsStore.swift` / `SettingsStore+Defaults.swift` | add `claudeWarmingEnabled` setting |
| `MenuDescriptor.swift` / `MenuContent.swift` | add `.claudeWarmingPingNow` menu action |
| `StatusItemController+Actions.swift` / `+MenuActionMapping.swift` | handle ping action |
| `LogCategories.swift` | add `claudeWarming` log category |

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./Scripts/compile_and_run.sh`
- toggled "Enable Claude Warming" on/off in Claude provider settings
- verified warming service starts and pings immediately
- verified "Ping Now" menu action triggers a manual ping
- verified warming status appears in the Claude menu
- verified state persists across app restart