### PR TITLE
Add Claude Opus 4.7 pricing

### DIFF
--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
@@ -175,6 +175,16 @@ enum CostUsagePricing {
             outputCostPerTokenAboveThreshold: nil,
             cacheCreationInputCostPerTokenAboveThreshold: nil,
             cacheReadInputCostPerTokenAboveThreshold: nil),
+        "claude-opus-4-7": ClaudePricing(
+            inputCostPerToken: 5e-6,
+            outputCostPerToken: 2.5e-5,
+            cacheCreationInputCostPerToken: 6.25e-6,
+            cacheReadInputCostPerToken: 5e-7,
+            thresholdTokens: nil,
+            inputCostPerTokenAboveThreshold: nil,
+            outputCostPerTokenAboveThreshold: nil,
+            cacheCreationInputCostPerTokenAboveThreshold: nil,
+            cacheReadInputCostPerTokenAboveThreshold: nil),
         "claude-sonnet-4-5": ClaudePricing(
             inputCostPerToken: 3e-6,
             outputCostPerToken: 1.5e-5,

--- a/Tests/CodexBarTests/CostUsagePricingTests.swift
+++ b/Tests/CodexBarTests/CostUsagePricingTests.swift
@@ -91,6 +91,17 @@ struct CostUsagePricingTests {
     }
 
     @Test
+    func `claude cost supports opus47`() {
+        let cost = CostUsagePricing.claudeCostUSD(
+            model: "claude-opus-4-7",
+            inputTokens: 10,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            outputTokens: 5)
+        #expect(cost == 10 * 5e-6 + 5 * 2.5e-5)
+    }
+
+    @Test
     func `claude cost returns nil for unknown models`() {
         let cost = CostUsagePricing.claudeCostUSD(
             model: "glm-4.6",


### PR DESCRIPTION
## Summary
- Add `claude-opus-4-7` to the Claude pricing map. 
- Pricing stays identical to 4.5 and 4.6, flat across the full 1M context.
<img width="328" height="240" alt="image" src="https://github.com/user-attachments/assets/bdac040e-003f-412d-96df-30012f719984" />

## Validation
- `swift test --filter CostUsagePricingTests`
- `./Scripts/compile_and_run.sh`

