### PR TITLE
Clarify cost display as API-rate estimate

### DIFF
--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -148,9 +148,11 @@ struct CostHistoryChartMenuView: View {
             }
 
             if let total = self.totalCostUSD {
-                Text("Total (30d): \(UsageFormatter.usdString(total))")
+                Text("Est. total (30d): \(UsageFormatter.usdString(total))")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.head)
             }
         }
         .padding(.horizontal, 16)

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -181,7 +181,7 @@ struct UsageMenuCardView: View {
                     }
                     if let tokenUsage = self.model.tokenUsage {
                         VStack(alignment: .leading, spacing: 6) {
-                            Text("Cost")
+                            Text("cost_header_estimated")
                                 .font(.body)
                                 .fontWeight(.medium)
                             Text(tokenUsage.sessionLine)
@@ -598,7 +598,7 @@ struct UsageMenuCardCostSectionView: View {
                 VStack(alignment: .leading, spacing: 10) {
                     if let tokenUsage = self.model.tokenUsage {
                         VStack(alignment: .leading, spacing: 6) {
-                            Text("Cost")
+                            Text("cost_header_estimated")
                                 .font(.body)
                                 .fontWeight(.medium)
                             Text(tokenUsage.sessionLine)
@@ -1556,7 +1556,7 @@ extension UsageMenuCardView.Model {
         return TokenUsageSection(
             sessionLine: sessionLine,
             monthLine: monthLine,
-            hintLine: nil,
+            hintLine: UsageFormatter.costEstimateHint,
             errorLine: err,
             errorCopyText: (error?.isEmpty ?? true) ? nil : error)
     }

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1556,7 +1556,7 @@ extension UsageMenuCardView.Model {
         return TokenUsageSection(
             sessionLine: sessionLine,
             monthLine: monthLine,
-            hintLine: UsageFormatter.costEstimateHint,
+            hintLine: String(localized: "cost_estimate_hint"),
             errorLine: err,
             errorCopyText: (error?.isEmpty ?? true) ? nil : error)
     }

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -622,3 +622,7 @@
 "refresh_5min" = "5 min";
 "refresh_15min" = "15 min";
 "refresh_30min" = "30 min";
+
+/* Cost estimation */
+"cost_header_estimated" = "Cost (estimated)";
+"cost_estimate_hint" = "Estimated from local logs · may differ from your bill";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -602,3 +602,7 @@
 "refresh_5min" = "5 min";
 "refresh_15min" = "15 min";
 "refresh_30min" = "30 min";
+
+/* Cost estimation */
+"cost_header_estimated" = "Custo (estimado)";
+"cost_estimate_hint" = "Estimado a partir de logs locais · pode diferir da sua fatura";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -632,3 +632,7 @@
 
 /* Additional keys */
 "not_found" = "未找到";
+
+/* Cost estimation */
+"cost_header_estimated" = "费用（估算）";
+"cost_estimate_hint" = "根据本地日志估算 · 可能与账单不同";

--- a/Sources/CodexBarCLI/CLICostCommand.swift
+++ b/Sources/CodexBarCLI/CLICostCommand.swift
@@ -79,7 +79,7 @@ extension CodexBarCLI {
         useColor: Bool) -> String
     {
         let name = ProviderDescriptorRegistry.descriptor(for: provider).metadata.displayName
-        let header = Self.costHeaderLine("\(name) Cost (local)", useColor: useColor)
+        let header = Self.costHeaderLine("\(name) Cost (API-rate estimate)", useColor: useColor)
 
         let todayCost = snapshot.sessionCostUSD.map { UsageFormatter.usdString($0) } ?? "—"
         let todayTokens = snapshot.sessionTokens.map { UsageFormatter.tokenCountString($0) }
@@ -89,7 +89,7 @@ extension CodexBarCLI {
         let monthTokens = snapshot.last30DaysTokens.map { UsageFormatter.tokenCountString($0) }
         let monthLine = monthTokens.map { "Last 30 days: \(monthCost) · \($0) tokens" } ?? "Last 30 days: \(monthCost)"
 
-        return [header, todayLine, monthLine].joined(separator: "\n")
+        return [header, todayLine, monthLine, UsageFormatter.costEstimateHint].joined(separator: "\n")
     }
 
     private static func costHeaderLine(_ header: String, useColor: Bool) -> String {

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -109,6 +109,8 @@ public enum UsageFormatter {
         value.formatted(.currency(code: "USD").locale(Locale(identifier: "en_US")))
     }
 
+    public static let costEstimateHint = "Estimated from local logs · may differ from your bill"
+
     /// Formats a currency value with the specified currency code.
     /// Uses FormatStyle with explicit en_US locale to ensure consistent formatting
     /// regardless of the user's system locale (e.g., pt-BR users see $54.72 not US$ 54,72).

--- a/Tests/CodexBarTests/CLICostTests.swift
+++ b/Tests/CodexBarTests/CLICostTests.swift
@@ -30,9 +30,10 @@ struct CLICostTests {
             .replacingOccurrences(of: "\u{00A0}", with: " ")
             .replacingOccurrences(of: "$ ", with: "$")
 
-        #expect(output.contains("Claude Cost (local)"))
+        #expect(output.contains("Claude Cost (API-rate estimate)"))
         #expect(output.contains("Today: $1.25 · 1.2K tokens"))
         #expect(output.contains("Last 30 days: $9.99 · 9K tokens"))
+        #expect(output.contains(UsageFormatter.costEstimateHint))
     }
 
     @Test
@@ -137,5 +138,12 @@ struct CLICostTests {
         #expect(!json.contains("\"gpt-5.2\""))
         #expect(json.contains("\"cost\":0"))
         #expect(json.contains("\"totalTokens\":140"))
+    }
+
+    @Test
+    func `cost estimate hint is stable string`() {
+        let hint = UsageFormatter.costEstimateHint
+        #expect(!hint.isEmpty)
+        #expect(hint.contains("Estimated"))
     }
 }


### PR DESCRIPTION
## Summary
- Add persistent hint below cost figures: *"Estimated from local logs · may differ from your bill"*
- Change "Cost" section header to "Cost (estimated)" with localization (en, pt-BR, zh-Hans)
- Update CLI output from "(local)" to "(API-rate estimate)" with footer disclaimer
- Update chart footer to "Est. total (30d)" with truncation safety

Closes #549.

## Context
Users on flat-rate subscriptions (Claude Max, Codex Pro) panic when they see dollar amounts computed from local logs at API pricing rates. The hint clarifies these are estimates, not invoiced charges. The wording is universally accurate — API users also benefit since local log estimates may differ from actual invoices due to caching, batching, and discount tiers.

Prior PR #464 was closed as too large (subscription detection + settings toggle). This PR follows the guidance to "reopen as a fresh, smaller PR" — no conditional logic, no new settings, just clear labeling.

## Changes
| File | Change |
|------|--------|
| `UsageFormatter.swift` | Add `costEstimateHint` public constant |
| `MenuCardView.swift` | Assign hint to `hintLine`, change 2× `Text("Cost")` → localized key |
| `CostHistoryChartMenuView.swift` | Footer "Est. total (30d)" + `lineLimit(1)` + `truncationMode(.head)` |
| `CLICostCommand.swift` | Header "(API-rate estimate)" + footer disclaimer |
| `en/pt-BR/zh-Hans .strings` | Add `cost_header_estimated` + `cost_estimate_hint` keys |
| `CLICostTests.swift` | Update CLI assertion + add hint stability test |

## Validation
- `swift build` — clean (942 targets)
- `swift test --filter CLICostTests` — all 5 tests pass (including updated + new tests)
- Tested locally on macOS — built from source and verified UI + CLI
- Translations are machine-generated for pt-BR and zh-Hans — happy to take corrections

## Screenshots

### Menu bar (dark mode)

<img width="308" alt="Cost estimated menu card" src="https://github.com/user-attachments/assets/99e453e5-89a3-479b-8602-cb52e955c790" />

**Before:** Header says "Cost", no hint line
**After:** Header says "Cost (estimated)", hint line reads "Estimated from local logs · may differ from your bill"

### CLI output
```
Claude Cost (API-rate estimate)
Today: $113.58 · 154M tokens
Last 30 days: $1,097.61 · 1.3B tokens
Estimated from local logs · may differ from your bill
```

## Deferred (separate PRs)
- Widget labels → "Today est." / "30d est." (compact widget layout requires different approach)
- Preferences subtitle wording update