### PR TITLE
Fix CLI release version fallback

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -143,9 +143,11 @@ jobs:
             lipo -archs "$BIN" | tr ' ' '\n' | grep -Fx "${{ matrix.asset-arch }}"
           else
             "$BIN" --help
-            "$BIN" --version
             file "$BIN" | grep -q "${{ matrix.asset-arch }}"
           fi
+          printf '%s\n' "${RELEASE_TAG#v}" > "$BIN_DIR/VERSION"
+          "$BIN" --version | grep -Fx "CodexBar ${RELEASE_TAG#v}"
+          rm "$BIN_DIR/VERSION"
 
       - name: Package
         id: pkg
@@ -164,9 +166,10 @@ jobs:
           OUT_DIR="$(mktemp -d)"
           install -m 0755 "$BIN_DIR/CodexBarCLI" "$OUT_DIR/CodexBarCLI"
           ln -s "CodexBarCLI" "$OUT_DIR/codexbar"
+          printf '%s\n' "${SAFE_REF_NAME#v}" > "$OUT_DIR/VERSION"
 
           ASSET="CodexBarCLI-${SAFE_REF_NAME}-${{ matrix.platform }}-${{ matrix.asset-arch }}.tar.gz"
-          (cd "$OUT_DIR" && tar czf "$ASSET" CodexBarCLI codexbar)
+          (cd "$OUT_DIR" && tar czf "$ASSET" CodexBarCLI codexbar VERSION)
           if command -v sha256sum >/dev/null 2>&1; then
             sha256sum "$OUT_DIR/$ASSET" > "$OUT_DIR/$ASSET.sha256"
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Settings: avoid packaged-app crashes from SwiftPM localization bundle lookup when opening Settings or About (#896, fixes #891). Thanks @lederniermagicien!
+- CLI: include a VERSION file in standalone release archives so `--version` reports the release tag outside the app bundle (#898). Thanks @ThiagoCAltoe!
 
 ## 0.25 — 2026-05-10
 

--- a/Sources/CodexBarCLI/CLIIO.swift
+++ b/Sources/CodexBarCLI/CLIIO.swift
@@ -47,7 +47,10 @@ extension CodexBarCLI {
         guard let executablePath, !executablePath.isEmpty else { return nil }
 
         let executableURL = URL(fileURLWithPath: executablePath).resolvingSymlinksInPath()
-        return Self.containingAppVersion(for: executableURL)
+        if let version = Self.containingAppVersion(for: executableURL) {
+            return version
+        }
+        return Self.adjacentVersionFileVersion(for: executableURL)
     }
 
     static func containingAppVersion(for executableURL: URL) -> String? {
@@ -68,6 +71,21 @@ extension CodexBarCLI {
         }
 
         return nil
+    }
+
+    static func adjacentVersionFileVersion(for executableURL: URL) -> String? {
+        let versionURL = executableURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("VERSION")
+        guard let raw = try? String(contentsOf: versionURL, encoding: .utf8) else {
+            return nil
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.hasPrefix("v"), trimmed.dropFirst().first?.isNumber == true {
+            return String(trimmed.dropFirst())
+        }
+        return trimmed
     }
 
     static func platformExit(_ code: Int32) -> Never {

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -97,6 +97,28 @@ struct CLIEntryTests {
     }
 
     @Test
+    func `CLI version falls back to adjacent VERSION file`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-cli-version-file-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let emptyBundleURL = root.appendingPathComponent("Empty.bundle", isDirectory: true)
+        let binURL = root.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: emptyBundleURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: binURL, withIntermediateDirectories: true)
+
+        let helperURL = binURL.appendingPathComponent("CodexBarCLI")
+        try Data().write(to: helperURL)
+        try "v3.2.1\n".write(
+            to: binURL.appendingPathComponent("VERSION"),
+            atomically: true,
+            encoding: .utf8)
+
+        let emptyBundle = try #require(Bundle(url: emptyBundleURL))
+        #expect(CodexBarCLI.currentVersion(bundle: emptyBundle, executablePath: helperURL.path) == "3.2.1")
+    }
+
+    @Test
     func `render open AI web dashboard text includes summary`() {
         let event = CreditEvent(
             date: Date(timeIntervalSince1970: 1_700_000_000),

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -116,6 +116,18 @@ struct CLIEntryTests {
 
         let emptyBundle = try #require(Bundle(url: emptyBundleURL))
         #expect(CodexBarCLI.currentVersion(bundle: emptyBundle, executablePath: helperURL.path) == "3.2.1")
+
+        try "3.2.2\n".write(
+            to: binURL.appendingPathComponent("VERSION"),
+            atomically: true,
+            encoding: .utf8)
+        #expect(CodexBarCLI.currentVersion(bundle: emptyBundle, executablePath: helperURL.path) == "3.2.2")
+
+        try "version-3.2.3\n".write(
+            to: binURL.appendingPathComponent("VERSION"),
+            atomically: true,
+            encoding: .utf8)
+        #expect(CodexBarCLI.currentVersion(bundle: emptyBundle, executablePath: helperURL.path) == "version-3.2.3")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add a standalone `VERSION` file fallback for `CodexBarCLI --version` when the binary is not inside `CodexBar.app`.
- Include `VERSION` in release CLI tarballs so downloaded standalone `codexbar`/`CodexBarCLI` assets report the release version.
- Extend the release smoke test and CLI entry tests to cover the fallback.

## Validation

- `git diff --check HEAD~1..HEAD`

Not run locally:

- `swift test --filter CLIEntryTests` because Swift is not installed in this Windows environment.
