### PR TITLE
fix: keep refresh menu open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.25 — Unreleased
 
 ### Fixes
+- Menu: keep the status menu open when manually refreshing usage from the menu (#845).
 - Augment: report the real 1-minute keepalive check/min-refresh intervals in startup logs and docs (#434). Thanks @guglielmofonda!
 
 ## 0.24 — 2026-05-06

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -1,7 +1,7 @@
 import AppKit
 import CodexBarCore
 
-extension StatusItemController {
+extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     // MARK: - Actions reachable from menus
 
     func refreshStore(forceTokenUsage: Bool) {
@@ -17,6 +17,12 @@ extension StatusItemController {
 
     @objc func refreshNow() {
         self.refreshStore(forceTokenUsage: true)
+    }
+
+    nonisolated func performPersistentRefreshAction() {
+        Task { @MainActor [weak self] in
+            self?.refreshNow()
+        }
     }
 
     @objc func refreshAugmentSession() {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -74,10 +74,7 @@ extension StatusItemController {
         guard self.shouldMergeIcons else {
             return self.makeMenu(for: nil)
         }
-        let menu = NSMenu()
-        menu.autoenablesItems = false
-        menu.delegate = self
-        return menu
+        return self.makeBaseMenu()
     }
 
     func menuWillOpen(_ menu: NSMenu) {
@@ -600,6 +597,11 @@ extension StatusItemController {
                     }
                     menu.addItem(item)
                 case let .action(title, action):
+                    if case .refresh = action {
+                        menu.addItem(self.makePersistentMenuActionItem(title: title, action: action, width: width))
+                        continue
+                    }
+
                     let (selector, represented) = self.selector(for: action)
                     let item = NSMenuItem(title: title, action: selector, keyEquivalent: "")
                     item.target = self
@@ -662,6 +664,56 @@ extension StatusItemController {
         }
     }
 
+    private func makePersistentMenuActionItem(
+        title: String,
+        action: MenuDescriptor.MenuAction,
+        width: CGFloat) -> NSMenuItem
+    {
+        let shortcut = self.shortcut(for: action)
+        let row = PersistentMenuActionItemView(
+            title: title,
+            systemImageName: action.systemImageName,
+            shortcutText: shortcut.map { self.shortcutLabel(for: $0) },
+            width: width,
+            onClick: { [weak self] in
+                self?.performPersistentMenuAction(action)
+            })
+
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: shortcut?.key ?? "")
+        item.keyEquivalentModifierMask = shortcut?.modifiers ?? NSEvent.ModifierFlags()
+        item.isEnabled = true
+        item.view = row
+        item.toolTip = title
+        return item
+    }
+
+    private func performPersistentMenuAction(_ action: MenuDescriptor.MenuAction) {
+        switch action {
+        case .refresh:
+            self.refreshNow()
+        default:
+            break
+        }
+    }
+
+    private func shortcutLabel(for shortcut: (key: String, modifiers: NSEvent.ModifierFlags)) -> String {
+        var label = ""
+        if shortcut.modifiers.contains(.control) {
+            label += "^"
+        }
+        if shortcut.modifiers.contains(.option) {
+            label += "⌥"
+        }
+        if shortcut.modifiers.contains(.shift) {
+            label += "⇧"
+        }
+        if shortcut.modifiers.contains(.command) {
+            label += "⌘"
+        }
+        label += shortcut.key.uppercased()
+        return label
+    }
+
     private func makeWrappedSecondaryTextItem(text: String, width: CGFloat) -> NSMenuItem {
         let item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
         let view = self.makeWrappedSecondaryTextView(text: text)
@@ -703,12 +755,18 @@ extension StatusItemController {
     }
 
     func makeMenu(for provider: UsageProvider?) -> NSMenu {
-        let menu = NSMenu()
-        menu.autoenablesItems = false
-        menu.delegate = self
+        let menu = self.makeBaseMenu()
         if let provider {
             self.menuProviders[ObjectIdentifier(menu)] = provider
         }
+        return menu
+    }
+
+    private func makeBaseMenu() -> NSMenu {
+        let menu = StatusItemMenu()
+        menu.autoenablesItems = false
+        menu.delegate = self
+        menu.persistentActionDelegate = self
         return menu
     }
 

--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -168,3 +168,105 @@ struct MenuCardSectionContainerView<Content: View>: View {
             }
     }
 }
+
+@MainActor
+final class PersistentMenuActionItemView: NSView, MenuCardHighlighting {
+    private let backgroundView = NSView()
+    private let imageView = NSImageView()
+    private let titleField: NSTextField
+    private let shortcutField: NSTextField?
+    private let onClick: () -> Void
+
+    init(
+        title: String,
+        systemImageName: String?,
+        shortcutText: String?,
+        width: CGFloat,
+        onClick: @escaping () -> Void)
+    {
+        self.titleField = NSTextField(labelWithString: title)
+        self.shortcutField = shortcutText.map(NSTextField.init(labelWithString:))
+        self.onClick = onClick
+        super.init(frame: NSRect(origin: .zero, size: NSSize(width: width, height: 28)))
+        self.setupView(systemImageName: systemImageName)
+        self.setHighlighted(false)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard event.type == .leftMouseUp else { return }
+        self.onClick()
+    }
+
+    func setHighlighted(_ highlighted: Bool) {
+        let primaryColor = highlighted ? NSColor.selectedMenuItemTextColor : NSColor.controlTextColor
+        let secondaryColor = highlighted ? NSColor.selectedMenuItemTextColor : NSColor.secondaryLabelColor
+        self.backgroundView.isHidden = !highlighted
+        self.titleField.textColor = primaryColor
+        self.shortcutField?.textColor = secondaryColor
+        self.imageView.contentTintColor = primaryColor
+    }
+
+    private func setupView(systemImageName: String?) {
+        self.backgroundView.wantsLayer = true
+        self.backgroundView.layer?.cornerRadius = 6
+        self.backgroundView.layer?.backgroundColor = NSColor.selectedContentBackgroundColor.cgColor
+        self.backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        self.addSubview(self.backgroundView)
+
+        if let systemImageName,
+           let image = NSImage(systemSymbolName: systemImageName, accessibilityDescription: nil)
+        {
+            image.isTemplate = true
+            image.size = NSSize(width: 16, height: 16)
+            self.imageView.image = image
+        }
+        self.imageView.translatesAutoresizingMaskIntoConstraints = false
+
+        self.titleField.font = NSFont.menuFont(ofSize: NSFont.systemFontSize)
+        self.titleField.lineBreakMode = .byTruncatingTail
+        self.titleField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        self.titleField.translatesAutoresizingMaskIntoConstraints = false
+
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        let stack = NSStackView()
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.spacing = 8
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.addArrangedSubview(self.imageView)
+        stack.addArrangedSubview(self.titleField)
+        stack.addArrangedSubview(spacer)
+        if let shortcutField {
+            shortcutField.font = NSFont.menuFont(ofSize: NSFont.smallSystemFontSize)
+            shortcutField.translatesAutoresizingMaskIntoConstraints = false
+            stack.addArrangedSubview(shortcutField)
+        }
+        self.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            self.backgroundView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 6),
+            self.backgroundView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -6),
+            self.backgroundView.topAnchor.constraint(equalTo: self.topAnchor, constant: 2),
+            self.backgroundView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -2),
+
+            self.imageView.widthAnchor.constraint(equalToConstant: 18),
+            self.imageView.heightAnchor.constraint(equalToConstant: 18),
+
+            stack.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 12),
+            stack.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -12),
+            stack.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+        ])
+    }
+}

--- a/Sources/CodexBar/StatusItemMenu.swift
+++ b/Sources/CodexBar/StatusItemMenu.swift
@@ -1,0 +1,26 @@
+import AppKit
+
+protocol StatusItemMenuPersistentActionDelegate: AnyObject {
+    func performPersistentRefreshAction()
+}
+
+final class StatusItemMenu: NSMenu {
+    weak var persistentActionDelegate: StatusItemMenuPersistentActionDelegate?
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if Self.isRefreshKeyEquivalent(event) {
+            self.persistentActionDelegate?.performPersistentRefreshAction()
+            return true
+        }
+
+        return super.performKeyEquivalent(with: event)
+    }
+
+    private nonisolated static func isRefreshKeyEquivalent(_ event: NSEvent) -> Bool {
+        guard event.type == .keyDown else { return false }
+        guard event.charactersIgnoringModifiers?.lowercased() == "r" else { return false }
+
+        let relevantModifiers = event.modifierFlags.intersection([.command, .option, .control, .shift])
+        return relevantModifiers == .command
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -1,0 +1,76 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+private final class RefreshShortcutRecorder: StatusItemMenuPersistentActionDelegate {
+    var refreshCount = 0
+
+    func performPersistentRefreshAction() {
+        self.refreshCount += 1
+    }
+}
+
+@MainActor
+@Suite(.serialized)
+struct StatusMenuPersistentRefreshTests {
+    private func makeSettings() -> SettingsStore {
+        let suite = "StatusMenuPersistentRefreshTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        return SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+    }
+
+    @Test
+    func `refresh menu item is view backed so mouse activation keeps the menu open`() throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+
+        let refreshItem = try #require(menu.items.first { $0.title == "Refresh" })
+        #expect(refreshItem.action == nil)
+        #expect(refreshItem.target == nil)
+        #expect(refreshItem.view != nil)
+        #expect(refreshItem.keyEquivalent == "r")
+        #expect(refreshItem.keyEquivalentModifierMask == [.command])
+    }
+
+    @Test
+    func `status item menu intercepts refresh shortcut without native item selection`() throws {
+        let menu = StatusItemMenu()
+        let recorder = RefreshShortcutRecorder()
+        menu.persistentActionDelegate = recorder
+        let event = try #require(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: 0,
+            windowNumber: 0,
+            context: nil,
+            characters: "r",
+            charactersIgnoringModifiers: "r",
+            isARepeat: false,
+            keyCode: 15))
+
+        #expect(menu.performKeyEquivalent(with: event) == true)
+        #expect(recorder.refreshCount == 1)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the status menu refresh behavior so manually refreshing usage from the menu no longer closes the menu immediately.

## Root Cause

The `Refresh` row was backed by a native `NSMenuItem` action. When the item was selected, AppKit treated it as a normal menu command and dismissed the status menu right after triggering the refresh. That made it difficult to refresh and continue inspecting the updated menu contents.

## Changes

- Replaces the native `Refresh` action row with a view-backed persistent menu action.
- Adds `StatusItemMenu` to intercept `Command-R` and route it through the same refresh action without relying on native item selection.
- Preserves the visible shortcut label and menu row styling for the refresh action.
- Adds focused tests for the view-backed refresh item and shortcut interception.
- Adds an unreleased changelog entry for the menu behavior fix.

## Impact

Users can click `Refresh` or press `Command-R` while the status menu is open and keep the menu visible, making it easier to verify fresh usage data without reopening the menu.

## Validation

- `git diff --check`
- `.build/lint-tools/bin/swiftformat Sources Tests --lint`
- `DYLD_FRAMEWORK_PATH=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib .build/lint-tools/bin/swiftlint --strict --quiet`
- `SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift build --target CodexBar -Xswiftc -plugin-path -Xswiftc /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib/swift/host/plugins`

`swift test` is currently blocked locally by the package compiling `CodexBarLinuxTests`, which imports `Testing` but fails with `no such module 'Testing'` in this toolchain invocation.

Fixes #845