### PR TITLE
Fix Ollama Safari cookie fallback

### DIFF
--- a/Sources/CodexBar/Providers/Ollama/OllamaProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Ollama/OllamaProviderImplementation.swift
@@ -48,7 +48,7 @@ struct OllamaProviderImplementation: ProviderImplementation {
             ProviderCookieSourceUI.subtitle(
                 source: context.settings.ollamaCookieSource,
                 keychainDisabled: context.settings.debugDisableKeychainAccess,
-                auto: "Automatic imports browser cookies.",
+                auto: "Automatic imports Chrome first, then falls back to Safari and other browser sessions.",
                 manual: "Paste a Cookie header or cURL capture from Ollama settings.",
                 off: "Ollama cookies are disabled.")
         }
@@ -57,7 +57,7 @@ struct OllamaProviderImplementation: ProviderImplementation {
             ProviderSettingsPickerDescriptor(
                 id: "ollama-cookie-source",
                 title: "Cookie source",
-                subtitle: "Automatic imports browser cookies.",
+                subtitle: "Automatic imports Chrome first, then falls back to Safari and other browser sessions.",
                 dynamicSubtitle: cookieSubtitle,
                 binding: cookieBinding,
                 options: cookieOptions,

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
@@ -35,6 +35,7 @@ public enum OllamaUsageError: LocalizedError, Sendable {
     case parseFailed(String)
     case networkError(String)
     case noSessionCookie
+    case browserCookieAccessDenied(String)
 
     public var errorDescription: String? {
         switch self {
@@ -47,7 +48,9 @@ public enum OllamaUsageError: LocalizedError, Sendable {
         case let .networkError(message):
             "Ollama request failed: \(message)"
         case .noSessionCookie:
-            "No Ollama session cookie found. Please log in to ollama.com in your browser."
+            "No Ollama session cookie found. Log in to ollama.com in Chrome or Safari, or paste a manual Cookie header."
+        case let .browserCookieAccessDenied(message):
+            "Ollama browser cookies are not readable. \(message)"
         }
     }
 }
@@ -82,23 +85,34 @@ public enum OllamaCookieImporter {
         logger: ((String) -> Void)? = nil) throws -> [SessionInfo]
     {
         let log: (String) -> Void = { msg in logger?("[ollama-cookie] \(msg)") }
+        var accessDeniedHints: [String] = []
         let preferredSources = preferredBrowsers.isEmpty
             ? ollamaCookieImportOrder.cookieImportCandidates(using: browserDetection)
             : preferredBrowsers.cookieImportCandidates(using: browserDetection)
-        let preferredCandidates = self.collectSessionInfo(from: preferredSources, logger: log)
-        return try self.selectSessionInfosWithFallback(
-            preferredCandidates: preferredCandidates,
-            allowFallbackBrowsers: allowFallbackBrowsers,
-            loadFallbackCandidates: {
-                guard !preferredBrowsers.isEmpty else { return [] }
-                let fallbackSources = self.fallbackBrowserSources(
-                    browserDetection: browserDetection,
-                    excluding: preferredSources)
-                guard !fallbackSources.isEmpty else { return [] }
-                log("No recognized Ollama session in preferred browsers; trying fallback import order")
-                return self.collectSessionInfo(from: fallbackSources, logger: log)
-            },
+        let preferredCandidates = self.collectSessionInfo(
+            from: preferredSources,
+            accessDeniedHints: &accessDeniedHints,
             logger: log)
+        do {
+            return try self.selectSessionInfosWithFallback(
+                preferredCandidates: preferredCandidates,
+                allowFallbackBrowsers: allowFallbackBrowsers,
+                loadFallbackCandidates: {
+                    guard !preferredBrowsers.isEmpty else { return [] }
+                    let fallbackSources = self.fallbackBrowserSources(
+                        browserDetection: browserDetection,
+                        excluding: preferredSources)
+                    guard !fallbackSources.isEmpty else { return [] }
+                    log("No recognized Ollama session in preferred browsers; trying fallback import order")
+                    return self.collectSessionInfo(
+                        from: fallbackSources,
+                        accessDeniedHints: &accessDeniedHints,
+                        logger: log)
+                },
+                logger: log)
+        } catch OllamaUsageError.noSessionCookie where !accessDeniedHints.isEmpty {
+            throw OllamaUsageError.browserCookieAccessDenied(self.accessDeniedMessage(from: accessDeniedHints))
+        }
     }
 
     public static func importSession(
@@ -194,6 +208,7 @@ public enum OllamaCookieImporter {
 
     private static func collectSessionInfo(
         from browserSources: [Browser],
+        accessDeniedHints: inout [String],
         logger: @escaping (String) -> Void) -> [SessionInfo]
     {
         var candidates: [SessionInfo] = []
@@ -211,10 +226,23 @@ public enum OllamaCookieImporter {
                 }
             } catch {
                 BrowserCookieAccessGate.recordIfNeeded(error)
+                if let cookieError = error as? BrowserCookieError,
+                   let hint = cookieError.accessDeniedHint
+                {
+                    accessDeniedHints.append(hint)
+                }
                 logger("\(browserSource.displayName) cookie import failed: \(error.localizedDescription)")
             }
         }
         return candidates
+    }
+
+    private static func accessDeniedMessage(from hints: [String]) -> String {
+        let uniqueHints = Array(Set(hints)).sorted()
+        let details = uniqueHints.joined(separator: " ")
+        return details.isEmpty
+            ? "Grant CodexBar Full Disk Access in System Settings -> Privacy & Security, then refresh."
+            : "\(details) Grant CodexBar Full Disk Access in System Settings -> Privacy & Security, then refresh."
     }
 
     private static func containsRecognizedSessionCookie(in cookies: [HTTPCookie]) -> Bool {
@@ -369,7 +397,10 @@ public struct OllamaUsageFetcher: Sendable {
             return [CookieCandidate(cookieHeader: manualHeader, sourceLabel: "manual cookie header")]
         }
         #if os(macOS)
-        let sessions = try OllamaCookieImporter.importSessions(browserDetection: self.browserDetection, logger: logger)
+        let sessions = try OllamaCookieImporter.importSessions(
+            browserDetection: self.browserDetection,
+            allowFallbackBrowsers: true,
+            logger: logger)
         return sessions.map { session in
             CookieCandidate(cookieHeader: session.cookieHeader, sourceLabel: session.sourceLabel)
         }
@@ -451,7 +482,10 @@ public struct OllamaUsageFetcher: Sendable {
             return manualHeader
         }
         #if os(macOS)
-        let session = try OllamaCookieImporter.importSession(browserDetection: self.browserDetection, logger: logger)
+        let session = try OllamaCookieImporter.importSession(
+            browserDetection: self.browserDetection,
+            allowFallbackBrowsers: true,
+            logger: logger)
         logger?("[ollama] Using cookies from \(session.sourceLabel)")
         return session.cookieHeader
         #else

--- a/docs/ollama.md
+++ b/docs/ollama.md
@@ -21,7 +21,7 @@ The Ollama provider scrapes the **Plan & Billing** page to extract Cloud Usage l
 
 1. Open **Settings → Providers**.
 2. Enable **Ollama**.
-3. Leave **Cookie source** on **Auto** (recommended, imports Chrome cookies by default).
+3. Leave **Cookie source** on **Auto**. CodexBar tries Chrome first, then falls back to Safari and other available browser sessions.
 
 ### Manual cookie import (optional)
 
@@ -42,7 +42,14 @@ The Ollama provider scrapes the **Plan & Billing** page to extract Cloud Usage l
 ### “No Ollama session cookie found”
 
 Log in to `https://ollama.com/settings` in Chrome, then refresh in CodexBar.
-If your active session is only in Safari (or another browser), use **Cookie source → Manual** and paste a cookie header.
+If your active session is only in Safari, refresh once more and allow any macOS browser-data prompt.
+If automatic import still cannot see the session, use **Cookie source → Manual** and paste a cookie header.
+
+### “Ollama browser cookies are not readable”
+
+Safari cookie files are protected by macOS privacy controls. Open **System Settings → Privacy & Security → Full Disk Access**,
+add **CodexBar.app**, then refresh Ollama in CodexBar. If you do not want to grant Full Disk Access, use
+**Cookie source → Manual** and paste a cookie header from `https://ollama.com/settings`.
 
 ### “Ollama session cookie expired”
 


### PR DESCRIPTION
## Summary
- make Ollama auto cookie import fall back from Chrome to Safari/other available browser sessions
- surface Safari/Full Disk Access failures instead of the misleading generic no-session-cookie error
- clarify the no-session-cookie/settings copy and update Ollama docs for Safari-only sessions

## Bug
Ollama provider auto mode claimed to import browser cookies, but the fetch path used the default preferred browser list (`[.chrome]`) without enabling fallback. Users logged in only through Safari saw `No Ollama session cookie found` even though a valid Ollama Cloud browser session existed.

There is a second Safari-specific failure mode: CodexBar can find Safari's cookie store but macOS can deny app access to `~/Library/Containers/com.apple.Safari/Data/Library/Cookies/Cookies.binarycookies`. Previously that also collapsed to `No Ollama session cookie found`, hiding the real fix: grant CodexBar Full Disk Access or use a manual Cookie header.

## Fix
The fetcher now keeps Chrome-first behavior but passes `allowFallbackBrowsers: true` for automatic cookie resolution. Manual cookie mode is unchanged. If fallback reaches a browser cookie store but receives an access-denied error, Ollama now returns a user-facing Full Disk Access message instead of the generic no-session-cookie error.

## Verification
- `git diff --check` passed for changed files
- `CodexBarCLI usage --provider ollama --source web --format json --pretty -v` succeeded locally after the fallback and returned Ollama account/usage JSON
- local app log reproduced the Safari permission failure: Safari cookie file exists, but CodexBar.app cannot read it without Full Disk Access
- `swift test --filter OllamaUsageFetcherTests` is currently blocked locally before reaching project code by `KeyboardShortcuts` failing to build: missing `PreviewsMacros.SwiftUIView` for SwiftUI `#Preview` macros under the Command Line Tools-only toolchain
- `./Scripts/compile_and_run.sh` is also blocked locally by Xcode-only tooling unless local build workarounds are applied; the machine has Xcode installed but its license has not been accepted for CLI use
