### PR TITLE
Fix: Align models.dev refresh guard with lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixes
 - Startup: avoid blocking menu-bar creation on synchronous defaults migration/default seeding when macOS preferences services stall.
 - Cost history: keep manual refreshes on the incremental scanner cache and drain per-line JSON parse allocations so large Codex/Claude histories do not trigger full local log rescans and CPU/memory spikes.
+- Cost history: preserve cached models.dev pricing when an upstream catalog only changes a pinned snapshot suffix for the same model family (#883). Thanks @iam-brain!
 - Codex: restrict OAuth auto fallback to missing/invalid auth so transient API/decode errors do not spawn `codex app-server` and burn tokens (#876, fixes #874). Thanks @ViperThanks!
 - Accessibility: add VoiceOver labels for status icons, menu rows, provider switcher buttons, and usage charts (#860, fixes #859). Thanks @WadydX!
 - Menu bar: keep status items visible on launch by avoiding macOS autosaved hidden menu-extra state from v0.24 (#861).

--- a/Sources/CodexBarCore/Vendored/CostUsage/ModelsDevPricing.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/ModelsDevPricing.swift
@@ -163,9 +163,7 @@ struct ModelsDevProvider: Codable, Equatable, Sendable {
     }
 
     func containsModel(matching cachedModel: ModelsDevModel) -> Bool {
-        self.models.values.contains {
-            $0.isPriceable && ModelsDevModelIDNormalizer.idsMatch($0.id, cachedModel.id)
-        }
+        self.pricing(modelID: cachedModel.id) != nil
     }
 }
 
@@ -305,11 +303,6 @@ enum ModelsDevModelIDNormalizer {
         }
 
         return candidates
-    }
-
-    static func idsMatch(_ lhs: String, _ rhs: String) -> Bool {
-        let lhsCandidates = Set(self.candidates(lhs))
-        return self.candidates(rhs).contains { lhsCandidates.contains($0) }
     }
 }
 

--- a/Tests/CodexBarTests/ModelsDevPricingTests.swift
+++ b/Tests/CodexBarTests/ModelsDevPricingTests.swift
@@ -386,6 +386,52 @@ struct ModelsDevPricingTests {
     }
 
     @Test
+    func `refresh preserves cache when fetched catalog only has different pinned snapshot`() async throws {
+        let root = try Self.cacheRoot()
+        let old = Date(timeIntervalSince1970: 1)
+        let cachedCatalog = try Self.catalog("""
+        {
+          "google-vertex-anthropic": {
+            "id": "google-vertex-anthropic",
+            "models": {
+              "claude-sonnet-4@20250101": {
+                "id": "claude-sonnet-4@20250101",
+                "cost": { "input": 3, "output": 15 }
+              }
+            }
+          }
+        }
+        """)
+        ModelsDevCache.save(catalog: cachedCatalog, fetchedAt: old, cacheRoot: root)
+
+        let fetchedCatalog = Data("""
+        {
+          "google-vertex-anthropic": {
+            "id": "google-vertex-anthropic",
+            "models": {
+              "claude-sonnet-4@20250201": {
+                "id": "claude-sonnet-4@20250201",
+                "cost": { "input": 99, "output": 99 }
+              }
+            }
+          }
+        }
+        """.utf8)
+        await ModelsDevPricingPipeline.refreshIfNeeded(
+            now: Date(timeIntervalSince1970: 1 + ModelsDevCache.ttlSeconds + 1),
+            cacheRoot: root,
+            client: ModelsDevClient(transport: MockTransport(
+                result: .success((fetchedCatalog, Self.response(status: 200))))))
+
+        let lookup = try #require(ModelsDevPricingPipeline.lookup(
+            providerID: "google-vertex-anthropic",
+            modelID: "claude-sonnet-4@20250101",
+            cacheRoot: root))
+
+        #expect(lookup.pricing.inputCostPerToken == 3 / 1_000_000.0)
+    }
+
+    @Test
     func `refresh ignores unpriceable models in old cache continuity check`() async throws {
         let root = try Self.cacheRoot()
         let old = Date(timeIntervalSince1970: 1)


### PR DESCRIPTION
## Summary
Follow-up to #881 / #863 for the pinned snapshot continuity edge case.

- route models.dev refresh continuity through the same provider-scoped `pricing(modelID:)` lookup used at runtime
- keep exact/base/default fallback behavior, but avoid treating different pinned `@YYYYMMDD` snapshots as covering one another when no base/default candidate exists
- add a regression test for `claude-sonnet-4@20250101` vs `claude-sonnet-4@20250201`

## Verification
- swift test --filter ModelsDevPricingTests
- pnpm check