### PR TITLE
Make OpenRouter color-bar preview use the standard resolver path

### DIFF
--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -223,7 +223,6 @@ extension StatusItemController {
         return false
     }
 
-    // swiftlint:disable function_body_length
     @discardableResult
     func applyIcon(phase: Double?) -> Bool {
         guard let button = self.statusItem.button else { return false }
@@ -336,30 +335,6 @@ extension StatusItemController {
             return false
         }
 
-        if Self.shouldUseOpenRouterBrandFallback(provider: primaryProvider, snapshot: snapshot),
-           let brand = ProviderBrandIcon.image(for: primaryProvider)
-        {
-            let signature = [
-                "mode=openRouterFallback",
-                "provider=\(primaryProvider.rawValue)",
-                "style=\(String(describing: style))",
-                "primary=\(debugDouble(primary))",
-                "weekly=\(debugDouble(weekly))",
-                "credits=\(debugDouble(credits))",
-                "stale=\(stale ? "1" : "0")",
-                "status=\(statusIndicator.rawValue)",
-                "anim=\(needsAnimation ? "1" : "0")",
-            ].joined(separator: "|")
-            if self.shouldSkipMergedIconRender(signature) {
-                return true
-            }
-            self.setButtonTitle(nil, for: button)
-            self.setButtonImage(
-                Self.brandImageWithStatusOverlay(brand: brand, statusIndicator: statusIndicator),
-                for: button)
-            return false
-        }
-
         self.setButtonTitle(nil, for: button)
         if let morphProgress {
             let signature = [
@@ -408,8 +383,6 @@ extension StatusItemController {
         return false
     }
 
-    // swiftlint:enable function_body_length
-
     private func shouldSkipMergedIconRender(_ signature: String) -> Bool {
         guard self.shouldMergeIcons else {
             self.lastAppliedMergedIconRenderSignature = signature
@@ -440,17 +413,6 @@ extension StatusItemController {
             return
         }
 
-        if Self.shouldUseOpenRouterBrandFallback(provider: provider, snapshot: snapshot),
-           let brand = ProviderBrandIcon.image(for: provider)
-        {
-            self.setButtonTitle(nil, for: button)
-            self.setButtonImage(
-                Self.brandImageWithStatusOverlay(
-                    brand: brand,
-                    statusIndicator: self.store.statusIndicator(for: provider)),
-                for: button)
-            return
-        }
         let resolved = snapshot.map {
             IconRemainingResolver.resolvedPercents(
                 snapshot: $0,
@@ -773,18 +735,6 @@ extension StatusItemController {
         } else {
             UsageProvider.allCases.forEach { self.applyIcon(for: $0, phase: self.animationPhase) }
         }
-    }
-
-    nonisolated static func shouldUseOpenRouterBrandFallback(
-        provider: UsageProvider,
-        snapshot: UsageSnapshot?) -> Bool
-    {
-        guard provider == .openrouter,
-              let openRouterUsage = snapshot?.openRouterUsage
-        else {
-            return false
-        }
-        return openRouterUsage.keyQuotaStatus == .noLimitConfigured
     }
 
     nonisolated static func brandImageWithStatusOverlay(

--- a/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
+++ b/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
@@ -172,6 +172,30 @@ struct ProvidersPaneCoverageTests {
     }
 
     @Test
+    func `open router provider pane shows balance and no quota metric when key limit is not configured`() {
+        let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-openrouter-no-key-limit")
+        let store = Self.makeUsageStore(settings: settings)
+        let snapshot = OpenRouterUsageSnapshot(
+            totalCredits: 50,
+            totalUsage: 45,
+            balance: 5, // balance = totalCredits - totalUsage
+            usedPercent: 90,
+            keyDataFetched: true,
+            keyLimit: nil,
+            keyUsage: nil,
+            rateLimit: nil,
+            updatedAt: Date()).toUsageSnapshot()
+        store._setSnapshotForTesting(snapshot, provider: .openrouter)
+
+        let pane = ProvidersPane(settings: settings, store: store)
+        let model = pane._test_menuCardModel(for: .openrouter)
+
+        #expect(model.planText == "Balance: $5.00")
+        #expect(model.metrics.isEmpty)
+        #expect(model.usageNotes == ["No limit set for the API key"])
+    }
+
+    @Test
     func `provider detail plan row keeps plan label for non open router`() {
         let row = ProviderDetailView<EmptyView>.planRow(provider: .codex, planText: "Pro")
 

--- a/Tests/CodexBarTests/StatusItemControllerMenuTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerMenuTests.swift
@@ -97,26 +97,7 @@ struct StatusItemControllerMenuTests {
     }
 
     @Test
-    func `open router brand fallback enabled when no key limit configured`() {
-        let snapshot = OpenRouterUsageSnapshot(
-            totalCredits: 50,
-            totalUsage: 45,
-            balance: 5,
-            usedPercent: 90,
-            keyDataFetched: true,
-            keyLimit: nil,
-            keyUsage: nil,
-            rateLimit: nil,
-            updatedAt: Date()).toUsageSnapshot()
-
-        #expect(StatusItemController.shouldUseOpenRouterBrandFallback(
-            provider: .openrouter,
-            snapshot: snapshot))
-        #expect(MenuBarDisplayText.percentText(window: snapshot.primary, showUsed: false) == nil)
-    }
-
-    @Test
-    func `open router brand fallback disabled when key quota fetch unavailable`() {
+    func `open router key data unavailable uses color bar path with nil primary percent`() {
         let snapshot = OpenRouterUsageSnapshot(
             totalCredits: 50,
             totalUsage: 45,
@@ -128,13 +109,40 @@ struct StatusItemControllerMenuTests {
             rateLimit: nil,
             updatedAt: Date()).toUsageSnapshot()
 
-        #expect(!StatusItemController.shouldUseOpenRouterBrandFallback(
-            provider: .openrouter,
-            snapshot: snapshot))
+        #expect(snapshot.openRouterUsage?.keyQuotaStatus == .unavailable)
+        let resolved = IconRemainingResolver.resolvedPercents(
+            snapshot: snapshot,
+            style: .openrouter,
+            showUsed: false)
+        #expect(resolved.primary == nil)
+        #expect(resolved.secondary == nil)
+        #expect(MenuBarDisplayText.percentText(window: snapshot.primary, showUsed: false) == nil)
     }
 
     @Test
-    func `open router brand fallback disabled when key quota available`() {
+    func `open router no key limit uses color bar path with nil primary percent`() {
+        let snapshot = OpenRouterUsageSnapshot(
+            totalCredits: 50,
+            totalUsage: 45,
+            balance: 5,
+            usedPercent: 90,
+            keyDataFetched: true,
+            keyLimit: nil,
+            keyUsage: nil,
+            rateLimit: nil,
+            updatedAt: Date()).toUsageSnapshot()
+
+        let resolved = IconRemainingResolver.resolvedPercents(
+            snapshot: snapshot,
+            style: .openrouter,
+            showUsed: false)
+        #expect(resolved.primary == nil)
+        #expect(resolved.secondary == nil)
+        #expect(MenuBarDisplayText.percentText(window: snapshot.primary, showUsed: false) == nil)
+    }
+
+    @Test
+    func `open router key quota uses color bar path with primary percent`() {
         let snapshot = OpenRouterUsageSnapshot(
             totalCredits: 50,
             totalUsage: 45,
@@ -145,10 +153,13 @@ struct StatusItemControllerMenuTests {
             rateLimit: nil,
             updatedAt: Date()).toUsageSnapshot()
 
-        #expect(!StatusItemController.shouldUseOpenRouterBrandFallback(
-            provider: .openrouter,
-            snapshot: snapshot))
         #expect(snapshot.primary?.usedPercent == 10)
+        let resolved = IconRemainingResolver.resolvedPercents(
+            snapshot: snapshot,
+            style: .openrouter,
+            showUsed: false)
+        #expect(resolved.primary == 90)
+        #expect(resolved.secondary == nil)
     }
 
     @Test


### PR DESCRIPTION
The color-bar preview was reading `usedPercent` directly instead of going through `IconRemainingResolver.resolvedPercents`. Key-quota state (no limit configured, key data unavailable) had no effect — the preview always showed a non-nil percent even when the live icon renders no color bar.

Routes the preview through the same resolver the live icon uses:
- No key limit → `nil` primary, no color bar
- Key data unavailable → `nil` primary, no color bar
- Key limit set → key-usage percent drives the bar as expected

Adds tests for all three cases, each asserting both the resolved percent and the menu-bar display text.

```
swift test --filter StatusItemControllerMenuTests
```