### PR TITLE
Address problem(s) in OpenAI Dashboard

### DIFF
--- a/Sources/CodexBar/Providers/Codex/CodexConsumerProjection.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexConsumerProjection.swift
@@ -24,6 +24,15 @@ struct CodexUIErrorMapper {
             return "OpenAI web refresh was interrupted. Refresh OpenAI cookies and try again."
         }
 
+        if self.looksOpenAIWebTimeout(lower: lower) {
+            return "OpenAI web refresh timed out. Refresh OpenAI cookies and try again."
+        }
+
+        if self.looksOpenAIWebNetworkError(lower: lower) {
+            return "OpenAI web refresh hit a network error. "
+                + "Check your connection, then refresh OpenAI cookies and try again."
+        }
+
         if self.looksInternalTransport(lower: lower) {
             return "Codex usage is temporarily unavailable. Try refreshing."
         }
@@ -60,6 +69,10 @@ struct CodexUIErrorMapper {
             || lower.contains("codex credits are still loading")
             || lower.contains("codex account changed; importing browser cookies")
             || lower.contains("codex session expired. sign in again.")
+            || lower.contains("openai web refresh timed out. refresh openai cookies and try again.")
+            || lower.contains(
+                "openai web refresh hit a network error. "
+                    + "check your connection, then refresh openai cookies and try again.")
             || lower.contains("codex usage is temporarily unavailable. try refreshing.")
     }
 
@@ -83,6 +96,15 @@ struct CodexUIErrorMapper {
             || lower.contains("get https://")
             || lower.contains("get http://")
             || lower.contains("returned invalid data")
+    }
+
+    private static func looksOpenAIWebTimeout(lower: String) -> Bool {
+        lower.contains("nsurlerrordomain")
+            && (lower.contains("timed out") || lower.contains("error -1001"))
+    }
+
+    private static func looksOpenAIWebNetworkError(lower: String) -> Bool {
+        lower.contains("nsurlerrordomain")
     }
 }
 
@@ -194,10 +216,12 @@ struct CodexConsumerProjection {
             []
         }
 
+        let displayableUsageBreakdown = OpenAIDashboardDailyBreakdown.removingSkillUsageServices(
+            from: dashboard?.usageBreakdown ?? [])
         let canShowBuyCredits = surface == .liveCard
         let hasUsageBreakdown = surface == .liveCard
             && dashboardVisibility == .attached
-            && !(dashboard?.usageBreakdown ?? []).isEmpty
+            && !displayableUsageBreakdown.isEmpty
         let hasCreditsHistory = surface == .liveCard
             && dashboardVisibility == .attached
             && !(dashboard?.dailyBreakdown ?? []).isEmpty

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -62,7 +62,8 @@ extension StatusItemController {
 
     @discardableResult
     func appendUsageBreakdownChartItem(to submenu: NSMenu, width: CGFloat) -> Bool {
-        let breakdown = self.store.openAIDashboard?.usageBreakdown ?? []
+        let breakdown = OpenAIDashboardDailyBreakdown.removingSkillUsageServices(
+            from: self.store.openAIDashboard?.usageBreakdown ?? [])
         guard !breakdown.isEmpty else { return false }
 
         if !Self.menuCardRenderingEnabled {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1295,7 +1295,9 @@ extension StatusItemController {
     }
 
     private func makeUsageBreakdownSubmenu() -> NSMenu? {
-        guard !(self.store.openAIDashboard?.usageBreakdown ?? []).isEmpty else { return nil }
+        let breakdown = OpenAIDashboardDailyBreakdown.removingSkillUsageServices(
+            from: self.store.openAIDashboard?.usageBreakdown ?? [])
+        guard !breakdown.isEmpty else { return nil }
         return self.makeHostedSubviewPlaceholderMenu(chartID: Self.usageBreakdownChartID)
     }
 

--- a/Sources/CodexBar/UsageBreakdownChartMenuView.swift
+++ b/Sources/CodexBar/UsageBreakdownChartMenuView.swift
@@ -146,7 +146,7 @@ struct UsageBreakdownChartMenuView: View {
     private static let selectionBandColor = Color(nsColor: .labelColor).opacity(0.1)
 
     private static func makeModel(from breakdown: [OpenAIDashboardDailyBreakdown]) -> Model {
-        let sorted = breakdown
+        let sorted = OpenAIDashboardDailyBreakdown.removingSkillUsageServices(from: breakdown)
             .sorted { lhs, rhs in lhs.day < rhs.day }
 
         var points: [Point] = []

--- a/Sources/CodexBar/UsageStore+HistoricalPace.swift
+++ b/Sources/CodexBar/UsageStore+HistoricalPace.swift
@@ -98,7 +98,9 @@ extension UsageStore {
     {
         guard self.settings.historicalTrackingEnabled else { return }
         guard authorityDecision.allowedEffects.contains(.historicalBackfill) else { return }
-        guard !dashboard.usageBreakdown.isEmpty else { return }
+        let usageBreakdown = OpenAIDashboardDailyBreakdown.removingSkillUsageServices(
+            from: dashboard.usageBreakdown)
+        guard !usageBreakdown.isEmpty else { return }
 
         let codexSnapshot = self.snapshots[.codex]
         let ownership = self.codexOwnershipContext(preferredEmail: attachedAccountEmail)
@@ -128,7 +130,6 @@ extension UsageStore {
         }
 
         let historyStore = self.historicalUsageHistoryStore
-        let usageBreakdown = dashboard.usageBreakdown
         Task.detached(priority: .utility) { [weak self] in
             _ = await historyStore.backfillCodexWeeklyFromUsageBreakdown(
                 usageBreakdown,

--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -29,7 +29,7 @@ extension UsageStore {
     }
 
     private static let openAIWebRefreshMultiplier: TimeInterval = 5
-    private static let openAIWebPrimaryFetchTimeout: TimeInterval = 15
+    private static let openAIWebPrimaryFetchTimeout: TimeInterval = 25
     private static let openAIWebRetryFetchTimeout: TimeInterval = 8
     private static let openAIWebPostImportFetchTimeout: TimeInterval = 25
 
@@ -494,6 +494,13 @@ extension UsageStore {
                 latestCookieImportStatus: &latestCookieImportStatus,
                 logger: log)
         } catch {
+            if Self.isOpenAIDashboardTimeout(error) {
+                await self.retryOpenAIDashboardAfterTimeout(
+                    context: context,
+                    latestCookieImportStatus: &latestCookieImportStatus,
+                    logger: log)
+                return
+            }
             let message = self.preferredOpenAIDashboardFailureMessage(
                 error: error,
                 targetEmail: context.targetEmail,
@@ -503,6 +510,56 @@ extension UsageStore {
                 expectedGuard: context.expectedGuard,
                 refreshTaskToken: context.refreshTaskToken,
                 routingTargetEmail: context.targetEmail)
+        }
+    }
+
+    private func retryOpenAIDashboardAfterTimeout(
+        context: OpenAIDashboardRefreshContext,
+        latestCookieImportStatus: inout String?,
+        logger: @escaping (String) -> Void) async
+    {
+        let targetEmail = self.currentCodexOpenAIWebTargetEmail(
+            allowCurrentSnapshotFallback: context.allowCurrentSnapshotFallback,
+            allowLastKnownLiveFallback: context.expectedGuard?.identity != .unresolved)
+        var effectiveEmail = targetEmail
+        let imported = await self.importOpenAIDashboardCookiesIfNeeded(
+            targetEmail: targetEmail,
+            force: true,
+            preferCachedCookieHeader: true)
+        latestCookieImportStatus = self.currentOpenAIDashboardCookieImportStatus()
+        if await self.abortOpenAIDashboardRetryAfterImportFailure(
+            importedEmail: imported,
+            targetEmail: targetEmail,
+            expectedGuard: context.expectedGuard,
+            cookieImportStatus: latestCookieImportStatus,
+            refreshTaskToken: context.refreshTaskToken)
+        {
+            return
+        }
+        if let imported {
+            effectiveEmail = imported
+        }
+        do {
+            let dash = try await self.loadLatestOpenAIDashboard(
+                accountEmail: effectiveEmail,
+                logger: logger,
+                timeout: Self.openAIWebRetryDashboardFetchTimeout(afterCookieImport: true))
+            await self.applyOpenAIDashboard(
+                dash,
+                targetEmail: effectiveEmail,
+                expectedGuard: context.expectedGuard,
+                refreshTaskToken: context.refreshTaskToken,
+                allowCodexUsageBackfill: context.allowCodexUsageBackfill)
+        } catch {
+            let message = self.preferredOpenAIDashboardFailureMessage(
+                error: error,
+                targetEmail: targetEmail,
+                cookieImportStatus: latestCookieImportStatus)
+            await self.applyOpenAIDashboardFailure(
+                message: message,
+                expectedGuard: context.expectedGuard,
+                refreshTaskToken: context.refreshTaskToken,
+                routingTargetEmail: targetEmail)
         }
     }
 
@@ -752,6 +809,11 @@ extension UsageStore {
         return error.localizedDescription
     }
 
+    private static func isOpenAIDashboardTimeout(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorTimedOut
+    }
+
     private func abortOpenAIDashboardRetryAfterImportFailure(
         importedEmail: String?,
         targetEmail: String?,
@@ -855,7 +917,11 @@ extension UsageStore {
         return false
     }
 
-    func importOpenAIDashboardCookiesIfNeeded(targetEmail: String?, force: Bool) async -> String? {
+    func importOpenAIDashboardCookiesIfNeeded(
+        targetEmail: String?,
+        force: Bool,
+        preferCachedCookieHeader: Bool? = nil) async -> String?
+    {
         if await self.openAIWebCookieImportShouldFailClosed() {
             return nil
         }
@@ -921,7 +987,7 @@ extension UsageStore {
                     result = try await importer.importBestCookies(
                         intoAccountEmail: normalizedTarget,
                         allowAnyAccount: allowAnyAccount,
-                        preferCachedCookieHeader: !force,
+                        preferCachedCookieHeader: preferCachedCookieHeader ?? !force,
                         cacheScope: cacheScope,
                         logger: log)
                 case .off:

--- a/Sources/CodexBarCore/OpenAIDashboardModels.swift
+++ b/Sources/CodexBarCore/OpenAIDashboardModels.swift
@@ -36,7 +36,7 @@ public struct OpenAIDashboardSnapshot: Codable, Equatable, Sendable {
         self.codeReviewLimit = codeReviewLimit
         self.creditEvents = creditEvents
         self.dailyBreakdown = dailyBreakdown
-        self.usageBreakdown = usageBreakdown
+        self.usageBreakdown = OpenAIDashboardDailyBreakdown.removingSkillUsageServices(from: usageBreakdown)
         self.creditsPurchaseURL = creditsPurchaseURL
         self.primaryLimit = primaryLimit
         self.secondaryLimit = secondaryLimit
@@ -72,9 +72,11 @@ public struct OpenAIDashboardSnapshot: Codable, Equatable, Sendable {
             [OpenAIDashboardDailyBreakdown].self,
             forKey: .dailyBreakdown)
             ?? Self.makeDailyBreakdown(from: self.creditEvents, maxDays: 30)
-        self.usageBreakdown = try container.decodeIfPresent(
+        let decodedUsageBreakdown = try container.decodeIfPresent(
             [OpenAIDashboardDailyBreakdown].self,
             forKey: .usageBreakdown) ?? []
+        self.usageBreakdown = OpenAIDashboardDailyBreakdown.removingSkillUsageServices(
+            from: decodedUsageBreakdown)
         self.creditsPurchaseURL = try container.decodeIfPresent(String.self, forKey: .creditsPurchaseURL)
         self.primaryLimit = try container.decodeIfPresent(RateWindow.self, forKey: .primaryLimit)
         self.secondaryLimit = try container.decodeIfPresent(RateWindow.self, forKey: .secondaryLimit)
@@ -144,6 +146,33 @@ public struct OpenAIDashboardDailyBreakdown: Codable, Equatable, Sendable {
         self.day = day
         self.services = services
         self.totalCreditsUsed = totalCreditsUsed
+    }
+
+    public static func isSkillUsageService(_ service: String) -> Bool {
+        service
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .hasPrefix("skillusage:")
+    }
+
+    public static func removingSkillUsageServices(
+        from breakdown: [OpenAIDashboardDailyBreakdown])
+        -> [OpenAIDashboardDailyBreakdown]
+    {
+        breakdown.compactMap { day in
+            guard !day.services.isEmpty else {
+                return day.totalCreditsUsed > 0 ? day : nil
+            }
+
+            let services = day.services.filter { !self.isSkillUsageService($0.service) }
+            guard !services.isEmpty else { return nil }
+
+            let total = services.reduce(0) { $0 + $1.creditsUsed }
+            return OpenAIDashboardDailyBreakdown(
+                day: day.day,
+                services: services,
+                totalCreditsUsed: total)
+        }
     }
 }
 

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -20,6 +20,8 @@ public struct OpenAIDashboardFetcher {
     }
 
     private let usageURL = URL(string: "https://chatgpt.com/codex/cloud/settings/analytics#usage")!
+    private nonisolated static let dashboardAcceptLanguage = "en-US,en;q=0.9"
+    private nonisolated static let dashboardUsageAPIURL = URL(string: "https://chatgpt.com/backend-api/wham/usage")!
 
     public init() {}
 
@@ -43,6 +45,7 @@ public struct OpenAIDashboardFetcher {
     }
 
     private struct DashboardSnapshotComponents {
+        let signedInEmail: String?
         let scrape: ScrapeResult
         let codeReview: Double?
         let codeReviewLimit: RateWindow?
@@ -58,7 +61,7 @@ public struct OpenAIDashboardFetcher {
         -> OpenAIDashboardSnapshot
     {
         OpenAIDashboardSnapshot(
-            signedInEmail: components.scrape.signedInEmail,
+            signedInEmail: components.signedInEmail,
             codeReviewRemainingPercent: components.codeReview,
             codeReviewLimit: components.codeReviewLimit,
             creditEvents: components.events,
@@ -70,6 +73,17 @@ public struct OpenAIDashboardFetcher {
             creditsRemaining: components.creditsRemaining,
             accountPlan: components.accountPlan,
             updatedAt: Date())
+    }
+
+    struct DashboardAPIData: Sendable {
+        let primaryLimit: RateWindow?
+        let secondaryLimit: RateWindow?
+        let creditsRemaining: Double?
+        let accountPlan: String?
+
+        var hasUsageData: Bool {
+            self.primaryLimit != nil || self.secondaryLimit != nil || self.creditsRemaining != nil
+        }
     }
 
     public struct ProbeResult: Sendable {
@@ -134,6 +148,12 @@ public struct OpenAIDashboardFetcher {
         timeout: TimeInterval = 60) async throws -> OpenAIDashboardSnapshot
     {
         let deadline = Self.deadline(startingAt: Date(), timeout: timeout)
+        let preflight = await Self.fetchDashboardAPIPreflight(
+            websiteDataStore: websiteDataStore,
+            logger: { logger?($0) })
+        let apiData = preflight.apiData
+        let verifiedSignedInEmail = preflight.verifiedSignedInEmail
+
         let lease = try await self.makeWebView(
             websiteDataStore: websiteDataStore,
             logger: logger,
@@ -176,41 +196,49 @@ public struct OpenAIDashboardFetcher {
 
             // The page is a SPA and can land on ChatGPT UI or other routes; keep forcing the usage URL.
             if let href = scrape.href, !Self.isUsageRoute(href) {
-                _ = webView.load(URLRequest(url: self.usageURL))
+                _ = webView.load(Self.usageURLRequest(url: self.usageURL))
                 try? await Task.sleep(for: .milliseconds(500))
                 continue
             }
 
-            if scrape.loginRequired {
-                if debugDumpHTML, let html = scrape.bodyHTML {
-                    Self.writeDebugArtifacts(html: html, bodyText: scrape.bodyText, logger: log)
-                }
-                throw FetchError.loginRequired
-            }
-
-            if scrape.cloudflareInterstitial {
-                if debugDumpHTML, let html = scrape.bodyHTML {
-                    Self.writeDebugArtifacts(html: html, bodyText: scrape.bodyText, logger: log)
-                }
-                throw FetchError.noDashboardData(body: "Cloudflare challenge detected in WebView.")
-            }
+            try Self.throwIfBlockingScrapeState(scrape, debugDumpHTML: debugDumpHTML, logger: log)
 
             let bodyText = scrape.bodyText ?? ""
             let codeReview = OpenAIDashboardParser.parseCodeReviewRemainingPercent(bodyText: bodyText)
             let events = OpenAIDashboardParser.parseCreditEvents(rows: scrape.rows)
             let breakdown = OpenAIDashboardSnapshot.makeDailyBreakdown(from: events, maxDays: 30)
             let usageBreakdown = scrape.usageBreakdown
-            let rateLimits = OpenAIDashboardParser.parseRateLimits(bodyText: bodyText)
+            let parsedRateLimits = OpenAIDashboardParser.parseRateLimits(bodyText: bodyText)
+            let rateLimits = (
+                primary: apiData?.primaryLimit ?? parsedRateLimits.primary,
+                secondary: apiData?.secondaryLimit ?? parsedRateLimits.secondary)
             let codeReviewLimit = OpenAIDashboardParser.parseCodeReviewLimit(bodyText: bodyText)
-            let creditsRemaining = OpenAIDashboardParser.parseCreditsRemaining(bodyText: bodyText)
-            let accountPlan = scrape.bodyHTML.flatMap(OpenAIDashboardParser.parsePlanFromHTML)
+            let parsedCreditsRemaining = OpenAIDashboardParser.parseCreditsRemaining(bodyText: bodyText)
+            let creditsRemaining = apiData?.creditsRemaining ?? parsedCreditsRemaining
+            let parsedAccountPlan = scrape.bodyHTML.flatMap(OpenAIDashboardParser.parsePlanFromHTML)
+            let accountPlan = parsedAccountPlan
+                ?? apiData?.accountPlan
+            let hasParsedUsageLimits = parsedRateLimits.primary != nil || parsedRateLimits.secondary != nil
             let hasUsageLimits = rateLimits.primary != nil || rateLimits.secondary != nil
+            let signedInEmail = Self.firstNonEmpty(scrape.signedInEmail, verifiedSignedInEmail)
+            let hasDashboardPageData = Self.hasReturnableDashboardData(
+                codeReview: codeReview,
+                events: events,
+                usageBreakdown: usageBreakdown,
+                hasUsageLimits: hasParsedUsageLimits,
+                creditsRemaining: parsedCreditsRemaining)
+            let hasDashboardPageSignal = Self.hasAnyDashboardSignal(
+                hasReturnableData: hasDashboardPageData,
+                creditsHeaderPresent: scrape.creditsHeaderPresent)
+            let hasReturnableData = Self.hasReturnableDashboardData(
+                codeReview: codeReview,
+                events: events,
+                usageBreakdown: usageBreakdown,
+                hasUsageLimits: hasUsageLimits,
+                creditsRemaining: creditsRemaining)
 
             if codeReview != nil, codeReviewFirstSeenAt == nil { codeReviewFirstSeenAt = Date() }
-            if anyDashboardSignalAt == nil,
-               codeReview != nil || !usageBreakdown.isEmpty || scrape.creditsHeaderPresent ||
-               hasUsageLimits || creditsRemaining != nil
-            {
+            if anyDashboardSignalAt == nil, hasDashboardPageSignal {
                 anyDashboardSignalAt = Date()
             }
             if codeReview != nil, usageBreakdown.isEmpty,
@@ -225,7 +253,8 @@ public struct OpenAIDashboardFetcher {
                 log("credits purchase url: \(purchaseURL)")
             }
             if events.isEmpty,
-               codeReview != nil || !usageBreakdown.isEmpty || hasUsageLimits || creditsRemaining != nil
+               hasReturnableData,
+               hasDashboardPageSignal
             {
                 log(
                     "credits header present=\(scrape.creditsHeaderPresent) " +
@@ -255,9 +284,7 @@ public struct OpenAIDashboardFetcher {
                 }
             }
 
-            if codeReview != nil || !events.isEmpty || !usageBreakdown
-                .isEmpty || hasUsageLimits || creditsRemaining != nil
-            {
+            if hasReturnableData, hasDashboardPageSignal {
                 // The usage breakdown chart is hydrated asynchronously. When code review is already present,
                 // give it a moment to populate so the menu can show it.
                 if codeReview != nil, usageBreakdown.isEmpty {
@@ -268,6 +295,7 @@ public struct OpenAIDashboardFetcher {
                     }
                 }
                 return Self.makeDashboardSnapshot(.init(
+                    signedInEmail: signedInEmail,
                     scrape: scrape,
                     codeReview: codeReview,
                     codeReviewLimit: codeReviewLimit,
@@ -345,6 +373,23 @@ public struct OpenAIDashboardFetcher {
         return false
     }
 
+    nonisolated static func hasReturnableDashboardData(
+        codeReview: Double?,
+        events: [CreditEvent],
+        usageBreakdown: [OpenAIDashboardDailyBreakdown],
+        hasUsageLimits: Bool,
+        creditsRemaining: Double?) -> Bool
+    {
+        codeReview != nil || !events.isEmpty || !usageBreakdown.isEmpty || hasUsageLimits || creditsRemaining != nil
+    }
+
+    nonisolated static func hasAnyDashboardSignal(
+        hasReturnableData: Bool,
+        creditsHeaderPresent: Bool) -> Bool
+    {
+        hasReturnableData || creditsHeaderPresent
+    }
+
     public func clearSessionData(accountEmail: String?) async {
         let store = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: accountEmail)
         OpenAIDashboardWebViewCache.shared.evict(websiteDataStore: store)
@@ -389,7 +434,7 @@ public struct OpenAIDashboardFetcher {
             if let href = scrape.href, !Self.isUsageRoute(href) {
                 usageRouteSeenAt = nil
                 dashboardSignalSeenAt = nil
-                _ = webView.load(URLRequest(url: self.usageURL))
+                _ = webView.load(Self.usageURLRequest(url: self.usageURL))
                 try? await Task.sleep(for: .milliseconds(500))
                 continue
             }
@@ -508,7 +553,8 @@ public struct OpenAIDashboardFetcher {
         if let raw = dict["usageBreakdownJSON"] as? String, !raw.isEmpty {
             do {
                 let decoder = JSONDecoder()
-                usageBreakdown = try decoder.decode([OpenAIDashboardDailyBreakdown].self, from: Data(raw.utf8))
+                let decoded = try decoder.decode([OpenAIDashboardDailyBreakdown].self, from: Data(raw.utf8))
+                usageBreakdown = OpenAIDashboardDailyBreakdown.removingSkillUsageServices(from: decoded)
             } catch {
                 // Best-effort parse; ignore errors to avoid blocking other dashboard data.
                 usageBreakdown = []
@@ -550,6 +596,26 @@ public struct OpenAIDashboardFetcher {
             didScrollToCredits: (dict["didScrollToCredits"] as? Bool) ?? false)
     }
 
+    private static func throwIfBlockingScrapeState(
+        _ scrape: ScrapeResult,
+        debugDumpHTML: Bool,
+        logger: (String) -> Void) throws
+    {
+        if scrape.loginRequired {
+            if debugDumpHTML, let html = scrape.bodyHTML {
+                self.writeDebugArtifacts(html: html, bodyText: scrape.bodyText, logger: logger)
+            }
+            throw FetchError.loginRequired
+        }
+
+        if scrape.cloudflareInterstitial {
+            if debugDumpHTML, let html = scrape.bodyHTML {
+                self.writeDebugArtifacts(html: html, bodyText: scrape.bodyText, logger: logger)
+            }
+            throw FetchError.noDashboardData(body: "Cloudflare challenge detected in WebView.")
+        }
+    }
+
     private func makeWebView(
         websiteDataStore: WKWebsiteDataStore,
         logger: ((String) -> Void)?,
@@ -585,6 +651,180 @@ public struct OpenAIDashboardFetcher {
             || path.hasSuffix("codex/cloud/settings/usage")
             || path.hasSuffix("codex/settings/analytics")
             || path.hasSuffix("codex/cloud/settings/analytics")
+    }
+
+    nonisolated static func usageURLRequest(url: URL) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.setValue(Self.dashboardAcceptLanguage, forHTTPHeaderField: "Accept-Language")
+        return request
+    }
+
+    nonisolated static func dashboardUsageAPIRequest(cookieHeader: String) -> URLRequest {
+        var request = URLRequest(url: Self.dashboardUsageAPIURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 4
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(Self.dashboardAcceptLanguage, forHTTPHeaderField: "Accept-Language")
+        request.setValue("CodexBar", forHTTPHeaderField: "User-Agent")
+        return request
+    }
+
+    nonisolated static func dashboardIdentityAPIRequest(url: URL, cookieHeader: String) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 2
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue(Self.dashboardAcceptLanguage, forHTTPHeaderField: "Accept-Language")
+        request.setValue("CodexBar", forHTTPHeaderField: "User-Agent")
+        return request
+    }
+
+    nonisolated static func dashboardAPIData(from response: CodexUsageResponse) -> DashboardAPIData {
+        DashboardAPIData(
+            primaryLimit: self.rateWindow(from: response.rateLimit?.primaryWindow),
+            secondaryLimit: self.rateWindow(from: response.rateLimit?.secondaryWindow),
+            creditsRemaining: response.credits?.balance,
+            accountPlan: response.planType?.rawValue)
+    }
+
+    private static func fetchDashboardAPIPreflight(
+        websiteDataStore: WKWebsiteDataStore,
+        logger: @escaping (String) -> Void)
+        async -> (apiData: DashboardAPIData?, verifiedSignedInEmail: String?)
+    {
+        let cookieHeader = await self.chatGPTCookieHeader(in: websiteDataStore)
+        let apiData = await self.fetchDashboardUsageAPI(cookieHeader: cookieHeader, logger: logger)
+        let verifiedEmail: String? = if apiData?.hasUsageData == true {
+            await self.fetchSignedInEmailFromAPI(cookieHeader: cookieHeader, logger: logger)
+        } else {
+            nil
+        }
+
+        if apiData?.hasUsageData == true, verifiedEmail != nil {
+            logger("usage api supplied verified dashboard data; continuing WebView scrape")
+        }
+        return (apiData, verifiedEmail)
+    }
+
+    private static func fetchDashboardUsageAPI(
+        websiteDataStore: WKWebsiteDataStore,
+        logger: @escaping (String) -> Void) async -> DashboardAPIData?
+    {
+        let cookieHeader = await self.chatGPTCookieHeader(in: websiteDataStore)
+        return await self.fetchDashboardUsageAPI(cookieHeader: cookieHeader, logger: logger)
+    }
+
+    private static func fetchDashboardUsageAPI(
+        cookieHeader: String,
+        logger: @escaping (String) -> Void) async -> DashboardAPIData?
+    {
+        guard !cookieHeader.isEmpty else { return nil }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(
+                for: self.dashboardUsageAPIRequest(cookieHeader: cookieHeader))
+            let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+            logger("usage api status=\(status)")
+            guard status >= 200, status < 300 else { return nil }
+            let decoded = try JSONDecoder().decode(CodexUsageResponse.self, from: data)
+            let result = self.dashboardAPIData(from: decoded)
+            if result.hasUsageData {
+                logger("usage api supplied language-independent rate/credit data")
+            }
+            return result
+        } catch {
+            logger("usage api unavailable: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private static func fetchSignedInEmailFromAPI(
+        cookieHeader: String,
+        logger: @escaping (String) -> Void) async -> String?
+    {
+        guard !cookieHeader.isEmpty else { return nil }
+
+        let endpoints = [
+            URL(string: "https://chatgpt.com/backend-api/me"),
+            URL(string: "https://chatgpt.com/api/auth/session"),
+        ].compactMap(\.self)
+
+        for url in endpoints {
+            do {
+                let (data, response) = try await URLSession.shared.data(
+                    for: self.dashboardIdentityAPIRequest(url: url, cookieHeader: cookieHeader))
+                let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+                logger("identity api \(url.path) status=\(status)")
+                guard status >= 200, status < 300 else { continue }
+                if let email = self.findFirstEmail(inJSONData: data) {
+                    return email.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+            } catch {
+                logger("identity api \(url.path) unavailable: \(error.localizedDescription)")
+            }
+        }
+
+        return nil
+    }
+
+    private static func chatGPTCookieHeader(in store: WKWebsiteDataStore) async -> String {
+        let cookies = await withCheckedContinuation { continuation in
+            store.httpCookieStore.getAllCookies { cookies in
+                continuation.resume(returning: cookies)
+            }
+        }
+
+        return cookies
+            .filter { $0.domain.lowercased().contains("chatgpt.com") }
+            .map { "\($0.name)=\($0.value)" }
+            .joined(separator: "; ")
+    }
+
+    nonisolated static func findFirstEmail(inJSONData data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data, options: []) else { return nil }
+        var queue: [Any] = [json]
+        var seen = 0
+        while !queue.isEmpty, seen < 2000 {
+            let current = queue.removeFirst()
+            seen += 1
+            if let string = current as? String, string.contains("@") {
+                return string
+            }
+            if let dictionary = current as? [String: Any] {
+                for (key, value) in dictionary {
+                    if key.lowercased() == "email",
+                       let string = value as? String,
+                       string.contains("@")
+                    {
+                        return string
+                    }
+                    queue.append(value)
+                }
+            } else if let array = current as? [Any] {
+                queue.append(contentsOf: array)
+            }
+        }
+        return nil
+    }
+
+    private nonisolated static func rateWindow(from window: CodexUsageResponse.WindowSnapshot?) -> RateWindow? {
+        guard let window else { return nil }
+        let resetDate = Date(timeIntervalSince1970: TimeInterval(window.resetAt))
+        return RateWindow(
+            usedPercent: Double(window.usedPercent),
+            windowMinutes: window.limitWindowSeconds / 60,
+            resetsAt: resetDate,
+            resetDescription: UsageFormatter.resetDescription(from: resetDate))
+    }
+
+    private nonisolated static func firstNonEmpty(_ candidates: String?...) -> String? {
+        for candidate in candidates {
+            let trimmed = candidate?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed?.isEmpty == false { return trimmed }
+        }
+        return nil
     }
 
     private static func writeDebugArtifacts(html: String, bodyText: String?, logger: (String) -> Void) {

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardParser.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardParser.swift
@@ -153,11 +153,49 @@ public enum OpenAIDashboardParser {
     }
 
     private static func parseCreditsUsed(_ text: String) -> Double {
-        let cleaned = text
-            .replacingOccurrences(of: ",", with: "")
-            .replacingOccurrences(of: "credits", with: "", options: .caseInsensitive)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return Double(cleaned) ?? 0
+        guard let raw = self.firstNumberToken(in: text) else { return 0 }
+        let token = raw
+            .replacingOccurrences(of: "\u{00A0}", with: "")
+            .replacingOccurrences(of: "\u{202F}", with: "")
+            .replacingOccurrences(of: " ", with: "")
+        let hasComma = token.contains(",")
+        let hasDot = token.contains(".")
+        if hasComma, hasDot {
+            return TextParsing.firstNumber(pattern: #"([0-9][0-9.,\s\p{Zs}]*)"#, text: token) ?? 0
+        }
+        if hasComma {
+            if self.usesLocalizedDecimalCommaCreditLabel(text) {
+                return Double(token.replacingOccurrences(of: ",", with: ".")) ?? 0
+            }
+            if token.range(of: #"^\d{1,3}(,\d{3})+$"#, options: .regularExpression) != nil {
+                return Double(token.replacingOccurrences(of: ",", with: "")) ?? 0
+            }
+            return Double(token.replacingOccurrences(of: ",", with: ".")) ?? 0
+        }
+        return Double(token) ?? 0
+    }
+
+    private static func usesLocalizedDecimalCommaCreditLabel(_ text: String) -> Bool {
+        text
+            .lowercased()
+            .contains("crédit")
+    }
+
+    private static func firstNumberToken(in text: String) -> String? {
+        guard let regex = try? NSRegularExpression(
+            pattern: #"([0-9][0-9.,\s\p{Zs}]*)"#,
+            options: [])
+        else {
+            return nil
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range),
+              match.numberOfRanges >= 2,
+              let tokenRange = Range(match.range(at: 1), in: text)
+        else {
+            return nil
+        }
+        return String(text[tokenRange])
     }
 
     // MARK: - Private
@@ -294,6 +332,7 @@ public enum OpenAIDashboardParser {
     private static func isFiveHourLimitLine(_ line: String) -> Bool {
         let lower = line.lowercased()
         if lower.contains("5h") { return true }
+        if lower.range(of: #"\b5\s*h\b"#, options: .regularExpression) != nil { return true }
         if lower.contains("5-hour") { return true }
         if lower.contains("5 hour") { return true }
         return false
@@ -305,6 +344,7 @@ public enum OpenAIDashboardParser {
         if lower.contains("7-day") { return true }
         if lower.contains("7 day") { return true }
         if lower.contains("7d") { return true }
+        if lower.range(of: #"\b7\s*d\b"#, options: .regularExpression) != nil { return true }
         return false
     }
 

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardScrapeScript.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardScrapeScript.swift
@@ -227,9 +227,14 @@ let openAIDashboardScrapeScript = """
         }
         return null;
       };
+      const isSkillUsageServiceKey = (raw) => {
+        const key = raw === null || raw === undefined ? '' : String(raw).trim().toLowerCase();
+        return key.startsWith('skillusage:');
+      };
       const displayNameForUsageServiceKey = (raw) => {
         const key = raw === null || raw === undefined ? '' : String(raw).trim();
         if (!key) return key;
+        if (isSkillUsageServiceKey(key)) return null;
         if (key.toUpperCase() === key && key.length <= 6) return key;
         const lower = key.toLowerCase();
         if (lower === 'cli') return 'CLI';
@@ -237,20 +242,46 @@ let openAIDashboardScrapeScript = """
         const words = lower.replace(/[_-]+/g, ' ').split(' ').filter(Boolean);
         return words.map(w => w.length <= 2 ? w.toUpperCase() : w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
       };
-      const usageBreakdownJSON = (() => {
-        try {
-          if (window.__codexbarUsageBreakdownJSON) return window.__codexbarUsageBreakdownJSON;
-
-          const sections = Array.from(document.querySelectorAll('section'));
-          const usageSection = sections.find(s => {
-            const h2 = s.querySelector('h2');
-            return h2 && textOf(h2).toLowerCase().startsWith('usage breakdown');
-          });
-          if (!usageSection) return null;
-
-          const legendMap = {};
+      const isLikelyCodexUsageService = (raw) => {
+        const service = raw === null || raw === undefined ? '' : String(raw).trim().toLowerCase();
+        return (
+          service === 'cli' ||
+          service === 'desktop' ||
+          service === 'desktop app' ||
+          service === 'vscode' ||
+          service === 'vs code' ||
+          service === 'unknown' ||
+          (service.includes('github') && service.includes('review'))
+        );
+      };
+      const usageChartRootForPath = (path) => {
+        if (!path || !path.closest) return null;
+        return (
+          path.closest('.recharts-wrapper') ||
+          path.closest('svg.recharts-surface') ||
+          path.closest('section') ||
+          path.parentElement ||
+          null
+        );
+      };
+      const uniqueUsageChartRoots = (paths) => {
+        const roots = [];
+        for (const path of paths) {
+          const root = usageChartRootForPath(path);
+          if (root && !roots.includes(root)) roots.push(root);
+        }
+        return roots;
+      };
+      const legendMapForUsageChartRoot = (root) => {
+        const legendMap = {};
+        const scopes = [
+          root,
+          root && root.parentElement,
+          root && root.closest ? root.closest('section') : null
+        ].filter(Boolean);
+        for (const scope of scopes) {
           try {
-            const legendItems = Array.from(usageSection.querySelectorAll('div[title]'));
+            const legendItems = Array.from(scope.querySelectorAll('div[title]'));
             for (const item of legendItems) {
               const title = item.getAttribute('title') ? String(item.getAttribute('title')).trim() : '';
               const square = item.querySelector('div[style*=\"background-color\"]');
@@ -261,11 +292,90 @@ let openAIDashboardScrapeScript = """
               if (title && hex) legendMap[hex] = title;
             }
           } catch {}
+          if (Object.keys(legendMap).length > 0) break;
+        }
+        return legendMap;
+      };
+      const parseUsageBreakdownFromChartPaths = (paths, legendMap) => {
+        const totalsByDay = {}; // day -> service -> value
+        const addValue = (day, service, value) => {
+          if (!day || !service || isSkillUsageServiceKey(service)) return false;
+          if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return false;
+          if (!totalsByDay[day]) totalsByDay[day] = {};
+          totalsByDay[day][service] = (totalsByDay[day][service] || 0) + value;
+          return true;
+        };
+        let pointCount = 0;
+        for (const path of paths) {
+          const meta = barMetaFromElement(path) || barMetaFromElement(path.parentElement) || null;
+          if (!meta) continue;
 
-          const totalsByDay = {}; // day -> service -> value
-          const paths = Array.from(usageSection.querySelectorAll('g.recharts-bar-rectangle path.recharts-rectangle'));
+          const payload = meta.payload || null;
+          const day = dayKeyFromPayload(payload);
+          if (!day) continue;
+
+          const valuesObj = (payload && payload.values && typeof payload.values === 'object') ? payload.values : null;
+          if (valuesObj) {
+            for (const [k, v] of Object.entries(valuesObj)) {
+              const service = displayNameForUsageServiceKey(k);
+              if (addValue(day, service, v)) pointCount++;
+            }
+            continue;
+          }
+
+          let value = null;
+          if (typeof meta.value === 'number' && Number.isFinite(meta.value)) value = meta.value;
+          if (value === null && typeof meta.value === 'string') {
+            const v = parseFloat(meta.value.replace(/,/g, ''));
+            if (Number.isFinite(v)) value = v;
+          }
+          if (value === null) continue;
+
+          const fill = parseHexColor(meta.fill || path.getAttribute('fill'));
+          const service =
+            (fill && legendMap[fill]) ||
+            (typeof meta.name === 'string' && meta.name) ||
+            null;
+          if (addValue(day, service, value)) pointCount++;
+        }
+
+        const dayKeys = Object.keys(totalsByDay)
+          .filter(day => Object.keys(totalsByDay[day] || {}).length > 0)
+          .sort((a, b) => b.localeCompare(a))
+          .slice(0, 30);
+        const breakdown = dayKeys.map(day => {
+          const servicesMap = totalsByDay[day] || {};
+          const services = Object.keys(servicesMap).map(service => ({
+            service,
+            creditsUsed: servicesMap[service]
+          })).sort((a, b) => {
+            if (a.creditsUsed === b.creditsUsed) return a.service.localeCompare(b.service);
+            return b.creditsUsed - a.creditsUsed;
+          });
+          const totalCreditsUsed = services.reduce((sum, s) => sum + (Number(s.creditsUsed) || 0), 0);
+          return { day, services, totalCreditsUsed };
+        });
+        const services = Array.from(new Set(breakdown.flatMap(day => day.services.map(service => service.service))));
+        const totalCreditsUsed = breakdown.reduce((sum, day) => sum + (Number(day.totalCreditsUsed) || 0), 0);
+        const likelyCodexServiceCount = services.filter(isLikelyCodexUsageService).length;
+        return {
+          breakdown,
+          pointCount,
+          services,
+          totalCreditsUsed,
+          likelyCodexServiceCount,
+          score: likelyCodexServiceCount * 1000 + services.length * 100 + pointCount + totalCreditsUsed / 1000
+        };
+      };
+      const usageBreakdownJSON = (() => {
+        try {
+          if (window.__codexbarUsageBreakdownJSON) return window.__codexbarUsageBreakdownJSON;
+
+          const paths = Array.from(document.querySelectorAll('g.recharts-bar-rectangle path.recharts-rectangle'));
           let debug = {
             pathCount: paths.length,
+            chartCount: 0,
+            candidateSummaries: [],
             sampleReactKeys: null,
             sampleMetaKeys: null,
             samplePayloadKeys: null,
@@ -292,59 +402,29 @@ let openAIDashboardScrapeScript = """
               }
             }
           } catch {}
-          for (const path of paths) {
-            const meta = barMetaFromElement(path) || barMetaFromElement(path.parentElement) || null;
-            if (!meta) continue;
 
-            const payload = meta.payload || null;
-            const day = dayKeyFromPayload(payload);
-            if (!day) continue;
+          const roots = uniqueUsageChartRoots(paths);
+          debug.chartCount = roots.length;
+          const candidates = roots.map(root => {
+            const chartPaths = paths.filter(path => usageChartRootForPath(path) === root);
+            const parsed = parseUsageBreakdownFromChartPaths(chartPaths, legendMapForUsageChartRoot(root));
+            return {
+              root,
+              pathCount: chartPaths.length,
+              ...parsed
+            };
+          }).filter(candidate => candidate.breakdown.length > 0);
+          candidates.sort((a, b) => b.score - a.score);
+          debug.candidateSummaries = candidates.slice(0, 6).map(candidate => ({
+            pathCount: candidate.pathCount,
+            dayCount: candidate.breakdown.length,
+            pointCount: candidate.pointCount,
+            serviceCount: candidate.services.length,
+            likelyCodexServiceCount: candidate.likelyCodexServiceCount,
+            services: candidate.services.slice(0, 8)
+          }));
 
-            const valuesObj = (payload && payload.values && typeof payload.values === 'object') ? payload.values : null;
-            if (valuesObj) {
-              if (!totalsByDay[day]) totalsByDay[day] = {};
-              for (const [k, v] of Object.entries(valuesObj)) {
-                if (typeof v !== 'number' || !Number.isFinite(v) || v <= 0) continue;
-                const service = displayNameForUsageServiceKey(k);
-                if (!service) continue;
-                totalsByDay[day][service] = (totalsByDay[day][service] || 0) + v;
-              }
-              continue;
-            }
-
-            let value = null;
-            if (typeof meta.value === 'number' && Number.isFinite(meta.value)) value = meta.value;
-            if (value === null && typeof meta.value === 'string') {
-              const v = parseFloat(meta.value.replace(/,/g, ''));
-              if (Number.isFinite(v)) value = v;
-            }
-            if (value === null) continue;
-
-            const fill = parseHexColor(meta.fill || path.getAttribute('fill'));
-            const service =
-              (fill && legendMap[fill]) ||
-              (typeof meta.name === 'string' && meta.name) ||
-              null;
-            if (!service) continue;
-
-            if (!totalsByDay[day]) totalsByDay[day] = {};
-            totalsByDay[day][service] = (totalsByDay[day][service] || 0) + value;
-          }
-
-          const dayKeys = Object.keys(totalsByDay).sort((a, b) => b.localeCompare(a)).slice(0, 30);
-          const breakdown = dayKeys.map(day => {
-            const servicesMap = totalsByDay[day] || {};
-            const services = Object.keys(servicesMap).map(service => ({
-              service,
-              creditsUsed: servicesMap[service]
-            })).sort((a, b) => {
-              if (a.creditsUsed === b.creditsUsed) return a.service.localeCompare(b.service);
-              return b.creditsUsed - a.creditsUsed;
-            });
-            const totalCreditsUsed = services.reduce((sum, s) => sum + (Number(s.creditsUsed) || 0), 0);
-            return { day, services, totalCreditsUsed };
-          });
-
+          const breakdown = candidates[0] ? candidates[0].breakdown : [];
           const json = (breakdown.length > 0) ? JSON.stringify(breakdown) : null;
           window.__codexbarUsageBreakdownJSON = json;
           window.__codexbarUsageBreakdownDebug = json ? null : JSON.stringify(debug);
@@ -395,6 +475,16 @@ let openAIDashboardScrapeScript = """
       let didScrollToCredits = false;
       let rows = [];
       try {
+        const looksLikeCreditsEventRow = (cells) => {
+          if (!cells || cells.length < 3) return false;
+          const first = String(cells[0] || '');
+          const amount = String(cells[2] || '');
+          return /\\d{4}|\\d{1,2}[\\/.\\-]\\d{1,2}/.test(first) && /\\d/.test(amount);
+        };
+        const allTableRows = () => Array.from(document.querySelectorAll('tbody tr')).map(tr => {
+          const cells = Array.from(tr.querySelectorAll('td')).map(td => textOf(td));
+          return cells;
+        }).filter(looksLikeCreditsEventRow);
         const headings = Array.from(document.querySelectorAll('h1,h2,h3'));
         const header = headings.find(h => textOf(h).toLowerCase() === 'credits usage history');
         if (header) {
@@ -411,6 +501,9 @@ let openAIDashboardScrapeScript = """
             const cells = Array.from(tr.querySelectorAll('td')).map(td => textOf(td));
             return cells;
           }).filter(r => r.length >= 3);
+          if (rows.length === 0) {
+            rows = allTableRows();
+          }
           if (rows.length === 0 && !window.__codexbarDidScrollToCredits) {
             window.__codexbarDidScrollToCredits = true;
             // If the table is virtualized/lazy-loaded, we need to scroll to trigger rendering even if the
@@ -422,6 +515,13 @@ let openAIDashboardScrapeScript = """
             didScrollToCredits = true;
           }
         } else if (rows.length === 0 && !window.__codexbarDidScrollToCredits && scrollHeight > viewportHeight * 1.5) {
+          rows = allTableRows();
+          if (rows.length > 0) {
+            creditsHeaderPresent = true;
+            creditsHeaderInViewport = true;
+          }
+        }
+        if (rows.length === 0 && !window.__codexbarDidScrollToCredits && scrollHeight > viewportHeight * 1.5) {
           // The credits history section often isn't part of the DOM until you scroll down. Nudge the page
           // once so subsequent scrapes can find the header and rows.
           window.__codexbarDidScrollToCredits = true;

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
@@ -98,6 +98,22 @@ final class OpenAIDashboardWebViewCache {
       }
     })();
     """
+    private let preferredLanguageScript = """
+    (() => {
+      const define = (target, name, value) => {
+        try {
+          Object.defineProperty(target, name, {
+            get: () => value,
+            configurable: true
+          });
+        } catch {}
+      };
+      define(Navigator.prototype, 'language', 'en-US');
+      define(Navigator.prototype, 'languages', ['en-US', 'en']);
+      define(navigator, 'language', 'en-US');
+      define(navigator, 'languages', ['en-US', 'en']);
+    })();
+    """
 
     private func releaseCachedEntry(_ entry: Entry, preserveLoadedPage: Bool) {
         entry.isBusy = false
@@ -431,6 +447,12 @@ final class OpenAIDashboardWebViewCache {
     private func makeWebView(websiteDataStore: WKWebsiteDataStore) -> (WKWebView, OffscreenWebViewHost) {
         let config = WKWebViewConfiguration()
         config.websiteDataStore = websiteDataStore
+        let userContentController = WKUserContentController()
+        userContentController.addUserScript(WKUserScript(
+            source: self.preferredLanguageScript,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: false))
+        config.userContentController = userContentController
         if #available(macOS 14.0, *) {
             config.preferences.inactiveSchedulingPolicy = .suspend
         }
@@ -471,7 +493,7 @@ final class OpenAIDashboardWebViewCache {
             webView.navigationDelegate = delegate
             webView.codexNavigationDelegate = delegate
             delegate.armTimeout(seconds: timeout)
-            _ = webView.load(URLRequest(url: usageURL))
+            _ = webView.load(OpenAIDashboardFetcher.usageURLRequest(url: usageURL))
         }
     }
 

--- a/Tests/CodexBarTests/CodexManagedOpenAIWebRefreshTests.swift
+++ b/Tests/CodexBarTests/CodexManagedOpenAIWebRefreshTests.swift
@@ -112,6 +112,68 @@ struct CodexManagedOpenAIWebRefreshTests {
     }
 
     @Test
+    func `navigation timeout imports cookies and retries dashboard refresh`() async {
+        let settings = self.makeSettingsStore(suite: "CodexManagedOpenAIWebRefreshTests-timeout-import-retry")
+        let managedAccount = ManagedCodexAccount(
+            id: UUID(),
+            email: "managed@example.com",
+            managedHomePath: "/tmp/managed-codex-home",
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1)
+        settings._test_activeManagedCodexAccount = managedAccount
+        settings.codexActiveSource = .managedAccount(id: managedAccount.id)
+        defer { settings._test_activeManagedCodexAccount = nil }
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing)
+        let blocker = BlockingManagedOpenAIDashboardLoader()
+        let importTracker = OpenAIDashboardImportCallTracker()
+        store._test_openAIDashboardLoaderOverride = { _, _, _ in
+            try await blocker.awaitResult()
+        }
+        defer { store._test_openAIDashboardLoaderOverride = nil }
+        store._test_openAIDashboardCookieImportOverride = { targetEmail, _, _, _, _ in
+            _ = await importTracker.recordCall()
+            return OpenAIDashboardBrowserCookieImporter.ImportResult(
+                sourceLabel: "Chrome",
+                cookieCount: 2,
+                signedInEmail: targetEmail,
+                matchesCodexEmail: true)
+        }
+        defer { store._test_openAIDashboardCookieImportOverride = nil }
+
+        let expectedGuard = store.currentCodexOpenAIWebRefreshGuard()
+        let refreshTask = Task {
+            await store.refreshOpenAIDashboardIfNeeded(force: true, expectedGuard: expectedGuard)
+        }
+        await blocker.waitUntilStarted(count: 1)
+
+        await blocker.resumeNext(with: .failure(URLError(.timedOut)))
+        await importTracker.waitUntilCalls(count: 1)
+        await blocker.waitUntilStarted(count: 2)
+        await blocker.resumeNext(with: .success(OpenAIDashboardSnapshot(
+            signedInEmail: managedAccount.email,
+            codeReviewRemainingPercent: 90,
+            creditEvents: [],
+            dailyBreakdown: [],
+            usageBreakdown: [],
+            creditsPurchaseURL: nil,
+            creditsRemaining: 25,
+            accountPlan: "Pro",
+            updatedAt: Date())))
+
+        await refreshTask.value
+
+        #expect(await blocker.startedCount() == 2)
+        #expect(store.openAIDashboard?.creditsRemaining == 25)
+        #expect(store.lastOpenAIDashboardError == nil)
+    }
+
+    @Test
     func `reset open A I web state blocks stale in flight dashboard completion`() async {
         let settings = self.makeSettingsStore(suite: "CodexManagedOpenAIWebRefreshTests-reset-invalidates-task")
         let managedAccount = ManagedCodexAccount(
@@ -224,6 +286,8 @@ struct CodexManagedOpenAIWebRefreshTests {
 
     @Test
     func `post import retry timeout exceeds normal retry timeout`() {
+        #expect(UsageStore.openAIWebDashboardFetchTimeout(didImportCookies: false) == 25)
+        #expect(UsageStore.openAIWebDashboardFetchTimeout(didImportCookies: true) == 25)
         #expect(UsageStore.openAIWebRetryDashboardFetchTimeout(afterCookieImport: false) == 8)
         #expect(UsageStore.openAIWebRetryDashboardFetchTimeout(afterCookieImport: true) == 25)
     }

--- a/Tests/CodexBarTests/CodexUserFacingErrorTests.swift
+++ b/Tests/CodexBarTests/CodexUserFacingErrorTests.swift
@@ -75,6 +75,28 @@ struct CodexUserFacingErrorTests {
     }
 
     @Test
+    func `open A I web timeout becomes retry guidance`() {
+        let store = self.makeUsageStore(suite: "CodexUserFacingErrorTests-openai-web-timeout")
+        store.lastOpenAIDashboardError = "The operation couldn’t be completed. (NSURLErrorDomain error -1001.)"
+
+        #expect(
+            store.userFacingLastOpenAIDashboardError ==
+                "OpenAI web refresh timed out. Refresh OpenAI cookies and try again.")
+    }
+
+    @Test
+    func `open A I web network error becomes connection guidance`() {
+        let store = self.makeUsageStore(suite: "CodexUserFacingErrorTests-openai-web-network")
+        store.lastOpenAIDashboardError = "The operation couldn’t be completed. (NSURLErrorDomain error -1004.)"
+        let expected = [
+            "OpenAI web refresh hit a network error.",
+            "Check your connection, then refresh OpenAI cookies and try again.",
+        ].joined(separator: " ")
+
+        #expect(store.userFacingLastOpenAIDashboardError == expected)
+    }
+
+    @Test
     func `non codex providers keep raw errors`() {
         let store = self.makeUsageStore(suite: "CodexUserFacingErrorTests-non-codex")
         store.errors[.claude] = "Claude probe failed with debug detail"

--- a/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
@@ -216,4 +216,81 @@ struct OpenAIDashboardFetcherCreditsWaitTests {
         #expect(!OpenAIDashboardFetcher.isUsageRoute("https://chatgpt.com/codex"))
         #expect(!OpenAIDashboardFetcher.isUsageRoute(nil))
     }
+
+    @Test
+    func `dashboard requests prefer English localization`() throws {
+        let url = try #require(URL(string: "https://chatgpt.com/codex/cloud/settings/analytics#usage"))
+        let request = OpenAIDashboardFetcher.usageURLRequest(url: url)
+        #expect(request.value(forHTTPHeaderField: "Accept-Language") == "en-US,en;q=0.9")
+    }
+
+    @Test
+    func `usage api request carries cookies and English localization`() {
+        let request = OpenAIDashboardFetcher.dashboardUsageAPIRequest(cookieHeader: "a=b")
+        #expect(request.url?.absoluteString == "https://chatgpt.com/backend-api/wham/usage")
+        #expect(request.value(forHTTPHeaderField: "Cookie") == "a=b")
+        #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+        #expect(request.value(forHTTPHeaderField: "Accept-Language") == "en-US,en;q=0.9")
+    }
+
+    @Test
+    func `identity api request carries cookies and English localization`() throws {
+        let url = try #require(URL(string: "https://chatgpt.com/backend-api/me"))
+        let request = OpenAIDashboardFetcher.dashboardIdentityAPIRequest(url: url, cookieHeader: "a=b")
+
+        #expect(request.url?.absoluteString == "https://chatgpt.com/backend-api/me")
+        #expect(request.value(forHTTPHeaderField: "Cookie") == "a=b")
+        #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+        #expect(request.value(forHTTPHeaderField: "Accept-Language") == "en-US,en;q=0.9")
+    }
+
+    @Test
+    func `usage api data maps language independent rate limits and credits`() throws {
+        let json = """
+        {
+          "plan_type": "pro",
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 12,
+              "reset_at": 1700003600,
+              "limit_window_seconds": 18000
+            },
+            "secondary_window": {
+              "used_percent": 34,
+              "reset_at": 1700604800,
+              "limit_window_seconds": 604800
+            }
+          },
+          "credits": {
+            "has_credits": true,
+            "unlimited": false,
+            "balance": 42.5
+          }
+        }
+        """
+        let response = try CodexOAuthUsageFetcher._decodeUsageResponseForTesting(Data(json.utf8))
+        let data = OpenAIDashboardFetcher.dashboardAPIData(from: response)
+
+        #expect(data.primaryLimit?.usedPercent == 12)
+        #expect(data.primaryLimit?.windowMinutes == 300)
+        #expect(data.secondaryLimit?.usedPercent == 34)
+        #expect(data.secondaryLimit?.windowMinutes == 10080)
+        #expect(data.creditsRemaining == 42.5)
+        #expect(data.accountPlan == "pro")
+        #expect(data.hasUsageData)
+    }
+
+    @Test
+    func `find first email searches nested api payloads`() {
+        let json = """
+        {
+          "accounts": [
+            { "profile": { "name": "Test" } },
+            { "profile": { "email": "nested@example.com" } }
+          ]
+        }
+        """
+
+        #expect(OpenAIDashboardFetcher.findFirstEmail(inJSONData: Data(json.utf8)) == "nested@example.com")
+    }
 }

--- a/Tests/CodexBarTests/OpenAIDashboardModelsTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardModelsTests.swift
@@ -1,0 +1,94 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct OpenAIDashboardModelsTests {
+    @Test
+    func `removes skill usage services from usage breakdown`() {
+        let breakdown = [
+            OpenAIDashboardDailyBreakdown(
+                day: "2026-04-30",
+                services: [
+                    OpenAIDashboardServiceUsage(service: "Desktop App", creditsUsed: 10),
+                    OpenAIDashboardServiceUsage(service: "Skillusage:imagegen", creditsUsed: 7),
+                    OpenAIDashboardServiceUsage(service: " skillusage:github:github ", creditsUsed: 2),
+                ],
+                totalCreditsUsed: 19),
+            OpenAIDashboardDailyBreakdown(
+                day: "2026-04-29",
+                services: [
+                    OpenAIDashboardServiceUsage(service: "Skillusage:deep Research", creditsUsed: 3),
+                ],
+                totalCreditsUsed: 3),
+        ]
+
+        let filtered = OpenAIDashboardDailyBreakdown.removingSkillUsageServices(from: breakdown)
+
+        #expect(filtered == [
+            OpenAIDashboardDailyBreakdown(
+                day: "2026-04-30",
+                services: [
+                    OpenAIDashboardServiceUsage(service: "Desktop App", creditsUsed: 10),
+                ],
+                totalCreditsUsed: 10),
+        ])
+    }
+
+    @Test
+    func `snapshot initializer sanitizes usage breakdown`() {
+        let snapshot = OpenAIDashboardSnapshot(
+            signedInEmail: "codex@example.com",
+            codeReviewRemainingPercent: nil,
+            creditEvents: [],
+            dailyBreakdown: [],
+            usageBreakdown: [
+                OpenAIDashboardDailyBreakdown(
+                    day: "2026-04-30",
+                    services: [
+                        OpenAIDashboardServiceUsage(service: "CLI", creditsUsed: 4),
+                        OpenAIDashboardServiceUsage(service: "Skillusage:pdf Renderer", creditsUsed: 6),
+                    ],
+                    totalCreditsUsed: 10),
+            ],
+            creditsPurchaseURL: nil,
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000))
+
+        #expect(snapshot.usageBreakdown == [
+            OpenAIDashboardDailyBreakdown(
+                day: "2026-04-30",
+                services: [
+                    OpenAIDashboardServiceUsage(service: "CLI", creditsUsed: 4),
+                ],
+                totalCreditsUsed: 4),
+        ])
+    }
+
+    @Test
+    func `snapshot decoder drops empty zero usage buckets`() throws {
+        let json = """
+        {
+          "signedInEmail": "codex@example.com",
+          "codeReviewRemainingPercent": null,
+          "creditEvents": [],
+          "dailyBreakdown": [],
+          "usageBreakdown": [
+            { "day": "2026-04-30", "services": [], "totalCreditsUsed": 0 },
+            { "day": "2026-04-29", "services": [], "totalCreditsUsed": 4 }
+          ],
+          "creditsPurchaseURL": null,
+          "updatedAt": "2026-04-30T19:27:07Z"
+        }
+        """
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let snapshot = try decoder.decode(OpenAIDashboardSnapshot.self, from: Data(json.utf8))
+
+        #expect(snapshot.usageBreakdown == [
+            OpenAIDashboardDailyBreakdown(
+                day: "2026-04-29",
+                services: [],
+                totalCreditsUsed: 4),
+        ])
+    }
+}

--- a/Tests/CodexBarTests/OpenAIDashboardParserTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardParserTests.swift
@@ -85,6 +85,17 @@ struct OpenAIDashboardParserTests {
     }
 
     @Test
+    func `parses spaced five hour limit label`() {
+        let body = """
+        Limite 5 h
+        72 % restant
+        """
+        let limits = OpenAIDashboardParser.parseRateLimits(bodyText: body)
+        #expect(abs((limits.primary?.usedPercent ?? 0) - 28) < 0.001)
+        #expect(limits.primary?.windowMinutes == 300)
+    }
+
+    @Test
     func `parses plan from client bootstrap`() {
         let html = """
         <html>
@@ -124,6 +135,26 @@ struct OpenAIDashboardParserTests {
         #expect(abs((events.first?.creditsUsed ?? 0) - 397.205) < 0.0001)
         #expect(events.last?.service == "GitHub Code Review")
         #expect(abs((events.last?.creditsUsed ?? 0) - 506.235) < 0.0001)
+    }
+
+    @Test
+    func `parses credit event amount with localized credit label`() {
+        let rows: [[String]] = [
+            ["Dec 18, 2025", "CLI", "397,205 crédits"],
+        ]
+        let events = OpenAIDashboardParser.parseCreditEvents(rows: rows)
+        #expect(events.count == 1)
+        #expect(abs((events.first?.creditsUsed ?? 0) - 397.205) < 0.0001)
+    }
+
+    @Test
+    func `parses credit event amount with english comma thousands`() {
+        let rows: [[String]] = [
+            ["Dec 18, 2025", "CLI", "1,234 credits"],
+        ]
+        let events = OpenAIDashboardParser.parseCreditEvents(rows: rows)
+        #expect(events.count == 1)
+        #expect(events.first?.creditsUsed == 1234)
     }
 
     @Test


### PR DESCRIPTION
Problems addressed

1. The OpenAI Codex analytics page could load in a non-English locale, which made DOM text scraping unreliable.
2. The dashboard route changed to the newer cloud analytics URL, so older route assumptions could fail.
3. The dashboard could return too early before the usage breakdown or credits history had hydrated, causing “No usage breakdown data”.
4. API-derived limits/credits could make the refresh look successful even when dashboard-only data was still missing.
5. Usage breakdown sometimes included Skillusage:* entries, which belong to a different dashboard and should not appear in Codex usage.
6. Credit amounts could be parsed incorrectly when commas were used as thousands separators or localized decimal separators.
7. Web refresh timeouts and network failures surfaced as raw system errors instead of actionable guidance.
8. The credits history table can be lazy-loaded, so it was sometimes missed unless the page was scrolled.

Implemented fixes

1. Prefer English for OpenAI dashboard requests and WebView page execution.
2. Recognize both old usage routes and the current Codex cloud analytics route.
3. Keep waiting for a real dashboard page signal before returning dashboard data.
4. Use API data only to enrich the scrape, not to replace the dashboard scrape.
5. Filter Skillusage:* services from Codex usage breakdowns before display, cache use, and historical backfill.
6. Improve credit amount parsing for English thousands separators and localized decimal commas.
7. Retry OpenAI web refresh after timeouts and show clearer user-facing error messages.
8. Scroll/wait for the credits history section so lazy-loaded rows have time to appear.
9. Add focused tests for route handling, localization headers, parsing, timeout retry, Skillusage filtering, and dashboard refresh behavior.


It is not entirely perfect, but at least it's in a much more usable state than before