### PR TITLE
Add provider changelog links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Display: add a setting to hide quota-warning tick marks on usage bars while keeping quota warning notifications active (#918, fixes #916). Thanks @ThiagoCAltoe!
+- Menu: add an opt-in setting for provider changelog links, starting with Codex, Claude Code, and Gemini CLI (#929, fixes #660). Thanks @ThiagoCAltoe!
 - Moonshot / Kimi API: add API-key balance tracking, CLI support, docs, and menu bar balance copy (#899). Thanks @giuseppebisemi!
 
 ### Fixed

--- a/Sources/CodexBar/MenuContent.swift
+++ b/Sources/CodexBar/MenuContent.swift
@@ -118,6 +118,8 @@ struct MenuContent: View {
             self.actions.openDashboard()
         case .statusPage:
             self.actions.openStatusPage()
+        case .changelog:
+            self.actions.openChangelog()
         case .addCodexAccount:
             self.actions.addCodexAccount()
         case .requestCodexSystemPromotion:
@@ -150,6 +152,7 @@ struct MenuActions {
     let refreshAugmentSession: () -> Void
     let openDashboard: () -> Void
     let openStatusPage: () -> Void
+    let openChangelog: () -> Void
     let addCodexAccount: () -> Void
     let switchAccount: (UsageProvider) -> Void
     let openTerminal: (String) -> Void

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -424,7 +424,7 @@ struct MenuDescriptor {
         if metadata?.statusPageURL != nil || metadata?.statusLinkURL != nil {
             entries.append(.action("Status Page", .statusPage))
         }
-        if metadata?.changelogURL != nil {
+        if store.settings.providerChangelogLinksEnabled, metadata?.changelogURL != nil {
             entries.append(.action("Changelog", .changelog))
         }
 

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -32,6 +32,7 @@ struct MenuDescriptor {
         case refresh = "arrow.clockwise"
         case dashboard = "chart.bar"
         case statusPage = "waveform.path.ecg"
+        case changelog = "list.bullet.rectangle"
         case addAccount = "plus"
         case systemAccount = "person.crop.circle"
         case switchAccount = "key"
@@ -55,6 +56,7 @@ struct MenuDescriptor {
         case refreshAugmentSession
         case dashboard
         case statusPage
+        case changelog
         case addCodexAccount
         case requestCodexSystemPromotion(UUID)
         case addProviderAccount(UsageProvider)
@@ -422,6 +424,9 @@ struct MenuDescriptor {
         if metadata?.statusPageURL != nil || metadata?.statusLinkURL != nil {
             entries.append(.action("Status Page", .statusPage))
         }
+        if metadata?.changelogURL != nil {
+            entries.append(.action("Changelog", .changelog))
+        }
 
         if let statusLine = self.statusLine(for: provider, store: store) {
             entries.append(.text(statusLine, .secondary))
@@ -550,6 +555,7 @@ extension MenuDescriptor.MenuAction {
         case .refreshAugmentSession: MenuDescriptor.MenuActionSystemImage.refresh.rawValue
         case .dashboard: MenuDescriptor.MenuActionSystemImage.dashboard.rawValue
         case .statusPage: MenuDescriptor.MenuActionSystemImage.statusPage.rawValue
+        case .changelog: MenuDescriptor.MenuActionSystemImage.changelog.rawValue
         case .addCodexAccount, .addProviderAccount: MenuDescriptor.MenuActionSystemImage.addAccount.rawValue
         case .requestCodexSystemPromotion:
             nil

--- a/Sources/CodexBar/PreferencesDisplayPane.swift
+++ b/Sources/CodexBar/PreferencesDisplayPane.swift
@@ -83,6 +83,10 @@ struct DisplayPane: View {
                         subtitle: L("show_reset_time_as_clock_subtitle"),
                         binding: self.$settings.resetTimesShowAbsolute)
                     PreferenceToggleRow(
+                        title: L("show_provider_changelog_links_title"),
+                        subtitle: L("show_provider_changelog_links_subtitle"),
+                        binding: self.$settings.providerChangelogLinksEnabled)
+                    PreferenceToggleRow(
                         title: L("show_credits_extra_usage_title"),
                         subtitle: L("show_credits_extra_usage_subtitle"),
                         binding: self.$settings.showOptionalCreditsAndExtraUsage)

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -486,6 +486,8 @@
 "show_quota_warning_markers_subtitle" = "Draw threshold tick marks on usage bars when quota warnings are configured.";
 "show_reset_time_as_clock_title" = "Show reset time as clock";
 "show_reset_time_as_clock_subtitle" = "Display reset times as absolute clock values instead of countdowns.";
+"show_provider_changelog_links_title" = "Show provider changelog links";
+"show_provider_changelog_links_subtitle" = "Adds release-notes links for supported CLI-backed providers to the menu.";
 "show_credits_extra_usage_title" = "Show credits + extra usage";
 "show_credits_extra_usage_subtitle" = "Show Codex Credits and Claude Extra usage sections in the menu.";
 "show_all_token_accounts_title" = "Show all token accounts";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -466,6 +466,8 @@
 "show_quota_warning_markers_subtitle" = "Desenha marcas de limite nas barras de uso quando os alertas de cota estão configurados.";
 "show_reset_time_as_clock_title" = "Mostrar renovação como horário";
 "show_reset_time_as_clock_subtitle" = "Mostra horários de renovação como horas absolutas, em vez de contagens regressivas.";
+"show_provider_changelog_links_title" = "Mostrar links de changelog dos provedores";
+"show_provider_changelog_links_subtitle" = "Adiciona links de notas de versão para provedores baseados em CLI compatíveis no menu.";
 "show_credits_extra_usage_title" = "Mostrar créditos + uso extra";
 "show_credits_extra_usage_subtitle" = "Mostra as seções de créditos do Codex e uso extra do Claude no menu.";
 "show_all_token_accounts_title" = "Mostrar todas as contas de token";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -493,6 +493,8 @@
 "show_quota_warning_markers_subtitle" = "配置配额警告后，在用量条上绘制阈值刻度标记。";
 "show_reset_time_as_clock_title" = "将重置时间显示为时钟";
 "show_reset_time_as_clock_subtitle" = "将重置时间显示为绝对时钟值而非倒计时。";
+"show_provider_changelog_links_title" = "显示提供商变更日志链接";
+"show_provider_changelog_links_subtitle" = "在菜单中为支持的 CLI 提供商添加发布说明链接。";
 "show_credits_extra_usage_title" = "显示积分 + 额外用量";
 "show_credits_extra_usage_subtitle" = "在菜单中显示 Codex 积分和 Claude 额外用量部分。";
 "show_all_token_accounts_title" = "显示所有令牌账户";

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -172,6 +172,14 @@ extension SettingsStore {
         }
     }
 
+    var providerChangelogLinksEnabled: Bool {
+        get { self.defaultsState.providerChangelogLinksEnabled }
+        set {
+            self.defaultsState.providerChangelogLinksEnabled = newValue
+            self.userDefaults.set(newValue, forKey: "providerChangelogLinksEnabled")
+        }
+    }
+
     var menuBarShowsBrandIconWithPercent: Bool {
         get { self.defaultsState.menuBarShowsBrandIconWithPercent }
         set {

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -19,6 +19,7 @@ extension SettingsStore {
         _ = self.quotaWarningMarkersVisible
         _ = self.usageBarsShowUsed
         _ = self.resetTimesShowAbsolute
+        _ = self.providerChangelogLinksEnabled
         _ = self.menuBarShowsBrandIconWithPercent
         _ = self.menuBarShowsHighestUsage
         _ = self.menuBarDisplayMode

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -295,6 +295,8 @@ extension SettingsStore {
         }
         let usageBarsShowUsed = userDefaults.object(forKey: "usageBarsShowUsed") as? Bool ?? false
         let resetTimesShowAbsolute = userDefaults.object(forKey: "resetTimesShowAbsolute") as? Bool ?? false
+        let providerChangelogLinksEnabled = userDefaults.object(
+            forKey: "providerChangelogLinksEnabled") as? Bool ?? false
         let menuBarShowsBrandIconWithPercent = userDefaults.object(
             forKey: "menuBarShowsBrandIconWithPercent") as? Bool ?? false
         let menuBarDisplayModeRaw = userDefaults.string(forKey: "menuBarDisplayMode")
@@ -373,6 +375,7 @@ extension SettingsStore {
             quotaWarningMarkersVisible: quotaWarningMarkersVisible,
             usageBarsShowUsed: usageBarsShowUsed,
             resetTimesShowAbsolute: resetTimesShowAbsolute,
+            providerChangelogLinksEnabled: providerChangelogLinksEnabled,
             menuBarShowsBrandIconWithPercent: menuBarShowsBrandIconWithPercent,
             menuBarDisplayModeRaw: menuBarDisplayModeRaw,
             historicalTrackingEnabled: historicalTrackingEnabled,

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -19,6 +19,7 @@ struct SettingsDefaultsState {
     var quotaWarningMarkersVisible: Bool
     var usageBarsShowUsed: Bool
     var resetTimesShowAbsolute: Bool
+    var providerChangelogLinksEnabled: Bool
     var menuBarShowsBrandIconWithPercent: Bool
     var menuBarDisplayModeRaw: String?
     var historicalTrackingEnabled: Bool

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -119,6 +119,16 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         NSWorkspace.shared.open(url)
     }
 
+    @objc func openChangelog() {
+        let preferred = self.lastMenuProvider
+            ?? (self.store.isEnabled(.codex) ? .codex : self.store.enabledProviders().first)
+
+        let provider = preferred ?? .codex
+        let meta = self.store.metadata(for: provider)
+        guard let urlString = meta.changelogURL, let url = URL(string: urlString) else { return }
+        NSWorkspace.shared.open(url)
+    }
+
     @objc func openTerminalCommand(_ sender: NSMenuItem) {
         let command = sender.representedObject as? String ?? "claude"
         Self.openTerminal(command: command)

--- a/Sources/CodexBar/StatusItemController+MenuActionMapping.swift
+++ b/Sources/CodexBar/StatusItemController+MenuActionMapping.swift
@@ -8,6 +8,7 @@ extension StatusItemController {
         case .refreshAugmentSession: (#selector(self.refreshAugmentSession), nil)
         case .dashboard: (#selector(self.openDashboard), nil)
         case .statusPage: (#selector(self.openStatusPage), nil)
+        case .changelog: (#selector(self.openChangelog), nil)
         case .addCodexAccount: (#selector(self.addManagedCodexAccountFromMenu(_:)), nil)
         case let .addProviderAccount(provider): (#selector(self.runSwitchAccount(_:)), provider.rawValue)
         case let .requestCodexSystemPromotion(managedAccountID):

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeProviderDescriptor.swift
@@ -24,6 +24,7 @@ public enum ClaudeProviderDescriptor {
                 browserCookieOrder: ProviderBrowserCookieDefaults.defaultImportOrder,
                 dashboardURL: "https://console.anthropic.com/settings/billing",
                 subscriptionDashboardURL: "https://claude.ai/settings/usage",
+                changelogURL: "https://github.com/anthropics/claude-code/releases",
                 statusPageURL: "https://status.claude.com/"),
             branding: ProviderBranding(
                 iconStyle: .claude,

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -24,6 +24,7 @@ public enum CodexProviderDescriptor {
                 browserCookieOrder: ProviderBrowserCookieDefaults.codexCookieImportOrder
                     ?? ProviderBrowserCookieDefaults.defaultImportOrder,
                 dashboardURL: "https://chatgpt.com/codex/settings/usage",
+                changelogURL: "https://github.com/openai/codex/releases",
                 statusPageURL: "https://status.openai.com/"),
             branding: ProviderBranding(
                 iconStyle: .codex,

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiProviderDescriptor.swift
@@ -22,6 +22,7 @@ public enum GeminiProviderDescriptor {
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
                 dashboardURL: "https://gemini.google.com",
+                changelogURL: "https://github.com/google-gemini/gemini-cli/releases",
                 statusPageURL: nil,
                 statusLinkURL: "https://www.google.com/appsstatus/dashboard/products/npdyhgECDJ6tB66MxXyo/history",
                 statusWorkspaceProductID: "npdyhgECDJ6tB66MxXyo"),

--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -106,6 +106,8 @@ public struct ProviderMetadata: Sendable {
     public let browserCookieOrder: BrowserCookieImportOrder?
     public let dashboardURL: String?
     public let subscriptionDashboardURL: String?
+    /// Provider-specific release notes or changelog URL for CLI/provider updates.
+    public let changelogURL: String?
     /// Statuspage.io base URL for incident polling (append /api/v2/status.json).
     public let statusPageURL: String?
     /// Browser-only status link (no API polling); used when statusPageURL is nil.
@@ -130,6 +132,7 @@ public struct ProviderMetadata: Sendable {
         browserCookieOrder: BrowserCookieImportOrder? = nil,
         dashboardURL: String?,
         subscriptionDashboardURL: String? = nil,
+        changelogURL: String? = nil,
         statusPageURL: String?,
         statusLinkURL: String? = nil,
         statusWorkspaceProductID: String? = nil)
@@ -150,6 +153,7 @@ public struct ProviderMetadata: Sendable {
         self.browserCookieOrder = browserCookieOrder
         self.dashboardURL = dashboardURL
         self.subscriptionDashboardURL = subscriptionDashboardURL
+        self.changelogURL = changelogURL
         self.statusPageURL = statusPageURL
         self.statusLinkURL = statusLinkURL
         self.statusWorkspaceProductID = statusWorkspaceProductID

--- a/Tests/CodexBarTests/ProviderChangelogLinkTests.swift
+++ b/Tests/CodexBarTests/ProviderChangelogLinkTests.swift
@@ -15,17 +15,33 @@ struct ProviderChangelogLinkTests {
     }
 
     @Test
-    func `provider menu shows changelog action only when URL is known`() {
-        let codexDescriptor = self.makeDescriptor(provider: .codex, suite: "ProviderChangelogLinkTests-codex")
+    func `provider menu hides changelog action until enabled`() {
+        let codexDescriptor = self.makeDescriptor(
+            provider: .codex,
+            suite: "ProviderChangelogLinkTests-codex-default")
+        #expect(!self.actionTitles(from: codexDescriptor).contains("Changelog"))
+    }
+
+    @Test
+    func `provider menu shows changelog action only when setting and URL are present`() {
+        let codexDescriptor = self.makeDescriptor(
+            provider: .codex,
+            suite: "ProviderChangelogLinkTests-codex",
+            changelogLinksEnabled: true)
         #expect(self.actionTitles(from: codexDescriptor).contains("Changelog"))
 
         let openRouterDescriptor = self.makeDescriptor(
             provider: .openrouter,
-            suite: "ProviderChangelogLinkTests-openrouter")
+            suite: "ProviderChangelogLinkTests-openrouter",
+            changelogLinksEnabled: true)
         #expect(!self.actionTitles(from: openRouterDescriptor).contains("Changelog"))
     }
 
-    private func makeDescriptor(provider: UsageProvider, suite: String) -> MenuDescriptor {
+    private func makeDescriptor(
+        provider: UsageProvider,
+        suite: String,
+        changelogLinksEnabled: Bool = false) -> MenuDescriptor
+    {
         let defaults = UserDefaults(suiteName: suite)!
         defaults.removePersistentDomain(forName: suite)
         let settings = SettingsStore(
@@ -34,6 +50,7 @@ struct ProviderChangelogLinkTests {
             zaiTokenStore: NoopZaiTokenStore(),
             syntheticTokenStore: NoopSyntheticTokenStore())
         settings.statusChecksEnabled = false
+        settings.providerChangelogLinksEnabled = changelogLinksEnabled
 
         let fetcher = UsageFetcher(environment: [:])
         let store = UsageStore(

--- a/Tests/CodexBarTests/ProviderChangelogLinkTests.swift
+++ b/Tests/CodexBarTests/ProviderChangelogLinkTests.swift
@@ -6,7 +6,7 @@ import Testing
 @MainActor
 struct ProviderChangelogLinkTests {
     @Test
-    func `known CLI providers declare changelog URLs`() throws {
+    func `known CLI providers declare changelog URLs`() {
         let metadata = ProviderDefaults.metadata
 
         #expect(metadata[.codex]?.changelogURL == "https://github.com/openai/codex/releases")
@@ -15,11 +15,13 @@ struct ProviderChangelogLinkTests {
     }
 
     @Test
-    func `provider menu shows changelog action only when URL is known`() throws {
+    func `provider menu shows changelog action only when URL is known`() {
         let codexDescriptor = self.makeDescriptor(provider: .codex, suite: "ProviderChangelogLinkTests-codex")
         #expect(self.actionTitles(from: codexDescriptor).contains("Changelog"))
 
-        let openRouterDescriptor = self.makeDescriptor(provider: .openrouter, suite: "ProviderChangelogLinkTests-openrouter")
+        let openRouterDescriptor = self.makeDescriptor(
+            provider: .openrouter,
+            suite: "ProviderChangelogLinkTests-openrouter")
         #expect(!self.actionTitles(from: openRouterDescriptor).contains("Changelog"))
     }
 
@@ -46,7 +48,7 @@ struct ProviderChangelogLinkTests {
             settings: settings,
             account: fetcher.loadAccountInfo(),
             updateReady: false,
-            includeContextualActions: false)
+            includeContextualActions: true)
     }
 
     private func actionTitles(from descriptor: MenuDescriptor) -> [String] {

--- a/Tests/CodexBarTests/ProviderChangelogLinkTests.swift
+++ b/Tests/CodexBarTests/ProviderChangelogLinkTests.swift
@@ -1,0 +1,60 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct ProviderChangelogLinkTests {
+    @Test
+    func `known CLI providers declare changelog URLs`() throws {
+        let metadata = ProviderDefaults.metadata
+
+        #expect(metadata[.codex]?.changelogURL == "https://github.com/openai/codex/releases")
+        #expect(metadata[.claude]?.changelogURL == "https://github.com/anthropics/claude-code/releases")
+        #expect(metadata[.gemini]?.changelogURL == "https://github.com/google-gemini/gemini-cli/releases")
+    }
+
+    @Test
+    func `provider menu shows changelog action only when URL is known`() throws {
+        let codexDescriptor = self.makeDescriptor(provider: .codex, suite: "ProviderChangelogLinkTests-codex")
+        #expect(self.actionTitles(from: codexDescriptor).contains("Changelog"))
+
+        let openRouterDescriptor = self.makeDescriptor(provider: .openrouter, suite: "ProviderChangelogLinkTests-openrouter")
+        #expect(!self.actionTitles(from: openRouterDescriptor).contains("Changelog"))
+    }
+
+    private func makeDescriptor(provider: UsageProvider, suite: String) -> MenuDescriptor {
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+
+        let fetcher = UsageFetcher(environment: [:])
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing)
+
+        return MenuDescriptor.build(
+            provider: provider,
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updateReady: false,
+            includeContextualActions: false)
+    }
+
+    private func actionTitles(from descriptor: MenuDescriptor) -> [String] {
+        descriptor.sections
+            .flatMap(\.entries)
+            .compactMap { entry -> String? in
+                guard case let .action(title, _) = entry else { return nil }
+                return title
+            }
+    }
+}

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -138,6 +138,32 @@ struct SettingsStoreTests {
     }
 
     @Test
+    func `provider changelog links setting defaults off and persists`() throws {
+        let suite = "SettingsStoreTests-provider-changelog-links"
+        let defaultsA = try #require(UserDefaults(suiteName: suite))
+        defaultsA.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        let storeA = SettingsStore(
+            userDefaults: defaultsA,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        #expect(storeA.providerChangelogLinksEnabled == false)
+        #expect(defaultsA.bool(forKey: "providerChangelogLinksEnabled") == false)
+        storeA.providerChangelogLinksEnabled = true
+
+        let defaultsB = try #require(UserDefaults(suiteName: suite))
+        let storeB = SettingsStore(
+            userDefaults: defaultsB,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        #expect(storeB.providerChangelogLinksEnabled == true)
+    }
+
+    @Test
     func `persists selected menu provider across instances`() throws {
         let suite = "SettingsStoreTests-selectedMenuProvider"
         let defaultsA = try #require(UserDefaults(suiteName: suite))


### PR DESCRIPTION
## Summary
- add optional provider changelog/release notes metadata
- show a Changelog menu item only for providers with a known URL
- seed links for Codex, Claude Code, and Gemini CLI

## Validation
- Verified configured URLs return HTTP 200
- git diff --check
- swift test --filter ProviderChangelogLinkTests could not be run locally because Swift is not installed in this environment

Closes #660