### PR TITLE
[codex] Coalesce historical pace reset buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - CLI: route Claude token-account `--source cli` reads through the selected OAuth/session credential so `--all-accounts` no longer relabels ambient CLI usage (#403).
 - Codex: keep session and weekly quota-warning marker thresholds independent so usage bars do not duplicate marker lines (#938, fixes #927). Thanks @iam-brain!
 - Menu: avoid rebuilding visible menus during background open-menu refreshes so hover submenus stay responsive (#923, fixes #909). Thanks @AmrMohamad!
+- Codex: coalesce historical pace reset timestamps into 5-minute buckets so dashboard and live reset jitter do not duplicate weekly history windows (#901). Thanks @zhulijin1991!
 - Settings: let stale managed Codex account records be removed even when their stored home path is outside CodexBar's managed-home directory, and keep CLI known-owner tests from writing fixtures into the live app store.
 - Settings: apply the selected app language from packaged SwiftPM resources instead of falling back to English when the `.lproj` directory casing differs (#908).
 - Claude: handle Enterprise/organization web accounts whose session quota window is null and expose an optional Org ID field for Claude token accounts (#941, fixes #940). Thanks @clintandrewhall!

--- a/Sources/CodexBar/HistoricalUsagePace.swift
+++ b/Sources/CodexBar/HistoricalUsagePace.swift
@@ -80,7 +80,7 @@ actor HistoricalUsageHistoryStore {
     private static let backfillCalibrationMinimumCredits = 0.001
     private static let backfillSampleFractions: [Double] = (0...14).map { Double($0) / 14.0 }
     private static let coverageTolerance: TimeInterval = 16 * 60 * 60
-    private static let resetBucketSeconds: TimeInterval = 60
+    private static let resetBucketSeconds: TimeInterval = 5 * 60
 
     private let fileURL: URL
     private var records: [HistoricalUsageRecord] = []
@@ -762,7 +762,7 @@ enum CodexHistoricalPaceEvaluator {
     static let minimumWeeksForRisk = 5
     private static let recencyTauWeeks: Double = 3
     private static let epsilon: Double = 1e-9
-    private static let resetBucketSeconds: TimeInterval = 60
+    private static let resetBucketSeconds: TimeInterval = 5 * 60
 
     static func evaluate(window: RateWindow, now: Date, dataset: CodexHistoricalDataset?) -> UsagePace? {
         guard let dataset else { return nil }

--- a/Tests/CodexBarTests/HistoricalUsagePaceOwnershipTests.swift
+++ b/Tests/CodexBarTests/HistoricalUsagePaceOwnershipTests.swift
@@ -283,7 +283,7 @@ extension HistoricalUsagePaceTests {
                     windowMinutes: record.windowMinutes)
             },
             to: fileURL)
-        let expectedResetAt = fixtureResetAt.addingTimeInterval(dateShift)
+        let expectedResetAt = Self.normalizeReset(fixtureResetAt.addingTimeInterval(dateShift))
 
         let dataset = await store.loadCodexDataset(
             canonicalAccountKey: providerAccountKey,

--- a/Tests/CodexBarTests/HistoricalUsagePaceTestSupport.swift
+++ b/Tests/CodexBarTests/HistoricalUsagePaceTestSupport.swift
@@ -94,7 +94,7 @@ extension HistoricalUsagePaceTests {
     }
 
     static func normalizeReset(_ value: Date) -> Date {
-        let bucket = 60.0
+        let bucket = 5 * 60.0
         let rounded = (value.timeIntervalSinceReferenceDate / bucket).rounded() * bucket
         return Date(timeIntervalSinceReferenceDate: rounded)
     }

--- a/Tests/CodexBarTests/HistoricalUsagePaceTests.swift
+++ b/Tests/CodexBarTests/HistoricalUsagePaceTests.swift
@@ -286,6 +286,44 @@ struct HistoricalUsagePaceTests {
     }
 
     @Test
+    func `history store backfill is idempotent across minute scale reset jitter`() async {
+        let fileURL = Self.makeTempURL()
+        let store = HistoricalUsageHistoryStore(fileURL: fileURL)
+        let now = Date(timeIntervalSince1970: 1_770_000_000)
+        let windowMinutes = 10080
+        let canonicalReset = Self.normalizeReset(now.addingTimeInterval(2 * 24 * 60 * 60))
+        let firstWindow = RateWindow(
+            usedPercent: 50,
+            windowMinutes: windowMinutes,
+            resetsAt: canonicalReset.addingTimeInterval(-90),
+            resetDescription: nil)
+        let secondWindow = RateWindow(
+            usedPercent: 50,
+            windowMinutes: windowMinutes,
+            resetsAt: canonicalReset.addingTimeInterval(90),
+            resetDescription: nil)
+
+        let breakdown = Self.syntheticBreakdown(endingAt: now, days: 35, dailyCredits: 10)
+        let first = await store.backfillCodexWeeklyFromUsageBreakdown(
+            breakdown,
+            referenceWindow: firstWindow,
+            now: now,
+            accountKey: nil)
+        let recordsAfterFirst = (try? Self.readHistoricalRecords(from: fileURL)) ?? []
+        let second = await store.backfillCodexWeeklyFromUsageBreakdown(
+            breakdown,
+            referenceWindow: secondWindow,
+            now: now,
+            accountKey: nil)
+        let recordsAfterSecond = (try? Self.readHistoricalRecords(from: fileURL)) ?? []
+
+        #expect((first?.weeks.count ?? 0) >= 3)
+        #expect(first?.weeks.count == second?.weeks.count)
+        #expect(recordsAfterSecond.count == recordsAfterFirst.count)
+        #expect(Self.datasetCurveSignature(first) == Self.datasetCurveSignature(second))
+    }
+
+    @Test
     func `history store backfill fills incomplete existing week`() async {
         let fileURL = Self.makeTempURL()
         let store = HistoricalUsageHistoryStore(fileURL: fileURL)
@@ -358,7 +396,7 @@ struct HistoricalUsagePaceTests {
         let store = HistoricalUsageHistoryStore(fileURL: fileURL)
         let windowMinutes = 10080
         let duration = TimeInterval(windowMinutes) * 60
-        let canonicalReset = Date(timeIntervalSince1970: 1_770_000_000)
+        let canonicalReset = Self.normalizeReset(Date(timeIntervalSince1970: 1_770_000_000))
         let windowStart = canonicalReset.addingTimeInterval(-duration)
 
         let samples: [(u: Double, used: Double)] = [
@@ -370,7 +408,7 @@ struct HistoricalUsagePaceTests {
             (0.98, 95),
         ]
         for (index, sample) in samples.enumerated() {
-            let jitteredReset = canonicalReset.addingTimeInterval(index.isMultiple(of: 2) ? -20 : 20)
+            let jitteredReset = canonicalReset.addingTimeInterval(index.isMultiple(of: 2) ? -100 : 100)
             _ = await store.recordCodexWeekly(
                 window: RateWindow(
                     usedPercent: sample.used,
@@ -400,7 +438,7 @@ struct HistoricalUsagePaceTests {
             window: RateWindow(
                 usedPercent: 35,
                 windowMinutes: windowMinutes,
-                resetsAt: targetReset.addingTimeInterval(30),
+                resetsAt: targetReset.addingTimeInterval(120),
                 resetDescription: nil),
             sampledAt: targetStart.addingTimeInterval(duration * 0.5),
             accountKey: nil)


### PR DESCRIPTION
## Summary
- Coalesce historical weekly reset timestamps into five-minute buckets instead of one-minute buckets.
- Keep the historical store and pace evaluator using the same reset normalization.
- Add regression coverage for minute-scale reset jitter during historical backfill.

## Root cause
Weekly reset timestamps can vary by a few minutes between dashboard-derived backfill data and live usage samples. The previous one-minute bucket could split a single logical reset window into multiple historical weeks, which made historical pace calculations over-weight duplicated windows and produce misleading pace labels.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --enable-swift-testing --filter HistoricalUsagePaceTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./Scripts/lint.sh lint`
