### PR TITLE
feat(http): add shared provider client seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.27.0 — Unreleased
 
 ### Added
+- Providers: route app-owned provider HTTP calls through a shared transport seam for cleaner proxy and test support (#892). Thanks @serezha93!
 - Website: replace provider-letter tiles with brand logos, add light/dark landing-page themes, and collapse OpenCode/OpenCode Go into one company entry (#989). Thanks @pasangimhana!
 - Claude: add an Anthropic Admin API source and allow `sk-ant-admin...` keys in Claude token accounts for API spend/token tracking (#966).
 - Grok: add xAI Grok provider support with local identity detection and billing decoding for the Grok CLI integration (#965). Thanks @taibaran!

--- a/Sources/CodexBar/Providers/Antigravity/AntigravityLoginRunner.swift
+++ b/Sources/CodexBar/Providers/Antigravity/AntigravityLoginRunner.swift
@@ -149,7 +149,7 @@ enum AntigravityLoginRunner {
             "grant_type": "authorization_code",
         ])
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw AntigravityLoginError.failed("Invalid token response.")
         }
@@ -171,7 +171,7 @@ enum AntigravityLoginRunner {
         request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
                 return nil
             }

--- a/Sources/CodexBar/UsageStore+Status.swift
+++ b/Sources/CodexBar/UsageStore+Status.swift
@@ -1,3 +1,4 @@
+import CodexBarCore
 import Foundation
 
 extension UsageStore {
@@ -6,7 +7,7 @@ extension UsageStore {
         var request = URLRequest(url: apiURL)
         request.timeoutInterval = 10
 
-        let (data, _) = try await URLSession.shared.data(for: request, delegate: nil)
+        let (data, _) = try await ProviderHTTPClient.shared.data(for: request)
 
         struct Response: Decodable {
             struct Status: Decodable {
@@ -52,7 +53,7 @@ extension UsageStore {
         }
         var request = URLRequest(url: url)
         request.timeoutInterval = 10
-        let (data, _) = try await URLSession.shared.data(for: request, delegate: nil)
+        let (data, _) = try await ProviderHTTPClient.shared.data(for: request)
         return try Self.parseGoogleWorkspaceStatus(data: data, productID: productID)
     }
 

--- a/Sources/CodexBar/UsageStore+Status.swift
+++ b/Sources/CodexBar/UsageStore+Status.swift
@@ -2,12 +2,16 @@ import CodexBarCore
 import Foundation
 
 extension UsageStore {
-    static func fetchStatus(from baseURL: URL) async throws -> ProviderStatus {
+    static func fetchStatus(
+        from baseURL: URL,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared)
+        async throws -> ProviderStatus
+    {
         let apiURL = baseURL.appendingPathComponent("api/v2/status.json")
         var request = URLRequest(url: apiURL)
         request.timeoutInterval = 10
 
-        let (data, _) = try await ProviderHTTPClient.shared.data(for: request)
+        let (data, _) = try await transport.data(for: request)
 
         struct Response: Decodable {
             struct Status: Decodable {
@@ -47,13 +51,17 @@ extension UsageStore {
             updatedAt: response.page?.updatedAt)
     }
 
-    static func fetchWorkspaceStatus(productID: String) async throws -> ProviderStatus {
+    static func fetchWorkspaceStatus(
+        productID: String,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared)
+        async throws -> ProviderStatus
+    {
         guard let url = URL(string: "https://www.google.com/appsstatus/dashboard/incidents.json") else {
             throw URLError(.badURL)
         }
         var request = URLRequest(url: url)
         request.timeoutInterval = 10
-        let (data, _) = try await ProviderHTTPClient.shared.data(for: request)
+        let (data, _) = try await transport.data(for: request)
         return try Self.parseGoogleWorkspaceStatus(data: data, productID: productID)
     }
 

--- a/Sources/CodexBarCore/ProviderHTTPClient.swift
+++ b/Sources/CodexBarCore/ProviderHTTPClient.swift
@@ -3,13 +3,19 @@ import Foundation
 import FoundationNetworking
 #endif
 
-public final class ProviderHTTPClient: @unchecked Sendable {
+public protocol ProviderHTTPTransport: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: ProviderHTTPTransport {}
+
+public final class ProviderHTTPClient: ProviderHTTPTransport, @unchecked Sendable {
     public static let shared = ProviderHTTPClient()
 
     private let session: URLSession
 
-    public init(session: URLSession? = nil) {
-        self.session = session ?? URLSession.shared
+    public init(session: URLSession = .shared) {
+        self.session = session
     }
 
     public func data(for request: URLRequest) async throws -> (Data, URLResponse) {

--- a/Sources/CodexBarCore/ProviderHTTPClient.swift
+++ b/Sources/CodexBarCore/ProviderHTTPClient.swift
@@ -1,0 +1,18 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public final class ProviderHTTPClient: @unchecked Sendable {
+    public static let shared = ProviderHTTPClient()
+
+    private let session: URLSession
+
+    public init(session: URLSession? = nil) {
+        self.session = session ?? URLSession.shared
+    }
+
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.session.data(for: request)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Abacus/AbacusUsageFetcher.swift
@@ -224,7 +224,7 @@ public enum AbacusUsageFetcher {
             request.httpBody = Data("{}".utf8)
         }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw AbacusUsageError.networkError("Invalid response from \(url.lastPathComponent)")

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanUsageFetcher.swift
@@ -108,7 +108,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         request.setValue(region.gatewayBaseURLString, forHTTPHeaderField: "Origin")
         request.setValue(region.dashboardURL.absoluteString, forHTTPHeaderField: "Referer")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw AlibabaCodingPlanUsageError.networkError("Invalid response")
         }
@@ -158,7 +158,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         request.setValue(region.gatewayBaseURLString, forHTTPHeaderField: "Origin")
         request.setValue(region.consoleRefererURL.absoluteString, forHTTPHeaderField: "Referer")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw AlibabaCodingPlanUsageError.networkError("Invalid response")
         }
@@ -338,7 +338,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
             "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             forHTTPHeaderField: "Accept")
 
-        if let (data, response) = try? await URLSession.shared.data(for: request),
+        if let (data, response) = try? await ProviderHTTPClient.shared.data(for: request),
            let httpResponse = response as? HTTPURLResponse,
            httpResponse.statusCode == 200,
            let html = String(data: data, encoding: .utf8),
@@ -404,7 +404,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
             .absoluteString + "/"
         request.setValue(referer, forHTTPHeaderField: "Referer")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             return nil
         }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityRemoteUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityRemoteUsageFetcher.swift
@@ -61,7 +61,7 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
         homeDirectory: String = NSHomeDirectory(),
         environment: [String: String] = ProcessInfo.processInfo.environment,
         dataLoader: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = { request in
-            try await URLSession.shared.data(for: request)
+            try await ProviderHTTPClient.shared.data(for: request)
         },
         oauthClientResolver: @escaping @Sendable () -> AntigravityOAuthClient? = {
             AntigravityOAuthConfig.resolvedClient()

--- a/Sources/CodexBarCore/Providers/Augment/AugmentSessionKeepalive.swift
+++ b/Sources/CodexBarCore/Providers/Augment/AugmentSessionKeepalive.swift
@@ -377,7 +377,7 @@ public final class AugmentSessionKeepalive {
             request.setValue("https://app.augmentcode.com", forHTTPHeaderField: "Referer")
 
             do {
-                let (data, response) = try await URLSession.shared.data(for: request)
+                let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
                 guard let httpResponse = response as? HTTPURLResponse else {
                     self.log("   ✗ Invalid response type")

--- a/Sources/CodexBarCore/Providers/Augment/AugmentStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Augment/AugmentStatusProbe.swift
@@ -497,7 +497,7 @@ public struct AugmentStatusProbe: Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw AugmentStatusProbeError.networkError("Invalid response")
@@ -535,7 +535,7 @@ public struct AugmentStatusProbe: Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw AugmentStatusProbeError.networkError("Invalid response")

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockUsageStats.swift
@@ -246,7 +246,7 @@ enum BedrockUsageFetcher {
             region: ceRegion,
             service: "ce")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw BedrockUsageError.networkError("Invalid response")

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeAdminAPIUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeAdminAPIUsageFetcher.swift
@@ -36,7 +36,7 @@ public enum ClaudeAdminAPIUsageFetcher {
         apiKey: String,
         costURL: URL = Self.costReportURL,
         messagesURL: URL = Self.messagesUsageURL,
-        session: URLSession = .shared,
+        session: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         now: Date = Date()) async throws -> ClaudeAdminAPIUsageSnapshot
     {
         let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -75,7 +75,7 @@ public enum ClaudeAdminAPIUsageFetcher {
         apiKey: String,
         baseURL: URL,
         range: DateRange,
-        session: URLSession) async throws -> CostReportResponse
+        session: any ProviderHTTPTransport) async throws -> CostReportResponse
     {
         let url = Self.url(
             baseURL: baseURL,
@@ -91,7 +91,7 @@ public enum ClaudeAdminAPIUsageFetcher {
         apiKey: String,
         baseURL: URL,
         range: DateRange,
-        session: URLSession) async throws -> MessagesUsageResponse
+        session: any ProviderHTTPTransport) async throws -> MessagesUsageResponse
     {
         let url = Self.url(
             baseURL: baseURL,
@@ -107,7 +107,7 @@ public enum ClaudeAdminAPIUsageFetcher {
         url: URL,
         apiKey: String,
         endpoint: String,
-        session: URLSession) async throws -> Data
+        session: any ProviderHTTPTransport) async throws -> Data
     {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -1011,7 +1011,7 @@ public enum ClaudeOAuthCredentialsStore {
             ]
             request.httpBody = (components.percentEncodedQuery ?? "").data(using: .utf8)
 
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
             guard let http = response as? HTTPURLResponse else {
                 throw ClaudeOAuthCredentialsError.refreshFailed("Invalid response")

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthUsageFetcher.swift
@@ -52,7 +52,7 @@ enum ClaudeOAuthUsageFetcher {
         request.setValue(Self.claudeCodeUserAgent(), forHTTPHeaderField: "User-Agent")
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             guard let http = response as? HTTPURLResponse else {
                 throw ClaudeOAuthFetchError.invalidResponse
             }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -292,7 +292,7 @@ public enum ClaudeWebAPIFetcher {
             request.timeoutInterval = 20
 
             do {
-                let (data, response) = try await URLSession.shared.data(for: request)
+                let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
                 let http = response as? HTTPURLResponse
                 let contentType = http?.allHeaderFields["Content-Type"] as? String
                 let truncated = data.prefix(Self.maxProbeBytes)
@@ -428,7 +428,7 @@ public enum ClaudeWebAPIFetcher {
         request.httpMethod = "GET"
         request.timeoutInterval = 15
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FetchError.invalidResponse
@@ -458,7 +458,7 @@ public enum ClaudeWebAPIFetcher {
         request.httpMethod = "GET"
         request.timeoutInterval = 15
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FetchError.invalidResponse
@@ -662,7 +662,7 @@ public enum ClaudeWebAPIFetcher {
         request.timeoutInterval = 15
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else { return nil }
             logger?("Account API status: \(httpResponse.statusCode)")
             guard httpResponse.statusCode == 200 else { return nil }
@@ -921,7 +921,7 @@ private enum ClaudeWebExtraUsageCost {
         request.timeoutInterval = 15
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else { return nil }
             logger?("Overage API status: \(httpResponse.statusCode)")
             guard httpResponse.statusCode == 200 else { return nil }

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
@@ -17,7 +17,7 @@ public enum CodebuffUsageFetcher {
         apiKey: String,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         includeSubscription: Bool = true,
-        session: URLSession = .shared) async throws -> CodebuffUsageSnapshot
+        session: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> CodebuffUsageSnapshot
     {
         let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
@@ -52,7 +52,7 @@ public enum CodebuffUsageFetcher {
         apiKey: String,
         baseURL: URL,
         includeSubscription: Bool,
-        session: URLSession) async throws -> (UsagePayload, SubscriptionPayload?)
+        session: any ProviderHTTPTransport) async throws -> (UsagePayload, SubscriptionPayload?)
     {
         try await withThrowingTaskGroup(of: FetchResult.self) { group in
             group.addTask {
@@ -223,7 +223,7 @@ public enum CodebuffUsageFetcher {
     private static func fetchUsagePayload(
         apiKey: String,
         baseURL: URL,
-        session: URLSession) async throws -> UsagePayload
+        session: any ProviderHTTPTransport) async throws -> UsagePayload
     {
         var request = URLRequest(url: self.usageURL(baseURL: baseURL))
         request.httpMethod = "POST"
@@ -246,7 +246,7 @@ public enum CodebuffUsageFetcher {
     private static func fetchSubscriptionPayload(
         apiKey: String,
         baseURL: URL,
-        session: URLSession) async throws -> SubscriptionPayload
+        session: any ProviderHTTPTransport) async throws -> SubscriptionPayload
     {
         var request = URLRequest(url: self.subscriptionURL(baseURL: baseURL))
         request.httpMethod = "GET"
@@ -266,7 +266,7 @@ public enum CodebuffUsageFetcher {
 
     private static func send(
         request: URLRequest,
-        session: URLSession) async throws -> (Data, HTTPURLResponse)
+        session: any ProviderHTTPTransport) async throws -> (Data, HTTPURLResponse)
     {
         do {
             let (data, response) = try await session.data(for: request)

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
@@ -209,7 +209,7 @@ public enum CodexOAuthUsageFetcher {
         }
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             guard let http = response as? HTTPURLResponse else {
                 throw CodexOAuthFetchError.invalidResponse
             }

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexTokenRefresher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexTokenRefresher.swift
@@ -49,7 +49,7 @@ public enum CodexTokenRefresher {
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             guard let http = response as? HTTPURLResponse else {
                 throw RefreshError.invalidResponse("No HTTP response")
             }

--- a/Sources/CodexBarCore/Providers/Codex/CodexOpenAIWorkspaceResolver.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOpenAIWorkspaceResolver.swift
@@ -38,7 +38,7 @@ public enum CodexOpenAIWorkspaceResolver {
 
     public static func resolve(
         credentials: CodexOAuthCredentials,
-        session: URLSession = .shared) async throws -> CodexOpenAIWorkspaceIdentity?
+        session: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> CodexOpenAIWorkspaceIdentity?
     {
         guard let workspaceAccountID = normalizeWorkspaceAccountID(credentials.accountId) else {
             return nil
@@ -56,7 +56,7 @@ public enum CodexOpenAIWorkspaceResolver {
 
     public static func listWorkspaces(
         credentials: CodexOAuthCredentials,
-        session: URLSession = .shared) async throws -> [CodexOpenAIWorkspaceIdentity]
+        session: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> [CodexOpenAIWorkspaceIdentity]
     {
         var request = URLRequest(url: self.accountsURL)
         request.httpMethod = "GET"

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
@@ -18,7 +18,7 @@ public enum CommandCodeUsageFetcher {
 
     public static func fetchUsage(
         cookieHeader: String,
-        session: URLSession = .shared,
+        session: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         now: Date = Date()) async throws -> CommandCodeUsageSnapshot
     {
         async let creditsResult = self.fetchCredits(cookieHeader: cookieHeader, session: session)
@@ -66,7 +66,7 @@ public enum CommandCodeUsageFetcher {
 
     private static func fetchCredits(
         cookieHeader: String,
-        session: URLSession) async throws -> CreditsPayload
+        session: any ProviderHTTPTransport) async throws -> CreditsPayload
     {
         let url = self.apiBase.appendingPathComponent(self.creditsPath)
         let data = try await self.send(url: url, cookieHeader: cookieHeader, session: session)
@@ -75,7 +75,7 @@ public enum CommandCodeUsageFetcher {
 
     private static func fetchSubscription(
         cookieHeader: String,
-        session: URLSession) async throws -> SubscriptionPayload?
+        session: any ProviderHTTPTransport) async throws -> SubscriptionPayload?
     {
         let url = self.apiBase.appendingPathComponent(self.subscriptionsPath)
         let data = try await self.send(url: url, cookieHeader: cookieHeader, session: session)
@@ -85,7 +85,7 @@ public enum CommandCodeUsageFetcher {
     private static func send(
         url: URL,
         cookieHeader: String,
-        session: URLSession) async throws -> Data
+        session: any ProviderHTTPTransport) async throws -> Data
     {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotDeviceFlow.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotDeviceFlow.swift
@@ -98,7 +98,7 @@ public struct CopilotDeviceFlow: Sendable {
         ]
         postRequest.httpBody = Self.formURLEncodedBody(body)
 
-        let (data, response) = try await URLSession.shared.data(for: postRequest)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: postRequest)
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             throw URLError(.badServerResponse)
@@ -127,7 +127,7 @@ public struct CopilotDeviceFlow: Sendable {
             try await Task.sleep(nanoseconds: UInt64(interval) * 1_000_000_000)
             try Task.checkCancellation()
 
-            let (data, _) = try await URLSession.shared.data(for: request)
+            let (data, _) = try await ProviderHTTPClient.shared.data(for: request)
 
             // Check for error in JSON
             if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
@@ -49,7 +49,7 @@ public struct CopilotUsageFetcher: Sendable {
         request.setValue("token \(self.token)", forHTTPHeaderField: "Authorization")
         self.addCommonHeaders(to: &request)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw URLError(.badServerResponse)
@@ -107,7 +107,7 @@ public struct CopilotUsageFetcher: Sendable {
         request.setValue("token \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw URLError(.badServerResponse)
         }

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
@@ -99,7 +99,11 @@ public struct CopilotUsageFetcher: Sendable {
         try await self.fetchGitHubIdentity(token: token).login
     }
 
-    public static func fetchGitHubIdentity(token: String) async throws -> GitHubUserIdentity {
+    public static func fetchGitHubIdentity(
+        token: String,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared)
+        async throws -> GitHubUserIdentity
+    {
         guard let url = URL(string: "https://api.github.com/user") else {
             throw URLError(.badURL)
         }
@@ -107,7 +111,7 @@ public struct CopilotUsageFetcher: Sendable {
         request.setValue("token \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
+        let (data, response) = try await transport.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw URLError(.badServerResponse)
         }

--- a/Sources/CodexBarCore/Providers/Crof/CrofUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Crof/CrofUsageFetcher.swift
@@ -41,7 +41,7 @@ public enum CrofUsageFetcher {
 
     public static func fetchUsage(
         apiKey: String,
-        session: URLSession = .shared) async throws -> CrofUsageSnapshot
+        session: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> CrofUsageSnapshot
     {
         let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -670,13 +670,13 @@ public struct CursorStatusProbe: Sendable {
     public let baseURL: URL
     public var timeout: TimeInterval = 15.0
     private let browserDetection: BrowserDetection
-    private let urlSession: URLSession
+    private let urlSession: any ProviderHTTPTransport
 
     public init(
         baseURL: URL = URL(string: "https://cursor.com")!,
         timeout: TimeInterval = 15.0,
         browserDetection: BrowserDetection,
-        urlSession: URLSession = .shared)
+        urlSession: any ProviderHTTPTransport = ProviderHTTPClient.shared)
     {
         self.baseURL = baseURL
         self.timeout = timeout
@@ -1160,7 +1160,7 @@ public struct CursorStatusProbe: Sendable {
         baseURL: URL = URL(string: "https://cursor.com")!,
         timeout: TimeInterval = 15.0,
         browserDetection: BrowserDetection,
-        urlSession: URLSession = .shared)
+        urlSession: any ProviderHTTPTransport = ProviderHTTPClient.shared)
     {
         _ = baseURL
         _ = timeout

--- a/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekUsageFetcher.swift
@@ -135,7 +135,7 @@ public struct DeepSeekUsageFetcher: Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.timeoutInterval = Self.timeoutSeconds
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw DeepSeekUsageError.networkError("Invalid response")

--- a/Sources/CodexBarCore/Providers/Doubao/DoubaoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Doubao/DoubaoUsageFetcher.swift
@@ -135,7 +135,7 @@ public struct DoubaoUsageFetcher: Sendable {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw DoubaoUsageError.networkError("Invalid response")

--- a/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsUsageFetcher.swift
@@ -196,7 +196,7 @@ public struct ElevenLabsUsageFetcher: Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.timeoutInterval = Self.timeoutSeconds
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ElevenLabsUsageError.networkError("Invalid response")
         }

--- a/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Factory/FactoryStatusProbe.swift
@@ -1266,7 +1266,7 @@ public struct FactoryStatusProbe: Sendable {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await URLSession.shared.data(for: request)
+            (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         } catch {
             return nil
         }
@@ -1303,7 +1303,7 @@ public struct FactoryStatusProbe: Sendable {
             request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
         }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FactoryStatusProbeError.networkError("Invalid response")
@@ -1368,7 +1368,7 @@ public struct FactoryStatusProbe: Sendable {
             request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
         }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FactoryStatusProbeError.networkError("Invalid response")
@@ -1502,7 +1502,7 @@ public struct FactoryStatusProbe: Sendable {
         }
         request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FactoryStatusProbeError.networkError("Invalid WorkOS response")
         }
@@ -1572,7 +1572,7 @@ public struct FactoryStatusProbe: Sendable {
         }
         request.httpBody = try JSONSerialization.data(withJSONObject: body, options: [])
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FactoryStatusProbeError.networkError("Invalid WorkOS response")
         }

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe+DataLoader.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe+DataLoader.swift
@@ -7,7 +7,7 @@ extension GeminiStatusProbe {
     public static func defaultDataLoader(for request: URLRequest) async throws -> (Data, URLResponse) {
         let loader = Self.dataLoaderWithCurlFallback(
             primary: { request in
-                try await URLSession.shared.data(for: request)
+                try await ProviderHTTPClient.shared.data(for: request)
             },
             fallback: Self.curlDataLoader)
         return try await loader(request)

--- a/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
@@ -54,7 +54,7 @@ public enum GrokWebBillingFetcher {
 
     public static func fetch(
         credentials: GrokCredentials,
-        session: URLSession = .shared,
+        session: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         endpoint: URL = Self.defaultEndpoint) async throws -> GrokWebBillingSnapshot
     {
         try await self.fetch(
@@ -66,7 +66,7 @@ public enum GrokWebBillingFetcher {
 
     public static func fetch(
         cookieHeader: String,
-        session: URLSession = .shared,
+        session: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         endpoint: URL = Self.defaultEndpoint) async throws -> GrokWebBillingSnapshot
     {
         try await self.fetch(
@@ -79,7 +79,7 @@ public enum GrokWebBillingFetcher {
     private static func fetch(
         authorizationHeader: String?,
         cookieHeader: String?,
-        session: URLSession,
+        session: any ProviderHTTPTransport,
         endpoint: URL) async throws -> GrokWebBillingSnapshot
     {
         do {
@@ -100,7 +100,7 @@ public enum GrokWebBillingFetcher {
     private static func fetchOnce(
         authorizationHeader: String?,
         cookieHeader: String?,
-        session: URLSession,
+        session: any ProviderHTTPTransport,
         endpoint: URL) async throws -> GrokWebBillingSnapshot
     {
         var request = URLRequest(url: endpoint)

--- a/Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift
@@ -271,7 +271,7 @@ public struct KiloUsageFetcher: Sendable {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await URLSession.shared.data(for: request)
+            (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         } catch {
             throw KiloUsageError.networkError(error.localizedDescription)
         }
@@ -332,7 +332,7 @@ public struct KiloUsageFetcher: Sendable {
         let trpcRequest = try self.makeOrgListTRPCRequest(baseURL: baseURL, apiKey: apiKey)
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: trpcRequest)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: trpcRequest)
             guard let httpResponse = response as? HTTPURLResponse else {
                 throw KiloUsageError.networkError("Invalid response")
             }
@@ -391,7 +391,7 @@ public struct KiloUsageFetcher: Sendable {
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw KiloUsageError.networkError("Invalid response")
         }

--- a/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
@@ -46,7 +46,7 @@ public struct KimiUsageFetcher: Sendable {
         let requestBody = ["scope": ["FEATURE_CODING"]]
         request.httpBody = try? JSONSerialization.data(withJSONObject: requestBody)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw KimiAPIError.networkError("Invalid response")
         }

--- a/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/KimiK2/KimiK2UsageFetcher.swift
@@ -123,7 +123,7 @@ public struct KimiK2UsageFetcher: Sendable {
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw KimiK2UsageError.networkError("Invalid response")

--- a/Sources/CodexBarCore/Providers/Manus/ManusUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Manus/ManusUsageFetcher.swift
@@ -103,7 +103,7 @@ public enum ManusUsageFetcher {
             userAgent,
             forHTTPHeaderField: "User-Agent")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ManusAPIError.networkError("Invalid response")
         }

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoUsageFetcher.swift
@@ -99,7 +99,7 @@ public enum MiMoUsageFetcher {
                 "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
             forHTTPHeaderField: "User-Agent")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw MiMoUsageError.networkError("Invalid response")
         }

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -52,7 +52,7 @@ public struct MiniMaxUsageFetcher: Sendable {
         apiToken: String,
         region: MiniMaxAPIRegion = .global,
         now: Date = Date(),
-        session: URLSession = .shared) async throws -> MiniMaxUsageSnapshot
+        session: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> MiniMaxUsageSnapshot
     {
         let cleaned = apiToken.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else {
@@ -89,7 +89,7 @@ public struct MiniMaxUsageFetcher: Sendable {
         apiToken: String,
         region: MiniMaxAPIRegion,
         now: Date,
-        session: URLSession) async throws -> MiniMaxUsageSnapshot
+        session: any ProviderHTTPTransport) async throws -> MiniMaxUsageSnapshot
     {
         var request = URLRequest(url: region.apiRemainsURL)
         request.httpMethod = "GET"
@@ -146,7 +146,7 @@ public struct MiniMaxUsageFetcher: Sendable {
             self.resolveCodingPlanRefererURL(region: region, environment: environment).absoluteString,
             forHTTPHeaderField: "referer")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw MiniMaxUsageError.networkError("Invalid response")
         }
@@ -209,7 +209,7 @@ public struct MiniMaxUsageFetcher: Sendable {
             self.resolveCodingPlanRefererURL(region: region, environment: environment).absoluteString,
             forHTTPHeaderField: "referer")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw MiniMaxUsageError.networkError("Invalid response")
         }

--- a/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralUsageFetcher.swift
@@ -36,7 +36,7 @@ public enum MistralUsageFetcher {
             request.setValue(csrfToken, forHTTPHeaderField: "X-CSRFTOKEN")
         }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw MistralUsageError.apiError("Invalid response type")

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotUsageFetcher.swift
@@ -101,7 +101,7 @@ public struct MoonshotUsageFetcher: Sendable {
     public static func fetchUsage(
         apiKey: String,
         region: MoonshotRegion = .international,
-        session: URLSession = .shared) async throws -> MoonshotUsageSnapshot
+        session: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> MoonshotUsageSnapshot
     {
         let cleaned = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else {

--- a/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPICreditBalanceFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPICreditBalanceFetcher.swift
@@ -121,7 +121,7 @@ public enum OpenAIAPICreditBalanceFetcher {
     public static func fetchBalance(
         apiKey: String,
         url: URL = Self.creditGrantsURL,
-        session: URLSession = .shared,
+        session: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         now: Date = Date()) async throws -> OpenAIAPICreditBalanceSnapshot
     {
         let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIUsageFetcher.swift
@@ -44,7 +44,7 @@ public enum OpenAIAPIUsageFetcher {
         apiKey: String,
         costsURL: URL = Self.organizationCostsURL,
         completionsURL: URL = Self.organizationCompletionsUsageURL,
-        session: URLSession = .shared,
+        session: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         now: Date = Date()) async throws -> OpenAIAPIUsageSnapshot
     {
         let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -87,7 +87,7 @@ public enum OpenAIAPIUsageFetcher {
         apiKey: String,
         baseURL: URL,
         range: DateRange,
-        session: URLSession) async throws -> CostsResponse
+        session: any ProviderHTTPTransport) async throws -> CostsResponse
     {
         let url = Self.url(
             baseURL: baseURL,
@@ -103,7 +103,7 @@ public enum OpenAIAPIUsageFetcher {
         apiKey: String,
         baseURL: URL,
         range: DateRange,
-        session: URLSession) async throws -> CompletionsUsageResponse
+        session: any ProviderHTTPTransport) async throws -> CompletionsUsageResponse
     {
         let url = Self.url(
             baseURL: baseURL,
@@ -119,7 +119,7 @@ public enum OpenAIAPIUsageFetcher {
         url: URL,
         apiKey: String,
         endpoint: String,
-        session: URLSession) async throws -> Data
+        session: any ProviderHTTPTransport) async throws -> Data
     {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"

--- a/Sources/CodexBarCore/Providers/OpenCode/OpenCodeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCode/OpenCodeUsageFetcher.swift
@@ -84,7 +84,7 @@ public struct OpenCodeUsageFetcher: Sendable {
         timeout: TimeInterval,
         now: Date = Date(),
         workspaceIDOverride: String? = nil,
-        session: URLSession = .shared) async throws -> OpenCodeUsageSnapshot
+        session: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> OpenCodeUsageSnapshot
     {
         guard let requestCookieHeader = OpenCodeWebCookieSupport.requestCookieHeader(from: cookieHeader) else {
             throw OpenCodeUsageError.invalidCredentials
@@ -108,7 +108,7 @@ public struct OpenCodeUsageFetcher: Sendable {
     private static func fetchWorkspaceID(
         cookieHeader: String,
         timeout: TimeInterval,
-        session: URLSession) async throws -> String
+        session: any ProviderHTTPTransport) async throws -> String
     {
         let text = try await self.fetchServerText(
             request: ServerRequest(
@@ -157,7 +157,7 @@ public struct OpenCodeUsageFetcher: Sendable {
         workspaceID: String,
         cookieHeader: String,
         timeout: TimeInterval,
-        session: URLSession) async throws -> String
+        session: any ProviderHTTPTransport) async throws -> String
     {
         let referer = URL(string: "https://opencode.ai/workspace/\(workspaceID)/billing") ?? self.baseURL
         let text = try await self.fetchServerText(
@@ -249,7 +249,7 @@ public struct OpenCodeUsageFetcher: Sendable {
         request serverRequest: ServerRequest,
         cookieHeader: String,
         timeout: TimeInterval,
-        session: URLSession) async throws -> String
+        session: any ProviderHTTPTransport) async throws -> String
     {
         let url = self.serverRequestURL(
             serverID: serverRequest.serverID,

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterUsageStats.swift
@@ -240,7 +240,7 @@ public struct OpenRouterUsageFetcher: Sendable {
         let title = Self.sanitizedHeaderValue(environment[self.clientTitleEnvKey]) ?? Self.defaultClientTitle
         request.setValue(title, forHTTPHeaderField: "X-Title")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw OpenRouterUsageError.networkError("Invalid response")
@@ -350,7 +350,7 @@ public struct OpenRouterUsageFetcher: Sendable {
         request.timeoutInterval = timeoutSeconds
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200

--- a/Sources/CodexBarCore/Providers/Perplexity/PerplexityUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Perplexity/PerplexityUsageFetcher.swift
@@ -43,7 +43,7 @@ public struct PerplexityUsageFetcher: Sendable {
             "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse else {
             throw PerplexityAPIError.networkError("Invalid response")
         }

--- a/Sources/CodexBarCore/Providers/StepFun/StepFunUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/StepFun/StepFunUsageFetcher.swift
@@ -280,7 +280,7 @@ public struct StepFunUsageFetcher: Sendable {
         }
         request.timeoutInterval = self.timeoutSeconds
 
-        let (_, response) = try await URLSession.shared.data(for: request)
+        let (_, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw StepFunUsageError.networkError("Invalid response fetching platform page")
@@ -326,7 +326,7 @@ public struct StepFunUsageFetcher: Sendable {
         request.setValue("INGRESSCOOKIE=\(ingressCookie)", forHTTPHeaderField: "Cookie")
         request.timeoutInterval = self.timeoutSeconds
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw StepFunUsageError.networkError("Invalid response from RegisterDevice")
@@ -372,7 +372,7 @@ public struct StepFunUsageFetcher: Sendable {
             forHTTPHeaderField: "Cookie")
         request.timeoutInterval = self.timeoutSeconds
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw StepFunUsageError.networkError("Invalid response from SignInByPassword")
@@ -411,7 +411,7 @@ public struct StepFunUsageFetcher: Sendable {
         request.setValue("Oasis-Token=\(token); Oasis-Webid=\(self.webID)", forHTTPHeaderField: "Cookie")
         request.timeoutInterval = self.timeoutSeconds
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw StepFunUsageError.networkError("Invalid response")
@@ -456,7 +456,7 @@ public struct StepFunUsageFetcher: Sendable {
         request.setValue("Oasis-Token=\(token); Oasis-Webid=\(self.webID)", forHTTPHeaderField: "Cookie")
         request.timeoutInterval = self.timeoutSeconds
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
             Self.log.debug("StepFun plan status request failed, skipping plan name")

--- a/Sources/CodexBarCore/Providers/Synthetic/SyntheticUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Synthetic/SyntheticUsageStats.swift
@@ -104,7 +104,7 @@ public struct SyntheticUsageFetcher: Sendable {
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw SyntheticUsageError.networkError("Invalid response")

--- a/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Venice/VeniceUsageFetcher.swift
@@ -172,7 +172,7 @@ public struct VeniceUsageFetcher: Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.timeoutInterval = Self.timeoutSeconds
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw VeniceUsageError.networkError("Invalid response")

--- a/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAITokenRefresher.swift
+++ b/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAITokenRefresher.swift
@@ -49,7 +49,7 @@ public enum VertexAITokenRefresher {
         request.httpBody = bodyString.data(using: .utf8)
 
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
+            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             guard let http = response as? HTTPURLResponse else {
                 throw RefreshError.invalidResponse("No HTTP response")
             }

--- a/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAIUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/VertexAI/VertexAIOAuth/VertexAIUsageFetcher.swift
@@ -219,7 +219,7 @@ public enum VertexAIUsageFetcher {
             let response: URLResponse
 
             do {
-                (data, response) = try await URLSession.shared.data(for: request)
+                (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             } catch {
                 throw VertexAIFetchError.networkError(error)
             }

--- a/Sources/CodexBarCore/Providers/Warp/WarpUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Warp/WarpUsageFetcher.swift
@@ -206,7 +206,7 @@ public struct WarpUsageFetcher: Sendable {
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw WarpUsageError.networkError("Invalid response")

--- a/Sources/CodexBarCore/Providers/Windsurf/WindsurfWebFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Windsurf/WindsurfWebFetcher.swift
@@ -139,7 +139,7 @@ public enum WindsurfWebFetcher {
         manualSessionInput: String? = nil,
         timeout: TimeInterval = 15,
         logger: ((String) -> Void)? = nil,
-        session: URLSession = .shared) async throws -> UsageSnapshot
+        session: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> UsageSnapshot
     {
         let log: (String) -> Void = { msg in logger?("[windsurf-web] \(msg)") }
 
@@ -257,7 +257,7 @@ public enum WindsurfWebFetcher {
         sessionInfos: [WindsurfDevinSessionImporter.SessionInfo],
         timeout: TimeInterval,
         logger log: (String) -> Void,
-        session: URLSession) async throws -> UsageSnapshot
+        session: any ProviderHTTPTransport) async throws -> UsageSnapshot
     {
         var lastError: Error?
         for sessionInfo in sessionInfos {
@@ -316,7 +316,7 @@ public enum WindsurfWebFetcher {
     private static func fetchPlanStatus(
         auth: WindsurfDevinSessionAuth,
         timeout: TimeInterval,
-        session: URLSession) async throws -> WindsurfGetPlanStatusResponse
+        session: any ProviderHTTPTransport) async throws -> WindsurfGetPlanStatusResponse
     {
         guard let url = URL(string: self.getPlanStatusURL) else {
             throw WindsurfWebFetcherError.apiCallFailed("Invalid GetPlanStatus URL")

--- a/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
@@ -326,7 +326,7 @@ public struct ZaiUsageFetcher: Sendable {
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "authorization")
         request.setValue("application/json", forHTTPHeaderField: "accept")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ZaiUsageError.networkError("Invalid response")
@@ -607,7 +607,7 @@ extension ZaiUsageFetcher {
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw ZaiUsageError.networkError("Invalid response")

--- a/Tests/CodexBarTests/CopilotUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CopilotUsageFetcherTests.swift
@@ -2,69 +2,27 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
-@Suite(.serialized)
 struct CopilotUsageFetcherTests {
     @Test
     func `fetchGitHubIdentity uses shared client`() async throws {
-        let registered = URLProtocol.registerClass(CopilotHTTPStubURLProtocol.self)
-        defer {
-            if registered {
-                URLProtocol.unregisterClass(CopilotHTTPStubURLProtocol.self)
-            }
-            CopilotHTTPStubURLProtocol.handler = nil
-            CopilotHTTPStubURLProtocol.requests = []
-        }
-
-        CopilotHTTPStubURLProtocol.requests = []
-        CopilotHTTPStubURLProtocol.handler = { request in
-            CopilotHTTPStubURLProtocol.requests.append(request)
+        let transport = ProviderHTTPTransportStub { request in
             guard request.value(forHTTPHeaderField: "Authorization") == "token abc123" else {
                 throw URLError(.userAuthenticationRequired)
             }
-            let response = HTTPURLResponse(
-                url: try #require(request.url),
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
                 statusCode: 200,
                 httpVersion: "HTTP/1.1",
                 headerFields: ["Content-Type": "application/json"])!
             return (Data(#"{"login":"testuser","id":123}"#.utf8), response)
         }
 
-        let identity = try await CopilotUsageFetcher.fetchGitHubIdentity(token: "abc123")
+        let identity = try await CopilotUsageFetcher.fetchGitHubIdentity(token: "abc123", transport: transport)
 
         #expect(identity.login == "testuser")
         #expect(identity.id == 123)
-        #expect(CopilotHTTPStubURLProtocol.requests.count == 1)
-        #expect(CopilotHTTPStubURLProtocol.requests.first?.url?.host == "api.github.com")
+        let requests = await transport.requests()
+        #expect(requests.count == 1)
+        #expect(requests.first?.url?.host == "api.github.com")
     }
-}
-
-final class CopilotHTTPStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (Data, URLResponse))?
-    nonisolated(unsafe) static var requests: [URLRequest] = []
-
-    override class func canInit(with request: URLRequest) -> Bool {
-        true
-    }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-        request
-    }
-
-    override func startLoading() {
-        guard let handler = Self.handler else {
-            self.client?.urlProtocol(self, didFailWithError: URLError(.cannotLoadFromNetwork))
-            return
-        }
-
-        do {
-            let (data, response) = try handler(self.request)
-            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            self.client?.urlProtocol(self, didLoad: data)
-            self.client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            self.client?.urlProtocol(self, didFailWithError: error)
-        }
-    }
-
-    override func stopLoading() {}
 }

--- a/Tests/CodexBarTests/CopilotUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CopilotUsageFetcherTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct CopilotUsageFetcherTests {
+    @Test
+    func `fetchGitHubIdentity uses shared client`() async throws {
+        let registered = URLProtocol.registerClass(CopilotHTTPStubURLProtocol.self)
+        defer {
+            if registered {
+                URLProtocol.unregisterClass(CopilotHTTPStubURLProtocol.self)
+            }
+            CopilotHTTPStubURLProtocol.handler = nil
+            CopilotHTTPStubURLProtocol.requests = []
+        }
+
+        CopilotHTTPStubURLProtocol.requests = []
+        CopilotHTTPStubURLProtocol.handler = { request in
+            CopilotHTTPStubURLProtocol.requests.append(request)
+            guard request.value(forHTTPHeaderField: "Authorization") == "token abc123" else {
+                throw URLError(.userAuthenticationRequired)
+            }
+            let response = HTTPURLResponse(
+                url: try #require(request.url),
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"])!
+            return (Data(#"{"login":"testuser","id":123}"#.utf8), response)
+        }
+
+        let identity = try await CopilotUsageFetcher.fetchGitHubIdentity(token: "abc123")
+
+        #expect(identity.login == "testuser")
+        #expect(identity.id == 123)
+        #expect(CopilotHTTPStubURLProtocol.requests.count == 1)
+        #expect(CopilotHTTPStubURLProtocol.requests.first?.url?.host == "api.github.com")
+    }
+}
+
+final class CopilotHTTPStubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (Data, URLResponse))?
+    nonisolated(unsafe) static var requests: [URLRequest] = []
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.cannotLoadFromNetwork))
+            return
+        }
+
+        do {
+            let (data, response) = try handler(self.request)
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            self.client?.urlProtocol(self, didLoad: data)
+            self.client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            self.client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/CodexBarTests/GoogleWorkspaceStatusNetworkTests.swift
+++ b/Tests/CodexBarTests/GoogleWorkspaceStatusNetworkTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+@Suite(.serialized)
+@MainActor
+struct GoogleWorkspaceStatusNetworkTests {
+    @Test
+    func `fetchWorkspaceStatus uses shared client`() async throws {
+        let registered = URLProtocol.registerClass(WorkspaceStatusStubURLProtocol.self)
+        defer {
+            if registered {
+                URLProtocol.unregisterClass(WorkspaceStatusStubURLProtocol.self)
+            }
+            WorkspaceStatusStubURLProtocol.handler = nil
+            WorkspaceStatusStubURLProtocol.requests = []
+        }
+
+        WorkspaceStatusStubURLProtocol.requests = []
+        WorkspaceStatusStubURLProtocol.handler = { request in
+            WorkspaceStatusStubURLProtocol.requests.append(request)
+            let response = HTTPURLResponse(
+                url: try #require(request.url),
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"])!
+            let body = Data(#"""
+            [
+              {
+                "begin": "2026-05-10T10:00:00+00:00",
+                "end": null,
+                "affected_products": [
+                  {"title": "Gemini", "id": "npdyhgECDJ6tB66MxXyo"}
+                ],
+                "most_recent_update": {
+                  "when": "2026-05-10T10:15:00+00:00",
+                  "status": "SERVICE_OUTAGE",
+                  "text": "**Summary**\nGemini API error.\n"
+                }
+              }
+            ]
+            """#.utf8)
+            return (body, response)
+        }
+
+        let status = try await UsageStore.fetchWorkspaceStatus(productID: "npdyhgECDJ6tB66MxXyo")
+
+        #expect(status.indicator == .critical)
+        #expect(status.description == "Gemini API error.")
+        #expect(WorkspaceStatusStubURLProtocol.requests.count == 1)
+        #expect(WorkspaceStatusStubURLProtocol.requests.first?.url?.host == "www.google.com")
+    }
+}
+
+final class WorkspaceStatusStubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (Data, URLResponse))?
+    nonisolated(unsafe) static var requests: [URLRequest] = []
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.cannotLoadFromNetwork))
+            return
+        }
+
+        do {
+            let (data, response) = try handler(self.request)
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            self.client?.urlProtocol(self, didLoad: data)
+            self.client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            self.client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/CodexBarTests/GoogleWorkspaceStatusNetworkTests.swift
+++ b/Tests/CodexBarTests/GoogleWorkspaceStatusNetworkTests.swift
@@ -2,25 +2,13 @@ import Foundation
 import Testing
 @testable import CodexBar
 
-@Suite(.serialized)
 @MainActor
 struct GoogleWorkspaceStatusNetworkTests {
     @Test
     func `fetchWorkspaceStatus uses shared client`() async throws {
-        let registered = URLProtocol.registerClass(WorkspaceStatusStubURLProtocol.self)
-        defer {
-            if registered {
-                URLProtocol.unregisterClass(WorkspaceStatusStubURLProtocol.self)
-            }
-            WorkspaceStatusStubURLProtocol.handler = nil
-            WorkspaceStatusStubURLProtocol.requests = []
-        }
-
-        WorkspaceStatusStubURLProtocol.requests = []
-        WorkspaceStatusStubURLProtocol.handler = { request in
-            WorkspaceStatusStubURLProtocol.requests.append(request)
-            let response = HTTPURLResponse(
-                url: try #require(request.url),
+        let transport = ProviderHTTPTransportStub { request in
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
                 statusCode: 200,
                 httpVersion: "HTTP/1.1",
                 headerFields: ["Content-Type": "application/json"])!
@@ -43,42 +31,14 @@ struct GoogleWorkspaceStatusNetworkTests {
             return (body, response)
         }
 
-        let status = try await UsageStore.fetchWorkspaceStatus(productID: "npdyhgECDJ6tB66MxXyo")
+        let status = try await UsageStore.fetchWorkspaceStatus(
+            productID: "npdyhgECDJ6tB66MxXyo",
+            transport: transport)
 
         #expect(status.indicator == .critical)
         #expect(status.description == "Gemini API error.")
-        #expect(WorkspaceStatusStubURLProtocol.requests.count == 1)
-        #expect(WorkspaceStatusStubURLProtocol.requests.first?.url?.host == "www.google.com")
+        let requests = await transport.requests()
+        #expect(requests.count == 1)
+        #expect(requests.first?.url?.host == "www.google.com")
     }
-}
-
-final class WorkspaceStatusStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (Data, URLResponse))?
-    nonisolated(unsafe) static var requests: [URLRequest] = []
-
-    override class func canInit(with request: URLRequest) -> Bool {
-        true
-    }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-        request
-    }
-
-    override func startLoading() {
-        guard let handler = Self.handler else {
-            self.client?.urlProtocol(self, didFailWithError: URLError(.cannotLoadFromNetwork))
-            return
-        }
-
-        do {
-            let (data, response) = try handler(self.request)
-            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            self.client?.urlProtocol(self, didLoad: data)
-            self.client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            self.client?.urlProtocol(self, didFailWithError: error)
-        }
-    }
-
-    override func stopLoading() {}
 }

--- a/Tests/CodexBarTests/ProviderHTTPClientTests.swift
+++ b/Tests/CodexBarTests/ProviderHTTPClientTests.swift
@@ -9,8 +9,8 @@ struct ProviderHTTPClientTests {
         StubURLProtocol.requests = []
         StubURLProtocol.handler = { request in
             StubURLProtocol.requests.append(request)
-            let response = HTTPURLResponse(
-                url: try #require(request.url),
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
                 statusCode: 200,
                 httpVersion: "HTTP/1.1",
                 headerFields: ["Content-Type": "application/json"])!
@@ -24,7 +24,7 @@ struct ProviderHTTPClientTests {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [StubURLProtocol.self]
         let client = ProviderHTTPClient(session: URLSession(configuration: configuration))
-        let request = URLRequest(url: URL(string: "https://example.com/status")!)
+        let request = try URLRequest(url: #require(URL(string: "https://example.com/status")))
 
         let (data, response) = try await client.data(for: request)
 
@@ -40,11 +40,11 @@ final class StubURLProtocol: URLProtocol {
     nonisolated(unsafe) static var handler: ((URLRequest) throws -> (Data, URLResponse))?
     nonisolated(unsafe) static var requests: [URLRequest] = []
 
-    override class func canInit(with request: URLRequest) -> Bool {
+    override static func canInit(with request: URLRequest) -> Bool {
         true
     }
 
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
         request
     }
 

--- a/Tests/CodexBarTests/ProviderHTTPClientTests.swift
+++ b/Tests/CodexBarTests/ProviderHTTPClientTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct ProviderHTTPClientTests {
+    @Test
+    func `client loads requests through an injected session`() async throws {
+        StubURLProtocol.requests = []
+        StubURLProtocol.handler = { request in
+            StubURLProtocol.requests.append(request)
+            let response = HTTPURLResponse(
+                url: try #require(request.url),
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"])!
+            return (Data(#"{"ok":true}"#.utf8), response)
+        }
+        defer {
+            StubURLProtocol.handler = nil
+            StubURLProtocol.requests = []
+        }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [StubURLProtocol.self]
+        let client = ProviderHTTPClient(session: URLSession(configuration: configuration))
+        let request = URLRequest(url: URL(string: "https://example.com/status")!)
+
+        let (data, response) = try await client.data(for: request)
+
+        let body = try #require(String(data: data, encoding: .utf8))
+        #expect(body == #"{"ok":true}"#)
+        #expect((response as? HTTPURLResponse)?.statusCode == 200)
+        #expect(StubURLProtocol.requests.count == 1)
+        #expect(StubURLProtocol.requests.first?.url?.host == "example.com")
+    }
+}
+
+final class StubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (Data, URLResponse))?
+    nonisolated(unsafe) static var requests: [URLRequest] = []
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.cannotLoadFromNetwork))
+            return
+        }
+
+        do {
+            let (data, response) = try handler(self.request)
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            self.client?.urlProtocol(self, didLoad: data)
+            self.client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            self.client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Tests/CodexBarTests/ProviderHTTPTransportStub.swift
+++ b/Tests/CodexBarTests/ProviderHTTPTransportStub.swift
@@ -1,0 +1,20 @@
+import Foundation
+@testable import CodexBarCore
+
+actor ProviderHTTPTransportStub: ProviderHTTPTransport {
+    private let handler: @Sendable (URLRequest) async throws -> (Data, URLResponse)
+    private var recordedRequests: [URLRequest] = []
+
+    init(handler: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse)) {
+        self.handler = handler
+    }
+
+    func requests() -> [URLRequest] {
+        self.recordedRequests
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        self.recordedRequests.append(request)
+        return try await self.handler(request)
+    }
+}


### PR DESCRIPTION
## Summary
Add a shared ProviderHTTPClient seam and route a few network call sites through it:
- Copilot GitHub identity fetch
- Factory status probe
- Google Workspace status fetch

## Why
This is a narrow first step toward the broader proxy work. It keeps the PR small and reviewable while proving the shared HTTP path with tests.

## Testing
- swift test --filter ProviderHTTPClientTests
- swift test --filter CopilotUsageFetcherTests
- swift test --filter GoogleWorkspaceStatusNetworkTests
- swift test --filter FactoryStatusProbeFetchTests
