### PR TITLE
Add weekly reset confetti

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fc2d77d3435ccf0f5a2d2a8f782cbb3c38264c7542f33838f2409544695bce6e",
+  "originHash" : "6e0bbde3ad4d9af0981adadaf1f109eb154e54018d06dbe966616f09c3898482",
   "pins" : [
     {
       "identity" : "commander",
@@ -53,6 +53,14 @@
       "state" : {
         "revision" : "0687f71944021d616d34d922343dcef086855920",
         "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "vortex",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/zats/Vortex",
+      "state" : {
+        "revision" : "ef5392088d4aeb255c4eee83157dbdafcd31bf07"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log", from: "1.12.0"),
         .package(url: "https://github.com/apple/swift-syntax", from: "600.0.1"),
         .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "2.4.0"),
+        .package(url: "https://github.com/zats/Vortex", revision: "ef5392088d4aeb255c4eee83157dbdafcd31bf07"),
         sweetCookieKitDependency,
     ],
     targets: {
@@ -82,6 +83,7 @@ let package = Package(
                 dependencies: [
                     .product(name: "Sparkle", package: "Sparkle"),
                     .product(name: "KeyboardShortcuts", package: "KeyboardShortcuts"),
+                    .product(name: "Vortex", package: "Vortex"),
                     "CodexBarMacroSupport",
                     "CodexBarCore",
                 ],

--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -278,6 +278,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     let updaterController: UpdaterProviding = makeUpdaterController()
+    private let confettiOverlayController = ScreenConfettiOverlayController()
+    private let confettiLogger = CodexBarLog.logger(LogCategories.confetti)
     private var statusController: StatusItemControlling?
     private var store: UsageStore?
     private var settings: SettingsStore?
@@ -285,6 +287,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var preferencesSelection: PreferencesSelection?
     private var managedCodexAccountCoordinator: ManagedCodexAccountCoordinator?
     private var codexAccountPromotionCoordinator: CodexAccountPromotionCoordinator?
+    private var hasInstalledWeeklyLimitResetObserver = false
 
     func configure(_ dependencies: Dependencies) {
         self.store = dependencies.store
@@ -307,10 +310,33 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.statusController?.openMenuFromShortcut()
             }
         }
+        if !self.hasInstalledWeeklyLimitResetObserver {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(self.handleWeeklyLimitResetNotification(_:)),
+                name: .codexbarWeeklyLimitReset,
+                object: nil)
+            self.hasInstalledWeeklyLimitResetObserver = true
+        }
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        self.confettiOverlayController.dismiss()
         TTYCommandRunner.terminateActiveProcessesForAppShutdown()
+    }
+
+    @objc private func handleWeeklyLimitResetNotification(_ notification: Notification) {
+        guard let event = notification.object as? WeeklyLimitResetEvent else { return }
+        guard self.settings?.confettiOnWeeklyLimitResetsEnabled == true else { return }
+        let origin = self.statusController?.celebrationOriginPoint(for: event.provider)
+        self.confettiLogger.info(
+            "Triggering confetti",
+            metadata: [
+                "provider": event.provider.rawValue,
+                "accountIdentifier": event.accountIdentifier,
+                "originKnown": origin == nil ? "0" : "1",
+            ])
+        self.confettiOverlayController.play(originInScreen: origin)
     }
 
     /// Use the classic (non-Liquid Glass) app icon on macOS versions before 26.
@@ -381,5 +407,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             PreferencesSelection(),
             fallbackManagedCodexAccountCoordinator,
             fallbackCodexAccountPromotionCoordinator)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }

--- a/Sources/CodexBar/Notifications+CodexBar.swift
+++ b/Sources/CodexBar/Notifications+CodexBar.swift
@@ -1,7 +1,24 @@
+import CodexBarCore
 import Foundation
 
 extension Notification.Name {
     static let codexbarOpenSettings = Notification.Name("codexbarOpenSettings")
     static let codexbarDebugBlinkNow = Notification.Name("codexbarDebugBlinkNow")
+    static let codexbarWeeklyLimitReset = Notification.Name("codexbarWeeklyLimitReset")
     static let codexbarProviderConfigDidChange = Notification.Name("codexbarProviderConfigDidChange")
+}
+
+@MainActor
+final class WeeklyLimitResetEvent: NSObject {
+    let provider: UsageProvider
+    let accountIdentifier: String
+    let accountLabel: String?
+    let usedPercent: Double
+
+    init(provider: UsageProvider, accountIdentifier: String, accountLabel: String?, usedPercent: Double) {
+        self.provider = provider
+        self.accountIdentifier = accountIdentifier
+        self.accountLabel = accountLabel
+        self.usedPercent = usedPercent
+    }
 }

--- a/Sources/CodexBar/PreferencesAdvancedPane.swift
+++ b/Sources/CodexBar/PreferencesAdvancedPane.swift
@@ -64,6 +64,10 @@ struct AdvancedPane: View {
                         title: "Surprise me",
                         subtitle: "Check if you like your agents having some fun up there.",
                         binding: self.$settings.randomBlinkEnabled)
+                    PreferenceToggleRow(
+                        title: "Weekly limit confetti",
+                        subtitle: "Play full-screen confetti when weekly usage resets.",
+                        binding: self.$settings.confettiOnWeeklyLimitResetsEnabled)
                 }
 
                 Divider()

--- a/Sources/CodexBar/ScreenConfettiOverlayController.swift
+++ b/Sources/CodexBar/ScreenConfettiOverlayController.swift
@@ -1,0 +1,290 @@
+import AppKit
+import CodexBarCore
+import SwiftUI
+import Vortex
+
+@MainActor
+final class ScreenConfettiOverlayController {
+    private static let overlayLifetime: TimeInterval = 5
+
+    private let logger = CodexBarLog.logger(LogCategories.confetti)
+    private var windows: [NSWindow] = []
+    private var dismissalTask: Task<Void, Never>?
+
+    func play(originInScreen origin: CGPoint?) {
+        guard self.windows.isEmpty else {
+            self.logger.debug("Ignoring confetti trigger while overlay is already active")
+            return
+        }
+
+        let screens = NSScreen.screens
+        guard !screens.isEmpty else {
+            self.logger.error("Cannot present confetti overlay because no screens were found")
+            return
+        }
+
+        let palette = Self.randomPalette()
+        self.windows = screens.map { screen in
+            let frame = screen.frame
+            let localOrigin = Self.localOrigin(in: frame, from: origin)
+            let contentView = ScreenConfettiOverlayView(origin: localOrigin, colors: palette)
+                .allowsHitTesting(false)
+            let hostingView = NSHostingView(rootView: contentView)
+            hostingView.wantsLayer = true
+            hostingView.layer?.backgroundColor = NSColor.clear.cgColor
+
+            let window = ClickThroughOverlayPanel(
+                contentRect: frame,
+                styleMask: [.borderless, .nonactivatingPanel],
+                backing: .buffered,
+                defer: false,
+                screen: screen)
+            window.contentView = hostingView
+            window.level = .statusBar
+            window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle, .stationary]
+            window.backgroundColor = .clear
+            window.isOpaque = false
+            window.hasShadow = false
+            window.ignoresMouseEvents = true
+            window.acceptsMouseMovedEvents = false
+            window.isMovable = false
+            window.isReleasedWhenClosed = false
+            window.canHide = false
+            window.hidesOnDeactivate = false
+            window.becomesKeyOnlyIfNeeded = false
+            window.isExcludedFromWindowsMenu = true
+            window.setFrame(frame, display: false)
+            return window
+        }
+
+        self.logger.info(
+            "Presenting confetti overlay",
+            metadata: [
+                "screenCount": "\(self.windows.count)",
+                "originKnown": origin == nil ? "0" : "1",
+            ])
+
+        for window in self.windows {
+            window.orderFrontRegardless()
+        }
+
+        self.dismissalTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(Self.overlayLifetime))
+            self?.dismiss()
+        }
+    }
+
+    func dismiss() {
+        self.dismissalTask?.cancel()
+        self.dismissalTask = nil
+
+        guard !self.windows.isEmpty else { return }
+        for window in self.windows {
+            window.orderOut(nil)
+            window.close()
+        }
+        self.windows.removeAll(keepingCapacity: true)
+    }
+
+    private static func localOrigin(in screenFrame: CGRect, from globalOrigin: CGPoint?) -> CGPoint {
+        let fallback = CGPoint(x: screenFrame.maxX - 28, y: screenFrame.maxY - 8)
+        let resolved: CGPoint = if let globalOrigin, screenFrame.contains(globalOrigin) {
+            globalOrigin
+        } else {
+            fallback
+        }
+
+        let insetFrame = screenFrame.insetBy(dx: 8, dy: 8)
+        return CGPoint(
+            x: min(max(resolved.x, insetFrame.minX), insetFrame.maxX) - screenFrame.minX,
+            y: min(max(resolved.y, insetFrame.minY), insetFrame.maxY) - screenFrame.minY)
+    }
+
+    private static func randomPalette() -> [Color] {
+        let hue = Double.random(in: 0...1)
+        let hueOffsets = [0.0, 0.08, 0.16, 0.5, 0.66, 0.83]
+        return hueOffsets.map { offset in
+            Color(
+                hue: (hue + offset).truncatingRemainder(dividingBy: 1),
+                saturation: Double.random(in: 0.55...0.95),
+                brightness: Double.random(in: 0.85...1))
+        }
+    }
+}
+
+private final class ClickThroughOverlayPanel: NSPanel {
+    override var canBecomeKey: Bool {
+        false
+    }
+
+    override var canBecomeMain: Bool {
+        false
+    }
+
+    override var acceptsFirstResponder: Bool {
+        false
+    }
+}
+
+private struct ScreenConfettiOverlayView: View {
+    private static let clockwiseRotationAngles: [Double] = [270, 234, 198, 162, 126, 90]
+    private static let counterclockwiseRotationAngles: [Double] = [90, 126, 162, 198, 234, 270]
+
+    let origin: CGPoint
+    let colors: [Color]
+
+    @Environment(\.self) private var environment
+    @State private var visiblePhaseCount = 0
+
+    var body: some View {
+        GeometryReader { proxy in
+            let clockwiseAngles = Array(Self.clockwiseRotationAngles.prefix(self.visiblePhaseCount).enumerated())
+            let counterclockwiseAngles = Array(
+                Self.counterclockwiseRotationAngles.prefix(self.visiblePhaseCount).enumerated())
+            ZStack {
+                ForEach(clockwiseAngles, id: \.offset) { index, angle in
+                    VortexView(self.makeFireworkConfettiSystem(
+                        in: proxy.size,
+                        launchAngle: angle,
+                        phaseIndex: index,
+                        lateralOffset: -12))
+                    {
+                        RoundedRectangle(cornerRadius: 2, style: .continuous)
+                            .fill(.white)
+                            .frame(width: 10, height: 20)
+                            .tag("confetti-bar")
+
+                        Circle()
+                            .fill(.white)
+                            .frame(width: 9, height: 9)
+                            .tag("confetti-dot")
+
+                        Capsule(style: .continuous)
+                            .fill(.white)
+                            .frame(width: 8, height: 16)
+                            .rotationEffect(.degrees(30))
+                            .tag("confetti-pill")
+
+                        Circle()
+                            .fill(.white)
+                            .frame(width: 6, height: 6)
+                            .blur(radius: 1)
+                            .tag("confetti-tracer")
+                    }
+                }
+
+                ForEach(counterclockwiseAngles, id: \.offset) { index, angle in
+                    VortexView(self.makeFireworkConfettiSystem(
+                        in: proxy.size,
+                        launchAngle: angle,
+                        phaseIndex: index,
+                        lateralOffset: 12))
+                    {
+                        RoundedRectangle(cornerRadius: 2, style: .continuous)
+                            .fill(.white)
+                            .frame(width: 10, height: 20)
+                            .tag("confetti-bar")
+
+                        Circle()
+                            .fill(.white)
+                            .frame(width: 9, height: 9)
+                            .tag("confetti-dot")
+
+                        Capsule(style: .continuous)
+                            .fill(.white)
+                            .frame(width: 8, height: 16)
+                            .rotationEffect(.degrees(30))
+                            .tag("confetti-pill")
+
+                        Circle()
+                            .fill(.white)
+                            .frame(width: 6, height: 6)
+                            .blur(radius: 1)
+                            .tag("confetti-tracer")
+                    }
+                }
+            }
+            .ignoresSafeArea()
+            .allowsHitTesting(false)
+            .task {
+                self.visiblePhaseCount = 1
+                for phaseCount in 2...Self.clockwiseRotationAngles.count {
+                    try? await Task.sleep(for: .milliseconds(60))
+                    self.visiblePhaseCount = phaseCount
+                }
+            }
+        }
+    }
+
+    private func makeFireworkConfettiSystem(
+        in size: CGSize,
+        launchAngle: Double,
+        phaseIndex: Int,
+        lateralOffset: CGFloat)
+        -> VortexSystem
+    {
+        let canvasOrigin = self.canvasOrigin(in: size, lateralOffset: lateralOffset)
+        let normalizedX = size.width > 0 ? canvasOrigin.x / size.width : 1
+        let normalizedY = size.height > 0 ? canvasOrigin.y / size.height : 0
+        let resolvedColors = self.colors.map { color -> VortexSystem.Color in
+            let components = color.resolve(in: self.environment)
+            return VortexSystem.Color(
+                red: Double(components.red),
+                green: Double(components.green),
+                blue: Double(components.blue),
+                opacity: Double(components.opacity))
+        }
+
+        let explosion = VortexSystem(
+            tags: ["confetti-bar", "confetti-dot", "confetti-pill"],
+            spawnOccasion: .onDeath,
+            shape: .point,
+            birthRate: 24000,
+            emissionLimit: 42,
+            emissionDuration: 0.08,
+            idleDuration: 10,
+            lifespan: 4.2,
+            speed: 0.72,
+            speedVariation: 0.44,
+            angleRange: .degrees(360),
+            acceleration: [0, 0.32],
+            dampingFactor: 0.18,
+            angularSpeed: [0, 0, 3],
+            angularSpeedVariation: [2, 2, 14],
+            colors: .random(resolvedColors),
+            size: 0.74,
+            sizeVariation: 0.26,
+            sizeMultiplierAtDeath: 0.94,
+            stretchFactor: 0.82)
+
+        return VortexSystem(
+            tags: ["confetti-tracer"],
+            secondarySystems: [explosion],
+            position: [normalizedX, normalizedY],
+            shape: .point,
+            birthRate: 18,
+            emissionLimit: 4,
+            emissionDuration: 0.22,
+            idleDuration: 10,
+            lifespan: 0.58 + (Double(phaseIndex) * 0.03),
+            speed: 1.36 + (Double(phaseIndex) * 0.04),
+            speedVariation: 0.12,
+            angle: .degrees(launchAngle),
+            angleRange: .degrees(12),
+            acceleration: [0, 0.12],
+            dampingFactor: 0.06,
+            angularSpeed: [0, 0, 6],
+            angularSpeedVariation: [1, 1, 8],
+            colors: .single(.white),
+            size: 0.34,
+            sizeVariation: 0.08,
+            sizeMultiplierAtDeath: 0.4,
+            stretchFactor: 1.3)
+    }
+
+    private func canvasOrigin(in size: CGSize, lateralOffset: CGFloat = 0) -> CGPoint {
+        CGPoint(
+            x: min(max(self.origin.x + lateralOffset, 0), size.width),
+            y: min(max(size.height - self.origin.y + 18, 0), size.height))
+    }
+}

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -192,6 +192,14 @@ extension SettingsStore {
         }
     }
 
+    var confettiOnWeeklyLimitResetsEnabled: Bool {
+        get { self.defaultsState.confettiOnWeeklyLimitResetsEnabled }
+        set {
+            self.defaultsState.confettiOnWeeklyLimitResetsEnabled = newValue
+            self.userDefaults.set(newValue, forKey: "confettiOnWeeklyLimitResetsEnabled")
+        }
+    }
+
     var menuBarShowsHighestUsage: Bool {
         get { self.defaultsState.menuBarShowsHighestUsage }
         set {

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -22,6 +22,7 @@ extension SettingsStore {
         _ = self.costUsageEnabled
         _ = self.hidePersonalInfo
         _ = self.randomBlinkEnabled
+        _ = self.confettiOnWeeklyLimitResetsEnabled
         _ = self.claudeOAuthKeychainPromptMode
         _ = self.claudeOAuthKeychainReadStrategy
         _ = self.claudeWebExtrasEnabled

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -255,6 +255,8 @@ extension SettingsStore {
         let costUsageEnabled = userDefaults.object(forKey: "tokenCostUsageEnabled") as? Bool ?? false
         let hidePersonalInfo = userDefaults.object(forKey: "hidePersonalInfo") as? Bool ?? false
         let randomBlinkEnabled = userDefaults.object(forKey: "randomBlinkEnabled") as? Bool ?? false
+        let confettiOnWeeklyLimitResetsEnabled = userDefaults.object(
+            forKey: "confettiOnWeeklyLimitResetsEnabled") as? Bool ?? false
         let menuBarShowsHighestUsage = userDefaults.object(forKey: "menuBarShowsHighestUsage") as? Bool ?? false
         let claudeOAuthKeychainPromptModeRaw = userDefaults.string(forKey: "claudeOAuthKeychainPromptMode")
         let claudeOAuthKeychainReadStrategyRaw = userDefaults.string(forKey: "claudeOAuthKeychainReadStrategy")
@@ -299,6 +301,7 @@ extension SettingsStore {
             costUsageEnabled: costUsageEnabled,
             hidePersonalInfo: hidePersonalInfo,
             randomBlinkEnabled: randomBlinkEnabled,
+            confettiOnWeeklyLimitResetsEnabled: confettiOnWeeklyLimitResetsEnabled,
             menuBarShowsHighestUsage: menuBarShowsHighestUsage,
             claudeOAuthKeychainPromptModeRaw: claudeOAuthKeychainPromptModeRaw,
             claudeOAuthKeychainReadStrategyRaw: claudeOAuthKeychainReadStrategyRaw,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -21,6 +21,7 @@ struct SettingsDefaultsState {
     var costUsageEnabled: Bool
     var hidePersonalInfo: Bool
     var randomBlinkEnabled: Bool
+    var confettiOnWeeklyLimitResetsEnabled: Bool
     var menuBarShowsHighestUsage: Bool
     var claudeOAuthKeychainPromptModeRaw: String?
     var claudeOAuthKeychainReadStrategyRaw: String?

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -198,6 +198,26 @@ extension StatusItemController {
         item.button?.performClick(nil)
     }
 
+    func celebrationOriginPoint(for provider: UsageProvider?) -> CGPoint? {
+        let item: NSStatusItem = if self.shouldMergeIcons {
+            self.statusItem
+        } else if let provider, let existing = self.statusItems[provider], existing.isVisible {
+            existing
+        } else {
+            self.lazyStatusItem(for: provider ?? .codex)
+        }
+
+        guard let button = item.button,
+              let window = button.window
+        else {
+            return nil
+        }
+
+        let buttonFrameInWindow = button.convert(button.bounds, to: nil)
+        let screenFrame = window.convertToScreen(buttonFrameInWindow)
+        return CGPoint(x: screenFrame.midX, y: screenFrame.midY)
+    }
+
     private func openSettings(tab: PreferencesTab) {
         DispatchQueue.main.async {
             self.preferencesSelection.tab = tab

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -9,6 +9,13 @@ import SwiftUI
 @MainActor
 protocol StatusItemControlling: AnyObject {
     func openMenuFromShortcut()
+    func celebrationOriginPoint(for provider: UsageProvider?) -> CGPoint?
+}
+
+extension StatusItemControlling {
+    func celebrationOriginPoint(for provider: UsageProvider?) -> CGPoint? {
+        nil
+    }
 }
 
 @MainActor

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -2,6 +2,15 @@ import CodexBarCore
 import Foundation
 
 extension UsageStore {
+    private nonisolated static let weeklyLimitResetThreshold = 1.0
+    private nonisolated static let weeklyLimitResetDetectorDefaultsKey = "weeklyLimitResetDetectorStates"
+    private nonisolated static let weeklyWindowMinutes = 7 * 24 * 60
+
+    struct WeeklyLimitResetDetectorState: Codable, Equatable {
+        let wasAboveThreshold: Bool
+        let lastObservedAt: Date
+    }
+
     func supportsPlanUtilizationHistory(for provider: UsageProvider) -> Bool {
         switch provider {
         case .codex, .claude:
@@ -65,6 +74,22 @@ extension UsageStore {
         now: Date = Date())
         async
     {
+        let samples = self.planUtilizationSeriesSamples(provider: provider, snapshot: snapshot, capturedAt: now)
+        guard !samples.isEmpty else { return }
+
+        let detectorAccountKey = self.planUtilizationAccountKey(
+            for: provider,
+            snapshot: snapshot,
+            preferredAccount: account)
+        await MainActor.run {
+            self.postWeeklyLimitResetCelebrationIfNeeded(
+                provider: provider,
+                account: account,
+                snapshot: snapshot,
+                accountKey: detectorAccountKey,
+                samples: samples)
+        }
+
         guard self.supportsPlanUtilizationHistory(for: provider) else { return }
         guard !self.shouldDeferClaudePlanUtilizationHistory(provider: provider) else { return }
 
@@ -80,7 +105,6 @@ extension UsageStore {
                 shouldAdoptUnscopedHistory: shouldAdoptUnscopedHistory,
                 providerBuckets: &providerBuckets)
             let histories = providerBuckets.histories(for: accountKey)
-            let samples = self.planUtilizationSeriesSamples(provider: provider, snapshot: snapshot, capturedAt: now)
 
             guard let updatedHistories = Self.updatedPlanUtilizationHistories(
                 existingHistories: histories,
@@ -195,6 +219,62 @@ extension UsageStore {
         return max(0, min(100, value))
     }
 
+    private func postWeeklyLimitResetCelebrationIfNeeded(
+        provider: UsageProvider,
+        account: ProviderTokenAccount?,
+        snapshot: UsageSnapshot,
+        accountKey: String?,
+        samples: [PlanUtilizationSeriesSample])
+    {
+        guard let weeklySample = samples.last(where: { $0.name == .weekly }) else { return }
+
+        let accountIdentifier = self.weeklyLimitResetAccountIdentifier(
+            provider: provider,
+            account: account,
+            snapshot: snapshot,
+            accountKey: accountKey)
+        let detectorKey = Self.weeklyLimitResetDetectorStateKey(
+            provider: provider,
+            accountIdentifier: accountIdentifier)
+        let currentUsed = weeklySample.entry.usedPercent
+        let currentObservedAt = weeklySample.entry.capturedAt
+        let wasAboveThreshold = currentUsed > Self.weeklyLimitResetThreshold
+        if let existingState = self.weeklyLimitResetDetectorStates[detectorKey],
+           currentObservedAt <= existingState.lastObservedAt
+        {
+            return
+        }
+
+        let shouldPost = self.weeklyLimitResetDetectorStates[detectorKey]?.wasAboveThreshold == true
+            && !wasAboveThreshold
+        self.weeklyLimitResetDetectorStates[detectorKey] = WeeklyLimitResetDetectorState(
+            wasAboveThreshold: wasAboveThreshold,
+            lastObservedAt: currentObservedAt)
+        self.persistWeeklyLimitResetDetectorStates()
+
+        guard shouldPost else { return }
+        let accountLabel = self.weeklyLimitResetAccountLabel(
+            provider: provider,
+            account: account,
+            snapshot: snapshot)
+        let event = WeeklyLimitResetEvent(
+            provider: provider,
+            accountIdentifier: accountIdentifier,
+            accountLabel: accountLabel,
+            usedPercent: currentUsed)
+
+        CodexBarLog.logger(LogCategories.confetti).info(
+            "Weekly limit reset",
+            metadata: [
+                "provider": provider.rawValue,
+                "accountIdentifier": accountIdentifier,
+                "accountLabel": accountLabel ?? "",
+                "usedPercent": String(format: "%.2f", currentUsed),
+                "observedAt": String(format: "%.0f", currentObservedAt.timeIntervalSince1970),
+            ])
+        NotificationCenter.default.post(name: .codexbarWeeklyLimitReset, object: event)
+    }
+
     private func planUtilizationSeriesSamples(
         provider: UsageProvider,
         snapshot: UsageSnapshot,
@@ -235,7 +315,10 @@ extension UsageStore {
             appendWindow(snapshot.secondary, name: .weekly)
             appendWindow(snapshot.tertiary, name: .opus)
         default:
-            break
+            for window in [snapshot.primary, snapshot.secondary, snapshot.tertiary] {
+                guard let window, window.windowMinutes == Self.weeklyWindowMinutes else { continue }
+                appendWindow(window, name: .weekly)
+            }
         }
 
         return samplesByKey.values.sorted { lhs, rhs in
@@ -424,6 +507,63 @@ extension UsageStore {
 
     private func shouldDeferClaudePlanUtilizationHistory(provider: UsageProvider) -> Bool {
         provider == .claude && self.shouldHidePlanUtilizationMenuItem(for: .claude)
+    }
+
+    private func weeklyLimitResetAccountIdentifier(
+        provider: UsageProvider,
+        account: ProviderTokenAccount?,
+        snapshot: UsageSnapshot,
+        accountKey: String?) -> String
+    {
+        let identity = snapshot.identity(for: provider)
+        return account?.id.uuidString.lowercased()
+            ?? accountKey
+            ?? identity?.accountEmail
+            ?? identity?.accountOrganization
+            ?? provider.rawValue
+    }
+
+    private func weeklyLimitResetAccountLabel(
+        provider: UsageProvider,
+        account: ProviderTokenAccount?,
+        snapshot: UsageSnapshot) -> String?
+    {
+        let identity = snapshot.identity(for: provider)
+        return account?.label
+            ?? identity?.accountEmail
+            ?? identity?.accountOrganization
+    }
+
+    private nonisolated static func weeklyLimitResetDetectorStateKey(
+        provider: UsageProvider,
+        accountIdentifier: String) -> String
+    {
+        "\(provider.rawValue):\(accountIdentifier)"
+    }
+
+    nonisolated static func loadWeeklyLimitResetDetectorStates(from userDefaults: UserDefaults)
+        -> [String: WeeklyLimitResetDetectorState]
+    {
+        guard let data = userDefaults.data(forKey: self.weeklyLimitResetDetectorDefaultsKey) else { return [:] }
+        do {
+            return try JSONDecoder().decode([String: WeeklyLimitResetDetectorState].self, from: data)
+        } catch {
+            CodexBarLog.logger(LogCategories.confetti).error(
+                "Failed to decode weekly limit reset detector state",
+                metadata: ["error": String(describing: error)])
+            return [:]
+        }
+    }
+
+    private func persistWeeklyLimitResetDetectorStates() {
+        do {
+            let data = try JSONEncoder().encode(self.weeklyLimitResetDetectorStates)
+            self.settings.userDefaults.set(data, forKey: Self.weeklyLimitResetDetectorDefaultsKey)
+        } catch {
+            CodexBarLog.logger(LogCategories.confetti).error(
+                "Failed to encode weekly limit reset detector state",
+                metadata: ["error": String(describing: error)])
+        }
     }
 
     private func resolvePlanUtilizationAccountKey(

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -205,6 +205,7 @@ final class UsageStore {
     @ObservationIgnored var lastKnownSessionWindowSource: [UsageProvider: SessionQuotaWindowSource] = [:]
     @ObservationIgnored var lastTokenFetchAt: [UsageProvider: Date] = [:]
     @ObservationIgnored var planUtilizationHistory: [UsageProvider: PlanUtilizationHistoryBuckets] = [:]
+    @ObservationIgnored var weeklyLimitResetDetectorStates: [String: WeeklyLimitResetDetectorState] = [:]
     @ObservationIgnored private var hasCompletedInitialRefresh: Bool = false
     @ObservationIgnored private let tokenFetchTTL: TimeInterval = 60 * 60
     @ObservationIgnored private let tokenFetchTimeout: TimeInterval = 10 * 60
@@ -256,6 +257,7 @@ final class UsageStore {
             implementation.makeRuntime().map { (implementation.id, $0) }
         })
         self.planUtilizationHistory = planUtilizationHistoryStore.load()
+        self.weeklyLimitResetDetectorStates = Self.loadWeeklyLimitResetDetectorStates(from: settings.userDefaults)
         self.logStartupState()
         self.bindSettings()
         self.pathDebugInfo = PathDebugSnapshot(

--- a/Sources/CodexBarCore/Logging/LogCategories.swift
+++ b/Sources/CodexBarCore/Logging/LogCategories.swift
@@ -14,6 +14,7 @@ public enum LogCategories {
     public static let codexRPC = "codex-rpc"
     public static let configMigration = "config-migration"
     public static let configStore = "config-store"
+    public static let confetti = "confetti"
     public static let cookieCache = "cookie-cache"
     public static let cookieHeaderStore = "cookie-header-store"
     public static let copilotTokenStore = "copilot-token-store"

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -6,6 +6,7 @@ import Testing
 
 @Suite(.serialized)
 @MainActor
+// swiftlint:disable:next type_body_length
 struct SettingsStoreTests {
     private final class ObservationFlag: @unchecked Sendable {
         private let lock = NSLock()
@@ -83,6 +84,31 @@ struct SettingsStoreTests {
 
         #expect(storeB.refreshFrequency == .fifteenMinutes)
         #expect(storeB.refreshFrequency.seconds == 900)
+    }
+
+    @Test
+    func `weekly confetti setting defaults off and persists`() throws {
+        let suite = "SettingsStoreTests-weekly-confetti"
+        let defaultsA = try #require(UserDefaults(suiteName: suite))
+        defaultsA.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        let storeA = SettingsStore(
+            userDefaults: defaultsA,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        #expect(storeA.confettiOnWeeklyLimitResetsEnabled == false)
+        storeA.confettiOnWeeklyLimitResetsEnabled = true
+
+        let defaultsB = try #require(UserDefaults(suiteName: suite))
+        let storeB = SettingsStore(
+            userDefaults: defaultsB,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        #expect(storeB.confettiOnWeeklyLimitResetsEnabled == true)
     }
 
     @Test

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 @testable import CodexBar
 
+// swiftlint:disable:next type_body_length
 struct UsageStorePlanUtilizationTests {
     @Test
     func `coalesces changed usage within hour into single entry`() throws {
@@ -649,6 +650,228 @@ struct UsageStorePlanUtilizationTests {
         #expect(findSeries(histories, name: .session, windowMinutes: 300)?.entries.last?.usedPercent == 10)
         #expect(findSeries(histories, name: .weekly, windowMinutes: 10080)?.entries.last?.usedPercent == 20)
         #expect(findSeries(histories, name: .opus, windowMinutes: 10080)?.entries.last?.usedPercent == 30)
+    }
+
+    @MainActor
+    @Test
+    func `weekly quota celebration posts when weekly usage resets to zero`() async {
+        let store = Self.makeStore()
+        var events: [WeeklyLimitResetEvent] = []
+        let token = NotificationCenter.default.addObserver(
+            forName: .codexbarWeeklyLimitReset,
+            object: nil,
+            queue: nil)
+        { notification in
+            if let event = notification.object as? WeeklyLimitResetEvent {
+                events.append(event)
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        let before = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 99, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "alice@example.com",
+                accountOrganization: nil,
+                loginMethod: "max"))
+        let after = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 0, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date(timeIntervalSince1970: 1_700_003_600),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "alice@example.com",
+                accountOrganization: nil,
+                loginMethod: "max"))
+
+        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: after, now: after.updatedAt)
+
+        #expect(events.count == 1)
+        #expect(events[0].provider == .claude)
+        #expect(events[0].accountLabel == "alice@example.com")
+        #expect(events[0].usedPercent == 0)
+    }
+
+    @MainActor
+    @Test
+    func `weekly quota celebration posts when reset lands mid hour without history split`() async {
+        let store = Self.makeStore()
+        var events: [WeeklyLimitResetEvent] = []
+        let token = NotificationCenter.default.addObserver(
+            forName: .codexbarWeeklyLimitReset,
+            object: nil,
+            queue: nil)
+        { notification in
+            if let event = notification.object as? WeeklyLimitResetEvent {
+                events.append(event)
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        let before = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 40,
+                windowMinutes: 10080,
+                resetsAt: Date(timeIntervalSince1970: 1_700_100_000),
+                resetDescription: nil),
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "alice@example.com",
+                accountOrganization: nil,
+                loginMethod: "max"))
+        let after = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 0,
+                windowMinutes: 10080,
+                resetsAt: Date(timeIntervalSince1970: 1_700_100_030),
+                resetDescription: nil),
+            updatedAt: Date(timeIntervalSince1970: 1_700_001_800),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "alice@example.com",
+                accountOrganization: nil,
+                loginMethod: "max"))
+
+        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: after, now: after.updatedAt)
+
+        let histories = store.planUtilizationHistory(for: .claude)
+        #expect(findSeries(histories, name: .weekly, windowMinutes: 10080)?.entries.count == 1)
+        #expect(findSeries(histories, name: .weekly, windowMinutes: 10080)?.entries.last?.usedPercent == 40)
+        #expect(events.count == 1)
+        #expect(events[0].usedPercent == 0)
+    }
+
+    @MainActor
+    @Test
+    func `weekly quota celebration ignores first seen reset sample`() async {
+        let store = Self.makeStore()
+        var eventCount = 0
+        let token = NotificationCenter.default.addObserver(
+            forName: .codexbarWeeklyLimitReset,
+            object: nil,
+            queue: nil)
+        { _ in
+            eventCount += 1
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 0, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "alice@example.com",
+                accountOrganization: nil,
+                loginMethod: "max"))
+
+        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: snapshot, now: snapshot.updatedAt)
+
+        #expect(eventCount == 0)
+    }
+
+    @MainActor
+    @Test
+    func `weekly quota celebration fires once across repeated low samples`() async {
+        let store = Self.makeStore()
+        var events: [WeeklyLimitResetEvent] = []
+        let token = NotificationCenter.default.addObserver(
+            forName: .codexbarWeeklyLimitReset,
+            object: nil,
+            queue: nil)
+        { notification in
+            if let event = notification.object as? WeeklyLimitResetEvent {
+                events.append(event)
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        let before = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 60, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "alice@example.com",
+                accountOrganization: nil,
+                loginMethod: "max"))
+        let firstLow = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 1, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date(timeIntervalSince1970: 1_700_001_800),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "alice@example.com",
+                accountOrganization: nil,
+                loginMethod: "max"))
+        let secondLow = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 0, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date(timeIntervalSince1970: 1_700_002_100),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "alice@example.com",
+                accountOrganization: nil,
+                loginMethod: "max"))
+
+        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: firstLow, now: firstLow.updatedAt)
+        await store.recordPlanUtilizationHistorySample(provider: .claude, snapshot: secondLow, now: secondLow.updatedAt)
+
+        #expect(events.count == 1)
+        #expect(events[0].usedPercent == 1)
+    }
+
+    @MainActor
+    @Test
+    func `weekly quota celebration posts for generic provider weekly lane`() async {
+        let store = Self.makeStore()
+        var events: [WeeklyLimitResetEvent] = []
+        let token = NotificationCenter.default.addObserver(
+            forName: .codexbarWeeklyLimitReset,
+            object: nil,
+            queue: nil)
+        { notification in
+            if let event = notification.object as? WeeklyLimitResetEvent {
+                events.append(event)
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        let before = UsageSnapshot(
+            primary: RateWindow(usedPercent: 92, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 15, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            identity: ProviderIdentitySnapshot(
+                providerID: .zai,
+                accountEmail: nil,
+                accountOrganization: "zai-org",
+                loginMethod: "pro"))
+        let after = UsageSnapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 15, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date(timeIntervalSince1970: 1_700_003_600),
+            identity: ProviderIdentitySnapshot(
+                providerID: .zai,
+                accountEmail: nil,
+                accountOrganization: "zai-org",
+                loginMethod: "pro"))
+
+        await store.recordPlanUtilizationHistorySample(provider: .zai, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(provider: .zai, snapshot: after, now: after.updatedAt)
+
+        #expect(events.count == 1)
+        #expect(events[0].provider == .zai)
+        #expect(events[0].accountLabel == "zai-org")
+        #expect(events[0].usedPercent == 0)
     }
 
     @MainActor


### PR DESCRIPTION
Bringing some joy for the weekly limits reset with opt-in confetti setting

https://github.com/user-attachments/assets/5865da8a-1a02-437c-ab52-4ea628c41e55

TLDR is every time we fetch usage we compare was the previous weekly usage was > 1% and new is ≤ 1% - if condition is met we fire confetti