### PR TITLE
Balance-style menu-bar display for OpenRouter, Mistral, and Kimi K2

### DIFF
--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -459,7 +459,7 @@ struct ProvidersPane: View {
                     id: MenuBarMetricPreference.primary.rawValue,
                     title: "Primary (API key limit)"),
             ]
-        } else if provider == .deepseek {
+        } else if SettingsStore.isBalanceOnlyProvider(provider) {
             options = [
                 ProviderSettingsPickerOption(id: MenuBarMetricPreference.automatic.rawValue, title: "Automatic"),
             ]
@@ -507,9 +507,7 @@ struct ProvidersPane: View {
         return ProviderSettingsPickerDescriptor(
             id: "menuBarMetric",
             title: "Menu bar metric",
-            subtitle: provider == .deepseek
-                ? "Shows the DeepSeek balance in the menu bar."
-                : "Choose which window drives the menu bar percent.",
+            subtitle: Self.menuBarMetricPickerSubtitle(for: provider),
             binding: Binding(
                 get: {
                     self.settings
@@ -523,6 +521,19 @@ struct ProvidersPane: View {
             options: options,
             isVisible: { true },
             onChange: nil)
+    }
+
+    private static func menuBarMetricPickerSubtitle(for provider: UsageProvider) -> String {
+        switch provider {
+        case .deepseek:
+            "Shows the DeepSeek balance in the menu bar."
+        case .mistral:
+            "Shows current-month Mistral API spend in the menu bar."
+        case .kimik2:
+            "Shows Kimi K2 API-key credits in the menu bar."
+        default:
+            "Choose which window drives the menu bar percent."
+        }
     }
 
     func menuCardModel(for provider: UsageProvider) -> UsageMenuCardView.Model {

--- a/Sources/CodexBar/SettingsStore+MenuPreferences.swift
+++ b/Sources/CodexBar/SettingsStore+MenuPreferences.swift
@@ -3,6 +3,9 @@ import Foundation
 
 extension SettingsStore {
     func menuBarMetricPreference(for provider: UsageProvider) -> MenuBarMetricPreference {
+        if Self.isBalanceOnlyProvider(provider) {
+            return .automatic
+        }
         if provider == .openrouter {
             let raw = self.menuBarMetricPreferencesRaw[provider.rawValue] ?? ""
             let preference = MenuBarMetricPreference(rawValue: raw) ?? .automatic
@@ -28,6 +31,10 @@ extension SettingsStore {
     }
 
     func setMenuBarMetricPreference(_ preference: MenuBarMetricPreference, for provider: UsageProvider) {
+        if Self.isBalanceOnlyProvider(provider) {
+            self.menuBarMetricPreferencesRaw[provider.rawValue] = MenuBarMetricPreference.automatic.rawValue
+            return
+        }
         if provider == .openrouter {
             switch preference {
             case .automatic, .primary:
@@ -95,5 +102,14 @@ extension SettingsStore {
 
     var resetTimeDisplayStyle: ResetTimeDisplayStyle {
         self.resetTimesShowAbsolute ? .absolute : .countdown
+    }
+
+    static func isBalanceOnlyProvider(_ provider: UsageProvider) -> Bool {
+        switch provider {
+        case .deepseek, .mistral, .kimik2:
+            true
+        default:
+            false
+        }
     }
 }

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -571,6 +571,16 @@ extension StatusItemController {
         {
             return balance
         }
+        if provider == .mistral,
+           let spend = Self.mistralSpendDisplayText(snapshot: snapshot)
+        {
+            return spend
+        }
+        if provider == .kimik2,
+           let credits = Self.kimiK2CreditsDisplayText(snapshot: snapshot)
+        {
+            return credits
+        }
 
         let percentWindow = self.menuBarPercentWindow(for: provider, snapshot: snapshot)
         let mode = self.settings.menuBarDisplayMode
@@ -624,6 +634,39 @@ extension StatusItemController {
 
         let balance = rawValue.split(separator: " ", maxSplits: 1).first
         return balance.map(String.init)
+    }
+
+    nonisolated static func mistralSpendDisplayText(snapshot: UsageSnapshot?) -> String? {
+        self.displayValue(
+            from: snapshot?.identity?.loginMethod,
+            prefix: "API spend:",
+            removingSuffix: " this month")
+    }
+
+    nonisolated static func kimiK2CreditsDisplayText(snapshot: UsageSnapshot?) -> String? {
+        self.displayValue(
+            from: snapshot?.identity?.loginMethod,
+            prefix: "Credits:",
+            removingSuffix: " left")
+    }
+
+    private nonisolated static func displayValue(
+        from text: String?,
+        prefix: String,
+        removingSuffix suffix: String)
+        -> String?
+    {
+        guard let rawValue = text?.trimmingCharacters(in: .whitespacesAndNewlines),
+              rawValue.hasPrefix(prefix)
+        else {
+            return nil
+        }
+        let valueStart = rawValue.index(rawValue.startIndex, offsetBy: prefix.count)
+        var value = rawValue[valueStart...].trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.hasSuffix(suffix) {
+            value = String(value.dropLast(suffix.count)).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return value.isEmpty ? nil : value
     }
 
     private func menuBarPercentWindow(for provider: UsageProvider, snapshot: UsageSnapshot?) -> RateWindow? {

--- a/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
@@ -29,26 +29,13 @@ public struct KimiK2UsageSummary: Sendable {
     }
 
     public func toUsageSnapshot() -> UsageSnapshot {
-        let total = max(0, self.consumed + self.remaining)
-        let usedPercent: Double = if total > 0 {
-            min(100, max(0, (self.consumed / total) * 100))
-        } else {
-            0
-        }
-        let usedText = String(format: "%.0f", self.consumed)
-        let totalText = String(format: "%.0f", total)
-        let rateWindow = RateWindow(
-            usedPercent: usedPercent,
-            windowMinutes: nil,
-            resetsAt: nil,
-            resetDescription: total > 0 ? "Credits: \(usedText)/\(totalText)" : nil)
         let identity = ProviderIdentitySnapshot(
             providerID: .kimik2,
             accountEmail: nil,
             accountOrganization: nil,
-            loginMethod: nil)
+            loginMethod: "Credits: \(UsageFormatter.creditsString(from: self.remaining))")
         return UsageSnapshot(
-            primary: rateWindow,
+            primary: nil,
             secondary: nil,
             tertiary: nil,
             providerCost: nil,

--- a/Sources/CodexBarCore/Providers/Mistral/MistralModels.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralModels.swift
@@ -102,23 +102,48 @@ public struct MistralUsageSnapshot: Sendable {
     public let endDate: Date?
     public let updatedAt: Date
 
+    public init(
+        totalCost: Double,
+        currency: String,
+        currencySymbol: String,
+        totalInputTokens: Int,
+        totalOutputTokens: Int,
+        totalCachedTokens: Int,
+        modelCount: Int,
+        startDate: Date?,
+        endDate: Date?,
+        updatedAt: Date)
+    {
+        self.totalCost = totalCost
+        self.currency = currency
+        self.currencySymbol = currencySymbol
+        self.totalInputTokens = totalInputTokens
+        self.totalOutputTokens = totalOutputTokens
+        self.totalCachedTokens = totalCachedTokens
+        self.modelCount = modelCount
+        self.startDate = startDate
+        self.endDate = endDate
+        self.updatedAt = updatedAt
+    }
+
     public func toUsageSnapshot() -> UsageSnapshot {
-        let resetDate = self.endDate.map { Calendar.current.date(byAdding: .second, value: 1, to: $0) ?? $0 }
-        let costDescription = if self.totalCost > 0 {
+        // Negative totalCost means a refund/credit adjustment; clamp to zero rather than
+        // showing a confusing negative amount in the menu bar.
+        let spendText = if self.totalCost > 0 {
             "\(self.currencySymbol)\(String(format: "%.4f", self.totalCost)) this month"
         } else {
-            "No usage this month"
+            "\(self.currencySymbol)0.0000 this month"
         }
-        let primary = RateWindow(
-            usedPercent: 0,
-            windowMinutes: nil,
-            resetsAt: resetDate,
-            resetDescription: costDescription)
+        let identity = ProviderIdentitySnapshot(
+            providerID: .mistral,
+            accountEmail: nil,
+            accountOrganization: nil,
+            loginMethod: "API spend: \(spendText)")
         return UsageSnapshot(
-            primary: primary,
+            primary: nil,
             secondary: nil,
             providerCost: nil,
             updatedAt: self.updatedAt,
-            identity: nil)
+            identity: identity)
     }
 }

--- a/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
+++ b/Tests/CodexBarTests/KimiK2UsageFetcherTests.swift
@@ -85,4 +85,17 @@ struct KimiK2UsageFetcherTests {
             return message == "Root JSON is not an object."
         }
     }
+
+    @Test
+    func `converts api key credits into text only snapshot`() {
+        let usage = KimiK2UsageSummary(
+            consumed: 10,
+            remaining: 25,
+            averageTokens: nil,
+            updatedAt: Date()).toUsageSnapshot()
+
+        #expect(usage.primary == nil)
+        #expect(usage.identity?.providerID == .kimik2)
+        #expect(usage.identity?.loginMethod == "Credits: 25 left")
+    }
 }

--- a/Tests/CodexBarTests/MistralUsageParserTests.swift
+++ b/Tests/CodexBarTests/MistralUsageParserTests.swift
@@ -82,7 +82,7 @@ struct MistralUsageParserTests {
 
 struct MistralUsageSnapshotConversionTests {
     @Test
-    func `converts cost into primary resetDescription so it surfaces as detail text`() {
+    func `converts cost into text only current month api spend`() {
         let snapshot = MistralUsageSnapshot(
             totalCost: 1.2345,
             currency: "EUR",
@@ -96,17 +96,14 @@ struct MistralUsageSnapshotConversionTests {
             updatedAt: Date())
 
         let usage = snapshot.toUsageSnapshot()
-        #expect(usage.primary != nil)
-        #expect(usage.primary?.usedPercent == 0)
-        #expect(usage.primary?.resetDescription?.contains("€1.2345") == true)
-        // providerCost is intentionally nil: the menu card's providerCostSection requires
-        // limit > 0 to render a bar, and Mistral is pay-as-you-go with no quota. The cost
-        // is surfaced via primary.resetDescription (rendered as detail text in the card).
+        #expect(usage.primary == nil)
+        #expect(usage.identity?.providerID == .mistral)
+        #expect(usage.identity?.loginMethod == "API spend: €1.2345 this month")
         #expect(usage.providerCost == nil)
     }
 
     @Test
-    func `converts zero cost with no-usage description`() {
+    func `converts zero cost into zero spend text`() {
         let snapshot = MistralUsageSnapshot(
             totalCost: 0,
             currency: "USD",
@@ -120,7 +117,8 @@ struct MistralUsageSnapshotConversionTests {
             updatedAt: Date())
 
         let usage = snapshot.toUsageSnapshot()
-        #expect(usage.primary?.resetDescription == "No usage this month")
+        #expect(usage.primary == nil)
+        #expect(usage.identity?.loginMethod == "API spend: $0.0000 this month")
     }
 }
 

--- a/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
+++ b/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
@@ -45,6 +45,32 @@ struct ProvidersPaneCoverageTests {
     }
 
     @Test
+    func `mistral menu bar metric picker shows spend only copy`() {
+        let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-mistral-picker")
+        let store = Self.makeUsageStore(settings: settings)
+        let pane = ProvidersPane(settings: settings, store: store)
+
+        let picker = pane._test_menuBarMetricPicker(for: .mistral)
+        #expect(picker?.options.map(\.id) == [
+            MenuBarMetricPreference.automatic.rawValue,
+        ])
+        #expect(picker?.subtitle == "Shows current-month Mistral API spend in the menu bar.")
+    }
+
+    @Test
+    func `kimi k2 menu bar metric picker shows credits only copy`() {
+        let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-kimik2-picker")
+        let store = Self.makeUsageStore(settings: settings)
+        let pane = ProvidersPane(settings: settings, store: store)
+
+        let picker = pane._test_menuBarMetricPicker(for: .kimik2)
+        #expect(picker?.options.map(\.id) == [
+            MenuBarMetricPreference.automatic.rawValue,
+        ])
+        #expect(picker?.subtitle == "Shows Kimi K2 API-key credits in the menu bar.")
+    }
+
+    @Test
     func `cursor menu bar metric picker omits tertiary api lane when snapshot has no api metric`() {
         let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-cursor-no-tertiary-picker")
         let store = Self.makeUsageStore(settings: settings)

--- a/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
@@ -71,6 +71,19 @@ struct SettingsStoreAdditionalTests {
     }
 
     @Test
+    func `menu bar metric preference restricts text only balance providers to automatic`() {
+        let settings = Self.makeSettingsStore(suite: "SettingsStoreAdditionalTests-text-only-metric")
+
+        for provider in [UsageProvider.deepseek, .mistral, .kimik2] {
+            settings.setMenuBarMetricPreference(.primary, for: provider)
+            #expect(settings.menuBarMetricPreference(for: provider) == .automatic)
+
+            settings.setMenuBarMetricPreference(.secondary, for: provider)
+            #expect(settings.menuBarMetricPreference(for: provider) == .automatic)
+        }
+    }
+
+    @Test
     func `minimax auth mode uses stored values`() {
         let settings = Self.makeSettingsStore(suite: "SettingsStoreAdditionalTests-minimax")
         settings.minimaxAPIToken = "sk-api-test-token"

--- a/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
+++ b/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
@@ -72,6 +72,75 @@ struct StatusItemBalanceDisplayTests {
     }
 
     @Test
+    func `menu bar display text uses mistral current month api spend`() {
+        let settings = self.makeSettings(
+            suiteName: "StatusItemBalanceDisplayTests-mistral-spend",
+            provider: .mistral)
+        let (store, controller) = self.makeStoreAndController(settings: settings)
+        let snapshot = MistralUsageSnapshot(
+            totalCost: 1.2345,
+            currency: "EUR",
+            currencySymbol: "€",
+            totalInputTokens: 10000,
+            totalOutputTokens: 5000,
+            totalCachedTokens: 0,
+            modelCount: 2,
+            startDate: nil,
+            endDate: nil,
+            updatedAt: Date()).toUsageSnapshot()
+
+        store._setSnapshotForTesting(snapshot, provider: .mistral)
+        store._setErrorForTesting(nil, provider: .mistral)
+
+        let displayText = controller.menuBarDisplayText(for: .mistral, snapshot: snapshot)
+
+        #expect(snapshot.primary == nil)
+        #expect(snapshot.identity?.loginMethod == "API spend: €1.2345 this month")
+        #expect(displayText == "€1.2345")
+    }
+
+    @Test
+    func `menu bar display text uses kimi k2 api key credits`() {
+        let settings = self.makeSettings(
+            suiteName: "StatusItemBalanceDisplayTests-kimik2-credits",
+            provider: .kimik2)
+        let (store, controller) = self.makeStoreAndController(settings: settings)
+        let snapshot = KimiK2UsageSummary(
+            consumed: 75,
+            remaining: 1234.5,
+            averageTokens: nil,
+            updatedAt: Date()).toUsageSnapshot()
+
+        store._setSnapshotForTesting(snapshot, provider: .kimik2)
+        store._setErrorForTesting(nil, provider: .kimik2)
+
+        let displayText = controller.menuBarDisplayText(for: .kimik2, snapshot: snapshot)
+
+        #expect(snapshot.primary == nil)
+        #expect(snapshot.identity?.loginMethod == "Credits: 1234.5 left")
+        #expect(displayText == "1234.5")
+    }
+
+    @Test
+    func `mistral primary window is nil even when billing end date is set`() {
+        let endDate = Date(timeIntervalSinceNow: 3600)
+        let snapshot = MistralUsageSnapshot(
+            totalCost: 0.5,
+            currency: "USD",
+            currencySymbol: "$",
+            totalInputTokens: 1000,
+            totalOutputTokens: 500,
+            totalCachedTokens: 0,
+            modelCount: 1,
+            startDate: nil,
+            endDate: endDate,
+            updatedAt: Date()).toUsageSnapshot()
+
+        // Mistral doesn't expose a reset time — primary is always nil.
+        #expect(snapshot.primary == nil)
+    }
+
+    @Test
     func `button title spacing only applies when image is present`() {
         #expect(StatusItemController.buttonTitle("42%", hasImage: true) == " 42%")
         #expect(StatusItemController.buttonTitle("42%", hasImage: false) == "42%")


### PR DESCRIPTION
Extends the balance display pattern to three providers that don't have a meaningful quota-percent to show:

- **OpenRouter**: shows account balance (e.g. `$12.34`) in automatic mode; key-usage percent still applies when a key limit is configured
- **Mistral**: shows current-month API spend from the billing endpoint (e.g. `€1.2345`)
- **Kimi K2**: shows remaining credits from the account summary

Also extracts `SettingsStore.isBalanceOnlyProvider(_:)` so the preference UI and the display logic share a single list of which providers skip the quota-percent path.

Edge case: Mistral's billing endpoint can return a negative `totalCost` for refund/credit-adjustment months. The display clamps to zero rather than showing a confusing negative value in the menu bar.

```
swift test --filter 'StatusItemBalanceDisplayTests|MistralUsage|KimiK2'
```