### PR TITLE
Prefer verification_uri_complete for Copilot login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Providers & Usage
 - Gemini: discover OAuth config in fnm/Homebrew/bundled CLI layouts so expired-token refresh keeps working (#723). Thanks @Leechael!
+- Copilot: open the complete device-login verification URL when available so the browser flow carries the user code (#739). Thanks @skhe!
 
 ### Fixes
 - Keychain cache: preserve cached credentials when macOS temporarily denies keychain UI after wake, avoiding repeated prompts (#594). Thanks @josepe98!

--- a/Sources/CodexBar/Providers/Copilot/CopilotLoginFlow.swift
+++ b/Sources/CodexBar/Providers/Copilot/CopilotLoginFlow.swift
@@ -30,7 +30,7 @@ struct CopilotLoginFlow {
                 return // Cancelled
             }
 
-            if let url = URL(string: code.verificationUri) {
+            if let url = URL(string: code.verificationURLToOpen) {
                 NSWorkspace.shared.open(url)
             }
 

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotDeviceFlow.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotDeviceFlow.swift
@@ -11,13 +11,19 @@ public struct CopilotDeviceFlow: Sendable {
         public let deviceCode: String
         public let userCode: String
         public let verificationUri: String
+        public let verificationUriComplete: String?
         public let expiresIn: Int
         public let interval: Int
+
+        public var verificationURLToOpen: String {
+            self.verificationUriComplete ?? self.verificationUri
+        }
 
         enum CodingKeys: String, CodingKey {
             case deviceCode = "device_code"
             case userCode = "user_code"
             case verificationUri = "verification_uri"
+            case verificationUriComplete = "verification_uri_complete"
             case expiresIn = "expires_in"
             case interval
         }

--- a/Tests/CodexBarTests/CopilotDeviceFlowTests.swift
+++ b/Tests/CodexBarTests/CopilotDeviceFlowTests.swift
@@ -1,0 +1,42 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct CopilotDeviceFlowTests {
+    @Test
+    func `prefers verification uri complete when available`() throws {
+        let response = try JSONDecoder().decode(
+            CopilotDeviceFlow.DeviceCodeResponse.self,
+            from: Data(
+                """
+                {
+                  "device_code": "device-code",
+                  "user_code": "ABCD-EFGH",
+                  "verification_uri": "https://github.com/login/device",
+                  "verification_uri_complete": "https://github.com/login/device?user_code=ABCD-EFGH",
+                  "expires_in": 900,
+                  "interval": 5
+                }
+                """.utf8))
+
+        #expect(response.verificationURLToOpen == "https://github.com/login/device?user_code=ABCD-EFGH")
+    }
+
+    @Test
+    func `falls back to verification uri when complete url missing`() throws {
+        let response = try JSONDecoder().decode(
+            CopilotDeviceFlow.DeviceCodeResponse.self,
+            from: Data(
+                """
+                {
+                  "device_code": "device-code",
+                  "user_code": "ABCD-EFGH",
+                  "verification_uri": "https://github.com/login/device",
+                  "expires_in": 900,
+                  "interval": 5
+                }
+                """.utf8))
+
+        #expect(response.verificationURLToOpen == "https://github.com/login/device")
+    }
+}


### PR DESCRIPTION
Fixes #738

This updates the Copilot device login flow to prefer `verification_uri_complete` over `verification_uri` when opening the browser.

Why:
- GitHub device flow can return a complete verification URL that already carries the user code
- CodexBar currently ignores that field and always opens the bare verification page
- In practice, this can make the Copilot login flow confusing because the user code is not reliably visible in the browser flow

Changes:
- Decode `verification_uri_complete` in `CopilotDeviceFlow.DeviceCodeResponse`
- Add a small `verificationURLToOpen` helper with fallback to `verification_uri`
- Use that helper in `CopilotLoginFlow`
- Add tests for both the preferred and fallback paths

Verification:
- `swift build`
- `swift test --filter CopilotDeviceFlowTests`

Notes:
- `pnpm check` could not complete in my environment because the lint script attempted to download SwiftFormat and failed before running the checks.