### PR TITLE
feat(providers): Add StepFun provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Usage pace: compute pace for any explicit reset window instead of a provider allowlist (#875). Thanks @ViperThanks!
 - Crof: add API-key provider support with request quota and credit balance tracking (#872). Thanks @baanish!
 - Command Code: add browser-cookie provider support for monthly USD billing credits (#857). Thanks @sixhobbits!
+- StepFun: add username/password or Oasis-Token provider support for Step Plan rate-limit tracking (#815). Thanks @tevenfeng!
 - OpenRouter, Mistral, and Kimi K2: show balance/spend metrics in menu bar text when quota percentage is not useful (#853). Thanks @willytop8!
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Or download release tarballs from GitHub Releases:
 - [Codebuff](docs/codebuff.md) — API token (or `~/.config/manicode/credentials.json`) for credit balance + weekly rate limit.
 - [Crof](docs/crof.md) — API key for dollar credit balance and request quota tracking.
 - [Command Code](docs/command-code.md) — Browser cookies for monthly USD credits from Command Code billing.
+- [StepFun](docs/stepfun.md) — Username + password login for Step Plan rate limits (5‑hour + weekly windows) and subscription plan name.
 - Open to new providers: [provider authoring guide](docs/provider.md).
 
 ## Icon & Screenshot

--- a/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
@@ -46,6 +46,7 @@ enum ProviderImplementationRegistry {
         case .crof: CrofProviderImplementation()
         case .venice: VeniceProviderImplementation()
         case .commandcode: CommandCodeProviderImplementation()
+        case .stepfun: StepFunProviderImplementation()
         }
     }
 

--- a/Sources/CodexBar/Providers/StepFun/StepFunProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/StepFun/StepFunProviderImplementation.swift
@@ -1,0 +1,161 @@
+import AppKit
+import CodexBarCore
+import CodexBarMacroSupport
+import Foundation
+import SwiftUI
+
+@ProviderImplementationRegistration
+struct StepFunProviderImplementation: ProviderImplementation {
+    let id: UsageProvider = .stepfun
+
+    @MainActor
+    func presentation(context _: ProviderPresentationContext) -> ProviderPresentation {
+        ProviderPresentation { _ in "web" }
+    }
+
+    @MainActor
+    func observeSettings(_ settings: SettingsStore) {
+        _ = settings.stepfunCookieSource
+        _ = settings.stepfunUsername
+        _ = settings.stepfunPassword
+        _ = settings.stepfunToken
+    }
+
+    @MainActor
+    func isAvailable(context: ProviderAvailabilityContext) -> Bool {
+        // Available if any auth method is configured
+        if !context.settings.stepfunUsername.isEmpty, !context.settings.stepfunPassword.isEmpty {
+            return true
+        }
+        if context.settings.stepfunCookieSource == .manual, !context.settings.stepfunToken.isEmpty {
+            return true
+        }
+        if CookieHeaderCache.load(provider: .stepfun) != nil {
+            return true
+        }
+        if StepFunSettingsReader.username(environment: context.environment) != nil,
+           StepFunSettingsReader.password(environment: context.environment) != nil
+        {
+            return true
+        }
+        if StepFunSettingsReader.token(environment: context.environment) != nil {
+            return true
+        }
+        return false
+    }
+
+    @MainActor
+    func settingsSnapshot(context: ProviderSettingsSnapshotContext) -> ProviderSettingsSnapshotContribution? {
+        .stepfun(context.settings.stepfunSettingsSnapshot(tokenOverride: context.tokenOverride))
+    }
+
+    @MainActor
+    func tokenAccountsVisibility(context: ProviderSettingsContext, support: TokenAccountSupport) -> Bool {
+        guard support.requiresManualCookieSource else { return true }
+        if !context.settings.tokenAccounts(for: context.provider).isEmpty { return true }
+        return context.settings.stepfunCookieSource == .manual
+    }
+
+    @MainActor
+    func applyTokenAccountCookieSource(settings: SettingsStore) {
+        if settings.stepfunCookieSource != .manual {
+            settings.stepfunCookieSource = .manual
+        }
+    }
+
+    // MARK: - Settings Pickers
+
+    @MainActor
+    func settingsPickers(context: ProviderSettingsContext) -> [ProviderSettingsPickerDescriptor] {
+        let cookieBinding = Binding(
+            get: { context.settings.stepfunCookieSource.rawValue },
+            set: { raw in
+                context.settings.stepfunCookieSource = ProviderCookieSource(rawValue: raw) ?? .auto
+            })
+        let cookieOptions = ProviderCookieSourceUI.options(
+            allowsOff: true,
+            keychainDisabled: context.settings.debugDisableKeychainAccess)
+
+        let cookieSubtitle: () -> String? = {
+            ProviderCookieSourceUI.subtitle(
+                source: context.settings.stepfunCookieSource,
+                keychainDisabled: context.settings.debugDisableKeychainAccess,
+                auto: "Uses username + password to login and obtain an Oasis-Token automatically.",
+                manual: "Manually paste an Oasis-Token from a browser session.",
+                off: "StepFun authentication is disabled.")
+        }
+
+        return [
+            ProviderSettingsPickerDescriptor(
+                id: "stepfun-cookie-source",
+                title: "Auth source",
+                subtitle: "Uses username + password to login and obtain an Oasis-Token automatically.",
+                dynamicSubtitle: cookieSubtitle,
+                binding: cookieBinding,
+                options: cookieOptions,
+                isVisible: nil,
+                onChange: nil,
+                trailingText: {
+                    guard let entry = CookieHeaderCache.load(provider: .stepfun) else { return nil }
+                    let when = entry.storedAt.relativeDescription()
+                    return "Cached: \(entry.sourceLabel) • \(when)"
+                }),
+        ]
+    }
+
+    // MARK: - Settings Fields
+
+    @MainActor
+    func settingsFields(context: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {
+        // Auto mode: show username + password fields
+        let autoFields: [ProviderSettingsFieldDescriptor] = [
+            ProviderSettingsFieldDescriptor(
+                id: "stepfun-username",
+                title: "Username",
+                subtitle: "StepFun platform account (phone number or email).",
+                kind: .plain,
+                placeholder: "user@example.com",
+                binding: context.stringBinding(\.stepfunUsername),
+                actions: [],
+                isVisible: { context.settings.stepfunCookieSource != .manual },
+                onActivate: nil),
+            ProviderSettingsFieldDescriptor(
+                id: "stepfun-password",
+                title: "Password",
+                subtitle: "Your StepFun platform password. Used to login and obtain a session token.",
+                kind: .secure,
+                placeholder: "Password",
+                binding: context.stringBinding(\.stepfunPassword),
+                actions: [],
+                isVisible: { context.settings.stepfunCookieSource != .manual },
+                onActivate: nil),
+        ]
+
+        // Manual mode: show token field
+        let manualFields: [ProviderSettingsFieldDescriptor] = [
+            ProviderSettingsFieldDescriptor(
+                id: "stepfun-token",
+                title: "Oasis-Token",
+                subtitle: "Paste the Oasis-Token from a logged-in browser session on platform.stepfun.com.",
+                kind: .secure,
+                placeholder: "Oasis-Token=…",
+                binding: context.stringBinding(\.stepfunToken),
+                actions: [
+                    ProviderSettingsActionDescriptor(
+                        id: "stepfun-open-platform",
+                        title: "Open StepFun Platform",
+                        style: .link,
+                        isVisible: nil,
+                        perform: {
+                            if let url = URL(string: "https://platform.stepfun.com/plan-usage") {
+                                NSWorkspace.shared.open(url)
+                            }
+                        }),
+                ],
+                isVisible: { context.settings.stepfunCookieSource == .manual },
+                onActivate: nil),
+        ]
+
+        return autoFields + manualFields
+    }
+}

--- a/Sources/CodexBar/Providers/StepFun/StepFunSettingsStore.swift
+++ b/Sources/CodexBar/Providers/StepFun/StepFunSettingsStore.swift
@@ -1,0 +1,65 @@
+import CodexBarCore
+import Foundation
+
+extension SettingsStore {
+    /// Username for StepFun login — stored in the apiKey config field.
+    var stepfunUsername: String {
+        get { self.configSnapshot.providerConfig(for: .stepfun)?.sanitizedAPIKey ?? "" }
+        set {
+            self.updateProviderConfig(provider: .stepfun) { entry in
+                entry.apiKey = self.normalizedConfigValue(newValue)
+            }
+            self.logProviderModeChange(provider: .stepfun, field: "username", value: newValue.isEmpty ? "(cleared)" : "(updated)")
+        }
+    }
+
+    /// Password for StepFun login — stored in the cookieHeader config field (secure storage).
+    var stepfunPassword: String {
+        get { self.configSnapshot.providerConfig(for: .stepfun)?.sanitizedCookieHeader ?? "" }
+        set {
+            self.updateProviderConfig(provider: .stepfun) { entry in
+                entry.cookieHeader = self.normalizedConfigValue(newValue)
+            }
+            self.logSecretUpdate(provider: .stepfun, field: "password", value: newValue)
+        }
+    }
+
+    /// Manual Oasis-Token — stored in the region config field (repurposed for token).
+    var stepfunToken: String {
+        get { self.configSnapshot.providerConfig(for: .stepfun)?.region ?? "" }
+        set {
+            self.updateProviderConfig(provider: .stepfun) { entry in
+                entry.region = self.normalizedConfigValue(newValue)
+            }
+            self.logSecretUpdate(provider: .stepfun, field: "token", value: newValue)
+        }
+    }
+
+    var stepfunCookieSource: ProviderCookieSource {
+        get { self.resolvedCookieSource(provider: .stepfun, fallback: .auto) }
+        set {
+            self.updateProviderConfig(provider: .stepfun) { entry in
+                entry.cookieSource = newValue
+            }
+            self.logProviderModeChange(provider: .stepfun, field: "cookieSource", value: newValue.rawValue)
+        }
+    }
+
+    func stepfunSettingsSnapshot(tokenOverride: TokenAccountOverride?) -> ProviderSettingsSnapshot
+        .StepFunProviderSettings
+    {
+        ProviderSettingsSnapshot.StepFunProviderSettings(
+            cookieSource: self.stepfunSnapshotCookieSource(tokenOverride: tokenOverride),
+            manualToken: self.stepfunSnapshotToken(tokenOverride: tokenOverride),
+            username: self.stepfunUsername,
+            password: self.stepfunPassword)
+    }
+
+    private func stepfunSnapshotToken(tokenOverride: TokenAccountOverride?) -> String {
+        self.stepfunToken
+    }
+
+    private func stepfunSnapshotCookieSource(tokenOverride: TokenAccountOverride?) -> ProviderCookieSource {
+        self.stepfunCookieSource
+    }
+}

--- a/Sources/CodexBar/Providers/StepFun/StepFunSettingsStore.swift
+++ b/Sources/CodexBar/Providers/StepFun/StepFunSettingsStore.swift
@@ -56,10 +56,30 @@ extension SettingsStore {
     }
 
     private func stepfunSnapshotToken(tokenOverride: TokenAccountOverride?) -> String {
-        self.stepfunToken
+        let fallback = self.stepfunToken
+        guard let support = TokenAccountSupportCatalog.support(for: .stepfun),
+              case .cookieHeader = support.injection
+        else {
+            return fallback
+        }
+        guard let account = ProviderTokenAccountSelection.selectedAccount(
+            provider: .stepfun,
+            settings: self,
+            override: tokenOverride)
+        else {
+            return fallback
+        }
+        return TokenAccountSupportCatalog.normalizedCookieHeader(account.token, support: support)
     }
 
     private func stepfunSnapshotCookieSource(tokenOverride: TokenAccountOverride?) -> ProviderCookieSource {
-        self.stepfunCookieSource
+        let fallback = self.stepfunCookieSource
+        guard let support = TokenAccountSupportCatalog.support(for: .stepfun),
+              support.requiresManualCookieSource
+        else {
+            return fallback
+        }
+        if self.tokenAccounts(for: .stepfun).isEmpty { return fallback }
+        return .manual
     }
 }

--- a/Sources/CodexBar/Providers/StepFun/StepFunSettingsStore.swift
+++ b/Sources/CodexBar/Providers/StepFun/StepFunSettingsStore.swift
@@ -9,7 +9,10 @@ extension SettingsStore {
             self.updateProviderConfig(provider: .stepfun) { entry in
                 entry.apiKey = self.normalizedConfigValue(newValue)
             }
-            self.logProviderModeChange(provider: .stepfun, field: "username", value: newValue.isEmpty ? "(cleared)" : "(updated)")
+            self.logProviderModeChange(
+                provider: .stepfun,
+                field: "username",
+                value: newValue.isEmpty ? "(cleared)" : "(updated)")
         }
     }
 

--- a/Sources/CodexBar/Resources/ProviderIcon-stepfun.svg
+++ b/Sources/CodexBar/Resources/ProviderIcon-stepfun.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="_图层_2" data-name="图层 2" viewBox="0 0 84.47 84.47">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: url(#_未命名的渐变_64);
+      }
+      .cls-1, .cls-4 {
+        stroke-width: 0px;
+      }
+      .cls-4 {
+        fill: #999999;
+      }
+    </style>
+    <radialGradient id="_未命名的渐变_64" data-name="未命名的渐变 64" cx="25.5" cy="102.67" fx="25.5" fy="102.67" r="51.59" gradientTransform="translate(-112.31 94.12) rotate(-75.81) scale(1 1.32)" gradientUnits="userSpaceOnUse">
+      <stop offset=".4" stop-color="#888888"/>
+      <stop offset=".43" stop-color="#878787" stop-opacity=".92"/>
+      <stop offset=".52" stop-color="#868686" stop-opacity=".68"/>
+      <stop offset=".61" stop-color="#858585" stop-opacity=".47"/>
+      <stop offset=".69" stop-color="#858585" stop-opacity=".3"/>
+      <stop offset=".78" stop-color="#848484" stop-opacity=".17"/>
+      <stop offset=".86" stop-color="#848484" stop-opacity=".08"/>
+      <stop offset=".94" stop-color="#848484" stop-opacity=".02"/>
+      <stop offset="1" stop-color="#848484" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <g id="_图层_1-2" data-name="图层 1">
+    <g>
+      <path class="cls-4" d="m42.23,0C18.91,0,0,18.91,0,42.23s18.91,42.23,42.23,42.23,42.23-18.91,42.23-42.23S65.56,0,42.23,0Zm-11.35,69.03h-15.44v-15.44h15.44v15.44Zm19.07,0h-15.44v-15.44h15.44v15.44Zm0-19.08h-15.44v-15.44h15.44v15.44Zm0-19.07h-15.44v-15.44h15.44v15.44Zm19.07,0h-15.44v-15.44h15.44v15.44Z"/>
+      <path class="cls-1" d="m47.24.3C24.08-2.46,3.07,14.07.3,37.23c-2.76,23.16,13.77,44.17,36.92,46.94,23.16,2.76,44.17-13.77,46.94-36.92C86.93,24.08,70.4,3.07,47.24.3Zm-16.36,68.73h-15.44v-15.44h15.44v15.44Zm19.07,0h-15.44v-15.44h15.44v15.44Zm0-19.08h-15.44v-15.44h15.44v15.44Zm0-19.07h-15.44v-15.44h15.44v15.44Zm19.07,0h-15.44v-15.44h15.44v15.44Z"/>
+    </g>
+  </g>
+</svg>

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -203,6 +203,9 @@ extension StatusItemController {
             guard let view = item.view else { return false }
             return abs(view.frame.width - menuWidth) <= 0.5
         }
+        let providerSwitcherWidthMatches = (menu.items.first?.view as? ProviderSwitcherView).map { view in
+            abs(view.frame.width - menuWidth) <= 0.5
+        } ?? false
         let canSmartUpdate = self.shouldMergeIcons &&
             enabledProviders.count > 1 &&
             !isOverviewSelected &&
@@ -216,16 +219,62 @@ extension StatusItemController {
             !menu.items.isEmpty &&
             menu.items.first?.view is ProviderSwitcherView
 
+        #if DEBUG
+        if self.openMenus[ObjectIdentifier(menu)] != nil {
+            self.menuLogger.debug(
+                "populateMenu(open): provider=\(String(describing: provider)) display=\(enabledProviders.map(\.rawValue)) " +
+                    "available=\(self.store.enabledProviders().map(\.rawValue)) selection=\(String(describing: switcherSelection)) " +
+                    "last=\(String(describing: self.lastMergedSwitcherSelection)) smart=\(canSmartUpdate)")
+        }
+        #endif
+
         if canSmartUpdate {
-            self.updateMenuContent(
+            self.updateMenuContentPreservingSwitcher(
                 menu,
                 provider: selectedProvider,
                 currentProvider: currentProvider,
+                switcherSelection: switcherSelection ?? .provider(currentProvider),
                 menuWidth: menuWidth,
+                codexAccountDisplay: nil,
+                tokenAccountDisplay: nil,
                 openAIContext: openAIContext)
             return
         }
 
+        let canPreserveProviderSwitcher = self.shouldMergeIcons &&
+            enabledProviders.count > 1 &&
+            switcherProvidersMatch &&
+            switcherUsageBarsShowUsedMatch &&
+            switcherOverviewAvailabilityMatches &&
+            providerSwitcherWidthMatches &&
+            !menu.items.isEmpty &&
+            menu.items.first?.view is ProviderSwitcherView
+
+        #if DEBUG
+        if self.openMenus[ObjectIdentifier(menu)] != nil {
+            self.menuLogger.debug(
+                "populateMenu(open): preserveSwitcher=\(canPreserveProviderSwitcher) widthMatch=\(providerSwitcherWidthMatches)")
+        }
+        #endif
+
+        if canPreserveProviderSwitcher {
+            self.updateMenuContentPreservingSwitcher(
+                menu,
+                provider: selectedProvider,
+                currentProvider: currentProvider,
+                switcherSelection: switcherSelection ?? .provider(currentProvider),
+                menuWidth: menuWidth,
+                codexAccountDisplay: codexAccountDisplay,
+                tokenAccountDisplay: tokenAccountDisplay,
+                openAIContext: openAIContext)
+            return
+        }
+
+        #if DEBUG
+        if self.openMenus[ObjectIdentifier(menu)] != nil, menu.items.first?.view is ProviderSwitcherView {
+            self.menuLogger.debug("populateMenu(open): rebuilding whole menu and replacing provider switcher")
+        }
+        #endif
         menu.removeAllItems()
         self.addProviderSwitcherIfNeeded(
             to: menu,
@@ -298,12 +347,15 @@ extension StatusItemController {
         return reusableRows
     }
 
-    /// Smart update: only rebuild content sections when switching providers (keep the switcher intact).
-    private func updateMenuContent(
+    /// Smart update: rebuild everything below the provider switcher while keeping the switcher view intact.
+    private func updateMenuContentPreservingSwitcher(
         _ menu: NSMenu,
         provider: UsageProvider?,
         currentProvider: UsageProvider,
+        switcherSelection: ProviderSwitcherSelection,
         menuWidth: CGFloat,
+        codexAccountDisplay: CodexAccountMenuDisplay?,
+        tokenAccountDisplay: TokenAccountMenuDisplay?,
         openAIContext: OpenAIWebContext)
     {
         // Batch menu updates to prevent visual flickering during provider switch.
@@ -311,23 +363,20 @@ extension StatusItemController {
         CATransaction.setDisableActions(true)
         defer { CATransaction.commit() }
 
-        var contentStartIndex = 0
-        if menu.items.first?.view is ProviderSwitcherView {
-            contentStartIndex = 2
-        }
-        if menu.items.count > contentStartIndex,
-           menu.items[contentStartIndex].view is CodexAccountSwitcherView
-        {
-            contentStartIndex += 2
-        }
-        if menu.items.count > contentStartIndex,
-           menu.items[contentStartIndex].view is TokenAccountSwitcherView
-        {
-            contentStartIndex += 2
-        }
+        let contentStartIndex = menu.items.first?.view is ProviderSwitcherView ? 2 : 0
+        (menu.items.first?.view as? ProviderSwitcherView)?.updateSelection(switcherSelection)
         while menu.items.count > contentStartIndex {
             menu.removeItem(at: contentStartIndex)
         }
+
+        self.lastMergedSwitcherSelection = switcherSelection
+        let enabledProviders = self.store.enabledProvidersForDisplay()
+        self.lastSwitcherProviders = enabledProviders
+        self.lastSwitcherUsageBarsShowUsed = self.settings.usageBarsShowUsed
+        self.lastSwitcherIncludesOverview = self.includesOverviewTab(enabledProviders: enabledProviders)
+        self.addCodexAccountSwitcherIfNeeded(to: menu, display: codexAccountDisplay, width: menuWidth)
+        self.lastCodexAccountMenuDisplay = codexAccountDisplay
+        self.addTokenAccountSwitcherIfNeeded(to: menu, display: tokenAccountDisplay, width: menuWidth)
 
         let descriptor = MenuDescriptor.build(
             provider: provider,
@@ -336,22 +385,38 @@ extension StatusItemController {
             account: self.account,
             managedCodexAccountCoordinator: self.managedCodexAccountCoordinator,
             codexAccountPromotionCoordinator: self.codexAccountPromotionCoordinator,
-            updateReady: self.updater.updateStatus.isUpdateReady)
+            updateReady: self.updater.updateStatus.isUpdateReady,
+            includeContextualActions: switcherSelection != .overview)
 
         let menuContext = MenuCardContext(
             currentProvider: currentProvider,
             selectedProvider: provider,
             menuWidth: menuWidth,
-            tokenAccountDisplay: nil,
+            tokenAccountDisplay: tokenAccountDisplay,
             openAIContext: openAIContext)
-        let addedOpenAIWebItems = self.addMenuCards(to: menu, context: menuContext)
-        self.addOpenAIWebItemsIfNeeded(
-            to: menu,
-            currentProvider: currentProvider,
-            context: openAIContext,
-            addedOpenAIWebItems: addedOpenAIWebItems)
-        if self.addUsageHistoryMenuItemIfNeeded(to: menu, provider: currentProvider, width: menuWidth) {
-            menu.addItem(.separator())
+        self.store.refreshStorageFootprintsForOverview()
+        if switcherSelection == .overview {
+            let enabledProviders = self.store.enabledProvidersForDisplay()
+            if self.addOverviewRows(
+                to: menu,
+                enabledProviders: enabledProviders,
+                menuWidth: menuWidth)
+            {
+                menu.addItem(.separator())
+            } else {
+                self.addOverviewEmptyState(to: menu, enabledProviders: enabledProviders)
+                menu.addItem(.separator())
+            }
+        } else {
+            let addedOpenAIWebItems = self.addMenuCards(to: menu, context: menuContext)
+            self.addOpenAIWebItemsIfNeeded(
+                to: menu,
+                currentProvider: currentProvider,
+                context: openAIContext,
+                addedOpenAIWebItems: addedOpenAIWebItems)
+            if self.addUsageHistoryMenuItemIfNeeded(to: menu, provider: currentProvider, width: menuWidth) {
+                menu.addItem(.separator())
+            }
         }
         self.addActionableSections(descriptor.sections, to: menu, width: menuWidth)
     }
@@ -791,22 +856,34 @@ extension StatusItemController {
             },
             onSelect: { [weak self, weak menu] selection in
                 guard let self, let menu else { return }
+                let provider: UsageProvider?
                 switch selection {
                 case .overview:
                     self.settings.mergedMenuLastSelectedWasOverview = true
-                    self.lastMergedSwitcherSelection = .overview
-                    let provider = self.resolvedMenuProvider()
-                    self.lastMenuProvider = provider ?? .codex
-                    self.populateMenu(menu, provider: provider)
-                case let .provider(provider):
+                    provider = self.resolvedMenuProvider()
+                case let .provider(selectedProvider):
                     self.settings.mergedMenuLastSelectedWasOverview = false
-                    self.lastMergedSwitcherSelection = .provider(provider)
-                    self.selectedMenuProvider = provider
-                    self.lastMenuProvider = provider
-                    self.populateMenu(menu, provider: provider)
+                    self.selectedMenuProvider = selectedProvider
+                    provider = selectedProvider
                 }
-                self.markMenuFresh(menu)
-                self.applyIcon(phase: nil)
+                switch selection {
+                case .overview:
+                    self.lastMenuProvider = provider ?? .codex
+                case let .provider(provider):
+                    self.lastMenuProvider = provider
+                }
+                self.lastMergedSwitcherSelection = selection
+                self.providerSwitcherUpdateToken &+= 1
+                let updateToken = self.providerSwitcherUpdateToken
+                Task { @MainActor [weak self, weak menu] in
+                    await Task.yield()
+                    guard let self, let menu else { return }
+                    guard self.providerSwitcherUpdateToken == updateToken else { return }
+                    self.applyIcon(phase: nil)
+                    guard self.openMenus[ObjectIdentifier(menu)] != nil else { return }
+                    self.populateMenu(menu, provider: provider)
+                    self.markMenuFresh(menu)
+                }
             })
         let item = NSMenuItem()
         item.view = view

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -222,22 +222,26 @@ extension StatusItemController {
         #if DEBUG
         if self.openMenus[ObjectIdentifier(menu)] != nil {
             self.menuLogger.debug(
-                "populateMenu(open): provider=\(String(describing: provider)) display=\(enabledProviders.map(\.rawValue)) " +
-                    "available=\(self.store.enabledProviders().map(\.rawValue)) selection=\(String(describing: switcherSelection)) " +
-                    "last=\(String(describing: self.lastMergedSwitcherSelection)) smart=\(canSmartUpdate)")
+                "populateMenu(open): provider=\(String(describing: provider)) " +
+                    "display=\(enabledProviders.map(\.rawValue)) " +
+                    "available=\(self.store.enabledProviders().map(\.rawValue)) " +
+                    "selection=\(String(describing: switcherSelection)) " +
+                    "last=\(String(describing: self.lastMergedSwitcherSelection)) " +
+                    "smart=\(canSmartUpdate)")
         }
         #endif
 
         if canSmartUpdate {
             self.updateMenuContentPreservingSwitcher(
                 menu,
-                provider: selectedProvider,
-                currentProvider: currentProvider,
-                switcherSelection: switcherSelection ?? .provider(currentProvider),
-                menuWidth: menuWidth,
-                codexAccountDisplay: nil,
-                tokenAccountDisplay: nil,
-                openAIContext: openAIContext)
+                context: MenuUpdateContext(
+                    provider: selectedProvider,
+                    currentProvider: currentProvider,
+                    switcherSelection: switcherSelection ?? .provider(currentProvider),
+                    menuWidth: menuWidth,
+                    codexAccountDisplay: nil,
+                    tokenAccountDisplay: nil,
+                    openAIContext: openAIContext))
             return
         }
 
@@ -253,20 +257,22 @@ extension StatusItemController {
         #if DEBUG
         if self.openMenus[ObjectIdentifier(menu)] != nil {
             self.menuLogger.debug(
-                "populateMenu(open): preserveSwitcher=\(canPreserveProviderSwitcher) widthMatch=\(providerSwitcherWidthMatches)")
+                "populateMenu(open): preserveSwitcher=\(canPreserveProviderSwitcher) " +
+                    "widthMatch=\(providerSwitcherWidthMatches)")
         }
         #endif
 
         if canPreserveProviderSwitcher {
             self.updateMenuContentPreservingSwitcher(
                 menu,
-                provider: selectedProvider,
-                currentProvider: currentProvider,
-                switcherSelection: switcherSelection ?? .provider(currentProvider),
-                menuWidth: menuWidth,
-                codexAccountDisplay: codexAccountDisplay,
-                tokenAccountDisplay: tokenAccountDisplay,
-                openAIContext: openAIContext)
+                context: MenuUpdateContext(
+                    provider: selectedProvider,
+                    currentProvider: currentProvider,
+                    switcherSelection: switcherSelection ?? .provider(currentProvider),
+                    menuWidth: menuWidth,
+                    codexAccountDisplay: codexAccountDisplay,
+                    tokenAccountDisplay: tokenAccountDisplay,
+                    openAIContext: openAIContext))
             return
         }
 
@@ -298,29 +304,10 @@ extension StatusItemController {
             menuWidth: menuWidth,
             tokenAccountDisplay: tokenAccountDisplay,
             openAIContext: openAIContext)
-        self.store.refreshStorageFootprintsForOverview()
-        if isOverviewSelected {
-            if self.addOverviewRows(
-                to: menu,
-                enabledProviders: enabledProviders,
-                menuWidth: menuWidth)
-            {
-                menu.addItem(.separator())
-            } else {
-                self.addOverviewEmptyState(to: menu, enabledProviders: enabledProviders)
-                menu.addItem(.separator())
-            }
-        } else {
-            let addedOpenAIWebItems = self.addMenuCards(to: menu, context: menuContext)
-            self.addOpenAIWebItemsIfNeeded(
-                to: menu,
-                currentProvider: currentProvider,
-                context: openAIContext,
-                addedOpenAIWebItems: addedOpenAIWebItems)
-            if self.addUsageHistoryMenuItemIfNeeded(to: menu, provider: currentProvider, width: menuWidth) {
-                menu.addItem(.separator())
-            }
-        }
+        self.addPrimaryMenuContent(
+            to: menu,
+            context: menuContext,
+            switcherSelection: switcherSelection ?? .provider(currentProvider))
         self.addActionableSections(descriptor.sections, to: menu, width: menuWidth)
     }
 
@@ -348,15 +335,20 @@ extension StatusItemController {
     }
 
     /// Smart update: rebuild everything below the provider switcher while keeping the switcher view intact.
+    private struct MenuUpdateContext {
+        let provider: UsageProvider?
+        let currentProvider: UsageProvider
+        let switcherSelection: ProviderSwitcherSelection
+        let menuWidth: CGFloat
+        let codexAccountDisplay: CodexAccountMenuDisplay?
+        let tokenAccountDisplay: TokenAccountMenuDisplay?
+        let openAIContext: OpenAIWebContext
+    }
+
+    /// Smart update: rebuild everything below the provider switcher while keeping the switcher view intact.
     private func updateMenuContentPreservingSwitcher(
         _ menu: NSMenu,
-        provider: UsageProvider?,
-        currentProvider: UsageProvider,
-        switcherSelection: ProviderSwitcherSelection,
-        menuWidth: CGFloat,
-        codexAccountDisplay: CodexAccountMenuDisplay?,
-        tokenAccountDisplay: TokenAccountMenuDisplay?,
-        openAIContext: OpenAIWebContext)
+        context: MenuUpdateContext)
     {
         // Batch menu updates to prevent visual flickering during provider switch.
         CATransaction.begin()
@@ -364,61 +356,38 @@ extension StatusItemController {
         defer { CATransaction.commit() }
 
         let contentStartIndex = menu.items.first?.view is ProviderSwitcherView ? 2 : 0
-        (menu.items.first?.view as? ProviderSwitcherView)?.updateSelection(switcherSelection)
+        (menu.items.first?.view as? ProviderSwitcherView)?.updateSelection(context.switcherSelection)
         while menu.items.count > contentStartIndex {
             menu.removeItem(at: contentStartIndex)
         }
 
-        self.lastMergedSwitcherSelection = switcherSelection
+        self.lastMergedSwitcherSelection = context.switcherSelection
         let enabledProviders = self.store.enabledProvidersForDisplay()
         self.lastSwitcherProviders = enabledProviders
         self.lastSwitcherUsageBarsShowUsed = self.settings.usageBarsShowUsed
         self.lastSwitcherIncludesOverview = self.includesOverviewTab(enabledProviders: enabledProviders)
-        self.addCodexAccountSwitcherIfNeeded(to: menu, display: codexAccountDisplay, width: menuWidth)
-        self.lastCodexAccountMenuDisplay = codexAccountDisplay
-        self.addTokenAccountSwitcherIfNeeded(to: menu, display: tokenAccountDisplay, width: menuWidth)
+        self.addCodexAccountSwitcherIfNeeded(to: menu, display: context.codexAccountDisplay, width: context.menuWidth)
+        self.lastCodexAccountMenuDisplay = context.codexAccountDisplay
+        self.addTokenAccountSwitcherIfNeeded(to: menu, display: context.tokenAccountDisplay, width: context.menuWidth)
 
         let descriptor = MenuDescriptor.build(
-            provider: provider,
+            provider: context.provider,
             store: self.store,
             settings: self.settings,
             account: self.account,
             managedCodexAccountCoordinator: self.managedCodexAccountCoordinator,
             codexAccountPromotionCoordinator: self.codexAccountPromotionCoordinator,
             updateReady: self.updater.updateStatus.isUpdateReady,
-            includeContextualActions: switcherSelection != .overview)
+            includeContextualActions: context.switcherSelection != .overview)
 
         let menuContext = MenuCardContext(
-            currentProvider: currentProvider,
-            selectedProvider: provider,
-            menuWidth: menuWidth,
-            tokenAccountDisplay: tokenAccountDisplay,
-            openAIContext: openAIContext)
-        self.store.refreshStorageFootprintsForOverview()
-        if switcherSelection == .overview {
-            let enabledProviders = self.store.enabledProvidersForDisplay()
-            if self.addOverviewRows(
-                to: menu,
-                enabledProviders: enabledProviders,
-                menuWidth: menuWidth)
-            {
-                menu.addItem(.separator())
-            } else {
-                self.addOverviewEmptyState(to: menu, enabledProviders: enabledProviders)
-                menu.addItem(.separator())
-            }
-        } else {
-            let addedOpenAIWebItems = self.addMenuCards(to: menu, context: menuContext)
-            self.addOpenAIWebItemsIfNeeded(
-                to: menu,
-                currentProvider: currentProvider,
-                context: openAIContext,
-                addedOpenAIWebItems: addedOpenAIWebItems)
-            if self.addUsageHistoryMenuItemIfNeeded(to: menu, provider: currentProvider, width: menuWidth) {
-                menu.addItem(.separator())
-            }
-        }
-        self.addActionableSections(descriptor.sections, to: menu, width: menuWidth)
+            currentProvider: context.currentProvider,
+            selectedProvider: context.provider,
+            menuWidth: context.menuWidth,
+            tokenAccountDisplay: context.tokenAccountDisplay,
+            openAIContext: context.openAIContext)
+        self.addPrimaryMenuContent(to: menu, context: menuContext, switcherSelection: context.switcherSelection)
+        self.addActionableSections(descriptor.sections, to: menu, width: context.menuWidth)
     }
 
     private struct OpenAIWebContext {
@@ -631,6 +600,41 @@ extension StatusItemController {
             }
         }
         menu.addItem(.separator())
+    }
+
+    private func addPrimaryMenuContent(
+        to menu: NSMenu,
+        context: MenuCardContext,
+        switcherSelection: ProviderSwitcherSelection)
+    {
+        self.store.refreshStorageFootprintsForOverview()
+        if switcherSelection == .overview {
+            let enabledProviders = self.store.enabledProvidersForDisplay()
+            if self.addOverviewRows(
+                to: menu,
+                enabledProviders: enabledProviders,
+                menuWidth: context.menuWidth)
+            {
+                menu.addItem(.separator())
+            } else {
+                self.addOverviewEmptyState(to: menu, enabledProviders: enabledProviders)
+                menu.addItem(.separator())
+            }
+        } else {
+            let addedOpenAIWebItems = self.addMenuCards(to: menu, context: context)
+            self.addOpenAIWebItemsIfNeeded(
+                to: menu,
+                currentProvider: context.currentProvider,
+                context: context.openAIContext,
+                addedOpenAIWebItems: addedOpenAIWebItems)
+            if self.addUsageHistoryMenuItemIfNeeded(
+                to: menu,
+                provider: context.currentProvider,
+                width: context.menuWidth)
+            {
+                menu.addItem(.separator())
+            }
+        }
     }
 
     private func addActionableSections(_ sections: [MenuDescriptor.Section], to menu: NSMenu, width: CGFloat) {
@@ -1568,120 +1572,6 @@ extension StatusItemController {
             let height = view.fittingSize.height
             view.frame = NSRect(origin: .zero, size: NSSize(width: width, height: height))
         }
-    }
-
-    func menuCardModel(
-        for provider: UsageProvider?,
-        snapshotOverride: UsageSnapshot? = nil,
-        errorOverride: String? = nil) -> UsageMenuCardView.Model?
-    {
-        let target = provider ?? self.store.enabledProvidersForDisplay().first ?? .codex
-        let metadata = self.store.metadata(for: target)
-
-        let surface: CodexConsumerProjection.Surface = if snapshotOverride != nil || errorOverride != nil {
-            .overrideCard
-        } else {
-            .liveCard
-        }
-        // Override cards belong to a specific account/context (e.g. a per-account
-        // refresh result). Never fall back to the provider-level live snapshot here —
-        // that data belongs to a *different* account and would render misleading
-        // duplicate cards when an account refresh failed or was cancelled.
-        let snapshot: UsageSnapshot? = if surface == .overrideCard {
-            snapshotOverride
-        } else {
-            snapshotOverride ?? self.store.snapshot(for: target)
-        }
-        let now = Date()
-        let codexProjection = self.store.codexConsumerProjectionIfNeeded(
-            for: target,
-            surface: surface,
-            snapshotOverride: snapshotOverride,
-            errorOverride: errorOverride,
-            now: now)
-        let credits: CreditsSnapshot?
-        let creditsError: String?
-        let dashboard: OpenAIDashboardSnapshot?
-        let dashboardError: String?
-        let tokenSnapshot: CostUsageTokenSnapshot?
-        let tokenError: String?
-        if let codexProjection {
-            credits = codexProjection.credits?.snapshot
-            creditsError = codexProjection.credits?.userFacingError
-            dashboard = nil
-            dashboardError = codexProjection.userFacingErrors.dashboard
-            if surface == .liveCard {
-                tokenSnapshot = self.store.tokenSnapshot(for: target)
-                tokenError = self.store.tokenError(for: target)
-            } else {
-                tokenSnapshot = nil
-                tokenError = nil
-            }
-        } else if target == .claude || target == .vertexai, snapshotOverride == nil {
-            credits = nil
-            creditsError = nil
-            dashboard = nil
-            dashboardError = nil
-            tokenSnapshot = self.store.tokenSnapshot(for: target)
-            tokenError = self.store.tokenError(for: target)
-        } else {
-            credits = nil
-            creditsError = nil
-            dashboard = nil
-            dashboardError = nil
-            tokenSnapshot = nil
-            tokenError = nil
-        }
-
-        let sourceLabel = snapshotOverride == nil ? self.store.sourceLabel(for: target) : nil
-        let kiloAutoMode = target == .kilo && self.settings.kiloUsageDataSource == .auto
-        // Abacus uses primary for monthly credits (no secondary window)
-        let paceWindow = target == .abacus ? snapshot?.primary : snapshot?.secondary
-        let weeklyPace = if let codexProjection,
-                            let weekly = codexProjection.rateWindow(for: .weekly)
-        {
-            self.store.weeklyPace(provider: target, window: weekly, now: now)
-        } else {
-            paceWindow.flatMap { window in
-                self.store.weeklyPace(provider: target, window: window, now: now)
-            }
-        }
-        let input = UsageMenuCardView.Model.Input(
-            provider: target,
-            metadata: metadata,
-            snapshot: snapshot,
-            codexProjection: codexProjection,
-            credits: credits,
-            creditsError: creditsError,
-            dashboard: dashboard,
-            dashboardError: dashboardError,
-            tokenSnapshot: tokenSnapshot,
-            tokenError: tokenError,
-            account: self.store.accountInfo(for: target),
-            isRefreshing: self.store.shouldShowRefreshingMenuCard(for: target),
-            lastError: errorOverride
-                ?? codexProjection?.userFacingErrors.usage
-                ?? self.store.userFacingError(for: target),
-            usageBarsShowUsed: self.settings.usageBarsShowUsed,
-            resetTimeDisplayStyle: self.settings.resetTimeDisplayStyle,
-            tokenCostUsageEnabled: self.settings.isCostUsageEffectivelyEnabled(for: target),
-            showOptionalCreditsAndExtraUsage: self.settings.showOptionalCreditsAndExtraUsage,
-            sourceLabel: sourceLabel,
-            kiloAutoMode: kiloAutoMode,
-            hidePersonalInfo: self.settings.hidePersonalInfo,
-            claudePeakHoursEnabled: self.settings.claudePeakHoursEnabled,
-            weeklyPace: weeklyPace,
-            quotaWarningThresholds: [
-                .session: self.quotaWarningMarkerThresholds(provider: target, window: .session),
-                .weekly: self.quotaWarningMarkerThresholds(provider: target, window: .weekly),
-            ],
-            now: now)
-        return UsageMenuCardView.Model.make(input)
-    }
-
-    private func quotaWarningMarkerThresholds(provider: UsageProvider, window: QuotaWarningWindow) -> [Int] {
-        guard self.settings.quotaWarningEnabled(provider: provider, window: window) else { return [] }
-        return self.settings.resolvedQuotaWarningThresholds(provider: provider, window: window)
     }
 
     @objc private func menuCardNoOp(_ sender: NSMenuItem) {

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -1,0 +1,116 @@
+import CodexBarCore
+import Foundation
+
+extension StatusItemController {
+    func menuCardModel(
+        for provider: UsageProvider?,
+        snapshotOverride: UsageSnapshot? = nil,
+        errorOverride: String? = nil) -> UsageMenuCardView.Model?
+    {
+        let target = provider ?? self.store.enabledProvidersForDisplay().first ?? .codex
+        let metadata = self.store.metadata(for: target)
+
+        let surface: CodexConsumerProjection.Surface = if snapshotOverride != nil || errorOverride != nil {
+            .overrideCard
+        } else {
+            .liveCard
+        }
+        // Override cards belong to a specific account/context. Never fall back to
+        // provider-level live data here; that can belong to a different account.
+        let snapshot: UsageSnapshot? = if surface == .overrideCard {
+            snapshotOverride
+        } else {
+            snapshotOverride ?? self.store.snapshot(for: target)
+        }
+        let now = Date()
+        let codexProjection = self.store.codexConsumerProjectionIfNeeded(
+            for: target,
+            surface: surface,
+            snapshotOverride: snapshotOverride,
+            errorOverride: errorOverride,
+            now: now)
+        let credits: CreditsSnapshot?
+        let creditsError: String?
+        let dashboard: OpenAIDashboardSnapshot?
+        let dashboardError: String?
+        let tokenSnapshot: CostUsageTokenSnapshot?
+        let tokenError: String?
+        if let codexProjection {
+            credits = codexProjection.credits?.snapshot
+            creditsError = codexProjection.credits?.userFacingError
+            dashboard = nil
+            dashboardError = codexProjection.userFacingErrors.dashboard
+            if surface == .liveCard {
+                tokenSnapshot = self.store.tokenSnapshot(for: target)
+                tokenError = self.store.tokenError(for: target)
+            } else {
+                tokenSnapshot = nil
+                tokenError = nil
+            }
+        } else if target == .claude || target == .vertexai, snapshotOverride == nil {
+            credits = nil
+            creditsError = nil
+            dashboard = nil
+            dashboardError = nil
+            tokenSnapshot = self.store.tokenSnapshot(for: target)
+            tokenError = self.store.tokenError(for: target)
+        } else {
+            credits = nil
+            creditsError = nil
+            dashboard = nil
+            dashboardError = nil
+            tokenSnapshot = nil
+            tokenError = nil
+        }
+
+        let sourceLabel = snapshotOverride == nil ? self.store.sourceLabel(for: target) : nil
+        let kiloAutoMode = target == .kilo && self.settings.kiloUsageDataSource == .auto
+        // Abacus uses primary for monthly credits (no secondary window)
+        let paceWindow = target == .abacus ? snapshot?.primary : snapshot?.secondary
+        let weeklyPace = if let codexProjection,
+                            let weekly = codexProjection.rateWindow(for: .weekly)
+        {
+            self.store.weeklyPace(provider: target, window: weekly, now: now)
+        } else {
+            paceWindow.flatMap { window in
+                self.store.weeklyPace(provider: target, window: window, now: now)
+            }
+        }
+        let input = UsageMenuCardView.Model.Input(
+            provider: target,
+            metadata: metadata,
+            snapshot: snapshot,
+            codexProjection: codexProjection,
+            credits: credits,
+            creditsError: creditsError,
+            dashboard: dashboard,
+            dashboardError: dashboardError,
+            tokenSnapshot: tokenSnapshot,
+            tokenError: tokenError,
+            account: self.store.accountInfo(for: target),
+            isRefreshing: self.store.shouldShowRefreshingMenuCard(for: target),
+            lastError: errorOverride
+                ?? codexProjection?.userFacingErrors.usage
+                ?? self.store.userFacingError(for: target),
+            usageBarsShowUsed: self.settings.usageBarsShowUsed,
+            resetTimeDisplayStyle: self.settings.resetTimeDisplayStyle,
+            tokenCostUsageEnabled: self.settings.isCostUsageEffectivelyEnabled(for: target),
+            showOptionalCreditsAndExtraUsage: self.settings.showOptionalCreditsAndExtraUsage,
+            sourceLabel: sourceLabel,
+            kiloAutoMode: kiloAutoMode,
+            hidePersonalInfo: self.settings.hidePersonalInfo,
+            claudePeakHoursEnabled: self.settings.claudePeakHoursEnabled,
+            weeklyPace: weeklyPace,
+            quotaWarningThresholds: [
+                .session: self.quotaWarningMarkerThresholds(provider: target, window: .session),
+                .weekly: self.quotaWarningMarkerThresholds(provider: target, window: .weekly),
+            ],
+            now: now)
+        return UsageMenuCardView.Model.make(input)
+    }
+
+    private func quotaWarningMarkerThresholds(provider: UsageProvider, window: QuotaWarningWindow) -> [Int] {
+        guard self.settings.quotaWarningEnabled(provider: provider, window: window) else { return [] }
+        return self.settings.resolvedQuotaWarningThresholds(provider: provider, window: window)
+    }
+}

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -224,7 +224,12 @@ final class ProviderSwitcherView: NSView {
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        self.window?.acceptsMouseMovedEvents = true
+        if let window = self.window {
+            window.acceptsMouseMovedEvents = true
+        } else if self.hoveredButtonTag != nil {
+            self.hoveredButtonTag = nil
+            self.updateButtonStyles()
+        }
     }
 
     override func updateTrackingAreas() {
@@ -301,11 +306,9 @@ final class ProviderSwitcherView: NSView {
     }
 
     private func applySelection(at index: Int) {
-        for (idx, button) in self.buttons.enumerated() {
-            button.state = (idx == index) ? .on : .off
-        }
-        self.updateButtonStyles()
-        self.onSelect(self.segments[index].selection)
+        let selection = self.segments[index].selection
+        self.updateSelection(selection)
+        self.onSelect(selection)
     }
 
     #if DEBUG
@@ -565,6 +568,14 @@ final class ProviderSwitcherView: NSView {
 
     override var intrinsicContentSize: NSSize {
         NSSize(width: self.preferredWidth, height: self.frame.size.height)
+    }
+
+    func updateSelection(_ selection: ProviderSwitcherSelection) {
+        for (index, button) in self.buttons.enumerated() {
+            let isSelected = self.segments.indices.contains(index) && self.segments[index].selection == selection
+            button.state = isSelected ? .on : .off
+        }
+        self.updateButtonStyles()
     }
 
     @objc private func handleSelection(_ sender: NSButton) {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -144,8 +144,11 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var lastMergedSwitcherSelection: ProviderSwitcherSelection?
     /// Tracks the visible Codex account switcher contents for merged-menu smart updates.
     var lastCodexAccountMenuDisplay: CodexAccountMenuDisplay?
+    /// Monotonic token used to ignore stale deferred provider-switcher menu rebuilds.
+    var providerSwitcherUpdateToken = 0
     var lastAppliedMergedIconRenderSignature: String?
     let loginLogger = CodexBarLog.logger(LogCategories.login)
+    let menuLogger = CodexBarLog.logger(LogCategories.app)
     var selectedMenuProvider: UsageProvider? {
         get { self.settings.selectedMenuProvider }
         set { self.settings.selectedMenuProvider = newValue }
@@ -532,6 +535,11 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             {
                 return
             }
+            guard !self.isMergedMenuOpen else {
+                self.updateAnimationState()
+                self.updateBlinkingState()
+                return
+            }
             self.attachMenus()
         } else {
             UsageProvider.allCases.forEach { self.applyIcon(for: $0, phase: phase) }
@@ -539,6 +547,11 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         }
         self.updateAnimationState()
         self.updateBlinkingState()
+    }
+
+    var isMergedMenuOpen: Bool {
+        guard let mergedMenu else { return false }
+        return self.openMenus[ObjectIdentifier(mergedMenu)] != nil
     }
 
     /// Lazily retrieves or creates a status item for the given provider
@@ -600,6 +613,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         #endif
         self.invalidateMenus()
         if self.shouldMergeIcons {
+            guard !self.isMergedMenuOpen else { return }
             self.attachMenus()
         } else {
             self.attachMenus(fallback: self.fallbackProvider)

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -899,6 +899,7 @@ extension UsageStore {
                 .jetbrains: "JetBrains AI debug log not yet implemented",
                 .venice: "Venice debug log not yet implemented",
                 .commandcode: "Command Code debug log not yet implemented",
+                .stepfun: "StepFun debug log not yet implemented",
             ]
             let buildText = {
                 switch provider {
@@ -973,7 +974,7 @@ extension UsageStore {
                         hasTokenAccount: deepSeekHasTokenAccount)
                 case .gemini, .antigravity, .opencode, .opencodego, .factory, .copilot, .vertexai, .kilo, .kiro, .kimi,
                      .kimik2, .jetbrains, .perplexity, .abacus, .mistral, .codebuff, .crof, .windsurf, .venice,
-                     .commandcode:
+                     .commandcode, .stepfun:
                     return unimplementedDebugLogMessages[provider] ?? "Debug log not yet implemented"
                 }
             }

--- a/Sources/CodexBarCLI/TokenAccountCLI.swift
+++ b/Sources/CodexBarCLI/TokenAccountCLI.swift
@@ -200,8 +200,17 @@ struct TokenAccountCLIContext {
                 mistral: ProviderSettingsSnapshot.MistralProviderSettings(
                     cookieSource: cookieSource,
                     manualCookieHeader: cookieHeader))
-        case .gemini, .antigravity, .copilot, .kiro, .vertexai, .kimik2, .synthetic, .openrouter, .warp,
-             .deepseek, .codebuff, .crof, .venice, .commandcode, .stepfun:
+        case .stepfun:
+            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
+            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
+            return self.makeSnapshot(
+                stepfun: ProviderSettingsSnapshot.StepFunProviderSettings(
+                    cookieSource: cookieSource,
+                    manualToken: cookieHeader ?? "",
+                    username: config?.sanitizedAPIKey ?? "",
+                    password: ""))
+        case .gemini, .antigravity, .copilot, .kiro, .vertexai, .kimik2, .synthetic, .openrouter, .warp, .deepseek,
+             .codebuff, .crof, .venice, .commandcode:
             return nil
         case .windsurf:
             return nil

--- a/Sources/CodexBarCLI/TokenAccountCLI.swift
+++ b/Sources/CodexBarCLI/TokenAccountCLI.swift
@@ -77,6 +77,9 @@ struct TokenAccountCLIContext {
 
     func settingsSnapshot(for provider: UsageProvider, account: ProviderTokenAccount?) -> ProviderSettingsSnapshot? {
         let config = self.providerConfig(for: provider)
+        if let snapshot = self.makeCookieBackedSnapshot(provider: provider, account: account, config: config) {
+            return snapshot
+        }
 
         switch provider {
         case .codex:
@@ -93,80 +96,6 @@ struct TokenAccountCLIContext {
                     webExtrasEnabled: false,
                     cookieSource: cookieSource,
                     manualCookieHeader: routing.manualCookieHeader))
-        case .cursor:
-            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
-            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
-            return self.makeSnapshot(
-                cursor: ProviderSettingsSnapshot.CursorProviderSettings(
-                    cookieSource: cookieSource,
-                    manualCookieHeader: cookieHeader))
-        case .opencode:
-            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
-            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
-            return self.makeSnapshot(
-                opencode: ProviderSettingsSnapshot.OpenCodeProviderSettings(
-                    cookieSource: cookieSource,
-                    manualCookieHeader: cookieHeader,
-                    workspaceID: config?.workspaceID))
-        case .opencodego:
-            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
-            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
-            return self.makeSnapshot(
-                opencodego: ProviderSettingsSnapshot.OpenCodeProviderSettings(
-                    cookieSource: cookieSource,
-                    manualCookieHeader: cookieHeader,
-                    workspaceID: config?.workspaceID))
-        case .alibaba:
-            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
-            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
-            return self.makeSnapshot(
-                alibaba: ProviderSettingsSnapshot.AlibabaCodingPlanProviderSettings(
-                    cookieSource: cookieSource,
-                    manualCookieHeader: cookieHeader,
-                    apiRegion: self.resolveAlibabaCodingPlanRegion(config)))
-        case .factory:
-            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
-            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
-            return self.makeSnapshot(
-                factory: ProviderSettingsSnapshot.FactoryProviderSettings(
-                    cookieSource: cookieSource,
-                    manualCookieHeader: cookieHeader))
-        case .minimax:
-            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
-            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
-            return self.makeSnapshot(
-                minimax: ProviderSettingsSnapshot.MiniMaxProviderSettings(
-                    cookieSource: cookieSource,
-                    manualCookieHeader: cookieHeader,
-                    apiRegion: self.resolveMiniMaxRegion(config)))
-        case .augment:
-            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
-            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
-            return self.makeSnapshot(
-                augment: ProviderSettingsSnapshot.AugmentProviderSettings(
-                    cookieSource: cookieSource,
-                    manualCookieHeader: cookieHeader))
-        case .amp:
-            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
-            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
-            return self.makeSnapshot(
-                amp: ProviderSettingsSnapshot.AmpProviderSettings(
-                    cookieSource: cookieSource,
-                    manualCookieHeader: cookieHeader))
-        case .ollama:
-            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
-            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
-            return self.makeSnapshot(
-                ollama: ProviderSettingsSnapshot.OllamaProviderSettings(
-                    cookieSource: cookieSource,
-                    manualCookieHeader: cookieHeader))
-        case .kimi:
-            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
-            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
-            return self.makeSnapshot(
-                kimi: ProviderSettingsSnapshot.KimiProviderSettings(
-                    cookieSource: cookieSource,
-                    manualCookieHeader: cookieHeader))
         case .zai:
             return self.makeSnapshot(
                 zai: ProviderSettingsSnapshot.ZaiProviderSettings(apiRegion: self.resolveZaiRegion(config)))
@@ -179,40 +108,97 @@ struct TokenAccountCLIContext {
             return self.makeSnapshot(
                 jetbrains: ProviderSettingsSnapshot.JetBrainsProviderSettings(
                     ideBasePath: nil))
+        default:
+            return nil
+        }
+    }
+
+    private func makeCookieBackedSnapshot(
+        provider: UsageProvider,
+        account: ProviderTokenAccount?,
+        config: ProviderConfig?) -> ProviderSettingsSnapshot?
+    {
+        let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
+        let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
+
+        switch provider {
+        case .cursor:
+            return self.makeSnapshot(
+                cursor: ProviderSettingsSnapshot.CursorProviderSettings(
+                    cookieSource: cookieSource,
+                    manualCookieHeader: cookieHeader))
+        case .opencode:
+            return self.makeSnapshot(
+                opencode: ProviderSettingsSnapshot.OpenCodeProviderSettings(
+                    cookieSource: cookieSource,
+                    manualCookieHeader: cookieHeader,
+                    workspaceID: config?.workspaceID))
+        case .opencodego:
+            return self.makeSnapshot(
+                opencodego: ProviderSettingsSnapshot.OpenCodeProviderSettings(
+                    cookieSource: cookieSource,
+                    manualCookieHeader: cookieHeader,
+                    workspaceID: config?.workspaceID))
+        case .alibaba:
+            return self.makeSnapshot(
+                alibaba: ProviderSettingsSnapshot.AlibabaCodingPlanProviderSettings(
+                    cookieSource: cookieSource,
+                    manualCookieHeader: cookieHeader,
+                    apiRegion: self.resolveAlibabaCodingPlanRegion(config)))
+        case .factory:
+            return self.makeSnapshot(
+                factory: ProviderSettingsSnapshot.FactoryProviderSettings(
+                    cookieSource: cookieSource,
+                    manualCookieHeader: cookieHeader))
+        case .minimax:
+            return self.makeSnapshot(
+                minimax: ProviderSettingsSnapshot.MiniMaxProviderSettings(
+                    cookieSource: cookieSource,
+                    manualCookieHeader: cookieHeader,
+                    apiRegion: self.resolveMiniMaxRegion(config)))
+        case .augment:
+            return self.makeSnapshot(
+                augment: ProviderSettingsSnapshot.AugmentProviderSettings(
+                    cookieSource: cookieSource,
+                    manualCookieHeader: cookieHeader))
+        case .amp:
+            return self.makeSnapshot(
+                amp: ProviderSettingsSnapshot.AmpProviderSettings(
+                    cookieSource: cookieSource,
+                    manualCookieHeader: cookieHeader))
+        case .ollama:
+            return self.makeSnapshot(
+                ollama: ProviderSettingsSnapshot.OllamaProviderSettings(
+                    cookieSource: cookieSource,
+                    manualCookieHeader: cookieHeader))
+        case .kimi:
+            return self.makeSnapshot(
+                kimi: ProviderSettingsSnapshot.KimiProviderSettings(
+                    cookieSource: cookieSource,
+                    manualCookieHeader: cookieHeader))
         case .perplexity:
-            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
-            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
             return self.makeSnapshot(
                 perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings(
                     cookieSource: cookieSource,
                     manualCookieHeader: cookieHeader))
         case .abacus:
-            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
-            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
             return self.makeSnapshot(
                 abacus: ProviderSettingsSnapshot.AbacusProviderSettings(
                     cookieSource: cookieSource,
                     manualCookieHeader: cookieHeader))
         case .mistral:
-            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
-            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
             return self.makeSnapshot(
                 mistral: ProviderSettingsSnapshot.MistralProviderSettings(
                     cookieSource: cookieSource,
                     manualCookieHeader: cookieHeader))
         case .stepfun:
-            let cookieHeader = self.manualCookieHeader(provider: provider, account: account, config: config)
-            let cookieSource = self.cookieSource(provider: provider, account: account, config: config)
             return self.makeSnapshot(
                 stepfun: ProviderSettingsSnapshot.StepFunProviderSettings(
                     cookieSource: cookieSource,
                     manualToken: cookieHeader ?? "",
                     username: config?.sanitizedAPIKey ?? "",
                     password: ""))
-        case .gemini, .antigravity, .copilot, .kiro, .vertexai, .kimik2, .synthetic, .openrouter, .warp, .deepseek,
-             .codebuff, .crof, .venice, .commandcode:
-            return nil
-        case .windsurf:
+        default:
             return nil
         }
     }

--- a/Sources/CodexBarCLI/TokenAccountCLI.swift
+++ b/Sources/CodexBarCLI/TokenAccountCLI.swift
@@ -201,7 +201,7 @@ struct TokenAccountCLIContext {
                     cookieSource: cookieSource,
                     manualCookieHeader: cookieHeader))
         case .gemini, .antigravity, .copilot, .kiro, .vertexai, .kimik2, .synthetic, .openrouter, .warp,
-             .deepseek, .codebuff, .crof, .venice, .commandcode:
+             .deepseek, .codebuff, .crof, .venice, .commandcode, .stepfun:
             return nil
         case .windsurf:
             return nil
@@ -226,7 +226,8 @@ struct TokenAccountCLIContext {
         jetbrains: ProviderSettingsSnapshot.JetBrainsProviderSettings? = nil,
         perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings? = nil,
         abacus: ProviderSettingsSnapshot.AbacusProviderSettings? = nil,
-        mistral: ProviderSettingsSnapshot.MistralProviderSettings? = nil) -> ProviderSettingsSnapshot
+        mistral: ProviderSettingsSnapshot.MistralProviderSettings? = nil,
+        stepfun: ProviderSettingsSnapshot.StepFunProviderSettings? = nil) -> ProviderSettingsSnapshot
     {
         ProviderSettingsSnapshot.make(
             codex: codex,
@@ -246,7 +247,8 @@ struct TokenAccountCLIContext {
             jetbrains: jetbrains,
             perplexity: perplexity,
             abacus: abacus,
-            mistral: mistral)
+            mistral: mistral,
+            stepfun: stepfun)
     }
 
     private func makeCodexSettingsSnapshot(account: ProviderTokenAccount?) ->

--- a/Sources/CodexBarCore/Logging/LogCategories.swift
+++ b/Sources/CodexBarCore/Logging/LogCategories.swift
@@ -74,4 +74,5 @@ public enum LogCategories {
     public static let zaiSettings = "zai-settings"
     public static let zaiTokenStore = "zai-token-store"
     public static let zaiUsage = "zai-usage"
+    public static let stepfunUsage = "stepfun-usage"
 }

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -86,6 +86,7 @@ public enum ProviderDescriptorRegistry {
         .crof: CrofProviderDescriptor.descriptor,
         .venice: VeniceProviderDescriptor.descriptor,
         .commandcode: CommandCodeProviderDescriptor.descriptor,
+        .stepfun: StepFunProviderDescriptor.descriptor,
     ]
     private static let bootstrap: Void = {
         for provider in UsageProvider.allCases {

--- a/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
@@ -23,7 +23,8 @@ public struct ProviderSettingsSnapshot: Sendable {
         windsurf: WindsurfProviderSettings? = nil,
         perplexity: PerplexityProviderSettings? = nil,
         abacus: AbacusProviderSettings? = nil,
-        mistral: MistralProviderSettings? = nil) -> ProviderSettingsSnapshot
+        mistral: MistralProviderSettings? = nil,
+        stepfun: StepFunProviderSettings? = nil) -> ProviderSettingsSnapshot
     {
         ProviderSettingsSnapshot(
             debugMenuEnabled: debugMenuEnabled,
@@ -47,7 +48,8 @@ public struct ProviderSettingsSnapshot: Sendable {
             windsurf: windsurf,
             perplexity: perplexity,
             abacus: abacus,
-            mistral: mistral)
+            mistral: mistral,
+            stepfun: stepfun)
     }
 
     public struct CodexProviderSettings: Sendable {
@@ -290,6 +292,25 @@ public struct ProviderSettingsSnapshot: Sendable {
         }
     }
 
+    public struct StepFunProviderSettings: Sendable {
+        public let cookieSource: ProviderCookieSource
+        public let manualToken: String
+        public let username: String
+        public let password: String
+
+        public init(
+            cookieSource: ProviderCookieSource = .auto,
+            manualToken: String = "",
+            username: String = "",
+            password: String = "")
+        {
+            self.cookieSource = cookieSource
+            self.manualToken = manualToken
+            self.username = username
+            self.password = password
+        }
+    }
+
     public let debugMenuEnabled: Bool
     public let debugKeepCLISessionsAlive: Bool
     public let codex: CodexProviderSettings?
@@ -313,6 +334,7 @@ public struct ProviderSettingsSnapshot: Sendable {
     public let perplexity: PerplexityProviderSettings?
     public let abacus: AbacusProviderSettings?
     public let mistral: MistralProviderSettings?
+    public let stepfun: StepFunProviderSettings?
 
     public var jetbrainsIDEBasePath: String? {
         self.jetbrains?.ideBasePath
@@ -341,7 +363,8 @@ public struct ProviderSettingsSnapshot: Sendable {
         windsurf: WindsurfProviderSettings? = nil,
         perplexity: PerplexityProviderSettings? = nil,
         abacus: AbacusProviderSettings? = nil,
-        mistral: MistralProviderSettings? = nil)
+        mistral: MistralProviderSettings? = nil,
+        stepfun: StepFunProviderSettings? = nil)
     {
         self.debugMenuEnabled = debugMenuEnabled
         self.debugKeepCLISessionsAlive = debugKeepCLISessionsAlive
@@ -366,6 +389,7 @@ public struct ProviderSettingsSnapshot: Sendable {
         self.perplexity = perplexity
         self.abacus = abacus
         self.mistral = mistral
+        self.stepfun = stepfun
     }
 }
 
@@ -391,6 +415,7 @@ public enum ProviderSettingsSnapshotContribution: Sendable {
     case perplexity(ProviderSettingsSnapshot.PerplexityProviderSettings)
     case abacus(ProviderSettingsSnapshot.AbacusProviderSettings)
     case mistral(ProviderSettingsSnapshot.MistralProviderSettings)
+    case stepfun(ProviderSettingsSnapshot.StepFunProviderSettings)
 }
 
 public struct ProviderSettingsSnapshotBuilder: Sendable {
@@ -417,6 +442,7 @@ public struct ProviderSettingsSnapshotBuilder: Sendable {
     public var perplexity: ProviderSettingsSnapshot.PerplexityProviderSettings?
     public var abacus: ProviderSettingsSnapshot.AbacusProviderSettings?
     public var mistral: ProviderSettingsSnapshot.MistralProviderSettings?
+    public var stepfun: ProviderSettingsSnapshot.StepFunProviderSettings?
 
     public init(debugMenuEnabled: Bool = false, debugKeepCLISessionsAlive: Bool = false) {
         self.debugMenuEnabled = debugMenuEnabled
@@ -447,6 +473,7 @@ public struct ProviderSettingsSnapshotBuilder: Sendable {
         case let .perplexity(value): self.perplexity = value
         case let .abacus(value): self.abacus = value
         case let .mistral(value): self.mistral = value
+        case let .stepfun(value): self.stepfun = value
         }
     }
 
@@ -474,6 +501,7 @@ public struct ProviderSettingsSnapshotBuilder: Sendable {
             windsurf: self.windsurf,
             perplexity: self.perplexity,
             abacus: self.abacus,
-            mistral: self.mistral)
+            mistral: self.mistral,
+            stepfun: self.stepfun)
     }
 }

--- a/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
+++ b/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
@@ -89,6 +89,12 @@ public enum ProviderTokenResolver {
         self.veniceResolution(environment: environment)?.token
     }
 
+    public static func stepfunToken(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
+    {
+        self.stepfunResolution(environment: environment)?.token
+    }
+
     public static func deepseekResolution(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
     {
@@ -112,6 +118,12 @@ public enum ProviderTokenResolver {
         authFileURL: URL? = nil) -> String?
     {
         self.codebuffResolution(environment: environment, authFileURL: authFileURL)?.token
+    }
+
+    public static func stepfunResolution(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
+    {
+        self.resolveEnv(StepFunSettingsReader.token(environment: environment))
     }
 
     public static func zaiResolution(

--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -36,6 +36,7 @@ public enum UsageProvider: String, CaseIterable, Sendable, Codable {
     case crof
     case venice
     case commandcode
+    case stepfun
 }
 
 // swiftformat:enable sortDeclarations
@@ -74,6 +75,7 @@ public enum IconStyle: Sendable, CaseIterable {
     case crof
     case venice
     case commandcode
+    case stepfun
     case combined
 }
 

--- a/Sources/CodexBarCore/Providers/StepFun/StepFunProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/StepFun/StepFunProviderDescriptor.swift
@@ -47,6 +47,10 @@ struct StepFunWebFetchStrategy: ProviderFetchStrategy {
     let kind: ProviderFetchKind = .web
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        // Respect the "Off" auth source — if explicitly disabled, don't fetch.
+        if let settings = context.settings?.stepfun, settings.cookieSource == .off {
+            return false
+        }
         // Available if any auth method is configured:
         // 1. Username + password from Settings UI
         // 2. Manual token from Settings UI

--- a/Sources/CodexBarCore/Providers/StepFun/StepFunProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/StepFun/StepFunProviderDescriptor.swift
@@ -1,0 +1,164 @@
+import CodexBarMacroSupport
+import Foundation
+
+@ProviderDescriptorRegistration
+@ProviderDescriptorDefinition
+public enum StepFunProviderDescriptor {
+    static func makeDescriptor() -> ProviderDescriptor {
+        ProviderDescriptor(
+            id: .stepfun,
+            metadata: ProviderMetadata(
+                id: .stepfun,
+                displayName: "StepFun",
+                sessionLabel: "5h Window",
+                weeklyLabel: "Weekly Window",
+                opusLabel: nil,
+                supportsOpus: false,
+                supportsCredits: false,
+                creditsHint: "",
+                toggleTitle: "Show StepFun usage",
+                cliName: "stepfun",
+                defaultEnabled: false,
+                isPrimaryProvider: false,
+                usesAccountFallback: false,
+                browserCookieOrder: nil,
+                dashboardURL: "https://platform.stepfun.com/plan-usage",
+                statusPageURL: nil,
+                statusLinkURL: nil),
+            branding: ProviderBranding(
+                iconStyle: .stepfun,
+                iconResourceName: "ProviderIcon-stepfun",
+                color: ProviderColor(red: 0.13, green: 0.59, blue: 0.95)),
+            tokenCost: ProviderTokenCostConfig(
+                supportsTokenCost: false,
+                noDataMessage: { "StepFun per-day cost history is not available via API." }),
+            fetchPlan: ProviderFetchPlan(
+                sourceModes: [.auto, .web],
+                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [StepFunWebFetchStrategy()] })),
+            cli: ProviderCLIConfig(
+                name: "stepfun",
+                aliases: ["step-fun", "sf"],
+                versionDetector: nil))
+    }
+}
+
+struct StepFunWebFetchStrategy: ProviderFetchStrategy {
+    let id: String = "stepfun.web"
+    let kind: ProviderFetchKind = .web
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        // Available if any auth method is configured:
+        // 1. Username + password from Settings UI
+        // 2. Manual token from Settings UI
+        // 3. Cached token from previous login
+        // 4. Username + password from env vars
+        // 5. Direct token from env var
+        if let settings = context.settings?.stepfun {
+            if !settings.username.isEmpty, !settings.password.isEmpty { return true }
+            if settings.cookieSource == .manual, !settings.manualToken.isEmpty { return true }
+        }
+        if CookieHeaderCache.load(provider: .stepfun) != nil { return true }
+        if StepFunSettingsReader.username(environment: context.env) != nil,
+           StepFunSettingsReader.password(environment: context.env) != nil
+        { return true }
+        if StepFunSettingsReader.token(environment: context.env) != nil { return true }
+        return false
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        let cookieSource = context.settings?.stepfun?.cookieSource ?? .auto
+
+        do {
+            let token = try await Self.resolveToken(context: context, allowCached: true)
+            let usage = try await StepFunUsageFetcher.fetchUsage(token: token)
+            return self.makeResult(
+                usage: usage.toUsageSnapshot(),
+                sourceLabel: "web")
+        } catch StepFunUsageError.apiError where cookieSource != .manual {
+            // Token may be stale — clear cache and retry with fresh login
+            CookieHeaderCache.clear(provider: .stepfun)
+            let token = try await Self.resolveToken(context: context, allowCached: false)
+            let usage = try await StepFunUsageFetcher.fetchUsage(token: token)
+            return self.makeResult(
+                usage: usage.toUsageSnapshot(),
+                sourceLabel: "web")
+        }
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+
+    // MARK: - Token Resolution
+
+    private static func resolveToken(
+        context: ProviderFetchContext,
+        allowCached: Bool) async throws -> String
+    {
+        let settings = context.settings?.stepfun
+
+        // 1. Manual mode: use the token directly from settings
+        if settings?.cookieSource == .manual {
+            let manualToken = settings?.manualToken ?? ""
+            guard !manualToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw StepFunUsageError.missingToken
+            }
+            return StepFunTokenNormalizer.normalize(manualToken)
+        }
+
+        // 2. Cached token from previous login
+        if allowCached, let cached = CookieHeaderCache.load(provider: .stepfun) {
+            return StepFunTokenNormalizer.normalize(cached.cookieHeader)
+        }
+
+        // 3. Username + password from Settings UI → perform full login flow
+        //    (register device → sign in by password → get Oasis-Token)
+        if let settings, !settings.username.isEmpty, !settings.password.isEmpty {
+            let token = try await StepFunUsageFetcher.login(
+                username: settings.username,
+                password: settings.password)
+            CookieHeaderCache.store(provider: .stepfun, cookieHeader: token, sourceLabel: "login")
+            return token
+        }
+
+        // 4. Direct token from env var
+        if let token = StepFunSettingsReader.token(environment: context.env) {
+            return token
+        }
+
+        // 5. Username + password from env vars → perform full login flow
+        if let username = StepFunSettingsReader.username(environment: context.env),
+           let password = StepFunSettingsReader.password(environment: context.env)
+        {
+            let token = try await StepFunUsageFetcher.login(username: username, password: password)
+            CookieHeaderCache.store(provider: .stepfun, cookieHeader: token, sourceLabel: "login")
+            return token
+        }
+
+        throw StepFunUsageError.missingCredentials
+    }
+}
+
+// MARK: - Token Normalizer
+
+public enum StepFunTokenNormalizer {
+    /// Normalize a StepFun token value — extracts the Oasis-Token from a cookie header
+    /// or returns the raw token value if it's not a cookie header.
+    public static func normalize(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+
+        // If it looks like a cookie header, extract Oasis-Token
+        if trimmed.contains("Oasis-Token=") {
+            let parts = trimmed.components(separatedBy: "Oasis-Token=")
+            if parts.count > 1 {
+                let afterToken = parts[1]
+                let tokenValue = afterToken.components(separatedBy: ";").first?
+                    .trimmingCharacters(in: .whitespaces) ?? afterToken
+                return tokenValue
+            }
+        }
+
+        return trimmed
+    }
+}

--- a/Sources/CodexBarCore/Providers/StepFun/StepFunProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/StepFun/StepFunProviderDescriptor.swift
@@ -47,26 +47,7 @@ struct StepFunWebFetchStrategy: ProviderFetchStrategy {
     let kind: ProviderFetchKind = .web
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        // Respect the "Off" auth source — if explicitly disabled, don't fetch.
-        if let settings = context.settings?.stepfun, settings.cookieSource == .off {
-            return false
-        }
-        // Available if any auth method is configured:
-        // 1. Username + password from Settings UI
-        // 2. Manual token from Settings UI
-        // 3. Cached token from previous login
-        // 4. Username + password from env vars
-        // 5. Direct token from env var
-        if let settings = context.settings?.stepfun {
-            if !settings.username.isEmpty, !settings.password.isEmpty { return true }
-            if settings.cookieSource == .manual, !settings.manualToken.isEmpty { return true }
-        }
-        if CookieHeaderCache.load(provider: .stepfun) != nil { return true }
-        if StepFunSettingsReader.username(environment: context.env) != nil,
-           StepFunSettingsReader.password(environment: context.env) != nil
-        { return true }
-        if StepFunSettingsReader.token(environment: context.env) != nil { return true }
-        return false
+        context.settings?.stepfun?.cookieSource != .off
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
@@ -157,9 +138,8 @@ public enum StepFunTokenNormalizer {
             let parts = trimmed.components(separatedBy: "Oasis-Token=")
             if parts.count > 1 {
                 let afterToken = parts[1]
-                let tokenValue = afterToken.components(separatedBy: ";").first?
+                return afterToken.components(separatedBy: ";").first?
                     .trimmingCharacters(in: .whitespaces) ?? afterToken
-                return tokenValue
             }
         }
 

--- a/Sources/CodexBarCore/Providers/StepFun/StepFunSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/StepFun/StepFunSettingsReader.swift
@@ -8,19 +8,19 @@ public struct StepFunSettingsReader: Sendable {
     public static func username(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        Self.cleaned(environment[Self.usernameEnvironmentKey])
+        self.cleaned(environment[self.usernameEnvironmentKey])
     }
 
     public static func password(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        Self.cleaned(environment[Self.passwordEnvironmentKey])
+        self.cleaned(environment[self.passwordEnvironmentKey])
     }
 
     public static func token(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        Self.cleaned(environment[Self.tokenEnvironmentKey])
+        self.cleaned(environment[self.tokenEnvironmentKey])
     }
 
     private static func cleaned(_ raw: String?) -> String? {

--- a/Sources/CodexBarCore/Providers/StepFun/StepFunSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/StepFun/StepFunSettingsReader.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public struct StepFunSettingsReader: Sendable {
+    public static let usernameEnvironmentKey = "STEPFUN_USERNAME"
+    public static let passwordEnvironmentKey = "STEPFUN_PASSWORD"
+    public static let tokenEnvironmentKey = "STEPFUN_TOKEN"
+
+    public static func username(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
+    {
+        Self.cleaned(environment[Self.usernameEnvironmentKey])
+    }
+
+    public static func password(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
+    {
+        Self.cleaned(environment[Self.passwordEnvironmentKey])
+    }
+
+    public static func token(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
+    {
+        Self.cleaned(environment[Self.tokenEnvironmentKey])
+    }
+
+    private static func cleaned(_ raw: String?) -> String? {
+        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
+            (value.hasPrefix("'") && value.hasSuffix("'"))
+        {
+            value.removeFirst()
+            value.removeLast()
+        }
+        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Sources/CodexBarCore/Providers/StepFun/StepFunUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/StepFun/StepFunUsageFetcher.swift
@@ -75,16 +75,16 @@ public struct StepFunRateLimitResponse: Decodable, Sendable {
 
 // MARK: - Plan status response types
 
-struct StepFunPlanStatusResponse: Decodable, Sendable {
+struct StepFunPlanStatusResponse: Decodable {
     let status: Int?
     let subscription: StepFunSubscription?
 
     var planName: String? {
-        subscription?.name?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.subscription?.name?.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 
-struct StepFunSubscription: Decodable, Sendable {
+struct StepFunSubscription: Decodable {
     let name: String?
     let planType: Int?
     let planStatus: Int?
@@ -98,17 +98,17 @@ struct StepFunSubscription: Decodable, Sendable {
 
 // MARK: - Auth response types
 
-struct StepFunRegisterDeviceResponse: Decodable, Sendable {
+struct StepFunRegisterDeviceResponse: Decodable {
     let accessToken: StepFunTokenPair?
     let refreshToken: StepFunTokenPair?
 }
 
-struct StepFunLoginResponse: Decodable, Sendable {
+struct StepFunLoginResponse: Decodable {
     let accessToken: StepFunTokenPair?
     let refreshToken: StepFunTokenPair?
 }
 
-struct StepFunTokenPair: Decodable, Sendable {
+struct StepFunTokenPair: Decodable {
     let raw: String
 }
 
@@ -211,10 +211,14 @@ public enum StepFunUsageError: LocalizedError, Sendable {
 public struct StepFunUsageFetcher: Sendable {
     private static let log = CodexBarLog.logger(LogCategories.stepfunUsage)
     private static let platformURL = URL(string: "https://platform.stepfun.com")!
-    private static let apiURL = URL(string: "https://platform.stepfun.com/api/step.openapi.devcenter.Dashboard/QueryStepPlanRateLimit")!
-    private static let planStatusURL = URL(string: "https://platform.stepfun.com/api/step.openapi.devcenter.Dashboard/GetStepPlanStatus")!
-    private static let registerDeviceURL = URL(string: "https://platform.stepfun.com/passport/proto.api.passport.v1.PassportService/RegisterDevice")!
-    private static let loginURL = URL(string: "https://platform.stepfun.com/passport/proto.api.passport.v1.PassportService/SignInByPassword")!
+    private static let apiURL =
+        URL(string: "https://platform.stepfun.com/api/step.openapi.devcenter.Dashboard/QueryStepPlanRateLimit")!
+    private static let planStatusURL =
+        URL(string: "https://platform.stepfun.com/api/step.openapi.devcenter.Dashboard/GetStepPlanStatus")!
+    private static let registerDeviceURL =
+        URL(string: "https://platform.stepfun.com/passport/proto.api.passport.v1.PassportService/RegisterDevice")!
+    private static let loginURL =
+        URL(string: "https://platform.stepfun.com/passport/proto.api.passport.v1.PassportService/SignInByPassword")!
     private static let timeoutSeconds: TimeInterval = 15
 
     private static let webID = "c8a1002d2c457e758785a9979832217c7c0b884c"
@@ -225,7 +229,8 @@ public struct StepFunUsageFetcher: Sendable {
         "oasis-appid": appID,
         "oasis-platform": "web",
         "oasis-webid": webID,
-        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
     ]
 
     // MARK: - Public API
@@ -260,13 +265,11 @@ public struct StepFunUsageFetcher: Sendable {
         let anonToken = try await self.registerDevice(ingressCookie: ingressCookie)
 
         // Step 3: SignInByPassword → get authenticated token
-        let authToken = try await self.signInByPassword(
+        return try await self.signInByPassword(
             username: username,
             password: password,
             ingressCookie: ingressCookie,
             anonToken: anonToken)
-
-        return authToken
     }
 
     private static func getIngressCookie() async throws -> (String, HTTPURLResponse) {
@@ -364,7 +367,9 @@ public struct StepFunUsageFetcher: Sendable {
         for (key, value) in self.baseHeaders {
             request.setValue(value, forHTTPHeaderField: key)
         }
-        request.setValue("Oasis-Token=\(anonToken); Oasis-Webid=\(webID); INGRESSCOOKIE=\(ingressCookie)", forHTTPHeaderField: "Cookie")
+        request.setValue(
+            "Oasis-Token=\(anonToken); Oasis-Webid=\(self.webID); INGRESSCOOKIE=\(ingressCookie)",
+            forHTTPHeaderField: "Cookie")
         request.timeoutInterval = self.timeoutSeconds
 
         let (data, response) = try await URLSession.shared.data(for: request)
@@ -403,7 +408,7 @@ public struct StepFunUsageFetcher: Sendable {
         for (key, value) in self.baseHeaders {
             request.setValue(value, forHTTPHeaderField: key)
         }
-        request.setValue("Oasis-Token=\(token); Oasis-Webid=\(webID)", forHTTPHeaderField: "Cookie")
+        request.setValue("Oasis-Token=\(token); Oasis-Webid=\(self.webID)", forHTTPHeaderField: "Cookie")
         request.timeoutInterval = self.timeoutSeconds
 
         let (data, response) = try await URLSession.shared.data(for: request)
@@ -448,7 +453,7 @@ public struct StepFunUsageFetcher: Sendable {
         for (key, value) in self.baseHeaders {
             request.setValue(value, forHTTPHeaderField: key)
         }
-        request.setValue("Oasis-Token=\(token); Oasis-Webid=\(webID)", forHTTPHeaderField: "Cookie")
+        request.setValue("Oasis-Token=\(token); Oasis-Webid=\(self.webID)", forHTTPHeaderField: "Cookie")
         request.timeoutInterval = self.timeoutSeconds
 
         let (data, response) = try await URLSession.shared.data(for: request)

--- a/Sources/CodexBarCore/Providers/StepFun/StepFunUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/StepFun/StepFunUsageFetcher.swift
@@ -1,0 +1,430 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+// MARK: - API response types
+
+/// A flexible number type that can decode from both JSON integers and floats.
+/// The StepFun API returns `five_hour_usage_left_rate: 1` (int) or `0.99781543` (float).
+public struct StepFunFlexibleNumber: Decodable, Sendable {
+    public let value: Double
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let intVal = try? container.decode(Int.self) {
+            self.value = Double(intVal)
+        } else if let doubleVal = try? container.decode(Double.self) {
+            self.value = doubleVal
+        } else {
+            self.value = 0
+        }
+    }
+
+    public init(_ value: Double) {
+        self.value = value
+    }
+}
+
+/// A flexible timestamp type that can decode from both JSON strings and integers.
+/// The StepFun API returns timestamps as strings like `"1777528800"`.
+public struct StepFunFlexibleTimestamp: Decodable, Sendable {
+    public let value: Int64
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let strVal = try? container.decode(String.self), let parsed = Int64(strVal) {
+            self.value = parsed
+        } else if let intVal = try? container.decode(Int64.self) {
+            self.value = intVal
+        } else {
+            self.value = 0
+        }
+    }
+
+    public init(_ value: Int64) {
+        self.value = value
+    }
+}
+
+public struct StepFunRateLimitResponse: Decodable, Sendable {
+    public let status: Int?
+    public let code: Int?
+    public let message: String?
+    public let desc: String?
+    public let fiveHourUsageLeftRate: StepFunFlexibleNumber?
+    public let weeklyUsageLeftRate: StepFunFlexibleNumber?
+    public let fiveHourUsageResetTime: StepFunFlexibleTimestamp?
+    public let weeklyUsageResetTime: StepFunFlexibleTimestamp?
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case code
+        case message
+        case desc
+        case fiveHourUsageLeftRate = "five_hour_usage_left_rate"
+        case weeklyUsageLeftRate = "weekly_usage_left_rate"
+        case fiveHourUsageResetTime = "five_hour_usage_reset_time"
+        case weeklyUsageResetTime = "weekly_usage_reset_time"
+    }
+
+    public var isSuccess: Bool {
+        self.status == 1
+    }
+}
+
+// MARK: - Auth response types
+
+struct StepFunRegisterDeviceResponse: Decodable, Sendable {
+    let accessToken: StepFunTokenPair?
+    let refreshToken: StepFunTokenPair?
+}
+
+struct StepFunLoginResponse: Decodable, Sendable {
+    let accessToken: StepFunTokenPair?
+    let refreshToken: StepFunTokenPair?
+}
+
+struct StepFunTokenPair: Decodable, Sendable {
+    let raw: String
+}
+
+// MARK: - Domain snapshot
+
+public struct StepFunUsageSnapshot: Sendable {
+    public let fiveHourUsageLeftRate: Double
+    public let weeklyUsageLeftRate: Double
+    public let fiveHourUsageResetTime: Date
+    public let weeklyUsageResetTime: Date
+    public let updatedAt: Date
+
+    public init(
+        fiveHourUsageLeftRate: Double,
+        weeklyUsageLeftRate: Double,
+        fiveHourUsageResetTime: Date,
+        weeklyUsageResetTime: Date,
+        updatedAt: Date)
+    {
+        self.fiveHourUsageLeftRate = fiveHourUsageLeftRate
+        self.weeklyUsageLeftRate = weeklyUsageLeftRate
+        self.fiveHourUsageResetTime = fiveHourUsageResetTime
+        self.weeklyUsageResetTime = weeklyUsageResetTime
+        self.updatedAt = updatedAt
+    }
+
+    public func toUsageSnapshot() -> UsageSnapshot {
+        // Five-hour window: primary
+        let fiveHourUsedPercent = max(0, min(100, (1.0 - self.fiveHourUsageLeftRate) * 100))
+        let fiveHourResetDescription = UsageFormatter.resetDescription(from: self.fiveHourUsageResetTime)
+        let fiveHourWindow = RateWindow(
+            usedPercent: fiveHourUsedPercent,
+            windowMinutes: 300,
+            resetsAt: self.fiveHourUsageResetTime,
+            resetDescription: fiveHourResetDescription)
+
+        // Weekly window: secondary
+        let weeklyUsedPercent = max(0, min(100, (1.0 - self.weeklyUsageLeftRate) * 100))
+        let weeklyResetDescription = UsageFormatter.resetDescription(from: self.weeklyUsageResetTime)
+        let weeklyWindow = RateWindow(
+            usedPercent: weeklyUsedPercent,
+            windowMinutes: 10080,
+            resetsAt: self.weeklyUsageResetTime,
+            resetDescription: weeklyResetDescription)
+
+        let identity = ProviderIdentitySnapshot(
+            providerID: .stepfun,
+            accountEmail: nil,
+            accountOrganization: nil,
+            loginMethod: "password")
+
+        return UsageSnapshot(
+            primary: fiveHourWindow,
+            secondary: weeklyWindow,
+            tertiary: nil,
+            updatedAt: self.updatedAt,
+            identity: identity)
+    }
+}
+
+// MARK: - Errors
+
+public enum StepFunUsageError: LocalizedError, Sendable {
+    case missingCredentials
+    case missingToken
+    case networkError(String)
+    case apiError(String)
+    case parseFailed(String)
+    case loginFailed(String)
+    case deviceRegistrationFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingCredentials:
+            "Missing StepFun username or password. Set STEPFUN_USERNAME and STEPFUN_PASSWORD environment variables."
+        case .missingToken:
+            "Missing StepFun authentication token."
+        case let .networkError(message):
+            "StepFun network error: \(message)"
+        case let .apiError(message):
+            "StepFun API error: \(message)"
+        case let .parseFailed(message):
+            "Failed to parse StepFun response: \(message)"
+        case let .loginFailed(message):
+            "StepFun login failed: \(message)"
+        case let .deviceRegistrationFailed(message):
+            "StepFun device registration failed: \(message)"
+        }
+    }
+}
+
+// MARK: - Fetcher
+
+public struct StepFunUsageFetcher: Sendable {
+    private static let log = CodexBarLog.logger(LogCategories.stepfunUsage)
+    private static let platformURL = URL(string: "https://platform.stepfun.com")!
+    private static let apiURL = URL(string: "https://platform.stepfun.com/api/step.openapi.devcenter.Dashboard/QueryStepPlanRateLimit")!
+    private static let registerDeviceURL = URL(string: "https://platform.stepfun.com/passport/proto.api.passport.v1.PassportService/RegisterDevice")!
+    private static let loginURL = URL(string: "https://platform.stepfun.com/passport/proto.api.passport.v1.PassportService/SignInByPassword")!
+    private static let timeoutSeconds: TimeInterval = 15
+
+    private static let webID = "c8a1002d2c457e758785a9979832217c7c0b884c"
+    private static let appID = "10300"
+
+    private static let baseHeaders: [String: String] = [
+        "content-type": "application/json",
+        "oasis-appid": appID,
+        "oasis-platform": "web",
+        "oasis-webid": webID,
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
+    ]
+
+    // MARK: - Public API
+
+    /// Perform the full login flow (username + password → Oasis-Token) and return the token.
+    /// Does NOT fetch usage — the caller should cache the token and then call `fetchUsage(token:)`.
+    public static func login(username: String, password: String) async throws -> String {
+        try await self.fullLogin(username: username, password: password)
+    }
+
+    /// Fetch usage data using an existing Oasis-Token (from env var or cached).
+    public static func fetchUsage(token: String) async throws -> StepFunUsageSnapshot {
+        guard !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw StepFunUsageError.missingToken
+        }
+        return try await self.queryUsage(token: token)
+    }
+
+    /// Full login flow: username + password → token, then fetch usage.
+    public static func fetchUsage(username: String, password: String) async throws -> StepFunUsageSnapshot {
+        let token = try await self.fullLogin(username: username, password: password)
+        return try await self.queryUsage(token: token)
+    }
+
+    // MARK: - Login
+
+    private static func fullLogin(username: String, password: String) async throws -> String {
+        // Step 1: Get INGRESSCOOKIE by visiting the platform homepage
+        let (ingressCookie, _) = try await self.getIngressCookie()
+
+        // Step 2: RegisterDevice → get anonymous token
+        let anonToken = try await self.registerDevice(ingressCookie: ingressCookie)
+
+        // Step 3: SignInByPassword → get authenticated token
+        let authToken = try await self.signInByPassword(
+            username: username,
+            password: password,
+            ingressCookie: ingressCookie,
+            anonToken: anonToken)
+
+        return authToken
+    }
+
+    private static func getIngressCookie() async throws -> (String, HTTPURLResponse) {
+        var request = URLRequest(url: self.platformURL)
+        request.httpMethod = "GET"
+        for (key, value) in self.baseHeaders {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+        request.timeoutInterval = self.timeoutSeconds
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw StepFunUsageError.networkError("Invalid response fetching platform page")
+        }
+
+        // Extract INGRESSCOOKIE from Set-Cookie headers
+        let setCookieHeaders = httpResponse.allHeaderFields.filter { ($0.key as? String)?.lowercased() == "set-cookie" }
+        var ingressCookie = ""
+        for (_, value) in setCookieHeaders {
+            let cookieString = "\(value)"
+            if cookieString.contains("INGRESSCOOKIE=") {
+                let parts = cookieString.components(separatedBy: "INGRESSCOOKIE=")
+                if parts.count > 1 {
+                    let valuePart = parts[1].components(separatedBy: ";").first ?? ""
+                    ingressCookie = valuePart.trimmingCharacters(in: .whitespaces)
+                }
+            }
+        }
+
+        // Also check cookies from the URLSession cookie store
+        if ingressCookie.isEmpty {
+            let cookies = HTTPCookieStorage.shared.cookies(for: self.platformURL) ?? []
+            for cookie in cookies where cookie.name == "INGRESSCOOKIE" {
+                ingressCookie = cookie.value
+                break
+            }
+        }
+
+        guard !ingressCookie.isEmpty else {
+            throw StepFunUsageError.loginFailed("Could not obtain INGRESSCOOKIE")
+        }
+
+        return (ingressCookie, httpResponse)
+    }
+
+    private static func registerDevice(ingressCookie: String) async throws -> String {
+        var request = URLRequest(url: self.registerDeviceURL)
+        request.httpMethod = "POST"
+        request.httpBody = Data("{}".utf8)
+        for (key, value) in self.baseHeaders {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+        request.setValue("INGRESSCOOKIE=\(ingressCookie)", forHTTPHeaderField: "Cookie")
+        request.timeoutInterval = self.timeoutSeconds
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw StepFunUsageError.networkError("Invalid response from RegisterDevice")
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            Self.log.error("StepFun RegisterDevice returned \(httpResponse.statusCode): \(body)")
+            throw StepFunUsageError.deviceRegistrationFailed("HTTP \(httpResponse.statusCode)")
+        }
+
+        let decoded: StepFunRegisterDeviceResponse
+        do {
+            decoded = try JSONDecoder().decode(StepFunRegisterDeviceResponse.self, from: data)
+        } catch {
+            throw StepFunUsageError.parseFailed("RegisterDevice response: \(error.localizedDescription)")
+        }
+
+        guard let accessToken = decoded.accessToken?.raw, !accessToken.isEmpty else {
+            throw StepFunUsageError.deviceRegistrationFailed("No access token in RegisterDevice response")
+        }
+
+        let refreshToken = decoded.refreshToken?.raw ?? ""
+        // Combine access + refresh tokens like the Python tool does
+        return "\(accessToken)...\(refreshToken)"
+    }
+
+    private static func signInByPassword(
+        username: String,
+        password: String,
+        ingressCookie: String,
+        anonToken: String) async throws -> String
+    {
+        var request = URLRequest(url: self.loginURL)
+        request.httpMethod = "POST"
+        let body: [String: String] = ["username": username, "password": password]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        for (key, value) in self.baseHeaders {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+        request.setValue("Oasis-Token=\(anonToken); Oasis-Webid=\(webID); INGRESSCOOKIE=\(ingressCookie)", forHTTPHeaderField: "Cookie")
+        request.timeoutInterval = self.timeoutSeconds
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw StepFunUsageError.networkError("Invalid response from SignInByPassword")
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            Self.log.error("StepFun SignInByPassword returned \(httpResponse.statusCode): \(body)")
+            throw StepFunUsageError.loginFailed("HTTP \(httpResponse.statusCode)")
+        }
+
+        let decoded: StepFunLoginResponse
+        do {
+            decoded = try JSONDecoder().decode(StepFunLoginResponse.self, from: data)
+        } catch {
+            throw StepFunUsageError.parseFailed("SignInByPassword response: \(error.localizedDescription)")
+        }
+
+        guard let accessToken = decoded.accessToken?.raw, !accessToken.isEmpty else {
+            throw StepFunUsageError.loginFailed("No access token in login response")
+        }
+
+        let refreshToken = decoded.refreshToken?.raw ?? ""
+        return "\(accessToken)...\(refreshToken)"
+    }
+
+    // MARK: - Query usage
+
+    private static func queryUsage(token: String) async throws -> StepFunUsageSnapshot {
+        var request = URLRequest(url: self.apiURL)
+        request.httpMethod = "POST"
+        request.httpBody = Data("{}".utf8)
+        for (key, value) in self.baseHeaders {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+        request.setValue("Oasis-Token=\(token); Oasis-Webid=\(webID)", forHTTPHeaderField: "Cookie")
+        request.timeoutInterval = self.timeoutSeconds
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw StepFunUsageError.networkError("Invalid response")
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            Self.log.error("StepFun API returned \(httpResponse.statusCode): \(body)")
+            throw StepFunUsageError.apiError("HTTP \(httpResponse.statusCode)")
+        }
+
+        if let jsonString = String(data: data, encoding: .utf8) {
+            Self.log.debug("StepFun API response: \(jsonString)")
+        }
+
+        return try self.parseSnapshot(data: data)
+    }
+
+    public static func _parseSnapshotForTesting(_ data: Data) throws -> StepFunUsageSnapshot {
+        try self.parseSnapshot(data: data)
+    }
+
+    private static func parseSnapshot(data: Data) throws -> StepFunUsageSnapshot {
+        let decoded: StepFunRateLimitResponse
+        do {
+            decoded = try JSONDecoder().decode(StepFunRateLimitResponse.self, from: data)
+        } catch {
+            throw StepFunUsageError.parseFailed(error.localizedDescription)
+        }
+
+        guard decoded.isSuccess else {
+            let msg = decoded.message ?? decoded.code.map(String.init) ?? "unknown"
+            throw StepFunUsageError.apiError(msg)
+        }
+
+        guard let fiveHourRate = decoded.fiveHourUsageLeftRate,
+              let weeklyRate = decoded.weeklyUsageLeftRate,
+              let fiveHourReset = decoded.fiveHourUsageResetTime,
+              let weeklyReset = decoded.weeklyUsageResetTime
+        else {
+            throw StepFunUsageError.parseFailed("Missing usage rate or reset time fields")
+        }
+
+        return StepFunUsageSnapshot(
+            fiveHourUsageLeftRate: fiveHourRate.value,
+            weeklyUsageLeftRate: weeklyRate.value,
+            fiveHourUsageResetTime: Date(timeIntervalSince1970: TimeInterval(fiveHourReset.value)),
+            weeklyUsageResetTime: Date(timeIntervalSince1970: TimeInterval(weeklyReset.value)),
+            updatedAt: Date())
+    }
+}

--- a/Sources/CodexBarCore/Providers/StepFun/StepFunUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/StepFun/StepFunUsageFetcher.swift
@@ -73,6 +73,29 @@ public struct StepFunRateLimitResponse: Decodable, Sendable {
     }
 }
 
+// MARK: - Plan status response types
+
+struct StepFunPlanStatusResponse: Decodable, Sendable {
+    let status: Int?
+    let subscription: StepFunSubscription?
+
+    var planName: String? {
+        subscription?.name?.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+struct StepFunSubscription: Decodable, Sendable {
+    let name: String?
+    let planType: Int?
+    let planStatus: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case planType = "plan_type"
+        case planStatus = "status"
+    }
+}
+
 // MARK: - Auth response types
 
 struct StepFunRegisterDeviceResponse: Decodable, Sendable {
@@ -96,6 +119,7 @@ public struct StepFunUsageSnapshot: Sendable {
     public let weeklyUsageLeftRate: Double
     public let fiveHourUsageResetTime: Date
     public let weeklyUsageResetTime: Date
+    public let planName: String?
     public let updatedAt: Date
 
     public init(
@@ -103,12 +127,14 @@ public struct StepFunUsageSnapshot: Sendable {
         weeklyUsageLeftRate: Double,
         fiveHourUsageResetTime: Date,
         weeklyUsageResetTime: Date,
+        planName: String? = nil,
         updatedAt: Date)
     {
         self.fiveHourUsageLeftRate = fiveHourUsageLeftRate
         self.weeklyUsageLeftRate = weeklyUsageLeftRate
         self.fiveHourUsageResetTime = fiveHourUsageResetTime
         self.weeklyUsageResetTime = weeklyUsageResetTime
+        self.planName = planName
         self.updatedAt = updatedAt
     }
 
@@ -131,11 +157,14 @@ public struct StepFunUsageSnapshot: Sendable {
             resetsAt: self.weeklyUsageResetTime,
             resetDescription: weeklyResetDescription)
 
+        let trimmedPlan = self.planName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let loginMethod = (trimmedPlan?.isEmpty ?? true) ? "password" : trimmedPlan
+
         let identity = ProviderIdentitySnapshot(
             providerID: .stepfun,
             accountEmail: nil,
             accountOrganization: nil,
-            loginMethod: "password")
+            loginMethod: loginMethod)
 
         return UsageSnapshot(
             primary: fiveHourWindow,
@@ -183,6 +212,7 @@ public struct StepFunUsageFetcher: Sendable {
     private static let log = CodexBarLog.logger(LogCategories.stepfunUsage)
     private static let platformURL = URL(string: "https://platform.stepfun.com")!
     private static let apiURL = URL(string: "https://platform.stepfun.com/api/step.openapi.devcenter.Dashboard/QueryStepPlanRateLimit")!
+    private static let planStatusURL = URL(string: "https://platform.stepfun.com/api/step.openapi.devcenter.Dashboard/GetStepPlanStatus")!
     private static let registerDeviceURL = URL(string: "https://platform.stepfun.com/passport/proto.api.passport.v1.PassportService/RegisterDevice")!
     private static let loginURL = URL(string: "https://platform.stepfun.com/passport/proto.api.passport.v1.PassportService/SignInByPassword")!
     private static let timeoutSeconds: TimeInterval = 15
@@ -392,7 +422,51 @@ public struct StepFunUsageFetcher: Sendable {
             Self.log.debug("StepFun API response: \(jsonString)")
         }
 
-        return try self.parseSnapshot(data: data)
+        var snapshot = try self.parseSnapshot(data: data)
+
+        // Fetch plan name in parallel is not needed — just do it sequentially.
+        // If plan status fails, we still return usage data without plan name.
+        if let planName = try? await self.queryPlanStatus(token: token) {
+            snapshot = StepFunUsageSnapshot(
+                fiveHourUsageLeftRate: snapshot.fiveHourUsageLeftRate,
+                weeklyUsageLeftRate: snapshot.weeklyUsageLeftRate,
+                fiveHourUsageResetTime: snapshot.fiveHourUsageResetTime,
+                weeklyUsageResetTime: snapshot.weeklyUsageResetTime,
+                planName: planName,
+                updatedAt: snapshot.updatedAt)
+        }
+
+        return snapshot
+    }
+
+    // MARK: - Plan Status
+
+    private static func queryPlanStatus(token: String) async throws -> String? {
+        var request = URLRequest(url: self.planStatusURL)
+        request.httpMethod = "POST"
+        request.httpBody = Data("{}".utf8)
+        for (key, value) in self.baseHeaders {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+        request.setValue("Oasis-Token=\(token); Oasis-Webid=\(webID)", forHTTPHeaderField: "Cookie")
+        request.timeoutInterval = self.timeoutSeconds
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            Self.log.debug("StepFun plan status request failed, skipping plan name")
+            return nil
+        }
+
+        let decoded: StepFunPlanStatusResponse
+        do {
+            decoded = try JSONDecoder().decode(StepFunPlanStatusResponse.self, from: data)
+        } catch {
+            Self.log.debug("StepFun plan status parse failed: \(error.localizedDescription)")
+            return nil
+        }
+
+        return decoded.planName
     }
 
     public static func _parseSnapshotForTesting(_ data: Data) throws -> StepFunUsageSnapshot {

--- a/Sources/CodexBarCore/TokenAccountSupportCatalog+Data.swift
+++ b/Sources/CodexBarCore/TokenAccountSupportCatalog+Data.swift
@@ -100,5 +100,12 @@ extension TokenAccountSupportCatalog {
             injection: .environment(key: VeniceSettingsReader.apiKeyEnvironmentKey),
             requiresManualCookieSource: false,
             cookieName: nil),
+        .stepfun: TokenAccountSupport(
+            title: "Session tokens",
+            subtitle: "Store multiple StepFun Oasis-Token values.",
+            placeholder: "Oasis-Token=…",
+            injection: .cookieHeader,
+            requiresManualCookieSource: true,
+            cookieName: nil),
     ]
 }

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
@@ -236,7 +236,7 @@ enum CostUsageScanner {
         case .zai, .gemini, .antigravity, .cursor, .opencode, .opencodego, .alibaba, .factory, .copilot,
              .minimax, .kilo, .kiro, .kimi,
              .kimik2, .augment, .jetbrains, .amp, .ollama, .synthetic, .openrouter, .warp, .perplexity, .abacus,
-             .mistral, .deepseek, .codebuff, .crof, .windsurf, .venice, .commandcode:
+             .mistral, .deepseek, .codebuff, .crof, .windsurf, .venice, .commandcode, .stepfun:
             return emptyReport
         }
     }

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -84,6 +84,7 @@ enum ProviderChoice: String, AppEnum {
         case .crof: return nil // Crof not yet supported in widgets
         case .venice: return nil // Venice not yet supported in widgets
         case .commandcode: return nil // CommandCode not yet supported in widgets
+        case .stepfun: return nil // StepFun not yet supported in widgets
         }
     }
 }

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -290,6 +290,7 @@ private struct ProviderSwitchChip: View {
         case .crof: "Crof"
         case .venice: "Venice"
         case .commandcode: "Command Code"
+        case .stepfun: "StepFun"
         }
     }
 }
@@ -665,6 +666,8 @@ enum WidgetColors {
             Color(red: 51 / 255, green: 153 / 255, blue: 1.0)
         case .commandcode:
             Color(red: 0, green: 0, blue: 0)
+        case .stepfun:
+            Color(red: 255 / 255, green: 140 / 255, blue: 0 / 255) // StepFun orange
         }
     }
 }

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -1086,6 +1086,7 @@ struct SettingsStoreTests {
             .crof,
             .venice,
             .commandcode,
+            .stepfun,
         ])
 
         // Move one provider; ensure it's persisted across instances.

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -560,7 +560,7 @@ struct StatusMenuTests {
     }
 
     @Test
-    func `merged provider switch rebuilds stale width switcher rows`() {
+    func `merged provider switch rebuilds stale width switcher rows`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -595,6 +595,8 @@ struct StatusMenuTests {
             statusBar: self.makeStatusBarForTesting())
 
         let menu = controller.makeMenu()
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
+        defer { StatusItemController.resetMenuRefreshEnabledForTesting() }
         controller.menuWillOpen(menu)
 
         let initialSwitcher = menu.items.first?.view as? ProviderSwitcherView
@@ -605,6 +607,8 @@ struct StatusMenuTests {
         let nextProviderButton = self.switcherButtons(in: menu).first(where: { $0.state == .off })
         #expect(nextProviderButton != nil)
         nextProviderButton?.performClick(nil)
+        await Task.yield()
+        await Task.yield()
 
         let updatedSwitcher = menu.items.first?.view as? ProviderSwitcherView
         #expect(updatedSwitcher != nil)

--- a/Tests/CodexBarTests/StepFunUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/StepFunUsageFetcherTests.swift
@@ -1,0 +1,233 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct StepFunSettingsReaderTests {
+    @Test
+    func `reads STEPFUN_TOKEN`() {
+        let env = ["STEPFUN_TOKEN": "some-oasis-token-value"]
+        #expect(StepFunSettingsReader.token(environment: env) == "some-oasis-token-value")
+    }
+
+    @Test
+    func `reads STEPFUN_USERNAME`() {
+        let env = ["STEPFUN_USERNAME": "user@example.com"]
+        #expect(StepFunSettingsReader.username(environment: env) == "user@example.com")
+    }
+
+    @Test
+    func `reads STEPFUN_PASSWORD`() {
+        let env = ["STEPFUN_PASSWORD": "secret123"]
+        #expect(StepFunSettingsReader.password(environment: env) == "secret123")
+    }
+
+    @Test
+    func `trims whitespace from token`() {
+        let env = ["STEPFUN_TOKEN": "  some-token  "]
+        #expect(StepFunSettingsReader.token(environment: env) == "some-token")
+    }
+
+    @Test
+    func `strips double quotes from token`() {
+        let env = ["STEPFUN_TOKEN": "\"some-token\""]
+        #expect(StepFunSettingsReader.token(environment: env) == "some-token")
+    }
+
+    @Test
+    func `strips single quotes from token`() {
+        let env = ["STEPFUN_TOKEN": "'some-token'"]
+        #expect(StepFunSettingsReader.token(environment: env) == "some-token")
+    }
+
+    @Test
+    func `returns nil when no env vars present`() {
+        #expect(StepFunSettingsReader.token(environment: [:]) == nil)
+        #expect(StepFunSettingsReader.username(environment: [:]) == nil)
+        #expect(StepFunSettingsReader.password(environment: [:]) == nil)
+    }
+
+    @Test
+    func `returns nil for empty values`() {
+        let env = ["STEPFUN_TOKEN": "", "STEPFUN_USERNAME": "", "STEPFUN_PASSWORD": ""]
+        #expect(StepFunSettingsReader.token(environment: env) == nil)
+        #expect(StepFunSettingsReader.username(environment: env) == nil)
+        #expect(StepFunSettingsReader.password(environment: env) == nil)
+    }
+
+    @Test
+    func `returns nil for whitespace-only values`() {
+        let env = ["STEPFUN_TOKEN": "   "]
+        #expect(StepFunSettingsReader.token(environment: env) == nil)
+    }
+}
+
+struct StepFunProviderTokenResolverTests {
+    @Test
+    func `resolves token from environment`() {
+        let env = ["STEPFUN_TOKEN": "my-test-token"]
+        let resolution = ProviderTokenResolver.stepfunResolution(environment: env)
+        #expect(resolution?.token == "my-test-token")
+        #expect(resolution?.source == .environment)
+    }
+
+    @Test
+    func `returns nil when token absent`() {
+        let resolution = ProviderTokenResolver.stepfunResolution(environment: [:])
+        #expect(resolution == nil)
+    }
+}
+
+struct StepFunUsageFetcherParsingTests {
+    @Test
+    func `parses real API response format with string timestamps and integer rates`() throws {
+        // This matches the actual StepFun API response format:
+        // - timestamps as strings (e.g. "1777528800")
+        // - rates can be integers (e.g. 1) or floats (e.g. 0.99781543)
+        let json = """
+        {
+            "status": 1,
+            "desc": "",
+            "five_hour_usage_left_rate": 1,
+            "five_hour_usage_reset_time": "1777528800",
+            "weekly_usage_left_rate": 0.99781543,
+            "weekly_usage_reset_time": "1777899600"
+        }
+        """
+        let data = Data(json.utf8)
+        let snapshot = try StepFunUsageFetcher._parseSnapshotForTesting(data)
+
+        #expect(snapshot.fiveHourUsageLeftRate == 1.0)
+        #expect(snapshot.weeklyUsageLeftRate > 0.997 && snapshot.weeklyUsageLeftRate < 0.998)
+    }
+
+    @Test
+    func `parses response with float rates and integer timestamps`() throws {
+        let json = """
+        {
+            "status": 1,
+            "five_hour_usage_left_rate": 0.75,
+            "weekly_usage_left_rate": 0.5,
+            "five_hour_usage_reset_time": 1746000000,
+            "weekly_usage_reset_time": 1746500000
+        }
+        """
+        let data = Data(json.utf8)
+        let snapshot = try StepFunUsageFetcher._parseSnapshotForTesting(data)
+
+        #expect(snapshot.fiveHourUsageLeftRate == 0.75)
+        #expect(snapshot.weeklyUsageLeftRate == 0.5)
+    }
+
+    @Test
+    func `throws on failed API status`() {
+        let json = """
+        {
+            "status": 0,
+            "message": "Unauthorized",
+            "five_hour_usage_left_rate": 0.75,
+            "weekly_usage_left_rate": 0.5,
+            "five_hour_usage_reset_time": "1746000000",
+            "weekly_usage_reset_time": "1746500000"
+        }
+        """
+        let data = Data(json.utf8)
+        #expect(throws: StepFunUsageError.self) {
+            try StepFunUsageFetcher._parseSnapshotForTesting(data)
+        }
+    }
+
+    @Test
+    func `throws on missing fields`() {
+        let json = """
+        {
+            "status": 1
+        }
+        """
+        let data = Data(json.utf8)
+        #expect(throws: StepFunUsageError.self) {
+            try StepFunUsageFetcher._parseSnapshotForTesting(data)
+        }
+    }
+
+    @Test
+    func `throws on invalid JSON`() {
+        let data = Data("not json".utf8)
+        #expect(throws: StepFunUsageError.self) {
+            try StepFunUsageFetcher._parseSnapshotForTesting(data)
+        }
+    }
+
+    @Test
+    func `snapshot maps to UsageSnapshot correctly`() throws {
+        let json = """
+        {
+            "status": 1,
+            "five_hour_usage_left_rate": 0.8,
+            "weekly_usage_left_rate": 0.6,
+            "five_hour_usage_reset_time": "1746000000",
+            "weekly_usage_reset_time": "1746500000"
+        }
+        """
+        let data = Data(json.utf8)
+        let snapshot = try StepFunUsageFetcher._parseSnapshotForTesting(data)
+        let usage = snapshot.toUsageSnapshot()
+
+        // Five-hour window: 20% used (1.0 - 0.8)
+        let primaryUsed = usage.primary?.usedPercent ?? 0
+        #expect(primaryUsed > 19.9 && primaryUsed < 20.1)
+
+        // Weekly window: 40% used (1.0 - 0.6)
+        let secondaryUsed = usage.secondary?.usedPercent ?? 0
+        #expect(secondaryUsed > 39.9 && secondaryUsed < 40.1)
+        #expect(usage.secondary?.windowMinutes == 10080)
+
+        // Identity
+        #expect(usage.identity?.providerID == .stepfun)
+        #expect(usage.identity?.loginMethod == "password")
+    }
+
+    @Test
+    func `clamps used percent to 0-100 range`() throws {
+        let json = """
+        {
+            "status": 1,
+            "five_hour_usage_left_rate": 0.0,
+            "weekly_usage_left_rate": 1,
+            "five_hour_usage_reset_time": "1746000000",
+            "weekly_usage_reset_time": "1746500000"
+        }
+        """
+        let data = Data(json.utf8)
+        let snapshot = try StepFunUsageFetcher._parseSnapshotForTesting(data)
+        let usage = snapshot.toUsageSnapshot()
+
+        // 0% remaining → 100% used
+        #expect(usage.primary?.usedPercent == 100.0)
+        // 100% remaining → 0% used (integer 1 parsed as 1.0)
+        #expect(usage.secondary?.usedPercent == 0.0)
+    }
+}
+
+struct StepFunTokenNormalizerTests {
+    @Test
+    func `extracts Oasis-Token from cookie header`() {
+        let input = "Oasis-Token=abc123...def456; Oasis-Webid=someid"
+        #expect(StepFunTokenNormalizer.normalize(input) == "abc123...def456")
+    }
+
+    @Test
+    func `returns raw value when not a cookie header`() {
+        let input = "abc123...def456"
+        #expect(StepFunTokenNormalizer.normalize(input) == "abc123...def456")
+    }
+
+    @Test
+    func `returns empty for empty string`() {
+        #expect(StepFunTokenNormalizer.normalize("") == "")
+    }
+
+    @Test
+    func `trims whitespace`() {
+        #expect(StepFunTokenNormalizer.normalize("  token123  ") == "token123")
+    }
+}

--- a/Tests/CodexBarTests/StepFunUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/StepFunUsageFetcherTests.swift
@@ -223,7 +223,7 @@ struct StepFunTokenNormalizerTests {
 
     @Test
     func `returns empty for empty string`() {
-        #expect(StepFunTokenNormalizer.normalize("") == "")
+        #expect(StepFunTokenNormalizer.normalize("").isEmpty)
     }
 
     @Test

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -265,4 +265,11 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Status: none yet.
 - Details: `docs/command-code.md`.
 
+## StepFun
+- Username/password login or manual Oasis-Token.
+- Reads Step Plan 5-hour and weekly rate-limit windows from `platform.stepfun.com`.
+- Shows subscription plan name when the Step Plan status API returns one.
+- Status: none yet.
+- Details: `docs/stepfun.md`.
+
 See also: `docs/provider.md` for architecture notes.

--- a/docs/stepfun.md
+++ b/docs/stepfun.md
@@ -1,0 +1,57 @@
+---
+summary: "StepFun provider data sources: username + password login for Step Plan rate limits and subscription plan name."
+read_when:
+  - Adding or tweaking StepFun rate limit parsing
+  - Updating StepFun login flow
+  - Documenting new provider behavior
+---
+
+# StepFun provider
+
+StepFun (阶跃星辰) is a web-based provider. Usage data comes from the Step Plan rate limit API,
+authenticated via an Oasis-Token obtained through a username + password login flow.
+
+## Data sources
+
+1. **Authentication** — Three methods (in priority order):
+   - **Auto mode**: Username + password entered in Settings → Providers → StepFun.
+     CodexBar performs a 3-step login flow to obtain an Oasis-Token:
+       1. `GET https://platform.stepfun.com` → `INGRESSCOOKIE`
+       2. `POST …/RegisterDevice` → anonymous token
+       3. `POST …/SignInByPassword` → authenticated Oasis-Token
+     The token is cached in Keychain-backed `CookieHeaderCache` and reused until it expires.
+   - **Manual mode**: Paste an Oasis-Token directly in Settings → Providers → StepFun.
+   - **Environment variables**: `STEPFUN_USERNAME` + `STEPFUN_PASSWORD`, or `STEPFUN_TOKEN`.
+
+2. **Rate limit endpoint**
+   - `POST https://platform.stepfun.com/api/step.openapi.devcenter.Dashboard/QueryStepPlanRateLimit`
+   - Request headers: `Cookie: Oasis-Token=<token>`, `Content-Type: application/json`
+   - Response fields:
+     - `five_hour_usage_left_rate` — remaining fraction for the 5-hour window (e.g. `0.99781543`)
+     - `weekly_usage_left_rate` — remaining fraction for the weekly window
+     - `five_hour_usage_reset_time` — reset timestamp (string or integer)
+     - `weekly_usage_reset_time` — reset timestamp (string or integer)
+
+3. **Plan status endpoint**
+   - `POST https://platform.stepfun.com/api/step.openapi.devcenter.Dashboard/GetStepPlanStatus`
+   - Same auth headers as above
+   - Response → `subscription.name` → plan name (e.g. "Plus", "Mini")
+   - If this request fails, usage data is still displayed without a plan name.
+
+## Usage details
+
+- **Primary window** (top bar): 5-hour rate limit (300 minutes).
+- **Secondary window** (bottom bar): weekly rate limit (10 080 minutes).
+- `usedPercent` is computed as `(1.0 - left_rate) × 100`.
+- Plan name is shown as the `loginMethod` label in the menu card (e.g. "Plus").
+- When auth source is set to **Off**, no background refreshes occur.
+- Token expiry triggers automatic re-login (cache is cleared and the 3-step flow runs again).
+
+## Key files
+
+- `Sources/CodexBarCore/Providers/StepFun/StepFunProviderDescriptor.swift` (descriptor + web fetch strategy)
+- `Sources/CodexBarCore/Providers/StepFun/StepFunUsageFetcher.swift` (login flow + HTTP client + JSON parser)
+- `Sources/CodexBarCore/Providers/StepFun/StepFunSettingsReader.swift` (env var resolution)
+- `Sources/CodexBar/Providers/StepFun/StepFunProviderImplementation.swift` (settings fields + activation logic)
+- `Sources/CodexBar/Providers/StepFun/StepFunSettingsStore.swift` (SettingsStore extension)
+- `Tests/CodexBarTests/StepFunUsageFetcherTests.swift` (22 test cases)


### PR DESCRIPTION
## Summary

Adds **StepFun (阶跃星辰)** as a new web-based provider that monitors Step Plan rate limits via the `platform.stepfun.com` API.

## Authentication

StepFun uses a **username + password login flow** to obtain an Oasis-Token session:

1. **Auto mode** (default): Enter username/password in Settings UI → app automatically performs the 3-step login flow:
   - Fetch `INGRESSCOOKIE` from platform homepage
   - `RegisterDevice` → get anonymous token
   - `SignInByPassword` → get authenticated Oasis-Token
   - Token cached in Keychain-backed `CookieHeaderCache` for reuse
   - On token expiry (API error), automatically clears cache and re-authenticates

2. **Manual mode**: Directly paste an Oasis-Token from a browser session

3. **Environment variables**: `STEPFUN_USERNAME` + `STEPFUN_PASSWORD`, or `STEPFUN_TOKEN`

## Usage Data

| Window | API Field | Maps To |
|--------|-----------|---------|
| 5-hour session | `five_hour_usage_left_rate` | Primary RateWindow (300 min) |
| Weekly | `weekly_usage_left_rate` | Secondary RateWindow (10080 min) |

Reset times are displayed from `five_hour_usage_reset_time` / `weekly_usage_reset_time`.

## Files Added

- `Sources/CodexBarCore/Providers/StepFun/` — descriptor, usage fetcher, settings reader
- `Sources/CodexBar/Providers/StepFun/` — app implementation, settings store
- `Sources/CodexBar/Resources/ProviderIcon-stepfun.svg` — provider icon
- `Tests/CodexBarTests/StepFunUsageFetcherTests.swift` — 22 test cases

## Files Modified

- `Providers.swift` — added `case stepfun` to `UsageProvider` / `IconStyle`
- `ProviderDescriptor.swift` — registered StepFun descriptor
- `ProviderImplementationRegistry.swift` — added implementation factory
- `ProviderTokenResolver.swift` — added `stepfunResolution()`
- `ProviderSettingsSnapshot.swift` — added `StepFunProviderSettings`
- `TokenAccountSupportCatalog+Data.swift` — added token account support
- Widget files, CLI, CostUsageScanner, UsageStore — added `.stepfun` cases

## Testing

- 22 unit tests covering settings reader, token resolver, API response parsing, and token normalization
- API response parser handles both string (`"1777528800"`) and integer timestamps, and both integer (`1`) and float (`0.99781543`) rate values
- Build and full test suite pass
<img width="310" height="320" alt="image" src="https://github.com/user-attachments/assets/6e69a41e-f4d0-406b-95cb-4d516285b8c9" />
<img width="720" height="668" alt="image" src="https://github.com/user-attachments/assets/4607cb74-f377-4255-bb0d-00a2351822b3" />

