### PR TITLE
Add option to hide quota warning markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.26 — Unreleased
 
 ### Added
+- Display: add a setting to hide quota-warning tick marks on usage bars while keeping quota warning notifications active (#918, fixes #916). Thanks @ThiagoCAltoe!
 - Moonshot / Kimi API: add API-key balance tracking, CLI support, docs, and menu bar balance copy (#899). Thanks @giuseppebisemi!
 
 ### Fixed

--- a/Sources/CodexBar/PreferencesDisplayPane.swift
+++ b/Sources/CodexBar/PreferencesDisplayPane.swift
@@ -75,6 +75,10 @@ struct DisplayPane: View {
                         subtitle: L("show_usage_as_used_subtitle"),
                         binding: self.$settings.usageBarsShowUsed)
                     PreferenceToggleRow(
+                        title: L("show_quota_warning_markers_title"),
+                        subtitle: L("show_quota_warning_markers_subtitle"),
+                        binding: self.$settings.quotaWarningMarkersVisible)
+                    PreferenceToggleRow(
                         title: L("show_reset_time_as_clock_title"),
                         subtitle: L("show_reset_time_as_clock_subtitle"),
                         binding: self.$settings.resetTimesShowAbsolute)

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -629,6 +629,7 @@ struct ProvidersPane: View {
     }
 
     private func quotaWarningMarkerThresholds(provider: UsageProvider, window: QuotaWarningWindow) -> [Int] {
+        guard self.settings.quotaWarningMarkersVisible else { return [] }
         guard self.settings.quotaWarningEnabled(provider: provider, window: window) else { return [] }
         return self.settings.resolvedQuotaWarningThresholds(provider: provider, window: window)
     }

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -482,6 +482,8 @@
 "section_menu_content" = "Menu content";
 "show_usage_as_used_title" = "Show usage as used";
 "show_usage_as_used_subtitle" = "Progress bars fill as you consume quota (instead of showing remaining).";
+"show_quota_warning_markers_title" = "Show quota warning markers";
+"show_quota_warning_markers_subtitle" = "Draw threshold tick marks on usage bars when quota warnings are configured.";
 "show_reset_time_as_clock_title" = "Show reset time as clock";
 "show_reset_time_as_clock_subtitle" = "Display reset times as absolute clock values instead of countdowns.";
 "show_credits_extra_usage_title" = "Show credits + extra usage";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -462,6 +462,8 @@
 "section_menu_content" = "Conteúdo do menu";
 "show_usage_as_used_title" = "Mostrar uso como consumido";
 "show_usage_as_used_subtitle" = "As barras de progresso preenchem conforme você consome a cota (em vez de mostrar o restante).";
+"show_quota_warning_markers_title" = "Mostrar marcadores de alerta de cota";
+"show_quota_warning_markers_subtitle" = "Desenha marcas de limite nas barras de uso quando os alertas de cota estão configurados.";
 "show_reset_time_as_clock_title" = "Mostrar renovação como horário";
 "show_reset_time_as_clock_subtitle" = "Mostra horários de renovação como horas absolutas, em vez de contagens regressivas.";
 "show_credits_extra_usage_title" = "Mostrar créditos + uso extra";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -489,6 +489,8 @@
 "section_menu_content" = "菜单内容";
 "show_usage_as_used_title" = "显示已使用用量";
 "show_usage_as_used_subtitle" = "进度条随用量消耗而填充（而非显示剩余量）。";
+"show_quota_warning_markers_title" = "显示配额警告标记";
+"show_quota_warning_markers_subtitle" = "配置配额警告后，在用量条上绘制阈值刻度标记。";
 "show_reset_time_as_clock_title" = "将重置时间显示为时钟";
 "show_reset_time_as_clock_subtitle" = "将重置时间显示为绝对时钟值而非倒计时。";
 "show_credits_extra_usage_title" = "显示积分 + 额外用量";

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -148,6 +148,14 @@ extension SettingsStore {
         }
     }
 
+    var quotaWarningMarkersVisible: Bool {
+        get { self.defaultsState.quotaWarningMarkersVisible }
+        set {
+            self.defaultsState.quotaWarningMarkersVisible = newValue
+            self.userDefaults.set(newValue, forKey: "quotaWarningMarkersVisible")
+        }
+    }
+
     var usageBarsShowUsed: Bool {
         get { self.defaultsState.usageBarsShowUsed }
         set {

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -16,6 +16,7 @@ extension SettingsStore {
         _ = self.quotaWarningWindowEnabled(.session)
         _ = self.quotaWarningWindowEnabled(.weekly)
         _ = self.quotaWarningSoundEnabled
+        _ = self.quotaWarningMarkersVisible
         _ = self.usageBarsShowUsed
         _ = self.resetTimesShowAbsolute
         _ = self.menuBarShowsBrandIconWithPercent

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -288,6 +288,11 @@ extension SettingsStore {
             userDefaults.set(true, forKey: "sessionQuotaNotificationsEnabled")
         }
         let quotaWarnings = Self.loadQuotaWarningDefaults(userDefaults: userDefaults)
+        let quotaWarningMarkersVisibleDefault = userDefaults.object(forKey: "quotaWarningMarkersVisible") as? Bool
+        let quotaWarningMarkersVisible = quotaWarningMarkersVisibleDefault ?? true
+        if Self.isRunningTests, quotaWarningMarkersVisibleDefault == nil {
+            userDefaults.set(true, forKey: "quotaWarningMarkersVisible")
+        }
         let usageBarsShowUsed = userDefaults.object(forKey: "usageBarsShowUsed") as? Bool ?? false
         let resetTimesShowAbsolute = userDefaults.object(forKey: "resetTimesShowAbsolute") as? Bool ?? false
         let menuBarShowsBrandIconWithPercent = userDefaults.object(
@@ -365,6 +370,7 @@ extension SettingsStore {
             quotaWarningSessionEnabled: quotaWarnings.sessionEnabled,
             quotaWarningWeeklyEnabled: quotaWarnings.weeklyEnabled,
             quotaWarningSoundEnabled: quotaWarnings.soundEnabled,
+            quotaWarningMarkersVisible: quotaWarningMarkersVisible,
             usageBarsShowUsed: usageBarsShowUsed,
             resetTimesShowAbsolute: resetTimesShowAbsolute,
             menuBarShowsBrandIconWithPercent: menuBarShowsBrandIconWithPercent,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -16,6 +16,7 @@ struct SettingsDefaultsState {
     var quotaWarningSessionEnabled: Bool
     var quotaWarningWeeklyEnabled: Bool
     var quotaWarningSoundEnabled: Bool
+    var quotaWarningMarkersVisible: Bool
     var usageBarsShowUsed: Bool
     var resetTimesShowAbsolute: Bool
     var menuBarShowsBrandIconWithPercent: Bool

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -117,6 +117,7 @@ extension StatusItemController {
     }
 
     private func quotaWarningMarkerThresholds(provider: UsageProvider, window: QuotaWarningWindow) -> [Int] {
+        guard self.settings.quotaWarningMarkersVisible else { return [] }
         guard self.settings.quotaWarningEnabled(provider: provider, window: window) else { return [] }
         return self.settings.resolvedQuotaWarningThresholds(provider: provider, window: window)
     }

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -534,10 +534,12 @@ struct SettingsStoreTests {
         #expect(store.quotaWarningWindowEnabled(.session) == true)
         #expect(store.quotaWarningWindowEnabled(.weekly) == true)
         #expect(store.quotaWarningSoundEnabled == true)
+        #expect(store.quotaWarningMarkersVisible == true)
         #expect(defaults.array(forKey: "quotaWarningThresholds") as? [Int] == [50, 20])
         #expect(defaults.object(forKey: "quotaWarningSessionEnabled") as? Bool == true)
         #expect(defaults.object(forKey: "quotaWarningWeeklyEnabled") as? Bool == true)
         #expect(defaults.bool(forKey: "quotaWarningSoundEnabled") == true)
+        #expect(defaults.object(forKey: "quotaWarningMarkersVisible") as? Bool == true)
     }
 
     @Test

--- a/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
+++ b/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
@@ -213,6 +213,41 @@ struct UsageStoreSessionQuotaTransitionTests {
     }
 
     @Test
+    func `hidden quota warning markers do not disable warning notifications`() {
+        let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-markers-hidden")
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.quotaWarningNotificationsEnabled = true
+        settings.quotaWarningMarkersVisible = false
+        settings.quotaWarningThresholds = [50, 20]
+        settings.setQuotaWarningWindowEnabled(.session, enabled: true)
+        settings.setQuotaWarningWindowEnabled(.weekly, enabled: true)
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        store.handleQuotaWarningTransitions(
+            provider: .codex,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(usedPercent: 40, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()))
+        store.handleQuotaWarningTransitions(
+            provider: .codex,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(usedPercent: 55, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()))
+
+        #expect(notifier.quotaWarningPosts.count == 1)
+        #expect(notifier.quotaWarningPosts.first?.event.threshold == 50)
+    }
+
+    @Test
     func `quota warning crossing multiple thresholds posts most severe only`() {
         let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-severe")
         settings.refreshFrequency = .manual


### PR DESCRIPTION
## Summary
- add a Display setting to hide quota warning threshold markers on usage bars
- keep quota warning notifications/thresholds active while suppressing only the visual tick marks
- preserve existing behavior by defaulting the new setting to enabled
- add localized strings and cover the default in SettingsStore tests

Closes #916

## Validation
- `git diff --check`
- `rg -n "quotaWarningMarkersVisible|show_quota_warning_markers" Sources Tests`

Note: full Swift tests were not run here because this environment does not have `swift` installed.