### PR TITLE
Stabilize Codex account switcher menu layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Settings: apply the selected app language from packaged SwiftPM resources instead of falling back to English when the `.lproj` directory casing differs (#908).
 - ChatGPT credits: restrict purchase links to real HTTPS `chatgpt.com` settings/usage/billing/credits paths and drop query/fragment data (#903). Thanks @ThiagoCAltoe!
 - z.ai: show the MCP quota bucket as monthly instead of a misleading 1-minute window (#904). Thanks @ThiagoCAltoe!
-
+- Menu: middle-truncate long account emails in Codex account controls and keep the Codex account switcher visible during merged-menu refreshes with transient account snapshots.
 ## 0.25.1 — 2026-05-11
 
 ### Fixed

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -231,13 +231,13 @@ private struct UsageMenuCardHeaderView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
             HStack(alignment: .firstTextBaseline) {
-                Text(self.model.providerName)
-                    .font(.headline)
+                Text(self.model.providerName).font(.headline)
                     .fontWeight(.semibold)
+                    .lineLimit(1).truncationMode(.tail).layoutPriority(1)
                 Spacer()
-                Text(self.model.email)
-                    .font(.subheadline)
+                Text(self.model.email).font(.subheadline)
                     .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                    .lineLimit(1).truncationMode(.middle)
             }
             let subtitleAlignment: VerticalAlignment = self.model.subtitleStyle == .error ? .top : .firstTextBaseline
             HStack(alignment: subtitleAlignment) {

--- a/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
@@ -196,6 +196,14 @@ extension SettingsStore {
         return true
     }
 
+    func selectDisplayedCodexVisibleAccount(_ account: CodexVisibleAccount) {
+        if self.selectCodexVisibleAccount(id: account.id) {
+            return
+        }
+        // An open menu can preserve a previously rendered account row while the live projection is briefly incomplete.
+        self.codexActiveSource = account.selectionSource
+    }
+
     func selectAuthenticatedManagedCodexAccount(_ account: ManagedCodexAccount) {
         if let visibleAccountID = self.codexVisibleAccountProjection.visibleAccounts
             .first(where: { $0.storedAccountID == account.id })?

--- a/Sources/CodexBar/StatusItemController+AccountMenuDisplay.swift
+++ b/Sources/CodexBar/StatusItemController+AccountMenuDisplay.swift
@@ -1,0 +1,49 @@
+import AppKit
+import CodexBarCore
+
+extension StatusItemController {
+    func tokenAccountMenuDisplay(for provider: UsageProvider) -> TokenAccountMenuDisplay? {
+        guard TokenAccountSupportCatalog.support(for: provider) != nil else { return nil }
+        let accounts = self.settings.tokenAccounts(for: provider)
+        guard accounts.count > 1 else { return nil }
+        let activeIndex = self.settings.tokenAccountsData(for: provider)?.clampedActiveIndex() ?? 0
+        let showAll = self.settings.multiAccountMenuLayout == .stacked
+        let snapshots = showAll ? (self.store.accountSnapshots[provider] ?? []) : []
+        return TokenAccountMenuDisplay(
+            provider: provider,
+            accounts: accounts,
+            snapshots: snapshots,
+            activeIndex: activeIndex,
+            layout: showAll ? .stacked : .segmented)
+    }
+
+    func codexAccountMenuDisplay(for provider: UsageProvider) -> CodexAccountMenuDisplay? {
+        guard provider == .codex else { return nil }
+        let projection = self.settings.codexVisibleAccountProjection
+        guard projection.visibleAccounts.count > 1 else { return nil }
+        let showAll = self.settings.multiAccountMenuLayout == .stacked
+        let accounts = showAll
+            ? self.store.limitedCodexVisibleAccounts(
+                projection.visibleAccounts,
+                activeVisibleAccountID: projection.activeVisibleAccountID)
+            : projection.visibleAccounts
+        return CodexAccountMenuDisplay(
+            accounts: accounts,
+            snapshots: showAll ? self.store.codexAccountSnapshots : [],
+            activeVisibleAccountID: projection.activeVisibleAccountID,
+            layout: showAll ? .stacked : .segmented)
+    }
+
+    func stableCodexAccountMenuDisplay(
+        _ display: CodexAccountMenuDisplay?,
+        menu: NSMenu,
+        provider: UsageProvider) -> CodexAccountMenuDisplay?
+    {
+        guard provider == .codex else { return display }
+        guard display == nil else { return display }
+        guard self.openMenus[ObjectIdentifier(menu)] != nil else { return display }
+        guard menu.items.contains(where: { $0.view is CodexAccountSwitcherView }) else { return display }
+        guard let previous = self.lastCodexAccountMenuDisplay, previous.showSwitcher else { return display }
+        return previous
+    }
+}

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -177,7 +177,13 @@ extension StatusItemController {
             switcherSelection?.provider ?? provider
         }
         let currentProvider = selectedProvider ?? enabledProviders.first ?? .codex
-        let codexAccountDisplay = isOverviewSelected ? nil : self.codexAccountMenuDisplay(for: currentProvider)
+        let rawCodexAccountDisplay = isOverviewSelected ? nil : self.codexAccountMenuDisplay(for: currentProvider)
+        let codexAccountDisplay = isOverviewSelected
+            ? nil
+            : self.stableCodexAccountMenuDisplay(
+                rawCodexAccountDisplay,
+                menu: menu,
+                provider: currentProvider)
         let tokenAccountDisplay = isOverviewSelected ? nil : self.tokenAccountMenuDisplay(for: currentProvider)
         let showAllAccounts = (tokenAccountDisplay?.showAll ?? false) || (codexAccountDisplay?.showAll ?? false)
         let openAIContext = self.openAIWebContext(
@@ -244,8 +250,8 @@ extension StatusItemController {
                     currentProvider: currentProvider,
                     switcherSelection: switcherSelection ?? .provider(currentProvider),
                     menuWidth: menuWidth,
-                    codexAccountDisplay: nil,
-                    tokenAccountDisplay: nil,
+                    codexAccountDisplay: codexAccountDisplay,
+                    tokenAccountDisplay: tokenAccountDisplay,
                     openAIContext: openAIContext))
             return
         }
@@ -969,9 +975,9 @@ extension StatusItemController {
             accounts: display.accounts,
             selectedAccountID: display.activeVisibleAccountID,
             width: width,
-            onSelect: { [weak self, weak menu] visibleAccountID in
+            onSelect: { [weak self, weak menu] account in
                 guard let self else { return }
-                self.handleCodexVisibleAccountSelection(visibleAccountID, menu: menu)
+                self.handleCodexVisibleAccountSelection(account, menu: menu)
             })
         let item = NSMenuItem()
         item.view = view
@@ -980,8 +986,9 @@ extension StatusItemController {
     }
 
     @discardableResult
-    private func handleCodexVisibleAccountSelection(_ visibleAccountID: String, menu: NSMenu?) -> Bool {
-        guard self.settings.selectCodexVisibleAccount(id: visibleAccountID) else { return false }
+    private func handleCodexVisibleAccountSelection(_ account: CodexVisibleAccount, menu: NSMenu?) -> Bool {
+        let visibleAccountID = account.id
+        self.settings.selectDisplayedCodexVisibleAccount(account)
         if self.store.prepareCodexAccountScopedRefreshIfNeeded(), let menu {
             self.refreshOpenMenuIfStillVisible(menu, provider: .codex)
         }
@@ -1027,38 +1034,6 @@ extension StatusItemController {
             return .overview
         }
         return .provider(self.resolvedMenuProvider(enabledProviders: enabledProviders) ?? .codex)
-    }
-
-    private func tokenAccountMenuDisplay(for provider: UsageProvider) -> TokenAccountMenuDisplay? {
-        guard TokenAccountSupportCatalog.support(for: provider) != nil else { return nil }
-        let accounts = self.settings.tokenAccounts(for: provider)
-        guard accounts.count > 1 else { return nil }
-        let activeIndex = self.settings.tokenAccountsData(for: provider)?.clampedActiveIndex() ?? 0
-        let showAll = self.settings.multiAccountMenuLayout == .stacked
-        let snapshots = showAll ? (self.store.accountSnapshots[provider] ?? []) : []
-        return TokenAccountMenuDisplay(
-            provider: provider,
-            accounts: accounts,
-            snapshots: snapshots,
-            activeIndex: activeIndex,
-            layout: showAll ? .stacked : .segmented)
-    }
-
-    private func codexAccountMenuDisplay(for provider: UsageProvider) -> CodexAccountMenuDisplay? {
-        guard provider == .codex else { return nil }
-        let projection = self.settings.codexVisibleAccountProjection
-        guard projection.visibleAccounts.count > 1 else { return nil }
-        let showAll = self.settings.multiAccountMenuLayout == .stacked
-        let accounts = showAll
-            ? self.store.limitedCodexVisibleAccounts(
-                projection.visibleAccounts,
-                activeVisibleAccountID: projection.activeVisibleAccountID)
-            : projection.visibleAccounts
-        return CodexAccountMenuDisplay(
-            accounts: accounts,
-            snapshots: showAll ? self.store.codexAccountSnapshots : [],
-            activeVisibleAccountID: projection.activeVisibleAccountID,
-            layout: showAll ? .stacked : .segmented)
     }
 
     private func menuNeedsRefresh(_ menu: NSMenu) -> Bool {

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -938,7 +938,7 @@ final class TokenAccountSwitcherView: NSView {
                 button.setButtonType(.toggle)
                 button.controlSize = .small
                 button.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
-                button.cell?.lineBreakMode = .byTruncatingTail
+                button.cell?.lineBreakMode = account.displayName.contains("@") ? .byTruncatingMiddle : .byTruncatingTail
                 button.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
                 button.wantsLayer = true
                 button.layer?.cornerRadius = 6
@@ -997,7 +997,7 @@ final class TokenAccountSwitcherView: NSView {
 
 final class CodexAccountSwitcherView: NSView {
     private let accounts: [CodexVisibleAccount]
-    private let onSelect: (String) -> Void
+    private let onSelect: (CodexVisibleAccount) -> Void
     private var selectedAccountID: String
     private var buttons: [NSButton] = []
     private let preferredSize: NSSize
@@ -1015,7 +1015,7 @@ final class CodexAccountSwitcherView: NSView {
         accounts: [CodexVisibleAccount],
         selectedAccountID: String?,
         width: CGFloat,
-        onSelect: @escaping (String) -> Void)
+        onSelect: @escaping (CodexVisibleAccount) -> Void)
     {
         self.accounts = accounts
         self.onSelect = onSelect
@@ -1115,7 +1115,7 @@ final class CodexAccountSwitcherView: NSView {
         }
 
         guard let workspace = account.menuWorkspaceLabel else {
-            return self.truncateTail(account.email, toFit: availableTextWidth)
+            return self.truncateMiddle(account.email, toFit: availableTextWidth)
         }
 
         let separator = "|"
@@ -1127,7 +1127,7 @@ final class CodexAccountSwitcherView: NSView {
         var workspaceWidth = max(minimumWorkspaceWidth, contentWidth - emailWidth)
 
         func makeTitle() -> String {
-            let email = self.truncateTail(account.email, toFit: emailWidth)
+            let email = self.truncateMiddle(account.email, toFit: emailWidth)
             let workspace = self.truncateTail(workspace, toFit: workspaceWidth)
             return "\(email)\(separator)\(workspace)"
         }
@@ -1135,7 +1135,7 @@ final class CodexAccountSwitcherView: NSView {
         var title = makeTitle()
         var attempts = 0
         while self.textWidth(title) > availableTextWidth, attempts < 16 {
-            let emailText = self.truncateTail(account.email, toFit: emailWidth)
+            let emailText = self.truncateMiddle(account.email, toFit: emailWidth)
             let workspaceText = self.truncateTail(workspace, toFit: workspaceWidth)
             let emailRenderedWidth = self.textWidth(emailText)
             let workspaceRenderedWidth = self.textWidth(workspaceText)
@@ -1181,6 +1181,52 @@ final class CodexAccountSwitcherView: NSView {
         return candidate + ellipsis
     }
 
+    private func truncateMiddle(_ text: String, toFit width: CGFloat) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return text }
+        if self.textWidth(trimmed) <= width {
+            return trimmed
+        }
+
+        let ellipsis = "…"
+        let ellipsisWidth = self.textWidth(ellipsis)
+        guard ellipsisWidth < width else { return ellipsis }
+
+        var prefix = ""
+        var suffix = ""
+        var prefixIndex = trimmed.startIndex
+        var suffixIndex = trimmed.endIndex
+        var best = ellipsis
+        var takeSuffixNext = true
+
+        while prefixIndex < suffixIndex {
+            let nextPrefix: String
+            let nextSuffix: String
+            if takeSuffixNext {
+                let previousIndex = trimmed.index(before: suffixIndex)
+                nextPrefix = prefix
+                nextSuffix = String(trimmed[previousIndex]) + suffix
+                suffixIndex = previousIndex
+            } else {
+                nextPrefix = prefix + String(trimmed[prefixIndex])
+                nextSuffix = suffix
+                prefixIndex = trimmed.index(after: prefixIndex)
+            }
+
+            let candidate = nextPrefix + ellipsis + nextSuffix
+            if self.textWidth(candidate) > width {
+                break
+            }
+
+            prefix = nextPrefix
+            suffix = nextSuffix
+            best = candidate
+            takeSuffixNext.toggle()
+        }
+
+        return best
+    }
+
     private func textWidth(_ text: String) -> CGFloat {
         let attributes: [NSAttributedString.Key: Any] = [.font: self.buttonFont]
         return ceil((text as NSString).size(withAttributes: attributes).width)
@@ -1197,10 +1243,10 @@ final class CodexAccountSwitcherView: NSView {
 
     @objc private func handleSelect(_ sender: NSButton) {
         guard let accountID = sender.identifier?.rawValue else { return }
-        guard self.accounts.contains(where: { $0.id == accountID }) else { return }
+        guard let account = self.accounts.first(where: { $0.id == accountID }) else { return }
         self.selectedAccountID = accountID
         self.updateButtonStyles()
-        self.onSelect(accountID)
+        self.onSelect(account)
     }
 
     #if DEBUG
@@ -1210,6 +1256,11 @@ final class CodexAccountSwitcherView: NSView {
 
     func _test_buttonToolTips() -> [String?] {
         self.buttons.map(\.toolTip)
+    }
+
+    func _test_selectAccount(id: String) {
+        guard let button = self.buttons.first(where: { $0.identifier?.rawValue == id }) else { return }
+        self.handleSelect(button)
     }
     #endif
 }

--- a/Tests/CodexBarTests/StatusMenuCodexSwitcherTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCodexSwitcherTests.swift
@@ -239,6 +239,124 @@ struct StatusMenuCodexSwitcherTests {
     }
 
     @Test
+    func `merged codex menu smart refresh keeps account switcher visible`() throws {
+        self.disableMenuCardsForTesting()
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
+        defer { StatusItemController.setMenuRefreshEnabledForTesting(false) }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        settings.multiAccountMenuLayout = .segmented
+
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            guard let metadata = registry.metadata[provider] else { continue }
+            settings.setProviderEnabled(
+                provider: provider,
+                metadata: metadata,
+                enabled: provider == .codex || provider == .claude)
+        }
+
+        let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-111111111111"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "managed@example.com",
+            managedHomePath: "/tmp/managed-home",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "live@example.com",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date())
+        settings.codexActiveSource = .liveSystem
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+
+        #expect(menu.items.count(where: { $0.view is CodexAccountSwitcherView }) == 1)
+
+        controller.menuContentVersion &+= 1
+        controller.refreshOpenMenusIfNeeded()
+
+        #expect(menu.items.count(where: { $0.view is CodexAccountSwitcherView }) == 1)
+
+        settings._test_liveSystemCodexAccount = nil
+        controller.menuContentVersion &+= 1
+        controller.refreshOpenMenusIfNeeded()
+
+        #expect(menu.items.count(where: { $0.view is CodexAccountSwitcherView }) == 1)
+
+        controller.menuDidClose(menu)
+        controller.menuContentVersion &+= 1
+        controller.menuWillOpen(menu)
+
+        #expect(menu.items.count(where: { $0.view is CodexAccountSwitcherView }) == 0)
+    }
+
+    @Test
+    func `codex menu can select preserved switcher row during transient account projection`() throws {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        self.enableOnlyCodex(settings)
+
+        let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-111111111111"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "managed@example.com",
+            managedHomePath: "/tmp/managed-home",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "live@example.com",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date())
+        settings.codexActiveSource = .managedAccount(id: managedAccountID)
+
+        let liveAccount = try #require(settings.codexVisibleAccountProjection.visibleAccounts
+            .first { $0.selectionSource == .liveSystem })
+        settings._test_liveSystemCodexAccount = nil
+
+        #expect(settings.codexVisibleAccountProjection.visibleAccounts.map(\.email) == ["managed@example.com"])
+        settings.selectDisplayedCodexVisibleAccount(liveAccount)
+        #expect(settings.codexActiveSource == .liveSystem)
+    }
+
+    @Test
     func `codex stacked multi account layout shows account cards`() throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
@@ -430,6 +548,84 @@ struct StatusMenuCodexSwitcherTests {
         #expect(view.frame.width == 310)
         #expect(view.intrinsicContentSize.width == 310)
         #expect(view.fittingSize.width == 310)
+    }
+
+    @Test
+    func `codex switcher middle truncates long account emails`() {
+        let accounts = [
+            CodexVisibleAccount(
+                id: "live:provider:account-personal",
+                email: "local-person-with-an-extremely-long-name@example.com",
+                workspaceLabel: nil,
+                workspaceAccountID: "account-managed",
+                storedAccountID: nil,
+                selectionSource: .liveSystem,
+                isActive: true,
+                isLive: true,
+                canReauthenticate: true,
+                canRemove: false),
+            CodexVisibleAccount(
+                id: "managed:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                email: "second-person-with-an-extremely-long-name@example.com",
+                workspaceLabel: nil,
+                workspaceAccountID: "account-gmail",
+                storedAccountID: UUID(),
+                selectionSource: .managedAccount(id: UUID()),
+                isActive: false,
+                isLive: false,
+                canReauthenticate: true,
+                canRemove: true),
+        ]
+
+        let view = CodexAccountSwitcherView(
+            accounts: accounts,
+            selectedAccountID: accounts.first?.id,
+            width: 220,
+            onSelect: { _ in })
+        let titles = view._test_buttonTitles()
+
+        #expect(titles.count == 2)
+        #expect(titles[0].hasPrefix("local"))
+        #expect(titles[0].contains("…"))
+        #expect(titles[0].hasSuffix(".com"))
+        #expect(titles[1].hasPrefix("second"))
+        #expect(titles[1].contains("…"))
+        #expect(titles[1].hasSuffix(".com"))
+    }
+
+    @Test
+    func `codex account switcher passes the selected displayed account`() throws {
+        let managedID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-111111111111"))
+        let accounts = [
+            CodexVisibleAccount(
+                id: "live@example.com",
+                email: "live@example.com",
+                storedAccountID: nil,
+                selectionSource: .liveSystem,
+                isActive: true,
+                isLive: true,
+                canReauthenticate: true,
+                canRemove: false),
+            CodexVisibleAccount(
+                id: "managed@example.com",
+                email: "managed@example.com",
+                storedAccountID: managedID,
+                selectionSource: .managedAccount(id: managedID),
+                isActive: false,
+                isLive: false,
+                canReauthenticate: true,
+                canRemove: true),
+        ]
+        var selectedAccount: CodexVisibleAccount?
+        let view = CodexAccountSwitcherView(
+            accounts: accounts,
+            selectedAccountID: accounts.first?.id,
+            width: 220,
+            onSelect: { selectedAccount = $0 })
+
+        view._test_selectAccount(id: "managed@example.com")
+
+        #expect(selectedAccount == accounts[1])
     }
 
     @Test


### PR DESCRIPTION
## Summary
- middle-truncate long Codex account emails in segmented switchers and menu card headers
- preserve the Codex account switcher during merged-menu smart refreshes so the menu height does not jump
- keep an already visible Codex account switcher stable while an open menu sees a transient single-account snapshot

## Validation
- swift test --filter StatusMenuCodexSwitcherTests
- make check
- swift test