### PR TITLE
Add zh-Hans translations for Claude peak hour labels

### DIFF
--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -385,8 +385,11 @@
 "metric_secondary" = "次要（%@）";
 "metric_tertiary" = "第三（%@）";
 "multiple_workspaces_found" = "CodexBar 发现了 %1$@ 的多个工作区。请选择要添加的工作区。";
+"off_peak" = "非高峰";
+"off_peak_peak_in" = "非高峰 · %@ 后进入高峰";
 "ory_session_…=…; csrftoken=…" = "";
 "overview_choose_providers" = "选择最多 %1$@ 个提供商";
+"peak_ends_in" = "高峰 · %@ 后结束";
 "remove_account_message" = "从 CodexBar 中移除 %@？其托管的 Codex 主目录将被删除。";
 "version_format" = "版本 %@";
 "vertex_ai_login_instructions" = "要使用 Vertex AI 跟踪，您需要通过 Google Cloud 进行认证。


### PR DESCRIPTION
## Summary

Backfills three Simplified Chinese strings that exist in `en.lproj` and `pt-BR.lproj` but are missing from `zh-Hans.lproj`:

- `off_peak` → 非高峰
- `off_peak_peak_in` → 非高峰 · %@ 后进入高峰
- `peak_ends_in` → 高峰 · %@ 后结束

These keys ship the Claude peak-hours indicator label rendered by `ClaudePeakHours.status`. Without them, Chinese users fall back to the literal English/key text.

After this change, `zh-Hans` and `en` are key-equivalent (modulo the existing `not_found` entry, which is referenced by `PreferencesDebugPane`).

## Verification

- `plutil -lint Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings` → OK
- Diffed key sets between `en.lproj` and `zh-Hans.lproj`; no other gaps.
- Insertion preserves alphabetical ordering to match `en.lproj`/`pt-BR.lproj`.

> Drafted with AI assistance; verified by author before publishing.