### PR TITLE
Fix: Separate Codex quota marker windows

### DIFF
--- a/Sources/CodexBar/QuotaWarningSettingsViews.swift
+++ b/Sources/CodexBar/QuotaWarningSettingsViews.swift
@@ -27,15 +27,8 @@ struct GlobalQuotaWarningSettingsView: View {
                 .toggleStyle(.checkbox)
             }
 
-            QuotaWarningThresholdField(
-                title: L("quota_warning_warn_at"),
-                subtitle: L("quota_warning_global_threshold_subtitle"),
-                thresholds: { self.settings.quotaWarningThresholds },
-                setThresholds: { self.settings.quotaWarningThresholds = $0 })
-                .disabled(!self.settings.quotaWarningWindowEnabled(.session) && !self.settings
-                    .quotaWarningWindowEnabled(.weekly))
-                .opacity(!self.settings.quotaWarningWindowEnabled(.session) && !self.settings
-                    .quotaWarningWindowEnabled(.weekly) ? 0.55 : 1)
+            self.windowThresholdField(.session)
+            self.windowThresholdField(.weekly)
 
             Toggle(isOn: self.$settings.quotaWarningSoundEnabled) {
                 Text(L("quota_warning_sound"))
@@ -44,6 +37,16 @@ struct GlobalQuotaWarningSettingsView: View {
             .toggleStyle(.checkbox)
         }
         .padding(.leading, 20)
+    }
+
+    private func windowThresholdField(_ window: QuotaWarningWindow) -> some View {
+        QuotaWarningThresholdField(
+            title: String(format: L("quota_warning_window_warn_at"), window.localizedCapitalizedDisplayName),
+            subtitle: L("quota_warning_global_threshold_subtitle"),
+            thresholds: { self.settings.quotaWarningThresholds(window) },
+            setThresholds: { self.settings.setQuotaWarningThresholds(window, thresholds: $0) })
+            .disabled(!self.settings.quotaWarningWindowEnabled(window))
+            .opacity(!self.settings.quotaWarningWindowEnabled(window) ? 0.55 : 1)
     }
 }
 
@@ -73,7 +76,7 @@ struct ProviderQuotaWarningSettingsView: View {
                         self.settings.setQuotaWarningOverride(
                             provider: self.provider,
                             window: window,
-                            thresholds: self.settings.quotaWarningThresholds,
+                            thresholds: self.settings.quotaWarningThresholds(window),
                             enabled: self.settings.quotaWarningWindowEnabled(window))
                     } else {
                         self.settings.setQuotaWarningOverride(
@@ -127,7 +130,7 @@ struct ProviderQuotaWarningSettingsView: View {
                 }
             } else {
                 Text(String(format: L("quota_warning_inherited"), Self.thresholdText(
-                    self.settings.quotaWarningThresholds,
+                    self.settings.quotaWarningThresholds(window),
                     enabled: self.settings.quotaWarningWindowEnabled(window))))
                     .font(.footnote)
                     .foregroundStyle(.secondary)

--- a/Sources/CodexBar/SettingsStore+Config.swift
+++ b/Sources/CodexBar/SettingsStore+Config.swift
@@ -11,7 +11,9 @@ extension SettingsStore {
     }
 
     func resolvedQuotaWarningThresholds(provider: UsageProvider, window: QuotaWarningWindow) -> [Int] {
-        self.quotaWarningConfig(for: provider).thresholds(for: window, global: self.quotaWarningThresholds)
+        self.quotaWarningConfig(for: provider).thresholds(
+            for: window,
+            global: self.quotaWarningThresholds(window))
     }
 
     func quotaWarningEnabled(provider: UsageProvider, window: QuotaWarningWindow) -> Bool {

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -116,7 +116,32 @@ extension SettingsStore {
         set {
             let sanitized = QuotaWarningThresholds.sanitized(newValue)
             self.defaultsState.quotaWarningThresholdsRaw = sanitized
+            self.defaultsState.quotaWarningSessionThresholdsRaw = sanitized
+            self.defaultsState.quotaWarningWeeklyThresholdsRaw = sanitized
             self.userDefaults.set(sanitized, forKey: "quotaWarningThresholds")
+            self.userDefaults.set(sanitized, forKey: "quotaWarningSessionThresholds")
+            self.userDefaults.set(sanitized, forKey: "quotaWarningWeeklyThresholds")
+        }
+    }
+
+    func quotaWarningThresholds(_ window: QuotaWarningWindow) -> [Int] {
+        switch window {
+        case .session:
+            QuotaWarningThresholds.sanitized(self.defaultsState.quotaWarningSessionThresholdsRaw)
+        case .weekly:
+            QuotaWarningThresholds.sanitized(self.defaultsState.quotaWarningWeeklyThresholdsRaw)
+        }
+    }
+
+    func setQuotaWarningThresholds(_ window: QuotaWarningWindow, thresholds: [Int]) {
+        let sanitized = QuotaWarningThresholds.sanitized(thresholds)
+        switch window {
+        case .session:
+            self.defaultsState.quotaWarningSessionThresholdsRaw = sanitized
+            self.userDefaults.set(sanitized, forKey: "quotaWarningSessionThresholds")
+        case .weekly:
+            self.defaultsState.quotaWarningWeeklyThresholdsRaw = sanitized
+            self.userDefaults.set(sanitized, forKey: "quotaWarningWeeklyThresholds")
         }
     }
 

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -367,6 +367,8 @@ extension SettingsStore {
             sessionQuotaNotificationsEnabled: sessionQuotaNotificationsEnabled,
             quotaWarningNotificationsEnabled: quotaWarnings.notificationsEnabled,
             quotaWarningThresholdsRaw: quotaWarnings.thresholdsRaw,
+            quotaWarningSessionThresholdsRaw: quotaWarnings.sessionThresholdsRaw,
+            quotaWarningWeeklyThresholdsRaw: quotaWarnings.weeklyThresholdsRaw,
             quotaWarningSessionEnabled: quotaWarnings.sessionEnabled,
             quotaWarningWeeklyEnabled: quotaWarnings.weeklyEnabled,
             quotaWarningSoundEnabled: quotaWarnings.soundEnabled,
@@ -404,6 +406,8 @@ extension SettingsStore {
     private struct LoadedQuotaWarningDefaults {
         var notificationsEnabled: Bool
         var thresholdsRaw: [Int]
+        var sessionThresholdsRaw: [Int]
+        var weeklyThresholdsRaw: [Int]
         var sessionEnabled: Bool
         var weeklyEnabled: Bool
         var soundEnabled: Bool
@@ -415,6 +419,16 @@ extension SettingsStore {
         let thresholdsRaw = QuotaWarningThresholds.sanitized(rawThresholds ?? QuotaWarningThresholds.defaults)
         if Self.isRunningTests, rawThresholds != thresholdsRaw {
             userDefaults.set(thresholdsRaw, forKey: "quotaWarningThresholds")
+        }
+        let rawSessionThresholds = userDefaults.array(forKey: "quotaWarningSessionThresholds") as? [Int]
+        let sessionThresholdsRaw = QuotaWarningThresholds.sanitized(rawSessionThresholds ?? thresholdsRaw)
+        if Self.isRunningTests, rawSessionThresholds != sessionThresholdsRaw {
+            userDefaults.set(sessionThresholdsRaw, forKey: "quotaWarningSessionThresholds")
+        }
+        let rawWeeklyThresholds = userDefaults.array(forKey: "quotaWarningWeeklyThresholds") as? [Int]
+        let weeklyThresholdsRaw = QuotaWarningThresholds.sanitized(rawWeeklyThresholds ?? thresholdsRaw)
+        if Self.isRunningTests, rawWeeklyThresholds != weeklyThresholdsRaw {
+            userDefaults.set(weeklyThresholdsRaw, forKey: "quotaWarningWeeklyThresholds")
         }
 
         let sessionDefault = userDefaults.object(forKey: "quotaWarningSessionEnabled") as? Bool
@@ -438,6 +452,8 @@ extension SettingsStore {
         return LoadedQuotaWarningDefaults(
             notificationsEnabled: notificationsEnabled,
             thresholdsRaw: thresholdsRaw,
+            sessionThresholdsRaw: sessionThresholdsRaw,
+            weeklyThresholdsRaw: weeklyThresholdsRaw,
             sessionEnabled: sessionEnabled,
             weeklyEnabled: weeklyEnabled,
             soundEnabled: soundEnabled)

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -13,6 +13,8 @@ struct SettingsDefaultsState {
     var sessionQuotaNotificationsEnabled: Bool
     var quotaWarningNotificationsEnabled: Bool
     var quotaWarningThresholdsRaw: [Int]
+    var quotaWarningSessionThresholdsRaw: [Int]
+    var quotaWarningWeeklyThresholdsRaw: [Int]
     var quotaWarningSessionEnabled: Bool
     var quotaWarningWeeklyEnabled: Bool
     var quotaWarningSoundEnabled: Bool

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -609,6 +609,27 @@ struct SettingsStoreTests {
     }
 
     @Test
+    func `global quota warning thresholds resolve independently by window`() throws {
+        let suite = "SettingsStoreTests-quota-warning-window-thresholds"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        store.setQuotaWarningThresholds(.session, thresholds: [25])
+        store.setQuotaWarningThresholds(.weekly, thresholds: [75, 10])
+
+        #expect(store.quotaWarningThresholds(.session) == [25])
+        #expect(store.quotaWarningThresholds(.weekly) == [75, 10])
+        #expect(store.resolvedQuotaWarningThresholds(provider: .codex, window: .session) == [25])
+        #expect(store.resolvedQuotaWarningThresholds(provider: .codex, window: .weekly) == [75, 10])
+    }
+
+    @Test
     func `provider quota warning windows override global enablement independently`() throws {
         let suite = "SettingsStoreTests-quota-warning-provider-window-override"
         let defaults = try #require(UserDefaults(suiteName: suite))


### PR DESCRIPTION
## Summary
- split global quota warning marker thresholds by session and weekly windows
- resolve Codex marker rendering and provider override defaults from the matching window
- update provider inherited settings copy and tests so settings text matches runtime marker behavior

## Root cause
Session and weekly marker rendering had separate model slots, but both inherited the same global quota warning threshold list. That made Codex show the same marker lines on both the session and weekly quota bars.

Closes #927

## Validation
- swift test --filter SettingsStoreTests
- swift test --filter MenuCardQuotaWarningMarkerTests
- make check
- subagent audit: no material issues after follow-up fix