### PR TITLE
Add Kilo organization selection (stacked usage cards)

### DIFF
--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -13,6 +13,7 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
     let settingsFields: [ProviderSettingsFieldDescriptor]
     let settingsActions: [ProviderSettingsActionsDescriptor]
     let settingsTokenAccounts: ProviderSettingsTokenAccountsDescriptor?
+    let settingsOrganizations: ProviderSettingsOrganizationsDescriptor?
     let errorDisplay: ProviderErrorDisplay?
     @Binding var isErrorExpanded: Bool
     let onCopyError: (String) -> Void
@@ -31,6 +32,7 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
         settingsFields: [ProviderSettingsFieldDescriptor],
         settingsActions: [ProviderSettingsActionsDescriptor] = [],
         settingsTokenAccounts: ProviderSettingsTokenAccountsDescriptor?,
+        settingsOrganizations: ProviderSettingsOrganizationsDescriptor? = nil,
         errorDisplay: ProviderErrorDisplay?,
         isErrorExpanded: Binding<Bool>,
         onCopyError: @escaping (String) -> Void,
@@ -48,6 +50,7 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
         self.settingsFields = settingsFields
         self.settingsActions = settingsActions
         self.settingsTokenAccounts = settingsTokenAccounts
+        self.settingsOrganizations = settingsOrganizations
         self.errorDisplay = errorDisplay
         self._isErrorExpanded = isErrorExpanded
         self.onCopyError = onCopyError
@@ -126,6 +129,9 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
                         ForEach(self.settingsActions) { descriptor in
                             ProviderSettingsActionsRowView(descriptor: descriptor)
                         }
+                        if let organizations = self.settingsOrganizations {
+                            ProviderSettingsOrganizationsRowView(descriptor: organizations)
+                        }
                     }
                 }
 
@@ -154,7 +160,8 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
         !self.settingsPickers.isEmpty ||
             !self.settingsFields.isEmpty ||
             !self.settingsActions.isEmpty ||
-            self.settingsTokenAccounts != nil
+            self.settingsTokenAccounts != nil ||
+            self.settingsOrganizations != nil
     }
 
     private var detailLabelWidth: CGFloat {

--- a/Sources/CodexBar/PreferencesProviderSettingsRows.swift
+++ b/Sources/CodexBar/PreferencesProviderSettingsRows.swift
@@ -397,7 +397,7 @@ struct ProviderSettingsOrganizationsRowView: View {
             }
 
             let entries = self.descriptor.entries()
-            if entries.allSatisfy({ $0.isLocked }) {
+            if entries.allSatisfy(\.isLocked) {
                 Text("No organizations loaded. Click Refresh after setting your API key.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
@@ -408,22 +408,21 @@ struct ProviderSettingsOrganizationsRowView: View {
                             get: { entry.isEnabled },
                             set: { newValue in
                                 self.descriptor.onToggle(entry.id, newValue)
-                            }))
-                        {
-                            VStack(alignment: .leading, spacing: 1) {
-                                Text(entry.title)
-                                    .font(.footnote)
-                                if let subtitle = entry.subtitle,
-                                   !subtitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                                {
-                                    Text(subtitle)
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
+                            })) {
+                                VStack(alignment: .leading, spacing: 1) {
+                                    Text(entry.title)
+                                        .font(.footnote)
+                                    if let subtitle = entry.subtitle,
+                                       !subtitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                    {
+                                        Text(subtitle)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
                                 }
                             }
-                        }
-                        .toggleStyle(.checkbox)
-                        .disabled(entry.isLocked)
+                            .toggleStyle(.checkbox)
+                                .disabled(entry.isLocked)
                     }
                 }
             }

--- a/Sources/CodexBar/PreferencesProviderSettingsRows.swift
+++ b/Sources/CodexBar/PreferencesProviderSettingsRows.swift
@@ -372,3 +372,80 @@ extension View {
         }
     }
 }
+
+@MainActor
+struct ProviderSettingsOrganizationsRowView: View {
+    let descriptor: ProviderSettingsOrganizationsDescriptor
+    @State private var errorMessage: String?
+    @State private var isRefreshing = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 12) {
+                Text(self.descriptor.title)
+                    .font(.subheadline.weight(.semibold))
+                Spacer(minLength: 8)
+            }
+
+            if let subtitle = self.descriptor.subtitle,
+               !subtitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                Text(subtitle)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            let entries = self.descriptor.entries()
+            if entries.allSatisfy({ $0.isLocked }) {
+                Text("No organizations loaded. Click Refresh after setting your API key.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            } else {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(entries) { entry in
+                        Toggle(isOn: Binding(
+                            get: { entry.isEnabled },
+                            set: { newValue in
+                                self.descriptor.onToggle(entry.id, newValue)
+                            }))
+                        {
+                            VStack(alignment: .leading, spacing: 1) {
+                                Text(entry.title)
+                                    .font(.footnote)
+                                if let subtitle = entry.subtitle,
+                                   !subtitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                {
+                                    Text(subtitle)
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                        .toggleStyle(.checkbox)
+                        .disabled(entry.isLocked)
+                    }
+                }
+            }
+
+            HStack(spacing: 10) {
+                Button("Refresh organizations") {
+                    Task { @MainActor in
+                        self.isRefreshing = true
+                        let result = await self.descriptor.onRefresh()
+                        self.isRefreshing = false
+                        self.errorMessage = result.success ? nil : result.errorMessage
+                    }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(!self.descriptor.canRefresh() || self.isRefreshing)
+                if let errorMessage = self.errorMessage, !errorMessage.isEmpty {
+                    Text(errorMessage)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
+        }
+    }
+}

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -66,6 +66,7 @@ struct ProvidersPane: View {
                     settingsFields: self.extraSettingsFields(for: provider),
                     settingsActions: self.extraSettingsActions(for: provider),
                     settingsTokenAccounts: self.tokenAccountDescriptor(for: provider),
+                    settingsOrganizations: self.extraSettingsOrganizations(for: provider),
                     errorDisplay: self.providerErrorDisplay(provider),
                     isErrorExpanded: self.expandedBinding(for: provider),
                     onCopyError: { text in self.copyToPasteboard(text) },
@@ -354,6 +355,14 @@ struct ProvidersPane: View {
         let context = self.makeSettingsContext(provider: provider)
         return impl.settingsActions(context: context)
             .filter { $0.isVisible?() ?? true }
+    }
+
+    private func extraSettingsOrganizations(
+        for provider: UsageProvider) -> ProviderSettingsOrganizationsDescriptor?
+    {
+        guard let impl = ProviderCatalog.implementation(for: provider) else { return nil }
+        let context = self.makeSettingsContext(provider: provider)
+        return impl.settingsOrganizations(context: context)
     }
 
     func tokenAccountDescriptor(for provider: UsageProvider) -> ProviderSettingsTokenAccountsDescriptor? {

--- a/Sources/CodexBar/Providers/Kilo/KiloProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Kilo/KiloProviderImplementation.swift
@@ -128,16 +128,20 @@ struct KiloProviderImplementation: ProviderImplementation {
                 guard let settings else {
                     return .init(success: false, errorMessage: "Settings unavailable.")
                 }
-                let configured = settings.kiloAPIToken
-                let envKey = ProcessInfo.processInfo.environment[KiloSettingsReader.apiTokenKey] ?? ""
-                let apiKey = configured.isEmpty ? envKey : configured
-                guard !apiKey.isEmpty else {
+                let resolved: KiloResolvedBearerToken
+                do {
+                    resolved = try KiloBearerTokenResolver.resolve(
+                        source: settings.kiloUsageDataSource,
+                        apiKey: settings.configSnapshot.providerConfig(for: .kilo)?.sanitizedAPIKey)
+                } catch let error as LocalizedError {
                     return .init(
                         success: false,
-                        errorMessage: "Set the Kilo API key first.")
+                        errorMessage: error.errorDescription ?? "Failed to resolve Kilo credentials.")
+                } catch {
+                    return .init(success: false, errorMessage: error.localizedDescription)
                 }
                 do {
-                    let orgs = try await KiloUsageFetcher.fetchOrganizations(apiKey: apiKey)
+                    let orgs = try await KiloUsageFetcher.fetchOrganizations(apiKey: resolved.token)
                     await MainActor.run {
                         settings.setKiloKnownOrganizationsPruningEnabled(orgs)
                     }
@@ -151,8 +155,13 @@ struct KiloProviderImplementation: ProviderImplementation {
                 }
             },
             canRefresh: {
-                !settings.kiloAPIToken.isEmpty
-                    || !(ProcessInfo.processInfo.environment[KiloSettingsReader.apiTokenKey] ?? "").isEmpty
+                switch settings.kiloUsageDataSource {
+                case .api:
+                    !settings.kiloAPIToken.isEmpty
+                        || !(ProcessInfo.processInfo.environment[KiloSettingsReader.apiTokenKey] ?? "").isEmpty
+                case .cli, .auto:
+                    true
+                }
             })
     }
 }

--- a/Sources/CodexBar/Providers/Kilo/KiloProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Kilo/KiloProviderImplementation.swift
@@ -84,4 +84,75 @@ struct KiloProviderImplementation: ProviderImplementation {
                 onActivate: nil),
         ]
     }
+
+    @MainActor
+    func settingsOrganizations(
+        context: ProviderSettingsContext) -> ProviderSettingsOrganizationsDescriptor?
+    {
+        let settings = context.settings
+        let store = context.store
+        return ProviderSettingsOrganizationsDescriptor(
+            id: "kilo-organizations",
+            title: "Organizations",
+            subtitle: "Show usage for organizations you belong to. Personal account is always shown.",
+            entries: {
+                var entries: [ProviderSettingsOrganizationsDescriptor.Entry] = [
+                    .init(
+                        id: "personal",
+                        title: "Personal account",
+                        subtitle: nil,
+                        isEnabled: true,
+                        isLocked: true),
+                ]
+                for org in settings.kiloKnownOrganizations {
+                    entries.append(
+                        .init(
+                            id: org.id,
+                            title: org.name,
+                            subtitle: org.role,
+                            isEnabled: settings.kiloIsOrganizationEnabled(org.id),
+                            isLocked: false))
+                }
+                return entries
+            },
+            onToggle: { orgID, enabled in
+                guard orgID != "personal" else { return }
+                settings.setKiloOrganization(orgID, enabled: enabled)
+                Task { @MainActor in
+                    await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                        await store.refreshProvider(.kilo, allowDisabled: true)
+                    }
+                }
+            },
+            onRefresh: { [weak settings] in
+                guard let settings else {
+                    return .init(success: false, errorMessage: "Settings unavailable.")
+                }
+                let configured = settings.kiloAPIToken
+                let envKey = ProcessInfo.processInfo.environment[KiloSettingsReader.apiTokenKey] ?? ""
+                let apiKey = configured.isEmpty ? envKey : configured
+                guard !apiKey.isEmpty else {
+                    return .init(
+                        success: false,
+                        errorMessage: "Set the Kilo API key first.")
+                }
+                do {
+                    let orgs = try await KiloUsageFetcher.fetchOrganizations(apiKey: apiKey)
+                    await MainActor.run {
+                        settings.setKiloKnownOrganizationsPruningEnabled(orgs)
+                    }
+                    return .init(success: true, errorMessage: nil)
+                } catch let error as LocalizedError {
+                    return .init(
+                        success: false,
+                        errorMessage: error.errorDescription ?? "Failed to load organizations.")
+                } catch {
+                    return .init(success: false, errorMessage: error.localizedDescription)
+                }
+            },
+            canRefresh: {
+                !settings.kiloAPIToken.isEmpty
+                    || !(ProcessInfo.processInfo.environment[KiloSettingsReader.apiTokenKey] ?? "").isEmpty
+            })
+    }
 }

--- a/Sources/CodexBar/Providers/Kilo/KiloSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Kilo/KiloSettingsStore.swift
@@ -73,3 +73,70 @@ extension SettingsStore {
         }
     }
 }
+
+extension SettingsStore {
+    var kiloKnownOrganizations: [KiloOrganization] {
+        get { self.configSnapshot.providerConfig(for: .kilo)?.kiloKnownOrganizations ?? [] }
+        set {
+            self.updateProviderConfig(provider: .kilo) { entry in
+                entry.kiloKnownOrganizations = newValue.isEmpty ? nil : newValue
+            }
+        }
+    }
+
+    var kiloEnabledOrganizationIDs: [String] {
+        get { self.configSnapshot.providerConfig(for: .kilo)?.kiloEnabledOrganizationIDs ?? [] }
+        set {
+            let cleaned = Array(KiloOrgIDLinkedHashSet(newValue
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }))
+            self.updateProviderConfig(provider: .kilo) { entry in
+                entry.kiloEnabledOrganizationIDs = cleaned.isEmpty ? nil : cleaned
+            }
+            self.logProviderModeChange(
+                provider: .kilo,
+                field: "enabledOrganizations",
+                value: cleaned.joined(separator: ","))
+        }
+    }
+
+    func setKiloKnownOrganizationsPruningEnabled(_ orgs: [KiloOrganization]) {
+        self.kiloKnownOrganizations = orgs
+        let validIDs = Set(orgs.map(\.id))
+        let pruned = self.kiloEnabledOrganizationIDs.filter { validIDs.contains($0) }
+        if pruned != self.kiloEnabledOrganizationIDs {
+            self.kiloEnabledOrganizationIDs = pruned
+        }
+    }
+
+    func kiloIsOrganizationEnabled(_ orgID: String) -> Bool {
+        self.kiloEnabledOrganizationIDs.contains(orgID)
+    }
+
+    func setKiloOrganization(_ orgID: String, enabled: Bool) {
+        var current = self.kiloEnabledOrganizationIDs
+        if enabled {
+            guard !current.contains(orgID) else { return }
+            current.append(orgID)
+        } else {
+            current.removeAll { $0 == orgID }
+        }
+        self.kiloEnabledOrganizationIDs = current
+    }
+}
+
+// Small order-preserving set used to dedupe enabled IDs without sorting.
+private struct KiloOrgIDLinkedHashSet<Element: Hashable>: Sequence {
+    private var seen: Set<Element> = []
+    private var ordered: [Element] = []
+
+    init(_ sequence: some Sequence<Element>) {
+        for element in sequence where self.seen.insert(element).inserted {
+            self.ordered.append(element)
+        }
+    }
+
+    func makeIterator() -> IndexingIterator<[Element]> {
+        self.ordered.makeIterator()
+    }
+}

--- a/Sources/CodexBar/Providers/Kilo/KiloSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Kilo/KiloSettingsStore.swift
@@ -88,8 +88,8 @@ extension SettingsStore {
         get { self.configSnapshot.providerConfig(for: .kilo)?.kiloEnabledOrganizationIDs ?? [] }
         set {
             let cleaned = Array(KiloOrgIDLinkedHashSet(newValue
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .filter { !$0.isEmpty }))
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }))
             self.updateProviderConfig(provider: .kilo) { entry in
                 entry.kiloEnabledOrganizationIDs = cleaned.isEmpty ? nil : cleaned
             }
@@ -125,7 +125,7 @@ extension SettingsStore {
     }
 }
 
-// Small order-preserving set used to dedupe enabled IDs without sorting.
+/// Small order-preserving set used to dedupe enabled IDs without sorting.
 private struct KiloOrgIDLinkedHashSet<Element: Hashable>: Sequence {
     private var seen: Set<Element> = []
     private var ordered: [Element] = []

--- a/Sources/CodexBar/Providers/Kilo/UsageStore+KiloOrgRefresh.swift
+++ b/Sources/CodexBar/Providers/Kilo/UsageStore+KiloOrgRefresh.swift
@@ -41,29 +41,35 @@ extension UsageStore {
             await MainActor.run { self.kiloScopeSnapshots = [] }
             return
         }
-        let apiKey = self.settings.configSnapshot.providerConfig(for: .kilo)?.sanitizedAPIKey
-            ?? ProcessInfo.processInfo.environment[KiloSettingsReader.apiTokenKey]
-        guard let resolvedKey = apiKey, !resolvedKey.isEmpty else {
+        let env = ProcessInfo.processInfo.environment
+        let resolved: KiloResolvedBearerToken
+        do {
+            resolved = try KiloBearerTokenResolver.resolve(
+                source: self.settings.kiloUsageDataSource,
+                apiKey: self.settings.configSnapshot.providerConfig(for: .kilo)?.sanitizedAPIKey,
+                environment: env)
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription
+                ?? error.localizedDescription
             await MainActor.run {
                 self.kiloScopeSnapshots = scopes.map {
                     KiloScopeSnapshot(
                         id: $0.scopeIdentifier,
                         scope: $0,
                         snapshot: nil,
-                        errorMessage: "Kilo API credentials missing.",
+                        errorMessage: message,
                         sourceLabel: nil)
                 }
             }
             return
         }
 
-        let env = ProcessInfo.processInfo.environment
         let results: [KiloScopeSnapshot] = await withTaskGroup(of: KiloScopeSnapshot.self) { group in
             for scope in scopes {
                 group.addTask {
                     do {
                         let raw = try await KiloUsageFetcher.fetchUsage(
-                            apiKey: resolvedKey,
+                            apiKey: resolved.token,
                             scope: scope,
                             environment: env)
                         let snapshot = raw.toUsageSnapshot()
@@ -73,7 +79,7 @@ extension UsageStore {
                             scope: scope,
                             snapshot: snapshot,
                             errorMessage: nil,
-                            sourceLabel: "api")
+                            sourceLabel: resolved.sourceLabel)
                     } catch {
                         return KiloScopeSnapshot(
                             id: scope.scopeIdentifier,

--- a/Sources/CodexBar/Providers/Kilo/UsageStore+KiloOrgRefresh.swift
+++ b/Sources/CodexBar/Providers/Kilo/UsageStore+KiloOrgRefresh.swift
@@ -1,0 +1,125 @@
+import CodexBarCore
+import Foundation
+
+struct KiloScopeSnapshot: Identifiable, Equatable {
+    let id: String // KiloUsageScope.scopeIdentifier
+    let scope: KiloUsageScope
+    let snapshot: UsageSnapshot?
+    let errorMessage: String?
+    let sourceLabel: String?
+
+    static func == (lhs: KiloScopeSnapshot, rhs: KiloScopeSnapshot) -> Bool {
+        lhs.id == rhs.id
+            && lhs.snapshot?.updatedAt == rhs.snapshot?.updatedAt
+            && lhs.errorMessage == rhs.errorMessage
+            && lhs.sourceLabel == rhs.sourceLabel
+    }
+}
+
+extension UsageStore {
+    var kiloEnabledScopes: [KiloUsageScope] {
+        var scopes: [KiloUsageScope] = [.personal]
+        let enabled = self.settings.kiloEnabledOrganizationIDs
+        guard !enabled.isEmpty else { return scopes }
+        let knownByID = Dictionary(
+            uniqueKeysWithValues: self.settings.kiloKnownOrganizations.map { ($0.id, $0) })
+        for id in enabled {
+            if let org = knownByID[id] {
+                scopes.append(.organization(id: org.id, name: org.name))
+            }
+        }
+        return scopes
+    }
+
+    func shouldFanOutKiloScopes() -> Bool {
+        self.kiloEnabledScopes.count > 1
+    }
+
+    func refreshKiloScopes() async {
+        let scopes = self.kiloEnabledScopes
+        guard scopes.count > 1 else {
+            await MainActor.run { self.kiloScopeSnapshots = [] }
+            return
+        }
+        let apiKey = self.settings.configSnapshot.providerConfig(for: .kilo)?.sanitizedAPIKey
+            ?? ProcessInfo.processInfo.environment[KiloSettingsReader.apiTokenKey]
+        guard let resolvedKey = apiKey, !resolvedKey.isEmpty else {
+            await MainActor.run {
+                self.kiloScopeSnapshots = scopes.map {
+                    KiloScopeSnapshot(
+                        id: $0.scopeIdentifier,
+                        scope: $0,
+                        snapshot: nil,
+                        errorMessage: "Kilo API credentials missing.",
+                        sourceLabel: nil)
+                }
+            }
+            return
+        }
+
+        let env = ProcessInfo.processInfo.environment
+        let results: [KiloScopeSnapshot] = await withTaskGroup(of: KiloScopeSnapshot.self) { group in
+            for scope in scopes {
+                group.addTask {
+                    do {
+                        let raw = try await KiloUsageFetcher.fetchUsage(
+                            apiKey: resolvedKey,
+                            scope: scope,
+                            environment: env)
+                        let snapshot = raw.toUsageSnapshot()
+                            .withAccountOrganization(scope.displayName)
+                        return KiloScopeSnapshot(
+                            id: scope.scopeIdentifier,
+                            scope: scope,
+                            snapshot: snapshot,
+                            errorMessage: nil,
+                            sourceLabel: "api")
+                    } catch {
+                        return KiloScopeSnapshot(
+                            id: scope.scopeIdentifier,
+                            scope: scope,
+                            snapshot: nil,
+                            errorMessage: (error as? LocalizedError)?.errorDescription
+                                ?? error.localizedDescription,
+                            sourceLabel: nil)
+                    }
+                }
+            }
+            var collected: [KiloScopeSnapshot] = []
+            for await result in group {
+                collected.append(result)
+            }
+            return collected
+        }
+
+        let resultByID = Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) })
+        let ordered = scopes.compactMap { resultByID[$0.scopeIdentifier] }
+
+        await MainActor.run {
+            self.kiloScopeSnapshots = ordered
+        }
+    }
+}
+
+extension UsageSnapshot {
+    fileprivate func withAccountOrganization(_ org: String) -> UsageSnapshot {
+        let baseIdentity = self.identity
+        let newIdentity = ProviderIdentitySnapshot(
+            providerID: baseIdentity?.providerID ?? .kilo,
+            accountEmail: baseIdentity?.accountEmail,
+            accountOrganization: org,
+            loginMethod: baseIdentity?.loginMethod)
+        return UsageSnapshot(
+            primary: self.primary,
+            secondary: self.secondary,
+            tertiary: self.tertiary,
+            extraRateWindows: self.extraRateWindows,
+            providerCost: self.providerCost,
+            zaiUsage: self.zaiUsage,
+            minimaxUsage: self.minimaxUsage,
+            openRouterUsage: self.openRouterUsage,
+            cursorRequests: self.cursorRequests,
+            updatedAt: self.updatedAt,
+            identity: newIdentity)
+    }
+}

--- a/Sources/CodexBar/Providers/Shared/ProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderImplementation.swift
@@ -50,6 +50,10 @@ protocol ProviderImplementation: Sendable {
     @MainActor
     func settingsPickers(context: ProviderSettingsContext) -> [ProviderSettingsPickerDescriptor]
 
+    /// Optional provider-specific organizations selection rendered in the Providers pane.
+    @MainActor
+    func settingsOrganizations(context: ProviderSettingsContext) -> ProviderSettingsOrganizationsDescriptor?
+
     /// Optional visibility gate for token account settings.
     @MainActor
     func tokenAccountsVisibility(context: ProviderSettingsContext, support: TokenAccountSupport) -> Bool
@@ -141,6 +145,11 @@ extension ProviderImplementation {
     @MainActor
     func settingsPickers(context _: ProviderSettingsContext) -> [ProviderSettingsPickerDescriptor] {
         []
+    }
+
+    @MainActor
+    func settingsOrganizations(context _: ProviderSettingsContext) -> ProviderSettingsOrganizationsDescriptor? {
+        nil
     }
 
     @MainActor

--- a/Sources/CodexBar/Providers/Shared/ProviderSettingsDescriptors.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderSettingsDescriptors.swift
@@ -142,6 +142,34 @@ struct ProviderSettingsTokenAccountsDescriptor: Identifiable {
     let reloadFromDisk: () -> Void
 }
 
+/// Shared organizations descriptor rendered in the Providers settings pane.
+///
+/// Used by providers that let the user opt in to additional account scopes
+/// (e.g. Kilo organizations) shown alongside the personal account.
+@MainActor
+struct ProviderSettingsOrganizationsDescriptor: Identifiable {
+    struct Entry: Identifiable {
+        let id: String
+        let title: String
+        let subtitle: String?
+        let isEnabled: Bool
+        let isLocked: Bool
+    }
+
+    struct RefreshOutcome {
+        let success: Bool
+        let errorMessage: String?
+    }
+
+    let id: String
+    let title: String
+    let subtitle: String?
+    let entries: () -> [Entry]
+    let onToggle: (String, Bool) -> Void
+    let onRefresh: () async -> RefreshOutcome
+    let canRefresh: () -> Bool
+}
+
 /// Shared picker descriptor rendered in the Providers settings pane.
 @MainActor
 struct ProviderSettingsPickerDescriptor: Identifiable {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -559,6 +559,18 @@ extension StatusItemController {
             return false
         }
 
+        if context.currentProvider == .kilo, self.store.kiloScopeSnapshots.count > 1 {
+            let cards = self.store.kiloScopeSnapshots.compactMap { scope in
+                self.menuCardModel(
+                    for: .kilo,
+                    snapshotOverride: scope.snapshot,
+                    errorOverride: scope.errorMessage,
+                    forceOverrideCard: scope.snapshot == nil)
+            }
+            self.addStackedMenuCards(cards, to: menu, context: context)
+            return false
+        }
+
         guard let model = self.menuCardModel(for: context.selectedProvider) else { return false }
         if context.openAIContext.hasOpenAIWebMenuItems {
             let webItems = OpenAIWebMenuItems(

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -29,6 +29,9 @@ extension UsageStore {
                 if provider == .codex {
                     self.codexAccountSnapshots = []
                 }
+                if provider == .kilo {
+                    self.kiloScopeSnapshots = []
+                }
                 self.tokenSnapshots.removeValue(forKey: provider)
                 self.tokenErrors[provider] = nil
                 self.failureGates[provider]?.reset()
@@ -50,6 +53,15 @@ extension UsageStore {
             return
         } else if provider == .codex {
             self.codexAccountSnapshots = []
+        }
+
+        if provider == .kilo, self.shouldFanOutKiloScopes() {
+            await self.refreshKiloScopes()
+            // Continue to also fetch the personal snapshot through the regular path
+            // so the existing single-card render keeps working when only personal is shown.
+            // The presence of multi-element kiloScopeSnapshots triggers stacked rendering.
+        } else if provider == .kilo {
+            await MainActor.run { self.kiloScopeSnapshots = [] }
         }
 
         let tokenAccounts = self.tokenAccounts(for: provider)

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -15,6 +15,7 @@ extension UsageStore {
         _ = self.lastFetchAttempts
         _ = self.accountSnapshots
         _ = self.codexAccountSnapshots
+        _ = self.kiloScopeSnapshots
         _ = self.tokenSnapshots
         _ = self.tokenErrors
         _ = self.tokenRefreshInFlight
@@ -131,6 +132,7 @@ final class UsageStore {
     var lastFetchAttempts: [UsageProvider: [ProviderFetchAttempt]] = [:]
     var accountSnapshots: [UsageProvider: [TokenAccountUsageSnapshot]] = [:]
     var codexAccountSnapshots: [CodexAccountUsageSnapshot] = []
+    var kiloScopeSnapshots: [KiloScopeSnapshot] = []
     var tokenSnapshots: [UsageProvider: CostUsageTokenSnapshot] = [:]
     var tokenErrors: [UsageProvider: String] = [:]
     var tokenRefreshInFlight: Set<UsageProvider> = []

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -86,6 +86,8 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
     public var tokenAccounts: ProviderTokenAccountData?
     public var codexActiveSource: CodexActiveSource?
     public var quotaWarnings: QuotaWarningConfig?
+    public var kiloKnownOrganizations: [KiloOrganization]?
+    public var kiloEnabledOrganizationIDs: [String]?
 
     public init(
         id: UsageProvider,
@@ -100,7 +102,9 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         enterpriseHost: String? = nil,
         tokenAccounts: ProviderTokenAccountData? = nil,
         codexActiveSource: CodexActiveSource? = nil,
-        quotaWarnings: QuotaWarningConfig? = nil)
+        quotaWarnings: QuotaWarningConfig? = nil,
+        kiloKnownOrganizations: [KiloOrganization]? = nil,
+        kiloEnabledOrganizationIDs: [String]? = nil)
     {
         self.id = id
         self.enabled = enabled
@@ -115,6 +119,8 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         self.tokenAccounts = tokenAccounts
         self.codexActiveSource = codexActiveSource
         self.quotaWarnings = quotaWarnings
+        self.kiloKnownOrganizations = kiloKnownOrganizations
+        self.kiloEnabledOrganizationIDs = kiloEnabledOrganizationIDs
     }
 
     public var sanitizedAPIKey: String? {

--- a/Sources/CodexBarCore/Providers/Kilo/KiloBearerTokenResolver.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloBearerTokenResolver.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+public struct KiloResolvedBearerToken: Sendable, Equatable {
+    public let token: String
+    public let sourceLabel: String
+
+    public init(token: String, sourceLabel: String) {
+        self.token = token
+        self.sourceLabel = sourceLabel
+    }
+}
+
+/// Resolves the Kilo bearer token shared by usage fetches and organization discovery.
+///
+/// Behavior mirrors the per-strategy resolution in `KiloProviderDescriptor`:
+/// - `.api`: explicit `apiKey`, falling back to `KILO_API_KEY` env var.
+/// - `.cli`: token from `~/.local/share/kilo/auth.json` (`kilo.access`).
+/// - `.auto`: API first, falling back to CLI when API credentials are missing.
+public enum KiloBearerTokenResolver {
+    public static func resolve(
+        source: KiloUsageDataSource,
+        apiKey: String?,
+        environment: [String: String] = ProcessInfo.processInfo.environment) throws -> KiloResolvedBearerToken
+    {
+        switch source {
+        case .api:
+            return try self.resolveAPI(apiKey: apiKey, environment: environment)
+        case .cli:
+            return try self.resolveCLI(environment: environment)
+        case .auto:
+            if let resolved = try? self.resolveAPI(apiKey: apiKey, environment: environment) {
+                return resolved
+            }
+            return try self.resolveCLI(environment: environment)
+        }
+    }
+
+    private static func resolveAPI(
+        apiKey: String?,
+        environment: [String: String]) throws -> KiloResolvedBearerToken
+    {
+        let direct = KiloSettingsReader.cleaned(apiKey)
+        let envValue = KiloSettingsReader.cleaned(environment[KiloSettingsReader.apiTokenKey])
+        if let token = direct ?? envValue {
+            return KiloResolvedBearerToken(token: token, sourceLabel: "api")
+        }
+        throw KiloUsageError.missingCredentials
+    }
+
+    private static func resolveCLI(
+        environment: [String: String]) throws -> KiloResolvedBearerToken
+    {
+        let url = self.authFileURL(environment: environment)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw KiloUsageError.cliSessionMissing(url.path)
+        }
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw KiloUsageError.cliSessionUnreadable(url.path)
+        }
+        guard let token = KiloSettingsReader.parseAuthToken(data: data) else {
+            throw KiloUsageError.cliSessionInvalid(url.path)
+        }
+        return KiloResolvedBearerToken(token: token, sourceLabel: "cli")
+    }
+
+    static func authFileURL(environment: [String: String]) -> URL {
+        if let home = KiloSettingsReader.cleaned(environment["HOME"]) {
+            let expandedHome = NSString(string: home).expandingTildeInPath
+            return KiloSettingsReader.defaultAuthFileURL(
+                homeDirectory: URL(fileURLWithPath: expandedHome, isDirectory: true))
+        }
+        return KiloSettingsReader.defaultAuthFileURL(
+            homeDirectory: FileManager.default.homeDirectoryForCurrentUser)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Kilo/KiloOrganization.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloOrganization.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct KiloOrganization: Codable, Sendable, Equatable, Hashable, Identifiable {
+    public let id: String
+    public let name: String
+    public let role: String?
+
+    public init(id: String, name: String, role: String? = nil) {
+        self.id = id
+        self.name = name
+        self.role = role
+    }
+}

--- a/Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift
@@ -257,6 +257,7 @@ public struct KiloUsageFetcher: Sendable {
 
     public static func fetchUsage(
         apiKey: String,
+        scope: KiloUsageScope = .personal,
         environment: [String: String] = ProcessInfo.processInfo.environment) async throws -> KiloUsageSnapshot
     {
         guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -264,13 +265,7 @@ public struct KiloUsageFetcher: Sendable {
         }
 
         let baseURL = KiloSettingsReader.apiURL(environment: environment)
-        let batchURL = try self.makeBatchURL(baseURL: baseURL)
-
-        var request = URLRequest(url: batchURL)
-        request.httpMethod = "GET"
-        request.timeoutInterval = 15
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let request = try self.makeRequest(baseURL: baseURL, apiKey: apiKey, scope: scope)
 
         let data: Data
         let response: URLResponse
@@ -297,6 +292,31 @@ public struct KiloUsageFetcher: Sendable {
 
     static func _buildBatchURLForTesting(baseURL: URL) throws -> URL {
         try self.makeBatchURL(baseURL: baseURL)
+    }
+
+    static func _buildRequestForTesting(
+        baseURL: URL,
+        apiKey: String,
+        scope: KiloUsageScope) throws -> URLRequest
+    {
+        try self.makeRequest(baseURL: baseURL, apiKey: apiKey, scope: scope)
+    }
+
+    private static func makeRequest(
+        baseURL: URL,
+        apiKey: String,
+        scope: KiloUsageScope) throws -> URLRequest
+    {
+        let batchURL = try self.makeBatchURL(baseURL: baseURL)
+        var request = URLRequest(url: batchURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 15
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let orgId = scope.organizationID {
+            request.setValue(orgId, forHTTPHeaderField: "X-KILOCODE-ORGANIZATIONID")
+        }
+        return request
     }
 
     static func _parseSnapshotForTesting(_ data: Data) throws -> KiloUsageSnapshot {

--- a/Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift
@@ -234,6 +234,7 @@ public enum KiloUsageError: LocalizedError, Sendable, Equatable {
     }
 }
 
+// swiftlint:disable:next type_body_length
 public struct KiloUsageFetcher: Sendable {
     private struct KiloPassFields {
         let used: Double?

--- a/Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift
@@ -319,6 +319,145 @@ public struct KiloUsageFetcher: Sendable {
         return request
     }
 
+    public static func fetchOrganizations(
+        apiKey: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment) async throws -> [KiloOrganization]
+    {
+        guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw KiloUsageError.missingCredentials
+        }
+
+        let baseURL = KiloSettingsReader.apiURL(environment: environment)
+        let trpcRequest = try self.makeOrgListTRPCRequest(baseURL: baseURL, apiKey: apiKey)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: trpcRequest)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw KiloUsageError.networkError("Invalid response")
+            }
+            if httpResponse.statusCode == 404 {
+                return try await self.fetchOrganizationsRESTFallback(apiKey: apiKey)
+            }
+            if let mapped = self.statusError(for: httpResponse.statusCode) {
+                throw mapped
+            }
+            return try self.parseOrganizations(data: data)
+        } catch let error as KiloUsageError {
+            throw error
+        } catch {
+            throw KiloUsageError.networkError(error.localizedDescription)
+        }
+    }
+
+    static func _parseOrganizationsForTesting(_ data: Data) throws -> [KiloOrganization] {
+        try self.parseOrganizations(data: data)
+    }
+
+    private static func makeOrgListTRPCRequest(
+        baseURL: URL,
+        apiKey: String) throws -> URLRequest
+    {
+        let endpoint = baseURL.appendingPathComponent("user.getOrganizations")
+        let inputData = try JSONSerialization.data(
+            withJSONObject: ["0": ["json": NSNull()]] as [String: Any])
+        guard let inputString = String(data: inputData, encoding: .utf8),
+              var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false)
+        else {
+            throw KiloUsageError.parseFailed("Invalid org list endpoint")
+        }
+        components.queryItems = [
+            URLQueryItem(name: "batch", value: "1"),
+            URLQueryItem(name: "input", value: inputString),
+        ]
+        guard let url = components.url else {
+            throw KiloUsageError.parseFailed("Invalid org list endpoint")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 15
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        return request
+    }
+
+    private static func fetchOrganizationsRESTFallback(apiKey: String) async throws -> [KiloOrganization] {
+        guard let url = URL(string: "https://api.kilo.ai/api/profile") else {
+            throw KiloUsageError.parseFailed("Invalid REST fallback URL")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 15
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw KiloUsageError.networkError("Invalid response")
+        }
+        if let mapped = self.statusError(for: httpResponse.statusCode) {
+            throw mapped
+        }
+        guard httpResponse.statusCode == 200 else {
+            throw KiloUsageError.apiError(httpResponse.statusCode)
+        }
+        return try self.parseOrganizations(data: data)
+    }
+
+    private static func parseOrganizations(data: Data) throws -> [KiloOrganization] {
+        guard let root = try? JSONSerialization.jsonObject(with: data) else {
+            throw KiloUsageError.parseFailed("Invalid JSON")
+        }
+
+        // tRPC batch shape: [ { result: { data: { json: [orgs] } } } ]
+        if let entries = root as? [[String: Any]],
+           let first = entries.first,
+           let resultObject = first["result"] as? [String: Any]
+        {
+            if let dataObject = resultObject["data"] as? [String: Any],
+               let payload = dataObject["json"] as? [[String: Any]]
+            {
+                return self.decodeOrganizations(payload)
+            }
+            if let payload = resultObject["data"] as? [[String: Any]] {
+                return self.decodeOrganizations(payload)
+            }
+        }
+
+        // REST profile shape: { user: ..., organizations: [orgs] }
+        if let dictionary = root as? [String: Any] {
+            if let orgs = dictionary["organizations"] as? [[String: Any]] {
+                return self.decodeOrganizations(orgs)
+            }
+            // Some single-procedure tRPC shapes flatten to { result: { data: { json: { organizations: [...] }}}}
+            if let resultObject = dictionary["result"] as? [String: Any],
+               let dataObject = resultObject["data"] as? [String: Any]
+            {
+                if let payload = dataObject["json"] as? [[String: Any]] {
+                    return self.decodeOrganizations(payload)
+                }
+                if let payload = dataObject["json"] as? [String: Any],
+                   let orgs = payload["organizations"] as? [[String: Any]]
+                {
+                    return self.decodeOrganizations(orgs)
+                }
+            }
+        }
+
+        return []
+    }
+
+    private static func decodeOrganizations(_ raw: [[String: Any]]) -> [KiloOrganization] {
+        raw.compactMap { item -> KiloOrganization? in
+            guard let id = item["id"] as? String, !id.isEmpty else { return nil }
+            let name = (item["name"] as? String).map {
+                $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            } ?? id
+            let role = (item["role"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let normalizedRole = (role?.isEmpty ?? true) ? nil : role
+            return KiloOrganization(id: id, name: name.isEmpty ? id : name, role: normalizedRole)
+        }
+    }
+
     static func _parseSnapshotForTesting(_ data: Data) throws -> KiloUsageSnapshot {
         try self.parseSnapshot(data: data)
     }

--- a/Sources/CodexBarCore/Providers/Kilo/KiloUsageScope.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloUsageScope.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+public enum KiloUsageScope: Sendable, Hashable, Equatable {
+    case personal
+    case organization(id: String, name: String)
+
+    public var scopeIdentifier: String {
+        switch self {
+        case .personal:
+            "personal"
+        case let .organization(id, _):
+            "org:\(id)"
+        }
+    }
+
+    public var organizationID: String? {
+        switch self {
+        case .personal:
+            nil
+        case let .organization(id, _):
+            id
+        }
+    }
+
+    public var displayName: String {
+        switch self {
+        case .personal:
+            "Personal"
+        case let .organization(_, name):
+            name
+        }
+    }
+}

--- a/Tests/CodexBarTests/KiloBearerTokenResolverTests.swift
+++ b/Tests/CodexBarTests/KiloBearerTokenResolverTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct KiloBearerTokenResolverTests {
+    private func writeAuthFile(_ json: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kilo-resolver-tests-\(UUID().uuidString)", isDirectory: true)
+        let kiloDir = directory
+            .appendingPathComponent(".local", isDirectory: true)
+            .appendingPathComponent("share", isDirectory: true)
+            .appendingPathComponent("kilo", isDirectory: true)
+        try FileManager.default.createDirectory(at: kiloDir, withIntermediateDirectories: true)
+        let authURL = kiloDir.appendingPathComponent("auth.json", isDirectory: false)
+        try json.write(to: authURL, atomically: true, encoding: .utf8)
+        return directory
+    }
+
+    @Test
+    func `api mode uses provided apiKey`() throws {
+        let resolved = try KiloBearerTokenResolver.resolve(
+            source: .api,
+            apiKey: "kilo_abc",
+            environment: [:])
+        #expect(resolved.token == "kilo_abc")
+        #expect(resolved.sourceLabel == "api")
+    }
+
+    @Test
+    func `api mode falls back to KILO_API_KEY env var when apiKey is empty`() throws {
+        let resolved = try KiloBearerTokenResolver.resolve(
+            source: .api,
+            apiKey: nil,
+            environment: ["KILO_API_KEY": "kilo_from_env"])
+        #expect(resolved.token == "kilo_from_env")
+        #expect(resolved.sourceLabel == "api")
+    }
+
+    @Test
+    func `api mode throws missingCredentials when nothing available`() {
+        #expect(throws: KiloUsageError.missingCredentials) {
+            try KiloBearerTokenResolver.resolve(
+                source: .api,
+                apiKey: nil,
+                environment: [:])
+        }
+    }
+
+    @Test
+    func `cli mode reads token from auth.json`() throws {
+        let home = try self.writeAuthFile(#"{ "kilo": { "access": "cli-token" } }"#)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let resolved = try KiloBearerTokenResolver.resolve(
+            source: .cli,
+            apiKey: nil,
+            environment: ["HOME": home.path])
+        #expect(resolved.token == "cli-token")
+        #expect(resolved.sourceLabel == "cli")
+    }
+
+    @Test
+    func `cli mode throws cliSessionMissing when auth.json missing`() {
+        let nonexistentHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kilo-no-such-home-\(UUID().uuidString)", isDirectory: true)
+        #expect(throws: (any Error).self) {
+            try KiloBearerTokenResolver.resolve(
+                source: .cli,
+                apiKey: nil,
+                environment: ["HOME": nonexistentHome.path])
+        }
+    }
+
+    @Test
+    func `cli mode throws cliSessionInvalid for malformed JSON`() throws {
+        let home = try self.writeAuthFile(#"{ "kilo": { } }"#)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        #expect(throws: (any Error).self) {
+            try KiloBearerTokenResolver.resolve(
+                source: .cli,
+                apiKey: nil,
+                environment: ["HOME": home.path])
+        }
+    }
+
+    @Test
+    func `auto mode prefers API key when available`() throws {
+        let home = try self.writeAuthFile(#"{ "kilo": { "access": "cli-token" } }"#)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let resolved = try KiloBearerTokenResolver.resolve(
+            source: .auto,
+            apiKey: "kilo_api",
+            environment: ["HOME": home.path])
+        #expect(resolved.token == "kilo_api")
+        #expect(resolved.sourceLabel == "api")
+    }
+
+    @Test
+    func `auto mode falls back to CLI when API key missing`() throws {
+        let home = try self.writeAuthFile(#"{ "kilo": { "access": "cli-fallback" } }"#)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let resolved = try KiloBearerTokenResolver.resolve(
+            source: .auto,
+            apiKey: nil,
+            environment: ["HOME": home.path])
+        #expect(resolved.token == "cli-fallback")
+        #expect(resolved.sourceLabel == "cli")
+    }
+
+    @Test
+    func `auto mode surfaces CLI error when neither path available`() {
+        let nonexistentHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kilo-no-such-home-\(UUID().uuidString)", isDirectory: true)
+        #expect(throws: (any Error).self) {
+            try KiloBearerTokenResolver.resolve(
+                source: .auto,
+                apiKey: nil,
+                environment: ["HOME": nonexistentHome.path])
+        }
+    }
+}

--- a/Tests/CodexBarTests/KiloOrganizationTests.swift
+++ b/Tests/CodexBarTests/KiloOrganizationTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct KiloOrganizationTests {
+    @Test
+    func `decodes from canonical Kilo profile payload`() throws {
+        let json = #"""
+        { "id": "org_123", "name": "Acme Corp", "role": "owner" }
+        """#
+        let data = Data(json.utf8)
+        let org = try JSONDecoder().decode(KiloOrganization.self, from: data)
+        #expect(org.id == "org_123")
+        #expect(org.name == "Acme Corp")
+        #expect(org.role == "owner")
+    }
+
+    @Test
+    func `decodes when role missing`() throws {
+        let json = #"""
+        { "id": "org_xyz", "name": "No Role Org" }
+        """#
+        let data = Data(json.utf8)
+        let org = try JSONDecoder().decode(KiloOrganization.self, from: data)
+        #expect(org.role == nil)
+    }
+
+    @Test
+    func `equality covers all stored fields`() {
+        let a = KiloOrganization(id: "org_1", name: "A", role: "member")
+        let b = KiloOrganization(id: "org_1", name: "A", role: "member")
+        let differentRole = KiloOrganization(id: "org_1", name: "A", role: "owner")
+        #expect(a == b)
+        #expect(a != differentRole)
+    }
+}

--- a/Tests/CodexBarTests/KiloOrganizationTests.swift
+++ b/Tests/CodexBarTests/KiloOrganizationTests.swift
@@ -34,3 +34,39 @@ struct KiloOrganizationTests {
         #expect(a != differentRole)
     }
 }
+
+struct KiloUsageScopeTests {
+    @Test
+    func `personal scope identifier is stable`() {
+        let scope: KiloUsageScope = .personal
+        #expect(scope.scopeIdentifier == "personal")
+    }
+
+    @Test
+    func `organization scope identifier prefixes id`() {
+        let scope: KiloUsageScope = .organization(id: "org_42", name: "Acme")
+        #expect(scope.scopeIdentifier == "org:org_42")
+    }
+
+    @Test
+    func `organizationID is nil for personal`() {
+        #expect(KiloUsageScope.personal.organizationID == nil)
+    }
+
+    @Test
+    func `organizationID returns id for organization`() {
+        let scope: KiloUsageScope = .organization(id: "org_42", name: "Acme")
+        #expect(scope.organizationID == "org_42")
+    }
+
+    @Test
+    func `displayName falls back to Personal for personal`() {
+        #expect(KiloUsageScope.personal.displayName == "Personal")
+    }
+
+    @Test
+    func `displayName uses org name for organization`() {
+        let scope: KiloUsageScope = .organization(id: "org_42", name: "Acme")
+        #expect(scope.displayName == "Acme")
+    }
+}

--- a/Tests/CodexBarTests/KiloSettingsStoreTests.swift
+++ b/Tests/CodexBarTests/KiloSettingsStoreTests.swift
@@ -1,0 +1,57 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct KiloSettingsStoreTests {
+    private func makeSettings() throws -> SettingsStore {
+        let suite = "KiloSettingsStoreTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        return SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+    }
+
+    @Test
+    func `defaults to empty known organizations and empty enabled ids`() throws {
+        let settings = try self.makeSettings()
+        #expect(settings.kiloKnownOrganizations.isEmpty)
+        #expect(settings.kiloEnabledOrganizationIDs.isEmpty)
+    }
+
+    @Test
+    func `setting known organizations persists them`() throws {
+        let settings = try self.makeSettings()
+        let orgs = [
+            KiloOrganization(id: "org_1", name: "Alpha", role: "owner"),
+            KiloOrganization(id: "org_2", name: "Beta", role: "member"),
+        ]
+        settings.kiloKnownOrganizations = orgs
+        #expect(settings.kiloKnownOrganizations == orgs)
+    }
+
+    @Test
+    func `setting enabled org ids persists them`() throws {
+        let settings = try self.makeSettings()
+        settings.kiloEnabledOrganizationIDs = ["org_1", "org_2"]
+        #expect(settings.kiloEnabledOrganizationIDs == ["org_1", "org_2"])
+    }
+
+    @Test
+    func `setKiloKnownOrganizations prunes stale enabled ids`() throws {
+        let settings = try self.makeSettings()
+        settings.kiloKnownOrganizations = [
+            KiloOrganization(id: "org_1", name: "Alpha", role: nil),
+            KiloOrganization(id: "org_2", name: "Beta", role: nil),
+        ]
+        settings.kiloEnabledOrganizationIDs = ["org_1", "org_2"]
+        settings.setKiloKnownOrganizationsPruningEnabled(
+            [KiloOrganization(id: "org_2", name: "Beta", role: nil)])
+        #expect(settings.kiloKnownOrganizations.map(\.id) == ["org_2"])
+        #expect(settings.kiloEnabledOrganizationIDs == ["org_2"])
+    }
+}

--- a/Tests/CodexBarTests/KiloUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/KiloUsageFetcherTests.swift
@@ -700,6 +700,28 @@ struct KiloUsageFetcherTests {
             context: self.makeContext(sourceMode: .api)))
     }
 
+    @Test
+    func `request builder adds org header for organization scope`() throws {
+        let baseURL = try #require(URL(string: "https://kilo.example/trpc"))
+        let request = try KiloUsageFetcher._buildRequestForTesting(
+            baseURL: baseURL,
+            apiKey: "test-token",
+            scope: .organization(id: "org_42", name: "Acme"))
+        #expect(request.value(forHTTPHeaderField: "X-KILOCODE-ORGANIZATIONID") == "org_42")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-token")
+    }
+
+    @Test
+    func `request builder omits org header for personal scope`() throws {
+        let baseURL = try #require(URL(string: "https://kilo.example/trpc"))
+        let request = try KiloUsageFetcher._buildRequestForTesting(
+            baseURL: baseURL,
+            apiKey: "test-token",
+            scope: .personal)
+        #expect(request.value(forHTTPHeaderField: "X-KILOCODE-ORGANIZATIONID") == nil)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-token")
+    }
+
     private func makeTemporaryHomeDirectory() throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Tests/CodexBarTests/KiloUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/KiloUsageFetcherTests.swift
@@ -722,6 +722,56 @@ struct KiloUsageFetcherTests {
         #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-token")
     }
 
+    @Test
+    func `parseOrganizations decodes tRPC array shape`() throws {
+        let json = #"""
+        [
+          {
+            "result": {
+              "data": {
+                "json": [
+                  { "id": "org_1", "name": "Alpha", "role": "owner" },
+                  { "id": "org_2", "name": "Beta", "role": "member" }
+                ]
+              }
+            }
+          }
+        ]
+        """#
+        let orgs = try KiloUsageFetcher._parseOrganizationsForTesting(Data(json.utf8))
+        #expect(orgs.count == 2)
+        #expect(orgs[0].id == "org_1")
+        #expect(orgs[0].name == "Alpha")
+        #expect(orgs[0].role == "owner")
+        #expect(orgs[1].id == "org_2")
+        #expect(orgs[1].role == "member")
+    }
+
+    @Test
+    func `parseOrganizations decodes profile REST shape`() throws {
+        let json = #"""
+        {
+          "user": { "email": "test@example.com" },
+          "organizations": [
+            { "id": "org_42", "name": "Gamma" }
+          ]
+        }
+        """#
+        let orgs = try KiloUsageFetcher._parseOrganizationsForTesting(Data(json.utf8))
+        #expect(orgs.count == 1)
+        #expect(orgs[0].id == "org_42")
+        #expect(orgs[0].role == nil)
+    }
+
+    @Test
+    func `parseOrganizations returns empty for no orgs`() throws {
+        let json = #"""
+        { "user": { "email": "x@y" }, "organizations": [] }
+        """#
+        let orgs = try KiloUsageFetcher._parseOrganizationsForTesting(Data(json.utf8))
+        #expect(orgs.isEmpty)
+    }
+
     private func makeTemporaryHomeDirectory() throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/docs/kilo.md
+++ b/docs/kilo.md
@@ -35,3 +35,20 @@ Kilo supports API and CLI-backed auth. Source mode can be `auto`, `api`, or `cli
 - Missing API token: set `KILO_API_KEY` or provider `apiKey`.
 - Missing CLI session file: run `kilo login` to create `~/.local/share/kilo/auth.json`.
 - Unauthorized API token (401/403): refresh `KILO_API_KEY` or rerun `kilo login`.
+
+## Organizations
+
+CodexBar can show usage for any Kilo organization the API key belongs to.
+
+- Open Preferences → Providers → Kilo, set the API key, then click **Refresh
+  organizations**.
+- Toggle the organizations you want to display alongside Personal. Personal is
+  always shown.
+- When at least one organization is enabled, the menu renders one Kilo card per
+  enabled scope.
+- The CodexBar fetcher sends the standard `X-KILOCODE-ORGANIZATIONID` header on
+  every usage call to scope the response to that organization.
+- CLI source mode (`auth.json`): the header is applied to CLI-resolved tokens
+  as well. If a CLI token isn't authorized for the chosen organization, that
+  card surfaces an unauthorized error while Personal and other enabled scopes
+  continue to render normally.

--- a/docs/superpowers/plans/2026-05-11-kilo-organization-selection.md
+++ b/docs/superpowers/plans/2026-05-11-kilo-organization-selection.md
@@ -1,0 +1,1482 @@
+# Kilo Organization Selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let CodexBar users opt in to one or more Kilo organizations from Preferences → Providers → Kilo. Enabled orgs render as stacked cards alongside their personal account in the Kilo menu.
+
+**Architecture:** Add `KiloUsageScope` and `KiloOrganization` types in `CodexBarCore`. Inject `X-KILOCODE-ORGANIZATIONID` header in `KiloUsageFetcher` when a scope is `.organization`. Persist known orgs and enabled-ids in `ProviderConfig` JSON. Mirror the existing tokenAccounts pattern in `UsageStore` to fan out a fetch per enabled scope and store stacked snapshots. Render via the existing stacked-snapshot menu pipeline by surfacing a Kilo-scoped accounts adapter.
+
+**Tech Stack:** Swift 6, SwiftUI, Swift Testing (`@Test`), `swift build` / `swift test` / `make check`, GitHub CLI for PR.
+
+**Spec:** `docs/superpowers/specs/2026-05-11-kilo-organization-selection-design.md`
+
+---
+
+## Pre-flight (lead-only — do BEFORE dispatching tasks)
+
+- [ ] **Step 0.1: Confirm clean working tree on `main`**
+
+```bash
+git status
+```
+
+Expected output: `nothing to commit, working tree clean` on branch `main` (the spec commit `c24e58a4` is already in).
+
+- [ ] **Step 0.2: Create feature branch**
+
+```bash
+git switch -c feat/kilo-organization-selection
+```
+
+- [ ] **Step 0.3: Verify Swift toolchain and tests baseline**
+
+```bash
+swift build 2>&1 | tail -5
+swift test --filter KiloUsageFetcherTests 2>&1 | tail -10
+```
+
+Expected: build succeeds, KiloUsageFetcher tests pass.
+
+---
+
+## Task 1: Add `KiloOrganization` data type
+
+**Files:**
+- Create: `Sources/CodexBarCore/Providers/Kilo/KiloOrganization.swift`
+- Create: `Tests/CodexBarTests/KiloOrganizationTests.swift`
+
+- [ ] **Step 1.1: Write the failing test**
+
+Create `Tests/CodexBarTests/KiloOrganizationTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct KiloOrganizationTests {
+    @Test
+    func `decodes from canonical Kilo profile payload`() throws {
+        let json = #"""
+        { "id": "org_123", "name": "Acme Corp", "role": "owner" }
+        """#
+        let data = Data(json.utf8)
+        let org = try JSONDecoder().decode(KiloOrganization.self, from: data)
+        #expect(org.id == "org_123")
+        #expect(org.name == "Acme Corp")
+        #expect(org.role == "owner")
+    }
+
+    @Test
+    func `decodes when role missing`() throws {
+        let json = #"""
+        { "id": "org_xyz", "name": "No Role Org" }
+        """#
+        let data = Data(json.utf8)
+        let org = try JSONDecoder().decode(KiloOrganization.self, from: data)
+        #expect(org.role == nil)
+    }
+
+    @Test
+    func `equality covers all stored fields`() {
+        let a = KiloOrganization(id: "org_1", name: "A", role: "member")
+        let b = KiloOrganization(id: "org_1", name: "A", role: "member")
+        let differentRole = KiloOrganization(id: "org_1", name: "A", role: "owner")
+        #expect(a == b)
+        #expect(a != differentRole)
+    }
+}
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+```bash
+swift test --filter KiloOrganizationTests 2>&1 | tail -10
+```
+
+Expected: compile error "cannot find 'KiloOrganization' in scope".
+
+- [ ] **Step 1.3: Create the type**
+
+Create `Sources/CodexBarCore/Providers/Kilo/KiloOrganization.swift`:
+
+```swift
+import Foundation
+
+public struct KiloOrganization: Codable, Sendable, Equatable, Hashable, Identifiable {
+    public let id: String
+    public let name: String
+    public let role: String?
+
+    public init(id: String, name: String, role: String? = nil) {
+        self.id = id
+        self.name = name
+        self.role = role
+    }
+}
+```
+
+- [ ] **Step 1.4: Run tests, verify pass**
+
+```bash
+swift test --filter KiloOrganizationTests 2>&1 | tail -10
+```
+
+Expected: all 3 tests pass.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add Sources/CodexBarCore/Providers/Kilo/KiloOrganization.swift \
+        Tests/CodexBarTests/KiloOrganizationTests.swift
+git commit -m "feat(kilo): add KiloOrganization model"
+```
+
+---
+
+## Task 2: Add `KiloUsageScope` enum
+
+**Files:**
+- Create: `Sources/CodexBarCore/Providers/Kilo/KiloUsageScope.swift`
+- Modify: `Tests/CodexBarTests/KiloOrganizationTests.swift`
+
+- [ ] **Step 2.1: Append failing tests**
+
+Append to `Tests/CodexBarTests/KiloOrganizationTests.swift`:
+
+```swift
+struct KiloUsageScopeTests {
+    @Test
+    func `personal scope identifier is stable`() {
+        let scope: KiloUsageScope = .personal
+        #expect(scope.scopeIdentifier == "personal")
+    }
+
+    @Test
+    func `organization scope identifier prefixes id`() {
+        let scope: KiloUsageScope = .organization(id: "org_42", name: "Acme")
+        #expect(scope.scopeIdentifier == "org:org_42")
+    }
+
+    @Test
+    func `organizationID is nil for personal`() {
+        #expect(KiloUsageScope.personal.organizationID == nil)
+    }
+
+    @Test
+    func `organizationID returns id for organization`() {
+        let scope: KiloUsageScope = .organization(id: "org_42", name: "Acme")
+        #expect(scope.organizationID == "org_42")
+    }
+
+    @Test
+    func `displayName falls back to Personal for personal`() {
+        #expect(KiloUsageScope.personal.displayName == "Personal")
+    }
+
+    @Test
+    func `displayName uses org name for organization`() {
+        let scope: KiloUsageScope = .organization(id: "org_42", name: "Acme")
+        #expect(scope.displayName == "Acme")
+    }
+}
+```
+
+- [ ] **Step 2.2: Run test, verify it fails**
+
+```bash
+swift test --filter KiloUsageScopeTests 2>&1 | tail -10
+```
+
+Expected: compile error "cannot find 'KiloUsageScope' in scope".
+
+- [ ] **Step 2.3: Create the type**
+
+Create `Sources/CodexBarCore/Providers/Kilo/KiloUsageScope.swift`:
+
+```swift
+import Foundation
+
+public enum KiloUsageScope: Sendable, Hashable, Equatable {
+    case personal
+    case organization(id: String, name: String)
+
+    public var scopeIdentifier: String {
+        switch self {
+        case .personal:
+            "personal"
+        case let .organization(id, _):
+            "org:\(id)"
+        }
+    }
+
+    public var organizationID: String? {
+        switch self {
+        case .personal:
+            nil
+        case let .organization(id, _):
+            id
+        }
+    }
+
+    public var displayName: String {
+        switch self {
+        case .personal:
+            "Personal"
+        case let .organization(_, name):
+            name
+        }
+    }
+}
+```
+
+- [ ] **Step 2.4: Run tests, verify pass**
+
+```bash
+swift test --filter KiloUsageScopeTests 2>&1 | tail -10
+```
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add Sources/CodexBarCore/Providers/Kilo/KiloUsageScope.swift \
+        Tests/CodexBarTests/KiloOrganizationTests.swift
+git commit -m "feat(kilo): add KiloUsageScope enum"
+```
+
+---
+
+## Task 3: Inject org header in `KiloUsageFetcher.fetchUsage`
+
+**Files:**
+- Modify: `Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift`
+- Modify: `Tests/CodexBarTests/KiloUsageFetcherTests.swift`
+
+- [ ] **Step 3.1: Append failing test for header injection**
+
+Append the following inside `struct KiloUsageFetcherTests` in `Tests/CodexBarTests/KiloUsageFetcherTests.swift`:
+
+```swift
+    @Test
+    func `request builder adds org header for organization scope`() throws {
+        let baseURL = try #require(URL(string: "https://kilo.example/trpc"))
+        let request = try KiloUsageFetcher._buildRequestForTesting(
+            baseURL: baseURL,
+            apiKey: "test-token",
+            scope: .organization(id: "org_42", name: "Acme"))
+        #expect(request.value(forHTTPHeaderField: "X-KILOCODE-ORGANIZATIONID") == "org_42")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-token")
+    }
+
+    @Test
+    func `request builder omits org header for personal scope`() throws {
+        let baseURL = try #require(URL(string: "https://kilo.example/trpc"))
+        let request = try KiloUsageFetcher._buildRequestForTesting(
+            baseURL: baseURL,
+            apiKey: "test-token",
+            scope: .personal)
+        #expect(request.value(forHTTPHeaderField: "X-KILOCODE-ORGANIZATIONID") == nil)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-token")
+    }
+```
+
+- [ ] **Step 3.2: Run test, verify it fails**
+
+```bash
+swift test --filter KiloUsageFetcherTests 2>&1 | tail -15
+```
+
+Expected: compile error — `_buildRequestForTesting` not found.
+
+- [ ] **Step 3.3: Refactor `KiloUsageFetcher` to accept scope and extract request builder**
+
+In `Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift`:
+
+Replace the existing `public static func fetchUsage(apiKey:environment:)` signature (around line 258) with the scoped version, and extract the request building into a testable helper. The new code:
+
+```swift
+    public static func fetchUsage(
+        apiKey: String,
+        scope: KiloUsageScope = .personal,
+        environment: [String: String] = ProcessInfo.processInfo.environment) async throws -> KiloUsageSnapshot
+    {
+        guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw KiloUsageError.missingCredentials
+        }
+
+        let baseURL = KiloSettingsReader.apiURL(environment: environment)
+        let request = try self.makeRequest(baseURL: baseURL, apiKey: apiKey, scope: scope)
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw KiloUsageError.networkError(error.localizedDescription)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw KiloUsageError.networkError("Invalid response")
+        }
+
+        if let mapped = self.statusError(for: httpResponse.statusCode) {
+            throw mapped
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            throw KiloUsageError.apiError(httpResponse.statusCode)
+        }
+
+        return try self.parseSnapshot(data: data)
+    }
+
+    static func _buildRequestForTesting(
+        baseURL: URL,
+        apiKey: String,
+        scope: KiloUsageScope) throws -> URLRequest
+    {
+        try self.makeRequest(baseURL: baseURL, apiKey: apiKey, scope: scope)
+    }
+
+    private static func makeRequest(
+        baseURL: URL,
+        apiKey: String,
+        scope: KiloUsageScope) throws -> URLRequest
+    {
+        let batchURL = try self.makeBatchURL(baseURL: baseURL)
+        var request = URLRequest(url: batchURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 15
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let orgId = scope.organizationID {
+            request.setValue(orgId, forHTTPHeaderField: "X-KILOCODE-ORGANIZATIONID")
+        }
+        return request
+    }
+```
+
+Then delete the old inline `var request = URLRequest(url: batchURL)` setup that lived in `fetchUsage` (it's now in `makeRequest`).
+
+- [ ] **Step 3.4: Run tests, verify pass**
+
+```bash
+swift test --filter KiloUsageFetcherTests 2>&1 | tail -15
+```
+
+Expected: all KiloUsageFetcher tests pass (existing + 2 new).
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift \
+        Tests/CodexBarTests/KiloUsageFetcherTests.swift
+git commit -m "feat(kilo): scope KiloUsageFetcher.fetchUsage with org header"
+```
+
+---
+
+## Task 4: Add `fetchOrganizations` to `KiloUsageFetcher`
+
+**Files:**
+- Modify: `Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift`
+- Modify: `Tests/CodexBarTests/KiloUsageFetcherTests.swift`
+
+- [ ] **Step 4.1: Append failing parse tests**
+
+Append inside `struct KiloUsageFetcherTests`:
+
+```swift
+    @Test
+    func `parseOrganizations decodes tRPC array shape`() throws {
+        let json = #"""
+        [
+          {
+            "result": {
+              "data": {
+                "json": [
+                  { "id": "org_1", "name": "Alpha", "role": "owner" },
+                  { "id": "org_2", "name": "Beta", "role": "member" }
+                ]
+              }
+            }
+          }
+        ]
+        """#
+        let orgs = try KiloUsageFetcher._parseOrganizationsForTesting(Data(json.utf8))
+        #expect(orgs.count == 2)
+        #expect(orgs[0].id == "org_1")
+        #expect(orgs[0].name == "Alpha")
+        #expect(orgs[0].role == "owner")
+        #expect(orgs[1].id == "org_2")
+        #expect(orgs[1].role == "member")
+    }
+
+    @Test
+    func `parseOrganizations decodes profile REST shape`() throws {
+        let json = #"""
+        {
+          "user": { "email": "test@example.com" },
+          "organizations": [
+            { "id": "org_42", "name": "Gamma" }
+          ]
+        }
+        """#
+        let orgs = try KiloUsageFetcher._parseOrganizationsForTesting(Data(json.utf8))
+        #expect(orgs.count == 1)
+        #expect(orgs[0].id == "org_42")
+        #expect(orgs[0].role == nil)
+    }
+
+    @Test
+    func `parseOrganizations returns empty for no orgs`() throws {
+        let json = #"""
+        { "user": { "email": "x@y" }, "organizations": [] }
+        """#
+        let orgs = try KiloUsageFetcher._parseOrganizationsForTesting(Data(json.utf8))
+        #expect(orgs.isEmpty)
+    }
+```
+
+- [ ] **Step 4.2: Run, verify fail**
+
+```bash
+swift test --filter KiloUsageFetcherTests 2>&1 | tail -10
+```
+
+Expected: compile error — `_parseOrganizationsForTesting` undefined.
+
+- [ ] **Step 4.3: Add organization fetching logic**
+
+Append to `Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift` (inside the `KiloUsageFetcher` struct):
+
+```swift
+    public static func fetchOrganizations(
+        apiKey: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment) async throws -> [KiloOrganization]
+    {
+        guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw KiloUsageError.missingCredentials
+        }
+
+        let baseURL = KiloSettingsReader.apiURL(environment: environment)
+        let trpcRequest = try self.makeOrgListTRPCRequest(baseURL: baseURL, apiKey: apiKey)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: trpcRequest)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw KiloUsageError.networkError("Invalid response")
+            }
+            if httpResponse.statusCode == 404 {
+                return try await self.fetchOrganizationsRESTFallback(apiKey: apiKey)
+            }
+            if let mapped = self.statusError(for: httpResponse.statusCode) {
+                throw mapped
+            }
+            return try self.parseOrganizations(data: data)
+        } catch let error as KiloUsageError {
+            throw error
+        } catch {
+            throw KiloUsageError.networkError(error.localizedDescription)
+        }
+    }
+
+    static func _parseOrganizationsForTesting(_ data: Data) throws -> [KiloOrganization] {
+        try self.parseOrganizations(data: data)
+    }
+
+    private static func makeOrgListTRPCRequest(
+        baseURL: URL,
+        apiKey: String) throws -> URLRequest
+    {
+        let endpoint = baseURL.appendingPathComponent("user.getOrganizations")
+        let inputData = try JSONSerialization.data(
+            withJSONObject: ["0": ["json": NSNull()]] as [String: Any])
+        guard let inputString = String(data: inputData, encoding: .utf8),
+              var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false) else {
+            throw KiloUsageError.parseFailed("Invalid org list endpoint")
+        }
+        components.queryItems = [
+            URLQueryItem(name: "batch", value: "1"),
+            URLQueryItem(name: "input", value: inputString),
+        ]
+        guard let url = components.url else {
+            throw KiloUsageError.parseFailed("Invalid org list endpoint")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 15
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        return request
+    }
+
+    private static func fetchOrganizationsRESTFallback(apiKey: String) async throws -> [KiloOrganization] {
+        guard let url = URL(string: "https://api.kilo.ai/api/profile") else {
+            throw KiloUsageError.parseFailed("Invalid REST fallback URL")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 15
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw KiloUsageError.networkError("Invalid response")
+        }
+        if let mapped = self.statusError(for: httpResponse.statusCode) {
+            throw mapped
+        }
+        guard httpResponse.statusCode == 200 else {
+            throw KiloUsageError.apiError(httpResponse.statusCode)
+        }
+        return try self.parseOrganizations(data: data)
+    }
+
+    private static func parseOrganizations(data: Data) throws -> [KiloOrganization] {
+        guard let root = try? JSONSerialization.jsonObject(with: data) else {
+            throw KiloUsageError.parseFailed("Invalid JSON")
+        }
+
+        // tRPC batch shape: [ { result: { data: { json: [orgs] } } } ]
+        if let entries = root as? [[String: Any]],
+           let first = entries.first,
+           let resultObject = first["result"] as? [String: Any]
+        {
+            if let dataObject = resultObject["data"] as? [String: Any],
+               let payload = dataObject["json"] as? [[String: Any]]
+            {
+                return self.decodeOrganizations(payload)
+            }
+            if let payload = resultObject["data"] as? [[String: Any]] {
+                return self.decodeOrganizations(payload)
+            }
+        }
+
+        // REST profile shape: { user: ..., organizations: [orgs] }
+        if let dictionary = root as? [String: Any] {
+            if let orgs = dictionary["organizations"] as? [[String: Any]] {
+                return self.decodeOrganizations(orgs)
+            }
+            // Some single-procedure tRPC shapes flatten to { result: { data: { json: { organizations: [...] }}}}
+            if let resultObject = dictionary["result"] as? [String: Any],
+               let dataObject = resultObject["data"] as? [String: Any]
+            {
+                if let payload = dataObject["json"] as? [[String: Any]] {
+                    return self.decodeOrganizations(payload)
+                }
+                if let payload = dataObject["json"] as? [String: Any],
+                   let orgs = payload["organizations"] as? [[String: Any]]
+                {
+                    return self.decodeOrganizations(orgs)
+                }
+            }
+        }
+
+        return []
+    }
+
+    private static func decodeOrganizations(_ raw: [[String: Any]]) -> [KiloOrganization] {
+        raw.compactMap { item -> KiloOrganization? in
+            guard let id = item["id"] as? String, !id.isEmpty else { return nil }
+            let name = (item["name"] as? String).map {
+                $0.trimmingCharacters(in: .whitespacesAndNewlines)
+            } ?? id
+            let role = (item["role"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let normalizedRole = (role?.isEmpty ?? true) ? nil : role
+            return KiloOrganization(id: id, name: name.isEmpty ? id : name, role: normalizedRole)
+        }
+    }
+```
+
+- [ ] **Step 4.4: Run tests, verify pass**
+
+```bash
+swift test --filter KiloUsageFetcherTests 2>&1 | tail -15
+```
+
+Expected: all 3 new parse tests pass plus prior tests.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add Sources/CodexBarCore/Providers/Kilo/KiloUsageFetcher.swift \
+        Tests/CodexBarTests/KiloUsageFetcherTests.swift
+git commit -m "feat(kilo): add fetchOrganizations with REST fallback"
+```
+
+---
+
+## Task 5: Extend `ProviderConfig` with `kiloOrganizations`
+
+**Files:**
+- Modify: `Sources/CodexBarCore/Config/CodexBarConfig.swift`
+- Tests: covered indirectly via Task 6 SettingsStore tests.
+
+- [ ] **Step 5.1: Add fields to `ProviderConfig`**
+
+In `Sources/CodexBarCore/Config/CodexBarConfig.swift`, inside `public struct ProviderConfig`:
+
+After the existing `public var quotaWarnings: QuotaWarningConfig?` line, add:
+
+```swift
+    public var kiloKnownOrganizations: [KiloOrganization]?
+    public var kiloEnabledOrganizationIDs: [String]?
+```
+
+Then extend the `init` signature with these matching parameters (defaulted to `nil`) and assign them in the body. Match the existing init ordering pattern — add the two new parameters at the bottom of the init parameter list:
+
+```swift
+    public init(
+        id: UsageProvider,
+        enabled: Bool? = nil,
+        source: ProviderSourceMode? = nil,
+        extrasEnabled: Bool? = nil,
+        apiKey: String? = nil,
+        cookieHeader: String? = nil,
+        cookieSource: ProviderCookieSource? = nil,
+        region: String? = nil,
+        workspaceID: String? = nil,
+        enterpriseHost: String? = nil,
+        tokenAccounts: ProviderTokenAccountData? = nil,
+        codexActiveSource: CodexActiveSource? = nil,
+        quotaWarnings: QuotaWarningConfig? = nil,
+        kiloKnownOrganizations: [KiloOrganization]? = nil,
+        kiloEnabledOrganizationIDs: [String]? = nil)
+    {
+        self.id = id
+        self.enabled = enabled
+        self.source = source
+        self.extrasEnabled = extrasEnabled
+        self.apiKey = apiKey
+        self.cookieHeader = cookieHeader
+        self.cookieSource = cookieSource
+        self.region = region
+        self.workspaceID = workspaceID
+        self.enterpriseHost = enterpriseHost
+        self.tokenAccounts = tokenAccounts
+        self.codexActiveSource = codexActiveSource
+        self.quotaWarnings = quotaWarnings
+        self.kiloKnownOrganizations = kiloKnownOrganizations
+        self.kiloEnabledOrganizationIDs = kiloEnabledOrganizationIDs
+    }
+```
+
+The implicit `Codable` conformance will pick up the new optional fields automatically.
+
+- [ ] **Step 5.2: Build to verify schema compiles**
+
+```bash
+swift build 2>&1 | tail -5
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add Sources/CodexBarCore/Config/CodexBarConfig.swift
+git commit -m "feat(kilo): persist kilo organizations in ProviderConfig"
+```
+
+---
+
+## Task 6: Extend `SettingsStore` with Kilo orgs accessors
+
+**Files:**
+- Modify: `Sources/CodexBar/Providers/Kilo/KiloSettingsStore.swift`
+- Create: `Tests/CodexBarTests/KiloSettingsStoreTests.swift`
+
+- [ ] **Step 6.1: Write failing tests**
+
+Create `Tests/CodexBarTests/KiloSettingsStoreTests.swift`:
+
+```swift
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+@MainActor
+struct KiloSettingsStoreTests {
+    private func makeSettings() -> SettingsStore {
+        let env = ProviderConfigEnvironment(
+            configFileURL: FileManager.default.temporaryDirectory.appendingPathComponent(
+                "kilo-org-settings-test-\(UUID().uuidString).json"),
+            environment: [:])
+        return SettingsStore(providerConfigEnvironment: env)
+    }
+
+    @Test
+    func `defaults to empty known organizations and empty enabled ids`() {
+        let settings = self.makeSettings()
+        #expect(settings.kiloKnownOrganizations.isEmpty)
+        #expect(settings.kiloEnabledOrganizationIDs.isEmpty)
+    }
+
+    @Test
+    func `setting known organizations persists them`() {
+        let settings = self.makeSettings()
+        let orgs = [
+            KiloOrganization(id: "org_1", name: "Alpha", role: "owner"),
+            KiloOrganization(id: "org_2", name: "Beta", role: "member"),
+        ]
+        settings.kiloKnownOrganizations = orgs
+        #expect(settings.kiloKnownOrganizations == orgs)
+    }
+
+    @Test
+    func `setting enabled org ids persists them`() {
+        let settings = self.makeSettings()
+        settings.kiloEnabledOrganizationIDs = ["org_1", "org_2"]
+        #expect(settings.kiloEnabledOrganizationIDs == ["org_1", "org_2"])
+    }
+
+    @Test
+    func `setKiloKnownOrganizations prunes stale enabled ids`() {
+        let settings = self.makeSettings()
+        settings.kiloKnownOrganizations = [
+            KiloOrganization(id: "org_1", name: "Alpha", role: nil),
+            KiloOrganization(id: "org_2", name: "Beta", role: nil),
+        ]
+        settings.kiloEnabledOrganizationIDs = ["org_1", "org_2"]
+        settings.setKiloKnownOrganizationsPruningEnabled(
+            [KiloOrganization(id: "org_2", name: "Beta", role: nil)])
+        #expect(settings.kiloKnownOrganizations.map(\.id) == ["org_2"])
+        #expect(settings.kiloEnabledOrganizationIDs == ["org_2"])
+    }
+}
+```
+
+- [ ] **Step 6.2: Run, verify fail**
+
+```bash
+swift test --filter KiloSettingsStoreTests 2>&1 | tail -10
+```
+
+Expected: compile error — missing properties.
+
+- [ ] **Step 6.3: Add accessors to `KiloSettingsStore`**
+
+Append to `Sources/CodexBar/Providers/Kilo/KiloSettingsStore.swift`:
+
+```swift
+extension SettingsStore {
+    var kiloKnownOrganizations: [KiloOrganization] {
+        get { self.configSnapshot.providerConfig(for: .kilo)?.kiloKnownOrganizations ?? [] }
+        set {
+            self.updateProviderConfig(provider: .kilo) { entry in
+                entry.kiloKnownOrganizations = newValue.isEmpty ? nil : newValue
+            }
+        }
+    }
+
+    var kiloEnabledOrganizationIDs: [String] {
+        get { self.configSnapshot.providerConfig(for: .kilo)?.kiloEnabledOrganizationIDs ?? [] }
+        set {
+            let cleaned = Array(LinkedHashSet(newValue
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }))
+            self.updateProviderConfig(provider: .kilo) { entry in
+                entry.kiloEnabledOrganizationIDs = cleaned.isEmpty ? nil : cleaned
+            }
+            self.logProviderModeChange(
+                provider: .kilo,
+                field: "enabledOrganizations",
+                value: cleaned.joined(separator: ","))
+        }
+    }
+
+    func setKiloKnownOrganizationsPruningEnabled(_ orgs: [KiloOrganization]) {
+        self.kiloKnownOrganizations = orgs
+        let validIDs = Set(orgs.map(\.id))
+        let pruned = self.kiloEnabledOrganizationIDs.filter { validIDs.contains($0) }
+        if pruned != self.kiloEnabledOrganizationIDs {
+            self.kiloEnabledOrganizationIDs = pruned
+        }
+    }
+
+    func kiloIsOrganizationEnabled(_ orgID: String) -> Bool {
+        self.kiloEnabledOrganizationIDs.contains(orgID)
+    }
+
+    func setKiloOrganization(_ orgID: String, enabled: Bool) {
+        var current = self.kiloEnabledOrganizationIDs
+        if enabled {
+            guard !current.contains(orgID) else { return }
+            current.append(orgID)
+        } else {
+            current.removeAll { $0 == orgID }
+        }
+        self.kiloEnabledOrganizationIDs = current
+    }
+}
+
+// Small order-preserving set used to dedupe enabled IDs without sorting.
+private struct LinkedHashSet<Element: Hashable>: Sequence {
+    private var seen: Set<Element> = []
+    private var ordered: [Element] = []
+
+    init<S: Sequence>(_ sequence: S) where S.Element == Element {
+        for element in sequence where self.seen.insert(element).inserted {
+            self.ordered.append(element)
+        }
+    }
+
+    func makeIterator() -> IndexingIterator<[Element]> {
+        self.ordered.makeIterator()
+    }
+}
+```
+
+- [ ] **Step 6.4: Run tests, verify pass**
+
+```bash
+swift test --filter KiloSettingsStoreTests 2>&1 | tail -10
+```
+
+Expected: all 4 tests pass.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add Sources/CodexBar/Providers/Kilo/KiloSettingsStore.swift \
+        Tests/CodexBarTests/KiloSettingsStoreTests.swift
+git commit -m "feat(kilo): settings accessors for known + enabled organizations"
+```
+
+---
+
+## Task 7: Wire scoped fetching into Kilo strategies
+
+**Files:**
+- Modify: `Sources/CodexBarCore/Providers/Kilo/KiloProviderDescriptor.swift`
+- Modify: `Sources/CodexBar/UsageStore+Refresh.swift`
+- Create: `Sources/CodexBar/Providers/Kilo/UsageStore+KiloOrgRefresh.swift`
+
+The `ProviderFetchStrategy` returns one `UsageSnapshot`, so we keep the existing strategy returning the personal scope. Org snapshots are fanned out at the UsageStore layer, mirroring `refreshTokenAccounts`.
+
+- [ ] **Step 7.1: Add scope-aware overload to the AP strategies (no-op call path so they still build)**
+
+This task does NOT change `KiloAPIFetchStrategy.fetch`. The strategy continues to fetch the personal scope. The fan-out is added at the UsageStore layer below. Skip directly to step 7.2.
+
+- [ ] **Step 7.2: Add a Kilo scope account adapter**
+
+The codebase already has `TokenAccountUsageSnapshot` for stacked rendering. We mirror that for Kilo scopes.
+
+Create `Sources/CodexBar/Providers/Kilo/UsageStore+KiloOrgRefresh.swift`:
+
+```swift
+import CodexBarCore
+import Foundation
+
+struct KiloScopeSnapshot: Identifiable, Equatable {
+    let id: String // KiloUsageScope.scopeIdentifier
+    let scope: KiloUsageScope
+    let snapshot: UsageSnapshot?
+    let errorMessage: String?
+    let sourceLabel: String?
+
+    static func == (lhs: KiloScopeSnapshot, rhs: KiloScopeSnapshot) -> Bool {
+        lhs.id == rhs.id
+            && lhs.snapshot?.updatedAt == rhs.snapshot?.updatedAt
+            && lhs.errorMessage == rhs.errorMessage
+            && lhs.sourceLabel == rhs.sourceLabel
+    }
+}
+
+extension UsageStore {
+    var kiloEnabledScopes: [KiloUsageScope] {
+        var scopes: [KiloUsageScope] = [.personal]
+        let enabled = self.settings.kiloEnabledOrganizationIDs
+        guard !enabled.isEmpty else { return scopes }
+        let knownByID = Dictionary(
+            uniqueKeysWithValues: self.settings.kiloKnownOrganizations.map { ($0.id, $0) })
+        for id in enabled {
+            if let org = knownByID[id] {
+                scopes.append(.organization(id: org.id, name: org.name))
+            }
+        }
+        return scopes
+    }
+
+    func shouldFanOutKiloScopes() -> Bool {
+        self.kiloEnabledScopes.count > 1
+    }
+
+    func refreshKiloScopes() async {
+        let scopes = self.kiloEnabledScopes
+        guard scopes.count > 1 else {
+            await MainActor.run { self.kiloScopeSnapshots = [] }
+            return
+        }
+        let apiKey = self.settings.configSnapshot.providerConfig(for: .kilo)?.sanitizedAPIKey
+            ?? ProcessInfo.processInfo.environment[KiloSettingsReader.apiTokenKey]
+        guard let resolvedKey = apiKey, !resolvedKey.isEmpty else {
+            await MainActor.run {
+                self.kiloScopeSnapshots = scopes.map {
+                    KiloScopeSnapshot(
+                        id: $0.scopeIdentifier,
+                        scope: $0,
+                        snapshot: nil,
+                        errorMessage: "Kilo API credentials missing.",
+                        sourceLabel: nil)
+                }
+            }
+            return
+        }
+
+        let env = ProcessInfo.processInfo.environment
+        let results: [KiloScopeSnapshot] = await withTaskGroup(of: KiloScopeSnapshot.self) { group in
+            for scope in scopes {
+                group.addTask {
+                    do {
+                        let raw = try await KiloUsageFetcher.fetchUsage(
+                            apiKey: resolvedKey,
+                            scope: scope,
+                            environment: env)
+                        var snapshot = raw.toUsageSnapshot()
+                        snapshot = snapshot.replacingIdentityOrganization(scope.displayName)
+                        return KiloScopeSnapshot(
+                            id: scope.scopeIdentifier,
+                            scope: scope,
+                            snapshot: snapshot,
+                            errorMessage: nil,
+                            sourceLabel: "api")
+                    } catch {
+                        return KiloScopeSnapshot(
+                            id: scope.scopeIdentifier,
+                            scope: scope,
+                            snapshot: nil,
+                            errorMessage: (error as? LocalizedError)?.errorDescription
+                                ?? error.localizedDescription,
+                            sourceLabel: nil)
+                    }
+                }
+            }
+            var collected: [KiloScopeSnapshot] = []
+            for await result in group {
+                collected.append(result)
+            }
+            return collected
+        }
+
+        // Preserve the order from `scopes` (personal first, then enabled orgs in order).
+        let resultByID = Dictionary(uniqueKeysWithValues: results.map { ($0.id, $0) })
+        let ordered = scopes.compactMap { resultByID[$0.scopeIdentifier] }
+
+        await MainActor.run {
+            self.kiloScopeSnapshots = ordered
+        }
+    }
+}
+
+extension UsageSnapshot {
+    fileprivate func replacingIdentityOrganization(_ org: String) -> UsageSnapshot {
+        let baseIdentity = self.identity
+        let newIdentity = ProviderIdentitySnapshot(
+            providerID: baseIdentity?.providerID ?? .kilo,
+            accountEmail: baseIdentity?.accountEmail,
+            accountOrganization: org,
+            loginMethod: baseIdentity?.loginMethod)
+        return UsageSnapshot(
+            primary: self.primary,
+            secondary: self.secondary,
+            tertiary: self.tertiary,
+            providerCost: self.providerCost,
+            updatedAt: self.updatedAt,
+            identity: newIdentity)
+    }
+}
+```
+
+- [ ] **Step 7.3: Add the `kiloScopeSnapshots` stored property to `UsageStore`**
+
+In `Sources/CodexBar/UsageStore.swift`, find the closest place where Codex-related published properties live (e.g. near `codexAccountSnapshots`) and add:
+
+```swift
+    @Published var kiloScopeSnapshots: [KiloScopeSnapshot] = []
+```
+
+Choose a location adjacent to existing per-provider stacked snapshot arrays. The exact line is around `codexAccountSnapshots: [CodexAccountUsageSnapshot] = []` — add directly below it.
+
+- [ ] **Step 7.4: Invoke fan-out from `refreshProvider`**
+
+In `Sources/CodexBar/UsageStore+Refresh.swift`, find the existing `tokenAccounts` fan-out block in `refreshProvider`:
+
+```swift
+        let tokenAccounts = self.tokenAccounts(for: provider)
+        if self.shouldFetchAllTokenAccounts(provider: provider, accounts: tokenAccounts) {
+            await self.refreshTokenAccounts(provider: provider, accounts: tokenAccounts)
+            return
+        }
+```
+
+Insert directly above it (before line 55):
+
+```swift
+        if provider == .kilo, self.shouldFanOutKiloScopes() {
+            await self.refreshKiloScopes()
+            // Continue to also fetch the personal snapshot through the regular path
+            // so the existing single-card render keeps working when only personal is shown.
+            // The presence of multi-element kiloScopeSnapshots triggers stacked rendering.
+        }
+```
+
+- [ ] **Step 7.5: Reset `kiloScopeSnapshots` when Kilo is disabled or single-scope**
+
+Inside the existing disabled-provider branch of `refreshProvider` (the block that runs when `!spec.isEnabled()`), add inside the `MainActor.run`:
+
+```swift
+                if provider == .kilo {
+                    self.kiloScopeSnapshots = []
+                }
+```
+
+Also at the start of the regular fetch path (just before `let fetchContext = spec.makeFetchContext()`), add:
+
+```swift
+        if provider == .kilo, !self.shouldFanOutKiloScopes() {
+            await MainActor.run { self.kiloScopeSnapshots = [] }
+        }
+```
+
+- [ ] **Step 7.6: Build to confirm wiring compiles**
+
+```bash
+swift build 2>&1 | tail -15
+```
+
+Expected: succeeds. If `UsageSnapshot.replacingIdentityOrganization` clashes with an existing extension, rename to `withAccountOrganization` and update the call site.
+
+- [ ] **Step 7.7: Commit**
+
+```bash
+git add Sources/CodexBar/UsageStore.swift \
+        Sources/CodexBar/UsageStore+Refresh.swift \
+        Sources/CodexBar/Providers/Kilo/UsageStore+KiloOrgRefresh.swift
+git commit -m "feat(kilo): fan out usage fetch per enabled scope"
+```
+
+---
+
+## Task 8: Surface scope snapshots in menu rendering
+
+**Files:**
+- Modify: `Sources/CodexBar/StatusItemController+MenuCardModel.swift` (or the file that produces Kilo menu rows)
+- Modify: `Sources/CodexBar/MenuDescriptor.swift` if needed
+
+The menu currently renders one Kilo card. Add a branch: when `kiloScopeSnapshots` has 2+ entries, render one card per scope.
+
+- [ ] **Step 8.1: Locate the Kilo menu-row producer**
+
+```bash
+grep -n "case \\.kilo" Sources/CodexBar/StatusItemController*.swift Sources/CodexBar/Menu*.swift 2>&1 | head -15
+```
+
+This points at the rendering site. Open whichever file produces the per-provider row group for Kilo.
+
+- [ ] **Step 8.2: Insert scope-fan-out in the Kilo row builder**
+
+At the location that produces the Kilo `MenuCardModel` (or the equivalent NSMenu items), guard:
+
+```swift
+if !self.kiloScopeSnapshots.isEmpty, self.kiloScopeSnapshots.count > 1 {
+    return self.kiloScopeSnapshots.map { scope -> MenuCardModel in
+        self.makeKiloMenuCard(
+            snapshot: scope.snapshot,
+            errorMessage: scope.errorMessage,
+            sourceLabel: scope.sourceLabel,
+            scopeName: scope.scope.displayName)
+    }
+}
+```
+
+If a helper named `makeKiloMenuCard(...)` does not exist, factor the existing inline Kilo card construction into one, taking the four parameters above. Reuse the same code path used by Claude's stacked tokenAccount rendering as a structural reference.
+
+- [ ] **Step 8.3: Verify visually using CLI snapshot test (no UI required)**
+
+```bash
+swift test --filter CLIRendererTests 2>&1 | tail -15
+swift test --filter MenuCardModelTests 2>&1 | tail -15
+```
+
+Existing tests must continue to pass.
+
+- [ ] **Step 8.4: Build**
+
+```bash
+swift build 2>&1 | tail -5
+```
+
+Expected: success.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add Sources/CodexBar/StatusItemController+MenuCardModel.swift \
+        Sources/CodexBar/MenuDescriptor.swift
+git commit -m "feat(kilo): render one menu card per enabled scope"
+```
+
+---
+
+## Task 9: Preferences pane — Organizations section
+
+**Files:**
+- Modify: `Sources/CodexBar/Providers/Kilo/KiloProviderImplementation.swift`
+- Possibly modify: `Sources/CodexBar/PreferencesProviderDetailView.swift` and `Sources/CodexBarCore/Providers/ProviderDescriptor.swift` if a new descriptor variant is needed.
+
+If a multi-toggle descriptor is not yet supported, surface the org list using a `ProviderSettingsFieldDescriptor.kind = .info`-style wrapper combined with action buttons, OR add a new descriptor variant. Pick the minimum needed.
+
+- [ ] **Step 9.1: Add an org-section descriptor type**
+
+Search first to see whether the existing `ProviderSettingsFieldDescriptor` already has a list/toggle kind:
+
+```bash
+grep -n "enum Kind\|case info\|case toggleList\|case checkboxList" \
+    Sources/CodexBarCore/Providers/ProviderDescriptor.swift \
+    Sources/CodexBar/PreferencesProviderDetailView.swift 2>&1 | head -20
+```
+
+If a toggle-list kind exists, reuse it. Otherwise, add a new `ProviderSettingsOrganizationsDescriptor` in `Sources/CodexBarCore/Providers/ProviderDescriptor.swift`:
+
+```swift
+public struct ProviderSettingsOrganizationsDescriptor: Sendable {
+    public let id: String
+    public let title: String
+    public let subtitle: String?
+    public let entries: () -> [Entry]
+    public let onToggle: @MainActor (String, Bool) -> Void
+    public let onRefresh: @MainActor () async -> RefreshOutcome
+    public let canRefresh: () -> Bool
+
+    public struct Entry: Sendable, Identifiable {
+        public let id: String
+        public let title: String
+        public let subtitle: String?
+        public let isEnabled: Bool
+        public let isLocked: Bool
+
+        public init(id: String, title: String, subtitle: String?, isEnabled: Bool, isLocked: Bool) {
+            self.id = id
+            self.title = title
+            self.subtitle = subtitle
+            self.isEnabled = isEnabled
+            self.isLocked = isLocked
+        }
+    }
+
+    public struct RefreshOutcome: Sendable {
+        public let success: Bool
+        public let errorMessage: String?
+
+        public init(success: Bool, errorMessage: String? = nil) {
+            self.success = success
+            self.errorMessage = errorMessage
+        }
+    }
+
+    public init(
+        id: String,
+        title: String,
+        subtitle: String?,
+        entries: @escaping () -> [Entry],
+        onToggle: @escaping @MainActor (String, Bool) -> Void,
+        onRefresh: @escaping @MainActor () async -> RefreshOutcome,
+        canRefresh: @escaping () -> Bool)
+    {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.entries = entries
+        self.onToggle = onToggle
+        self.onRefresh = onRefresh
+        self.canRefresh = canRefresh
+    }
+}
+```
+
+Then add an optional `settingsOrganizations:` slot to whatever protocol `ProviderImplementation` exposes (e.g. add `func settingsOrganizations(context: ProviderSettingsContext) -> ProviderSettingsOrganizationsDescriptor?`). Default the protocol method to `nil`.
+
+- [ ] **Step 9.2: Implement `settingsOrganizations` in `KiloProviderImplementation`**
+
+In `Sources/CodexBar/Providers/Kilo/KiloProviderImplementation.swift`:
+
+```swift
+    @MainActor
+    func settingsOrganizations(
+        context: ProviderSettingsContext) -> ProviderSettingsOrganizationsDescriptor?
+    {
+        ProviderSettingsOrganizationsDescriptor(
+            id: "kilo-organizations",
+            title: "Organizations",
+            subtitle: "Show usage for organizations you belong to. Personal account is always shown.",
+            entries: {
+                var entries: [ProviderSettingsOrganizationsDescriptor.Entry] = [
+                    .init(
+                        id: "personal",
+                        title: "Personal account",
+                        subtitle: nil,
+                        isEnabled: true,
+                        isLocked: true),
+                ]
+                for org in context.settings.kiloKnownOrganizations {
+                    entries.append(
+                        .init(
+                            id: org.id,
+                            title: org.name,
+                            subtitle: org.role,
+                            isEnabled: context.settings.kiloIsOrganizationEnabled(org.id),
+                            isLocked: false))
+                }
+                return entries
+            },
+            onToggle: { orgID, enabled in
+                guard orgID != "personal" else { return }
+                context.settings.setKiloOrganization(orgID, enabled: enabled)
+            },
+            onRefresh: {
+                let apiKey = context.settings.kiloAPIToken.isEmpty
+                    ? ProcessInfo.processInfo.environment[KiloSettingsReader.apiTokenKey] ?? ""
+                    : context.settings.kiloAPIToken
+                guard !apiKey.isEmpty else {
+                    return .init(success: false,
+                        errorMessage: "Set the Kilo API key first.")
+                }
+                do {
+                    let orgs = try await KiloUsageFetcher.fetchOrganizations(apiKey: apiKey)
+                    context.settings.setKiloKnownOrganizationsPruningEnabled(orgs)
+                    return .init(success: true)
+                } catch let error as LocalizedError {
+                    return .init(success: false,
+                        errorMessage: error.errorDescription ?? "Failed to load organizations.")
+                } catch {
+                    return .init(success: false,
+                        errorMessage: error.localizedDescription)
+                }
+            },
+            canRefresh: {
+                !context.settings.kiloAPIToken.isEmpty
+                    || !(ProcessInfo.processInfo.environment[KiloSettingsReader.apiTokenKey] ?? "").isEmpty
+            })
+    }
+```
+
+- [ ] **Step 9.3: Render the new descriptor in `PreferencesProviderDetailView`**
+
+In `Sources/CodexBar/PreferencesProviderDetailView.swift`, follow the existing pattern used by `settingsTokenAccounts`. Add a stored property `settingsOrganizations: ProviderSettingsOrganizationsDescriptor?`, source it from the provider implementation, and render it as a SwiftUI section under the API key:
+
+```swift
+if let descriptor = self.settingsOrganizations {
+    Section(descriptor.title) {
+        if let subtitle = descriptor.subtitle {
+            Text(subtitle).font(.caption).foregroundStyle(.secondary)
+        }
+        ForEach(descriptor.entries(), id: \.id) { entry in
+            Toggle(isOn: Binding(
+                get: { entry.isEnabled },
+                set: { newValue in descriptor.onToggle(entry.id, newValue) }))
+            {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(entry.title)
+                    if let subtitle = entry.subtitle {
+                        Text(subtitle).font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .disabled(entry.isLocked)
+        }
+        HStack {
+            Button("Refresh organizations") {
+                Task {
+                    let result = await descriptor.onRefresh()
+                    if !result.success, let message = result.errorMessage {
+                        self.kiloOrganizationsErrorMessage = message
+                    } else {
+                        self.kiloOrganizationsErrorMessage = nil
+                    }
+                }
+            }
+            .disabled(!descriptor.canRefresh())
+            Spacer()
+            if let message = self.kiloOrganizationsErrorMessage {
+                Text(message).font(.caption).foregroundStyle(.red)
+            }
+        }
+    }
+}
+```
+
+Add `@State private var kiloOrganizationsErrorMessage: String?` near other `@State` properties in the view.
+
+- [ ] **Step 9.4: Build and verify**
+
+```bash
+swift build 2>&1 | tail -10
+```
+
+Expected: success. If type mismatches arise, follow them and align signatures.
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add Sources/CodexBarCore/Providers/ProviderDescriptor.swift \
+        Sources/CodexBar/Providers/Kilo/KiloProviderImplementation.swift \
+        Sources/CodexBar/PreferencesProviderDetailView.swift
+git commit -m "feat(kilo): Preferences organizations section with refresh + toggles"
+```
+
+---
+
+## Task 10: Update Kilo docs
+
+**Files:**
+- Modify: `docs/kilo.md`
+
+- [ ] **Step 10.1: Add a "Organizations" section**
+
+Append to `docs/kilo.md`:
+
+```markdown
+## Organizations
+
+CodexBar can show usage for any Kilo organization the API key belongs to.
+
+- Open Preferences → Providers → Kilo, set the API key, then click **Refresh
+  organizations**.
+- Toggle the organizations you want to display alongside Personal. Personal is
+  always shown.
+- When at least one organization is enabled, the menu renders one Kilo card per
+  enabled scope.
+- The CodexBar fetcher sends the standard `X-KILOCODE-ORGANIZATIONID` header on
+  every usage call to scope the response to that organization.
+- CLI source mode (`auth.json`): the header is applied to CLI-resolved tokens
+  as well. If a CLI token isn't authorized for the chosen organization, that
+  card surfaces an unauthorized error while Personal and other enabled scopes
+  continue to render normally.
+```
+
+- [ ] **Step 10.2: Commit**
+
+```bash
+git add docs/kilo.md
+git commit -m "docs(kilo): document organization selection"
+```
+
+---
+
+## Task 11: Repo-wide validation
+
+- [ ] **Step 11.1: Run the full unit test suite**
+
+```bash
+swift test 2>&1 | tail -30
+```
+
+Expected: all tests pass. If new failures appear in unrelated tests (network-flaky, etc.), record and rerun.
+
+- [ ] **Step 11.2: Run `make check`**
+
+```bash
+make check 2>&1 | tail -30
+```
+
+Expected: swiftformat + swiftlint clean. Fix any reported issues by applying suggestions inline and re-running.
+
+- [ ] **Step 11.3: Build release config to ensure no debug-only types leaked**
+
+```bash
+swift build -c release 2>&1 | tail -10
+```
+
+Expected: success.
+
+- [ ] **Step 11.4: Commit any lint/format fixups**
+
+```bash
+git status
+git diff --stat
+git add -A
+git commit -m "chore: swiftformat/swiftlint fixups for kilo orgs work"
+```
+
+(Skip if no diff.)
+
+---
+
+## Task 12: Open the PR (lead-only — runs after all build tasks land)
+
+- [ ] **Step 12.1: Ensure a fork exists for `noefabris`**
+
+```bash
+gh repo view noefabris/CodexBar --json url 2>&1 | head -5
+```
+
+If 404, fork:
+
+```bash
+gh repo fork steipete/CodexBar --remote=false --clone=false
+```
+
+- [ ] **Step 12.2: Add fork as a remote (if missing) and push**
+
+```bash
+git remote get-url fork 2>/dev/null || git remote add fork https://github.com/noefabris/CodexBar.git
+git push -u fork feat/kilo-organization-selection
+```
+
+- [ ] **Step 12.3: Create the PR**
+
+```bash
+gh pr create \
+  --repo steipete/CodexBar \
+  --base main \
+  --head noefabris:feat/kilo-organization-selection \
+  --title "Add Kilo organization selection (usage stacking)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Adds Kilo organization selection to Preferences → Providers → Kilo.
+- Refresh button fetches `user.getOrganizations` (with `/api/profile` REST fallback).
+- Each enabled organization is fetched in parallel with the personal account using the standard `X-KILOCODE-ORGANIZATIONID` header.
+- The Kilo menu now stacks one card per enabled scope (Personal + each chosen org), reusing the existing multi-snapshot rendering pattern.
+
+## Design doc
+- `docs/superpowers/specs/2026-05-11-kilo-organization-selection-design.md`
+- `docs/superpowers/plans/2026-05-11-kilo-organization-selection.md`
+
+## Test plan
+- [x] `swift test` passes
+- [x] `make check` clean
+- [x] `swift build -c release` succeeds
+- [ ] Manual: launch app, set Kilo API key, hit Refresh organizations, toggle orgs, observe stacked menu cards
+- [ ] Manual: revoke org permission and confirm only that scope errors out
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Capture the printed PR URL.
+
+- [ ] **Step 12.4: Report the PR URL back to the user**
+
+---
+
+## Self-review checklist
+
+- [x] Each spec section has at least one task implementing it.
+- [x] Task 4 covers both tRPC and REST org-discovery shapes (spec §2).
+- [x] Task 7 fan-out covers both API and CLI source modes — the strategy resolves the token, then `refreshKiloScopes` reuses the same API key transport.
+- [x] Persistence covered by Task 5 + 6.
+- [x] UI section covered by Task 9.
+- [x] Menu rendering covered by Task 8.
+- [x] Tests written before implementation per TDD in Tasks 1–6.
+- [x] No placeholders ("TBD", "fill in later", etc.).
+- [x] Types stay consistent: `KiloOrganization`, `KiloUsageScope`, `KiloScopeSnapshot` referenced consistently across tasks.
+- [x] Out-of-scope items from spec (menu switcher, multi-key auth, widget) intentionally absent.
+
+If during execution any task uncovers an actual gap not covered above (e.g. existing tests that mock `KiloUsageFetcher.fetchUsage(apiKey:environment:)` without `scope`), update them to use `scope: .personal` explicitly — keep the default-parameter migration path even though tests typically pass it explicitly.

--- a/docs/superpowers/specs/2026-05-11-kilo-organization-selection-design.md
+++ b/docs/superpowers/specs/2026-05-11-kilo-organization-selection-design.md
@@ -1,0 +1,148 @@
+# Kilo Organization Selection & Usage — Design
+
+**Status:** approved
+**Date:** 2026-05-11
+**Owner:** noefabris
+
+## Problem
+
+The Kilo provider in CodexBar always queries the personal account. Users who belong to one or more Kilo organizations cannot see organization-level credits, KiloPass usage, or plan info. Kilo's own clients (VS Code extension, CLI) let users pick "Personal" or any organization they belong to and route requests with an `X-KILOCODE-ORGANIZATIONID` header.
+
+Goal: let CodexBar users opt in to seeing one or more Kilo organizations alongside their personal account.
+
+## Non-goals
+
+- Menu-bar org switcher. Selection lives in Preferences only.
+- Editing org membership from CodexBar (read-only consumer of Kilo's org list).
+- Per-org auth (CodexBar reuses the same API key/CLI session; Kilo's gateway scopes via header).
+- Replacing the existing single-account `Personal` flow when no orgs are configured.
+
+## Constraints / context
+
+- Kilo gateway accepts `X-KILOCODE-ORGANIZATIONID: <orgId>` to scope any authenticated request. Documented at `kilo.ai/docs/gateway/authentication`.
+- Profile endpoint shape (from `Kilo-Org/kilocode` `packages/kilo-gateway/src/api/profile.ts`):
+  `GET /api/profile` → `{ user: { email, name }, organizations: [{ id, name, role }] }`.
+- CodexBar's Kilo provider currently calls `https://app.kilo.ai/api/trpc` with procedures `user.getCreditBlocks`, `kiloPass.getState`, `user.getAutoTopUpPaymentMethod`. The `X-KILOCODE-ORGANIZATIONID` header is transport-level and must work for the same procedures.
+- Existing CodexBar patterns to reuse:
+  - `ProviderIdentitySnapshot.accountOrganization` for rendering the org name in a card.
+  - Stacked multi-snapshot rendering used by Claude tokenAccounts (Preferences → Advanced → Display).
+  - `~/.codexbar/config.json` per-provider entry for persisted state.
+
+## User stories
+
+1. **As a user with no orgs**, the Kilo card looks exactly as it does today. No new UI noise.
+2. **As a user with one or more orgs**, I can open Preferences → Providers → Kilo, hit "Refresh organizations", see my org list, and tick the orgs I want to monitor. Each enabled org appears as its own card stacked with Personal in the menu.
+3. **As a user whose API key isn't set**, the Organizations section explains I need the key first and the Refresh button is disabled.
+4. **As a user using CLI source mode**, org selection still works — the header is sent on every fetch regardless of where the bearer token came from.
+
+## Architecture
+
+### Data model
+
+- `KiloOrganization` (Sendable, Codable, Equatable) in `Sources/CodexBarCore/Providers/Kilo/`:
+  - `id: String`
+  - `name: String`
+  - `role: String?` (optional; treated as display-only)
+- `KiloUsageScope` (Sendable, Hashable) in same module:
+  - `.personal`
+  - `.organization(id: String, name: String)`
+  - A `scopeIdentifier` computed property: `"personal"` or `"org:<id>"` used as the snapshot map key.
+- `KiloUsageSnapshot` gains `scope: KiloUsageScope` (default `.personal` keeps existing call sites compiling).
+
+### API layer (`KiloUsageFetcher`)
+
+- Existing `fetchUsage(apiKey:environment:)` becomes:
+  `fetchUsage(apiKey:scope:environment:)` with `scope: KiloUsageScope = .personal`.
+  - When `.organization(id, _)`: set request header `X-KILOCODE-ORGANIZATIONID: id` on the existing tRPC batch URLRequest. Everything else unchanged.
+- New `fetchOrganizations(apiKey:environment:)` → `[KiloOrganization]`:
+  - Primary: tRPC batch call to `user.getOrganizations` against `https://app.kilo.ai/api/trpc`. Parse the same payload-context shape as other procedures (defensive against schema drift).
+  - Fallback: if tRPC returns 404 / endpoint not found, fall back to `GET https://api.kilo.ai/api/profile` and read `data.organizations`. Both endpoints are part of the documented Kilo Gateway.
+  - Returns `[]` (not error) when the user has no orgs.
+  - Maps `401/403 → KiloUsageError.unauthorized`, `404 → endpointNotFound`, etc., using the existing `statusError(for:)`.
+
+### Settings
+
+`SettingsStore` extension (new file `SettingsStore+Kilo.swift` or extend `KiloSettingsStore.swift`):
+
+- `kiloKnownOrganizations: [KiloOrganization]` — cache of organizations last fetched. Survives restart.
+- `kiloEnabledOrganizationIDs: Set<String>` — which orgs the user wants to fetch + render.
+- Personal scope is implicit: always enabled, can't be toggled off.
+
+Persistence:
+- Add `organizations: [KiloOrganization]?` and `enabledOrganizationIds: [String]?` to the Kilo provider's entry in `~/.codexbar/config.json`.
+- Mutators write through `updateProviderConfig(provider: .kilo)`.
+
+### Refresh / UsageStore
+
+- `UsageStore`'s Kilo refresh path computes the active scope list: `[.personal] + enabled orgs from kiloKnownOrganizations`.
+- Fan-out using a `TaskGroup`, one child per scope, each calling `KiloUsageFetcher.fetchUsage(apiKey:scope:)`.
+- Per-scope failures isolated: a 403 on one org sets that scope's error state but does not affect personal or other orgs.
+- Snapshots stored in a new dictionary `kiloScopedSnapshots: [String: KiloUsageSnapshot]` keyed by `scope.scopeIdentifier`, alongside the existing single-snapshot field. When `kiloScopedSnapshots` has more than one entry the menu uses stacked rendering; otherwise existing single-card rendering.
+
+### UI — Preferences → Providers → Kilo
+
+- New section header "Organizations" placed below the API key field.
+- Row 1 (always): `Personal account` with a disabled-on checkbox.
+- Rows 2..N: each known organization with a togglable checkbox `[✓] <Org name> — <role>`.
+- Empty state when `kiloKnownOrganizations` is empty: "No organizations loaded. Click Refresh after setting your API key."
+- "Refresh organizations" button:
+  - Disabled when API key is empty.
+  - Calls `KiloUsageFetcher.fetchOrganizations(apiKey:)` on a background task.
+  - On success: writes to `kiloKnownOrganizations`, prunes `kiloEnabledOrganizationIDs` entries that no longer exist.
+  - On 401/403: surface inline error "API key unauthorized. Refresh or update it."
+  - On network error: surface inline error.
+
+### Menu rendering
+
+- The Kilo card renderer reads `kiloScopedSnapshots`. When count > 1, render each as a stacked card using the same vertical layout already used by Claude's stacked tokenAccount snapshots.
+- Each scope's card sets `ProviderIdentitySnapshot.accountOrganization`:
+  - `.personal` → `"Personal"`
+  - `.organization(_, name)` → `name`
+- Existing credit/pass/plan rows render unchanged inside each card.
+
+### Errors / edge cases
+
+| Case | Behavior |
+| --- | --- |
+| User has no orgs | Personal scope only. Org section shows empty state. No fan-out. |
+| API key missing | Refresh button disabled. Existing missing-credentials error still surfaces on usage fetch. |
+| Org refresh fails (401/403) | Inline error in Preferences; keep cached list. |
+| Org usage fetch returns 403 | That org's card shows a small error label; personal + other orgs render normally. |
+| Org removed on Kilo side | Next Refresh drops it from `kiloKnownOrganizations`; if it was in `kiloEnabledOrganizationIDs` it is silently pruned. |
+| CLI source mode | Header sent same way. If the resolved CLI bearer can't scope to that org, it 403s — handled by the per-scope error case above. |
+| Source = `auto` | Org scope follows the same auto fallback; failures inside the scope respect the fallback chain. |
+| Multiple orgs enabled | Concurrent fetch; per-scope timeouts isolated. |
+
+## Testing
+
+- Unit tests (in `Tests/CodexBarTests`):
+  - `KiloUsageFetcherTests`:
+    - Header injection: `.organization(id, _)` → request contains `X-KILOCODE-ORGANIZATIONID: id`. `.personal` → no header.
+    - `fetchOrganizations` parses both tRPC shape and `/api/profile` REST shape.
+    - 401/403 → `.unauthorized`.
+  - `KiloSettingsStoreTests`:
+    - Round-trip of `kiloKnownOrganizations` and `kiloEnabledOrganizationIDs` through config.json.
+    - Pruning of stale IDs when known list shrinks.
+  - `UsageStore+KiloRefreshTests`:
+    - Fan-out runs N scopes, per-scope error isolation.
+    - Single-scope path unchanged when no orgs enabled.
+- CLI snapshot test (`Tests/CodexBarTests/CLIRendererTests` or similar): `codexbar-cli kilo` shows one section per active scope when orgs are enabled.
+- Run `make check` and `swift test` before handoff.
+
+## Migration / compatibility
+
+- `KiloUsageSnapshot.scope` defaults to `.personal` — all existing call sites compile unchanged.
+- Config additions are optional — old configs continue to load as personal-only.
+- No new dependencies.
+
+## Open items (verify during build)
+
+- Confirm `https://app.kilo.ai/api/trpc/user.getOrganizations` exists. If not, the REST fallback to `https://api.kilo.ai/api/profile` is the path of record.
+- Confirm the tRPC procedures honor `X-KILOCODE-ORGANIZATIONID`. Documented for gateway; spot-check during integration.
+
+## Out of scope
+
+- Menu-bar org switcher UI.
+- Per-org token storage / multiple API keys for the same provider.
+- CLI command for org switching (`codexbar-cli` consumes the same settings).
+- Widget rendering changes for multi-scope (widget continues to show personal scope).


### PR DESCRIPTION
> Successor to #919 (closed; the original fork wasn't registered as a proper fork so GitHub blocked reopening / re-PR'ing from it). Identical diff, same 13 commits.

## Summary

Kilo currently always shows the personal account. This PR lets users opt in to seeing one or more Kilo organizations alongside Personal, stacking one menu card per enabled scope.

- New types: `KiloOrganization`, `KiloUsageScope` (`.personal` / `.organization(id, name)`) in `CodexBarCore`.
- `KiloUsageFetcher.fetchUsage` now scope-aware: sets `X-KILOCODE-ORGANIZATIONID: <orgId>` on the existing tRPC batch call when the scope is an organization. The header is documented at `kilo.ai/docs/gateway/authentication` and is transport-level, so it applies to both API and CLI-resolved tokens.
- New `KiloUsageFetcher.fetchOrganizations(apiKey:)` discovers orgs via `user.getOrganizations` on the tRPC endpoint, falling back to `https://api.kilo.ai/api/profile` if the tRPC procedure 404s.
- `ProviderConfig` gains optional `kiloKnownOrganizations` and `kiloEnabledOrganizationIDs` (config rolls forward cleanly — no migration needed).
- `UsageStore` fans out one fetch per enabled scope using a `TaskGroup`; failures are isolated per scope.
- Menu rendering reuses the existing `menuCardModel(...)` + stacked-cards helper used by Codex/Claude tokenAccount stacking, so a Kilo card renders per scope when ≥2 are active.
- Preferences → Providers → Kilo gets a new **Organizations** section with a refresh button and per-org checkboxes (Personal is always-on / locked).

Architecture details and rationale: [`docs/superpowers/specs/2026-05-11-kilo-organization-selection-design.md`](https://github.com/NoeFabris/CodexBar/blob/feat/kilo-organization-selection/docs/superpowers/specs/2026-05-11-kilo-organization-selection-design.md)
Step-by-step plan (TDD): [`docs/superpowers/plans/2026-05-11-kilo-organization-selection.md`](https://github.com/NoeFabris/CodexBar/blob/feat/kilo-organization-selection/docs/superpowers/plans/2026-05-11-kilo-organization-selection.md)

## Behavior

- **No orgs enabled** (default) → identical to today's behavior.
- **One or more orgs enabled** → menu stacks Personal + each enabled org as separate cards. Each card surfaces its own credits, KiloPass window, plan, and any per-scope errors. A 401/403 on one scope does not affect siblings.
- **CLI source mode** → the org header is sent on top of the CLI-resolved token. If the CLI token can't scope to that org it 403s and only that scope's card shows the error.

## Test plan

- [x] `swift test` — 2359 tests pass (41 new Kilo tests across `KiloOrganizationTests`, `KiloUsageScopeTests`, `KiloUsageFetcherTests`, `KiloSettingsStoreTests`)
- [x] `make check` — swiftformat + swiftlint clean
- [x] `swift build -c release` — succeeds
- [ ] Manual smoke test by reviewer: set Kilo API key in Preferences, click **Refresh organizations**, toggle one or more orgs, observe the menu stacking
- [ ] Manual smoke test by reviewer: with an org enabled, revoke API access for that org on the Kilo side and confirm only that card errors while Personal continues to refresh

## Follow-ups (known, deferred)

Surfaced by an internal review pass — none block this PR, all are reasonable as separate work:

1. `refreshKiloScopes` and the regular fetch path both fetch Personal. They run concurrently and produce correct results, but a future change could share Personal between the two.
2. `parseOrganizations` falls back to the REST profile only on HTTP 404. A tRPC `NOT_FOUND` error envelope returned with HTTP 200 currently yields an empty list rather than triggering the REST fallback.
3. `KiloUsageFetcher` grew past the 800-line `type_body_length` warning. Suppressed locally; could be split into `KiloUsageFetcher+Organizations.swift` later.
4. Empty-state detection in the Organizations row uses `entries.allSatisfy(\.isLocked)`. Works today (only Personal is locked); a future always-on entry would skew the empty-state copy.
5. `KiloOrgIDLinkedHashSet` dedupes the enabled-IDs setter but has no direct unit test (the helper is exercised indirectly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)