### PR TITLE
Show DeepSeek balance without quota progress bar

### DIFF
--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1128,12 +1128,17 @@ extension UsageMenuCardView.Model {
             primaryPacePercent = regen.pace.pacePercent
             primaryPaceOnTop = regen.pace.paceOnTop
         }
+        let primaryStatusText = input.provider == .deepseek ? primaryDetailText : nil
+        if input.provider == .deepseek {
+            primaryDetailText = nil
+        }
         return Metric(
             id: "primary",
             title: input.metadata.sessionLabel,
             percent: Self.clamped(
                 input.usageBarsShowUsed ? primary.usedPercent : primary.remainingPercent),
             percentStyle: percentStyle,
+            statusText: primaryStatusText,
             resetText: primaryResetText,
             detailText: primaryDetailText,
             detailLeftText: primaryDetailLeft,

--- a/Tests/CodexBarTests/MenuCardModelTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelTests.swift
@@ -777,6 +777,53 @@ struct MenuCardModelTests {
     }
 
     @Test
+    func `deepseek model shows balance as status text instead of percentage detail`() throws {
+        let now = Date()
+        let identity = ProviderIdentitySnapshot(
+            providerID: .deepseek,
+            accountEmail: nil,
+            accountOrganization: nil,
+            loginMethod: nil)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 0,
+                windowMinutes: nil,
+                resetsAt: nil,
+                resetDescription: "$9.32 (Paid: $9.32 / Granted: $0.00)"),
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: now,
+            identity: identity)
+        let metadata = try #require(ProviderDefaults.metadata[.deepseek])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .deepseek,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        let primary = try #require(model.metrics.first)
+        #expect(primary.title == "Balance")
+        #expect(primary.statusText == "$9.32 (Paid: $9.32 / Granted: $0.00)")
+        #expect(primary.detailText == nil)
+        #expect(primary.resetText == nil)
+    }
+
+    @Test
     func `mistral model surfaces monthly cost as primary detail text`() throws {
         let now = Date()
         let resetsAt = now.addingTimeInterval(3 * 24 * 60 * 60)


### PR DESCRIPTION
## Summary

- Render the DeepSeek menu card balance row as plain balance text
- Avoid showing a quota-style progress bar / `100% left` label for DeepSeek
- Add model coverage for the DeepSeek balance row

## Why

DeepSeek only exposes account balance data via its balance API. It does not expose a
session, weekly, monthly, or total quota denominator.

Showing `100% left` can imply there is a fixed quota/limit, which is misleading for a
prepaid balance-style provider.

## Screenshot

Before:

<img width="320" height="386" alt="DeepSeek balance row with 100 percent left progress
bar" src="https://github.com/user-attachments/assets/493fcbbe-6ef0-41ab-aa0b-0b1b1524641a"
/>

After:

<img width="320" height="360" alt="DeepSeek balance row without quota progress bar"
src="https://github.com/user-attachments/assets/e6c1d857-01f6-4296-8f7b-0ec1c2035254" />

## Testing

- [x] `swift test --filter MenuCardModelTests`
- [x] Local app build via `./Scripts/compile_and_run.sh`