### PR TITLE
Add Moonshot / Kimi API provider support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.26 — Unreleased
 
+### Added
+- Moonshot / Kimi API: add API-key balance tracking, CLI support, docs, and menu bar balance copy (#899). Thanks @giuseppebisemi!
+
 ### Fixed
 - Settings: apply the selected app language from packaged SwiftPM resources instead of falling back to English when the `.lproj` directory casing differs (#908).
 - ChatGPT credits: restrict purchase links to real HTTPS `chatgpt.com` settings/usage/billing/credits paths and drop query/fragment data (#903). Thanks @ThiagoCAltoe!
@@ -14,7 +17,6 @@
 - CLI: include a VERSION file in standalone release archives so `--version` reports the release tag outside the app bundle (#898). Thanks @ThiagoCAltoe!
 - Pi: rebuild stale session cost caches after cache-version migrations so refreshed cost history reflects current scanner data.
 - Keychain cache: reduce repeated development prompt churn by trusting the bundled helper when writing CodexBar-owned cache items (#888).
-
 ## 0.25 — 2026-05-10
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Or download release tarballs from GitHub Releases:
 - [Abacus AI](docs/abacus.md) — Browser cookie auth for ChatLLM/RouteLLM compute credit tracking.
 - Mistral — Browser cookies for monthly spend tracking.
 - [DeepSeek](docs/deepseek.md) — API key for credit balance tracking (paid vs. granted breakdown).
+- [Moonshot / Kimi API](docs/moonshot.md) — API key for Moonshot/Kimi API account balance tracking.
 - [Venice](docs/venice.md) — API key for DIEM or USD balance tracking.
 - [Codebuff](docs/codebuff.md) — API token (or `~/.config/manicode/credentials.json`) for credit balance + weekly rate limit.
 - [Crof](docs/crof.md) — API key for dollar credit balance and request quota tracking.

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -66,7 +66,7 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
         else {
             return nil
         }
-        guard provider == .openrouter || provider == .mimo else {
+        guard provider == .openrouter || provider == .mimo || provider == .moonshot else {
             return (label: "Plan", value: rawPlan)
         }
 

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -541,7 +541,7 @@ struct ProvidersPane: View {
         case .deepseek:
             L("menu_bar_metric_subtitle_deepseek")
         case .moonshot:
-            "Shows the Moonshot balance in the menu bar."
+            L("menu_bar_metric_subtitle_moonshot")
         case .mistral:
             L("menu_bar_metric_subtitle_mistral")
         case .kimik2:

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -540,6 +540,8 @@ struct ProvidersPane: View {
         switch provider {
         case .deepseek:
             L("menu_bar_metric_subtitle_deepseek")
+        case .moonshot:
+            "Shows the Moonshot balance in the menu bar."
         case .mistral:
             L("menu_bar_metric_subtitle_mistral")
         case .kimik2:

--- a/Sources/CodexBar/Providers/Moonshot/MoonshotProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Moonshot/MoonshotProviderImplementation.swift
@@ -1,0 +1,88 @@
+import AppKit
+import CodexBarCore
+import CodexBarMacroSupport
+import Foundation
+import SwiftUI
+
+@ProviderImplementationRegistration
+struct MoonshotProviderImplementation: ProviderImplementation {
+    let id: UsageProvider = .moonshot
+
+    @MainActor
+    func presentation(context _: ProviderPresentationContext) -> ProviderPresentation {
+        ProviderPresentation { _ in "api" }
+    }
+
+    @MainActor
+    func observeSettings(_ settings: SettingsStore) {
+        _ = settings.moonshotAPIToken
+        _ = settings.moonshotRegion
+    }
+
+    @MainActor
+    func settingsSnapshot(context: ProviderSettingsSnapshotContext)
+        -> ProviderSettingsSnapshotContribution?
+    {
+        .moonshot(context.settings.moonshotSettingsSnapshot())
+    }
+
+    @MainActor
+    func isAvailable(context: ProviderAvailabilityContext) -> Bool {
+        if MoonshotSettingsReader.apiKey(environment: context.environment) != nil {
+            return true
+        }
+        context.settings.ensureMoonshotAPITokenLoaded()
+        return !context.settings.moonshotAPIToken.trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
+    }
+
+    @MainActor
+    func settingsPickers(context: ProviderSettingsContext) -> [ProviderSettingsPickerDescriptor] {
+        let binding = Binding(
+            get: { context.settings.moonshotRegion.rawValue },
+            set: { raw in
+                context.settings.moonshotRegion = MoonshotRegion(rawValue: raw) ?? .international
+            })
+        let options = MoonshotRegion.allCases.map {
+            ProviderSettingsPickerOption(id: $0.rawValue, title: $0.displayName)
+        }
+
+        return [
+            ProviderSettingsPickerDescriptor(
+                id: "moonshot-api-region",
+                title: "API region",
+                subtitle: "Choose the Moonshot/Kimi API host for international or China mainland accounts.",
+                binding: binding,
+                options: options,
+                isVisible: nil,
+                onChange: nil),
+        ]
+    }
+
+    @MainActor
+    func settingsFields(context: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {
+        [
+            ProviderSettingsFieldDescriptor(
+                id: "moonshot-api-key",
+                title: "API key",
+                subtitle: "Stored in ~/.codexbar/config.json.",
+                kind: .secure,
+                placeholder: "sk-...",
+                binding: context.stringBinding(\.moonshotAPIToken),
+                actions: [
+                    ProviderSettingsActionDescriptor(
+                        id: "moonshot-open-dashboard",
+                        title: "Open Moonshot Console",
+                        style: .link,
+                        isVisible: nil,
+                        perform: {
+                            if let url = URL(string: "https://platform.moonshot.ai/console/account") {
+                                NSWorkspace.shared.open(url)
+                            }
+                        }),
+                ],
+                isVisible: nil,
+                onActivate: { context.settings.ensureMoonshotAPITokenLoaded() }),
+        ]
+    }
+}

--- a/Sources/CodexBar/Providers/Moonshot/MoonshotSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Moonshot/MoonshotSettingsStore.swift
@@ -1,0 +1,44 @@
+import CodexBarCore
+import Foundation
+
+extension SettingsStore {
+    var moonshotAPIToken: String {
+        get { self.configSnapshot.providerConfig(for: .moonshot)?.sanitizedAPIKey ?? "" }
+        set {
+            self.updateProviderConfig(provider: .moonshot) { entry in
+                entry.apiKey = self.normalizedConfigValue(newValue)
+            }
+            self.logSecretUpdate(provider: .moonshot, field: "apiKey", value: newValue)
+        }
+    }
+
+    var moonshotRegion: MoonshotRegion {
+        get {
+            let raw = self.configSnapshot.providerConfig(for: .moonshot)?.region
+            return MoonshotRegion(rawValue: raw ?? "") ?? .international
+        }
+        set {
+            self.updateProviderConfig(provider: .moonshot) { entry in
+                entry.region = newValue.rawValue
+            }
+        }
+    }
+
+    func ensureMoonshotAPITokenLoaded() {}
+
+    var configuredMoonshotRegion: MoonshotRegion? {
+        guard let raw = self.configSnapshot.providerConfig(for: .moonshot)?.region?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !raw.isEmpty
+        else {
+            return nil
+        }
+        return MoonshotRegion(rawValue: raw)
+    }
+}
+
+extension SettingsStore {
+    func moonshotSettingsSnapshot() -> ProviderSettingsSnapshot.MoonshotProviderSettings {
+        ProviderSettingsSnapshot.MoonshotProviderSettings(region: self.configuredMoonshotRegion)
+    }
+}

--- a/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
@@ -34,6 +34,7 @@ enum ProviderImplementationRegistry {
         case .augment: AugmentProviderImplementation()
         case .jetbrains: JetBrainsProviderImplementation()
         case .kimik2: KimiK2ProviderImplementation()
+        case .moonshot: MoonshotProviderImplementation()
         case .amp: AmpProviderImplementation()
         case .ollama: OllamaProviderImplementation()
         case .synthetic: SyntheticProviderImplementation()

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -461,6 +461,7 @@
 "menu_bar_metric_title" = "Menu bar metric";
 "menu_bar_metric_subtitle" = "Choose which window drives the menu bar percent.";
 "menu_bar_metric_subtitle_deepseek" = "Shows the DeepSeek balance in the menu bar.";
+"menu_bar_metric_subtitle_moonshot" = "Shows the Moonshot / Kimi API balance in the menu bar.";
 "menu_bar_metric_subtitle_mistral" = "Shows current-month Mistral API spend in the menu bar.";
 "menu_bar_metric_subtitle_kimik2" = "Shows Kimi K2 API-key credits in the menu bar.";
 "automatic" = "Automatic";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -441,6 +441,7 @@
 "menu_bar_metric_title" = "Métrica da barra de menus";
 "menu_bar_metric_subtitle" = "Escolha qual janela define a porcentagem da barra de menus.";
 "menu_bar_metric_subtitle_deepseek" = "Mostra o saldo do DeepSeek na barra de menus.";
+"menu_bar_metric_subtitle_moonshot" = "Mostra o saldo da API Moonshot / Kimi na barra de menus.";
 "menu_bar_metric_subtitle_mistral" = "Mostra o gasto da API Mistral no mês atual na barra de menus.";
 "menu_bar_metric_subtitle_kimik2" = "Mostra os créditos da chave de API do Kimi K2 na barra de menus.";
 "automatic" = "Automático";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -468,6 +468,7 @@
 "menu_bar_metric_title" = "菜单栏指标";
 "menu_bar_metric_subtitle" = "选择哪个窗口驱动菜单栏百分比。";
 "menu_bar_metric_subtitle_deepseek" = "在菜单栏显示 DeepSeek 余额。";
+"menu_bar_metric_subtitle_moonshot" = "在菜单栏显示 Moonshot / Kimi API 余额。";
 "menu_bar_metric_subtitle_mistral" = "在菜单栏显示 Mistral API 本月支出。";
 "menu_bar_metric_subtitle_kimik2" = "在菜单栏显示 Kimi K2 API Key 额度。";
 "automatic" = "自动";

--- a/Sources/CodexBar/SettingsStore+MenuPreferences.swift
+++ b/Sources/CodexBar/SettingsStore+MenuPreferences.swift
@@ -106,7 +106,7 @@ extension SettingsStore {
 
     static func isBalanceOnlyProvider(_ provider: UsageProvider) -> Bool {
         switch provider {
-        case .deepseek, .mistral, .kimik2:
+        case .deepseek, .mistral, .kimik2, .moonshot:
             true
         default:
             false

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -562,6 +562,11 @@ extension StatusItemController {
         {
             return balance
         }
+        if provider == .moonshot,
+           let balance = Self.moonshotBalanceDisplayText(snapshot: snapshot)
+        {
+            return balance
+        }
         if provider == .mistral,
            let spend = Self.mistralSpendDisplayText(snapshot: snapshot)
         {
@@ -627,6 +632,19 @@ extension StatusItemController {
         return balance.map(String.init)
     }
 
+    nonisolated static func moonshotBalanceDisplayText(snapshot: UsageSnapshot?) -> String? {
+        self.displayValue(
+            from: snapshot?.loginMethod(for: .moonshot),
+            prefix: "Balance:",
+            removingSuffix: "")
+            .flatMap { value in
+                value
+                    .split(separator: "·", maxSplits: 1)
+                    .first?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+    }
+
     nonisolated static func mistralSpendDisplayText(snapshot: UsageSnapshot?) -> String? {
         self.displayValue(
             from: snapshot?.identity?.loginMethod,
@@ -654,7 +672,7 @@ extension StatusItemController {
         }
         let valueStart = rawValue.index(rawValue.startIndex, offsetBy: prefix.count)
         var value = rawValue[valueStart...].trimmingCharacters(in: .whitespacesAndNewlines)
-        if value.hasSuffix(suffix) {
+        if !suffix.isEmpty, value.hasSuffix(suffix) {
             value = String(value.dropLast(suffix.count)).trimmingCharacters(in: .whitespacesAndNewlines)
         }
         return value.isEmpty ? nil : value

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -972,8 +972,8 @@ extension UsageStore {
                         hasEnvToken: deepSeekHasEnvToken,
                         hasTokenAccount: deepSeekHasTokenAccount)
                 case .gemini, .antigravity, .opencode, .opencodego, .factory, .copilot, .vertexai, .kilo, .kiro, .kimi,
-                     .kimik2, .jetbrains, .perplexity, .mimo, .doubao, .abacus, .mistral, .codebuff, .crof, .windsurf,
-                     .venice, .manus, .commandcode, .stepfun:
+                     .kimik2, .moonshot, .jetbrains, .perplexity, .mimo, .doubao, .abacus, .mistral, .codebuff, .crof,
+                     .windsurf, .venice, .manus, .commandcode, .stepfun:
                     return unimplementedDebugLogMessages[provider] ?? "Debug log not yet implemented"
                 }
             }

--- a/Sources/CodexBarCLI/TokenAccountCLI.swift
+++ b/Sources/CodexBarCLI/TokenAccountCLI.swift
@@ -100,6 +100,10 @@ struct TokenAccountCLIContext {
         case .zai:
             return self.makeSnapshot(
                 zai: ProviderSettingsSnapshot.ZaiProviderSettings(apiRegion: self.resolveZaiRegion(config)))
+        case .moonshot:
+            return self.makeSnapshot(
+                moonshot: ProviderSettingsSnapshot.MoonshotProviderSettings(
+                    region: self.resolveMoonshotRegion(config)))
         case .kilo:
             return self.makeSnapshot(
                 kilo: ProviderSettingsSnapshot.KiloProviderSettings(
@@ -227,6 +231,7 @@ struct TokenAccountCLIContext {
         minimax: ProviderSettingsSnapshot.MiniMaxProviderSettings? = nil,
         manus: ProviderSettingsSnapshot.ManusProviderSettings? = nil,
         zai: ProviderSettingsSnapshot.ZaiProviderSettings? = nil,
+        moonshot: ProviderSettingsSnapshot.MoonshotProviderSettings? = nil,
         kilo: ProviderSettingsSnapshot.KiloProviderSettings? = nil,
         kimi: ProviderSettingsSnapshot.KimiProviderSettings? = nil,
         augment: ProviderSettingsSnapshot.AugmentProviderSettings? = nil,
@@ -253,6 +258,7 @@ struct TokenAccountCLIContext {
             kilo: kilo,
             kimi: kimi,
             augment: augment,
+            moonshot: moonshot,
             amp: amp,
             ollama: ollama,
             jetbrains: jetbrains,
@@ -394,6 +400,15 @@ struct TokenAccountCLIContext {
             return .global
         }
         return MiniMaxAPIRegion(rawValue: raw) ?? .global
+    }
+
+    private func resolveMoonshotRegion(_ config: ProviderConfig?) -> MoonshotRegion? {
+        guard let raw = config?.region?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty
+        else {
+            return nil
+        }
+        return MoonshotRegion(rawValue: raw) ?? .international
     }
 
     private func resolveAlibabaCodingPlanRegion(_ config: ProviderConfig?) -> AlibabaCodingPlanAPIRegion {

--- a/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
@@ -154,6 +154,15 @@ public enum CodexBarConfigValidator {
                         code: "invalid_region",
                         message: "Region \(region) is not a valid Alibaba Coding Plan region."))
                 }
+            case .moonshot:
+                if MoonshotRegion(rawValue: region) == nil {
+                    issues.append(CodexBarConfigIssue(
+                        severity: .error,
+                        provider: provider,
+                        field: "region",
+                        code: "invalid_region",
+                        message: "Region \(region) is not a valid Moonshot region."))
+                }
             default:
                 issues.append(CodexBarConfigIssue(
                     severity: .warning,

--- a/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
+++ b/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
@@ -63,6 +63,8 @@ public enum ProviderConfigEnvironment {
             SyntheticSettingsReader.apiKeyKey
         case .openrouter:
             OpenRouterSettingsReader.envKey
+        case .moonshot:
+            MoonshotSettingsReader.apiKeyEnvironmentKeys.first
         case .venice:
             VeniceSettingsReader.apiKeyEnvironmentKey
         default:

--- a/Sources/CodexBarCore/Logging/LogCategories.swift
+++ b/Sources/CodexBarCore/Logging/LogCategories.swift
@@ -48,6 +48,7 @@ public enum LogCategories {
     public static let minimaxCookieStore = "minimax-cookie-store"
     public static let minimaxUsage = "minimax-usage"
     public static let minimaxWeb = "minimax-web"
+    public static let moonshotUsage = "moonshot-usage"
     public static let notifications = "notifications"
     public static let openAIWeb = "openai-web"
     public static let openAIWebview = "openai-webview"

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderDescriptor.swift
@@ -1,0 +1,71 @@
+import CodexBarMacroSupport
+import Foundation
+
+@ProviderDescriptorRegistration
+@ProviderDescriptorDefinition
+public enum MoonshotProviderDescriptor {
+    static func makeDescriptor() -> ProviderDescriptor {
+        ProviderDescriptor(
+            id: .moonshot,
+            metadata: ProviderMetadata(
+                id: .moonshot,
+                displayName: "Moonshot / Kimi API",
+                sessionLabel: "Balance",
+                weeklyLabel: "Balance",
+                opusLabel: nil,
+                supportsOpus: false,
+                supportsCredits: false,
+                creditsHint: "",
+                toggleTitle: "Show Moonshot / Kimi API balance",
+                cliName: "moonshot",
+                defaultEnabled: false,
+                isPrimaryProvider: false,
+                usesAccountFallback: false,
+                browserCookieOrder: nil,
+                dashboardURL: "https://platform.moonshot.ai/console/account",
+                statusPageURL: nil),
+            branding: ProviderBranding(
+                iconStyle: .kimi,
+                iconResourceName: "ProviderIcon-kimi",
+                color: ProviderColor(red: 32 / 255, green: 93 / 255, blue: 235 / 255)),
+            tokenCost: ProviderTokenCostConfig(
+                supportsTokenCost: false,
+                noDataMessage: { "Moonshot / Kimi API cost summary is not available." }),
+            fetchPlan: ProviderFetchPlan(
+                sourceModes: [.auto, .api],
+                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [MoonshotAPIFetchStrategy()] })),
+            cli: ProviderCLIConfig(
+                name: "moonshot",
+                aliases: [],
+                versionDetector: nil))
+    }
+}
+
+struct MoonshotAPIFetchStrategy: ProviderFetchStrategy {
+    let id: String = "moonshot.api"
+    let kind: ProviderFetchKind = .apiToken
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        Self.resolveToken(environment: context.env) != nil
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        guard let apiKey = Self.resolveToken(environment: context.env) else {
+            throw MoonshotUsageError.missingCredentials
+        }
+        let region =
+            context.settings?.moonshot?.region ?? MoonshotSettingsReader.region(environment: context.env)
+        let usage = try await MoonshotUsageFetcher.fetchUsage(apiKey: apiKey, region: region)
+        return self.makeResult(
+            usage: usage.toUsageSnapshot(),
+            sourceLabel: "api")
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+
+    private static func resolveToken(environment: [String: String]) -> String? {
+        ProviderTokenResolver.moonshotToken(environment: environment)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotRegion.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotRegion.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public enum MoonshotRegion: String, CaseIterable, Sendable {
+    case international
+    case china
+
+    private static let balancePath = "v1/users/me/balance"
+
+    public var displayName: String {
+        switch self {
+        case .international:
+            "International (api.moonshot.ai)"
+        case .china:
+            "China (api.moonshot.cn)"
+        }
+    }
+
+    public var apiBaseURLString: String {
+        switch self {
+        case .international:
+            "https://api.moonshot.ai"
+        case .china:
+            "https://api.moonshot.cn"
+        }
+    }
+
+    public var balanceURL: URL {
+        URL(string: self.apiBaseURLString)!.appendingPathComponent(Self.balancePath)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotSettingsReader.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+public struct MoonshotSettingsReader: Sendable {
+    public static let apiKeyEnvironmentKeys = [
+        "MOONSHOT_API_KEY",
+        "MOONSHOT_KEY",
+    ]
+    public static let regionEnvironmentKey = "MOONSHOT_REGION"
+
+    public static func apiKey(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
+    {
+        for key in self.apiKeyEnvironmentKeys {
+            guard let raw = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !raw.isEmpty
+            else {
+                continue
+            }
+            let cleaned = Self.cleaned(raw)
+            if !cleaned.isEmpty {
+                return cleaned
+            }
+        }
+
+        return nil
+    }
+
+    public static func region(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> MoonshotRegion
+    {
+        guard let raw = environment[self.regionEnvironmentKey] else {
+            return .international
+        }
+        let cleaned = Self.cleaned(raw).lowercased()
+        return MoonshotRegion(rawValue: cleaned) ?? .international
+    }
+
+    private static func cleaned(_ raw: String) -> String {
+        var value = raw
+        if (value.hasPrefix("\"") && value.hasSuffix("\""))
+            || (value.hasPrefix("'") && value.hasSuffix("'"))
+        {
+            value.removeFirst()
+            value.removeLast()
+        }
+        return value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotUsageFetcher.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public struct MoonshotUsageSnapshot: Sendable {
+    public let summary: MoonshotUsageSummary
+
+    public init(summary: MoonshotUsageSummary) {
+        self.summary = summary
+    }
+
+    public func toUsageSnapshot() -> UsageSnapshot {
+        self.summary.toUsageSnapshot()
+    }
+}
+
+public struct MoonshotUsageSummary: Sendable {
+    public let availableBalance: Double
+    public let voucherBalance: Double
+    public let cashBalance: Double
+    public let updatedAt: Date
+
+    public init(
+        availableBalance: Double, voucherBalance: Double, cashBalance: Double, updatedAt: Date)
+    {
+        self.availableBalance = availableBalance
+        self.voucherBalance = voucherBalance
+        self.cashBalance = cashBalance
+        self.updatedAt = updatedAt
+    }
+
+    public func toUsageSnapshot() -> UsageSnapshot {
+        let balance = UsageFormatter.usdString(self.availableBalance)
+        let loginMethod: String
+        if self.cashBalance < 0 {
+            let deficit = UsageFormatter.usdString(abs(self.cashBalance))
+            loginMethod = "Balance: \(balance) · \(deficit) in deficit"
+        } else {
+            loginMethod = "Balance: \(balance)"
+        }
+        let identity = ProviderIdentitySnapshot(
+            providerID: .moonshot,
+            accountEmail: nil,
+            accountOrganization: nil,
+            loginMethod: loginMethod)
+        return UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            providerCost: nil,
+            updatedAt: self.updatedAt,
+            identity: identity)
+    }
+}
+
+public enum MoonshotUsageError: LocalizedError, Sendable {
+    case missingCredentials
+    case networkError(String)
+    case apiError(String)
+    case parseFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingCredentials:
+            "Missing Moonshot API key."
+        case let .networkError(message):
+            "Moonshot network error: \(message)"
+        case let .apiError(message):
+            "Moonshot API error: \(message)"
+        case let .parseFailed(message):
+            "Failed to parse Moonshot response: \(message)"
+        }
+    }
+}
+
+public struct MoonshotUsageFetcher: Sendable {
+    private static let log = CodexBarLog.logger(LogCategories.moonshotUsage)
+
+    public static func fetchUsage(
+        apiKey: String,
+        region: MoonshotRegion = .international,
+        session: URLSession = .shared) async throws -> MoonshotUsageSnapshot
+    {
+        let cleaned = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleaned.isEmpty else {
+            throw MoonshotUsageError.missingCredentials
+        }
+
+        var request = URLRequest(url: self.resolveBalanceURL(region: region))
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(cleaned)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw MoonshotUsageError.networkError("Invalid response")
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let body = String(data: data, encoding: .utf8) ?? "HTTP \(httpResponse.statusCode)"
+            Self.log.error("Moonshot API returned \(httpResponse.statusCode): \(body)")
+            throw MoonshotUsageError.apiError(body)
+        }
+
+        let summary = try self.parseSummary(data: data)
+        return MoonshotUsageSnapshot(summary: summary)
+    }
+
+    public static func resolveBalanceURL(region: MoonshotRegion) -> URL {
+        region.balanceURL
+    }
+
+    static func _parseSummaryForTesting(_ data: Data) throws -> MoonshotUsageSummary {
+        try self.parseSummary(data: data)
+    }
+
+    private static func parseSummary(data: Data) throws -> MoonshotUsageSummary {
+        guard let json = try? JSONSerialization.jsonObject(with: data),
+              let dictionary = json as? [String: Any]
+        else {
+            throw MoonshotUsageError.parseFailed("Root JSON is not an object.")
+        }
+
+        guard let payload = dictionary["data"] as? [String: Any] else {
+            throw MoonshotUsageError.parseFailed("Missing data object.")
+        }
+        guard let availableBalance = self.double(from: payload["available_balance"]) else {
+            throw MoonshotUsageError.parseFailed("Missing available_balance.")
+        }
+        guard let voucherBalance = self.double(from: payload["voucher_balance"]) else {
+            throw MoonshotUsageError.parseFailed("Missing voucher_balance.")
+        }
+        guard let cashBalance = self.double(from: payload["cash_balance"]) else {
+            throw MoonshotUsageError.parseFailed("Missing cash_balance.")
+        }
+
+        return MoonshotUsageSummary(
+            availableBalance: availableBalance,
+            voucherBalance: voucherBalance,
+            cashBalance: cashBalance,
+            updatedAt: Date())
+    }
+
+    private static func double(from raw: Any?) -> Double? {
+        if let value = raw as? Double {
+            return value
+        }
+        if let value = raw as? Int {
+            return Double(value)
+        }
+        if let value = raw as? String {
+            return Double(value)
+        }
+        return nil
+    }
+}

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotUsageFetcher.swift
@@ -55,6 +55,25 @@ public struct MoonshotUsageSummary: Sendable {
     }
 }
 
+private struct MoonshotBalanceResponse: Decodable {
+    let code: Int
+    let data: MoonshotBalanceData
+    let scode: String
+    let status: Bool
+}
+
+private struct MoonshotBalanceData: Decodable {
+    let availableBalance: Double
+    let voucherBalance: Double
+    let cashBalance: Double
+
+    private enum CodingKeys: String, CodingKey {
+        case availableBalance = "available_balance"
+        case voucherBalance = "voucher_balance"
+        case cashBalance = "cash_balance"
+    }
+}
+
 public enum MoonshotUsageError: LocalizedError, Sendable {
     case missingCredentials
     case networkError(String)
@@ -77,6 +96,7 @@ public enum MoonshotUsageError: LocalizedError, Sendable {
 
 public struct MoonshotUsageFetcher: Sendable {
     private static let log = CodexBarLog.logger(LogCategories.moonshotUsage)
+    private static let timeoutSeconds: TimeInterval = 15
 
     public static func fetchUsage(
         apiKey: String,
@@ -92,6 +112,7 @@ public struct MoonshotUsageFetcher: Sendable {
         request.httpMethod = "GET"
         request.setValue("Bearer \(cleaned)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = Self.timeoutSeconds
 
         let (data, response) = try await session.data(for: request)
 
@@ -100,9 +121,8 @@ public struct MoonshotUsageFetcher: Sendable {
         }
 
         guard httpResponse.statusCode == 200 else {
-            let body = String(data: data, encoding: .utf8) ?? "HTTP \(httpResponse.statusCode)"
-            Self.log.error("Moonshot API returned \(httpResponse.statusCode): \(body)")
-            throw MoonshotUsageError.apiError(body)
+            Self.log.error("Moonshot API returned HTTP \(httpResponse.statusCode)")
+            throw MoonshotUsageError.apiError("HTTP \(httpResponse.statusCode)")
         }
 
         let summary = try self.parseSummary(data: data)
@@ -118,42 +138,21 @@ public struct MoonshotUsageFetcher: Sendable {
     }
 
     private static func parseSummary(data: Data) throws -> MoonshotUsageSummary {
-        guard let json = try? JSONSerialization.jsonObject(with: data),
-              let dictionary = json as? [String: Any]
-        else {
-            throw MoonshotUsageError.parseFailed("Root JSON is not an object.")
+        let response: MoonshotBalanceResponse
+        do {
+            response = try JSONDecoder().decode(MoonshotBalanceResponse.self, from: data)
+        } catch {
+            throw MoonshotUsageError.parseFailed(error.localizedDescription)
         }
 
-        guard let payload = dictionary["data"] as? [String: Any] else {
-            throw MoonshotUsageError.parseFailed("Missing data object.")
-        }
-        guard let availableBalance = self.double(from: payload["available_balance"]) else {
-            throw MoonshotUsageError.parseFailed("Missing available_balance.")
-        }
-        guard let voucherBalance = self.double(from: payload["voucher_balance"]) else {
-            throw MoonshotUsageError.parseFailed("Missing voucher_balance.")
-        }
-        guard let cashBalance = self.double(from: payload["cash_balance"]) else {
-            throw MoonshotUsageError.parseFailed("Missing cash_balance.")
+        guard response.code == 0, response.status else {
+            throw MoonshotUsageError.apiError("code \(response.code), scode \(response.scode)")
         }
 
         return MoonshotUsageSummary(
-            availableBalance: availableBalance,
-            voucherBalance: voucherBalance,
-            cashBalance: cashBalance,
+            availableBalance: response.data.availableBalance,
+            voucherBalance: response.data.voucherBalance,
+            cashBalance: response.data.cashBalance,
             updatedAt: Date())
-    }
-
-    private static func double(from raw: Any?) -> Double? {
-        if let value = raw as? Double {
-            return value
-        }
-        if let value = raw as? Int {
-            return Double(value)
-        }
-        if let value = raw as? String {
-            return Double(value)
-        }
-        return nil
     }
 }

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -74,6 +74,7 @@ public enum ProviderDescriptorRegistry {
         .augment: AugmentProviderDescriptor.descriptor,
         .jetbrains: JetBrainsProviderDescriptor.descriptor,
         .kimik2: KimiK2ProviderDescriptor.descriptor,
+        .moonshot: MoonshotProviderDescriptor.descriptor,
         .amp: AmpProviderDescriptor.descriptor,
         .ollama: OllamaProviderDescriptor.descriptor,
         .synthetic: SyntheticProviderDescriptor.descriptor,

--- a/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
@@ -18,6 +18,7 @@ public struct ProviderSettingsSnapshot: Sendable {
         kilo: KiloProviderSettings? = nil,
         kimi: KimiProviderSettings? = nil,
         augment: AugmentProviderSettings? = nil,
+        moonshot: MoonshotProviderSettings? = nil,
         amp: AmpProviderSettings? = nil,
         ollama: OllamaProviderSettings? = nil,
         jetbrains: JetBrainsProviderSettings? = nil,
@@ -45,6 +46,7 @@ public struct ProviderSettingsSnapshot: Sendable {
             kilo: kilo,
             kimi: kimi,
             augment: augment,
+            moonshot: moonshot,
             amp: amp,
             ollama: ollama,
             jetbrains: jetbrains,
@@ -225,6 +227,14 @@ public struct ProviderSettingsSnapshot: Sendable {
         }
     }
 
+    public struct MoonshotProviderSettings: Sendable {
+        public let region: MoonshotRegion?
+
+        public init(region: MoonshotRegion? = nil) {
+            self.region = region
+        }
+    }
+
     public struct JetBrainsProviderSettings: Sendable {
         public let ideBasePath: String?
 
@@ -354,6 +364,7 @@ public struct ProviderSettingsSnapshot: Sendable {
     public let kilo: KiloProviderSettings?
     public let kimi: KimiProviderSettings?
     public let augment: AugmentProviderSettings?
+    public let moonshot: MoonshotProviderSettings?
     public let amp: AmpProviderSettings?
     public let commandcode: CommandCodeProviderSettings?
     public let ollama: OllamaProviderSettings?
@@ -386,6 +397,7 @@ public struct ProviderSettingsSnapshot: Sendable {
         kilo: KiloProviderSettings?,
         kimi: KimiProviderSettings?,
         augment: AugmentProviderSettings?,
+        moonshot: MoonshotProviderSettings? = nil,
         amp: AmpProviderSettings?,
         commandcode: CommandCodeProviderSettings? = nil,
         ollama: OllamaProviderSettings?,
@@ -413,6 +425,7 @@ public struct ProviderSettingsSnapshot: Sendable {
         self.kilo = kilo
         self.kimi = kimi
         self.augment = augment
+        self.moonshot = moonshot
         self.amp = amp
         self.commandcode = commandcode
         self.ollama = ollama
@@ -441,6 +454,7 @@ public enum ProviderSettingsSnapshotContribution: Sendable {
     case kilo(ProviderSettingsSnapshot.KiloProviderSettings)
     case kimi(ProviderSettingsSnapshot.KimiProviderSettings)
     case augment(ProviderSettingsSnapshot.AugmentProviderSettings)
+    case moonshot(ProviderSettingsSnapshot.MoonshotProviderSettings)
     case amp(ProviderSettingsSnapshot.AmpProviderSettings)
     case commandcode(ProviderSettingsSnapshot.CommandCodeProviderSettings)
     case ollama(ProviderSettingsSnapshot.OllamaProviderSettings)
@@ -470,6 +484,7 @@ public struct ProviderSettingsSnapshotBuilder: Sendable {
     public var kilo: ProviderSettingsSnapshot.KiloProviderSettings?
     public var kimi: ProviderSettingsSnapshot.KimiProviderSettings?
     public var augment: ProviderSettingsSnapshot.AugmentProviderSettings?
+    public var moonshot: ProviderSettingsSnapshot.MoonshotProviderSettings?
     public var amp: ProviderSettingsSnapshot.AmpProviderSettings?
     public var commandcode: ProviderSettingsSnapshot.CommandCodeProviderSettings?
     public var ollama: ProviderSettingsSnapshot.OllamaProviderSettings?
@@ -503,6 +518,7 @@ public struct ProviderSettingsSnapshotBuilder: Sendable {
         case let .kilo(value): self.kilo = value
         case let .kimi(value): self.kimi = value
         case let .augment(value): self.augment = value
+        case let .moonshot(value): self.moonshot = value
         case let .amp(value): self.amp = value
         case let .commandcode(value): self.commandcode = value
         case let .ollama(value): self.ollama = value
@@ -534,6 +550,7 @@ public struct ProviderSettingsSnapshotBuilder: Sendable {
             kilo: self.kilo,
             kimi: self.kimi,
             augment: self.augment,
+            moonshot: self.moonshot,
             amp: self.amp,
             commandcode: self.commandcode,
             ollama: self.ollama,

--- a/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
+++ b/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
@@ -56,6 +56,10 @@ public enum ProviderTokenResolver {
         self.kimiK2Resolution(environment: environment)?.token
     }
 
+    public static func moonshotToken(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        self.moonshotResolution(environment: environment)?.token
+    }
+
     public static func kiloToken(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         authFileURL: URL? = nil) -> String?
@@ -207,6 +211,12 @@ public enum ProviderTokenResolver {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
     {
         self.resolveEnv(KimiK2SettingsReader.apiKey(environment: environment))
+    }
+
+    public static func moonshotResolution(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
+    {
+        self.resolveEnv(MoonshotSettingsReader.apiKey(environment: environment))
     }
 
     public static func kiloResolution(

--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -24,6 +24,7 @@ public enum UsageProvider: String, CaseIterable, Sendable, Codable {
     case augment
     case jetbrains
     case kimik2
+    case moonshot
     case amp
     case ollama
     case synthetic
@@ -67,6 +68,7 @@ public enum IconStyle: Sendable, CaseIterable {
     case vertexai
     case augment
     case jetbrains
+    case moonshot
     case amp
     case ollama
     case synthetic

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
@@ -236,7 +236,8 @@ enum CostUsageScanner {
             return self.loadClaudeDaily(provider: .vertexai, range: range, now: now, options: filtered)
         case .openai, .zai, .gemini, .antigravity, .cursor, .opencode, .opencodego, .alibaba, .factory, .copilot,
              .minimax, .manus, .kilo, .kiro, .kimi,
-             .kimik2, .augment, .jetbrains, .amp, .ollama, .synthetic, .openrouter, .warp, .perplexity, .mimo,
+             .kimik2, .moonshot, .augment, .jetbrains, .amp, .ollama, .synthetic, .openrouter, .warp, .perplexity,
+             .mimo,
              .doubao, .abacus, .mistral, .deepseek, .codebuff, .crof, .windsurf, .venice, .commandcode, .stepfun:
             return emptyReport
         }

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -72,6 +72,7 @@ enum ProviderChoice: String, AppEnum {
         case .jetbrains: return nil // JetBrains not yet supported in widgets
         case .kimi: return nil // Kimi not yet supported in widgets
         case .kimik2: return nil // Kimi K2 not yet supported in widgets
+        case .moonshot: return nil // Moonshot not yet supported in widgets
         case .amp: return nil // Amp not yet supported in widgets
         case .ollama: return nil // Ollama not yet supported in widgets
         case .synthetic: return nil // Synthetic not yet supported in widgets

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -278,6 +278,7 @@ private struct ProviderSwitchChip: View {
         case .jetbrains: "JetBrains"
         case .kimi: "Kimi"
         case .kimik2: "Kimi K2"
+        case .moonshot: "Moonshot"
         case .amp: "Amp"
         case .ollama: "Ollama"
         case .synthetic: "Synthetic"
@@ -646,6 +647,8 @@ enum WidgetColors {
             Color(red: 254 / 255, green: 96 / 255, blue: 60 / 255) // Kimi orange
         case .kimik2:
             Color(red: 76 / 255, green: 0 / 255, blue: 255 / 255) // Kimi K2 purple
+        case .moonshot:
+            Color(red: 32 / 255, green: 93 / 255, blue: 235 / 255)
         case .amp:
             Color(red: 220 / 255, green: 38 / 255, blue: 38 / 255) // Amp red
         case .ollama:

--- a/Tests/CodexBarTests/MoonshotSettingsReaderTests.swift
+++ b/Tests/CodexBarTests/MoonshotSettingsReaderTests.swift
@@ -1,0 +1,68 @@
+import CodexBarCore
+import Testing
+
+struct MoonshotSettingsReaderTests {
+    @Test
+    func `api key prefers MOONSHOT API KEY`() {
+        let env = [
+            "MOONSHOT_API_KEY": "primary-token",
+            "MOONSHOT_KEY": "fallback-token",
+        ]
+
+        #expect(MoonshotSettingsReader.apiKey(environment: env) == "primary-token")
+    }
+
+    @Test
+    func `api key strips quotes`() {
+        let env = ["MOONSHOT_KEY": "\"quoted-token\""]
+
+        #expect(MoonshotSettingsReader.apiKey(environment: env) == "quoted-token")
+    }
+
+    @Test
+    func `region parses china`() {
+        let env = ["MOONSHOT_REGION": "china"]
+
+        #expect(MoonshotSettingsReader.region(environment: env) == .china)
+    }
+
+    @Test
+    func `default settings snapshot does not mask environment region`() {
+        let settings = ProviderSettingsSnapshot.MoonshotProviderSettings()
+
+        #expect(settings.region == nil)
+    }
+
+    @Test
+    func `region defaults to international for unknown values`() {
+        let env = ["MOONSHOT_REGION": "moon"]
+
+        #expect(MoonshotSettingsReader.region(environment: env) == .international)
+    }
+}
+
+struct MoonshotProviderTokenResolverTests {
+    @Test
+    func `resolves from environment`() {
+        let env = ["MOONSHOT_API_KEY": "env-token"]
+        let resolution = ProviderTokenResolver.moonshotResolution(environment: env)
+
+        #expect(resolution?.token == "env-token")
+        #expect(resolution?.source == .environment)
+    }
+
+    @Test
+    func `uses kimi branding icon`() {
+        let branding = MoonshotProviderDescriptor.descriptor.branding
+
+        #expect(branding.iconStyle == .kimi)
+        #expect(branding.iconResourceName == "ProviderIcon-kimi")
+    }
+
+    @Test
+    func `dashboard url opens account console`() {
+        #expect(
+            MoonshotProviderDescriptor.descriptor.metadata.dashboardURL
+                == "https://platform.moonshot.ai/console/account")
+    }
+}

--- a/Tests/CodexBarTests/MoonshotUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/MoonshotUsageFetcherTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct MoonshotUsageFetcherTests {
+    @Test
+    func `parses documented response`() throws {
+        let json = """
+        {
+          "code": 0,
+          "data": {
+            "available_balance": 49.58,
+            "voucher_balance": 50.00,
+            "cash_balance": 12.34
+          },
+          "scode": "0x0",
+          "status": true
+        }
+        """
+
+        let summary = try MoonshotUsageFetcher._parseSummaryForTesting(Data(json.utf8))
+
+        #expect(summary.availableBalance == 49.58)
+        #expect(summary.voucherBalance == 50.00)
+        #expect(summary.cashBalance == 12.34)
+
+        let usage = MoonshotUsageSnapshot(summary: summary).toUsageSnapshot()
+        #expect(usage.primary == nil)
+        #expect(usage.secondary == nil)
+        #expect(usage.loginMethod(for: .moonshot) == "Balance: $49.58")
+    }
+
+    @Test
+    func `negative cash balance is surfaced as deficit`() throws {
+        let json = """
+        {
+          "code": 0,
+          "data": {
+            "available_balance": 49.58,
+            "voucher_balance": 50.00,
+            "cash_balance": -0.42
+          },
+          "scode": "0x0",
+          "status": true
+        }
+        """
+
+        let summary = try MoonshotUsageFetcher._parseSummaryForTesting(Data(json.utf8))
+        let usage = MoonshotUsageSnapshot(summary: summary).toUsageSnapshot()
+
+        #expect(summary.cashBalance == -0.42)
+        #expect(usage.loginMethod(for: .moonshot)?.contains("in deficit") == true)
+    }
+
+    @Test
+    func `invalid root returns parse error`() {
+        let json = """
+        [{ "available_balance": 1 }]
+        """
+
+        #expect {
+            _ = try MoonshotUsageFetcher._parseSummaryForTesting(Data(json.utf8))
+        } throws: { error in
+            guard case let MoonshotUsageError.parseFailed(message) = error else { return false }
+            return message == "Root JSON is not an object."
+        }
+    }
+
+    @Test
+    func `international host uses moonshot ai`() {
+        let url = MoonshotUsageFetcher.resolveBalanceURL(region: .international)
+
+        #expect(url.absoluteString == "https://api.moonshot.ai/v1/users/me/balance")
+    }
+
+    @Test
+    func `china host uses moonshot cn`() {
+        let url = MoonshotUsageFetcher.resolveBalanceURL(region: .china)
+
+        #expect(url.absoluteString == "https://api.moonshot.cn/v1/users/me/balance")
+    }
+}

--- a/Tests/CodexBarTests/MoonshotUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/MoonshotUsageFetcherTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
+@Suite(.serialized)
 struct MoonshotUsageFetcherTests {
     @Test
     func `parses documented response`() throws {
@@ -61,8 +62,31 @@ struct MoonshotUsageFetcherTests {
         #expect {
             _ = try MoonshotUsageFetcher._parseSummaryForTesting(Data(json.utf8))
         } throws: { error in
-            guard case let MoonshotUsageError.parseFailed(message) = error else { return false }
-            return message == "Root JSON is not an object."
+            guard case MoonshotUsageError.parseFailed = error else { return false }
+            return true
+        }
+    }
+
+    @Test
+    func `api code failure returns api error`() {
+        let json = """
+        {
+          "code": 401,
+          "data": {
+            "available_balance": 0,
+            "voucher_balance": 0,
+            "cash_balance": 0
+          },
+          "scode": "unauthorized",
+          "status": false
+        }
+        """
+
+        #expect {
+            _ = try MoonshotUsageFetcher._parseSummaryForTesting(Data(json.utf8))
+        } throws: { error in
+            guard case let MoonshotUsageError.apiError(message) = error else { return false }
+            return message == "code 401, scode unauthorized"
         }
     }
 
@@ -79,4 +103,118 @@ struct MoonshotUsageFetcherTests {
 
         #expect(url.absoluteString == "https://api.moonshot.cn/v1/users/me/balance")
     }
+
+    @Test
+    func `fetch usage sends bearer token and bounded request`() async throws {
+        defer {
+            MoonshotStubURLProtocol.requests = []
+            MoonshotStubURLProtocol.handler = nil
+        }
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MoonshotStubURLProtocol.self]
+        let session = URLSession(configuration: config)
+
+        MoonshotStubURLProtocol.requests = []
+        MoonshotStubURLProtocol.handler = { request in
+            let url = try #require(request.url)
+            #expect(url.absoluteString == "https://api.moonshot.cn/v1/users/me/balance")
+            #expect(request.httpMethod == "GET")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer live-token")
+            #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+            #expect(request.timeoutInterval == 15)
+
+            let body = """
+            {
+              "code": 0,
+              "data": {
+                "available_balance": 9.87,
+                "voucher_balance": 1.23,
+                "cash_balance": 8.64
+              },
+              "scode": "0x0",
+              "status": true
+            }
+            """
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"])!
+            return (response, Data(body.utf8))
+        }
+
+        let snapshot = try await MoonshotUsageFetcher.fetchUsage(
+            apiKey: " live-token ",
+            region: .china,
+            session: session)
+
+        #expect(MoonshotStubURLProtocol.requests.count == 1)
+        #expect(snapshot.summary.availableBalance == 9.87)
+        #expect(snapshot.toUsageSnapshot().loginMethod(for: .moonshot) == "Balance: $9.87")
+    }
+
+    @Test
+    func `fetch usage surfaces http failure without leaking body`() async throws {
+        defer {
+            MoonshotStubURLProtocol.requests = []
+            MoonshotStubURLProtocol.handler = nil
+        }
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MoonshotStubURLProtocol.self]
+        let session = URLSession(configuration: config)
+
+        MoonshotStubURLProtocol.requests = []
+        MoonshotStubURLProtocol.handler = { request in
+            let url = try #require(request.url)
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"])!
+            return (response, Data(#"{"error":"secret-ish provider body"}"#.utf8))
+        }
+
+        await #expect {
+            _ = try await MoonshotUsageFetcher.fetchUsage(
+                apiKey: "live-token",
+                session: session)
+        } throws: { error in
+            guard case let MoonshotUsageError.apiError(message) = error else { return false }
+            return message == "HTTP 401"
+        }
+    }
+}
+
+final class MoonshotStubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var requests: [URLRequest] = []
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override static func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.requests.append(self.request)
+        guard let handler = Self.handler else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        do {
+            let (response, data) = try handler(self.request)
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            self.client?.urlProtocol(self, didLoad: data)
+            self.client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            self.client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
 }

--- a/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
+++ b/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
@@ -52,6 +52,21 @@ struct ProviderConfigEnvironmentTests {
     }
 
     @Test
+    func `applies API key override for moonshot`() {
+        let config = ProviderConfig(id: .moonshot, apiKey: "moon-token")
+        let env = ProviderConfigEnvironment.applyAPIKeyOverride(
+            base: [:],
+            provider: .moonshot,
+            config: config)
+
+        let key = MoonshotSettingsReader.apiKeyEnvironmentKeys.first
+        #expect(key != nil)
+        guard let key else { return }
+
+        #expect(env[key] == "moon-token")
+    }
+
+    @Test
     func `ignores legacy API key override for deepseek`() {
         let config = ProviderConfig(id: .deepseek, apiKey: "ds-token")
         let env = ProviderConfigEnvironment.applyAPIKeyOverride(

--- a/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
+++ b/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
@@ -54,7 +54,7 @@ struct ProvidersPaneCoverageTests {
         #expect(picker?.options.map(\.id) == [
             MenuBarMetricPreference.automatic.rawValue,
         ])
-        #expect(picker?.subtitle == "Shows the Moonshot balance in the menu bar.")
+        #expect(picker?.subtitle == "Shows the Moonshot / Kimi API balance in the menu bar.")
     }
 
     @Test

--- a/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
+++ b/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
@@ -45,6 +45,19 @@ struct ProvidersPaneCoverageTests {
     }
 
     @Test
+    func `moonshot menu bar metric picker shows balance only copy`() {
+        let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-moonshot-picker")
+        let store = Self.makeUsageStore(settings: settings)
+        let pane = ProvidersPane(settings: settings, store: store)
+
+        let picker = pane._test_menuBarMetricPicker(for: .moonshot)
+        #expect(picker?.options.map(\.id) == [
+            MenuBarMetricPreference.automatic.rawValue,
+        ])
+        #expect(picker?.subtitle == "Shows the Moonshot balance in the menu bar.")
+    }
+
+    @Test
     func `mistral menu bar metric picker shows spend only copy`() {
         let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-mistral-picker")
         let store = Self.makeUsageStore(settings: settings)
@@ -195,6 +208,14 @@ struct ProvidersPaneCoverageTests {
 
         #expect(row?.label == "Balance")
         #expect(row?.value == "$4.61")
+    }
+
+    @Test
+    func `provider detail plan row formats moonshot as balance`() {
+        let row = ProviderDetailView<EmptyView>.planRow(provider: .moonshot, planText: "Balance: $49.58")
+
+        #expect(row?.label == "Balance")
+        #expect(row?.value == "$49.58")
     }
 
     @Test

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -1097,6 +1097,7 @@ struct SettingsStoreTests {
             .augment,
             .jetbrains,
             .kimik2,
+            .moonshot,
             .amp,
             .ollama,
             .synthetic,

--- a/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
+++ b/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
@@ -72,6 +72,31 @@ struct StatusItemBalanceDisplayTests {
     }
 
     @Test
+    func `menu bar display text uses moonshot balance`() {
+        let settings = self.makeSettings(
+            suiteName: "StatusItemBalanceDisplayTests-moonshot-balance",
+            provider: .moonshot)
+        let (store, controller) = self.makeStoreAndController(settings: settings)
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .moonshot,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "Balance: $49.58 · $0.42 in deficit"))
+
+        store._setSnapshotForTesting(snapshot, provider: .moonshot)
+        store._setErrorForTesting(nil, provider: .moonshot)
+
+        let displayText = controller.menuBarDisplayText(for: .moonshot, snapshot: snapshot)
+
+        #expect(snapshot.primary == nil)
+        #expect(displayText == "$49.58")
+    }
+
+    @Test
     func `menu bar display text uses mistral current month api spend`() {
         let settings = self.makeSettings(
             suiteName: "StatusItemBalanceDisplayTests-mistral-spend",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -63,7 +63,7 @@ See `docs/configuration.md` for the schema.
     - `web` (macOS only): web-only where that provider exposes an explicit web source; no CLI/API fallback.
     - `cli`: CLI/local-helper source where the provider exposes one (for example Codex RPC/PTy, Claude PTY, Kilo CLI fallback, Kiro CLI, local probes).
     - `oauth`: OAuth-backed source where supported (Codex, Claude, Vertex AI).
-    - `api`: API-key/token flow when the provider supports it (z.ai, Gemini, Alibaba, Copilot, Kilo, Kimi K2, MiniMax, Warp, OpenRouter, Synthetic, DeepSeek, Codebuff).
+    - `api`: API-key/token flow when the provider supports it (z.ai, Gemini, Alibaba, Copilot, Kilo, Kimi K2, MiniMax, Warp, OpenRouter, Synthetic, DeepSeek, Moonshot, Codebuff).
     - Output `source` reflects the strategy actually used (`openai-web`, `web`, `oauth`, `api`, `local`, `cli`, or provider CLI label).
     - Codex web: OpenAI web dashboard (usage limits, credits remaining, code review remaining, usage breakdown).
         - `--web-timeout <seconds>` (default: 60)
@@ -115,6 +115,7 @@ codexbar --provider claude --all-accounts --format json --pretty
 codexbar --json-only --format json --pretty
 codexbar --provider gemini --source api --format json --pretty
 KILO_API_KEY=... codexbar --provider kilo --source api --format json --pretty
+MOONSHOT_API_KEY=... codexbar --provider moonshot --source api --format json --pretty
 codexbar config validate --format json --pretty
 codexbar config dump --pretty
 codexbar cache clear --cookies

--- a/docs/moonshot.md
+++ b/docs/moonshot.md
@@ -1,0 +1,50 @@
+---
+summary: "Moonshot / Kimi API provider data sources: API key + balance endpoint."
+read_when:
+  - Adding or tweaking Moonshot balance parsing
+  - Updating Moonshot / Kimi API key handling
+  - Documenting Moonshot / Kimi API provider behavior
+---
+
+# Moonshot / Kimi API provider
+
+Moonshot / Kimi API is API-only. Balance is reported by `GET /v1/users/me/balance`,
+so CodexBar only needs a valid API key to show the current account balance.
+
+## Rationale
+
+Kimi API docs use the Moonshot API surface for current Kimi models: examples read
+`MOONSHOT_API_KEY` and call `https://api.moonshot.ai/v1`, including the Kimi K2.6
+quickstart. This provider is therefore named after the account and billing surface,
+not a specific Kimi model version.
+
+The existing `Kimi K2` provider remains separate because it targets the legacy
+`kimi-k2.ai` credit endpoint. Migrating or deprecating that provider should be a
+separate cleanup so existing user settings are not silently repointed.
+
+## Data sources
+
+1. **API key** stored in `~/.codexbar/config.json` or supplied via `MOONSHOT_API_KEY` / `MOONSHOT_KEY`.
+   CodexBar stores the key in config after you paste it in Settings → Providers → Moonshot / Kimi API.
+2. **Region**
+   - International: `https://api.moonshot.ai/v1/users/me/balance`
+   - China mainland: `https://api.moonshot.cn/v1/users/me/balance`
+   - Configure with Settings → Providers → Moonshot → API region or `MOONSHOT_REGION`.
+3. **Balance endpoint**
+   - Request headers: `Authorization: Bearer <api key>`, `Accept: application/json`
+   - Response contains `available_balance`, `voucher_balance`, and `cash_balance`.
+
+## Usage details
+
+- The menu card shows the available balance.
+- If `cash_balance` is negative, the card also surfaces the deficit.
+- There is no session or weekly window — Moonshot / Kimi API does not expose per-window quota via API.
+- Settings config takes precedence over environment variables when both are present.
+
+## Key files
+
+- `Sources/CodexBarCore/Providers/Moonshot/MoonshotProviderDescriptor.swift` (descriptor + fetch strategy)
+- `Sources/CodexBarCore/Providers/Moonshot/MoonshotUsageFetcher.swift` (HTTP client + JSON parser)
+- `Sources/CodexBarCore/Providers/Moonshot/MoonshotSettingsReader.swift` (env var resolution)
+- `Sources/CodexBar/Providers/Moonshot/MoonshotProviderImplementation.swift` (settings field + activation logic)
+- `Sources/CodexBar/Providers/Moonshot/MoonshotSettingsStore.swift` (SettingsStore extension)

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -258,6 +258,14 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Status: `https://status.deepseek.com` (link only, no auto-polling).
 - Details: `docs/deepseek.md`.
 
+## Moonshot / Kimi API
+- API key via `MOONSHOT_API_KEY` / `MOONSHOT_KEY` env var or provider config.
+- Reads `GET /v1/users/me/balance` from the selected Moonshot region.
+- Region: international (`api.moonshot.ai`) or China mainland (`api.moonshot.cn`), configurable in Settings or `MOONSHOT_REGION`.
+- Shows available balance; negative cash balance is surfaced as a deficit.
+- Status: none yet.
+- Details: `docs/moonshot.md`.
+
 ## Venice
 - API key via `VENICE_API_KEY` / `VENICE_KEY` env var or Venice token accounts.
 - Shows current DIEM or USD balance; DIEM epoch allocation progress when available.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -49,6 +49,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 | Abacus AI | Browser cookies → compute points + billing API (`web`). |
 | Mistral | Console billing API via Ory Kratos session cookies (`web`). |
 | DeepSeek | API key from env or token accounts → balance endpoint (`api`). |
+| Moonshot | API key from config/env → balance endpoint (`api`). |
 | Codebuff | API token from config/env or `codebuff login` credentials → usage API (`api`). |
 | Crof | API key from config/env → credit balance + requests quota API (`api`). |
 | Venice | API key from config/env → DIEM/USD balance API (`api`). |


### PR DESCRIPTION
Replacement for #899 because the contributor branch has maintainer edits disabled.

## Summary
- add Moonshot / Kimi API as an API-key balance provider with international and China mainland balance endpoints
- harden balance parsing with typed decoding, API status validation, bounded request timeout, and non-leaky HTTP errors
- wire menu/settings/CLI/docs/changelog, including en/zh-Hans/pt-BR menu subtitle copy

## Proof
- `plutil -lint` for en, zh-Hans, pt-BR Localizable.strings
- localization key check: en/zh-Hans/pt-BR all include `menu_bar_metric_subtitle_moonshot`
- `./Scripts/lint.sh lint`
- `swift test --filter Moonshot`
- `swift test --filter ProvidersPaneCoverageTests`
- `swift test --filter ProviderConfigEnvironmentTests`
- `swift test --filter StatusItemBalanceDisplayTests`
- `swift test --filter LocalizationBundleTests`
- live CLI: `codexbar --provider moonshot --source api --format json` returned provider `moonshot`, source `api`, current balance, and timestamp using the real API key

Co-authored-by: giuseppebisemi <giuseppe.bisemi@gmail.com>