### PR TITLE
Fix Factory session recovery and usage fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixes
 - Codex: ignore invalid zero-minute subscription history so the utilization submenu no longer shows duplicate Session tabs.
 - Codex: clean up cached CLI status probes during app shutdown so `codex -s read-only` workers are not orphaned after restart.
+- Droid: preserve Factory session fallbacks, use the current usage endpoint, and clarify browser-login messaging (#792). Thanks @JosephDoUrden for the original stale-session fix!
 - Menu: keep merged-menu cards, switcher rows, wrapped status text, and hosted chart submenus aligned with the real AppKit menu width so menus no longer grow oversized or show narrower chart submenus after width changes. Thanks @ngutman!
 - Widgets: package App Intents metadata for the widget extension and use configuration defaults so configurable widgets load correctly in WidgetKit (#783). Thanks @ngutman and @vincentyangch!
 

--- a/Sources/CodexBar/Providers/Factory/FactoryProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Factory/FactoryProviderImplementation.swift
@@ -82,4 +82,11 @@ struct FactoryProviderImplementation: ProviderImplementation {
         await context.controller.runFactoryLoginFlow()
         return true
     }
+
+    @MainActor
+    func loginMenuAction(context _: ProviderMenuLoginContext)
+        -> (label: String, action: MenuDescriptor.MenuAction)?
+    {
+        ("Open Droid in Browser...", .loginToProvider(url: "https://app.factory.ai"))
+    }
 }

--- a/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
@@ -651,6 +651,7 @@ public struct FactoryStatusProbe: Sendable {
             } catch {
                 if case FactoryStatusProbeError.notLoggedIn = error {
                     CookieHeaderCache.clear(provider: .factory)
+                    await FactorySessionStore.shared.clearSession()
                 }
                 lastError = error
             }

--- a/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
@@ -444,6 +444,13 @@ public actor FactorySessionStore {
         return self.sessionCookies
     }
 
+    public func clearCookies() {
+        self.loadFromDiskIfNeeded()
+        self.didLoadFromDisk = true
+        self.sessionCookies = []
+        self.saveToDisk()
+    }
+
     public func setBearerToken(_ token: String?) {
         self.didLoadFromDisk = true
         self.bearerToken = token
@@ -477,6 +484,13 @@ public actor FactorySessionStore {
     public func hasValidSession() -> Bool {
         self.loadFromDiskIfNeeded()
         return !self.sessionCookies.isEmpty || self.bearerToken != nil || self.refreshToken != nil
+    }
+
+    func resetInMemoryForTesting() {
+        self.sessionCookies = []
+        self.bearerToken = nil
+        self.refreshToken = nil
+        self.didLoadFromDisk = false
     }
 
     private func saveToDisk() {
@@ -516,6 +530,7 @@ public actor FactorySessionStore {
         guard !payload.isEmpty,
               let data = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted])
         else {
+            try? FileManager.default.removeItem(at: self.fileURL)
             return
         }
         try? data.write(to: self.fileURL)
@@ -651,7 +666,7 @@ public struct FactoryStatusProbe: Sendable {
             } catch {
                 if case FactoryStatusProbeError.notLoggedIn = error {
                     CookieHeaderCache.clear(provider: .factory)
-                    await FactorySessionStore.shared.clearSession()
+                    await FactorySessionStore.shared.clearCookies()
                 }
                 lastError = error
             }
@@ -660,19 +675,19 @@ public struct FactoryStatusProbe: Sendable {
         // Filter to only installed browsers to avoid unnecessary keychain prompts
         let installedChromiumAndFirefox = [.chrome, .firefox].cookieImportCandidates(using: self.browserDetection)
 
-        let attempts: [FetchAttemptResult] = await [
-            self.attemptStoredCookies(logger: log),
-            self.attemptStoredBearer(logger: log),
-            self.attemptStoredRefreshToken(logger: log),
-            self.attemptLocalStorageTokens(logger: log),
-            self.attemptBrowserCookies(logger: log, sources: [.safari]),
-            self.attemptWorkOSCookies(logger: log, sources: [.safari]),
-            self.attemptBrowserCookies(logger: log, sources: installedChromiumAndFirefox),
-            self.attemptWorkOSCookies(logger: log, sources: installedChromiumAndFirefox),
+        let attempts: [() async -> FetchAttemptResult] = [
+            { await self.attemptStoredCookies(logger: log) },
+            { await self.attemptStoredBearer(logger: log) },
+            { await self.attemptStoredRefreshToken(logger: log) },
+            { await self.attemptLocalStorageTokens(logger: log) },
+            { await self.attemptBrowserCookies(logger: log, sources: [.safari]) },
+            { await self.attemptWorkOSCookies(logger: log, sources: [.safari]) },
+            { await self.attemptBrowserCookies(logger: log, sources: installedChromiumAndFirefox) },
+            { await self.attemptWorkOSCookies(logger: log, sources: installedChromiumAndFirefox) },
         ]
 
-        for result in attempts {
-            switch result {
+        for attempt in attempts {
+            switch await attempt() {
             case let .success(snapshot):
                 return snapshot
             case let .failure(error):

--- a/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
@@ -421,7 +421,7 @@ public actor FactorySessionStore {
     private var sessionCookies: [HTTPCookie] = []
     private var bearerToken: String?
     private var refreshToken: String?
-    private let fileURL: URL
+    private var fileURL: URL
     private var didLoadFromDisk = false
 
     private init() {
@@ -491,6 +491,15 @@ public actor FactorySessionStore {
         self.bearerToken = nil
         self.refreshToken = nil
         self.didLoadFromDisk = false
+    }
+
+    func useFileURLForTesting(_ fileURL: URL) {
+        self.fileURL = fileURL
+        self.sessionCookies = []
+        self.bearerToken = nil
+        self.refreshToken = nil
+        self.didLoadFromDisk = false
+        try? FileManager.default.removeItem(at: fileURL)
     }
 
     private func saveToDisk() {
@@ -666,7 +675,6 @@ public struct FactoryStatusProbe: Sendable {
             } catch {
                 if case FactoryStatusProbeError.notLoggedIn = error {
                     CookieHeaderCache.clear(provider: .factory)
-                    await FactorySessionStore.shared.clearCookies()
                 }
                 lastError = error
             }
@@ -748,8 +756,8 @@ public struct FactoryStatusProbe: Sendable {
             return try await .success(self.fetchWithCookies(storedCookies, logger: logger))
         } catch {
             if case FactoryStatusProbeError.notLoggedIn = error {
-                await FactorySessionStore.shared.clearSession()
-                logger("Stored session invalid, cleared")
+                await FactorySessionStore.shared.clearCookies()
+                logger("Stored session cookies invalid, cleared")
             } else {
                 logger("Stored session failed: \(error.localizedDescription)")
             }

--- a/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
@@ -402,7 +402,7 @@ public enum FactoryStatusProbeError: LocalizedError, Sendable {
     public var errorDescription: String? {
         switch self {
         case .notLoggedIn:
-            "Not logged in to Factory. Please log in via the CodexBar menu."
+            "No usable Droid session found. Log in to app.factory.ai in \(factoryCookieImportOrder.loginHint), then refresh Droid."
         case let .networkError(msg):
             "Factory API error: \(msg)"
         case let .parseFailed(msg):

--- a/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
@@ -402,7 +402,8 @@ public enum FactoryStatusProbeError: LocalizedError, Sendable {
     public var errorDescription: String? {
         switch self {
         case .notLoggedIn:
-            "No usable Droid session found. Log in to app.factory.ai in \(factoryCookieImportOrder.loginHint), then refresh Droid."
+            "No usable Droid session found. Log in to app.factory.ai in \(factoryCookieImportOrder.loginHint), " +
+                "then refresh Droid."
         case let .networkError(msg):
             "Factory API error: \(msg)"
         case let .parseFailed(msg):

--- a/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
@@ -1080,10 +1080,19 @@ public struct FactoryStatusProbe: Sendable {
         userId: String?,
         baseURL: URL) async throws -> FactoryUsageResponse
     {
-        let url = baseURL.appendingPathComponent("/api/organization/subscription/usage")
+        var components = URLComponents(
+            url: baseURL.appendingPathComponent("/api/organization/subscription/usage"),
+            resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "useCache", value: "true"),
+        ]
+        if let userId {
+            components?.queryItems?.append(URLQueryItem(name: "userId", value: userId))
+        }
+        let url = components?.url ?? baseURL.appendingPathComponent("/api/organization/subscription/usage")
         var request = URLRequest(url: url)
         request.timeoutInterval = self.timeout
-        request.httpMethod = "POST"
+        request.httpMethod = "GET"
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("https://app.factory.ai", forHTTPHeaderField: "Origin")
@@ -1095,13 +1104,6 @@ public struct FactoryStatusProbe: Sendable {
         if let bearerToken {
             request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
         }
-
-        // Build request body
-        var body: [String: Any] = ["useCache": true]
-        if let userId {
-            body["userId"] = userId
-        }
-        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
 
         let (data, response) = try await URLSession.shared.data(for: request)
 

--- a/Tests/CodexBarTests/FactoryStatusProbeFetchTests.swift
+++ b/Tests/CodexBarTests/FactoryStatusProbeFetchTests.swift
@@ -5,7 +5,103 @@ import Testing
 @Suite(.serialized)
 struct FactoryStatusProbeFetchTests {
     @Test
-    func `preserves stored Factory refresh token when cached header is not logged in`() async throws {
+    func `keeps stored Factory cookies available when cached header is not logged in`() async throws {
+        let registered = URLProtocol.registerClass(FactoryStubURLProtocol.self)
+        defer {
+            if registered {
+                URLProtocol.unregisterClass(FactoryStubURLProtocol.self)
+            }
+            FactoryStubURLProtocol.handler = nil
+            FactoryStubURLProtocol.requests = []
+        }
+        FactoryStubURLProtocol.requests = []
+
+        FactoryStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            if url.host == "app.factory.ai",
+               url.path == "/api/app/auth/me",
+               request.value(forHTTPHeaderField: "Cookie")?.contains("stale-cache") == true
+            {
+                return Self.makeResponse(url: url, body: "{}", statusCode: 401)
+            }
+            if url.host == "api.factory.ai", url.path == "/api/app/auth/me" {
+                let body = """
+                {
+                  "organization": {
+                    "id": "org_1",
+                    "name": "Acme",
+                    "subscription": {
+                      "factoryTier": "team",
+                      "orbSubscription": {
+                        "plan": { "name": "Team", "id": "plan_1" },
+                        "status": "active"
+                      }
+                    }
+                  }
+                }
+                """
+                return Self.makeResponse(url: url, body: body)
+            }
+            if url.host == "api.factory.ai", url.path == "/api/organization/subscription/usage" {
+                let body = """
+                {
+                  "usage": {
+                    "standard": {
+                      "userTokens": 100,
+                      "totalAllowance": 1000
+                    }
+                  },
+                  "userId": "user-1"
+                }
+                """
+                return Self.makeResponse(url: url, body: body)
+            }
+            return Self.makeResponse(url: url, body: "{}", statusCode: 404)
+        }
+
+        let cookie = try #require(HTTPCookie(properties: [
+            .domain: "app.factory.ai",
+            .path: "/",
+            .name: "session",
+            .value: "valid-session",
+        ]))
+
+        let sessionFile = try await Self.isolateFactorySessionStore()
+        defer {
+            try? FileManager.default.removeItem(at: sessionFile)
+        }
+
+        await FactorySessionStore.shared.clearSession()
+        CookieHeaderCache.store(provider: .factory, cookieHeader: "session=stale-cache", sourceLabel: "Chrome")
+        await FactorySessionStore.shared.setCookies([cookie])
+        await FactorySessionStore.shared.resetInMemoryForTesting()
+        defer {
+            CookieHeaderCache.clear(provider: .factory)
+        }
+
+        let probe = FactoryStatusProbe(
+            timeout: 0.1,
+            browserDetection: BrowserDetection(
+                homeDirectory: "/tmp/codexbar-empty-browser-home",
+                cacheTTL: 0,
+                fileExists: { _ in false },
+                directoryContents: { _ in nil }))
+
+        let snapshot = try await probe.fetch()
+
+        #expect(CookieHeaderCache.load(provider: .factory) == nil)
+        #expect(snapshot.userId == "user-1")
+        #expect(await FactorySessionStore.shared.getCookies().map(\.value) == ["valid-session"])
+        #expect(Self.requestTrace() == [
+            "GET app.factory.ai/api/app/auth/me",
+            "GET api.factory.ai/api/app/auth/me",
+            "GET api.factory.ai/api/organization/subscription/usage?useCache=true",
+        ])
+        await FactorySessionStore.shared.clearSession()
+    }
+
+    @Test
+    func `preserves stored Factory refresh token when stored cookies are not logged in`() async throws {
         let registered = URLProtocol.registerClass(FactoryStubURLProtocol.self)
         defer {
             if registered {
@@ -19,6 +115,12 @@ struct FactoryStatusProbeFetchTests {
         FactoryStubURLProtocol.handler = { request in
             guard let url = request.url else { throw URLError(.badURL) }
             if url.host == "app.factory.ai", url.path == "/api/app/auth/me" {
+                return Self.makeResponse(url: url, body: "{}", statusCode: 401)
+            }
+            if url.host == "api.factory.ai",
+               url.path == "/api/app/auth/me",
+               request.value(forHTTPHeaderField: "Cookie")?.contains("stale-session") == true
+            {
                 return Self.makeResponse(url: url, body: "{}", statusCode: 401)
             }
             if url.host == "api.workos.com", url.path == "/user_management/authenticate" {
@@ -76,6 +178,11 @@ struct FactoryStatusProbeFetchTests {
             .value: "stale-session",
         ]))
 
+        let sessionFile = try await Self.isolateFactorySessionStore()
+        defer {
+            try? FileManager.default.removeItem(at: sessionFile)
+        }
+
         await FactorySessionStore.shared.clearSession()
         CookieHeaderCache.store(provider: .factory, cookieHeader: "session=stale-cache", sourceLabel: "Chrome")
         await FactorySessionStore.shared.setCookies([cookie])
@@ -101,6 +208,8 @@ struct FactoryStatusProbeFetchTests {
         #expect(await FactorySessionStore.shared.getBearerToken() == "fresh-access")
         #expect(await FactorySessionStore.shared.getRefreshToken() == "fresh-refresh")
         #expect(Self.requestTrace() == [
+            "GET app.factory.ai/api/app/auth/me",
+            "GET api.factory.ai/api/app/auth/me",
             "GET app.factory.ai/api/app/auth/me",
             "POST api.workos.com/user_management/authenticate",
             "GET api.factory.ai/api/app/auth/me",
@@ -204,6 +313,15 @@ struct FactoryStatusProbeFetchTests {
             let query = url.query.map { "?\($0)" } ?? ""
             return "\(request.httpMethod ?? "?") \(url.host ?? "unknown")\(url.path)\(query)"
         }
+    }
+
+    private static func isolateFactorySessionStore() async throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-factory-tests", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent("\(UUID().uuidString).json")
+        await FactorySessionStore.shared.useFileURLForTesting(fileURL)
+        return fileURL
     }
 
     private static func requestJSONBody(from request: URLRequest) throws -> [String: Any] {

--- a/Tests/CodexBarTests/FactoryStatusProbeFetchTests.swift
+++ b/Tests/CodexBarTests/FactoryStatusProbeFetchTests.swift
@@ -5,6 +5,58 @@ import Testing
 @Suite(.serialized)
 struct FactoryStatusProbeFetchTests {
     @Test
+    func `clears stored Factory session when cached header is not logged in`() async throws {
+        let registered = URLProtocol.registerClass(FactoryStubURLProtocol.self)
+        defer {
+            if registered {
+                URLProtocol.unregisterClass(FactoryStubURLProtocol.self)
+            }
+            FactoryStubURLProtocol.handler = nil
+        }
+
+        FactoryStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            return Self.makeResponse(url: url, body: "{}", statusCode: 401)
+        }
+
+        let cookie = try #require(HTTPCookie(properties: [
+            .domain: "app.factory.ai",
+            .path: "/",
+            .name: "session",
+            .value: "stale-session",
+        ]))
+
+        await FactorySessionStore.shared.clearSession()
+        CookieHeaderCache.store(provider: .factory, cookieHeader: "session=stale-cache", sourceLabel: "Chrome")
+        await FactorySessionStore.shared.setCookies([cookie])
+        await FactorySessionStore.shared.setBearerToken("stale-bearer")
+        await FactorySessionStore.shared.setRefreshToken("stale-refresh")
+        defer {
+            CookieHeaderCache.clear(provider: .factory)
+        }
+
+        let probe = FactoryStatusProbe(
+            timeout: 0.1,
+            browserDetection: BrowserDetection(
+                homeDirectory: "/tmp/codexbar-empty-browser-home",
+                cacheTTL: 0,
+                fileExists: { _ in false },
+                directoryContents: { _ in nil }))
+
+        do {
+            _ = try await probe.fetch()
+        } catch FactoryStatusProbeError.notLoggedIn {
+        } catch FactoryStatusProbeError.noSessionCookie {
+        } catch {}
+
+        #expect(CookieHeaderCache.load(provider: .factory) == nil)
+        #expect(await FactorySessionStore.shared.getCookies().isEmpty)
+        #expect(await FactorySessionStore.shared.getBearerToken() == nil)
+        #expect(await FactorySessionStore.shared.getRefreshToken() == nil)
+        await FactorySessionStore.shared.clearSession()
+    }
+
+    @Test
     func `fetches snapshot using cookie header override`() async throws {
         let registered = URLProtocol.registerClass(FactoryStubURLProtocol.self)
         defer {

--- a/Tests/CodexBarTests/FactoryStatusProbeFetchTests.swift
+++ b/Tests/CodexBarTests/FactoryStatusProbeFetchTests.swift
@@ -101,10 +101,10 @@ struct FactoryStatusProbeFetchTests {
         #expect(await FactorySessionStore.shared.getBearerToken() == "fresh-access")
         #expect(await FactorySessionStore.shared.getRefreshToken() == "fresh-refresh")
         #expect(Self.requestTrace() == [
-            "app.factory.ai/api/app/auth/me",
-            "api.workos.com/user_management/authenticate",
-            "api.factory.ai/api/app/auth/me",
-            "api.factory.ai/api/organization/subscription/usage",
+            "GET app.factory.ai/api/app/auth/me",
+            "POST api.workos.com/user_management/authenticate",
+            "GET api.factory.ai/api/app/auth/me",
+            "GET api.factory.ai/api/organization/subscription/usage?useCache=true",
         ])
         await FactorySessionStore.shared.clearSession()
     }
@@ -201,7 +201,8 @@ struct FactoryStatusProbeFetchTests {
     private static func requestTrace() -> [String] {
         FactoryStubURLProtocol.requests.compactMap { request in
             guard let url = request.url else { return nil }
-            return "\(url.host ?? "unknown")\(url.path)"
+            let query = url.query.map { "?\($0)" } ?? ""
+            return "\(request.httpMethod ?? "?") \(url.host ?? "unknown")\(url.path)\(query)"
         }
     }
 

--- a/Tests/CodexBarTests/FactoryStatusProbeFetchTests.swift
+++ b/Tests/CodexBarTests/FactoryStatusProbeFetchTests.swift
@@ -1,22 +1,72 @@
-import CodexBarCore
 import Foundation
 import Testing
+@testable import CodexBarCore
 
 @Suite(.serialized)
 struct FactoryStatusProbeFetchTests {
     @Test
-    func `clears stored Factory session when cached header is not logged in`() async throws {
+    func `preserves stored Factory refresh token when cached header is not logged in`() async throws {
         let registered = URLProtocol.registerClass(FactoryStubURLProtocol.self)
         defer {
             if registered {
                 URLProtocol.unregisterClass(FactoryStubURLProtocol.self)
             }
             FactoryStubURLProtocol.handler = nil
+            FactoryStubURLProtocol.requests = []
         }
+        FactoryStubURLProtocol.requests = []
 
         FactoryStubURLProtocol.handler = { request in
             guard let url = request.url else { throw URLError(.badURL) }
-            return Self.makeResponse(url: url, body: "{}", statusCode: 401)
+            if url.host == "app.factory.ai", url.path == "/api/app/auth/me" {
+                return Self.makeResponse(url: url, body: "{}", statusCode: 401)
+            }
+            if url.host == "api.workos.com", url.path == "/user_management/authenticate" {
+                let requestBody = try Self.requestJSONBody(from: request)
+                guard requestBody["refresh_token"] as? String == "stale-refresh" else {
+                    throw URLError(.userAuthenticationRequired)
+                }
+                let body = """
+                {
+                  "access_token": "fresh-access",
+                  "refresh_token": "fresh-refresh"
+                }
+                """
+                return Self.makeResponse(url: url, body: body)
+            }
+            if url.host == "api.factory.ai", url.path == "/api/app/auth/me" {
+                let body = """
+                {
+                  "organization": {
+                    "id": "org_1",
+                    "name": "Acme",
+                    "subscription": {
+                      "factoryTier": "team",
+                      "orbSubscription": {
+                        "plan": { "name": "Team", "id": "plan_1" },
+                        "status": "active"
+                      }
+                    }
+                  }
+                }
+                """
+                return Self.makeResponse(url: url, body: body)
+            }
+            if url.host == "api.factory.ai", url.path == "/api/organization/subscription/usage" {
+                let body = """
+                {
+                  "usage": {
+                    "standard": {
+                      "userTokens": 100,
+                      "totalAllowance": 1000
+                    }
+                  },
+                  "userId": "user-1"
+                }
+                """
+                return Self.makeResponse(url: url, body: body)
+            }
+            return Self.makeResponse(url: url, body: "{}", statusCode: 404)
         }
 
         let cookie = try #require(HTTPCookie(properties: [
@@ -29,8 +79,8 @@ struct FactoryStatusProbeFetchTests {
         await FactorySessionStore.shared.clearSession()
         CookieHeaderCache.store(provider: .factory, cookieHeader: "session=stale-cache", sourceLabel: "Chrome")
         await FactorySessionStore.shared.setCookies([cookie])
-        await FactorySessionStore.shared.setBearerToken("stale-bearer")
         await FactorySessionStore.shared.setRefreshToken("stale-refresh")
+        await FactorySessionStore.shared.resetInMemoryForTesting()
         defer {
             CookieHeaderCache.clear(provider: .factory)
         }
@@ -43,16 +93,19 @@ struct FactoryStatusProbeFetchTests {
                 fileExists: { _ in false },
                 directoryContents: { _ in nil }))
 
-        do {
-            _ = try await probe.fetch()
-        } catch FactoryStatusProbeError.notLoggedIn {
-        } catch FactoryStatusProbeError.noSessionCookie {
-        } catch {}
+        let snapshot = try await probe.fetch()
 
         #expect(CookieHeaderCache.load(provider: .factory) == nil)
+        #expect(snapshot.userId == "user-1")
         #expect(await FactorySessionStore.shared.getCookies().isEmpty)
-        #expect(await FactorySessionStore.shared.getBearerToken() == nil)
-        #expect(await FactorySessionStore.shared.getRefreshToken() == nil)
+        #expect(await FactorySessionStore.shared.getBearerToken() == "fresh-access")
+        #expect(await FactorySessionStore.shared.getRefreshToken() == "fresh-refresh")
+        #expect(Self.requestTrace() == [
+            "app.factory.ai/api/app/auth/me",
+            "api.workos.com/user_management/authenticate",
+            "api.factory.ai/api/app/auth/me",
+            "api.factory.ai/api/organization/subscription/usage",
+        ])
         await FactorySessionStore.shared.clearSession()
     }
 
@@ -64,7 +117,9 @@ struct FactoryStatusProbeFetchTests {
                 URLProtocol.unregisterClass(FactoryStubURLProtocol.self)
             }
             FactoryStubURLProtocol.handler = nil
+            FactoryStubURLProtocol.requests = []
         }
+        FactoryStubURLProtocol.requests = []
 
         FactoryStubURLProtocol.handler = { request in
             guard let url = request.url else { throw URLError(.badURL) }
@@ -142,10 +197,49 @@ struct FactoryStatusProbeFetchTests {
             headerFields: ["Content-Type": "application/json"])!
         return (response, Data(body.utf8))
     }
+
+    private static func requestTrace() -> [String] {
+        FactoryStubURLProtocol.requests.compactMap { request in
+            guard let url = request.url else { return nil }
+            return "\(url.host ?? "unknown")\(url.path)"
+        }
+    }
+
+    private static func requestJSONBody(from request: URLRequest) throws -> [String: Any] {
+        let data = try self.requestBodyData(from: request)
+        return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private static func requestBodyData(from request: URLRequest) throws -> Data {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            throw URLError(.badServerResponse)
+        }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1024)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count < 0 {
+                throw stream.streamError ?? URLError(.cannotDecodeRawData)
+            }
+            if count == 0 {
+                break
+            }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
 }
 
 final class FactoryStubURLProtocol: URLProtocol {
     nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var requests: [URLRequest] = []
 
     override static func canInit(with request: URLRequest) -> Bool {
         guard let host = request.url?.host else { return false }
@@ -162,6 +256,7 @@ final class FactoryStubURLProtocol: URLProtocol {
             return
         }
         do {
+            Self.requests.append(self.request)
             let (response, data) = try handler(self.request)
             self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
             self.client?.urlProtocol(self, didLoad: data)


### PR DESCRIPTION
## Summary

- preserve stored Factory bearer/refresh tokens when clearing stale cached cookie headers
- keep Factory fallback attempts lazy so a stale cookie cache does not erase valid recovered credentials
- update Droid/Factory usage fetching to use the current GET usage endpoint instead of the old POST request
- add coverage for stale cached header recovery and the Factory usage request method/query

Supersedes #324. Originally contributed by @JosephDoUrden there; thank you for finding and fixing the stale Factory session case.

## Test plan

- swift test --filter FactoryStatusProbeFetchTests
- pnpm check
- ./Scripts/compile_and_run.sh
- CodexBar.app/Contents/Helpers/CodexBarCLI usage --provider factory --source auto --format json --pretty