### PR TITLE
Preserve tiered pricing boundaries

### DIFF
--- a/Sources/CodexBarCore/PiSessionCostCache.swift
+++ b/Sources/CodexBarCore/PiSessionCostCache.swift
@@ -76,6 +76,7 @@ struct PiPackedUsage: Codable, Equatable {
     var totalTokens: Int = 0
     var costNanos: Int64 = 0
     var costSampleCount: Int = 0
+    var usageSampleCount: Int?
 
     var isZero: Bool {
         self.inputTokens == 0
@@ -85,5 +86,6 @@ struct PiPackedUsage: Codable, Equatable {
             && self.totalTokens == 0
             && self.costNanos == 0
             && self.costSampleCount == 0
+            && (self.usageSampleCount ?? 0) == 0
     }
 }

--- a/Sources/CodexBarCore/PiSessionCostScanner.swift
+++ b/Sources/CodexBarCore/PiSessionCostScanner.swift
@@ -519,7 +519,8 @@ enum PiSessionCostScanner {
             outputTokens: rawUsage.outputTokens,
             totalTokens: rawUsage.totalTokens,
             costNanos: costNanos,
-            costSampleCount: costUSD == nil ? 0 : 1)
+            costSampleCount: costUSD == nil ? 0 : 1,
+            usageSampleCount: 1)
     }
 
     private static func computedCostUSD(
@@ -625,8 +626,13 @@ enum PiSessionCostScanner {
                     modelName: modelName,
                     usage: packed,
                     pricingContext: pricingContext)
-                let costNanos = currentPricingCost.map { Int64(($0 * self.costScale).rounded()) }
-                    ?? (packed.costSampleCount > 0 ? packed.costNanos : nil)
+                let usageSampleCount = packed.usageSampleCount
+                let hasCompleteCachedCost = (usageSampleCount ?? 0) > 0
+                    && packed.costSampleCount == usageSampleCount
+                // Cached costs are accumulated per message, which preserves Claude long-context threshold boundaries.
+                let costNanos = hasCompleteCachedCost
+                    ? packed.costNanos
+                    : currentPricingCost.map { Int64(($0 * self.costScale).rounded()) }
                 breakdown.append(CostUsageDailyReport.ModelBreakdown(
                     modelName: modelName,
                     costUSD: costNanos.map { Double($0) / Self.costScale },
@@ -719,14 +725,23 @@ enum PiSessionCostScanner {
     }
 
     private static func addPacked(a: PiPackedUsage, b: PiPackedUsage, sign: Int) -> PiPackedUsage {
-        PiPackedUsage(
+        let aUsageSampleCount = a.usageSampleCount ?? (a.isZero ? 0 : nil)
+        let bUsageSampleCount = b.usageSampleCount ?? (b.isZero ? 0 : nil)
+        let usageSampleCount: Int? = if let aCount = aUsageSampleCount, let bCount = bUsageSampleCount {
+            max(0, aCount + sign * bCount)
+        } else {
+            nil
+        }
+
+        return PiPackedUsage(
             inputTokens: max(0, a.inputTokens + sign * b.inputTokens),
             cacheReadTokens: max(0, a.cacheReadTokens + sign * b.cacheReadTokens),
             cacheWriteTokens: max(0, a.cacheWriteTokens + sign * b.cacheWriteTokens),
             outputTokens: max(0, a.outputTokens + sign * b.outputTokens),
             totalTokens: max(0, a.totalTokens + sign * b.totalTokens),
             costNanos: max(0, a.costNanos + Int64(sign) * b.costNanos),
-            costSampleCount: max(0, a.costSampleCount + sign * b.costSampleCount))
+            costSampleCount: max(0, a.costSampleCount + sign * b.costSampleCount),
+            usageSampleCount: usageSampleCount)
     }
 
     private static func parseSessionStartFromFilename(_ filename: String) -> Date? {

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner+Claude.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner+Claude.swift
@@ -45,6 +45,7 @@ extension CostUsageScanner {
             let cacheCreate: Int
             let output: Int
             let costNanos: Int
+            let costPriced: Bool
         }
 
         func add(dayKey: String, model: String, tokens: ClaudeTokens, days: inout [String: [String: [Int]]]) {
@@ -52,12 +53,14 @@ extension CostUsageScanner {
             else { return }
             let normModel = CostUsagePricing.normalizeClaudeModel(model)
             var dayModels = days[dayKey] ?? [:]
-            var packed = dayModels[normModel] ?? [0, 0, 0, 0, 0]
+            var packed = dayModels[normModel] ?? [0, 0, 0, 0, 0, 0, 0]
             packed[0] = (packed[safe: 0] ?? 0) + tokens.input
             packed[1] = (packed[safe: 1] ?? 0) + tokens.cacheRead
             packed[2] = (packed[safe: 2] ?? 0) + tokens.cacheCreate
             packed[3] = (packed[safe: 3] ?? 0) + tokens.output
             packed[4] = (packed[safe: 4] ?? 0) + tokens.costNanos
+            packed[5] = (packed[safe: 5] ?? 0) + 1
+            packed[6] = (packed[safe: 6] ?? 0) + (tokens.costPriced ? 1 : 0)
             dayModels[normModel] = packed
             days[dayKey] = dayModels
         }
@@ -129,7 +132,8 @@ extension CostUsageScanner {
                         cacheRead: cacheRead,
                         cacheCreate: cacheCreate,
                         output: output,
-                        costNanos: costNanos)
+                        costNanos: costNanos,
+                        costPriced: cost != nil)
 
                     guard CostUsageDayRange.isInRange(
                         dayKey: dayKey,
@@ -156,7 +160,8 @@ extension CostUsageScanner {
                         cacheRead: tokens.cacheRead,
                         cacheCreate: tokens.cacheCreate,
                         output: tokens.output,
-                        costNanos: tokens.costNanos)
+                        costNanos: tokens.costNanos,
+                        costPriced: tokens.costPriced)
 
                     // Streaming chunks share message.id + requestId inside a file.
                     // Keep overwriting so the final cumulative chunk wins.
@@ -178,7 +183,8 @@ extension CostUsageScanner {
                 cacheRead: row.cacheRead,
                 cacheCreate: row.cacheCreate,
                 output: row.output,
-                costNanos: row.costNanos)
+                costNanos: row.costNanos,
+                costPriced: row.costPriced ?? (row.costNanos > 0))
             add(dayKey: row.dayKey, model: row.model, tokens: tokens, days: &days)
         }
 
@@ -242,12 +248,14 @@ extension CostUsageScanner {
 
         func addRow(_ row: ClaudeUsageRow) {
             var dayModels = days[row.dayKey] ?? [:]
-            var packed = dayModels[row.model] ?? [0, 0, 0, 0, 0]
+            var packed = dayModels[row.model] ?? [0, 0, 0, 0, 0, 0, 0]
             packed[0] = (packed[safe: 0] ?? 0) + row.input
             packed[1] = (packed[safe: 1] ?? 0) + row.cacheRead
             packed[2] = (packed[safe: 2] ?? 0) + row.cacheCreate
             packed[3] = (packed[safe: 3] ?? 0) + row.output
             packed[4] = (packed[safe: 4] ?? 0) + row.costNanos
+            packed[5] = (packed[safe: 5] ?? 0) + 1
+            packed[6] = (packed[safe: 6] ?? 0) + ((row.costPriced ?? (row.costNanos > 0)) ? 1 : 0)
             dayModels[row.model] = packed
             days[row.dayKey] = dayModels
         }
@@ -645,6 +653,9 @@ extension CostUsageScanner {
                 let cacheCreate = packed[safe: 2] ?? 0
                 let output = packed[safe: 3] ?? 0
                 let cachedCost = packed[safe: 4] ?? 0
+                let sampleCount = packed[safe: 5] ?? 0
+                let pricedSampleCount = packed[safe: 6] ?? 0
+                let hasCompleteCachedCost = sampleCount > 0 && pricedSampleCount == sampleCount
                 let totalTokens = input + cacheRead + cacheCreate + output
 
                 // Cache tokens are tracked separately; totalTokens includes input + cache.
@@ -661,8 +672,8 @@ extension CostUsageScanner {
                     outputTokens: output,
                     modelsDevCatalog: modelsDevCatalog,
                     modelsDevCacheRoot: modelsDevCacheRoot)
-                let cost = currentPricingCost
-                    ?? (cachedCost > 0 ? Double(cachedCost) / costScale : nil)
+                // Cached costs are accumulated per request, which preserves Claude long-context threshold boundaries.
+                let cost = hasCompleteCachedCost ? Double(cachedCost) / costScale : currentPricingCost
                 breakdown.append(
                     CostUsageDailyReport.ModelBreakdown(
                         modelName: model,

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
@@ -210,6 +210,7 @@ enum CostUsageScanner {
         let cacheCreate: Int
         let output: Int
         let costNanos: Int
+        let costPriced: Bool?
     }
 
     static func loadDailyReport(

--- a/Tests/CodexBarTests/CostUsageScannerTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerTests.swift
@@ -151,6 +151,81 @@ struct CostUsageScannerTests {
     }
 
     @Test
+    func `claude report preserves per-request threshold pricing`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 5, day: 9)
+        let first = env.isoString(for: day)
+        let second = env.isoString(for: day.addingTimeInterval(1))
+        let model = "claude-sonnet-4-6"
+        let firstEntry: [String: Any] = [
+            "type": "assistant",
+            "timestamp": first,
+            "requestId": "req_one",
+            "message": [
+                "id": "msg_one",
+                "model": model,
+                "usage": [
+                    "input_tokens": 150_000,
+                    "output_tokens": 0,
+                ],
+            ],
+        ]
+        let secondEntry: [String: Any] = [
+            "type": "assistant",
+            "timestamp": second,
+            "requestId": "req_two",
+            "message": [
+                "id": "msg_two",
+                "model": model,
+                "usage": [
+                    "input_tokens": 150_000,
+                    "output_tokens": 0,
+                ],
+            ],
+        ]
+
+        _ = try env.writeClaudeProjectFile(
+            relativePath: "project-a/threshold.jsonl",
+            contents: env.jsonl([firstEntry, secondEntry]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: nil,
+            claudeProjectsRoots: [env.claudeProjectsRoot],
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .claude,
+            since: day,
+            until: day,
+            now: day,
+            options: options)
+        let expectedRequestCost = CostUsagePricing.claudeCostUSD(
+            model: model,
+            inputTokens: 150_000,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            outputTokens: 0,
+            modelsDevCacheRoot: env.cacheRoot) ?? 0
+        let aggregateCost = CostUsagePricing.claudeCostUSD(
+            model: model,
+            inputTokens: 300_000,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            outputTokens: 0,
+            modelsDevCacheRoot: env.cacheRoot) ?? 0
+        let expectedCost = expectedRequestCost * 2
+
+        #expect(report.data.count == 1)
+        #expect(report.data.first?.inputTokens == 300_000)
+        #expect(abs((report.data.first?.costUSD ?? 0) - expectedCost) < 0.000001)
+        #expect(abs((report.data.first?.costUSD ?? 0) - aggregateCost) > 0.000001)
+        #expect(abs((report.data.first?.modelBreakdowns?.first?.costUSD ?? 0) - expectedCost) < 0.000001)
+    }
+
+    @Test
     func `claude parses large lines with usage at tail`() throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }

--- a/Tests/CodexBarTests/PiSessionCostScannerTests.swift
+++ b/Tests/CodexBarTests/PiSessionCostScannerTests.swift
@@ -420,6 +420,80 @@ struct PiSessionCostScannerTests {
     }
 
     @Test
+    func `pi scanner preserves per-message threshold pricing`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 5, day: 9)
+        let model = "claude-sonnet-4-6"
+        let firstAssistant: [String: Any] = [
+            "type": "message",
+            "timestamp": env.isoString(for: day),
+            "message": [
+                "role": "assistant",
+                "provider": "anthropic",
+                "model": model,
+                "timestamp": Int(day.timeIntervalSince1970 * 1000),
+                "usage": [
+                    "input": 150_000,
+                    "output": 0,
+                    "totalTokens": 150_000,
+                ],
+            ],
+        ]
+        let secondAssistant: [String: Any] = [
+            "type": "message",
+            "timestamp": env.isoString(for: day.addingTimeInterval(1)),
+            "message": [
+                "role": "assistant",
+                "provider": "anthropic",
+                "model": model,
+                "timestamp": Int(day.addingTimeInterval(1).timeIntervalSince1970 * 1000),
+                "usage": [
+                    "input": 150_000,
+                    "output": 0,
+                    "totalTokens": 150_000,
+                ],
+            ],
+        ]
+
+        _ = try env.writePiSessionFile(
+            relativePath: "2026-05-09T10-00-00-000Z_threshold.jsonl",
+            contents: env.jsonl([firstAssistant, secondAssistant]))
+
+        let report = PiSessionCostScanner.loadDailyReport(
+            provider: .claude,
+            since: day,
+            until: day,
+            now: day,
+            options: PiSessionCostScanner.Options(
+                piSessionsRoot: env.piSessionsRoot,
+                cacheRoot: env.cacheRoot,
+                refreshMinIntervalSeconds: 0))
+        let expectedRequestCost = CostUsagePricing.claudeCostUSD(
+            model: model,
+            inputTokens: 150_000,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            outputTokens: 0,
+            modelsDevCacheRoot: env.cacheRoot) ?? 0
+        let aggregateCost = CostUsagePricing.claudeCostUSD(
+            model: model,
+            inputTokens: 300_000,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            outputTokens: 0,
+            modelsDevCacheRoot: env.cacheRoot) ?? 0
+        let expectedCost = expectedRequestCost * 2
+
+        #expect(report.data.count == 1)
+        #expect(report.data.first?.totalTokens == 300_000)
+        #expect(abs((report.data.first?.costUSD ?? 0) - expectedCost) < 0.000001)
+        #expect(abs((report.data.first?.costUSD ?? 0) - aggregateCost) > 0.000001)
+        #expect(abs((report.data.first?.modelBreakdowns?.first?.costUSD ?? 0) - expectedCost) < 0.000001)
+    }
+
+    @Test
     func `pi scanner reparses unchanged cached file when scan window expands`() throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }


### PR DESCRIPTION
## Summary
- Preserve Claude per-request and Pi per-message cost boundaries when rendering daily reports for threshold-priced models.
- Track priced-sample completeness so cached per-sample costs are only trusted when every sample in a model/day bucket was priced.
- Fall back conservatively for legacy or mixed partial caches instead of treating partial cached cost totals as authoritative.

## Reasoning
- Follow-up to #884: automated review correctly caught that re-rating aggregate day/model totals can cross Claude long-context thresholds that individual requests never crossed.
- Threshold/tiered pricing is not linear across aggregate totals, so report building must prefer complete per-sample cost sums and avoid partial cached sums.

## Scope
- Claude cost-usage report construction.
- Pi session cost report construction/cache shape.
- Regression tests for multiple below-threshold samples whose aggregate crosses the threshold.

## Screenshots
N/A

## GIFs
N/A

## References
- Follows #884.
- Addresses Codex bot P1 feedback on preserving threshold pricing boundaries.

## Validation
- `swift test --filter CostUsageScannerTests --filter PiSessionCostScannerTests`
- `make check`
- `./Scripts/compile_and_run.sh`

## Audit
- GPT-5.5 high subagent audit completed.
- Initial P2 finding about mixed priced/unpriced caches fixed.
- Follow-up P2 finding about legacy cache completeness fixed.
- Final pass found no remaining P1/P2 findings.
