### PR TITLE
Add hourly usage chart for z.ai provider

### DIFF
--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -55,6 +55,14 @@ extension StatusItemController {
             } else {
                 false
             }
+        case Self.zaiHourlyUsageChartID:
+            if let providerRawValue = placeholder.toolTip,
+               let provider = UsageProvider(rawValue: providerRawValue)
+            {
+                self.appendZaiHourlyUsageChartItem(to: menu, provider: provider, width: width)
+            } else {
+                false
+            }
         default:
             false
         }
@@ -197,5 +205,40 @@ extension StatusItemController {
     private func storageBreakdownMenuMaxHeight() -> CGFloat {
         let visibleHeight = NSScreen.main?.visibleFrame.height ?? 900
         return min(620, max(360, floor(visibleHeight * 0.72)))
+    }
+
+    @discardableResult
+    func appendZaiHourlyUsageChartItem(
+        to submenu: NSMenu,
+        provider: UsageProvider,
+        width: CGFloat) -> Bool
+    {
+        guard provider == .zai,
+              let snapshot = self.store.snapshot(for: provider),
+              let modelUsage = snapshot.zaiUsage?.modelUsage
+        else { return false }
+
+        if !Self.menuCardRenderingEnabled {
+            let chartItem = NSMenuItem()
+            chartItem.isEnabled = false
+            chartItem.representedObject = Self.zaiHourlyUsageChartID
+            chartItem.toolTip = provider.rawValue
+            submenu.addItem(chartItem)
+            return true
+        }
+
+        let chartView = ZaiHourlyUsageChartMenuView(modelUsage: modelUsage, width: width)
+        let hosting = MenuHostingView(rootView: chartView)
+        let controller = NSHostingController(rootView: chartView)
+        let size = controller.sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude))
+        hosting.frame = NSRect(origin: .zero, size: NSSize(width: width, height: size.height))
+
+        let chartItem = NSMenuItem()
+        chartItem.view = hosting
+        chartItem.isEnabled = false
+        chartItem.representedObject = Self.zaiHourlyUsageChartID
+        chartItem.toolTip = provider.rawValue
+        submenu.addItem(chartItem)
+        return true
     }
 }

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -35,6 +35,7 @@ extension StatusItemController {
     static let costHistoryChartID = "costHistoryChart"
     static let usageHistoryChartID = "usageHistoryChart"
     static let storageBreakdownID = "storageBreakdown"
+    static let zaiHourlyUsageChartID = "zaiHourlyUsageChart"
 
     private func shortcut(for action: MenuDescriptor.MenuAction) -> (key: String, modifiers: NSEvent.ModifierFlags)? {
         switch action {
@@ -667,6 +668,13 @@ extension StatusItemController {
                 context: context.openAIContext,
                 addedOpenAIWebItems: addedOpenAIWebItems)
             if self.addUsageHistoryMenuItemIfNeeded(
+                to: menu,
+                provider: context.currentProvider,
+                width: context.menuWidth)
+            {
+                menu.addItem(.separator())
+            }
+            if self.addZaiHourlyUsageMenuItemIfNeeded(
                 to: menu,
                 provider: context.currentProvider,
                 width: context.menuWidth)
@@ -1570,6 +1578,7 @@ extension StatusItemController {
             Self.costHistoryChartID,
             Self.usageHistoryChartID,
             Self.storageBreakdownID,
+            Self.zaiHourlyUsageChartID,
         ]
         return menu.items.contains { item in
             guard let id = item.representedObject as? String else { return false }

--- a/Sources/CodexBar/StatusItemController+ZaiHourlyChartMenu.swift
+++ b/Sources/CodexBar/StatusItemController+ZaiHourlyChartMenu.swift
@@ -1,0 +1,31 @@
+import AppKit
+import CodexBarCore
+import SwiftUI
+
+extension StatusItemController {
+    @discardableResult
+    func addZaiHourlyUsageMenuItemIfNeeded(to menu: NSMenu, provider: UsageProvider, width: CGFloat) -> Bool {
+        guard provider == .zai else { return false }
+        guard let snapshot = self.store.snapshot(for: provider),
+              snapshot.zaiUsage?.modelUsage != nil
+        else { return false }
+        let submenu = self.makeHostedSubviewPlaceholderMenu(chartID: Self.zaiHourlyUsageChartID, provider: provider)
+        let item = self.makeMenuCardItem(
+            HStack(spacing: 0) {
+                Text("Hourly Usage")
+                    .font(.system(size: NSFont.menuFont(ofSize: 0).pointSize))
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.leading, 14)
+                    .padding(.trailing, 28)
+                    .padding(.vertical, 8)
+            },
+            id: "zaiHourlyUsageSubmenu",
+            width: width,
+            submenu: submenu,
+            submenuIndicatorAlignment: .trailing,
+            submenuIndicatorTopPadding: 0)
+        menu.addItem(item)
+        return true
+    }
+}

--- a/Sources/CodexBar/ZaiHourlyUsageChartMenuView.swift
+++ b/Sources/CodexBar/ZaiHourlyUsageChartMenuView.swift
@@ -1,0 +1,251 @@
+import CodexBarCore
+import SwiftUI
+
+@MainActor
+struct ZaiHourlyUsageChartMenuView: View {
+    private let modelUsage: ZaiModelUsageData
+    private let width: CGFloat
+
+    @State private var selectedRange: RangeOption = .today
+    @State private var isExpanded = true
+    @State private var hoveredBarIndex: Int?
+
+    private enum RangeOption: Int, CaseIterable {
+        case today = 0
+        case last24h = 1
+    }
+
+    private let barHeight: CGFloat = 60
+    private let barGap: CGFloat = 2
+    private let maxLabelCount = 5
+
+    private let colorPalette: [Color] = [
+        Color(red: 10 / 255, green: 132 / 255, blue: 1),
+        Color(red: 255 / 255, green: 159 / 255, blue: 10 / 255),
+        Color(red: 48 / 255, green: 209 / 255, blue: 88 / 255),
+        Color(red: 94 / 255, green: 92 / 255, blue: 230 / 255),
+        Color(red: 100 / 255, green: 210 / 255, blue: 255 / 255),
+        Color(red: 255 / 255, green: 55 / 255, blue: 95 / 255),
+    ]
+
+    init(modelUsage: ZaiModelUsageData, width: CGFloat) {
+        self.modelUsage = modelUsage
+        self.width = width
+    }
+
+    private var range: ZaiHourlyRange {
+        switch self.selectedRange {
+        case .today: .today(referenceDate: Date())
+        case .last24h: .last24h
+        }
+    }
+
+    private var bars: [ZaiHourlyBar] {
+        ZaiHourlyBars.from(modelData: self.modelUsage, range: self.range)
+    }
+
+    private var modelNames: [String] {
+        self.modelUsage.modelNames
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 4) {
+                Button(
+                    action: { withAnimation(.easeInOut(duration: 0.2)) { self.isExpanded.toggle() } },
+                    label: {
+                        Image(systemName: self.isExpanded ? "chevron.down" : "chevron.right")
+                            .font(.system(size: 8))
+                            .foregroundColor(.secondary)
+                            .frame(width: 10)
+                    })
+                    .buttonStyle(.plain)
+
+                Text("Hourly Tokens")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(.primary)
+
+                Spacer()
+
+                if self.isExpanded {
+                    self.rangeToggle
+                }
+            }
+
+            if self.isExpanded {
+                VStack(alignment: .leading, spacing: 4) {
+                    if self.bars.isEmpty {
+                        Text("No data")
+                            .font(.system(size: 10))
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.vertical, 16)
+                    } else {
+                        GeometryReader { geometry in
+                            let barWidth = max(
+                                (geometry.size.width - self.barGap * CGFloat(max(self.bars.count - 1, 0)))
+                                    / CGFloat(self.bars.count),
+                                2)
+                            HStack(alignment: .bottom, spacing: self.barGap) {
+                                ForEach(Array(self.bars.enumerated()), id: \.offset) { index, bar in
+                                    VStack(spacing: 0) {
+                                        Spacer(minLength: 0)
+                                        self.barStack(bar: bar, barWidth: barWidth, maxTotal: self.maxTotal)
+                                    }
+                                    .frame(width: barWidth, height: self.barHeight)
+                                    .contentShape(Rectangle())
+                                    .onHover { hovering in
+                                        self.hoveredBarIndex = hovering ? index : nil
+                                    }
+                                    .overlay(alignment: .bottom) {
+                                        if self.hoveredBarIndex == index {
+                                            self.tooltipOverlay(bar: bar)
+                                        }
+                                    }
+                                }
+                            }
+                            .frame(height: self.barHeight)
+                        }
+                        .frame(height: self.barHeight)
+
+                        self.legend
+                        self.xAxisLabels
+                    }
+                }
+                .padding(.top, 6)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .frame(minWidth: self.width, maxWidth: .infinity, alignment: .topLeading)
+        .animation(.easeInOut(duration: 0.2), value: self.isExpanded)
+    }
+
+    private var maxTotal: Int {
+        self.bars.map(\.totalTokens).max() ?? 1
+    }
+
+    private var rangeToggle: some View {
+        Picker("", selection: Binding(
+            get: { self.selectedRange.rawValue },
+            set: { self.selectedRange = RangeOption(rawValue: $0) ?? .today }))
+        {
+            Text("Today").tag(RangeOption.today.rawValue)
+            Text("24h").tag(RangeOption.last24h.rawValue)
+        }
+        .pickerStyle(.segmented)
+        .frame(width: 100)
+        .scaleEffect(0.8)
+        .frame(width: 80, height: 16)
+    }
+
+    @ViewBuilder
+    private func barStack(bar: ZaiHourlyBar, barWidth: CGFloat, maxTotal: Int) -> some View {
+        let scaleFactor = CGFloat(bar.totalTokens) / CGFloat(max(maxTotal, 1))
+
+        VStack(spacing: 0) {
+            ForEach(Array(bar.segments.enumerated()), id: \.offset) { segIndex, segment in
+                let segFraction = CGFloat(segment.tokens) / CGFloat(max(bar.totalTokens, 1))
+                let segHeight = max(
+                    self.barHeight * scaleFactor * segFraction,
+                    segment.tokens > 0 ? 1 : 0)
+                RoundedRectangle(cornerRadius: segIndex == bar.segments.count - 1 ? 2 : 0)
+                    .fill(self.colorForModel(segment.model))
+                    .frame(height: segHeight)
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 2))
+    }
+
+    private func tooltipOverlay(bar: ZaiHourlyBar) -> some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(bar.label + ":00")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(.primary)
+            ForEach(Array(bar.segments.enumerated()), id: \.offset) { _, segment in
+                HStack(spacing: 3) {
+                    Circle()
+                        .fill(self.colorForModel(segment.model))
+                        .frame(width: 5, height: 5)
+                    Text(segment.model)
+                        .font(.system(size: 9))
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+                        .layoutPriority(1)
+                    Text(self.formatTokenCount(segment.tokens))
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundColor(.primary)
+                }
+            }
+            Divider()
+                .background(Color.primary.opacity(0.15))
+            Text(self.formatTokenCount(bar.totalTokens))
+                .font(.system(size: 10, weight: .bold))
+                .foregroundColor(.primary)
+        }
+        .padding(6)
+        .frame(minWidth: 90, maxWidth: 140)
+        .background(Color(nsColor: .controlBackgroundColor).opacity(0.95))
+        .background(.ultraThinMaterial)
+        .cornerRadius(6)
+        .shadow(color: .black.opacity(0.2), radius: 4, y: 2)
+        .offset(y: -self.barHeight - 8)
+    }
+
+    private var legend: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(self.modelNames, id: \.self) { name in
+                    HStack(spacing: 2) {
+                        Circle()
+                            .fill(self.colorForModel(name))
+                            .frame(width: 6, height: 6)
+                        Text(name)
+                            .font(.system(size: 9))
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+        }
+    }
+
+    private var xAxisLabels: some View {
+        HStack(spacing: 0) {
+            ForEach(Array(self.labelIndices.enumerated()), id: \.offset) { _, index in
+                if index < self.bars.count {
+                    Text(self.bars[index].label)
+                        .font(.system(size: 9))
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+        }
+    }
+
+    private var labelIndices: [Int] {
+        guard self.bars.count > self.maxLabelCount else { return Array(0..<self.bars.count) }
+        let step = max(1, self.bars.count / (self.maxLabelCount - 1))
+        var indices = stride(from: 0, to: self.bars.count, by: step).map(\.self)
+        if indices.last != self.bars.count - 1 {
+            indices.append(self.bars.count - 1)
+        }
+        return indices
+    }
+
+    private func colorForModel(_ name: String) -> Color {
+        let index = self.modelNames.firstIndex(of: name) ?? 0
+        return self.colorPalette[index % self.colorPalette.count]
+    }
+
+    private func formatTokenCount(_ count: Int) -> String {
+        if count >= 1_000_000 {
+            String(format: "%.1fM", Double(count) / 1_000_000)
+        } else if count >= 1000 {
+            String(format: "%.1fk", Double(count) / 1000)
+        } else {
+            "\(count)"
+        }
+    }
+}

--- a/Sources/CodexBarCore/Providers/Zai/ZaiAPIRegion.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiAPIRegion.swift
@@ -5,6 +5,7 @@ public enum ZaiAPIRegion: String, CaseIterable, Sendable {
     case bigmodelCN = "bigmodel-cn"
 
     private static let quotaPath = "api/monitor/usage/quota/limit"
+    private static let modelUsagePath = "api/monitor/usage/model-usage"
 
     public var displayName: String {
         switch self {
@@ -26,5 +27,9 @@ public enum ZaiAPIRegion: String, CaseIterable, Sendable {
 
     public var quotaLimitURL: URL {
         URL(string: self.baseURLString)!.appendingPathComponent(Self.quotaPath)
+    }
+
+    public var modelUsageURL: URL {
+        URL(string: self.baseURLString)!.appendingPathComponent(Self.modelUsagePath)
     }
 }

--- a/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
@@ -53,7 +53,7 @@ struct ZaiAPIFetchStrategy: ProviderFetchStrategy {
             throw ZaiSettingsError.missingToken
         }
         let region = context.settings?.zai?.apiRegion ?? .global
-        let usage = try await ZaiUsageFetcher.fetchUsage(
+        let usage = try await ZaiUsageFetcher.fetchUsageWithModelUsage(
             apiKey: apiKey,
             region: region,
             environment: context.env)

--- a/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
@@ -141,6 +141,7 @@ public struct ZaiUsageSnapshot: Sendable {
     public let sessionTokenLimit: ZaiLimitEntry?
     public let timeLimit: ZaiLimitEntry?
     public let planName: String?
+    public let modelUsage: ZaiModelUsageData?
     public let updatedAt: Date
 
     public init(
@@ -148,12 +149,14 @@ public struct ZaiUsageSnapshot: Sendable {
         sessionTokenLimit: ZaiLimitEntry? = nil,
         timeLimit: ZaiLimitEntry?,
         planName: String?,
+        modelUsage: ZaiModelUsageData? = nil,
         updatedAt: Date)
     {
         self.tokenLimit = tokenLimit
         self.sessionTokenLimit = sessionTokenLimit
         self.timeLimit = timeLimit
         self.planName = planName
+        self.modelUsage = modelUsage
         self.updatedAt = updatedAt
     }
 
@@ -418,6 +421,7 @@ public struct ZaiUsageFetcher: Sendable {
             sessionTokenLimit: sessionTokenLimit,
             timeLimit: timeLimit,
             planName: responseData.planName,
+            modelUsage: nil,
             updatedAt: Date())
     }
 
@@ -436,6 +440,267 @@ public struct ZaiUsageFetcher: Sendable {
         }
         return base
     }
+}
+
+// MARK: - Model Usage Data
+
+/// Per-model hourly token usage from the z.ai model-usage API
+public struct ZaiModelUsageData: Sendable {
+    public let xTime: [String]
+    public let modelDataList: [ZaiModelDataItem]
+
+    public init(xTime: [String], modelDataList: [ZaiModelDataItem]) {
+        self.xTime = xTime
+        self.modelDataList = modelDataList
+    }
+
+    public var modelNames: [String] {
+        self.modelDataList.compactMap(\.modelName)
+    }
+}
+
+public struct ZaiModelDataItem: Sendable {
+    public let modelName: String?
+    public let tokensUsage: [Int?]
+
+    public init(modelName: String?, tokensUsage: [Int?]) {
+        self.modelName = modelName
+        self.tokensUsage = tokensUsage
+    }
+}
+
+// MARK: - Hourly Chart Data
+
+public enum ZaiHourlyRange: Equatable, Sendable {
+    case today(referenceDate: Date)
+    case last24h
+
+    public var isToday: Bool {
+        if case .today = self { return true }
+        return false
+    }
+}
+
+public struct ZaiHourlyBar: Sendable {
+    public let label: String
+    public let segments: [(model: String, tokens: Int)]
+
+    public init(label: String, segments: [(model: String, tokens: Int)]) {
+        self.label = label
+        self.segments = segments
+    }
+
+    public var totalTokens: Int {
+        self.segments.reduce(0) { $0 + $1.tokens }
+    }
+}
+
+public enum ZaiHourlyBars: Sendable {
+    public static func from(modelData: ZaiModelUsageData, range: ZaiHourlyRange) -> [ZaiHourlyBar] {
+        let calendar = Calendar.current
+        let referenceDate: Date = switch range {
+        case let .today(ref): ref
+        case .last24h: Date()
+        }
+
+        let todayStart = calendar.startOfDay(for: referenceDate)
+
+        var bars: [ZaiHourlyBar] = []
+        for (index, timeString) in modelData.xTime.enumerated() {
+            guard let hourDate = parseHourDate(timeString) else { continue }
+
+            if case .today = range {
+                if hourDate < todayStart { continue }
+            }
+
+            var segments: [(model: String, tokens: Int)] = []
+            for item in modelData.modelDataList {
+                guard index < item.tokensUsage.count,
+                      let tokenCount = item.tokensUsage[index], tokenCount > 0
+                else { continue }
+                segments.append((model: item.modelName ?? "Unknown", tokens: tokenCount))
+            }
+
+            let total = segments.reduce(0) { $0 + $1.tokens }
+            guard total > 0 else { continue }
+
+            let label = self.formatHourLabel(hourDate: hourDate)
+            bars.append(ZaiHourlyBar(label: label, segments: segments))
+        }
+
+        return bars
+    }
+
+    public static func parseHourDate(_ string: String) -> Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter.date(from: string)
+    }
+
+    private static func formatHourLabel(hourDate: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter.string(from: hourDate)
+    }
+}
+
+// MARK: - Model Usage Fetcher Extension
+
+extension ZaiUsageFetcher {
+    /// Fetches hourly model usage data for the last 24 hours
+    public static func fetchModelUsage(
+        apiKey: String,
+        region: ZaiAPIRegion = .global,
+        environment: [String: String] = ProcessInfo.processInfo.environment) async throws -> ZaiModelUsageData
+    {
+        guard !apiKey.isEmpty else {
+            throw ZaiUsageError.invalidCredentials
+        }
+
+        let baseURL: URL = if let host = ZaiSettingsReader.apiHost(environment: environment),
+                              let hostURL = URL(string: host), hostURL.scheme != nil
+        {
+            hostURL.appendingPathComponent("api/monitor/usage/model-usage")
+        } else {
+            region.modelUsageURL
+        }
+
+        let now = Date()
+        let calendar = Calendar.current
+        guard let startDate = calendar.date(byAdding: .day, value: -1, to: calendar.startOfDay(for: now)) else {
+            throw ZaiUsageError.parseFailed("Invalid date calculation")
+        }
+
+        let startComponents = calendar.dateComponents([.year, .month, .day, .hour], from: startDate)
+        let endComponents = calendar.dateComponents([.year, .month, .day, .hour], from: now)
+        let startTime = String(
+            format: "%04d-%02d-%02d %02d:00:00",
+            startComponents.year!,
+            startComponents.month!,
+            startComponents.day!,
+            startComponents.hour!)
+        let endTime = String(
+            format: "%04d-%02d-%02d %02d:59:59",
+            endComponents.year!,
+            endComponents.month!,
+            endComponents.day!,
+            endComponents.hour!)
+
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false) else {
+            throw ZaiUsageError.networkError("Invalid URL")
+        }
+        components.queryItems = [
+            URLQueryItem(name: "startTime", value: startTime),
+            URLQueryItem(name: "endTime", value: endTime),
+        ]
+
+        guard let requestURL = components.url else {
+            throw ZaiUsageError.networkError("Invalid URL")
+        }
+
+        var request = URLRequest(url: requestURL)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ZaiUsageError.networkError("Invalid response")
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let errorMessage = String(data: data, encoding: .utf8) ?? "Unknown error"
+            Self.log.error("z.ai model-usage API returned \(httpResponse.statusCode): \(errorMessage)")
+            throw ZaiUsageError.apiError("HTTP \(httpResponse.statusCode): \(errorMessage)")
+        }
+
+        guard !data.isEmpty else { return ZaiModelUsageData(xTime: [], modelDataList: []) }
+
+        return try Self.parseModelUsage(from: data)
+    }
+
+    static func parseModelUsage(from data: Data) throws -> ZaiModelUsageData {
+        let decoder = JSONDecoder()
+        let apiResponse = try decoder.decode(ZaiModelUsageAPIResponse.self, from: data)
+
+        guard apiResponse.isSuccess else {
+            throw ZaiUsageError.apiError(apiResponse.msg)
+        }
+
+        guard let responseData = apiResponse.data else {
+            return ZaiModelUsageData(xTime: [], modelDataList: [])
+        }
+
+        let items = responseData.modelDataList?.map { raw in
+            ZaiModelDataItem(
+                modelName: raw.modelName,
+                tokensUsage: raw.tokensUsage ?? [])
+        } ?? []
+
+        return ZaiModelUsageData(
+            xTime: responseData.xTime ?? [],
+            modelDataList: items)
+    }
+
+    /// Fetches both quota and model usage concurrently, returning a snapshot with both
+    public static func fetchUsageWithModelUsage(
+        apiKey: String,
+        region: ZaiAPIRegion = .global,
+        environment: [String: String] = ProcessInfo.processInfo.environment) async throws -> ZaiUsageSnapshot
+    {
+        async let quotaTask = Self.fetchUsage(apiKey: apiKey, region: region, environment: environment)
+        async let modelUsageTask = Self.fetchModelUsage(apiKey: apiKey, region: region, environment: environment)
+
+        let snapshot = try await quotaTask
+        let modelUsage: ZaiModelUsageData?
+        do {
+            modelUsage = try await modelUsageTask
+        } catch {
+            Self.log.info("z.ai model usage fetch failed (non-fatal): \(error.localizedDescription)")
+            modelUsage = nil
+        }
+
+        guard modelUsage != nil else { return snapshot }
+
+        return ZaiUsageSnapshot(
+            tokenLimit: snapshot.tokenLimit,
+            sessionTokenLimit: snapshot.sessionTokenLimit,
+            timeLimit: snapshot.timeLimit,
+            planName: snapshot.planName,
+            modelUsage: modelUsage,
+            updatedAt: snapshot.updatedAt)
+    }
+}
+
+// MARK: - Model Usage API Response (private)
+
+private struct ZaiModelUsageAPIResponse: Decodable {
+    let code: Int
+    let msg: String
+    let data: ZaiModelUsageRawData?
+    let success: Bool
+
+    var isSuccess: Bool {
+        self.success && self.code == 200
+    }
+}
+
+private struct ZaiModelUsageRawData: Decodable {
+    let xTime: [String]?
+    let modelDataList: [ZaiModelDataItemRaw]?
+
+    enum CodingKeys: String, CodingKey {
+        case xTime = "x_time"
+        case modelDataList
+    }
+}
+
+private struct ZaiModelDataItemRaw: Decodable {
+    let modelName: String?
+    let tokensUsage: [Int?]?
 }
 
 /// Errors that can occur during z.ai usage fetching

--- a/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
@@ -498,20 +498,23 @@ public struct ZaiHourlyBar: Sendable {
 public enum ZaiHourlyBars: Sendable {
     public static func from(modelData: ZaiModelUsageData, range: ZaiHourlyRange) -> [ZaiHourlyBar] {
         let calendar = Calendar.current
+        let now = Date()
         let referenceDate: Date = switch range {
         case let .today(ref): ref
-        case .last24h: Date()
+        case .last24h: now
         }
 
         let todayStart = calendar.startOfDay(for: referenceDate)
+        let cutoff: Date = switch range {
+        case .today: todayStart
+        case .last24h: calendar.date(byAdding: .hour, value: -24, to: now) ?? now
+        }
 
         var bars: [ZaiHourlyBar] = []
         for (index, timeString) in modelData.xTime.enumerated() {
             guard let hourDate = parseHourDate(timeString) else { continue }
 
-            if case .today = range {
-                if hourDate < todayStart { continue }
-            }
+            if hourDate < cutoff { continue }
 
             var segments: [(model: String, tokens: Int)] = []
             for item in modelData.modelDataList {
@@ -560,9 +563,9 @@ extension ZaiUsageFetcher {
         }
 
         let baseURL: URL = if let host = ZaiSettingsReader.apiHost(environment: environment),
-                              let hostURL = URL(string: host), hostURL.scheme != nil
+                              let resolved = Self.modelUsageURL(baseURLString: host)
         {
-            hostURL.appendingPathComponent("api/monitor/usage/model-usage")
+            resolved
         } else {
             region.modelUsageURL
         }
@@ -672,6 +675,23 @@ extension ZaiUsageFetcher {
             planName: snapshot.planName,
             modelUsage: modelUsage,
             updatedAt: snapshot.updatedAt)
+    }
+
+    private static func modelUsageURL(baseURLString: String) -> URL? {
+        guard let cleaned = ZaiSettingsReader.cleaned(baseURLString) else { return nil }
+        let path = "api/monitor/usage/model-usage"
+
+        if let url = URL(string: cleaned), url.scheme != nil {
+            if url.path.isEmpty || url.path == "/" {
+                return url.appendingPathComponent(path)
+            }
+            return url
+        }
+        guard let base = URL(string: "https://\(cleaned)") else { return nil }
+        if base.path.isEmpty || base.path == "/" {
+            return base.appendingPathComponent(path)
+        }
+        return base
     }
 }
 


### PR DESCRIPTION
## Summary

- Ports the beautiful stacked bar chart from [zai-usage-menu-bar](https://github.com/n1majne3/zai-usage-menu-bar) to show hourly per-model token usage for the z.ai provider
- Fetches model-usage data (`/api/monitor/usage/model-usage`) concurrently with existing quota data during regular refresh cycles
- Chart supports Today/24h toggle, per-model color coding, interactive hover tooltips, and collapse/expand

## Implementation Details

- **Data layer**: Added `ZaiModelUsageData`, `ZaiHourlyBar`, `ZaiHourlyRange` types and `fetchModelUsage()`/`fetchUsageWithModelUsage()` to `ZaiUsageFetcher`. Model usage is stored in `ZaiUsageSnapshot.modelUsage` (optional, non-persisted like other z.ai fields)
- **Chart view**: Pure SwiftUI implementation (no external libraries) in `ZaiHourlyUsageChartMenuView.swift` — follows CodexBar's `@MainActor` chart patterns while preserving the visual quality of the upstream project
- **Menu integration**: Lazy-loaded via `StatusItemController+HostedSubmenus` hydration pattern, identical to existing chart views

## Files Changed

| File | Change |
|------|--------|
| `ZaiUsageStats.swift` | +265 lines — model usage types, fetcher, `ZaiHourlyBars` converter |
| `ZaiHourlyUsageChartMenuView.swift` | New — stacked bar chart SwiftUI view |
| `StatusItemController+ZaiHourlyChartMenu.swift` | New — menu item creation |
| `StatusItemController+HostedSubmenus.swift` | +43 — hydration case + append method |
| `StatusItemController+Menu.swift` | +9 — chart ID, menu wiring |
| `ZaiAPIRegion.swift` | +5 — `modelUsageURL` property |
| `ZaiProviderDescriptor.swift` | 1 line — use `fetchUsageWithModelUsage` |

## Test plan

- [x] `swift build` — compiles cleanly
- [x] `swift test` — all 2341 tests pass
- [x] `make check` — 0 lint violations across 801 files
- [x] Manual test — "Hourly Usage" submenu appears for z.ai, chart renders with stacked bars, Today/24h toggle works, hover tooltips show per-model breakdown