### PR TITLE
Clarify Gemini source label

### DIFF
--- a/Sources/CodexBarCore/Providers/Gemini/GeminiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiProviderDescriptor.swift
@@ -42,6 +42,8 @@ public enum GeminiProviderDescriptor {
 }
 
 struct GeminiStatusFetchStrategy: ProviderFetchStrategy {
+    static let sourceLabel = "oauth-api"
+
     let id: String = "gemini.api"
     let kind: ProviderFetchKind = .apiToken
 
@@ -54,7 +56,7 @@ struct GeminiStatusFetchStrategy: ProviderFetchStrategy {
         let snap = try await probe.fetch()
         return self.makeResult(
             usage: snap.toUsageSnapshot(),
-            sourceLabel: "api")
+            sourceLabel: Self.sourceLabel)
     }
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {

--- a/Tests/CodexBarTests/GeminiSourceLabelTests.swift
+++ b/Tests/CodexBarTests/GeminiSourceLabelTests.swift
@@ -1,0 +1,9 @@
+import Testing
+@testable import CodexBarCore
+
+struct GeminiSourceLabelTests {
+    @Test
+    func `Gemini source label reflects OAuth backed API requests`() {
+        #expect(GeminiStatusFetchStrategy.sourceLabel == "oauth-api")
+    }
+}


### PR DESCRIPTION
## Summary
- keep Gemini on the existing API fetch path
- label successful Gemini fetches as `oauth-api` to reflect the OAuth-backed Code Assist flow
- add a regression test for the Gemini source label

## Validation
- git diff --check
- swift test --filter GeminiSourceLabelTests could not be run locally because Swift is not installed in this environment

Closes #880