### PR TITLE
Add Antigravity account switching

### DIFF
--- a/Sources/CodexBar/ProviderRegistry.swift
+++ b/Sources/CodexBar/ProviderRegistry.swift
@@ -37,6 +37,10 @@ struct ProviderRegistry {
                 isEnabled: { settings.isProviderEnabled(provider: provider, metadata: meta) },
                 descriptor: descriptor,
                 makeFetchContext: {
+                    let account = ProviderTokenAccountSelection.selectedAccount(
+                        provider: provider,
+                        settings: settings,
+                        override: nil)
                     let sourceMode = ProviderCatalog.implementation(for: provider)?
                         .sourceMode(context: ProviderSourceModeContext(provider: provider, settings: settings))
                         ?? .auto
@@ -59,7 +63,16 @@ struct ProviderRegistry {
                         settings: snapshot,
                         fetcher: fetcher,
                         claudeFetcher: claudeFetcher,
-                        browserDetection: browserDetection)
+                        browserDetection: browserDetection,
+                        selectedTokenAccountID: account?.id,
+                        tokenAccountTokenUpdater: { provider, accountID, token in
+                            await MainActor.run {
+                                settings.updateTokenAccount(
+                                    provider: provider,
+                                    accountID: accountID,
+                                    token: token)
+                            }
+                        })
                 })
             specs[provider] = spec
         }

--- a/Sources/CodexBar/Providers/Antigravity/AntigravityLoginFlow.swift
+++ b/Sources/CodexBar/Providers/Antigravity/AntigravityLoginFlow.swift
@@ -14,6 +14,9 @@ extension StatusItemController {
         }
         let result = await AntigravityLoginRunner.run(onPhaseChange: phaseHandler) {
             Task { @MainActor in
+                if let credentials = try? AntigravityOAuthCredentialsStore().load() {
+                    self.store.settings.upsertAntigravityOAuthAccount(credentials)
+                }
                 await store.refresh()
                 CodexBarLog.logger(LogCategories.login).info("Auto-refreshed after Antigravity auth")
             }

--- a/Sources/CodexBar/Providers/Antigravity/AntigravityLoginRunner.swift
+++ b/Sources/CodexBar/Providers/Antigravity/AntigravityLoginRunner.swift
@@ -109,7 +109,7 @@ enum AntigravityLoginRunner {
         }
     }
 
-    private static func makeAuthorizationURL(
+    static func makeAuthorizationURL(
         redirectURL: URL,
         state: String,
         oauthClient: AntigravityOAuthClient) throws -> URL
@@ -123,7 +123,7 @@ enum AntigravityLoginRunner {
             URLQueryItem(name: "response_type", value: "code"),
             URLQueryItem(name: "scope", value: AntigravityOAuthConfig.scopes.joined(separator: " ")),
             URLQueryItem(name: "access_type", value: "offline"),
-            URLQueryItem(name: "prompt", value: "consent"),
+            URLQueryItem(name: "prompt", value: "select_account consent"),
             URLQueryItem(name: "state", value: state),
         ]
         guard let url = components.url else {

--- a/Sources/CodexBar/Providers/Antigravity/AntigravityProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Antigravity/AntigravityProviderImplementation.swift
@@ -11,6 +11,7 @@ struct AntigravityProviderImplementation: ProviderImplementation {
     @MainActor
     func observeSettings(_ settings: SettingsStore) {
         _ = settings.antigravityUsageDataSource
+        _ = settings.tokenAccountsData(for: .antigravity)
     }
 
     @MainActor
@@ -56,11 +57,10 @@ struct AntigravityProviderImplementation: ProviderImplementation {
 
     @MainActor
     func settingsActions(context: ProviderSettingsContext) -> [ProviderSettingsActionsDescriptor] {
-        let credentialsPath = AntigravityOAuthCredentialsStore().fileURL.path
-        let credentialsExist = FileManager.default.fileExists(atPath: credentialsPath)
-        let loginTitle = credentialsExist ? "Re-authenticate" : "Login with Google"
+        let accountCount = context.settings.tokenAccounts(for: .antigravity).count
+        let loginTitle = accountCount > 0 ? "Add Google Account" : "Login with Google"
         let subtitle = """
-        Stores credentials in ~/.codexbar/antigravity/oauth_creds.json. Uses Antigravity.app OAuth when available, \
+        Stores each signed-in Google account for quick Antigravity switching. Uses Antigravity.app OAuth when available, \
         or ANTIGRAVITY_OAUTH_CLIENT_ID and ANTIGRAVITY_OAUTH_CLIENT_SECRET as an override.
         """
         return [
@@ -88,6 +88,11 @@ struct AntigravityProviderImplementation: ProviderImplementation {
 
     @MainActor
     func appendUsageMenuEntries(context _: ProviderMenuUsageContext, entries _: inout [ProviderMenuEntry]) {}
+
+    @MainActor
+    func loginMenuAction(context _: ProviderMenuLoginContext) -> (label: String, action: MenuDescriptor.MenuAction)? {
+        ("Add Account...", .switchAccount(.antigravity))
+    }
 
     @MainActor
     func runLoginFlow(context: ProviderLoginContext) async -> Bool {

--- a/Sources/CodexBar/Providers/Antigravity/AntigravityProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Antigravity/AntigravityProviderImplementation.swift
@@ -60,7 +60,8 @@ struct AntigravityProviderImplementation: ProviderImplementation {
         let accountCount = context.settings.tokenAccounts(for: .antigravity).count
         let loginTitle = accountCount > 0 ? "Add Google Account" : "Login with Google"
         let subtitle = """
-        Stores each signed-in Google account for quick Antigravity switching. Uses Antigravity.app OAuth when available, \
+        Stores each signed-in Google account for quick Antigravity switching. \
+        Uses Antigravity.app OAuth when available, \
         or ANTIGRAVITY_OAUTH_CLIENT_ID and ANTIGRAVITY_OAUTH_CLIENT_SECRET as an override.
         """
         return [

--- a/Sources/CodexBar/Providers/Antigravity/AntigravitySettingsStore.swift
+++ b/Sources/CodexBar/Providers/Antigravity/AntigravitySettingsStore.swift
@@ -22,12 +22,14 @@ extension SettingsStore {
 
     func upsertAntigravityOAuthAccount(_ credentials: AntigravityOAuthCredentials) {
         guard let token = try? AntigravityOAuthCredentialsStore.tokenAccountValue(for: credentials) else { return }
-        let email = credentials.email?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let label = (email?.isEmpty == false) ? email! : "Google Account"
+        let trimmedEmail = credentials.email?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let email = (trimmedEmail?.isEmpty == false) ? trimmedEmail : nil
         let data = self.tokenAccountsData(for: .antigravity)
-        if let data,
+        let label = email ?? "Google Account \((data?.accounts.count ?? 0) + 1)"
+        if let email,
+           let data,
            let index = data.accounts.firstIndex(where: { account in
-               account.externalIdentifier == email || account.label == label
+               account.externalIdentifier == email
            })
         {
             let account = data.accounts[index]
@@ -36,8 +38,7 @@ extension SettingsStore {
                 accountID: account.id,
                 label: label,
                 token: token,
-                externalIdentifier: .some(email),
-                organizationID: .some(nil))
+                externalIdentifier: .some(email))
             self.setActiveTokenAccountIndex(index, for: .antigravity)
         } else {
             self.addTokenAccount(

--- a/Sources/CodexBar/Providers/Antigravity/AntigravitySettingsStore.swift
+++ b/Sources/CodexBar/Providers/Antigravity/AntigravitySettingsStore.swift
@@ -19,6 +19,34 @@ extension SettingsStore {
             self.logProviderModeChange(provider: .antigravity, field: "usageSource", value: newValue.rawValue)
         }
     }
+
+    func upsertAntigravityOAuthAccount(_ credentials: AntigravityOAuthCredentials) {
+        guard let token = try? AntigravityOAuthCredentialsStore.tokenAccountValue(for: credentials) else { return }
+        let email = credentials.email?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let label = (email?.isEmpty == false) ? email! : "Google Account"
+        let data = self.tokenAccountsData(for: .antigravity)
+        if let data,
+           let index = data.accounts.firstIndex(where: { account in
+               account.externalIdentifier == email || account.label == label
+           })
+        {
+            let account = data.accounts[index]
+            self.updateTokenAccount(
+                provider: .antigravity,
+                accountID: account.id,
+                label: label,
+                token: token,
+                externalIdentifier: .some(email),
+                organizationID: .some(nil))
+            self.setActiveTokenAccountIndex(index, for: .antigravity)
+        } else {
+            self.addTokenAccount(
+                provider: .antigravity,
+                label: label,
+                token: token,
+                externalIdentifier: email)
+        }
+    }
 }
 
 extension SettingsStore {

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -265,6 +265,10 @@ extension UsageStore {
         override: TokenAccountOverride?,
         codexActiveSourceOverride: CodexActiveSource? = nil) -> ProviderFetchContext
     {
+        let account = ProviderTokenAccountSelection.selectedAccount(
+            provider: provider,
+            settings: self.settings,
+            override: override)
         let sourceMode = self.sourceMode(for: provider)
         let snapshot = ProviderRegistry.makeSettingsSnapshot(
             settings: self.settings,
@@ -289,7 +293,16 @@ extension UsageStore {
             settings: snapshot,
             fetcher: fetcher,
             claudeFetcher: self.claudeFetcher,
-            browserDetection: self.browserDetection)
+            browserDetection: self.browserDetection,
+            selectedTokenAccountID: account?.id,
+            tokenAccountTokenUpdater: { [weak settings = self.settings] provider, accountID, token in
+                await MainActor.run {
+                    settings?.updateTokenAccount(
+                        provider: provider,
+                        accountID: accountID,
+                        token: token)
+                }
+            })
     }
 
     func sourceMode(for provider: UsageProvider) -> ProviderSourceMode {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
@@ -208,6 +208,8 @@ public enum AntigravityOAuthConfig {
 }
 
 public struct AntigravityOAuthCredentialsStore: @unchecked Sendable {
+    public static let environmentCredentialsKey = "ANTIGRAVITY_OAUTH_CREDENTIALS_JSON"
+
     public let fileURL: URL
     private let fileManager: FileManager
 
@@ -246,6 +248,17 @@ public struct AntigravityOAuthCredentialsStore: @unchecked Sendable {
     public static func defaultURL(home: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
         self.defaultDirectoryURL(home: home)
             .appendingPathComponent("oauth_creds.json")
+    }
+
+    public static func tokenAccountValue(for credentials: AntigravityOAuthCredentials) throws -> String {
+        let data = try JSONEncoder.antigravityCredentials.encode(credentials)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    public static func credentials(fromTokenAccountValue value: String) -> AntigravityOAuthCredentials? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, let data = trimmed.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(AntigravityOAuthCredentials.self, from: data)
     }
 
     private func applySecurePermissionsIfNeeded() throws {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
@@ -252,7 +252,10 @@ public struct AntigravityOAuthCredentialsStore: @unchecked Sendable {
 
     public static func tokenAccountValue(for credentials: AntigravityOAuthCredentials) throws -> String {
         let data = try JSONEncoder.antigravityCredentials.encode(credentials)
-        return String(decoding: data, as: UTF8.self)
+        guard let value = String(data: data, encoding: .utf8) else {
+            throw CocoaError(.coderInvalidValue)
+        }
+        return value
     }
 
     public static func credentials(fromTokenAccountValue value: String) -> AntigravityOAuthCredentials? {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -87,8 +87,8 @@ struct AntigravityOAuthFetchStrategy: ProviderFetchStrategy {
         true
     }
 
-    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
-        let fetcher = AntigravityRemoteUsageFetcher()
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        let fetcher = AntigravityRemoteUsageFetcher(environment: context.env)
         let snapshot = try await fetcher.fetch()
         let usage = if snapshot.modelQuotas.isEmpty {
             UsageSnapshot(

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -88,7 +88,17 @@ struct AntigravityOAuthFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        let fetcher = AntigravityRemoteUsageFetcher(environment: context.env)
+        let fetcher = AntigravityRemoteUsageFetcher(
+            environment: context.env,
+            credentialsUpdateHandler: { credentials in
+                guard let accountID = context.selectedTokenAccountID,
+                      let updater = context.tokenAccountTokenUpdater
+                else {
+                    return
+                }
+                let token = try AntigravityOAuthCredentialsStore.tokenAccountValue(for: credentials)
+                await updater(.antigravity, accountID, token)
+            })
         let snapshot = try await fetcher.fetch()
         let usage = if snapshot.modelQuotas.isEmpty {
             UsageSnapshot(

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityRemoteUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityRemoteUsageFetcher.swift
@@ -26,6 +26,7 @@ public enum AntigravityRemoteFetchError: LocalizedError, Sendable, Equatable {
 public struct AntigravityRemoteUsageFetcher: Sendable {
     public var timeout: TimeInterval = 10.0
     public var homeDirectory: String
+    public var environment: [String: String]
     public var dataLoader: @Sendable (URLRequest) async throws -> (Data, URLResponse)
     public var oauthClientResolver: @Sendable () -> AntigravityOAuthClient?
 
@@ -40,7 +41,7 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
 
     private struct FetchContext {
         let timeout: TimeInterval
-        let store: AntigravityOAuthCredentialsStore
+        let store: AntigravityOAuthCredentialsStore?
         let dataLoader: @Sendable (URLRequest) async throws -> (Data, URLResponse)
         let oauthClientResolver: @Sendable () -> AntigravityOAuthClient?
     }
@@ -48,6 +49,7 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
     public init(
         timeout: TimeInterval = 10.0,
         homeDirectory: String = NSHomeDirectory(),
+        environment: [String: String] = ProcessInfo.processInfo.environment,
         dataLoader: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse) = { request in
             try await URLSession.shared.data(for: request)
         },
@@ -57,20 +59,20 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
     {
         self.timeout = timeout
         self.homeDirectory = homeDirectory
+        self.environment = environment
         self.dataLoader = dataLoader
         self.oauthClientResolver = oauthClientResolver
     }
 
     public func fetch() async throws -> AntigravityStatusSnapshot {
-        let source = try Self.resolveCredentialSource(homeDirectory: self.homeDirectory)
-        let store = source.primaryStore
+        let source = try Self.resolveCredentialSource(homeDirectory: self.homeDirectory, environment: self.environment)
         guard let credentials = source.credentials else {
             throw AntigravityRemoteFetchError.notLoggedIn
         }
         return try await Self.fetchSnapshot(
             using: credentials,
             timeout: self.timeout,
-            store: store,
+            store: source.store,
             dataLoader: self.dataLoader,
             oauthClientResolver: self.oauthClientResolver)
     }
@@ -78,7 +80,7 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
     private static func fetchSnapshot(
         using initialCredentials: AntigravityOAuthCredentials,
         timeout: TimeInterval,
-        store: AntigravityOAuthCredentialsStore,
+        store: AntigravityOAuthCredentialsStore?,
         dataLoader: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse),
         oauthClientResolver: @escaping @Sendable () -> AntigravityOAuthClient?) async throws
         -> AntigravityStatusSnapshot
@@ -98,11 +100,15 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
             guard let refreshToken = credentials.refreshToken?.trimmedNonEmpty else {
                 throw AntigravityRemoteFetchError.notLoggedIn
             }
-            accessToken = try await Self.refreshAccessToken(
+            let refreshed = try await Self.refreshAccessToken(
                 credentials: credentials,
                 refreshToken: refreshToken,
                 context: context)
-            credentials = try store.load() ?? credentials
+            accessToken = refreshed.accessToken
+            credentials = refreshed.credentials
+            if let store {
+                credentials = try store.load() ?? credentials
+            }
             credentials.accessToken = credentials.accessToken?.trimmedNonEmpty ?? accessToken
         }
 
@@ -242,7 +248,9 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
         }
 
         if let projectID = initialResponse.projectID {
-            try? Self.updateStoredProjectID(projectID, store: context.store)
+            if let store = context.store {
+                try? Self.updateStoredProjectID(projectID, store: store)
+            }
             return projectID
         }
 
@@ -267,7 +275,9 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
                 timeout: context.timeout,
                 dataLoader: context.dataLoader)
             if let projectID = onboardResponse.projectID {
-                try? Self.updateStoredProjectID(projectID, store: context.store)
+                if let store = context.store {
+                    try? Self.updateStoredProjectID(projectID, store: store)
+                }
                 return projectID
             }
         } catch {
@@ -283,7 +293,9 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
                 timeout: context.timeout,
                 dataLoader: context.dataLoader)
             if let projectID = refreshed.projectID {
-                try? Self.updateStoredProjectID(projectID, store: context.store)
+                if let store = context.store {
+                    try? Self.updateStoredProjectID(projectID, store: store)
+                }
                 return projectID
             }
         }
@@ -439,19 +451,32 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
         return AntigravityOAuthCredentialsStore(fileURL: AntigravityOAuthCredentialsStore.defaultURL(home: homeURL))
     }
 
-    private static func resolveCredentialSource(homeDirectory: String) throws -> (
+    private static func resolveCredentialSource(
+        homeDirectory: String,
+        environment: [String: String]) throws -> (
         credentials: AntigravityOAuthCredentials?,
-        primaryStore: AntigravityOAuthCredentialsStore)
+        store: AntigravityOAuthCredentialsStore?)
     {
         let primaryStore = Self.credentialsStore(homeDirectory: homeDirectory)
+        if let tokenValue = environment[AntigravityOAuthCredentialsStore.environmentCredentialsKey] {
+            guard let credentials = AntigravityOAuthCredentialsStore.credentials(fromTokenAccountValue: tokenValue) else {
+                throw AntigravityRemoteFetchError.parseFailed("Could not decode selected account credentials.")
+            }
+            return (credentials, nil)
+        }
         return try (primaryStore.load(), primaryStore)
+    }
+
+    private struct RefreshResult {
+        let accessToken: String
+        let credentials: AntigravityOAuthCredentials
     }
 
     private static func refreshAccessToken(
         credentials: AntigravityOAuthCredentials,
         refreshToken: String,
         context: FetchContext) async throws
-        -> String
+        -> RefreshResult
     {
         let oauthClient = try Self.refreshOAuthClient(
             from: credentials,
@@ -481,8 +506,11 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
             throw AntigravityRemoteFetchError.parseFailed("Could not parse refresh response")
         }
 
-        try Self.updateStoredCredentials(json, store: context.store)
-        return accessToken
+        let updatedCredentials = Self.updatedCredentials(credentials, refreshResponse: json)
+        if let store = context.store {
+            try store.save(updatedCredentials)
+        }
+        return RefreshResult(accessToken: accessToken, credentials: updatedCredentials)
     }
 
     private static func refreshOAuthClient(
@@ -502,11 +530,11 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
         return client
     }
 
-    private static func updateStoredCredentials(
-        _ refreshResponse: [String: Any],
-        store: AntigravityOAuthCredentialsStore) throws
+    private static func updatedCredentials(
+        _ credentials: AntigravityOAuthCredentials,
+        refreshResponse: [String: Any]) -> AntigravityOAuthCredentials
     {
-        guard var credentials = try store.load() else { return }
+        var credentials = credentials
         if let accessToken = refreshResponse["access_token"] as? String {
             credentials.accessToken = accessToken
         }
@@ -519,7 +547,7 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
         if let idToken = refreshResponse["id_token"] as? String {
             credentials.idToken = idToken
         }
-        try store.save(credentials)
+        return credentials
     }
 
     private static func updateStoredProjectID(_ projectID: String, store: AntigravityOAuthCredentialsStore) throws {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityRemoteUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityRemoteUsageFetcher.swift
@@ -29,6 +29,7 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
     public var environment: [String: String]
     public var dataLoader: @Sendable (URLRequest) async throws -> (Data, URLResponse)
     public var oauthClientResolver: @Sendable () -> AntigravityOAuthClient?
+    public var credentialsUpdateHandler: @Sendable (AntigravityOAuthCredentials) async throws -> Void
 
     private static let log = CodexBarLog.logger(LogCategories.antigravity)
     private static let userAgent = "antigravity"
@@ -44,6 +45,15 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
         let store: AntigravityOAuthCredentialsStore?
         let dataLoader: @Sendable (URLRequest) async throws -> (Data, URLResponse)
         let oauthClientResolver: @Sendable () -> AntigravityOAuthClient?
+        let credentialsUpdateHandler: @Sendable (AntigravityOAuthCredentials) async throws -> Void
+
+        func persistCredentials(_ credentials: AntigravityOAuthCredentials) async throws {
+            if let store {
+                try store.save(credentials)
+            } else {
+                try await self.credentialsUpdateHandler(credentials)
+            }
+        }
     }
 
     public init(
@@ -55,13 +65,15 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
         },
         oauthClientResolver: @escaping @Sendable () -> AntigravityOAuthClient? = {
             AntigravityOAuthConfig.resolvedClient()
-        })
+        },
+        credentialsUpdateHandler: @escaping @Sendable (AntigravityOAuthCredentials) async throws -> Void = { _ in })
     {
         self.timeout = timeout
         self.homeDirectory = homeDirectory
         self.environment = environment
         self.dataLoader = dataLoader
         self.oauthClientResolver = oauthClientResolver
+        self.credentialsUpdateHandler = credentialsUpdateHandler
     }
 
     public func fetch() async throws -> AntigravityStatusSnapshot {
@@ -69,20 +81,14 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
         guard let credentials = source.credentials else {
             throw AntigravityRemoteFetchError.notLoggedIn
         }
-        return try await Self.fetchSnapshot(
+        return try await self.fetchSnapshot(
             using: credentials,
-            timeout: self.timeout,
-            store: source.store,
-            dataLoader: self.dataLoader,
-            oauthClientResolver: self.oauthClientResolver)
+            store: source.store)
     }
 
-    private static func fetchSnapshot(
+    private func fetchSnapshot(
         using initialCredentials: AntigravityOAuthCredentials,
-        timeout: TimeInterval,
-        store: AntigravityOAuthCredentialsStore?,
-        dataLoader: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse),
-        oauthClientResolver: @escaping @Sendable () -> AntigravityOAuthClient?) async throws
+        store: AntigravityOAuthCredentialsStore?) async throws
         -> AntigravityStatusSnapshot
     {
         guard let storedAccessToken = initialCredentials.accessToken?.trimmedNonEmpty else {
@@ -92,10 +98,11 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
         var credentials = initialCredentials
         var accessToken = storedAccessToken
         let context = FetchContext(
-            timeout: timeout,
+            timeout: self.timeout,
             store: store,
-            dataLoader: dataLoader,
-            oauthClientResolver: oauthClientResolver)
+            dataLoader: self.dataLoader,
+            oauthClientResolver: self.oauthClientResolver,
+            credentialsUpdateHandler: self.credentialsUpdateHandler)
         if Self.shouldRefresh(expiryDate: credentials.expiryDate, now: Date()) {
             guard let refreshToken = credentials.refreshToken?.trimmedNonEmpty else {
                 throw AntigravityRemoteFetchError.notLoggedIn
@@ -115,18 +122,26 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
         let claims = Self.extractClaims(from: credentials)
         let codeAssist = try await Self.loadCodeAssist(
             accessToken: accessToken,
-            timeout: timeout,
-            dataLoader: dataLoader)
+            timeout: self.timeout,
+            dataLoader: self.dataLoader)
         let projectId = try await Self.resolveProjectID(
             accessToken: accessToken,
             storedProjectID: credentials.projectID?.trimmedNonEmpty,
             initialResponse: codeAssist,
             context: context)
+        if let projectId, credentials.projectID?.trimmedNonEmpty != projectId {
+            credentials.projectID = projectId
+            do {
+                try await context.persistCredentials(credentials)
+            } catch {
+                Self.log.warning("Could not persist Antigravity project ID: \(error.localizedDescription)")
+            }
+        }
         let models = try await Self.fetchModelQuotas(
             accessToken: accessToken,
             projectId: projectId,
-            timeout: timeout,
-            dataLoader: dataLoader)
+            timeout: self.timeout,
+            dataLoader: self.dataLoader)
 
         return AntigravityStatusSnapshot(
             modelQuotas: models,
@@ -248,9 +263,6 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
         }
 
         if let projectID = initialResponse.projectID {
-            if let store = context.store {
-                try? Self.updateStoredProjectID(projectID, store: store)
-            }
             return projectID
         }
 
@@ -275,9 +287,6 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
                 timeout: context.timeout,
                 dataLoader: context.dataLoader)
             if let projectID = onboardResponse.projectID {
-                if let store = context.store {
-                    try? Self.updateStoredProjectID(projectID, store: store)
-                }
                 return projectID
             }
         } catch {
@@ -293,9 +302,6 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
                 timeout: context.timeout,
                 dataLoader: context.dataLoader)
             if let projectID = refreshed.projectID {
-                if let store = context.store {
-                    try? Self.updateStoredProjectID(projectID, store: store)
-                }
                 return projectID
             }
         }
@@ -459,7 +465,8 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
     {
         let primaryStore = Self.credentialsStore(homeDirectory: homeDirectory)
         if let tokenValue = environment[AntigravityOAuthCredentialsStore.environmentCredentialsKey] {
-            guard let credentials = AntigravityOAuthCredentialsStore.credentials(fromTokenAccountValue: tokenValue) else {
+            guard let credentials = AntigravityOAuthCredentialsStore.credentials(fromTokenAccountValue: tokenValue)
+            else {
                 throw AntigravityRemoteFetchError.parseFailed("Could not decode selected account credentials.")
             }
             return (credentials, nil)
@@ -507,9 +514,7 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
         }
 
         let updatedCredentials = Self.updatedCredentials(credentials, refreshResponse: json)
-        if let store = context.store {
-            try store.save(updatedCredentials)
-        }
+        try await context.persistCredentials(updatedCredentials)
         return RefreshResult(accessToken: accessToken, credentials: updatedCredentials)
     }
 
@@ -548,13 +553,6 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
             credentials.idToken = idToken
         }
         return credentials
-    }
-
-    private static func updateStoredProjectID(_ projectID: String, store: AntigravityOAuthCredentialsStore) throws {
-        guard var credentials = try store.load() else { return }
-        guard credentials.projectID?.trimmedNonEmpty != projectID else { return }
-        credentials.projectID = projectID
-        try store.save(credentials)
     }
 
     private static func formBody(_ values: [String: String]) -> Data? {

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -18,6 +18,8 @@ public enum ProviderSourceMode: String, CaseIterable, Sendable, Codable {
 }
 
 public struct ProviderFetchContext: Sendable {
+    public typealias TokenAccountTokenUpdater = @Sendable (UsageProvider, UUID, String) async -> Void
+
     public let runtime: ProviderRuntime
     public let sourceMode: ProviderSourceMode
     public let includeCredits: Bool
@@ -29,6 +31,8 @@ public struct ProviderFetchContext: Sendable {
     public let fetcher: UsageFetcher
     public let claudeFetcher: any ClaudeUsageFetching
     public let browserDetection: BrowserDetection
+    public let selectedTokenAccountID: UUID?
+    public let tokenAccountTokenUpdater: TokenAccountTokenUpdater?
 
     public init(
         runtime: ProviderRuntime,
@@ -41,7 +45,9 @@ public struct ProviderFetchContext: Sendable {
         settings: ProviderSettingsSnapshot?,
         fetcher: UsageFetcher,
         claudeFetcher: any ClaudeUsageFetching,
-        browserDetection: BrowserDetection)
+        browserDetection: BrowserDetection,
+        selectedTokenAccountID: UUID? = nil,
+        tokenAccountTokenUpdater: TokenAccountTokenUpdater? = nil)
     {
         self.runtime = runtime
         self.sourceMode = sourceMode
@@ -54,6 +60,8 @@ public struct ProviderFetchContext: Sendable {
         self.fetcher = fetcher
         self.claudeFetcher = claudeFetcher
         self.browserDetection = browserDetection
+        self.selectedTokenAccountID = selectedTokenAccountID
+        self.tokenAccountTokenUpdater = tokenAccountTokenUpdater
     }
 }
 

--- a/Sources/CodexBarCore/TokenAccountSupportCatalog+Data.swift
+++ b/Sources/CodexBarCore/TokenAccountSupportCatalog+Data.swift
@@ -23,6 +23,13 @@ extension TokenAccountSupportCatalog {
             injection: .environment(key: DeepSeekSettingsReader.apiKeyEnvironmentKey),
             requiresManualCookieSource: false,
             cookieName: nil),
+        .antigravity: TokenAccountSupport(
+            title: "Google accounts",
+            subtitle: "Store multiple Antigravity Google OAuth accounts for quick switching.",
+            placeholder: "Antigravity OAuth credentials JSON",
+            injection: .environment(key: AntigravityOAuthCredentialsStore.environmentCredentialsKey),
+            requiresManualCookieSource: false,
+            cookieName: nil),
         .zai: TokenAccountSupport(
             title: "API tokens",
             subtitle: "Stored in the CodexBar config file.",

--- a/Tests/CodexBarTests/AntigravityLoginAlertTests.swift
+++ b/Tests/CodexBarTests/AntigravityLoginAlertTests.swift
@@ -1,7 +1,25 @@
+import CodexBarCore
+import Foundation
 import Testing
 @testable import CodexBar
 
 struct AntigravityLoginAlertTests {
+    @Test
+    func `authorization URL asks Google to select an account`() throws {
+        let redirectURL = try #require(URL(string: "http://127.0.0.1:54321/callback"))
+        let url = try AntigravityLoginRunner.makeAuthorizationURL(
+            redirectURL: redirectURL,
+            state: "state",
+            oauthClient: AntigravityOAuthClient(
+                clientID: "client.apps.googleusercontent.com",
+                clientSecret: "secret"))
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let prompt = components.queryItems?.first(where: { $0.name == "prompt" })?.value
+
+        #expect(prompt?.split(separator: " ").contains("select_account") == true)
+        #expect(prompt?.split(separator: " ").contains("consent") == true)
+    }
+
     @Test
     func `returns alert for timeout`() {
         let result = AntigravityLoginRunner.Result(outcome: .timedOut)

--- a/Tests/CodexBarTests/AntigravityRemoteUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AntigravityRemoteUsageFetcherTests.swift
@@ -5,6 +5,206 @@ import Testing
 @Suite(.serialized)
 struct AntigravityRemoteUsageFetcherTests {
     @Test
+    func `antigravity supports token accounts for quick account switching`() {
+        let support = TokenAccountSupportCatalog.support(for: .antigravity)
+
+        #expect(support?.title == "Google accounts")
+        #expect(support?.requiresManualCookieSource == false)
+        #expect(TokenAccountSupportCatalog.envOverride(
+            for: .antigravity,
+            token: "serialized-credentials")?[AntigravityOAuthCredentialsStore.environmentCredentialsKey] ==
+            "serialized-credentials")
+    }
+
+    @Test
+    func `oauth credentials round trip through token account value`() throws {
+        let credentials = AntigravityOAuthCredentials(
+            accessToken: "access-token",
+            refreshToken: "refresh-token",
+            expiryDate: Date(timeIntervalSince1970: 1_700_000_000),
+            idToken: GeminiAPITestHelpers.makeIDToken(email: "user@example.com"),
+            email: "user@example.com",
+            projectID: "project-123",
+            clientID: "client-id",
+            clientSecret: "client-secret")
+
+        let token = try AntigravityOAuthCredentialsStore.tokenAccountValue(for: credentials)
+        let decoded = try #require(AntigravityOAuthCredentialsStore.credentials(fromTokenAccountValue: token))
+
+        #expect(decoded == credentials)
+    }
+
+    @Test
+    func `remote fetch uses selected token account credentials before shared credentials`() async throws {
+        let env = try GeminiTestEnvironment()
+        defer { env.cleanup() }
+        try env.writeAntigravityCredentials(
+            accessToken: "shared-token",
+            refreshToken: nil,
+            expiry: Date().addingTimeInterval(3600),
+            idToken: GeminiAPITestHelpers.makeIDToken(email: "shared@example.com"),
+            email: "shared@example.com")
+        let selectedCredentials = AntigravityOAuthCredentials(
+            accessToken: "selected-token",
+            refreshToken: nil,
+            expiryDate: Date().addingTimeInterval(3600),
+            idToken: GeminiAPITestHelpers.makeIDToken(email: "selected@example.com"),
+            email: "selected@example.com",
+            projectID: nil,
+            clientID: nil,
+            clientSecret: nil)
+        let token = try AntigravityOAuthCredentialsStore.tokenAccountValue(for: selectedCredentials)
+
+        let dataLoader = GeminiAPITestHelpers.dataLoader { request in
+            guard let url = request.url, let host = url.host else {
+                throw URLError(.badURL)
+            }
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer selected-token")
+
+            switch host {
+            case "cloudcode-pa.googleapis.com":
+                if url.path == "/v1internal:loadCodeAssist" {
+                    return GeminiAPITestHelpers.response(
+                        url: url.absoluteString,
+                        status: 200,
+                        body: GeminiAPITestHelpers.jsonData([
+                            "currentTier": ["id": "free-tier", "name": "free"],
+                            "cloudaicompanionProject": "managed-project-123",
+                        ]))
+                }
+                if url.path == "/v1internal:fetchAvailableModels" {
+                    return GeminiAPITestHelpers.response(
+                        url: url.absoluteString,
+                        status: 200,
+                        body: Self.availableModelsResponse())
+                }
+                return GeminiAPITestHelpers.response(url: url.absoluteString, status: 404, body: Data())
+            default:
+                return GeminiAPITestHelpers.response(url: url.absoluteString, status: 404, body: Data())
+            }
+        }
+
+        let fetcher = AntigravityRemoteUsageFetcher(
+            timeout: 1,
+            homeDirectory: env.homeURL.path,
+            environment: [AntigravityOAuthCredentialsStore.environmentCredentialsKey: token],
+            dataLoader: dataLoader)
+        let snapshot = try await fetcher.fetch()
+
+        #expect(snapshot.accountEmail == "selected@example.com")
+    }
+
+    @Test
+    func `remote fetch refreshes selected token account without mutating shared credentials`() async throws {
+        let env = try GeminiTestEnvironment()
+        defer { env.cleanup() }
+        try env.writeAntigravityCredentials(
+            accessToken: "shared-token",
+            refreshToken: "shared-refresh",
+            expiry: Date().addingTimeInterval(3600),
+            idToken: GeminiAPITestHelpers.makeIDToken(email: "shared@example.com"),
+            email: "shared@example.com",
+            clientID: "shared-client-id",
+            clientSecret: "shared-client-secret")
+        let selectedCredentials = AntigravityOAuthCredentials(
+            accessToken: "selected-old-token",
+            refreshToken: "selected-refresh",
+            expiryDate: Date().addingTimeInterval(-3600),
+            idToken: GeminiAPITestHelpers.makeIDToken(email: "selected-old@example.com"),
+            email: "selected-old@example.com",
+            projectID: nil,
+            clientID: "selected-client-id",
+            clientSecret: "selected-client-secret")
+        let token = try AntigravityOAuthCredentialsStore.tokenAccountValue(for: selectedCredentials)
+
+        let dataLoader = GeminiAPITestHelpers.dataLoader { request in
+            guard let url = request.url, let host = url.host else {
+                throw URLError(.badURL)
+            }
+
+            switch host {
+            case "oauth2.googleapis.com":
+                let body = String(data: request.httpBody ?? Data(), encoding: .utf8) ?? ""
+                #expect(body.contains("client_id=selected-client-id"))
+                #expect(body.contains("refresh_token=selected-refresh"))
+                return GeminiAPITestHelpers.response(
+                    url: url.absoluteString,
+                    status: 200,
+                    body: GeminiAPITestHelpers.jsonData([
+                        "access_token": "selected-new-token",
+                        "expires_in": 3600,
+                        "id_token": GeminiAPITestHelpers.makeIDToken(email: "selected-new@example.com"),
+                    ]))
+            case "cloudcode-pa.googleapis.com":
+                #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer selected-new-token")
+                if url.path == "/v1internal:loadCodeAssist" {
+                    return GeminiAPITestHelpers.response(
+                        url: url.absoluteString,
+                        status: 200,
+                        body: GeminiAPITestHelpers.jsonData([
+                            "currentTier": ["id": "free-tier", "name": "free"],
+                            "cloudaicompanionProject": "selected-project-123",
+                        ]))
+                }
+                if url.path == "/v1internal:fetchAvailableModels" {
+                    return GeminiAPITestHelpers.response(
+                        url: url.absoluteString,
+                        status: 200,
+                        body: Self.availableModelsResponse())
+                }
+                return GeminiAPITestHelpers.response(url: url.absoluteString, status: 404, body: Data())
+            default:
+                return GeminiAPITestHelpers.response(url: url.absoluteString, status: 404, body: Data())
+            }
+        }
+
+        let fetcher = AntigravityRemoteUsageFetcher(
+            timeout: 1,
+            homeDirectory: env.homeURL.path,
+            environment: [AntigravityOAuthCredentialsStore.environmentCredentialsKey: token],
+            dataLoader: dataLoader)
+        let snapshot = try await fetcher.fetch()
+        let shared = try env.readAntigravityCredentials()
+
+        #expect(snapshot.accountEmail == "selected-new@example.com")
+        #expect(shared["access_token"] as? String == "shared-token")
+        #expect(shared["email"] as? String == "shared@example.com")
+    }
+
+    @Test
+    func `remote fetch rejects invalid selected token account instead of falling back to shared credentials`() async throws {
+        let env = try GeminiTestEnvironment()
+        defer { env.cleanup() }
+        try env.writeAntigravityCredentials(
+            accessToken: "shared-token",
+            refreshToken: nil,
+            expiry: Date().addingTimeInterval(3600),
+            idToken: GeminiAPITestHelpers.makeIDToken(email: "shared@example.com"),
+            email: "shared@example.com")
+
+        let fetcher = AntigravityRemoteUsageFetcher(
+            timeout: 1,
+            homeDirectory: env.homeURL.path,
+            environment: [AntigravityOAuthCredentialsStore.environmentCredentialsKey: "not-json"],
+            dataLoader: GeminiAPITestHelpers.dataLoader { _ in
+                throw URLError(.badServerResponse)
+            })
+
+        do {
+            _ = try await fetcher.fetch()
+            #expect(Bool(false), "Expected selected account decode failure")
+        } catch let error as AntigravityRemoteFetchError {
+            guard case let .parseFailed(message) = error else {
+                #expect(Bool(false), "Unexpected Antigravity error: \(error)")
+                return
+            }
+            #expect(message.contains("selected account"))
+        } catch {
+            #expect(Bool(false), "Unexpected error: \(error)")
+        }
+    }
+
+    @Test
     func `remote fetch maps cloud code models into antigravity usage`() async throws {
         let env = try GeminiTestEnvironment()
         defer { env.cleanup() }

--- a/Tests/CodexBarTests/AntigravityRemoteUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AntigravityRemoteUsageFetcherTests.swift
@@ -2,6 +2,18 @@ import CodexBarCore
 import Foundation
 import Testing
 
+private actor AntigravityCredentialUpdateCapture {
+    private var captured: [AntigravityOAuthCredentials] = []
+
+    func append(_ credentials: AntigravityOAuthCredentials) {
+        self.captured.append(credentials)
+    }
+
+    func values() -> [AntigravityOAuthCredentials] {
+        self.captured
+    }
+}
+
 @Suite(.serialized)
 struct AntigravityRemoteUsageFetcherTests {
     @Test
@@ -116,6 +128,7 @@ struct AntigravityRemoteUsageFetcherTests {
             clientID: "selected-client-id",
             clientSecret: "selected-client-secret")
         let token = try AntigravityOAuthCredentialsStore.tokenAccountValue(for: selectedCredentials)
+        let updateCapture = AntigravityCredentialUpdateCapture()
 
         let dataLoader = GeminiAPITestHelpers.dataLoader { request in
             guard let url = request.url, let host = url.host else {
@@ -162,17 +175,79 @@ struct AntigravityRemoteUsageFetcherTests {
             timeout: 1,
             homeDirectory: env.homeURL.path,
             environment: [AntigravityOAuthCredentialsStore.environmentCredentialsKey: token],
-            dataLoader: dataLoader)
+            dataLoader: dataLoader,
+            credentialsUpdateHandler: { credentials in
+                await updateCapture.append(credentials)
+            })
         let snapshot = try await fetcher.fetch()
         let shared = try env.readAntigravityCredentials()
+        let updatedCredentials = await updateCapture.values()
 
         #expect(snapshot.accountEmail == "selected-new@example.com")
         #expect(shared["access_token"] as? String == "shared-token")
         #expect(shared["email"] as? String == "shared@example.com")
+        #expect(updatedCredentials.last?.accessToken == "selected-new-token")
+        #expect(updatedCredentials.last?.projectID == "selected-project-123")
     }
 
     @Test
-    func `remote fetch rejects invalid selected token account instead of falling back to shared credentials`() async throws {
+    func `remote fetch ignores selected token account project id persistence failure`() async throws {
+        let env = try GeminiTestEnvironment()
+        defer { env.cleanup() }
+        let selectedCredentials = AntigravityOAuthCredentials(
+            accessToken: "selected-token",
+            refreshToken: nil,
+            expiryDate: Date().addingTimeInterval(3600),
+            idToken: GeminiAPITestHelpers.makeIDToken(email: "selected@example.com"),
+            email: "selected@example.com",
+            projectID: nil,
+            clientID: nil,
+            clientSecret: nil)
+        let token = try AntigravityOAuthCredentialsStore.tokenAccountValue(for: selectedCredentials)
+
+        let dataLoader = GeminiAPITestHelpers.dataLoader { request in
+            guard let url = request.url, let host = url.host else {
+                throw URLError(.badURL)
+            }
+
+            switch host {
+            case "cloudcode-pa.googleapis.com":
+                if url.path == "/v1internal:loadCodeAssist" {
+                    return GeminiAPITestHelpers.response(
+                        url: url.absoluteString,
+                        status: 200,
+                        body: GeminiAPITestHelpers.jsonData([
+                            "currentTier": ["id": "free-tier", "name": "free"],
+                            "cloudaicompanionProject": "selected-project-123",
+                        ]))
+                }
+                if url.path == "/v1internal:fetchAvailableModels" {
+                    return GeminiAPITestHelpers.response(
+                        url: url.absoluteString,
+                        status: 200,
+                        body: Self.availableModelsResponse())
+                }
+                return GeminiAPITestHelpers.response(url: url.absoluteString, status: 404, body: Data())
+            default:
+                return GeminiAPITestHelpers.response(url: url.absoluteString, status: 404, body: Data())
+            }
+        }
+
+        let fetcher = AntigravityRemoteUsageFetcher(
+            timeout: 1,
+            homeDirectory: env.homeURL.path,
+            environment: [AntigravityOAuthCredentialsStore.environmentCredentialsKey: token],
+            dataLoader: dataLoader,
+            credentialsUpdateHandler: { _ in
+                throw CocoaError(.fileWriteUnknown)
+            })
+        let snapshot = try await fetcher.fetch()
+
+        #expect(snapshot.accountEmail == "selected@example.com")
+    }
+
+    @Test
+    func `remote fetch rejects invalid selected token account`() async throws {
         let env = try GeminiTestEnvironment()
         defer { env.cleanup() }
         try env.writeAntigravityCredentials(

--- a/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
@@ -462,6 +462,29 @@ struct SettingsStoreCoverageTests {
         #expect(decoded.accessToken == "updated-access")
     }
 
+    @Test
+    func `upsert antigravity oauth account does not merge missing email accounts by fallback label`() {
+        let settings = Self.makeSettingsStore()
+        let first = AntigravityOAuthCredentials(
+            accessToken: "first-access",
+            refreshToken: "first-refresh",
+            expiryDate: Date(timeIntervalSince1970: 1_700_000_000),
+            email: nil)
+        let second = AntigravityOAuthCredentials(
+            accessToken: "second-access",
+            refreshToken: "second-refresh",
+            expiryDate: Date(timeIntervalSince1970: 1_700_000_100),
+            email: nil)
+
+        settings.upsertAntigravityOAuthAccount(first)
+        settings.upsertAntigravityOAuthAccount(second)
+
+        let accounts = settings.tokenAccounts(for: .antigravity)
+        #expect(accounts.count == 2)
+        #expect(accounts.map(\.label) == ["Google Account 1", "Google Account 2"])
+        #expect(settings.selectedTokenAccount(for: .antigravity)?.id == accounts.last?.id)
+    }
+
     private static func makeSettingsStore(suiteName: String = "SettingsStoreCoverageTests") -> SettingsStore {
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)

--- a/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
@@ -434,6 +434,34 @@ struct SettingsStoreCoverageTests {
         #expect(settings.claudeOAuthKeychainReadStrategy == .securityCLIExperimental)
     }
 
+    @Test
+    func `upsert antigravity oauth account adds and updates active token account`() throws {
+        let settings = Self.makeSettingsStore()
+        let first = AntigravityOAuthCredentials(
+            accessToken: "first-access",
+            refreshToken: "first-refresh",
+            expiryDate: Date(timeIntervalSince1970: 1_700_000_000),
+            email: "user@example.com")
+        let updated = AntigravityOAuthCredentials(
+            accessToken: "updated-access",
+            refreshToken: "first-refresh",
+            expiryDate: Date(timeIntervalSince1970: 1_700_000_100),
+            email: "user@example.com")
+
+        settings.upsertAntigravityOAuthAccount(first)
+        settings.upsertAntigravityOAuthAccount(updated)
+
+        let accounts = settings.tokenAccounts(for: .antigravity)
+        #expect(accounts.count == 1)
+        let account = try #require(accounts.first)
+        #expect(account.label == "user@example.com")
+        #expect(account.externalIdentifier == "user@example.com")
+        #expect(settings.selectedTokenAccount(for: .antigravity)?.id == account.id)
+
+        let decoded = try #require(AntigravityOAuthCredentialsStore.credentials(fromTokenAccountValue: account.token))
+        #expect(decoded.accessToken == "updated-access")
+    }
+
     private static func makeSettingsStore(suiteName: String = "SettingsStoreCoverageTests") -> SettingsStore {
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -1,14 +1,32 @@
 ---
-summary: "Antigravity provider notes: local LSP probing, port discovery, quota parsing, and UI mapping."
+summary: "Antigravity provider notes: OAuth usage, multi-account switching, local LSP probing, and quota parsing."
 read_when:
   - Adding or modifying the Antigravity provider
   - Debugging Antigravity port detection or quota parsing
   - Adjusting Antigravity menu labels or model mapping
+  - Working with Antigravity OAuth or account switching
 ---
 
 # Antigravity provider
 
-Antigravity is a local-only provider. We talk directly to the Antigravity language server running on the same machine.
+Antigravity supports local IDE probing and Google OAuth-backed remote usage. The OAuth path can store multiple Google accounts through the shared token-account switcher.
+
+## OAuth account switching
+
+- Login still uses Antigravity's Google OAuth client, discovered from `Antigravity.app` or overridden with `ANTIGRAVITY_OAUTH_CLIENT_ID` and `ANTIGRAVITY_OAUTH_CLIENT_SECRET`.
+- A successful login writes the latest shared credentials to `~/.codexbar/antigravity/oauth_creds.json` and upserts a token-account entry for the Google account.
+- Each token-account entry stores serialized `AntigravityOAuthCredentials` and is injected into remote fetches through `ANTIGRAVITY_OAUTH_CREDENTIALS_JSON`.
+- When a token account is selected, the OAuth fetcher uses that account before falling back to the shared credentials file.
+- The menu action is labeled `Add Account...`; switching between saved accounts uses the existing segmented/stacked token-account menu UI.
+
+## Remote OAuth data sources
+
+- `POST https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist`
+- `POST https://cloudcode-pa.googleapis.com/v1internal:onboardUser`
+- `POST https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels`
+- `POST https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota`
+
+## Local data sources + fallback order
 
 ## Data sources + fallback order
 


### PR DESCRIPTION
## Summary
- Adds Antigravity to CodexBar's existing token-account quick switching system for multiple Google OAuth accounts.
- Upserts successful Antigravity OAuth logins into token accounts while preserving the shared `~/.codexbar/antigravity/oauth_creds.json` fallback when no token account is selected.
- Passes selected account credentials to remote usage fetches through `ANTIGRAVITY_OAUTH_CREDENTIALS_JSON`, with invalid selected-account JSON failing closed instead of silently falling back to shared credentials.
- Keeps selected-account refresh/project updates isolated from shared credentials and writes those updates back to the selected token account.
- Forces the Google OAuth account chooser for "Add Google Account" so adding another account does not silently reuse the current browser session.

## Review feedback addressed
- Codex P1: selected token-account refresh/project updates were not persisted back into the token account. Fixed by threading a selected-account token updater through `ProviderFetchContext` into the Antigravity fetcher.
- Codex P2: missing-email OAuth credentials could merge distinct accounts through the fallback `Google Account` label. Fixed by matching only non-empty email identifiers and using numbered fallback labels.
- Copilot low-confidence note: existing token-account `organizationID` is no longer cleared during Antigravity account updates.
- Follow-up local review: project ID persistence is best effort again, so a cache write failure does not fail an otherwise successful usage fetch.

## Testing
- `./Scripts/lint.sh format && ./Scripts/lint.sh lint` passed, 0 violations.
- `swift test --filter AntigravityRemoteUsageFetcherTests` passed, 16 tests.
- `swift test --filter SettingsStoreCoverageTests` passed, 28 tests.
- `swift test --filter AntigravityLoginAlertTests` passed, 5 tests.
- `swift test` passed, 2356 tests in 292 suites.
- `./Scripts/compile_and_run.sh` passed, built the production app, packaged `CodexBar.app`, launched it, and verified `OK: CodexBar is running.`

Closes #936
