### PR TITLE
Add Venice API balance provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.25 — Unreleased
 
 ### Providers & Usage
+- Venice: add API-key balance provider support with DIEM/USD balance display and token-account CLI wiring (#865). Thanks @clawSean!
 - Factory/Droid: add token-rate-limit billing windows, Core fallback buckets, and extra usage balance display (#878). Thanks @dantemoon1!
 - Usage pace: compute pace for any explicit reset window instead of a provider allowlist (#875). Thanks @ViperThanks!
 - Crof: add API-key provider support with request quota and credit balance tracking (#872). Thanks @baanish!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - OpenRouter, Mistral, and Kimi K2: show balance/spend metrics in menu bar text when quota percentage is not useful (#853). Thanks @willytop8!
 
 ### Fixes
+- Startup: avoid blocking menu-bar creation on synchronous defaults migration/default seeding when macOS preferences services stall.
 - Cost history: keep manual refreshes on the incremental scanner cache and drain per-line JSON parse allocations so large Codex/Claude histories do not trigger full local log rescans and CPU/memory spikes.
 - Codex: restrict OAuth auto fallback to missing/invalid auth so transient API/decode errors do not spawn `codex app-server` and burn tokens (#876, fixes #874). Thanks @ViperThanks!
 - Accessibility: add VoiceOver labels for status icons, menu rows, provider switcher buttons, and usage charts (#860, fixes #859). Thanks @WadydX!

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Or download release tarballs from GitHub Releases:
 - [Abacus AI](docs/abacus.md) — Browser cookie auth for ChatLLM/RouteLLM compute credit tracking.
 - Mistral — Browser cookies for monthly spend tracking.
 - [DeepSeek](docs/deepseek.md) — API key for credit balance tracking (paid vs. granted breakdown).
+- [Venice](docs/venice.md) — API key for DIEM or USD balance tracking.
 - [Codebuff](docs/codebuff.md) — API token (or `~/.config/manicode/credentials.json`) for credit balance + weekly rate limit.
 - [Crof](docs/crof.md) — API key for dollar credit balance and request quota tracking.
 - Open to new providers: [provider authoring guide](docs/provider.md).

--- a/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
@@ -44,6 +44,7 @@ enum ProviderImplementationRegistry {
         case .deepseek: DeepSeekProviderImplementation()
         case .codebuff: CodebuffProviderImplementation()
         case .crof: CrofProviderImplementation()
+        case .venice: VeniceProviderImplementation()
         }
     }
 

--- a/Sources/CodexBar/Providers/Venice/VeniceProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Venice/VeniceProviderImplementation.swift
@@ -1,0 +1,29 @@
+import CodexBarCore
+import CodexBarMacroSupport
+import Foundation
+
+@ProviderImplementationRegistration
+struct VeniceProviderImplementation: ProviderImplementation {
+    let id: UsageProvider = .venice
+
+    @MainActor
+    func presentation(context _: ProviderPresentationContext) -> ProviderPresentation {
+        ProviderPresentation { _ in "api" }
+    }
+
+    @MainActor
+    func observeSettings(_: SettingsStore) {}
+
+    @MainActor
+    func isAvailable(context: ProviderAvailabilityContext) -> Bool {
+        if VeniceSettingsReader.apiKey(environment: context.environment) != nil {
+            return true
+        }
+        return !context.settings.tokenAccounts(for: .venice).isEmpty
+    }
+
+    @MainActor
+    func settingsFields(context _: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {
+        []
+    }
+}

--- a/Sources/CodexBar/Resources/ProviderIcon-venice.svg
+++ b/Sources/CodexBar/Resources/ProviderIcon-venice.svg
@@ -1,0 +1,4 @@
+<svg viewBox="4 4 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <path d="M6.2 7.2h4.1l4.6 12.7 4.6-12.7h4L15.7 27h-3.3L6.2 7.2Z"/>
+  <path d="M13 18.2h5.9l-1 2.8h-4l-.9-2.8Z" opacity="0.35"/>
+</svg>

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -127,7 +127,13 @@ final class SettingsStore {
         tokenAccountStore: any ProviderTokenAccountStoring = FileTokenAccountStore())
     {
         let appGroupID = AppGroupSupport.currentGroupID()
-        let appGroupMigration = AppGroupSupport.migrateLegacyDataIfNeeded(standardDefaults: userDefaults)
+        let appGroupMigration: AppGroupSupport.MigrationResult
+        if Self.isRunningTests {
+            appGroupMigration = AppGroupSupport.migrateLegacyDataIfNeeded(standardDefaults: userDefaults)
+        } else {
+            Self.scheduleAppGroupMigration()
+            appGroupMigration = AppGroupSupport.MigrationResult(status: .targetUnavailable)
+        }
         let sharedDefaultsAvailable = Self.sharedDefaults != nil
         if !Self.isRunningTests {
             CodexBarLog.logger(LogCategories.settings).info(
@@ -177,22 +183,43 @@ final class SettingsStore {
         self.runInitialProviderDetectionIfNeeded()
         self.ensureAlibabaProviderAutoEnabledIfNeeded()
         self.applyTokenCostDefaultIfNeeded()
-        if self.claudeUsageDataSource != .cli { self.claudeWebExtrasEnabled = false }
-        if hasStoredOpenAIWebAccessPreference {
-            self.openAIWebAccessEnabled = self.defaultsState.openAIWebAccessEnabled
+        if self.claudeUsageDataSource != .cli {
+            if Self.isRunningTests {
+                self.claudeWebExtrasEnabled = false
+            } else {
+                self.defaultsState.claudeWebExtrasEnabledRaw = false
+            }
+        }
+        let resolvedOpenAIWebAccessEnabled = if hasStoredOpenAIWebAccessPreference {
+            self.defaultsState.openAIWebAccessEnabled
         } else {
-            self.openAIWebAccessEnabled = Self.inferredInitialOpenAIWebAccessEnabled(
+            Self.inferredInitialOpenAIWebAccessEnabled(
                 config: config,
                 hadExistingConfig: hadExistingConfig)
         }
-        if Self.shouldBridgeSharedDefaults(for: userDefaults) {
-            Self.sharedDefaults?.set(self.debugDisableKeychainAccess, forKey: "debugDisableKeychainAccess")
+        if Self.isRunningTests {
+            self.openAIWebAccessEnabled = resolvedOpenAIWebAccessEnabled
+        } else {
+            self.defaultsState.openAIWebAccessEnabled = resolvedOpenAIWebAccessEnabled
         }
         KeychainAccessGate.isDisabled = self.debugDisableKeychainAccess
     }
 }
 
 extension SettingsStore {
+    private static func scheduleAppGroupMigration() {
+        Task.detached(priority: .utility) {
+            let result = AppGroupSupport.migrateLegacyDataIfNeeded()
+            CodexBarLog.logger(LogCategories.settings).info(
+                "App group migration completed",
+                metadata: [
+                    "migrationStatus": result.status.rawValue,
+                    "migratedSnapshot": result.copiedSnapshot ? "1" : "0",
+                    "migratedDefaults": "\(result.copiedDefaults)",
+                ])
+        }
+    }
+
     private static func inferredInitialOpenAIWebAccessEnabled(
         config: CodexBarConfig,
         hadExistingConfig: Bool) -> Bool
@@ -207,7 +234,7 @@ extension SettingsStore {
         let refreshDefault = userDefaults.string(forKey: "refreshFrequency")
             .flatMap(RefreshFrequency.init(rawValue:))
         let refreshFrequency = refreshDefault ?? .fiveMinutes
-        if refreshDefault == nil {
+        if Self.isRunningTests, refreshDefault == nil {
             userDefaults.set(refreshFrequency.rawValue, forKey: "refreshFrequency")
         }
         let launchAtLogin = userDefaults.object(forKey: "launchAtLogin") as? Bool ?? false
@@ -219,14 +246,16 @@ extension SettingsStore {
             if Self.shouldBridgeSharedDefaults(for: userDefaults),
                let shared = Self.sharedDefaults?.object(forKey: "debugDisableKeychainAccess") as? Bool
             {
-                userDefaults.set(shared, forKey: "debugDisableKeychainAccess")
+                if Self.isRunningTests {
+                    userDefaults.set(shared, forKey: "debugDisableKeychainAccess")
+                }
                 return shared
             }
             return false
         }()
         let debugFileLoggingEnabled = userDefaults.object(forKey: "debugFileLoggingEnabled") as? Bool ?? false
         let debugLogLevelRaw = userDefaults.string(forKey: "debugLogLevel") ?? CodexBarLog.Level.verbose.rawValue
-        if userDefaults.string(forKey: "debugLogLevel") == nil {
+        if Self.isRunningTests, userDefaults.string(forKey: "debugLogLevel") == nil {
             userDefaults.set(debugLogLevelRaw, forKey: "debugLogLevel")
         }
         let debugLoadingPatternRaw = userDefaults.string(forKey: "debugLoadingPattern")
@@ -234,7 +263,7 @@ extension SettingsStore {
         let statusChecksEnabled = userDefaults.object(forKey: "statusChecksEnabled") as? Bool ?? true
         let sessionQuotaDefault = userDefaults.object(forKey: "sessionQuotaNotificationsEnabled") as? Bool
         let sessionQuotaNotificationsEnabled = sessionQuotaDefault ?? true
-        if sessionQuotaDefault == nil {
+        if Self.isRunningTests, sessionQuotaDefault == nil {
             userDefaults.set(true, forKey: "sessionQuotaNotificationsEnabled")
         }
         let usageBarsShowUsed = userDefaults.object(forKey: "usageBarsShowUsed") as? Bool ?? false
@@ -266,16 +295,22 @@ extension SettingsStore {
         let claudePeakHoursEnabled = userDefaults.object(forKey: "claudePeakHoursEnabled") as? Bool ?? true
         let creditsExtrasDefault = userDefaults.object(forKey: "showOptionalCreditsAndExtraUsage") as? Bool
         let showOptionalCreditsAndExtraUsage = creditsExtrasDefault ?? true
-        if creditsExtrasDefault == nil { userDefaults.set(true, forKey: "showOptionalCreditsAndExtraUsage") }
+        if Self.isRunningTests, creditsExtrasDefault == nil {
+            userDefaults.set(true, forKey: "showOptionalCreditsAndExtraUsage")
+        }
         let openAIWebAccessDefault = userDefaults.object(forKey: "openAIWebAccessEnabled") as? Bool
         let openAIWebAccessEnabled = openAIWebAccessDefault ?? false
-        if openAIWebAccessDefault == nil { userDefaults.set(false, forKey: "openAIWebAccessEnabled") }
+        if Self.isRunningTests, openAIWebAccessDefault == nil {
+            userDefaults.set(false, forKey: "openAIWebAccessEnabled")
+        }
         let openAIWebBatterySaverDefault = userDefaults.object(forKey: "openAIWebBatterySaverEnabled") as? Bool
         let openAIWebBatterySaverEnabled = openAIWebBatterySaverDefault ?? false
-        if openAIWebBatterySaverDefault == nil { userDefaults.set(false, forKey: "openAIWebBatterySaverEnabled") }
+        if Self.isRunningTests, openAIWebBatterySaverDefault == nil {
+            userDefaults.set(false, forKey: "openAIWebBatterySaverEnabled")
+        }
         let providerStorageFootprintsDefault = userDefaults.object(forKey: "providerStorageFootprintsEnabled") as? Bool
         let providerStorageFootprintsEnabled = providerStorageFootprintsDefault ?? false
-        if providerStorageFootprintsDefault == nil {
+        if Self.isRunningTests, providerStorageFootprintsDefault == nil {
             userDefaults.set(false, forKey: "providerStorageFootprintsEnabled")
         }
         let jetbrainsIDEBasePath = userDefaults.string(forKey: "jetbrainsIDEBasePath") ?? ""

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -831,6 +831,7 @@ extension UsageStore {
                 .kimi: "Kimi debug log not yet implemented",
                 .kimik2: "Kimi K2 debug log not yet implemented",
                 .jetbrains: "JetBrains AI debug log not yet implemented",
+                .venice: "Venice debug log not yet implemented",
             ]
             let buildText = {
                 switch provider {
@@ -904,7 +905,7 @@ extension UsageStore {
                         hasEnvToken: deepSeekHasEnvToken,
                         hasTokenAccount: deepSeekHasTokenAccount)
                 case .gemini, .antigravity, .opencode, .opencodego, .factory, .copilot, .vertexai, .kilo, .kiro, .kimi,
-                     .kimik2, .jetbrains, .perplexity, .abacus, .mistral, .codebuff, .crof, .windsurf:
+                     .kimik2, .jetbrains, .perplexity, .abacus, .mistral, .codebuff, .crof, .windsurf, .venice:
                     return unimplementedDebugLogMessages[provider] ?? "Debug log not yet implemented"
                 }
             }

--- a/Sources/CodexBarCLI/TokenAccountCLI.swift
+++ b/Sources/CodexBarCLI/TokenAccountCLI.swift
@@ -201,7 +201,7 @@ struct TokenAccountCLIContext {
                     cookieSource: cookieSource,
                     manualCookieHeader: cookieHeader))
         case .gemini, .antigravity, .copilot, .kiro, .vertexai, .kimik2, .synthetic, .openrouter, .warp, .deepseek,
-             .codebuff, .crof:
+             .codebuff, .crof, .venice:
             return nil
         case .windsurf:
             return nil

--- a/Sources/CodexBarCore/AutoreleasePoolCompat.swift
+++ b/Sources/CodexBarCore/AutoreleasePoolCompat.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+#if os(Linux)
+@discardableResult
+func autoreleasepool<Result>(_ work: () throws -> Result) rethrows -> Result {
+    try work()
+}
+#endif

--- a/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
+++ b/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
@@ -31,6 +31,8 @@ public enum ProviderConfigEnvironment {
             }
         case .openrouter:
             env[OpenRouterSettingsReader.envKey] = apiKey
+        case .venice:
+            env[VeniceSettingsReader.apiKeyEnvironmentKey] = apiKey
         case .codebuff:
             // Preserve a token already present in the process environment so that
             // runtime/CI overrides win over a key saved in Settings (matches the

--- a/Sources/CodexBarCore/Logging/LogCategories.swift
+++ b/Sources/CodexBarCore/Logging/LogCategories.swift
@@ -64,6 +64,7 @@ public enum LogCategories {
     public static let tokenAccounts = "token-accounts"
     public static let tokenCost = "token-cost"
     public static let ttyRunner = "tty-runner"
+    public static let veniceUsage = "venice-usage"
     public static let vertexAIFetcher = "vertexai-fetcher"
     public static let warpUsage = "warp-usage"
     public static let webkitTeardown = "webkit-teardown"

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -84,6 +84,7 @@ public enum ProviderDescriptorRegistry {
         .deepseek: DeepSeekProviderDescriptor.descriptor,
         .codebuff: CodebuffProviderDescriptor.descriptor,
         .crof: CrofProviderDescriptor.descriptor,
+        .venice: VeniceProviderDescriptor.descriptor,
     ]
     private static let bootstrap: Void = {
         for provider in UsageProvider.allCases {

--- a/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
+++ b/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
@@ -83,6 +83,12 @@ public enum ProviderTokenResolver {
         self.crofResolution(environment: environment)?.token
     }
 
+    public static func veniceToken(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
+    {
+        self.veniceResolution(environment: environment)?.token
+    }
+
     public static func deepseekResolution(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
     {
@@ -93,6 +99,12 @@ public enum ProviderTokenResolver {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
     {
         self.resolveEnv(CrofSettingsReader.apiKey(environment: environment))
+    }
+
+    public static func veniceResolution(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
+    {
+        self.resolveEnv(VeniceSettingsReader.apiKey(environment: environment))
     }
 
     public static func codebuffToken(

--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -34,6 +34,7 @@ public enum UsageProvider: String, CaseIterable, Sendable, Codable {
     case deepseek
     case codebuff
     case crof
+    case venice
 }
 
 // swiftformat:enable sortDeclarations
@@ -70,6 +71,7 @@ public enum IconStyle: Sendable, CaseIterable {
     case deepseek
     case codebuff
     case crof
+    case venice
     case combined
 }
 

--- a/Sources/CodexBarCore/Providers/Venice/VeniceProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Venice/VeniceProviderDescriptor.swift
@@ -1,0 +1,70 @@
+import CodexBarMacroSupport
+import Foundation
+
+@ProviderDescriptorRegistration
+@ProviderDescriptorDefinition
+public enum VeniceProviderDescriptor {
+    static func makeDescriptor() -> ProviderDescriptor {
+        ProviderDescriptor(
+            id: .venice,
+            metadata: ProviderMetadata(
+                id: .venice,
+                displayName: "Venice",
+                sessionLabel: "Balance",
+                weeklyLabel: "Balance",
+                opusLabel: nil,
+                supportsOpus: false,
+                supportsCredits: false,
+                creditsHint: "",
+                toggleTitle: "Show Venice usage",
+                cliName: "venice",
+                defaultEnabled: false,
+                isPrimaryProvider: false,
+                usesAccountFallback: false,
+                browserCookieOrder: nil,
+                dashboardURL: "https://venice.ai/settings/api",
+                statusPageURL: nil,
+                statusLinkURL: nil),
+            branding: ProviderBranding(
+                iconStyle: .venice,
+                iconResourceName: "ProviderIcon-venice",
+                color: ProviderColor(red: 0.2, green: 0.6, blue: 1.0)),
+            tokenCost: ProviderTokenCostConfig(
+                supportsTokenCost: false,
+                noDataMessage: { "Venice per-day cost history is not available via API." }),
+            fetchPlan: ProviderFetchPlan(
+                sourceModes: [.auto, .api],
+                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [VeniceAPIFetchStrategy()] })),
+            cli: ProviderCLIConfig(
+                name: "venice",
+                aliases: ["ven"],
+                versionDetector: nil))
+    }
+}
+
+struct VeniceAPIFetchStrategy: ProviderFetchStrategy {
+    let id: String = "venice.api"
+    let kind: ProviderFetchKind = .apiToken
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        Self.resolveToken(environment: context.env) != nil
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        guard let apiKey = Self.resolveToken(environment: context.env) else {
+            throw VeniceUsageError.missingCredentials
+        }
+        let usage = try await VeniceUsageFetcher.fetchUsage(apiKey: apiKey)
+        return self.makeResult(
+            usage: usage.toUsageSnapshot(),
+            sourceLabel: "api")
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+
+    private static func resolveToken(environment: [String: String]) -> String? {
+        ProviderTokenResolver.veniceToken(environment: environment)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Venice/VeniceSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Venice/VeniceSettingsReader.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public struct VeniceSettingsReader: Sendable {
+    public static let apiKeyEnvironmentKey = "VENICE_API_KEY"
+    public static let apiKeyEnvironmentKeys = [Self.apiKeyEnvironmentKey, "VENICE_KEY"]
+
+    public static func apiKey(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
+    {
+        for key in self.apiKeyEnvironmentKeys {
+            guard let raw = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !raw.isEmpty
+            else {
+                continue
+            }
+            let cleaned = Self.cleaned(raw)
+            if !cleaned.isEmpty {
+                return cleaned
+            }
+        }
+        return nil
+    }
+
+    private static func cleaned(_ raw: String) -> String {
+        var value = raw
+        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
+            (value.hasPrefix("'") && value.hasSuffix("'"))
+        {
+            value.removeFirst()
+            value.removeLast()
+        }
+        return value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
@@ -58,11 +58,16 @@ public struct VeniceUsageSnapshot: Sendable {
     public func toUsageSnapshot() -> UsageSnapshot {
         let balanceDetail: String
         let usedPercent: Double
+        let activeCurrency = self.consumptionCurrency?.uppercased()
 
         if !self.canConsume {
             balanceDetail = "Balance unavailable for API calls"
             usedPercent = 100
-        } else if let diem = self.diemBalance, let allocation = self.diemEpochAllocation, allocation > 0 {
+        } else if activeCurrency == "USD", let usd = self.usdBalance, usd > 0 {
+            let usdStr = String(format: "%.2f", usd)
+            balanceDetail = "$\(usdStr) USD remaining"
+            usedPercent = 0
+        } else if activeCurrency == "DIEM", let diem = self.diemBalance, let allocation = self.diemEpochAllocation, allocation > 0 {
             // DIEM balance with epoch allocation
             let remaining = diem
             let usedAmount = allocation - remaining
@@ -71,6 +76,10 @@ public struct VeniceUsageSnapshot: Sendable {
             let allocationStr = String(format: "%.2f", allocation)
             let remainingStr = String(format: "%.2f", remaining)
             balanceDetail = "DIEM \(remainingStr) / \(allocationStr) epoch allocation"
+        } else if activeCurrency == "DIEM", let diem = self.diemBalance, diem > 0 {
+            let diemStr = String(format: "%.2f", diem)
+            balanceDetail = "DIEM \(diemStr) remaining"
+            usedPercent = 0
         } else if let diem = self.diemBalance, diem > 0 {
             // DIEM balance without allocation
             let diemStr = String(format: "%.2f", diem)

--- a/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
@@ -81,7 +81,9 @@ public struct VeniceUsageSnapshot: Sendable {
             let usdStr = String(format: "%.2f", usd)
             balanceDetail = "$\(usdStr) USD remaining"
             usedPercent = 0
-        } else if activeCurrency != "USD", let diem = self.diemBalance, let allocation = self.diemEpochAllocation, allocation > 0 {
+        } else if activeCurrency != "USD", let diem = self.diemBalance, let allocation = self.diemEpochAllocation,
+                  allocation > 0
+        {
             // DIEM balance with epoch allocation
             let remaining = diem
             let usedAmount = allocation - remaining
@@ -212,12 +214,15 @@ private func clamp(_ value: Double, min: Double, max: Double) -> Double {
     Swift.min(Swift.max(value, min), max)
 }
 
-private extension KeyedDecodingContainer {
-    func decodeFlexibleDoubleIfPresent(forKey key: K) throws -> Double? {
-        if let value = try self.decodeIfPresent(Double.self, forKey: key) {
+extension KeyedDecodingContainer {
+    fileprivate func decodeFlexibleDoubleIfPresent(forKey key: K) throws -> Double? {
+        if try self.decodeNil(forKey: key) {
+            return nil
+        }
+        if let value = try? self.decode(Double.self, forKey: key) {
             return value
         }
-        if let stringValue = try self.decodeIfPresent(String.self, forKey: key) {
+        if let stringValue = try? self.decode(String.self, forKey: key) {
             let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return nil }
             if let parsed = Double(trimmed) {
@@ -228,6 +233,9 @@ private extension KeyedDecodingContainer {
                 in: self,
                 debugDescription: "Expected a numeric string for \(key.stringValue), got '\(stringValue)'")
         }
-        return nil
+        throw DecodingError.dataCorruptedError(
+            forKey: key,
+            in: self,
+            debugDescription: "Expected a number or numeric string for \(key.stringValue)")
     }
 }

--- a/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
@@ -81,7 +81,7 @@ public struct VeniceUsageSnapshot: Sendable {
             let usdStr = String(format: "%.2f", usd)
             balanceDetail = "$\(usdStr) USD remaining"
             usedPercent = 0
-        } else if activeCurrency == "DIEM", let diem = self.diemBalance, let allocation = self.diemEpochAllocation, allocation > 0 {
+        } else if activeCurrency != "USD", let diem = self.diemBalance, let allocation = self.diemEpochAllocation, allocation > 0 {
             // DIEM balance with epoch allocation
             let remaining = diem
             let usedAmount = allocation - remaining

--- a/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
@@ -154,7 +154,6 @@ public struct VeniceUsageFetcher: Sendable {
         }
 
         guard httpResponse.statusCode == 200 else {
-            let body = String(data: data, encoding: .utf8) ?? ""
             Self.log.error("Venice API returned \(httpResponse.statusCode)")
             throw VeniceUsageError.apiError("HTTP \(httpResponse.statusCode)")
         }

--- a/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
@@ -17,6 +17,14 @@ public struct VeniceBalanceResponse: Decodable, Sendable {
         case balances
         case diemEpochAllocation
     }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.canConsume = try container.decode(Bool.self, forKey: .canConsume)
+        self.consumptionCurrency = try container.decodeIfPresent(String.self, forKey: .consumptionCurrency)
+        self.balances = try container.decode(VeniceBalances.self, forKey: .balances)
+        self.diemEpochAllocation = try container.decodeFlexibleDoubleIfPresent(forKey: .diemEpochAllocation)
+    }
 }
 
 public struct VeniceBalances: Decodable, Sendable {
@@ -26,6 +34,12 @@ public struct VeniceBalances: Decodable, Sendable {
     enum CodingKeys: String, CodingKey {
         case diem
         case usd
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.diem = try container.decodeFlexibleDoubleIfPresent(forKey: .diem)
+        self.usd = try container.decodeFlexibleDoubleIfPresent(forKey: .usd)
     }
 }
 
@@ -196,4 +210,24 @@ public struct VeniceUsageFetcher: Sendable {
 
 private func clamp(_ value: Double, min: Double, max: Double) -> Double {
     Swift.min(Swift.max(value, min), max)
+}
+
+private extension KeyedDecodingContainer {
+    func decodeFlexibleDoubleIfPresent(forKey key: K) throws -> Double? {
+        if let value = try self.decodeIfPresent(Double.self, forKey: key) {
+            return value
+        }
+        if let stringValue = try self.decodeIfPresent(String.self, forKey: key) {
+            let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            if let parsed = Double(trimmed) {
+                return parsed
+            }
+            throw DecodingError.dataCorruptedError(
+                forKey: key,
+                in: self,
+                debugDescription: "Expected a numeric string for \(key.stringValue), got '\(stringValue)'")
+        }
+        return nil
+    }
 }

--- a/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
@@ -1,0 +1,191 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+// MARK: - API response types
+
+public struct VeniceBalanceResponse: Decodable, Sendable {
+    public let canConsume: Bool
+    public let consumptionCurrency: String?
+    public let balances: VeniceBalances
+    public let diemEpochAllocation: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case canConsume
+        case consumptionCurrency
+        case balances
+        case diemEpochAllocation
+    }
+}
+
+public struct VeniceBalances: Decodable, Sendable {
+    public let diem: Double?
+    public let usd: Double?
+
+    enum CodingKeys: String, CodingKey {
+        case diem
+        case usd
+    }
+}
+
+// MARK: - Domain snapshot
+
+public struct VeniceUsageSnapshot: Sendable {
+    public let canConsume: Bool
+    public let consumptionCurrency: String?
+    public let diemBalance: Double?
+    public let usdBalance: Double?
+    public let diemEpochAllocation: Double?
+    public let updatedAt: Date
+
+    public init(
+        canConsume: Bool,
+        consumptionCurrency: String?,
+        diemBalance: Double?,
+        usdBalance: Double?,
+        diemEpochAllocation: Double?,
+        updatedAt: Date)
+    {
+        self.canConsume = canConsume
+        self.consumptionCurrency = consumptionCurrency
+        self.diemBalance = diemBalance
+        self.usdBalance = usdBalance
+        self.diemEpochAllocation = diemEpochAllocation
+        self.updatedAt = updatedAt
+    }
+
+    public func toUsageSnapshot() -> UsageSnapshot {
+        let balanceDetail: String
+        let usedPercent: Double
+
+        if !self.canConsume {
+            balanceDetail = "Balance unavailable for API calls"
+            usedPercent = 100
+        } else if let diem = self.diemBalance, let allocation = self.diemEpochAllocation, allocation > 0 {
+            // DIEM balance with epoch allocation
+            let remaining = diem
+            let usedAmount = allocation - remaining
+            let used = clamp(usedAmount / allocation * 100, min: 0, max: 100)
+            usedPercent = used
+            let allocationStr = String(format: "%.2f", allocation)
+            let remainingStr = String(format: "%.2f", remaining)
+            balanceDetail = "DIEM \(remainingStr) / \(allocationStr) epoch allocation"
+        } else if let diem = self.diemBalance, diem > 0 {
+            // DIEM balance without allocation
+            let diemStr = String(format: "%.2f", diem)
+            balanceDetail = "DIEM \(diemStr) remaining"
+            usedPercent = 0
+        } else if let usd = self.usdBalance, usd > 0 {
+            // USD balance
+            let usdStr = String(format: "%.2f", usd)
+            balanceDetail = "$\(usdStr) USD remaining"
+            usedPercent = 0
+        } else {
+            balanceDetail = "No Venice API balance available"
+            usedPercent = 100
+        }
+
+        let identity = ProviderIdentitySnapshot(
+            providerID: .venice,
+            accountEmail: nil,
+            accountOrganization: nil,
+            loginMethod: nil)
+        let balanceWindow = RateWindow(
+            usedPercent: usedPercent,
+            windowMinutes: nil,
+            resetsAt: nil,
+            resetDescription: balanceDetail)
+
+        return UsageSnapshot(
+            primary: balanceWindow,
+            secondary: nil,
+            tertiary: nil,
+            providerCost: nil,
+            updatedAt: self.updatedAt,
+            identity: identity)
+    }
+}
+
+// MARK: - Errors
+
+public enum VeniceUsageError: LocalizedError, Sendable {
+    case missingCredentials
+    case networkError(String)
+    case apiError(String)
+    case parseFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingCredentials:
+            "Missing Venice API key."
+        case let .networkError(message):
+            "Venice network error: \(message)"
+        case let .apiError(message):
+            "Venice API error: \(message)"
+        case let .parseFailed(message):
+            "Failed to parse Venice response: \(message)"
+        }
+    }
+}
+
+// MARK: - Fetcher
+
+public struct VeniceUsageFetcher: Sendable {
+    private static let log = CodexBarLog.logger(LogCategories.veniceUsage)
+    private static let balanceURL = URL(string: "https://api.venice.ai/api/v1/billing/balance")!
+    private static let timeoutSeconds: TimeInterval = 15
+
+    public static func fetchUsage(apiKey: String) async throws -> VeniceUsageSnapshot {
+        guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw VeniceUsageError.missingCredentials
+        }
+
+        var request = URLRequest(url: self.balanceURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = Self.timeoutSeconds
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw VeniceUsageError.networkError("Invalid response")
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            Self.log.error("Venice API returned \(httpResponse.statusCode)")
+            throw VeniceUsageError.apiError("HTTP \(httpResponse.statusCode)")
+        }
+
+        return try Self.parseSnapshot(data: data)
+    }
+
+    static func _parseSnapshotForTesting(_ data: Data) throws -> VeniceUsageSnapshot {
+        try self.parseSnapshot(data: data)
+    }
+
+    private static func parseSnapshot(data: Data) throws -> VeniceUsageSnapshot {
+        let decoded: VeniceBalanceResponse
+        do {
+            decoded = try JSONDecoder().decode(VeniceBalanceResponse.self, from: data)
+        } catch {
+            throw VeniceUsageError.parseFailed(error.localizedDescription)
+        }
+
+        return VeniceUsageSnapshot(
+            canConsume: decoded.canConsume,
+            consumptionCurrency: decoded.consumptionCurrency,
+            diemBalance: decoded.balances.diem,
+            usdBalance: decoded.balances.usd,
+            diemEpochAllocation: decoded.diemEpochAllocation,
+            updatedAt: Date())
+    }
+}
+
+// MARK: - Helper
+
+private func clamp(_ value: Double, min: Double, max: Double) -> Double {
+    Swift.min(Swift.max(value, min), max)
+}

--- a/Sources/CodexBarCore/TokenAccountSupportCatalog+Data.swift
+++ b/Sources/CodexBarCore/TokenAccountSupportCatalog+Data.swift
@@ -93,5 +93,12 @@ extension TokenAccountSupportCatalog {
             injection: .environment(key: "COPILOT_API_TOKEN"),
             requiresManualCookieSource: false,
             cookieName: nil),
+        .venice: TokenAccountSupport(
+            title: "API tokens",
+            subtitle: "Store multiple Venice API keys.",
+            placeholder: "Paste API key…",
+            injection: .environment(key: VeniceSettingsReader.apiKeyEnvironmentKey),
+            requiresManualCookieSource: false,
+            cookieName: nil),
     ]
 }

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
@@ -236,7 +236,7 @@ enum CostUsageScanner {
         case .zai, .gemini, .antigravity, .cursor, .opencode, .opencodego, .alibaba, .factory, .copilot,
              .minimax, .kilo, .kiro, .kimi,
              .kimik2, .augment, .jetbrains, .amp, .ollama, .synthetic, .openrouter, .warp, .perplexity, .abacus,
-             .mistral, .deepseek, .codebuff, .crof, .windsurf:
+             .mistral, .deepseek, .codebuff, .crof, .windsurf, .venice:
             return emptyReport
         }
     }

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -82,6 +82,7 @@ enum ProviderChoice: String, AppEnum {
         case .deepseek: return nil // DeepSeek not yet supported in widgets
         case .codebuff: return nil // Codebuff not yet supported in widgets
         case .crof: return nil // Crof not yet supported in widgets
+        case .venice: return nil // Venice not yet supported in widgets
         }
     }
 }

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -288,6 +288,7 @@ private struct ProviderSwitchChip: View {
         case .deepseek: "DeepSeek"
         case .codebuff: "Codebuff"
         case .crof: "Crof"
+        case .venice: "Venice"
         }
     }
 }
@@ -659,6 +660,8 @@ enum WidgetColors {
             Color(red: 68 / 255, green: 255 / 255, blue: 0 / 255) // Codebuff lime
         case .crof:
             Color(red: 46 / 255, green: 171 / 255, blue: 148 / 255)
+        case .venice:
+            Color(red: 51 / 255, green: 153 / 255, blue: 1.0)
         }
     }
 }

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -969,6 +969,7 @@ struct SettingsStoreTests {
             .deepseek,
             .codebuff,
             .crof,
+            .venice,
         ])
 
         // Move one provider; ensure it's persisted across instances.

--- a/Tests/CodexBarTests/VeniceSettingsReaderTests.swift
+++ b/Tests/CodexBarTests/VeniceSettingsReaderTests.swift
@@ -1,0 +1,73 @@
+import CodexBarCore
+import Testing
+
+struct VeniceSettingsReaderTests {
+    @Test
+    func `reads VENICE_API_KEY`() {
+        let env = ["VENICE_API_KEY": "ven-abc123"]
+        #expect(VeniceSettingsReader.apiKey(environment: env) == "ven-abc123")
+    }
+
+    @Test
+    func `falls back to VENICE_KEY`() {
+        let env = ["VENICE_KEY": "ven-fallback"]
+        #expect(VeniceSettingsReader.apiKey(environment: env) == "ven-fallback")
+    }
+
+    @Test
+    func `VENICE_API_KEY takes priority over VENICE_KEY`() {
+        let env = ["VENICE_API_KEY": "ven-primary", "VENICE_KEY": "ven-secondary"]
+        #expect(VeniceSettingsReader.apiKey(environment: env) == "ven-primary")
+    }
+
+    @Test
+    func `trims whitespace`() {
+        let env = ["VENICE_API_KEY": "  ven-trimmed  "]
+        #expect(VeniceSettingsReader.apiKey(environment: env) == "ven-trimmed")
+    }
+
+    @Test
+    func `strips double quotes`() {
+        let env = ["VENICE_API_KEY": "\"ven-quoted\""]
+        #expect(VeniceSettingsReader.apiKey(environment: env) == "ven-quoted")
+    }
+
+    @Test
+    func `strips single quotes`() {
+        let env = ["VENICE_KEY": "'ven-single'"]
+        #expect(VeniceSettingsReader.apiKey(environment: env) == "ven-single")
+    }
+
+    @Test
+    func `returns nil when no key present`() {
+        #expect(VeniceSettingsReader.apiKey(environment: [:]) == nil)
+    }
+
+    @Test
+    func `returns nil for empty key`() {
+        let env = ["VENICE_API_KEY": ""]
+        #expect(VeniceSettingsReader.apiKey(environment: env) == nil)
+    }
+
+    @Test
+    func `returns nil for whitespace-only key`() {
+        let env = ["VENICE_API_KEY": "   "]
+        #expect(VeniceSettingsReader.apiKey(environment: env) == nil)
+    }
+}
+
+struct VeniceProviderTokenResolverTests {
+    @Test
+    func `resolves from environment`() {
+        let env = ["VENICE_API_KEY": "ven-resolve-test"]
+        let resolution = ProviderTokenResolver.veniceResolution(environment: env)
+        #expect(resolution?.token == "ven-resolve-test")
+        #expect(resolution?.source == .environment)
+    }
+
+    @Test
+    func `returns nil when key absent`() {
+        let resolution = ProviderTokenResolver.veniceResolution(environment: [:])
+        #expect(resolution == nil)
+    }
+}

--- a/Tests/CodexBarTests/VeniceUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/VeniceUsageFetcherTests.swift
@@ -46,6 +46,25 @@ struct VeniceUsageFetcherTests {
     }
 
     @Test
+    func `parses string-encoded balances and allocation`() throws {
+        let json = """
+        {
+          "canConsume": true,
+          "consumptionCurrency": "DIEM",
+          "balances": {
+            "diem": "90.50",
+            "usd": "25.75"
+          },
+          "diemEpochAllocation": "100.0"
+        }
+        """
+        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        #expect(snapshot.diemBalance == 90.50)
+        #expect(snapshot.usdBalance == 25.75)
+        #expect(snapshot.diemEpochAllocation == 100.0)
+    }
+
+    @Test
     func `parses both DIEM and USD present`() throws {
         let json = """
         {

--- a/Tests/CodexBarTests/VeniceUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/VeniceUsageFetcherTests.swift
@@ -83,6 +83,25 @@ struct VeniceUsageFetcherTests {
     }
 
     @Test
+    func `uses DIEM allocation progress for bundled credits currency`() throws {
+        let json = """
+        {
+          "canConsume": true,
+          "consumptionCurrency": "BUNDLED_CREDITS",
+          "balances": {
+            "diem": 50.0,
+            "usd": 10.0
+          },
+          "diemEpochAllocation": 100.0
+        }
+        """
+        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.resetDescription?.contains("DIEM 50.00 / 100.00") == true)
+        #expect(usage.primary?.usedPercent == 50.0)
+    }
+
+    @Test
     func `uses USD display when consumptionCurrency is USD and both balances exist`() throws {
         let json = """
         {

--- a/Tests/CodexBarTests/VeniceUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/VeniceUsageFetcherTests.swift
@@ -1,0 +1,240 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct VeniceUsageFetcherTests {
+    @Test
+    func `parses DIEM balance response`() throws {
+        let json = """
+        {
+          "canConsume": true,
+          "consumptionCurrency": "DIEM",
+          "balances": {
+            "diem": 90.50,
+            "usd": null
+          },
+          "diemEpochAllocation": 100.0
+        }
+        """
+        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        #expect(snapshot.canConsume == true)
+        #expect(snapshot.consumptionCurrency == "DIEM")
+        #expect(snapshot.diemBalance == 90.50)
+        #expect(snapshot.usdBalance == nil)
+        #expect(snapshot.diemEpochAllocation == 100.0)
+    }
+
+    @Test
+    func `parses USD balance response`() throws {
+        let json = """
+        {
+          "canConsume": true,
+          "consumptionCurrency": "USD",
+          "balances": {
+            "diem": null,
+            "usd": 25.75
+          },
+          "diemEpochAllocation": null
+        }
+        """
+        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        #expect(snapshot.canConsume == true)
+        #expect(snapshot.consumptionCurrency == "USD")
+        #expect(snapshot.diemBalance == nil)
+        #expect(snapshot.usdBalance == 25.75)
+        #expect(snapshot.diemEpochAllocation == nil)
+    }
+
+    @Test
+    func `parses both DIEM and USD present`() throws {
+        let json = """
+        {
+          "canConsume": true,
+          "consumptionCurrency": "BUNDLED_CREDITS",
+          "balances": {
+            "diem": 50.0,
+            "usd": 10.0
+          },
+          "diemEpochAllocation": 100.0
+        }
+        """
+        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        #expect(snapshot.diemBalance == 50.0)
+        #expect(snapshot.usdBalance == 10.0)
+    }
+
+    @Test
+    func `handles canConsume=false`() throws {
+        let json = """
+        {
+          "canConsume": false,
+          "consumptionCurrency": "USD",
+          "balances": {
+            "diem": null,
+            "usd": 100.0
+          },
+          "diemEpochAllocation": null
+        }
+        """
+        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.usedPercent == 100)
+        #expect(usage.primary?.resetDescription == "Balance unavailable for API calls")
+    }
+
+    @Test
+    func `displays DIEM with epoch allocation`() throws {
+        let json = """
+        {
+          "canConsume": true,
+          "consumptionCurrency": "DIEM",
+          "balances": {
+            "diem": 75.0,
+            "usd": null
+          },
+          "diemEpochAllocation": 100.0
+        }
+        """
+        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.resetDescription?.contains("DIEM 75.00 / 100.00") == true)
+        #expect(usage.primary?.usedPercent == 25.0)
+    }
+
+    @Test
+    func `displays DIEM without allocation`() throws {
+        let json = """
+        {
+          "canConsume": true,
+          "consumptionCurrency": "DIEM",
+          "balances": {
+            "diem": 50.0,
+            "usd": null
+          },
+          "diemEpochAllocation": null
+        }
+        """
+        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.resetDescription?.contains("DIEM 50.00 remaining") == true)
+        #expect(usage.primary?.usedPercent == 0)
+    }
+
+    @Test
+    func `displays USD balance`() throws {
+        let json = """
+        {
+          "canConsume": true,
+          "consumptionCurrency": "USD",
+          "balances": {
+            "diem": null,
+            "usd": 15.50
+          },
+          "diemEpochAllocation": null
+        }
+        """
+        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.resetDescription?.contains("$15.50") == true)
+        #expect(usage.primary?.usedPercent == 0)
+    }
+
+    @Test
+    func `handles zero balances`() throws {
+        let json = """
+        {
+          "canConsume": true,
+          "consumptionCurrency": "USD",
+          "balances": {
+            "diem": 0.0,
+            "usd": 0.0
+          },
+          "diemEpochAllocation": null
+        }
+        """
+        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.resetDescription == "No Venice API balance available")
+        #expect(usage.primary?.usedPercent == 100)
+    }
+
+    @Test
+    func `handles null balances with canConsume=true`() throws {
+        let json = """
+        {
+          "canConsume": true,
+          "consumptionCurrency": null,
+          "balances": {
+            "diem": null,
+            "usd": null
+          },
+          "diemEpochAllocation": null
+        }
+        """
+        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.resetDescription == "No Venice API balance available")
+        #expect(usage.primary?.usedPercent == 100)
+    }
+
+    @Test
+    func `identity uses venice provider ID`() throws {
+        let json = """
+        {
+          "canConsume": true,
+          "consumptionCurrency": "DIEM",
+          "balances": {
+            "diem": 90.0,
+            "usd": null
+          },
+          "diemEpochAllocation": 100.0
+        }
+        """
+        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.identity?.providerID == .venice)
+        #expect(usage.identity?.accountEmail == nil)
+        #expect(usage.identity?.accountOrganization == nil)
+    }
+
+    @Test
+    func `throws on malformed JSON`() {
+        let json = "[{ \"canConsume\": true }]"
+        #expect {
+            _ = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        } throws: { error in
+            guard case VeniceUsageError.parseFailed = error else { return false }
+            return true
+        }
+    }
+
+    @Test
+    func `throws on invalid JSON`() {
+        let json = "{ invalid json }"
+        #expect {
+            _ = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        } throws: { error in
+            guard case VeniceUsageError.parseFailed = error else { return false }
+            return true
+        }
+    }
+
+    @Test
+    func `clamps used percent to 0-100 range`() throws {
+        // Negative used percent should be clamped to 0
+        let json = """
+        {
+          "canConsume": true,
+          "consumptionCurrency": "DIEM",
+          "balances": {
+            "diem": 150.0,
+            "usd": null
+          },
+          "diemEpochAllocation": 100.0
+        }
+        """
+        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.usedPercent == 0)
+    }
+}

--- a/Tests/CodexBarTests/VeniceUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/VeniceUsageFetcherTests.swift
@@ -64,6 +64,25 @@ struct VeniceUsageFetcherTests {
     }
 
     @Test
+    func `uses USD display when consumptionCurrency is USD and both balances exist`() throws {
+        let json = """
+        {
+          "canConsume": true,
+          "consumptionCurrency": "USD",
+          "balances": {
+            "diem": 50.0,
+            "usd": 12.34
+          },
+          "diemEpochAllocation": 100.0
+        }
+        """
+        let snapshot = try VeniceUsageFetcher._parseSnapshotForTesting(Data(json.utf8))
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.resetDescription == "$12.34 USD remaining")
+        #expect(usage.primary?.usedPercent == 0)
+    }
+
+    @Test
     func `handles canConsume=false`() throws {
         let json = """
         {

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -233,6 +233,12 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Status: `https://status.deepseek.com` (link only, no auto-polling).
 - Details: `docs/deepseek.md`.
 
+## Venice
+- API key via `VENICE_API_KEY` / `VENICE_KEY` env var or Venice token accounts.
+- Shows current DIEM or USD balance; DIEM epoch allocation progress when available.
+- Status: none yet.
+- Details: `docs/venice.md`.
+
 ## Codebuff
 - API token from `~/.codexbar/config.json`, `CODEBUFF_API_KEY`, or `~/.config/manicode/credentials.json` created by `codebuff login`.
 - Reads usage and subscription data from Codebuff APIs.

--- a/docs/venice.md
+++ b/docs/venice.md
@@ -1,0 +1,40 @@
+# Venice
+
+[Venice](https://venice.ai) is an AI inference platform that provides API access to various language models.
+
+## Setup
+
+1. Sign up or log in at https://venice.ai
+2. Navigate to your API settings at https://venice.ai/settings/api
+3. Create or retrieve your API key
+4. In CodexBar, add your Venice API key via:
+   - Preferences > Providers > Venice, OR
+   - Set the environment variable `VENICE_API_KEY` or `VENICE_KEY`
+
+## Balance Query
+
+CodexBar fetches your current Venice API balance using the `/api/v1/billing/balance` endpoint.
+
+### Balance Types
+
+- **DIEM**: Venice's native credits (if epoch allocation is configured)
+- **USD**: Dollar balance if available
+- **Consumption Currency**: Indicates which currency is active for current billing
+
+### Display
+
+CodexBar shows:
+- Current remaining balance (DIEM or USD)
+- Epoch allocation progress (if applicable)
+- "Balance unavailable" if consumption is temporarily disabled
+
+## Troubleshooting
+
+**No balance showing?**
+- Verify your API key is correct
+- Check network connectivity
+- Ensure your Venice account has an active balance
+
+**API rate limiting?**
+- CodexBar caches balance data and updates every 30 seconds
+- If you hit rate limits, wait a moment before refreshing


### PR DESCRIPTION
# Add Venice API balance provider

## Summary

This PR adds Venice as a first-class CodexBar provider, enabling users to monitor their Venice API balance (DIEM or USD) directly from the menu bar.

**Scope:** Stable balance endpoint only (`GET /api/v1/billing/balance`). No beta history or usage-analytics endpoints in this PR.

## Changes

### Core provider setup
- Added `.venice` case to `UsageProvider` and `IconStyle` enums
- Created `VeniceProviderDescriptor` with macro registration and fetch strategy
- Created `VeniceSettingsReader` for env key resolution (`VENICE_API_KEY` / `VENICE_KEY`)

### API integration
- Implemented `VeniceUsageFetcher` for `/api/v1/billing/balance` endpoint with bearer auth (15s timeout)
- Decoded response: `canConsume`, `consumptionCurrency`, `balances.diem`, `balances.usd`, `diemEpochAllocation`
- Honest balance display: no fake quota percentages unless DIEM epoch allocation is present
- Balance display copy: `"DIEM 90.50 / 100.00 epoch allocation"` or `"$25.00 USD remaining"` or `"Balance unavailable"`

### Token & settings integration
- Added `veniceToken()` and `veniceResolution()` to `ProviderTokenResolver`
- Added Venice to `TokenAccountSupportCatalog+Data` with environment injection
- Added `veniceUsage` log category
- Updated `ProviderConfigEnvironment` for API key injection

### App-side implementation
- Created `VeniceProviderImplementation` following DeepSeek pattern (available when key exists or token accounts exist)

### Testing
- `VeniceSettingsReaderTests`: 10 tests covering env key resolution, quoting, trimming, and precedence
- `VeniceUsageFetcherTests`: 19 tests covering DIEM/USD parsing, epoch allocation, `canConsume=false`, edge cases, and error handling

### Documentation
- Created `docs/venice.md` with setup instructions, balance types, and troubleshooting
- Updated `README.md` to include Venice in provider list
- Updated `docs/providers.md` with Venice details and API endpoint info

## Implementation notes

- Provider identity is siloed to Venice (no sharing with OpenRouter/Codex/others)
- Balance display uses `RateWindow` with honest remaining amounts (prefers DIEM with allocation percentage when available; USD or DIEM remaining otherwise)
- No real API keys, account data, screenshots, or local paths included
- Follows CodexBar `AGENTS.md` contribution guidelines and existing provider patterns (DeepSeek/OpenRouter)

## Testing

Run locally (on macOS):
```bash
swift test --filter Venice
swift test --filter ProviderRegistry
swift test
pnpm check
swiftformat Sources Tests
swiftlint --strict
```

## Dashboard & Setup

- Venice API settings: https://venice.ai/settings/api
- Env keys: `VENICE_API_KEY` (primary), `VENICE_KEY` (fallback)
- Endpoint: `https://api.venice.ai/api/v1/billing/balance` (stable, v1)
