### PR TITLE
Fix Settings crash in packaged app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.26 — Unreleased
 
+### Fixed
+- Settings: avoid packaged-app crashes from SwiftPM localization bundle lookup when opening Settings or About (#896, fixes #891). Thanks @lederniermagicien!
+
 ## 0.25 — 2026-05-10
 
 ### Highlights

--- a/Sources/CodexBar/Localization.swift
+++ b/Sources/CodexBar/Localization.swift
@@ -8,10 +8,9 @@ private func appLanguageDefaults() -> UserDefaults {
     return UserDefaults(suiteName: "CodexBar") ?? .standard
 }
 
-private func codexBarLocalizationResourceBundle(
+func codexBarLocalizationResourceBundle(
     mainBundle: Bundle = .main,
-    bundleName: String = "CodexBar_CodexBar")
-    -> Bundle
+    bundleName: String = "CodexBar_CodexBar") -> Bundle
 {
     guard mainBundle.bundleURL.pathExtension == "app" else {
         return Bundle.module

--- a/Sources/CodexBar/Localization.swift
+++ b/Sources/CodexBar/Localization.swift
@@ -8,30 +8,55 @@ private func appLanguageDefaults() -> UserDefaults {
     return UserDefaults(suiteName: "CodexBar") ?? .standard
 }
 
+private func codexBarLocalizationResourceBundle(
+    mainBundle: Bundle = .main,
+    bundleName: String = "CodexBar_CodexBar")
+    -> Bundle
+{
+    guard mainBundle.bundleURL.pathExtension == "app" else {
+        return Bundle.module
+    }
+
+    if let url = mainBundle.url(forResource: bundleName, withExtension: "bundle"),
+       let bundle = Bundle(url: url)
+    {
+        return bundle
+    }
+
+    if let resourceURL = mainBundle.resourceURL?.absoluteURL,
+       let bundle = Bundle(url: resourceURL.appendingPathComponent("\(bundleName).bundle"))
+    {
+        return bundle
+    }
+
+    return mainBundle
+}
+
 private func localizedBundle() -> Bundle {
+    let resourceBundle = codexBarLocalizationResourceBundle()
     let language = appLanguageDefaults().string(forKey: "appLanguage") ?? ""
     if !language.isEmpty {
-        if let path = Bundle.module.path(forResource: language, ofType: "lproj"),
+        if let path = resourceBundle.path(forResource: language, ofType: "lproj"),
            let bundle = Bundle(path: path)
         {
             return bundle
         }
     } else {
         // System mode: follow macOS language preferences
-        if let preferred = Bundle.module.preferredLocalizations.first,
-           let path = Bundle.module.path(forResource: preferred, ofType: "lproj"),
+        if let preferred = resourceBundle.preferredLocalizations.first,
+           let path = resourceBundle.path(forResource: preferred, ofType: "lproj"),
            let bundle = Bundle(path: path)
         {
             return bundle
         }
     }
     // Fallback to en.lproj
-    if let path = Bundle.module.path(forResource: "en", ofType: "lproj"),
+    if let path = resourceBundle.path(forResource: "en", ofType: "lproj"),
        let bundle = Bundle(path: path)
     {
         return bundle
     }
-    return Bundle.module
+    return resourceBundle
 }
 
 func L(_ key: String) -> String {

--- a/Tests/CodexBarTests/LocalizationBundleTests.swift
+++ b/Tests/CodexBarTests/LocalizationBundleTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct LocalizationBundleTests {
+    @Test
+    func `packaged app resolves localization bundle from resources`() throws {
+        let fixture = try Self.makeAppBundleFixture(includeLocalizationBundle: true)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let bundle = codexBarLocalizationResourceBundle(mainBundle: fixture.appBundle)
+
+        #expect(bundle.bundleURL.lastPathComponent == "CodexBar_CodexBar.bundle")
+        #expect(bundle.path(forResource: "en", ofType: "lproj") != nil)
+    }
+
+    @Test
+    func `packaged app falls back to main bundle without touching SwiftPM module`() throws {
+        let fixture = try Self.makeAppBundleFixture(includeLocalizationBundle: false)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let bundle = codexBarLocalizationResourceBundle(mainBundle: fixture.appBundle)
+
+        #expect(bundle.bundleURL == fixture.appBundle.bundleURL)
+    }
+
+    private static func makeAppBundleFixture(
+        includeLocalizationBundle: Bool) throws -> (root: URL, appBundle: Bundle)
+    {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "codexbar-localization-\(UUID().uuidString)",
+            isDirectory: true)
+        let appURL = root.appendingPathComponent("CodexBar.app", isDirectory: true)
+        let contentsURL = appURL.appendingPathComponent("Contents", isDirectory: true)
+        let resourcesURL = contentsURL.appendingPathComponent("Resources", isDirectory: true)
+        try FileManager.default.createDirectory(at: resourcesURL, withIntermediateDirectories: true)
+
+        let info = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>CFBundleExecutable</key><string>CodexBar</string>
+            <key>CFBundleIdentifier</key><string>com.steipete.codexbar.tests</string>
+            <key>CFBundleName</key><string>CodexBar</string>
+            <key>CFBundlePackageType</key><string>APPL</string>
+        </dict>
+        </plist>
+        """
+        try info.write(
+            to: contentsURL.appendingPathComponent("Info.plist"),
+            atomically: true,
+            encoding: .utf8)
+
+        if includeLocalizationBundle {
+            let lprojURL = resourcesURL
+                .appendingPathComponent("CodexBar_CodexBar.bundle", isDirectory: true)
+                .appendingPathComponent("en.lproj", isDirectory: true)
+            try FileManager.default.createDirectory(at: lprojURL, withIntermediateDirectories: true)
+            try "\"Settings\" = \"Settings\";\n".write(
+                to: lprojURL.appendingPathComponent("Localizable.strings"),
+                atomically: true,
+                encoding: .utf8)
+        }
+
+        let appBundle = try #require(Bundle(url: appURL))
+        return (root, appBundle)
+    }
+}


### PR DESCRIPTION
## Summary
- Fix packaged app localization lookup so Settings does not touch SwiftPM `Bundle.module` at runtime
- Keep SwiftPM/test execution on `Bundle.module`, and use the packaged `CodexBar_CodexBar.bundle` only inside the app bundle

## Validation
- `make check`
- `swift test`
- `CODEXBAR_SIGNING=adhoc ./Scripts/package_app.sh debug`
- Relaunched the freshly built app and opened Settings without a crash

## Screenshots
N/A - crash fix, no visual UI changes.

Closes #891