### PR TITLE
Block OpenCode Go cookie leakage on redirects

### DIFF
--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -99,7 +99,7 @@ public struct OpenCodeGoUsageFetcher: Sendable {
         configuration.httpCookieStorage = nil
         return URLSession(
             configuration: configuration,
-            delegate: self.redirectGuardDelegate,
+            delegate: OpenCodeGoUsageFetcher.redirectGuardDelegate,
             delegateQueue: nil)
     }()
 

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -33,6 +33,26 @@ public struct OpenCodeGoUsageFetcher: Sendable {
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
         "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
 
+    private final class RedirectGuardDelegate: NSObject, URLSessionTaskDelegate {
+        func urlSession(
+            _ session: URLSession,
+            task: URLSessionTask,
+            willPerformHTTPRedirection response: HTTPURLResponse,
+            newRequest request: URLRequest,
+            completionHandler: @escaping (URLRequest?) -> Void)
+        {
+            guard let sourceHost = task.originalRequest?.url?.host?.lowercased(),
+                  let destinationHost = request.url?.host?.lowercased(),
+                  sourceHost == destinationHost,
+                  request.url?.scheme?.lowercased() == "https"
+            else {
+                completionHandler(nil)
+                return
+            }
+            completionHandler(request)
+        }
+    }
+
     private struct ServerRequest {
         let serverID: String
         let args: String?
@@ -73,14 +93,24 @@ public struct OpenCodeGoUsageFetcher: Sendable {
         "renewAt",
         "renew_at",
     ]
+    private static let redirectGuardDelegate = RedirectGuardDelegate()
+    private static let redirectGuardSession: URLSession = {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpCookieStorage = nil
+        return URLSession(
+            configuration: configuration,
+            delegate: self.redirectGuardDelegate,
+            delegateQueue: nil)
+    }()
 
     public static func fetchUsage(
         cookieHeader: String,
         timeout: TimeInterval,
         now: Date = Date(),
         workspaceIDOverride: String? = nil,
-        session: URLSession = .shared) async throws -> OpenCodeGoUsageSnapshot
+        session: URLSession? = nil) async throws -> OpenCodeGoUsageSnapshot
     {
+        let session = session ?? self.redirectGuardSession
         guard let requestCookieHeader = OpenCodeWebCookieSupport.requestCookieHeader(from: cookieHeader) else {
             throw OpenCodeGoUsageError.invalidCredentials
         }


### PR DESCRIPTION
## Summary
- add a guarded URLSession for OpenCode Go usage requests
- block cross-host and non-HTTPS redirects so cookies are not forwarded away from opencode.ai
- keep same-host HTTPS redirects working and preserve injected test sessions

## Verification
- swift test --filter OpenCodeGoUsageFetcherErrorTests
- fresh review passes against the PR diff found no remaining OpenCode Go issues

Note: branch name intentionally avoids slashes so the fork's current push CI branch pattern can match it.