### PR TITLE
fix: follow overview order for merged icon

### DIFF
--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -596,6 +596,20 @@ extension StatusItemController {
         {
             return highest.provider
         }
+        if self.shouldMergeIcons, self.settings.mergedMenuLastSelectedWasOverview {
+            let enabledProviders = self.store.enabledProvidersForDisplay()
+            let overviewProviders = self.settings.resolvedMergedOverviewProviders(
+                activeProviders: enabledProviders,
+                maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit)
+            for provider in overviewProviders {
+                if self.store.isEnabled(provider), self.store.snapshot(for: provider) != nil {
+                    return provider
+                }
+            }
+            if let provider = overviewProviders.first(where: { self.store.isEnabled($0) }) {
+                return provider
+            }
+        }
         if self.shouldMergeIcons,
            let selected = self.selectedMenuProvider,
            self.store.isEnabled(selected)

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -601,11 +601,6 @@ extension StatusItemController {
             let overviewProviders = self.settings.resolvedMergedOverviewProviders(
                 activeProviders: enabledProviders,
                 maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit)
-            for provider in overviewProviders {
-                if self.store.isEnabled(provider), self.store.snapshot(for: provider) != nil {
-                    return provider
-                }
-            }
             if let provider = overviewProviders.first(where: { self.store.isEnabled($0) }) {
                 return provider
             }

--- a/Tests/CodexBarTests/StatusItemAnimationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationSignatureTests.swift
@@ -70,4 +70,59 @@ struct StatusItemAnimationSignatureTests {
         #expect(combinedSignature != codexSignature)
         #expect(codexSignature?.contains("style=codex") == true)
     }
+
+    @Test
+    func `merged icon follows overview provider order when overview is selected`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationSignatureTests-merged-overview-provider-order"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        settings.mergedMenuLastSelectedWasOverview = true
+        settings.menuBarShowsBrandIconWithPercent = false
+        settings.setProviderOrder([.cursor, .codex, .claude])
+
+        let registry = ProviderRegistry.shared
+        if let cursorMeta = registry.metadata[.cursor] {
+            settings.setProviderEnabled(provider: .cursor, metadata: cursorMeta, enabled: true)
+        }
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 50, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        store._setSnapshotForTesting(snapshot, provider: .cursor)
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+
+        #expect(store.enabledProvidersForDisplay().prefix(3) == [.cursor, .codex, .claude])
+        #expect(settings.resolvedMergedOverviewProviders(activeProviders: store.enabledProvidersForDisplay()) == [
+            .cursor,
+            .codex,
+            .claude,
+        ])
+
+        controller.applyIcon(phase: nil)
+
+        #expect(controller.lastAppliedMergedIconRenderSignature?.contains("provider=cursor") == true)
+    }
 }

--- a/Tests/CodexBarTests/StatusItemAnimationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationSignatureTests.swift
@@ -72,8 +72,12 @@ struct StatusItemAnimationSignatureTests {
     }
 
     @Test
-    func `merged icon follows overview provider order when overview is selected`() {
+    func `merged icon follows overview provider order when first overview provider is loading`() {
+        let suite = "StatusItemAnimationSignatureTests-merged-overview-provider-order"
+        let defaults = UserDefaults(suiteName: suite)
+        defaults?.removePersistentDomain(forName: suite)
         let settings = SettingsStore(
+            userDefaults: defaults ?? .standard,
             configStore: testConfigStore(suiteName: "StatusItemAnimationSignatureTests-merged-overview-provider-order"),
             zaiTokenStore: NoopZaiTokenStore(),
             syntheticTokenStore: NoopSyntheticTokenStore())
@@ -110,7 +114,6 @@ struct StatusItemAnimationSignatureTests {
             primary: RateWindow(usedPercent: 50, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
             secondary: nil,
             updatedAt: Date())
-        store._setSnapshotForTesting(snapshot, provider: .cursor)
         store._setSnapshotForTesting(snapshot, provider: .codex)
         store._setSnapshotForTesting(snapshot, provider: .claude)
 


### PR DESCRIPTION
Fixes #681

## Summary

- make the merged icon follow the Overview provider order when Overview is selected
- add a focused regression test for the merged icon provider selection

## Validation

- `swift test --filter StatusItemAnimationSignatureTests`
- `./Scripts/compile_and_run.sh`
- verified the merged icon follows the first Overview provider instead of a stale previously selected provider