### PR TITLE
Add macOS arm64 CLI release workflow

### DIFF
--- a/.github/workflows/release-macos-cli.yml
+++ b/.github/workflows/release-macos-cli.yml
@@ -1,0 +1,80 @@
+name: Release macOS CLI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-macos-cli:
+    runs-on: macos-15
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Runner info
+        run: |
+          set -euo pipefail
+          uname -a
+          uname -m
+          swift --version
+
+      - name: Build CodexBarCLI (release, arm64)
+        run: swift build -c release --arch arm64 --product CodexBarCLI
+
+      - name: Smoke test CodexBarCLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          BIN_DIR="$(swift build -c release --arch arm64 --product CodexBarCLI --show-bin-path)"
+          BIN="$BIN_DIR/CodexBarCLI"
+          file "$BIN" | grep -q "arm64"
+          "$BIN" --help >/dev/null
+          "$BIN" --version >/dev/null
+
+      - name: Package
+        id: pkg
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          if [[ -z "$TAG" ]]; then
+            echo "Missing tag (GITHUB_REF_NAME)." >&2
+            exit 1
+          fi
+
+          BIN_DIR="$(swift build -c release --arch arm64 --product CodexBarCLI --show-bin-path)"
+          OUT_DIR="$(mktemp -d)"
+          install -m 0755 "$BIN_DIR/CodexBarCLI" "$OUT_DIR/CodexBarCLI"
+          ln -s "CodexBarCLI" "$OUT_DIR/codexbar"
+
+          ASSET="CodexBarCLI-${TAG}-macos-arm64.tar.gz"
+          (cd "$OUT_DIR" && tar czf "$ASSET" CodexBarCLI codexbar)
+          shasum -a 256 "$OUT_DIR/$ASSET" > "$OUT_DIR/$ASSET.sha256"
+
+          echo "out_dir=$OUT_DIR" >> "$GITHUB_OUTPUT"
+          echo "asset=$ASSET" >> "$GITHUB_OUTPUT"
+
+      - name: Upload release assets
+        if: github.event_name == 'release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          OUT_DIR="${{ steps.pkg.outputs.out_dir }}"
+          ASSET="${{ steps.pkg.outputs.asset }}"
+          gh release upload "$TAG" "$OUT_DIR/$ASSET" "$OUT_DIR/$ASSET.sha256" --clobber
+
+      - name: Upload workflow artifact (manual runs)
+        if: github.event_name != 'release'
+        uses: actions/upload-artifact@v6
+        with:
+          name: codexbar-macos-cli-arm64
+          path: |
+            ${{ steps.pkg.outputs.out_dir }}/${{ steps.pkg.outputs.asset }}
+            ${{ steps.pkg.outputs.out_dir }}/${{ steps.pkg.outputs.asset }}.sha256

--- a/.github/workflows/release-macos-cli.yml
+++ b/.github/workflows/release-macos-cli.yml
@@ -40,18 +40,19 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF_NAME}"
-          if [[ -z "$TAG" ]]; then
+          REF_NAME="${GITHUB_REF_NAME}"
+          if [[ -z "$REF_NAME" ]]; then
             echo "Missing tag (GITHUB_REF_NAME)." >&2
             exit 1
           fi
+          SAFE_REF_NAME="${REF_NAME//\//-}"
 
           BIN_DIR="$(swift build -c release --arch arm64 --product CodexBarCLI --show-bin-path)"
           OUT_DIR="$(mktemp -d)"
           install -m 0755 "$BIN_DIR/CodexBarCLI" "$OUT_DIR/CodexBarCLI"
           ln -s "CodexBarCLI" "$OUT_DIR/codexbar"
 
-          ASSET="CodexBarCLI-${TAG}-macos-arm64.tar.gz"
+          ASSET="CodexBarCLI-${SAFE_REF_NAME}-macos-arm64.tar.gz"
           (cd "$OUT_DIR" && tar czf "$ASSET" CodexBarCLI codexbar)
           shasum -a 256 "$OUT_DIR/$ASSET" > "$OUT_DIR/$ASSET.sha256"
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ brew install steipete/tap/codexbar
 Or download `CodexBarCLI-v<tag>-linux-<arch>.tar.gz` from GitHub Releases.
 Linux support via Omarchy: community Waybar module and TUI, driven by the `codexbar` executable.
 
+### macOS Apple Silicon CLI (M-series)
+Download `CodexBarCLI-v<tag>-macos-arm64.tar.gz` from GitHub Releases.
+
 ### First run
 - Open Settings → Providers and enable what you use.
 - Install/sign in to the provider sources you rely on (e.g. `codex`, `claude`, `gemini`, browser cookies, or OAuth; Antigravity requires the Antigravity app running).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,6 +27,16 @@ tar -xzf CodexBarCLI-v0.17.0-linux-x86_64.tar.gz
 ./codexbar usage --format json --pretty
 ```
 
+### macOS Apple Silicon install (CLI tarball)
+- Download `CodexBarCLI-<tag>-macos-arm64.tar.gz` from GitHub Releases.
+- Extract; run `./codexbar` (symlink) or `./CodexBarCLI`.
+
+```
+tar -xzf CodexBarCLI-v0.17.0-macos-arm64.tar.gz
+./codexbar --version
+./codexbar usage --format json --pretty
+```
+
 ## Build
 - `./Scripts/package_app.sh` (or `./Scripts/compile_and_run.sh`) bundles `CodexBarCLI` into `CodexBar.app/Contents/Helpers/CodexBarCLI`.
 - Standalone: `swift build -c release --product CodexBarCLI` (binary at `./.build/release/CodexBarCLI`).


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow to build and package `CodexBarCLI` for macOS Apple Silicon (`arm64`)
- run a smoke test to verify the binary is arm64 and executable
- upload release assets (`.tar.gz` + `.sha256`) and workflow artifacts for manual runs
- document Apple Silicon CLI download path in README and CLI docs

## Why
This makes Apple Silicon users (including MacBook Air M5) first-class release targets with ready-to-download CLI artifacts from GitHub Releases.

## Validation
- local build: `swift build -c release --arch arm64 --product CodexBarCLI`
