### PR TITLE
fix(claude/oauth): fall back when five_hour window is missing from response

### DIFF
--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -608,13 +608,28 @@ final class UsageStore {
         provider: UsageProvider,
         snapshot: UsageSnapshot) -> (window: RateWindow, source: SessionQuotaWindowSource)?
     {
-        if let primary = snapshot.primary {
+        if let primary = snapshot.primary, Self.isSessionWindow(primary) {
             return (primary, .primary)
         }
         if provider == .copilot, let secondary = snapshot.secondary {
             return (secondary, .copilotSecondaryFallback)
         }
         return nil
+    }
+
+    /// A "session" window is the short (~5h) rolling lane that session-quota
+    /// notifications are designed for. When Claude's OAuth response omits the
+    /// five-hour block, `ClaudeUsageFetcher` promotes a weekly window into
+    /// `primary` so the menu bar still renders usable data — but that weekly
+    /// window must not drive session-quota depleted/restored transitions.
+    /// Treat anything up to ~6 hours as a session lane; longer windows are
+    /// weekly/model-specific fallbacks and are ignored here.
+    private static func isSessionWindow(_ window: RateWindow) -> Bool {
+        guard let minutes = window.windowMinutes else {
+            // Unknown duration — preserve legacy behaviour (treat as session).
+            return true
+        }
+        return minutes <= 360
     }
 
     func handleSessionQuotaTransition(provider: UsageProvider, snapshot: UsageSnapshot) {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -833,7 +833,19 @@ extension ClaudeUsageFetcher {
                 resetDescription: resetDescription)
         }
 
-        guard let primary = makeWindow(usage.fiveHour, windowMinutes: 5 * 60) else {
+        // Fall back through the available windows when the five-hour session
+        // window is missing from the response (observed in the wild for some
+        // organisations — see https://github.com/steipete/CodexBar/issues/726).
+        // Previously we threw away the entire snapshot, discarding weekly and
+        // model-specific data the user could still see. Now we surface the
+        // most relevant available window as `primary` so the menu bar renders
+        // something useful instead of an "unavailable" state.
+        guard let primary = makeWindow(usage.fiveHour, windowMinutes: 5 * 60)
+            ?? makeWindow(usage.sevenDay, windowMinutes: 7 * 24 * 60)
+            ?? makeWindow(usage.sevenDaySonnet, windowMinutes: 7 * 24 * 60)
+            ?? makeWindow(usage.sevenDayOpus, windowMinutes: 7 * 24 * 60)
+            ?? makeWindow(usage.sevenDayOAuthApps, windowMinutes: 7 * 24 * 60)
+        else {
             throw ClaudeUsageError.parseFailed("missing session data")
         }
 

--- a/Tests/CodexBarTests/ClaudeUsageTests.swift
+++ b/Tests/CodexBarTests/ClaudeUsageTests.swift
@@ -1389,4 +1389,47 @@ extension ClaudeUsageTests {
         }
         #expect(flags.respectPromptCooldownFlags == [true])
     }
+
+    /// Regression for https://github.com/steipete/CodexBar/issues/726: when the
+    /// OAuth usage response is missing the `five_hour` block, the snapshot must
+    /// still be produced using whichever windows are available instead of being
+    /// thrown away entirely.
+    @Test
+    func `mapOAuthUsage falls back to seven-day window when five_hour is absent`() throws {
+        let json = """
+        {
+          "seven_day": { "utilization": 42, "resets_at": "2025-12-29T23:00:00.000Z" },
+          "seven_day_sonnet": { "utilization": 17, "resets_at": "2025-12-29T23:00:00.000Z" }
+        }
+        """
+        let snapshot = try ClaudeUsageFetcher._mapOAuthUsageForTesting(Data(json.utf8))
+        #expect(snapshot.primary.usedPercent == 42)
+        #expect(snapshot.secondary?.usedPercent == 42)
+        #expect(snapshot.opus?.usedPercent == 17)
+    }
+
+    /// Regression for https://github.com/steipete/CodexBar/issues/726: when
+    /// `five_hour.utilization` itself is missing (the exact shape from the
+    /// reporter's debug output), we should still map the remaining data.
+    @Test
+    func `mapOAuthUsage falls back when five_hour has no utilization`() throws {
+        let json = """
+        {
+          "five_hour": { "resets_at": "2025-12-23T16:00:00.000Z" },
+          "seven_day": { "utilization": 9, "resets_at": "2025-12-29T23:00:00.000Z" }
+        }
+        """
+        let snapshot = try ClaudeUsageFetcher._mapOAuthUsageForTesting(Data(json.utf8))
+        #expect(snapshot.primary.usedPercent == 9)
+    }
+
+    /// When *every* window is missing we still want to signal an error rather
+    /// than synthesise fake data.
+    @Test
+    func `mapOAuthUsage throws when no windows are present`() throws {
+        let json = "{}"
+        #expect(throws: ClaudeUsageError.self) {
+            try ClaudeUsageFetcher._mapOAuthUsageForTesting(Data(json.utf8))
+        }
+    }
 }

--- a/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
+++ b/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
@@ -77,4 +77,100 @@ struct UsageStoreSessionQuotaTransitionTests {
 
         #expect(notifier.posts.isEmpty)
     }
+
+    /// Regression for https://github.com/steipete/CodexBar/pull/741: when the
+    /// Claude OAuth response is missing the `five_hour` window,
+    /// `ClaudeUsageFetcher` promotes a weekly window into `primary` so the menu
+    /// bar still renders. That weekly window MUST NOT drive session-quota
+    /// depleted/restored notifications, because it does not represent the 5h
+    /// session lane.
+    @Test
+    func `claude weekly primary fallback does not emit session quota notifications`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreSessionQuotaTransitionTests-claude-weekly-fallback"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.sessionQuotaNotificationsEnabled = true
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        let weeklyMinutes = 7 * 24 * 60
+
+        // First snapshot: weekly-as-primary at 20% used — establishes baseline.
+        let first = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: weeklyMinutes,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        store.handleSessionQuotaTransition(provider: .claude, snapshot: first)
+
+        // Second snapshot: weekly-as-primary crosses into depleted territory.
+        // Under the old code this would fire a spurious session-depleted
+        // notification; with the session-window guard it must stay silent.
+        let second = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 100,
+                windowMinutes: weeklyMinutes,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        store.handleSessionQuotaTransition(provider: .claude, snapshot: second)
+
+        #expect(notifier.posts.isEmpty)
+    }
+
+    /// Sanity check: a genuine 5h session window still drives notifications so
+    /// the guard introduced above is not over-broad.
+    @Test
+    func `claude five hour primary still emits session quota notifications`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreSessionQuotaTransitionTests-claude-five-hour"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.sessionQuotaNotificationsEnabled = true
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        let sessionMinutes = 5 * 60
+
+        let baseline = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: sessionMinutes,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        store.handleSessionQuotaTransition(provider: .claude, snapshot: baseline)
+
+        let depleted = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 100,
+                windowMinutes: sessionMinutes,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        store.handleSessionQuotaTransition(provider: .claude, snapshot: depleted)
+
+        #expect(notifier.posts.contains(where: { $0.provider == .claude }))
+    }
 }


### PR DESCRIPTION
### Summary

Fixes #726.

When the Claude OAuth usage response omits the `five_hour` block (or when
`five_hour` is present but has no `utilization` value), `mapOAuthUsage`
was discarding the entire snapshot with `ClaudeUsageError.parseFailed("missing session data")`,
even if the response still contained `seven_day`, `seven_day_sonnet`,
`seven_day_opus`, or `seven_day_oauth_apps`. The user's menu bar therefore
went blank despite the API returning usable data — matching the exact
symptom reported in the issue ("raw response returned, but parser drops
it after a 5h query returns none").

### Reproduction

Before this change, on `main`:

```swift
let json = """
{
  "seven_day": { "utilization": 42, "resets_at": "2025-12-29T23:00:00.000Z" },
  "seven_day_sonnet": { "utilization": 17, "resets_at": "2025-12-29T23:00:00.000Z" }
}
"""
try ClaudeUsageFetcher._mapOAuthUsageForTesting(Data(json.utf8))
// throws ClaudeUsageError.parseFailed("missing session data")
```

After this change the same input returns a `ClaudeUsageSnapshot` with the
seven-day window promoted to `primary` (and kept as `secondary`) and the
Sonnet window as `opus`.

### Approach

`mapOAuthUsage` now falls back through the available windows in a simple
chain of `??` expressions:

```swift
guard let primary = makeWindow(usage.fiveHour, windowMinutes: 5 * 60)
    ?? makeWindow(usage.sevenDay, windowMinutes: 7 * 24 * 60)
    ?? makeWindow(usage.sevenDaySonnet, windowMinutes: 7 * 24 * 60)
    ?? makeWindow(usage.sevenDayOpus, windowMinutes: 7 * 24 * 60)
    ?? makeWindow(usage.sevenDayOAuthApps, windowMinutes: 7 * 24 * 60)
else {
    throw ClaudeUsageError.parseFailed("missing session data")
}
```

`secondary` and `opus` assignments are unchanged, so in the common case
(five-hour present) the snapshot looks identical to today. The error is
only thrown when nothing at all is available.

This mirrors the tolerant decoding pattern added for Codex OAuth in #710.

### Tests

Three new regression tests under `Tests/CodexBarTests/ClaudeUsageTests.swift`:

1. `mapOAuthUsage falls back to seven-day window when five_hour is absent`
2. `mapOAuthUsage falls back when five_hour has no utilization` — the exact
   shape from the reporter's debug output
3. `mapOAuthUsage throws when no windows are present` — makes sure we
   don't synthesise fake data when the response is empty

### Build / verification

- `swift build` → clean on Swift 6.2 (Xcode 16.4, macOS 15.5)
- `swiftformat --config .swiftformat <changed files>` → clean
- Regression tests are colocated with `ClaudeUsageTests` and use the
  existing `_mapOAuthUsageForTesting` debug hook; no new debug surface
  was needed.

**Note on `swift test`:** `swift test` currently fails on this repo from
a clean checkout (both on `main` and with this change) because the
`KeyboardShortcuts` dependency's `#Preview` macros can't resolve
`PreviewsMacros` under plain SwiftPM. That's pre-existing and unrelated
to this fix — happy to adjust if CI has a different entry point I should
be running.

### Scope

Code change is small and localized: 14 lines in `ClaudeUsageFetcher.swift`,
no public API or behavioural changes when `five_hour` is present.