### PR TITLE
fix(linux): use swift-crypto for Bedrock signing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,6 +20,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.1"),
         .package(url: "https://github.com/steipete/Commander", from: "0.2.1"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
         .package(url: "https://github.com/apple/swift-log", from: "1.12.0"),
         .package(url: "https://github.com/apple/swift-syntax", from: "600.0.1"),
         .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "2.4.0"),
@@ -32,6 +33,7 @@ let package = Package(
                 name: "CodexBarCore",
                 dependencies: [
                     "CodexBarMacroSupport",
+                    .product(name: "Crypto", package: "swift-crypto"),
                     .product(name: "Logging", package: "swift-log"),
                     .product(name: "SweetCookieKit", package: "SweetCookieKit"),
                 ],

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockAWSSigner.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockAWSSigner.swift
@@ -1,4 +1,8 @@
+#if canImport(CryptoKit)
 import CryptoKit
+#else
+import Crypto
+#endif
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking


### PR DESCRIPTION
## Summary
- Adds swift-crypto as a package dependency for cross-platform crypto APIs.
- Keeps CryptoKit on platforms where it is available and imports Crypto on Linux.
- Fixes the Linux CLI build failure in BedrockAWSSigner caused by `no such module 'CryptoKit'`.

## Testing
- Not run locally; relying on GitHub CI.