### PR TITLE
Added Copilot login through GHE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Providers & Usage
 - Alibaba: clarify China-region API-key failures when the console endpoint requires a browser session (#628). Thanks @XWind18!
+- Copilot: support GitHub Enterprise hosts for the device-flow login and usage API paths (#827). Thanks @ramzesenok!
 - OpenRouter and DeepSeek: show remaining account balances in the menu bar, while preserving OpenRouter's API-key limit metric when explicitly selected (#832). Thanks @giuseppebisemi!
 - Codebuff: add provider support with credit balance tracking, weekly rate-limit usage, API-token settings, and `codebuff login` credential import (#837). Thanks @anandghegde!
 - Copilot: add multi-account support with GitHub OAuth sign-in, account switching, and per-account usage cards (#637). Thanks @ajmccall!

--- a/Sources/CodexBar/Providers/Copilot/CopilotLoginFlow.swift
+++ b/Sources/CodexBar/Providers/Copilot/CopilotLoginFlow.swift
@@ -5,7 +5,8 @@ import SwiftUI
 @MainActor
 struct CopilotLoginFlow {
     static func run(settings: SettingsStore) async {
-        let flow = CopilotDeviceFlow()
+        let enterpriseHost = settings.copilotEnterpriseHost
+        let flow = CopilotDeviceFlow(enterpriseHost: enterpriseHost.isEmpty ? nil : enterpriseHost)
 
         do {
             let code = try await flow.requestDeviceCode()
@@ -91,7 +92,9 @@ struct CopilotLoginFlow {
                     let resolvedUsername = resolvedIdentity.login
                     let planSuffix: String
                     do {
-                        let fetcher = CopilotUsageFetcher(token: token)
+                        let fetcher = CopilotUsageFetcher(
+                            token: token,
+                            enterpriseHost: enterpriseHost.isEmpty ? nil : enterpriseHost)
                         let usage = try await fetcher.fetch()
                         let plan = usage.identity(for: .copilot)?.loginMethod ?? ""
                         planSuffix = plan.isEmpty ? "" : " (\(plan))"

--- a/Sources/CodexBar/Providers/Copilot/CopilotProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Copilot/CopilotProviderImplementation.swift
@@ -16,6 +16,7 @@ struct CopilotProviderImplementation: ProviderImplementation {
     @MainActor
     func observeSettings(_ settings: SettingsStore) {
         _ = settings.copilotAPIToken
+        _ = settings.copilotEnterpriseHost
     }
 
     @MainActor
@@ -34,9 +35,19 @@ struct CopilotProviderImplementation: ProviderImplementation {
     func settingsFields(context: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {
         [
             ProviderSettingsFieldDescriptor(
+                id: "copilot-enterprise-host",
+                title: "Enterprise host",
+                subtitle: "Optional. Enter your GitHub Enterprise host, for example octocorp.ghe.com. Leave blank for github.com.",
+                kind: .plain,
+                placeholder: "github.com",
+                binding: context.stringBinding(\.copilotEnterpriseHost),
+                actions: [],
+                isVisible: nil,
+                onActivate: nil),
+            ProviderSettingsFieldDescriptor(
                 id: "copilot-add-account",
                 title: "GitHub Login",
-                subtitle: "Add accounts via GitHub OAuth Device Flow.",
+                subtitle: "Add accounts via GitHub OAuth Device Flow on the selected host.",
                 kind: .plain,
                 placeholder: nil,
                 binding: .constant(""),

--- a/Sources/CodexBar/Providers/Copilot/CopilotSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Copilot/CopilotSettingsStore.swift
@@ -12,6 +12,15 @@ extension SettingsStore {
         }
     }
 
+    var copilotEnterpriseHost: String {
+        get { self.configSnapshot.providerConfig(for: .copilot)?.sanitizedEnterpriseHost ?? "" }
+        set {
+            self.updateProviderConfig(provider: .copilot) { entry in
+                entry.enterpriseHost = self.normalizedConfigValue(newValue)
+            }
+        }
+    }
+
     func ensureCopilotAPITokenLoaded() {}
 }
 
@@ -24,6 +33,9 @@ extension SettingsStore {
             settings: self,
             override: tokenOverride)
         let token = account?.token ?? self.copilotAPIToken
-        return ProviderSettingsSnapshot.CopilotProviderSettings(apiToken: self.normalizedConfigValue(token))
+        let host = CopilotDeviceFlow.normalizedHost(self.copilotEnterpriseHost)
+        return ProviderSettingsSnapshot.CopilotProviderSettings(
+            apiToken: self.normalizedConfigValue(token),
+            enterpriseHost: host == CopilotDeviceFlow.defaultHost ? nil : host)
     }
 }

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -82,6 +82,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
     public var cookieSource: ProviderCookieSource?
     public var region: String?
     public var workspaceID: String?
+    public var enterpriseHost: String?
     public var tokenAccounts: ProviderTokenAccountData?
     public var codexActiveSource: CodexActiveSource?
 
@@ -95,6 +96,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         cookieSource: ProviderCookieSource? = nil,
         region: String? = nil,
         workspaceID: String? = nil,
+        enterpriseHost: String? = nil,
         tokenAccounts: ProviderTokenAccountData? = nil,
         codexActiveSource: CodexActiveSource? = nil)
     {
@@ -107,6 +109,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         self.cookieSource = cookieSource
         self.region = region
         self.workspaceID = workspaceID
+        self.enterpriseHost = enterpriseHost
         self.tokenAccounts = tokenAccounts
         self.codexActiveSource = codexActiveSource
     }
@@ -117,6 +120,10 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
 
     public var sanitizedCookieHeader: String? {
         Self.clean(self.cookieHeader)
+    }
+
+    public var sanitizedEnterpriseHost: String? {
+        Self.clean(self.enterpriseHost)
     }
 
     private static func clean(_ raw: String?) -> String? {

--- a/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
@@ -177,6 +177,18 @@ public enum CodexBarConfigValidator {
                 message: "workspaceID is set but only opencode and opencodego support workspaceID."))
         }
 
+        if let enterpriseHost = entry.enterpriseHost,
+           !enterpriseHost.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+           provider != .copilot
+        {
+            issues.append(CodexBarConfigIssue(
+                severity: .warning,
+                provider: provider,
+                field: "enterpriseHost",
+                code: "enterprise_host_unused",
+                message: "enterpriseHost is set but only copilot supports enterpriseHost."))
+        }
+
         if let tokenAccounts = entry.tokenAccounts, !tokenAccounts.accounts.isEmpty,
            TokenAccountSupportCatalog.support(for: provider) == nil
         {

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotDeviceFlow.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotDeviceFlow.swift
@@ -4,8 +4,11 @@ import FoundationNetworking
 #endif
 
 public struct CopilotDeviceFlow: Sendable {
+    public static let defaultHost = "github.com"
+
     private let clientID = "Iv1.b507a08c87ecfe98" // VS Code Client ID
     private let scopes = "read:user"
+    private let host: String
 
     public struct DeviceCodeResponse: Decodable, Sendable {
         public let deviceCode: String
@@ -41,11 +44,48 @@ public struct CopilotDeviceFlow: Sendable {
         }
     }
 
-    public init() {}
+    public init(enterpriseHost: String? = nil) {
+        self.host = Self.normalizedHost(enterpriseHost)
+    }
+
+    public var deviceCodeURL: URL? {
+        Self.makeRequestURL(host: self.host, path: "/login/device/code")
+    }
+
+    public var accessTokenURL: URL? {
+        Self.makeRequestURL(host: self.host, path: "/login/oauth/access_token")
+    }
+
+    public static func normalizedHost(_ raw: String?) -> String {
+        guard var host = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !host.isEmpty else {
+            return self.defaultHost
+        }
+        let componentsValue = host.contains("://") ? host : "https://\(host)"
+        if let components = URLComponents(string: componentsValue),
+           let parsedHost = components.host,
+           !parsedHost.isEmpty
+        {
+            host = parsedHost
+            if let port = components.port {
+                host += ":\(port)"
+            }
+        } else {
+            if host.hasPrefix("https://") {
+                host.removeFirst("https://".count)
+            } else if host.hasPrefix("http://") {
+                host.removeFirst("http://".count)
+            }
+            host = host.split(separator: "/", maxSplits: 1).first.map(String.init) ?? host
+        }
+        let normalized = host.trimmingCharacters(in: CharacterSet(charactersIn: ".")).lowercased()
+        return normalized.isEmpty ? Self.defaultHost : normalized
+    }
 
     public func requestDeviceCode() async throws -> DeviceCodeResponse {
-        let components = URLComponents(string: "https://github.com/login/device/code")!
-        let request = URLRequest(url: components.url!)
+        guard let deviceCodeURL = self.deviceCodeURL else {
+            throw URLError(.badURL)
+        }
+        let request = URLRequest(url: deviceCodeURL)
 
         var postRequest = request
         postRequest.httpMethod = "POST"
@@ -68,8 +108,10 @@ public struct CopilotDeviceFlow: Sendable {
     }
 
     public func pollForToken(deviceCode: String, interval: Int) async throws -> String {
-        let url = URL(string: "https://github.com/login/oauth/access_token")!
-        var request = URLRequest(url: url)
+        guard let accessTokenURL = self.accessTokenURL else {
+            throw URLError(.badURL)
+        }
+        var request = URLRequest(url: accessTokenURL)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
@@ -117,6 +159,10 @@ public struct CopilotDeviceFlow: Sendable {
             }
             .joined(separator: "&")
         return Data(pairs.utf8)
+    }
+
+    static func makeRequestURL(host: String, path: String) -> URL? {
+        URL(string: "https://\(host)\(path)")
     }
 
     private static func formEncode(_ value: String) -> String {

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotProviderDescriptor.swift
@@ -51,7 +51,9 @@ struct CopilotAPIFetchStrategy: ProviderFetchStrategy {
         guard let token = Self.resolveToken(context: context), !token.isEmpty else {
             throw URLError(.userAuthenticationRequired)
         }
-        let fetcher = CopilotUsageFetcher(token: token)
+        let fetcher = CopilotUsageFetcher(
+            token: token,
+            enterpriseHost: context.settings?.copilot?.enterpriseHost)
         let snap = try await fetcher.fetch()
         return self.makeResult(
             usage: snap,

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
@@ -15,13 +15,32 @@ public struct CopilotUsageFetcher: Sendable {
     }
 
     private let token: String
+    private let enterpriseHost: String?
 
-    public init(token: String) {
+    public init(token: String, enterpriseHost: String? = nil) {
         self.token = token
+        self.enterpriseHost = enterpriseHost
+    }
+
+    public static func apiHost(enterpriseHost: String?) -> String {
+        let host = CopilotDeviceFlow.normalizedHost(enterpriseHost)
+        if host == CopilotDeviceFlow.defaultHost {
+            return "api.github.com"
+        }
+        if host.hasPrefix("api.") {
+            return host
+        }
+        return "api.\(host)"
+    }
+
+    public static func usageURL(enterpriseHost: String?) -> URL? {
+        CopilotDeviceFlow.makeRequestURL(
+            host: self.apiHost(enterpriseHost: enterpriseHost),
+            path: "/copilot_internal/user")
     }
 
     public func fetch() async throws -> UsageSnapshot {
-        guard let url = URL(string: "https://api.github.com/copilot_internal/user") else {
+        guard let url = Self.usageURL(enterpriseHost: self.enterpriseHost) else {
             throw URLError(.badURL)
         }
 

--- a/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
@@ -166,9 +166,11 @@ public struct ProviderSettingsSnapshot: Sendable {
 
     public struct CopilotProviderSettings: Sendable {
         public let apiToken: String?
+        public let enterpriseHost: String?
 
-        public init(apiToken: String? = nil) {
+        public init(apiToken: String? = nil, enterpriseHost: String? = nil) {
             self.apiToken = apiToken
+            self.enterpriseHost = enterpriseHost
         }
     }
 

--- a/Tests/CodexBarTests/CopilotDeviceFlowTests.swift
+++ b/Tests/CodexBarTests/CopilotDeviceFlowTests.swift
@@ -39,4 +39,53 @@ struct CopilotDeviceFlowTests {
 
         #expect(response.verificationURLToOpen == "https://github.com/login/device")
     }
+
+    @Test
+    func `device flow uses github by default`() throws {
+        let flow = CopilotDeviceFlow()
+        let deviceCodeURL = try #require(flow.deviceCodeURL)
+        let accessTokenURL = try #require(flow.accessTokenURL)
+
+        #expect(deviceCodeURL.absoluteString == "https://github.com/login/device/code")
+        #expect(accessTokenURL.absoluteString == "https://github.com/login/oauth/access_token")
+    }
+
+    @Test
+    func `device flow uses enterprise host`() throws {
+        let flow = CopilotDeviceFlow(enterpriseHost: "https://octocorp.ghe.com/login")
+        let deviceCodeURL = try #require(flow.deviceCodeURL)
+        let accessTokenURL = try #require(flow.accessTokenURL)
+
+        #expect(deviceCodeURL.absoluteString == "https://octocorp.ghe.com/login/device/code")
+        #expect(accessTokenURL.absoluteString == "https://octocorp.ghe.com/login/oauth/access_token")
+    }
+
+    @Test
+    func `device flow rejects invalid enterprise host without crashing`() {
+        let flow = CopilotDeviceFlow(enterpriseHost: "foo bar")
+
+        #expect(flow.deviceCodeURL == nil)
+        #expect(flow.accessTokenURL == nil)
+    }
+
+    @Test
+    func `device flow preserves enterprise host port`() throws {
+        let flow = CopilotDeviceFlow(enterpriseHost: "https://octocorp.ghe.com:8443/login")
+        let deviceCodeURL = try #require(flow.deviceCodeURL)
+        let accessTokenURL = try #require(flow.accessTokenURL)
+
+        #expect(deviceCodeURL.absoluteString == "https://octocorp.ghe.com:8443/login/device/code")
+        #expect(accessTokenURL.absoluteString == "https://octocorp.ghe.com:8443/login/oauth/access_token")
+    }
+
+    @Test
+    func `usage url uses enterprise api host`() throws {
+        let defaultURL = try #require(CopilotUsageFetcher.usageURL(enterpriseHost: nil))
+        let enterpriseURL = try #require(CopilotUsageFetcher.usageURL(enterpriseHost: "octocorp.ghe.com"))
+        let enterprisePortURL = try #require(CopilotUsageFetcher.usageURL(enterpriseHost: "octocorp.ghe.com:8443"))
+
+        #expect(defaultURL.absoluteString == "https://api.github.com/copilot_internal/user")
+        #expect(enterpriseURL.absoluteString == "https://api.octocorp.ghe.com/copilot_internal/user")
+        #expect(enterprisePortURL.absoluteString == "https://api.octocorp.ghe.com:8443/copilot_internal/user")
+    }
 }

--- a/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
@@ -138,6 +138,26 @@ struct SettingsStoreCoverageTests {
     }
 
     @Test
+    func `copilot enterprise host persists in provider config`() throws {
+        let suite = "SettingsStoreCoverageTests-copilot-enterprise-host"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        let first = Self.makeSettingsStore(userDefaults: defaults, configStore: configStore)
+
+        first.copilotEnterpriseHost = "https://octocorp.ghe.com/login"
+        #expect(first.copilotEnterpriseHost == "https://octocorp.ghe.com/login")
+        #expect(first.copilotSettingsSnapshot(tokenOverride: nil).enterpriseHost == "octocorp.ghe.com")
+
+        let second = Self.makeSettingsStore(userDefaults: defaults, configStore: configStore)
+        #expect(second.copilotEnterpriseHost == "https://octocorp.ghe.com/login")
+
+        second.copilotEnterpriseHost = "github.com"
+        #expect(second.copilotEnterpriseHost == "github.com")
+        #expect(second.copilotSettingsSnapshot(tokenOverride: nil).enterpriseHost == nil)
+    }
+
+    @Test
     func `removing another token account preserves active selection`() throws {
         let settings = Self.makeSettingsStore()
 

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -16,12 +16,18 @@ Copilot uses GitHub OAuth device flow and the Copilot internal usage API. No bro
      - `POST https://github.com/login/device/code`
    - Token polling:
      - `POST https://github.com/login/oauth/access_token`
+   - Optional enterprise host:
+     - set Copilot `enterpriseHost` in `~/.codexbar/config.json` or the provider settings UI
+     - CodexBar normalizes values such as `https://octocorp.ghe.com/login` to `octocorp.ghe.com`
+     - device flow uses `https://<enterpriseHost>/login/...`
    - Scope: `read:user`.
    - Token stored in config:
      - `~/.codexbar/config.json` → `providers[].apiKey` for `copilot`
+      - token accounts use `providers[].tokenAccounts`
 
 2) **Usage fetch**
    - `GET https://api.github.com/copilot_internal/user`
+   - With an enterprise host, the API host is `api.<enterpriseHost>`.
    - Headers:
      - `Authorization: token <github_oauth_token>`
      - `Accept: application/json`


### PR DESCRIPTION
Adding a textfield in the Settings > Providers > GitHub Copilot to enter your Enterprise host and get logged in through it instead of the default github.com 