### PR TITLE
Clarify unofficial Kimi K2 provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Codex: prefer per-event token usage over divergent total counters when scanning local cost history, preventing large false cost spikes (#968). Thanks @Ifan24!
+- Kimi K2: label the legacy provider as unofficial and remove links that presented the legacy endpoint as an official Kimi account surface (#967, fixes #473). Thanks @mturac!
 - OpenAI: shorten the provider label to "OpenAI" so the menu tab no longer clips.
 - Packaging: skip slow widget App Intents metadata during dev restarts and preserve the previous app bundle if required metadata generation times out.
 - Claude: keep the last successful usage card visible across transient probe timeouts while still clearing stale data after Claude auth changes.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Or download release tarballs from GitHub Releases:
 - [Manus](docs/manus.md) — Browser `session_id` auth for credit balance, monthly credits, and daily refresh tracking.
 - [MiniMax](docs/minimax.md) — API token, cookie header, or browser cookies for coding-plan usage.
 - [Kimi](docs/kimi.md) — Auth token (JWT from `kimi-auth` cookie) for weekly quota + 5‑hour rate limit.
-- [Kimi K2](docs/kimi-k2.md) — API key for credit-based usage totals.
+- [Kimi K2 (unofficial)](docs/kimi-k2.md) — Legacy API key flow for credit-based usage totals.
 - [Kilo](docs/kilo.md) — API token with CLI-auth fallback for Kilo Pass usage.
 - [Kiro](docs/kiro.md) — CLI-based usage; monthly credits + bonus credits.
 - [Vertex AI](docs/vertexai.md) — Google Cloud gcloud OAuth with token cost tracking from local Claude logs.

--- a/Sources/CodexBar/Providers/KimiK2/KimiK2ProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/KimiK2/KimiK2ProviderImplementation.swift
@@ -18,18 +18,18 @@ struct KimiK2ProviderImplementation: ProviderImplementation {
             ProviderSettingsFieldDescriptor(
                 id: "kimi-k2-api-token",
                 title: "API key",
-                subtitle: "Stored in ~/.codexbar/config.json. Generate one at kimi-k2.ai.",
+                subtitle: "Stored in ~/.codexbar/config.json. For the official Kimi API, use Moonshot / Kimi API.",
                 kind: .secure,
                 placeholder: "Paste API key…",
                 binding: context.stringBinding(\.kimiK2APIToken),
                 actions: [
                     ProviderSettingsActionDescriptor(
                         id: "kimi-k2-open-api-keys",
-                        title: "Open API Keys",
+                        title: "Open legacy provider docs",
                         style: .link,
                         isVisible: nil,
                         perform: {
-                            if let url = URL(string: "https://kimi-k2.ai/user-center/api-keys") {
+                            if let url = URL(string: "https://github.com/steipete/CodexBar/blob/main/docs/kimi-k2.md") {
                                 NSWorkspace.shared.open(url)
                             }
                         }),

--- a/Sources/CodexBarCore/Providers/KimiK2/KimiK2ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/KimiK2/KimiK2ProviderDescriptor.swift
@@ -9,20 +9,20 @@ public enum KimiK2ProviderDescriptor {
             id: .kimik2,
             metadata: ProviderMetadata(
                 id: .kimik2,
-                displayName: "Kimi K2",
+                displayName: "Kimi K2 (unofficial)",
                 sessionLabel: "Credits",
                 weeklyLabel: "Credits",
                 opusLabel: nil,
                 supportsOpus: false,
                 supportsCredits: false,
                 creditsHint: "",
-                toggleTitle: "Show Kimi K2 usage",
+                toggleTitle: "Show unofficial Kimi K2 usage",
                 cliName: "kimik2",
                 defaultEnabled: false,
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
                 browserCookieOrder: nil,
-                dashboardURL: "https://kimi-k2.ai/my-credits",
+                dashboardURL: nil,
                 statusPageURL: nil),
             branding: ProviderBranding(
                 iconStyle: .kimi,
@@ -30,7 +30,7 @@ public enum KimiK2ProviderDescriptor {
                 color: ProviderColor(red: 76 / 255, green: 0 / 255, blue: 255 / 255)),
             tokenCost: ProviderTokenCostConfig(
                 supportsTokenCost: false,
-                noDataMessage: { "Kimi K2 cost summary is not available." }),
+                noDataMessage: { "Unofficial Kimi K2 cost summary is not available." }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .api],
                 pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [KimiK2APIFetchStrategy()] })),

--- a/Tests/CodexBarTests/ProviderMetadataStatusLinkTests.swift
+++ b/Tests/CodexBarTests/ProviderMetadataStatusLinkTests.swift
@@ -12,4 +12,13 @@ struct ProviderMetadataStatusLinkTests {
                 "Expected \(provider.rawValue) statusLinkURL to be \(expected)")
         }
     }
+
+    @Test
+    func `kimi K2 metadata does not present legacy endpoint as official`() throws {
+        let meta = try #require(ProviderDefaults.metadata[.kimik2])
+
+        #expect(meta.displayName == "Kimi K2 (unofficial)")
+        #expect(meta.toggleTitle == "Show unofficial Kimi K2 usage")
+        #expect(meta.dashboardURL == nil)
+    }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -118,7 +118,7 @@
           <span class="chip">K</span><span class="meta"><span class="name">Kimi</span><span class="auth">Token</span></span>
         </a></li>
         <li><a class="provider" style="--brand:#4C00FF" href="https://github.com/steipete/CodexBar/blob/main/docs/kimi-k2.md">
-          <span class="chip">K</span><span class="meta"><span class="name">Kimi K2</span><span class="auth">API key</span></span>
+          <span class="chip">K</span><span class="meta"><span class="name">Kimi K2</span><span class="auth">Legacy API</span></span>
         </a></li>
         <li><a class="provider" style="--brand:#F27027" href="https://github.com/steipete/CodexBar/blob/main/docs/kilo.md">
           <span class="chip">K</span><span class="meta"><span class="name">Kilo</span><span class="auth">API key</span></span>

--- a/docs/kimi-k2.md
+++ b/docs/kimi-k2.md
@@ -8,13 +8,18 @@ read_when:
 
 # Kimi K2 provider
 
-Kimi K2 is API-only. Usage is reported by the credit counter behind `GET https://kimi-k2.ai/api/user/credits`,
-so CodexBar only needs a valid API key to pull your remaining balance and usage.
+> This is a legacy, unofficial provider for the `kimi-k2.ai` credit endpoint.
+> For the official Kimi API account and billing surface, use the Moonshot / Kimi
+> API provider instead.
+
+Kimi K2 is API-only. Usage is reported by the credit counter behind
+`GET https://kimi-k2.ai/api/user/credits`, so CodexBar only needs a valid API
+key for that legacy endpoint to pull your remaining balance and usage.
 
 ## Data sources + fallback order
 
 1) **API key** stored in `~/.codexbar/config.json` or supplied via `KIMI_K2_API_KEY` / `KIMI_API_KEY` / `KIMI_KEY`.
-   CodexBar stores the key in config after you paste it in Preferences → Providers → Kimi K2.
+   CodexBar stores the key in config after you paste it in Preferences → Providers → Kimi K2 (unofficial).
 2) **Credit endpoint**
    - `GET https://kimi-k2.ai/api/user/credits`
    - Request headers: `Authorization: Bearer <api key>`, `Accept: application/json`

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -33,7 +33,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 | Kimi | Auth token from `kimi-auth` cookie/manual token/env → usage API (`web`). |
 | Kilo | API token from config/env → usage API (`api`); auto falls back to CLI session auth (`cli`). |
 | Copilot | Device-flow/env/config token → `copilot_internal` API (`api`). |
-| Kimi K2 | API key from config/env → credit endpoint (`api`). |
+| Kimi K2 (unofficial) | API key from config/env → legacy credit endpoint (`api`). |
 | Kiro | CLI command via `kiro-cli chat --no-interactive "/usage"` (`cli`). |
 | Vertex AI | Google ADC OAuth (gcloud) → Cloud Monitoring quota usage (`oauth`). |
 | Augment | `auggie` CLI first, then browser-cookie web fallback (`cli`, `web`). |
@@ -103,9 +103,10 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Status: none yet.
 - Details: `docs/kilo.md`.
 
-## Kimi K2
+## Kimi K2 (unofficial)
 - API key via `~/.codexbar/config.json` or `KIMI_K2_API_KEY`/`KIMI_API_KEY` env var.
-- Shows credit usage based on consumed/remaining totals.
+- Shows credit usage from the legacy `kimi-k2.ai` consumed/remaining totals.
+- Use Moonshot / Kimi API for the official Kimi API account and billing surface.
 - Status: none yet.
 - Details: `docs/kimi-k2.md`.
 

--- a/docs/social.html
+++ b/docs/social.html
@@ -217,7 +217,7 @@
         <li><div class="tile" style="--brand:#E85A6A"><div class="chip">z</div><div class="name">z.ai</div></div></li>
         <li><div class="tile" style="--brand:#FE6060"><div class="chip">M</div><div class="name">MiniMax</div></div></li>
         <li><div class="tile" style="--brand:#FE603C"><div class="chip">K</div><div class="name">Kimi</div></div></li>
-        <li><div class="tile" style="--brand:#4C00FF"><div class="chip">K</div><div class="name">Kimi K2</div></div></li>
+        <li><div class="tile" style="--brand:#4C00FF"><div class="chip">K</div><div class="name">Kimi K2 Legacy</div></div></li>
         <li><div class="tile" style="--brand:#F27027"><div class="chip">K</div><div class="name">Kilo</div></div></li>
         <li><div class="tile" style="--brand:#FF9900;--ink:#0a0a0c"><div class="chip">K</div><div class="name">Kiro</div></div></li>
 


### PR DESCRIPTION
## Summary
- label the legacy Kimi K2 provider as unofficial in provider metadata and docs
- remove the kimi-k2.ai dashboard link from provider metadata so it is not presented as an official account surface
- point the settings action at the legacy provider docs and add a metadata regression test

Fixes #473

## Tests
- git diff --check
- swift test --skip-update --filter ProviderMetadataStatusLinkTests
- make check