### PR TITLE
Handle fnm Gemini OAuth config discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.22 — Unreleased
 
+### Providers & Usage
+- Gemini: discover OAuth config in fnm/Homebrew/bundled CLI layouts so expired-token refresh keeps working (#723). Thanks @Leechael!
+
 ## 0.21 — 2026-04-18
 
 ### Highlights

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
@@ -475,20 +475,280 @@ public struct GeminiStatusProbe: Sendable {
         }
 
         // Resolve symlinks to find the actual installation
-        let fm = FileManager.default
-        var realPath = geminiPath
-        if let resolved = try? fm.destinationOfSymbolicLink(atPath: geminiPath) {
-            if resolved.hasPrefix("/") {
-                realPath = resolved
-            } else {
-                realPath = (geminiPath as NSString).deletingLastPathComponent + "/" + resolved
+        let resolvedGeminiPath = URL(fileURLWithPath: geminiPath).resolvingSymlinksInPath().path
+
+        // Try the legacy layouts first — they're cheap file reads and cover the common cases
+        // (Homebrew, npm/bun sibling, Nix) without spawning subprocesses or walking the tree.
+        if let credentials = Self.extractOAuthCredentialsFromLegacyPaths(realGeminiPath: resolvedGeminiPath) {
+            return credentials
+        }
+
+        // For fnm-managed installs, ask fnm where the package lives
+        if Self.isLikelyFnmManagedPath(geminiPath) || Self.isLikelyFnmManagedPath(resolvedGeminiPath),
+           let fnmPath = TTYCommandRunner.which("fnm"),
+           let packageRoot = Self.resolveGeminiPackageRootViaFnm(fnmPath: fnmPath, environment: env),
+           let credentials = Self.extractOAuthCredentials(fromGeminiPackageRoot: packageRoot)
+        {
+            return credentials
+        }
+
+        // Fall back to walking up the directory tree from the binary
+        if let packageRoot = Self.findGeminiPackageRoot(startingAt: resolvedGeminiPath),
+           let credentials = Self.extractOAuthCredentials(fromGeminiPackageRoot: packageRoot)
+        {
+            return credentials
+        }
+
+        return nil
+    }
+
+    private static func isLikelyFnmManagedPath(_ path: String) -> Bool {
+        let normalized = path.replacingOccurrences(of: "\\", with: "/")
+        return normalized.contains("/fnm_multishells/")
+            || (normalized.contains("/node-versions/") && normalized.contains("/fnm/"))
+    }
+
+    private static func resolveGeminiPackageRootViaFnm(
+        fnmPath: String,
+        environment: [String: String]) -> String?
+    {
+        guard let currentVersion = runProcess(
+            executable: fnmPath,
+            arguments: ["current"],
+            environment: environment,
+            timeout: 2.0),
+            !currentVersion.isEmpty
+        else {
+            return nil
+        }
+
+        // Prefer npm root -g because require.resolve searches from the current
+        // working directory and often fails for globally-installed packages.
+        if let npmRoot = runProcess(
+            executable: fnmPath,
+            arguments: [
+                "exec",
+                "--using",
+                currentVersion,
+                "npm",
+                "root",
+                "-g",
+            ],
+            environment: environment,
+            timeout: 4.0),
+            !npmRoot.isEmpty
+        {
+            let packageRoot = "\(npmRoot)/@google/gemini-cli"
+            let packageJSONPath = "\(packageRoot)/package.json"
+            if FileManager.default.fileExists(atPath: packageJSONPath) {
+                return packageRoot
             }
         }
 
-        // Navigate from bin/gemini to the oauth2.js file
-        // Homebrew path: .../libexec/lib/node_modules/@google/gemini-cli/node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js
-        // Bun/npm path: .../node_modules/@google/gemini-cli-core/dist/src/code_assist/oauth2.js (sibling package)
-        let binDir = (realPath as NSString).deletingLastPathComponent
+        // Fallback for non-npm global installations.
+        if let packageJSONPath = runProcess(
+            executable: fnmPath,
+            arguments: [
+                "exec",
+                "--using",
+                currentVersion,
+                "node",
+                "-p",
+                "require.resolve('@google/gemini-cli/package.json')",
+            ],
+            environment: environment,
+            timeout: 4.0),
+            !packageJSONPath.isEmpty
+        {
+            return (packageJSONPath as NSString).deletingLastPathComponent
+        }
+
+        return nil
+    }
+
+    private static func runProcess(
+        executable: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval) -> String?
+    {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+
+        var mergedEnvironment = environment
+        mergedEnvironment["PATH"] = PathBuilder.effectivePATH(
+            purposes: [.tty, .nodeTooling],
+            env: environment,
+            loginPATH: LoginShellPathCache.shared.current)
+        process.environment = mergedEnvironment
+
+        let stdout = Pipe()
+        process.standardOutput = stdout
+        process.standardError = Pipe()
+        process.standardInput = nil
+
+        let exitSemaphore = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in
+            exitSemaphore.signal()
+        }
+
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+
+        let didExit = exitSemaphore.wait(timeout: .now() + timeout) == .success
+        if !didExit {
+            if process.isRunning {
+                process.terminate()
+                _ = exitSemaphore.wait(timeout: .now() + 0.5)
+            }
+            return nil
+        }
+
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        guard process.terminationStatus == 0,
+              let output = String(data: data, encoding: .utf8)?
+                  .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !output.isEmpty
+        else {
+            return nil
+        }
+
+        return output.components(separatedBy: .newlines).first?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func findGeminiPackageRoot(startingAt path: String) -> String? {
+        let fileManager = FileManager.default
+        var currentURL = URL(fileURLWithPath: path).standardizedFileURL
+
+        var isDirectory: ObjCBool = false
+        if !fileManager.fileExists(atPath: currentURL.path, isDirectory: &isDirectory) || !isDirectory.boolValue {
+            currentURL.deleteLastPathComponent()
+        }
+
+        // Bound the walk so an unrelated Gemini install elsewhere on the host
+        // (e.g. a global npm/brew install unrelated to the resolved binary) can't
+        // contaminate discovery started from the actual binary path.
+        let maxAscents = 8
+        for _ in 0...maxAscents {
+            let packageJSONURL = currentURL.appendingPathComponent("package.json")
+            if let data = try? Data(contentsOf: packageJSONURL),
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               json["name"] as? String == "@google/gemini-cli"
+            {
+                return currentURL.path
+            }
+
+            // Also check for a global Node installation layout:
+            // <current>/lib/node_modules/@google/gemini-cli/package.json
+            let globalPackageJSONURL = currentURL
+                .appendingPathComponent("lib")
+                .appendingPathComponent("node_modules")
+                .appendingPathComponent("@google")
+                .appendingPathComponent("gemini-cli")
+                .appendingPathComponent("package.json")
+            if let data = try? Data(contentsOf: globalPackageJSONURL),
+               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               json["name"] as? String == "@google/gemini-cli"
+            {
+                return globalPackageJSONURL.deletingLastPathComponent().path
+            }
+
+            let parentURL = currentURL.deletingLastPathComponent()
+            if parentURL.path == currentURL.path {
+                return nil
+            }
+            currentURL = parentURL
+        }
+
+        return nil
+    }
+
+    private static func extractOAuthCredentials(fromGeminiPackageRoot packageRoot: String) -> OAuthClientCredentials? {
+        // Check the standard distributed file first, then any sibling core package
+        let oauthFile = "dist/src/code_assist/oauth2.js"
+        let candidatePaths = [
+            "\(packageRoot)/\(oauthFile)",
+            "\(packageRoot)/node_modules/@google/gemini-cli-core/\(oauthFile)",
+        ]
+
+        for path in candidatePaths {
+            if let content = try? String(contentsOfFile: path, encoding: .utf8),
+               let credentials = Self.parseOAuthCredentials(from: content)
+            {
+                return credentials
+            }
+        }
+
+        return Self.extractOAuthCredentialsFromBundle(packageRoot: packageRoot)
+    }
+
+    private static func extractOAuthCredentialsFromBundle(packageRoot: String) -> OAuthClientCredentials? {
+        let bundleRoot = URL(fileURLWithPath: packageRoot).appendingPathComponent("bundle", isDirectory: true)
+        let entryURL = bundleRoot.appendingPathComponent("gemini.js")
+
+        guard FileManager.default.fileExists(atPath: entryURL.path) else {
+            return nil
+        }
+
+        var pendingURLs = [entryURL]
+        var visitedPaths = Set<String>()
+
+        while !pendingURLs.isEmpty {
+            let currentURL = pendingURLs.removeFirst()
+            let standardizedPath = currentURL.standardizedFileURL.path
+            guard visitedPaths.insert(standardizedPath).inserted,
+                  let content = try? String(contentsOf: currentURL, encoding: .utf8)
+            else {
+                continue
+            }
+
+            if let credentials = Self.parseOAuthCredentials(from: content) {
+                return credentials
+            }
+
+            let imports = Self.extractRelativeJavaScriptImports(from: content)
+            for importPath in imports {
+                let nextURL = URL(fileURLWithPath: importPath, relativeTo: currentURL.deletingLastPathComponent())
+                    .standardizedFileURL
+                guard nextURL.path.hasPrefix(bundleRoot.path) else { continue }
+                pendingURLs.append(nextURL)
+            }
+        }
+
+        return nil
+    }
+
+    private static func extractRelativeJavaScriptImports(from content: String) -> [String] {
+        let patterns = [
+            #"(?:import|export)\s+(?:[^;]*?\s+from\s+)?[\"'](\./[^\"']+\.js)[\"']"#,
+            #"import\(\s*[\"'](\./[^\"']+\.js)[\"']\s*\)"#,
+        ]
+
+        var discoveredPaths: [String] = []
+        var seen = Set<String>()
+        let fullRange = NSRange(content.startIndex..., in: content)
+
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern) else { continue }
+            for match in regex.matches(in: content, range: fullRange) {
+                guard let range = Range(match.range(at: 1), in: content) else { continue }
+                let path = String(content[range])
+                if seen.insert(path).inserted {
+                    discoveredPaths.append(path)
+                }
+            }
+        }
+
+        return discoveredPaths
+    }
+
+    private static func extractOAuthCredentialsFromLegacyPaths(realGeminiPath: String) -> OAuthClientCredentials? {
+        let binDir = (realGeminiPath as NSString).deletingLastPathComponent
         let baseDir = (binDir as NSString).deletingLastPathComponent
 
         let oauthSubpath =
@@ -509,8 +769,10 @@ public struct GeminiStatusProbe: Sendable {
         ]
 
         for path in possiblePaths {
-            if let content = try? String(contentsOfFile: path, encoding: .utf8) {
-                return self.parseOAuthCredentials(from: content)
+            if let content = try? String(contentsOfFile: path, encoding: .utf8),
+               let credentials = Self.parseOAuthCredentials(from: content)
+            {
+                return credentials
             }
         }
 

--- a/Tests/CodexBarTests/GeminiStatusProbeAPITests.swift
+++ b/Tests/CodexBarTests/GeminiStatusProbeAPITests.swift
@@ -67,6 +67,13 @@ struct GeminiStatusProbeAPITests {
 
             switch host {
             case "oauth2.googleapis.com":
+                // Fail the refresh if the client_id did not come from the test stub.
+                // This guards against the probe accidentally extracting OAuth creds
+                // from an unrelated Gemini install on the developer's machine.
+                let body = request.httpBody.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+                guard body.contains("client_id=test-client-id") else {
+                    return GeminiAPITestHelpers.response(url: url.absoluteString, status: 400, body: Data())
+                }
                 let json = GeminiAPITestHelpers.jsonData([
                     "access_token": "new-token",
                     "expires_in": 3600,
@@ -139,6 +146,13 @@ struct GeminiStatusProbeAPITests {
 
             switch host {
             case "oauth2.googleapis.com":
+                // Fail the refresh if the client_id did not come from the test stub.
+                // This guards against the probe accidentally extracting OAuth creds
+                // from an unrelated Gemini install on the developer's machine.
+                let body = request.httpBody.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+                guard body.contains("client_id=test-client-id") else {
+                    return GeminiAPITestHelpers.response(url: url.absoluteString, status: 400, body: Data())
+                }
                 let json = GeminiAPITestHelpers.jsonData([
                     "access_token": "new-token",
                     "expires_in": 3600,
@@ -178,6 +192,116 @@ struct GeminiStatusProbeAPITests {
         let probe = GeminiStatusProbe(timeout: 2, homeDirectory: env.homeURL.path, dataLoader: dataLoader)
         let snapshot = try await probe.fetch()
         #expect(snapshot.accountPlan == "Paid")
+    }
+
+    @Test
+    func `refreshes expired token with fnm bundle layout`() async throws {
+        let env = try GeminiTestEnvironment()
+        defer { env.cleanup() }
+        try env.writeCredentials(
+            accessToken: "old-token",
+            refreshToken: "refresh-token",
+            expiry: Date().addingTimeInterval(-3600),
+            idToken: GeminiAPITestHelpers.makeIDToken(email: "user@example.com"))
+
+        let binURL = try env.writeFakeGeminiCLI(layout: .fnmBundle)
+        // Match the real fnm layout: package root is inside the same multishell
+        // dir as the bin symlink target, under lib/node_modules/@google/gemini-cli.
+        let multishellRoot = binURL.deletingLastPathComponent().deletingLastPathComponent()
+        let packageJSONPath = multishellRoot
+            .appendingPathComponent("lib")
+            .appendingPathComponent("node_modules")
+            .appendingPathComponent("@google")
+            .appendingPathComponent("gemini-cli")
+            .appendingPathComponent("package.json")
+        let npmRoot = packageJSONPath
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .path
+        _ = try env.writeFakeFnm(npmRoot: npmRoot, geminiPackageJSONPath: packageJSONPath.path)
+
+        let previousPath = ProcessInfo.processInfo.environment["PATH"]
+        let fakeBinDir = env.homeURL.appendingPathComponent("bin").path
+        let pathValue = if let previousPath, !previousPath.isEmpty {
+            "\(fakeBinDir):\(binURL.deletingLastPathComponent().path):\(previousPath)"
+        } else {
+            "\(fakeBinDir):\(binURL.deletingLastPathComponent().path)"
+        }
+        setenv("PATH", pathValue, 1)
+
+        let previousGeminiPath = ProcessInfo.processInfo.environment["GEMINI_CLI_PATH"]
+        unsetenv("GEMINI_CLI_PATH")
+        defer {
+            if let previousPath {
+                setenv("PATH", previousPath, 1)
+            } else {
+                unsetenv("PATH")
+            }
+
+            if let previousGeminiPath {
+                setenv("GEMINI_CLI_PATH", previousGeminiPath, 1)
+            } else {
+                unsetenv("GEMINI_CLI_PATH")
+            }
+        }
+
+        let dataLoader = GeminiAPITestHelpers.dataLoader { request in
+            guard let url = request.url, let host = url.host else {
+                throw URLError(.badURL)
+            }
+
+            switch host {
+            case "oauth2.googleapis.com":
+                // Fail the refresh if the client_id did not come from the test stub.
+                // This guards against the probe accidentally extracting OAuth creds
+                // from an unrelated Gemini install on the developer's machine.
+                let body = request.httpBody.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+                guard body.contains("client_id=test-client-id") else {
+                    return GeminiAPITestHelpers.response(url: url.absoluteString, status: 400, body: Data())
+                }
+                let json = GeminiAPITestHelpers.jsonData([
+                    "access_token": "new-token",
+                    "expires_in": 3600,
+                    "id_token": GeminiAPITestHelpers.makeIDToken(email: "user@example.com"),
+                ])
+                return GeminiAPITestHelpers.response(url: url.absoluteString, status: 200, body: json)
+            case "cloudresourcemanager.googleapis.com":
+                let json = GeminiAPITestHelpers.jsonData(["projects": []])
+                return GeminiAPITestHelpers.response(url: url.absoluteString, status: 200, body: json)
+            case "cloudcode-pa.googleapis.com":
+                if url.path == "/v1internal:loadCodeAssist" {
+                    let auth = request.value(forHTTPHeaderField: "Authorization")
+                    if auth != "Bearer new-token" {
+                        return GeminiAPITestHelpers.response(url: url.absoluteString, status: 401, body: Data())
+                    }
+                    return GeminiAPITestHelpers.response(
+                        url: url.absoluteString,
+                        status: 200,
+                        body: GeminiAPITestHelpers.loadCodeAssistStandardTierResponse())
+                }
+                if url.path != "/v1internal:retrieveUserQuota" {
+                    return GeminiAPITestHelpers.response(url: url.absoluteString, status: 404, body: Data())
+                }
+                let auth = request.value(forHTTPHeaderField: "Authorization")
+                if auth != "Bearer new-token" {
+                    return GeminiAPITestHelpers.response(url: url.absoluteString, status: 401, body: Data())
+                }
+                return GeminiAPITestHelpers.response(
+                    url: url.absoluteString,
+                    status: 200,
+                    body: GeminiAPITestHelpers.sampleQuotaResponse())
+            default:
+                return GeminiAPITestHelpers.response(url: url.absoluteString, status: 404, body: Data())
+            }
+        }
+
+        let probe = GeminiStatusProbe(timeout: 2, homeDirectory: env.homeURL.path, dataLoader: dataLoader)
+        let snapshot = try await probe.fetch()
+        #expect(snapshot.accountPlan == "Paid")
+
+        let updated = try env.readCredentials()
+        #expect(updated["access_token"] as? String == "new-token")
     }
 
     @Test

--- a/Tests/CodexBarTests/GeminiTestEnvironment.swift
+++ b/Tests/CodexBarTests/GeminiTestEnvironment.swift
@@ -4,6 +4,7 @@ struct GeminiTestEnvironment {
     enum GeminiCLILayout {
         case npmNested
         case nixShare
+        case fnmBundle
     }
 
     let homeURL: URL
@@ -57,9 +58,9 @@ struct GeminiTestEnvironment {
         let binDir = base.appendingPathComponent("bin")
         try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
 
-        let oauthPath: URL = switch layout {
+        switch layout {
         case .npmNested:
-            base
+            let oauthPath = base
                 .appendingPathComponent("lib")
                 .appendingPathComponent("node_modules")
                 .appendingPathComponent("@google")
@@ -71,8 +72,28 @@ struct GeminiTestEnvironment {
                 .appendingPathComponent("src")
                 .appendingPathComponent("code_assist")
                 .appendingPathComponent("oauth2.js")
+
+            if includeOAuth {
+                try FileManager.default.createDirectory(
+                    at: oauthPath.deletingLastPathComponent(),
+                    withIntermediateDirectories: true)
+
+                let oauthContent = """
+                const OAUTH_CLIENT_ID = 'test-client-id';
+                const OAUTH_CLIENT_SECRET = 'test-client-secret';
+                """
+                try oauthContent.write(to: oauthPath, atomically: true, encoding: .utf8)
+            }
+
+            let geminiBinary = binDir.appendingPathComponent("gemini")
+            try "#!/bin/bash\nexit 0\n".write(to: geminiBinary, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: geminiBinary.path)
+            return geminiBinary
+
         case .nixShare:
-            base
+            let oauthPath = base
                 .appendingPathComponent("share")
                 .appendingPathComponent("gemini-cli")
                 .appendingPathComponent("node_modules")
@@ -82,25 +103,144 @@ struct GeminiTestEnvironment {
                 .appendingPathComponent("src")
                 .appendingPathComponent("code_assist")
                 .appendingPathComponent("oauth2.js")
-        }
 
-        if includeOAuth {
-            try FileManager.default.createDirectory(
-                at: oauthPath.deletingLastPathComponent(),
-                withIntermediateDirectories: true)
+            if includeOAuth {
+                try FileManager.default.createDirectory(
+                    at: oauthPath.deletingLastPathComponent(),
+                    withIntermediateDirectories: true)
 
-            let oauthContent = """
-            const OAUTH_CLIENT_ID = 'test-client-id';
-            const OAUTH_CLIENT_SECRET = 'test-client-secret';
+                let oauthContent = """
+                const OAUTH_CLIENT_ID = 'test-client-id';
+                const OAUTH_CLIENT_SECRET = 'test-client-secret';
+                """
+                try oauthContent.write(to: oauthPath, atomically: true, encoding: .utf8)
+            }
+
+            let geminiBinary = binDir.appendingPathComponent("gemini")
+            try "#!/bin/bash\nexit 0\n".write(to: geminiBinary, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: geminiBinary.path)
+            return geminiBinary
+
+        case .fnmBundle:
+            // Mirror a real fnm multishell layout: bin/gemini is a single relative
+            // symlink into the same multishell's lib/node_modules/@google/gemini-cli,
+            // which is a plain directory with the real package.json + bundle/*.js.
+            let multishellRoot = self.homeURL
+                .appendingPathComponent("Library")
+                .appendingPathComponent("Caches")
+                .appendingPathComponent("fnm_multishells")
+                .appendingPathComponent("12345_67890")
+            let binDir = multishellRoot.appendingPathComponent("bin")
+            let packageRoot = multishellRoot
+                .appendingPathComponent("lib")
+                .appendingPathComponent("node_modules")
+                .appendingPathComponent("@google")
+                .appendingPathComponent("gemini-cli")
+            let bundleDir = packageRoot.appendingPathComponent("bundle")
+            try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: bundleDir, withIntermediateDirectories: true)
+
+            let packageJSON = """
+            {
+              "name": "@google/gemini-cli"
+            }
             """
-            try oauthContent.write(to: oauthPath, atomically: true, encoding: .utf8)
-        }
+            try packageJSON.write(
+                to: packageRoot.appendingPathComponent("package.json"),
+                atomically: true,
+                encoding: .utf8)
 
-        let geminiBinary = binDir.appendingPathComponent("gemini")
-        try "#!/bin/bash\nexit 0\n".write(to: geminiBinary, atomically: true, encoding: .utf8)
+            let chunkName = "chunk-TEST123.js"
+            let geminiEntry = bundleDir.appendingPathComponent("gemini.js")
+            let geminiContent = """
+            #!/usr/bin/env node
+            import { start } from "./\(chunkName)";
+            start();
+            """
+            try geminiContent.write(to: geminiEntry, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: geminiEntry.path)
+
+            let chunkContent = if includeOAuth {
+                """
+                export const start = () => {};
+                const OAUTH_CLIENT_ID = 'test-client-id';
+                const OAUTH_CLIENT_SECRET = 'test-client-secret';
+                """
+            } else {
+                "export const start = () => {};\n"
+            }
+            try chunkContent.write(
+                to: bundleDir.appendingPathComponent(chunkName),
+                atomically: true,
+                encoding: .utf8)
+
+            // Relative symlink matching what fnm actually creates:
+            //   fnm_multishells/XXX/bin/gemini -> ../lib/node_modules/@google/gemini-cli/bundle/gemini.js
+            // Use the path-based API so the target is stored as a literal relative
+            // string; the URL-based API resolves URL(fileURLWithPath: "../...") against
+            // the process CWD, which produces a bogus absolute target.
+            let geminiBinary = binDir.appendingPathComponent("gemini")
+            try FileManager.default.createSymbolicLink(
+                atPath: geminiBinary.path,
+                withDestinationPath: "../lib/node_modules/@google/gemini-cli/bundle/gemini.js")
+
+            return geminiBinary
+        }
+    }
+
+    func writeFakeFnm(
+        currentVersion: String = "v24.6.0",
+        npmRoot: String? = nil,
+        geminiPackageJSONPath: String) throws -> URL
+    {
+        let binDir = self.homeURL.appendingPathComponent("bin")
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+
+        let fnmPath = binDir.appendingPathComponent("fnm")
+        let script = if let npmRoot {
+            """
+            #!/bin/bash
+            if [ "$1" = "current" ]; then
+              printf '%s\n' "\(currentVersion)"
+              exit 0
+            fi
+
+            if [ "$1" = "exec" ] && [ "$4" = "npm" ] && [ "$5" = "root" ] && [ "$6" = "-g" ]; then
+              printf '%s\n' "\(npmRoot)"
+              exit 0
+            fi
+
+            if [ "$1" = "exec" ] && [ "$4" = "node" ]; then
+              printf '%s\n' "\(geminiPackageJSONPath)"
+              exit 0
+            fi
+
+            exit 1
+            """
+        } else {
+            """
+            #!/bin/bash
+            if [ "$1" = "current" ]; then
+              printf '%s\n' "\(currentVersion)"
+              exit 0
+            fi
+
+            if [ "$1" = "exec" ]; then
+              printf '%s\n' "\(geminiPackageJSONPath)"
+              exit 0
+            fi
+
+            exit 1
+            """
+        }
+        try script.write(to: fnmPath, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes(
             [.posixPermissions: 0o755],
-            ofItemAtPath: geminiBinary.path)
-        return geminiBinary
+            ofItemAtPath: fnmPath.path)
+        return fnmPath
     }
 }


### PR DESCRIPTION
Fixes Gemini OAuth token refresh when the CLI is installed via fnm. Also
handles the Homebrew multi-level symlink chain that #497 aims to fix.

## Symptom

Refreshing an expired Gemini access token fails with:

> Gemini API error: Could not find Gemini CLI OAuth configuration

## Root cause

The old discovery reads `oauth2.js` from a hard-coded list of `node_modules`
paths relative to the `gemini` binary's parent directory. Two things break
that assumption on fnm:

1. The binary lives under `fnm_multishells/<shell-id>/bin/gemini`, a single
   relative symlink into the same multishell's
   `lib/node_modules/@google/gemini-cli`. The parent-directory math in the
   old code lands outside the package root.
2. Recent Gemini CLI releases ship `bundle/gemini.js` plus hashed
   `chunk-*.js` files instead of `dist/src/code_assist/oauth2.js`. The
   chunk filename is not stable across releases, so any hard-coded path
   misses the OAuth constants.

Separately, Homebrew exposes `gemini` through a 4-level symlink chain
(`/usr/local/bin/gemini` → `/opt/homebrew/bin/gemini` →
`../Cellar/gemini-cli/<ver>/bin/gemini` → `../libexec/bin/gemini`). The
old `destinationOfSymbolicLink` call only resolved one level, so discovery
landed in `/opt/homebrew/bin/` and missed the `libexec/` tree.
`URL.resolvingSymlinksInPath()` resolves the full chain, so the manual
walk is no longer needed.

## Changes

`extractOAuthCredentials()` tries three strategies in order:

1. **Legacy `oauth2.js` paths** — Homebrew libexec, npm nested, Nix share,
   bun/npm sibling. Plain file reads, no subprocesses. Matches the pre-PR
   code path.
2. **fnm-managed paths** (`fnm_multishells` / `fnm/node-versions`) — runs
   `fnm current`, then `fnm exec --using <ver> npm root -g` to get the
   global `node_modules` directory. Falls back to
   `node -p require.resolve('@google/gemini-cli/package.json')` when
   `npm root -g` does not expose the package.
3. **Directory walk-up** — from the resolved binary, walks up looking for
   a `@google/gemini-cli/package.json` (and
   `lib/node_modules/@google/gemini-cli/package.json` at each level).
   Bounded to 8 ascents so an unrelated Gemini install elsewhere on the
   host cannot contaminate discovery.

Inside the resolved package root, the probe tries
`dist/src/code_assist/oauth2.js` first, then follows relative `import` /
`export` statements from `bundle/gemini.js` until it finds the chunk
holding `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET`.

## Tests

- `GeminiTestEnvironment.GeminiCLILayout.fnmBundle` mirrors the real fnm
  multishell layout: one relative symlink
  `bin/gemini -> ../lib/node_modules/@google/gemini-cli/bundle/gemini.js`,
  with `package.json` and `bundle/*.js` as real files in the same
  multishell directory.
- `refreshes expired token with fnm bundle layout` runs the full refresh
  flow through the probe.
- All three refresh tests assert `client_id=test-client-id` in the refresh
  request body. A developer machine with a real `@google/gemini-cli`
  install would otherwise silently extract its OAuth constants. Without
  the assertion the test passes through the wrong code path.
- Existing `npmNested` and `nixShare` layout tests still pass.

## Verification

- `swift test --no-parallel` passes locally and on CI (macOS + Linux CLI
  build).
- Expired-token refresh works against a real fnm-installed Gemini CLI on
  the dev machine.