### PR TITLE
Fix models.dev pricing refresh continuity

### DIFF
--- a/Sources/CodexBarCore/Vendored/CostUsage/ModelsDevPricing.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/ModelsDevPricing.swift
@@ -161,7 +161,9 @@ struct ModelsDevProvider: Codable, Equatable, Sendable {
     }
 
     func containsModel(matching cachedModel: ModelsDevModel) -> Bool {
-        self.models.values.contains { $0.isPriceable && $0.normalizedID == cachedModel.normalizedID }
+        self.models.values.contains {
+            $0.isPriceable && ModelsDevModelIDNormalizer.idsMatch($0.id, cachedModel.id)
+        }
     }
 }
 
@@ -301,6 +303,11 @@ enum ModelsDevModelIDNormalizer {
         }
 
         return candidates
+    }
+
+    static func idsMatch(_ lhs: String, _ rhs: String) -> Bool {
+        let lhsCandidates = Set(self.candidates(lhs))
+        return self.candidates(rhs).contains { lhsCandidates.contains($0) }
     }
 }
 

--- a/Sources/CodexBarCore/Vendored/CostUsage/ModelsDevPricing.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/ModelsDevPricing.swift
@@ -75,7 +75,7 @@ struct ModelsDevCatalog: Codable, Equatable, Sendable {
     func containsProviderModels(from cachedCatalog: ModelsDevCatalog) -> Bool {
         cachedCatalog.providers.allSatisfy { providerID, cachedProvider in
             guard let provider = self.providers[ModelsDevProvider.normalizeProviderID(providerID)] else { return false }
-            return cachedProvider.models.keys.allSatisfy { provider.models.keys.contains($0) }
+            return cachedProvider.models.values.allSatisfy { provider.containsModel(matching: $0) }
         }
     }
 }
@@ -159,6 +159,10 @@ struct ModelsDevProvider: Codable, Equatable, Sendable {
 
         return nil
     }
+
+    func containsModel(matching cachedModel: ModelsDevModel) -> Bool {
+        self.models.values.contains { $0.isPriceable && $0.normalizedID == cachedModel.normalizedID }
+    }
 }
 
 struct ModelsDevModel: Codable, Equatable, Sendable {
@@ -169,6 +173,10 @@ struct ModelsDevModel: Codable, Equatable, Sendable {
 
     var normalizedID: String {
         ModelsDevModelIDNormalizer.normalize(self.id)
+    }
+
+    var isPriceable: Bool {
+        self.cost?.input != nil && self.cost?.output != nil
     }
 
     func pricing(providerID: String, providerName: String?) -> ModelsDevPricingInfo? {

--- a/Sources/CodexBarCore/Vendored/CostUsage/ModelsDevPricing.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/ModelsDevPricing.swift
@@ -75,7 +75,9 @@ struct ModelsDevCatalog: Codable, Equatable, Sendable {
     func containsProviderModels(from cachedCatalog: ModelsDevCatalog) -> Bool {
         cachedCatalog.providers.allSatisfy { providerID, cachedProvider in
             guard let provider = self.providers[ModelsDevProvider.normalizeProviderID(providerID)] else { return false }
-            return cachedProvider.models.values.allSatisfy { provider.containsModel(matching: $0) }
+            return cachedProvider.models.values
+                .filter(\.isPriceable)
+                .allSatisfy { provider.containsModel(matching: $0) }
         }
     }
 }

--- a/Tests/CodexBarTests/ModelsDevPricingTests.swift
+++ b/Tests/CodexBarTests/ModelsDevPricingTests.swift
@@ -322,6 +322,70 @@ struct ModelsDevPricingTests {
     }
 
     @Test
+    func `refresh updates cache when fetched catalog canonicalizes alias model id`() async throws {
+        let root = try Self.cacheRoot()
+        let old = Date(timeIntervalSince1970: 1)
+        try ModelsDevCache.save(catalog: Self.fixtureCatalog(), fetchedAt: old, cacheRoot: root)
+
+        let canonicalizedCatalog = Data("""
+        {
+          "openai": {
+            "id": "openai",
+            "models": {
+              "gpt-4o-mini": {
+                "id": "gpt-4o-mini",
+                "cost": { "input": 99, "output": 99 }
+              },
+              "shared-model": {
+                "id": "shared-model",
+                "cost": { "input": 99, "output": 99 }
+              }
+            }
+          },
+          "anthropic": {
+            "id": "anthropic",
+            "models": {
+              "claude-sonnet-4-6": {
+                "id": "claude-sonnet-4-6",
+                "cost": { "input": 99, "output": 99 }
+              },
+              "shared-model": {
+                "id": "shared-model",
+                "cost": { "input": 99, "output": 99 }
+              }
+            }
+          },
+          "google-vertex-anthropic": {
+            "id": "google-vertex-anthropic",
+            "models": {
+              "claude-sonnet-4-6": {
+                "id": "claude-sonnet-4-6",
+                "cost": { "input": 99, "output": 99 }
+              }
+            }
+          }
+        }
+        """.utf8)
+        await ModelsDevPricingPipeline.refreshIfNeeded(
+            now: Date(timeIntervalSince1970: 1 + ModelsDevCache.ttlSeconds + 1),
+            cacheRoot: root,
+            client: ModelsDevClient(transport: MockTransport(
+                result: .success((canonicalizedCatalog, Self.response(status: 200))))))
+
+        let defaultLookup = try #require(ModelsDevPricingPipeline.lookup(
+            providerID: "google-vertex-anthropic",
+            modelID: "claude-sonnet-4-6@default",
+            cacheRoot: root))
+        let baseLookup = try #require(ModelsDevPricingPipeline.lookup(
+            providerID: "google-vertex-anthropic",
+            modelID: "claude-sonnet-4-6",
+            cacheRoot: root))
+
+        #expect(defaultLookup.pricing.inputCostPerToken == 99 / 1_000_000.0)
+        #expect(baseLookup.pricing.inputCostPerToken == 99 / 1_000_000.0)
+    }
+
+    @Test
     func `fresh cache does not refresh`() async throws {
         let root = try Self.cacheRoot()
         try ModelsDevCache.save(catalog: Self.fixtureCatalog(), fetchedAt: Date(), cacheRoot: root)

--- a/Tests/CodexBarTests/ModelsDevPricingTests.swift
+++ b/Tests/CodexBarTests/ModelsDevPricingTests.swift
@@ -386,6 +386,55 @@ struct ModelsDevPricingTests {
     }
 
     @Test
+    func `refresh ignores unpriceable models in old cache continuity check`() async throws {
+        let root = try Self.cacheRoot()
+        let old = Date(timeIntervalSince1970: 1)
+        let cachedCatalog = try Self.catalog("""
+        {
+          "openai": {
+            "id": "openai",
+            "models": {
+              "gpt-4o-mini": {
+                "id": "gpt-4o-mini",
+                "cost": { "input": 0.15, "output": 0.6 }
+              },
+              "unpriced-preview": {
+                "id": "unpriced-preview"
+              }
+            }
+          }
+        }
+        """)
+        ModelsDevCache.save(catalog: cachedCatalog, fetchedAt: old, cacheRoot: root)
+
+        let fetchedCatalog = Data("""
+        {
+          "openai": {
+            "id": "openai",
+            "models": {
+              "gpt-4o-mini": {
+                "id": "gpt-4o-mini",
+                "cost": { "input": 99, "output": 99 }
+              }
+            }
+          }
+        }
+        """.utf8)
+        await ModelsDevPricingPipeline.refreshIfNeeded(
+            now: Date(timeIntervalSince1970: 1 + ModelsDevCache.ttlSeconds + 1),
+            cacheRoot: root,
+            client: ModelsDevClient(transport: MockTransport(
+                result: .success((fetchedCatalog, Self.response(status: 200))))))
+
+        let lookup = try #require(ModelsDevPricingPipeline.lookup(
+            providerID: "openai",
+            modelID: "gpt-4o-mini",
+            cacheRoot: root))
+
+        #expect(lookup.pricing.inputCostPerToken == 99 / 1_000_000.0)
+    }
+
+    @Test
     func `fresh cache does not refresh`() async throws {
         let root = try Self.cacheRoot()
         try ModelsDevCache.save(catalog: Self.fixtureCatalog(), fetchedAt: Date(), cacheRoot: root)
@@ -448,6 +497,10 @@ struct ModelsDevPricingTests {
 
     private static func fixtureCatalog() throws -> ModelsDevCatalog {
         try JSONDecoder().decode(ModelsDevCatalog.self, from: self.fixtureData())
+    }
+
+    private static func catalog(_ json: String) throws -> ModelsDevCatalog {
+        try JSONDecoder().decode(ModelsDevCatalog.self, from: Data(json.utf8))
     }
 
     private static func cacheRoot() throws -> URL {

--- a/Tests/CodexBarTests/ModelsDevPricingTests.swift
+++ b/Tests/CodexBarTests/ModelsDevPricingTests.swift
@@ -203,6 +203,125 @@ struct ModelsDevPricingTests {
     }
 
     @Test
+    func `refresh updates cache when fetched catalog renames model key but keeps id`() async throws {
+        let root = try Self.cacheRoot()
+        let old = Date(timeIntervalSince1970: 1)
+        try ModelsDevCache.save(catalog: Self.fixtureCatalog(), fetchedAt: old, cacheRoot: root)
+
+        let renamedCatalog = Data("""
+        {
+          "openai": {
+            "id": "openai",
+            "models": {
+              "gpt-4o-mini-renamed": {
+                "id": "gpt-4o-mini",
+                "cost": { "input": 99, "output": 99 }
+              },
+              "shared-model": {
+                "id": "shared-model",
+                "cost": { "input": 99, "output": 99 }
+              }
+            }
+          },
+          "anthropic": {
+            "id": "anthropic",
+            "models": {
+              "claude-sonnet-4-6": {
+                "id": "claude-sonnet-4-6",
+                "cost": { "input": 99, "output": 99 }
+              },
+              "shared-model": {
+                "id": "shared-model",
+                "cost": { "input": 99, "output": 99 }
+              }
+            }
+          },
+          "google-vertex-anthropic": {
+            "id": "google-vertex-anthropic",
+            "models": {
+              "claude-sonnet-4-6-renamed": {
+                "id": "claude-sonnet-4-6@default",
+                "cost": { "input": 99, "output": 99 }
+              }
+            }
+          }
+        }
+        """.utf8)
+        await ModelsDevPricingPipeline.refreshIfNeeded(
+            now: Date(timeIntervalSince1970: 1 + ModelsDevCache.ttlSeconds + 1),
+            cacheRoot: root,
+            client: ModelsDevClient(transport: MockTransport(
+                result: .success((renamedCatalog, Self.response(status: 200))))))
+
+        let lookup = try #require(ModelsDevPricingPipeline.lookup(
+            providerID: "openai",
+            modelID: "gpt-4o-mini",
+            cacheRoot: root))
+
+        #expect(lookup.normalizedModelID == "gpt-4o-mini")
+        #expect(lookup.pricing.inputCostPerToken == 99 / 1_000_000.0)
+    }
+
+    @Test
+    func `refresh preserves cache when fetched matching model is not priceable`() async throws {
+        let root = try Self.cacheRoot()
+        let old = Date(timeIntervalSince1970: 1)
+        try ModelsDevCache.save(catalog: Self.fixtureCatalog(), fetchedAt: old, cacheRoot: root)
+
+        let partialCatalog = Data("""
+        {
+          "openai": {
+            "id": "openai",
+            "models": {
+              "gpt-4o-mini": {
+                "id": "gpt-4o-mini",
+                "cost": { "input": 99 }
+              },
+              "shared-model": {
+                "id": "shared-model",
+                "cost": { "input": 99, "output": 99 }
+              }
+            }
+          },
+          "anthropic": {
+            "id": "anthropic",
+            "models": {
+              "claude-sonnet-4-6": {
+                "id": "claude-sonnet-4-6",
+                "cost": { "input": 99, "output": 99 }
+              },
+              "shared-model": {
+                "id": "shared-model",
+                "cost": { "input": 99, "output": 99 }
+              }
+            }
+          },
+          "google-vertex-anthropic": {
+            "id": "google-vertex-anthropic",
+            "models": {
+              "claude-sonnet-4-6@default": {
+                "id": "claude-sonnet-4-6@default",
+                "cost": { "input": 99, "output": 99 }
+              }
+            }
+          }
+        }
+        """.utf8)
+        await ModelsDevPricingPipeline.refreshIfNeeded(
+            now: Date(timeIntervalSince1970: 1 + ModelsDevCache.ttlSeconds + 1),
+            cacheRoot: root,
+            client: ModelsDevClient(transport: MockTransport(
+                result: .success((partialCatalog, Self.response(status: 200))))))
+
+        let lookup = try #require(ModelsDevPricingPipeline.lookup(
+            providerID: "openai",
+            modelID: "gpt-4o-mini",
+            cacheRoot: root))
+
+        #expect(lookup.pricing.inputCostPerToken == 0.15 / 1_000_000.0)
+    }
+
+    @Test
     func `fresh cache does not refresh`() async throws {
         let root = try Self.cacheRoot()
         try ModelsDevCache.save(catalog: Self.fixtureCatalog(), fetchedAt: Date(), cacheRoot: root)


### PR DESCRIPTION
## Summary
Follow-up to #863 after the late Codex review comment on the merged models.dev pricing pipeline.

- accept models.dev catalog refreshes when upstream renames model map keys but keeps the same model identity
- keep stale pricing when a fetched matching model is no longer priceable
- compare refresh continuity through the same provider-scoped lookup path used at runtime
- preserve stale pricing when the refreshed catalog only has a different pinned @YYYYMMDD snapshot and no base/default candidate
- ignore unpriceable models already present in the old cache when deciding whether a refresh is safe

## Verification
- swift test --filter ModelsDevPricingTests
- pnpm check
- ./Scripts/compile_and_run.sh