### PR TITLE
[codex] reduce keychain prompt churn during dev runs

### DIFF
--- a/Scripts/compile_and_run.sh
+++ b/Scripts/compile_and_run.sh
@@ -64,13 +64,47 @@ has_signing_identity() {
   security find-identity -p codesigning -v 2>/dev/null | grep -F "${identity}" >/dev/null 2>&1
 }
 
+detect_codesigning_identity() {
+  local preferred_prefixes=(
+    "Developer ID Application:"
+    "Apple Development:"
+    "Apple Distribution:"
+  )
+  local prefix
+  local identities
+  identities="$(security find-identity -p codesigning -v 2>/dev/null || true)"
+  for prefix in "${preferred_prefixes[@]}"; do
+    awk -v prefix="${prefix}" '
+      index($0, "\"" prefix) {
+        sub(/^[^\"]*\"/, "")
+        sub(/\".*$/, "")
+        print
+        exit
+      }
+    ' <<<"${identities}"
+  done | sed -n '1p'
+}
+
+export_team_id_from_identity() {
+  local identity="${1:-}"
+  if [[ -n "${APP_TEAM_ID:-}" || -z "${identity}" ]]; then
+    return
+  fi
+  if [[ "${identity}" =~ \(([A-Z0-9]{10})\)$ ]]; then
+    APP_TEAM_ID="${BASH_REMATCH[1]}"
+    export APP_TEAM_ID
+  fi
+}
+
 resolve_signing_mode() {
   if [[ -n "${SIGNING_MODE}" ]]; then
+    export_team_id_from_identity "${APP_IDENTITY:-}"
     return
   fi
 
   if [[ -n "${APP_IDENTITY:-}" ]]; then
     if has_signing_identity "${APP_IDENTITY}"; then
+      export_team_id_from_identity "${APP_IDENTITY}"
       SIGNING_MODE="identity"
       return
     fi
@@ -87,10 +121,20 @@ resolve_signing_mode() {
     if has_signing_identity "${candidate}"; then
       APP_IDENTITY="${candidate}"
       export APP_IDENTITY
+      export_team_id_from_identity "${APP_IDENTITY}"
       SIGNING_MODE="identity"
       return
     fi
   done
+
+  candidate="$(detect_codesigning_identity)"
+  if [[ -n "${candidate}" ]]; then
+    APP_IDENTITY="${candidate}"
+    export APP_IDENTITY
+    export_team_id_from_identity "${APP_IDENTITY}"
+    SIGNING_MODE="identity"
+    return
+  fi
 
   SIGNING_MODE="adhoc"
 }

--- a/Sources/CodexBarCore/KeychainCacheStore.swift
+++ b/Sources/CodexBarCore/KeychainCacheStore.swift
@@ -102,25 +102,12 @@ public enum KeychainCacheStore {
             kSecAttrService as String: self.serviceName,
             kSecAttrAccount as String: key.account,
         ]
-        var updateAttrs: [String: Any] = [
-            kSecValueData as String: data,
-        ]
-        if let access = self.cacheAccessControl() {
-            updateAttrs[kSecAttrAccess as String] = access
-        }
 
-        let updateStatus = SecItemUpdate(query as CFDictionary, updateAttrs as CFDictionary)
+        let updateStatus = SecItemUpdate(
+            query as CFDictionary,
+            [kSecValueData as String: data] as CFDictionary)
         if updateStatus == errSecSuccess {
             return
-        }
-        if updateStatus != errSecItemNotFound, updateAttrs[kSecAttrAccess as String] != nil {
-            let dataOnlyStatus = SecItemUpdate(
-                query as CFDictionary,
-                [kSecValueData as String: data] as CFDictionary)
-            if dataOnlyStatus == errSecSuccess {
-                self.log.error("Keychain cache ACL update failed (\(key.account)): \(updateStatus)")
-                return
-            }
         }
         if updateStatus != errSecItemNotFound {
             self.log.error("Keychain cache update failed (\(key.account)): \(updateStatus)")


### PR DESCRIPTION
## Purpose

Reduce repeated macOS Keychain prompts during local CodexBar development runs.

Two prompt sources were addressed:

- `compile_and_run.sh` could fall back to ad-hoc signing even when the developer had a valid local signing identity. Ad-hoc signing changes the app identity across rebuilds, which makes Keychain approvals unstable.
- `KeychainCacheStore.store` tried to rewrite the `CodexBar Cache` item ACL on every cache update. Updating `kSecAttrAccess` can trigger the "change the owner" login keychain prompt even when CodexBar only needs to refresh cached data.

## Changes

- Auto-detect a stable local code signing identity in `Scripts/compile_and_run.sh` before falling back to ad-hoc signing.
- Derive `APP_TEAM_ID` from the detected identity when possible, while preserving explicit `APP_IDENTITY` / `APP_TEAM_ID` overrides and Peter's existing preferred identity path.
- Update existing `KeychainCacheStore` entries by writing only `kSecValueData`.
- Keep the existing ACL setup for newly-created `CodexBar Cache` entries.

## Verified behavior

- Confirmed the local run script now selects a real Developer ID identity instead of ad-hoc signing on a machine with valid identities:
  - `Developer ID Application: Nimrod Gutman (GZS353X62E)`
- Confirmed `KeychainCacheStore` still stores, overwrites, loads, clears, and lists cache entries through the focused test suite.
- Confirmed new cache entries still attach the existing trusted app/CLI helper ACL path; only existing-entry updates avoid ACL rewrites.
- Confirmed CodexBar can be packaged, signed, and launched with the updated script. The normal packaging path hit the existing widget App Intents metadata timeout, so the app was launched with `CODEXBAR_ALLOW_MISSING_WIDGET_METADATA=1`; the script reported `OK: CodexBar is running.`

## Validation

- `swift test --filter KeychainCacheStoreTests`
  - Passed: 8 tests
- `make check`
  - Passed: SwiftFormat reported 0 files requiring formatting
  - Passed: SwiftLint reported 0 violations
- `CODEXBAR_ALLOW_MISSING_WIDGET_METADATA=1 ./Scripts/compile_and_run.sh --wait`
  - Passed: packaged, signed, launched, and confirmed CodexBar stayed running

## Notes

Existing cache items with stale ACLs are no longer repaired during routine cache refreshes. That is intentional: the ACL repair attempt was the prompt trigger, and these entries are caches. If a local cache item is already in a bad state, deleting the `com.steipete.codexbar.cache` generic-password items lets CodexBar recreate them with the current ACL.
