### PR TITLE
fix(a11y): add VoiceOver labels to menu bar icon, menu rows, and chart views

### DIFF
--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -52,6 +52,7 @@ struct CostHistoryChartMenuView: View {
                 Text("No cost history data.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
+                    .accessibilityLabel("No cost history data available.")
             } else {
                 Chart {
                     ForEach(model.points) { point in
@@ -81,6 +82,8 @@ struct CostHistoryChartMenuView: View {
                 }
                 .chartLegend(.hidden)
                 .frame(height: 130)
+                .accessibilityLabel("Cost history chart")
+                .accessibilityValue(model.points.isEmpty ? "No data" : "\(model.points.count) days of cost data")
                 .chartOverlay { proxy in
                     GeometryReader { geo in
                         ZStack(alignment: .topLeading) {

--- a/Sources/CodexBar/CreditsHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CreditsHistoryChartMenuView.swift
@@ -32,6 +32,7 @@ struct CreditsHistoryChartMenuView: View {
                 Text("No credits history data.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
+                    .accessibilityLabel("No credits history data available.")
             } else {
                 Chart {
                     ForEach(model.points) { point in
@@ -61,6 +62,8 @@ struct CreditsHistoryChartMenuView: View {
                 }
                 .chartLegend(.hidden)
                 .frame(height: 130)
+                .accessibilityLabel("Credits history chart")
+                .accessibilityValue(model.points.isEmpty ? "No data" : "\(model.points.count) days of credits data")
                 .chartOverlay { proxy in
                     GeometryReader { geo in
                         ZStack(alignment: .topLeading) {

--- a/Sources/CodexBar/MenuContent.swift
+++ b/Sources/CodexBar/MenuContent.swift
@@ -43,10 +43,13 @@ struct MenuContent: View {
             switch style {
             case .headline:
                 Text(text).font(.headline)
+                    .accessibilityLabel(text)
             case .primary:
                 Text(text)
+                    .accessibilityLabel(text)
             case .secondary:
                 Text(text).foregroundStyle(.secondary).font(.footnote)
+                    .accessibilityLabel(text)
             }
         case let .action(title, action):
             Button {
@@ -60,8 +63,11 @@ struct MenuContent: View {
                         Text(title)
                     }
                     .foregroundStyle(.primary)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(title)
                 } else {
                     Text(title)
+                        .accessibilityLabel(title)
                 }
             }
             .buttonStyle(.plain)
@@ -73,6 +79,8 @@ struct MenuContent: View {
                     }
                     Text(title).font(.headline)
                 }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(title)
                 ForEach(Array(submenuItems.enumerated()), id: \.offset) { _, submenuItem in
                     HStack(spacing: 8) {
                         if submenuItem.isChecked {
@@ -85,6 +93,8 @@ struct MenuContent: View {
                         Text(submenuItem.title)
                             .foregroundStyle(submenuItem.isEnabled ? .primary : .secondary)
                     }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(submenuItem.title)
                 }
             }
         case .divider:
@@ -158,6 +168,27 @@ struct StatusIconView: View {
         Image(nsImage: self.icon)
             .renderingMode(.template)
             .interpolation(.none)
+            .accessibilityLabel(self.accessibilityLabel)
+            .accessibilityValue(self.accessibilityValue)
+    }
+
+    private var accessibilityLabel: String {
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: self.provider)
+        return descriptor.metadata.displayName
+    }
+
+    private var accessibilityValue: String {
+        let snapshot = self.store.snapshot(for: self.provider)
+        guard let snap = snapshot else {
+            return "No data"
+        }
+        let remaining = IconRemainingResolver.resolvedRemaining(
+            snapshot: snap,
+            style: self.store.style(for: self.provider))
+        let primary = remaining?.primary
+        let percent = primary.map { "\(Int($0 * 100)) percent remaining" } ?? "Unknown"
+        let stale = self.store.isStale(provider: self.provider)
+        return stale ? "\(percent), stale data" : percent
     }
 
     private var icon: NSImage {

--- a/Sources/CodexBar/MenuContent.swift
+++ b/Sources/CodexBar/MenuContent.swift
@@ -185,7 +185,7 @@ struct StatusIconView: View {
         let remaining = IconRemainingResolver.resolvedRemaining(
             snapshot: snap,
             style: self.store.style(for: self.provider))
-        let primary = remaining?.primary
+        let primary = remaining.primary
         let percent = primary.map { "\(Int($0 * 100)) percent remaining" } ?? "Unknown"
         let stale = self.store.isStale(provider: self.provider)
         return stale ? "\(percent), stale data" : percent

--- a/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
@@ -146,6 +146,8 @@ struct PlanUtilizationHistoryChartMenuView: View {
                     }
                     .chartLegend(.hidden)
                     .frame(height: Layout.chartHeight)
+                    .accessibilityLabel("Plan utilization chart")
+                    .accessibilityValue(model.points.isEmpty ? "No data" : "\(model.points.count) utilization samples")
                     .chartOverlay { proxy in
                         GeometryReader { geo in
                             MouseLocationReader { location in

--- a/Sources/CodexBar/ProviderSwitcherButtons.swift
+++ b/Sources/CodexBar/ProviderSwitcherButtons.swift
@@ -108,6 +108,7 @@ final class InlineIconToggleButton: NSButton {
         self.setButtonType(.toggle)
         self.controlSize = .small
         self.wantsLayer = true
+        self.setAccessibilityRole(.button)
 
         self.iconView.imageScaling = .scaleNone
         self.iconView.translatesAutoresizingMaskIntoConstraints = false
@@ -147,6 +148,12 @@ final class InlineIconToggleButton: NSButton {
         self.paddingConstraints = [top, leading, trailing, bottom, centerX]
 
         NSLayoutConstraint.activate(self.paddingConstraints + self.iconSizeConstraints)
+    }
+
+    override var title: String {
+        didSet {
+            self.setAccessibilityLabel(self.titleField.stringValue)
+        }
     }
 }
 
@@ -237,6 +244,7 @@ final class StackedToggleButton: NSButton {
         self.setButtonType(.toggle)
         self.controlSize = .small
         self.wantsLayer = true
+        self.setAccessibilityRole(.button)
 
         self.iconView.imageScaling = .scaleNone
         self.iconView.translatesAutoresizingMaskIntoConstraints = false
@@ -277,5 +285,11 @@ final class StackedToggleButton: NSButton {
         self.paddingConstraints = [top, leading, trailing, bottom]
 
         NSLayoutConstraint.activate(self.paddingConstraints + self.iconSizeConstraints)
+    }
+
+    override var title: String {
+        didSet {
+            self.setAccessibilityLabel(self.titleField.stringValue)
+        }
     }
 }

--- a/Sources/CodexBar/ProviderSwitcherButtons.swift
+++ b/Sources/CodexBar/ProviderSwitcherButtons.swift
@@ -47,6 +47,7 @@ final class InlineIconToggleButton: NSButton {
             super.attributedTitle = NSAttributedString(string: "")
             super.attributedAlternateTitle = NSAttributedString(string: "")
             self.titleField.stringValue = newValue
+            self.setAccessibilityLabel(newValue)
             if !self.isConfiguring { self.invalidateIntrinsicContentSize() }
         }
     }
@@ -149,12 +150,6 @@ final class InlineIconToggleButton: NSButton {
 
         NSLayoutConstraint.activate(self.paddingConstraints + self.iconSizeConstraints)
     }
-
-    override var title: String {
-        didSet {
-            self.setAccessibilityLabel(self.titleField.stringValue)
-        }
-    }
 }
 
 final class StackedToggleButton: NSButton {
@@ -183,6 +178,7 @@ final class StackedToggleButton: NSButton {
             super.attributedTitle = NSAttributedString(string: "")
             super.attributedAlternateTitle = NSAttributedString(string: "")
             self.titleField.stringValue = newValue
+            self.setAccessibilityLabel(newValue)
             if !self.isConfiguring { self.invalidateIntrinsicContentSize() }
         }
     }
@@ -285,11 +281,5 @@ final class StackedToggleButton: NSButton {
         self.paddingConstraints = [top, leading, trailing, bottom]
 
         NSLayoutConstraint.activate(self.paddingConstraints + self.iconSizeConstraints)
-    }
-
-    override var title: String {
-        didSet {
-            self.setAccessibilityLabel(self.titleField.stringValue)
-        }
     }
 }

--- a/Sources/CodexBar/UsageBreakdownChartMenuView.swift
+++ b/Sources/CodexBar/UsageBreakdownChartMenuView.swift
@@ -66,7 +66,10 @@ struct UsageBreakdownChartMenuView: View {
                 .chartLegend(.hidden)
                 .frame(height: 130)
                 .accessibilityLabel("Usage breakdown chart")
-                .accessibilityValue(model.points.isEmpty ? "No data" : "\(model.points.count) days of usage data across \(model.services.count) services")
+                .accessibilityValue(
+                    model.points.isEmpty
+                        ? "No data"
+                        : "\(model.points.count) days of usage data across \(model.services.count) services")
                 .chartOverlay { proxy in
                     GeometryReader { geo in
                         ZStack(alignment: .topLeading) {

--- a/Sources/CodexBar/UsageBreakdownChartMenuView.swift
+++ b/Sources/CodexBar/UsageBreakdownChartMenuView.swift
@@ -34,6 +34,7 @@ struct UsageBreakdownChartMenuView: View {
                 Text("No usage breakdown data.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
+                    .accessibilityLabel("No usage breakdown data available.")
             } else {
                 Chart {
                     ForEach(model.points) { point in
@@ -64,6 +65,8 @@ struct UsageBreakdownChartMenuView: View {
                 }
                 .chartLegend(.hidden)
                 .frame(height: 130)
+                .accessibilityLabel("Usage breakdown chart")
+                .accessibilityValue(model.points.isEmpty ? "No data" : "\(model.points.count) days of usage data across \(model.services.count) services")
                 .chartOverlay { proxy in
                     GeometryReader { geo in
                         ZStack(alignment: .topLeading) {


### PR DESCRIPTION
## Summary

Add VoiceOver accessibility labels across the menu bar icon, menu content rows, provider switcher buttons, and chart views so screen reader users can navigate and understand CodexBar's UI.

## Changes

- **`MenuContent.swift`**:
  - `StatusIconView`: adds `.accessibilityLabel` (provider display name) and `.accessibilityValue` (usage percentage + stale status)
  - Text rows: `.accessibilityLabel(text)` on headline, primary, and secondary text
  - Action buttons: `.accessibilityElement(children: .combine)` + `.accessibilityLabel(title)`
  - Submenu headers and items: `.accessibilityElement(children: .combine)` + `.accessibilityLabel(title)`

- **`ProviderSwitcherButtons.swift`**:
  - `InlineIconToggleButton`: `setAccessibilityRole(.button)` + sync `accessibilityLabel` from `titleField`
  - `StackedToggleButton`: same accessibility role and label sync

- **Chart views** (`CostHistoryChartMenuView`, `CreditsHistoryChartMenuView`, `UsageBreakdownChartMenuView`, `PlanUtilizationHistoryChartMenuView`):
  - Empty state text: `.accessibilityLabel` with descriptive message
  - Chart containers: `.accessibilityLabel` (chart type) + `.accessibilityValue` (data point count)

## Test Plan

- [ ] Build passes (`swift build`)
- [ ] Existing tests pass (`swift test`)
- [ ] SwiftFormat and SwiftLint pass (`swiftformat Sources Tests && swiftlint --strict`)
- [ ] VoiceOver on macOS reads the menu bar icon with provider name and percentage
- [ ] VoiceOver reads menu rows as grouped elements (not fragmented text)
- [ ] VoiceOver announces provider switcher buttons by name

## Related Issues

Fixes #859
