### PR TITLE
Restrict Codex OAuth CLI fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,15 @@ jobs:
             --skip CLIOpenAIDashboardCacheTests \
             --skip CodexAccountScopedRefreshDashboardCleanupTests \
             --skip CodexAccountScopedRefreshTests \
+            --skip CodexBaselineCharacterizationTests \
             --skip CodexDashboardWorkedExampleParityTests \
+            --skip CodexUsageFetcherFallbackTests \
             --skip CodexWebDashboardStrategyAuthorityTests \
             --skip OpenAIDashboardNavigationDelegateTests \
             --skip StatusMenuTokenAccountSwitcherTests \
             --skip SubprocessRunnerTests
           swift test --no-parallel \
-            --filter 'ClaudeOAuthCredentialsStoreSecurityCLITests|CLIOpenAIDashboardCacheTests|CodexAccountScopedRefreshDashboardCleanupTests|CodexAccountScopedRefreshTests|CodexDashboardWorkedExampleParityTests|CodexWebDashboardStrategyAuthorityTests|OpenAIDashboardNavigationDelegateTests|SubprocessRunnerTests'
+            --filter 'ClaudeOAuthCredentialsStoreSecurityCLITests|CLIOpenAIDashboardCacheTests|CodexAccountScopedRefreshDashboardCleanupTests|CodexAccountScopedRefreshTests|CodexBaselineCharacterizationTests|CodexDashboardWorkedExampleParityTests|CodexUsageFetcherFallbackTests|CodexWebDashboardStrategyAuthorityTests|OpenAIDashboardNavigationDelegateTests|SubprocessRunnerTests'
 
   build-linux-cli:
     timeout-minutes: 20

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexTokenRefresher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexTokenRefresher.swift
@@ -87,7 +87,7 @@ public enum CodexTokenRefresher {
     }
 
     private static func refreshFailureError(statusCode: Int, data: Data) -> RefreshError {
-        if let errorCode = Self.extractErrorCode(from: data) {
+        if let errorCode = extractErrorCode(from: data) {
             switch errorCode.lowercased() {
             case "refresh_token_expired":
                 return .expired

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexTokenRefresher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexTokenRefresher.swift
@@ -54,20 +54,8 @@ public enum CodexTokenRefresher {
                 throw RefreshError.invalidResponse("No HTTP response")
             }
 
-            if http.statusCode == 401 {
-                if let errorCode = Self.extractErrorCode(from: data) {
-                    switch errorCode.lowercased() {
-                    case "refresh_token_expired": throw RefreshError.expired
-                    case "refresh_token_reused": throw RefreshError.reused
-                    case "refresh_token_invalidated": throw RefreshError.revoked
-                    default: throw RefreshError.expired
-                    }
-                }
-                throw RefreshError.expired
-            }
-
             guard http.statusCode == 200 else {
-                throw RefreshError.invalidResponse("Status \(http.statusCode)")
+                throw Self.refreshFailureError(statusCode: http.statusCode, data: data)
             }
 
             guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
@@ -97,4 +85,33 @@ public enum CodexTokenRefresher {
         if let error = json["error"] as? String { return error }
         return json["code"] as? String
     }
+
+    private static func refreshFailureError(statusCode: Int, data: Data) -> RefreshError {
+        if let errorCode = Self.extractErrorCode(from: data) {
+            switch errorCode.lowercased() {
+            case "refresh_token_expired":
+                return .expired
+            case "refresh_token_reused":
+                return .reused
+            case "invalid_grant", "refresh_token_invalidated":
+                return .revoked
+            default:
+                break
+            }
+        }
+
+        if statusCode == 401 {
+            return .expired
+        }
+
+        return .invalidResponse("Status \(statusCode)")
+    }
 }
+
+#if DEBUG
+extension CodexTokenRefresher {
+    static func _refreshFailureErrorForTesting(statusCode: Int, data: Data) -> RefreshError {
+        self.refreshFailureError(statusCode: statusCode, data: data)
+    }
+}
+#endif

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -157,7 +157,33 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
         guard context.sourceMode == .auto else { return false }
-        return true
+
+        // Auto mode may launch the CLI as the next strategy. Keep that fallback
+        // limited to OAuth states the CLI can actually repair, otherwise
+        // transient API or decode failures can spawn `codex app-server`
+        // repeatedly instead of surfacing the original OAuth failure.
+        if let fetchError = error as? CodexOAuthFetchError {
+            switch fetchError {
+            case .unauthorized:
+                return true
+            case .invalidResponse, .serverError, .networkError:
+                return false
+            }
+        }
+        if let credentialsError = error as? CodexOAuthCredentialsError {
+            switch credentialsError {
+            case .notFound, .missingTokens:
+                return true
+            case .decodeFailed:
+                return false
+            }
+        }
+        switch error as? CodexTokenRefresher.RefreshError {
+        case .expired, .revoked, .reused:
+            return true
+        case .networkError, .invalidResponse, .none:
+            return false
+        }
     }
 
     private static func mapCredits(_ credits: CodexUsageResponse.CreditDetails?) -> CreditsSnapshot? {
@@ -177,13 +203,6 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
             credentials: credentials,
             updatedAt: updatedAt)
 
-        if sourceMode == .auto,
-           usageResponse.rateLimit?.hasWindowDecodeFailure == true,
-           reconciled?.session == nil
-        {
-            throw UsageError.noRateLimitsFound
-        }
-
         if let reconciled {
             return CodexOAuthFetchStrategy().makeResult(
                 usage: reconciled.toUsageSnapshot(),
@@ -195,10 +214,9 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
             throw UsageError.noRateLimitsFound
         }
 
-        if sourceMode == .auto {
-            throw UsageError.noRateLimitsFound
-        }
-
+        // Credits can still be useful when the OAuth API omits or partially
+        // fails to decode rate-limit windows. Returning the partial OAuth result
+        // prevents auto mode from escalating a usable response into CLI fallback.
         return CodexOAuthFetchStrategy().makeResult(
             usage: UsageSnapshot(
                 primary: nil,

--- a/Tests/CodexBarTests/CodexBaselineCharacterizationTests.swift
+++ b/Tests/CodexBarTests/CodexBaselineCharacterizationTests.swift
@@ -208,7 +208,7 @@ struct CodexBaselineCharacterizationTests {
     }
 
     @Test
-    func `app auto falls back from failing OAuth to successful CLI`() async throws {
+    func `app auto does not fall back from non auth failing OAuth`() async throws {
         let stubCLIPath = try self.makeStubCodexCLI()
         let oauthHome = try self.makeUnavailableOAuthHome()
         defer { try? FileManager.default.removeItem(at: oauthHome) }
@@ -220,16 +220,20 @@ struct CodexBaselineCharacterizationTests {
 
         let outcome = await self.fetchOutcome(runtime: .app, sourceMode: .auto, env: env)
 
-        #expect(outcome.attempts.map(\.strategyID) == ["codex.oauth", "codex.cli"])
-        #expect(outcome.attempts.map(\.wasAvailable) == [true, true])
+        #expect(outcome.attempts.map(\.strategyID) == ["codex.oauth"])
+        #expect(outcome.attempts.map(\.wasAvailable) == [true])
         #expect(outcome.attempts[0].errorDescription?.isEmpty == false)
-        #expect(outcome.attempts[1].errorDescription == nil)
 
         switch outcome.result {
-        case let .success(result):
-            #expect(result.sourceLabel == "codex-cli")
-            #expect(result.usage.primary?.windowMinutes == 300)
-            #expect(result.usage.secondary?.windowMinutes == 10080)
+        case .success:
+            Issue.record("Expected non-auth OAuth failure to stop before CLI fallback")
+        case let .failure(error as CodexOAuthFetchError):
+            switch error {
+            case .networkError:
+                break
+            default:
+                Issue.record("Expected network error, got \(error)")
+            }
         case let .failure(error):
             Issue.record("Unexpected failure: \(error)")
         }

--- a/Tests/CodexBarTests/CodexOAuthTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthTests.swift
@@ -3,6 +3,22 @@ import Testing
 @testable import CodexBarCore
 
 struct CodexOAuthTests {
+    private func makeContext(sourceMode: ProviderSourceMode = .auto) -> ProviderFetchContext {
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        return ProviderFetchContext(
+            runtime: .app,
+            sourceMode: sourceMode,
+            includeCredits: true,
+            webTimeout: 60,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: [:],
+            settings: nil,
+            fetcher: UsageFetcher(),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+            browserDetection: browserDetection)
+    }
+
     @Test
     func `parses O auth credentials`() throws {
         let json = """
@@ -339,7 +355,7 @@ struct CodexOAuthTests {
     }
 
     @Test
-    func `auto mode falls back when primary window is malformed but weekly window survives`() throws {
+    func `auto mode keeps weekly window when primary window is malformed`() throws {
         let json = """
         {
           "rate_limit": {
@@ -363,12 +379,14 @@ struct CodexOAuthTests {
             accountId: nil,
             lastRefresh: Date())
 
-        #expect(throws: UsageError.noRateLimitsFound) {
-            _ = try CodexOAuthFetchStrategy._mapResultForTesting(
-                Data(json.utf8),
-                credentials: creds,
-                sourceMode: .auto)
-        }
+        let result = try CodexOAuthFetchStrategy._mapResultForTesting(
+            Data(json.utf8),
+            credentials: creds,
+            sourceMode: .auto)
+
+        #expect(result.usage.primary == nil)
+        #expect(result.usage.secondary?.usedPercent == 43)
+        #expect(result.usage.secondary?.windowMinutes == 10080)
     }
 
     @Test
@@ -442,7 +460,7 @@ struct CodexOAuthTests {
     }
 
     @Test
-    func `auto mode falls back when reversed session window is malformed in secondary`() throws {
+    func `auto mode keeps weekly window when reversed session window is malformed`() throws {
         let json = """
         {
           "rate_limit": {
@@ -466,12 +484,14 @@ struct CodexOAuthTests {
             accountId: nil,
             lastRefresh: Date())
 
-        #expect(throws: UsageError.noRateLimitsFound) {
-            _ = try CodexOAuthFetchStrategy._mapResultForTesting(
-                Data(json.utf8),
-                credentials: creds,
-                sourceMode: .auto)
-        }
+        let result = try CodexOAuthFetchStrategy._mapResultForTesting(
+            Data(json.utf8),
+            credentials: creds,
+            sourceMode: .auto)
+
+        #expect(result.usage.primary == nil)
+        #expect(result.usage.secondary?.usedPercent == 43)
+        #expect(result.usage.secondary?.windowMinutes == 10080)
     }
 
     @Test
@@ -573,7 +593,7 @@ struct CodexOAuthTests {
     }
 
     @Test
-    func `credits only O auth payload falls back in auto mode`() throws {
+    func `credits only O auth payload returns credits in auto mode`() throws {
         let json = """
         {
           "rate_limit": {
@@ -594,12 +614,74 @@ struct CodexOAuthTests {
             accountId: nil,
             lastRefresh: Date())
 
-        #expect(throws: UsageError.noRateLimitsFound) {
-            _ = try CodexOAuthFetchStrategy._mapResultForTesting(
-                Data(json.utf8),
-                credentials: creds,
-                sourceMode: .auto)
+        let result = try CodexOAuthFetchStrategy._mapResultForTesting(
+            Data(json.utf8),
+            credentials: creds,
+            sourceMode: .auto)
+
+        #expect(result.usage.primary == nil)
+        #expect(result.usage.secondary == nil)
+        #expect(result.credits?.remaining == 14.5)
+        #expect(result.sourceLabel == "oauth")
+    }
+
+    @Test
+    func `auto mode only falls back from O auth on auth failures`() {
+        let strategy = CodexOAuthFetchStrategy()
+        let context = self.makeContext(sourceMode: .auto)
+
+        #expect(strategy.shouldFallback(on: CodexOAuthFetchError.unauthorized, context: context))
+        #expect(strategy.shouldFallback(on: CodexOAuthCredentialsError.notFound, context: context))
+        #expect(strategy.shouldFallback(on: CodexOAuthCredentialsError.missingTokens, context: context))
+        #expect(strategy.shouldFallback(on: CodexTokenRefresher.RefreshError.expired, context: context))
+        #expect(strategy.shouldFallback(on: CodexTokenRefresher.RefreshError.revoked, context: context))
+        #expect(strategy.shouldFallback(on: CodexTokenRefresher.RefreshError.reused, context: context))
+
+        #expect(!strategy.shouldFallback(on: UsageError.noRateLimitsFound, context: context))
+        #expect(!strategy.shouldFallback(on: CodexOAuthCredentialsError.decodeFailed("bad json"), context: context))
+        #expect(!strategy.shouldFallback(on: CodexOAuthFetchError.invalidResponse, context: context))
+        #expect(!strategy.shouldFallback(on: CodexOAuthFetchError.serverError(500, "offline"), context: context))
+        #expect(!strategy.shouldFallback(
+            on: CodexOAuthFetchError.networkError(URLError(.notConnectedToInternet)),
+            context: context))
+        #expect(!strategy.shouldFallback(
+            on: CodexTokenRefresher.RefreshError.networkError(URLError(.timedOut)),
+            context: context))
+    }
+
+    @Test
+    func `non 401 invalid grant refresh failure is treated as revoked`() {
+        let data = Data(#"{"error":"invalid_grant"}"#.utf8)
+        let error = CodexTokenRefresher._refreshFailureErrorForTesting(statusCode: 400, data: data)
+
+        switch error {
+        case .revoked:
+            break
+        default:
+            Issue.record("Expected invalid_grant to be treated as revoked")
         }
+    }
+
+    @Test
+    func `non auth refresh failure remains invalid response`() {
+        let data = Data(#"{"error":"invalid_request"}"#.utf8)
+        let error = CodexTokenRefresher._refreshFailureErrorForTesting(statusCode: 400, data: data)
+
+        switch error {
+        case let .invalidResponse(message):
+            #expect(message == "Status 400")
+        default:
+            Issue.record("Expected invalid_request to remain an invalid response")
+        }
+    }
+
+    @Test
+    func `explicit O auth mode never falls back to CLI`() {
+        let strategy = CodexOAuthFetchStrategy()
+        let context = self.makeContext(sourceMode: .oauth)
+
+        #expect(!strategy.shouldFallback(on: CodexOAuthFetchError.unauthorized, context: context))
+        #expect(!strategy.shouldFallback(on: CodexTokenRefresher.RefreshError.expired, context: context))
     }
 
     @Test

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -49,6 +49,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 | Codebuff | API token from config/env or `codebuff login` credentials → usage API (`api`). |
 
 ## Codex
+- App Auto: OAuth API first; falls back to CLI only when OAuth credentials are missing or auth/refresh is invalid.
 - Web dashboard (optional, off by default): `https://chatgpt.com/codex/settings/usage` via WebView + browser cookies.
 - Battery saver toggle (currently off by default): reduces routine OpenAI web refreshes but still allows explicit manual refreshes.
 - CLI RPC default: `codex ... app-server` JSON-RPC (`account/read`, `account/rateLimits/read`).


### PR DESCRIPTION
## Summary
- restrict Codex OAuth auto fallback to missing/invalid auth cases
- keep transient OAuth API, decode, and no-rate-limit errors from spawning the CLI fallback
- return partial OAuth data in auto mode when the API response has usable windows or credits
- document the safer Codex auto fallback rule

Fixes #874.

## Validation
- `swift build --target CodexBarCore`
- `git diff --check`

Note: `swift test --filter CodexOAuthTests` could not run in this environment because only Command Line Tools are active and the KeyboardShortcuts dependency fails to compile SwiftUI `#Preview` macros without full Xcode (`PreviewsMacros` not found).
