### PR TITLE
Fix Codex workspace account matching

### DIFF
--- a/Sources/CodexBar/CodexAccountPromotionPlanning.swift
+++ b/Sources/CodexBar/CodexAccountPromotionPlanning.swift
@@ -58,7 +58,11 @@ struct CodexDisplacedLivePreservationPlanner {
         }
 
         if let targetAuthIdentity = context.target.authIdentity,
-           CodexIdentityMatcher.matches(targetAuthIdentity.identity, liveAuthIdentity.identity)
+           CodexIdentityMatcher.matches(
+               targetAuthIdentity.identity,
+               lhsEmail: targetAuthIdentity.email,
+               liveAuthIdentity.identity,
+               rhsEmail: liveAuthIdentity.email)
         {
             return .none(reason: .targetMatchesLiveAuthIdentity)
         }
@@ -96,7 +100,11 @@ struct CodexDisplacedLivePreservationPlanner {
     {
         candidates.first { candidate in
             guard let candidateAuthIdentity = candidate.authIdentity else { return false }
-            return CodexIdentityMatcher.matches(candidateAuthIdentity.identity, liveAuthIdentity.identity)
+            return CodexIdentityMatcher.matches(
+                candidateAuthIdentity.identity,
+                lhsEmail: candidateAuthIdentity.email,
+                liveAuthIdentity.identity,
+                rhsEmail: liveAuthIdentity.email)
         }
     }
 
@@ -108,8 +116,12 @@ struct CodexDisplacedLivePreservationPlanner {
         switch liveAuthIdentity.identity {
         case let .providerAccount(id):
             let providerAccountID = ManagedCodexAccount.normalizeProviderAccountID(id)
-            if let destination = candidates.first(where: { $0.persisted.providerAccountID == providerAccountID }),
-               let reason = self.providerRepairReason(for: destination)
+            if let destination = candidates.first(where: {
+                guard $0.persisted.providerAccountID == providerAccountID else { return false }
+                guard let liveEmail = liveAuthIdentity.email else { return true }
+                return $0.persisted.email == liveEmail
+            }),
+                let reason = self.providerRepairReason(for: destination)
             {
                 return (destination, reason)
             }
@@ -149,9 +161,16 @@ struct CodexDisplacedLivePreservationPlanner {
         let providerAccountID = ManagedCodexAccount.normalizeProviderAccountID(id)
         return candidates.contains { candidate in
             guard candidate.persisted.providerAccountID == providerAccountID else { return false }
+            if let liveEmail = liveAuthIdentity.email, candidate.persisted.email != liveEmail {
+                return false
+            }
             guard case .readable = candidate.homeState else { return false }
             guard let candidateAuthIdentity = candidate.authIdentity else { return false }
-            return !CodexIdentityMatcher.matches(candidateAuthIdentity.identity, liveAuthIdentity.identity)
+            return !CodexIdentityMatcher.matches(
+                candidateAuthIdentity.identity,
+                lhsEmail: candidateAuthIdentity.email,
+                liveAuthIdentity.identity,
+                rhsEmail: liveAuthIdentity.email)
         }
     }
 

--- a/Sources/CodexBar/CodexAccountPromotionService.swift
+++ b/Sources/CodexBar/CodexAccountPromotionService.swift
@@ -259,7 +259,12 @@ final class CodexAccountPromotionService {
     private func convergedActiveSource(for context: PreparedPromotionContext) -> CodexActiveSource? {
         if let liveAuthIdentity = context.live.authIdentity {
             let targetIdentity = context.target.authIdentity ?? context.target.persistedIdentity
-            guard CodexIdentityMatcher.matches(targetIdentity.identity, liveAuthIdentity.identity) else {
+            guard CodexIdentityMatcher.matches(
+                targetIdentity.identity,
+                lhsEmail: targetIdentity.email,
+                liveAuthIdentity.identity,
+                rhsEmail: liveAuthIdentity.email)
+            else {
                 return nil
             }
 
@@ -280,7 +285,9 @@ final class CodexAccountPromotionService {
 
         guard CodexIdentityMatcher.matches(
             context.snapshot.runtimeIdentity(for: context.target.persisted),
-            context.snapshot.runtimeIdentity(for: liveSystemAccount))
+            lhsEmail: context.snapshot.runtimeEmail(for: context.target.persisted),
+            context.snapshot.runtimeIdentity(for: liveSystemAccount),
+            rhsEmail: liveSystemAccount.email)
         else {
             return nil
         }

--- a/Sources/CodexBar/CodexAccountReconciliation.swift
+++ b/Sources/CodexBar/CodexAccountReconciliation.swift
@@ -102,7 +102,11 @@ extension CodexVisibleAccountProjection {
             let normalizedEmail = Self.normalizeVisibleEmail(liveSystemAccount.email)
             let liveIdentity = snapshot.runtimeIdentity(for: liveSystemAccount)
             if let existingIndex = drafts.firstIndex(where: { draft in
-                CodexIdentityMatcher.matches(draft.identity, liveIdentity)
+                CodexIdentityMatcher.matches(
+                    draft.identity,
+                    lhsEmail: draft.email,
+                    liveIdentity,
+                    rhsEmail: normalizedEmail)
             }) {
                 let existingDraft = drafts[existingIndex]
                 let liveWorkspaceLabel = Self.normalizeWorkspaceLabel(liveSystemAccount.workspaceLabel)

--- a/Sources/CodexBar/ManagedCodexAccountService.swift
+++ b/Sources/CodexBar/ManagedCodexAccountService.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CodexBarCore
 import Foundation
 
@@ -16,11 +17,27 @@ protocol ManagedCodexIdentityReading: Sendable {
 
 protocol ManagedCodexWorkspaceResolving: Sendable {
     func resolveWorkspaceIdentity(homePath: String, providerAccountID: String) async -> CodexOpenAIWorkspaceIdentity?
+    func availableWorkspaceIdentities(homePath: String) async -> [CodexOpenAIWorkspaceIdentity]
+}
+
+extension ManagedCodexWorkspaceResolving {
+    func availableWorkspaceIdentities(homePath _: String) async -> [CodexOpenAIWorkspaceIdentity] {
+        []
+    }
+}
+
+protocol ManagedCodexWorkspaceSelecting: Sendable {
+    @MainActor
+    func selectWorkspace(
+        email: String,
+        currentWorkspaceID: String?,
+        workspaces: [CodexOpenAIWorkspaceIdentity]) async -> CodexOpenAIWorkspaceIdentity?
 }
 
 enum ManagedCodexAccountServiceError: Error, Equatable {
     case loginFailed
     case missingEmail
+    case workspaceSelectionCancelled
     case unsafeManagedHome(String)
 }
 
@@ -102,6 +119,65 @@ struct DefaultManagedCodexWorkspaceResolver: ManagedCodexWorkspaceResolving {
             workspaceAccountID: normalizedProviderAccountID,
             workspaceLabel: cachedLabel)
     }
+
+    func availableWorkspaceIdentities(homePath: String) async -> [CodexOpenAIWorkspaceIdentity] {
+        let env = CodexHomeScope.scopedEnvironment(
+            base: ProcessInfo.processInfo.environment,
+            codexHome: homePath)
+        guard let credentials = try? CodexOAuthCredentialsStore.load(env: env),
+              let identities = try? await CodexOpenAIWorkspaceResolver.listWorkspaces(credentials: credentials)
+        else {
+            return []
+        }
+
+        for identity in identities {
+            try? self.workspaceCache.store(identity)
+        }
+        return identities
+    }
+}
+
+struct CodexWorkspaceAlertSelector: ManagedCodexWorkspaceSelecting {
+    @MainActor
+    func selectWorkspace(
+        email: String,
+        currentWorkspaceID: String?,
+        workspaces: [CodexOpenAIWorkspaceIdentity]) async -> CodexOpenAIWorkspaceIdentity?
+    {
+        guard workspaces.count > 1 else { return workspaces.first }
+
+        let popup = NSPopUpButton(frame: NSRect(x: 0, y: 0, width: 360, height: 26), pullsDown: false)
+        let sortedWorkspaces = workspaces.sorted { lhs, rhs in
+            self.workspaceTitle(lhs) < self.workspaceTitle(rhs)
+        }
+        for workspace in sortedWorkspaces {
+            popup.addItem(withTitle: self.workspaceTitle(workspace))
+            popup.lastItem?.representedObject = workspace.workspaceAccountID
+        }
+        if let currentWorkspaceID,
+           let selectedIndex = sortedWorkspaces.firstIndex(where: { $0.workspaceAccountID == currentWorkspaceID })
+        {
+            popup.selectItem(at: selectedIndex)
+        }
+
+        let alert = NSAlert()
+        alert.messageText = "Choose Codex workspace"
+        alert.informativeText = "CodexBar found multiple workspaces for \(email). Choose the one to add."
+        alert.alertStyle = .informational
+        alert.accessoryView = popup
+        alert.addButton(withTitle: "Add Workspace")
+        alert.addButton(withTitle: "Cancel")
+
+        guard alert.runModal() == .alertFirstButtonReturn else {
+            return nil
+        }
+        let selectedWorkspaceID = popup.selectedItem?.representedObject as? String
+        return sortedWorkspaces.first { $0.workspaceAccountID == selectedWorkspaceID }
+    }
+
+    private func workspaceTitle(_ workspace: CodexOpenAIWorkspaceIdentity) -> String {
+        workspace.workspaceLabel ?? workspace.workspaceAccountID
+    }
 }
 
 @MainActor
@@ -111,6 +187,7 @@ final class ManagedCodexAccountService {
     private let loginRunner: any ManagedCodexLoginRunning
     private let identityReader: any ManagedCodexIdentityReading
     private let workspaceResolver: any ManagedCodexWorkspaceResolving
+    private let workspaceSelector: any ManagedCodexWorkspaceSelecting
     private let fileManager: FileManager
 
     init(
@@ -119,6 +196,7 @@ final class ManagedCodexAccountService {
         loginRunner: any ManagedCodexLoginRunning,
         identityReader: any ManagedCodexIdentityReading,
         workspaceResolver: any ManagedCodexWorkspaceResolving = DefaultManagedCodexWorkspaceResolver(),
+        workspaceSelector: any ManagedCodexWorkspaceSelecting = CodexWorkspaceAlertSelector(),
         fileManager: FileManager = .default)
     {
         self.store = store
@@ -126,6 +204,7 @@ final class ManagedCodexAccountService {
         self.loginRunner = loginRunner
         self.identityReader = identityReader
         self.workspaceResolver = workspaceResolver
+        self.workspaceSelector = workspaceSelector
         self.fileManager = fileManager
     }
 
@@ -136,6 +215,7 @@ final class ManagedCodexAccountService {
             loginRunner: DefaultManagedCodexLoginRunner(),
             identityReader: DefaultManagedCodexIdentityReader(),
             workspaceResolver: DefaultManagedCodexWorkspaceResolver(),
+            workspaceSelector: CodexWorkspaceAlertSelector(),
             fileManager: fileManager)
     }
 
@@ -160,18 +240,23 @@ final class ManagedCodexAccountService {
             else {
                 throw ManagedCodexAccountServiceError.missingEmail
             }
-            let providerAccountID: String? = switch identity.identity {
+            let authenticatedProviderAccountID: String? = switch identity.identity {
             case let .providerAccount(id):
                 ManagedCodexAccount.normalizeProviderAccountID(id)
             case .emailOnly, .unresolved:
                 nil
             }
-            let workspaceIdentity: CodexOpenAIWorkspaceIdentity? = if let providerAccountID {
-                await self.workspaceResolver.resolveWorkspaceIdentity(
+            let selectedWorkspace = try await self.selectedWorkspaceIdentity(
+                email: rawEmail,
+                homePath: homeURL.path,
+                authenticatedProviderAccountID: authenticatedProviderAccountID)
+            let providerAccountID = selectedWorkspace?.workspaceAccountID ?? authenticatedProviderAccountID
+            let workspaceIdentity: CodexOpenAIWorkspaceIdentity? = if let selectedWorkspace {
+                selectedWorkspace
+            } else {
+                await self.resolvedWorkspaceIdentity(
                     homePath: homeURL.path,
                     providerAccountID: providerAccountID)
-            } else {
-                nil
             }
 
             let now = Date().timeIntervalSince1970
@@ -243,6 +328,51 @@ final class ManagedCodexAccountService {
         if self.fileManager.fileExists(atPath: homeURL.path) {
             try self.fileManager.removeItem(at: homeURL)
         }
+    }
+
+    private func selectedWorkspaceIdentity(
+        email: String,
+        homePath: String,
+        authenticatedProviderAccountID: String?) async throws -> CodexOpenAIWorkspaceIdentity?
+    {
+        let workspaces = await self.workspaceResolver.availableWorkspaceIdentities(homePath: homePath)
+        guard workspaces.count > 1 else {
+            return workspaces.first { $0.workspaceAccountID == authenticatedProviderAccountID }
+        }
+        guard let selected = await self.workspaceSelector.selectWorkspace(
+            email: email,
+            currentWorkspaceID: authenticatedProviderAccountID,
+            workspaces: workspaces)
+        else {
+            throw ManagedCodexAccountServiceError.workspaceSelectionCancelled
+        }
+        try self.persistSelectedWorkspaceID(selected.workspaceAccountID, homePath: homePath)
+        return selected
+    }
+
+    private func resolvedWorkspaceIdentity(
+        homePath: String,
+        providerAccountID: String?) async -> CodexOpenAIWorkspaceIdentity?
+    {
+        guard let providerAccountID else { return nil }
+        return await self.workspaceResolver.resolveWorkspaceIdentity(
+            homePath: homePath,
+            providerAccountID: providerAccountID)
+    }
+
+    private func persistSelectedWorkspaceID(_ workspaceID: String, homePath: String) throws {
+        let env = CodexHomeScope.scopedEnvironment(
+            base: ProcessInfo.processInfo.environment,
+            codexHome: homePath)
+        let credentials = try CodexOAuthCredentialsStore.load(env: env)
+        try CodexOAuthCredentialsStore.save(
+            CodexOAuthCredentials(
+                accessToken: credentials.accessToken,
+                refreshToken: credentials.refreshToken,
+                idToken: credentials.idToken,
+                accountId: workspaceID,
+                lastRefresh: credentials.lastRefresh),
+            env: env)
     }
 
     private func reconciledExistingAccount(

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -611,6 +611,8 @@ struct ProvidersPane: View {
             case .missingEmail:
                 "Codex login completed, but no account email was available. Try again after confirming "
                     + "the account is fully signed in."
+            case .workspaceSelectionCancelled:
+                "CodexBar found multiple workspaces, but no workspace was selected."
             case let .unsafeManagedHome(path):
                 "CodexBar refused to modify an unexpected managed home path: \(path)"
             }

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -292,6 +292,8 @@ extension StatusItemController {
             case .missingEmail:
                 "Codex login completed, but no account email was available. " +
                     "Try again after confirming the account is fully signed in."
+            case .workspaceSelectionCancelled:
+                "CodexBar found multiple workspaces, but no workspace was selected."
             case let .unsafeManagedHome(path):
                 "CodexBar refused to modify an unexpected managed home path: \(path)"
             }

--- a/Sources/CodexBarCore/CodexManagedAccounts.swift
+++ b/Sources/CodexBarCore/CodexManagedAccounts.swift
@@ -86,7 +86,9 @@ public struct ManagedCodexAccountSet: Codable, Sendable {
     public func account(email: String, providerAccountID: String? = nil) -> ManagedCodexAccount? {
         let normalizedEmail = ManagedCodexAccount.normalizeEmail(email)
         if let normalizedProviderAccountID = ManagedCodexAccount.normalizeProviderAccountID(providerAccountID),
-           let exactMatch = self.accounts.first(where: { $0.providerAccountID == normalizedProviderAccountID })
+           let exactMatch = self.accounts.first(where: {
+               $0.email == normalizedEmail && $0.providerAccountID == normalizedProviderAccountID
+           })
         {
             return exactMatch
         }
@@ -104,7 +106,7 @@ public struct ManagedCodexAccountSet: Codable, Sendable {
 
     private static func sanitizedAccounts(_ accounts: [ManagedCodexAccount]) -> [ManagedCodexAccount] {
         var seenIDs: Set<UUID> = []
-        var seenProviderAccountIDs: Set<String> = []
+        var seenProviderAccountKeys: Set<String> = []
         var seenLegacyEmails: Set<String> = []
         var sanitized: [ManagedCodexAccount] = []
         sanitized.reserveCapacity(accounts.count)
@@ -112,7 +114,9 @@ public struct ManagedCodexAccountSet: Codable, Sendable {
         for account in accounts {
             guard seenIDs.insert(account.id).inserted else { continue }
             if let providerAccountID = account.providerAccountID {
-                guard seenProviderAccountIDs.insert(providerAccountID).inserted else { continue }
+                guard seenProviderAccountKeys.insert("\(account.email)\u{0}\(providerAccountID)").inserted else {
+                    continue
+                }
             } else {
                 guard seenLegacyEmails.insert(account.email).inserted else { continue }
             }

--- a/Sources/CodexBarCore/Providers/Codex/CodexAccountReconciliation.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexAccountReconciliation.swift
@@ -44,7 +44,9 @@ public enum CodexActiveSourceResolver {
         guard let liveSystemAccount else { return false }
         return CodexIdentityMatcher.matches(
             snapshot.runtimeIdentity(for: storedAccount),
-            snapshot.runtimeIdentity(for: liveSystemAccount))
+            lhsEmail: snapshot.runtimeEmail(for: storedAccount),
+            snapshot.runtimeIdentity(for: liveSystemAccount),
+            rhsEmail: liveSystemAccount.email)
     }
 }
 
@@ -155,7 +157,11 @@ public struct DefaultCodexAccountReconciler {
             let matchingStoredAccountForLiveSystemAccount = liveSystemAccount.flatMap { liveAccount in
                 accounts.accounts.first { account in
                     guard let runtimeAccount = runtimeAccounts[account.id] else { return false }
-                    return CodexIdentityMatcher.matches(runtimeAccount.identity, self.runtimeIdentity(for: liveAccount))
+                    return CodexIdentityMatcher.matches(
+                        runtimeAccount.identity,
+                        lhsEmail: runtimeAccount.email,
+                        self.runtimeIdentity(for: liveAccount),
+                        rhsEmail: liveAccount.email)
                 }
             }
 
@@ -232,6 +238,22 @@ public enum CodexIdentityMatcher {
         default:
             false
         }
+    }
+
+    public static func matches(
+        _ lhs: CodexIdentity,
+        lhsEmail: String?,
+        _ rhs: CodexIdentity,
+        rhsEmail: String?) -> Bool
+    {
+        guard self.matches(lhs, rhs) else { return false }
+        guard case .providerAccount = lhs, case .providerAccount = rhs else { return true }
+        guard let normalizedLeftEmail = CodexIdentityResolver.normalizeEmail(lhsEmail),
+              let normalizedRightEmail = CodexIdentityResolver.normalizeEmail(rhsEmail)
+        else {
+            return true
+        }
+        return normalizedLeftEmail == normalizedRightEmail
     }
 
     public static func normalized(_ identity: CodexIdentity, fallbackEmail: String) -> CodexIdentity {

--- a/Sources/CodexBarCore/Providers/Codex/CodexOpenAIWorkspaceResolver.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOpenAIWorkspaceResolver.swift
@@ -44,13 +44,29 @@ public enum CodexOpenAIWorkspaceResolver {
             return nil
         }
 
+        let identities = try await self.listWorkspaces(credentials: credentials, session: session)
+        if let identity = identities.first(where: { $0.workspaceAccountID == workspaceAccountID }) {
+            return identity
+        }
+
+        return CodexOpenAIWorkspaceIdentity(
+            workspaceAccountID: workspaceAccountID,
+            workspaceLabel: nil)
+    }
+
+    public static func listWorkspaces(
+        credentials: CodexOAuthCredentials,
+        session: URLSession = .shared) async throws -> [CodexOpenAIWorkspaceIdentity]
+    {
         var request = URLRequest(url: self.accountsURL)
         request.httpMethod = "GET"
         request.timeoutInterval = 20
         request.setValue("Bearer \(credentials.accessToken)", forHTTPHeaderField: "Authorization")
         request.setValue("codex-cli", forHTTPHeaderField: "User-Agent")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue(workspaceAccountID, forHTTPHeaderField: "ChatGPT-Account-Id")
+        if let workspaceAccountID = normalizeWorkspaceAccountID(credentials.accountId) {
+            request.setValue(workspaceAccountID, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
 
         let (data, response) = try await session.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
@@ -60,17 +76,12 @@ public enum CodexOpenAIWorkspaceResolver {
         }
 
         let decoded = try JSONDecoder().decode(AccountsResponse.self, from: data)
-        if let account = decoded.items.first(where: {
-            Self.normalizeWorkspaceAccountID($0.id) == workspaceAccountID
-        }) {
+        return decoded.items.compactMap { account in
+            guard let workspaceAccountID = self.normalizeWorkspaceAccountID(account.id) else { return nil }
             return CodexOpenAIWorkspaceIdentity(
                 workspaceAccountID: workspaceAccountID,
                 workspaceLabel: self.resolveWorkspaceLabel(from: account))
         }
-
-        return CodexOpenAIWorkspaceIdentity(
-            workspaceAccountID: workspaceAccountID,
-            workspaceLabel: nil)
     }
 
     public static func normalizeWorkspaceAccountID(_ value: String?) -> String? {

--- a/Tests/CodexBarTests/CodexAccountProviderIdentityReconciliationTests.swift
+++ b/Tests/CodexBarTests/CodexAccountProviderIdentityReconciliationTests.swift
@@ -1,0 +1,48 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct CodexAccountProviderIdentityReconciliationTests {
+    @Test
+    func `same provider account id with different email does not merge live and managed rows`() {
+        let stored = ManagedCodexAccount(
+            id: UUID(),
+            email: "mi.chaelfmk5542@gmail.com",
+            providerAccountID: "team-4107",
+            workspaceLabel: "4107",
+            workspaceAccountID: "team-4107",
+            managedHomePath: "/tmp/managed-a",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 3)
+        let live = ObservedSystemCodexAccount(
+            email: "mich.aelfmk5542@gmail.com",
+            workspaceLabel: "4107",
+            workspaceAccountID: "team-4107",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "team-4107"))
+        let snapshot = CodexAccountReconciliationSnapshot(
+            storedAccounts: [stored],
+            activeStoredAccount: stored,
+            liveSystemAccount: live,
+            matchingStoredAccountForLiveSystemAccount: nil,
+            activeSource: .managedAccount(id: stored.id),
+            hasUnreadableAddedAccountStore: false,
+            storedAccountRuntimeIdentities: [stored.id: .providerAccount(id: "team-4107")],
+            storedAccountRuntimeEmails: [stored.id: "mi.chaelfmk5542@gmail.com"])
+
+        let resolution = CodexActiveSourceResolver.resolve(from: snapshot)
+        let projection = CodexVisibleAccountProjection.make(from: snapshot)
+
+        #expect(resolution.resolvedSource == .managedAccount(id: stored.id))
+        #expect(projection.visibleAccounts.count == 2)
+        #expect(projection.visibleAccounts.map(\.email).sorted() == [
+            "mi.chaelfmk5542@gmail.com",
+            "mich.aelfmk5542@gmail.com",
+        ])
+        #expect(projection.activeVisibleAccountID == "mi.chaelfmk5542@gmail.com")
+        #expect(projection.liveVisibleAccountID == "mich.aelfmk5542@gmail.com")
+    }
+}

--- a/Tests/CodexBarTests/ManagedCodexAccountServiceTests.swift
+++ b/Tests/CodexBarTests/ManagedCodexAccountServiceTests.swift
@@ -114,6 +114,101 @@ struct ManagedCodexAccountServiceTests {
     }
 
     @Test
+    func `same workspace provider id with different emails does not overwrite existing account`() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let existingHome = root.appendingPathComponent("accounts/existing", isDirectory: true)
+        try FileManager.default.createDirectory(at: existingHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let existingID = try #require(UUID(uuidString: "10101010-2020-3030-4040-505050505050"))
+        let existingAccount = ManagedCodexAccount(
+            id: existingID,
+            email: "mi.chaelfmk5542@gmail.com",
+            providerAccountID: "team-4107",
+            workspaceLabel: "4107",
+            workspaceAccountID: "team-4107",
+            managedHomePath: existingHome.path,
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1)
+        let store = InMemoryManagedCodexAccountStore(
+            accounts: ManagedCodexAccountSet(
+                version: FileManagedCodexAccountStore.currentVersion,
+                accounts: [existingAccount]))
+        let service = ManagedCodexAccountService(
+            store: store,
+            homeFactory: TestManagedCodexHomeFactory(root: root),
+            loginRunner: StubManagedCodexLoginRunner.success,
+            identityReader: StubManagedCodexIdentityReader.accounts([
+                .init(identity: .providerAccount(id: "team-4107"), email: "mich.aelfmk5542@gmail.com", plan: "Team"),
+            ]),
+            workspaceResolver: StubManagedCodexWorkspaceResolver(identities: [
+                "team-4107": CodexOpenAIWorkspaceIdentity(
+                    workspaceAccountID: "team-4107",
+                    workspaceLabel: "4107"),
+            ]))
+
+        let added = try await service.authenticateManagedAccount()
+
+        let original = try #require(
+            store.snapshot.account(email: "mi.chaelfmk5542@gmail.com", providerAccountID: "team-4107"))
+        let newAccount = try #require(
+            store.snapshot.account(email: "mich.aelfmk5542@gmail.com", providerAccountID: "team-4107"))
+        #expect(store.snapshot.accounts.count == 2)
+        #expect(original.id == existingID)
+        #expect(original.managedHomePath == existingHome.path)
+        #expect(newAccount.id == added.id)
+        #expect(newAccount.id != existingID)
+        #expect(newAccount.workspaceLabel == "4107")
+        #expect(FileManager.default.fileExists(atPath: existingHome.path))
+        #expect(FileManager.default.fileExists(atPath: newAccount.managedHomePath))
+    }
+
+    @Test
+    func `selected workspace is persisted and used as account identity`() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let store = InMemoryManagedCodexAccountStore(
+            accounts: ManagedCodexAccountSet(
+                version: FileManagedCodexAccountStore.currentVersion,
+                accounts: []))
+        let workspaces = [
+            CodexOpenAIWorkspaceIdentity(
+                workspaceAccountID: "workspace-personal",
+                workspaceLabel: "Personal"),
+            CodexOpenAIWorkspaceIdentity(
+                workspaceAccountID: "workspace-team",
+                workspaceLabel: "Team"),
+        ]
+        let service = ManagedCodexAccountService(
+            store: store,
+            homeFactory: TestManagedCodexHomeFactory(root: root),
+            loginRunner: WritingManagedCodexLoginRunner(
+                credentials: CodexOAuthCredentials(
+                    accessToken: "access-token",
+                    refreshToken: "refresh-token",
+                    idToken: nil,
+                    accountId: "workspace-personal",
+                    lastRefresh: nil)),
+            identityReader: StubManagedCodexIdentityReader.accounts([
+                .init(identity: .providerAccount(id: "workspace-personal"), email: "alice@example.com", plan: "Pro"),
+            ]),
+            workspaceResolver: StubManagedCodexWorkspaceResolver(
+                identities: Dictionary(uniqueKeysWithValues: workspaces.map { ($0.workspaceAccountID, $0) }),
+                availableIdentities: workspaces),
+            workspaceSelector: StubManagedCodexWorkspaceSelector(selectedWorkspaceID: "workspace-team"))
+
+        let account = try await service.authenticateManagedAccount()
+        let credentials = try CodexOAuthCredentialsStore.load(env: ["CODEX_HOME": account.managedHomePath])
+
+        #expect(account.providerAccountID == "workspace-team")
+        #expect(account.workspaceLabel == "Team")
+        #expect(credentials.accountId == "workspace-team")
+        #expect(store.snapshot.accounts.count == 1)
+    }
+
+    @Test
     func `reauth keeps previous home when store write fails`() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         let existingHome = root.appendingPathComponent("accounts/existing", isDirectory: true)
@@ -750,6 +845,19 @@ private struct StubManagedCodexLoginRunner: ManagedCodexLoginRunning {
         result: CodexLoginRunner.Result(outcome: .success, output: "ok"))
 }
 
+private struct WritingManagedCodexLoginRunner: ManagedCodexLoginRunning {
+    let credentials: CodexOAuthCredentials
+
+    func run(homePath: String, timeout _: TimeInterval) async -> CodexLoginRunner.Result {
+        do {
+            try CodexOAuthCredentialsStore.save(self.credentials, env: ["CODEX_HOME": homePath])
+            return CodexLoginRunner.Result(outcome: .success, output: "ok")
+        } catch {
+            return CodexLoginRunner.Result(outcome: .failed(status: 1), output: String(describing: error))
+        }
+    }
+}
+
 private enum TestManagedCodexAccountStoreError: Error, Equatable {
     case writeFailed
 }
@@ -787,9 +895,14 @@ private final class StubManagedCodexIdentityReader: ManagedCodexIdentityReading,
 
 private struct StubManagedCodexWorkspaceResolver: ManagedCodexWorkspaceResolving {
     let identities: [String: CodexOpenAIWorkspaceIdentity]
+    let availableIdentities: [CodexOpenAIWorkspaceIdentity]
 
-    init(identities: [String: CodexOpenAIWorkspaceIdentity] = [:]) {
+    init(
+        identities: [String: CodexOpenAIWorkspaceIdentity] = [:],
+        availableIdentities: [CodexOpenAIWorkspaceIdentity] = [])
+    {
         self.identities = identities
+        self.availableIdentities = availableIdentities
     }
 
     func resolveWorkspaceIdentity(
@@ -797,5 +910,21 @@ private struct StubManagedCodexWorkspaceResolver: ManagedCodexWorkspaceResolving
         providerAccountID: String) async -> CodexOpenAIWorkspaceIdentity?
     {
         self.identities[providerAccountID]
+    }
+
+    func availableWorkspaceIdentities(homePath _: String) async -> [CodexOpenAIWorkspaceIdentity] {
+        self.availableIdentities
+    }
+}
+
+private struct StubManagedCodexWorkspaceSelector: ManagedCodexWorkspaceSelecting {
+    let selectedWorkspaceID: String?
+
+    func selectWorkspace(
+        email _: String,
+        currentWorkspaceID _: String?,
+        workspaces: [CodexOpenAIWorkspaceIdentity]) async -> CodexOpenAIWorkspaceIdentity?
+    {
+        workspaces.first { $0.workspaceAccountID == self.selectedWorkspaceID }
     }
 }

--- a/Tests/CodexBarTests/ManagedCodexAccountStoreTests.swift
+++ b/Tests/CodexBarTests/ManagedCodexAccountStoreTests.swift
@@ -205,6 +205,36 @@ func `FileManagedCodexAccountStore keeps same email rows when hydrated provider 
 }
 
 @Test
+func `managed account set keeps same provider account I D when emails differ`() {
+    let firstID = UUID()
+    let secondID = UUID()
+    let first = ManagedCodexAccount(
+        id: firstID,
+        email: "mi.chaelfmk5542@gmail.com",
+        providerAccountID: "team-4107",
+        managedHomePath: "/tmp/managed-home-1",
+        createdAt: 10,
+        updatedAt: 20,
+        lastAuthenticatedAt: nil)
+    let second = ManagedCodexAccount(
+        id: secondID,
+        email: "mich.aelfmk5542@gmail.com",
+        providerAccountID: "team-4107",
+        managedHomePath: "/tmp/managed-home-2",
+        createdAt: 30,
+        updatedAt: 40,
+        lastAuthenticatedAt: nil)
+
+    let set = ManagedCodexAccountSet(
+        version: FileManagedCodexAccountStore.currentVersion,
+        accounts: [first, second])
+
+    #expect(set.accounts.count == 2)
+    #expect(set.account(email: "mi.chaelfmk5542@gmail.com", providerAccountID: "team-4107")?.id == firstID)
+    #expect(set.account(email: "mich.aelfmk5542@gmail.com", providerAccountID: "team-4107")?.id == secondID)
+}
+
+@Test
 func `FileManagedCodexAccountStore hydrates provider account I D from id token when account field is absent`() throws {
     let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
     defer { try? FileManager.default.removeItem(at: root) }


### PR DESCRIPTION
## Summary
- Treat provider-backed Codex managed account identity as email plus workspace account ID so different OpenAI users in the same team workspace do not overwrite each other.
- Prompt for workspace selection when login exposes multiple OpenAI workspaces, persist the selected workspace ID into the managed auth file, and cache workspace labels for display.
- Make live/managed reconciliation and promotion convergence email-aware for provider identities so same-workspace/different-email accounts remain distinct.
- Add regression coverage for workspace persistence, same-workspace different-email account storage, and live/managed projection splitting.

## Verification
- `pnpm check`
- `swift test --filter CodexAccountProviderIdentityReconciliationTests`
- `swift test --filter ManagedCodexAccountServiceTests`
- `swift test --filter ManagedCodexAccountStoreTests`
- `swift test --filter CodexAccountReconciliationTests`
- `swift test --filter CodexAccountPromotionPlanningTests`
- `swift test --filter CodexAccountPromotionServiceTests`
- `./Scripts/compile_and_run.sh`

## Notes
- `./Scripts/compile_and_run.sh --test` hit an existing headless AppKit status-bar drawing crash in `NSStatusBarButtonCell drawWithFrame`, outside the Codex account identity path. The targeted account and promotion test suites above pass, and the app was rebuilt/relaunched successfully with `./Scripts/compile_and_run.sh`.