### PR TITLE
[codex] Preserve keychain cache on temporary lock

### DIFF
--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -36,6 +36,9 @@ public enum CookieHeaderCache {
         case let .found(entry):
             self.log.debug("Cookie cache hit", metadata: ["provider": provider.rawValue])
             return entry
+        case .temporarilyUnavailable:
+            self.log.debug("Cookie cache temporarily unavailable", metadata: ["provider": provider.rawValue])
+            return nil
         case .invalid:
             self.log.warning("Cookie cache invalid; clearing", metadata: ["provider": provider.rawValue])
             KeychainCacheStore.clear(key: key)

--- a/Sources/CodexBarCore/KeychainCacheStore.swift
+++ b/Sources/CodexBarCore/KeychainCacheStore.swift
@@ -21,6 +21,7 @@ public enum KeychainCacheStore {
     public enum LoadResult<Entry> {
         case found(Entry)
         case missing
+        case temporarilyUnavailable
         case invalid
     }
 
@@ -29,6 +30,9 @@ public enum KeychainCacheStore {
     private static let cacheLabel = "CodexBar Cache"
     private nonisolated(unsafe) static var globalServiceOverride: String?
     @TaskLocal private static var serviceOverride: String?
+    #if DEBUG && os(macOS)
+    @TaskLocal private static var loadFailureStatusOverride: OSStatus?
+    #endif
     private static let testStoreLock = NSLock()
     private struct TestStoreKey: Hashable {
         let service: String
@@ -42,6 +46,11 @@ public enum KeychainCacheStore {
         key: Key,
         as type: Entry.Type = Entry.self) -> LoadResult<Entry>
     {
+        #if DEBUG && os(macOS)
+        if let status = self.loadFailureStatusOverride {
+            return self.loadResultForKeychainReadFailure(status: status, key: key)
+        }
+        #endif
         if let testResult = loadFromTestStore(key: key, as: type) {
             return testResult
         }
@@ -170,6 +179,17 @@ public enum KeychainCacheStore {
         self.serviceOverride
     }
 
+    #if DEBUG && os(macOS)
+    public static func withLoadFailureStatusOverrideForTesting<T>(
+        _ status: OSStatus?,
+        operation: () throws -> T) rethrows -> T
+    {
+        try self.$loadFailureStatusOverride.withValue(status) {
+            try operation()
+        }
+    }
+    #endif
+
     static func setTestStoreForTesting(_ enabled: Bool) {
         self.testStoreLock.lock()
         defer { self.testStoreLock.unlock() }
@@ -213,7 +233,7 @@ public enum KeychainCacheStore {
         case errSecInteractionNotAllowed:
             // Keychain is temporarily locked, e.g. immediately after wake from sleep.
             self.log.info("Keychain cache temporarily locked (\(key.account)), will retry on next access")
-            return .missing
+            return .temporarilyUnavailable
         default:
             self.log.error("Keychain cache read failed (\(key.account)): \(status)")
             return .invalid

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -207,6 +207,7 @@ public enum ClaudeOAuthCredentialsStore {
 
                 var lastError: Error?
                 var expiredRecord: ClaudeOAuthCredentialRecord?
+                var cacheTemporarilyUnavailable = false
 
                 switch KeychainCacheStore.load(key: ClaudeOAuthCredentialsStore.cacheKey, as: CacheEntry.self) {
                 case let .found(entry):
@@ -239,6 +240,8 @@ public enum ClaudeOAuthCredentialsStore {
                     }
                 case .invalid:
                     KeychainCacheStore.clear(key: ClaudeOAuthCredentialsStore.cacheKey)
+                case .temporarilyUnavailable:
+                    cacheTemporarilyUnavailable = true
                 case .missing:
                     break
                 }
@@ -259,7 +262,9 @@ public enum ClaudeOAuthCredentialsStore {
                                 owner: .claudeCLI,
                                 source: .memoryCache),
                             timestamp: Date())
-                        ClaudeOAuthCredentialsStore.saveToCacheKeychain(fileData, owner: .claudeCLI)
+                        if !cacheTemporarilyUnavailable {
+                            ClaudeOAuthCredentialsStore.saveToCacheKeychain(fileData, owner: .claudeCLI)
+                        }
                         return record
                     }
                 } catch let error as ClaudeOAuthCredentialsError {
@@ -274,7 +279,8 @@ public enum ClaudeOAuthCredentialsStore {
                 if allowClaudeKeychainRepairWithoutPrompt, !allowKeychainPrompt {
                     if let repaired = recovery.repairFromClaudeKeychainWithoutPromptIfAllowed(
                         now: Date(),
-                        respectKeychainPromptCooldown: shouldRespectKeychainPromptCooldownForSilentProbes)
+                        respectKeychainPromptCooldown: shouldRespectKeychainPromptCooldownForSilentProbes,
+                        allowCacheKeychainWrite: !cacheTemporarilyUnavailable)
                     {
                         return repaired
                     }
@@ -283,6 +289,7 @@ public enum ClaudeOAuthCredentialsStore {
                 if let prompted = self.loadFromClaudeKeychainWithPromptIfAllowed(
                     allowKeychainPrompt: allowKeychainPrompt,
                     respectKeychainPromptCooldown: respectKeychainPromptCooldown,
+                    allowCacheKeychainWrite: !cacheTemporarilyUnavailable,
                     lastError: &lastError)
                 {
                     return prompted
@@ -299,6 +306,7 @@ public enum ClaudeOAuthCredentialsStore {
         private func loadFromClaudeKeychainWithPromptIfAllowed(
             allowKeychainPrompt: Bool,
             respectKeychainPromptCooldown: Bool,
+            allowCacheKeychainWrite: Bool,
             lastError: inout Error?) -> ClaudeOAuthCredentialRecord?
         {
             let shouldApplyPromptCooldown =
@@ -355,7 +363,9 @@ public enum ClaudeOAuthCredentialsStore {
                             owner: .claudeCLI,
                             source: .memoryCache),
                         timestamp: Date())
-                    ClaudeOAuthCredentialsStore.saveToCacheKeychain(keychainData, owner: .claudeCLI)
+                    if allowCacheKeychainWrite {
+                        ClaudeOAuthCredentialsStore.saveToCacheKeychain(keychainData, owner: .claudeCLI)
+                    }
                     return record
                 }
 
@@ -404,7 +414,9 @@ public enum ClaudeOAuthCredentialsStore {
                         owner: .claudeCLI,
                         source: .memoryCache),
                     timestamp: Date())
-                ClaudeOAuthCredentialsStore.saveToCacheKeychain(keychainData, owner: .claudeCLI)
+                if allowCacheKeychainWrite {
+                    ClaudeOAuthCredentialsStore.saveToCacheKeychain(keychainData, owner: .claudeCLI)
+                }
                 return record
             } catch let error as ClaudeOAuthCredentialsError {
                 if case .notFound = error {
@@ -423,24 +435,28 @@ public enum ClaudeOAuthCredentialsStore {
                 let current = ClaudeOAuthCredentialsStore.currentFileFingerprint()
                 let stored = ClaudeOAuthCredentialsStore.loadFileFingerprint()
                 guard current != stored else { return false }
-                ClaudeOAuthCredentialsStore.saveFileFingerprint(current)
                 ClaudeOAuthCredentialsStore.log.info("Claude OAuth credentials file changed; invalidating cache")
 
                 ClaudeOAuthCredentialsStore.writeMemoryCache(record: nil, timestamp: nil)
 
                 var shouldClearKeychainCache = false
+                var shouldSaveFileFingerprint = true
                 if let current {
                     if let modifiedAtMs = current.modifiedAtMs {
                         let modifiedAt = Date(timeIntervalSince1970: TimeInterval(Double(modifiedAtMs) / 1000.0))
-                        if case let .found(entry) = KeychainCacheStore.load(
+                        switch KeychainCacheStore.load(
                             key: ClaudeOAuthCredentialsStore.cacheKey,
                             as: CacheEntry.self)
                         {
+                        case let .found(entry):
                             if entry.storedAt < modifiedAt {
                                 shouldClearKeychainCache = true
                             }
-                        } else {
+                        case .missing, .invalid:
                             shouldClearKeychainCache = true
+                        case .temporarilyUnavailable:
+                            shouldClearKeychainCache = false
+                            shouldSaveFileFingerprint = false
                         }
                     } else {
                         shouldClearKeychainCache = true
@@ -451,6 +467,9 @@ public enum ClaudeOAuthCredentialsStore {
 
                 if shouldClearKeychainCache {
                     ClaudeOAuthCredentialsStore.clearCacheKeychain()
+                }
+                if shouldSaveFileFingerprint {
+                    ClaudeOAuthCredentialsStore.saveFileFingerprint(current)
                 }
                 return true
             }
@@ -507,6 +526,8 @@ public enum ClaudeOAuthCredentialsStore {
                         owner: entry.owner ?? .claudeCLI,
                         source: .cacheKeychain)
                     return isRefreshableOrValid(record)
+                case .temporarilyUnavailable:
+                    return true
                 default:
                     break
                 }
@@ -697,7 +718,8 @@ public enum ClaudeOAuthCredentialsStore {
 
         func repairFromClaudeKeychainWithoutPromptIfAllowed(
             now: Date,
-            respectKeychainPromptCooldown: Bool) -> ClaudeOAuthCredentialRecord?
+            respectKeychainPromptCooldown: Bool,
+            allowCacheKeychainWrite: Bool = true) -> ClaudeOAuthCredentialRecord?
         {
             #if os(macOS)
             let mode = ClaudeOAuthKeychainPromptPreference.current()
@@ -735,7 +757,9 @@ public enum ClaudeOAuthCredentialsStore {
                             owner: .claudeCLI,
                             source: .memoryCache),
                         timestamp: now)
-                    ClaudeOAuthCredentialsStore.saveToCacheKeychain(securityData, owner: .claudeCLI)
+                    if allowCacheKeychainWrite {
+                        ClaudeOAuthCredentialsStore.saveToCacheKeychain(securityData, owner: .claudeCLI)
+                    }
 
                     ClaudeOAuthCredentialsStore.log.info(
                         "Claude keychain credentials loaded without prompt; syncing OAuth cache",
@@ -773,7 +797,9 @@ public enum ClaudeOAuthCredentialsStore {
                         owner: .claudeCLI,
                         source: .memoryCache),
                     timestamp: now)
-                ClaudeOAuthCredentialsStore.saveToCacheKeychain(data, owner: .claudeCLI)
+                if allowCacheKeychainWrite {
+                    ClaudeOAuthCredentialsStore.saveToCacheKeychain(data, owner: .claudeCLI)
+                }
 
                 ClaudeOAuthCredentialsStore.log.info(
                     "Claude keychain credentials loaded without prompt; syncing OAuth cache",

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreTemporaryKeychainCacheTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreTemporaryKeychainCacheTests.swift
@@ -1,0 +1,237 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct ClaudeOAuthCredentialsStoreTemporaryKeychainCacheTests {
+    private struct WrongCacheEntry: Codable {
+        let value: String
+    }
+
+    private func makeCredentialsData(accessToken: String, expiresAt: Date, refreshToken: String? = nil) -> Data {
+        let millis = Int(expiresAt.timeIntervalSince1970 * 1000)
+        let refreshField: String = {
+            guard let refreshToken else { return "" }
+            return ",\n            \"refreshToken\": \"\(refreshToken)\""
+        }()
+        let json = """
+        {
+          "claudeAiOauth": {
+            "accessToken": "\(accessToken)",
+            "expiresAt": \(millis),
+            "scopes": ["user:profile"]\(refreshField)
+          }
+        }
+        """
+        return Data(json.utf8)
+    }
+
+    #if os(macOS)
+    @Test
+    func `credentials file invalidation preserves keychain cache when temporarily unavailable`() throws {
+        let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
+        try KeychainCacheStore.withServiceOverrideForTesting(service) {
+            KeychainCacheStore.setTestStoreForTesting(true)
+            defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+            try ClaudeOAuthCredentialsStore.withIsolatedMemoryCacheForTesting {
+                try ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+                    ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting()
+                    defer { ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting() }
+
+                    let tempDir = FileManager.default.temporaryDirectory
+                        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+                    try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+                    let fileURL = tempDir.appendingPathComponent("credentials.json")
+                    try ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                        let firstFile = self.makeCredentialsData(
+                            accessToken: "first-file",
+                            expiresAt: Date(timeIntervalSinceNow: 3600))
+                        try firstFile.write(to: fileURL)
+                        #expect(ClaudeOAuthCredentialsStore.invalidateCacheIfCredentialsFileChanged())
+
+                        let cacheKey = KeychainCacheStore.Key.oauth(provider: .claude)
+                        let cachedData = self.makeCredentialsData(
+                            accessToken: "cached-token",
+                            expiresAt: Date(timeIntervalSinceNow: 3600))
+                        KeychainCacheStore.store(
+                            key: cacheKey,
+                            entry: ClaudeOAuthCredentialsStore.CacheEntry(
+                                data: cachedData,
+                                storedAt: Date(),
+                                owner: .claudeCLI))
+                        defer { KeychainCacheStore.clear(key: cacheKey) }
+
+                        let updatedFile = self.makeCredentialsData(
+                            accessToken: "updated-file-token-longer",
+                            expiresAt: Date(timeIntervalSinceNow: 3600))
+                        try updatedFile.write(to: fileURL)
+
+                        KeychainCacheStore.withLoadFailureStatusOverrideForTesting(errSecInteractionNotAllowed) {
+                            #expect(ClaudeOAuthCredentialsStore.invalidateCacheIfCredentialsFileChanged())
+                        }
+
+                        switch KeychainCacheStore.load(
+                            key: cacheKey,
+                            as: ClaudeOAuthCredentialsStore.CacheEntry.self)
+                        {
+                        case let .found(entry):
+                            let parsed = try ClaudeOAuthCredentials.parse(data: entry.data)
+                            #expect(parsed.accessToken == "cached-token")
+                        case .missing, .temporarilyUnavailable, .invalid:
+                            #expect(Bool(false), "Expected temporary unavailability not to clear Claude cache")
+                        }
+
+                        #expect(ClaudeOAuthCredentialsStore.invalidateCacheIfCredentialsFileChanged())
+
+                        switch KeychainCacheStore.load(
+                            key: cacheKey,
+                            as: ClaudeOAuthCredentialsStore.CacheEntry.self)
+                        {
+                        case .missing:
+                            #expect(true)
+                        case .found, .temporarilyUnavailable, .invalid:
+                            #expect(Bool(false), "Expected pending invalidation to clear stale Claude cache")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    func `temporary keychain cache unavailability does not overwrite cache from credentials file fallback`() throws {
+        let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
+        try KeychainCacheStore.withServiceOverrideForTesting(service) {
+            try KeychainAccessGate.withTaskOverrideForTesting(true) {
+                KeychainCacheStore.setTestStoreForTesting(true)
+                defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+                try ClaudeOAuthCredentialsStore.withIsolatedMemoryCacheForTesting {
+                    try ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+                        ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting()
+                        defer { ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting() }
+
+                        let tempDir = FileManager.default.temporaryDirectory
+                            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+                        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+                        let fileURL = tempDir.appendingPathComponent("credentials.json")
+                        try ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                            let fileData = self.makeCredentialsData(
+                                accessToken: "file-fallback-token",
+                                expiresAt: Date(timeIntervalSinceNow: 3600))
+                            try fileData.write(to: fileURL)
+
+                            let cacheKey = KeychainCacheStore.Key.oauth(provider: .claude)
+                            let cachedData = self.makeCredentialsData(
+                                accessToken: "cached-token",
+                                expiresAt: Date(timeIntervalSinceNow: 3600))
+                            KeychainCacheStore.store(
+                                key: cacheKey,
+                                entry: ClaudeOAuthCredentialsStore.CacheEntry(
+                                    data: cachedData,
+                                    storedAt: Date(),
+                                    owner: .claudeCLI))
+                            defer { KeychainCacheStore.clear(key: cacheKey) }
+
+                            let loaded = try KeychainCacheStore.withLoadFailureStatusOverrideForTesting(
+                                errSecInteractionNotAllowed)
+                            {
+                                try ClaudeOAuthCredentialsStore.load(environment: [:], allowKeychainPrompt: false)
+                            }
+                            #expect(loaded.accessToken == "file-fallback-token")
+
+                            switch KeychainCacheStore.load(
+                                key: cacheKey,
+                                as: ClaudeOAuthCredentialsStore.CacheEntry.self)
+                            {
+                            case let .found(entry):
+                                let parsed = try ClaudeOAuthCredentials.parse(data: entry.data)
+                                #expect(parsed.accessToken == "cached-token")
+                            case .missing, .temporarilyUnavailable, .invalid:
+                                #expect(Bool(false), "Expected file fallback not to overwrite unavailable cache")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    func `has cached credentials treats temporary keychain cache unavailability as present`() {
+        let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
+        KeychainCacheStore.withServiceOverrideForTesting(service) {
+            KeychainCacheStore.setTestStoreForTesting(true)
+            defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+            ClaudeOAuthCredentialsStore.withIsolatedMemoryCacheForTesting {
+                ClaudeOAuthCredentialsStore.invalidateCache()
+                let cacheKey = KeychainCacheStore.Key.oauth(provider: .claude)
+                let cachedData = self.makeCredentialsData(
+                    accessToken: "cached-token",
+                    expiresAt: Date(timeIntervalSinceNow: 3600))
+                KeychainCacheStore.store(
+                    key: cacheKey,
+                    entry: ClaudeOAuthCredentialsStore.CacheEntry(data: cachedData, storedAt: Date()))
+                defer { KeychainCacheStore.clear(key: cacheKey) }
+
+                let hasCached = KeychainCacheStore.withLoadFailureStatusOverrideForTesting(
+                    errSecInteractionNotAllowed)
+                {
+                    ClaudeOAuthCredentialsStore.hasCachedCredentials(environment: [:])
+                }
+
+                #expect(hasCached == true)
+            }
+        }
+    }
+    #endif
+
+    @Test
+    func `invalid keychain cache is cleared by load`() throws {
+        let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
+        try KeychainCacheStore.withServiceOverrideForTesting(service) {
+            try KeychainAccessGate.withTaskOverrideForTesting(true) {
+                KeychainCacheStore.setTestStoreForTesting(true)
+                defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+                ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting()
+                defer { ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting() }
+
+                try ClaudeOAuthCredentialsStore.withIsolatedMemoryCacheForTesting {
+                    try ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+                        let tempDir = FileManager.default.temporaryDirectory
+                            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+                        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+                        let fileURL = tempDir.appendingPathComponent("credentials.json")
+                        try ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                            let cacheKey = KeychainCacheStore.Key.oauth(provider: .claude)
+                            KeychainCacheStore.store(key: cacheKey, entry: WrongCacheEntry(value: "wrong-shape"))
+
+                            do {
+                                _ = try ClaudeOAuthCredentialsStore.load(environment: [:], allowKeychainPrompt: false)
+                                Issue.record("Expected ClaudeOAuthCredentialsError.notFound")
+                            } catch let error as ClaudeOAuthCredentialsError {
+                                guard case .notFound = error else {
+                                    Issue.record("Expected .notFound, got \(error)")
+                                    return
+                                }
+                            }
+
+                            switch KeychainCacheStore.load(
+                                key: cacheKey,
+                                as: ClaudeOAuthCredentialsStore.CacheEntry.self)
+                            {
+                            case .missing:
+                                #expect(true)
+                            case .found, .temporarilyUnavailable, .invalid:
+                                #expect(Bool(false), "Expected invalid Claude cache to be cleared")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/CodexBarTests/CookieHeaderCacheTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheTests.swift
@@ -4,6 +4,10 @@ import Testing
 
 @Suite(.serialized)
 struct CookieHeaderCacheTests {
+    private struct WrongEntry: Codable {
+        let value: String
+    }
+
     @Test
     func `stores and loads entry`() {
         KeychainCacheStore.setTestStoreForTesting(true)
@@ -104,5 +108,66 @@ struct CookieHeaderCacheTests {
 
         let loadedAgain = CookieHeaderCache.load(provider: provider)
         #expect(loadedAgain?.cookieHeader == "auth=legacy")
+    }
+
+    #if os(macOS)
+    @Test
+    func `temporary keychain unavailability returns nil without migrating legacy file`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+        let legacyBase = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        CookieHeaderCache.setLegacyBaseURLOverrideForTesting(legacyBase)
+        defer { CookieHeaderCache.setLegacyBaseURLOverrideForTesting(nil) }
+
+        let provider: UsageProvider = .codex
+        let legacyURL = legacyBase.appendingPathComponent("\(provider.rawValue)-cookie.json")
+        CookieHeaderCache.store(
+            CookieHeaderCache.Entry(
+                cookieHeader: "auth=legacy",
+                storedAt: Date(timeIntervalSince1970: 0),
+                sourceLabel: "Legacy"),
+            to: legacyURL)
+        #expect(FileManager.default.fileExists(atPath: legacyURL.path) == true)
+
+        let loaded = KeychainCacheStore.withLoadFailureStatusOverrideForTesting(errSecInteractionNotAllowed) {
+            CookieHeaderCache.load(provider: provider)
+        }
+
+        #expect(loaded == nil)
+        #expect(FileManager.default.fileExists(atPath: legacyURL.path) == true)
+
+        switch KeychainCacheStore.load(key: .cookie(provider: provider), as: CookieHeaderCache.Entry.self) {
+        case .missing:
+            #expect(true)
+        case .found, .temporarilyUnavailable, .invalid:
+            #expect(Bool(false), "Expected temporary miss not to migrate legacy cache")
+        }
+    }
+    #endif
+
+    @Test
+    func `invalid keychain cache is cleared`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+        let legacyBase = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        CookieHeaderCache.setLegacyBaseURLOverrideForTesting(legacyBase)
+        defer { CookieHeaderCache.setLegacyBaseURLOverrideForTesting(nil) }
+
+        let provider: UsageProvider = .codex
+        let key = KeychainCacheStore.Key.cookie(provider: provider)
+        KeychainCacheStore.store(key: key, entry: WrongEntry(value: "not-a-cookie-entry"))
+
+        #expect(CookieHeaderCache.load(provider: provider) == nil)
+
+        switch KeychainCacheStore.load(key: key, as: CookieHeaderCache.Entry.self) {
+        case .missing:
+            #expect(true)
+        case .found, .temporarilyUnavailable, .invalid:
+            #expect(Bool(false), "Expected invalid cookie cache to be cleared")
+        }
     }
 }

--- a/Tests/CodexBarTests/KeychainCacheStoreTests.swift
+++ b/Tests/CodexBarTests/KeychainCacheStoreTests.swift
@@ -24,7 +24,7 @@ struct KeychainCacheStoreTests {
         switch KeychainCacheStore.load(key: key, as: TestEntry.self) {
         case let .found(loaded):
             #expect(loaded == entry)
-        case .missing, .invalid:
+        case .missing, .temporarilyUnavailable, .invalid:
             #expect(Bool(false), "Expected keychain cache entry")
         }
     }
@@ -45,7 +45,7 @@ struct KeychainCacheStoreTests {
         switch KeychainCacheStore.load(key: key, as: TestEntry.self) {
         case let .found(loaded):
             #expect(loaded == second)
-        case .missing, .invalid:
+        case .missing, .temporarilyUnavailable, .invalid:
             #expect(Bool(false), "Expected overwritten keychain cache entry")
         }
     }
@@ -64,24 +64,51 @@ struct KeychainCacheStoreTests {
         switch KeychainCacheStore.load(key: key, as: TestEntry.self) {
         case .missing:
             #expect(true)
-        case .found, .invalid:
+        case .found, .temporarilyUnavailable, .invalid:
             #expect(Bool(false), "Expected keychain cache entry to be cleared")
         }
     }
 
     #if os(macOS)
     @Test
-    func `interaction not allowed is treated as temporarily missing`() {
+    func `interaction not allowed is treated as temporarily unavailable`() {
         let key = KeychainCacheStore.Key(category: "test", identifier: UUID().uuidString)
         let result: KeychainCacheStore.LoadResult<TestEntry> = KeychainCacheStore.loadResultForKeychainReadFailure(
             status: errSecInteractionNotAllowed,
             key: key)
 
         switch result {
-        case .missing:
+        case .temporarilyUnavailable:
             #expect(true)
-        case .found, .invalid:
-            #expect(Bool(false), "Expected temporary keychain lock to preserve cache")
+        case .found, .missing, .invalid:
+            #expect(Bool(false), "Expected temporary keychain lock to be retry-later")
+        }
+    }
+
+    @Test
+    func `load failure override bypasses test store without affecting store or clear`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+        let key = KeychainCacheStore.Key(category: "test", identifier: UUID().uuidString)
+        let entry = TestEntry(value: "stored", storedAt: Date(timeIntervalSince1970: 0))
+        KeychainCacheStore.store(key: key, entry: entry)
+        defer { KeychainCacheStore.clear(key: key) }
+
+        KeychainCacheStore.withLoadFailureStatusOverrideForTesting(errSecInteractionNotAllowed) {
+            switch KeychainCacheStore.load(key: key, as: TestEntry.self) {
+            case .temporarilyUnavailable:
+                #expect(true)
+            case .found, .missing, .invalid:
+                #expect(Bool(false), "Expected override to run before test store")
+            }
+        }
+
+        switch KeychainCacheStore.load(key: key, as: TestEntry.self) {
+        case let .found(loaded):
+            #expect(loaded == entry)
+        case .missing, .temporarilyUnavailable, .invalid:
+            #expect(Bool(false), "Expected override not to mutate test store")
         }
     }
     #endif


### PR DESCRIPTION
## Summary
- Treat `errSecInteractionNotAllowed` keychain-cache reads as temporarily unavailable instead of missing.
- Preserve Claude OAuth and cookie caches during temporary keychain unavailability without clearing, overwriting, or migrating durable data.
- Keep Claude credentials-file invalidation pending until the cache read can complete, so stale cache entries are cleared on the next successful read.

## Root Cause
A temporary keychain lock was previously collapsed into cache-missing behavior. Some callers used non-`.found` results as a signal to clear or migrate cache data, which could erase valid Claude OAuth or cookie cache entries. The Claude credentials-file invalidation path also advanced the file fingerprint before cache invalidation had actually completed, which could leave stale keychain cache data accepted after a temporary lock.

## Validation
- `swift test --filter KeychainCacheStoreTests`
- `swift test --filter ClaudeOAuthCredentialsStoreTests`
- `swift test --filter ClaudeOAuthCredentialsStoreTemporaryKeychainCacheTests`
- `swift test --filter CookieHeaderCacheTests`
- `swift test`
- `pnpm check`
- `git diff --check`
- `./Scripts/compile_and_run.sh`