### PR TITLE
Fix open menu refresh glitch

### DIFF
--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -4,15 +4,21 @@ import CodexBarCore
 extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     // MARK: - Actions reachable from menus
 
-    func refreshStore(forceTokenUsage: Bool) {
+    func refreshStore(forceTokenUsage: Bool, refreshOpenMenusWhenComplete: Bool = true) {
         Task {
             await ProviderInteractionContext.$current.withValue(.userInitiated) {
                 await self.store.refresh(forceTokenUsage: forceTokenUsage)
                 self.store.scheduleStorageFootprintRefreshForOverview(force: true)
                 self.invalidateMenus()
-                self.refreshOpenMenusIfNeeded()
+                if refreshOpenMenusWhenComplete {
+                    self.refreshOpenMenusIfNeeded()
+                }
             }
         }
+    }
+
+    func refreshOpenMenusAfterExplicitStoreAction() {
+        self.invalidateMenus(refreshOpenMenus: true)
     }
 
     @objc func refreshNow() {
@@ -32,6 +38,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             await ProviderInteractionContext.$current.withValue(.userInitiated) {
                 await self.store.refresh(forceTokenUsage: false)
             }
+            self.refreshOpenMenusAfterExplicitStoreAction()
         }
     }
 

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1129,10 +1129,10 @@ extension StatusItemController {
     }
 
     private func scheduleOpenMenuRefresh(for menu: NSMenu) {
-        // Kick off a user-initiated refresh on open (non-forced) and re-check after a delay.
+        // Kick off a refresh on open (non-forced) and re-check after a delay.
         // NEVER block menu opening with network requests.
         if !self.store.isRefreshing {
-            self.refreshStore(forceTokenUsage: false)
+            self.refreshStore(forceTokenUsage: false, refreshOpenMenusWhenComplete: false)
         }
         let key = ObjectIdentifier(menu)
         self.menuRefreshTasks[key]?.cancel()
@@ -1151,7 +1151,7 @@ extension StatusItemController {
             let retryMissingSnapshotCount = retryProviders.count { self.store.snapshot(for: $0) == nil }
             let willRetryRefresh = retryStaleProviderCount > 0 || retryMissingSnapshotCount > 0
             guard willRetryRefresh else { return }
-            self.refreshStore(forceTokenUsage: false)
+            self.refreshStore(forceTokenUsage: false, refreshOpenMenusWhenComplete: false)
         }
     }
 

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -329,7 +329,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.observeStoreChanges()
-                self.invalidateMenus(refreshOpenMenus: !self.store.isRefreshing)
+                self.invalidateMenus()
             }
         }
     }

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -1,0 +1,136 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct StatusMenuOpenRefreshTests {
+    private func makeSettings() -> SettingsStore {
+        let suite = "StatusMenuOpenRefreshTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        return SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+    }
+
+    private func makeCodexStore(settings: SettingsStore) -> UsageStore {
+        let now = Date()
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 22,
+                    windowMinutes: 300,
+                    resetsAt: now.addingTimeInterval(1800),
+                    resetDescription: nil),
+                secondary: nil,
+                tertiary: nil,
+                updatedAt: now,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "codex@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Plus Plan")),
+            provider: .codex)
+        return store
+    }
+
+    @Test
+    func `store observation marks open menu stale without rebuilding during tracking`() async {
+        StatusItemController.menuCardRenderingEnabled = false
+        StatusItemController.setMenuRefreshEnabledForTesting(false)
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let store = self.makeCodexStore(settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        let key = ObjectIdentifier(menu)
+        controller.openMenus[key] = menu
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
+        defer { StatusItemController.resetMenuRefreshEnabledForTesting() }
+
+        let openedVersion = controller.menuVersions[key]
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { _ in
+            rebuildCount += 1
+        }
+
+        let now = Date()
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 33,
+                    windowMinutes: 300,
+                    resetsAt: now.addingTimeInterval(1800),
+                    resetDescription: nil),
+                secondary: nil,
+                tertiary: nil,
+                updatedAt: now,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "codex@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Plus Plan")),
+            provider: .codex)
+
+        for _ in 0..<20 where controller.menuContentVersion == openedVersion {
+            await Task.yield()
+        }
+
+        #expect(controller.menuContentVersion != openedVersion)
+        #expect(controller.menuVersions[key] == openedVersion)
+        #expect(rebuildCount == 0)
+    }
+
+    @Test
+    func `explicit store actions refresh a visible open menu`() {
+        StatusItemController.menuCardRenderingEnabled = false
+        StatusItemController.setMenuRefreshEnabledForTesting(false)
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let store = self.makeCodexStore(settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        let key = ObjectIdentifier(menu)
+        controller.openMenus[key] = menu
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
+        defer { StatusItemController.resetMenuRefreshEnabledForTesting() }
+
+        let openedVersion = controller.menuVersions[key]
+
+        controller.refreshOpenMenusAfterExplicitStoreAction()
+
+        #expect(controller.menuContentVersion != openedVersion)
+        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -85,6 +85,7 @@ struct StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
+        settings.providerDetectionCompleted = true
         settings.alibabaCodingPlanAPIRegion = .chinaMainland
 
         let fetcher = UsageFetcher()
@@ -314,17 +315,15 @@ struct StatusMenuTests {
                     loginMethod: "Plus Plan")),
             provider: .codex)
 
-        for _ in 0..<50
-            where controller.menuContentVersion == openedVersion ||
-            controller.menuVersions[key] != controller.menuContentVersion
-        {
-            StatusItemController.setMenuRefreshEnabledForTesting(true)
-            controller.refreshOpenMenusIfNeeded()
-            try? await Task.sleep(for: .milliseconds(20))
+        for _ in 0..<50 where controller.menuContentVersion == openedVersion {
+            await Task.yield()
         }
 
+        let staleVersion = controller.menuContentVersion
+        controller.refreshOpenMenusIfNeeded()
+
         #expect(controller.menuContentVersion != openedVersion)
-        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+        #expect(controller.menuVersions[key] == staleVersion)
     }
 
     @Test
@@ -609,9 +608,16 @@ struct StatusMenuTests {
 
         let nextProviderButton = self.switcherButtons(in: menu).first(where: { $0.state == .off })
         #expect(nextProviderButton != nil)
-        nextProviderButton?.performClick(nil)
-        await Task.yield()
-        await Task.yield()
+        let clickedNextProvider = nextProviderButton.map {
+            initialSwitcher?._test_simulateRuntimeClick(buttonTag: $0.tag)
+        } ?? false
+        #expect(clickedNextProvider == true)
+        for _ in 0..<50
+            where initialSwitcherID == (menu.items.first?.view as? ProviderSwitcherView)
+            .map(ObjectIdentifier.init)
+        {
+            await Task.yield()
+        }
 
         let updatedSwitcher = menu.items.first?.view as? ProviderSwitcherView
         #expect(updatedSwitcher != nil)


### PR DESCRIPTION
## Summary
- Avoid rebuilding the visible AppKit menu while it is already open/tracking during background/open-menu refreshes.
- Keep store updates and menu invalidation intact so the next menu presentation uses fresh content.
- Preserve explicit refresh behavior so user-triggered refreshes can still update open menus intentionally.

## Why this fixes the glitch
CodexBar runs as a macOS menu bar app built around `NSStatusItem`/`NSMenu`, with several menu rows hosted through SwiftUI/AppKit views. The recorded glitch showed the middle hosted rows blanking into a large gap while native AppKit rows remained visible. That matches an AppKit menu-tracking hazard: mutating or rebuilding an `NSMenu` while it is currently open can leave hosted view rows in a transient broken visual state.

The existing open-menu refresh path refreshed provider data and then repopulated the currently visible menu after store observation. This patch lets the refresh update the backing store and mark menu content stale, but defers the visible rebuild until the menu is explicitly refreshed or opened again. That keeps the menu stable during AppKit tracking while preserving fresh data for the next render.

## Validation
- `swift test --filter StatusMenuTests`
- `swift test --filter StatusMenuOpenRefreshTests`
- `make check`

## Scope
Only the staged menu-refresh fix is included: three status item controller files plus focused menu regression tests.