### PR TITLE
Feat: Add models.dev pricing metadata pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.25 — Unreleased
 
 ### Providers & Usage
+- Cost history: add an additive models.dev pricing metadata parser/cache pipeline for future provider-scoped cost lookups (#863). Thanks @iam-brain!
 - Venice: add API-key balance provider support with DIEM/USD balance display and token-account CLI wiring (#865). Thanks @clawSean!
 - Factory/Droid: add token-rate-limit billing windows, Core fallback buckets, and extra usage balance display (#878). Thanks @dantemoon1!
 - Usage pace: compute pace for any explicit reset window instead of a provider allowlist (#875). Thanks @ViperThanks!

--- a/Sources/CodexBarCore/Vendored/CostUsage/ModelsDevPricing.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/ModelsDevPricing.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 struct ModelsDevPricingInfo: Codable, Equatable, Sendable {
     var providerID: String

--- a/Sources/CodexBarCore/Vendored/CostUsage/ModelsDevPricing.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/ModelsDevPricing.swift
@@ -1,0 +1,460 @@
+import Foundation
+
+struct ModelsDevPricingInfo: Codable, Equatable, Sendable {
+    var providerID: String
+    var providerName: String?
+    var modelID: String
+    var modelName: String?
+    var inputCostPerToken: Double
+    var outputCostPerToken: Double
+    var cacheReadInputCostPerToken: Double?
+    var cacheCreationInputCostPerToken: Double?
+    var contextWindow: Int?
+    var thresholdTokens: Int?
+    var inputCostPerTokenAboveThreshold: Double?
+    var outputCostPerTokenAboveThreshold: Double?
+    var cacheReadInputCostPerTokenAboveThreshold: Double?
+    var cacheCreationInputCostPerTokenAboveThreshold: Double?
+}
+
+struct ModelsDevPricingLookup: Equatable, Sendable {
+    var pricing: ModelsDevPricingInfo
+    var normalizedModelID: String
+}
+
+struct ModelsDevCatalog: Codable, Equatable, Sendable {
+    var providers: [String: ModelsDevProvider]
+
+    init(providers: [String: ModelsDevProvider]) {
+        self.providers = providers
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: ModelsDevAnyCodingKey.self)
+        if let providersKey = ModelsDevAnyCodingKey(stringValue: "providers"),
+           let decoded = try? container.decode([String: ModelsDevProvider].self, forKey: providersKey)
+        {
+            self.providers = decoded.reduce(into: [:]) { result, item in
+                var provider = item.value
+                provider.mapKey = provider.mapKey ?? item.key
+                let providerID = ModelsDevProvider.normalizeProviderID(provider.id ?? item.key)
+                result[providerID] = provider
+            }
+            return
+        }
+
+        var providers: [String: ModelsDevProvider] = [:]
+
+        for key in container.allKeys {
+            guard var provider = try? container.decode(ModelsDevProvider.self, forKey: key) else { continue }
+            provider.mapKey = key.stringValue
+            let providerID = ModelsDevProvider.normalizeProviderID(provider.id ?? key.stringValue)
+            providers[providerID] = provider
+        }
+
+        self.providers = providers
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: ModelsDevAnyCodingKey.self)
+        try container.encode(self.providers, forKey: ModelsDevAnyCodingKey(stringValue: "providers")!)
+    }
+
+    func pricing(providerID rawProviderID: String, modelID rawModelID: String) -> ModelsDevPricingLookup? {
+        let providerID = ModelsDevProvider.normalizeProviderID(rawProviderID)
+        return self.providers[providerID]?.pricing(modelID: rawModelID)
+    }
+
+    func containsProviderIDs(_ providerIDs: some Sequence<String>) -> Bool {
+        providerIDs.allSatisfy { self.providers.keys.contains(ModelsDevProvider.normalizeProviderID($0)) }
+    }
+
+    func containsProviderModels(from cachedCatalog: ModelsDevCatalog) -> Bool {
+        cachedCatalog.providers.allSatisfy { providerID, cachedProvider in
+            guard let provider = self.providers[ModelsDevProvider.normalizeProviderID(providerID)] else { return false }
+            return cachedProvider.models.keys.allSatisfy { provider.models.keys.contains($0) }
+        }
+    }
+}
+
+private struct ModelsDevAnyCodingKey: CodingKey {
+    var intValue: Int?
+    var stringValue: String
+
+    init?(intValue: Int) {
+        self.intValue = intValue
+        self.stringValue = String(intValue)
+    }
+
+    init?(stringValue: String) {
+        self.intValue = nil
+        self.stringValue = stringValue
+    }
+}
+
+struct ModelsDevProvider: Codable, Equatable, Sendable {
+    var id: String?
+    var name: String?
+    var models: [String: ModelsDevModel]
+    var mapKey: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case models
+    }
+
+    init(id: String?, name: String?, models: [String: ModelsDevModel], mapKey: String? = nil) {
+        self.id = id
+        self.name = name
+        self.models = models
+        self.mapKey = mapKey
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decodeIfPresent(String.self, forKey: .id)
+        self.name = try container.decodeIfPresent(String.self, forKey: .name)
+
+        let modelContainer = try container.nestedContainer(keyedBy: ModelsDevAnyCodingKey.self, forKey: .models)
+        var models: [String: ModelsDevModel] = [:]
+        for key in modelContainer.allKeys {
+            guard let model = try? modelContainer.decode(ModelsDevModel.self, forKey: key) else { continue }
+            models[key.stringValue] = model
+        }
+        self.models = models
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(self.id, forKey: .id)
+        try container.encodeIfPresent(self.name, forKey: .name)
+        try container.encode(self.models, forKey: .models)
+    }
+
+    static func normalizeProviderID(_ raw: String) -> String {
+        raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    func pricing(modelID rawModelID: String) -> ModelsDevPricingLookup? {
+        let candidates = ModelsDevModelIDNormalizer.candidates(rawModelID)
+        for candidate in candidates {
+            if let model = self.models[candidate],
+               let pricing = model.pricing(providerID: self.id ?? self.mapKey ?? "", providerName: self.name)
+            {
+                return ModelsDevPricingLookup(pricing: pricing, normalizedModelID: candidate)
+            }
+        }
+
+        for candidate in candidates {
+            if let match = self.models.values.first(where: { $0.normalizedID == candidate }),
+               let pricing = match.pricing(providerID: self.id ?? self.mapKey ?? "", providerName: self.name)
+            {
+                return ModelsDevPricingLookup(pricing: pricing, normalizedModelID: match.normalizedID)
+            }
+        }
+
+        return nil
+    }
+}
+
+struct ModelsDevModel: Codable, Equatable, Sendable {
+    var id: String
+    var name: String?
+    var cost: ModelsDevCost?
+    var limit: ModelsDevLimit?
+
+    var normalizedID: String {
+        ModelsDevModelIDNormalizer.normalize(self.id)
+    }
+
+    func pricing(providerID: String, providerName: String?) -> ModelsDevPricingInfo? {
+        guard let input = self.cost?.input, let output = self.cost?.output else { return nil }
+
+        // models.dev publishes USD per 1M tokens. CodexBar cost math uses USD per token.
+        let unit = 1_000_000.0
+        let contextOver200K = self.cost?.contextOver200K
+        return ModelsDevPricingInfo(
+            providerID: ModelsDevProvider.normalizeProviderID(providerID),
+            providerName: providerName,
+            modelID: self.id,
+            modelName: self.name,
+            inputCostPerToken: input / unit,
+            outputCostPerToken: output / unit,
+            cacheReadInputCostPerToken: self.cost?.cacheRead.map { $0 / unit },
+            cacheCreationInputCostPerToken: self.cost?.cacheWrite.map { $0 / unit },
+            contextWindow: self.limit?.context,
+            thresholdTokens: contextOver200K == nil ? nil : 200_000,
+            inputCostPerTokenAboveThreshold: contextOver200K?.input.map { $0 / unit },
+            outputCostPerTokenAboveThreshold: contextOver200K?.output.map { $0 / unit },
+            cacheReadInputCostPerTokenAboveThreshold: contextOver200K?.cacheRead.map { $0 / unit },
+            cacheCreationInputCostPerTokenAboveThreshold: contextOver200K?.cacheWrite.map { $0 / unit })
+    }
+}
+
+struct ModelsDevCost: Codable, Equatable, Sendable {
+    var input: Double?
+    var output: Double?
+    var cacheRead: Double?
+    var cacheWrite: Double?
+    var contextOver200K: ModelsDevContextOver200KCost?
+
+    private enum CodingKeys: String, CodingKey {
+        case input
+        case output
+        case cacheRead = "cache_read"
+        case cacheWrite = "cache_write"
+        case contextOver200K = "context_over_200k"
+    }
+}
+
+struct ModelsDevContextOver200KCost: Codable, Equatable, Sendable {
+    var input: Double?
+    var output: Double?
+    var cacheRead: Double?
+    var cacheWrite: Double?
+
+    private enum CodingKeys: String, CodingKey {
+        case input
+        case output
+        case cacheRead = "cache_read"
+        case cacheWrite = "cache_write"
+    }
+}
+
+struct ModelsDevLimit: Codable, Equatable, Sendable {
+    var context: Int?
+}
+
+enum ModelsDevModelIDNormalizer {
+    static func normalize(_ raw: String) -> String {
+        raw.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func candidates(_ raw: String) -> [String] {
+        var candidates: [String] = []
+
+        func append(_ value: String) {
+            let normalized = self.normalize(value)
+            guard !normalized.isEmpty, !candidates.contains(normalized) else { return }
+            candidates.append(normalized)
+        }
+
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        append(trimmed)
+
+        if trimmed.hasPrefix("openai/") {
+            append(String(trimmed.dropFirst("openai/".count)))
+        }
+
+        if trimmed.hasPrefix("anthropic.") {
+            append(String(trimmed.dropFirst("anthropic.".count)))
+        }
+
+        if let lastDot = trimmed.lastIndex(of: "."),
+           trimmed.contains("claude-")
+        {
+            let tail = String(trimmed[trimmed.index(after: lastDot)...])
+            if tail.hasPrefix("claude-") {
+                append(tail)
+            }
+        }
+
+        var index = 0
+        while index < candidates.count {
+            let candidate = candidates[index]
+            if let atSign = candidate.firstIndex(of: "@") {
+                let base = String(candidate[..<atSign])
+                append(base)
+                let suffix = String(candidate[candidate.index(after: atSign)...])
+                if suffix.range(of: #"^\d{8}$"#, options: .regularExpression) != nil {
+                    append("\(base)-\(suffix)")
+                }
+            } else if candidate.hasPrefix("claude-") {
+                append("\(candidate)@default")
+            }
+
+            if let dated = candidate.range(of: #"-\d{4}-\d{2}-\d{2}$"#, options: .regularExpression) {
+                append(String(candidate[..<dated.lowerBound]))
+            }
+            if let compactDate = candidate.range(of: #"-\d{8}$"#, options: .regularExpression) {
+                append(String(candidate[..<compactDate.lowerBound]))
+            }
+            if let version = candidate.range(of: #"-v\d+:\d+$"#, options: .regularExpression) {
+                var base = candidate
+                base.removeSubrange(version)
+                append(base)
+            }
+
+            index += 1
+        }
+
+        return candidates
+    }
+}
+
+struct ModelsDevCacheArtifact: Codable, Equatable, Sendable {
+    var version: Int
+    var fetchedAt: Date
+    var catalog: ModelsDevCatalog
+}
+
+struct ModelsDevCacheLoadResult: Equatable, Sendable {
+    var artifact: ModelsDevCacheArtifact?
+    var isStale: Bool
+    var error: ModelsDevCache.Error?
+}
+
+enum ModelsDevCache {
+    enum Error: Swift.Error, Equatable, Sendable {
+        case unreadable
+        case invalidVersion
+        case invalidJSON
+    }
+
+    static let artifactVersion = 1
+    static let ttlSeconds: TimeInterval = 24 * 60 * 60
+
+    private static func defaultCacheRoot() -> URL {
+        let root = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        return root.appendingPathComponent("CodexBar", isDirectory: true)
+    }
+
+    static func cacheFileURL(cacheRoot: URL? = nil) -> URL {
+        let root = cacheRoot ?? self.defaultCacheRoot()
+        return root
+            .appendingPathComponent("model-pricing", isDirectory: true)
+            .appendingPathComponent("models-dev-v\(Self.artifactVersion).json", isDirectory: false)
+    }
+
+    static func load(now: Date = Date(), cacheRoot: URL? = nil) -> ModelsDevCacheLoadResult {
+        let url = self.cacheFileURL(cacheRoot: cacheRoot)
+        guard let data = try? Data(contentsOf: url) else {
+            return ModelsDevCacheLoadResult(artifact: nil, isStale: true, error: .unreadable)
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let decoded = try? decoder.decode(ModelsDevCacheArtifact.self, from: data) else {
+            return ModelsDevCacheLoadResult(artifact: nil, isStale: true, error: .invalidJSON)
+        }
+        guard decoded.version == Self.artifactVersion else {
+            return ModelsDevCacheLoadResult(artifact: nil, isStale: true, error: .invalidVersion)
+        }
+
+        return ModelsDevCacheLoadResult(
+            artifact: decoded,
+            isStale: now.timeIntervalSince(decoded.fetchedAt) > Self.ttlSeconds,
+            error: nil)
+    }
+
+    static func save(catalog: ModelsDevCatalog, fetchedAt: Date = Date(), cacheRoot: URL? = nil) {
+        let artifact = ModelsDevCacheArtifact(
+            version: Self.artifactVersion,
+            fetchedAt: fetchedAt,
+            catalog: catalog)
+        self.save(artifact: artifact, cacheRoot: cacheRoot)
+    }
+
+    static func save(artifact: ModelsDevCacheArtifact, cacheRoot: URL? = nil) {
+        let url = self.cacheFileURL(cacheRoot: cacheRoot)
+        let dir = url.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        guard let data = try? encoder.encode(artifact) else { return }
+
+        let tmp = dir.appendingPathComponent(".tmp-\(UUID().uuidString).json", isDirectory: false)
+        do {
+            try data.write(to: tmp, options: [.atomic])
+            if FileManager.default.fileExists(atPath: url.path) {
+                _ = try FileManager.default.replaceItemAt(url, withItemAt: tmp)
+            } else {
+                try FileManager.default.moveItem(at: tmp, to: url)
+            }
+        } catch {
+            try? FileManager.default.removeItem(at: tmp)
+        }
+    }
+}
+
+protocol ModelsDevHTTPTransport: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+struct URLSessionModelsDevTransport: ModelsDevHTTPTransport {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await URLSession.shared.data(for: request)
+    }
+}
+
+struct ModelsDevClient: Sendable {
+    enum Error: Swift.Error, Equatable, Sendable {
+        case invalidResponse
+        case httpStatus(Int)
+        case invalidJSON
+    }
+
+    var url: URL
+    var transport: any ModelsDevHTTPTransport
+
+    init(
+        url: URL = URL(string: "https://models.dev/api.json")!,
+        transport: any ModelsDevHTTPTransport = URLSessionModelsDevTransport())
+    {
+        self.url = url
+        self.transport = transport
+    }
+
+    func fetchCatalog() async throws -> ModelsDevCatalog {
+        var request = URLRequest(url: self.url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 20
+
+        let (data, response) = try await self.transport.data(for: request)
+        guard let http = response as? HTTPURLResponse else { throw Error.invalidResponse }
+        guard (200..<300).contains(http.statusCode) else { throw Error.httpStatus(http.statusCode) }
+
+        do {
+            return try JSONDecoder().decode(ModelsDevCatalog.self, from: data)
+        } catch {
+            throw Error.invalidJSON
+        }
+    }
+}
+
+enum ModelsDevPricingPipeline {
+    static func lookup(
+        providerID: String,
+        modelID: String,
+        now: Date = Date(),
+        cacheRoot: URL? = nil) -> ModelsDevPricingLookup?
+    {
+        ModelsDevCache.load(now: now, cacheRoot: cacheRoot)
+            .artifact?
+            .catalog
+            .pricing(providerID: providerID, modelID: modelID)
+    }
+
+    static func refreshIfNeeded(
+        now: Date = Date(),
+        cacheRoot: URL? = nil,
+        client: ModelsDevClient = ModelsDevClient()) async
+    {
+        let load = ModelsDevCache.load(now: now, cacheRoot: cacheRoot)
+        guard load.isStale else { return }
+
+        do {
+            let catalog = try await client.fetchCatalog()
+            if let oldCatalog = load.artifact?.catalog,
+               !catalog.containsProviderModels(from: oldCatalog)
+            {
+                return
+            }
+            ModelsDevCache.save(catalog: catalog, fetchedAt: now, cacheRoot: cacheRoot)
+        } catch {
+            // Best-effort refresh only. Future scanner integration should keep using the last valid cache.
+        }
+    }
+}

--- a/Tests/CodexBarTests/Fixtures/models-dev-subset.json
+++ b/Tests/CodexBarTests/Fixtures/models-dev-subset.json
@@ -1,0 +1,89 @@
+{
+  "openai": {
+    "id": "openai",
+    "name": "OpenAI",
+    "models": {
+      "gpt-4o-mini": {
+        "id": "gpt-4o-mini",
+        "name": "GPT-4o mini",
+        "cost": {
+          "input": 0.15,
+          "output": 0.6,
+          "cache_read": 0.08
+        },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        }
+      },
+      "shared-model": {
+        "id": "shared-model",
+        "name": "Shared model via OpenAI",
+        "cost": {
+          "input": 1,
+          "output": 2
+        },
+        "limit": {
+          "context": 128000
+        }
+      }
+    }
+  },
+  "anthropic": {
+    "id": "anthropic",
+    "name": "Anthropic",
+    "models": {
+      "shared-model": {
+        "id": "shared-model",
+        "name": "Shared model via Anthropic",
+        "cost": {
+          "input": 3,
+          "output": 4
+        },
+        "limit": {
+          "context": 200000
+        }
+      },
+      "claude-sonnet-4-6": {
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "context_over_200k": {
+            "input": 6,
+            "output": 22.5,
+            "cache_read": 0.6,
+            "cache_write": 7.5
+          }
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        }
+      }
+    }
+  },
+  "google-vertex-anthropic": {
+    "id": "google-vertex-anthropic",
+    "name": "Vertex (Anthropic)",
+    "models": {
+      "claude-sonnet-4-6@default": {
+        "id": "claude-sonnet-4-6@default",
+        "name": "Claude Sonnet 4.6",
+        "cost": {
+          "input": 3.1,
+          "output": 15.1,
+          "cache_read": 0.31,
+          "cache_write": 3.76
+        },
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        }
+      }
+    }
+  }
+}

--- a/Tests/CodexBarTests/ModelsDevPricingTests.swift
+++ b/Tests/CodexBarTests/ModelsDevPricingTests.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import Testing
 @testable import CodexBarCore
 

--- a/Tests/CodexBarTests/ModelsDevPricingTests.swift
+++ b/Tests/CodexBarTests/ModelsDevPricingTests.swift
@@ -1,0 +1,307 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ModelsDevPricingTests {
+    @Test
+    func `parses models dev subset`() throws {
+        let catalog = try Self.fixtureCatalog()
+
+        #expect(catalog.providers["openai"]?.name == "OpenAI")
+        #expect(catalog.providers["anthropic"]?.models["claude-sonnet-4-6"]?.cost?.cacheWrite == 3.75)
+        #expect(catalog.providers["anthropic"]?.models["claude-sonnet-4-6"]?.limit?.context == 1_000_000)
+    }
+
+    @Test
+    func `looks up pricing by provider and model`() throws {
+        let catalog = try Self.fixtureCatalog()
+
+        let openAI = try #require(catalog.pricing(providerID: "openai", modelID: "shared-model"))
+        let anthropic = try #require(catalog.pricing(providerID: "anthropic", modelID: "shared-model"))
+
+        #expect(openAI.pricing.inputCostPerToken == 1 / 1_000_000.0)
+        #expect(openAI.pricing.outputCostPerToken == 2 / 1_000_000.0)
+        #expect(anthropic.pricing.inputCostPerToken == 3 / 1_000_000.0)
+        #expect(anthropic.pricing.outputCostPerToken == 4 / 1_000_000.0)
+    }
+
+    @Test
+    func `does not fall back across providers`() throws {
+        let catalog = try Self.fixtureCatalog()
+
+        #expect(catalog.pricing(providerID: "openai", modelID: "claude-sonnet-4-6") == nil)
+        #expect(catalog.pricing(providerID: "anthropic", modelID: "gpt-4o-mini") == nil)
+    }
+
+    @Test
+    func `supports provider scoped alias normalization`() throws {
+        let catalog = try Self.fixtureCatalog()
+
+        let anthropic = try #require(catalog.pricing(
+            providerID: "anthropic",
+            modelID: "anthropic.us-east-1.claude-sonnet-4-6-v1:0"))
+        let vertex = try #require(catalog.pricing(
+            providerID: "google-vertex-anthropic",
+            modelID: "claude-sonnet-4-6"))
+
+        #expect(anthropic.normalizedModelID == "claude-sonnet-4-6")
+        #expect(vertex.normalizedModelID == "claude-sonnet-4-6@default")
+        #expect(vertex.pricing.inputCostPerToken == 3.1 / 1_000_000.0)
+    }
+
+    @Test
+    func `converts models dev per million token prices to per token prices`() throws {
+        let pricing = try #require(try Self.fixtureCatalog().pricing(
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-6")?
+            .pricing)
+
+        #expect(pricing.inputCostPerToken == 3 / 1_000_000.0)
+        #expect(pricing.outputCostPerToken == 15 / 1_000_000.0)
+        #expect(pricing.cacheReadInputCostPerToken == 0.3 / 1_000_000.0)
+        #expect(pricing.cacheCreationInputCostPerToken == 3.75 / 1_000_000.0)
+        #expect(pricing.thresholdTokens == 200_000)
+        #expect(pricing.inputCostPerTokenAboveThreshold == 6 / 1_000_000.0)
+        #expect(pricing.outputCostPerTokenAboveThreshold == 22.5 / 1_000_000.0)
+        #expect(pricing.cacheReadInputCostPerTokenAboveThreshold == 0.6 / 1_000_000.0)
+        #expect(pricing.cacheCreationInputCostPerTokenAboveThreshold == 7.5 / 1_000_000.0)
+    }
+
+    @Test
+    func `stale cache is still readable`() throws {
+        let root = try Self.cacheRoot()
+        let old = Date(timeIntervalSince1970: 1)
+        try ModelsDevCache.save(catalog: Self.fixtureCatalog(), fetchedAt: old, cacheRoot: root)
+
+        let load = ModelsDevCache.load(
+            now: Date(timeIntervalSince1970: 1 + ModelsDevCache.ttlSeconds + 1),
+            cacheRoot: root)
+
+        #expect(load.artifact != nil)
+        #expect(load.isStale)
+        #expect(load.error == nil)
+    }
+
+    @Test
+    func `pipeline lookup reads cached pricing`() throws {
+        let root = try Self.cacheRoot()
+        try ModelsDevCache.save(catalog: Self.fixtureCatalog(), fetchedAt: Date(), cacheRoot: root)
+
+        let lookup = try #require(ModelsDevPricingPipeline.lookup(
+            providerID: "openai",
+            modelID: "gpt-4o-mini",
+            cacheRoot: root))
+
+        #expect(lookup.pricing.inputCostPerToken == 0.15 / 1_000_000.0)
+    }
+
+    @Test
+    func `network failure preserves last valid cache`() async throws {
+        let root = try Self.cacheRoot()
+        let old = Date(timeIntervalSince1970: 1)
+        try ModelsDevCache.save(catalog: Self.fixtureCatalog(), fetchedAt: old, cacheRoot: root)
+
+        await ModelsDevPricingPipeline.refreshIfNeeded(
+            now: Date(timeIntervalSince1970: 1 + ModelsDevCache.ttlSeconds + 1),
+            cacheRoot: root,
+            client: ModelsDevClient(transport: MockTransport(result: .failure(MockError.failed))))
+
+        let lookup = try #require(ModelsDevPricingPipeline.lookup(
+            providerID: "openai",
+            modelID: "gpt-4o-mini",
+            cacheRoot: root))
+
+        #expect(lookup.pricing.inputCostPerToken == 0.15 / 1_000_000.0)
+    }
+
+    @Test
+    func `refresh preserves cache when fetched catalog drops cached provider`() async throws {
+        let root = try Self.cacheRoot()
+        let old = Date(timeIntervalSince1970: 1)
+        try ModelsDevCache.save(catalog: Self.fixtureCatalog(), fetchedAt: old, cacheRoot: root)
+
+        let partialCatalog = Data("""
+        {
+          "openai": { "id": 7, "models": [] },
+          "anthropic": {
+            "id": "anthropic",
+            "models": {
+              "shared-model": {
+                "id": "shared-model",
+                "cost": { "input": 99, "output": 99 }
+              }
+            }
+          }
+        }
+        """.utf8)
+        await ModelsDevPricingPipeline.refreshIfNeeded(
+            now: Date(timeIntervalSince1970: 1 + ModelsDevCache.ttlSeconds + 1),
+            cacheRoot: root,
+            client: ModelsDevClient(transport: MockTransport(
+                result: .success((partialCatalog, Self.response(status: 200))))))
+
+        let lookup = try #require(ModelsDevPricingPipeline.lookup(
+            providerID: "openai",
+            modelID: "gpt-4o-mini",
+            cacheRoot: root))
+
+        #expect(lookup.pricing.inputCostPerToken == 0.15 / 1_000_000.0)
+    }
+
+    @Test
+    func `refresh preserves cache when fetched catalog drops cached model`() async throws {
+        let root = try Self.cacheRoot()
+        let old = Date(timeIntervalSince1970: 1)
+        try ModelsDevCache.save(catalog: Self.fixtureCatalog(), fetchedAt: old, cacheRoot: root)
+
+        let partialCatalog = Data("""
+        {
+          "openai": {
+            "id": "openai",
+            "models": {
+              "shared-model": {
+                "id": "shared-model",
+                "cost": { "input": 99, "output": 99 }
+              }
+            }
+          },
+          "anthropic": {
+            "id": "anthropic",
+            "models": {
+              "shared-model": {
+                "id": "shared-model",
+                "cost": { "input": 99, "output": 99 }
+              }
+            }
+          },
+          "google-vertex-anthropic": {
+            "id": "google-vertex-anthropic",
+            "models": {
+              "claude-sonnet-4-6@default": {
+                "id": "claude-sonnet-4-6@default",
+                "cost": { "input": 99, "output": 99 }
+              }
+            }
+          }
+        }
+        """.utf8)
+        await ModelsDevPricingPipeline.refreshIfNeeded(
+            now: Date(timeIntervalSince1970: 1 + ModelsDevCache.ttlSeconds + 1),
+            cacheRoot: root,
+            client: ModelsDevClient(transport: MockTransport(
+                result: .success((partialCatalog, Self.response(status: 200))))))
+
+        let lookup = try #require(ModelsDevPricingPipeline.lookup(
+            providerID: "openai",
+            modelID: "gpt-4o-mini",
+            cacheRoot: root))
+
+        #expect(lookup.pricing.inputCostPerToken == 0.15 / 1_000_000.0)
+    }
+
+    @Test
+    func `fresh cache does not refresh`() async throws {
+        let root = try Self.cacheRoot()
+        try ModelsDevCache.save(catalog: Self.fixtureCatalog(), fetchedAt: Date(), cacheRoot: root)
+        let transport = TrackingTransport(result: .failure(MockError.failed))
+
+        await ModelsDevPricingPipeline.refreshIfNeeded(
+            now: Date(),
+            cacheRoot: root,
+            client: ModelsDevClient(transport: transport))
+
+        #expect(transport.calls == 0)
+    }
+
+    @Test
+    func `corrupt cache is ignored safely`() throws {
+        let root = try Self.cacheRoot()
+        let url = ModelsDevCache.cacheFileURL(cacheRoot: root)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("not json".utf8).write(to: url)
+
+        let load = ModelsDevCache.load(cacheRoot: root)
+
+        #expect(load.artifact == nil)
+        #expect(load.isStale)
+        #expect(load.error == .invalidJSON)
+    }
+
+    @Test
+    func `client fetches with mock transport`() async throws {
+        let data = try Self.fixtureData()
+        let client = ModelsDevClient(transport: MockTransport(result: .success((data, Self.response(status: 200)))))
+
+        let catalog = try await client.fetchCatalog()
+
+        #expect(catalog.providers["google-vertex-anthropic"]?.models["claude-sonnet-4-6@default"]?.cost?.input == 3.1)
+    }
+
+    @Test
+    func `client reports http and json failures`() async throws {
+        let data = try Self.fixtureData()
+        let httpClient = ModelsDevClient(transport: MockTransport(result: .success((data, Self.response(status: 500)))))
+        let jsonClient = ModelsDevClient(transport: MockTransport(
+            result: .success((Data("not json".utf8), Self.response(status: 200)))))
+
+        await #expect(throws: ModelsDevClient.Error.httpStatus(500)) {
+            _ = try await httpClient.fetchCatalog()
+        }
+        await #expect(throws: ModelsDevClient.Error.invalidJSON) {
+            _ = try await jsonClient.fetchCatalog()
+        }
+    }
+
+    private static func fixtureData() throws -> Data {
+        let url = try #require(Bundle.module.url(
+            forResource: "models-dev-subset",
+            withExtension: "json",
+            subdirectory: "Fixtures"))
+        return try Data(contentsOf: url)
+    }
+
+    private static func fixtureCatalog() throws -> ModelsDevCatalog {
+        try JSONDecoder().decode(ModelsDevCatalog.self, from: self.fixtureData())
+    }
+
+    private static func cacheRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-modelsdev-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private static func response(status: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://models.dev/api.json")!,
+            statusCode: status,
+            httpVersion: nil,
+            headerFields: nil)!
+    }
+}
+
+private enum MockError: Error {
+    case failed
+}
+
+private struct MockTransport: ModelsDevHTTPTransport {
+    let result: Result<(Data, URLResponse), Error>
+
+    func data(for _: URLRequest) async throws -> (Data, URLResponse) {
+        try self.result.get()
+    }
+}
+
+private final class TrackingTransport: ModelsDevHTTPTransport, @unchecked Sendable {
+    private(set) var calls = 0
+    let result: Result<(Data, URLResponse), Error>
+
+    init(result: Result<(Data, URLResponse), Error>) {
+        self.result = result
+    }
+
+    func data(for _: URLRequest) async throws -> (Data, URLResponse) {
+        self.calls += 1
+        return try self.result.get()
+    }
+}

--- a/docs/model-pricing.md
+++ b/docs/model-pricing.md
@@ -1,0 +1,34 @@
+# Model pricing metadata
+
+CodexBar has an additive models.dev pricing pipeline for future cost lookup work. Existing hardcoded pricing remains unchanged for now.
+
+## Source and cache
+
+- Source API: `https://models.dev/api.json`
+- No API key is required.
+- Local cache: `~/Library/Caches/CodexBar/model-pricing/models-dev-v1.json`
+- TTL: 24 hours
+
+The pipeline lets future scanner code read the last valid cache synchronously with `ModelsDevPricingPipeline.lookup` and refresh stale metadata separately with `ModelsDevPricingPipeline.refreshIfNeeded`. If a refresh fails, the last valid cache remains usable.
+
+## Lookup rules
+
+Pricing is scoped by provider id and model id. This prevents two providers with the same model id or display name from sharing pricing accidentally.
+
+Planned local source mapping:
+
+- Codex/OpenAI logs: models.dev provider id `openai`
+- Claude logs: models.dev provider id `anthropic`
+- Vertex AI Claude logs: models.dev provider id `google-vertex-anthropic`
+
+The first integration PR only adds the parser, client, cache, provider-scoped lookup, and tests. It does not route live cost calculations through models.dev yet.
+
+## Units
+
+models.dev publishes costs as USD per 1M tokens. CodexBar converts those to USD per token in the metadata layer:
+
+```text
+perToken = modelsDevCost / 1_000_000
+```
+
+When models.dev includes `cost.context_over_200k`, CodexBar parses those values as the above-200k-token pricing lane and converts them with the same per-1M-token rule.


### PR DESCRIPTION
# Model pricing metadata

CodexBar has an additive models.dev pricing pipeline for future cost lookup work. Existing hardcoded pricing remains unchanged for now.

## Source and cache

- Source API: `https://models.dev/api.json`
- No API key is required.
- Local cache: `~/Library/Caches/CodexBar/model-pricing/models-dev-v1.json`
- TTL: 24 hours

The pipeline lets future scanner code read the last valid cache synchronously with `ModelsDevPricingPipeline.lookup` and refresh stale metadata separately with `ModelsDevPricingPipeline.refreshIfNeeded`. If a refresh fails, the last valid cache remains usable.

## Lookup rules

Pricing is scoped by provider id and model id. This prevents two providers with the same model id or display name from sharing pricing accidentally.

Planned local source mapping:

- Codex/OpenAI logs: models.dev provider id `openai`
- Claude logs: models.dev provider id `anthropic`
- Vertex AI Claude logs: models.dev provider id `google-vertex-anthropic`

The first integration PR only adds the parser, client, cache, provider-scoped lookup, and tests. It does not route live cost calculations through models.dev yet.

## Units

models.dev publishes costs as USD per 1M tokens. CodexBar converts those to USD per token in the metadata layer:

```text
perToken = modelsDevCost / 1_000_000
```

When models.dev includes `cost.context_over_200k`, CodexBar parses those values as the above-200k-token pricing lane and converts them with the same per-1M-token rule.


## Summary
- add an additive models.dev pricing metadata parser/client/cache pipeline
- support provider-scoped model lookup, cache TTL handling, and per-1M-token to per-token conversion
- document the cache path and future lookup rules
- fix Linux CLI builds by importing FoundationNetworking where Swift exposes URLSession networking types separately

## Reasoning
- reduce reliance on user-curated and logged model pricing, which is brittle as providers add aliases, change prices, and introduce threshold pricing
- transition toward Anomaly's models.dev online catalog because it already does the cataloging work, tracks provider-scoped model metadata, and exposes a free API without requiring an API key
- keep this additive first so CodexBar can validate the catalog/cache pipeline before switching existing cost calculations away from the fallback pricing tables

## Scope
- does not switch existing Codex/Claude cost calculations to models.dev
- does not migrate or change existing fallback pricing tables
- no API key required for models.dev

## References
- models.dev catalog API: `https://models.dev/api.json`

## Validation
- `swift test --filter ModelsDevPricingTests`
- `pnpm check`
- `./Scripts/compile_and_run.sh`
- Latest PR CI after rebase: Linux CLI x64 and arm64 checks pass.
- Latest PR CI after rebase: macOS `lint-build-test` currently fails in existing Codex RPC fallback/baseline tests with `timeout(method: "initialize")`; the models.dev pricing suite passes locally.
- `swift test` was also run earlier; it still fails on the pre-existing `MistralUsageParserTests.parses dates from response` expectation (expected month 11, got 10).