### PR TITLE
fix: broaden CLI binary lookup to native installer paths

### DIFF
--- a/Sources/CodexBarCore/PathEnvironment.swift
+++ b/Sources/CodexBarCore/PathEnvironment.swift
@@ -58,9 +58,13 @@ public enum BinaryLocator {
     }
 
     /// Well-known installation paths for the Claude CLI binary.
-    /// Covers the macOS Terminal installer (cmux.app), ~/.claude/bin, and Homebrew.
+    /// Covers Anthropic's native installer (`~/.local/bin`), the `claude migrate-installer`
+    /// self-updating location (`~/.claude/local`), the legacy per-user installer
+    /// (`~/.claude/bin`), Homebrew, and the macOS Terminal installer (cmux.app).
     static func claudeWellKnownPaths(home: String) -> [String] {
         [
+            "\(home)/.local/bin/claude",
+            "\(home)/.claude/local/claude",
             "\(home)/.claude/bin/claude",
             "/opt/homebrew/bin/claude",
             "/usr/local/bin/claude",


### PR DESCRIPTION
## Summary

Expand `claudeWellKnownPaths()` so the CLI lookup also covers the native installer's default output locations, in addition to the existing Homebrew / npm paths:

- `~/.local/bin/claude` — where the official `curl -fsSL https://claude.ai/install.sh | bash` installs the native binary.
- `~/.claude/local/claude` — where `claude migrate-installer` moves an npm-managed install for self-updates.

Lookup order is unchanged (login-shell PATH still wins, then env PATH, then `command -v`, then aliases, then well-known paths), so Homebrew / npm users are unaffected. This only helps the subset of users who installed via the native installer and haven't added the location to their shell PATH (e.g., launching from Finder on macOS where the login-shell PATH isn't captured).

CHANGELOG v0.7.0 already advertised `~/.claude/local/claude` as supported; that entry currently doesn't match the code, and this PR realigns the two.

## Test plan

- [x] `swift build -c release` — clean.
- [x] `swift test --filter PathBuilderTests` — 19/19 passing; existing tests for `resolveClaudeBinary` still hold because the new paths only participate at the well-known tier and each test seeds its own `MockFileManager` executable set.
- [ ] Manual: on a machine with only `~/.local/bin/claude` present, CodexBar now detects and uses it.

