### PR TITLE
fix(pi): rebuild stale session cost cache

### DIFF
--- a/Sources/CodexBarCore/PiSessionCostCache.swift
+++ b/Sources/CodexBarCore/PiSessionCostCache.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum PiSessionCostCacheIO {
-    private static let artifactVersion = 1
+    private static let artifactVersion = 2
 
     private static func defaultCacheRoot() -> URL {
         let root = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
@@ -50,7 +50,7 @@ struct PiSessionCostCache: Codable {
     var daysByProvider: [String: [String: [String: PiPackedUsage]]] = [:]
     var files: [String: PiSessionFileUsage] = [:]
 
-    init(version: Int = 1) {
+    init(version: Int = 2) {
         self.version = version
     }
 }

--- a/Tests/CodexBarTests/PiSessionCostScannerTests.swift
+++ b/Tests/CodexBarTests/PiSessionCostScannerTests.swift
@@ -494,6 +494,122 @@ struct PiSessionCostScannerTests {
     }
 
     @Test
+    func `pi scanner ignores v1 cache missing usage sample counts`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 5, day: 10)
+        let model = "claude-sonnet-4-6"
+        let firstAssistant: [String: Any] = [
+            "type": "message",
+            "timestamp": env.isoString(for: day),
+            "message": [
+                "role": "assistant",
+                "provider": "anthropic",
+                "model": model,
+                "timestamp": Int(day.timeIntervalSince1970 * 1000),
+                "usage": [
+                    "input": 150_000,
+                    "output": 0,
+                    "totalTokens": 150_000,
+                ],
+            ],
+        ]
+        let secondAssistant: [String: Any] = [
+            "type": "message",
+            "timestamp": env.isoString(for: day.addingTimeInterval(1)),
+            "message": [
+                "role": "assistant",
+                "provider": "anthropic",
+                "model": model,
+                "timestamp": Int(day.addingTimeInterval(1).timeIntervalSince1970 * 1000),
+                "usage": [
+                    "input": 150_000,
+                    "output": 0,
+                    "totalTokens": 150_000,
+                ],
+            ],
+        ]
+
+        let fileURL = try env.writePiSessionFile(
+            relativePath: "2026-05-10T10-00-00-000Z_threshold.jsonl",
+            contents: env.jsonl([firstAssistant, secondAssistant]))
+        let attrs = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        let mtime = try #require(attrs[.modificationDate] as? Date)
+        let size = try #require((attrs[.size] as? NSNumber)?.int64Value)
+
+        let requestCost = CostUsagePricing.claudeCostUSD(
+            model: model,
+            inputTokens: 150_000,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            outputTokens: 0,
+            modelsDevCacheRoot: env.cacheRoot) ?? 0
+        let aggregateCost = CostUsagePricing.claudeCostUSD(
+            model: model,
+            inputTokens: 300_000,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            outputTokens: 0,
+            modelsDevCacheRoot: env.cacheRoot) ?? 0
+        let aggregatePacked = PiPackedUsage(
+            inputTokens: 300_000,
+            totalTokens: 300_000,
+            costNanos: Int64((aggregateCost * 1_000_000_000).rounded()),
+            costSampleCount: 2,
+            usageSampleCount: nil)
+        let dayKey = "2026-05-10"
+        let contributions = [
+            UsageProvider.claude.rawValue: [
+                dayKey: [
+                    model: aggregatePacked,
+                ],
+            ],
+        ]
+        let oldFileUsage = PiSessionFileUsage(
+            mtimeUnixMs: Int64(mtime.timeIntervalSince1970 * 1000),
+            size: size,
+            parsedBytes: size,
+            lastModelContext: nil,
+            contributions: contributions)
+        var oldCache = PiSessionCostCache(version: 1)
+        oldCache.lastScanUnixMs = Int64(day.timeIntervalSince1970 * 1000)
+        oldCache.scanSinceKey = dayKey
+        oldCache.scanUntilKey = dayKey
+        oldCache.daysByProvider = contributions
+        oldCache.files = [fileURL.path: oldFileUsage]
+        let oldCacheURL = env.cacheRoot
+            .appendingPathComponent("cost-usage", isDirectory: true)
+            .appendingPathComponent("pi-sessions-v1.json", isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: oldCacheURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+        try JSONEncoder().encode(oldCache).write(to: oldCacheURL)
+
+        let report = PiSessionCostScanner.loadDailyReport(
+            provider: .claude,
+            since: day,
+            until: day,
+            now: day,
+            options: PiSessionCostScanner.Options(
+                piSessionsRoot: env.piSessionsRoot,
+                cacheRoot: env.cacheRoot,
+                refreshMinIntervalSeconds: 3600))
+
+        let expectedCost = requestCost * 2
+        #expect(report.data.count == 1)
+        #expect(report.data.first?.totalTokens == 300_000)
+        #expect(abs((report.data.first?.costUSD ?? 0) - expectedCost) < 0.000001)
+        #expect(abs((report.data.first?.costUSD ?? 0) - aggregateCost) > 0.000001)
+
+        let newCache = PiSessionCostCacheIO.load(cacheRoot: env.cacheRoot)
+        let rebuilt = newCache.daysByProvider[UsageProvider.claude.rawValue]?[dayKey]?[model]
+        #expect(newCache.version == 2)
+        #expect(rebuilt?.usageSampleCount == 2)
+        #expect(rebuilt?.costSampleCount == 2)
+    }
+
+    @Test
     func `pi scanner reparses unchanged cached file when scan window expands`() throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }


### PR DESCRIPTION
## Summary
- bump the Pi session cost cache artifact to v2 so stale v1 aggregate-cost entries are ignored
- add regression coverage for v1 caches missing usage sample counts, verifying the scanner rebuilds per-message cost samples
- verified against real local Pi sessions and confirmed rebuilt v2 cache records matching usage/cost sample counts

## Validation
- `swift test --filter PiSessionCostScannerTests`
- `make check`
- `./Scripts/compile_and_run.sh`
- `pnpm check` could not run: command `check` not found
- Full `swift test` ran 2328 tests and failed with 2 existing/ambient OpenAI dashboard navigation/cache issues outside this Pi cache change