### PR TITLE
fix(cli): provider selection queries all 28 providers when 3+ are enabled

### DIFF
--- a/Sources/CodexBarCLI/CLIHelpers.swift
+++ b/Sources/CodexBarCLI/CLIHelpers.swift
@@ -17,9 +17,12 @@ extension CodexBarCLI {
         if let rawOverride, let parsed = ProviderSelection(argument: rawOverride) {
             return parsed
         }
-        if enabled.count >= 3 { return .all }
-        if enabled.count == 2 {
-            let enabledSet = Set(enabled)
+        let allProviders = Set(ProviderDescriptorRegistry.all.map(\ .id))
+        let enabledSet = Set(enabled)
+        if !enabled.isEmpty, enabledSet == allProviders {
+            return .all
+        }
+        if enabled.count >= 2 {
             let primary = Set(ProviderDescriptorRegistry.all.filter(\ .metadata.isPrimaryProvider).map(\ .id))
             if !primary.isEmpty, enabledSet == primary {
                 return .both
@@ -372,6 +375,10 @@ extension CodexBarCLI {
 
     static func _decodeSourceModeForTesting(from values: ParsedValues) -> ProviderSourceMode? {
         self.decodeSourceMode(from: values)
+    }
+
+    static func _providerSelectionForTesting(rawOverride: String?, enabled: [UsageProvider]) -> ProviderSelection {
+        self.providerSelection(rawOverride: rawOverride, enabled: enabled)
     }
 }
 #endif

--- a/TestsLinux/ProviderSelectionTests.swift
+++ b/TestsLinux/ProviderSelectionTests.swift
@@ -1,0 +1,16 @@
+@testable import CodexBarCLI
+import CodexBarCore
+import Testing
+
+@Suite
+struct ProviderSelectionTests {
+    @Test
+    func threeEnabledProviders_returnsOnlyThoseThree() {
+        let enabled: [UsageProvider] = [.codex, .claude, .copilot]
+        let result = CodexBarCLI._providerSelectionForTesting(
+            rawOverride: nil, enabled: enabled).asList
+
+        #expect(Set(result) == Set(enabled),
+                "Expected \(enabled.map(\.rawValue)) but got \(result.map(\.rawValue))")
+    }
+}


### PR DESCRIPTION
## Summary

- `providerSelection()` returned `.all` when `enabled.count >= 3`, which expands to every registered provider (currently 28) instead of just the user's enabled ones. A config with e.g. codex + claude + copilot would query all 28 providers, producing 25 spurious errors and unnecessary overhead.
- Now `.all` only triggers when the enabled set matches the full registry; otherwise uses `.custom(enabled)`.

Bug introduced in a1b94b48 ("refactor: move provider secrets to config", Jan 18 2026) — the `>= 3` threshold was likely safe when there were few providers but broke as the registry grew.

## Test plan

- [x] Added regression test in `TestsLinux/ProviderSelectionTests.swift` that fails without the fix (3 enabled → 28 queried) and passes with it
- [x] All existing `CodexBarLinuxTests` pass (12 total)