### PR TITLE
Fix Droid zero usage ratio

### DIFF
--- a/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
@@ -343,6 +343,7 @@ public struct FactoryStatusSnapshot: Sendable {
         // avoiding issues with missing/sentinel values in totalAllowance.
         let unlimitedThreshold: Int64 = 1_000_000_000_000
         if let ratio = apiRatio,
+           !(ratio == 0 && used > 0 && allowance > 0 && allowance <= unlimitedThreshold),
            let percent = Self.percentFromAPIRatio(ratio, allowance: allowance, unlimitedThreshold: unlimitedThreshold)
         {
             return percent

--- a/Tests/CodexBarTests/FactoryStatusProbeTests.swift
+++ b/Tests/CodexBarTests/FactoryStatusProbeTests.swift
@@ -106,6 +106,33 @@ struct FactoryStatusSnapshotTests {
     }
 
     @Test
+    func `falls back to calculation when API ratio is zero but usage and allowance are present`() {
+        let snapshot = FactoryStatusSnapshot(
+            standardUserTokens: 5_826_293,
+            standardOrgTokens: 0,
+            standardAllowance: 20_000_000,
+            standardUsedRatio: 0,
+            premiumUserTokens: 0,
+            premiumOrgTokens: 0,
+            premiumAllowance: 0,
+            premiumUsedRatio: 0,
+            periodStart: nil,
+            periodEnd: nil,
+            planName: nil,
+            tier: nil,
+            organizationName: nil,
+            accountEmail: nil,
+            userId: nil,
+            rawJSON: nil)
+
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(usage.primary?.usedPercent ?? 0 > 29)
+        #expect(usage.primary?.usedPercent ?? 0 < 30)
+        #expect(usage.secondary?.usedPercent == 0)
+    }
+
+    @Test
     func `falls back to calculation when API ratio missing`() {
         let snapshot = FactoryStatusSnapshot(
             standardUserTokens: 50_000_000,


### PR DESCRIPTION
## Summary
- fall back to token/allowance math when Factory returns usedRatio=0 with non-zero usage
- add a regression test matching the observed Droid API payload

## Validation
- swift test --filter FactoryStatusSnapshotTests
- ./Scripts/compile_and_run.sh --test --wait (tests passed; command timed out during later packaging metadata)
- ./Scripts/compile_and_run.sh --wait