### PR TITLE
Fix widget App Intents packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 - Codex: clean up cached CLI status probes during app shutdown so `codex -s read-only` workers are not orphaned after restart.
+- Widgets: package `Metadata.appintents` for the widget extension and use App Intent parameter defaults so configurable widgets load correctly in WidgetKit. Thanks @vincentyangch!
 
 ## 0.22 — 2026-04-21
 

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -98,6 +98,86 @@ path.write_text(text)
 PY
 }
 
+generate_widget_appintents_metadata() {
+  local widget_resources_dir="$1"
+  local xcode_conf
+  local host_arch
+  local derived_dir
+  local build_dir
+  local object_dir
+  local source_file_list
+  local const_values_list
+  local dependency_metadata
+  local static_dependency_metadata
+  local appintents_tool
+  local sdk_root
+  local swiftc_path
+  local toolchain_dir
+  local xcode_version
+
+  xcode_conf="Release"
+  if [[ "$LOWER_CONF" == "debug" ]]; then
+    xcode_conf="Debug"
+  fi
+
+  host_arch=$(uname -m)
+  derived_dir="$ROOT/.build/xcode-widget-metadata-${LOWER_CONF}"
+  build_dir="$derived_dir/Build/Intermediates.noindex/CodexBar.build/${xcode_conf}/CodexBarWidget.build"
+  object_dir="$build_dir/Objects-normal/${host_arch}"
+  source_file_list="$object_dir/CodexBarWidget.SwiftFileList"
+  const_values_list="$object_dir/CodexBarWidget.SwiftConstValuesFileList"
+  dependency_metadata="$build_dir/CodexBarWidget.DependencyMetadataFileList"
+  static_dependency_metadata="$build_dir/CodexBarWidget.DependencyStaticMetadataFileList"
+
+  appintents_tool=$(xcrun --find appintentsmetadataprocessor)
+  sdk_root=$(xcrun --sdk macosx --show-sdk-path)
+  swiftc_path=$(xcrun --find swiftc)
+  toolchain_dir=$(dirname "$(dirname "$(dirname "$swiftc_path")")")
+  xcode_version=$(xcodebuild -version | awk '/Build version/ { print $3 }')
+
+  rm -rf "$derived_dir"
+  xcodebuild \
+    -workspace "$ROOT/.swiftpm/xcode/package.xcworkspace" \
+    -scheme CodexBarWidget \
+    -configuration "$xcode_conf" \
+    -destination "platform=macOS,arch=${host_arch}" \
+    -derivedDataPath "$derived_dir" \
+    build >/dev/null
+
+  if [[ ! -f "$source_file_list" ]]; then
+    echo "ERROR: Missing App Intents metadata inputs for CodexBarWidget." >&2
+    exit 1
+  fi
+
+  find "$object_dir" -name '*.swiftconstvalues' | sort > "$const_values_list"
+  if [[ ! -s "$const_values_list" ]]; then
+    echo "ERROR: Missing App Intents const-values outputs for CodexBarWidget." >&2
+    exit 1
+  fi
+  rm -rf "$widget_resources_dir/Metadata.appintents"
+  mkdir -p "$widget_resources_dir"
+
+  "$appintents_tool" \
+    --output "$widget_resources_dir" \
+    --toolchain-dir "$toolchain_dir" \
+    --module-name CodexBarWidget \
+    --sdk-root "$sdk_root" \
+    --xcode-version "$xcode_version" \
+    --platform-family macOS \
+    --deployment-target 14.0 \
+    --target-triple "${host_arch}-apple-macos14.0" \
+    --source-file-list "$source_file_list" \
+    --swift-const-vals-list "$const_values_list" \
+    --metadata-file-list "$dependency_metadata" \
+    --static-metadata-file-list "$static_dependency_metadata" \
+    --force >/dev/null
+
+  if [[ ! -f "$widget_resources_dir/Metadata.appintents/extract.actionsdata" ]]; then
+    echo "ERROR: Failed to generate App Intents metadata for CodexBarWidget." >&2
+    exit 1
+  fi
+}
+
 KEYBOARD_SHORTCUTS_UTIL="$ROOT/.build/checkouts/KeyboardShortcuts/Sources/KeyboardShortcuts/Utilities.swift"
 if [[ ! -f "$KEYBOARD_SHORTCUTS_UTIL" ]]; then
   swift build -c "$CONF" --arch "${ARCH_LIST[0]}"
@@ -304,6 +384,7 @@ if [[ -n "$(resolve_binary_path "CodexBarWidget" "${ARCH_LIST[0]}")" ]]; then
 </plist>
 PLIST
   install_binary "CodexBarWidget" "$WIDGET_APP/Contents/MacOS/CodexBarWidget"
+  generate_widget_appintents_metadata "$WIDGET_APP/Contents/Resources"
 fi
 # Embed Sparkle.framework
 if [[ -d ".build/$CONF/Sparkle.framework" ]]; then

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -99,8 +99,8 @@ struct ProviderSelectionIntent: AppIntent, WidgetConfigurationIntent {
     static let title: LocalizedStringResource = "Provider"
     static let description = IntentDescription("Select the provider to display in the widget.")
 
-    @Parameter(title: "Provider")
-    var provider: ProviderChoice?
+    @Parameter(title: "Provider", default: .codex)
+    var provider: ProviderChoice
 
     init() {
         self.provider = .codex
@@ -131,11 +131,11 @@ struct CompactMetricSelectionIntent: AppIntent, WidgetConfigurationIntent {
     static let title: LocalizedStringResource = "Provider + Metric"
     static let description = IntentDescription("Select the provider and metric to display.")
 
-    @Parameter(title: "Provider")
-    var provider: ProviderChoice?
+    @Parameter(title: "Provider", default: .codex)
+    var provider: ProviderChoice
 
-    @Parameter(title: "Metric")
-    var metric: CompactMetric?
+    @Parameter(title: "Metric", default: .credits)
+    var metric: CompactMetric
 
     init() {
         self.provider = .codex
@@ -147,14 +147,6 @@ struct CodexBarWidgetEntry: TimelineEntry {
     let date: Date
     let provider: UsageProvider
     let snapshot: WidgetSnapshot
-}
-
-func resolvedWidgetProvider(_ choice: ProviderChoice?) -> UsageProvider {
-    choice?.provider ?? .codex
-}
-
-func resolvedCompactMetric(_ metric: CompactMetric?) -> CompactMetric {
-    metric ?? .credits
 }
 
 struct CodexBarCompactEntry: TimelineEntry {
@@ -180,7 +172,7 @@ struct CodexBarTimelineProvider: AppIntentTimelineProvider {
     }
 
     func snapshot(for configuration: ProviderSelectionIntent, in context: Context) async -> CodexBarWidgetEntry {
-        let provider = resolvedWidgetProvider(configuration.provider)
+        let provider = configuration.provider.provider
         return CodexBarWidgetEntry(
             date: Date(),
             provider: provider,
@@ -191,7 +183,7 @@ struct CodexBarTimelineProvider: AppIntentTimelineProvider {
         for configuration: ProviderSelectionIntent,
         in context: Context) async -> Timeline<CodexBarWidgetEntry>
     {
-        let provider = resolvedWidgetProvider(configuration.provider)
+        let provider = configuration.provider.provider
         let snapshot = WidgetSnapshotStore.load() ?? WidgetPreviewData.emptySnapshot()
         let entry = CodexBarWidgetEntry(date: Date(), provider: provider, snapshot: snapshot)
         let refresh = Date().addingTimeInterval(30 * 60)
@@ -257,8 +249,8 @@ struct CodexBarCompactTimelineProvider: AppIntentTimelineProvider {
     }
 
     func snapshot(for configuration: CompactMetricSelectionIntent, in context: Context) async -> CodexBarCompactEntry {
-        let provider = resolvedWidgetProvider(configuration.provider)
-        let metric = resolvedCompactMetric(configuration.metric)
+        let provider = configuration.provider.provider
+        let metric = configuration.metric
         return CodexBarCompactEntry(
             date: Date(),
             provider: provider,
@@ -270,8 +262,8 @@ struct CodexBarCompactTimelineProvider: AppIntentTimelineProvider {
         for configuration: CompactMetricSelectionIntent,
         in context: Context) async -> Timeline<CodexBarCompactEntry>
     {
-        let provider = resolvedWidgetProvider(configuration.provider)
-        let metric = resolvedCompactMetric(configuration.metric)
+        let provider = configuration.provider.provider
+        let metric = configuration.metric
         let snapshot = WidgetSnapshotStore.load() ?? WidgetPreviewData.emptySnapshot()
         let entry = CodexBarCompactEntry(
             date: Date(),

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -100,7 +100,7 @@ struct ProviderSelectionIntent: AppIntent, WidgetConfigurationIntent {
     static let description = IntentDescription("Select the provider to display in the widget.")
 
     @Parameter(title: "Provider")
-    var provider: ProviderChoice
+    var provider: ProviderChoice?
 
     init() {
         self.provider = .codex
@@ -132,10 +132,10 @@ struct CompactMetricSelectionIntent: AppIntent, WidgetConfigurationIntent {
     static let description = IntentDescription("Select the provider and metric to display.")
 
     @Parameter(title: "Provider")
-    var provider: ProviderChoice
+    var provider: ProviderChoice?
 
     @Parameter(title: "Metric")
-    var metric: CompactMetric
+    var metric: CompactMetric?
 
     init() {
         self.provider = .codex
@@ -147,6 +147,14 @@ struct CodexBarWidgetEntry: TimelineEntry {
     let date: Date
     let provider: UsageProvider
     let snapshot: WidgetSnapshot
+}
+
+func resolvedWidgetProvider(_ choice: ProviderChoice?) -> UsageProvider {
+    choice?.provider ?? .codex
+}
+
+func resolvedCompactMetric(_ metric: CompactMetric?) -> CompactMetric {
+    metric ?? .credits
 }
 
 struct CodexBarCompactEntry: TimelineEntry {
@@ -172,7 +180,7 @@ struct CodexBarTimelineProvider: AppIntentTimelineProvider {
     }
 
     func snapshot(for configuration: ProviderSelectionIntent, in context: Context) async -> CodexBarWidgetEntry {
-        let provider = configuration.provider.provider
+        let provider = resolvedWidgetProvider(configuration.provider)
         return CodexBarWidgetEntry(
             date: Date(),
             provider: provider,
@@ -183,7 +191,7 @@ struct CodexBarTimelineProvider: AppIntentTimelineProvider {
         for configuration: ProviderSelectionIntent,
         in context: Context) async -> Timeline<CodexBarWidgetEntry>
     {
-        let provider = configuration.provider.provider
+        let provider = resolvedWidgetProvider(configuration.provider)
         let snapshot = WidgetSnapshotStore.load() ?? WidgetPreviewData.emptySnapshot()
         let entry = CodexBarWidgetEntry(date: Date(), provider: provider, snapshot: snapshot)
         let refresh = Date().addingTimeInterval(30 * 60)
@@ -249,11 +257,12 @@ struct CodexBarCompactTimelineProvider: AppIntentTimelineProvider {
     }
 
     func snapshot(for configuration: CompactMetricSelectionIntent, in context: Context) async -> CodexBarCompactEntry {
-        let provider = configuration.provider.provider
+        let provider = resolvedWidgetProvider(configuration.provider)
+        let metric = resolvedCompactMetric(configuration.metric)
         return CodexBarCompactEntry(
             date: Date(),
             provider: provider,
-            metric: configuration.metric,
+            metric: metric,
             snapshot: WidgetSnapshotStore.load() ?? WidgetPreviewData.snapshot())
     }
 
@@ -261,12 +270,13 @@ struct CodexBarCompactTimelineProvider: AppIntentTimelineProvider {
         for configuration: CompactMetricSelectionIntent,
         in context: Context) async -> Timeline<CodexBarCompactEntry>
     {
-        let provider = configuration.provider.provider
+        let provider = resolvedWidgetProvider(configuration.provider)
+        let metric = resolvedCompactMetric(configuration.metric)
         let snapshot = WidgetSnapshotStore.load() ?? WidgetPreviewData.emptySnapshot()
         let entry = CodexBarCompactEntry(
             date: Date(),
             provider: provider,
-            metric: configuration.metric,
+            metric: metric,
             snapshot: snapshot)
         let refresh = Date().addingTimeInterval(30 * 60)
         return Timeline(entries: [entry], policy: .after(refresh))

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -106,13 +106,12 @@ struct CodexBarWidgetProviderTests {
     }
 
     @Test
-    func `widget provider resolution falls back to codex when provider intent is nil`() {
-        #expect(resolvedWidgetProvider(nil) == UsageProvider.codex)
-    }
+    func `widget configuration intents default to codex and credits`() {
+        let providerIntent = ProviderSelectionIntent()
+        let compactIntent = CompactMetricSelectionIntent()
 
-    @Test
-    func `compact widget resolution falls back to defaults when intent values are nil`() {
-        #expect(resolvedWidgetProvider(nil) == UsageProvider.codex)
-        #expect(resolvedCompactMetric(nil) == CompactMetric.credits)
+        #expect(providerIntent.provider == .codex)
+        #expect(compactIntent.provider == .codex)
+        #expect(compactIntent.metric == .credits)
     }
 }

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -104,4 +104,15 @@ struct CodexBarWidgetProviderTests {
 
         #expect(rows == [WidgetUsageRow(id: "weekly", title: "Weekly", percentLeft: 75)])
     }
+
+    @Test
+    func `widget provider resolution falls back to codex when provider intent is nil`() {
+        #expect(resolvedWidgetProvider(nil) == UsageProvider.codex)
+    }
+
+    @Test
+    func `compact widget resolution falls back to defaults when intent values are nil`() {
+        #expect(resolvedWidgetProvider(nil) == UsageProvider.codex)
+        #expect(resolvedCompactMetric(nil) == CompactMetric.credits)
+    }
 }


### PR DESCRIPTION
## Summary
- generate and bundle `Metadata.appintents` for `CodexBarWidget` during packaging so the widget extension ships the App Intents metadata WidgetKit expects
- keep widget configuration intent parameters non-optional and use `@Parameter(default:)` for Codex / Credits defaults instead of optional fallback helpers
- update focused widget tests to assert the configuration intent defaults directly

## Why
This supersedes #782 while preserving the original fix from @vincentyangch.

The packaging issue is real: the packaged widget extension was shipping without `Resources/Metadata.appintents`, and this branch keeps that fix. The follow-up cleanup keeps the App Intent model aligned with Apple's documented widget configuration style by using non-optional parameters with defaults rather than optional parameters plus runtime fallback helpers.

## Details
- retains commit `ab904049` from @vincentyangch for widget metadata generation and packaging
- adds follow-up commit `7d9d440b` to replace optional widget configuration parameters with `@Parameter(default:)`
- removes now-unnecessary `resolvedWidgetProvider` / `resolvedCompactMetric` helpers
- updates tests to cover default intent construction

## Validation
- `swift test -q --filter CodexBarWidgetProviderTests`
- `pnpm check`
- `./Scripts/compile_and_run.sh`
- verified packaged widget bundle contains:
  - `Metadata.appintents/version.json`
  - `Metadata.appintents/extract.actionsdata`

## Credit
Original packaging fix by @vincentyangch in #782; this PR carries that change forward with a small follow-up cleanup.
