### PR TITLE
fix(pt-BR): translate quota warning settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Codex: keep background `/status` probes out of Codex Desktop history by using isolated non-persistent CLI storage (#953).
 - Menu: stabilize the Cost submenu by using a native menu item and deferring open-menu rebuilds while tracking (#954). Thanks @getogrand!
+- Localization: add Brazilian Portuguese quota-warning settings strings (#958). Thanks @ThiagoCAltoe!
 
 ## 0.26.0 — 2026-05-15
 

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -79,6 +79,7 @@
 "Codex login failed" = "Falha no login do Codex";
 "Codex login timed out" = "Tempo esgotado no login do Codex";
 "CodexBar Lifecycle Keepalive" = "Keepalive do ciclo de vida do CodexBar";
+"CodexBar can't show its menu bar icon" = "O CodexBar não consegue mostrar o ícone na barra de menus";
 "CodexBar could not read managed account storage. " = "O CodexBar não conseguiu ler o armazenamento de contas gerenciadas. ";
 "Configure…" = "Configurar…";
 "Connected" = "Conectado";
@@ -109,6 +110,7 @@
 "Disable Keychain access" = "Desativar acesso ao Keychain";
 "Disabled" = "Desativado";
 "Disconnected" = "Desconectado";
+"Dismiss" = "Dispensar";
 "Display" = "Exibição";
 "Display mode" = "Modo de exibição";
 "Display reset times as absolute clock values instead of countdowns." = "Mostra horários de renovação como horas absolutas, em vez de contagens regressivas.";
@@ -205,6 +207,7 @@
 "Open Coding Plan" = "Abrir Coding Plan";
 "Open Console" = "Abrir console";
 "Open Dashboard" = "Abrir dashboard";
+"Open Menu Bar Settings" = "Abrir ajustes da barra de menus";
 "Open Mistral Admin" = "Abrir Mistral Admin";
 "Open Ollama Settings" = "Abrir ajustes do Ollama";
 "Open Terminal" = "Abrir Terminal";
@@ -434,6 +437,7 @@
 "quota_warning_depleted_only" = "somente ao esgotar";
 "quota_warning_upper" = "Limite superior";
 "quota_warning_lower" = "Limite inferior";
+"apply" = "Aplicar";
 "quit_app" = "Encerrar CodexBar";
 
 /* Tab titles */
@@ -591,6 +595,7 @@
 "login_shell_path" = "PATH do shell de login (captura na inicialização)";
 "cleared" = "Limpo.";
 "no_fetch_attempts" = "Ainda sem tentativas de busca.";
+"macOS Tahoe can block menu bar apps in System Settings → Menu Bar → Allow in the Menu Bar. CodexBar is running, but macOS may be hiding its icon. Open Menu Bar settings and turn CodexBar on." = "O macOS Tahoe pode bloquear apps da barra de menus em Ajustes do Sistema → Barra de Menus → Permitir na Barra de Menus. O CodexBar está em execução, mas o macOS pode estar ocultando seu ícone. Abra os ajustes da Barra de Menus e ative o CodexBar.";
 
 /* Metric preferences */
 "metric_pref_automatic" = "Automático";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -415,6 +415,25 @@
 "check_provider_status_subtitle" = "Consulta páginas de status da OpenAI/Claude e o Google Workspace para Gemini/Antigravity, exibindo incidentes no ícone e no menu.";
 "session_quota_notifications_title" = "Notificações de cota de sessão";
 "session_quota_notifications_subtitle" = "Notifica quando a cota de sessão de 5 horas chega a 0% e quando fica disponível novamente.";
+"quota_warning_notifications_title" = "Notificações de alerta de cota";
+"quota_warning_notifications_subtitle" = "Avisa quando a cota restante da sessão ou da semana fica abaixo dos limites configurados.";
+"quota_warnings_title" = "Alertas de cota";
+"quota_warning_session" = "sessão";
+"quota_warning_session_capitalized" = "Sessão";
+"quota_warning_weekly" = "semanal";
+"quota_warning_weekly_capitalized" = "Semanal";
+"quota_warning_warn_at" = "Alertar em";
+"quota_warning_global_threshold_subtitle" = "Percentuais restantes para as janelas de sessão e semanal, a menos que um provedor defina valores próprios.";
+"quota_warning_sound" = "Reproduzir som de notificação";
+"quota_warning_provider_inherits" = "Usa as configurações globais de alerta de cota, a menos que uma janela seja personalizada aqui.";
+"quota_warning_customize_thresholds" = "Personalizar limites de %@";
+"quota_warning_enable_warnings" = "Ativar alertas de %@";
+"quota_warning_window_warn_at" = "%@: alertar em";
+"quota_warning_off" = "Desativado";
+"quota_warning_inherited" = "Usando global: %@";
+"quota_warning_depleted_only" = "somente ao esgotar";
+"quota_warning_upper" = "Limite superior";
+"quota_warning_lower" = "Limite inferior";
 "quit_app" = "Encerrar CodexBar";
 
 /* Tab titles */

--- a/Sources/CodexBarCore/Providers/Codex/CodexCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexCLISession.swift
@@ -35,6 +35,15 @@ actor CodexCLISession {
     private var sessionArguments: [String] = []
     private var sessionWorkingDirectory: URL?
 
+    struct CaptureOptions {
+        let timeout: TimeInterval
+        let rows: UInt16
+        let cols: UInt16
+        let environment: [String: String]
+        let extraArgs: [String]
+        let workingDirectory: URL?
+    }
+
     private struct RollingBuffer {
         private let maxNeedle: Int
         private var tail = Data()
@@ -86,20 +95,9 @@ actor CodexCLISession {
     // swiftlint:disable cyclomatic_complexity
     func captureStatus(
         binary: String,
-        timeout: TimeInterval,
-        rows: UInt16,
-        cols: UInt16,
-        environment: [String: String],
-        extraArgs: [String],
-        workingDirectory: URL?) async throws -> String
+        options: CaptureOptions) async throws -> String
     {
-        try self.ensureStarted(
-            binary: binary,
-            rows: rows,
-            cols: cols,
-            environment: environment,
-            extraArgs: extraArgs,
-            workingDirectory: workingDirectory)
+        try self.ensureStarted(binary: binary, options: options)
         if let startedAt {
             let sinceStart = Date().timeIntervalSince(startedAt)
             if sinceStart < 0.4 {
@@ -127,7 +125,7 @@ actor CodexCLISession {
         var updateScanBuffer = RollingBuffer(maxNeedle: updateMaxNeedle)
 
         var buffer = Data()
-        let deadline = Date().addingTimeInterval(timeout)
+        let deadline = Date().addingTimeInterval(options.timeout)
         var nextCursorCheckAt = Date(timeIntervalSince1970: 0)
 
         var skippedCodexUpdate = false
@@ -262,20 +260,16 @@ actor CodexCLISession {
 
     private func ensureStarted(
         binary: String,
-        rows: UInt16,
-        cols: UInt16,
-        environment: [String: String],
-        extraArgs: [String],
-        workingDirectory: URL?) throws
+        options: CaptureOptions) throws
     {
         if let proc = self.process,
            proc.isRunning,
            self.binaryPath == binary,
-           self.ptyRows == rows,
-           self.ptyCols == cols,
-           self.sessionEnvironment == environment,
-           self.sessionArguments == extraArgs,
-           self.sessionWorkingDirectory == workingDirectory
+           self.ptyRows == options.rows,
+           self.ptyCols == options.cols,
+           self.sessionEnvironment == options.environment,
+           self.sessionArguments == options.extraArgs,
+           self.sessionWorkingDirectory == options.workingDirectory
         {
             return
         }
@@ -283,7 +277,7 @@ actor CodexCLISession {
 
         var primaryFD: Int32 = -1
         var secondaryFD: Int32 = -1
-        var win = winsize(ws_row: rows, ws_col: cols, ws_xpixel: 0, ws_ypixel: 0)
+        var win = winsize(ws_row: options.rows, ws_col: options.cols, ws_xpixel: 0, ws_ypixel: 0)
         guard openpty(&primaryFD, &secondaryFD, nil, nil, &win) == 0 else {
             throw SessionError.launchFailed("openpty failed")
         }
@@ -295,15 +289,15 @@ actor CodexCLISession {
         let proc = Process()
         let resolvedURL = URL(fileURLWithPath: binary)
         proc.executableURL = resolvedURL
-        proc.arguments = extraArgs
+        proc.arguments = options.extraArgs
         proc.standardInput = secondaryHandle
         proc.standardOutput = secondaryHandle
         proc.standardError = secondaryHandle
-        proc.currentDirectoryURL = workingDirectory
+        proc.currentDirectoryURL = options.workingDirectory
 
         let env = TTYCommandRunner.enrichedEnvironment(
-            baseEnv: environment,
-            home: environment["HOME"] ?? NSHomeDirectory())
+            baseEnv: options.environment,
+            home: options.environment["HOME"] ?? NSHomeDirectory())
         proc.environment = env
 
         do {
@@ -339,11 +333,11 @@ actor CodexCLISession {
         self.processGroup = processGroup
         self.binaryPath = binary
         self.startedAt = Date()
-        self.ptyRows = rows
-        self.ptyCols = cols
-        self.sessionEnvironment = environment
-        self.sessionArguments = extraArgs
-        self.sessionWorkingDirectory = workingDirectory
+        self.ptyRows = options.rows
+        self.ptyCols = options.cols
+        self.sessionEnvironment = options.environment
+        self.sessionArguments = options.extraArgs
+        self.sessionWorkingDirectory = options.workingDirectory
     }
 
     private func cleanup() {

--- a/Sources/CodexBarCore/Providers/Codex/CodexStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexStatusProbe.swift
@@ -212,12 +212,13 @@ public struct CodexStatusProbe {
             do {
                 text = try await CodexCLISession.shared.captureStatus(
                     binary: binary,
-                    timeout: timeout,
-                    rows: rows,
-                    cols: cols,
-                    environment: self.environment,
-                    extraArgs: extraArgs,
-                    workingDirectory: workingDirectory)
+                    options: .init(
+                        timeout: timeout,
+                        rows: rows,
+                        cols: cols,
+                        environment: self.environment,
+                        extraArgs: extraArgs,
+                        workingDirectory: workingDirectory))
             } catch CodexCLISession.SessionError.processExited {
                 throw CodexStatusProbeError.timedOut
             } catch CodexCLISession.SessionError.timedOut {

--- a/Sources/CodexBarCore/Providers/Codex/CodexStatusProbeIsolation.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexStatusProbeIsolation.swift
@@ -2,13 +2,12 @@ import Foundation
 
 enum CodexStatusProbeIsolation {
     static func supportDirectory(environment: [String: String]) throws -> URL {
-        let baseURL: URL
-        if let tmp = environment["TMPDIR"]?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !tmp.isEmpty
+        let baseURL: URL = if let tmp = environment["TMPDIR"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+                              !tmp.isEmpty
         {
-            baseURL = URL(fileURLWithPath: tmp, isDirectory: true)
+            URL(fileURLWithPath: tmp, isDirectory: true)
         } else {
-            baseURL = FileManager.default.temporaryDirectory
+            FileManager.default.temporaryDirectory
         }
 
         let directory = baseURL

--- a/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
@@ -55,15 +55,19 @@ struct StatusMenuSwitcherRefreshTests {
         let nextProviderButton = try #require(Self.switcherButtons(in: menu).first { $0.state == .off })
         #expect(initialSwitcher._test_simulateRuntimeClick(buttonTag: nextProviderButton.tag) == true)
 
-        for _ in 0..<50 {
+        var replacementSwitcher: ProviderSwitcherView?
+        for _ in 0..<100 {
             await Task.yield()
-            guard let currentSwitcher = menu.items.first?.view as? ProviderSwitcherView,
-                  initialSwitcherID == ObjectIdentifier(currentSwitcher)
-            else { break }
+            if let currentSwitcher = menu.items.first?.view as? ProviderSwitcherView,
+               initialSwitcherID != ObjectIdentifier(currentSwitcher)
+            {
+                replacementSwitcher = currentSwitcher
+                break
+            }
             try? await Task.sleep(for: .milliseconds(20))
         }
 
-        let updatedSwitcher = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        let updatedSwitcher = try #require(replacementSwitcher)
         #expect(initialSwitcherID != ObjectIdentifier(updatedSwitcher))
         #expect(updatedSwitcher.frame.width == 310)
     }

--- a/Tests/CodexBarTests/TTYCommandRunnerTests.swift
+++ b/Tests/CodexBarTests/TTYCommandRunnerTests.swift
@@ -141,7 +141,7 @@ struct TTYCommandRunnerEnvTests {
     }
 
     @Test
-    func `codex status probe uses non persistent thread storage`() throws {
+    func `codex status probe uses non persistent thread storage`() {
         let stateHome = URL(fileURLWithPath: "/tmp/codexbar status \"state\"", isDirectory: true)
         let args = CodexStatusProbeIsolation.codexArguments(stateHome: stateHome)
 


### PR DESCRIPTION
## Summary
- Add missing Brazilian Portuguese translations for quota warning settings
- Keep quota/session wording consistent with the existing pt-BR localization
- Preserve placeholder formatting for inherited/custom threshold labels

## Validation
- Checked no quota warning localization keys are missing in pt-BR
- Checked quota warning placeholders match the English strings
- Ran `git diff --check`
