### PR TITLE
Fix token account switcher not refreshing menu with new account data

### DIFF
--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -730,8 +730,9 @@ extension StatusItemController {
                 self.settings.setActiveTokenAccountIndex(index, for: display.provider)
                 Task { @MainActor in
                     await ProviderInteractionContext.$current.withValue(.userInitiated) {
-                        await self.store.refresh()
+                        await self.store.refreshProvider(display.provider)
                     }
+                    self.refreshOpenMenuIfStillVisible(menu, provider: display.provider)
                 }
                 self.populateMenu(menu, provider: display.provider)
                 self.markMenuFresh(menu)


### PR DESCRIPTION
## Summary

- Replace `store.refresh()` with targeted `store.refreshProvider(display.provider)` in the token account switcher's `onSelect` handler — avoids being silently dropped by the global `isRefreshing` guard when a menu-open refresh is already in-flight
- Add `refreshOpenMenuIfStillVisible` after the async fetch completes so the open menu updates in-place (matching the Codex account switcher pattern)

Fixes #798

## Test plan

- [ ] Enable a provider with 2+ token accounts (e.g. Claude with multiple session keys)
- [ ] Open the menu and switch between accounts — the usage card should update each time without needing to manually refresh or close/reopen the menu
- [ ] Verify switching while a background refresh is in-flight still picks up the new account

🤖 Generated with [Claude Code](https://claude.com/claude-code)