### PR TITLE
[codex] Fix OpenAI web dashboard handoff

### DIFF
--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -921,6 +921,7 @@ extension UsageStore {
                     result = try await importer.importBestCookies(
                         intoAccountEmail: normalizedTarget,
                         allowAnyAccount: allowAnyAccount,
+                        preferCachedCookieHeader: !force,
                         cacheScope: cacheScope,
                         logger: log)
                 case .off:

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
@@ -105,6 +105,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
     public func importBestCookies(
         intoAccountEmail targetEmail: String?,
         allowAnyAccount: Bool = false,
+        preferCachedCookieHeader: Bool = true,
         cacheScope: CookieHeaderCache.Scope? = nil,
         logger: ((String) -> Void)? = nil) async throws -> ImportResult
     {
@@ -130,27 +131,31 @@ public struct OpenAIDashboardBrowserCookieImporter {
 
         var diagnostics = ImportDiagnostics()
 
-        if let cached = CookieHeaderCache.load(provider: .codex, scope: cacheScope),
-           !cached.cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        {
-            log("Using cached cookie header from \(cached.sourceLabel)")
-            do {
-                return try await self.importManualCookies(
-                    cookieHeader: cached.cookieHeader,
-                    intoAccountEmail: context.targetEmail,
-                    allowAnyAccount: context.allowAnyAccount,
-                    cacheScope: cacheScope,
-                    logger: log)
-            } catch let error as ImportError {
-                switch error {
-                case .manualCookieHeaderInvalid, .noMatchingAccount, .dashboardStillRequiresLogin:
-                    CookieHeaderCache.clear(provider: .codex, scope: cacheScope)
-                default:
+        if preferCachedCookieHeader {
+            if let cached = CookieHeaderCache.load(provider: .codex, scope: cacheScope),
+               !cached.cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                log("Using cached cookie header from \(cached.sourceLabel)")
+                do {
+                    return try await self.importManualCookies(
+                        cookieHeader: cached.cookieHeader,
+                        intoAccountEmail: context.targetEmail,
+                        allowAnyAccount: context.allowAnyAccount,
+                        cacheScope: cacheScope,
+                        logger: log)
+                } catch let error as ImportError {
+                    switch error {
+                    case .manualCookieHeaderInvalid, .noMatchingAccount, .dashboardStillRequiresLogin:
+                        CookieHeaderCache.clear(provider: .codex, scope: cacheScope)
+                    default:
+                        throw error
+                    }
+                } catch {
                     throw error
                 }
-            } catch {
-                throw error
             }
+        } else {
+            log("Skipping cached cookie header; forcing fresh browser import")
         }
 
         // Filter to cookie-eligible browsers to avoid unnecessary keychain prompts
@@ -606,15 +611,11 @@ public struct OpenAIDashboardBrowserCookieImporter {
 
         // Validate against the persistent store (login + email sync).
         do {
-            defer {
-                // The probe is only a validation step. Start the real dashboard scrape with a
-                // fresh WKWebView instead of reusing the probe instance.
-                OpenAIDashboardWebViewCache.shared.evict(websiteDataStore: persistent)
-            }
             let probe = try await OpenAIDashboardFetcher().probeUsagePage(
                 websiteDataStore: persistent,
                 logger: logger,
-                timeout: 20)
+                timeout: 20,
+                preserveLoadedPageForReuse: true)
             let signed = probe.signedInEmail?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
             let matches = signed?.lowercased() == targetEmail.lowercased()
             logger("Persistent session signed in as: \(signed ?? "unknown")")
@@ -630,8 +631,12 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 signedInEmail: signed,
                 matchesCodexEmail: matches)
         } catch OpenAIDashboardFetcher.FetchError.loginRequired {
+            OpenAIDashboardWebViewCache.shared.evict(websiteDataStore: persistent)
             logger("Selected \(candidate.label) but dashboard still requires login.")
             throw ImportError.dashboardStillRequiresLogin
+        } catch {
+            OpenAIDashboardWebViewCache.shared.evict(websiteDataStore: persistent)
+            throw error
         }
     }
 
@@ -644,15 +649,11 @@ public struct OpenAIDashboardBrowserCookieImporter {
         await self.setCookies(candidate.cookies, into: persistent)
 
         do {
-            defer {
-                // The probe is only a validation step. Start the real dashboard scrape with a
-                // fresh WKWebView instead of reusing the probe instance.
-                OpenAIDashboardWebViewCache.shared.evict(websiteDataStore: persistent)
-            }
             let probe = try await OpenAIDashboardFetcher().probeUsagePage(
                 websiteDataStore: persistent,
                 logger: logger,
-                timeout: 20)
+                timeout: 20,
+                preserveLoadedPageForReuse: true)
             let signed = probe.signedInEmail?.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
             logger("Persistent session signed in as: \(signed ?? "unknown")")
             return ImportResult(
@@ -661,8 +662,12 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 signedInEmail: signed,
                 matchesCodexEmail: false)
         } catch OpenAIDashboardFetcher.FetchError.loginRequired {
+            OpenAIDashboardWebViewCache.shared.evict(websiteDataStore: persistent)
             logger("Selected \(candidate.label) but dashboard still requires login.")
             throw ImportError.dashboardStillRequiresLogin
+        } catch {
+            OpenAIDashboardWebViewCache.shared.evict(websiteDataStore: persistent)
+            throw error
         }
     }
 
@@ -816,6 +821,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
     public func importBestCookies(
         intoAccountEmail _: String?,
         allowAnyAccount _: Bool = false,
+        preferCachedCookieHeader _: Bool = true,
         cacheScope _: CookieHeaderCache.Scope? = nil,
         logger _: ((String) -> Void)? = nil) async throws -> ImportResult
     {

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -19,7 +19,7 @@ public struct OpenAIDashboardFetcher {
         }
     }
 
-    private let usageURL = URL(string: "https://chatgpt.com/codex/settings/usage")!
+    private let usageURL = URL(string: "https://chatgpt.com/codex/cloud/settings/analytics#usage")!
 
     public init() {}
 
@@ -95,6 +95,22 @@ public struct OpenAIDashboardFetcher {
             self.signedInEmail = signedInEmail
             self.bodyText = bodyText
         }
+    }
+
+    nonisolated static func shouldPreserveLoadedPageAfterProbe(_ result: ProbeResult) -> Bool {
+        guard !result.loginRequired, !result.workspacePicker, !result.cloudflareInterstitial else {
+            return false
+        }
+
+        guard self.isUsageRoute(result.href) else { return false }
+
+        guard let signedInEmail = result.signedInEmail?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !signedInEmail.isEmpty
+        else {
+            return false
+        }
+
+        return true
     }
 
     public func loadLatestDashboard(
@@ -342,13 +358,15 @@ public struct OpenAIDashboardFetcher {
     public func probeUsagePage(
         websiteDataStore: WKWebsiteDataStore,
         logger: ((String) -> Void)? = nil,
-        timeout: TimeInterval = 30) async throws -> ProbeResult
+        timeout: TimeInterval = 30,
+        preserveLoadedPageForReuse: Bool = false) async throws -> ProbeResult
     {
         let deadline = Self.deadline(startingAt: Date(), timeout: timeout)
         let lease = try await self.makeWebView(
             websiteDataStore: websiteDataStore,
             logger: logger,
-            timeout: Self.remainingTimeout(until: deadline))
+            timeout: Self.remainingTimeout(until: deadline),
+            preserveLoadedPageOnRelease: preserveLoadedPageForReuse)
         defer { lease.release() }
         let webView = lease.webView
         let log = lease.log
@@ -410,23 +428,28 @@ public struct OpenAIDashboardFetcher {
                 continue
             }
 
-            return ProbeResult(
+            let result = ProbeResult(
                 href: scrape.href,
                 loginRequired: scrape.loginRequired,
                 workspacePicker: scrape.workspacePicker,
                 cloudflareInterstitial: scrape.cloudflareInterstitial,
                 signedInEmail: normalizedEmail,
                 bodyText: scrape.bodyText)
+            lease.setPreserveLoadedPageOnRelease(
+                preserveLoadedPageForReuse && Self.shouldPreserveLoadedPageAfterProbe(result))
+            return result
         }
 
         log("Probe timed out (href=\(lastHref ?? "nil"))")
-        return ProbeResult(
+        let result = ProbeResult(
             href: lastHref,
             loginRequired: false,
             workspacePicker: false,
             cloudflareInterstitial: false,
             signedInEmail: nil,
             bodyText: lastBody)
+        lease.setPreserveLoadedPageOnRelease(false)
+        return result
     }
 
     // MARK: - JS scrape
@@ -530,13 +553,15 @@ public struct OpenAIDashboardFetcher {
     private func makeWebView(
         websiteDataStore: WKWebsiteDataStore,
         logger: ((String) -> Void)?,
-        timeout: TimeInterval) async throws -> OpenAIDashboardWebViewLease
+        timeout: TimeInterval,
+        preserveLoadedPageOnRelease: Bool = false) async throws -> OpenAIDashboardWebViewLease
     {
         try await OpenAIDashboardWebViewCache.shared.acquire(
             websiteDataStore: websiteDataStore,
             usageURL: self.usageURL,
             logger: logger,
-            navigationTimeout: timeout)
+            navigationTimeout: timeout,
+            preserveLoadedPageOnRelease: preserveLoadedPageOnRelease)
     }
 
     nonisolated static func sanitizedTimeout(_ timeout: TimeInterval) -> TimeInterval {
@@ -556,7 +581,10 @@ public struct OpenAIDashboardFetcher {
         guard let href, !href.isEmpty else { return false }
         let path = (URL(string: href)?.path ?? href)
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        return path.hasSuffix("codex/settings/usage") || path.hasSuffix("codex/cloud/settings/usage")
+        return path.hasSuffix("codex/settings/usage")
+            || path.hasSuffix("codex/cloud/settings/usage")
+            || path.hasSuffix("codex/settings/analytics")
+            || path.hasSuffix("codex/cloud/settings/analytics")
     }
 
     private static func writeDebugArtifacts(html: String, bodyText: String?, logger: (String) -> Void) {

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
@@ -6,6 +6,7 @@ import WebKit
 struct OpenAIDashboardWebViewLease {
     let webView: WKWebView
     let log: (String) -> Void
+    let setPreserveLoadedPageOnRelease: (Bool) -> Void
     let release: () -> Void
 }
 
@@ -14,17 +15,67 @@ final class OpenAIDashboardWebViewCache {
     static let shared = OpenAIDashboardWebViewCache()
     fileprivate static let log = CodexBarLog.logger(LogCategories.openAIWebview)
 
+    private final class ReleaseState {
+        var preserveLoadedPageOnRelease: Bool
+
+        init(preserveLoadedPageOnRelease: Bool) {
+            self.preserveLoadedPageOnRelease = preserveLoadedPageOnRelease
+        }
+    }
+
+    private struct AcquireOptions {
+        let allowTimeoutRetry: Bool
+        let preserveLoadedPageOnRelease: Bool
+    }
+
     private final class Entry {
         let webView: WKWebView
         let host: OffscreenWebViewHost
         var lastUsedAt: Date
         var isBusy: Bool
+        var preservedPageExpiresAt: Date?
+        var preservedPageExpiryTask: Task<Void, Never>?
 
-        init(webView: WKWebView, host: OffscreenWebViewHost, lastUsedAt: Date, isBusy: Bool) {
+        init(
+            webView: WKWebView,
+            host: OffscreenWebViewHost,
+            lastUsedAt: Date,
+            isBusy: Bool,
+            preservedPageExpiresAt: Date? = nil)
+        {
             self.webView = webView
             self.host = host
             self.lastUsedAt = lastUsedAt
             self.isBusy = isBusy
+            self.preservedPageExpiresAt = preservedPageExpiresAt
+        }
+
+        func armPreservedPage(until expiry: Date) {
+            self.preservedPageExpiresAt = expiry
+        }
+
+        func setPreservedPageExpiryTask(_ task: Task<Void, Never>?) {
+            self.preservedPageExpiryTask?.cancel()
+            self.preservedPageExpiryTask = task
+        }
+
+        func clearPreservedPage() {
+            self.preservedPageExpiresAt = nil
+            self.preservedPageExpiryTask?.cancel()
+            self.preservedPageExpiryTask = nil
+        }
+
+        func consumePreservedPageReuseIfAvailable(now: Date) -> Bool {
+            guard let preservedPageExpiresAt else { return false }
+            self.preservedPageExpiresAt = nil
+            self.preservedPageExpiryTask?.cancel()
+            self.preservedPageExpiryTask = nil
+            return preservedPageExpiresAt > now
+        }
+
+        func hasExpiredPreservedPage(now: Date) -> Bool {
+            guard let preservedPageExpiresAt else { return false }
+            return preservedPageExpiresAt <= now
         }
     }
 
@@ -32,19 +83,41 @@ final class OpenAIDashboardWebViewCache {
     /// Keep the WebView alive only long enough for immediate retries/menu reopens.
     /// Long-lived hidden ChatGPT tabs still consume noticeable energy on some setups.
     private let idleTimeout: TimeInterval = 60
+    /// Reuse the validated analytics page only for the immediate next handoff.
+    private let preservedPageHandoffTimeout: TimeInterval = 5
     private let blankURL = URL(string: "about:blank")!
+    private let reusablePageResetScript = """
+    (() => {
+      try {
+        delete window.__codexbarDidScrollToCredits;
+        delete window.__codexbarUsageBreakdownJSON;
+        delete window.__codexbarUsageBreakdownDebug;
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+    """
 
-    private func releaseCachedEntry(_ entry: Entry) {
+    private func releaseCachedEntry(_ entry: Entry, preserveLoadedPage: Bool) {
         entry.isBusy = false
         entry.lastUsedAt = Date()
-        self.prepareCachedWebViewForIdle(entry.webView, host: entry.host)
+        self.updatePreservedPageState(for: entry, preserveLoadedPage: preserveLoadedPage)
+        self.prepareCachedWebViewForIdle(
+            entry.webView,
+            host: entry.host,
+            preserveLoadedPage: preserveLoadedPage)
         self.prune(now: Date())
     }
 
-    private func releaseNewEntry(_ entry: Entry, webView: WKWebView) {
+    private func releaseNewEntry(_ entry: Entry, webView: WKWebView, preserveLoadedPage: Bool) {
         entry.isBusy = false
         entry.lastUsedAt = Date()
-        self.prepareCachedWebViewForIdle(webView, host: entry.host)
+        self.updatePreservedPageState(for: entry, preserveLoadedPage: preserveLoadedPage)
+        self.prepareCachedWebViewForIdle(
+            webView,
+            host: entry.host,
+            preserveLoadedPage: preserveLoadedPage)
         self.prune(now: Date())
     }
 
@@ -69,6 +142,31 @@ final class OpenAIDashboardWebViewCache {
 
     var idleTimeoutForTesting: TimeInterval {
         self.idleTimeout
+    }
+
+    var preservedPageHandoffTimeoutForTesting: TimeInterval {
+        self.preservedPageHandoffTimeout
+    }
+
+    func hasPreservedPageForTesting(for websiteDataStore: WKWebsiteDataStore) -> Bool {
+        let key = ObjectIdentifier(websiteDataStore)
+        return self.entries[key]?.preservedPageExpiresAt != nil
+    }
+
+    func markPreservedPageForTesting(
+        websiteDataStore: WKWebsiteDataStore,
+        expiresAt: Date = .init().addingTimeInterval(5))
+    {
+        let key = ObjectIdentifier(websiteDataStore)
+        guard let entry = self.entries[key] else { return }
+        entry.armPreservedPage(until: expiresAt)
+        self.schedulePreservedPageExpiry(for: key, entry: entry, expiresAt: expiresAt)
+    }
+
+    func consumePreservedPageForTesting(websiteDataStore: WKWebsiteDataStore, now: Date = Date()) -> Bool {
+        let key = ObjectIdentifier(websiteDataStore)
+        guard let entry = self.entries[key] else { return false }
+        return entry.consumePreservedPageReuseIfAvailable(now: now)
     }
 
     /// Seed a cached entry without navigating a real page (for test stability).
@@ -97,9 +195,14 @@ final class OpenAIDashboardWebViewCache {
     /// Clear all cached entries (for test isolation).
     func clearAllForTesting() {
         for (_, entry) in self.entries {
+            entry.clearPreservedPage()
             entry.host.close()
         }
         self.entries.removeAll()
+    }
+
+    func resetReusablePageStateForTesting(_ webView: WKWebView) async -> Bool {
+        await self.resetReusablePageState(webView)
     }
     #endif
 
@@ -107,7 +210,8 @@ final class OpenAIDashboardWebViewCache {
         websiteDataStore: WKWebsiteDataStore,
         usageURL: URL,
         logger: ((String) -> Void)?,
-        navigationTimeout: TimeInterval = 15) async throws -> OpenAIDashboardWebViewLease
+        navigationTimeout: TimeInterval = 15,
+        preserveLoadedPageOnRelease: Bool = false) async throws -> OpenAIDashboardWebViewLease
     {
         let deadline = Date().addingTimeInterval(max(navigationTimeout, 1))
         return try await self.acquire(
@@ -115,7 +219,9 @@ final class OpenAIDashboardWebViewCache {
             usageURL: usageURL,
             logger: logger,
             deadline: deadline,
-            allowTimeoutRetry: true)
+            options: .init(
+                allowTimeoutRetry: true,
+                preserveLoadedPageOnRelease: preserveLoadedPageOnRelease))
     }
 
     private func acquire(
@@ -123,7 +229,7 @@ final class OpenAIDashboardWebViewCache {
         usageURL: URL,
         logger: ((String) -> Void)?,
         deadline: Date,
-        allowTimeoutRetry: Bool) async throws -> OpenAIDashboardWebViewLease
+        options: AcquireOptions) async throws -> OpenAIDashboardWebViewLease
     {
         let now = Date()
         self.prune(now: now)
@@ -140,9 +246,13 @@ final class OpenAIDashboardWebViewCache {
                 let (webView, host) = self.makeWebView(websiteDataStore: websiteDataStore)
                 host.show()
                 do {
-                    try await self.prepareWebView(webView, usageURL: usageURL, timeout: remainingTimeout)
+                    try await self.prepareWebView(
+                        webView,
+                        usageURL: usageURL,
+                        timeout: remainingTimeout,
+                        canReuseLoadedPage: false)
                 } catch {
-                    if allowTimeoutRetry, Self.isPrepareTimeout(error) {
+                    if options.allowTimeoutRetry, Self.isPrepareTimeout(error) {
                         host.close()
                         log("Temporary OpenAI WebView timed out; retrying with a fresh WebView.")
                         return try await self.acquireTemporaryWebView(
@@ -157,18 +267,26 @@ final class OpenAIDashboardWebViewCache {
                 return OpenAIDashboardWebViewLease(
                     webView: webView,
                     log: log,
+                    setPreserveLoadedPageOnRelease: { _ in },
                     release: { host.close() })
             }
 
             entry.isBusy = true
             entry.lastUsedAt = now
+            let canReuseLoadedPage = entry.consumePreservedPageReuseIfAvailable(now: now)
+            let releaseState = ReleaseState(preserveLoadedPageOnRelease: options.preserveLoadedPageOnRelease)
             entry.host.show()
             do {
-                try await self.prepareWebView(entry.webView, usageURL: usageURL, timeout: remainingTimeout)
+                try await self.prepareWebView(
+                    entry.webView,
+                    usageURL: usageURL,
+                    timeout: remainingTimeout,
+                    canReuseLoadedPage: canReuseLoadedPage)
             } catch {
-                if allowTimeoutRetry, Self.isPrepareTimeout(error) {
+                if options.allowTimeoutRetry, Self.isPrepareTimeout(error) {
                     entry.isBusy = false
                     entry.lastUsedAt = Date()
+                    entry.clearPreservedPage()
                     entry.host.close()
                     self.entries.removeValue(forKey: key)
                     log("Cached OpenAI WebView timed out; recreating it.")
@@ -177,10 +295,13 @@ final class OpenAIDashboardWebViewCache {
                         usageURL: usageURL,
                         logger: logger,
                         deadline: deadline,
-                        allowTimeoutRetry: false)
+                        options: .init(
+                            allowTimeoutRetry: false,
+                            preserveLoadedPageOnRelease: options.preserveLoadedPageOnRelease))
                 }
                 entry.isBusy = false
                 entry.lastUsedAt = Date()
+                entry.clearPreservedPage()
                 entry.host.close()
                 self.entries.removeValue(forKey: key)
                 Self.log.warning("OpenAI webview prepare failed")
@@ -190,9 +311,14 @@ final class OpenAIDashboardWebViewCache {
             return OpenAIDashboardWebViewLease(
                 webView: entry.webView,
                 log: log,
+                setPreserveLoadedPageOnRelease: { preserveLoadedPageOnRelease in
+                    releaseState.preserveLoadedPageOnRelease = preserveLoadedPageOnRelease
+                },
                 release: { [weak self, weak entry] in
                     guard let self, let entry else { return }
-                    self.releaseCachedEntry(entry)
+                    self.releaseCachedEntry(
+                        entry,
+                        preserveLoadedPage: releaseState.preserveLoadedPageOnRelease)
                 })
         }
 
@@ -200,11 +326,16 @@ final class OpenAIDashboardWebViewCache {
         let entry = Entry(webView: webView, host: host, lastUsedAt: now, isBusy: true)
         self.entries[key] = entry
         host.show()
+        let releaseState = ReleaseState(preserveLoadedPageOnRelease: options.preserveLoadedPageOnRelease)
 
         do {
-            try await self.prepareWebView(webView, usageURL: usageURL, timeout: remainingTimeout)
+            try await self.prepareWebView(
+                webView,
+                usageURL: usageURL,
+                timeout: remainingTimeout,
+                canReuseLoadedPage: false)
         } catch {
-            if allowTimeoutRetry, Self.isPrepareTimeout(error) {
+            if options.allowTimeoutRetry, Self.isPrepareTimeout(error) {
                 self.entries.removeValue(forKey: key)
                 host.close()
                 log("OpenAI WebView timed out during prepare; retrying once.")
@@ -213,7 +344,9 @@ final class OpenAIDashboardWebViewCache {
                     usageURL: usageURL,
                     logger: logger,
                     deadline: deadline,
-                    allowTimeoutRetry: false)
+                    options: .init(
+                        allowTimeoutRetry: false,
+                        preserveLoadedPageOnRelease: options.preserveLoadedPageOnRelease))
             }
             self.entries.removeValue(forKey: key)
             host.close()
@@ -224,15 +357,22 @@ final class OpenAIDashboardWebViewCache {
         return OpenAIDashboardWebViewLease(
             webView: webView,
             log: log,
+            setPreserveLoadedPageOnRelease: { preserveLoadedPageOnRelease in
+                releaseState.preserveLoadedPageOnRelease = preserveLoadedPageOnRelease
+            },
             release: { [weak self, weak entry] in
                 guard let self, let entry else { return }
-                self.releaseNewEntry(entry, webView: webView)
+                self.releaseNewEntry(
+                    entry,
+                    webView: webView,
+                    preserveLoadedPage: releaseState.preserveLoadedPageOnRelease)
             })
     }
 
     func evict(websiteDataStore: WKWebsiteDataStore) {
         let key = ObjectIdentifier(websiteDataStore)
         guard let entry = self.entries.removeValue(forKey: key) else { return }
+        entry.clearPreservedPage()
         Self.log.debug("OpenAI webview evicted")
         entry.host.close()
     }
@@ -241,6 +381,7 @@ final class OpenAIDashboardWebViewCache {
         let existing = self.entries
         self.entries.removeAll()
         for (_, entry) in existing {
+            entry.clearPreservedPage()
             entry.host.close()
         }
         if !existing.isEmpty {
@@ -248,17 +389,35 @@ final class OpenAIDashboardWebViewCache {
         }
     }
 
-    private func prepareCachedWebViewForIdle(_ webView: WKWebView, host: OffscreenWebViewHost) {
+    private func prepareCachedWebViewForIdle(
+        _ webView: WKWebView,
+        host: OffscreenWebViewHost,
+        preserveLoadedPage: Bool)
+    {
+        webView.navigationDelegate = nil
+        webView.codexNavigationDelegate = nil
+        if preserveLoadedPage {
+            host.hide()
+            return
+        }
+
         // Detach the heavyweight ChatGPT SPA as soon as a scrape completes. Keeping the WebView object around
         // still helps with immediate reuse, but letting chatgpt.com remain the active document is too expensive.
         webView.stopLoading()
-        webView.navigationDelegate = nil
-        webView.codexNavigationDelegate = nil
         _ = webView.load(URLRequest(url: self.blankURL))
         host.hide()
     }
 
     private func prune(now: Date) {
+        for entry in self.entries.values where !entry.isBusy && entry.hasExpiredPreservedPage(now: now) {
+            entry.clearPreservedPage()
+            self.prepareCachedWebViewForIdle(
+                entry.webView,
+                host: entry.host,
+                preserveLoadedPage: false)
+            Self.log.debug("OpenAI webview preserved page expired")
+        }
+
         let expired = self.entries.filter { _, entry in
             !entry.isBusy && now.timeIntervalSince(entry.lastUsedAt) > self.idleTimeout
         }
@@ -281,13 +440,29 @@ final class OpenAIDashboardWebViewCache {
         return (webView, host)
     }
 
-    private func prepareWebView(_ webView: WKWebView, usageURL: URL, timeout: TimeInterval) async throws {
+    private func prepareWebView(
+        _ webView: WKWebView,
+        usageURL: URL,
+        timeout: TimeInterval,
+        canReuseLoadedPage: Bool) async throws
+    {
         #if DEBUG
         if usageURL.absoluteString == "about:blank" {
             _ = webView.loadHTMLString("", baseURL: nil)
             return
         }
         #endif
+
+        if canReuseLoadedPage,
+           let currentURL = webView.url?.absoluteString,
+           OpenAIDashboardFetcher.isUsageRoute(currentURL)
+        {
+            if await self.resetReusablePageState(webView) {
+                return
+            }
+
+            Self.log.debug("OpenAI preserved page reset failed; reloading usage URL")
+        }
 
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
             let delegate = NavigationDelegate { result in
@@ -310,7 +485,11 @@ final class OpenAIDashboardWebViewCache {
         let (webView, host) = self.makeWebView(websiteDataStore: websiteDataStore)
         host.show()
         do {
-            try await self.prepareWebView(webView, usageURL: usageURL, timeout: remainingTimeout)
+            try await self.prepareWebView(
+                webView,
+                usageURL: usageURL,
+                timeout: remainingTimeout,
+                canReuseLoadedPage: false)
         } catch {
             host.close()
             throw error
@@ -318,12 +497,67 @@ final class OpenAIDashboardWebViewCache {
         return OpenAIDashboardWebViewLease(
             webView: webView,
             log: log,
+            setPreserveLoadedPageOnRelease: { _ in },
             release: { host.close() })
     }
 
     private static func isPrepareTimeout(_ error: Error) -> Bool {
         let nsError = error as NSError
         return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorTimedOut
+    }
+
+    private func updatePreservedPageState(for entry: Entry, preserveLoadedPage: Bool) {
+        if preserveLoadedPage {
+            let expiresAt = Date().addingTimeInterval(self.preservedPageHandoffTimeout)
+            entry.armPreservedPage(until: expiresAt)
+            if let key = self.entries.first(where: { $0.value === entry })?.key {
+                self.schedulePreservedPageExpiry(for: key, entry: entry, expiresAt: expiresAt)
+            }
+        } else {
+            entry.clearPreservedPage()
+        }
+    }
+
+    private func schedulePreservedPageExpiry(
+        for key: ObjectIdentifier,
+        entry: Entry,
+        expiresAt: Date)
+    {
+        let delay = max(0, expiresAt.timeIntervalSinceNow)
+        let task = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard !Task.isCancelled else { return }
+            self?.expirePreservedPageIfNeeded(for: key, expectedExpiry: expiresAt)
+        }
+        entry.setPreservedPageExpiryTask(task)
+    }
+
+    private func expirePreservedPageIfNeeded(for key: ObjectIdentifier, expectedExpiry: Date) {
+        guard let entry = self.entries[key],
+              !entry.isBusy,
+              let preservedPageExpiresAt = entry.preservedPageExpiresAt,
+              preservedPageExpiresAt == expectedExpiry,
+              preservedPageExpiresAt <= Date()
+        else {
+            return
+        }
+
+        entry.clearPreservedPage()
+        self.prepareCachedWebViewForIdle(
+            entry.webView,
+            host: entry.host,
+            preserveLoadedPage: false)
+        Self.log.debug("OpenAI webview preserved page expired")
+        self.prune(now: Date())
+    }
+
+    private func resetReusablePageState(_ webView: WKWebView) async -> Bool {
+        do {
+            let any = try await webView.evaluateJavaScript(self.reusablePageResetScript)
+            return (any as? Bool) ?? true
+        } catch {
+            return false
+        }
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexWebDashboardStrategy.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexWebDashboardStrategy.swift
@@ -150,15 +150,43 @@ extension CodexWebDashboardStrategy {
         let log: @MainActor (String) -> Void = { line in
             logger.append(line)
         }
-        let result = try await Self.fetchOpenAIWebDashboard(
-            context: context,
-            options: options,
-            browserDetection: browserDetection,
-            logger: log)
-        return try Self.makeAuthorizedDashboardResult(
-            dashboard: result.dashboard,
-            context: context,
-            routingTargetEmail: result.routingTargetEmail)
+        do {
+            let result = try await Self.fetchOpenAIWebDashboard(
+                context: context,
+                options: options,
+                browserDetection: browserDetection,
+                preferCachedCookieHeader: true,
+                logger: log)
+            return try Self.makeAuthorizedDashboardResult(
+                dashboard: result.dashboard,
+                context: context,
+                routingTargetEmail: result.routingTargetEmail)
+        } catch {
+            guard Self.shouldRetryWithFreshBrowserImport(after: error) else {
+                throw error
+            }
+            log("Retrying OpenAI web dashboard with a fresh browser cookie import.")
+            let result = try await Self.fetchOpenAIWebDashboard(
+                context: context,
+                options: options,
+                browserDetection: browserDetection,
+                preferCachedCookieHeader: false,
+                logger: log)
+            return try Self.makeAuthorizedDashboardResult(
+                dashboard: result.dashboard,
+                context: context,
+                routingTargetEmail: result.routingTargetEmail)
+        }
+    }
+
+    nonisolated static func shouldRetryWithFreshBrowserImport(after error: Error) -> Bool {
+        if error is OpenAIWebCodexError {
+            return error as? OpenAIWebCodexError == .missingUsage
+        }
+        if case OpenAIDashboardFetcher.FetchError.noDashboardData = error {
+            return true
+        }
+        return false
     }
 
     @MainActor
@@ -222,6 +250,7 @@ extension CodexWebDashboardStrategy {
         context: ProviderFetchContext,
         options: OpenAIWebOptions,
         browserDetection: BrowserDetection,
+        preferCachedCookieHeader: Bool,
         logger: @MainActor @escaping (String) -> Void) async throws -> OpenAIWebDashboardFetchResult
     {
         let auth = context.fetcher.loadAuthBackedCodexAccount()
@@ -232,6 +261,7 @@ extension CodexWebDashboardStrategy {
             .importBestCookies(
                 intoAccountEmail: routingTargetEmail,
                 allowAnyAccount: allowAnyAccount,
+                preferCachedCookieHeader: preferCachedCookieHeader,
                 logger: logger)
         let effectiveEmail = routingTargetEmail ?? importResult.signedInEmail?
             .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Tests/CodexBarTests/CLIWebFallbackTests.swift
+++ b/Tests/CodexBarTests/CLIWebFallbackTests.swift
@@ -63,6 +63,16 @@ struct CLIWebFallbackTests {
     }
 
     @Test
+    func `codex retries fresh browser import for missing usage and no data`() {
+        #expect(CodexWebDashboardStrategy.shouldRetryWithFreshBrowserImport(
+            after: OpenAIWebCodexError.missingUsage))
+        #expect(CodexWebDashboardStrategy.shouldRetryWithFreshBrowserImport(
+            after: OpenAIDashboardFetcher.FetchError.noDashboardData(body: "missing")))
+        #expect(!CodexWebDashboardStrategy.shouldRetryWithFreshBrowserImport(
+            after: OpenAIDashboardFetcher.FetchError.loginRequired))
+    }
+
+    @Test
     func `codex display only falls back in auto`() {
         let strategy = CodexWebDashboardStrategy()
         let decision = self.makeCodexDisplayOnlyDecision()

--- a/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
@@ -109,6 +109,32 @@ struct OpenAIDashboardFetcherCreditsWaitTests {
     }
 
     @Test
+    func `probe handoff preserves page only after confirmed signed in email`() {
+        let result = OpenAIDashboardFetcher.ProbeResult(
+            href: "https://chatgpt.com/codex/cloud/settings/analytics#usage",
+            loginRequired: false,
+            workspacePicker: false,
+            cloudflareInterstitial: false,
+            signedInEmail: "user@example.com",
+            bodyText: "Credits remaining 42")
+
+        #expect(OpenAIDashboardFetcher.shouldPreserveLoadedPageAfterProbe(result))
+    }
+
+    @Test
+    func `probe handoff does not preserve timed out usage page without email`() {
+        let result = OpenAIDashboardFetcher.ProbeResult(
+            href: "https://chatgpt.com/codex/cloud/settings/analytics#usage",
+            loginRequired: false,
+            workspacePicker: false,
+            cloudflareInterstitial: false,
+            signedInEmail: nil,
+            bodyText: "Codex Analytics")
+
+        #expect(!OpenAIDashboardFetcher.shouldPreserveLoadedPageAfterProbe(result))
+    }
+
+    @Test
     func `probe grace restarts after route reload resets readiness timestamps`() {
         let now = Date()
         let shouldWait = OpenAIDashboardFetcher.shouldWaitForProbeReadiness(.init(
@@ -168,9 +194,20 @@ struct OpenAIDashboardFetcherCreditsWaitTests {
     }
 
     @Test
+    func `usage route matcher accepts analytics route`() {
+        #expect(OpenAIDashboardFetcher.isUsageRoute("https://chatgpt.com/codex/cloud/settings/analytics"))
+    }
+
+    @Test
+    func `usage route matcher accepts analytics usage hash route`() {
+        #expect(OpenAIDashboardFetcher.isUsageRoute("https://chatgpt.com/codex/cloud/settings/analytics#usage"))
+    }
+
+    @Test
     func `usage route matcher accepts trailing slash variants`() {
         #expect(OpenAIDashboardFetcher.isUsageRoute("https://chatgpt.com/codex/settings/usage/"))
         #expect(OpenAIDashboardFetcher.isUsageRoute("https://chatgpt.com/codex/cloud/settings/usage/"))
+        #expect(OpenAIDashboardFetcher.isUsageRoute("https://chatgpt.com/codex/cloud/settings/analytics/"))
     }
 
     @Test

--- a/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
@@ -138,6 +138,106 @@ struct OpenAIDashboardWebViewCacheTests {
         cache.clearAllForTesting()
     }
 
+    @Test
+    func `Preserved page handoff is consumed only once`() {
+        if self.shouldSkipOnCI() { return }
+        let cache = OpenAIDashboardWebViewCache()
+        let store = WKWebsiteDataStore.nonPersistent()
+        cache.cacheEntryForTesting(websiteDataStore: store)
+        cache.markPreservedPageForTesting(
+            websiteDataStore: store,
+            expiresAt: Date().addingTimeInterval(cache.preservedPageHandoffTimeoutForTesting))
+
+        #expect(cache.hasPreservedPageForTesting(for: store), "Expected preserved page handoff to be armed")
+        #expect(cache.consumePreservedPageForTesting(websiteDataStore: store), "First acquire should reuse handoff")
+        #expect(
+            !cache.consumePreservedPageForTesting(websiteDataStore: store),
+            "Second acquire should not keep reusing preserved page")
+
+        cache.clearAllForTesting()
+    }
+
+    @Test
+    func `Expired preserved page is cleared before idle eviction`() {
+        if self.shouldSkipOnCI() { return }
+        let cache = OpenAIDashboardWebViewCache()
+        let store = WKWebsiteDataStore.nonPersistent()
+        cache.cacheEntryForTesting(websiteDataStore: store)
+        cache.markPreservedPageForTesting(
+            websiteDataStore: store,
+            expiresAt: Date().addingTimeInterval(1))
+
+        let afterExpiry = Date().addingTimeInterval(cache.preservedPageHandoffTimeoutForTesting + 1)
+        cache.pruneForTesting(now: afterExpiry)
+
+        #expect(!cache.hasPreservedPageForTesting(for: store), "Expired preserved page should be cleared")
+        #expect(cache.hasCachedEntry(for: store), "Entry should remain cached after page handoff expires")
+
+        cache.clearAllForTesting()
+    }
+
+    @Test
+    func `Preserved page expiry is scheduled without future cache activity`() async throws {
+        if self.shouldSkipOnCI() { return }
+        let cache = OpenAIDashboardWebViewCache()
+        let store = WKWebsiteDataStore.nonPersistent()
+        let webView = cache.cacheEntryForTesting(websiteDataStore: store)
+
+        _ = webView.loadHTMLString("<html><body>alive</body></html>", baseURL: nil)
+        try? await Task.sleep(for: .milliseconds(150))
+
+        cache.markPreservedPageForTesting(
+            websiteDataStore: store,
+            expiresAt: Date().addingTimeInterval(0.2))
+
+        #expect(cache.hasPreservedPageForTesting(for: store), "Expected preserved page handoff to be armed")
+
+        try? await Task.sleep(for: .milliseconds(450))
+
+        let bodyText = try await webView.evaluateJavaScript(
+            "document.body ? String(document.body.innerText || '') : ''") as? String
+
+        #expect(!cache.hasPreservedPageForTesting(for: store), "Expected scheduled expiry to clear preserved page")
+        #expect(bodyText?.isEmpty == true, "Expected scheduled expiry to detach the preserved page to about:blank")
+
+        cache.clearAllForTesting()
+    }
+
+    @Test
+    func `Reused page reset clears one shot scraper globals`() async throws {
+        if self.shouldSkipOnCI() { return }
+        let cache = OpenAIDashboardWebViewCache()
+        let store = WKWebsiteDataStore.nonPersistent()
+        let url = try #require(URL(string: "about:blank"))
+
+        let lease = try await cache.acquire(
+            websiteDataStore: store,
+            usageURL: url,
+            logger: nil)
+
+        _ = try await lease.webView.evaluateJavaScript(
+            """
+            window.__codexbarDidScrollToCredits = true;
+            window.__codexbarUsageBreakdownJSON = '[{"day":"2026-04-19"}]';
+            window.__codexbarUsageBreakdownDebug = 'debug';
+            true;
+            """)
+
+        #expect(await cache.resetReusablePageStateForTesting(lease.webView))
+
+        let reset = try await lease.webView.evaluateJavaScript(
+            """
+            typeof window.__codexbarDidScrollToCredits === 'undefined' &&
+            typeof window.__codexbarUsageBreakdownJSON === 'undefined' &&
+            typeof window.__codexbarUsageBreakdownDebug === 'undefined'
+            """) as? Bool
+
+        #expect(reset == true, "Expected one-shot scraper globals to be cleared before reuse")
+
+        lease.release()
+        cache.clearAllForTesting()
+    }
+
     // MARK: - Eviction Tests
 
     @Test


### PR DESCRIPTION
## Summary

- accept the new OpenAI Codex analytics route
- retry with a fresh browser-cookie import when the first load lands in a partial analytics shell
- make preserved-page reuse one-shot, reset scraper globals before reuse, and expire preserved pages on a timer

## Root cause

OpenAI moved the Codex dashboard from the old usage route to the analytics route, which broke our route validation and made the hidden WebView more likely to get stuck on a partial analytics shell.

## Validation

- `pnpm check`
- `swift test --filter OpenAIDashboard`
- `swift test --filter OpenAIDashboardWebViewCacheTests`
- `./Scripts/compile_and_run.sh`
- `./CodexBar.app/Contents/Helpers/CodexBarCLI usage --provider codex --source web --json --verbose --web-timeout 45`
