### PR TITLE
fix: stabilize Cost submenu opening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Codex: keep background `/status` probes out of Codex Desktop history by using isolated non-persistent CLI storage (#953).
+- Menu: stabilize the Cost submenu by using a native menu item and deferring open-menu rebuilds while tracking (#954). Thanks @getogrand!
 
 ## 0.26.0 — 2026-05-15
 

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -9,9 +9,10 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             await ProviderInteractionContext.$current.withValue(.userInitiated) {
                 await self.store.refresh(forceTokenUsage: forceTokenUsage)
                 self.store.scheduleStorageFootprintRefreshForOverview(force: true)
-                self.invalidateMenus()
                 if refreshOpenMenusWhenComplete {
-                    self.refreshOpenMenusIfNeeded()
+                    self.refreshOpenMenusAfterExplicitStoreAction()
+                } else {
+                    self.invalidateMenus()
                 }
             }
         }

--- a/Sources/CodexBar/StatusItemController+CostMenuCard.swift
+++ b/Sources/CodexBar/StatusItemController+CostMenuCard.swift
@@ -1,0 +1,64 @@
+import AppKit
+
+extension StatusItemController {
+    static let costMenuTitle = "Cost"
+
+    func makeCostMenuCardItem(model: UsageMenuCardView.Model, submenu: NSMenu?) -> NSMenuItem {
+        let tooltipLines = Self.costMenuTooltipLines(tokenUsage: model.tokenUsage)
+        let visibleDetailLines = Self.costMenuVisibleDetailLines(tokenUsage: model.tokenUsage)
+        let item = NSMenuItem(title: Self.costMenuTitle, action: nil, keyEquivalent: "")
+        item.isEnabled = true
+        item.representedObject = "menuCardCost"
+        item.submenu = submenu
+        item.toolTip = tooltipLines.joined(separator: "\n")
+        if #available(macOS 14.4, *) {
+            item.subtitle = visibleDetailLines.joined(separator: "\n")
+        } else if !visibleDetailLines.isEmpty {
+            item.attributedTitle = Self.costMenuFallbackAttributedTitle(visibleDetailLines: visibleDetailLines)
+        }
+        return item
+    }
+
+    static func costMenuTooltipLines(tokenUsage: UsageMenuCardView.Model.TokenUsageSection?) -> [String] {
+        [
+            tokenUsage?.sessionLine,
+            tokenUsage?.monthLine,
+            tokenUsage?.hintLine,
+            tokenUsage?.errorLine,
+        ]
+            .compactMap(\.self)
+            .filter { !$0.isEmpty }
+    }
+
+    static func costMenuVisibleDetailLines(tokenUsage: UsageMenuCardView.Model.TokenUsageSection?) -> [String] {
+        let primaryLines = [
+            tokenUsage?.sessionLine,
+            tokenUsage?.monthLine,
+            tokenUsage?.errorLine,
+        ]
+            .compactMap(\.self)
+            .filter { !$0.isEmpty }
+        guard primaryLines.isEmpty else { return primaryLines }
+        return [tokenUsage?.hintLine]
+            .compactMap(\.self)
+            .filter { !$0.isEmpty }
+    }
+
+    static func costMenuFallbackAttributedTitle(visibleDetailLines: [String]) -> NSAttributedString {
+        let detailText = visibleDetailLines.joined(separator: " | ")
+        let title = detailText.isEmpty ? self.costMenuTitle : "\(self.costMenuTitle)  \(detailText)"
+        let attributedTitle = NSMutableAttributedString(
+            string: title,
+            attributes: [.font: NSFont.menuFont(ofSize: NSFont.systemFontSize)])
+        guard !detailText.isEmpty else { return attributedTitle }
+
+        let detailRange = (title as NSString).range(of: detailText)
+        attributedTitle.addAttributes(
+            [
+                .font: NSFont.menuFont(ofSize: NSFont.smallSystemFontSize),
+                .foregroundColor: NSColor.secondaryLabelColor,
+            ],
+            range: detailRange)
+        return attributedTitle
+    }
+}

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -18,21 +18,22 @@ extension StatusItemController {
         }
     }
 
-    func makeHostedSubviewPlaceholderMenu(chartID: String, provider: UsageProvider? = nil) -> NSMenu {
+    func makeHostedSubviewPlaceholderMenu(
+        chartID: String,
+        provider: UsageProvider? = nil,
+        width: CGFloat? = nil) -> NSMenu
+    {
         let submenu = NSMenu()
         submenu.autoenablesItems = false
+        if let width {
+            submenu.minimumWidth = width
+        }
         submenu.delegate = self
         let chartItem = NSMenuItem()
         chartItem.isEnabled = true
         chartItem.representedObject = chartID
         chartItem.toolTip = provider?.rawValue
         submenu.addItem(chartItem)
-        return submenu
-    }
-
-    func makeHydratedHostedSubviewMenu(chartID: String, provider: UsageProvider? = nil, width: CGFloat) -> NSMenu {
-        let submenu = self.makeHostedSubviewPlaceholderMenu(chartID: chartID, provider: provider)
-        self.hydrateHostedSubviewMenuIfNeeded(submenu, width: width)
         return submenu
     }
 

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -20,16 +20,23 @@ extension StatusItemController {
 
     func makeHostedSubviewPlaceholderMenu(chartID: String, provider: UsageProvider? = nil) -> NSMenu {
         let submenu = NSMenu()
+        submenu.autoenablesItems = false
         submenu.delegate = self
         let chartItem = NSMenuItem()
-        chartItem.isEnabled = false
+        chartItem.isEnabled = true
         chartItem.representedObject = chartID
         chartItem.toolTip = provider?.rawValue
         submenu.addItem(chartItem)
         return submenu
     }
 
-    func hydrateHostedSubviewMenuIfNeeded(_ menu: NSMenu) {
+    func makeHydratedHostedSubviewMenu(chartID: String, provider: UsageProvider? = nil, width: CGFloat) -> NSMenu {
+        let submenu = self.makeHostedSubviewPlaceholderMenu(chartID: chartID, provider: provider)
+        self.hydrateHostedSubviewMenuIfNeeded(submenu, width: width)
+        return submenu
+    }
+
+    func hydrateHostedSubviewMenuIfNeeded(_ menu: NSMenu, width requestedWidth: CGFloat? = nil) {
         guard let placeholder = menu.items.first,
               menu.items.count == 1,
               placeholder.view == nil,
@@ -38,7 +45,7 @@ extension StatusItemController {
             return
         }
 
-        let width = self.renderedMenuWidth(for: menu.supermenu ?? menu)
+        let width = requestedWidth ?? self.renderedMenuWidth(for: menu.supermenu ?? menu)
         menu.removeAllItems()
 
         let didHydrate: Bool = switch chartID {
@@ -99,7 +106,7 @@ extension StatusItemController {
 
         if !Self.menuCardRenderingEnabled {
             let chartItem = NSMenuItem()
-            chartItem.isEnabled = false
+            chartItem.isEnabled = true
             chartItem.representedObject = Self.usageBreakdownChartID
             submenu.addItem(chartItem)
             return true
@@ -113,7 +120,7 @@ extension StatusItemController {
 
         let chartItem = NSMenuItem()
         chartItem.view = hosting
-        chartItem.isEnabled = false
+        chartItem.isEnabled = true
         chartItem.representedObject = Self.usageBreakdownChartID
         submenu.addItem(chartItem)
         return true
@@ -126,7 +133,7 @@ extension StatusItemController {
 
         if !Self.menuCardRenderingEnabled {
             let chartItem = NSMenuItem()
-            chartItem.isEnabled = false
+            chartItem.isEnabled = true
             chartItem.representedObject = Self.creditsHistoryChartID
             submenu.addItem(chartItem)
             return true
@@ -140,7 +147,7 @@ extension StatusItemController {
 
         let chartItem = NSMenuItem()
         chartItem.view = hosting
-        chartItem.isEnabled = false
+        chartItem.isEnabled = true
         chartItem.representedObject = Self.creditsHistoryChartID
         submenu.addItem(chartItem)
         return true
@@ -157,7 +164,7 @@ extension StatusItemController {
 
         if !Self.menuCardRenderingEnabled {
             let chartItem = NSMenuItem()
-            chartItem.isEnabled = false
+            chartItem.isEnabled = true
             chartItem.representedObject = Self.costHistoryChartID
             submenu.addItem(chartItem)
             return true
@@ -175,7 +182,7 @@ extension StatusItemController {
 
         let chartItem = NSMenuItem()
         chartItem.view = hosting
-        chartItem.isEnabled = false
+        chartItem.isEnabled = true
         chartItem.representedObject = Self.costHistoryChartID
         submenu.addItem(chartItem)
         return true
@@ -194,7 +201,7 @@ extension StatusItemController {
 
         if !Self.menuCardRenderingEnabled {
             let item = NSMenuItem()
-            item.isEnabled = false
+            item.isEnabled = true
             item.representedObject = Self.storageBreakdownID
             item.toolTip = provider.rawValue
             submenu.addItem(item)

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1524,7 +1524,7 @@ extension StatusItemController {
             from: self.store.openAIDashboard?.usageBreakdown ?? [])
         guard !breakdown.isEmpty else { return nil }
         if let width {
-            return self.makeHydratedHostedSubviewMenu(chartID: Self.usageBreakdownChartID, width: width)
+            return self.makeHostedSubviewPlaceholderMenu(chartID: Self.usageBreakdownChartID, width: width)
         }
         return self.makeHostedSubviewPlaceholderMenu(chartID: Self.usageBreakdownChartID)
     }
@@ -1532,7 +1532,7 @@ extension StatusItemController {
     private func makeCreditsHistorySubmenu(width: CGFloat? = nil) -> NSMenu? {
         guard !(self.store.openAIDashboard?.dailyBreakdown ?? []).isEmpty else { return nil }
         if let width {
-            return self.makeHydratedHostedSubviewMenu(chartID: Self.creditsHistoryChartID, width: width)
+            return self.makeHostedSubviewPlaceholderMenu(chartID: Self.creditsHistoryChartID, width: width)
         }
         return self.makeHostedSubviewPlaceholderMenu(chartID: Self.creditsHistoryChartID)
     }
@@ -1541,7 +1541,7 @@ extension StatusItemController {
         guard [.codex, .claude, .vertexai, .bedrock].contains(provider) else { return nil }
         guard self.store.tokenSnapshot(for: provider)?.daily.isEmpty == false else { return nil }
         if let width {
-            return self.makeHydratedHostedSubviewMenu(
+            return self.makeHostedSubviewPlaceholderMenu(
                 chartID: Self.costHistoryChartID,
                 provider: provider,
                 width: width)
@@ -1552,7 +1552,7 @@ extension StatusItemController {
     private func makeStorageBreakdownSubmenu(provider: UsageProvider, width: CGFloat? = nil) -> NSMenu? {
         guard self.store.storageFootprint(for: provider)?.components.isEmpty == false else { return nil }
         if let width {
-            return self.makeHydratedHostedSubviewMenu(
+            return self.makeHostedSubviewPlaceholderMenu(
                 chartID: Self.storageBreakdownID,
                 provider: provider,
                 width: width)

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -7,7 +7,7 @@ import SwiftUI
 // MARK: - NSMenu construction
 
 extension StatusItemController {
-    private static let menuCardBaseWidth: CGFloat = 310
+    static let menuCardBaseWidth: CGFloat = 310
     private static let maxOverviewProviders = SettingsStore.mergedOverviewProviderLimit
     private static let overviewRowIdentifierPrefix = "overviewRow-"
     private static let defaultMenuOpenRefreshDelay: Duration = .seconds(1.2)
@@ -63,11 +63,6 @@ extension StatusItemController {
         measuringMenu.autoenablesItems = false
         self.addActionableSections(sections, to: measuringMenu, width: baseWidth)
         return ceil(measuringMenu.size.width)
-    }
-
-    func renderedMenuWidth(for menu: NSMenu) -> CGFloat {
-        let measuredWidth = ceil(menu.size.width)
-        return max(measuredWidth, Self.menuCardBaseWidth)
     }
 
     func makeMenu() -> NSMenu {
@@ -162,7 +157,7 @@ extension StatusItemController {
         }
     }
 
-    private func populateMenu(_ menu: NSMenu, provider: UsageProvider?) {
+    func populateMenu(_ menu: NSMenu, provider: UsageProvider?) {
         let enabledProviders = self.store.enabledProvidersForDisplay()
         let includesOverview = self.includesOverviewTab(enabledProviders: enabledProviders)
         let switcherSelection = self.shouldMergeIcons && enabledProviders.count > 1
@@ -1060,54 +1055,17 @@ extension StatusItemController {
         return .provider(self.resolvedMenuProvider(enabledProviders: enabledProviders) ?? .codex)
     }
 
-    private func menuNeedsRefresh(_ menu: NSMenu) -> Bool {
+    func menuNeedsRefresh(_ menu: NSMenu) -> Bool {
         let key = ObjectIdentifier(menu)
         return self.menuVersions[key] != self.menuContentVersion
     }
 
-    private func markMenuFresh(_ menu: NSMenu) {
+    func markMenuFresh(_ menu: NSMenu) {
         let key = ObjectIdentifier(menu)
         self.menuVersions[key] = self.menuContentVersion
     }
 
-    func refreshOpenMenusIfNeeded() {
-        guard Self.menuRefreshEnabled else { return }
-        guard !self.openMenus.isEmpty else { return }
-        var orphanedKeys: [ObjectIdentifier] = []
-        let hasOpenHostedSubviewMenu = self.hasOpenHostedSubviewMenu()
-        for (key, menu) in self.openMenus {
-            guard key == ObjectIdentifier(menu) else {
-                orphanedKeys.append(key)
-                continue
-            }
-
-            if self.isHostedSubviewMenu(menu) {
-                self.refreshHostedSubviewHeights(in: menu)
-                continue
-            }
-
-            if hasOpenHostedSubviewMenu {
-                continue
-            }
-
-            if self.menuNeedsRefresh(menu) {
-                let provider = self.menuProvider(for: menu)
-                self.populateMenu(menu, provider: provider)
-                self.markMenuFresh(menu)
-                // Heights are already set during populateMenu, no need to remeasure
-            }
-        }
-
-        // Clean up orphaned menu entries from all tracking dictionaries.
-        for key in orphanedKeys {
-            self.openMenus.removeValue(forKey: key)
-            self.menuRefreshTasks.removeValue(forKey: key)?.cancel()
-            self.menuProviders.removeValue(forKey: key)
-            self.menuVersions.removeValue(forKey: key)
-        }
-    }
-
-    private func menuProvider(for menu: NSMenu) -> UsageProvider? {
+    func menuProvider(for menu: NSMenu) -> UsageProvider? {
         if self.shouldMergeIcons {
             return self.resolvedMenuProvider()
         }
@@ -1120,7 +1078,7 @@ extension StatusItemController {
         return self.store.enabledProvidersForDisplay().first ?? .codex
     }
 
-    private func hasOpenHostedSubviewMenu() -> Bool {
+    func hasOpenHostedSubviewMenu() -> Bool {
         self.openMenus.values.contains { self.isHostedSubviewMenu($0) }
     }
 
@@ -1323,7 +1281,8 @@ extension StatusItemController {
             let usageSubmenu = self.makeUsageSubmenu(
                 provider: provider,
                 snapshot: self.store.snapshot(for: provider),
-                webItems: webItems)
+                webItems: webItems,
+                width: width)
             menu.addItem(self.makeMenuCardItem(
                 usageView,
                 id: "menuCardUsage",
@@ -1351,7 +1310,7 @@ extension StatusItemController {
                 topPadding: sectionSpacing,
                 bottomPadding: creditsBottomPadding,
                 width: width)
-            let creditsSubmenu = webItems.hasCreditsHistory ? self.makeCreditsHistorySubmenu() : nil
+            let creditsSubmenu = webItems.hasCreditsHistory ? self.makeCreditsHistorySubmenu(width: width) : nil
             menu.addItem(self.makeMenuCardItem(
                 creditsView,
                 id: "menuCardCredits",
@@ -1379,17 +1338,9 @@ extension StatusItemController {
             if hasCredits || hasExtraUsage {
                 menu.addItem(.separator())
             }
-            let costView = UsageMenuCardCostSectionView(
-                model: model,
-                topPadding: sectionSpacing,
-                bottomPadding: bottomPadding,
-                width: width)
-            let costSubmenu = webItems.hasCostHistory ? self.makeCostHistorySubmenu(provider: provider) : nil
-            menu.addItem(self.makeMenuCardItem(
-                costView,
-                id: "menuCardCost",
-                width: width,
-                submenu: costSubmenu))
+            let costSubmenu = webItems.hasCostHistory ? self
+                .makeCostHistorySubmenu(provider: provider, width: width) : nil
+            menu.addItem(self.makeCostMenuCardItem(model: model, submenu: costSubmenu))
         }
     }
 
@@ -1401,7 +1352,7 @@ extension StatusItemController {
             topPadding: 6,
             bottomPadding: 6,
             width: width)
-        let storageSubmenu = self.makeStorageBreakdownSubmenu(provider: provider)
+        let storageSubmenu = self.makeStorageBreakdownSubmenu(provider: provider, width: width)
         menu.addItem(self.makeMenuCardItem(
             storageView,
             id: "menuCardStorage",
@@ -1483,7 +1434,8 @@ extension StatusItemController {
 
     @discardableResult
     private func addCreditsHistorySubmenu(to menu: NSMenu) -> Bool {
-        guard let submenu = self.makeCreditsHistorySubmenu() else { return false }
+        guard let submenu = self.makeCreditsHistorySubmenu(width: self.renderedMenuWidth(for: menu))
+        else { return false }
         let item = NSMenuItem(title: "Credits history", action: nil, keyEquivalent: "")
         item.isEnabled = true
         item.submenu = submenu
@@ -1493,7 +1445,8 @@ extension StatusItemController {
 
     @discardableResult
     private func addUsageBreakdownSubmenu(to menu: NSMenu) -> Bool {
-        guard let submenu = self.makeUsageBreakdownSubmenu() else { return false }
+        guard let submenu = self.makeUsageBreakdownSubmenu(width: self.renderedMenuWidth(for: menu))
+        else { return false }
         let item = NSMenuItem(title: "Usage breakdown", action: nil, keyEquivalent: "")
         item.isEnabled = true
         item.submenu = submenu
@@ -1503,7 +1456,8 @@ extension StatusItemController {
 
     @discardableResult
     private func addCostHistorySubmenu(to menu: NSMenu, provider: UsageProvider) -> Bool {
-        guard let submenu = self.makeCostHistorySubmenu(provider: provider) else { return false }
+        guard let submenu = self.makeCostHistorySubmenu(provider: provider, width: self.renderedMenuWidth(for: menu))
+        else { return false }
         let item = NSMenuItem(title: "Usage history (30 days)", action: nil, keyEquivalent: "")
         item.isEnabled = true
         item.submenu = submenu
@@ -1514,10 +1468,11 @@ extension StatusItemController {
     private func makeUsageSubmenu(
         provider: UsageProvider,
         snapshot: UsageSnapshot?,
-        webItems: OpenAIWebMenuItems) -> NSMenu?
+        webItems: OpenAIWebMenuItems,
+        width: CGFloat? = nil) -> NSMenu?
     {
         if webItems.hasUsageBreakdown {
-            return self.makeUsageBreakdownSubmenu()
+            return self.makeUsageBreakdownSubmenu(width: width)
         }
         if provider == .zai {
             return self.makeZaiUsageDetailsSubmenu(snapshot: snapshot)
@@ -1564,26 +1519,44 @@ extension StatusItemController {
         return submenu
     }
 
-    private func makeUsageBreakdownSubmenu() -> NSMenu? {
+    private func makeUsageBreakdownSubmenu(width: CGFloat? = nil) -> NSMenu? {
         let breakdown = OpenAIDashboardDailyBreakdown.removingSkillUsageServices(
             from: self.store.openAIDashboard?.usageBreakdown ?? [])
         guard !breakdown.isEmpty else { return nil }
+        if let width {
+            return self.makeHydratedHostedSubviewMenu(chartID: Self.usageBreakdownChartID, width: width)
+        }
         return self.makeHostedSubviewPlaceholderMenu(chartID: Self.usageBreakdownChartID)
     }
 
-    private func makeCreditsHistorySubmenu() -> NSMenu? {
+    private func makeCreditsHistorySubmenu(width: CGFloat? = nil) -> NSMenu? {
         guard !(self.store.openAIDashboard?.dailyBreakdown ?? []).isEmpty else { return nil }
+        if let width {
+            return self.makeHydratedHostedSubviewMenu(chartID: Self.creditsHistoryChartID, width: width)
+        }
         return self.makeHostedSubviewPlaceholderMenu(chartID: Self.creditsHistoryChartID)
     }
 
-    private func makeCostHistorySubmenu(provider: UsageProvider) -> NSMenu? {
+    private func makeCostHistorySubmenu(provider: UsageProvider, width: CGFloat? = nil) -> NSMenu? {
         guard [.codex, .claude, .vertexai, .bedrock].contains(provider) else { return nil }
         guard self.store.tokenSnapshot(for: provider)?.daily.isEmpty == false else { return nil }
+        if let width {
+            return self.makeHydratedHostedSubviewMenu(
+                chartID: Self.costHistoryChartID,
+                provider: provider,
+                width: width)
+        }
         return self.makeHostedSubviewPlaceholderMenu(chartID: Self.costHistoryChartID, provider: provider)
     }
 
-    private func makeStorageBreakdownSubmenu(provider: UsageProvider) -> NSMenu? {
+    private func makeStorageBreakdownSubmenu(provider: UsageProvider, width: CGFloat? = nil) -> NSMenu? {
         guard self.store.storageFootprint(for: provider)?.components.isEmpty == false else { return nil }
+        if let width {
+            return self.makeHydratedHostedSubviewMenu(
+                chartID: Self.storageBreakdownID,
+                provider: provider,
+                width: width)
+        }
         return self.makeHostedSubviewPlaceholderMenu(chartID: Self.storageBreakdownID, provider: provider)
     }
 
@@ -1598,7 +1571,7 @@ extension StatusItemController {
         }
     }
 
-    private func refreshHostedSubviewHeights(in menu: NSMenu) {
+    func refreshHostedSubviewHeights(in menu: NSMenu) {
         let width = self.renderedMenuWidth(for: menu)
 
         for item in menu.items {

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -1,0 +1,67 @@
+import AppKit
+
+extension StatusItemController {
+    func renderedMenuWidth(for menu: NSMenu) -> CGFloat {
+        let measuredWidth = ceil(menu.size.width)
+        return max(measuredWidth, Self.menuCardBaseWidth)
+    }
+
+    func refreshOpenMenusIfNeeded() {
+        guard Self.menuRefreshEnabled else { return }
+        guard !self.openMenus.isEmpty else { return }
+        self.refreshOpenMenusIfNeeded(allowsParentRebuild: false)
+    }
+
+    func refreshOpenMenusForStructureChange() {
+        self.refreshOpenMenusAllowingParentRebuild()
+    }
+
+    func refreshOpenMenusAllowingParentRebuild() {
+        guard Self.menuRefreshEnabled else { return }
+        guard !self.openMenus.isEmpty else { return }
+        self.refreshOpenMenusIfNeeded(allowsParentRebuild: true)
+    }
+
+    private func refreshOpenMenusIfNeeded(allowsParentRebuild: Bool) {
+        var orphanedKeys: [ObjectIdentifier] = []
+        let hasOpenHostedSubviewMenu = self.hasOpenHostedSubviewMenu()
+        for (key, menu) in self.openMenus {
+            guard key == ObjectIdentifier(menu) else {
+                orphanedKeys.append(key)
+                continue
+            }
+            self.refreshOpenMenuIfNeeded(
+                menu,
+                allowsParentRebuild: allowsParentRebuild,
+                hasOpenHostedSubviewMenu: hasOpenHostedSubviewMenu)
+        }
+        self.removeOrphanedOpenMenuEntries(orphanedKeys)
+    }
+
+    private func refreshOpenMenuIfNeeded(
+        _ menu: NSMenu,
+        allowsParentRebuild: Bool,
+        hasOpenHostedSubviewMenu: Bool)
+    {
+        if self.isHostedSubviewMenu(menu) {
+            self.refreshHostedSubviewHeights(in: menu)
+            return
+        }
+        guard allowsParentRebuild else { return }
+        guard !hasOpenHostedSubviewMenu else { return }
+        guard self.menuNeedsRefresh(menu) else { return }
+
+        let provider = self.menuProvider(for: menu)
+        self.populateMenu(menu, provider: provider)
+        self.markMenuFresh(menu)
+    }
+
+    private func removeOrphanedOpenMenuEntries(_ keys: [ObjectIdentifier]) {
+        for key in keys {
+            self.openMenus.removeValue(forKey: key)
+            self.menuRefreshTasks.removeValue(forKey: key)?.cancel()
+            self.menuProviders.removeValue(forKey: key)
+            self.menuVersions.removeValue(forKey: key)
+        }
+    }
+}

--- a/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
+++ b/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
@@ -11,7 +11,7 @@ private final class UsageHistoryMenuHostingView<Content: View>: NSHostingView<Co
 extension StatusItemController {
     @discardableResult
     func addUsageHistoryMenuItemIfNeeded(to menu: NSMenu, provider: UsageProvider, width: CGFloat) -> Bool {
-        guard let submenu = self.makeUsageHistorySubmenu(provider: provider) else { return false }
+        guard let submenu = self.makeUsageHistorySubmenu(provider: provider, width: width) else { return false }
         let item = self.makeMenuCardItem(
             HStack(spacing: 0) {
                 Text("Subscription Utilization")
@@ -31,9 +31,15 @@ extension StatusItemController {
         return true
     }
 
-    private func makeUsageHistorySubmenu(provider: UsageProvider) -> NSMenu? {
+    private func makeUsageHistorySubmenu(provider: UsageProvider, width: CGFloat? = nil) -> NSMenu? {
         guard self.store.supportsPlanUtilizationHistory(for: provider) else { return nil }
         guard !self.store.shouldHidePlanUtilizationMenuItem(for: provider) else { return nil }
+        if let width {
+            return self.makeHydratedHostedSubviewMenu(
+                chartID: Self.usageHistoryChartID,
+                provider: provider,
+                width: width)
+        }
         return self.makeHostedSubviewPlaceholderMenu(chartID: Self.usageHistoryChartID, provider: provider)
     }
 
@@ -47,7 +53,7 @@ extension StatusItemController {
 
         if !Self.menuCardRenderingEnabled {
             let chartItem = NSMenuItem()
-            chartItem.isEnabled = false
+            chartItem.isEnabled = true
             chartItem.representedObject = Self.usageHistoryChartID
             submenu.addItem(chartItem)
             return true
@@ -65,7 +71,7 @@ extension StatusItemController {
 
         let chartItem = NSMenuItem()
         chartItem.view = hosting
-        chartItem.isEnabled = false
+        chartItem.isEnabled = true
         chartItem.representedObject = Self.usageHistoryChartID
         submenu.addItem(chartItem)
         return true

--- a/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
+++ b/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
@@ -35,7 +35,7 @@ extension StatusItemController {
         guard self.store.supportsPlanUtilizationHistory(for: provider) else { return nil }
         guard !self.store.shouldHidePlanUtilizationMenuItem(for: provider) else { return nil }
         if let width {
-            return self.makeHydratedHostedSubviewMenu(
+            return self.makeHostedSubviewPlaceholderMenu(
                 chartID: Self.usageHistoryChartID,
                 provider: provider,
                 width: width)

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -457,12 +457,12 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         guard Self.menuRefreshEnabled else { return }
         if !self.openMenus.isEmpty {
             guard refreshOpenMenus else { return }
-            self.refreshOpenMenusIfNeeded()
+            self.refreshOpenMenusAllowingParentRebuild()
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 // AppKit can ignore menu mutations while tracking; retry on the next run loop.
                 await Task.yield()
-                self.refreshOpenMenusIfNeeded()
+                self.refreshOpenMenusAllowingParentRebuild()
             }
             return
         }
@@ -520,7 +520,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.updateVisibility()
         self.updateIcons()
         if shouldRefreshOpenMenus {
-            self.refreshOpenMenusIfNeeded()
+            self.refreshOpenMenusForStructureChange()
         }
     }
 

--- a/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
@@ -1,0 +1,46 @@
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct StatusMenuCostMenuCardTests {
+    @Test
+    func `cost menu fallback keeps visible details in attributed title`() {
+        let tokenUsage = UsageMenuCardView.Model.TokenUsageSection(
+            sessionLine: "Today: $74.83 - 87M tokens",
+            monthLine: "Last 30 days: $4,279.64 - 5.7B tokens",
+            hintLine: "Costs are estimated from local usage.",
+            errorLine: "Cost refresh failed.",
+            errorCopyText: nil)
+
+        let visibleLines = StatusItemController.costMenuVisibleDetailLines(tokenUsage: tokenUsage)
+        #expect(visibleLines == [
+            "Today: $74.83 - 87M tokens",
+            "Last 30 days: $4,279.64 - 5.7B tokens",
+            "Cost refresh failed.",
+        ])
+
+        let fallbackTitle = StatusItemController.costMenuFallbackAttributedTitle(visibleDetailLines: visibleLines)
+        #expect(fallbackTitle.string.contains("Cost"))
+        #expect(fallbackTitle.string.contains("Today: $74.83 - 87M tokens"))
+        #expect(fallbackTitle.string.contains("Last 30 days: $4,279.64 - 5.7B tokens"))
+        #expect(fallbackTitle.string.contains("Cost refresh failed."))
+    }
+
+    @Test
+    func `cost menu tooltip preserves hint and error details`() {
+        let tokenUsage = UsageMenuCardView.Model.TokenUsageSection(
+            sessionLine: "Today: $1.00",
+            monthLine: "Last 30 days: $9.00",
+            hintLine: "Costs are estimated from local usage.",
+            errorLine: "Cost refresh failed.",
+            errorCopyText: nil)
+
+        #expect(StatusItemController.costMenuTooltipLines(tokenUsage: tokenUsage) == [
+            "Today: $1.00",
+            "Last 30 days: $9.00",
+            "Costs are estimated from local usage.",
+            "Cost refresh failed.",
+        ])
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
@@ -51,12 +51,14 @@ struct StatusMenuHostedSubmenuRefreshTests {
         #expect(NSStringFromSelector(submenuAction) == "submenuAction:")
         #expect((costItem.target as? NSMenu) === submenu)
         #expect(submenu.items.first?.representedObject as? String == StatusItemController.costHistoryChartID)
-        #expect(submenu.items.first?.view != nil)
+        #expect(submenu.minimumWidth >= StatusItemController.menuCardBaseWidth)
+        #expect(submenu.items.first?.view == nil)
 
         StatusItemController.setMenuRefreshEnabledForTesting(true)
         controller.menuWillOpen(submenu)
         let submenuKey = ObjectIdentifier(submenu)
         #expect(controller.openMenus[submenuKey] === submenu)
+        #expect(submenu.items.first?.view != nil)
 
         let oldParentVersion = try #require(controller.menuVersions[parentKey])
         controller.menuContentVersion &+= 1

--- a/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
@@ -7,7 +7,7 @@ import Testing
 @Suite(.serialized)
 struct StatusMenuHostedSubmenuRefreshTests {
     @Test
-    func `open hosted submenu defers parent menu rebuild until submenu closes`() throws {
+    func `open parent menu defers data rebuild until next open`() throws {
         let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
         let previousMenuRefresh = StatusItemController.menuRefreshEnabled
         StatusItemController.menuCardRenderingEnabled = true
@@ -45,7 +45,13 @@ struct StatusMenuHostedSubmenuRefreshTests {
         controller.menuVersions[parentKey] = controller.menuContentVersion
 
         let costItem = try #require(menu.items.first { ($0.representedObject as? String) == "menuCardCost" })
+        #expect(costItem.view == nil)
         let submenu = try #require(costItem.submenu)
+        let submenuAction = try #require(costItem.action)
+        #expect(NSStringFromSelector(submenuAction) == "submenuAction:")
+        #expect((costItem.target as? NSMenu) === submenu)
+        #expect(submenu.items.first?.representedObject as? String == StatusItemController.costHistoryChartID)
+        #expect(submenu.items.first?.view != nil)
 
         StatusItemController.setMenuRefreshEnabledForTesting(true)
         controller.menuWillOpen(submenu)
@@ -59,6 +65,10 @@ struct StatusMenuHostedSubmenuRefreshTests {
 
         controller.menuDidClose(submenu)
         #expect(controller.openMenus[submenuKey] == nil)
+
+        #expect(controller.menuVersions[parentKey] == oldParentVersion)
+        controller.menuDidClose(menu)
+        controller.menuWillOpen(menu)
         #expect(controller.menuVersions[parentKey] == controller.menuContentVersion)
     }
 

--- a/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
@@ -1,0 +1,97 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct StatusMenuSwitcherRefreshTests {
+    @Test
+    func `merged provider switch rebuilds stale width switcher rows`() async throws {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = false
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
+        defer {
+            StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering
+            StatusItemController.resetMenuRefreshEnabledForTesting()
+        }
+
+        let settings = Self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        Self.enableCodexAndClaude(settings)
+
+        let activeProviders: [UsageProvider] = [.codex, .claude]
+        _ = settings.setMergedOverviewProviderSelection(
+            provider: .codex,
+            isSelected: false,
+            activeProviders: activeProviders)
+        _ = settings.setMergedOverviewProviderSelection(
+            provider: .claude,
+            isSelected: false,
+            activeProviders: activeProviders)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        #expect(controller.openMenus[ObjectIdentifier(menu)] === menu)
+
+        let initialSwitcher = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        let initialSwitcherID = ObjectIdentifier(initialSwitcher)
+        initialSwitcher.frame.size.width = 250
+
+        let nextProviderButton = try #require(Self.switcherButtons(in: menu).first { $0.state == .off })
+        #expect(initialSwitcher._test_simulateRuntimeClick(buttonTag: nextProviderButton.tag) == true)
+
+        for _ in 0..<50 {
+            await Task.yield()
+            guard let currentSwitcher = menu.items.first?.view as? ProviderSwitcherView,
+                  initialSwitcherID == ObjectIdentifier(currentSwitcher)
+            else { break }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+
+        let updatedSwitcher = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        #expect(initialSwitcherID != ObjectIdentifier(updatedSwitcher))
+        #expect(updatedSwitcher.frame.width == 310)
+    }
+
+    private static func makeSettings() -> SettingsStore {
+        let suite = "StatusMenuSwitcherRefreshTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+    }
+
+    private static func enableCodexAndClaude(_ settings: SettingsStore) {
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            guard let metadata = registry.metadata[provider] else { continue }
+            let shouldEnable = provider == .codex || provider == .claude
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
+        }
+    }
+
+    private static func switcherButtons(in menu: NSMenu) -> [NSButton] {
+        guard let switcherView = menu.items.first?.view as? ProviderSwitcherView else { return [] }
+        return switcherView.subviews
+            .compactMap { $0 as? NSButton }
+            .sorted { $0.tag < $1.tag }
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -273,7 +273,7 @@ struct StatusMenuTests {
     }
 
     @Test
-    func `open menu refreshes after store data changes`() async {
+    func `open menu defers store data refresh until next open`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -323,6 +323,10 @@ struct StatusMenuTests {
         controller.refreshOpenMenusIfNeeded()
 
         #expect(controller.menuContentVersion != openedVersion)
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        controller.menuDidClose(menu)
+        controller.menuWillOpen(menu)
         #expect(controller.menuVersions[key] == staleVersion)
     }
 
@@ -562,72 +566,6 @@ struct StatusMenuTests {
     }
 
     @Test
-    func `merged provider switch rebuilds stale width switcher rows`() async {
-        self.disableMenuCardsForTesting()
-        let settings = self.makeSettings()
-        settings.statusChecksEnabled = false
-        settings.refreshFrequency = .manual
-        settings.mergeIcons = true
-        settings.selectedMenuProvider = .codex
-
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .codex || provider == .claude
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
-        let activeProviders: [UsageProvider] = [.codex, .claude]
-        _ = settings.setMergedOverviewProviderSelection(
-            provider: .codex,
-            isSelected: false,
-            activeProviders: activeProviders)
-        _ = settings.setMergedOverviewProviderSelection(
-            provider: .claude,
-            isSelected: false,
-            activeProviders: activeProviders)
-
-        let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
-        let controller = StatusItemController(
-            store: store,
-            settings: settings,
-            account: fetcher.loadAccountInfo(),
-            updater: DisabledUpdaterController(),
-            preferencesSelection: PreferencesSelection(),
-            statusBar: self.makeStatusBarForTesting())
-
-        let menu = controller.makeMenu()
-        StatusItemController.setMenuRefreshEnabledForTesting(true)
-        defer { StatusItemController.resetMenuRefreshEnabledForTesting() }
-        controller.menuWillOpen(menu)
-
-        let initialSwitcher = menu.items.first?.view as? ProviderSwitcherView
-        #expect(initialSwitcher != nil)
-        let initialSwitcherID = initialSwitcher.map(ObjectIdentifier.init)
-        initialSwitcher?.frame.size.width = 250
-
-        let nextProviderButton = self.switcherButtons(in: menu).first(where: { $0.state == .off })
-        #expect(nextProviderButton != nil)
-        let clickedNextProvider = nextProviderButton.map {
-            initialSwitcher?._test_simulateRuntimeClick(buttonTag: $0.tag)
-        } ?? false
-        #expect(clickedNextProvider == true)
-        for _ in 0..<50
-            where initialSwitcherID == (menu.items.first?.view as? ProviderSwitcherView)
-            .map(ObjectIdentifier.init)
-        {
-            await Task.yield()
-        }
-
-        let updatedSwitcher = menu.items.first?.view as? ProviderSwitcherView
-        #expect(updatedSwitcher != nil)
-        if let initialSwitcherID, let updatedSwitcher {
-            #expect(initialSwitcherID != ObjectIdentifier(updatedSwitcher))
-            #expect(updatedSwitcher.frame.width == 310)
-        }
-    }
-
-    @Test
     func `merged switcher includes overview tab when multiple providers enabled`() {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
@@ -759,7 +697,8 @@ struct StatusMenuTests {
             isSelected: true,
             activeProviders: activeProviders)
         controller.menuContentVersion &+= 1
-        controller.refreshOpenMenusIfNeeded()
+        controller.menuDidClose(menu)
+        controller.menuWillOpen(menu)
 
         let updatedButtons = self.switcherButtons(in: menu)
         #expect(updatedButtons.count == activeProviders.count + 1)
@@ -1325,6 +1264,8 @@ extension StatusMenuTests {
         let submenu = controller.makeHostedSubviewPlaceholderMenu(
             chartID: StatusItemController.costHistoryChartID,
             provider: .codex)
+        #expect(submenu.autoenablesItems == false)
+        #expect(submenu.items.first?.isEnabled == true)
 
         controller.hydrateHostedSubviewMenuIfNeeded(submenu)
         #expect(submenu.items.count == 1)
@@ -1352,6 +1293,7 @@ extension StatusMenuTests {
         #expect(submenu.items.count == 1)
         #expect(submenu.items.first?.title != "No data available")
         #expect(submenu.items.first?.representedObject as? String == StatusItemController.costHistoryChartID)
+        #expect(submenu.items.first?.isEnabled == true)
     }
 
     @Test


### PR DESCRIPTION
## Summary
This PR stabilizes the Cost submenu in the CodexBar menu. The user-visible issue was that hovering or clicking the `Cost` row usually did not open the submenu, even though the submenu data existed. In some timing windows it did open, which pointed to an AppKit menu tracking problem rather than a missing-data problem.

The fix keeps the actual behavior narrow: make the Cost row a native AppKit submenu item, hydrate chart submenus before AppKit starts submenu tracking, and stop ordinary data refreshes from rebuilding the parent menu while it is already open.

## User-facing problem
Before this change, the Cost submenu was unreliable from the user perspective:

- Opening the CodexBar menu and hovering over `Cost` usually did not show the right-side submenu.
- Clicking `Cost` also usually failed to open the submenu.
- The row sometimes appeared to lose focus while the pointer was on it.
- The submenu could appear occasionally, which made the bug feel intermittent and timing-dependent.

This was especially confusing because the Cost row itself rendered correctly and the underlying Cost history data was available. The broken part was the handoff from the parent menu row to the submenu.

## Root cause
The failure came from a combination of three AppKit-hosted menu behaviors.

### 1. The Cost row was view-backed instead of a native submenu row
The Cost row used a SwiftUI-backed menu card view with a submenu attached to the containing `NSMenuItem`. AppKit can support view-backed menu items, but submenu hover/click tracking is more fragile than with a plain native `NSMenuItem`.

For this particular row, AppKit had to track a submenu through a custom hosted view instead of a standard menu item title/subtitle row. That made the submenu handoff easier to interrupt when anything else changed in the menu.

### 2. The parent menu could rebuild while it was open
The menu refresh path allowed ordinary store/dashboard/token refreshes to repopulate an already-open parent menu. When that happened near a hover or click on `Cost`, the original menu item could be replaced before AppKit completed submenu tracking.

That explains the intermittent behavior: if no refresh/rebuild landed during the hover/click window, the submenu could open. If a rebuild landed during that window, AppKit lost the item it was tracking and the submenu did not appear.

### 3. Hosted chart submenus were hydrated lazily
Hosted chart submenus were represented by a placeholder item and hydrated when the submenu opened. That meant submenu contents changed right as AppKit was trying to open and measure the submenu. The placeholder/chart items were also not consistently enabled.

That extra mutation made submenu opening less deterministic, especially when combined with the parent menu rebuild issue.

## Fix details

### 1. Use a native AppKit item for Cost
The Cost row now uses a plain `NSMenuItem(title: "Cost", ...)` with its submenu attached directly to `item.submenu`. This lets AppKit own the normal submenu hover and click behavior for the row.

The visible Cost details are still preserved through the item tooltip and macOS 14.4+ subtitle support, but the row no longer depends on SwiftUI view-backed menu tracking.

### 2. Pre-hydrate hosted chart submenus when width is known
Hosted chart submenus now support a `makeHydratedHostedSubviewMenu(...)` path. When the parent menu already knows its rendered width, the submenu is built with the real hosted chart item immediately instead of waiting until `menuWillOpen`.

This reduces mutation during AppKit submenu opening and gives the chart view a stable width before the submenu is displayed.

### 3. Keep hosted submenu items enabled
The placeholder and hydrated chart items are now enabled. The unavailable-data fallback remains disabled, because that is a real non-interactive empty state.

This avoids putting disabled placeholder/chart rows in the submenu path AppKit needs to open and display.

### 4. Defer ordinary parent menu rebuilds while open
Open-menu refresh now has two paths:

- Ordinary data refreshes update menu content versions but do not rebuild the open parent menu. The latest data is picked up the next time the parent menu opens.
- Structure changes, such as provider switcher changes, can still rebuild an open parent menu when needed.

This prevents background data refreshes from replacing the `Cost` item while AppKit is tracking hover/click interaction. At the same time, provider switcher behavior remains responsive when the menu structure actually needs to change.

### 5. Avoid parent rebuilds while hosted submenus are open
If a hosted submenu is already open, parent menu rebuilds are skipped. Hosted submenu height refresh still runs for the submenu itself. This keeps the parent menu stable during submenu interaction.

## Regression coverage
This PR adds/updates focused coverage for the failure mode:

- Verifies that the Cost row is now a native item rather than a view-backed menu item.
- Verifies that the Cost submenu is pre-hydrated with the Cost history chart item.
- Verifies that ordinary data refreshes do not rebuild the open parent menu.
- Verifies that the parent menu refreshes when it is closed and opened again.
- Preserves coverage that provider switcher structure changes can still rebuild stale switcher rows.