### PR TITLE
Prefer Codex last token usage for cost scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Usage charts: reuse the OpenAI API inline dashboard for local Codex/Claude/Vertex/Bedrock cost history, OpenRouter day/week/month spend, z.ai hourly tokens, and Mistral daily spend.
 
 ### Fixed
+- Codex: prefer per-event token usage over divergent total counters when scanning local cost history, preventing large false cost spikes (#968). Thanks @Ifan24!
 - OpenAI: shorten the provider label to "OpenAI" so the menu tab no longer clips.
 - Packaging: skip slow widget App Intents metadata during dev restarts and preserve the previous app bundle if required metadata generation times out.
 - Claude: keep the last successful usage card visible across transient probe timeouts while still clearing stale data after Claude auth changes.

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageCache.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageCache.swift
@@ -4,7 +4,7 @@ enum CostUsageCacheIO {
     private static func artifactVersion(for provider: UsageProvider) -> Int {
         switch provider {
         case .codex:
-            6
+            7
         case .claude, .vertexai:
             2
         default:

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
@@ -93,19 +93,25 @@ enum CostUsageScanner {
             output: max(0, current.output - baseline.output))
     }
 
-    private static func codexMinNonZeroTotals(
-        _ preferred: CostUsageCodexTotals,
-        _ fallback: CostUsageCodexTotals) -> CostUsageCodexTotals
+    private static func codexDivergentTotalDelta(
+        rawBaseline: CostUsageCodexTotals?,
+        countedBaseline: CostUsageCodexTotals?,
+        current: CostUsageCodexTotals) -> CostUsageCodexTotals
     {
-        func choose(_ first: Int, _ second: Int) -> Int {
-            if first > 0, second > 0 { return min(first, second) }
-            return max(first, second)
+        let rawBaseline = rawBaseline ?? .init(input: 0, cached: 0, output: 0)
+        let countedBaseline = countedBaseline ?? .init(input: 0, cached: 0, output: 0)
+
+        func delta(raw: Int, counted: Int, current: Int) -> Int {
+            if current >= raw {
+                return max(0, current - raw)
+            }
+            return max(0, current - counted)
         }
 
         return CostUsageCodexTotals(
-            input: choose(preferred.input, fallback.input),
-            cached: choose(preferred.cached, fallback.cached),
-            output: choose(preferred.output, fallback.output))
+            input: delta(raw: rawBaseline.input, counted: countedBaseline.input, current: current.input),
+            cached: delta(raw: rawBaseline.cached, counted: countedBaseline.cached, current: current.cached),
+            output: delta(raw: rawBaseline.output, counted: countedBaseline.output, current: current.output))
     }
 
     private struct CodexScanResources {
@@ -696,11 +702,12 @@ enum CostUsageScanner {
                                 input: toInt(total["input_tokens"]),
                                 cached: toInt(total["cached_input_tokens"] ?? total["cache_read_input_tokens"]),
                                 output: toInt(total["output_tokens"]))
-                            let rawDelta = Self.codexTotalDelta(from: rawTotalsBaseline, to: next)
-                            let countedDelta = Self.codexTotalDelta(from: previousTotals, to: next)
                             let delta = sawDivergentTotals
-                                ? Self.codexMinNonZeroTotals(rawDelta, countedDelta)
-                                : rawDelta
+                                ? Self.codexDivergentTotalDelta(
+                                    rawBaseline: rawTotalsBaseline,
+                                    countedBaseline: previousTotals,
+                                    current: next)
+                                : Self.codexTotalDelta(from: rawTotalsBaseline, to: next)
                             let base = previousTotals ?? .init(input: 0, cached: 0, output: 0)
                             let countedTotals = Self.codexAddTotals(base, delta)
                             previousTotals = countedTotals
@@ -948,11 +955,12 @@ enum CostUsageScanner {
                                 rawTotals
                             }
 
-                            let rawDelta = Self.codexTotalDelta(from: rawTotalsBaseline, to: currentTotals)
-                            let countedDelta = Self.codexTotalDelta(from: previousTotals, to: currentTotals)
                             let delta = sawDivergentTotals
-                                ? Self.codexMinNonZeroTotals(rawDelta, countedDelta)
-                                : rawDelta
+                                ? Self.codexDivergentTotalDelta(
+                                    rawBaseline: rawTotalsBaseline,
+                                    countedBaseline: previousTotals,
+                                    current: currentTotals)
+                                : Self.codexTotalDelta(from: rawTotalsBaseline, to: currentTotals)
                             deltaInput = delta.input
                             deltaCached = delta.cached
                             deltaOutput = delta.output

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
@@ -68,6 +68,46 @@ enum CostUsageScanner {
         let totals: CostUsageCodexTotals
     }
 
+    private static func codexTotalsEqual(_ lhs: CostUsageCodexTotals?, _ rhs: CostUsageCodexTotals?) -> Bool {
+        lhs?.input == rhs?.input && lhs?.cached == rhs?.cached && lhs?.output == rhs?.output
+    }
+
+    private static func codexAddTotals(
+        _ lhs: CostUsageCodexTotals,
+        _ rhs: CostUsageCodexTotals) -> CostUsageCodexTotals
+    {
+        CostUsageCodexTotals(
+            input: lhs.input + rhs.input,
+            cached: lhs.cached + rhs.cached,
+            output: lhs.output + rhs.output)
+    }
+
+    private static func codexTotalDelta(
+        from baseline: CostUsageCodexTotals?,
+        to current: CostUsageCodexTotals) -> CostUsageCodexTotals
+    {
+        let baseline = baseline ?? .init(input: 0, cached: 0, output: 0)
+        return CostUsageCodexTotals(
+            input: max(0, current.input - baseline.input),
+            cached: max(0, current.cached - baseline.cached),
+            output: max(0, current.output - baseline.output))
+    }
+
+    private static func codexMinNonZeroTotals(
+        _ preferred: CostUsageCodexTotals,
+        _ fallback: CostUsageCodexTotals) -> CostUsageCodexTotals
+    {
+        func choose(_ first: Int, _ second: Int) -> Int {
+            if first > 0, second > 0 { return min(first, second) }
+            return max(first, second)
+        }
+
+        return CostUsageCodexTotals(
+            input: choose(preferred.input, fallback.input),
+            cached: choose(preferred.cached, fallback.cached),
+            output: choose(preferred.output, fallback.output))
+    }
+
     private struct CodexScanResources {
         let fileIndex: CodexSessionFileIndex
         let inheritedResolver: CodexInheritedTotalsResolver
@@ -570,6 +610,8 @@ enum CostUsageScanner {
     {
         var sessionId: String?
         var previousTotals: CostUsageCodexTotals?
+        var rawTotalsBaseline: CostUsageCodexTotals?
+        var sawDivergentTotals = false
         var snapshots: [CodexTimestampedTotals] = []
         var warnedAboutUnparsedTimestamp = false
 
@@ -620,28 +662,56 @@ enum CostUsageScanner {
                             return 0
                         }
 
-                        if let total = info["total_token_usage"] as? [String: Any] {
+                        let total = info["total_token_usage"] as? [String: Any]
+                        let last = info["last_token_usage"] as? [String: Any]
+
+                        if let last {
+                            let rawDelta = CostUsageCodexTotals(
+                                input: max(0, toInt(last["input_tokens"])),
+                                cached: max(0, toInt(last["cached_input_tokens"] ?? last["cache_read_input_tokens"])),
+                                output: max(0, toInt(last["output_tokens"])))
+                            let base = previousTotals ?? .init(input: 0, cached: 0, output: 0)
+                            let next = Self.codexAddTotals(base, rawDelta)
+                            previousTotals = next
+
+                            if let total {
+                                let rawTotals = CostUsageCodexTotals(
+                                    input: toInt(total["input_tokens"]),
+                                    cached: toInt(total["cached_input_tokens"] ?? total["cache_read_input_tokens"]),
+                                    output: toInt(total["output_tokens"]))
+                                rawTotalsBaseline = rawTotals
+                                if !Self.codexTotalsEqual(rawTotals, next) {
+                                    sawDivergentTotals = true
+                                }
+                            } else {
+                                rawTotalsBaseline = next
+                            }
+
+                            snapshots.append(CodexTimestampedTotals(
+                                timestamp: timestamp,
+                                date: parsedSnapshotDate(timestamp: timestamp),
+                                totals: next))
+                        } else if let total {
                             let next = CostUsageCodexTotals(
                                 input: toInt(total["input_tokens"]),
                                 cached: toInt(total["cached_input_tokens"] ?? total["cache_read_input_tokens"]),
                                 output: toInt(total["output_tokens"]))
-                            previousTotals = next
-                            snapshots.append(CodexTimestampedTotals(
-                                timestamp: timestamp,
-                                date: parsedSnapshotDate(timestamp: timestamp),
-                                totals: next))
-                        } else if let last = info["last_token_usage"] as? [String: Any] {
+                            let rawDelta = Self.codexTotalDelta(from: rawTotalsBaseline, to: next)
+                            let countedDelta = Self.codexTotalDelta(from: previousTotals, to: next)
+                            let delta = sawDivergentTotals
+                                ? Self.codexMinNonZeroTotals(rawDelta, countedDelta)
+                                : rawDelta
                             let base = previousTotals ?? .init(input: 0, cached: 0, output: 0)
-                            let next = CostUsageCodexTotals(
-                                input: base.input + toInt(last["input_tokens"]),
-                                cached: base
-                                    .cached + toInt(last["cached_input_tokens"] ?? last["cache_read_input_tokens"]),
-                                output: base.output + toInt(last["output_tokens"]))
-                            previousTotals = next
+                            let countedTotals = Self.codexAddTotals(base, delta)
+                            previousTotals = countedTotals
+                            rawTotalsBaseline = next
+                            if !Self.codexTotalsEqual(next, countedTotals) {
+                                sawDivergentTotals = true
+                            }
                             snapshots.append(CodexTimestampedTotals(
                                 timestamp: timestamp,
                                 date: parsedSnapshotDate(timestamp: timestamp),
-                                totals: next))
+                                totals: countedTotals))
                         }
                     }
                 })
@@ -671,6 +741,8 @@ enum CostUsageScanner {
         var inheritedTotals: CostUsageCodexTotals?
         var remainingInheritedTotals: CostUsageCodexTotals?
         var currentTurnID = initialCodexTurnID
+        var rawTotalsBaseline = initialTotals
+        var sawDivergentTotals = false
 
         var days: [String: [String: [Int]]] = [:]
         var rows: [CodexUsageRow] = []
@@ -828,7 +900,40 @@ enum CostUsageScanner {
                             return adjusted
                         }
 
-                        if let total {
+                        if let last {
+                            let rawDelta = CostUsageCodexTotals(
+                                input: max(0, toInt(last["input_tokens"])),
+                                cached: max(0, toInt(last["cached_input_tokens"] ?? last["cache_read_input_tokens"])),
+                                output: max(0, toInt(last["output_tokens"])))
+                            let adjustedDelta = adjustedLastDelta(rawDelta)
+                            deltaInput = adjustedDelta.input
+                            deltaCached = adjustedDelta.cached
+                            deltaOutput = adjustedDelta.output
+                            let prev = previousTotals ?? .init(input: 0, cached: 0, output: 0)
+                            let countedTotals = Self.codexAddTotals(prev, adjustedDelta)
+                            previousTotals = countedTotals
+
+                            if let total {
+                                let rawTotals = CostUsageCodexTotals(
+                                    input: toInt(total["input_tokens"]),
+                                    cached: toInt(total["cached_input_tokens"] ?? total["cache_read_input_tokens"]),
+                                    output: toInt(total["output_tokens"]))
+                                let currentTotals: CostUsageCodexTotals = if let inheritedTotals {
+                                    CostUsageCodexTotals(
+                                        input: max(0, rawTotals.input - inheritedTotals.input),
+                                        cached: max(0, rawTotals.cached - inheritedTotals.cached),
+                                        output: max(0, rawTotals.output - inheritedTotals.output))
+                                } else {
+                                    rawTotals
+                                }
+                                rawTotalsBaseline = currentTotals
+                                if !Self.codexTotalsEqual(currentTotals, countedTotals) {
+                                    sawDivergentTotals = true
+                                }
+                            } else {
+                                rawTotalsBaseline = countedTotals
+                            }
+                        } else if let total {
                             let rawTotals = CostUsageCodexTotals(
                                 input: toInt(total["input_tokens"]),
                                 cached: toInt(total["cached_input_tokens"] ?? total["cache_read_input_tokens"]),
@@ -843,26 +948,21 @@ enum CostUsageScanner {
                                 rawTotals
                             }
 
+                            let rawDelta = Self.codexTotalDelta(from: rawTotalsBaseline, to: currentTotals)
+                            let countedDelta = Self.codexTotalDelta(from: previousTotals, to: currentTotals)
+                            let delta = sawDivergentTotals
+                                ? Self.codexMinNonZeroTotals(rawDelta, countedDelta)
+                                : rawDelta
+                            deltaInput = delta.input
+                            deltaCached = delta.cached
+                            deltaOutput = delta.output
                             let prev = previousTotals ?? .init(input: 0, cached: 0, output: 0)
-                            deltaInput = max(0, currentTotals.input - prev.input)
-                            deltaCached = max(0, currentTotals.cached - prev.cached)
-                            deltaOutput = max(0, currentTotals.output - prev.output)
-                            previousTotals = currentTotals
+                            previousTotals = Self.codexAddTotals(prev, delta)
+                            rawTotalsBaseline = currentTotals
+                            if !Self.codexTotalsEqual(rawTotalsBaseline, previousTotals) {
+                                sawDivergentTotals = true
+                            }
                             remainingInheritedTotals = nil
-                        } else if let last {
-                            let rawDelta = CostUsageCodexTotals(
-                                input: max(0, toInt(last["input_tokens"])),
-                                cached: max(0, toInt(last["cached_input_tokens"] ?? last["cache_read_input_tokens"])),
-                                output: max(0, toInt(last["output_tokens"])))
-                            let adjustedDelta = adjustedLastDelta(rawDelta)
-                            deltaInput = adjustedDelta.input
-                            deltaCached = adjustedDelta.cached
-                            deltaOutput = adjustedDelta.output
-                            let prev = previousTotals ?? .init(input: 0, cached: 0, output: 0)
-                            previousTotals = CostUsageCodexTotals(
-                                input: prev.input + deltaInput,
-                                cached: prev.cached + deltaCached,
-                                output: prev.output + deltaOutput)
                         } else {
                             return
                         }
@@ -902,7 +1002,9 @@ enum CostUsageScanner {
             days: days,
             parsedBytes: parsedBytes,
             lastModel: currentModel,
-            lastTotals: previousTotals,
+            lastTotals: sawDivergentTotals && !Self.codexTotalsEqual(rawTotalsBaseline, previousTotals)
+                ? nil
+                : previousTotals,
             lastCodexTurnID: currentTurnID,
             sessionId: sessionId,
             forkedFromId: forkedFromId,

--- a/Tests/CodexBarTests/CostUsageCacheTests.swift
+++ b/Tests/CodexBarTests/CostUsageCacheTests.swift
@@ -10,7 +10,7 @@ struct CostUsageCacheTests {
         let codexURL = CostUsageCacheIO.cacheFileURL(provider: .codex, cacheRoot: root)
         let claudeURL = CostUsageCacheIO.cacheFileURL(provider: .claude, cacheRoot: root)
 
-        #expect(codexURL.lastPathComponent == "codex-v6.json")
+        #expect(codexURL.lastPathComponent == "codex-v7.json")
         #expect(claudeURL.lastPathComponent == "claude-v2.json")
     }
 }

--- a/Tests/CodexBarTests/CostUsageScannerBreakdownTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerBreakdownTests.swift
@@ -5,6 +5,51 @@ import Testing
 // swiftlint:disable file_length
 // swiftlint:disable type_body_length
 struct CostUsageScannerBreakdownTests {
+    private typealias Usage = (input: Int, cached: Int, output: Int)
+
+    private func codexTurnContext(timestamp: String, model: String) -> [String: Any] {
+        [
+            "type": "turn_context",
+            "timestamp": timestamp,
+            "payload": [
+                "model": model,
+            ],
+        ]
+    }
+
+    private func codexTokenCount(
+        timestamp: String,
+        model: String,
+        total: Usage? = nil,
+        last: Usage? = nil) -> [String: Any]
+    {
+        var info: [String: Any] = [
+            "model": model,
+        ]
+        if let total {
+            info["total_token_usage"] = [
+                "input_tokens": total.input,
+                "cached_input_tokens": total.cached,
+                "output_tokens": total.output,
+            ]
+        }
+        if let last {
+            info["last_token_usage"] = [
+                "input_tokens": last.input,
+                "cached_input_tokens": last.cached,
+                "output_tokens": last.output,
+            ]
+        }
+        return [
+            "type": "event_msg",
+            "timestamp": timestamp,
+            "payload": [
+                "type": "token_count",
+                "info": info,
+            ],
+        ]
+    }
+
     @Test
     func `codex daily report parses token counts and caches`() throws {
         let env = try CostUsageTestEnvironment()
@@ -95,6 +140,177 @@ struct CostUsageScannerBreakdownTests {
         #expect(second.data[0].modelsUsed == ["gpt-5.2-codex"])
         #expect(second.data[0].totalTokens == 176)
         #expect((second.data[0].costUSD ?? 0) > (first.data[0].costUSD ?? 0))
+    }
+
+    @Test
+    func `codex daily report prefers last token usage over divergent totals`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 5, day: 15)
+        let iso0 = env.isoString(for: day)
+        let model = "openai/gpt-5.5"
+        let turnContext = self.codexTurnContext(timestamp: iso0, model: model)
+
+        _ = try env.writeCodexSessionFile(
+            day: day,
+            filename: "session.jsonl",
+            contents: env.jsonl([
+                turnContext,
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: day.addingTimeInterval(1)),
+                    model: model,
+                    total: (input: 100, cached: 20, output: 10),
+                    last: (input: 100, cached: 20, output: 10)),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: day.addingTimeInterval(2)),
+                    model: model,
+                    total: (input: 160, cached: 40, output: 16),
+                    last: (input: 60, cached: 20, output: 6)),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: day.addingTimeInterval(3)),
+                    model: model,
+                    total: (input: 1000, cached: 900, output: 100),
+                    last: (input: 40, cached: 30, output: 5)),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: day.addingTimeInterval(4)),
+                    model: model,
+                    total: (input: 1050, cached: 930, output: 110),
+                    last: (input: 50, cached: 30, output: 10)),
+            ]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+        options.forceRescan = true
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: day,
+            until: day,
+            now: day,
+            options: options)
+        let expectedCost = CostUsagePricing.codexCostUSD(
+            model: model,
+            inputTokens: 250,
+            cachedInputTokens: 100,
+            outputTokens: 31)
+
+        #expect(report.data.count == 1)
+        #expect(report.data[0].inputTokens == 250)
+        #expect(report.data[0].outputTokens == 31)
+        #expect(report.data[0].totalTokens == 281)
+        #expect(abs((report.data[0].costUSD ?? 0) - (expectedCost ?? 0)) < 0.000001)
+    }
+
+    @Test
+    func `codex total only after divergent totals uses raw delta when it continues`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 5, day: 15)
+        let model = "openai/gpt-5.5"
+        let fileURL = try env.writeCodexSessionFile(
+            day: day,
+            filename: "mixed-raw-continuing.jsonl",
+            contents: env.jsonl([
+                self.codexTurnContext(timestamp: env.isoString(for: day), model: model),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: day.addingTimeInterval(1)),
+                    model: model,
+                    total: (input: 100, cached: 0, output: 0),
+                    last: (input: 100, cached: 0, output: 0)),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: day.addingTimeInterval(2)),
+                    model: model,
+                    total: (input: 1000, cached: 0, output: 0),
+                    last: (input: 40, cached: 0, output: 0)),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: day.addingTimeInterval(3)),
+                    model: model,
+                    total: (input: 1050, cached: 0, output: 0)),
+            ]))
+
+        let parsed = CostUsageScanner.parseCodexFile(
+            fileURL: fileURL,
+            range: CostUsageScanner.CostUsageDayRange(since: day, until: day))
+        let dayKey = CostUsageScanner.CostUsageDayRange.dayKey(from: day)
+        let packed = parsed.days[dayKey]?["gpt-5.5"] ?? []
+
+        #expect(packed[safe: 0] == 190)
+        #expect(parsed.lastTotals == nil)
+    }
+
+    @Test
+    func `codex total only after divergent totals can resume from counted baseline`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 5, day: 15)
+        let model = "openai/gpt-5.5"
+        let fileURL = try env.writeCodexSessionFile(
+            day: day,
+            filename: "mixed-counted-resume.jsonl",
+            contents: env.jsonl([
+                self.codexTurnContext(timestamp: env.isoString(for: day), model: model),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: day.addingTimeInterval(1)),
+                    model: model,
+                    total: (input: 100, cached: 0, output: 0),
+                    last: (input: 100, cached: 0, output: 0)),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: day.addingTimeInterval(2)),
+                    model: model,
+                    total: (input: 1000, cached: 0, output: 0),
+                    last: (input: 40, cached: 0, output: 0)),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: day.addingTimeInterval(3)),
+                    model: model,
+                    total: (input: 180, cached: 0, output: 0)),
+            ]))
+
+        let parsed = CostUsageScanner.parseCodexFile(
+            fileURL: fileURL,
+            range: CostUsageScanner.CostUsageDayRange(since: day, until: day))
+        let dayKey = CostUsageScanner.CostUsageDayRange.dayKey(from: day)
+        let packed = parsed.days[dayKey]?["gpt-5.5"] ?? []
+
+        #expect(packed[safe: 0] == 180)
+        #expect(parsed.lastTotals?.input == 180)
+    }
+
+    @Test
+    func `codex total only after last only counts from last based baseline`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 5, day: 15)
+        let model = "openai/gpt-5.5"
+        let fileURL = try env.writeCodexSessionFile(
+            day: day,
+            filename: "last-then-total.jsonl",
+            contents: env.jsonl([
+                self.codexTurnContext(timestamp: env.isoString(for: day), model: model),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: day.addingTimeInterval(1)),
+                    model: model,
+                    last: (input: 100, cached: 0, output: 0)),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: day.addingTimeInterval(2)),
+                    model: model,
+                    total: (input: 150, cached: 0, output: 0)),
+            ]))
+
+        let parsed = CostUsageScanner.parseCodexFile(
+            fileURL: fileURL,
+            range: CostUsageScanner.CostUsageDayRange(since: day, until: day))
+        let dayKey = CostUsageScanner.CostUsageDayRange.dayKey(from: day)
+        let packed = parsed.days[dayKey]?["gpt-5.5"] ?? []
+
+        #expect(packed[safe: 0] == 150)
+        #expect(parsed.lastTotals?.input == 150)
     }
 
     @Test
@@ -389,6 +605,83 @@ struct CostUsageScannerBreakdownTests {
         #expect(report.data[0].outputTokens == 2)
         #expect(report.data[0].totalTokens == 9)
         #expect(abs((report.data[0].costUSD ?? 0) - (expectedCost ?? 0)) < 0.000001)
+    }
+
+    @Test
+    func `codex forked child inherits counted parent totals when totals diverge`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let parentDay = try env.makeLocalNoon(year: 2026, month: 2, day: 27)
+        let childDay = try env.makeLocalNoon(year: 2026, month: 3, day: 11)
+        let model = "openai/gpt-5.2-codex"
+        let parentSessionId = "sess-parent-diverged"
+        let childSessionId = "sess-child-diverged"
+        let forkTs = env.isoString(for: parentDay.addingTimeInterval(2.5))
+
+        _ = try env.writeCodexSessionFile(
+            day: parentDay,
+            filename: "rollout-2026-02-27T11-29-28-\(parentSessionId).jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "session_meta",
+                    "payload": [
+                        "id": parentSessionId,
+                    ],
+                ],
+                self.codexTurnContext(timestamp: env.isoString(for: parentDay), model: model),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: parentDay.addingTimeInterval(1)),
+                    model: model,
+                    total: (input: 100, cached: 0, output: 0),
+                    last: (input: 100, cached: 0, output: 0)),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: parentDay.addingTimeInterval(2)),
+                    model: model,
+                    total: (input: 1000, cached: 0, output: 0),
+                    last: (input: 40, cached: 0, output: 0)),
+            ]))
+
+        _ = try env.writeCodexSessionFile(
+            day: childDay,
+            filename: "rollout-2026-03-11T11-30-27-\(childSessionId).jsonl",
+            contents: env.jsonl([
+                [
+                    "type": "session_meta",
+                    "payload": [
+                        "id": childSessionId,
+                        "forked_from_id": parentSessionId,
+                        "timestamp": forkTs,
+                    ],
+                ],
+                self.codexTurnContext(timestamp: env.isoString(for: childDay), model: model),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: childDay.addingTimeInterval(1)),
+                    model: model,
+                    total: (input: 140, cached: 0, output: 0)),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: childDay.addingTimeInterval(2)),
+                    model: model,
+                    total: (input: 170, cached: 0, output: 0)),
+            ]))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            claudeProjectsRoots: nil,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+        options.forceRescan = true
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: childDay,
+            until: childDay,
+            now: childDay,
+            options: options)
+
+        #expect(report.data.count == 1)
+        #expect(report.data[0].inputTokens == 30)
+        #expect(report.data[0].totalTokens == 30)
     }
 
     @Test

--- a/Tests/CodexBarTests/CostUsageScannerBreakdownTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerBreakdownTests.swift
@@ -244,6 +244,45 @@ struct CostUsageScannerBreakdownTests {
     }
 
     @Test
+    func `codex total only after divergent totals preserves zero raw dimensions`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 5, day: 15)
+        let model = "openai/gpt-5.5"
+        let fileURL = try env.writeCodexSessionFile(
+            day: day,
+            filename: "mixed-stale-dimension.jsonl",
+            contents: env.jsonl([
+                self.codexTurnContext(timestamp: env.isoString(for: day), model: model),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: day.addingTimeInterval(1)),
+                    model: model,
+                    total: (input: 100, cached: 0, output: 0),
+                    last: (input: 100, cached: 0, output: 0)),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: day.addingTimeInterval(2)),
+                    model: model,
+                    total: (input: 1000, cached: 900, output: 0),
+                    last: (input: 40, cached: 0, output: 0)),
+                self.codexTokenCount(
+                    timestamp: env.isoString(for: day.addingTimeInterval(3)),
+                    model: model,
+                    total: (input: 1050, cached: 900, output: 0)),
+            ]))
+
+        let parsed = CostUsageScanner.parseCodexFile(
+            fileURL: fileURL,
+            range: CostUsageScanner.CostUsageDayRange(since: day, until: day))
+        let dayKey = CostUsageScanner.CostUsageDayRange.dayKey(from: day)
+        let packed = parsed.days[dayKey]?["gpt-5.5"] ?? []
+
+        #expect(packed[safe: 0] == 190)
+        #expect(packed[safe: 1] == 0)
+        #expect(parsed.lastTotals == nil)
+    }
+
+    @Test
     func `codex total only after divergent totals can resume from counted baseline`() throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }


### PR DESCRIPTION
## Summary
- prefer `last_token_usage` when Codex token-count events include both last and total usage
- keep incremental baselines synced to the counted usage instead of persisting divergent raw totals
- disable Codex incremental cache reuse when raw totals remain divergent, and bump the Codex cost cache artifact to rescan old cached files
- add regressions for mixed last/total streams, total-only continuation after divergence, last-only to total-only fallback, and forked parent inheritance

## Context
I hit a long-running Codex session where `token_count` events carried both `total_token_usage` and `last_token_usage`, but the total counters could jump/diverge across the session stream. Diffing the totals as one monotonic counter inflated the local cost estimate dramatically. The `last_token_usage` values appear to be the stable incremental values for these events.

For the local repro log, the old total-diff accounting produced about 32.8B tokens on the spike day. The patched scanner reports 998,214,939 tokens for that same day, matching the sum of `last_token_usage` increments.

## Verification
- `swift test --filter CostUsageScannerBreakdownTests`
- `swift test`
- `make check`
- `git diff --check`
- local-only replay against the real spike JSONL with the patched scanner; not committed because it references a private session log
