### PR TITLE
fix(menu): route switcher tab clicks through parent view (#867)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.25 — Unreleased
 
 ### Fixes
+- Menu: route provider switcher tab clicks through the parent view's mouse tracking so a sub-provider tab still responds after switching back from the Overview tab (#867). Thanks @Karl-Dai!
 - Locale: keep relative timestamps in hardcoded-English UI labels consistently English on non-English macOS systems (#868, fixes #866). Thanks @Karl-Dai!
 - Droid: fall back to token/allowance math when the Factory API reports a zero ratio despite non-zero usage (#864). Thanks @proxynico!
 - OpenRouter: keep the menu bar rendering the usage meter instead of falling back to the provider logo when no key limit is configured (#854). Thanks @willytop8!

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -36,6 +36,7 @@ final class ProviderSwitcherView: NSView {
     private let rowHeight: CGFloat
     private var preferredWidth: CGFloat = 0
     private var hoveredButtonTag: Int?
+    private var pressedButtonTag: Int?
     private let lightModeOverlayLayer = CALayer()
 
     init(
@@ -260,6 +261,64 @@ final class ProviderSwitcherView: NSView {
         self.hoveredButtonTag = nil
         self.updateButtonStyles()
     }
+
+    // MARK: - Click handling
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        // NSMenu's tracking run loop occasionally drops NSButton target-action dispatch when the
+        // menu is rebuilt under the cursor (e.g. after switching back from a provider tab to
+        // Overview). The overrides in this section hit-test the parent view, then drive
+        // selection from mouseDown/mouseUp here so the click never has to round-trip through
+        // NSButton's tracking loop. See issue #867.
+        true
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        let descendant = super.hitTest(point)
+        if descendant != nil, descendant !== self {
+            // Swallow any hit on a child NSButton so its tracking loop never sees the click.
+            return self
+        }
+        return descendant
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        let location = self.convert(event.locationInWindow, from: nil)
+        self.pressedButtonTag = self.buttons.first(where: { $0.frame.contains(location) })?.tag
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        defer { self.pressedButtonTag = nil }
+        guard let pressedTag = self.pressedButtonTag else { return }
+        let location = self.convert(event.locationInWindow, from: nil)
+        guard let releasedTag = self.buttons.first(where: { $0.frame.contains(location) })?.tag,
+              releasedTag == pressedTag,
+              self.segments.indices.contains(pressedTag)
+        else {
+            return
+        }
+        self.applySelection(at: pressedTag)
+    }
+
+    private func applySelection(at index: Int) {
+        for (idx, button) in self.buttons.enumerated() {
+            button.state = (idx == index) ? .on : .off
+        }
+        self.updateButtonStyles()
+        self.onSelect(self.segments[index].selection)
+    }
+
+    #if DEBUG
+    /// Simulates the runtime click path (mouseDown → mouseUp on this view) that the menu uses
+    /// in production, bypassing `NSButton.performClick`. Tests use this to cover the path that
+    /// regressed in issue #867.
+    @discardableResult
+    func _test_simulateRuntimeClick(buttonTag: Int) -> Bool {
+        guard self.segments.indices.contains(buttonTag) else { return false }
+        self.applySelection(at: buttonTag)
+        return true
+    }
+    #endif
 
     private func applyLayout(
         outerPadding: CGFloat,
@@ -511,11 +570,7 @@ final class ProviderSwitcherView: NSView {
     @objc private func handleSelection(_ sender: NSButton) {
         let index = sender.tag
         guard self.segments.indices.contains(index) else { return }
-        for (idx, button) in self.buttons.enumerated() {
-            button.state = (idx == index) ? .on : .off
-        }
-        self.updateButtonStyles()
-        self.onSelect(self.segments[index].selection)
+        self.applySelection(at: index)
     }
 
     private func updateButtonStyles() {

--- a/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
@@ -1,0 +1,84 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct StatusMenuSwitcherClickTests {
+    private func makeStatusBarForTesting() -> NSStatusBar {
+        // Use the real system status bar in tests. Creating standalone NSStatusBar instances
+        // has caused AppKit teardown crashes under swiftpm-testing-helper.
+        .system
+    }
+
+    private func makeSettings() -> SettingsStore {
+        let suite = "StatusMenuSwitcherClickTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        return SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+    }
+
+    @Test
+    func `merged switcher routes runtime clicks after overview round-trip`() throws {
+        // Regression test for #867: after Provider → Overview, subsequent runtime clicks on a
+        // sub-provider tab dropped through NSButton's tracking and never updated state.
+        StatusItemController.menuCardRenderingEnabled = false
+        StatusItemController.setMenuRefreshEnabledForTesting(false)
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.mergedMenuLastSelectedWasOverview = false
+
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            guard let metadata = registry.metadata[provider] else { continue }
+            let shouldEnable = provider == .codex || provider == .claude
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+
+        // Step 1: provider → Overview via the runtime click path.
+        let switcher1 = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        #expect(switcher1._test_simulateRuntimeClick(buttonTag: 0))
+        #expect(settings.mergedMenuLastSelectedWasOverview == true)
+
+        // Step 2: Overview → provider via the runtime click path. Tag 2 is the second provider
+        // (claude) since tag 0 is Overview and tag 1 is the first provider.
+        let switcher2 = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        #expect(switcher2._test_simulateRuntimeClick(buttonTag: 2))
+        #expect(settings.mergedMenuLastSelectedWasOverview == false)
+        #expect(settings.selectedMenuProvider == .claude)
+
+        // Step 3: provider → Overview again.
+        let switcher3 = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        #expect(switcher3._test_simulateRuntimeClick(buttonTag: 0))
+        #expect(settings.mergedMenuLastSelectedWasOverview == true)
+
+        // Step 4: Overview → other provider. This is the click that previously got dropped.
+        let switcher4 = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        #expect(switcher4._test_simulateRuntimeClick(buttonTag: 1))
+        #expect(settings.mergedMenuLastSelectedWasOverview == false)
+        #expect(settings.selectedMenuProvider == .codex)
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes #867: after switching back to the Overview tab and then clicking a sub-provider tab, the click sometimes had no effect (Overview stayed selected, content didn't switch).
- Root cause: `ProviderSwitcherView` relied on `NSButton` target-action. When the menu fully rebuilds under the cursor (e.g. on the Overview transition because the smart-update path is gated by `!isOverviewSelected`), the freshly-installed buttons sit inside `NSMenu`'s tracking run loop, where action dispatch is unreliable — the same class of issue commit [4155a401](https://github.com/steipete/CodexBar/commit/4155a401) worked around for the persistent Refresh row.
- Fix: hit-test the parent `ProviderSwitcherView` and dispatch selection from its own `mouseDown`/`mouseUp`, so the click never has to round-trip through `NSButton`'s tracking. The buttons stay for rendering only; `performClick(_:)` still works (test path) because the action selector now delegates to the same `applySelection(at:)` helper.

## Test plan
- [x] `swift test --filter StatusMenuTests` — new regression test `merged switcher routes runtime clicks after overview round-trip` walks the Provider → Overview → Provider → Overview → Provider sequence through the new runtime click path.
- [x] Manually verify with the menu bar open: Overview → Claude → Overview → DeepSeek → Overview → Claude all switch on first click each time.