### PR TITLE
Support bundled Gemini CLI layout for OAuth credential extraction

### DIFF
--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
@@ -514,6 +514,15 @@ public struct GeminiStatusProbe: Sendable {
             }
         }
 
+        // Bundled format: realPath points into a bundle/ dir containing chunk-*.js files
+        // with OAuth credentials embedded in one of the chunks.
+        if let result = self.searchBundleDirectory(binDir, fm: fm) {
+            return result
+        }
+        if let result = self.searchBundleDirectory(baseDir + "/bundle", fm: fm) {
+            return result
+        }
+
         return nil
     }
 
@@ -542,6 +551,18 @@ public struct GeminiStatusProbe: Sendable {
         let clientSecret = String(content[secretRange])
 
         return OAuthClientCredentials(clientId: clientId, clientSecret: clientSecret)
+    }
+
+    private static func searchBundleDirectory(_ dir: String, fm: FileManager) -> OAuthClientCredentials? {
+        guard let entries = try? fm.contentsOfDirectory(atPath: dir) else { return nil }
+        for entry in entries where entry.hasPrefix("chunk-") && entry.hasSuffix(".js") {
+            let path = (dir as NSString).appendingPathComponent(entry)
+            guard let content = try? String(contentsOfFile: path, encoding: .utf8) else { continue }
+            if let result = self.parseOAuthCredentials(from: content) {
+                return result
+            }
+        }
+        return nil
     }
 
     private static func refreshAccessToken(


### PR DESCRIPTION
## Summary

- Newer versions of Gemini CLI (installed via npm) use a bundled format where all code is packed into `bundle/chunk-*.js` files instead of the traditional `dist/src/code_assist/oauth2.js` path
- This caused token refresh to fail with "Could not find Gemini CLI OAuth configuration" because none of the existing search paths matched
- Add `searchBundleDirectory` fallback that scans `chunk-*.js` files in the bundle directory for embedded `OAUTH_CLIENT_ID` and `OAUTH_CLIENT_SECRET`

## Test plan

- [x] All 39 `GeminiStatusProbe` tests pass
- [x] Manual verification: Gemini quota displays correctly after rebuild with bundled Gemini CLI (`~/.nvm/.../gemini-cli/bundle/chunk-*.js` layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)