### PR TITLE
Add Cursor extra usage menu bar metric

### DIFF
--- a/Sources/CodexBar/MenuBarMetricWindowResolver.swift
+++ b/Sources/CodexBar/MenuBarMetricWindowResolver.swift
@@ -17,6 +17,8 @@ enum MenuBarMetricWindowResolver {
     {
         guard let snapshot else { return nil }
         switch preference {
+        case .extraUsage:
+            return Self.extraUsageWindow(snapshot: snapshot)
         case .tertiary:
             return Self.window(in: snapshot, following: Self.tertiaryOrder(for: provider))
         case .primary:
@@ -140,5 +142,15 @@ enum MenuBarMetricWindowResolver {
         let windows = [primary, secondary, tertiary].compactMap(\.self)
         guard !windows.isEmpty else { return nil }
         return windows.max(by: { $0.usedPercent < $1.usedPercent })
+    }
+
+    private static func extraUsageWindow(snapshot: UsageSnapshot?) -> RateWindow? {
+        guard let cost = snapshot?.providerCost, cost.limit > 0 else { return nil }
+        let usedPercent = max(0, min(100, (cost.used / cost.limit) * 100))
+        return RateWindow(
+            usedPercent: usedPercent,
+            windowMinutes: nil,
+            resetsAt: cost.resetsAt,
+            resetDescription: nil)
     }
 }

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -465,6 +465,7 @@ struct ProvidersPane: View {
             let snapshot = self.store.snapshot(for: provider)
             let supportsAverage = self.settings.menuBarMetricSupportsAverage(for: provider)
             let supportsTertiary = self.settings.menuBarMetricSupportsTertiary(for: provider, snapshot: snapshot)
+            let supportsExtraUsage = self.settings.menuBarMetricSupportsExtraUsage(for: provider, snapshot: snapshot)
             var metricOptions: [ProviderSettingsPickerOption] = [
                 ProviderSettingsPickerOption(id: MenuBarMetricPreference.automatic.rawValue, title: "Automatic"),
                 ProviderSettingsPickerOption(
@@ -479,6 +480,11 @@ struct ProvidersPane: View {
                 metricOptions.append(ProviderSettingsPickerOption(
                     id: MenuBarMetricPreference.tertiary.rawValue,
                     title: "Tertiary (\(tertiaryTitle))"))
+            }
+            if supportsExtraUsage {
+                metricOptions.append(ProviderSettingsPickerOption(
+                    id: MenuBarMetricPreference.extraUsage.rawValue,
+                    title: MenuBarMetricPreference.extraUsage.label))
             }
             if supportsAverage {
                 metricOptions.append(ProviderSettingsPickerOption(

--- a/Sources/CodexBar/SettingsStore+MenuPreferences.swift
+++ b/Sources/CodexBar/SettingsStore+MenuPreferences.swift
@@ -9,7 +9,7 @@ extension SettingsStore {
             switch preference {
             case .automatic, .primary:
                 return preference
-            case .secondary, .average, .tertiary:
+            case .secondary, .average, .tertiary, .extraUsage:
                 return .automatic
             }
         }
@@ -21,6 +21,9 @@ extension SettingsStore {
         if preference == .tertiary, !self.menuBarMetricSupportsTertiary(for: provider) {
             return .automatic
         }
+        if preference == .extraUsage, !self.menuBarMetricSupportsExtraUsage(for: provider) {
+            return .automatic
+        }
         return preference
     }
 
@@ -29,12 +32,16 @@ extension SettingsStore {
             switch preference {
             case .automatic, .primary:
                 self.menuBarMetricPreferencesRaw[provider.rawValue] = preference.rawValue
-            case .secondary, .average, .tertiary:
+            case .secondary, .average, .tertiary, .extraUsage:
                 self.menuBarMetricPreferencesRaw[provider.rawValue] = MenuBarMetricPreference.automatic.rawValue
             }
             return
         }
         if preference == .tertiary, !self.menuBarMetricSupportsTertiary(for: provider) {
+            self.menuBarMetricPreferencesRaw[provider.rawValue] = MenuBarMetricPreference.automatic.rawValue
+            return
+        }
+        if preference == .extraUsage, !self.menuBarMetricSupportsExtraUsage(for: provider) {
             self.menuBarMetricPreferencesRaw[provider.rawValue] = MenuBarMetricPreference.automatic.rawValue
             return
         }
@@ -56,10 +63,25 @@ extension SettingsStore {
         return self.menuBarMetricSupportsTertiary(for: provider)
     }
 
+    func menuBarMetricSupportsExtraUsage(for provider: UsageProvider) -> Bool {
+        provider == .cursor
+    }
+
+    func menuBarMetricSupportsExtraUsage(for provider: UsageProvider, snapshot: UsageSnapshot?) -> Bool {
+        guard self.menuBarMetricSupportsExtraUsage(for: provider) else { return false }
+        guard let cost = snapshot?.providerCost else { return false }
+        return cost.limit > 0
+    }
+
     func menuBarMetricPreference(for provider: UsageProvider, snapshot: UsageSnapshot?) -> MenuBarMetricPreference {
         let preference = self.menuBarMetricPreference(for: provider)
         if preference == .tertiary,
            !self.menuBarMetricSupportsTertiary(for: provider, snapshot: snapshot)
+        {
+            return .automatic
+        }
+        if preference == .extraUsage,
+           !self.menuBarMetricSupportsExtraUsage(for: provider, snapshot: snapshot)
         {
             return .automatic
         }

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -43,6 +43,7 @@ enum MenuBarMetricPreference: String, CaseIterable, Identifiable {
     case primary
     case secondary
     case tertiary
+    case extraUsage
     case average
 
     var id: String {
@@ -55,6 +56,7 @@ enum MenuBarMetricPreference: String, CaseIterable, Identifiable {
         case .primary: "Primary"
         case .secondary: "Secondary"
         case .tertiary: "Tertiary"
+        case .extraUsage: "Extra usage"
         case .average: "Average"
         }
     }

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -185,6 +185,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         switch preference {
         case .secondary, .tertiary:
             return second ?? first
+        case .extraUsage:
+            return first
         case .average:
             guard self.settings.menuBarMetricSupportsAverage(for: .codex),
                   let primary = first,

--- a/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
+++ b/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
@@ -20,4 +20,25 @@ struct MenuBarMetricWindowResolverTests {
 
         #expect(window?.usedPercent == 92)
     }
+
+    @Test
+    func `extra usage metric maps provider cost into a menu bar window`() {
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 12, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 37.5,
+                limit: 150,
+                currencyCode: "USD",
+                updatedAt: Date()),
+            updatedAt: Date())
+
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .extraUsage,
+            provider: .cursor,
+            snapshot: snapshot,
+            supportsAverage: false)
+
+        #expect(window?.usedPercent == 25)
+    }
 }

--- a/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
+++ b/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
@@ -63,6 +63,48 @@ struct ProvidersPaneCoverageTests {
     }
 
     @Test
+    func `cursor menu bar metric picker omits extra usage when on demand budget is missing`() {
+        let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-cursor-no-extra-usage-picker")
+        let store = Self.makeUsageStore(settings: settings)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 12, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: RateWindow(usedPercent: 34, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                updatedAt: Date()),
+            provider: .cursor)
+        let pane = ProvidersPane(settings: settings, store: store)
+
+        let picker = pane._test_menuBarMetricPicker(for: .cursor)
+        let ids = picker?.options.map(\.id) ?? []
+        #expect(!ids.contains(MenuBarMetricPreference.extraUsage.rawValue))
+    }
+
+    @Test
+    func `cursor menu bar metric picker includes extra usage when on demand budget is available`() {
+        let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-cursor-extra-usage-picker")
+        let store = Self.makeUsageStore(settings: settings)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 12, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: RateWindow(usedPercent: 34, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                tertiary: RateWindow(usedPercent: 56, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                providerCost: ProviderCostSnapshot(
+                    used: 15,
+                    limit: 100,
+                    currencyCode: "USD",
+                    updatedAt: Date()),
+                updatedAt: Date()),
+            provider: .cursor)
+        let pane = ProvidersPane(settings: settings, store: store)
+
+        let picker = pane._test_menuBarMetricPicker(for: .cursor)
+        let ids = picker?.options.map(\.id) ?? []
+        #expect(ids.contains(MenuBarMetricPreference.extraUsage.rawValue))
+        let option = picker?.options.first { $0.id == MenuBarMetricPreference.extraUsage.rawValue }
+        #expect(option?.title == "Extra usage")
+    }
+
+    @Test
     func `zai menu bar metric picker omits tertiary lane when snapshot has no 5-hour metric`() {
         let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-zai-no-tertiary-picker")
         let store = Self.makeUsageStore(settings: settings)

--- a/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
@@ -36,6 +36,11 @@ struct SettingsStoreAdditionalTests {
         #expect(settings.menuBarMetricPreference(for: .cursor, snapshot: nil) == .automatic)
         #expect(settings.menuBarMetricSupportsTertiary(for: .cursor, snapshot: nil) == false)
 
+        settings.setMenuBarMetricPreference(.extraUsage, for: .cursor)
+        #expect(settings.menuBarMetricPreference(for: .cursor) == .extraUsage)
+        #expect(settings.menuBarMetricPreference(for: .cursor, snapshot: nil) == .automatic)
+        #expect(settings.menuBarMetricSupportsExtraUsage(for: .cursor, snapshot: nil) == false)
+
         settings.setMenuBarMetricPreference(.tertiary, for: .perplexity)
         #expect(settings.menuBarMetricPreference(for: .perplexity) == .tertiary)
         #expect(settings.menuBarMetricPreference(for: .perplexity, snapshot: nil) == .tertiary)
@@ -59,6 +64,9 @@ struct SettingsStoreAdditionalTests {
         #expect(settings.menuBarMetricPreference(for: .openrouter) == .primary)
 
         settings.setMenuBarMetricPreference(.tertiary, for: .openrouter)
+        #expect(settings.menuBarMetricPreference(for: .openrouter) == .automatic)
+
+        settings.setMenuBarMetricPreference(.extraUsage, for: .openrouter)
         #expect(settings.menuBarMetricPreference(for: .openrouter) == .automatic)
     }
 

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -726,6 +726,92 @@ struct StatusItemAnimationTests {
     }
 
     @Test
+    func `menu bar extra usage preference uses cursor on demand budget`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-cursor-extra-usage-pref"),
+            zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .cursor
+        settings.setMenuBarMetricPreference(.extraUsage, for: .cursor)
+
+        let registry = ProviderRegistry.shared
+        if let cursorMeta = registry.metadata[.cursor] {
+            settings.setProviderEnabled(provider: .cursor, metadata: cursorMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 20, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            tertiary: RateWindow(usedPercent: 72, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            providerCost: ProviderCostSnapshot(
+                used: 15,
+                limit: 100,
+                currencyCode: "USD",
+                updatedAt: Date()),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .cursor)
+        store._setErrorForTesting(nil, provider: .cursor)
+
+        let window = controller.menuBarMetricWindow(for: .cursor, snapshot: snapshot)
+
+        #expect(window?.usedPercent == 15)
+    }
+
+    @Test
+    func `menu bar extra usage preference falls back to automatic when cursor on demand budget is missing`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-cursor-extra-usage-missing-budget"),
+            zaiTokenStore: NoopZaiTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .cursor
+        settings.setMenuBarMetricPreference(.extraUsage, for: .cursor)
+
+        let registry = ProviderRegistry.shared
+        if let cursorMeta = registry.metadata[.cursor] {
+            settings.setProviderEnabled(provider: .cursor, metadata: cursorMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 72, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            tertiary: nil,
+            providerCost: nil,
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .cursor)
+        store._setErrorForTesting(nil, provider: .cursor)
+
+        let window = controller.menuBarMetricWindow(for: .cursor, snapshot: snapshot)
+
+        #expect(window?.usedPercent == 72)
+    }
+
+    @Test
     func `menu bar display text formats percent and pace`() {
         let now = Date(timeIntervalSince1970: 0)
         let percentWindow = RateWindow(usedPercent: 40, windowMinutes: nil, resetsAt: nil, resetDescription: nil)


### PR DESCRIPTION
## Summary
  - add an `Extra usage` option to Cursor's `Menu bar metric`
  - map Cursor on-demand budget into a menu bar rate window
  - hide the option when no on-demand budget is available and fall back to `Automatic`

  ## Testing
  - `swift test --filter 'MenuBarMetricWindowResolverTests|ProvidersPaneCoverageTests|SettingsStoreAdditionalTests|StatusItemAnimationTests'`