### PR TITLE
Add quota warning thresholds

### DIFF
--- a/Sources/CodexBar/AppNotifications.swift
+++ b/Sources/CodexBar/AppNotifications.swift
@@ -19,7 +19,13 @@ final class AppNotifications {
         _ = self.ensureAuthorizationTask()
     }
 
-    func post(idPrefix: String, title: String, body: String, badge: NSNumber? = nil) {
+    func post(
+        idPrefix: String,
+        title: String,
+        body: String,
+        badge: NSNumber? = nil,
+        soundEnabled: Bool = true)
+    {
         guard !Self.isRunningUnderTests else { return }
         let center = self.centerProvider()
         let logger = self.logger
@@ -34,7 +40,7 @@ final class AppNotifications {
             let content = UNMutableNotificationContent()
             content.title = title
             content.body = body
-            content.sound = .default
+            content.sound = soundEnabled ? .default : nil
             content.badge = badge
 
             let request = UNNotificationRequest(

--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -96,6 +96,13 @@ struct GeneralPane: View {
                         subtitle: "Notifies when the 5-hour session quota hits 0% and when it becomes " +
                             "available again.",
                         binding: self.$settings.sessionQuotaNotificationsEnabled)
+                    PreferenceToggleRow(
+                        title: "Quota warning notifications",
+                        subtitle: "Warns when session or weekly quota remaining crosses configured thresholds.",
+                        binding: self.$settings.quotaWarningNotificationsEnabled)
+                    if self.settings.quotaWarningNotificationsEnabled {
+                        GlobalQuotaWarningSettingsView(settings: self.settings)
+                    }
                 }
 
                 Divider()

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -125,6 +125,8 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
                     self.supplementarySettingsContent
                 }
 
+                ProviderQuotaWarningSettingsView(provider: self.provider, settings: self.store.settings)
+
                 if !self.settingsToggles.isEmpty {
                     ProviderSettingsSection(title: "Options") {
                         ForEach(self.settingsToggles) { toggle in

--- a/Sources/CodexBar/QuotaWarningSettingsViews.swift
+++ b/Sources/CodexBar/QuotaWarningSettingsViews.swift
@@ -1,0 +1,145 @@
+import CodexBarCore
+import SwiftUI
+
+@MainActor
+struct GlobalQuotaWarningSettingsView: View {
+    @Bindable var settings: SettingsStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            QuotaWarningThresholdField(
+                title: "Warn at",
+                subtitle: "Comma-separated remaining percentages. Applies to session and weekly windows unless " +
+                    "a provider overrides them.",
+                thresholds: { self.settings.quotaWarningThresholds },
+                setThresholds: { self.settings.quotaWarningThresholds = $0 })
+
+            Toggle(isOn: self.$settings.quotaWarningSoundEnabled) {
+                Text("Play notification sound")
+                    .font(.footnote)
+            }
+            .toggleStyle(.checkbox)
+        }
+        .padding(.leading, 20)
+    }
+}
+
+@MainActor
+struct ProviderQuotaWarningSettingsView: View {
+    let provider: UsageProvider
+    @Bindable var settings: SettingsStore
+
+    var body: some View {
+        ProviderSettingsSection(title: "Quota warnings") {
+            Text("Uses the global quota warning settings unless a window is customized here.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            self.windowRow(.session)
+            self.windowRow(.weekly)
+        }
+    }
+
+    private func windowRow(_ window: QuotaWarningWindow) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle(isOn: Binding(
+                get: { self.settings.hasQuotaWarningOverride(provider: self.provider, window: window) },
+                set: { isOn in
+                    if isOn {
+                        self.settings.setQuotaWarningThresholds(
+                            provider: self.provider,
+                            window: window,
+                            thresholds: self.settings.quotaWarningThresholds)
+                    } else {
+                        self.settings.setQuotaWarningThresholds(
+                            provider: self.provider,
+                            window: window,
+                            thresholds: nil)
+                    }
+                })) {
+                    Text("Customize \(window.displayName) thresholds")
+                        .font(.subheadline.weight(.semibold))
+                }
+                .toggleStyle(.checkbox)
+
+            if self.settings.hasQuotaWarningOverride(provider: self.provider, window: window) {
+                QuotaWarningThresholdField(
+                    title: "\(window.displayName.capitalized) warn at",
+                    subtitle: "",
+                    thresholds: {
+                        self.settings.resolvedQuotaWarningThresholds(provider: self.provider, window: window)
+                    },
+                    setThresholds: {
+                        self.settings.setQuotaWarningThresholds(
+                            provider: self.provider,
+                            window: window,
+                            thresholds: $0)
+                    })
+                    .padding(.leading, 20)
+            } else {
+                Text("Inherited: \(Self.thresholdText(self.settings.quotaWarningThresholds))")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .padding(.leading, 20)
+            }
+        }
+    }
+
+    private static func thresholdText(_ thresholds: [Int]) -> String {
+        QuotaWarningThresholds.sanitized(thresholds).map { "\($0)%" }.joined(separator: ", ")
+    }
+}
+
+@MainActor
+private struct QuotaWarningThresholdField: View {
+    let title: String
+    let subtitle: String
+    let thresholds: () -> [Int]
+    let setThresholds: ([Int]) -> Void
+
+    @State private var text: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(self.title)
+                    .font(.footnote.weight(.semibold))
+                    .frame(width: 110, alignment: .leading)
+
+                TextField("50, 20", text: self.$text)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.footnote)
+                    .frame(maxWidth: 180)
+                    .onSubmit { self.commit() }
+
+                Button("Apply") { self.commit() }
+                    .controlSize(.small)
+            }
+
+            if !self.subtitle.isEmpty {
+                Text(self.subtitle)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .onAppear { self.text = Self.text(from: self.thresholds()) }
+        .onChange(of: self.thresholds()) { _, value in
+            self.text = Self.text(from: value)
+        }
+    }
+
+    private func commit() {
+        let parsed = self.text
+            .split { !$0.isNumber }
+            .compactMap { Int($0) }
+        let sanitized = QuotaWarningThresholds.sanitized(parsed)
+        self.text = Self.text(from: sanitized)
+        self.setThresholds(sanitized)
+    }
+
+    private static func text(from thresholds: [Int]) -> String {
+        QuotaWarningThresholds.sanitized(thresholds).map(String.init).joined(separator: ", ")
+    }
+}

--- a/Sources/CodexBar/SessionQuotaNotifications.swift
+++ b/Sources/CodexBar/SessionQuotaNotifications.swift
@@ -8,6 +8,12 @@ enum SessionQuotaTransition: Equatable {
     case restored
 }
 
+struct QuotaWarningEvent: Equatable, Sendable {
+    let window: QuotaWarningWindow
+    let threshold: Int
+    let currentRemaining: Double
+}
+
 enum SessionQuotaNotificationLogic {
     static let depletedThreshold: Double = 0.0001
 
@@ -29,9 +35,40 @@ enum SessionQuotaNotificationLogic {
     }
 }
 
+enum QuotaWarningNotificationLogic {
+    static func crossedThreshold(
+        previousRemaining: Double?,
+        currentRemaining: Double,
+        thresholds: [Int],
+        alreadyFired: Set<Int>) -> Int?
+    {
+        let sanitized = QuotaWarningThresholds.sanitized(thresholds)
+        let eligible = sanitized.filter { threshold in
+            currentRemaining <= Double(threshold) && !alreadyFired.contains(threshold)
+        }
+        guard !eligible.isEmpty else { return nil }
+
+        if let previousRemaining {
+            let crossed = eligible.filter { previousRemaining > Double($0) }
+            return crossed.min()
+        }
+
+        return eligible.min()
+    }
+
+    static func firedThresholdsAfterWarning(threshold: Int, thresholds: [Int]) -> Set<Int> {
+        Set(QuotaWarningThresholds.sanitized(thresholds).filter { $0 >= threshold })
+    }
+
+    static func thresholdsToClear(currentRemaining: Double, alreadyFired: Set<Int>) -> Set<Int> {
+        Set(alreadyFired.filter { currentRemaining > Double($0) })
+    }
+}
+
 @MainActor
 protocol SessionQuotaNotifying: AnyObject {
     func post(transition: SessionQuotaTransition, provider: UsageProvider, badge: NSNumber?)
+    func postQuotaWarning(event: QuotaWarningEvent, provider: UsageProvider, soundEnabled: Bool)
 }
 
 @MainActor
@@ -59,5 +96,16 @@ final class SessionQuotaNotifier: SessionQuotaNotifying {
         let idPrefix = "session-\(providerText)-\(transitionText)"
         self.logger.info("enqueuing", metadata: ["prefix": idPrefix])
         AppNotifications.shared.post(idPrefix: idPrefix, title: title, body: body, badge: badge)
+    }
+
+    func postQuotaWarning(event: QuotaWarningEvent, provider: UsageProvider, soundEnabled: Bool = true) {
+        let providerName = ProviderDescriptorRegistry.descriptor(for: provider).metadata.displayName
+        let windowLabel = event.window.displayName
+        let threshold = event.threshold
+        let title = "\(providerName) \(windowLabel) quota low"
+        let body = "\(threshold)% remaining."
+        let idPrefix = "quota-warning-\(provider.rawValue)-\(event.window.rawValue)-\(threshold)"
+        self.logger.info("enqueuing", metadata: ["prefix": idPrefix])
+        AppNotifications.shared.post(idPrefix: idPrefix, title: title, body: body, soundEnabled: soundEnabled)
     }
 }

--- a/Sources/CodexBar/SettingsStore+Config.swift
+++ b/Sources/CodexBar/SettingsStore+Config.swift
@@ -6,6 +6,31 @@ extension SettingsStore {
         self.configSnapshot.providerConfig(for: provider)
     }
 
+    func quotaWarningConfig(for provider: UsageProvider) -> QuotaWarningConfig {
+        self.configSnapshot.providerConfig(for: provider)?.quotaWarnings ?? QuotaWarningConfig()
+    }
+
+    func resolvedQuotaWarningThresholds(provider: UsageProvider, window: QuotaWarningWindow) -> [Int] {
+        self.quotaWarningConfig(for: provider).thresholds(for: window, global: self.quotaWarningThresholds)
+    }
+
+    func hasQuotaWarningOverride(provider: UsageProvider, window: QuotaWarningWindow) -> Bool {
+        self.quotaWarningConfig(for: provider).hasOverride(for: window)
+    }
+
+    func setQuotaWarningThresholds(provider: UsageProvider, window: QuotaWarningWindow, thresholds: [Int]?) {
+        self.updateProviderConfig(provider: provider) { entry in
+            var config = entry.quotaWarnings ?? QuotaWarningConfig()
+            switch window {
+            case .session:
+                config.session = thresholds.map { QuotaWarningWindowConfig(thresholds: $0) }
+            case .weekly:
+                config.weekly = thresholds.map { QuotaWarningWindowConfig(thresholds: $0) }
+            }
+            entry.quotaWarnings = config.isEmpty ? nil : config
+        }
+    }
+
     var tokenAccountsByProvider: [UsageProvider: ProviderTokenAccountData] {
         get {
             Dictionary(uniqueKeysWithValues: self.configSnapshot.providers.compactMap { entry in

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -103,6 +103,31 @@ extension SettingsStore {
         }
     }
 
+    var quotaWarningNotificationsEnabled: Bool {
+        get { self.defaultsState.quotaWarningNotificationsEnabled }
+        set {
+            self.defaultsState.quotaWarningNotificationsEnabled = newValue
+            self.userDefaults.set(newValue, forKey: "quotaWarningNotificationsEnabled")
+        }
+    }
+
+    var quotaWarningThresholds: [Int] {
+        get { QuotaWarningThresholds.sanitized(self.defaultsState.quotaWarningThresholdsRaw) }
+        set {
+            let sanitized = QuotaWarningThresholds.sanitized(newValue)
+            self.defaultsState.quotaWarningThresholdsRaw = sanitized
+            self.userDefaults.set(sanitized, forKey: "quotaWarningThresholds")
+        }
+    }
+
+    var quotaWarningSoundEnabled: Bool {
+        get { self.defaultsState.quotaWarningSoundEnabled }
+        set {
+            self.defaultsState.quotaWarningSoundEnabled = newValue
+            self.userDefaults.set(newValue, forKey: "quotaWarningSoundEnabled")
+        }
+    }
+
     var usageBarsShowUsed: Bool {
         get { self.defaultsState.usageBarsShowUsed }
         set {

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -11,6 +11,9 @@ extension SettingsStore {
         _ = self.debugKeepCLISessionsAlive
         _ = self.statusChecksEnabled
         _ = self.sessionQuotaNotificationsEnabled
+        _ = self.quotaWarningNotificationsEnabled
+        _ = self.quotaWarningThresholds
+        _ = self.quotaWarningSoundEnabled
         _ = self.usageBarsShowUsed
         _ = self.resetTimesShowAbsolute
         _ = self.menuBarShowsBrandIconWithPercent

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -237,6 +237,19 @@ extension SettingsStore {
         if sessionQuotaDefault == nil {
             userDefaults.set(true, forKey: "sessionQuotaNotificationsEnabled")
         }
+        let quotaWarningNotificationsEnabled = userDefaults.object(
+            forKey: "quotaWarningNotificationsEnabled") as? Bool ?? false
+        let rawQuotaWarningThresholds = userDefaults.array(forKey: "quotaWarningThresholds") as? [Int]
+        let quotaWarningThresholdsRaw = QuotaWarningThresholds.sanitized(
+            rawQuotaWarningThresholds ?? QuotaWarningThresholds.defaults)
+        if rawQuotaWarningThresholds != quotaWarningThresholdsRaw {
+            userDefaults.set(quotaWarningThresholdsRaw, forKey: "quotaWarningThresholds")
+        }
+        let quotaWarningSoundDefault = userDefaults.object(forKey: "quotaWarningSoundEnabled") as? Bool
+        let quotaWarningSoundEnabled = quotaWarningSoundDefault ?? true
+        if quotaWarningSoundDefault == nil {
+            userDefaults.set(true, forKey: "quotaWarningSoundEnabled")
+        }
         let usageBarsShowUsed = userDefaults.object(forKey: "usageBarsShowUsed") as? Bool ?? false
         let resetTimesShowAbsolute = userDefaults.object(forKey: "resetTimesShowAbsolute") as? Bool ?? false
         let menuBarShowsBrandIconWithPercent = userDefaults.object(
@@ -294,6 +307,9 @@ extension SettingsStore {
             debugKeepCLISessionsAlive: debugKeepCLISessionsAlive,
             statusChecksEnabled: statusChecksEnabled,
             sessionQuotaNotificationsEnabled: sessionQuotaNotificationsEnabled,
+            quotaWarningNotificationsEnabled: quotaWarningNotificationsEnabled,
+            quotaWarningThresholdsRaw: quotaWarningThresholdsRaw,
+            quotaWarningSoundEnabled: quotaWarningSoundEnabled,
             usageBarsShowUsed: usageBarsShowUsed,
             resetTimesShowAbsolute: resetTimesShowAbsolute,
             menuBarShowsBrandIconWithPercent: menuBarShowsBrandIconWithPercent,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -11,6 +11,9 @@ struct SettingsDefaultsState {
     var debugKeepCLISessionsAlive: Bool
     var statusChecksEnabled: Bool
     var sessionQuotaNotificationsEnabled: Bool
+    var quotaWarningNotificationsEnabled: Bool
+    var quotaWarningThresholdsRaw: [Int]
+    var quotaWarningSoundEnabled: Bool
     var usageBarsShowUsed: Bool
     var resetTimesShowAbsolute: Bool
     var menuBarShowsBrandIconWithPercent: Bool

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -32,6 +32,7 @@ extension UsageStore {
                 self.statuses.removeValue(forKey: provider)
                 self.lastKnownSessionRemaining.removeValue(forKey: provider)
                 self.lastKnownSessionWindowSource.removeValue(forKey: provider)
+                self.quotaWarningState = self.quotaWarningState.filter { $0.key.provider != provider }
                 self.lastTokenFetchAt.removeValue(forKey: provider)
             }
             return
@@ -92,6 +93,7 @@ extension UsageStore {
                 return
             }
             await MainActor.run {
+                self.handleQuotaWarningTransitions(provider: provider, snapshot: scoped)
                 self.handleSessionQuotaTransition(provider: provider, snapshot: scoped)
                 self.snapshots[provider] = scoped
                 self.lastSourceLabels[provider] = result.sourceLabel

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -258,6 +258,7 @@ extension UsageStore {
                 scoped
             }
             await MainActor.run {
+                self.handleQuotaWarningTransitions(provider: provider, snapshot: labeled)
                 self.handleSessionQuotaTransition(provider: provider, snapshot: labeled)
                 self.snapshots[provider] = labeled
                 self.lastSourceLabels[provider] = result.sourceLabel

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -52,6 +52,9 @@ extension UsageStore {
             _ = self.settings.refreshFrequency
             _ = self.settings.statusChecksEnabled
             _ = self.settings.sessionQuotaNotificationsEnabled
+            _ = self.settings.quotaWarningNotificationsEnabled
+            _ = self.settings.quotaWarningThresholds
+            _ = self.settings.quotaWarningSoundEnabled
             _ = self.settings.usageBarsShowUsed
             _ = self.settings.costUsageEnabled
             _ = self.settings.randomBlinkEnabled
@@ -203,6 +206,7 @@ final class UsageStore {
     @ObservationIgnored var codexHistoricalDatasetAccountKey: String?
     @ObservationIgnored var lastKnownSessionRemaining: [UsageProvider: Double] = [:]
     @ObservationIgnored var lastKnownSessionWindowSource: [UsageProvider: SessionQuotaWindowSource] = [:]
+    @ObservationIgnored var quotaWarningState: [QuotaWarningStateKey: QuotaWarningState] = [:]
     @ObservationIgnored var lastTokenFetchAt: [UsageProvider: Date] = [:]
     @ObservationIgnored var planUtilizationHistory: [UsageProvider: PlanUtilizationHistoryBuckets] = [:]
     @ObservationIgnored var weeklyLimitResetDetectorStates: [String: WeeklyLimitResetDetectorState] = [:]
@@ -606,6 +610,16 @@ final class UsageStore {
         case copilotSecondaryFallback
     }
 
+    struct QuotaWarningStateKey: Hashable {
+        let provider: UsageProvider
+        let window: QuotaWarningWindow
+    }
+
+    struct QuotaWarningState {
+        var lastRemaining: Double?
+        var firedThresholds: Set<Int> = []
+    }
+
     private func sessionQuotaWindow(
         provider: UsageProvider,
         snapshot: UsageSnapshot) -> (window: RateWindow, source: SessionQuotaWindowSource)?
@@ -694,6 +708,54 @@ final class UsageStore {
         self.sessionQuotaLogger.info(message)
 
         self.sessionQuotaNotifier.post(transition: transition, provider: provider, badge: nil)
+    }
+
+    func handleQuotaWarningTransitions(provider: UsageProvider, snapshot: UsageSnapshot) {
+        guard self.settings.quotaWarningNotificationsEnabled else { return }
+
+        self.handleQuotaWarningTransition(provider: provider, window: .session, rateWindow: snapshot.primary)
+        self.handleQuotaWarningTransition(provider: provider, window: .weekly, rateWindow: snapshot.secondary)
+    }
+
+    private func handleQuotaWarningTransition(
+        provider: UsageProvider,
+        window: QuotaWarningWindow,
+        rateWindow: RateWindow?)
+    {
+        let key = QuotaWarningStateKey(provider: provider, window: window)
+        guard let rateWindow else {
+            self.quotaWarningState.removeValue(forKey: key)
+            return
+        }
+
+        let thresholds = self.settings.resolvedQuotaWarningThresholds(provider: provider, window: window)
+        let currentRemaining = rateWindow.remainingPercent
+        var state = self.quotaWarningState[key] ?? QuotaWarningState()
+        let cleared = QuotaWarningNotificationLogic.thresholdsToClear(
+            currentRemaining: currentRemaining,
+            alreadyFired: state.firedThresholds)
+        state.firedThresholds.subtract(cleared)
+
+        if let threshold = QuotaWarningNotificationLogic.crossedThreshold(
+            previousRemaining: state.lastRemaining,
+            currentRemaining: currentRemaining,
+            thresholds: thresholds,
+            alreadyFired: state.firedThresholds)
+        {
+            state.firedThresholds.formUnion(QuotaWarningNotificationLogic.firedThresholdsAfterWarning(
+                threshold: threshold,
+                thresholds: thresholds))
+            self.sessionQuotaNotifier.postQuotaWarning(
+                event: QuotaWarningEvent(
+                    window: window,
+                    threshold: threshold,
+                    currentRemaining: currentRemaining),
+                provider: provider,
+                soundEnabled: self.settings.quotaWarningSoundEnabled)
+        }
+
+        state.lastRemaining = currentRemaining
+        self.quotaWarningState[key] = state
     }
 
     private func refreshStatus(_ provider: UsageProvider) async {

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -84,6 +84,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
     public var workspaceID: String?
     public var tokenAccounts: ProviderTokenAccountData?
     public var codexActiveSource: CodexActiveSource?
+    public var quotaWarnings: QuotaWarningConfig?
 
     public init(
         id: UsageProvider,
@@ -96,7 +97,8 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         region: String? = nil,
         workspaceID: String? = nil,
         tokenAccounts: ProviderTokenAccountData? = nil,
-        codexActiveSource: CodexActiveSource? = nil)
+        codexActiveSource: CodexActiveSource? = nil,
+        quotaWarnings: QuotaWarningConfig? = nil)
     {
         self.id = id
         self.enabled = enabled
@@ -109,6 +111,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         self.workspaceID = workspaceID
         self.tokenAccounts = tokenAccounts
         self.codexActiveSource = codexActiveSource
+        self.quotaWarnings = quotaWarnings
     }
 
     public var sanitizedAPIKey: String? {
@@ -131,5 +134,78 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         }
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value
+    }
+}
+
+public enum QuotaWarningWindow: String, Codable, Sendable, CaseIterable {
+    case session
+    case weekly
+
+    public var displayName: String {
+        switch self {
+        case .session:
+            "session"
+        case .weekly:
+            "weekly"
+        }
+    }
+}
+
+public struct QuotaWarningWindowConfig: Codable, Sendable, Equatable {
+    public var thresholds: [Int]?
+
+    public init(thresholds: [Int]? = nil) {
+        self.thresholds = thresholds.map(QuotaWarningThresholds.sanitized)
+    }
+
+    public var hasOverride: Bool {
+        self.thresholds != nil
+    }
+}
+
+public struct QuotaWarningConfig: Codable, Sendable, Equatable {
+    public var session: QuotaWarningWindowConfig?
+    public var weekly: QuotaWarningWindowConfig?
+
+    public init(
+        session: QuotaWarningWindowConfig? = nil,
+        weekly: QuotaWarningWindowConfig? = nil)
+    {
+        self.session = session
+        self.weekly = weekly
+    }
+
+    public func thresholds(for window: QuotaWarningWindow, global: [Int]) -> [Int] {
+        switch window {
+        case .session:
+            QuotaWarningThresholds.sanitized(self.session?.thresholds ?? global)
+        case .weekly:
+            QuotaWarningThresholds.sanitized(self.weekly?.thresholds ?? global)
+        }
+    }
+
+    public func hasOverride(for window: QuotaWarningWindow) -> Bool {
+        switch window {
+        case .session:
+            self.session?.hasOverride ?? false
+        case .weekly:
+            self.weekly?.hasOverride ?? false
+        }
+    }
+
+    public var isEmpty: Bool {
+        self.session?.hasOverride != true && self.weekly?.hasOverride != true
+    }
+}
+
+public enum QuotaWarningThresholds {
+    public static let defaults = [50, 20]
+    public static let allowedRange = 1...99
+
+    public static func sanitized(_ raw: [Int]) -> [Int] {
+        let filtered = raw.filter { self.allowedRange.contains($0) }
+        let unique = Set(filtered)
+        let sorted = unique.sorted(by: >)
+        return sorted.isEmpty ? self.defaults : sorted
     }
 }

--- a/Sources/CodexBarCore/Logging/LogCategories.swift
+++ b/Sources/CodexBarCore/Logging/LogCategories.swift
@@ -54,6 +54,7 @@ public enum LogCategories {
     public static let perplexityWeb = "perplexity-web"
     public static let providerDetection = "provider-detection"
     public static let providers = "providers"
+    public static let quotaWarningNotifications = "quotaWarningNotifications"
     public static let sessionQuota = "sessionQuota"
     public static let sessionQuotaNotifications = "sessionQuotaNotifications"
     public static let settings = "settings"

--- a/Tests/CodexBarTests/CodexActiveSourceConfigTests.swift
+++ b/Tests/CodexBarTests/CodexActiveSourceConfigTests.swift
@@ -22,6 +22,26 @@ struct CodexActiveSourceConfigTests {
             from: Data(legacyJSON.utf8))
 
         #expect(decoded.providerConfig(for: .codex)?.codexActiveSource == nil)
+        #expect(decoded.providerConfig(for: .codex)?.quotaWarnings == nil)
+    }
+
+    @Test
+    func `provider config round trips quota warning overrides`() throws {
+        let config = CodexBarConfig(
+            providers: [
+                ProviderConfig(
+                    id: .codex,
+                    quotaWarnings: QuotaWarningConfig(
+                        session: QuotaWarningWindowConfig(thresholds: [10]),
+                        weekly: QuotaWarningWindowConfig(thresholds: [50, 20]))),
+            ])
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(CodexBarConfig.self, from: data)
+        let quotaWarnings = try #require(decoded.providerConfig(for: .codex)?.quotaWarnings)
+
+        #expect(quotaWarnings.thresholds(for: .session, global: [80]) == [10])
+        #expect(quotaWarnings.thresholds(for: .weekly, global: [80]) == [50, 20])
     }
 
     @Test

--- a/Tests/CodexBarTests/QuotaWarningNotificationLogicTests.swift
+++ b/Tests/CodexBarTests/QuotaWarningNotificationLogicTests.swift
@@ -1,0 +1,77 @@
+import Testing
+@testable import CodexBar
+
+struct QuotaWarningNotificationLogicTests {
+    @Test
+    func `does nothing without crossing`() {
+        let crossed = QuotaWarningNotificationLogic.crossedThreshold(
+            previousRemaining: 60,
+            currentRemaining: 55,
+            thresholds: [50, 20],
+            alreadyFired: [])
+
+        #expect(crossed == nil)
+    }
+
+    @Test
+    func `detects downward crossing`() {
+        let crossed = QuotaWarningNotificationLogic.crossedThreshold(
+            previousRemaining: 55,
+            currentRemaining: 45,
+            thresholds: [50, 20],
+            alreadyFired: [])
+
+        #expect(crossed == 50)
+    }
+
+    @Test
+    func `skips already fired thresholds`() {
+        let crossed = QuotaWarningNotificationLogic.crossedThreshold(
+            previousRemaining: 55,
+            currentRemaining: 45,
+            thresholds: [50, 20],
+            alreadyFired: [50])
+
+        #expect(crossed == nil)
+    }
+
+    @Test
+    func `chooses most severe threshold when crossing several at once`() {
+        let crossed = QuotaWarningNotificationLogic.crossedThreshold(
+            previousRemaining: 80,
+            currentRemaining: 10,
+            thresholds: [50, 20],
+            alreadyFired: [])
+
+        #expect(crossed == 20)
+    }
+
+    @Test
+    func `startup below threshold warns once at most severe threshold`() {
+        let crossed = QuotaWarningNotificationLogic.crossedThreshold(
+            previousRemaining: nil,
+            currentRemaining: 10,
+            thresholds: [50, 20],
+            alreadyFired: [])
+
+        #expect(crossed == 20)
+    }
+
+    @Test
+    func `warning marks threshold and higher thresholds fired`() {
+        let fired = QuotaWarningNotificationLogic.firedThresholdsAfterWarning(
+            threshold: 20,
+            thresholds: [50, 20])
+
+        #expect(fired == [50, 20])
+    }
+
+    @Test
+    func `recovery clears only thresholds below current remaining`() {
+        let cleared = QuotaWarningNotificationLogic.thresholdsToClear(
+            currentRemaining: 30,
+            alreadyFired: [50, 20])
+
+        #expect(cleared == [20])
+    }
+}

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -492,6 +492,64 @@ struct SettingsStoreTests {
     }
 
     @Test
+    func `defaults quota warnings to disabled with global thresholds and sound`() throws {
+        let suite = "SettingsStoreTests-quota-warning-defaults"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        #expect(store.quotaWarningNotificationsEnabled == false)
+        #expect(store.quotaWarningThresholds == [50, 20])
+        #expect(store.quotaWarningSoundEnabled == true)
+        #expect(defaults.array(forKey: "quotaWarningThresholds") as? [Int] == [50, 20])
+        #expect(defaults.bool(forKey: "quotaWarningSoundEnabled") == true)
+    }
+
+    @Test
+    func `sanitizes invalid quota warning thresholds from defaults`() throws {
+        let suite = "SettingsStoreTests-quota-warning-sanitize"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set([120, 20, 20, 0, 50], forKey: "quotaWarningThresholds")
+        let configStore = testConfigStore(suiteName: suite)
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        #expect(store.quotaWarningThresholds == [50, 20])
+        #expect(defaults.array(forKey: "quotaWarningThresholds") as? [Int] == [50, 20])
+    }
+
+    @Test
+    func `provider quota warning override resolves before global thresholds`() throws {
+        let suite = "SettingsStoreTests-quota-warning-provider-override"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        store.quotaWarningThresholds = [50, 20]
+
+        #expect(store.resolvedQuotaWarningThresholds(provider: .codex, window: .session) == [50, 20])
+        store.setQuotaWarningThresholds(provider: .codex, window: .session, thresholds: [10])
+        #expect(store.resolvedQuotaWarningThresholds(provider: .codex, window: .session) == [10])
+        #expect(store.resolvedQuotaWarningThresholds(provider: .codex, window: .weekly) == [50, 20])
+
+        store.setQuotaWarningThresholds(provider: .codex, window: .session, thresholds: nil)
+        #expect(store.resolvedQuotaWarningThresholds(provider: .codex, window: .session) == [50, 20])
+    }
+
+    @Test
     func `defaults claude usage source to auto`() throws {
         let suite = "SettingsStoreTests-claude-source"
         let defaults = try #require(UserDefaults(suiteName: suite))

--- a/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
+++ b/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
@@ -8,9 +8,17 @@ struct UsageStoreSessionQuotaTransitionTests {
     @MainActor
     final class SessionQuotaNotifierSpy: SessionQuotaNotifying {
         private(set) var posts: [(transition: SessionQuotaTransition, provider: UsageProvider)] = []
+        private(set) var quotaWarningPosts: [(
+            event: QuotaWarningEvent,
+            provider: UsageProvider,
+            soundEnabled: Bool)] = []
 
         func post(transition: SessionQuotaTransition, provider: UsageProvider, badge _: NSNumber?) {
             self.posts.append((transition: transition, provider: provider))
+        }
+
+        func postQuotaWarning(event: QuotaWarningEvent, provider: UsageProvider, soundEnabled: Bool) {
+            self.quotaWarningPosts.append((event: event, provider: provider, soundEnabled: soundEnabled))
         }
     }
 
@@ -76,5 +84,176 @@ struct UsageStoreSessionQuotaTransitionTests {
         store.handleSessionQuotaTransition(provider: .copilot, snapshot: primarySnapshot)
 
         #expect(notifier.posts.isEmpty)
+    }
+
+    @Test
+    func `quota warning disabled does not post`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-disabled"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.quotaWarningNotificationsEnabled = false
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 90, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        store.handleQuotaWarningTransitions(provider: .codex, snapshot: snapshot)
+
+        #expect(notifier.quotaWarningPosts.isEmpty)
+    }
+
+    @Test
+    func `quota warning posts once per downward threshold crossing`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-once"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.quotaWarningNotificationsEnabled = true
+        settings.quotaWarningThresholds = [50, 20]
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        store.handleQuotaWarningTransitions(
+            provider: .codex,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(usedPercent: 40, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()))
+        store.handleQuotaWarningTransitions(
+            provider: .codex,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(usedPercent: 55, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()))
+        store.handleQuotaWarningTransitions(
+            provider: .codex,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(usedPercent: 60, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()))
+
+        #expect(notifier.quotaWarningPosts.count == 1)
+        #expect(notifier.quotaWarningPosts.first?.event.window == .session)
+        #expect(notifier.quotaWarningPosts.first?.event.threshold == 50)
+    }
+
+    @Test
+    func `quota warning crossing multiple thresholds posts most severe only`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-severe"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.quotaWarningNotificationsEnabled = true
+        settings.quotaWarningThresholds = [50, 20]
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        store.handleQuotaWarningTransitions(
+            provider: .codex,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(usedPercent: 10, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()))
+        store.handleQuotaWarningTransitions(
+            provider: .codex,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(usedPercent: 85, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()))
+
+        #expect(notifier.quotaWarningPosts.map(\.event.threshold) == [20])
+    }
+
+    @Test
+    func `quota warning recovers and can fire again`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-recover"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.quotaWarningNotificationsEnabled = true
+        settings.quotaWarningThresholds = [50]
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        for used in [40, 55, 10, 55] {
+            store.handleQuotaWarningTransitions(
+                provider: .codex,
+                snapshot: UsageSnapshot(
+                    primary: RateWindow(
+                        usedPercent: Double(used),
+                        windowMinutes: nil,
+                        resetsAt: nil,
+                        resetDescription: nil),
+                    secondary: nil,
+                    updatedAt: Date()))
+        }
+
+        #expect(notifier.quotaWarningPosts.map(\.event.threshold) == [50, 50])
+    }
+
+    @Test
+    func `quota warning provider override beats global thresholds`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-override"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.quotaWarningNotificationsEnabled = true
+        settings.quotaWarningThresholds = [50]
+        settings.setQuotaWarningThresholds(provider: .codex, window: .session, thresholds: [10])
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        store.handleQuotaWarningTransitions(
+            provider: .codex,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(usedPercent: 40, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()))
+        store.handleQuotaWarningTransitions(
+            provider: .codex,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(usedPercent: 95, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()))
+
+        #expect(notifier.quotaWarningPosts.map(\.event.threshold) == [10])
     }
 }


### PR DESCRIPTION
## Summary
- Closes #617 by adding opt-in quota warning notifications for session and weekly quota windows.
- Adds sanitized global threshold settings with defaults of 50% and 20% remaining, plus a global notification sound toggle.
- Adds provider/window overrides that live in `ProviderConfig` and inherit global settings until customized.
- Reuses the existing `SessionQuotaNotifier` / `UsageStore` notification path and keeps depleted/restored 0% behavior unchanged.

## Notes
- Reviewed the intent behind PR #433, but did not port it directly because it is stale/conflicting and duplicates the current notification architecture.
- This PR intentionally stays scoped to the minimal #617 surface: macOS notification bubbles, sound toggle, configurable thresholds, and provider/window overrides. It does not add a Notifications tab, Shortcuts, or webhooks.

## Testing
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter QuotaWarning`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter UsageStoreSessionQuotaTransitionTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter SettingsStoreTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter CodexActiveSourceConfigTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./Scripts/lint.sh lint`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` builds and runs, but the full suite currently reports 4 failures in existing HistoricalUsagePace tests unrelated to this change.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./Scripts/compile_and_run.sh` builds the release binary, then fails during ad-hoc codesigning/packaging because the generated `CodexBar.app` / bundled `Sparkle.framework` has macOS resource-fork/Finder metadata.