### PR TITLE
Add Codebuff provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CodexBar 🎚️ - May your tokens never run out.
 
-Tiny macOS 14+ menu bar app that keeps your Codex, Claude, Cursor, Gemini, Antigravity, Droid (Factory), Copilot, z.ai, Kiro, Vertex AI, Augment, Amp, JetBrains AI, OpenRouter, Perplexity, and Abacus AI limits visible (session + weekly where available) and shows when each window resets. One status item per provider (or Merge Icons mode with a provider switcher and optional Overview tab); enable what you use from Settings. No Dock icon, minimal UI, dynamic bar icons in the menu bar.
+Tiny macOS 14+ menu bar app that keeps your Codex, Claude, Cursor, Gemini, Antigravity, Droid (Factory), Copilot, z.ai, Kiro, Vertex AI, Augment, Amp, JetBrains AI, OpenRouter, Perplexity, Abacus AI, and Codebuff limits visible (session + weekly where available) and shows when each window resets. One status item per provider (or Merge Icons mode with a provider switcher and optional Overview tab); enable what you use from Settings. No Dock icon, minimal UI, dynamic bar icons in the menu bar.
 
 <img src="codexbar.png" alt="CodexBar menu screenshot" width="520" />
 
@@ -49,6 +49,7 @@ Linux support via Omarchy: community Waybar module and TUI, driven by the `codex
 - [OpenRouter](docs/openrouter.md) — API token for credit-based usage tracking across multiple AI providers.
 - [Abacus AI](docs/abacus.md) — Browser cookie auth for ChatLLM/RouteLLM compute credit tracking.
 - [DeepSeek](docs/deepseek.md) — API key for credit balance tracking (paid vs. granted breakdown).
+- [Codebuff](docs/codebuff.md) — API token (or `~/.config/manicode/credentials.json`) for credit balance + weekly rate limit.
 - Open to new providers: [provider authoring guide](docs/provider.md).
 
 ## Icon & Screenshot

--- a/Sources/CodexBar/Providers/Codebuff/CodebuffProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Codebuff/CodebuffProviderImplementation.swift
@@ -1,0 +1,42 @@
+import AppKit
+import CodexBarCore
+import CodexBarMacroSupport
+import Foundation
+
+@ProviderImplementationRegistration
+struct CodebuffProviderImplementation: ProviderImplementation {
+    let id: UsageProvider = .codebuff
+
+    @MainActor
+    func observeSettings(_ settings: SettingsStore) {
+        _ = settings.codebuffAPIToken
+    }
+
+    @MainActor
+    func settingsFields(context: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {
+        [
+            ProviderSettingsFieldDescriptor(
+                id: "codebuff-api-key",
+                title: "API key",
+                subtitle: "Stored in ~/.codexbar/config.json. You can also provide CODEBUFF_API_KEY or let " +
+                    "CodexBar read ~/.config/manicode/credentials.json (created by `codebuff login`).",
+                kind: .secure,
+                placeholder: "cb_...",
+                binding: context.stringBinding(\.codebuffAPIToken),
+                actions: [
+                    ProviderSettingsActionDescriptor(
+                        id: "codebuff-open-dashboard",
+                        title: "Open Codebuff Dashboard",
+                        style: .link,
+                        isVisible: nil,
+                        perform: {
+                            if let url = URL(string: "https://www.codebuff.com/usage") {
+                                NSWorkspace.shared.open(url)
+                            }
+                        }),
+                ],
+                isVisible: nil,
+                onActivate: nil),
+        ]
+    }
+}

--- a/Sources/CodexBar/Providers/Codebuff/CodebuffSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Codebuff/CodebuffSettingsStore.swift
@@ -1,0 +1,14 @@
+import CodexBarCore
+import Foundation
+
+extension SettingsStore {
+    var codebuffAPIToken: String {
+        get { self.configSnapshot.providerConfig(for: .codebuff)?.sanitizedAPIKey ?? "" }
+        set {
+            self.updateProviderConfig(provider: .codebuff) { entry in
+                entry.apiKey = self.normalizedConfigValue(newValue)
+            }
+            self.logSecretUpdate(provider: .codebuff, field: "apiKey", value: newValue)
+        }
+    }
+}

--- a/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
@@ -41,6 +41,7 @@ enum ProviderImplementationRegistry {
         case .abacus: AbacusProviderImplementation()
         case .mistral: MistralProviderImplementation()
         case .deepseek: DeepSeekProviderImplementation()
+        case .codebuff: CodebuffProviderImplementation()
         }
     }
 

--- a/Sources/CodexBar/Resources/ProviderIcon-codebuff.svg
+++ b/Sources/CodexBar/Resources/ProviderIcon-codebuff.svg
@@ -1,0 +1,4 @@
+<svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M50 8L12 28V72L50 92L88 72V28L50 8ZM50 22.5L74 35.25V64.75L50 77.5L26 64.75V35.25L50 22.5Z" fill="#44FF00"/>
+  <path d="M50 40L61 46V54L50 60L39 54V46L50 40Z" fill="#44FF00"/>
+</svg>

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -892,7 +892,7 @@ extension UsageStore {
                         hasEnvToken: deepSeekHasEnvToken,
                         hasTokenAccount: deepSeekHasTokenAccount)
                 case .gemini, .antigravity, .opencode, .opencodego, .factory, .copilot, .vertexai, .kilo, .kiro, .kimi,
-                     .kimik2, .jetbrains, .perplexity, .abacus, .mistral:
+                     .kimik2, .jetbrains, .perplexity, .abacus, .mistral, .codebuff:
                     return unimplementedDebugLogMessages[provider] ?? "Debug log not yet implemented"
                 }
             }

--- a/Sources/CodexBarCLI/TokenAccountCLI.swift
+++ b/Sources/CodexBarCLI/TokenAccountCLI.swift
@@ -200,7 +200,8 @@ struct TokenAccountCLIContext {
                 mistral: ProviderSettingsSnapshot.MistralProviderSettings(
                     cookieSource: cookieSource,
                     manualCookieHeader: cookieHeader))
-        case .gemini, .antigravity, .copilot, .kiro, .vertexai, .kimik2, .synthetic, .openrouter, .warp, .deepseek:
+        case .gemini, .antigravity, .copilot, .kiro, .vertexai, .kimik2, .synthetic, .openrouter, .warp, .deepseek,
+             .codebuff:
             return nil
         }
     }

--- a/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
+++ b/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
@@ -31,6 +31,8 @@ public enum ProviderConfigEnvironment {
             }
         case .openrouter:
             env[OpenRouterSettingsReader.envKey] = apiKey
+        case .codebuff:
+            env[CodebuffSettingsReader.apiTokenKey] = apiKey
         default:
             break
         }

--- a/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
+++ b/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
@@ -32,7 +32,12 @@ public enum ProviderConfigEnvironment {
         case .openrouter:
             env[OpenRouterSettingsReader.envKey] = apiKey
         case .codebuff:
-            env[CodebuffSettingsReader.apiTokenKey] = apiKey
+            // Preserve a token already present in the process environment so that
+            // runtime/CI overrides win over a key saved in Settings (matches the
+            // precedence used by `ProviderTokenResolver.codebuffResolution`).
+            if CodebuffSettingsReader.apiKey(environment: base) == nil {
+                env[CodebuffSettingsReader.apiTokenKey] = apiKey
+            }
         default:
             break
         }

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffProviderDescriptor.swift
@@ -1,0 +1,86 @@
+import CodexBarMacroSupport
+import Foundation
+
+@ProviderDescriptorRegistration
+@ProviderDescriptorDefinition
+public enum CodebuffProviderDescriptor {
+    static func makeDescriptor() -> ProviderDescriptor {
+        ProviderDescriptor(
+            id: .codebuff,
+            metadata: ProviderMetadata(
+                id: .codebuff,
+                displayName: "Codebuff",
+                sessionLabel: "Credits",
+                weeklyLabel: "Weekly",
+                opusLabel: nil,
+                supportsOpus: false,
+                supportsCredits: true,
+                creditsHint: "Credit balance from the Codebuff API",
+                toggleTitle: "Show Codebuff usage",
+                cliName: "codebuff",
+                defaultEnabled: false,
+                isPrimaryProvider: false,
+                usesAccountFallback: false,
+                browserCookieOrder: nil,
+                dashboardURL: "https://www.codebuff.com/usage",
+                statusPageURL: nil,
+                statusLinkURL: nil),
+            branding: ProviderBranding(
+                iconStyle: .codebuff,
+                iconResourceName: "ProviderIcon-codebuff",
+                color: ProviderColor(red: 68 / 255, green: 255 / 255, blue: 0 / 255)),
+            tokenCost: ProviderTokenCostConfig(
+                supportsTokenCost: false,
+                noDataMessage: { "Codebuff cost summary is not yet supported." }),
+            fetchPlan: ProviderFetchPlan(
+                sourceModes: [.auto, .api],
+                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [CodebuffAPIFetchStrategy()] })),
+            cli: ProviderCLIConfig(
+                name: "codebuff",
+                aliases: ["manicode"],
+                versionDetector: nil))
+    }
+}
+
+struct CodebuffAPIFetchStrategy: ProviderFetchStrategy {
+    let id: String = "codebuff.api"
+    let kind: ProviderFetchKind = .apiToken
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        _ = context
+        // Keep the strategy available so missing-token surfaces as a user-friendly error
+        // instead of a generic "no strategy" outcome.
+        return true
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        guard let apiKey = Self.resolveToken(environment: context.env) else {
+            throw CodebuffUsageError.missingCredentials
+        }
+        let usage = try await CodebuffUsageFetcher.fetchUsage(apiKey: apiKey, environment: context.env)
+        return self.makeResult(
+            usage: usage.toUsageSnapshot(),
+            sourceLabel: "api")
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+
+    private static func resolveToken(environment: [String: String]) -> String? {
+        ProviderTokenResolver.codebuffToken(environment: environment)
+    }
+}
+
+/// Errors related to Codebuff settings.
+public enum CodebuffSettingsError: LocalizedError, Sendable {
+    case missingToken
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingToken:
+            "Codebuff API token not configured. Set CODEBUFF_API_KEY or run `codebuff login` to " +
+                "populate ~/.config/manicode/credentials.json."
+        }
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffProviderDescriptor.swift
@@ -54,10 +54,13 @@ struct CodebuffAPIFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        guard let apiKey = Self.resolveToken(environment: context.env) else {
+        guard let resolution = Self.resolveToken(environment: context.env) else {
             throw CodebuffUsageError.missingCredentials
         }
-        let usage = try await CodebuffUsageFetcher.fetchUsage(apiKey: apiKey, environment: context.env)
+        let usage = try await CodebuffUsageFetcher.fetchUsage(
+            apiKey: resolution.token,
+            environment: context.env,
+            includeSubscription: Self.shouldFetchSubscription(for: resolution))
         return self.makeResult(
             usage: usage.toUsageSnapshot(),
             sourceLabel: "api")
@@ -67,8 +70,12 @@ struct CodebuffAPIFetchStrategy: ProviderFetchStrategy {
         false
     }
 
-    private static func resolveToken(environment: [String: String]) -> String? {
-        ProviderTokenResolver.codebuffToken(environment: environment)
+    static func shouldFetchSubscription(for resolution: ProviderTokenResolution) -> Bool {
+        resolution.source == .authFile
+    }
+
+    private static func resolveToken(environment: [String: String]) -> ProviderTokenResolution? {
+        ProviderTokenResolver.codebuffResolution(environment: environment)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Reads Codebuff settings from the environment or the local credentials file
+/// that the `codebuff` CLI (formerly `manicode`) writes when the user logs in.
+public enum CodebuffSettingsReader {
+    /// Environment variable key for the Codebuff API token.
+    public static let apiTokenKey = "CODEBUFF_API_KEY"
+
+    /// Returns the API token from environment if present and non-empty.
+    public static func apiKey(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        self.cleaned(environment[self.apiTokenKey])
+    }
+
+    /// Returns the API base URL, defaulting to the production endpoint.
+    public static func apiURL(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL {
+        if let override = environment["CODEBUFF_API_URL"],
+           let url = URL(string: cleaned(override) ?? "")
+        {
+            return url
+        }
+        return URL(string: "https://www.codebuff.com")!
+    }
+
+    /// Returns the auth token from the local credentials file if present.
+    public static func authToken(
+        authFileURL: URL? = nil,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) -> String?
+    {
+        let fileURL = authFileURL ?? self.defaultAuthFileURL(homeDirectory: homeDirectory)
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        return self.parseAuthToken(data: data)
+    }
+
+    /// Default on-disk credentials path: `~/.config/manicode/credentials.json`.
+    static func defaultAuthFileURL(homeDirectory: URL) -> URL {
+        homeDirectory
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("manicode", isDirectory: true)
+            .appendingPathComponent("credentials.json", isDirectory: false)
+    }
+
+    static func parseAuthToken(data: Data) -> String? {
+        guard let payload = try? JSONDecoder().decode(CredentialsFile.self, from: data) else {
+            return nil
+        }
+        return self.cleaned(payload.authToken)
+    }
+
+    static func cleaned(_ raw: String?) -> String? {
+        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+
+        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
+            (value.hasPrefix("'") && value.hasSuffix("'"))
+        {
+            value.removeFirst()
+            value.removeLast()
+        }
+
+        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}
+
+private struct CredentialsFile: Decodable {
+    let authToken: String?
+    let fingerprintId: String?
+    let email: String?
+    let name: String?
+}

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift
@@ -43,7 +43,7 @@ public enum CodebuffSettingsReader {
         guard let payload = try? JSONDecoder().decode(CredentialsFile.self, from: data) else {
             return nil
         }
-        return self.cleaned(payload.authToken)
+        return self.cleaned(payload.default?.authToken) ?? self.cleaned(payload.authToken)
     }
 
     static func cleaned(_ raw: String?) -> String? {
@@ -64,6 +64,11 @@ public enum CodebuffSettingsReader {
 }
 
 private struct CredentialsFile: Decodable {
+    let `default`: CredentialsProfile?
+    let authToken: String?
+}
+
+private struct CredentialsProfile: Decodable {
     let authToken: String?
     let fingerprintId: String?
     let email: String?

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageError.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageError.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+public enum CodebuffUsageError: LocalizedError, Sendable, Equatable {
+    case missingCredentials
+    case unauthorized
+    case endpointNotFound
+    case serviceUnavailable(Int)
+    case apiError(Int)
+    case networkError(String)
+    case parseFailed(String)
+
+    public static let missingToken: CodebuffUsageError = .missingCredentials
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingCredentials:
+            "Codebuff API token not configured. Set CODEBUFF_API_KEY or run `codebuff login` to " +
+                "populate ~/.config/manicode/credentials.json."
+        case .unauthorized:
+            "Unauthorized. Please sign in to Codebuff again."
+        case .endpointNotFound:
+            "Codebuff usage endpoint not found."
+        case let .serviceUnavailable(status):
+            "Codebuff API is temporarily unavailable (status \(status))."
+        case let .apiError(status):
+            "Codebuff API returned an unexpected status (\(status))."
+        case let .networkError(message):
+            "Codebuff API error: \(message)"
+        case let .parseFailed(message):
+            "Could not parse Codebuff usage: \(message)"
+        }
+    }
+
+    public var isAuthRelated: Bool {
+        switch self {
+        case .unauthorized, .missingCredentials: true
+        default: false
+        }
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
@@ -1,0 +1,257 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Fetches live credit balance and subscription details from the Codebuff API.
+/// Uses Bearer token auth against the public www.codebuff.com endpoints used by
+/// the dashboard + the `codebuff` CLI.
+public enum CodebuffUsageFetcher {
+    private static let requestTimeoutSeconds: TimeInterval = 15
+
+    public static func fetchUsage(
+        apiKey: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        session: URLSession = .shared) async throws -> CodebuffUsageSnapshot
+    {
+        let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw CodebuffUsageError.missingCredentials
+        }
+
+        let baseURL = CodebuffSettingsReader.apiURL(environment: environment)
+        async let usage = self.fetchUsagePayload(apiKey: trimmed, baseURL: baseURL, session: session)
+        async let subscription = self.fetchSubscriptionPayload(
+            apiKey: trimmed,
+            baseURL: baseURL,
+            session: session)
+
+        let usageValues = try await usage
+        let subscriptionValues = try? await subscription
+
+        return CodebuffUsageSnapshot(
+            creditsUsed: usageValues.used,
+            creditsTotal: usageValues.total,
+            creditsRemaining: usageValues.remaining,
+            weeklyUsed: subscriptionValues?.weeklyUsed,
+            weeklyLimit: subscriptionValues?.weeklyLimit,
+            billingPeriodEnd: subscriptionValues?.billingPeriodEnd,
+            nextQuotaReset: usageValues.nextQuotaReset,
+            tier: subscriptionValues?.tier,
+            subscriptionStatus: subscriptionValues?.status,
+            autoTopUpEnabled: usageValues.autoTopupEnabled,
+            accountEmail: subscriptionValues?.email,
+            updatedAt: Date())
+    }
+
+    // MARK: - Endpoint helpers
+
+    struct UsagePayload {
+        let used: Double?
+        let total: Double?
+        let remaining: Double?
+        let nextQuotaReset: Date?
+        let autoTopupEnabled: Bool?
+    }
+
+    struct SubscriptionPayload {
+        let status: String?
+        let tier: String?
+        let billingPeriodEnd: Date?
+        let weeklyUsed: Double?
+        let weeklyLimit: Double?
+        let email: String?
+    }
+
+    static func usageURL(baseURL: URL) -> URL {
+        baseURL.appendingPathComponent("/api/v1/usage")
+    }
+
+    static func subscriptionURL(baseURL: URL) -> URL {
+        baseURL.appendingPathComponent("/api/user/subscription")
+    }
+
+    static func statusError(for statusCode: Int) -> CodebuffUsageError? {
+        switch statusCode {
+        case 401, 403: .unauthorized
+        case 404: .endpointNotFound
+        case 500...599: .serviceUnavailable(statusCode)
+        default: nil
+        }
+    }
+
+    static func parseUsagePayload(_ data: Data) throws -> UsagePayload {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CodebuffUsageError.parseFailed("Invalid JSON")
+        }
+
+        let used = self.double(from: root["usage"]) ?? self.double(from: root["used"])
+        let total = self.double(from: root["quota"]) ?? self.double(from: root["limit"])
+        let remaining = self.double(from: root["remainingBalance"]) ?? self.double(from: root["remaining"])
+        let reset = self.date(from: root["next_quota_reset"])
+        let autoTopUp = root["autoTopupEnabled"] as? Bool ?? root["auto_topup_enabled"] as? Bool
+
+        return UsagePayload(
+            used: used,
+            total: total,
+            remaining: remaining,
+            nextQuotaReset: reset,
+            autoTopupEnabled: autoTopUp)
+    }
+
+    static func parseSubscriptionPayload(_ data: Data) throws -> SubscriptionPayload {
+        guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw CodebuffUsageError.parseFailed("Invalid JSON")
+        }
+
+        let subscription = root["subscription"] as? [String: Any]
+        let rateLimit = root["rateLimit"] as? [String: Any]
+
+        let tier = (subscription?["tier"] as? String)
+            ?? (root["tier"] as? String)
+            ?? (subscription?["scheduledTier"] as? String)
+        let status = subscription?["status"] as? String
+        let email = root["email"] as? String ?? (root["user"] as? [String: Any])?["email"] as? String
+        let billingPeriodEnd = self.date(from: subscription?["billingPeriodEnd"])
+            ?? self.date(from: subscription?["currentPeriodEnd"])
+        let weeklyUsed = self.double(from: rateLimit?["weeklyUsed"])
+            ?? self.double(from: rateLimit?["used"])
+        let weeklyLimit = self.double(from: rateLimit?["weeklyLimit"])
+            ?? self.double(from: rateLimit?["limit"])
+
+        return SubscriptionPayload(
+            status: status,
+            tier: tier,
+            billingPeriodEnd: billingPeriodEnd,
+            weeklyUsed: weeklyUsed,
+            weeklyLimit: weeklyLimit,
+            email: email)
+    }
+
+    // MARK: - Test hooks
+
+    static func _parseUsagePayloadForTesting(_ data: Data) throws -> UsagePayload {
+        try self.parseUsagePayload(data)
+    }
+
+    static func _parseSubscriptionPayloadForTesting(_ data: Data) throws -> SubscriptionPayload {
+        try self.parseSubscriptionPayload(data)
+    }
+
+    static func _statusErrorForTesting(_ statusCode: Int) -> CodebuffUsageError? {
+        self.statusError(for: statusCode)
+    }
+
+    // MARK: - Networking
+
+    private static func fetchUsagePayload(
+        apiKey: String,
+        baseURL: URL,
+        session: URLSession) async throws -> UsagePayload
+    {
+        var request = URLRequest(url: self.usageURL(baseURL: baseURL))
+        request.httpMethod = "POST"
+        request.timeoutInterval = self.requestTimeoutSeconds
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: [:] as [String: Any])
+
+        let (data, response) = try await self.send(request: request, session: session)
+        if let err = self.statusError(for: response.statusCode) {
+            throw err
+        }
+        guard response.statusCode == 200 else {
+            throw CodebuffUsageError.apiError(response.statusCode)
+        }
+        return try self.parseUsagePayload(data)
+    }
+
+    private static func fetchSubscriptionPayload(
+        apiKey: String,
+        baseURL: URL,
+        session: URLSession) async throws -> SubscriptionPayload
+    {
+        var request = URLRequest(url: self.subscriptionURL(baseURL: baseURL))
+        request.httpMethod = "GET"
+        request.timeoutInterval = self.requestTimeoutSeconds
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await self.send(request: request, session: session)
+        if let err = self.statusError(for: response.statusCode) {
+            throw err
+        }
+        guard response.statusCode == 200 else {
+            throw CodebuffUsageError.apiError(response.statusCode)
+        }
+        return try self.parseSubscriptionPayload(data)
+    }
+
+    private static func send(
+        request: URLRequest,
+        session: URLSession) async throws -> (Data, HTTPURLResponse)
+    {
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw CodebuffUsageError.networkError("Invalid response")
+            }
+            return (data, httpResponse)
+        } catch let error as CodebuffUsageError {
+            throw error
+        } catch {
+            throw CodebuffUsageError.networkError(error.localizedDescription)
+        }
+    }
+
+    // MARK: - Value parsing
+
+    private static func double(from value: Any?) -> Double? {
+        switch value {
+        case let number as NSNumber:
+            let raw = number.doubleValue
+            return raw.isFinite ? raw : nil
+        case let string as String:
+            let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, let raw = Double(trimmed), raw.isFinite else { return nil }
+            return raw
+        default:
+            return nil
+        }
+    }
+
+    private static func date(from value: Any?) -> Date? {
+        switch value {
+        case let string as String:
+            let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            let fractional = ISO8601DateFormatter()
+            fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let date = fractional.date(from: trimmed) {
+                return date
+            }
+            let plain = ISO8601DateFormatter()
+            plain.formatOptions = [.withInternetDateTime]
+            if let date = plain.date(from: trimmed) {
+                return date
+            }
+            if let interval = Double(trimmed), interval.isFinite {
+                return Self.dateFromNumeric(interval)
+            }
+            return nil
+        case let number as NSNumber:
+            let raw = number.doubleValue
+            return raw.isFinite ? Self.dateFromNumeric(raw) : nil
+        default:
+            return nil
+        }
+    }
+
+    private static func dateFromNumeric(_ value: Double) -> Date? {
+        if value > 10_000_000_000 {
+            return Date(timeIntervalSince1970: value / 1000)
+        }
+        return Date(timeIntervalSince1970: value)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
@@ -8,6 +8,10 @@ import FoundationNetworking
 /// the dashboard + the `codebuff` CLI.
 public enum CodebuffUsageFetcher {
     private static let requestTimeoutSeconds: TimeInterval = 15
+    /// Extra grace period to wait for the optional subscription endpoint after the
+    /// primary usage call returns. Keeps the menu responsive when `/api/user/subscription`
+    /// is slow or hangs while `/api/v1/usage` succeeds quickly.
+    private static let subscriptionGraceSeconds: TimeInterval = 2
 
     public static func fetchUsage(
         apiKey: String,
@@ -20,14 +24,33 @@ public enum CodebuffUsageFetcher {
         }
 
         let baseURL = CodebuffSettingsReader.apiURL(environment: environment)
-        async let usage = self.fetchUsagePayload(apiKey: trimmed, baseURL: baseURL, session: session)
-        async let subscription = self.fetchSubscriptionPayload(
-            apiKey: trimmed,
-            baseURL: baseURL,
-            session: session)
 
-        let usageValues = try await usage
-        let subscriptionValues = try? await subscription
+        // Run usage and subscription in parallel. Usage data is required;
+        // subscription is best-effort and must never block the primary refresh.
+        let usageTask = Task {
+            try await self.fetchUsagePayload(apiKey: trimmed, baseURL: baseURL, session: session)
+        }
+        let subscriptionTask = Task {
+            try? await self.fetchSubscriptionPayload(
+                apiKey: trimmed,
+                baseURL: baseURL,
+                session: session)
+        }
+
+        let usageValues: UsagePayload
+        do {
+            usageValues = try await usageTask.value
+        } catch {
+            subscriptionTask.cancel()
+            throw error
+        }
+
+        // Once usage is in hand, only wait a short grace period for the optional
+        // subscription payload. If it isn't ready we proceed without it rather than
+        // letting users wait up to the full 15 s request timeout.
+        let subscriptionValues = await Self.awaitSubscription(
+            task: subscriptionTask,
+            graceSeconds: Self.subscriptionGraceSeconds)
 
         return CodebuffUsageSnapshot(
             creditsUsed: usageValues.used,
@@ -42,6 +65,28 @@ public enum CodebuffUsageFetcher {
             autoTopUpEnabled: usageValues.autoTopupEnabled,
             accountEmail: subscriptionValues?.email,
             updatedAt: Date())
+    }
+
+    /// Awaits the subscription task with a bounded grace period. Returns `nil`
+    /// (and cancels the task) if the grace window elapses before completion.
+    private static func awaitSubscription(
+        task: Task<SubscriptionPayload?, Never>,
+        graceSeconds: TimeInterval) async -> SubscriptionPayload?
+    {
+        await withTaskGroup(of: SubscriptionPayload?.self) { group in
+            group.addTask { await task.value }
+            group.addTask {
+                let nanos = UInt64(max(0, graceSeconds) * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: nanos)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            // Cancel whichever task is still running so we don't leak work or
+            // (in the timeout case) keep the URLSession request open longer than needed.
+            group.cancelAll()
+            task.cancel()
+            return first ?? nil
+        }
     }
 
     // MARK: - Endpoint helpers

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
@@ -80,12 +80,16 @@ public enum CodebuffUsageFetcher {
                 try? await Task.sleep(nanoseconds: nanos)
                 return nil
             }
-            let first = await group.next() ?? nil
+            let first: SubscriptionPayload? = if let value = await group.next() {
+                value
+            } else {
+                nil
+            }
             // Cancel whichever task is still running so we don't leak work or
             // (in the timeout case) keep the URLSession request open longer than needed.
             group.cancelAll()
             task.cancel()
-            return first ?? nil
+            return first
         }
     }
 
@@ -200,7 +204,7 @@ public enum CodebuffUsageFetcher {
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.httpBody = try? JSONSerialization.data(withJSONObject: [:] as [String: Any])
+        request.httpBody = try? JSONSerialization.data(withJSONObject: ["fingerprintId": "codexbar-usage"])
 
         let (data, response) = try await self.send(request: request, session: session)
         if let err = self.statusError(for: response.statusCode) {

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
@@ -16,6 +16,7 @@ public enum CodebuffUsageFetcher {
     public static func fetchUsage(
         apiKey: String,
         environment: [String: String] = ProcessInfo.processInfo.environment,
+        includeSubscription: Bool = true,
         session: URLSession = .shared) async throws -> CodebuffUsageSnapshot
     {
         let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -30,27 +31,35 @@ public enum CodebuffUsageFetcher {
         let usageTask = Task {
             try await self.fetchUsagePayload(apiKey: trimmed, baseURL: baseURL, session: session)
         }
-        let subscriptionTask = Task {
-            try? await self.fetchSubscriptionPayload(
-                apiKey: trimmed,
-                baseURL: baseURL,
-                session: session)
+        let subscriptionTask: Task<SubscriptionPayload?, Never>? = if includeSubscription {
+            Task {
+                try? await self.fetchSubscriptionPayload(
+                    apiKey: trimmed,
+                    baseURL: baseURL,
+                    session: session)
+            }
+        } else {
+            nil
         }
 
         let usageValues: UsagePayload
         do {
             usageValues = try await usageTask.value
         } catch {
-            subscriptionTask.cancel()
+            subscriptionTask?.cancel()
             throw error
         }
 
         // Once usage is in hand, only wait a short grace period for the optional
         // subscription payload. If it isn't ready we proceed without it rather than
         // letting users wait up to the full 15 s request timeout.
-        let subscriptionValues = await Self.awaitSubscription(
-            task: subscriptionTask,
-            graceSeconds: Self.subscriptionGraceSeconds)
+        let subscriptionValues: SubscriptionPayload? = if let subscriptionTask {
+            await Self.awaitSubscription(
+                task: subscriptionTask,
+                graceSeconds: Self.subscriptionGraceSeconds)
+        } else {
+            nil
+        }
 
         return CodebuffUsageSnapshot(
             creditsUsed: usageValues.used,
@@ -58,6 +67,7 @@ public enum CodebuffUsageFetcher {
             creditsRemaining: usageValues.remaining,
             weeklyUsed: subscriptionValues?.weeklyUsed,
             weeklyLimit: subscriptionValues?.weeklyLimit,
+            weeklyResetsAt: subscriptionValues?.weeklyResetsAt,
             billingPeriodEnd: subscriptionValues?.billingPeriodEnd,
             nextQuotaReset: usageValues.nextQuotaReset,
             tier: subscriptionValues?.tier,
@@ -109,6 +119,7 @@ public enum CodebuffUsageFetcher {
         let billingPeriodEnd: Date?
         let weeklyUsed: Double?
         let weeklyLimit: Double?
+        let weeklyResetsAt: Date?
         let email: String?
     }
 
@@ -156,9 +167,11 @@ public enum CodebuffUsageFetcher {
         let subscription = root["subscription"] as? [String: Any]
         let rateLimit = root["rateLimit"] as? [String: Any]
 
-        let tier = (subscription?["tier"] as? String)
-            ?? (root["tier"] as? String)
-            ?? (subscription?["scheduledTier"] as? String)
+        let tier = self.string(from: subscription?["displayName"])
+            ?? self.string(from: root["displayName"])
+            ?? self.string(from: subscription?["tier"])
+            ?? self.string(from: root["tier"])
+            ?? self.string(from: subscription?["scheduledTier"])
         let status = subscription?["status"] as? String
         let email = root["email"] as? String ?? (root["user"] as? [String: Any])?["email"] as? String
         let billingPeriodEnd = self.date(from: subscription?["billingPeriodEnd"])
@@ -167,6 +180,7 @@ public enum CodebuffUsageFetcher {
             ?? self.double(from: rateLimit?["used"])
         let weeklyLimit = self.double(from: rateLimit?["weeklyLimit"])
             ?? self.double(from: rateLimit?["limit"])
+        let weeklyResetsAt = self.date(from: rateLimit?["weeklyResetsAt"])
 
         return SubscriptionPayload(
             status: status,
@@ -174,6 +188,7 @@ public enum CodebuffUsageFetcher {
             billingPeriodEnd: billingPeriodEnd,
             weeklyUsed: weeklyUsed,
             weeklyLimit: weeklyLimit,
+            weeklyResetsAt: weeklyResetsAt,
             email: email)
     }
 
@@ -265,6 +280,23 @@ public enum CodebuffUsageFetcher {
             let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty, let raw = Double(trimmed), raw.isFinite else { return nil }
             return raw
+        default:
+            return nil
+        }
+    }
+
+    private static func string(from value: Any?) -> String? {
+        switch value {
+        case let string as String:
+            let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        case let number as NSNumber:
+            let raw = number.doubleValue
+            guard raw.isFinite else { return nil }
+            if raw.rounded(.towardZero) == raw {
+                return String(Int64(raw))
+            }
+            return String(raw)
         default:
             return nil
         }

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
@@ -26,40 +26,11 @@ public enum CodebuffUsageFetcher {
 
         let baseURL = CodebuffSettingsReader.apiURL(environment: environment)
 
-        // Run usage and subscription in parallel. Usage data is required;
-        // subscription is best-effort and must never block the primary refresh.
-        let usageTask = Task {
-            try await self.fetchUsagePayload(apiKey: trimmed, baseURL: baseURL, session: session)
-        }
-        let subscriptionTask: Task<SubscriptionPayload?, Never>? = if includeSubscription {
-            Task {
-                try? await self.fetchSubscriptionPayload(
-                    apiKey: trimmed,
-                    baseURL: baseURL,
-                    session: session)
-            }
-        } else {
-            nil
-        }
-
-        let usageValues: UsagePayload
-        do {
-            usageValues = try await usageTask.value
-        } catch {
-            subscriptionTask?.cancel()
-            throw error
-        }
-
-        // Once usage is in hand, only wait a short grace period for the optional
-        // subscription payload. If it isn't ready we proceed without it rather than
-        // letting users wait up to the full 15 s request timeout.
-        let subscriptionValues: SubscriptionPayload? = if let subscriptionTask {
-            await Self.awaitSubscription(
-                task: subscriptionTask,
-                graceSeconds: Self.subscriptionGraceSeconds)
-        } else {
-            nil
-        }
+        let (usageValues, subscriptionValues) = try await self.fetchPayloads(
+            apiKey: trimmed,
+            baseURL: baseURL,
+            includeSubscription: includeSubscription,
+            session: session)
 
         return CodebuffUsageSnapshot(
             creditsUsed: usageValues.used,
@@ -77,33 +48,74 @@ public enum CodebuffUsageFetcher {
             updatedAt: Date())
     }
 
-    /// Awaits the subscription task with a bounded grace period. Returns `nil`
-    /// (and cancels the task) if the grace window elapses before completion.
-    private static func awaitSubscription(
-        task: Task<SubscriptionPayload?, Never>,
-        graceSeconds: TimeInterval) async -> SubscriptionPayload?
+    private static func fetchPayloads(
+        apiKey: String,
+        baseURL: URL,
+        includeSubscription: Bool,
+        session: URLSession) async throws -> (UsagePayload, SubscriptionPayload?)
     {
-        await withTaskGroup(of: SubscriptionPayload?.self) { group in
-            group.addTask { await task.value }
+        try await withThrowingTaskGroup(of: FetchResult.self) { group in
             group.addTask {
-                let nanos = UInt64(max(0, graceSeconds) * 1_000_000_000)
-                try? await Task.sleep(nanoseconds: nanos)
-                return nil
+                try await .usage(self.fetchUsagePayload(apiKey: apiKey, baseURL: baseURL, session: session))
             }
-            let first: SubscriptionPayload? = if let value = await group.next() {
-                value
-            } else {
-                nil
+            if includeSubscription {
+                group.addTask {
+                    await .subscription(try? self.fetchSubscriptionPayload(
+                        apiKey: apiKey,
+                        baseURL: baseURL,
+                        session: session))
+                }
             }
-            // Cancel whichever task is still running so we don't leak work or
-            // (in the timeout case) keep the URLSession request open longer than needed.
-            group.cancelAll()
-            task.cancel()
-            return first
+
+            var usageValues: UsagePayload?
+            var subscriptionValues: SubscriptionPayload?
+            var subscriptionFinished = !includeSubscription
+            var timeoutStarted = false
+
+            while let result = try await group.next() {
+                switch result {
+                case let .usage(payload):
+                    usageValues = payload
+                    if subscriptionFinished {
+                        group.cancelAll()
+                        return (payload, subscriptionValues)
+                    }
+                    if !timeoutStarted {
+                        timeoutStarted = true
+                        group.addTask {
+                            let nanos = UInt64(max(0, Self.subscriptionGraceSeconds) * 1_000_000_000)
+                            try? await Task.sleep(nanoseconds: nanos)
+                            return .subscriptionTimeout
+                        }
+                    }
+
+                case let .subscription(payload):
+                    subscriptionValues = payload
+                    subscriptionFinished = true
+                    if let usageValues {
+                        group.cancelAll()
+                        return (usageValues, payload)
+                    }
+
+                case .subscriptionTimeout:
+                    if let usageValues {
+                        group.cancelAll()
+                        return (usageValues, subscriptionValues)
+                    }
+                }
+            }
+
+            throw CodebuffUsageError.networkError("Usage request did not complete")
         }
     }
 
     // MARK: - Endpoint helpers
+
+    private enum FetchResult {
+        case usage(UsagePayload)
+        case subscription(SubscriptionPayload?)
+        case subscriptionTimeout
+    }
 
     struct UsagePayload {
         let used: Double?
@@ -293,10 +305,7 @@ public enum CodebuffUsageFetcher {
         case let number as NSNumber:
             let raw = number.doubleValue
             guard raw.isFinite else { return nil }
-            if raw.rounded(.towardZero) == raw {
-                return String(Int64(raw))
-            }
-            return String(raw)
+            return number.stringValue
         default:
             return nil
         }

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageSnapshot.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// Parsed view of a Codebuff usage + subscription response pair.
+public struct CodebuffUsageSnapshot: Sendable {
+    public let creditsUsed: Double?
+    public let creditsTotal: Double?
+    public let creditsRemaining: Double?
+    public let weeklyUsed: Double?
+    public let weeklyLimit: Double?
+    public let billingPeriodEnd: Date?
+    public let nextQuotaReset: Date?
+    public let tier: String?
+    public let subscriptionStatus: String?
+    public let autoTopUpEnabled: Bool?
+    public let accountEmail: String?
+    public let updatedAt: Date
+
+    public init(
+        creditsUsed: Double? = nil,
+        creditsTotal: Double? = nil,
+        creditsRemaining: Double? = nil,
+        weeklyUsed: Double? = nil,
+        weeklyLimit: Double? = nil,
+        billingPeriodEnd: Date? = nil,
+        nextQuotaReset: Date? = nil,
+        tier: String? = nil,
+        subscriptionStatus: String? = nil,
+        autoTopUpEnabled: Bool? = nil,
+        accountEmail: String? = nil,
+        updatedAt: Date = Date())
+    {
+        self.creditsUsed = creditsUsed
+        self.creditsTotal = creditsTotal
+        self.creditsRemaining = creditsRemaining
+        self.weeklyUsed = weeklyUsed
+        self.weeklyLimit = weeklyLimit
+        self.billingPeriodEnd = billingPeriodEnd
+        self.nextQuotaReset = nextQuotaReset
+        self.tier = tier
+        self.subscriptionStatus = subscriptionStatus
+        self.autoTopUpEnabled = autoTopUpEnabled
+        self.accountEmail = accountEmail
+        self.updatedAt = updatedAt
+    }
+
+    public func toUsageSnapshot() -> UsageSnapshot {
+        let primary = self.makeCreditsWindow()
+        let secondary = self.makeWeeklyWindow()
+
+        let identity = ProviderIdentitySnapshot(
+            providerID: .codebuff,
+            accountEmail: self.accountEmail,
+            accountOrganization: nil,
+            loginMethod: self.makeLoginMethod())
+
+        return UsageSnapshot(
+            primary: primary,
+            secondary: secondary,
+            tertiary: nil,
+            providerCost: nil,
+            updatedAt: self.updatedAt,
+            identity: identity)
+    }
+
+    private func makeCreditsWindow() -> RateWindow? {
+        let total = self.resolvedTotal
+        guard let total, total > 0 else {
+            if self.creditsRemaining != nil || self.creditsUsed != nil {
+                // Degenerate case: show exhausted state so users notice missing configuration.
+                return RateWindow(
+                    usedPercent: 0,
+                    windowMinutes: nil,
+                    resetsAt: self.nextQuotaReset,
+                    resetDescription: nil)
+            }
+            return nil
+        }
+        let used = self.resolvedUsed
+        let percent = min(100, max(0, (used / total) * 100))
+        let usedText = Self.compactNumber(used)
+        let totalText = Self.compactNumber(total)
+        return RateWindow(
+            usedPercent: percent,
+            windowMinutes: nil,
+            resetsAt: self.nextQuotaReset,
+            resetDescription: "\(usedText)/\(totalText) credits")
+    }
+
+    private func makeWeeklyWindow() -> RateWindow? {
+        guard let limit = self.weeklyLimit, limit > 0 else { return nil }
+        let used = max(0, self.weeklyUsed ?? 0)
+        let percent = min(100, max(0, (used / limit) * 100))
+        return RateWindow(
+            usedPercent: percent,
+            windowMinutes: 7 * 24 * 60,
+            resetsAt: nil,
+            resetDescription: "\(Self.compactNumber(used))/\(Self.compactNumber(limit)) weekly")
+    }
+
+    private var resolvedTotal: Double? {
+        if let creditsTotal { return max(0, creditsTotal) }
+        if let creditsUsed, let creditsRemaining {
+            return max(0, creditsUsed + creditsRemaining)
+        }
+        return nil
+    }
+
+    private var resolvedUsed: Double {
+        if let creditsUsed {
+            return max(0, creditsUsed)
+        }
+        if let total = self.resolvedTotal, let creditsRemaining {
+            return max(0, total - creditsRemaining)
+        }
+        return 0
+    }
+
+    private func makeLoginMethod() -> String? {
+        var parts: [String] = []
+        if let tier = self.tier?.trimmingCharacters(in: .whitespacesAndNewlines), !tier.isEmpty {
+            parts.append(tier.capitalized)
+        }
+        if let remaining = self.creditsRemaining {
+            parts.append("\(Self.compactNumber(remaining)) remaining")
+        }
+        if self.autoTopUpEnabled == true {
+            parts.append("auto top-up")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    static func compactNumber(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.locale = Locale(identifier: "en_US")
+        formatter.maximumFractionDigits = value >= 1000 ? 0 : 1
+        return formatter.string(from: NSNumber(value: value)) ?? String(format: "%.0f", value)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageSnapshot.swift
@@ -66,9 +66,11 @@ public struct CodebuffUsageSnapshot: Sendable {
         let total = self.resolvedTotal
         guard let total, total > 0 else {
             if self.creditsRemaining != nil || self.creditsUsed != nil {
-                // Degenerate case: show exhausted state so users notice missing configuration.
+                // Degenerate case: no usable quota in the payload. Surface the row as fully
+                // exhausted so missing quota data is visibly surfaced (matches Kilo's behaviour
+                // for zero/unknown totals) rather than rendering a misleading healthy bar.
                 return RateWindow(
-                    usedPercent: 0,
+                    usedPercent: 100,
                     windowMinutes: nil,
                     resetsAt: self.nextQuotaReset,
                     resetDescription: nil)

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageSnapshot.swift
@@ -79,24 +79,27 @@ public struct CodebuffUsageSnapshot: Sendable {
         }
         let used = self.resolvedUsed
         let percent = min(100, max(0, (used / total) * 100))
-        let usedText = Self.compactNumber(used)
-        let totalText = Self.compactNumber(total)
+        // Note: do not stuff the credit balance ("X/Y credits") into `resetDescription` —
+        // generic renderers (UsageFormatter.resetLine) prepend "Resets " when `resetsAt`
+        // is absent, which would surface misleading text like "Resets 250/1,000 credits".
+        // The credits detail is shown via the dedicated Codebuff account panel instead.
         return RateWindow(
             usedPercent: percent,
             windowMinutes: nil,
             resetsAt: self.nextQuotaReset,
-            resetDescription: "\(usedText)/\(totalText) credits")
+            resetDescription: nil)
     }
 
     private func makeWeeklyWindow() -> RateWindow? {
         guard let limit = self.weeklyLimit, limit > 0 else { return nil }
         let used = max(0, self.weeklyUsed ?? 0)
         let percent = min(100, max(0, (used / limit) * 100))
+        // Same reasoning as above: avoid encoding non-reset detail in `resetDescription`.
         return RateWindow(
             usedPercent: percent,
             windowMinutes: 7 * 24 * 60,
             resetsAt: nil,
-            resetDescription: "\(Self.compactNumber(used))/\(Self.compactNumber(limit)) weekly")
+            resetDescription: nil)
     }
 
     private var resolvedTotal: Double? {

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageSnapshot.swift
@@ -7,6 +7,7 @@ public struct CodebuffUsageSnapshot: Sendable {
     public let creditsRemaining: Double?
     public let weeklyUsed: Double?
     public let weeklyLimit: Double?
+    public let weeklyResetsAt: Date?
     public let billingPeriodEnd: Date?
     public let nextQuotaReset: Date?
     public let tier: String?
@@ -21,6 +22,7 @@ public struct CodebuffUsageSnapshot: Sendable {
         creditsRemaining: Double? = nil,
         weeklyUsed: Double? = nil,
         weeklyLimit: Double? = nil,
+        weeklyResetsAt: Date? = nil,
         billingPeriodEnd: Date? = nil,
         nextQuotaReset: Date? = nil,
         tier: String? = nil,
@@ -34,6 +36,7 @@ public struct CodebuffUsageSnapshot: Sendable {
         self.creditsRemaining = creditsRemaining
         self.weeklyUsed = weeklyUsed
         self.weeklyLimit = weeklyLimit
+        self.weeklyResetsAt = weeklyResetsAt
         self.billingPeriodEnd = billingPeriodEnd
         self.nextQuotaReset = nextQuotaReset
         self.tier = tier
@@ -98,7 +101,7 @@ public struct CodebuffUsageSnapshot: Sendable {
         return RateWindow(
             usedPercent: percent,
             windowMinutes: 7 * 24 * 60,
-            resetsAt: nil,
+            resetsAt: self.weeklyResetsAt,
             resetDescription: nil)
     }
 

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -81,6 +81,7 @@ public enum ProviderDescriptorRegistry {
         .abacus: AbacusProviderDescriptor.descriptor,
         .mistral: MistralProviderDescriptor.descriptor,
         .deepseek: DeepSeekProviderDescriptor.descriptor,
+        .codebuff: CodebuffProviderDescriptor.descriptor,
     ]
     private static let bootstrap: Void = {
         for provider in UsageProvider.allCases {

--- a/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
+++ b/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
@@ -83,6 +83,13 @@ public enum ProviderTokenResolver {
         self.resolveEnv(DeepSeekSettingsReader.apiKey(environment: environment))
     }
 
+    public static func codebuffToken(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        authFileURL: URL? = nil) -> String?
+    {
+        self.codebuffResolution(environment: environment, authFileURL: authFileURL)?.token
+    }
+
     public static func zaiResolution(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
     {
@@ -167,6 +174,19 @@ public enum ProviderTokenResolver {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
     {
         self.resolveEnv(OpenRouterSettingsReader.apiToken(environment: environment))
+    }
+
+    public static func codebuffResolution(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        authFileURL: URL? = nil) -> ProviderTokenResolution?
+    {
+        if let resolution = self.resolveEnv(CodebuffSettingsReader.apiKey(environment: environment)) {
+            return resolution
+        }
+        if let token = CodebuffSettingsReader.authToken(authFileURL: authFileURL) {
+            return ProviderTokenResolution(token: token, source: .authFile)
+        }
+        return nil
     }
 
     public static func perplexityResolution(

--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -31,6 +31,7 @@ public enum UsageProvider: String, CaseIterable, Sendable, Codable {
     case abacus
     case mistral
     case deepseek
+    case codebuff
 }
 
 // swiftformat:enable sortDeclarations
@@ -64,6 +65,7 @@ public enum IconStyle: Sendable, CaseIterable {
     case abacus
     case mistral
     case deepseek
+    case codebuff
     case combined
 }
 

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
@@ -236,7 +236,7 @@ enum CostUsageScanner {
         case .zai, .gemini, .antigravity, .cursor, .opencode, .opencodego, .alibaba, .factory, .copilot,
              .minimax, .kilo, .kiro, .kimi,
              .kimik2, .augment, .jetbrains, .amp, .ollama, .synthetic, .openrouter, .warp, .perplexity, .abacus,
-             .mistral, .deepseek:
+             .mistral, .deepseek, .codebuff:
             return emptyReport
         }
     }

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -79,6 +79,7 @@ enum ProviderChoice: String, AppEnum {
         case .abacus: return nil // Abacus AI not yet supported in widgets
         case .mistral: return nil // Mistral not yet supported in widgets
         case .deepseek: return nil // DeepSeek not yet supported in widgets
+        case .codebuff: return nil // Codebuff not yet supported in widgets
         }
     }
 }

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -285,6 +285,7 @@ private struct ProviderSwitchChip: View {
         case .abacus: "Abacus"
         case .mistral: "Mistral"
         case .deepseek: "DeepSeek"
+        case .codebuff: "Codebuff"
         }
     }
 }
@@ -650,6 +651,8 @@ enum WidgetColors {
             Color(red: 255 / 255, green: 80 / 255, blue: 15 / 255) // Mistral orange
         case .deepseek:
             Color(red: 82 / 255, green: 125 / 255, blue: 240 / 255)
+        case .codebuff:
+            Color(red: 68 / 255, green: 255 / 255, blue: 0 / 255) // Codebuff lime
         }
     }
 }

--- a/Tests/CodexBarTests/CodebuffSettingsReaderTests.swift
+++ b/Tests/CodexBarTests/CodebuffSettingsReaderTests.swift
@@ -1,0 +1,100 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct CodebuffSettingsReaderTests {
+    @Test
+    func `api URL defaults to www codebuff com`() {
+        let url = CodebuffSettingsReader.apiURL(environment: [:])
+        #expect(url.scheme == "https")
+        #expect(url.host() == "www.codebuff.com")
+    }
+
+    @Test
+    func `api URL honors environment override`() {
+        let url = CodebuffSettingsReader.apiURL(environment: [
+            "CODEBUFF_API_URL": "https://staging.codebuff.com",
+        ])
+        #expect(url.host() == "staging.codebuff.com")
+    }
+
+    @Test
+    func `api key reads from CODEBUFF_API_KEY and trims wrapping whitespace`() {
+        let token = CodebuffSettingsReader.apiKey(environment: [
+            CodebuffSettingsReader.apiTokenKey: "  cb-test-token  ",
+        ])
+        #expect(token == "cb-test-token")
+    }
+
+    @Test
+    func `api key strips surrounding quotes`() {
+        let token = CodebuffSettingsReader.apiKey(environment: [
+            CodebuffSettingsReader.apiTokenKey: "\"cb-test-token\"",
+        ])
+        #expect(token == "cb-test-token")
+    }
+
+    @Test
+    func `api key returns nil for empty environment`() {
+        #expect(CodebuffSettingsReader.apiKey(environment: [:]) == nil)
+    }
+
+    @Test
+    func `auth token parses credentials json`() throws {
+        let contents = #"{"authToken":"file-token","fingerprintId":"fp-1","email":"a@b.com"}"#
+        let url = try self.writeTempFile(named: "credentials.json", contents: contents)
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let token = CodebuffSettingsReader.authToken(authFileURL: url)
+        #expect(token == "file-token")
+    }
+
+    @Test
+    func `auth token returns nil for malformed credentials json`() throws {
+        let url = try self.writeTempFile(named: "credentials.json", contents: "{not-json}")
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let token = CodebuffSettingsReader.authToken(authFileURL: url)
+        #expect(token == nil)
+    }
+
+    @Test
+    func `auth token returns nil when file missing`() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            .appendingPathComponent("credentials.json", isDirectory: false)
+        #expect(CodebuffSettingsReader.authToken(authFileURL: url) == nil)
+    }
+
+    @Test
+    func `descriptor uses codebuff dashboard URL`() {
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: .codebuff)
+        #expect(descriptor.metadata.dashboardURL == "https://www.codebuff.com/usage")
+        #expect(descriptor.metadata.displayName == "Codebuff")
+        #expect(descriptor.metadata.cliName == "codebuff")
+    }
+
+    @Test
+    func `descriptor uses dedicated codebuff icon resource`() {
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: .codebuff)
+        #expect(descriptor.branding.iconResourceName == "ProviderIcon-codebuff")
+    }
+
+    @Test
+    func `descriptor supports auto and API source modes`() {
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: .codebuff)
+        let expected: Set<ProviderSourceMode> = [.auto, .api]
+        #expect(descriptor.fetchPlan.sourceModes == expected)
+    }
+
+    // MARK: - Helpers
+
+    private func writeTempFile(named name: String, contents: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent(name, isDirectory: false)
+        try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+        return fileURL
+    }
+}

--- a/Tests/CodexBarTests/CodebuffSettingsReaderTests.swift
+++ b/Tests/CodexBarTests/CodebuffSettingsReaderTests.swift
@@ -50,6 +50,16 @@ struct CodebuffSettingsReaderTests {
     }
 
     @Test
+    func `auth token parses default profile credentials json`() throws {
+        let contents = #"{"default":{"authToken":"default-token","fingerprintId":"fp-1","email":"a@b.com"}}"#
+        let url = try self.writeTempFile(named: "credentials.json", contents: contents)
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        let token = CodebuffSettingsReader.authToken(authFileURL: url)
+        #expect(token == "default-token")
+    }
+
+    @Test
     func `auth token returns nil for malformed credentials json`() throws {
         let url = try self.writeTempFile(named: "credentials.json", contents: "{not-json}")
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }

--- a/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
@@ -1,0 +1,186 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct CodebuffUsageFetcherTests {
+    @Test
+    func `usage URL composes the correct endpoint`() {
+        let base = URL(string: "https://www.codebuff.com")!
+        let url = CodebuffUsageFetcher.usageURL(baseURL: base)
+        #expect(url.absoluteString == "https://www.codebuff.com/api/v1/usage")
+    }
+
+    @Test
+    func `subscription URL composes the correct endpoint`() {
+        let base = URL(string: "https://www.codebuff.com")!
+        let url = CodebuffUsageFetcher.subscriptionURL(baseURL: base)
+        #expect(url.absoluteString == "https://www.codebuff.com/api/user/subscription")
+    }
+
+    @Test
+    func `status 401 maps to unauthorized`() {
+        #expect(CodebuffUsageFetcher._statusErrorForTesting(401) == .unauthorized)
+        #expect(CodebuffUsageFetcher._statusErrorForTesting(403) == .unauthorized)
+    }
+
+    @Test
+    func `status 404 maps to endpoint not found`() {
+        #expect(CodebuffUsageFetcher._statusErrorForTesting(404) == .endpointNotFound)
+    }
+
+    @Test
+    func `status 500 maps to service unavailable`() {
+        guard case .serviceUnavailable(503) = CodebuffUsageFetcher._statusErrorForTesting(503)
+        else {
+            Issue.record("Expected .serviceUnavailable(503)")
+            return
+        }
+    }
+
+    @Test
+    func `status 200 returns nil`() {
+        #expect(CodebuffUsageFetcher._statusErrorForTesting(200) == nil)
+    }
+
+    @Test
+    func `usage payload parses numeric credit fields`() throws {
+        let json = """
+        {
+          "usage": 1250,
+          "quota": 5000,
+          "remainingBalance": 3750,
+          "autoTopupEnabled": true,
+          "next_quota_reset": "2026-05-01T00:00:00Z"
+        }
+        """
+
+        let payload = try CodebuffUsageFetcher._parseUsagePayloadForTesting(Data(json.utf8))
+        #expect(payload.used == 1250)
+        #expect(payload.total == 5000)
+        #expect(payload.remaining == 3750)
+        #expect(payload.autoTopupEnabled == true)
+        #expect(payload.nextQuotaReset != nil)
+    }
+
+    @Test
+    func `usage payload accepts string-encoded numbers`() throws {
+        let json = """
+        { "usage": "12", "quota": "100", "remainingBalance": "88" }
+        """
+        let payload = try CodebuffUsageFetcher._parseUsagePayloadForTesting(Data(json.utf8))
+        #expect(payload.used == 12)
+        #expect(payload.total == 100)
+        #expect(payload.remaining == 88)
+    }
+
+    @Test
+    func `usage payload returns nil fields when absent`() throws {
+        let payload = try CodebuffUsageFetcher._parseUsagePayloadForTesting(Data("{}".utf8))
+        #expect(payload.used == nil)
+        #expect(payload.total == nil)
+        #expect(payload.remaining == nil)
+        #expect(payload.autoTopupEnabled == nil)
+    }
+
+    @Test
+    func `usage payload throws on malformed JSON`() {
+        #expect {
+            _ = try CodebuffUsageFetcher._parseUsagePayloadForTesting(Data("not-json".utf8))
+        } throws: { error in
+            guard case CodebuffUsageError.parseFailed = error else { return false }
+            return true
+        }
+    }
+
+    @Test
+    func `subscription payload parses tier and weekly window`() throws {
+        let json = """
+        {
+          "hasSubscription": true,
+          "subscription": {
+            "status": "active",
+            "tier": "pro",
+            "billingPeriodEnd": "2026-05-15T00:00:00Z"
+          },
+          "rateLimit": {
+            "weeklyUsed": 2100,
+            "weeklyLimit": 7000
+          },
+          "email": "user@example.com"
+        }
+        """
+
+        let payload = try CodebuffUsageFetcher._parseSubscriptionPayloadForTesting(Data(json.utf8))
+        #expect(payload.tier == "pro")
+        #expect(payload.status == "active")
+        #expect(payload.weeklyUsed == 2100)
+        #expect(payload.weeklyLimit == 7000)
+        #expect(payload.email == "user@example.com")
+        #expect(payload.billingPeriodEnd != nil)
+    }
+
+    @Test
+    func `subscription payload falls back to scheduled tier`() throws {
+        let json = """
+        { "subscription": { "scheduledTier": "team" } }
+        """
+        let payload = try CodebuffUsageFetcher._parseSubscriptionPayloadForTesting(Data(json.utf8))
+        #expect(payload.tier == "team")
+    }
+
+    @Test
+    func `subscription payload tolerates missing rate limit`() throws {
+        let json = """
+        { "subscription": { "status": "trialing", "tier": "free" } }
+        """
+        let payload = try CodebuffUsageFetcher._parseSubscriptionPayloadForTesting(Data(json.utf8))
+        #expect(payload.weeklyUsed == nil)
+        #expect(payload.weeklyLimit == nil)
+        #expect(payload.status == "trialing")
+    }
+
+    @Test
+    func `snapshot maps to rate window with credits window`() {
+        let snapshot = CodebuffUsageSnapshot(
+            creditsUsed: 250,
+            creditsTotal: 1000,
+            creditsRemaining: 750,
+            weeklyUsed: 100,
+            weeklyLimit: 500,
+            tier: "pro",
+            autoTopUpEnabled: true,
+            updatedAt: Date())
+
+        let unified = snapshot.toUsageSnapshot()
+        #expect(unified.primary?.usedPercent == 25)
+        #expect(unified.primary?.resetDescription == "250/1,000 credits")
+        #expect(unified.secondary?.usedPercent == 20)
+        #expect(unified.secondary?.windowMinutes == 7 * 24 * 60)
+        #expect(unified.identity?.providerID == .codebuff)
+        #expect(unified.identity?.loginMethod?.contains("Pro") == true)
+        #expect(unified.identity?.loginMethod?.contains("auto top-up") == true)
+    }
+
+    @Test
+    func `snapshot infers total from used plus remaining`() {
+        let snapshot = CodebuffUsageSnapshot(
+            creditsUsed: 40,
+            creditsTotal: nil,
+            creditsRemaining: 60)
+
+        let unified = snapshot.toUsageSnapshot()
+        #expect(unified.primary?.usedPercent == 40)
+    }
+
+    @Test
+    func `missing credentials fetch call throws missing credentials`() async {
+        do {
+            _ = try await CodebuffUsageFetcher.fetchUsage(apiKey: "   ")
+            Issue.record("Expected missingCredentials error")
+        } catch let error as CodebuffUsageError {
+            #expect(error == .missingCredentials)
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+}

--- a/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
@@ -173,6 +173,31 @@ struct CodebuffUsageFetcherTests {
     }
 
     @Test
+    func `snapshot surfaces exhausted state when quota is missing from payload`() {
+        // Only `creditsUsed` is populated (no total, no remaining) — the API response is
+        // degenerate but we still want the row to be visible so the user notices the
+        // missing configuration instead of seeing an empty/healthy-looking bar.
+        let usedOnly = CodebuffUsageSnapshot(
+            creditsUsed: 42,
+            creditsTotal: nil,
+            creditsRemaining: nil)
+        #expect(usedOnly.toUsageSnapshot().primary?.usedPercent == 100)
+
+        // Only `creditsRemaining` is populated — same fallback should apply.
+        let remainingOnly = CodebuffUsageSnapshot(
+            creditsUsed: nil,
+            creditsTotal: nil,
+            creditsRemaining: 17)
+        #expect(remainingOnly.toUsageSnapshot().primary?.usedPercent == 100)
+    }
+
+    @Test
+    func `snapshot hides credit window when no credit fields are present`() {
+        let empty = CodebuffUsageSnapshot()
+        #expect(empty.toUsageSnapshot().primary == nil)
+    }
+
+    @Test
     func `missing credentials fetch call throws missing credentials`() async {
         do {
             _ = try await CodebuffUsageFetcher.fetchUsage(apiKey: "   ")

--- a/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
@@ -153,9 +153,13 @@ struct CodebuffUsageFetcherTests {
 
         let unified = snapshot.toUsageSnapshot()
         #expect(unified.primary?.usedPercent == 25)
-        #expect(unified.primary?.resetDescription == "250/1,000 credits")
+        // The credit balance is intentionally NOT stored in `resetDescription` —
+        // generic renderers prepend "Resets " when `resetsAt` is absent, which would
+        // surface misleading text like "Resets 250/1,000 credits".
+        #expect(unified.primary?.resetDescription == nil)
         #expect(unified.secondary?.usedPercent == 20)
         #expect(unified.secondary?.windowMinutes == 7 * 24 * 60)
+        #expect(unified.secondary?.resetDescription == nil)
         #expect(unified.identity?.providerID == .codebuff)
         #expect(unified.identity?.loginMethod?.contains("Pro") == true)
         #expect(unified.identity?.loginMethod?.contains("auto top-up") == true)

--- a/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
@@ -2,19 +2,52 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
+@Suite(.serialized)
 struct CodebuffUsageFetcherTests {
     @Test
-    func `usage URL composes the correct endpoint`() {
-        let base = URL(string: "https://www.codebuff.com")!
+    func `usage URL composes the correct endpoint`() throws {
+        let base = try #require(URL(string: "https://www.codebuff.com"))
         let url = CodebuffUsageFetcher.usageURL(baseURL: base)
         #expect(url.absoluteString == "https://www.codebuff.com/api/v1/usage")
     }
 
     @Test
-    func `subscription URL composes the correct endpoint`() {
-        let base = URL(string: "https://www.codebuff.com")!
+    func `subscription URL composes the correct endpoint`() throws {
+        let base = try #require(URL(string: "https://www.codebuff.com"))
         let url = CodebuffUsageFetcher.subscriptionURL(baseURL: base)
         #expect(url.absoluteString == "https://www.codebuff.com/api/user/subscription")
+    }
+
+    @Test
+    func `usage request sends required fingerprint id`() async throws {
+        defer {
+            CodebuffStubURLProtocol.handler = nil
+            CodebuffStubURLProtocol.requests = []
+            CodebuffStubURLProtocol.requestBodies = []
+        }
+        CodebuffStubURLProtocol.requests = []
+        CodebuffStubURLProtocol.requestBodies = []
+        CodebuffStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            switch url.path {
+            case "/api/v1/usage":
+                return try Self.makeResponse(url: url, body: #"{"usage":25,"quota":100,"remainingBalance":75}"#)
+            case "/api/user/subscription":
+                return try Self.makeResponse(url: url, body: "{}")
+            default:
+                return try Self.makeResponse(url: url, body: "{}", statusCode: 404)
+            }
+        }
+
+        let snapshot = try await CodebuffUsageFetcher.fetchUsage(apiKey: "cb-test", session: Self.makeSession())
+        let usageIndex = try #require(CodebuffStubURLProtocol.requests.firstIndex {
+            $0.url?.path == "/api/v1/usage"
+        })
+        let body = try #require(CodebuffStubURLProtocol.requestBodies[usageIndex])
+        let payload = try #require(JSONSerialization.jsonObject(with: body) as? [String: String])
+
+        #expect(payload["fingerprintId"] == "codexbar-usage")
+        #expect(snapshot.creditsUsed == 25)
     }
 
     @Test
@@ -211,5 +244,82 @@ struct CodebuffUsageFetcherTests {
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
+    }
+
+    private static func makeSession() -> URLSession {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [CodebuffStubURLProtocol.self]
+        return URLSession(configuration: config)
+    }
+
+    private static func makeResponse(
+        url: URL,
+        body: String,
+        statusCode: Int = 200) throws -> (HTTPURLResponse, Data)
+    {
+        guard let response = HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "application/json"])
+        else {
+            throw URLError(.badServerResponse)
+        }
+        return (response, Data(body.utf8))
+    }
+}
+
+final class CodebuffStubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+    nonisolated(unsafe) static var requests: [URLRequest] = []
+    nonisolated(unsafe) static var requestBodies: [Data?] = []
+
+    override static func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "www.codebuff.com"
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.requests.append(self.request)
+        Self.requestBodies.append(Self.bodyData(from: self.request))
+        guard let handler = Self.handler else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(self.request)
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            self.client?.urlProtocol(self, didLoad: data)
+            self.client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            self.client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+
+    private static func bodyData(from request: URLRequest) -> Data? {
+        if let httpBody = request.httpBody {
+            return httpBody
+        }
+        guard let stream = request.httpBodyStream else { return nil }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1024)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count > 0 {
+                data.append(buffer, count: count)
+            } else {
+                break
+            }
+        }
+        return data.isEmpty ? nil : data
     }
 }

--- a/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
@@ -51,6 +51,46 @@ struct CodebuffUsageFetcherTests {
     }
 
     @Test
+    func `usage fetch can skip subscription endpoint for API key tokens`() async throws {
+        defer {
+            CodebuffStubURLProtocol.handler = nil
+            CodebuffStubURLProtocol.requests = []
+            CodebuffStubURLProtocol.requestBodies = []
+        }
+        CodebuffStubURLProtocol.requests = []
+        CodebuffStubURLProtocol.requestBodies = []
+        CodebuffStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            switch url.path {
+            case "/api/v1/usage":
+                return try Self.makeResponse(url: url, body: #"{"usage":25,"quota":100,"remainingBalance":75}"#)
+            case "/api/user/subscription":
+                Issue.record("Subscription endpoint should not be called for API key tokens")
+                return try Self.makeResponse(url: url, body: "{}", statusCode: 500)
+            default:
+                return try Self.makeResponse(url: url, body: "{}", statusCode: 404)
+            }
+        }
+
+        let snapshot = try await CodebuffUsageFetcher.fetchUsage(
+            apiKey: "cb-test",
+            includeSubscription: false,
+            session: Self.makeSession())
+
+        #expect(snapshot.creditsUsed == 25)
+        #expect(CodebuffStubURLProtocol.requests.map(\.url?.path) == ["/api/v1/usage"])
+    }
+
+    @Test
+    func `api strategy only fetches subscription for credentials file tokens`() {
+        let envResolution = ProviderTokenResolution(token: "env-token", source: .environment)
+        let fileResolution = ProviderTokenResolution(token: "file-token", source: .authFile)
+
+        #expect(CodebuffAPIFetchStrategy.shouldFetchSubscription(for: envResolution) == false)
+        #expect(CodebuffAPIFetchStrategy.shouldFetchSubscription(for: fileResolution) == true)
+    }
+
+    @Test
     func `status 401 maps to unauthorized`() {
         #expect(CodebuffUsageFetcher._statusErrorForTesting(401) == .unauthorized)
         #expect(CodebuffUsageFetcher._statusErrorForTesting(403) == .unauthorized)
@@ -137,7 +177,8 @@ struct CodebuffUsageFetcherTests {
           },
           "rateLimit": {
             "weeklyUsed": 2100,
-            "weeklyLimit": 7000
+            "weeklyLimit": 7000,
+            "weeklyResetsAt": "2026-05-08T00:00:00Z"
           },
           "email": "user@example.com"
         }
@@ -148,17 +189,27 @@ struct CodebuffUsageFetcherTests {
         #expect(payload.status == "active")
         #expect(payload.weeklyUsed == 2100)
         #expect(payload.weeklyLimit == 7000)
+        #expect(payload.weeklyResetsAt != nil)
         #expect(payload.email == "user@example.com")
         #expect(payload.billingPeriodEnd != nil)
     }
 
     @Test
-    func `subscription payload falls back to scheduled tier`() throws {
+    func `subscription payload prefers display name over numeric tier`() throws {
         let json = """
-        { "subscription": { "scheduledTier": "team" } }
+        { "subscription": { "tier": 2, "displayName": "Pro" } }
         """
         let payload = try CodebuffUsageFetcher._parseSubscriptionPayloadForTesting(Data(json.utf8))
-        #expect(payload.tier == "team")
+        #expect(payload.tier == "Pro")
+    }
+
+    @Test
+    func `subscription payload falls back to numeric scheduled tier`() throws {
+        let json = """
+        { "subscription": { "scheduledTier": 3 } }
+        """
+        let payload = try CodebuffUsageFetcher._parseSubscriptionPayloadForTesting(Data(json.utf8))
+        #expect(payload.tier == "3")
     }
 
     @Test
@@ -180,6 +231,7 @@ struct CodebuffUsageFetcherTests {
             creditsRemaining: 750,
             weeklyUsed: 100,
             weeklyLimit: 500,
+            weeklyResetsAt: Date(timeIntervalSince1970: 1_777_680_000),
             tier: "pro",
             autoTopUpEnabled: true,
             updatedAt: Date())
@@ -192,6 +244,7 @@ struct CodebuffUsageFetcherTests {
         #expect(unified.primary?.resetDescription == nil)
         #expect(unified.secondary?.usedPercent == 20)
         #expect(unified.secondary?.windowMinutes == 7 * 24 * 60)
+        #expect(unified.secondary?.resetsAt == Date(timeIntervalSince1970: 1_777_680_000))
         #expect(unified.secondary?.resetDescription == nil)
         #expect(unified.identity?.providerID == .codebuff)
         #expect(unified.identity?.loginMethod?.contains("Pro") == true)

--- a/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
@@ -213,6 +213,15 @@ struct CodebuffUsageFetcherTests {
     }
 
     @Test
+    func `subscription payload formats oversized numeric tier without trapping`() throws {
+        let json = """
+        { "subscription": { "scheduledTier": 9223372036854775808 } }
+        """
+        let payload = try CodebuffUsageFetcher._parseSubscriptionPayloadForTesting(Data(json.utf8))
+        #expect(payload.tier == "9223372036854775808")
+    }
+
+    @Test
     func `subscription payload tolerates missing rate limit`() throws {
         let json = """
         { "subscription": { "status": "trialing", "tier": "free" } }

--- a/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
+++ b/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
@@ -93,6 +93,34 @@ struct ProviderConfigEnvironmentTests {
     }
 
     @Test
+    func `applies API key override for codebuff`() {
+        let config = ProviderConfig(id: .codebuff, apiKey: "cb-config-token")
+        let env = ProviderConfigEnvironment.applyAPIKeyOverride(
+            base: [:],
+            provider: .codebuff,
+            config: config)
+
+        #expect(env[CodebuffSettingsReader.apiTokenKey] == "cb-config-token")
+        #expect(
+            ProviderTokenResolver.codebuffToken(environment: env, authFileURL: nil)
+                == "cb-config-token")
+    }
+
+    @Test
+    func `codebuff config override leaves environment token alone`() {
+        let config = ProviderConfig(id: .codebuff, apiKey: "config-token")
+        let env = ProviderConfigEnvironment.applyAPIKeyOverride(
+            base: [CodebuffSettingsReader.apiTokenKey: "env-token"],
+            provider: .codebuff,
+            config: config)
+
+        #expect(env[CodebuffSettingsReader.apiTokenKey] == "env-token")
+        #expect(
+            ProviderTokenResolver.codebuffToken(environment: env, authFileURL: nil)
+                == "env-token")
+    }
+
+    @Test
     func `leaves environment when API key missing`() {
         let config = ProviderConfig(id: .zai, apiKey: nil)
         let env = ProviderConfigEnvironment.applyAPIKeyOverride(

--- a/Tests/CodexBarTests/ProviderTokenResolverTests.swift
+++ b/Tests/CodexBarTests/ProviderTokenResolverTests.swift
@@ -80,4 +80,53 @@ struct ProviderTokenResolverTests {
         try contents.write(to: fileURL, atomically: true, encoding: .utf8)
         return fileURL
     }
+
+    @Test
+    func `codebuff resolution prefers environment over credentials file`() throws {
+        let fileURL = try self.makeCodebuffCredentialsFile(
+            contents: #"{"authToken":"file-token"}"#)
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+
+        let env = [CodebuffSettingsReader.apiTokenKey: "env-token"]
+        let resolution = ProviderTokenResolver.codebuffResolution(
+            environment: env,
+            authFileURL: fileURL)
+
+        #expect(resolution?.token == "env-token")
+        #expect(resolution?.source == .environment)
+    }
+
+    @Test
+    func `codebuff resolution falls back to credentials file`() throws {
+        let fileURL = try self.makeCodebuffCredentialsFile(
+            contents: #"{"authToken":"file-token","fingerprintId":"fp"}"#)
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+
+        let resolution = ProviderTokenResolver.codebuffResolution(
+            environment: [:],
+            authFileURL: fileURL)
+
+        #expect(resolution?.token == "file-token")
+        #expect(resolution?.source == .authFile)
+    }
+
+    @Test
+    func `codebuff resolution returns nil for malformed credentials file`() throws {
+        let fileURL = try self.makeCodebuffCredentialsFile(contents: #"{not-json}"#)
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+
+        let resolution = ProviderTokenResolver.codebuffResolution(
+            environment: [:],
+            authFileURL: fileURL)
+        #expect(resolution == nil)
+    }
+
+    private func makeCodebuffCredentialsFile(contents: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fileURL = directory.appendingPathComponent("credentials.json", isDirectory: false)
+        try contents.write(to: fileURL, atomically: true, encoding: .utf8)
+        return fileURL
+    }
 }

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -940,6 +940,7 @@ struct SettingsStoreTests {
             .abacus,
             .mistral,
             .deepseek,
+            .codebuff,
         ])
 
         // Move one provider; ensure it's persisted across instances.

--- a/docs/codebuff.md
+++ b/docs/codebuff.md
@@ -1,0 +1,62 @@
+# Codebuff
+
+CodexBar surfaces [Codebuff](https://www.codebuff.com) credit balance and
+weekly rate limits next to your other AI providers.
+
+## Data sources
+
+- `POST https://www.codebuff.com/api/v1/usage` — current credit usage,
+  remaining balance, auto top-up state, and the next quota reset date.
+- `GET  https://www.codebuff.com/api/user/subscription` — subscription tier,
+  billing period end, and the weekly rate-limit window (`weeklyUsed` /
+  `weeklyLimit`).
+
+Both endpoints use a Bearer token. CodexBar never stores Codebuff credentials
+outside the existing macOS Keychain / `~/.codexbar/config.json` that the other
+providers use.
+
+## Authentication
+
+CodexBar resolves the Codebuff API token in this order:
+
+1. `CODEBUFF_API_KEY` environment variable (takes precedence so CI overrides
+   work).
+2. The per-provider API key stored in Settings → Providers → Codebuff (saved
+   in `~/.codexbar/config.json` via the normal CodexBar config flow).
+3. `~/.config/manicode/credentials.json` — the file the official `codebuff`
+   CLI (formerly `manicode`) writes after `codebuff login`. CodexBar reads
+   the `authToken` field and treats it as a Bearer token.
+
+If none of those is available, Codebuff shows the “missing token” error.
+
+## Credit window mapping
+
+- **Primary row** — credit balance (`usage / quota`), with the "next quota
+  reset" date if provided.
+- **Secondary row** — weekly rate-limit window (`weeklyUsed / weeklyLimit`)
+  shown with a 7-day window.
+
+The account panel shows the Codebuff tier (e.g. "Pro"), remaining balance,
+and whether auto top-up is enabled.
+
+## Troubleshooting
+
+- Run `codebuff login` to refresh `~/.config/manicode/credentials.json`.
+- Override the API base with `CODEBUFF_API_URL` for staging environments.
+- Verify your token works manually:
+
+  ```sh
+  curl -s -X POST -H "Authorization: Bearer $CODEBUFF_API_KEY" \
+    -H 'Content-Type: application/json' -d '{}' \
+    https://www.codebuff.com/api/v1/usage
+  ```
+
+## Related files
+
+- `Sources/CodexBarCore/Providers/Codebuff/` — descriptor, fetcher, snapshot,
+  settings reader, error types.
+- `Sources/CodexBar/Providers/Codebuff/` — settings store bridge + macOS
+  settings pane implementation.
+- `Tests/CodexBarTests/CodebuffSettingsReaderTests.swift`,
+  `CodebuffUsageFetcherTests.swift`, and the Codebuff extensions in
+  `ProviderTokenResolverTests.swift`.

--- a/docs/codebuff.md
+++ b/docs/codebuff.md
@@ -9,7 +9,7 @@ weekly rate limits next to your other AI providers.
   remaining balance, auto top-up state, and the next quota reset date.
 - `GET  https://www.codebuff.com/api/user/subscription` — subscription tier,
   billing period end, and the weekly rate-limit window (`weeklyUsed` /
-  `weeklyLimit`).
+  `weeklyLimit`) when CodexBar is using the CLI credentials-file session token.
 
 Both endpoints use a Bearer token. CodexBar never stores Codebuff credentials
 outside the existing macOS Keychain / `~/.codexbar/config.json` that the other
@@ -20,12 +20,14 @@ providers use.
 CodexBar resolves the Codebuff API token in this order:
 
 1. `CODEBUFF_API_KEY` environment variable (takes precedence so CI overrides
-   work).
+   work). API-key tokens fetch credit balance only.
 2. The per-provider API key stored in Settings → Providers → Codebuff (saved
-   in `~/.codexbar/config.json` via the normal CodexBar config flow).
+   in `~/.codexbar/config.json` via the normal CodexBar config flow). API-key
+   tokens fetch credit balance only.
 3. `~/.config/manicode/credentials.json` — the file the official `codebuff`
    CLI (formerly `manicode`) writes after `codebuff login`. CodexBar reads
-   the `authToken` field and treats it as a Bearer token.
+   the `authToken` field and uses that session token for both credit balance
+   and subscription metadata.
 
 If none of those is available, Codebuff shows the “missing token” error.
 


### PR DESCRIPTION
Supersedes #778.

Thanks to @anandghegde for the original Codebuff provider contribution. This branch keeps that work and adds the follow-up fixes for Codebuff usage auth, credential parsing, API-key behavior, provider-order coverage, subscription tier parsing, and weekly reset metadata.

Validation:
- swift test --filter Codebuff
- swift test --filter SettingsStoreTests
- pnpm check
- ./Scripts/compile_and_run.sh