### PR TITLE
Fix OpenAI analytics dashboard scraping

### DIFF
--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardCapturedDataParser.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardCapturedDataParser.swift
@@ -1,0 +1,446 @@
+import Foundation
+
+extension OpenAIDashboardParser {
+    public struct CapturedDashboardData: Equatable, Sendable {
+        public let primaryLimit: RateWindow?
+        public let secondaryLimit: RateWindow?
+        public let codeReviewLimit: RateWindow?
+        public let creditsRemaining: Double?
+        public let creditEvents: [CreditEvent]
+        public let usageBreakdown: [OpenAIDashboardDailyBreakdown]
+        public let debugSummary: String?
+
+        public init(
+            primaryLimit: RateWindow?,
+            secondaryLimit: RateWindow?,
+            codeReviewLimit: RateWindow?,
+            creditsRemaining: Double?,
+            creditEvents: [CreditEvent],
+            usageBreakdown: [OpenAIDashboardDailyBreakdown],
+            debugSummary: String?)
+        {
+            self.primaryLimit = primaryLimit
+            self.secondaryLimit = secondaryLimit
+            self.codeReviewLimit = codeReviewLimit
+            self.creditsRemaining = creditsRemaining
+            self.creditEvents = creditEvents
+            self.usageBreakdown = usageBreakdown
+            self.debugSummary = debugSummary
+        }
+
+        public var hasDashboardSignal: Bool {
+            self.primaryLimit != nil ||
+                self.secondaryLimit != nil ||
+                self.codeReviewLimit != nil ||
+                self.creditsRemaining != nil ||
+                !self.creditEvents.isEmpty ||
+                !self.usageBreakdown.isEmpty
+        }
+    }
+
+    public static func parseCapturedDashboardData(
+        responsesJSON: String,
+        now: Date = .init()) -> CapturedDashboardData?
+    {
+        guard let data = responsesJSON.data(using: .utf8), !data.isEmpty else { return nil }
+        guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else { return nil }
+        guard let responses = json as? [[String: Any]], !responses.isEmpty else { return nil }
+
+        let roots = responses.compactMap { response -> CapturedResponseRoot? in
+            guard let payload = response["json"] else { return nil }
+            return CapturedResponseRoot(url: response["url"] as? String, payload: payload)
+        }
+        guard !roots.isEmpty else { return nil }
+
+        let creditDetails = self.bestCapturedCreditDetails(in: roots)
+        let genericRateLimit = self.bestCapturedRateLimit(in: roots, preferCodeReview: false)
+        let codeReviewRateLimit = self.bestCapturedRateLimit(in: roots, preferCodeReview: true)
+        let creditHistory = self.bestCapturedCreditHistory(in: roots)
+        let usageSeries = self.bestCapturedUsageSeries(in: roots)
+
+        let creditsRemaining = creditDetails.flatMap(self.capturedCreditsRemaining(from:))
+        let creditEvents = self.parseCapturedCreditEvents(creditHistory)
+        let usageBreakdown = self.parseCapturedUsageBreakdown(usageSeries)
+        let primaryLimit = genericRateLimit.flatMap { self.capturedRateWindow(from: $0.primaryWindow, now: now) }
+        let secondaryLimit = genericRateLimit.flatMap { self.capturedRateWindow(from: $0.secondaryWindow, now: now) }
+        let codeReviewLimit = codeReviewRateLimit.flatMap { self.capturedRateWindow(from: $0.primaryWindow, now: now) }
+
+        let debugSummary = [
+            "capturedResponses=\(roots.count)",
+            "creditDetails=\(creditDetails == nil ? 0 : 1)",
+            "rateLimit=\(genericRateLimit == nil ? 0 : 1)",
+            "codeReviewRateLimit=\(codeReviewRateLimit == nil ? 0 : 1)",
+            "creditHistory=\(creditHistory?.count ?? 0)",
+            "usageSeriesDays=\(usageSeries?.count ?? 0)",
+        ].joined(separator: " ")
+
+        let result = CapturedDashboardData(
+            primaryLimit: primaryLimit,
+            secondaryLimit: secondaryLimit,
+            codeReviewLimit: codeReviewLimit,
+            creditsRemaining: creditsRemaining,
+            creditEvents: creditEvents,
+            usageBreakdown: usageBreakdown,
+            debugSummary: debugSummary)
+        return result.hasDashboardSignal ? result : nil
+    }
+
+    static func parseCreditsUsed(_ text: String) -> Double {
+        let cleaned = text
+            .replacingOccurrences(of: ",", with: "")
+            .replacingOccurrences(of: "credits", with: "", options: .caseInsensitive)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return Double(cleaned) ?? 0
+    }
+
+    // MARK: - Private
+
+    private struct CapturedResponseRoot {
+        let url: String?
+        let payload: Any
+    }
+
+    private struct CapturedSearchMatch<T> {
+        let value: T
+        let path: [String]
+        let url: String?
+        let score: Int
+    }
+
+    private struct CapturedRateLimitContainer {
+        let primaryWindow: [String: Any]?
+        let secondaryWindow: [String: Any]?
+    }
+
+    private static func bestCapturedCreditDetails(in roots: [CapturedResponseRoot]) -> [String: Any]? {
+        self.bestCapturedDictionary(in: roots) { dict, path, _ in
+            guard self.isCapturedCreditDetails(dict) else { return nil }
+            let pathText = self.capturedPathText(path)
+            var score = 10
+            if pathText.contains("creditdetails") { score += 30 }
+            if pathText.contains("credit") { score += 15 }
+            if pathText.contains("balance") { score += 10 }
+            return score
+        }?.value
+    }
+
+    private static func bestCapturedRateLimit(
+        in roots: [CapturedResponseRoot],
+        preferCodeReview: Bool)
+        -> CapturedRateLimitContainer?
+    {
+        self.bestCapturedDictionary(in: roots) { dict, path, _ in
+            guard self.isCapturedRateLimitContainer(dict) else { return nil }
+            let pathText = self.capturedPathText(path)
+            let isCodeReview = pathText.contains("review")
+            if preferCodeReview != isCodeReview { return nil }
+            var score = 10
+            if pathText.contains("coderreviewratelimit") || pathText.contains("codereviewratelimit") {
+                score += 40
+            }
+            if pathText.contains("ratelimit") { score += 25 }
+            if pathText.contains("primary_window") || pathText.contains("secondary_window") {
+                score += 5
+            }
+            return score
+        }.map { match in
+            CapturedRateLimitContainer(
+                primaryWindow: match.value["primary_window"] as? [String: Any],
+                secondaryWindow: match.value["secondary_window"] as? [String: Any])
+        }
+    }
+
+    private static func bestCapturedCreditHistory(in roots: [CapturedResponseRoot]) -> [[String: Any]]? {
+        self.bestCapturedArray(in: roots) { array, path, _ in
+            let items = array.compactMap { $0 as? [String: Any] }
+            guard items.count == array.count, self.isCapturedCreditHistory(items) else { return nil }
+            let pathText = self.capturedPathText(path)
+            var score = items.count
+            if pathText.contains("credit") { score += 20 }
+            if pathText.contains("history") { score += 15 }
+            if pathText.contains("usage") { score += 10 }
+            return score
+        }?.value.compactMap { $0 as? [String: Any] }
+    }
+
+    private static func bestCapturedUsageSeries(in roots: [CapturedResponseRoot]) -> [[String: Any]]? {
+        self.bestCapturedDictionary(in: roots) { dict, path, _ in
+            guard let items = dict["data"] as? [[String: Any]], self.isCapturedUsageSeries(items) else { return nil }
+            let pathText = self.capturedPathText(path)
+            var score = items.count
+            if pathText.contains("usage") { score += 20 }
+            if pathText.contains("breakdown") { score += 10 }
+            if pathText.contains("analytics") { score += 5 }
+            return score
+        }?.value["data"] as? [[String: Any]]
+    }
+
+    private static func bestCapturedDictionary(
+        in roots: [CapturedResponseRoot],
+        score: ([String: Any], [String], String?) -> Int?) -> CapturedSearchMatch<[String: Any]>?
+    {
+        var best: CapturedSearchMatch<[String: Any]>?
+        for root in roots {
+            var queue: [(value: Any, path: [String])] = [(root.payload, [])]
+            var index = 0
+            while index < queue.count {
+                let next = queue[index]
+                index += 1
+                if let dict = next.value as? [String: Any] {
+                    if let candidateScore = score(dict, next.path, root.url),
+                       best == nil || candidateScore > best?.score ?? .min
+                    {
+                        best = CapturedSearchMatch(
+                            value: dict,
+                            path: next.path,
+                            url: root.url,
+                            score: candidateScore)
+                    }
+                    for (key, value) in dict {
+                        queue.append((value, next.path + [key]))
+                    }
+                } else if let array = next.value as? [Any] {
+                    for (arrayIndex, value) in array.enumerated() {
+                        queue.append((value, next.path + ["[\(arrayIndex)]"]))
+                    }
+                }
+            }
+        }
+        return best
+    }
+
+    private static func bestCapturedArray(
+        in roots: [CapturedResponseRoot],
+        score: ([Any], [String], String?) -> Int?) -> CapturedSearchMatch<[Any]>?
+    {
+        var best: CapturedSearchMatch<[Any]>?
+        for root in roots {
+            var queue: [(value: Any, path: [String])] = [(root.payload, [])]
+            var index = 0
+            while index < queue.count {
+                let next = queue[index]
+                index += 1
+                if let dict = next.value as? [String: Any] {
+                    for (key, value) in dict {
+                        queue.append((value, next.path + [key]))
+                    }
+                } else if let array = next.value as? [Any] {
+                    if let candidateScore = score(array, next.path, root.url),
+                       best == nil || candidateScore > best?.score ?? .min
+                    {
+                        best = CapturedSearchMatch(
+                            value: array,
+                            path: next.path,
+                            url: root.url,
+                            score: candidateScore)
+                    }
+                    for (arrayIndex, value) in array.enumerated() {
+                        queue.append((value, next.path + ["[\(arrayIndex)]"]))
+                    }
+                }
+            }
+        }
+        return best
+    }
+
+    private static func isCapturedCreditDetails(_ dict: [String: Any]) -> Bool {
+        guard dict["balance"] != nil else { return false }
+        return dict["unlimited"] != nil || dict["approx_local_messages"] != nil || dict["approx_cloud_messages"] != nil
+    }
+
+    private static func isCapturedRateLimitContainer(_ dict: [String: Any]) -> Bool {
+        dict["primary_window"] is [String: Any] || dict["secondary_window"] is [String: Any]
+    }
+
+    private static func isCapturedCreditHistory(_ items: [[String: Any]]) -> Bool {
+        guard !items.isEmpty else { return false }
+        let matching = items.reduce(into: 0) { partial, item in
+            if item["date"] != nil,
+               item["credit_amount"] != nil,
+               item["product_surface"] != nil
+            {
+                partial += 1
+            }
+        }
+        return matching == items.count
+    }
+
+    private static func isCapturedUsageSeries(_ items: [[String: Any]]) -> Bool {
+        guard !items.isEmpty else { return false }
+        return items.contains { item in
+            item["date"] != nil && item["product_surface_usage_values"] is [String: Any]
+        }
+    }
+
+    private static func capturedCreditsRemaining(from dict: [String: Any]) -> Double? {
+        if let number = dict["balance"] as? NSNumber {
+            return number.doubleValue
+        }
+        if let string = dict["balance"] as? String {
+            return TextParsing.firstNumber(pattern: #"([0-9][0-9.,]*)"#, text: string)
+        }
+        return nil
+    }
+
+    private static func capturedRateWindow(from dict: [String: Any]?, now: Date) -> RateWindow? {
+        guard let dict else { return nil }
+        guard let remainingPercent = self.capturedDouble(dict["remaining_percent"]) else { return nil }
+        let usedPercent = max(0, min(100, 100 - remainingPercent))
+        let windowMinutes = self.capturedDouble(dict["limit_window_seconds"]).map { max(1, Int(round($0 / 60))) }
+        let resetAfterSeconds =
+            self.capturedDouble(dict["reset_after_seconds"]) ??
+            self.capturedDouble(dict["reset_after_seconds_remaining"])
+        let resetsAt = resetAfterSeconds.map { now.addingTimeInterval($0) }
+        return RateWindow(
+            usedPercent: usedPercent,
+            windowMinutes: windowMinutes,
+            resetsAt: resetsAt,
+            resetDescription: resetsAt.map { UsageFormatter.resetDescription(from: $0) })
+    }
+
+    private static func parseCapturedCreditEvents(_ items: [[String: Any]]?) -> [CreditEvent] {
+        guard let items else { return [] }
+        return items.compactMap { item in
+            guard let date = self.capturedDate(item["date"]) else { return nil }
+            guard let creditsUsed = self.capturedDouble(item["credit_amount"]) else { return nil }
+            let service = self.capturedProductSurfaceDisplayName(item["product_surface"] as? String)
+            return CreditEvent(date: date, service: service, creditsUsed: creditsUsed)
+        }
+        .sorted { $0.date > $1.date }
+    }
+
+    private static func parseCapturedUsageBreakdown(_ items: [[String: Any]]?) -> [OpenAIDashboardDailyBreakdown] {
+        guard let items else { return [] }
+        let dayEntries = items.compactMap { item -> (String, [String: Any])? in
+            guard let day = self.capturedDayKey(item["date"]) else { return nil }
+            guard let values = item["product_surface_usage_values"] as? [String: Any] else { return nil }
+            return (day, values)
+        }
+
+        guard !dayEntries.isEmpty else { return [] }
+
+        return dayEntries
+            .sorted { $0.0 > $1.0 }
+            .prefix(30)
+            .map { day, values in
+                let services = values.compactMap { key, rawValue -> OpenAIDashboardServiceUsage? in
+                    guard let credits = self.capturedDouble(rawValue), credits > 0 else { return nil }
+                    return OpenAIDashboardServiceUsage(
+                        service: self.capturedProductSurfaceDisplayName(key),
+                        creditsUsed: credits)
+                }
+                .sorted { lhs, rhs in
+                    if lhs.creditsUsed == rhs.creditsUsed { return lhs.service < rhs.service }
+                    return lhs.creditsUsed > rhs.creditsUsed
+                }
+                let total = services.reduce(0) { $0 + $1.creditsUsed }
+                return OpenAIDashboardDailyBreakdown(day: day, services: services, totalCreditsUsed: total)
+            }
+    }
+
+    private static func capturedProductSurfaceDisplayName(_ raw: String?) -> String {
+        switch raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "desktop_app":
+            "Desktop App"
+        case "cli":
+            "CLI"
+        case "vscode":
+            "Extension"
+        case "web":
+            "Cloud"
+        case "github":
+            "GitHub Turn"
+        case "github_code_review":
+            "GitHub Code Review"
+        case "jetbrains":
+            "JetBrains"
+        case "slack":
+            "Slack"
+        case "linear":
+            "Linear"
+        case "sdk":
+            "SDK"
+        case "exec":
+            "Exec"
+        case "unknown", nil, "":
+            "Other"
+        default:
+            self.normalizeCapturedIdentifier(raw ?? "")
+        }
+    }
+
+    private static func capturedDate(_ raw: Any?) -> Date? {
+        if let number = self.capturedDouble(raw) {
+            return Date(timeIntervalSince1970: number > 4_000_000_000 ? number / 1000 : number)
+        }
+        guard let string = raw as? String else { return nil }
+        if let date = ISO8601DateFormatter().date(from: string) { return date }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: string) { return date }
+
+        let formats = [
+            "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX",
+            "yyyy-MM-dd'T'HH:mm:ssXXXXX",
+            "yyyy-MM-dd",
+        ]
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        for format in formats {
+            dateFormatter.dateFormat = format
+            if let date = dateFormatter.date(from: string) {
+                return date
+            }
+        }
+        return nil
+    }
+
+    static func capturedDayKey(_ raw: Any?, timeZone: TimeZone = .current) -> String? {
+        if let string = raw as? String {
+            let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.count == 10, !trimmed.localizedCaseInsensitiveContains("t") {
+                return trimmed
+            }
+        }
+        guard let date = self.capturedDate(raw) else { return nil }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timeZone
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+
+    private static func capturedDouble(_ raw: Any?) -> Double? {
+        if let number = raw as? NSNumber { return number.doubleValue }
+        guard let string = raw as? String else { return nil }
+
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let normalized = trimmed.replacingOccurrences(of: ",", with: "")
+        if let value = Double(normalized) {
+            return value
+        }
+
+        let numericPattern = #"^-?[0-9]+(?:\.[0-9]+)?$"#
+        if normalized.range(of: numericPattern, options: .regularExpression) != nil {
+            return Double(normalized)
+        }
+        return nil
+    }
+
+    private static func capturedPathText(_ path: [String]) -> String {
+        path.joined(separator: ".").lowercased()
+    }
+
+    private static func normalizeCapturedIdentifier(_ raw: String) -> String {
+        let words = raw
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .split(whereSeparator: { $0 == "_" || $0 == "-" || $0 == " " })
+        return words.map { word in
+            let value = String(word)
+            return value.count <= 2 ? value.uppercased() : value.prefix(1).uppercased() + value.dropFirst()
+        }.joined(separator: " ")
+    }
+}

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -14,7 +14,7 @@ public struct OpenAIDashboardFetcher {
             case .loginRequired:
                 "OpenAI web access requires login."
             case let .noDashboardData(body):
-                "OpenAI dashboard data not found. Body sample: \(body.prefix(200))"
+                OpenAIDashboardFetcher.friendlyNoDashboardDataDescription(body)
             }
         }
     }
@@ -22,6 +22,23 @@ public struct OpenAIDashboardFetcher {
     private let usageURL = URL(string: "https://chatgpt.com/codex/settings/usage")!
 
     public init() {}
+
+    nonisolated static func friendlyNoDashboardDataDescription(_ body: String) -> String {
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lower = trimmed.lowercased()
+        if lower.contains("loading usage data") ||
+            lower.contains("codex analytics") ||
+            lower.contains("track threads and turns by client") ||
+            lower.contains("daily skill invocations")
+        {
+            return "OpenAI dashboard is still loading in ChatGPT. " +
+                "CodexBar will retry and keep cached values when available."
+        }
+        if trimmed.isEmpty {
+            return "OpenAI dashboard data not found."
+        }
+        return "OpenAI dashboard data not found. Body sample: \(trimmed.prefix(200))"
+    }
 
     public nonisolated static func offscreenHostWindowFrame(for visibleFrame: CGRect) -> CGRect {
         let width: CGFloat = min(1200, visibleFrame.width)
@@ -179,38 +196,39 @@ public struct OpenAIDashboardFetcher {
                 throw FetchError.noDashboardData(body: "Cloudflare challenge detected in WebView.")
             }
 
-            let bodyText = scrape.bodyText ?? ""
-            let codeReview = OpenAIDashboardParser.parseCodeReviewRemainingPercent(bodyText: bodyText)
-            let events = OpenAIDashboardParser.parseCreditEvents(rows: scrape.rows)
-            let breakdown = OpenAIDashboardSnapshot.makeDailyBreakdown(from: events, maxDays: 30)
-            let usageBreakdown = scrape.usageBreakdown
-            let rateLimits = OpenAIDashboardParser.parseRateLimits(bodyText: bodyText)
-            let codeReviewLimit = OpenAIDashboardParser.parseCodeReviewLimit(bodyText: bodyText)
-            let creditsRemaining = OpenAIDashboardParser.parseCreditsRemaining(bodyText: bodyText)
-            let accountPlan = scrape.bodyHTML.flatMap(OpenAIDashboardParser.parsePlanFromHTML)
-            let hasUsageLimits = rateLimits.primary != nil || rateLimits.secondary != nil
+            let signals = Self.parsedDashboardSignals(from: scrape)
+            let codeReview = signals.codeReview
+            let events = signals.events
+            let breakdown = signals.breakdown
+            let usageBreakdown = signals.usageBreakdown
+            let rateLimits = signals.rateLimits
+            let codeReviewLimit = signals.codeReviewLimit
+            let creditsRemaining = signals.creditsRemaining
+            let accountPlan = signals.accountPlan
+            let hasDashboardPayload = signals.hasDashboardPayload
 
-            if codeReview != nil, codeReviewFirstSeenAt == nil { codeReviewFirstSeenAt = Date() }
+            codeReviewFirstSeenAt = codeReviewFirstSeenAt ?? (codeReview == nil ? nil : Date())
             if anyDashboardSignalAt == nil,
-               codeReview != nil || !usageBreakdown.isEmpty || scrape.creditsHeaderPresent ||
-               hasUsageLimits || creditsRemaining != nil
+               hasDashboardPayload || scrape.creditsHeaderPresent
             {
                 anyDashboardSignalAt = Date()
             }
             if codeReview != nil, usageBreakdown.isEmpty,
-               let debug = scrape.usageBreakdownDebug, !debug.isEmpty,
+               let debug = signals.usageBreakdownDebug, !debug.isEmpty,
                debug != lastUsageBreakdownDebug
             {
                 lastUsageBreakdownDebug = debug
                 log("usage breakdown debug: \(debug)")
             }
+            if let debug = signals.capturedDebugSummary, !debug.isEmpty, debug != lastUsageBreakdownDebug {
+                lastUsageBreakdownDebug = debug
+                log("captured dashboard debug: \(debug)")
+            }
             if let purchaseURL = scrape.creditsPurchaseURL, purchaseURL != lastCreditsPurchaseURL {
                 lastCreditsPurchaseURL = purchaseURL
                 log("credits purchase url: \(purchaseURL)")
             }
-            if events.isEmpty,
-               codeReview != nil || !usageBreakdown.isEmpty || hasUsageLimits || creditsRemaining != nil
-            {
+            if events.isEmpty, hasDashboardPayload {
                 log(
                     "credits header present=\(scrape.creditsHeaderPresent) " +
                         "inViewport=\(scrape.creditsHeaderInViewport) didScroll=\(scrape.didScrollToCredits) " +
@@ -239,9 +257,7 @@ public struct OpenAIDashboardFetcher {
                 }
             }
 
-            if codeReview != nil || !events.isEmpty || !usageBreakdown
-                .isEmpty || hasUsageLimits || creditsRemaining != nil
-            {
+            if hasDashboardPayload {
                 // The usage breakdown chart is hydrated asynchronously. When code review is already present,
                 // give it a moment to populate so the menu can show it.
                 if codeReview != nil, usageBreakdown.isEmpty {
@@ -298,6 +314,24 @@ public struct OpenAIDashboardFetcher {
             return context.now.timeIntervalSince(anyDashboardSignalAt) < 6.5
         }
         return false
+    }
+
+    struct DashboardPayloadContext {
+        let codeReview: Double?
+        let events: [CreditEvent]
+        let usageBreakdown: [OpenAIDashboardDailyBreakdown]
+        let hasUsageLimits: Bool
+        let creditsRemaining: Double?
+        let captured: OpenAIDashboardParser.CapturedDashboardData?
+    }
+
+    nonisolated static func hasDashboardPayload(_ context: DashboardPayloadContext) -> Bool {
+        context.codeReview != nil ||
+            !context.events.isEmpty ||
+            !context.usageBreakdown.isEmpty ||
+            context.hasUsageLimits ||
+            context.creditsRemaining != nil ||
+            context.captured?.hasDashboardSignal == true
     }
 
     struct ProbeReadinessContext {
@@ -443,6 +477,7 @@ public struct OpenAIDashboardFetcher {
         let rows: [[String]]
         let usageBreakdown: [OpenAIDashboardDailyBreakdown]
         let usageBreakdownDebug: String?
+        let capturedDashboardData: OpenAIDashboardParser.CapturedDashboardData?
         let scrollY: Double
         let scrollHeight: Double
         let viewportHeight: Double
@@ -466,6 +501,7 @@ public struct OpenAIDashboardFetcher {
                 rows: [],
                 usageBreakdown: [],
                 usageBreakdownDebug: nil,
+                capturedDashboardData: nil,
                 scrollY: 0,
                 scrollHeight: 0,
                 viewportHeight: 0,
@@ -491,6 +527,10 @@ public struct OpenAIDashboardFetcher {
                 usageBreakdown = []
             }
         }
+        let capturedDashboardData: OpenAIDashboardParser.CapturedDashboardData? = {
+            guard let raw = dict["capturedResponsesJSON"] as? String, !raw.isEmpty else { return nil }
+            return OpenAIDashboardParser.parseCapturedDashboardData(responsesJSON: raw)
+        }()
 
         var signedInEmail = dict["signedInEmail"] as? String
         if let bodyHTML,
@@ -519,12 +559,72 @@ public struct OpenAIDashboardFetcher {
             rows: rows,
             usageBreakdown: usageBreakdown,
             usageBreakdownDebug: usageBreakdownDebug,
+            capturedDashboardData: capturedDashboardData,
             scrollY: (dict["scrollY"] as? NSNumber)?.doubleValue ?? 0,
             scrollHeight: (dict["scrollHeight"] as? NSNumber)?.doubleValue ?? 0,
             viewportHeight: (dict["viewportHeight"] as? NSNumber)?.doubleValue ?? 0,
             creditsHeaderPresent: (dict["creditsHeaderPresent"] as? Bool) ?? false,
             creditsHeaderInViewport: (dict["creditsHeaderInViewport"] as? Bool) ?? false,
             didScrollToCredits: (dict["didScrollToCredits"] as? Bool) ?? false)
+    }
+
+    private struct ParsedDashboardSignals {
+        let codeReview: Double?
+        let codeReviewLimit: RateWindow?
+        let events: [CreditEvent]
+        let breakdown: [OpenAIDashboardDailyBreakdown]
+        let usageBreakdown: [OpenAIDashboardDailyBreakdown]
+        let usageBreakdownDebug: String?
+        let capturedDebugSummary: String?
+        let rateLimits: (primary: RateWindow?, secondary: RateWindow?)
+        let creditsRemaining: Double?
+        let accountPlan: String?
+        let hasUsageLimits: Bool
+        let hasDashboardPayload: Bool
+    }
+
+    private nonisolated static func parsedDashboardSignals(from scrape: ScrapeResult) -> ParsedDashboardSignals {
+        let bodyText = scrape.bodyText ?? ""
+        let captured = scrape.capturedDashboardData
+        let parsedCodeReview = OpenAIDashboardParser.parseCodeReviewRemainingPercent(bodyText: bodyText)
+        let parsedEvents = OpenAIDashboardParser.parseCreditEvents(rows: scrape.rows)
+        let parsedUsageBreakdown = scrape.usageBreakdown
+        let parsedRateLimits = OpenAIDashboardParser.parseRateLimits(bodyText: bodyText)
+        let parsedCodeReviewLimit = OpenAIDashboardParser.parseCodeReviewLimit(bodyText: bodyText)
+        let parsedCreditsRemaining = OpenAIDashboardParser.parseCreditsRemaining(bodyText: bodyText)
+
+        let codeReviewLimit = parsedCodeReviewLimit ?? captured?.codeReviewLimit
+        let codeReview = parsedCodeReview ?? codeReviewLimit?.remainingPercent
+        let events = parsedEvents.isEmpty ? (captured?.creditEvents ?? []) : parsedEvents
+        let breakdown = OpenAIDashboardSnapshot.makeDailyBreakdown(from: events, maxDays: 30)
+        let usageBreakdown = parsedUsageBreakdown.isEmpty ? (captured?.usageBreakdown ?? []) : parsedUsageBreakdown
+        let rateLimits = (
+            primary: parsedRateLimits.primary ?? captured?.primaryLimit,
+            secondary: parsedRateLimits.secondary ?? captured?.secondaryLimit)
+        let creditsRemaining = parsedCreditsRemaining ?? captured?.creditsRemaining
+        let accountPlan = scrape.bodyHTML.flatMap(OpenAIDashboardParser.parsePlanFromHTML)
+        let hasUsageLimits = rateLimits.primary != nil || rateLimits.secondary != nil
+        let hasDashboardPayload = Self.hasDashboardPayload(.init(
+            codeReview: codeReview,
+            events: events,
+            usageBreakdown: usageBreakdown,
+            hasUsageLimits: hasUsageLimits,
+            creditsRemaining: creditsRemaining,
+            captured: captured))
+
+        return ParsedDashboardSignals(
+            codeReview: codeReview,
+            codeReviewLimit: codeReviewLimit,
+            events: events,
+            breakdown: breakdown,
+            usageBreakdown: usageBreakdown,
+            usageBreakdownDebug: scrape.usageBreakdownDebug,
+            capturedDebugSummary: captured?.debugSummary,
+            rateLimits: rateLimits,
+            creditsRemaining: creditsRemaining,
+            accountPlan: accountPlan,
+            hasUsageLimits: hasUsageLimits,
+            hasDashboardPayload: hasDashboardPayload)
     }
 
     private func makeWebView(
@@ -556,7 +656,10 @@ public struct OpenAIDashboardFetcher {
         guard let href, !href.isEmpty else { return false }
         let path = (URL(string: href)?.path ?? href)
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        return path.hasSuffix("codex/settings/usage") || path.hasSuffix("codex/cloud/settings/usage")
+        return path.hasSuffix("codex/settings/usage") ||
+            path.hasSuffix("codex/cloud/settings/usage") ||
+            path.hasSuffix("codex/settings/analytics") ||
+            path.hasSuffix("codex/cloud/settings/analytics")
     }
 
     private static func writeDebugArtifacts(html: String, bodyText: String?, logger: (String) -> Void) {
@@ -595,12 +698,19 @@ public struct OpenAIDashboardFetcher {
             case .loginRequired:
                 "OpenAI web access requires login."
             case let .noDashboardData(body):
-                "OpenAI dashboard data not found. Body sample: \(body.prefix(200))"
+                OpenAIDashboardFetcher.friendlyNoDashboardDataDescription(body)
             }
         }
     }
 
     public init() {}
+
+    nonisolated static func friendlyNoDashboardDataDescription(_ body: String) -> String {
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty
+            ? "OpenAI dashboard data not found."
+            : "OpenAI dashboard data not found. Body sample: \(trimmed.prefix(200))"
+    }
 
     public func loadLatestDashboard(
         accountEmail _: String?,

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardNetworkCaptureScript.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardNetworkCaptureScript.swift
@@ -1,0 +1,123 @@
+#if os(macOS)
+let openAIDashboardNetworkCaptureBootstrapScript = """
+(() => {
+  if (window.__codexbarDashboardNetworkCaptureInstalled) return;
+  window.__codexbarDashboardNetworkCaptureInstalled = true;
+
+  const storageKey = '__codexbarCapturedResponses';
+  const maxEntries = 40;
+  const maxTextLength = 200000;
+  const relevantNeedles = [
+    'creditdetails',
+    'credit_amount',
+    'creditsremaining',
+    'balance',
+    'product_surface_usage_values',
+    'premium_usage_values',
+    'primary_window',
+    'secondary_window',
+    'limit_window_seconds',
+    'reset_after_seconds',
+    'codereviewratelimit',
+    'ratelimit',
+    'additionalratelimits'
+  ];
+
+  const responseStore = () => {
+    if (!Array.isArray(window[storageKey])) {
+      window[storageKey] = [];
+    }
+    return window[storageKey];
+  };
+
+  const isRelevantJSONString = (text) => {
+    const lower = String(text || '').toLowerCase();
+    if (!lower) return false;
+    return relevantNeedles.some(needle => lower.includes(needle));
+  };
+
+  const pushJSONCapture = (url, status, json) => {
+    if (json === null || json === undefined) return;
+    let compact = '';
+    try {
+      compact = JSON.stringify(json);
+    } catch {
+      return;
+    }
+    if (!compact || !isRelevantJSONString(compact)) return;
+
+    const entries = responseStore();
+    entries.push({
+      url: String(url || ''),
+      status: Number(status) || 0,
+      json
+    });
+    if (entries.length > maxEntries) {
+      entries.splice(0, entries.length - maxEntries);
+    }
+  };
+
+  const maybeCaptureJSONText = (url, status, contentType, text) => {
+    if (typeof text !== 'string') return;
+    const clipped = text.length > maxTextLength ? text.slice(0, maxTextLength) : text;
+    const trimmed = clipped.trim();
+    const looksJSON = /json/i.test(String(contentType || '')) || trimmed.startsWith('{') || trimmed.startsWith('[');
+    if (!looksJSON || !trimmed) return;
+    try {
+      pushJSONCapture(url, status, JSON.parse(trimmed));
+    } catch {}
+  };
+
+  const originalFetch = window.fetch;
+  if (typeof originalFetch === 'function') {
+    window.fetch = function(...args) {
+      return originalFetch.apply(this, args).then(response => {
+        try {
+          const clone = response.clone();
+          const contentType = clone.headers && clone.headers.get ? (clone.headers.get('content-type') || '') : '';
+          const requestURL = clone.url || (
+            args[0] && typeof args[0] === 'object' && 'url' in args[0]
+              ? args[0].url
+              : args[0]
+          );
+          clone.text().then(text => {
+            maybeCaptureJSONText(requestURL, response.status, contentType, text);
+          }).catch(() => {});
+        } catch {}
+        return response;
+      });
+    };
+  }
+
+  const originalOpen = XMLHttpRequest.prototype.open;
+  const originalSend = XMLHttpRequest.prototype.send;
+
+  XMLHttpRequest.prototype.open = function(method, url) {
+    this.__codexbarCaptureURL = url;
+    return originalOpen.apply(this, arguments);
+  };
+
+  XMLHttpRequest.prototype.send = function() {
+    this.addEventListener('loadend', function() {
+      try {
+        const url = this.responseURL || this.__codexbarCaptureURL || '';
+        const contentType = this.getResponseHeader ? (this.getResponseHeader('content-type') || '') : '';
+        let text = '';
+        if (typeof this.responseText === 'string' && this.responseText) {
+          text = this.responseText;
+        } else if (typeof this.response === 'string' && this.response) {
+          text = this.response;
+        } else if (this.response && typeof this.response === 'object') {
+          try {
+            pushJSONCapture(url, this.status || 0, this.response);
+            return;
+          } catch {}
+        }
+        maybeCaptureJSONText(url, this.status || 0, contentType, text);
+      } catch {}
+    }, { once: true });
+    return originalSend.apply(this, arguments);
+  };
+})();
+"""
+#endif

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardParser.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardParser.swift
@@ -152,16 +152,6 @@ public enum OpenAIDashboardParser {
         .sorted { $0.date > $1.date }
     }
 
-    private static func parseCreditsUsed(_ text: String) -> Double {
-        let cleaned = text
-            .replacingOccurrences(of: ",", with: "")
-            .replacingOccurrences(of: "credits", with: "", options: .caseInsensitive)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return Double(cleaned) ?? 0
-    }
-
-    // MARK: - Private
-
     private static let codeReviewRegexes: [NSRegularExpression] = {
         let patterns = [
             #"Code\s*review[^0-9%]*([0-9]{1,3})%\s*remaining"#,

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardScrapeScript.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardScrapeScript.swift
@@ -539,6 +539,17 @@ let openAIDashboardScrapeScript = """
         } catch {}
       }
 
+      const capturedResponsesJSON = (() => {
+        try {
+          const responses = Array.isArray(window.__codexbarCapturedResponses)
+            ? window.__codexbarCapturedResponses
+            : [];
+          return responses.length > 0 ? JSON.stringify(responses) : null;
+        } catch {
+          return null;
+        }
+      })();
+
       return {
         loginRequired,
         workspacePicker,
@@ -551,6 +562,7 @@ let openAIDashboardScrapeScript = """
         rows,
         usageBreakdownJSON,
         usageBreakdownDebug,
+        capturedResponsesJSON,
         scrollY,
         scrollHeight,
         viewportHeight,

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
@@ -272,6 +272,10 @@ final class OpenAIDashboardWebViewCache {
     private func makeWebView(websiteDataStore: WKWebsiteDataStore) -> (WKWebView, OffscreenWebViewHost) {
         let config = WKWebViewConfiguration()
         config.websiteDataStore = websiteDataStore
+        config.userContentController.addUserScript(WKUserScript(
+            source: openAIDashboardNetworkCaptureBootstrapScript,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true))
         if #available(macOS 14.0, *) {
             config.preferences.inactiveSchedulingPolicy = .suspend
         }

--- a/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
@@ -168,9 +168,16 @@ struct OpenAIDashboardFetcherCreditsWaitTests {
     }
 
     @Test
+    func `usage route matcher accepts analytics dashboard routes`() {
+        #expect(OpenAIDashboardFetcher.isUsageRoute("https://chatgpt.com/codex/settings/analytics"))
+        #expect(OpenAIDashboardFetcher.isUsageRoute("https://chatgpt.com/codex/cloud/settings/analytics"))
+    }
+
+    @Test
     func `usage route matcher accepts trailing slash variants`() {
         #expect(OpenAIDashboardFetcher.isUsageRoute("https://chatgpt.com/codex/settings/usage/"))
         #expect(OpenAIDashboardFetcher.isUsageRoute("https://chatgpt.com/codex/cloud/settings/usage/"))
+        #expect(OpenAIDashboardFetcher.isUsageRoute("https://chatgpt.com/codex/cloud/settings/analytics/"))
     }
 
     @Test
@@ -178,5 +185,13 @@ struct OpenAIDashboardFetcherCreditsWaitTests {
         #expect(!OpenAIDashboardFetcher.isUsageRoute("https://chatgpt.com/"))
         #expect(!OpenAIDashboardFetcher.isUsageRoute("https://chatgpt.com/codex"))
         #expect(!OpenAIDashboardFetcher.isUsageRoute(nil))
+    }
+
+    @Test
+    func `analytics loading body maps to friendly no data description`() {
+        let message = OpenAIDashboardFetcher.friendlyNoDashboardDataDescription(
+            "Codex Analytics\nLoading usage data\nTrack threads and turns by client")
+        #expect(message.contains("still loading"))
+        #expect(!message.contains("Body sample"))
     }
 }

--- a/Tests/CodexBarTests/OpenAIDashboardParserTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardParserTests.swift
@@ -1,7 +1,7 @@
-import CodexBarCore
 import Foundation
 import Testing
 @testable import CodexBar
+@testable import CodexBarCore
 
 struct OpenAIDashboardParserTests {
     @Test
@@ -169,6 +169,128 @@ struct OpenAIDashboardParserTests {
         decoder.dateDecodingStrategy = .iso8601
         let snapshot = try decoder.decode(OpenAIDashboardSnapshot.self, from: Data(json.utf8))
         #expect(snapshot.usageBreakdown.isEmpty)
+    }
+
+    @Test
+    func `captured day key uses local timezone for iso timestamps`() throws {
+        let timeZone = try #require(TimeZone(secondsFromGMT: 60 * 60 * 3))
+        let day = OpenAIDashboardParser.capturedDayKey(
+            "2026-04-18T23:30:00Z",
+            timeZone: timeZone)
+        #expect(day == "2026-04-19")
+    }
+
+    @Test
+    func `parses captured dashboard responses`() {
+        let json = """
+        [
+          {
+            "url": "https://chatgpt.com/backend-api/codex/usage",
+            "json": {
+              "rateLimit": {
+                "primary_window": {
+                  "remaining_percent": 72,
+                  "limit_window_seconds": 18000,
+                  "reset_after_seconds": 3600
+                },
+                "secondary_window": {
+                  "remaining_percent": 41,
+                  "limit_window_seconds": 604800,
+                  "reset_after_seconds": 7200
+                }
+              },
+              "codeReviewRateLimit": {
+                "primary_window": {
+                  "remaining_percent": 42,
+                  "limit_window_seconds": 18000,
+                  "reset_after_seconds": 1800
+                }
+              },
+              "creditDetails": {
+                "balance": 2988.97,
+                "unlimited": false
+              }
+            }
+          },
+          {
+            "url": "https://chatgpt.com/backend-api/codex/credit-history",
+            "json": {
+              "data": [
+                {
+                  "date": "2026-04-18T00:00:00Z",
+                  "product_surface": "cli",
+                  "credit_amount": 397.205
+                }
+              ]
+            }
+          },
+          {
+            "url": "https://chatgpt.com/backend-api/codex/usage-breakdown",
+            "json": {
+              "data": [
+                {
+                  "date": "2026-04-18",
+                  "product_surface_usage_values": {
+                    "cli": 12,
+                    "github_code_review": 5,
+                    "unknown": 1
+                  }
+                }
+              ]
+            }
+          }
+        ]
+        """
+
+        let captured = OpenAIDashboardParser.parseCapturedDashboardData(
+            responsesJSON: json,
+            now: Date(timeIntervalSince1970: 1_776_500_000))
+
+        #expect(abs((captured?.creditsRemaining ?? 0) - 2988.97) < 0.001)
+        #expect(abs((captured?.primaryLimit?.usedPercent ?? 0) - 28) < 0.001)
+        #expect(captured?.primaryLimit?.windowMinutes == 300)
+        #expect(abs((captured?.secondaryLimit?.usedPercent ?? 0) - 59) < 0.001)
+        #expect(captured?.secondaryLimit?.windowMinutes == 10080)
+        #expect(abs((captured?.codeReviewLimit?.usedPercent ?? 0) - 58) < 0.001)
+        #expect(captured?.creditEvents.count == 1)
+        #expect(captured?.creditEvents.first?.service == "CLI")
+        #expect(abs((captured?.creditEvents.first?.creditsUsed ?? 0) - 397.205) < 0.0001)
+        #expect(captured?.usageBreakdown.count == 1)
+        #expect(captured?.usageBreakdown.first?.services.first?.service == "CLI")
+        #expect(abs((captured?.usageBreakdown.first?.totalCreditsUsed ?? 0) - 18) < 0.001)
+        #expect(captured?.hasDashboardSignal == true)
+    }
+
+    @Test
+    func `parses large captured response payloads`() throws {
+        let filler = (0..<2000).map { index in
+            [
+                "junk": [
+                    "id": index,
+                    "label": "node-\(index)",
+                ],
+            ]
+        }
+        let payload: [String: Any] = [
+            "nodes": filler,
+            "tail": [
+                "creditDetails": [
+                    "balance": 42,
+                    "unlimited": false,
+                ],
+            ],
+        ]
+        let response: [String: Any] = [
+            "url": "https://chatgpt.com/backend-api/codex/usage",
+            "json": payload,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: [response], options: [.sortedKeys])
+        let json = try #require(String(data: data, encoding: .utf8))
+
+        let captured = OpenAIDashboardParser.parseCapturedDashboardData(responsesJSON: json)
+
+        #expect(captured?.creditsRemaining == 42)
+        #expect(captured?.hasDashboardSignal == true)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- support the new Codex analytics dashboard routes and capture dashboard JSON responses in the embedded web view
- parse credits, limits, code review usage, and usage breakdown from captured network payloads when the DOM is incomplete
- fix captured local-day bucketing and make captured payload scanning linear-time, with parser coverage for the new paths

## Verification
- pnpm check
- swift test --filter OpenAIDashboard
- ./Scripts/compile_and_run.sh

## Notes
- verified the rebuilt app launches successfully after packaging
- verified a live OpenAI dashboard snapshot contains the expected signed-in account, plan, credits, and limits
