### PR TITLE
fix(claude): recognize OAuth subscription type

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentialModels.swift
@@ -10,19 +10,22 @@ public struct ClaudeOAuthCredentials: Sendable {
     public let expiresAt: Date?
     public let scopes: [String]
     public let rateLimitTier: String?
+    public let subscriptionType: String?
 
     public init(
         accessToken: String,
         refreshToken: String?,
         expiresAt: Date?,
         scopes: [String],
-        rateLimitTier: String?)
+        rateLimitTier: String?,
+        subscriptionType: String? = nil)
     {
         self.accessToken = accessToken
         self.refreshToken = refreshToken
         self.expiresAt = expiresAt
         self.scopes = scopes
         self.rateLimitTier = rateLimitTier
+        self.subscriptionType = subscriptionType
     }
 
     public var isExpired: Bool {
@@ -55,7 +58,8 @@ public struct ClaudeOAuthCredentials: Sendable {
             refreshToken: oauth.refreshToken,
             expiresAt: expiresAt,
             scopes: oauth.scopes ?? [],
-            rateLimitTier: oauth.rateLimitTier)
+            rateLimitTier: oauth.rateLimitTier,
+            subscriptionType: oauth.subscriptionType)
     }
 
     private struct Root: Decodable {
@@ -68,6 +72,7 @@ public struct ClaudeOAuthCredentials: Sendable {
         let expiresAt: Double?
         let scopes: [String]?
         let rateLimitTier: String?
+        let subscriptionType: String?
 
         enum CodingKeys: String, CodingKey {
             case accessToken
@@ -75,6 +80,7 @@ public struct ClaudeOAuthCredentials: Sendable {
             case expiresAt
             case scopes
             case rateLimitTier
+            case subscriptionType
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -951,13 +951,15 @@ public enum ClaudeOAuthCredentialsStore {
         func refreshAccessToken(
             refreshToken: String,
             existingScopes: [String],
-            existingRateLimitTier: String?) async throws -> ClaudeOAuthCredentials
+            existingRateLimitTier: String?,
+            existingSubscriptionType: String? = nil) async throws -> ClaudeOAuthCredentials
         {
             try await self.context.run {
                 let newCredentials = try await self.refreshAccessTokenCore(
                     refreshToken: refreshToken,
                     existingScopes: existingScopes,
-                    existingRateLimitTier: existingRateLimitTier)
+                    existingRateLimitTier: existingRateLimitTier,
+                    existingSubscriptionType: existingSubscriptionType)
 
                 ClaudeOAuthCredentialsStore.saveRefreshedCredentialsToCache(newCredentials)
                 ClaudeOAuthCredentialsStore.writeMemoryCache(
@@ -975,7 +977,8 @@ public enum ClaudeOAuthCredentialsStore {
         private func refreshAccessTokenCore(
             refreshToken: String,
             existingScopes: [String],
-            existingRateLimitTier: String?) async throws -> ClaudeOAuthCredentials
+            existingRateLimitTier: String?,
+            existingSubscriptionType: String?) async throws -> ClaudeOAuthCredentials
         {
             guard ClaudeOAuthRefreshFailureGate.shouldAttempt() else {
                 let status = ClaudeOAuthRefreshFailureGate.currentBlockStatus()
@@ -1051,7 +1054,8 @@ public enum ClaudeOAuthCredentialsStore {
                 refreshToken: tokenResponse.refreshToken ?? refreshToken,
                 expiresAt: expiresAt,
                 scopes: existingScopes,
-                rateLimitTier: existingRateLimitTier)
+                rateLimitTier: existingRateLimitTier,
+                subscriptionType: existingSubscriptionType)
         }
     }
 
@@ -1144,7 +1148,8 @@ public enum ClaudeOAuthCredentialsStore {
             let refreshed = try await refresher.refreshAccessToken(
                 refreshToken: refreshToken,
                 existingScopes: credentials.scopes,
-                existingRateLimitTier: credentials.rateLimitTier)
+                existingRateLimitTier: credentials.rateLimitTier,
+                existingSubscriptionType: credentials.subscriptionType)
             self.log.info("Token refresh successful, expires in \(refreshed.expiresIn ?? 0) seconds")
             return refreshed
         } catch {
@@ -1166,6 +1171,9 @@ public enum ClaudeOAuthCredentialsStore {
         }
         if let rateLimitTier = credentials.rateLimitTier {
             oauth["rateLimitTier"] = rateLimitTier
+        }
+        if let subscriptionType = credentials.subscriptionType {
+            oauth["subscriptionType"] = subscriptionType
         }
 
         let oauthData: [String: Any] = ["claudeAiOauth": oauth]
@@ -1918,12 +1926,14 @@ extension ClaudeOAuthCredentialsStore {
     public static func refreshAccessToken(
         refreshToken: String,
         existingScopes: [String],
-        existingRateLimitTier: String?) async throws -> ClaudeOAuthCredentials
+        existingRateLimitTier: String?,
+        existingSubscriptionType: String? = nil) async throws -> ClaudeOAuthCredentials
     {
         try await Refresher(context: self.currentCollaboratorContext()).refreshAccessToken(
             refreshToken: refreshToken,
             existingScopes: existingScopes,
-            existingRateLimitTier: existingRateLimitTier)
+            existingRateLimitTier: existingRateLimitTier,
+            existingSubscriptionType: existingSubscriptionType)
     }
 
     private enum RefreshFailureDisposition: String {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudePlan.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudePlan.swift
@@ -50,6 +50,11 @@ public enum ClaudePlan: String, CaseIterable, Sendable {
         self.fromRateLimitTier(rateLimitTier)
     }
 
+    public static func fromOAuthCredentials(subscriptionType: String?, rateLimitTier: String?) -> Self? {
+        self.fromCompatibilityLoginMethod(subscriptionType)
+            ?? self.fromOAuthRateLimitTier(rateLimitTier)
+    }
+
     public static func fromWebAccount(rateLimitTier: String?, billingType: String?) -> Self? {
         if let plan = self.fromRateLimitTier(rateLimitTier) {
             return plan
@@ -88,6 +93,10 @@ public enum ClaudePlan: String, CaseIterable, Sendable {
 
     public static func oauthLoginMethod(rateLimitTier: String?) -> String? {
         self.fromOAuthRateLimitTier(rateLimitTier)?.brandedLoginMethod
+    }
+
+    public static func oauthLoginMethod(subscriptionType: String?, rateLimitTier: String?) -> String? {
+        self.fromOAuthCredentials(subscriptionType: subscriptionType, rateLimitTier: rateLimitTier)?.brandedLoginMethod
     }
 
     public static func webLoginMethod(rateLimitTier: String?, billingType: String?) -> String? {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -846,7 +846,9 @@ extension ClaudeUsageFetcher {
             windowMinutes: 7 * 24 * 60)
         let extraRateWindows = Self.oauthExtraRateWindows(from: usage)
 
-        let loginMethod = ClaudePlan.oauthLoginMethod(rateLimitTier: credentials.rateLimitTier)
+        let loginMethod = ClaudePlan.oauthLoginMethod(
+            subscriptionType: credentials.subscriptionType,
+            rateLimitTier: credentials.rateLimitTier)
         let providerCost = Self.oauthExtraUsageCost(usage.extraUsage, loginMethod: loginMethod)
 
         return ClaudeUsageSnapshot(
@@ -1148,6 +1150,7 @@ extension ClaudeUsageFetcher {
 extension ClaudeUsageFetcher {
     public static func _mapOAuthUsageForTesting(
         _ data: Data,
+        subscriptionType: String? = nil,
         rateLimitTier: String? = nil) throws -> ClaudeUsageSnapshot
     {
         let usage = try ClaudeOAuthUsageFetcher.decodeUsageResponse(data)
@@ -1156,7 +1159,8 @@ extension ClaudeUsageFetcher {
             refreshToken: nil,
             expiresAt: Date().addingTimeInterval(3600),
             scopes: [],
-            rateLimitTier: rateLimitTier)
+            rateLimitTier: rateLimitTier,
+            subscriptionType: subscriptionType)
         return try Self.mapOAuthUsage(usage, credentials: creds)
     }
 }

--- a/Tests/CodexBarTests/ClaudeOAuthTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthTests.swift
@@ -12,6 +12,7 @@ struct ClaudeOAuthTests {
             "refreshToken": "test-refresh",
             "expiresAt": 4102444800000,
             "scopes": ["usage:read"],
+            "subscriptionType": "pro",
             "rateLimitTier": "default_claude_max_20x"
           }
         }
@@ -20,6 +21,7 @@ struct ClaudeOAuthTests {
         #expect(creds.accessToken == "test-token")
         #expect(creds.refreshToken == "test-refresh")
         #expect(creds.scopes == ["usage:read"])
+        #expect(creds.subscriptionType == "pro")
         #expect(creds.rateLimitTier == "default_claude_max_20x")
         #expect(creds.isExpired == false)
     }
@@ -78,6 +80,21 @@ struct ClaudeOAuthTests {
         #expect(snap.secondary?.usedPercent == 30)
         #expect(snap.opus?.usedPercent == 5)
         #expect(snap.primary.resetsAt != nil)
+        #expect(snap.loginMethod == "Claude Pro")
+    }
+
+    @Test
+    func `maps O auth subscription type when rate limit tier is generic`() throws {
+        let json = """
+        {
+          "five_hour": { "utilization": 12.5 },
+          "seven_day": { "utilization": 30 }
+        }
+        """
+        let snap = try ClaudeUsageFetcher._mapOAuthUsageForTesting(
+            Data(json.utf8),
+            subscriptionType: "pro",
+            rateLimitTier: "default_claude_ai")
         #expect(snap.loginMethod == "Claude Pro")
     }
 

--- a/Tests/CodexBarTests/ClaudePlanResolverTests.swift
+++ b/Tests/CodexBarTests/ClaudePlanResolverTests.swift
@@ -12,6 +12,20 @@ struct ClaudePlanResolverTests {
     }
 
     @Test
+    func `oauth subscription type maps pro when rate limit tier is generic`() {
+        #expect(
+            ClaudePlan.oauthLoginMethod(
+                subscriptionType: "pro",
+                rateLimitTier: "default_claude_ai")
+                == "Claude Pro")
+        #expect(
+            ClaudePlan.oauthLoginMethod(
+                subscriptionType: nil,
+                rateLimitTier: "default_claude_ai")
+                == nil)
+    }
+
+    @Test
     func `web fallback preserves stripe Claude compatibility`() {
         #expect(
             ClaudePlan.webLoginMethod(


### PR DESCRIPTION
## Summary

- Fixes #824.
- Parse and retain `subscriptionType` from Claude Code OAuth credentials.
- Prefer `subscriptionType` over `rateLimitTier` when deriving the Claude OAuth login method, while keeping `rateLimitTier` as a fallback.
- Preserve `subscriptionType` when refreshed OAuth credentials are written back to CodexBar's cache.
- Add regression coverage for Pro credentials that report `rateLimitTier: "default_claude_ai"`.

## Root Cause

Claude Code can store OAuth credentials for a Pro account with `subscriptionType: "pro"` while `rateLimitTier` is set to `default_claude_ai`, as documented in https://github.com/anthropics/claude-code/issues/38909. CodexBar only used `rateLimitTier` to infer the plan, so it could not derive `Claude Pro`; downstream subscription checks then treated the account as unknown and used the generic Claude dashboard URL.

## Solution

Use the explicit OAuth `subscriptionType` as the primary plan signal and fall back to `rateLimitTier` only when `subscriptionType` is absent. This avoids a broad "all OAuth means subscription" shortcut and keeps non-subscription OAuth accounts from being misclassified.

## Why This Fix

This changes the shared Claude OAuth credential model and plan resolver instead of patching the dashboard action. The dashboard was only the visible symptom; the broken state was that OAuth Pro credentials could not resolve to a subscription plan.

`subscriptionType` is the stable account-level signal in this credential shape. `rateLimitTier` can still identify Max, Team, Enterprise, and other known tiers, so CodexBar keeps it as a fallback. The fix does not map bare `default_claude_ai` to Pro, and it does not treat every OAuth account as a subscription.

The refreshed credential cache now preserves `subscriptionType`, so the fix survives token refresh instead of working only until the next cache write.

## Validation

- `swiftformat Sources Tests`
- `swiftlint --strict`
- `pnpm check`
- `git diff --check`
- `swift test --filter 'ClaudePlanResolverTests|ClaudeOAuthTests'`
- `swift test --filter OpenAIDashboardNavigationDelegateTests`
- `swift test --filter CodexAccountScopedRefreshTests`
- `TZ=UTC swift test --filter MistralUsageParserTests`
- `./Scripts/compile_and_run.sh`
