### PR TITLE
Refine Antigravity endpoint routing

### DIFF
--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -869,10 +869,12 @@ extension LocalhostSessionDelegate: URLSessionDelegate {
     func urlSession(
         _ session: URLSession,
         didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
+        completionHandler: @escaping @MainActor @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
     {
         let result = self.challengeResult(challenge)
-        completionHandler(result.disposition, result.credential)
+        Task { @MainActor in
+            completionHandler(result.disposition, result.credential)
+        }
     }
 }
 
@@ -881,10 +883,12 @@ extension LocalhostSessionDelegate: URLSessionTaskDelegate {
         _ session: URLSession,
         task: URLSessionTask,
         didReceive challenge: URLAuthenticationChallenge,
-        completionHandler: @escaping @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
+        completionHandler: @escaping @MainActor @Sendable (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
     {
         let result = self.challengeResult(challenge)
-        completionHandler(result.disposition, result.credential)
+        Task { @MainActor in
+            completionHandler(result.disposition, result.credential)
+        }
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -282,19 +282,19 @@ public struct AntigravityStatusProbe: Sendable {
             timeout: self.timeout)
 
         do {
-            let response = try await Self.makeRequest(
+            return try await Self.makeParsedRequest(
                 payload: RequestPayload(
                     path: Self.getUserStatusPath,
                     body: Self.defaultRequestBody()),
-                context: context)
-            return try Self.parseUserStatusResponse(response)
+                context: context,
+                parse: Self.parseUserStatusResponse)
         } catch {
-            let response = try await Self.makeRequest(
+            return try await Self.makeParsedRequest(
                 payload: RequestPayload(
                     path: Self.commandModelConfigPath,
                     body: Self.defaultRequestBody()),
-                context: context)
-            return try Self.parseCommandModelResponse(response)
+                context: context,
+                parse: Self.parseCommandModelResponse)
         }
     }
 
@@ -308,7 +308,7 @@ public struct AntigravityStatusProbe: Sendable {
                 extensionServerPort: processInfo.extensionPort,
                 extensionServerCSRFToken: processInfo.extensionServerCSRFToken),
             timeout: self.timeout)
-        let response = try await Self.makeRequest(
+        return try await Self.makeParsedRequest(
             payload: RequestPayload(
                 path: Self.getUserStatusPath,
                 body: Self.defaultRequestBody()),
@@ -319,8 +319,8 @@ public struct AntigravityStatusProbe: Sendable {
                     languageServerCSRFToken: processInfo.csrfToken,
                     extensionServerPort: processInfo.extensionPort,
                     extensionServerCSRFToken: processInfo.extensionServerCSRFToken),
-                timeout: self.timeout))
-        return try Self.parsePlanInfoSummary(response)
+                timeout: self.timeout),
+            parse: Self.parsePlanInfoSummary)
     }
 
     public static func isRunning(timeout: TimeInterval = 4.0) async -> Bool {
@@ -692,12 +692,12 @@ public struct AntigravityStatusProbe: Sendable {
 
     // MARK: - HTTP
 
-    private struct RequestPayload {
+    struct RequestPayload {
         let path: String
         let body: [String: Any]
     }
 
-    private struct RequestContext {
+    struct RequestContext {
         let endpoints: [AntigravityConnectionEndpoint]
         let timeout: TimeInterval
     }
@@ -736,6 +736,34 @@ public struct AntigravityStatusProbe: Sendable {
         context: RequestContext) async throws -> Data
     {
         try await self.sendRequest(payload: payload, context: context)
+    }
+
+    static func makeParsedRequest<T>(
+        payload: RequestPayload,
+        context: RequestContext,
+        send: @escaping @Sendable (RequestPayload, AntigravityConnectionEndpoint, TimeInterval) async throws -> Data =
+            sendRequest,
+        parse: @escaping @Sendable (Data) throws -> T) async throws -> T
+    {
+        var lastError: Error?
+
+        for endpoint in context.endpoints {
+            do {
+                let data = try await send(payload, endpoint, context.timeout)
+                return try parse(data)
+            } catch {
+                lastError = error
+                Self.log.debug("Antigravity request/parse attempt failed", metadata: [
+                    "path": payload.path,
+                    "source": endpoint.source.rawValue,
+                    "scheme": endpoint.scheme,
+                    "port": "\(endpoint.port)",
+                    "error": error.localizedDescription,
+                ])
+            }
+        }
+
+        throw lastError ?? AntigravityStatusProbeError.apiError("Invalid response")
     }
 
     private static func sendRequest(

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -265,14 +265,20 @@ public struct AntigravityStatusProbe: Sendable {
     public func fetch() async throws -> AntigravityStatusSnapshot {
         let processInfo = try await Self.detectProcessInfo(timeout: self.timeout)
         let ports = try await Self.listeningPorts(pid: processInfo.pid, timeout: self.timeout)
-        let connectPort = try await Self.findWorkingPort(
-            ports: ports,
-            csrfToken: processInfo.csrfToken,
+        let endpoint = try await Self.resolveWorkingEndpoint(
+            candidateEndpoints: Self.connectionCandidates(
+                listeningPorts: ports,
+                languageServerCSRFToken: processInfo.csrfToken,
+                extensionServerPort: processInfo.extensionPort,
+                extensionServerCSRFToken: processInfo.extensionServerCSRFToken),
             timeout: self.timeout)
         let context = RequestContext(
-            httpsPort: connectPort,
-            httpPort: processInfo.extensionPort,
-            csrfToken: processInfo.csrfToken,
+            endpoints: Self.requestEndpoints(
+                resolvedEndpoint: endpoint,
+                listeningPorts: ports,
+                languageServerCSRFToken: processInfo.csrfToken,
+                extensionServerPort: processInfo.extensionPort,
+                extensionServerCSRFToken: processInfo.extensionServerCSRFToken),
             timeout: self.timeout)
 
         do {
@@ -295,18 +301,24 @@ public struct AntigravityStatusProbe: Sendable {
     public func fetchPlanInfoSummary() async throws -> AntigravityPlanInfoSummary? {
         let processInfo = try await Self.detectProcessInfo(timeout: self.timeout)
         let ports = try await Self.listeningPorts(pid: processInfo.pid, timeout: self.timeout)
-        let connectPort = try await Self.findWorkingPort(
-            ports: ports,
-            csrfToken: processInfo.csrfToken,
+        let endpoint = try await Self.resolveWorkingEndpoint(
+            candidateEndpoints: Self.connectionCandidates(
+                listeningPorts: ports,
+                languageServerCSRFToken: processInfo.csrfToken,
+                extensionServerPort: processInfo.extensionPort,
+                extensionServerCSRFToken: processInfo.extensionServerCSRFToken),
             timeout: self.timeout)
         let response = try await Self.makeRequest(
             payload: RequestPayload(
                 path: Self.getUserStatusPath,
                 body: Self.defaultRequestBody()),
             context: RequestContext(
-                httpsPort: connectPort,
-                httpPort: processInfo.extensionPort,
-                csrfToken: processInfo.csrfToken,
+                endpoints: Self.requestEndpoints(
+                    resolvedEndpoint: endpoint,
+                    listeningPorts: ports,
+                    languageServerCSRFToken: processInfo.csrfToken,
+                    extensionServerPort: processInfo.extensionPort,
+                    extensionServerCSRFToken: processInfo.extensionServerCSRFToken),
                 timeout: self.timeout))
         return try Self.parsePlanInfoSummary(response)
     }
@@ -405,8 +417,25 @@ public struct AntigravityStatusProbe: Sendable {
     private struct ProcessInfoResult {
         let pid: Int
         let extensionPort: Int?
+        let extensionServerCSRFToken: String?
         let csrfToken: String
         let commandLine: String
+    }
+
+    struct AntigravityConnectionEndpoint: Sendable, Equatable {
+        enum Source: String, Sendable {
+            case languageServer = "language-server"
+            case extensionServer = "extension-server"
+        }
+
+        let scheme: String
+        let port: Int
+        let csrfToken: String
+        let source: Source
+
+        func matchesRequestTarget(_ other: Self) -> Bool {
+            self.scheme == other.scheme && self.port == other.port && self.csrfToken == other.csrfToken
+        }
     }
 
     private static func detectProcessInfo(timeout: TimeInterval) async throws -> ProcessInfoResult {
@@ -429,7 +458,13 @@ public struct AntigravityStatusProbe: Sendable {
             sawAntigravity = true
             guard let token = Self.extractFlag("--csrf_token", from: match.command) else { continue }
             let port = Self.extractPort("--extension_server_port", from: match.command)
-            return ProcessInfoResult(pid: match.pid, extensionPort: port, csrfToken: token, commandLine: match.command)
+            let extensionServerCSRFToken = Self.extractFlag("--extension_server_csrf_token", from: match.command)
+            return ProcessInfoResult(
+                pid: match.pid,
+                extensionPort: port,
+                extensionServerCSRFToken: extensionServerCSRFToken,
+                csrfToken: token,
+                commandLine: match.command)
         }
 
         if sawAntigravity {
@@ -508,21 +543,133 @@ public struct AntigravityStatusProbe: Sendable {
         return ports.sorted()
     }
 
-    private static func findWorkingPort(
-        ports: [Int],
-        csrfToken: String,
-        timeout: TimeInterval) async throws -> Int
+    static func connectionCandidates(
+        listeningPorts: [Int],
+        languageServerCSRFToken: String,
+        extensionServerPort: Int?,
+        extensionServerCSRFToken: String?) -> [AntigravityConnectionEndpoint]
     {
-        for port in ports {
-            let ok = await Self.testPortConnectivity(port: port, csrfToken: csrfToken, timeout: timeout)
-            if ok { return port }
+        var endpoints = Self.languageServerEndpoints(
+            listeningPorts: listeningPorts,
+            languageServerCSRFToken: languageServerCSRFToken)
+
+        for endpoint in Self.extensionServerEndpoints(
+            extensionServerPort: extensionServerPort,
+            languageServerCSRFToken: languageServerCSRFToken,
+            extensionServerCSRFToken: extensionServerCSRFToken)
+        {
+            guard !endpoints.contains(where: { $0.matchesRequestTarget(endpoint) }) else { continue }
+            endpoints.append(endpoint)
+        }
+
+        return endpoints
+    }
+
+    static func requestEndpoints(
+        resolvedEndpoint: AntigravityConnectionEndpoint,
+        listeningPorts: [Int],
+        languageServerCSRFToken: String,
+        extensionServerPort: Int?,
+        extensionServerCSRFToken: String?) -> [AntigravityConnectionEndpoint]
+    {
+        var endpoints = [resolvedEndpoint]
+
+        if resolvedEndpoint.source == .extensionServer {
+            Self.appendUniqueRequestTargets(
+                from: Self.extensionServerEndpoints(
+                    extensionServerPort: extensionServerPort,
+                    languageServerCSRFToken: languageServerCSRFToken,
+                    extensionServerCSRFToken: extensionServerCSRFToken),
+                to: &endpoints)
+            Self.appendUniqueRequestTargets(
+                from: Self.languageServerEndpoints(
+                    listeningPorts: listeningPorts,
+                    languageServerCSRFToken: languageServerCSRFToken),
+                to: &endpoints)
+        } else {
+            Self.appendUniqueRequestTargets(
+                from: Self.languageServerEndpoints(
+                    listeningPorts: listeningPorts,
+                    languageServerCSRFToken: languageServerCSRFToken),
+                to: &endpoints)
+            Self.appendUniqueRequestTargets(
+                from: Self.extensionServerEndpoints(
+                    extensionServerPort: extensionServerPort,
+                    languageServerCSRFToken: languageServerCSRFToken,
+                    extensionServerCSRFToken: extensionServerCSRFToken),
+                to: &endpoints)
+        }
+
+        return endpoints
+    }
+
+    private static func languageServerEndpoints(
+        listeningPorts: [Int],
+        languageServerCSRFToken: String) -> [AntigravityConnectionEndpoint]
+    {
+        listeningPorts.map {
+            AntigravityConnectionEndpoint(
+                scheme: "https",
+                port: $0,
+                csrfToken: languageServerCSRFToken,
+                source: .languageServer)
+        }
+    }
+
+    private static func extensionServerEndpoints(
+        extensionServerPort: Int?,
+        languageServerCSRFToken: String,
+        extensionServerCSRFToken: String?) -> [AntigravityConnectionEndpoint]
+    {
+        guard let extensionServerPort else { return [] }
+
+        var endpoints: [AntigravityConnectionEndpoint] = []
+        if let extensionServerCSRFToken {
+            endpoints.append(
+                AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: extensionServerPort,
+                    csrfToken: extensionServerCSRFToken,
+                    source: .extensionServer))
+        }
+
+        if extensionServerCSRFToken != languageServerCSRFToken {
+            endpoints.append(
+                AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: extensionServerPort,
+                    csrfToken: languageServerCSRFToken,
+                    source: .extensionServer))
+        }
+
+        return endpoints
+    }
+
+    private static func appendUniqueRequestTargets(
+        from candidates: [AntigravityConnectionEndpoint],
+        to endpoints: inout [AntigravityConnectionEndpoint])
+    {
+        for endpoint in candidates {
+            guard !endpoints.contains(where: { $0.matchesRequestTarget(endpoint) }) else { continue }
+            endpoints.append(endpoint)
+        }
+    }
+
+    static func resolveWorkingEndpoint(
+        candidateEndpoints: [AntigravityConnectionEndpoint],
+        timeout: TimeInterval,
+        testConnectivity: @escaping @Sendable (AntigravityConnectionEndpoint, TimeInterval) async -> Bool = Self
+            .testEndpointConnectivity) async throws -> AntigravityConnectionEndpoint
+    {
+        for endpoint in candidateEndpoints {
+            let ok = await testConnectivity(endpoint, timeout)
+            if ok { return endpoint }
         }
         throw AntigravityStatusProbeError.portDetectionFailed("no working API port found")
     }
 
-    private static func testPortConnectivity(
-        port: Int,
-        csrfToken: String,
+    private static func testEndpointConnectivity(
+        _ endpoint: AntigravityConnectionEndpoint,
         timeout: TimeInterval) async -> Bool
     {
         do {
@@ -530,15 +677,13 @@ public struct AntigravityStatusProbe: Sendable {
                 payload: RequestPayload(
                     path: self.unleashPath,
                     body: self.unleashRequestBody()),
-                context: RequestContext(
-                    httpsPort: port,
-                    httpPort: nil,
-                    csrfToken: csrfToken,
-                    timeout: timeout))
+                context: RequestContext(endpoints: [endpoint], timeout: timeout))
             return true
         } catch {
             self.log.debug("Port probe failed", metadata: [
-                "port": "\(port)",
+                "source": endpoint.source.rawValue,
+                "scheme": endpoint.scheme,
+                "port": "\(endpoint.port)",
                 "error": error.localizedDescription,
             ])
             return false
@@ -553,9 +698,7 @@ public struct AntigravityStatusProbe: Sendable {
     }
 
     private struct RequestContext {
-        let httpsPort: Int
-        let httpPort: Int?
-        let csrfToken: String
+        let endpoints: [AntigravityConnectionEndpoint]
         let timeout: TimeInterval
     }
 
@@ -592,29 +735,39 @@ public struct AntigravityStatusProbe: Sendable {
         payload: RequestPayload,
         context: RequestContext) async throws -> Data
     {
-        do {
-            return try await self.sendRequest(
-                scheme: "https",
-                port: context.httpsPort,
-                payload: payload,
-                context: context)
-        } catch {
-            guard let httpPort = context.httpPort, httpPort != context.httpsPort else { throw error }
-            return try await Self.sendRequest(
-                scheme: "http",
-                port: httpPort,
-                payload: payload,
-                context: context)
-        }
+        try await self.sendRequest(payload: payload, context: context)
     }
 
     private static func sendRequest(
-        scheme: String,
-        port: Int,
         payload: RequestPayload,
         context: RequestContext) async throws -> Data
     {
-        guard let url = URL(string: "\(scheme)://127.0.0.1:\(port)\(payload.path)") else {
+        var lastError: Error?
+
+        for endpoint in context.endpoints {
+            do {
+                return try await Self.sendRequest(payload: payload, endpoint: endpoint, timeout: context.timeout)
+            } catch {
+                lastError = error
+                Self.log.debug("Antigravity request attempt failed", metadata: [
+                    "path": payload.path,
+                    "source": endpoint.source.rawValue,
+                    "scheme": endpoint.scheme,
+                    "port": "\(endpoint.port)",
+                    "error": error.localizedDescription,
+                ])
+            }
+        }
+
+        throw lastError ?? AntigravityStatusProbeError.apiError("Invalid URL")
+    }
+
+    private static func sendRequest(
+        payload: RequestPayload,
+        endpoint: AntigravityConnectionEndpoint,
+        timeout: TimeInterval) async throws -> Data
+    {
+        guard let url = URL(string: "\(endpoint.scheme)://127.0.0.1:\(endpoint.port)\(payload.path)") else {
             throw AntigravityStatusProbeError.apiError("Invalid URL")
         }
 
@@ -622,15 +775,15 @@ public struct AntigravityStatusProbe: Sendable {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.httpBody = body
-        request.timeoutInterval = context.timeout
+        request.timeoutInterval = timeout
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(String(body.count), forHTTPHeaderField: "Content-Length")
         request.setValue("1", forHTTPHeaderField: "Connect-Protocol-Version")
-        request.setValue(context.csrfToken, forHTTPHeaderField: "X-Codeium-Csrf-Token")
+        request.setValue(endpoint.csrfToken, forHTTPHeaderField: "X-Codeium-Csrf-Token")
 
         let config = URLSessionConfiguration.ephemeral
-        config.timeoutIntervalForRequest = context.timeout
-        config.timeoutIntervalForResource = context.timeout
+        config.timeoutIntervalForRequest = timeout
+        config.timeoutIntervalForResource = timeout
         #if !os(Linux)
         config.waitsForConnectivity = false
         #endif
@@ -689,6 +842,27 @@ private final class LocalhostSessionDelegate: NSObject {
             state.cancel()
         }
     }
+
+    private func challengeResult(_ challenge: URLAuthenticationChallenge) -> (
+        disposition: URLSession.AuthChallengeDisposition,
+        credential: URLCredential?)
+    {
+        #if os(Linux)
+        return (.performDefaultHandling, nil)
+        #else
+        let protectionSpace = challenge.protectionSpace
+        let trust = protectionSpace.serverTrust
+        guard LocalhostTrustPolicy.shouldAcceptServerTrust(
+            host: protectionSpace.host,
+            authenticationMethod: protectionSpace.authenticationMethod,
+            hasServerTrust: trust != nil),
+            let trust
+        else {
+            return (.performDefaultHandling, nil)
+        }
+        return (.useCredential, URLCredential(trust: trust))
+        #endif
+    }
 }
 
 extension LocalhostSessionDelegate: URLSessionDelegate {
@@ -711,27 +885,6 @@ extension LocalhostSessionDelegate: URLSessionTaskDelegate {
     {
         let result = self.challengeResult(challenge)
         completionHandler(result.disposition, result.credential)
-    }
-
-    private func challengeResult(_ challenge: URLAuthenticationChallenge) -> (
-        disposition: URLSession.AuthChallengeDisposition,
-        credential: URLCredential?)
-    {
-        #if os(Linux)
-        return (.performDefaultHandling, nil)
-        #else
-        let protectionSpace = challenge.protectionSpace
-        let trust = protectionSpace.serverTrust
-        guard LocalhostTrustPolicy.shouldAcceptServerTrust(
-            host: protectionSpace.host,
-            authenticationMethod: protectionSpace.authenticationMethod,
-            hasServerTrust: trust != nil),
-            let trust
-        else {
-            return (.performDefaultHandling, nil)
-        }
-        return (.useCredential, URLCredential(trust: trust))
-        #endif
     }
 }
 

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -2,6 +2,24 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
+private final class AntigravityAttemptRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var endpoints: [AntigravityStatusProbe.AntigravityConnectionEndpoint] = []
+
+    func append(_ endpoint: AntigravityStatusProbe.AntigravityConnectionEndpoint) {
+        self.lock.lock()
+        self.endpoints.append(endpoint)
+        self.lock.unlock()
+    }
+
+    func snapshot() -> [AntigravityStatusProbe.AntigravityConnectionEndpoint] {
+        self.lock.lock()
+        let snapshot = self.endpoints
+        self.lock.unlock()
+        return snapshot
+    }
+}
+
 struct AntigravityStatusProbeTests {
     @Test
     func `localhost trust policy only accepts local server trust challenges`() {
@@ -31,6 +49,300 @@ struct AntigravityStatusProbeTests {
                 host: "127.0.0.1",
                 authenticationMethod: NSURLAuthenticationMethodServerTrust,
                 hasServerTrust: false))
+    }
+
+    @Test
+    func `localhost trust policy rejects non loopback hostnames that contain localhost`() {
+        #expect(
+            !LocalhostTrustPolicy.shouldAcceptServerTrust(
+                host: "localhost.example.com",
+                authenticationMethod: NSURLAuthenticationMethodServerTrust,
+                hasServerTrust: true))
+    }
+
+    @Test
+    func `connection candidates preserve scheme order and endpoint tokens`() {
+        let candidates = AntigravityStatusProbe.connectionCandidates(
+            listeningPorts: [64440],
+            languageServerCSRFToken: "language-token",
+            extensionServerPort: 64432,
+            extensionServerCSRFToken: "extension-token")
+
+        #expect(
+            candidates == [
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "https",
+                    port: 64440,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 64432,
+                    csrfToken: "extension-token",
+                    source: .extensionServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 64432,
+                    csrfToken: "language-token",
+                    source: .extensionServer),
+            ])
+    }
+
+    @Test
+    func `connection candidates restrict plain http probing to the declared extension port`() {
+        let candidates = AntigravityStatusProbe.connectionCandidates(
+            listeningPorts: [64440, 64441],
+            languageServerCSRFToken: "language-token",
+            extensionServerPort: 64432,
+            extensionServerCSRFToken: nil)
+
+        #expect(
+            candidates == [
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "https",
+                    port: 64440,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "https",
+                    port: 64441,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 64432,
+                    csrfToken: "language-token",
+                    source: .extensionServer),
+            ])
+    }
+
+    @Test
+    func `connection candidates preserve extension fallback when extension token is unavailable`() {
+        let candidates = AntigravityStatusProbe.connectionCandidates(
+            listeningPorts: [64440],
+            languageServerCSRFToken: "language-token",
+            extensionServerPort: 64432,
+            extensionServerCSRFToken: nil)
+
+        #expect(
+            candidates == [
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "https",
+                    port: 64440,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 64432,
+                    csrfToken: "language-token",
+                    source: .extensionServer),
+            ])
+    }
+
+    @Test
+    func `connection candidates do not duplicate the same http target when ports overlap`() {
+        let candidates = AntigravityStatusProbe.connectionCandidates(
+            listeningPorts: [64432],
+            languageServerCSRFToken: "language-token",
+            extensionServerPort: 64432,
+            extensionServerCSRFToken: nil)
+
+        #expect(
+            candidates == [
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "https",
+                    port: 64432,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 64432,
+                    csrfToken: "language-token",
+                    source: .extensionServer),
+            ])
+    }
+
+    @Test
+    func `request endpoints retry extension server after language server success`() {
+        let resolvedEndpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "https",
+            port: 64440,
+            csrfToken: "language-token",
+            source: .languageServer)
+
+        let endpoints = AntigravityStatusProbe.requestEndpoints(
+            resolvedEndpoint: resolvedEndpoint,
+            listeningPorts: [64440],
+            languageServerCSRFToken: "language-token",
+            extensionServerPort: 64432,
+            extensionServerCSRFToken: "extension-token")
+
+        #expect(
+            endpoints == [
+                resolvedEndpoint,
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 64432,
+                    csrfToken: "extension-token",
+                    source: .extensionServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 64432,
+                    csrfToken: "language-token",
+                    source: .extensionServer),
+            ])
+    }
+
+    @Test
+    func `request endpoints preserve extension fallback when extension token is unavailable`() {
+        let resolvedEndpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "https",
+            port: 64440,
+            csrfToken: "language-token",
+            source: .languageServer)
+
+        let endpoints = AntigravityStatusProbe.requestEndpoints(
+            resolvedEndpoint: resolvedEndpoint,
+            listeningPorts: [64440],
+            languageServerCSRFToken: "language-token",
+            extensionServerPort: 64432,
+            extensionServerCSRFToken: nil)
+
+        #expect(
+            endpoints == [
+                resolvedEndpoint,
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 64432,
+                    csrfToken: "language-token",
+                    source: .extensionServer),
+            ])
+    }
+
+    @Test
+    func `request endpoints retry alternate token after extension server wins discovery`() {
+        let resolvedEndpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "http",
+            port: 64432,
+            csrfToken: "extension-token",
+            source: .extensionServer)
+
+        let endpoints = AntigravityStatusProbe.requestEndpoints(
+            resolvedEndpoint: resolvedEndpoint,
+            listeningPorts: [64440],
+            languageServerCSRFToken: "language-token",
+            extensionServerPort: 64432,
+            extensionServerCSRFToken: "extension-token")
+
+        #expect(
+            endpoints == [
+                resolvedEndpoint,
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 64432,
+                    csrfToken: "language-token",
+                    source: .extensionServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "https",
+                    port: 64440,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+            ])
+    }
+
+    @Test
+    func `request endpoints keep https language server fallback after extension probe wins`() {
+        let resolvedEndpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "http",
+            port: 64432,
+            csrfToken: "language-token",
+            source: .extensionServer)
+
+        let endpoints = AntigravityStatusProbe.requestEndpoints(
+            resolvedEndpoint: resolvedEndpoint,
+            listeningPorts: [64432, 64440],
+            languageServerCSRFToken: "language-token",
+            extensionServerPort: 64432,
+            extensionServerCSRFToken: nil)
+
+        #expect(
+            endpoints == [
+                resolvedEndpoint,
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "https",
+                    port: 64432,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "https",
+                    port: 64440,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+            ])
+    }
+
+    @Test
+    func `endpoint resolver prefers successful https language server candidate`() async throws {
+        let candidates = AntigravityStatusProbe.connectionCandidates(
+            listeningPorts: [64440],
+            languageServerCSRFToken: "language-token",
+            extensionServerPort: 64432,
+            extensionServerCSRFToken: "extension-token")
+        let attempted = AntigravityAttemptRecorder()
+
+        let endpoint = try await AntigravityStatusProbe.resolveWorkingEndpoint(
+            candidateEndpoints: candidates,
+            timeout: 1)
+        { endpoint, _ in
+            attempted.append(endpoint)
+            return endpoint.scheme == "https" && endpoint.port == 64440
+        }
+
+        #expect(endpoint == candidates[0])
+        #expect(attempted.snapshot() == [candidates[0]])
+    }
+
+    @Test
+    func `endpoint resolver falls back to extension server after https language server candidates`() async throws {
+        let candidates = AntigravityStatusProbe.connectionCandidates(
+            listeningPorts: [64440, 64441],
+            languageServerCSRFToken: "language-token",
+            extensionServerPort: 64432,
+            extensionServerCSRFToken: "extension-token")
+        let attempted = AntigravityAttemptRecorder()
+
+        let endpoint = try await AntigravityStatusProbe.resolveWorkingEndpoint(
+            candidateEndpoints: candidates,
+            timeout: 1)
+        { endpoint, _ in
+            attempted.append(endpoint)
+            return endpoint.scheme == "http" && endpoint.port == 64432 && endpoint.source == .extensionServer
+        }
+
+        #expect(endpoint == candidates[2])
+        #expect(attempted.snapshot() == Array(candidates.prefix(3)))
+    }
+
+    @Test
+    func `endpoint resolver falls back to alternate extension token after primary token fails`() async throws {
+        let candidates = AntigravityStatusProbe.connectionCandidates(
+            listeningPorts: [64440],
+            languageServerCSRFToken: "language-token",
+            extensionServerPort: 64432,
+            extensionServerCSRFToken: "extension-token")
+        let attempted = AntigravityAttemptRecorder()
+
+        let endpoint = try await AntigravityStatusProbe.resolveWorkingEndpoint(
+            candidateEndpoints: candidates,
+            timeout: 1)
+        { endpoint, _ in
+            attempted.append(endpoint)
+            return endpoint.source == .extensionServer && endpoint.csrfToken == "language-token"
+        }
+
+        #expect(endpoint == candidates[2])
+        #expect(attempted.snapshot() == candidates)
+        #expect(endpoint.csrfToken == "language-token")
     }
 
     @Test

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -282,6 +282,53 @@ struct AntigravityStatusProbeTests {
     }
 
     @Test
+    func `parsed request retries later endpoints after api level error payload`() async throws {
+        let endpoints = [
+            AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                scheme: "https",
+                port: 64440,
+                csrfToken: "bad-token",
+                source: .languageServer),
+            AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                scheme: "http",
+                port: 64432,
+                csrfToken: "good-token",
+                source: .extensionServer),
+        ]
+        let attempted = AntigravityAttemptRecorder()
+
+        let snapshot = try await AntigravityStatusProbe.makeParsedRequest(
+            payload: AntigravityStatusProbe.RequestPayload(
+                path: "/exa.language_server_pb.LanguageServerService/GetUserStatus",
+                body: ["metadata": [:]]),
+            context: AntigravityStatusProbe.RequestContext(
+                endpoints: endpoints,
+                timeout: 1),
+            send: { _, endpoint, _ in
+                attempted.append(endpoint)
+                if endpoint.csrfToken == "bad-token" {
+                    return Data(#"{"code":16}"#.utf8)
+                }
+                return Data(
+                    #"""
+                    {
+                      "code": 0,
+                      "userStatus": {
+                        "email": "test@example.com",
+                        "cascadeModelConfigData": {
+                          "clientModelConfigs": []
+                        }
+                      }
+                    }
+                    """#.utf8)
+            },
+            parse: AntigravityStatusProbe.parseUserStatusResponse)
+
+        #expect(snapshot.accountEmail == "test@example.com")
+        #expect(attempted.snapshot() == endpoints)
+    }
+
+    @Test
     func `endpoint resolver prefers successful https language server candidate`() async throws {
         let candidates = AntigravityStatusProbe.connectionCandidates(
             listeningPorts: [64440],


### PR DESCRIPTION
## Summary
- tighten Antigravity endpoint discovery to prefer declared HTTPS language-server endpoints and only probe plain HTTP on the declared extension server
- preserve language-server HTTPS fallbacks after an extension-server probe wins, while keeping extension-token and alternate-token retries explicit
- dedupe identical request/discovery targets and expand Antigravity regression coverage for routing, fallback ordering, and token handling

## Verification
- swift test --filter AntigravityStatusProbeTests
- ./.build/debug/CodexBarCLI usage --provider antigravity --format json --pretty
- pnpm check
- APP_IDENTITY="Developer ID Application: Ratul Sarna (CDY7Z973ZG)" APP_TEAM_ID="CDY7Z973ZG" ./Scripts/compile_and_run.sh

## Notes
- Antigravity fetch succeeds against the local setup after these changes
- The existing URLSession delegate witness warnings in AntigravityStatusProbe.swift still remain and are not addressed in this PR