### PR TITLE
Fix Codex menu account refresh routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Settings: apply the selected app language from packaged SwiftPM resources instead of falling back to English when the `.lproj` directory casing differs (#908).
+- Codex: route menu account refreshes through the resolved live-vs-managed account source so matched accounts keep using the stable `CODEX_HOME` (#932, fixes #931). Thanks @ThiagoCAltoe!
 - ChatGPT credits: restrict purchase links to real HTTPS `chatgpt.com` settings/usage/billing/credits paths and drop query/fragment data (#903). Thanks @ThiagoCAltoe!
 - z.ai: show the MCP quota bucket as monthly instead of a misleading 1-minute window (#904). Thanks @ThiagoCAltoe!
 - Menu: middle-truncate long account emails in Codex account controls and keep the Codex account switcher visible during merged-menu refreshes with transient account snapshots.

--- a/Sources/CodexBar/ProviderRegistry.swift
+++ b/Sources/CodexBar/ProviderRegistry.swift
@@ -70,13 +70,17 @@ struct ProviderRegistry {
     @MainActor
     static func makeSettingsSnapshot(
         settings: SettingsStore,
-        tokenOverride: TokenAccountOverride?) -> ProviderSettingsSnapshot
+        tokenOverride: TokenAccountOverride?,
+        codexActiveSourceOverride: CodexActiveSource? = nil) -> ProviderSettingsSnapshot
     {
         settings.ensureTokenAccountsLoaded()
         var builder = ProviderSettingsSnapshotBuilder(
             debugMenuEnabled: settings.debugMenuEnabled,
             debugKeepCLISessionsAlive: settings.debugKeepCLISessionsAlive)
-        let context = ProviderSettingsSnapshotContext(settings: settings, tokenOverride: tokenOverride)
+        let context = ProviderSettingsSnapshotContext(
+            settings: settings,
+            tokenOverride: tokenOverride,
+            codexActiveSourceOverride: codexActiveSourceOverride)
         for implementation in ProviderCatalog.all {
             if let contribution = implementation.settingsSnapshot(context: context) {
                 builder.apply(contribution)
@@ -90,7 +94,8 @@ struct ProviderRegistry {
         base: [String: String],
         provider: UsageProvider,
         settings: SettingsStore,
-        tokenOverride: TokenAccountOverride?) -> [String: String]
+        tokenOverride: TokenAccountOverride?,
+        codexActiveSourceOverride: CodexActiveSource? = nil) -> [String: String]
     {
         let account = ProviderTokenAccountSelection.selectedAccount(
             provider: provider,
@@ -116,9 +121,10 @@ struct ProviderRegistry {
         // Mac's Codex sessions, not as account-owned remote state. If we later want
         // account-scoped token history in the UI, that needs an explicit product decision and
         // presentation change so the two concepts are not conflated.
+        let codexActiveSource = codexActiveSourceOverride ?? settings.codexActiveSource
         if provider == .codex,
-           case .managedAccount = settings.codexActiveSource,
-           let managedHomePath = settings.activeManagedCodexRemoteHomePath
+           case .managedAccount = codexActiveSource,
+           let managedHomePath = settings.managedCodexRemoteHomePath(forActiveSource: codexActiveSource)
         {
             env = CodexHomeScope.scopedEnvironment(base: env, codexHome: managedHomePath)
         }

--- a/Sources/CodexBar/ProviderRegistry.swift
+++ b/Sources/CodexBar/ProviderRegistry.swift
@@ -121,7 +121,7 @@ struct ProviderRegistry {
         // Mac's Codex sessions, not as account-owned remote state. If we later want
         // account-scoped token history in the UI, that needs an explicit product decision and
         // presentation change so the two concepts are not conflated.
-        let codexActiveSource = codexActiveSourceOverride ?? settings.codexActiveSource
+        let codexActiveSource = codexActiveSourceOverride ?? settings.codexResolvedActiveSource
         if provider == .codex,
            case .managedAccount = codexActiveSource,
            let managedHomePath = settings.managedCodexRemoteHomePath(forActiveSource: codexActiveSource)

--- a/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
@@ -24,7 +24,9 @@ struct CodexProviderImplementation: ProviderImplementation {
 
     @MainActor
     func settingsSnapshot(context: ProviderSettingsSnapshotContext) -> ProviderSettingsSnapshotContribution? {
-        .codex(context.settings.codexSettingsSnapshot(tokenOverride: context.tokenOverride))
+        .codex(context.settings.codexSettingsSnapshot(
+            tokenOverride: context.tokenOverride,
+            activeSourceOverride: context.codexActiveSourceOverride))
     }
 
     @MainActor

--- a/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
@@ -40,7 +40,9 @@ extension SettingsStore {
         return try store.loadAccounts()
     }
 
-    private func managedCodexAccountStoreState(activeSource: CodexActiveSource? = nil) -> ManagedCodexAccountStoreState {
+    private func managedCodexAccountStoreState(
+        activeSource: CodexActiveSource? = nil) -> ManagedCodexAccountStoreState
+    {
         let source = activeSource ?? self.codexResolvedActiveSource
         guard case let .managedAccount(id) = source else {
             return .none
@@ -183,8 +185,8 @@ extension SettingsStore {
     }
 
     func codexAccountReconciliationSnapshot(
-        activeSourceOverride: CodexActiveSource?
-    ) -> CodexAccountReconciliationSnapshot {
+        activeSourceOverride: CodexActiveSource?) -> CodexAccountReconciliationSnapshot
+    {
         self.codexAccountReconciler(
             activeSource: activeSourceOverride ?? self.codexPersistedActiveSource)
             .loadSnapshot()
@@ -500,8 +502,8 @@ extension SettingsStore {
 extension SettingsStore {
     func codexSettingsSnapshot(
         tokenOverride: TokenAccountOverride?,
-        activeSourceOverride: CodexActiveSource? = nil
-    ) -> ProviderSettingsSnapshot.CodexProviderSettings {
+        activeSourceOverride: CodexActiveSource? = nil) -> ProviderSettingsSnapshot.CodexProviderSettings
+    {
         let reconciliationSnapshot = self.codexAccountReconciliationSnapshot(
             activeSourceOverride: activeSourceOverride)
         let resolvedActiveSource = CodexActiveSourceResolver.resolve(from: reconciliationSnapshot)

--- a/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
@@ -40,8 +40,9 @@ extension SettingsStore {
         return try store.loadAccounts()
     }
 
-    private func managedCodexAccountStoreState() -> ManagedCodexAccountStoreState {
-        guard case let .managedAccount(id) = self.codexResolvedActiveSource else {
+    private func managedCodexAccountStoreState(activeSource: CodexActiveSource? = nil) -> ManagedCodexAccountStoreState {
+        let source = activeSource ?? self.codexResolvedActiveSource
+        guard case let .managedAccount(id) = source else {
             return .none
         }
         do {
@@ -64,7 +65,11 @@ extension SettingsStore {
     }
 
     var activeManagedCodexRemoteHomePath: String? {
-        guard case .managedAccount = self.codexResolvedActiveSource else {
+        self.managedCodexRemoteHomePath(forActiveSource: self.codexResolvedActiveSource)
+    }
+
+    func managedCodexRemoteHomePath(forActiveSource source: CodexActiveSource) -> String? {
+        guard case let .managedAccount(id) = source else {
             return nil
         }
 
@@ -73,10 +78,6 @@ extension SettingsStore {
             return override
         }
         #endif
-
-        guard case let .managedAccount(id) = self.codexResolvedActiveSource else {
-            return nil
-        }
 
         do {
             let accounts = try self.loadManagedCodexAccounts()
@@ -178,7 +179,15 @@ extension SettingsStore {
 
 extension SettingsStore {
     var codexAccountReconciliationSnapshot: CodexAccountReconciliationSnapshot {
-        self.codexAccountReconciler().loadSnapshot()
+        self.codexAccountReconciliationSnapshot(activeSourceOverride: nil)
+    }
+
+    func codexAccountReconciliationSnapshot(
+        activeSourceOverride: CodexActiveSource?
+    ) -> CodexAccountReconciliationSnapshot {
+        self.codexAccountReconciler(
+            activeSource: activeSourceOverride ?? self.codexPersistedActiveSource)
+            .loadSnapshot()
     }
 
     var codexVisibleAccountProjection: CodexVisibleAccountProjection {
@@ -221,7 +230,7 @@ extension SettingsStore {
         self.codexVisibleAccountProjection.source(forVisibleAccountID: id)
     }
 
-    private func codexAccountReconciler() -> DefaultCodexAccountReconciler {
+    private func codexAccountReconciler(activeSource: CodexActiveSource) -> DefaultCodexAccountReconciler {
         let baseEnvironment = self.codexReconciliationEnvironment()
         #if DEBUG
         let liveSystemAccountOverride = CodexManagedRemoteHomeTestingOverride.liveSystemAccount(for: self)
@@ -232,7 +241,7 @@ extension SettingsStore {
         let unreadableStoreOverride = CodexManagedRemoteHomeTestingOverride.isUnreadable(for: self)
         guard CodexManagedRemoteHomeTestingOverride.hasAnyOverride(for: self) else {
             return DefaultCodexAccountReconciler(
-                activeSource: self.codexPersistedActiveSource,
+                activeSource: activeSource,
                 baseEnvironment: baseEnvironment,
                 managedEnvironmentBuilder: { environment, account in
                     CodexHomeScope.scopedEnvironment(base: environment, codexHome: account.managedHomePath)
@@ -262,14 +271,14 @@ extension SettingsStore {
             systemObserver: CodexManagedRemoteHomeTestingSystemObserver(
                 overrideAccount: liveSystemAccountOverride,
                 usesInjectedEnvironment: reconciliationEnvironmentOverride != nil),
-            activeSource: self.codexPersistedActiveSource,
+            activeSource: activeSource,
             baseEnvironment: baseEnvironment,
             managedEnvironmentBuilder: { environment, account in
                 CodexHomeScope.scopedEnvironment(base: environment, codexHome: account.managedHomePath)
             })
         #else
         return DefaultCodexAccountReconciler(
-            activeSource: self.codexPersistedActiveSource,
+            activeSource: activeSource,
             baseEnvironment: baseEnvironment,
             managedEnvironmentBuilder: { environment, account in
                 CodexHomeScope.scopedEnvironment(base: environment, codexHome: account.managedHomePath)
@@ -489,8 +498,12 @@ extension SettingsStore {
 #endif
 
 extension SettingsStore {
-    func codexSettingsSnapshot(tokenOverride: TokenAccountOverride?) -> ProviderSettingsSnapshot.CodexProviderSettings {
-        let reconciliationSnapshot = self.codexAccountReconciliationSnapshot
+    func codexSettingsSnapshot(
+        tokenOverride: TokenAccountOverride?,
+        activeSourceOverride: CodexActiveSource? = nil
+    ) -> ProviderSettingsSnapshot.CodexProviderSettings {
+        let reconciliationSnapshot = self.codexAccountReconciliationSnapshot(
+            activeSourceOverride: activeSourceOverride)
         let resolvedActiveSource = CodexActiveSourceResolver.resolve(from: reconciliationSnapshot)
         return CodexProviderSettingsBuilder.make(input: CodexProviderSettingsBuilderInput(
             usageDataSource: self.codexUsageDataSource,

--- a/Sources/CodexBar/Providers/Shared/ProviderContext.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderContext.swift
@@ -34,4 +34,15 @@ struct ProviderVersionContext {
 struct ProviderSettingsSnapshotContext {
     let settings: SettingsStore
     let tokenOverride: TokenAccountOverride?
+    let codexActiveSourceOverride: CodexActiveSource?
+
+    init(
+        settings: SettingsStore,
+        tokenOverride: TokenAccountOverride?,
+        codexActiveSourceOverride: CodexActiveSource? = nil)
+    {
+        self.settings = settings
+        self.tokenOverride = tokenOverride
+        self.codexActiveSourceOverride = codexActiveSourceOverride
+    }
 }

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -101,18 +101,27 @@ extension UsageStore {
             self.codexAccountSnapshots = snapshots
         }
 
-        let currentProjection = self.settings.codexVisibleAccountProjection
-        let currentSelectionSource = originalVisibleAccountID.flatMap {
-            currentProjection.source(forVisibleAccountID: $0)
-        }
-        let selectionStillMatches = currentProjection.activeVisibleAccountID == originalVisibleAccountID &&
-            currentSelectionSource == originalSelectionSource
+        let selectionStillMatches = self.codexVisibleSelectionStillMatches(
+            originalVisibleAccountID: originalVisibleAccountID,
+            originalSelectionSource: originalSelectionSource)
         if let selectedOutcome, selectionStillMatches {
             await self.applySelectedCodexVisibleAccountOutcome(
                 selectedOutcome,
                 snapshot: selectedSnapshot,
                 sourceLabel: selectedSourceLabel)
         }
+    }
+
+    func codexVisibleSelectionStillMatches(
+        originalVisibleAccountID: String?,
+        originalSelectionSource: CodexActiveSource?) -> Bool
+    {
+        let currentProjection = self.settings.codexVisibleAccountProjection
+        let currentSelectionSource = originalVisibleAccountID.flatMap {
+            currentProjection.source(forVisibleAccountID: $0)
+        }
+        return currentProjection.activeVisibleAccountID == originalVisibleAccountID &&
+            currentSelectionSource == originalSelectionSource
     }
 
     func refreshTokenAccounts(provider: UsageProvider, accounts: [ProviderTokenAccount]) async {

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -61,7 +61,6 @@ extension UsageStore {
             return
         }
 
-        let originalSource = self.settings.codexActiveSource
         let originalVisibleAccountID = projection.activeVisibleAccountID
         let priorByAccountID = Dictionary(uniqueKeysWithValues: self.codexAccountSnapshots.map { ($0.id, $0) })
         var snapshots: [CodexAccountUsageSnapshot] = []
@@ -70,22 +69,11 @@ extension UsageStore {
         var selectedSourceLabel: String?
         var sawAnyNonCancellationOutcome = false
 
-        let restoreOriginalSelection = {
-            var restoredSelection = false
-            if let originalVisibleAccountID,
-               self.settings.selectCodexVisibleAccount(id: originalVisibleAccountID)
-            {
-                restoredSelection = true
-            }
-            if !restoredSelection {
-                self.settings.codexActiveSource = originalSource
-            }
-        }
-        defer { restoreOriginalSelection() }
-
         for account in accounts {
-            guard self.settings.selectCodexVisibleAccount(id: account.id) else { continue }
-            let outcome = await self.fetchOutcome(provider: .codex, override: nil)
+            let outcome = await self.fetchOutcome(
+                provider: .codex,
+                override: nil,
+                codexActiveSourceOverride: account.selectionSource)
             let isCancellation = Self.outcomeIsCancellation(outcome)
             if !isCancellation {
                 sawAnyNonCancellationOutcome = true
@@ -110,7 +98,6 @@ extension UsageStore {
             self.codexAccountSnapshots = snapshots
         }
 
-        restoreOriginalSelection()
         if let selectedOutcome {
             await self.applySelectedCodexVisibleAccountOutcome(
                 selectedOutcome,
@@ -244,24 +231,33 @@ extension UsageStore {
 
     func fetchOutcome(
         provider: UsageProvider,
-        override: TokenAccountOverride?) async -> ProviderFetchOutcome
+        override: TokenAccountOverride?,
+        codexActiveSourceOverride: CodexActiveSource? = nil) async -> ProviderFetchOutcome
     {
         let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
-        let context = self.makeFetchContext(provider: provider, override: override)
+        let context = self.makeFetchContext(
+            provider: provider,
+            override: override,
+            codexActiveSourceOverride: codexActiveSourceOverride)
         return await descriptor.fetchOutcome(context: context)
     }
 
     func makeFetchContext(
         provider: UsageProvider,
-        override: TokenAccountOverride?) -> ProviderFetchContext
+        override: TokenAccountOverride?,
+        codexActiveSourceOverride: CodexActiveSource? = nil) -> ProviderFetchContext
     {
         let sourceMode = self.sourceMode(for: provider)
-        let snapshot = ProviderRegistry.makeSettingsSnapshot(settings: self.settings, tokenOverride: override)
+        let snapshot = ProviderRegistry.makeSettingsSnapshot(
+            settings: self.settings,
+            tokenOverride: override,
+            codexActiveSourceOverride: codexActiveSourceOverride)
         let env = ProviderRegistry.makeEnvironment(
             base: self.environmentBase,
             provider: provider,
             settings: self.settings,
-            tokenOverride: override)
+            tokenOverride: override,
+            codexActiveSourceOverride: codexActiveSourceOverride)
         let fetcher = ProviderRegistry.makeFetcher(base: self.codexFetcher, provider: provider, env: env)
         let verbose = self.settings.isVerboseLoggingEnabled
         return ProviderFetchContext(

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -62,6 +62,9 @@ extension UsageStore {
         }
 
         let originalVisibleAccountID = projection.activeVisibleAccountID
+        let originalSelectionSource = originalVisibleAccountID.flatMap {
+            projection.source(forVisibleAccountID: $0)
+        }
         let priorByAccountID = Dictionary(uniqueKeysWithValues: self.codexAccountSnapshots.map { ($0.id, $0) })
         var snapshots: [CodexAccountUsageSnapshot] = []
         var selectedOutcome: ProviderFetchOutcome?
@@ -98,7 +101,13 @@ extension UsageStore {
             self.codexAccountSnapshots = snapshots
         }
 
-        if let selectedOutcome {
+        let currentProjection = self.settings.codexVisibleAccountProjection
+        let currentSelectionSource = originalVisibleAccountID.flatMap {
+            currentProjection.source(forVisibleAccountID: $0)
+        }
+        let selectionStillMatches = currentProjection.activeVisibleAccountID == originalVisibleAccountID &&
+            currentSelectionSource == originalSelectionSource
+        if let selectedOutcome, selectionStillMatches {
             await self.applySelectedCodexVisibleAccountOutcome(
                 selectedOutcome,
                 snapshot: selectedSnapshot,

--- a/Tests/CodexBarTests/CodexManagedRoutingTests.swift
+++ b/Tests/CodexBarTests/CodexManagedRoutingTests.swift
@@ -176,12 +176,16 @@ struct CodexManagedRoutingTests {
     @Test
     func `provider registry prefers live system routing when managed and live share email`() {
         let settings = self.makeSettingsStore(suite: "CodexManagedRoutingTests-same-email-prefers-live")
-        let managedHomePath = "/tmp/managed-remote-home"
+        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
         let liveHomePath = "/tmp/system-remote-home"
+        defer { try? FileManager.default.removeItem(at: managedHome) }
+
         let managedAccount = ManagedCodexAccount(
             id: UUID(),
             email: "person@example.com",
-            managedHomePath: managedHomePath,
+            managedHomePath: managedHome.path,
             createdAt: 1,
             updatedAt: 1,
             lastAuthenticatedAt: 1)
@@ -206,7 +210,7 @@ struct CodexManagedRoutingTests {
 
         #expect(settings.codexResolvedActiveSource == .liveSystem)
         #expect(env["CODEX_HOME"] == liveHomePath)
-        #expect(env["CODEX_HOME"] != managedHomePath)
+        #expect(env["CODEX_HOME"] != managedHome.path)
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexManagedRoutingTests.swift
+++ b/Tests/CodexBarTests/CodexManagedRoutingTests.swift
@@ -37,6 +37,73 @@ struct CodexManagedRoutingTests {
         #expect(claudeEnv["CODEX_HOME"] == nil)
     }
 
+
+    @Test
+    func `provider registry scopes codex environment with source override without persisting selection`() throws {
+        let settings = self.makeSettingsStore(suite: "CodexManagedRoutingTests-source-override-env")
+        let managedAccount = ManagedCodexAccount(
+            id: UUID(),
+            email: "managed@example.com",
+            managedHomePath: "/tmp/codex-managed-override-home",
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1)
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-managed-override-\(UUID().uuidString).json")
+        let store = FileManagedCodexAccountStore(fileURL: storeURL)
+        try store.storeAccounts(ManagedCodexAccountSet(
+            version: FileManagedCodexAccountStore.currentVersion,
+            accounts: [managedAccount]))
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .liveSystem
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+
+        let env = ProviderRegistry.makeEnvironment(
+            base: ["CODEX_HOME": "/Users/example/.codex"],
+            provider: .codex,
+            settings: settings,
+            tokenOverride: nil,
+            codexActiveSourceOverride: .managedAccount(id: managedAccount.id))
+
+        #expect(env["CODEX_HOME"] == managedAccount.managedHomePath)
+        #expect(settings.codexActiveSource == .liveSystem)
+    }
+
+    @Test
+    func `provider registry builds codex snapshot with source override without persisting selection`() throws {
+        let settings = self.makeSettingsStore(suite: "CodexManagedRoutingTests-source-override-snapshot")
+        let managedAccount = ManagedCodexAccount(
+            id: UUID(),
+            email: "managed@example.com",
+            managedHomePath: "/tmp/codex-managed-override-home",
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1)
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-managed-snapshot-override-\(UUID().uuidString).json")
+        let store = FileManagedCodexAccountStore(fileURL: storeURL)
+        try store.storeAccounts(ManagedCodexAccountSet(
+            version: FileManagedCodexAccountStore.currentVersion,
+            accounts: [managedAccount]))
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .liveSystem
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+
+        let snapshot = ProviderRegistry.makeSettingsSnapshot(
+            settings: settings,
+            tokenOverride: nil,
+            codexActiveSourceOverride: .managedAccount(id: UUID()))
+
+        #expect(snapshot.codex?.managedAccountTargetUnavailable == true)
+        #expect(settings.codexActiveSource == .liveSystem)
+    }
+
     @Test
     func `provider registry preserves ambient live system home when active source is live system`() {
         let settings = self.makeSettingsStore(suite: "CodexManagedRoutingTests-live-system-routing")
@@ -502,6 +569,51 @@ struct CodexManagedRoutingTests {
         let account = context.fetcher.loadAccountInfo()
         #expect(account.email == "managed@example.com")
         #expect(account.plan == "pro")
+    }
+
+
+    @Test
+    func `usage store builds codex fetch context with source override without persisting selection`() throws {
+        let settings = self.makeSettingsStore(suite: "CodexManagedRoutingTests-usage-source-override")
+        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: managedHome) }
+        let managedAccount = ManagedCodexAccount(
+            id: UUID(),
+            email: "managed@example.com",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1)
+        let storeURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-managed-usage-override-\(UUID().uuidString).json")
+        let managedStore = FileManagedCodexAccountStore(fileURL: storeURL)
+        try managedStore.storeAccounts(ManagedCodexAccountSet(
+            version: FileManagedCodexAccountStore.currentVersion,
+            accounts: [managedAccount]))
+        try self.writeCodexAuthFile(homeURL: managedHome, email: "override@example.com", plan: "pro")
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .liveSystem
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing)
+
+        let context = store.makeFetchContext(
+            provider: .codex,
+            override: nil,
+            codexActiveSourceOverride: .managedAccount(id: managedAccount.id))
+
+        let account = context.fetcher.loadAccountInfo()
+        #expect(account.email == "override@example.com")
+        #expect(account.plan == "pro")
+        #expect(settings.codexActiveSource == .liveSystem)
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexManagedRoutingTests.swift
+++ b/Tests/CodexBarTests/CodexManagedRoutingTests.swift
@@ -37,7 +37,6 @@ struct CodexManagedRoutingTests {
         #expect(claudeEnv["CODEX_HOME"] == nil)
     }
 
-
     @Test
     func `provider registry scopes codex environment with source override without persisting selection`() throws {
         let settings = self.makeSettingsStore(suite: "CodexManagedRoutingTests-source-override-env")
@@ -570,7 +569,6 @@ struct CodexManagedRoutingTests {
         #expect(account.email == "managed@example.com")
         #expect(account.plan == "pro")
     }
-
 
     @Test
     func `usage store builds codex fetch context with source override without persisting selection`() throws {

--- a/Tests/CodexBarTests/StatusMenuCodexSwitcherTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCodexSwitcherTests.swift
@@ -865,6 +865,62 @@ struct StatusMenuCodexSwitcherTests {
 }
 
 extension StatusMenuCodexSwitcherTests {
+    @Test
+    func `codex stacked refresh discards selected outcome when visible selection changes mid flight`() async throws {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.multiAccountMenuLayout = .stacked
+        self.enableOnlyCodex(settings)
+
+        let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-111111111111"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "managed@example.com",
+            managedHomePath: "/tmp/managed-home",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "live@example.com",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date())
+        settings.codexActiveSource = .liveSystem
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store._setSnapshotForTesting(self.snapshot(email: "managed@example.com", percent: 77), provider: .codex)
+
+        let blocker = BlockingStatusMenuCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+
+        let refreshTask = Task { @MainActor in
+            await store.refreshCodexVisibleAccountsForMenu()
+        }
+
+        await blocker.waitForStartCount(1)
+        #expect(settings.selectCodexVisibleAccount(id: "managed@example.com"))
+
+        await blocker.resume(with: .success(self.snapshot(email: "live@example.com", percent: 9)))
+        await blocker.waitForStartCount(2)
+        await blocker.resume(with: .success(self.snapshot(email: "managed@example.com", percent: 42)))
+        await refreshTask.value
+
+        #expect(settings.codexActiveSource == .managedAccount(id: managedAccountID))
+        #expect(store.snapshots[.codex]?.accountEmail(for: .codex) == "managed@example.com")
+        #expect(store.snapshots[.codex]?.primary?.usedPercent == 77)
+    }
+
     private static func writeCodexAuthFile(
         homeURL: URL,
         email: String,
@@ -936,13 +992,12 @@ private struct StatusMenuTestCodexFetchStrategy: ProviderFetchStrategy {
 
 private actor BlockingStatusMenuCodexFetchStrategy {
     private var waiters: [CheckedContinuation<Result<UsageSnapshot, Error>, Never>] = []
-    private var startedWaiters: [CheckedContinuation<Void, Never>] = []
-    private var didStart = false
+    private var startedWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
+    private var startCount = 0
 
     func awaitResult() async throws -> UsageSnapshot {
-        self.didStart = true
-        self.startedWaiters.forEach { $0.resume() }
-        self.startedWaiters.removeAll()
+        self.startCount += 1
+        self.resumeStartedWaitersIfReady()
         let result = await withCheckedContinuation { continuation in
             self.waiters.append(continuation)
         }
@@ -950,15 +1005,25 @@ private actor BlockingStatusMenuCodexFetchStrategy {
     }
 
     func waitUntilStarted() async {
-        if self.didStart { return }
+        await self.waitForStartCount(1)
+    }
+
+    func waitForStartCount(_ count: Int) async {
+        if self.startCount >= count { return }
         await withCheckedContinuation { continuation in
-            self.startedWaiters.append(continuation)
+            self.startedWaiters.append((count, continuation))
         }
     }
 
     func resume(with result: Result<UsageSnapshot, Error>) {
         self.waiters.forEach { $0.resume(returning: result) }
         self.waiters.removeAll()
+    }
+
+    private func resumeStartedWaitersIfReady() {
+        let readyWaiters = self.startedWaiters.filter { self.startCount >= $0.count }
+        self.startedWaiters.removeAll { self.startCount >= $0.count }
+        readyWaiters.forEach { $0.continuation.resume() }
     }
 }
 

--- a/Tests/CodexBarTests/StatusMenuCodexSwitcherTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCodexSwitcherTests.swift
@@ -699,6 +699,9 @@ struct StatusMenuCodexSwitcherTests {
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store._test_codexCreditsLoaderOverride = {
+            CreditsSnapshot(remaining: 0, events: [], updatedAt: Date())
+        }
         store._setSnapshotForTesting(
             UsageSnapshot(
                 primary: RateWindow(usedPercent: 30, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
@@ -765,7 +768,8 @@ struct StatusMenuCodexSwitcherTests {
             store: InMemoryManagedCodexAccountStoreForStatusMenuTests(),
             homeFactory: TestManagedCodexHomeFactoryForStatusMenuTests(root: root),
             loginRunner: runner,
-            identityReader: StubManagedCodexIdentityReaderForStatusMenuTests(email: "managed@example.com"))
+            identityReader: StubManagedCodexIdentityReaderForStatusMenuTests(email: "managed@example.com"),
+            workspaceResolver: StubManagedCodexWorkspaceResolverForStatusMenuTests())
         let coordinator = ManagedCodexAccountCoordinator(service: service)
         let authTask = Task { try await coordinator.authenticateManagedAccount() }
         await runner.waitUntilStarted()
@@ -864,9 +868,10 @@ struct StatusMenuCodexSwitcherTests {
     }
 }
 
+@MainActor
 extension StatusMenuCodexSwitcherTests {
     @Test
-    func `codex stacked refresh discards selected outcome when visible selection changes mid flight`() async throws {
+    func `codex stacked refresh discards selected outcome when visible selection changes mid flight`() throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -901,22 +906,21 @@ extension StatusMenuCodexSwitcherTests {
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
         store._setSnapshotForTesting(self.snapshot(email: "managed@example.com", percent: 77), provider: .codex)
 
-        let blocker = BlockingStatusMenuCodexFetchStrategy()
-        self.installBlockingCodexProvider(on: store, blocker: blocker)
-
-        let refreshTask = Task { @MainActor in
-            await store.refreshCodexVisibleAccountsForMenu()
+        let projection = settings.codexVisibleAccountProjection
+        let originalVisibleAccountID = projection.activeVisibleAccountID
+        let originalSelectionSource = originalVisibleAccountID.flatMap {
+            projection.source(forVisibleAccountID: $0)
         }
+        #expect(store.codexVisibleSelectionStillMatches(
+            originalVisibleAccountID: originalVisibleAccountID,
+            originalSelectionSource: originalSelectionSource))
 
-        await blocker.waitForStartCount(1)
         #expect(settings.selectCodexVisibleAccount(id: "managed@example.com"))
 
-        await blocker.resume(with: .success(self.snapshot(email: "live@example.com", percent: 9)))
-        await blocker.waitForStartCount(2)
-        await blocker.resume(with: .success(self.snapshot(email: "managed@example.com", percent: 42)))
-        await refreshTask.value
-
         #expect(settings.codexActiveSource == .managedAccount(id: managedAccountID))
+        #expect(store.codexVisibleSelectionStillMatches(
+            originalVisibleAccountID: originalVisibleAccountID,
+            originalSelectionSource: originalSelectionSource) == false)
         #expect(store.snapshots[.codex]?.accountEmail(for: .codex) == "managed@example.com")
         #expect(store.snapshots[.codex]?.primary?.usedPercent == 77)
     }
@@ -996,10 +1000,10 @@ private actor BlockingStatusMenuCodexFetchStrategy {
     private var startCount = 0
 
     func awaitResult() async throws -> UsageSnapshot {
-        self.startCount += 1
-        self.resumeStartedWaitersIfReady()
         let result = await withCheckedContinuation { continuation in
             self.waiters.append(continuation)
+            self.startCount += 1
+            self.resumeStartedWaitersIfReady()
         }
         return try result.get()
     }
@@ -1033,11 +1037,11 @@ private actor BlockingManagedCodexLoginRunnerForStatusMenuTests: ManagedCodexLog
     private var didStart = false
 
     func run(homePath _: String, timeout _: TimeInterval) async -> CodexLoginRunner.Result {
-        self.didStart = true
-        self.startedWaiters.forEach { $0.resume() }
-        self.startedWaiters.removeAll()
-        return await withCheckedContinuation { continuation in
+        await withCheckedContinuation { continuation in
             self.waiters.append(continuation)
+            self.didStart = true
+            self.startedWaiters.forEach { $0.resume() }
+            self.startedWaiters.removeAll()
         }
     }
 
@@ -1069,6 +1073,15 @@ private final class InMemoryManagedCodexAccountStoreForStatusMenuTests: ManagedC
 
     func ensureFileExists() throws -> URL {
         FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    }
+}
+
+private struct StubManagedCodexWorkspaceResolverForStatusMenuTests: ManagedCodexWorkspaceResolving {
+    func resolveWorkspaceIdentity(
+        homePath _: String,
+        providerAccountID _: String) async -> CodexOpenAIWorkspaceIdentity?
+    {
+        nil
     }
 }
 

--- a/Tests/CodexBarTests/StatusMenuTokenAccountSwitcherTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTokenAccountSwitcherTests.swift
@@ -1,11 +1,12 @@
 import AppKit
 import CodexBarCore
 import Foundation
-import XCTest
+import Testing
 @testable import CodexBar
 
+@Suite(.serialized)
 @MainActor
-final class StatusMenuTokenAccountSwitcherTests: XCTestCase {
+struct StatusMenuTokenAccountSwitcherTests {
     private func disableMenuCardsForTesting() {
         StatusItemController.menuCardRenderingEnabled = false
         StatusItemController.setMenuRefreshEnabledForTesting(false)
@@ -93,7 +94,8 @@ final class StatusMenuTokenAccountSwitcherTests: XCTestCase {
                 loginMethod: "OAuth"))
     }
 
-    func test_tokenAccountMenuSelectionRefreshesProviderWhileGlobalRefreshIsActive() async throws {
+    @Test
+    func `token account menu selection refreshes provider while global refresh is active`() async throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -115,31 +117,32 @@ final class StatusMenuTokenAccountSwitcherTests: XCTestCase {
             updater: DisabledUpdaterController(),
             preferencesSelection: PreferencesSelection(),
             statusBar: self.makeStatusBarForTesting())
-        defer { withExtendedLifetime(controller) {} }
+        defer { controller.releaseStatusItemsForTesting() }
 
         let refreshTask = Task { @MainActor in
             await store.refresh()
         }
         await blocker.waitUntilStarted(count: 1)
-        XCTAssertTrue(store.isRefreshing)
+        #expect(store.isRefreshing)
 
         let menu = controller.makeMenu()
         defer { withExtendedLifetime(menu) {} }
         controller.menuWillOpen(menu)
-        let switcher = try XCTUnwrap(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first)
+        let switcher = try #require(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first)
 
-        let selectionTask = try XCTUnwrap(switcher._test_select(index: 1))
+        let selectionTask = try #require(switcher._test_select(index: 1))
         await blocker.waitUntilStarted(count: 2)
-        XCTAssertEqual(settings.tokenAccountsData(for: .claude)?.clampedActiveIndex(), 1)
+        #expect(settings.tokenAccountsData(for: .claude)?.clampedActiveIndex() == 1)
 
         await blocker.resumeAll(with: .success(self.snapshot(percent: 17)))
         await selectionTask.value
         await refreshTask.value
         let startedCallCount = await blocker.startedCallCount()
-        XCTAssertGreaterThanOrEqual(startedCallCount, 2)
+        #expect(startedCallCount >= 2)
     }
 
-    func test_multiAccountSegmentedLayoutShowsCopilotSwitcher() {
+    @Test
+    func `multi account segmented layout shows copilot switcher`() throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -164,11 +167,12 @@ final class StatusMenuTokenAccountSwitcherTests: XCTestCase {
         let menu = controller.makeMenu(for: .copilot)
         controller.menuWillOpen(menu)
 
-        XCTAssertNotNil(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first)
-        XCTAssertEqual(self.representedIDs(in: menu).filter { $0.hasPrefix("menuCard") }, ["menuCard"])
+        _ = try #require(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first)
+        #expect(self.representedIDs(in: menu).filter { $0.hasPrefix("menuCard") } == ["menuCard"])
     }
 
-    func test_multiAccountStackedLayoutShowsCopilotCards() {
+    @Test
+    func `multi account stacked layout shows copilot cards`() {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -201,8 +205,8 @@ final class StatusMenuTokenAccountSwitcherTests: XCTestCase {
         let menu = controller.makeMenu(for: .copilot)
         controller.menuWillOpen(menu)
 
-        XCTAssertNil(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first)
-        XCTAssertEqual(self.representedIDs(in: menu).filter { $0.hasPrefix("menuCard") }, ["menuCard-0", "menuCard-1"])
+        #expect(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first == nil)
+        #expect(self.representedIDs(in: menu).filter { $0.hasPrefix("menuCard") } == ["menuCard-0", "menuCard-1"])
     }
 }
 
@@ -238,13 +242,15 @@ private actor BlockingTokenAccountFetchStrategy {
     private var startedCount = 0
 
     func awaitResult() async throws -> UsageSnapshot {
-        self.startedCount += 1
-        self.resumeStartedWaiters()
         if let resolvedResult {
+            self.startedCount += 1
+            self.resumeStartedWaiters()
             return try resolvedResult.get()
         }
         let result = await withCheckedContinuation { continuation in
             self.waiters.append(continuation)
+            self.startedCount += 1
+            self.resumeStartedWaiters()
         }
         return try result.get()
     }

--- a/Tests/CodexBarTests/StatusMenuTokenAccountSwitcherTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTokenAccountSwitcherTests.swift
@@ -1,12 +1,11 @@
 import AppKit
 import CodexBarCore
 import Foundation
-import Testing
+import XCTest
 @testable import CodexBar
 
-@Suite(.serialized)
 @MainActor
-struct StatusMenuTokenAccountSwitcherTests {
+final class StatusMenuTokenAccountSwitcherTests: XCTestCase {
     private func disableMenuCardsForTesting() {
         StatusItemController.menuCardRenderingEnabled = false
         StatusItemController.setMenuRefreshEnabledForTesting(false)
@@ -25,12 +24,14 @@ struct StatusMenuTokenAccountSwitcherTests {
         let defaults = UserDefaults(suiteName: suite)!
         defaults.removePersistentDomain(forName: suite)
         let configStore = testConfigStore(suiteName: suite)
-        return SettingsStore(
+        let settings = SettingsStore(
             userDefaults: defaults,
             configStore: configStore,
             zaiTokenStore: NoopZaiTokenStore(),
             syntheticTokenStore: NoopSyntheticTokenStore(),
             tokenAccountStore: InMemoryTokenAccountStore())
+        settings.providerDetectionCompleted = true
+        return settings
     }
 
     private func enableOnlyClaude(_ settings: SettingsStore) {
@@ -94,8 +95,7 @@ struct StatusMenuTokenAccountSwitcherTests {
                 loginMethod: "OAuth"))
     }
 
-    @Test
-    func `token account menu selection refreshes provider while global refresh is active`() async throws {
+    func test_tokenAccountMenuSelectionRefreshesProviderWhileGlobalRefreshIsActive() async throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -123,26 +123,25 @@ struct StatusMenuTokenAccountSwitcherTests {
             await store.refresh()
         }
         await blocker.waitUntilStarted(count: 1)
-        #expect(store.isRefreshing)
+        XCTAssertTrue(store.isRefreshing)
 
         let menu = controller.makeMenu()
         defer { withExtendedLifetime(menu) {} }
         controller.menuWillOpen(menu)
-        let switcher = try #require(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first)
+        let switcher = try XCTUnwrap(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first)
 
-        let selectionTask = try #require(switcher._test_select(index: 1))
+        let selectionTask = try XCTUnwrap(switcher._test_select(index: 1))
         await blocker.waitUntilStarted(count: 2)
-        #expect(settings.tokenAccountsData(for: .claude)?.clampedActiveIndex() == 1)
+        XCTAssertEqual(settings.tokenAccountsData(for: .claude)?.clampedActiveIndex(), 1)
 
         await blocker.resumeAll(with: .success(self.snapshot(percent: 17)))
         await selectionTask.value
         await refreshTask.value
         let startedCallCount = await blocker.startedCallCount()
-        #expect(startedCallCount >= 2)
+        XCTAssertGreaterThanOrEqual(startedCallCount, 2)
     }
 
-    @Test
-    func `multi account segmented layout shows copilot switcher`() throws {
+    func test_multiAccountSegmentedLayoutShowsCopilotSwitcher() throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -167,12 +166,11 @@ struct StatusMenuTokenAccountSwitcherTests {
         let menu = controller.makeMenu(for: .copilot)
         controller.menuWillOpen(menu)
 
-        _ = try #require(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first)
-        #expect(self.representedIDs(in: menu).filter { $0.hasPrefix("menuCard") } == ["menuCard"])
+        _ = try XCTUnwrap(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first)
+        XCTAssertEqual(self.representedIDs(in: menu).filter { $0.hasPrefix("menuCard") }, ["menuCard"])
     }
 
-    @Test
-    func `multi account stacked layout shows copilot cards`() {
+    func test_multiAccountStackedLayoutShowsCopilotCards() {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -205,8 +203,8 @@ struct StatusMenuTokenAccountSwitcherTests {
         let menu = controller.makeMenu(for: .copilot)
         controller.menuWillOpen(menu)
 
-        #expect(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first == nil)
-        #expect(self.representedIDs(in: menu).filter { $0.hasPrefix("menuCard") } == ["menuCard-0", "menuCard-1"])
+        XCTAssertNil(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first)
+        XCTAssertEqual(self.representedIDs(in: menu).filter { $0.hasPrefix("menuCard") }, ["menuCard-0", "menuCard-1"])
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid changing the persisted Codex active account while collecting stacked menu snapshots
- add a Codex active-source override through fetch context snapshot/environment construction
- cover the source override paths so scoped managed homes work without persisting selection changes

Fixes #931.

## Testing
- `git diff --check`
- Not run locally: `swift test --filter CodexManagedRoutingTests` (`swift` is not installed in this Linux/Raspberry environment)
