### PR TITLE
Restart Codex app when switching accounts

### DIFF
--- a/Sources/CodexBar/CodexAccountPromotionCoordinator.swift
+++ b/Sources/CodexBar/CodexAccountPromotionCoordinator.swift
@@ -103,6 +103,8 @@ final class CodexAccountPromotionCoordinator {
                 "CodexBar could not update managed account storage."
             case .liveAuthSwapFailed:
                 "CodexBar could not replace the live Codex auth on this Mac."
+            case .codexAppRestartFailed:
+                "CodexBar could not quit the running Codex app before switching accounts."
             }
 
             return CodexSystemAccountPromotionUserFacingError(title: title, message: message)

--- a/Sources/CodexBar/CodexAccountPromotionService.swift
+++ b/Sources/CodexBar/CodexAccountPromotionService.swift
@@ -144,6 +144,7 @@ enum CodexAccountPromotionError: Error, Equatable {
     case displacedLiveImportFailed
     case managedStoreCommitFailed
     case liveAuthSwapFailed
+    case codexAppRestartFailed
 }
 
 @MainActor
@@ -157,6 +158,8 @@ final class CodexAccountPromotionService {
     private let liveAuthSwapper: any CodexLiveAuthSwapping
     private let activeSourceWriter: any CodexActiveSourceWriting
     private let accountScopedRefresher: any CodexAccountScopedRefreshing
+    private let restartCodexAppOnSystemAccountSwitch: @MainActor @Sendable () -> Bool
+    private let codexAppRestarter: any CodexAppRestarting
     private let baseEnvironment: [String: String]
     private let fileManager: FileManager
 
@@ -170,6 +173,8 @@ final class CodexAccountPromotionService {
         liveAuthSwapper: any CodexLiveAuthSwapping,
         activeSourceWriter: any CodexActiveSourceWriting,
         accountScopedRefresher: any CodexAccountScopedRefreshing,
+        restartCodexAppOnSystemAccountSwitch: @MainActor @Sendable @escaping () -> Bool = { false },
+        codexAppRestarter: any CodexAppRestarting = DefaultCodexAppRestarter(),
         baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default)
     {
@@ -182,6 +187,8 @@ final class CodexAccountPromotionService {
         self.liveAuthSwapper = liveAuthSwapper
         self.activeSourceWriter = activeSourceWriter
         self.accountScopedRefresher = accountScopedRefresher
+        self.restartCodexAppOnSystemAccountSwitch = restartCodexAppOnSystemAccountSwitch
+        self.codexAppRestarter = codexAppRestarter
         self.baseEnvironment = baseEnvironment
         self.fileManager = fileManager
     }
@@ -202,6 +209,8 @@ final class CodexAccountPromotionService {
             liveAuthSwapper: DefaultCodexLiveAuthSwapper(),
             activeSourceWriter: SettingsStoreCodexActiveSourceWriter(settingsStore: settingsStore),
             accountScopedRefresher: UsageStoreCodexAccountScopedRefresher(usageStore: usageStore),
+            restartCodexAppOnSystemAccountSwitch: { settingsStore.codexRestartAppOnSystemAccountSwitch },
+            codexAppRestarter: DefaultCodexAppRestarter(),
             baseEnvironment: baseEnvironment,
             fileManager: fileManager)
     }
@@ -228,28 +237,37 @@ final class CodexAccountPromotionService {
         }
 
         let targetAuthMaterial = try self.requiredTargetAuthMaterial(from: context.target)
-        let preservationPlan = CodexDisplacedLivePreservationPlanner().makePlan(context: context)
-        let executionResult = try CodexDisplacedLivePreservationExecutor(
-            store: self.store,
-            homeFactory: self.homeFactory,
-            fileManager: self.fileManager)
-            .execute(plan: preservationPlan, context: context)
+        let codexAppURLs = try await self.stopCodexAppsIfRequested()
 
         do {
-            try self.liveAuthSwapper.swapLiveAuthData(targetAuthMaterial.rawData, liveHomeURL: context.live.homeURL)
+            let preservationPlan = CodexDisplacedLivePreservationPlanner().makePlan(context: context)
+            let executionResult = try CodexDisplacedLivePreservationExecutor(
+                store: self.store,
+                homeFactory: self.homeFactory,
+                fileManager: self.fileManager)
+                .execute(plan: preservationPlan, context: context)
+
+            do {
+                try self.liveAuthSwapper.swapLiveAuthData(targetAuthMaterial.rawData, liveHomeURL: context.live.homeURL)
+            } catch {
+                throw CodexAccountPromotionError.liveAuthSwapFailed
+            }
+
+            self.activeSourceWriter.writeCodexActiveSource(.liveSystem)
+            await self.accountScopedRefresher.refreshCodexAccountScopedState(allowDisabled: true)
+
+            await self.relaunchCodexAppsIfNeeded(codexAppURLs)
+
+            return CodexAccountPromotionResult(
+                targetManagedAccountID: id,
+                outcome: .promoted,
+                displacedLiveDisposition: executionResult.displacedLiveDisposition,
+                didMutateLiveAuth: true,
+                resultingActiveSource: .liveSystem)
         } catch {
-            throw CodexAccountPromotionError.liveAuthSwapFailed
+            await self.relaunchCodexAppsIfNeeded(codexAppURLs)
+            throw error
         }
-
-        self.activeSourceWriter.writeCodexActiveSource(.liveSystem)
-        await self.accountScopedRefresher.refreshCodexAccountScopedState(allowDisabled: true)
-
-        return CodexAccountPromotionResult(
-            targetManagedAccountID: id,
-            outcome: .promoted,
-            displacedLiveDisposition: executionResult.displacedLiveDisposition,
-            didMutateLiveAuth: true,
-            resultingActiveSource: .liveSystem)
     }
 
     nonisolated static func authFileURL(for homeURL: URL) -> URL {
@@ -300,5 +318,22 @@ final class CodexAccountPromotionService {
         case .unreadable:
             throw CodexAccountPromotionError.targetManagedAccountAuthUnreadable
         }
+    }
+
+    private func stopCodexAppsIfRequested() async throws -> [URL] {
+        guard self.restartCodexAppOnSystemAccountSwitch() else {
+            return []
+        }
+
+        do {
+            return try await self.codexAppRestarter.stopRunningCodexAppsForAccountSwitch()
+        } catch {
+            throw CodexAccountPromotionError.codexAppRestartFailed
+        }
+    }
+
+    private func relaunchCodexAppsIfNeeded(_ appURLs: [URL]) async {
+        guard !appURLs.isEmpty else { return }
+        await self.codexAppRestarter.relaunchCodexApps(at: appURLs)
     }
 }

--- a/Sources/CodexBar/CodexAppRestarter.swift
+++ b/Sources/CodexBar/CodexAppRestarter.swift
@@ -1,0 +1,99 @@
+import AppKit
+import Foundation
+
+@MainActor
+protocol CodexAppRestarting: Sendable {
+    func stopRunningCodexAppsForAccountSwitch() async throws -> [URL]
+    func relaunchCodexApps(at appURLs: [URL]) async
+}
+
+enum CodexAppRestartError: Error, Equatable {
+    case couldNotTerminateRunningApp
+}
+
+@MainActor
+struct DefaultCodexAppRestarter: CodexAppRestarting {
+    func stopRunningCodexAppsForAccountSwitch() async throws -> [URL] {
+        let applications = NSWorkspace.shared.runningApplications.filter(Self.isCodexDesktopApplication)
+        guard !applications.isEmpty else { return [] }
+
+        let appURLs = self.uniqueBundleURLs(from: applications)
+        applications.forEach { $0.terminate() }
+
+        if await self.waitUntilTerminated(applications) {
+            return appURLs
+        }
+
+        applications
+            .filter { !$0.isTerminated }
+            .forEach { $0.forceTerminate() }
+
+        guard await self.waitUntilTerminated(applications) else {
+            throw CodexAppRestartError.couldNotTerminateRunningApp
+        }
+
+        return appURLs
+    }
+
+    func relaunchCodexApps(at appURLs: [URL]) async {
+        for appURL in appURLs {
+            let configuration = NSWorkspace.OpenConfiguration()
+            configuration.activates = true
+            do {
+                try await NSWorkspace.shared.openApplication(at: appURL, configuration: configuration)
+            } catch {
+                _ = NSWorkspace.shared.open(appURL)
+            }
+        }
+    }
+
+    private func uniqueBundleURLs(from applications: [NSRunningApplication]) -> [URL] {
+        var seen: Set<String> = []
+        var urls: [URL] = []
+
+        for application in applications {
+            guard let bundleURL = application.bundleURL else { continue }
+            let standardizedPath = bundleURL.standardizedFileURL.path
+            guard seen.insert(standardizedPath).inserted else { continue }
+            urls.append(bundleURL)
+        }
+
+        return urls
+    }
+
+    private func waitUntilTerminated(
+        _ applications: [NSRunningApplication],
+        timeout: TimeInterval = 5,
+        pollInterval: TimeInterval = 0.1) async -> Bool
+    {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            if applications.allSatisfy(\.isTerminated) {
+                return true
+            }
+
+            try? await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+        }
+
+        return applications.allSatisfy(\.isTerminated)
+    }
+
+    private static func isCodexDesktopApplication(_ application: NSRunningApplication) -> Bool {
+        let localizedName = application.localizedName?.lowercased() ?? ""
+        let bundleIdentifier = application.bundleIdentifier?.lowercased() ?? ""
+        let bundleName = application.bundleURL?.lastPathComponent.lowercased() ?? ""
+
+        if localizedName == "codexbar" ||
+            bundleName == "codexbar.app" ||
+            bundleIdentifier.contains("codexbar")
+        {
+            return false
+        }
+
+        return localizedName == "codex" ||
+            bundleName == "codex.app" ||
+            bundleIdentifier.hasSuffix(".codex") ||
+            bundleIdentifier.contains(".codex.")
+    }
+}

--- a/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
@@ -20,6 +20,7 @@ struct CodexProviderImplementation: ProviderImplementation {
         _ = settings.codexUsageDataSource
         _ = settings.codexCookieSource
         _ = settings.codexCookieHeader
+        _ = settings.codexRestartAppOnSystemAccountSwitch
     }
 
     @MainActor
@@ -77,6 +78,20 @@ struct CodexProviderImplementation: ProviderImplementation {
                 title: "Historical tracking",
                 subtitle: "Stores local Codex usage history (8 weeks) to personalize Pace predictions.",
                 binding: context.boolBinding(\.historicalTrackingEnabled),
+                statusText: nil,
+                actions: [],
+                isVisible: nil,
+                onChange: nil,
+                onAppDidBecomeActive: nil,
+                onAppearWhenEnabled: nil),
+            ProviderSettingsToggleDescriptor(
+                id: "codex-restart-app-on-system-account-switch",
+                title: "Restart Codex app on system switch",
+                subtitle: [
+                    "Quit any running Codex.app before replacing the system account,",
+                    "then reopen it from the same path.",
+                ].joined(separator: " "),
+                binding: context.boolBinding(\.codexRestartAppOnSystemAccountSwitch),
                 statusText: nil,
                 actions: [],
                 isVisible: nil,

--- a/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
@@ -131,6 +131,21 @@ extension SettingsStore {
         }
     }
 
+    var codexRestartAppOnSystemAccountSwitch: Bool {
+        get {
+            self.configSnapshot.providerConfig(for: .codex)?.codexRestartAppOnSystemAccountSwitch ?? false
+        }
+        set {
+            self.updateProviderConfig(provider: .codex) { entry in
+                entry.codexRestartAppOnSystemAccountSwitch = newValue
+            }
+            self.logProviderModeChange(
+                provider: .codex,
+                field: "restartAppOnSystemAccountSwitch",
+                value: String(newValue))
+        }
+    }
+
     var codexResolvedActiveSource: CodexActiveSource {
         self.codexResolvedActiveSourceState.resolvedSource
     }

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -84,6 +84,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
     public var workspaceID: String?
     public var tokenAccounts: ProviderTokenAccountData?
     public var codexActiveSource: CodexActiveSource?
+    public var codexRestartAppOnSystemAccountSwitch: Bool?
 
     public init(
         id: UsageProvider,
@@ -96,7 +97,8 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         region: String? = nil,
         workspaceID: String? = nil,
         tokenAccounts: ProviderTokenAccountData? = nil,
-        codexActiveSource: CodexActiveSource? = nil)
+        codexActiveSource: CodexActiveSource? = nil,
+        codexRestartAppOnSystemAccountSwitch: Bool? = nil)
     {
         self.id = id
         self.enabled = enabled
@@ -109,6 +111,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         self.workspaceID = workspaceID
         self.tokenAccounts = tokenAccounts
         self.codexActiveSource = codexActiveSource
+        self.codexRestartAppOnSystemAccountSwitch = codexRestartAppOnSystemAccountSwitch
     }
 
     public var sanitizedAPIKey: String? {

--- a/Tests/CodexBarTests/CodexAccountPromotionServiceTests.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionServiceTests.swift
@@ -343,6 +343,90 @@ struct CodexAccountPromotionServiceTests {
     }
 
     @Test
+    func `restart enabled stops Codex app before swap and relaunches after promotion`() async throws {
+        let container = try CodexAccountPromotionTestContainer(
+            suiteName: "CodexAccountPromotionServiceTests-restart-enabled")
+        defer { container.tearDown() }
+
+        let target = try container.createManagedAccount(
+            persistedEmail: "beta@example.com",
+            authAccountID: "acct-beta")
+        try container.persistAccounts([target])
+        _ = try container.writeLiveOAuthAuthFile(
+            email: "alpha@example.com",
+            accountID: "acct-alpha")
+        let codexAppURL = URL(fileURLWithPath: "/Applications/Codex.app")
+        let restarter = RecordingCodexAppRestarter(stoppedURLs: [codexAppURL])
+        let swapper = RecordingCodexLiveAuthSwapper()
+
+        let result = try await container.makeService(
+            liveAuthSwapper: swapper,
+            restartCodexAppOnSystemAccountSwitch: { true },
+            codexAppRestarter: restarter)
+            .promoteManagedAccount(id: target.id)
+
+        #expect(result.outcome == .promoted)
+        #expect(restarter.stopCallCount == 1)
+        #expect(swapper.swapCallCount == 1)
+        #expect(restarter.relaunchCallCount == 1)
+        #expect(restarter.relaunchedURLs == [codexAppURL])
+    }
+
+    @Test
+    func `restart disabled leaves Codex app restarter idle`() async throws {
+        let container = try CodexAccountPromotionTestContainer(
+            suiteName: "CodexAccountPromotionServiceTests-restart-disabled")
+        defer { container.tearDown() }
+
+        let target = try container.createManagedAccount(
+            persistedEmail: "beta@example.com",
+            authAccountID: "acct-beta")
+        try container.persistAccounts([target])
+        _ = try container.writeLiveOAuthAuthFile(
+            email: "alpha@example.com",
+            accountID: "acct-alpha")
+        let restarter = RecordingCodexAppRestarter(
+            stoppedURLs: [URL(fileURLWithPath: "/Applications/Codex.app")])
+
+        let result = try await container.makeService(codexAppRestarter: restarter)
+            .promoteManagedAccount(id: target.id)
+
+        #expect(result.outcome == .promoted)
+        #expect(restarter.stopCallCount == 0)
+        #expect(restarter.relaunchCallCount == 0)
+    }
+
+    @Test
+    func `restart failure leaves live auth untouched`() async throws {
+        let container = try CodexAccountPromotionTestContainer(
+            suiteName: "CodexAccountPromotionServiceTests-restart-failure")
+        defer { container.tearDown() }
+
+        let target = try container.createManagedAccount(
+            persistedEmail: "beta@example.com",
+            authAccountID: "acct-beta")
+        try container.persistAccounts([target])
+        let liveAuthData = try container.writeLiveOAuthAuthFile(
+            email: "alpha@example.com",
+            accountID: "acct-alpha")
+        let restarter = RecordingCodexAppRestarter(stopError: PromotionTestError.appStopFailed)
+        let swapper = RecordingCodexLiveAuthSwapper()
+
+        await #expect(throws: CodexAccountPromotionError.codexAppRestartFailed) {
+            try await container.makeService(
+                liveAuthSwapper: swapper,
+                restartCodexAppOnSystemAccountSwitch: { true },
+                codexAppRestarter: restarter)
+                .promoteManagedAccount(id: target.id)
+        }
+
+        #expect(restarter.stopCallCount == 1)
+        #expect(restarter.relaunchCallCount == 0)
+        #expect(swapper.swapCallCount == 0)
+        #expect(try container.liveAuthData() == liveAuthData)
+    }
+
+    @Test
     func `refresh store failure leaves existing managed metadata stale after auth copy`() async throws {
         let container = try CodexAccountPromotionTestContainer(
             suiteName: "CodexAccountPromotionServiceTests-refresh-store-failure")

--- a/Tests/CodexBarTests/CodexAccountPromotionTestSupport.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionTestSupport.swift
@@ -81,7 +81,9 @@ final class CodexAccountPromotionTestContainer {
         store: (any ManagedCodexAccountStoring)? = nil,
         liveAuthSwapper: (any CodexLiveAuthSwapping)? = nil,
         activeSourceWriter: (any CodexActiveSourceWriting)? = nil,
-        accountScopedRefresher: (any CodexAccountScopedRefreshing)? = nil)
+        accountScopedRefresher: (any CodexAccountScopedRefreshing)? = nil,
+        restartCodexAppOnSystemAccountSwitch: @MainActor @Sendable @escaping () -> Bool = { false },
+        codexAppRestarter: (any CodexAppRestarting)? = nil)
         -> CodexAccountPromotionService
     {
         CodexAccountPromotionService(
@@ -96,6 +98,8 @@ final class CodexAccountPromotionTestContainer {
                 ?? SettingsStoreCodexActiveSourceWriter(settingsStore: self.settings),
             accountScopedRefresher: accountScopedRefresher
                 ?? UsageStoreCodexAccountScopedRefresher(usageStore: self.usageStore),
+            restartCodexAppOnSystemAccountSwitch: restartCodexAppOnSystemAccountSwitch,
+            codexAppRestarter: codexAppRestarter ?? RecordingCodexAppRestarter(),
             baseEnvironment: self.baseEnvironment,
             fileManager: .default)
     }
@@ -446,10 +450,41 @@ final class RecordingCodexLiveAuthSwapper: CodexLiveAuthSwapping, @unchecked Sen
     }
 }
 
+@MainActor
+final class RecordingCodexAppRestarter: CodexAppRestarting {
+    var stopCallCount = 0
+    var relaunchCallCount = 0
+    var stoppedURLs: [URL]
+    var relaunchedURLs: [URL] = []
+    var stopError: Error?
+
+    init(
+        stoppedURLs: [URL] = [],
+        stopError: Error? = nil)
+    {
+        self.stoppedURLs = stoppedURLs
+        self.stopError = stopError
+    }
+
+    func stopRunningCodexAppsForAccountSwitch() async throws -> [URL] {
+        self.stopCallCount += 1
+        if let stopError {
+            throw stopError
+        }
+        return self.stoppedURLs
+    }
+
+    func relaunchCodexApps(at appURLs: [URL]) async {
+        self.relaunchCallCount += 1
+        self.relaunchedURLs.append(contentsOf: appURLs)
+    }
+}
+
 enum PromotionTestError: Error, Equatable {
     case storeWriteFailed
     case swapFailed
     case unexpectedDisposition
+    case appStopFailed
 }
 
 private struct StubManagedCodexWorkspaceResolver: ManagedCodexWorkspaceResolving {

--- a/Tests/CodexBarTests/CodexActiveSourceConfigTests.swift
+++ b/Tests/CodexBarTests/CodexActiveSourceConfigTests.swift
@@ -95,4 +95,19 @@ struct CodexActiveSourceConfigTests {
 
         #expect(decoded.providerConfig(for: .codex)?.codexActiveSource == .managedAccount(id: accountID))
     }
+
+    @Test
+    func `provider config round trips Codex app restart preference`() throws {
+        let config = CodexBarConfig(
+            providers: [
+                ProviderConfig(
+                    id: .codex,
+                    codexRestartAppOnSystemAccountSwitch: true),
+            ])
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(CodexBarConfig.self, from: data)
+
+        #expect(decoded.providerConfig(for: .codex)?.codexRestartAppOnSystemAccountSwitch == true)
+    }
 }


### PR DESCRIPTION
## Summary
- add a Codex provider setting to restart Codex.app around system account switches
- quit running Codex.app instances before swapping live auth, then relaunch from the detected app path
- cover the setting persistence and restart promotion paths with tests

## Tests
- pnpm check
- swift test --filter CodexAccountPromotionServiceTests --filter CodexActiveSourceConfigTests
- ./Scripts/compile_and_run.sh