### PR TITLE
[codex] Fix update menu install action

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -60,15 +60,18 @@ let package = Package(
                 swiftSettings: [
                     .enableUpcomingFeature("StrictConcurrency"),
                 ]),
-            .testTarget(
-                name: "CodexBarLinuxTests",
-                dependencies: ["CodexBarCore", "CodexBarCLI"],
-                path: "TestsLinux",
-                swiftSettings: [
-                    .enableUpcomingFeature("StrictConcurrency"),
-                    .enableExperimentalFeature("SwiftTesting"),
-                ]),
         ]
+
+        #if os(Linux)
+        targets.append(.testTarget(
+            name: "CodexBarLinuxTests",
+            dependencies: ["CodexBarCore", "CodexBarCLI"],
+            path: "TestsLinux",
+            swiftSettings: [
+                .enableUpcomingFeature("StrictConcurrency"),
+                .enableExperimentalFeature("SwiftTesting"),
+            ]))
+        #endif
 
         #if os(macOS)
         targets.append(contentsOf: [

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -13,6 +13,18 @@ ensure_tools() {
 
 cmd="${1:-lint}"
 
+developer_dir="$(xcode-select -p 2>/dev/null || true)"
+sourcekit_lib_dir=""
+if [[ -n "${developer_dir}" && -d "${developer_dir}/Toolchains/XcodeDefault.xctoolchain/usr/lib/sourcekitdInProc.framework" ]]; then
+  sourcekit_lib_dir="${developer_dir}/Toolchains/XcodeDefault.xctoolchain/usr/lib"
+elif [[ -d /Library/Developer/CommandLineTools/usr/lib/sourcekitdInProc.framework ]]; then
+  sourcekit_lib_dir="/Library/Developer/CommandLineTools/usr/lib"
+fi
+
+if [[ -n "${sourcekit_lib_dir}" ]]; then
+  export DYLD_FRAMEWORK_PATH="${sourcekit_lib_dir}${DYLD_FRAMEWORK_PATH:+:${DYLD_FRAMEWORK_PATH}}"
+fi
+
 case "$cmd" in
   lint)
     ensure_tools

--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -125,6 +125,7 @@ protocol UpdaterProviding: AnyObject {
     var unavailableReason: String? { get }
     var updateStatus: UpdateStatus { get }
     func checkForUpdates(_ sender: Any?)
+    func installUpdate()
 }
 
 /// No-op updater used for debug builds and non-bundled runs to suppress Sparkle dialogs.
@@ -140,6 +141,7 @@ final class DisabledUpdaterController: UpdaterProviding {
     }
 
     func checkForUpdates(_ sender: Any?) {}
+    func installUpdate() {}
 }
 
 @MainActor
@@ -158,12 +160,25 @@ import Sparkle
 
 @MainActor
 final class SparkleUpdaterController: NSObject, UpdaterProviding, SPUUpdaterDelegate {
+    private final class ImmediateInstallHandler: @unchecked Sendable {
+        private let handler: () -> Void
+
+        init(_ handler: @escaping () -> Void) {
+            self.handler = handler
+        }
+
+        func install() {
+            self.handler()
+        }
+    }
+
     private lazy var controller = SPUStandardUpdaterController(
         startingUpdater: false,
         updaterDelegate: self,
         userDriverDelegate: nil)
     let updateStatus = UpdateStatus()
     let unavailableReason: String? = nil
+    private var immediateInstallHandler: ImmediateInstallHandler?
 
     init(savedAutoUpdate: Bool) {
         super.init()
@@ -191,20 +206,61 @@ final class SparkleUpdaterController: NSObject, UpdaterProviding, SPUUpdaterDele
         self.controller.checkForUpdates(sender)
     }
 
-    nonisolated func updater(_ updater: SPUUpdater, didDownloadUpdate item: SUAppcastItem) {
-        Task { @MainActor in
-            self.updateStatus.isUpdateReady = true
+    func installUpdate() {
+        guard let immediateInstallHandler else {
+            DispatchQueue.main.async { [weak self] in
+                self?.controller.checkForUpdates(nil)
+            }
+            return
         }
+
+        immediateInstallHandler.install()
+    }
+
+    nonisolated func updater(_ updater: SPUUpdater, didDownloadUpdate item: SUAppcastItem) {
+        _ = updater
+        _ = item
     }
 
     nonisolated func updater(_ updater: SPUUpdater, failedToDownloadUpdate item: SUAppcastItem, error: Error) {
+        _ = updater
+        _ = item
+        _ = error
         Task { @MainActor in
+            self.immediateInstallHandler = nil
             self.updateStatus.isUpdateReady = false
         }
     }
 
     nonisolated func userDidCancelDownload(_ updater: SPUUpdater) {
+        _ = updater
         Task { @MainActor in
+            self.immediateInstallHandler = nil
+            self.updateStatus.isUpdateReady = false
+        }
+    }
+
+    nonisolated func updater(
+        _ updater: SPUUpdater,
+        willInstallUpdateOnQuit item: SUAppcastItem,
+        immediateInstallationBlock immediateInstallHandler: @escaping () -> Void)
+        -> Bool
+    {
+        _ = updater
+        _ = item
+        let installHandler = ImmediateInstallHandler(immediateInstallHandler)
+        Task { @MainActor in
+            self.immediateInstallHandler = installHandler
+            self.updateStatus.isUpdateReady = true
+        }
+        return true
+    }
+
+    nonisolated func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
+        _ = updater
+        _ = error
+        Task { @MainActor in
+            self.immediateInstallHandler = nil
             self.updateStatus.isUpdateReady = false
         }
     }
@@ -219,10 +275,12 @@ final class SparkleUpdaterController: NSObject, UpdaterProviding, SPUUpdaterDele
         Task { @MainActor in
             switch choice {
             case .install, .skip:
+                self.immediateInstallHandler = nil
                 self.updateStatus.isUpdateReady = false
             case .dismiss:
                 self.updateStatus.isUpdateReady = downloaded
             @unknown default:
+                self.immediateInstallHandler = nil
                 self.updateStatus.isUpdateReady = false
             }
         }

--- a/Sources/CodexBar/MenuHighlightStyle.swift
+++ b/Sources/CodexBar/MenuHighlightStyle.swift
@@ -1,8 +1,18 @@
 import SwiftUI
 
-extension EnvironmentValues {
-    @Entry var menuItemHighlighted: Bool = false
+// swiftformat:disable environmentEntry
+private struct MenuItemHighlightedKey: EnvironmentKey {
+    static let defaultValue = false
 }
+
+extension EnvironmentValues {
+    var menuItemHighlighted: Bool {
+        get { self[MenuItemHighlightedKey.self] }
+        set { self[MenuItemHighlightedKey.self] = newValue }
+    }
+}
+
+// swiftformat:enable environmentEntry
 
 enum MenuHighlightStyle {
     static let selectionText = Color(nsColor: .selectedMenuItemTextColor)

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -43,7 +43,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     @objc func installUpdate() {
-        self.updater.checkForUpdates(nil)
+        self.updater.installUpdate()
     }
 
     @objc func openDashboard() {

--- a/Tests/CodexBarTests/StatusItemControllerMenuTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerMenuTests.swift
@@ -5,6 +5,26 @@ import Testing
 @testable import CodexBar
 
 struct StatusItemControllerMenuTests {
+    @MainActor
+    private final class RecordingUpdater: UpdaterProviding {
+        var automaticallyChecksForUpdates = false
+        var automaticallyDownloadsUpdates = false
+        let isAvailable = true
+        let unavailableReason: String? = nil
+        let updateStatus = UpdateStatus(isUpdateReady: true)
+        var checkForUpdatesCount = 0
+        var installUpdateCount = 0
+
+        func checkForUpdates(_ sender: Any?) {
+            _ = sender
+            self.checkForUpdatesCount += 1
+        }
+
+        func installUpdate() {
+            self.installUpdateCount += 1
+        }
+    }
+
     private func makeSnapshot(
         primary: RateWindow?,
         secondary: RateWindow?,
@@ -109,5 +129,36 @@ struct StatusItemControllerMenuTests {
         parentItem.submenu = NSMenu(title: "Session")
         submenuMenu.addItem(parentItem)
         #expect(ceil(submenuMenu.size.width) < 310)
+    }
+
+    @Test
+    @MainActor
+    func `update menu action installs prepared update instead of checking again`() throws {
+        let suite = "StatusItemControllerMenuTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let updater = RecordingUpdater()
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: updater,
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+
+        controller.installUpdate()
+
+        #expect(updater.installUpdateCount == 1)
+        #expect(updater.checkForUpdatesCount == 0)
     }
 }


### PR DESCRIPTION
## What was happening

When CodexBar had already downloaded an app update, the menu showed the restart/apply-update item as expected. Clicking that item the first time only closed the menu. The app did not restart, the update details did not appear, and reopening the menu showed the same restart/apply-update item again. Clicking the same item a second time was what finally brought up Sparkle’s update information prompt.

That made the update flow feel broken: the first click looked like it had been ignored, and users had to discover that repeating the same action would eventually continue the update.

## Why it happened

CodexBar was marking the update as ready when Sparkle reported that the update download had finished. That was too early for the menu action CodexBar exposed. The app was not retaining Sparkle’s immediate-installation callback, so the menu item’s action fell back to starting another update check with `checkForUpdates(nil)`.

As a result, the first click could dismiss the menu without invoking Sparkle’s prepared install path. A later click worked only because the repeated check flow caused Sparkle to present its update UI.

## What changed

- Capture Sparkle’s immediate installation block when Sparkle says the downloaded update can be installed on quit.
- Treat that delegate callback, rather than the earlier download callback, as the moment the update is actually ready for the restart/apply menu action.
- Route the menu item through the captured install callback so the first click performs the prepared update action.
- Clear the captured callback when the update flow is canceled, fails, aborts, or completes.
- Add regression coverage proving the menu action installs the prepared update instead of starting another update check.

This PR also includes two small local-verification fixes needed to run the full checks on macOS with the current toolchain: exclude the Linux-only test target on macOS, and make lint find SourceKit from the active Xcode/Command Line Tools install.

## Validation

- `swift test --filter StatusItemControllerMenuTests`
- `swift test`
- `make check`
