### PR TITLE
Fix battery drain from hung Codex RPC + 60 FPS animation loop

### DIFF
--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -6,6 +6,18 @@ extension StatusItemController {
     private static let loadingPercentEpsilon = 0.0001
     private static let blinkActiveTickInterval: Duration = .milliseconds(75)
     private static let blinkIdleFallbackInterval: Duration = .seconds(1)
+    /// Target frame rate for the menu-bar loading animation. Reduced from 60 FPS
+    /// to halve main-thread NSImage redraw cost while still feeling smooth (12 FPS
+    /// looks choppy). The phase increment below is derived from this so visible
+    /// animation speed stays constant if the value changes.
+    static let loadingAnimationFPS: Double = 30.0
+    /// Per-tick phase advance, derived so that animation speed remains 2.7
+    /// phase-units per second regardless of FPS. Originally `0.045` at 60 FPS.
+    static let loadingAnimationPhaseIncrement: Double = 2.7 / StatusItemController.loadingAnimationFPS
+    /// Hard ceiling on continuous animation duration. Guards against future
+    /// regressions of the `!hasData && !isStale` animation loop that pinned the
+    /// menu bar at full FPS until the user quit (#842).
+    private static let loadingAnimationMaxContinuousDuration: TimeInterval = 30.0
 
     func needsMenuBarIconAnimation() -> Bool {
         if self.shouldMergeIcons {
@@ -691,29 +703,44 @@ extension StatusItemController {
                     self.animationPattern = .knightRider
                 }
                 self.animationPhase = 0
+                self.animationStartedAt = Date()
                 let driver = DisplayLinkDriver(onTick: { [weak self] in
                     self?.updateAnimationFrame()
                 })
                 self.animationDriver = driver
-                driver.start(fps: 60)
+                driver.start(fps: Self.loadingAnimationFPS)
             } else if let forced = self.settings.debugLoadingPattern, forced != self.animationPattern {
                 self.animationPattern = forced
                 self.animationPhase = 0
             }
         } else {
-            self.animationDriver?.stop()
-            self.animationDriver = nil
-            self.animationPhase = 0
-            if self.shouldMergeIcons {
-                self.applyIcon(phase: nil)
-            } else {
-                UsageProvider.allCases.forEach { self.applyIcon(for: $0, phase: nil) }
-            }
+            self.stopLoadingAnimation()
+        }
+    }
+
+    private func stopLoadingAnimation() {
+        self.animationDriver?.stop()
+        self.animationDriver = nil
+        self.animationPhase = 0
+        self.animationStartedAt = nil
+        if self.shouldMergeIcons {
+            self.applyIcon(phase: nil)
+        } else {
+            UsageProvider.allCases.forEach { self.applyIcon(for: $0, phase: nil) }
         }
     }
 
     private func updateAnimationFrame() {
-        self.animationPhase += 0.045 // half-speed animation
+        // Hard ceiling guards against future regressions of the !hasData && !isStale
+        // animation loop that caused the menu bar to redraw at full FPS forever
+        // (see #842).
+        if let startedAt = self.animationStartedAt,
+           Date().timeIntervalSince(startedAt) > Self.loadingAnimationMaxContinuousDuration
+        {
+            self.stopLoadingAnimation()
+            return
+        }
+        self.animationPhase += Self.loadingAnimationPhaseIncrement
         if self.shouldMergeIcons {
             self.applyIcon(phase: self.animationPhase)
         } else {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -112,6 +112,10 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var animationDriver: DisplayLinkDriver?
     var animationPhase: Double = 0
     var animationPattern: LoadingPattern = .knightRider
+    /// Tracks when the loading animation last started. Used by the 30-second hard
+    /// ceiling in `updateAnimationFrame` to guard against future regressions of the
+    /// `!hasData && !isStale` animation loop. See #842.
+    var animationStartedAt: Date?
     private var lastConfigRevision: Int
     private var lastProviderOrder: [UsageProvider]
     private var lastMergeIcons: Bool

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -366,7 +366,7 @@ private struct RPCRateLimitsErrorBody: Decodable {
     }
 }
 
-private enum RPCWireError: Error, LocalizedError {
+enum RPCWireError: Error, LocalizedError {
     case startFailed(String)
     case requestFailed(String)
     case malformed(String)
@@ -538,9 +538,11 @@ private final class CodexRPCClient: @unchecked Sendable {
 
     /// Sendable wrapper so we can return `[String: Any]` payloads out of a
     /// `withThrowingTaskGroup` (which requires `Sendable` element types) without
-    /// having to rewrite every caller around `Data`. The inner dict only ever
-    /// holds JSON values produced by `JSONSerialization`, which are inherently
-    /// thread-safe value types post-decoding.
+    /// rewriting every caller around `Data`. Safe here because of *usage*, not
+    /// the underlying type: each message is produced once by `JSONSerialization`,
+    /// wrapped, handed back through `group.next()`, unwrapped, and used in the
+    /// caller — no shared mutable state across tasks. Do NOT reuse this wrapper
+    /// for dictionaries that any other task could mutate concurrently.
     private struct SendableJSONMessage: @unchecked Sendable {
         let value: [String: Any]
     }
@@ -594,7 +596,7 @@ private final class CodexRPCClient: @unchecked Sendable {
                 // On timeout, terminate the process so the stdout reader finishes
                 // and the awaiting body task exits its for-await loop instead of
                 // leaking. Then surface the timeout error to the caller.
-                self?.terminateProcessForTimeout()
+                self?.terminateProcessForTimeout(method: method)
                 throw RPCWireError.timeout(method: method)
             }
             do {
@@ -610,9 +612,9 @@ private final class CodexRPCClient: @unchecked Sendable {
         }
     }
 
-    private func terminateProcessForTimeout() {
+    private func terminateProcessForTimeout(method: String) {
         if self.process.isRunning {
-            Self.log.warning("Codex RPC timed out; terminating process")
+            Self.log.warning("Codex RPC timed out on `\(method)`; terminating process")
             self.process.terminate()
         }
     }

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -370,6 +370,7 @@ private enum RPCWireError: Error, LocalizedError {
     case startFailed(String)
     case requestFailed(String)
     case malformed(String)
+    case timeout(method: String)
 
     var errorDescription: String? {
         switch self {
@@ -379,6 +380,8 @@ private enum RPCWireError: Error, LocalizedError {
             "Codex connection failed: \(message)"
         case let .malformed(message):
             "Codex returned invalid data: \(message)"
+        case let .timeout(method):
+            "Codex RPC timed out waiting for `\(method)` reply."
         }
     }
 }
@@ -393,6 +396,14 @@ private final class CodexRPCClient: @unchecked Sendable {
     private let stdoutLineStream: AsyncStream<Data>
     private let stdoutLineContinuation: AsyncStream<Data>.Continuation
     private var nextID = 1
+    /// Per-method RPC timeouts. Bug #842: the `app-server` could accept `initialize`
+    /// and then never reply to `account/rateLimits/read`, leaving the reader awaiting
+    /// the stdout AsyncStream forever. That hang produced no error, so the TTY
+    /// fallback never ran and the menu-bar loading animation pinned at 60 FPS until
+    /// the user quit the app. These timeouts force the request path to throw, which
+    /// triggers `withFallback` to try the TTY secondary.
+    private let initializeTimeoutSeconds: TimeInterval
+    private let requestTimeoutSeconds: TimeInterval
 
     private final class LineBuffer: @unchecked Sendable {
         private let lock = NSLock()
@@ -424,8 +435,12 @@ private final class CodexRPCClient: @unchecked Sendable {
     init(
         executable: String = "codex",
         arguments: [String] = ["-s", "read-only", "-a", "untrusted", "app-server"],
-        environment: [String: String] = ProcessInfo.processInfo.environment) throws
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        initializeTimeoutSeconds: TimeInterval = 8.0,
+        requestTimeoutSeconds: TimeInterval = 3.0) throws
     {
+        self.initializeTimeoutSeconds = initializeTimeoutSeconds
+        self.requestTimeoutSeconds = requestTimeoutSeconds
         var stdoutContinuation: AsyncStream<Data>.Continuation!
         self.stdoutLineStream = AsyncStream<Data> { continuation in
             stdoutContinuation = continuation
@@ -497,7 +512,8 @@ private final class CodexRPCClient: @unchecked Sendable {
     func initialize(clientName: String, clientVersion: String) async throws {
         _ = try await self.request(
             method: "initialize",
-            params: ["clientInfo": ["name": clientName, "version": clientVersion]])
+            params: ["clientInfo": ["name": clientName, "version": clientVersion]],
+            timeout: self.initializeTimeoutSeconds)
         try self.sendNotification(method: "initialized")
     }
 
@@ -520,26 +536,84 @@ private final class CodexRPCClient: @unchecked Sendable {
 
     // MARK: - JSON-RPC helpers
 
-    private func request(method: String, params: [String: Any]? = nil) async throws -> [String: Any] {
+    /// Sendable wrapper so we can return `[String: Any]` payloads out of a
+    /// `withThrowingTaskGroup` (which requires `Sendable` element types) without
+    /// having to rewrite every caller around `Data`. The inner dict only ever
+    /// holds JSON values produced by `JSONSerialization`, which are inherently
+    /// thread-safe value types post-decoding.
+    private struct SendableJSONMessage: @unchecked Sendable {
+        let value: [String: Any]
+    }
+
+    private func request(
+        method: String,
+        params: [String: Any]? = nil,
+        timeout: TimeInterval? = nil) async throws -> [String: Any]
+    {
         let id = self.nextID
         self.nextID += 1
         try self.sendRequest(id: id, method: method, params: params)
 
-        while true {
-            let message = try await self.readNextMessage()
+        let resolvedTimeout = timeout ?? self.requestTimeoutSeconds
+        let wrapped = try await self.withTimeout(seconds: resolvedTimeout, method: method) {
+            while true {
+                let message = try await self.readNextMessage()
 
-            if message["id"] == nil, let methodName = message["method"] as? String {
-                Self.debugWriteStderr("[codex notify] \(methodName)\n")
-                continue
+                if message["id"] == nil, let methodName = message["method"] as? String {
+                    Self.debugWriteStderr("[codex notify] \(methodName)\n")
+                    continue
+                }
+
+                guard let messageID = self.jsonID(message["id"]), messageID == id else { continue }
+
+                if let error = message["error"] as? [String: Any], let messageText = error["message"] as? String {
+                    throw RPCWireError.requestFailed(messageText)
+                }
+
+                return SendableJSONMessage(value: message)
             }
+        }
+        return wrapped.value
+    }
 
-            guard let messageID = self.jsonID(message["id"]), messageID == id else { continue }
-
-            if let error = message["error"] as? [String: Any], let messageText = error["message"] as? String {
-                throw RPCWireError.requestFailed(messageText)
+    /// Race `body` against a timeout. On timeout, terminate the codex process so the
+    /// stdout AsyncStream finishes, which unblocks any pending `readNextMessage()`
+    /// calls — preventing the leaked-reader hang that caused the 60 FPS animation
+    /// to spin forever (see #842).
+    private func withTimeout<T: Sendable>(
+        seconds: TimeInterval,
+        method: String,
+        body: @escaping @Sendable () async throws -> T) async throws -> T
+    {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                try await body()
             }
+            group.addTask { [weak self] in
+                try await Task.sleep(for: .seconds(seconds))
+                // On timeout, terminate the process so the stdout reader finishes
+                // and the awaiting body task exits its for-await loop instead of
+                // leaking. Then surface the timeout error to the caller.
+                self?.terminateProcessForTimeout()
+                throw RPCWireError.timeout(method: method)
+            }
+            do {
+                guard let result = try await group.next() else {
+                    throw RPCWireError.timeout(method: method)
+                }
+                group.cancelAll()
+                return result
+            } catch {
+                group.cancelAll()
+                throw error
+            }
+        }
+    }
 
-            return message
+    private func terminateProcessForTimeout() {
+        if self.process.isRunning {
+            Self.log.warning("Codex RPC timed out; terminating process")
+            self.process.terminate()
         }
     }
 
@@ -598,6 +672,13 @@ public struct UsageFetcher: Sendable {
 
     private let environment: [String: String]
     private let codexStatusFetcher: CodexStatusFetcher
+    /// RPC + TTY timeouts. Defaults match the production behaviour. Tests inject
+    /// shorter values so they can prove the timeout actually fires without
+    /// stalling the suite. See #842 for context (60 FPS DisplayLink hang caused
+    /// by a wedged `account/rateLimits/read` reply).
+    let initializeTimeoutSeconds: TimeInterval
+    let requestTimeoutSeconds: TimeInterval
+    let ttyTimeoutSeconds: TimeInterval
 
     public init(environment: [String: String] = ProcessInfo.processInfo.environment) {
         self.init(environment: environment) { environment, keepCLISessionsAlive in
@@ -610,10 +691,16 @@ public struct UsageFetcher: Sendable {
 
     init(
         environment: [String: String],
-        codexStatusFetcher: @escaping CodexStatusFetcher)
+        codexStatusFetcher: @escaping CodexStatusFetcher,
+        initializeTimeoutSeconds: TimeInterval = 8.0,
+        requestTimeoutSeconds: TimeInterval = 3.0,
+        ttyTimeoutSeconds: TimeInterval = 10.0)
     {
         self.environment = environment
         self.codexStatusFetcher = codexStatusFetcher
+        self.initializeTimeoutSeconds = initializeTimeoutSeconds
+        self.requestTimeoutSeconds = requestTimeoutSeconds
+        self.ttyTimeoutSeconds = ttyTimeoutSeconds
         LoginShellPathCache.shared.captureOnce()
     }
 
@@ -624,7 +711,10 @@ public struct UsageFetcher: Sendable {
     }
 
     private func loadRPCUsage() async throws -> UsageSnapshot {
-        let rpc = try CodexRPCClient(environment: self.environment)
+        let rpc = try CodexRPCClient(
+            environment: self.environment,
+            initializeTimeoutSeconds: self.initializeTimeoutSeconds,
+            requestTimeoutSeconds: self.requestTimeoutSeconds)
         defer { rpc.shutdown() }
         do {
             try await rpc.initialize(clientName: "codexbar", clientVersion: "0.5.4")
@@ -659,7 +749,13 @@ public struct UsageFetcher: Sendable {
     }
 
     private func loadTTYUsage(keepCLISessionsAlive: Bool) async throws -> UsageSnapshot {
-        do {
+        // CodexStatusProbe.fetch() already has its own internal `timeout` (default
+        // 8s) that propagates into TTYCommandRunner / CodexCLISession. The outer
+        // race below is defence-in-depth: it bounds any future callsite that
+        // happens to bypass that probe (tests inject custom fetchers) and prevents
+        // a wedged TTY path from leaking into the same animation hang as the RPC
+        // path. See #842.
+        try await self.runWithTTYTimeout {
             let status = try await self.codexStatusFetcher(self.environment, keepCLISessionsAlive)
             guard let state = CodexReconciledState.fromCLI(
                 primary: Self.makeTTYWindow(
@@ -677,8 +773,6 @@ public struct UsageFetcher: Sendable {
                 throw UsageError.noRateLimitsFound
             }
             return state.toUsageSnapshot()
-        } catch {
-            throw error
         }
     }
 
@@ -689,7 +783,10 @@ public struct UsageFetcher: Sendable {
     }
 
     private func loadRPCCredits() async throws -> CreditsSnapshot {
-        let rpc = try CodexRPCClient(environment: self.environment)
+        let rpc = try CodexRPCClient(
+            environment: self.environment,
+            initializeTimeoutSeconds: self.initializeTimeoutSeconds,
+            requestTimeoutSeconds: self.requestTimeoutSeconds)
         defer { rpc.shutdown() }
         do {
             try await rpc.initialize(clientName: "codexbar", clientVersion: "0.5.4")
@@ -706,12 +803,34 @@ public struct UsageFetcher: Sendable {
     }
 
     private func loadTTYCredits(keepCLISessionsAlive: Bool) async throws -> CreditsSnapshot {
-        do {
+        // See `loadTTYUsage` for the rationale behind this defensive timeout.
+        try await self.runWithTTYTimeout {
             let status = try await self.codexStatusFetcher(self.environment, keepCLISessionsAlive)
             guard let credits = status.credits else { throw UsageError.noRateLimitsFound }
             return CreditsSnapshot(remaining: credits, events: [], updatedAt: Date())
-        } catch {
-            throw error
+        }
+    }
+
+    private func runWithTTYTimeout<T: Sendable>(
+        _ body: @escaping @Sendable () async throws -> T) async throws -> T
+    {
+        let budget = self.ttyTimeoutSeconds
+        return try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask { try await body() }
+            group.addTask {
+                try await Task.sleep(for: .seconds(budget))
+                throw RPCWireError.timeout(method: "tty/status")
+            }
+            do {
+                guard let result = try await group.next() else {
+                    throw RPCWireError.timeout(method: "tty/status")
+                }
+                group.cancelAll()
+                return result
+            } catch {
+                group.cancelAll()
+                throw error
+            }
         }
     }
 
@@ -733,7 +852,10 @@ public struct UsageFetcher: Sendable {
 
     public func debugRawRateLimits() async -> String {
         do {
-            let rpc = try CodexRPCClient(environment: self.environment)
+            let rpc = try CodexRPCClient(
+                environment: self.environment,
+                initializeTimeoutSeconds: self.initializeTimeoutSeconds,
+                requestTimeoutSeconds: self.requestTimeoutSeconds)
             defer { rpc.shutdown() }
             try await rpc.initialize(clientName: "codexbar", clientVersion: "0.5.4")
             let limits = try await rpc.fetchRateLimits()

--- a/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
+++ b/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
@@ -154,13 +154,17 @@ struct CodexUsageFetcherFallbackTests {
             ttyTimeoutSeconds: 0.5)
 
         let started = Date()
+        var caughtTimeout = false
         do {
             _ = try await fetcher.loadLatestUsage()
             Issue.record("Expected fetcher to throw when both RPC and TTY hang")
+        } catch let error as RPCWireError {
+            if case .timeout = error { caughtTimeout = true }
         } catch {
-            // Either path's timeout is acceptable; what matters is bounded duration.
+            Issue.record("Expected RPCWireError.timeout, got \(type(of: error)): \(error)")
         }
         let elapsed = Date().timeIntervalSince(started)
+        #expect(caughtTimeout, "Expected RPCWireError.timeout from RPC or TTY path")
         #expect(elapsed < 2.0, "Both-hang case must terminate fast, took \(elapsed)s")
     }
 

--- a/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
+++ b/Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift
@@ -1,5 +1,7 @@
+import AppKit
 import Foundation
 import Testing
+@testable import CodexBar
 @testable import CodexBarCore
 
 @Suite(.serialized)
@@ -77,6 +79,144 @@ struct CodexUsageFetcherFallbackTests {
         #expect(snapshot.secondary?.windowMinutes == 10080)
     }
 
+    // MARK: - Battery drain regression coverage (#842)
+
+    /// Test A: When `account/rateLimits/read` never receives a reply, the RPC path
+    /// must time out fast enough that the TTY fallback completes the call within
+    /// a couple of seconds — not "never" as observed in production.
+    @Test
+    func `Hung rate-limits read times out and falls back to TTY within budget`() async throws {
+        let stubCLIPath = try self.makeHungRateLimitsStubCodexCLI()
+        defer { try? FileManager.default.removeItem(atPath: stubCLIPath) }
+
+        let fetcher = UsageFetcher(
+            environment: ["CODEX_CLI_PATH": stubCLIPath],
+            codexStatusFetcher: Self.stubTTYStatus,
+            initializeTimeoutSeconds: 0.5,
+            requestTimeoutSeconds: 0.2)
+
+        let started = Date()
+        let snapshot = try await fetcher.loadLatestUsage()
+        let elapsed = Date().timeIntervalSince(started)
+
+        #expect(elapsed < 2.0, "Expected TTY fallback to complete in <2s, took \(elapsed)s")
+        #expect(snapshot.primary?.usedPercent == 12)
+        #expect(snapshot.secondary?.usedPercent == 25)
+    }
+
+    /// Test C: After Test A's hang, the fetcher must not have leaked a wedged
+    /// process / pipe — a follow-up call must also complete in budget.
+    @Test
+    func `Repeated hung RPC requests stay bounded across calls`() async throws {
+        let stubCLIPath = try self.makeHungRateLimitsStubCodexCLI()
+        defer { try? FileManager.default.removeItem(atPath: stubCLIPath) }
+
+        let fetcher = UsageFetcher(
+            environment: ["CODEX_CLI_PATH": stubCLIPath],
+            codexStatusFetcher: Self.stubTTYStatus,
+            initializeTimeoutSeconds: 0.5,
+            requestTimeoutSeconds: 0.2)
+
+        _ = try await fetcher.loadLatestUsage()
+        let started = Date()
+        let snapshot = try await fetcher.loadLatestUsage()
+        let elapsed = Date().timeIntervalSince(started)
+
+        #expect(elapsed < 2.0, "Second call should also complete in <2s, took \(elapsed)s")
+        #expect(snapshot.primary?.usedPercent == 12)
+    }
+
+    /// Test D: The TTY fallback also has a bounded execution. If the TTY path
+    /// itself hangs, the fetcher must throw within `ttyTimeoutSeconds`.
+    @Test
+    func `Hanging TTY fallback also times out within budget`() async throws {
+        let stubCLIPath = try self.makeHungRateLimitsStubCodexCLI()
+        defer { try? FileManager.default.removeItem(atPath: stubCLIPath) }
+
+        let hangingTTY: @Sendable ([String: String], Bool) async throws -> CodexStatusSnapshot = { _, _ in
+            try await Task.sleep(for: .seconds(30))
+            return CodexStatusSnapshot(
+                credits: nil,
+                fiveHourPercentLeft: nil,
+                weeklyPercentLeft: nil,
+                fiveHourResetDescription: nil,
+                weeklyResetDescription: nil,
+                fiveHourResetsAt: nil,
+                weeklyResetsAt: nil,
+                rawText: "")
+        }
+
+        let fetcher = UsageFetcher(
+            environment: ["CODEX_CLI_PATH": stubCLIPath],
+            codexStatusFetcher: hangingTTY,
+            initializeTimeoutSeconds: 0.5,
+            requestTimeoutSeconds: 0.2,
+            ttyTimeoutSeconds: 0.5)
+
+        let started = Date()
+        do {
+            _ = try await fetcher.loadLatestUsage()
+            Issue.record("Expected fetcher to throw when both RPC and TTY hang")
+        } catch {
+            // Either path's timeout is acceptable; what matters is bounded duration.
+        }
+        let elapsed = Date().timeIntervalSince(started)
+        #expect(elapsed < 2.0, "Both-hang case must terminate fast, took \(elapsed)s")
+    }
+
+    /// Test B: When an error is recorded for a provider, `isStale` returns true
+    /// and the menu-bar animation must NOT start. (Production bug: hung RPC
+    /// recorded no error so `isStale = false` and the 60 FPS DisplayLink ran
+    /// indefinitely.)
+    @Test
+    @MainActor
+    func `Recorded error marks provider stale and stops menu-bar animation`() {
+        _ = NSApplication.shared
+
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "BatteryDrain-StaleErrorStops"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let registry = ProviderRegistry.shared
+        if let meta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: meta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+
+        // No snapshot, but an error is recorded — exactly the post-fix shape we
+        // get when the RPC times out and the fallback also fails.
+        store._setErrorForTesting("simulated codex RPC timeout", provider: .codex)
+
+        #expect(store.isStale(provider: .codex) == true)
+
+        let env = ProcessInfo.processInfo.environment
+        let statusBar: NSStatusBar = (env["GITHUB_ACTIONS"] == "true" || env["CI"] == "true")
+            ? .system
+            : NSStatusBar()
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: statusBar)
+
+        #expect(
+            controller.needsMenuBarIconAnimation() == false,
+            "Animation must not run when provider is stale (errors[provider] != nil)")
+        #expect(controller.animationDriver == nil)
+    }
+
     private static let decodeMismatchBodyMessage = """
     failed to fetch codex rate limits: Decode error for https://chatgpt.com/backend-api/wham/usage:
     unknown variant `prolite`, expected one of `guest`, `free`, `go`, `plus`, `pro`;
@@ -152,6 +292,62 @@ struct CodexUsageFetcherFallbackTests {
             fiveHourResetsAt: nil,
             weeklyResetsAt: nil,
             rawText: "Credits: 42 credits\n5h limit: [#####] 88% left\nWeekly limit: [##] 75% left\n")
+    }
+
+    /// Stub `codex` CLI that accepts `initialize`, hangs forever on
+    /// `account/rateLimits/read`, but answers `account/read` and TTY (`/status`)
+    /// invocations normally. Models the exact production failure that caused
+    /// #842 — the RPC stream never returns, no error is recorded, and the
+    /// menu-bar animation pins at full FPS until the user quits.
+    private func makeHungRateLimitsStubCodexCLI() throws -> String {
+        let script = """
+        #!/usr/bin/python3
+        import json
+        import sys
+        import time
+
+        args = sys.argv[1:]
+        if "app-server" in args:
+            for line in sys.stdin:
+                if not line.strip():
+                    continue
+                message = json.loads(line)
+                method = message.get("method")
+                if method == "initialized":
+                    continue
+
+                identifier = message.get("id")
+                if method == "initialize":
+                    payload = {"id": identifier, "result": {}}
+                    print(json.dumps(payload), flush=True)
+                elif method == "account/rateLimits/read":
+                    # Never reply — this is the production failure mode.
+                    time.sleep(30)
+                elif method == "account/read":
+                    payload = {
+                        "id": identifier,
+                        "result": {
+                            "account": {
+                                "type": "chatgpt",
+                                "email": "stub@example.com",
+                                "planType": "plus"
+                            },
+                            "requiresOpenaiAuth": False
+                        }
+                    }
+                    print(json.dumps(payload), flush=True)
+                else:
+                    payload = {"id": identifier, "result": {}}
+                    print(json.dumps(payload), flush=True)
+        else:
+            sys.stdout.write("Credits: 42 credits\\n5h limit: [#####] 88% left\\nWeekly limit: [##] 75% left\\n")
+            sys.stdout.flush()
+        """
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-hung-stub-\(UUID().uuidString)", isDirectory: false)
+        try Data(script.utf8).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url.path
     }
 
     private func makeDecodeMismatchStubCodexCLI(


### PR DESCRIPTION
Closes #842.

## Summary

Three connected changes that together stop the menu-bar from spending CPU forever when a Codex RPC call hangs:

1. **Per-method RPC timeouts** so `account/rateLimits/read` (and friends) can't await stdout indefinitely.
2. **Process termination on timeout** so the AsyncStream reader actually exits instead of leaking.
3. **Animation hardening** — drop loading FPS 60→30, add a 30s hard ceiling on continuous animation.

## Root cause (verified in #842)

When `codex app-server` accepted `initialize` but never replied to `account/rateLimits/read`:

1. `CodexRPCClient.request` (`Sources/CodexBarCore/UsageFetcher.swift`) awaited `for await lineData in self.stdoutLineStream` with no per-request deadline.
2. `loadRPCUsage` hung, so `withFallback` never saw a throw and the TTY secondary never ran.
3. `UsageStore.isStale(provider:)` returns `errors[provider] != nil`. A hang records no error → `isStale = false`.
4. `shouldAnimate` returned `!hasData && !isStale` → `true`, so `DisplayLinkDriver.start(fps: 60)` ran main-thread NSImage redraws indefinitely. macOS flagged this as "Using Significant Energy."

The existing fallback-only animation guard (`Animation.swift:670` — *"Animating the fallback causes unnecessary CPU usage (battery drain). See #269, #139."*) didn't cover the hung-primary case.

## What changed

### `Sources/CodexBarCore/UsageFetcher.swift`
- `RPCWireError.timeout(method:)` added.
- `CodexRPCClient` and `UsageFetcher` take internal-only `initializeTimeoutSeconds` (default 8s), `requestTimeoutSeconds` (default 3s), `ttyTimeoutSeconds` (default 10s). Defaults match production behavior; tests inject shorter values.
- `request()` races the stdout read against `Task.sleep` via `withThrowingTaskGroup`. On timeout: `process.terminate()` (closes stdout, unblocks the AsyncStream reader, body task unwinds) → throw `RPCWireError.timeout` → propagates through `withFallback` to TTY.
- `loadTTYUsage` / `loadTTYCredits` get a defensive `runWithTTYTimeout` wrapper. `CodexStatusProbe.fetch()` already has its own internal `timeout`; the outer race is defense-in-depth and bounds injected test fetchers that bypass the probe.
- The terminate-on-timeout log line names the failing method so prod logs distinguish `initialize` vs `account/rateLimits/read` hangs.

### `Sources/CodexBar/StatusItemController+Animation.swift`
- `loadingAnimationFPS = 30.0` (was 60) — halves main-thread NSImage redraw cost. 12 FPS would be choppy; 30 stays smooth.
- `loadingAnimationPhaseIncrement = 2.7 / FPS` derived so visible animation speed is unchanged when FPS is tuned.
- `loadingAnimationMaxContinuousDuration: 30.0` — hard ceiling on continuous animation. Even if a future code path produces `!hasData && !isStale` indefinitely, the driver force-stops after 30s. Defense-in-depth on a bug class that has shipped twice (#269, #139, #842).
- Stop logic factored into `stopLoadingAnimation()` so the ceiling and the natural-stop path use the same teardown.

### `Sources/CodexBar/StatusItemController.swift`
- `var animationStartedAt: Date?` to track ceiling.

### `Tests/CodexBarTests/CodexUsageFetcherFallbackTests.swift`
4 new regression tests, extended in the existing file (no parallel suite):

| Test | What it locks in |
|---|---|
| Hung rate-limits read times out and falls back to TTY within budget | RPC timeout fires fast enough that TTY fallback completes in <2s |
| Repeated hung RPC requests stay bounded across calls | Process termination actually unblocks the reader (no leaked task / wedged pipe) |
| Hanging TTY fallback also times out within budget | Defensive TTY wrapper bounds custom fetchers; specifically asserts `RPCWireError.timeout` not just any throw |
| Recorded error marks provider stale and stops menu-bar animation | Second half of the chain — once an error is recorded, `shouldAnimate` returns false and `animationDriver` stays nil |

The first stub (`makeHungRateLimitsStubCodexCLI`) mirrors the production failure shape: responds to `initialize`, hangs forever on `account/rateLimits/read`, answers `account/read` and TTY normally.

## Decisions

- **Timeouts:** 8s for `initialize` (covers child-process spawn + cold init), 3s for everything else (read calls are sub-second on healthy networks). Single-budget would either be too tight for initialize or too loose for the actual bug path.
- **30 FPS:** The energy cost halves vs 60 FPS but stays perceptually smooth. 12 FPS was on the table but visibly choppy on continuous sweeps (Knight Rider).
- **30s hard ceiling:** Belt-and-suspenders. Max legitimate refresh budget is ~21s (8s init + 3s request + 10s TTY); 30s is well above that. Cheap insurance against future code paths bypassing the error-recording chain.
- **No new user-facing settings.** All timeouts are internal init parameters for tests only.

## Verification

- `swift build` — clean
- `swift test --filter CodexUsageFetcherFallbackTests` — 10/10 (6 existing + 4 new)
- `swift test --filter BatteryDrainDiagnosticTests` — 3/3
- Fast-path test runtimes well under their assertions (Test A: 0.41s vs 2s budget; Test C: 0.82s; Test D: 1.01s)

The macOS "Using Significant Energy" badge is a heuristic over time and not deterministically reproducible on demand. What's verified here is the underlying mechanism: the hung-RPC chain that produced sustained 60 FPS main-thread redraws.

## Out of scope

- WebKit/AuthKit dashboard refresh resilience (already addressed upstream)
- New "battery saver" user-facing toggle (this is a correctness fix, not a configurable behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)