### PR TITLE
Add Tahoe "Allow in Menu Bar" detection + user guidance dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - Kimi: rebalance provider icon alignment within its viewBox (#912). Thanks @giuseppebisemi!
+- Menu bar: detect when macOS Tahoe hides CodexBar behind the new Allow in Menu Bar setting and show recovery guidance (#945, fixes #890). Thanks @pdurlej!
 - Claude: show Enterprise OAuth spend-limit usage when the API returns only `extra_usage` data instead of session windows (#925).
 - CLI: route Claude token-account `--source cli` reads through the selected OAuth/session credential so `--all-accounts` no longer relabels ambient CLI usage (#403).
 - Codex: keep session and weekly quota-warning marker thresholds independent so usage bars do not duplicate marker lines (#938, fixes #927). Thanks @iam-brain!

--- a/Sources/CodexBar/MenuBarVisibilityWatcher.swift
+++ b/Sources/CodexBar/MenuBarVisibilityWatcher.swift
@@ -1,0 +1,110 @@
+import AppKit
+import Foundation
+
+struct StatusItemVisibilitySnapshot: Equatable {
+    let isVisible: Bool
+    let hasButton: Bool
+    let hasWindow: Bool
+    let hasScreen: Bool
+    let buttonWidth: CGFloat
+}
+
+@MainActor
+func isStatusItemBlocked(_ item: NSStatusItem) -> Bool {
+    MenuBarVisibilityWatcher.isBlockedSnapshot(
+        snapshot: StatusItemVisibilitySnapshot(
+            isVisible: item.isVisible,
+            hasButton: item.button != nil,
+            hasWindow: item.button?.window != nil,
+            hasScreen: item.button?.window?.screen != nil,
+            buttonWidth: item.button?.frame.size.width ?? 0))
+}
+
+enum MenuBarVisibilityWatcher {
+    static let guidanceShownKey = "hasShownTahoeAllowListGuidance"
+    static let guidanceLastShownAtKey = "tahoeAllowListGuidanceLastShownAt"
+    static let guidanceRepeatInterval: TimeInterval = 24 * 60 * 60
+    static let startupFreshnessInterval: TimeInterval = 10
+    static let settingsURL = URL(string: "x-apple.systempreferences:com.apple.MenuBarSettings")!
+
+    static func isBlockedSnapshot(snapshot: StatusItemVisibilitySnapshot) -> Bool {
+        guard snapshot.isVisible else { return false }
+        guard snapshot.hasButton else { return true }
+        return !snapshot.hasWindow || !snapshot.hasScreen || snapshot.buttonWidth <= 0
+    }
+
+    @MainActor
+    static func hasBlockedVisibleStatusItems(_ items: [NSStatusItem]) -> Bool {
+        let visibleItems = items.filter(\.isVisible)
+        guard !visibleItems.isEmpty else { return false }
+        return visibleItems.allSatisfy { item in
+            isStatusItemBlocked(item)
+        }
+    }
+
+    static func shouldShowGuidance(defaults: UserDefaults, now: Date = Date()) -> Bool {
+        guard defaults.bool(forKey: self.guidanceShownKey) else { return true }
+        let lastShownAt = defaults.double(forKey: self.guidanceLastShownAtKey)
+        guard lastShownAt > 0 else { return false }
+        return now.timeIntervalSince1970 - lastShownAt >= self.guidanceRepeatInterval
+    }
+
+    static func markGuidanceShown(defaults: UserDefaults, now: Date = Date()) {
+        defaults.set(true, forKey: self.guidanceShownKey)
+        defaults.set(now.timeIntervalSince1970, forKey: self.guidanceLastShownAtKey)
+    }
+
+    @MainActor
+    static func presentGuidance(
+        defaults: UserDefaults,
+        now: Date = Date(),
+        openURL: (URL) -> Void = { NSWorkspace.shared.open($0) })
+    {
+        self.markGuidanceShown(defaults: defaults, now: now)
+
+        let alert = NSAlert()
+        alert.messageText = L("CodexBar can't show its menu bar icon")
+        alert.informativeText = L(
+            "macOS Tahoe can block menu bar apps in System Settings → Menu Bar → Allow in the Menu Bar. "
+                + "CodexBar is running, but macOS may be hiding its icon. Open Menu Bar settings and turn CodexBar on.")
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: L("Open Menu Bar Settings"))
+        alert.addButton(withTitle: L("Dismiss"))
+
+        if alert.runModal() == .alertFirstButtonReturn {
+            openURL(self.settingsURL)
+        }
+    }
+}
+
+extension StatusItemController {
+    func scheduleTahoeAllowListVisibilityCheck(appLaunchedAt: Date = Date()) {
+        guard !SettingsStore.isRunningTests else { return }
+        if #available(macOS 26.0, *) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+                Task { @MainActor [weak self] in
+                    self?.checkTahoeAllowListVisibility(appLaunchedAt: appLaunchedAt)
+                }
+            }
+        }
+    }
+
+    private func checkTahoeAllowListVisibility(appLaunchedAt: Date, now: Date = Date()) {
+        guard now.timeIntervalSince(appLaunchedAt) <= MenuBarVisibilityWatcher.startupFreshnessInterval else {
+            return
+        }
+        guard MenuBarVisibilityWatcher.hasBlockedVisibleStatusItems(self.tahoeAllowListStatusItems) else {
+            return
+        }
+
+        self.menuLogger.error("Status item failed to materialize — likely blocked by Tahoe Allow in Menu Bar panel")
+        guard MenuBarVisibilityWatcher.shouldShowGuidance(defaults: self.settings.userDefaults, now: now) else {
+            return
+        }
+        MenuBarVisibilityWatcher.presentGuidance(defaults: self.settings.userDefaults, now: now)
+    }
+
+    private var tahoeAllowListStatusItems: [NSStatusItem] {
+        [self.statusItem] + Array(self.statusItems.values)
+    }
+}

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -79,6 +79,7 @@
 "Codex login failed" = "Codex login failed";
 "Codex login timed out" = "Codex login timed out";
 "CodexBar Lifecycle Keepalive" = "CodexBar Lifecycle Keepalive";
+"CodexBar can't show its menu bar icon" = "CodexBar can't show its menu bar icon";
 "CodexBar could not read managed account storage. " = "CodexBar could not read managed account storage. ";
 "Configure…" = "Configure…";
 "Connected" = "Connected";
@@ -108,6 +109,7 @@
 "Designs" = "Designs";
 "Disable Keychain access" = "Disable Keychain access";
 "Disabled" = "Disabled";
+"Dismiss" = "Dismiss";
 "Disconnected" = "Disconnected";
 "Display" = "Display";
 "Display mode" = "Display mode";
@@ -206,6 +208,7 @@
 "Open Console" = "Open Console";
 "Open Dashboard" = "Open Dashboard";
 "Open Mistral Admin" = "Open Mistral Admin";
+"Open Menu Bar Settings" = "Open Menu Bar Settings";
 "Open Ollama Settings" = "Open Ollama Settings";
 "Open Terminal" = "Open Terminal";
 "Open Usage Page" = "Open Usage Page";
@@ -592,6 +595,7 @@
 "login_shell_path" = "Login shell PATH (startup capture)";
 "cleared" = "Cleared.";
 "no_fetch_attempts" = "No fetch attempts yet.";
+"macOS Tahoe can block menu bar apps in System Settings → Menu Bar → Allow in the Menu Bar. CodexBar is running, but macOS may be hiding its icon. Open Menu Bar settings and turn CodexBar on." = "macOS Tahoe can block menu bar apps in System Settings → Menu Bar → Allow in the Menu Bar. CodexBar is running, but macOS may be hiding its icon. Open Menu Bar settings and turn CodexBar on.";
 
 /* Metric preferences */
 "metric_pref_automatic" = "Automatic";

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -268,6 +268,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.wireBindings()
         self.updateVisibility()
         self.updateIcons()
+        self.scheduleTahoeAllowListVisibilityCheck()
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(self.handleDebugReplayNotification(_:)),

--- a/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
+++ b/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct MenuBarVisibilityWatcherTests {
+    @Test
+    func `does not flag intentionally hidden status item`() {
+        let snapshot = StatusItemVisibilitySnapshot(
+            isVisible: false,
+            hasButton: true,
+            hasWindow: false,
+            hasScreen: false,
+            buttonWidth: 0)
+
+        #expect(!MenuBarVisibilityWatcher.isBlockedSnapshot(snapshot: snapshot))
+    }
+
+    @Test
+    func `flags visible item without attached window`() {
+        let snapshot = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: false,
+            hasScreen: false,
+            buttonWidth: 18)
+
+        #expect(MenuBarVisibilityWatcher.isBlockedSnapshot(snapshot: snapshot))
+    }
+
+    @Test
+    func `flags visible item without button`() {
+        let snapshot = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: false,
+            hasWindow: false,
+            hasScreen: false,
+            buttonWidth: 0)
+
+        #expect(MenuBarVisibilityWatcher.isBlockedSnapshot(snapshot: snapshot))
+    }
+
+    @Test
+    func `flags visible item with zero width`() {
+        let snapshot = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: true,
+            buttonWidth: 0)
+
+        #expect(MenuBarVisibilityWatcher.isBlockedSnapshot(snapshot: snapshot))
+    }
+
+    @Test
+    func `allows visible item attached to a screen with width`() {
+        let snapshot = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: true,
+            buttonWidth: 18)
+
+        #expect(!MenuBarVisibilityWatcher.isBlockedSnapshot(snapshot: snapshot))
+    }
+
+    @Test
+    func `guidance shows once then repeats after a day`() throws {
+        let defaults = try #require(UserDefaults(suiteName: "MenuBarVisibilityWatcherTests"))
+        defaults.removePersistentDomain(forName: "MenuBarVisibilityWatcherTests")
+        let now = Date(timeIntervalSince1970: 1000)
+
+        #expect(MenuBarVisibilityWatcher.shouldShowGuidance(defaults: defaults, now: now))
+
+        MenuBarVisibilityWatcher.markGuidanceShown(defaults: defaults, now: now)
+
+        #expect(!MenuBarVisibilityWatcher.shouldShowGuidance(
+            defaults: defaults,
+            now: now.addingTimeInterval(MenuBarVisibilityWatcher.guidanceRepeatInterval - 1)))
+        #expect(MenuBarVisibilityWatcher.shouldShowGuidance(
+            defaults: defaults,
+            now: now.addingTimeInterval(MenuBarVisibilityWatcher.guidanceRepeatInterval)))
+    }
+}


### PR DESCRIPTION
Fixes #890.

## Summary
- Add a Tahoe-only startup watcher that checks whether visible `NSStatusItem` buttons actually materialize in a menu bar window/screen.
- Log an error when the status item appears blocked by macOS' new Menu Bar allow-list.
- Show a dismissible guidance dialog with a direct `x-apple.systempreferences:com.apple.MenuBarSettings` button.
- Persist the guidance state with `hasShownTahoeAllowListGuidance`, while allowing it to reappear after 24h if the condition persists.
- Cover the detection and re-show policy with focused tests.

## Dialog copy
Title: `CodexBar can't show its menu bar icon`

Body: `macOS Tahoe can block menu bar apps in System Settings → Menu Bar → Allow in the Menu Bar. CodexBar is running, but macOS may be hiding its icon. Open Menu Bar settings and turn CodexBar on.`

Buttons: `Open Menu Bar Settings` / `Dismiss`

## Notes
Apple does not expose a public API for the Tahoe allow-list state, so this is intentionally a best-effort heuristic. It only runs immediately after startup to avoid confusing later manual hiding tools such as Bartender with the system-level block.

Root-cause context came from the community diagnosis in #890: https://github.com/steipete/CodexBar/issues/890#issuecomment-4448144584

## Testing
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter MenuBarVisibilityWatcherTests`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer make check`
- `git diff --check`

One local note: the default Command Line Tools developer dir failed on `KeyboardShortcuts` `#Preview` macros, so the successful build/test/lint runs above use the full Xcode developer dir.