### PR TITLE
Generalize pace display for quota windows

### DIFF
--- a/Sources/CodexBar/UsageStore+HistoricalPace.swift
+++ b/Sources/CodexBar/UsageStore+HistoricalPace.swift
@@ -3,22 +3,15 @@ import Foundation
 
 @MainActor
 extension UsageStore {
-    func supportsWeeklyPace(for provider: UsageProvider) -> Bool {
-        switch provider {
-        case .codex, .claude, .opencode, .abacus:
-            true
-        default:
-            false
-        }
-    }
-
     private static let minimumPaceExpectedPercent: Double = 3
     private static let backfillMaxTimestampMismatch: TimeInterval = 5 * 60
 
     func weeklyPace(provider: UsageProvider, window: RateWindow, now: Date = .init()) -> UsagePace? {
-        guard self.supportsWeeklyPace(for: provider) else { return nil }
         guard window.remainingPercent > 0 else { return nil }
         let resolved: UsagePace?
+        // Codex can refine pace with historical samples because its dashboard exposes enough weekly history to build
+        // an account-scoped usage curve. Other providers should not need a hard-coded allowlist: if their RateWindow
+        // includes a reset time and window duration, the generic linear pace calculation is already defensible.
         if provider == .codex, self.settings.historicalTrackingEnabled {
             let codexAccountKey = self.codexOwnershipContext().canonicalKey
             if self.codexHistoricalDatasetAccountKey == codexAccountKey,
@@ -32,6 +25,10 @@ extension UsageStore {
                 resolved = UsagePace.weekly(window: window, now: now, defaultWindowMinutes: 10080)
             }
         } else {
+            // Generic providers must carry an explicit window duration. Using the 10080-minute fallback for
+            // windows without windowMinutes would fabricate a weekly pace for non-weekly windows
+            // (e.g. Factory monthly with only resetsAt).
+            guard window.windowMinutes != nil else { return nil }
             resolved = UsagePace.weekly(window: window, now: now, defaultWindowMinutes: 10080)
         }
 

--- a/Tests/CodexBarTests/HistoricalUsagePaceBackfillAuthorityTests.swift
+++ b/Tests/CodexBarTests/HistoricalUsagePaceBackfillAuthorityTests.swift
@@ -343,4 +343,45 @@ extension HistoricalUsagePaceTests {
         #expect(computed != nil)
         #expect(abs((computed?.deltaPercent ?? 0) - (linear?.deltaPercent ?? 0)) < 0.001)
     }
+
+    @MainActor
+    @Test
+    func `usage store computes linear pace for providers with quota windows`() throws {
+        let suite = "HistoricalUsagePaceTests-generic-provider-\(UUID().uuidString)"
+        let store = try Self.makeUsageStoreForBackfillTests(
+            suite: suite,
+            historyFileURL: Self.makeTempURL())
+
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 40,
+            windowMinutes: 10080,
+            resetsAt: now.addingTimeInterval(4 * 24 * 60 * 60),
+            resetDescription: nil)
+
+        let pace = store.weeklyPace(provider: .zai, window: window, now: now)
+
+        #expect(pace != nil)
+        #expect(abs((pace?.deltaPercent ?? 0) - (40 - (3.0 / 7.0 * 100.0))) < 0.001)
+    }
+
+    @MainActor
+    @Test
+    func `usage store returns nil pace when generic window lacks explicit duration`() throws {
+        let suite = "HistoricalUsagePaceTests-no-window-minutes-\(UUID().uuidString)"
+        let store = try Self.makeUsageStoreForBackfillTests(
+            suite: suite,
+            historyFileURL: Self.makeTempURL())
+
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 40,
+            windowMinutes: nil,
+            resetsAt: now.addingTimeInterval(4 * 24 * 60 * 60),
+            resetDescription: nil)
+
+        let pace = store.weeklyPace(provider: .factory, window: window, now: now)
+
+        #expect(pace == nil)
+    }
 }

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -44,7 +44,8 @@ Pace compares your actual usage against the expected consumption rate for the cu
 
 When usage is in deficit, the right-hand label shows an estimated "Runs out in …" countdown. When usage will last until the reset, it shows "Lasts until reset".
 
-Pace is currently calculated for supported Codex, Claude, OpenCode, and Abacus windows and is hidden when less than 3% of the window has elapsed.
+Pace is calculated for any provider window with enough reset timing data and is hidden when less than 3% of the
+window has elapsed.
 
 ## Preferences notes
 - Advanced: “Disable Keychain access” turns off browser cookie import; paste Cookie headers manually in Providers.


### PR DESCRIPTION
## Summary
- remove the provider allowlist from pace calculation
- compute pace for any provider window with enough reset timing data
- add coverage for a non-allowlisted provider window
- update UI docs to describe data-driven pace support

This follows a data-driven pattern: instead of maintaining a provider allowlist, the feature is gated on whether the incoming window has sufficient reset timing data.

Fixes #807.

## Validation
- `swift build --target CodexBarCore`
- `git diff --check HEAD~1 HEAD`

Note: full `swift test` could not run on this machine because only Command Line Tools are active and the KeyboardShortcuts dependency fails to compile SwiftUI `#Preview` macros without full Xcode (`PreviewsMacros` not found).
