### PR TITLE
Harden ChatGPT purchase URL validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.26 — Unreleased
 
+### Fixed
+- ChatGPT credits: restrict purchase links to real HTTPS `chatgpt.com` settings/usage/billing/credits paths and drop query/fragment data (#903). Thanks @ThiagoCAltoe!
+
 ## 0.25.1 — 2026-05-11
 
 ### Fixed

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -90,13 +90,22 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         self.creditsPurchaseWindow = controller
     }
 
-    private static func sanitizedCreditsPurchaseURL(_ raw: String?) -> String? {
+    static func sanitizedCreditsPurchaseURL(_ raw: String?) -> String? {
         guard let raw, let url = URL(string: raw) else { return nil }
-        guard let host = url.host?.lowercased(), host.contains("chatgpt.com") else { return nil }
+        guard Self.isAllowedChatGPTPurchaseHost(url) else { return nil }
         let path = url.path.lowercased()
         let allowed = ["settings", "usage", "billing", "credits"]
         guard allowed.contains(where: { path.contains($0) }) else { return nil }
-        return url.absoluteString
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        components?.query = nil
+        components?.fragment = nil
+        return components?.url?.absoluteString ?? url.absoluteString
+    }
+
+    private static func isAllowedChatGPTPurchaseHost(_ url: URL) -> Bool {
+        guard url.scheme?.lowercased() == "https" else { return false }
+        guard let host = url.host?.lowercased() else { return false }
+        return host == "chatgpt.com" || host.hasSuffix(".chatgpt.com")
     }
 
     @objc func openStatusPage() {

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -93,9 +93,9 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     static func sanitizedCreditsPurchaseURL(_ raw: String?) -> String? {
         guard let raw, let url = URL(string: raw) else { return nil }
         guard Self.isAllowedChatGPTPurchaseHost(url) else { return nil }
-        let path = url.path.lowercased()
+        let pathComponents = url.pathComponents.map { $0.lowercased() }
         let allowed = ["settings", "usage", "billing", "credits"]
-        guard allowed.contains(where: { path.contains($0) }) else { return nil }
+        guard pathComponents.contains(where: { allowed.contains($0) }) else { return nil }
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
         components?.query = nil
         components?.fragment = nil

--- a/Tests/CodexBarTests/StatusItemPurchaseURLTests.swift
+++ b/Tests/CodexBarTests/StatusItemPurchaseURLTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct StatusItemPurchaseURLTests {
+    @Test
+    @MainActor
+    func `purchase URL accepts ChatGPT hosts`() {
+        #expect(
+            StatusItemController.sanitizedCreditsPurchaseURL("https://chatgpt.com/settings/billing")
+                == "https://chatgpt.com/settings/billing")
+        #expect(
+            StatusItemController
+                .sanitizedCreditsPurchaseURL("https://chatgpt.com/usage/credits?token=secret#fragment")
+                == "https://chatgpt.com/usage/credits")
+        #expect(
+            StatusItemController.sanitizedCreditsPurchaseURL("https://team.chatgpt.com/settings/billing")
+                == "https://team.chatgpt.com/settings/billing")
+    }
+
+    @Test
+    @MainActor
+    func `purchase URL rejects lookalike hosts`() {
+        #expect(
+            StatusItemController
+                .sanitizedCreditsPurchaseURL("https://chatgpt.com.evil.example/settings/billing") == nil)
+        #expect(
+            StatusItemController.sanitizedCreditsPurchaseURL("https://evil-chatgpt.com/settings/billing")
+                == nil)
+        #expect(
+            StatusItemController.sanitizedCreditsPurchaseURL("https://notchatgpt.com/settings/billing")
+                == nil)
+    }
+
+    @Test
+    @MainActor
+    func `purchase URL rejects non HTTPS and unrelated paths`() {
+        #expect(
+            StatusItemController.sanitizedCreditsPurchaseURL("http://chatgpt.com/settings/billing")
+                == nil)
+        #expect(
+            StatusItemController.sanitizedCreditsPurchaseURL("https://chatgpt.com/backend-api/accounts")
+                == nil)
+        #expect(StatusItemController.sanitizedCreditsPurchaseURL("not a url") == nil)
+    }
+}

--- a/Tests/CodexBarTests/StatusItemPurchaseURLTests.swift
+++ b/Tests/CodexBarTests/StatusItemPurchaseURLTests.swift
@@ -41,6 +41,9 @@ struct StatusItemPurchaseURLTests {
         #expect(
             StatusItemController.sanitizedCreditsPurchaseURL("https://chatgpt.com/backend-api/accounts")
                 == nil)
+        #expect(
+            StatusItemController.sanitizedCreditsPurchaseURL("https://chatgpt.com/backend-api/settings-token")
+                == nil)
         #expect(StatusItemController.sanitizedCreditsPurchaseURL("not a url") == nil)
     }
 }


### PR DESCRIPTION
## Summary
- Tightens ChatGPT purchase URL validation to require HTTPS.
- Accepts only `chatgpt.com` or real `*.chatgpt.com` subdomains.
- Rejects lookalike hosts such as `chatgpt.com.evil.example` and `evil-chatgpt.com`.

## Validation
- Added focused tests for accepted ChatGPT URLs, lookalike hosts, non-HTTPS URLs, and unrelated paths.
- Ran `git diff --check`.
- Could not run Swift tests in this environment because `swift` is not installed.