### PR TITLE
Fix z.ai MCP monthly window label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.26 — Unreleased
 
+### Fixed
+- z.ai: show the MCP quota bucket as monthly instead of a misleading 1-minute window (#904). Thanks @ThiagoCAltoe!
+
 ## 0.25.1 — 2026-05-11
 
 ### Fixed

--- a/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
@@ -96,6 +96,10 @@ extension ZaiLimitEntry {
         return "\(description) window"
     }
 
+    var isMCPMonthlyMarker: Bool {
+        self.type == .timeLimit && self.unit == .minutes && self.number == 1
+    }
+
     private var computedUsedPercent: Double? {
         guard let limit = self.usage, limit > 0 else { return nil }
 
@@ -197,6 +201,9 @@ extension ZaiUsageSnapshot {
     }
 
     private static func resetDescription(for limit: ZaiLimitEntry) -> String? {
+        if limit.isMCPMonthlyMarker {
+            return "Monthly"
+        }
         if let label = limit.windowLabel {
             return label
         }

--- a/Tests/CodexBarTests/ZaiProviderTests.swift
+++ b/Tests/CodexBarTests/ZaiProviderTests.swift
@@ -227,6 +227,49 @@ struct ZaiUsageParsingTests {
         #expect(snapshot.tokenLimit?.usage == 40_000_000)
         #expect(snapshot.timeLimit?.usageDetails.first?.modelCode == "search-prime")
         #expect(snapshot.tokenLimit?.percentage == 34.0)
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.secondary?.windowMinutes == nil)
+        #expect(usage.secondary?.resetDescription == "Monthly")
+    }
+
+    @Test
+    func `zai mcp time limit displays monthly instead of one minute window`() throws {
+        let json = """
+        {
+          "code": 200,
+          "msg": "Operation successful",
+          "data": {
+            "limits": [
+              {
+                "type": "TIME_LIMIT",
+                "unit": 5,
+                "number": 1,
+                "usage": 100,
+                "currentValue": 50,
+                "remaining": 50,
+                "percentage": 50,
+                "usageDetails": []
+              },
+              {
+                "type": "TOKENS_LIMIT",
+                "unit": 3,
+                "number": 5,
+                "percentage": 34,
+                "nextResetTime": 1768507567547
+              }
+            ]
+          },
+          "success": true
+        }
+        """
+
+        let snapshot = try ZaiUsageFetcher.parseUsageSnapshot(from: Data(json.utf8))
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(snapshot.timeLimit?.windowDescription == "1 minute")
+        #expect(usage.secondary?.windowMinutes == nil)
+        #expect(usage.secondary?.resetDescription == "Monthly")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- show z.ai MCP `TIME_LIMIT` usage as Monthly instead of the raw `1 minute window` API label
- keep token limit window labels unchanged
- add regression coverage for the z.ai MCP monthly label

Fixes #115.

## Validation
- `git diff --check`
- Swift tests not run locally (Swift toolchain is not installed on this Raspberry Pi). GitHub CI will validate.