### PR TITLE
MiniMax: fix remains-to-used mapping and add quota-style usage cards with weekly text window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Claude: wait for the CLI usage panel to finish rendering after the Current session label so slow Claude Code builds do not produce false "Missing Current session" errors (#959).
 - Claude: label five-hour session pace as "Projected empty" so it is not confused with the reset countdown (#960).
 - Claude: show Enterprise spend-limit usage in automatic menu bar metrics and expose the Extra usage metric picker when spend data is available (#964).
+- MiniMax: show Coding Plan model-remains quotas as used/limit cards and include weekly text-generation quota windows (#970). Thanks @Yuxin-Qiao!
 - Ollama: let automatic session import fall back from Chrome to Safari, Comet, and the rest of the browser import order when Chrome has no Ollama session (#962).
 
 ## 0.26.1 — 2026-05-15

--- a/Sources/CodexBar/MenuCardView+MiniMax.swift
+++ b/Sources/CodexBar/MenuCardView+MiniMax.swift
@@ -4,7 +4,7 @@ import Foundation
 extension UsageMenuCardView.Model {
     static func minimaxMetrics(services: [MiniMaxServiceUsage], input: Input) -> [Metric] {
         let percentStyle: PercentStyle = .used
-        let textGenerationCount = services.filter { $0.displayName == "Text Generation" }.count
+        let textGenerationCount = services.count { $0.displayName == "Text Generation" }
 
         return services.enumerated().map { index, service in
             let used = service.usage

--- a/Sources/CodexBar/MenuCardView+MiniMax.swift
+++ b/Sources/CodexBar/MenuCardView+MiniMax.swift
@@ -3,25 +3,32 @@ import Foundation
 
 extension UsageMenuCardView.Model {
     static func minimaxMetrics(services: [MiniMaxServiceUsage], input: Input) -> [Metric] {
-        let percentStyle: PercentStyle = input.usageBarsShowUsed ? .used : .left
+        let percentStyle: PercentStyle = .used
+        let textGenerationCount = services.filter { $0.displayName == "Text Generation" }.count
 
         return services.enumerated().map { index, service in
             let used = service.usage
-            let remaining = service.remaining
-            let displayValue = input.usageBarsShowUsed ? used : remaining
-            let displayPercent = input.usageBarsShowUsed ? service.percent : (100 - service.percent)
+            let displayPercent = min(100, max(0, service.percent))
+            let usageLabel = "Usage: \(used.formatted()) / \(service.limit.formatted())"
+            let usedLabel = "Used \(String(format: "%.0f%%", displayPercent))"
+            let title = if service.displayName == "Text Generation", textGenerationCount > 1 {
+                "Text Generation · \(service.windowType == "Weekly" ? "Weekly" : "5h")"
+            } else {
+                service.displayName
+            }
 
             return Metric(
                 id: "minimax-service-\(index)",
-                title: service.displayName,
-                percent: min(100, max(0, displayPercent)),
+                title: title,
+                percent: displayPercent,
                 percentStyle: percentStyle,
                 resetText: service.resetDescription,
-                detailText: "\(displayValue)/\(service.limit)",
-                detailLeftText: service.windowType,
-                detailRightText: String(format: "%.0f%%", displayPercent),
+                detailText: service.timeRange,
+                detailLeftText: usageLabel,
+                detailRightText: usedLabel,
                 pacePercent: nil,
-                paceOnTop: true)
+                paceOnTop: true,
+                cardStyle: true)
         }
     }
 }

--- a/Sources/CodexBar/MenuCardView+MiniMax.swift
+++ b/Sources/CodexBar/MenuCardView+MiniMax.swift
@@ -12,7 +12,7 @@ extension UsageMenuCardView.Model {
             let usageLabel = "Usage: \(used.formatted()) / \(service.limit.formatted())"
             let usedLabel = "Used \(String(format: "%.0f%%", displayPercent))"
             let title = if service.displayName == "Text Generation", textGenerationCount > 1 {
-                "Text Generation · \(service.windowType == "Weekly" ? "Weekly" : "5h")"
+                "Text Generation · \(Self.displayWindowBadge(for: service.windowType))"
             } else {
                 service.displayName
             }
@@ -30,5 +30,24 @@ extension UsageMenuCardView.Model {
                 paceOnTop: true,
                 cardStyle: true)
         }
+    }
+
+    private static func displayWindowBadge(for windowType: String) -> String {
+        let trimmed = windowType.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalized = trimmed.lowercased()
+
+        if normalized == "weekly" {
+            return "Weekly"
+        }
+        if normalized == "5 hours" || normalized == "5 hour" || normalized == "5h" {
+            return "5h"
+        }
+        if normalized == "today" {
+            return "Today"
+        }
+        if normalized == "daily" {
+            return "Daily"
+        }
+        return trimmed.isEmpty ? windowType : trimmed
     }
 }

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -37,6 +37,7 @@ struct UsageMenuCardView: View {
             let pacePercent: Double?
             let paceOnTop: Bool
             let warningMarkerPercents: [Double]
+            let cardStyle: Bool
 
             init(
                 id: String,
@@ -50,7 +51,8 @@ struct UsageMenuCardView: View {
                 detailRightText: String?,
                 pacePercent: Double?,
                 paceOnTop: Bool,
-                warningMarkerPercents: [Double] = [])
+                warningMarkerPercents: [Double] = [],
+                cardStyle: Bool = false)
             {
                 self.id = id
                 self.title = title
@@ -64,6 +66,7 @@ struct UsageMenuCardView: View {
                 self.pacePercent = pacePercent
                 self.paceOnTop = paceOnTop
                 self.warningMarkerPercents = warningMarkerPercents
+                self.cardStyle = cardStyle
             }
 
             var percentLabel: String {
@@ -425,6 +428,9 @@ private struct MetricRow: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(self.metric.cardStyle ? 10 : 0)
+        .background(self.metric.cardStyle ? Color.secondary.opacity(self.isHighlighted ? 0.2 : 0.08) : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: self.metric.cardStyle ? 10 : 0))
     }
 }
 

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxServiceUsage.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxServiceUsage.swift
@@ -47,13 +47,34 @@ public struct MiniMaxServiceUsage: Sendable {
 
     /// The display name for this service
     public var displayName: String {
-        switch self.serviceType {
+        let normalized = self.serviceType.lowercased()
+        return switch normalized {
         case "text-generation":
             "Text Generation"
         case "text-to-speech":
             "Text to Speech"
         case "image":
             "Image"
+        case "text generation":
+            "Text Generation"
+        case "text to speech":
+            "Text to Speech"
+        case "image generation":
+            "Image Generation"
+        case "text to video":
+            "Text to Video"
+        case "image to video":
+            "Image to Video"
+        case "music generation":
+            "Music Generation"
+        case "music generation · v2.6":
+            "Music Generation · v2.6"
+        case "music cover":
+            "Music Cover"
+        case "lyrics generation":
+            "Lyrics Generation"
+        case "image understanding":
+            "Image Understanding"
         default:
             self.serviceType
         }

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -623,51 +623,36 @@ enum MiniMaxUsageParser {
         // Convert model_remains to services array for multi-service UI display
         var services: [MiniMaxServiceUsage] = []
         for item in payload.data.modelRemains {
-            // Skip services with no quota (limit = 0)
-            guard let modelName = item.modelName,
-                  let limit = item.currentIntervalTotalCount,
-                  limit > 0,
-                  let remaining = item.currentIntervalUsageCount
-            else {
-                continue
-            }
-
-            // Calculate usage and percentage
-            // current_interval_usage_count is REMAINING quota (not used)
-            let used = max(0, limit - remaining)
-            let percent = limit > 0 ? Double(used) / Double(limit) * 100.0 : 0.0
-
-            // Parse time window
-            let startTime = self.dateFromEpoch(item.startTime)
-            let endTime = self.dateFromEpoch(item.endTime)
-
-            // Determine window type and time range
-            let (windowType, timeRange) = self.parseWindowInfo(
-                startTime: startTime,
-                endTime: endTime,
-                now: now)
-
-            // Calculate reset time
-            let resetsAt = self.resetsAt(end: endTime, remains: item.remainsTime, now: now)
-            let resetDescription = self.resetDescription(
-                for: windowType,
-                timeRange: timeRange,
-                now: now,
-                resetsAt: resetsAt)
-
-            // Map model_name to service type identifier
+            guard let modelName = item.modelName else { continue }
             let serviceTypeIdentifier = self.mapModelNameToServiceType(modelName: modelName)
 
-            let serviceUsage = MiniMaxServiceUsage(
+            if let intervalService = self.makeServiceUsage(
                 serviceType: serviceTypeIdentifier,
-                windowType: windowType,
-                timeRange: timeRange,
-                usage: used,
-                limit: limit,
-                percent: min(100.0, max(0.0, percent)),
-                resetsAt: resetsAt,
-                resetDescription: resetDescription)
-            services.append(serviceUsage)
+                windowTypeOverride: nil,
+                total: item.currentIntervalTotalCount,
+                remaining: item.currentIntervalUsageCount,
+                start: item.startTime,
+                end: item.endTime,
+                remainsTime: item.remainsTime,
+                now: now)
+            {
+                services.append(intervalService)
+            }
+
+            // current_weekly_usage_count is also REMAINING quota; render only when weekly quota is real.
+            if serviceTypeIdentifier == "Text Generation",
+               let weeklyService = self.makeServiceUsage(
+                   serviceType: serviceTypeIdentifier,
+                   windowTypeOverride: "Weekly",
+                   total: item.currentWeeklyTotalCount,
+                   remaining: item.currentWeeklyUsageCount,
+                   start: item.weeklyStartTime,
+                   end: item.weeklyEndTime,
+                   remainsTime: item.weeklyRemainsTime,
+                   now: now)
+            {
+                services.append(weeklyService)
+            }
         }
 
         // Use first service for backward compatibility fields
@@ -1065,7 +1050,8 @@ enum MiniMaxUsageParser {
                   let windowType = item.windowType,
                   let timeRange = item.timeRange,
                   let usage = item.usage,
-                  let limit = item.limit
+                  let limit = item.limit,
+                  limit > 0
             else {
                 continue
             }
@@ -1226,6 +1212,44 @@ enum MiniMaxUsageParser {
         let timeRange = "\(startStr)-\(endStr)(UTC+8)"
 
         return (windowType: windowType, timeRange: timeRange)
+    }
+
+    private static func makeServiceUsage(
+        serviceType: String,
+        windowTypeOverride: String?,
+        total: Int?,
+        remaining: Int?,
+        start: Int?,
+        end: Int?,
+        remainsTime: Int?,
+        now: Date) -> MiniMaxServiceUsage?
+    {
+        guard let total, total > 0, let remaining else { return nil }
+        let used = max(0, total - remaining)
+        if used == 0, total == 0 { return nil }
+
+        let startTime = self.dateFromEpoch(start)
+        let endTime = self.dateFromEpoch(end)
+        var (windowType, timeRange) = self.parseWindowInfo(startTime: startTime, endTime: endTime, now: now)
+        if let windowTypeOverride { windowType = windowTypeOverride }
+
+        let resetsAt = self.resetsAt(end: endTime, remains: remainsTime, now: now)
+        let resetDescription = self.resetDescription(
+            for: windowType,
+            timeRange: timeRange,
+            now: now,
+            resetsAt: resetsAt)
+
+        let percent = Double(used) / Double(total) * 100.0
+        return MiniMaxServiceUsage(
+            serviceType: serviceType,
+            windowType: windowType,
+            timeRange: timeRange,
+            usage: used,
+            limit: total,
+            percent: min(100.0, max(0.0, percent)),
+            resetsAt: resetsAt,
+            resetDescription: resetDescription)
     }
 
     private static func mapModelNameToServiceType(modelName: String) -> String {

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -627,28 +627,30 @@ enum MiniMaxUsageParser {
             let serviceTypeIdentifier = self.mapModelNameToServiceType(modelName: modelName)
 
             if let intervalService = self.makeServiceUsage(
-                serviceType: serviceTypeIdentifier,
-                windowTypeOverride: nil,
-                total: item.currentIntervalTotalCount,
-                remaining: item.currentIntervalUsageCount,
-                start: item.startTime,
-                end: item.endTime,
-                remainsTime: item.remainsTime,
+                ServiceUsageInput(
+                    serviceType: serviceTypeIdentifier,
+                    windowTypeOverride: nil,
+                    total: item.currentIntervalTotalCount,
+                    remaining: item.currentIntervalUsageCount,
+                    start: item.startTime,
+                    end: item.endTime,
+                    remainsTime: item.remainsTime),
                 now: now)
             {
                 services.append(intervalService)
             }
 
             // current_weekly_usage_count is also REMAINING quota; render only when weekly quota is real.
-            if serviceTypeIdentifier == "Text Generation",
+            if self.isTextGenerationModelName(modelName),
                let weeklyService = self.makeServiceUsage(
-                   serviceType: serviceTypeIdentifier,
-                   windowTypeOverride: "Weekly",
-                   total: item.currentWeeklyTotalCount,
-                   remaining: item.currentWeeklyUsageCount,
-                   start: item.weeklyStartTime,
-                   end: item.weeklyEndTime,
-                   remainsTime: item.weeklyRemainsTime,
+                   ServiceUsageInput(
+                       serviceType: serviceTypeIdentifier,
+                       windowTypeOverride: "Weekly",
+                       total: item.currentWeeklyTotalCount,
+                       remaining: item.currentWeeklyUsageCount,
+                       start: item.weeklyStartTime,
+                       end: item.weeklyEndTime,
+                       remainsTime: item.weeklyRemainsTime),
                    now: now)
             {
                 services.append(weeklyService)
@@ -1214,31 +1216,32 @@ enum MiniMaxUsageParser {
         return (windowType: windowType, timeRange: timeRange)
     }
 
-    private static func makeServiceUsage(
-        serviceType: String,
-        windowTypeOverride: String?,
-        total: Int?,
-        remaining: Int?,
-        start: Int?,
-        end: Int?,
-        remainsTime: Int?,
-        now: Date) -> MiniMaxServiceUsage?
-    {
-        guard let total, total > 0, let remaining else { return nil }
+    private struct ServiceUsageInput {
+        let serviceType: String
+        let windowTypeOverride: String?
+        let total: Int?
+        let remaining: Int?
+        let start: Int?
+        let end: Int?
+        let remainsTime: Int?
+    }
+
+    private static func makeServiceUsage(_ input: ServiceUsageInput, now: Date) -> MiniMaxServiceUsage? {
+        guard let total = input.total, total > 0, let remaining = input.remaining else { return nil }
         let used = max(0, total - remaining)
         if used == 0, total == 0 { return nil }
 
-        let startTime = self.dateFromEpoch(start)
-        let endTime = self.dateFromEpoch(end)
+        let startTime = self.dateFromEpoch(input.start)
+        let endTime = self.dateFromEpoch(input.end)
         var (windowType, timeRange) = self.parseWindowInfo(startTime: startTime, endTime: endTime, now: now)
-        if let windowTypeOverride { windowType = windowTypeOverride }
+        if let windowTypeOverride = input.windowTypeOverride { windowType = windowTypeOverride }
         if windowType.lowercased() == "weekly",
            let weeklyRange = self.formatMiniMaxDateTimeRange(startTime: startTime, endTime: endTime)
         {
             timeRange = weeklyRange
         }
 
-        let resetsAt = self.resetsAt(end: endTime, remains: remainsTime, now: now)
+        let resetsAt = self.resetsAt(end: endTime, remains: input.remainsTime, now: now)
         let resetDescription = self.resetDescription(
             for: windowType,
             timeRange: timeRange,
@@ -1247,7 +1250,7 @@ enum MiniMaxUsageParser {
 
         let percent = Double(used) / Double(total) * 100.0
         return MiniMaxServiceUsage(
-            serviceType: serviceType,
+            serviceType: input.serviceType,
             windowType: windowType,
             timeRange: timeRange,
             usage: used,
@@ -1258,12 +1261,12 @@ enum MiniMaxUsageParser {
     }
 
     private static func mapModelNameToServiceType(modelName: String) -> String {
-        let lower = modelName.lowercased()
-
         // Text Generation (文本生成): M2.7, M2.7-highspeed, MiniMax-M*, etc.
-        if lower.contains("minimax-m") {
+        if self.isTextGenerationModelName(modelName) {
             return "Text Generation"
         }
+
+        let lower = modelName.lowercased()
 
         // Text to Speech (语音合成): speech-hd, Speech 2.8, etc.
         if lower.contains("speech") {
@@ -1292,6 +1295,11 @@ enum MiniMaxUsageParser {
 
         // Default: use model name as-is
         return modelName
+    }
+
+    private static func isTextGenerationModelName(_ modelName: String) -> Bool {
+        let lower = modelName.lowercased()
+        return lower.contains("minimax-m") || lower.hasPrefix("m2.")
     }
 
     private static func formatMiniMaxDateTimeRange(startTime: Date?, endTime: Date?) -> String? {

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -1232,6 +1232,11 @@ enum MiniMaxUsageParser {
         let endTime = self.dateFromEpoch(end)
         var (windowType, timeRange) = self.parseWindowInfo(startTime: startTime, endTime: endTime, now: now)
         if let windowTypeOverride { windowType = windowTypeOverride }
+        if windowType.lowercased() == "weekly",
+           let weeklyRange = self.formatMiniMaxDateTimeRange(startTime: startTime, endTime: endTime)
+        {
+            timeRange = weeklyRange
+        }
 
         let resetsAt = self.resetsAt(end: endTime, remains: remainsTime, now: now)
         let resetDescription = self.resetDescription(
@@ -1287,6 +1292,17 @@ enum MiniMaxUsageParser {
 
         // Default: use model name as-is
         return modelName
+    }
+
+    private static func formatMiniMaxDateTimeRange(startTime: Date?, endTime: Date?) -> String? {
+        guard let startTime, let endTime else { return nil }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "Asia/Shanghai")
+        formatter.dateFormat = "MM/dd HH:mm"
+        let start = formatter.string(from: startTime)
+        let end = formatter.string(from: endTime)
+        return "\(start) - \(end)(UTC+8)"
     }
 }
 

--- a/Tests/CodexBarTests/MenuCardModelTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelTests.swift
@@ -653,6 +653,75 @@ struct MiniMaxMenuCardModelTests {
         #expect(used.metrics.first?.percent == 20)
         #expect(used.metrics.first?.cardStyle == true)
     }
+
+    @Test
+    func `text generation badge uses real window type when multiple windows exist`() throws {
+        let now = Date()
+        let minimax = MiniMaxUsageSnapshot(
+            planName: "Max",
+            availablePrompts: nil,
+            currentPrompts: nil,
+            remainingPrompts: nil,
+            windowMinutes: nil,
+            usedPercent: nil,
+            resetsAt: nil,
+            updatedAt: now,
+            services: [
+                MiniMaxServiceUsage(
+                    serviceType: "text-generation",
+                    windowType: "Today",
+                    timeRange: "2026/05/16 00:00 - 2026/05/17 00:00",
+                    usage: 2,
+                    limit: 10,
+                    percent: 20,
+                    resetsAt: now.addingTimeInterval(3600),
+                    resetDescription: "Resets in 1 hour"),
+                MiniMaxServiceUsage(
+                    serviceType: "text-generation",
+                    windowType: "Weekly",
+                    timeRange: "05/11 00:00 - 05/18 00:00(UTC+8)",
+                    usage: 20,
+                    limit: 100,
+                    percent: 20,
+                    resetsAt: now.addingTimeInterval(7200),
+                    resetDescription: "Resets in 2 hours"),
+            ])
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 1440, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            minimaxUsage: minimax,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .minimax,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "Max"))
+        let metadata = try #require(ProviderDefaults.metadata[.minimax])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .minimax,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: true,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.metrics.count == 2)
+        #expect(model.metrics[0].title == "Text Generation · Today")
+        #expect(model.metrics[1].title == "Text Generation · Weekly")
+    }
 }
 
 struct ClaudeMenuCardCostTests {

--- a/Tests/CodexBarTests/MenuCardModelTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelTests.swift
@@ -592,7 +592,7 @@ struct KiroMenuCardModelTests {
 
 struct MiniMaxMenuCardModelTests {
     @Test
-    func `minimax service metrics respect used and remaining display modes`() throws {
+    func `minimax service metrics use quota card copy`() throws {
         let now = Date()
         let minimax = MiniMaxUsageSnapshot(
             planName: "Max",
@@ -646,31 +646,12 @@ struct MiniMaxMenuCardModelTests {
             hidePersonalInfo: false,
             now: now))
 
-        let remaining = UsageMenuCardView.Model.make(.init(
-            provider: .minimax,
-            metadata: metadata,
-            snapshot: snapshot,
-            credits: nil,
-            creditsError: nil,
-            dashboard: nil,
-            dashboardError: nil,
-            tokenSnapshot: nil,
-            tokenError: nil,
-            account: AccountInfo(email: nil, plan: nil),
-            isRefreshing: false,
-            lastError: nil,
-            usageBarsShowUsed: false,
-            resetTimeDisplayStyle: .countdown,
-            tokenCostUsageEnabled: false,
-            showOptionalCreditsAndExtraUsage: true,
-            hidePersonalInfo: false,
-            now: now))
-
         #expect(used.metrics.first?.title == "Text Generation")
-        #expect(used.metrics.first?.detailText == "2/10")
+        #expect(used.metrics.first?.detailLeftText == "Usage: 2 / 10")
+        #expect(used.metrics.first?.detailRightText == "Used 20%")
+        #expect(used.metrics.first?.detailText == "10:00-15:00(UTC+8)")
         #expect(used.metrics.first?.percent == 20)
-        #expect(remaining.metrics.first?.detailText == "8/10")
-        #expect(remaining.metrics.first?.percent == 80)
+        #expect(used.metrics.first?.cardStyle == true)
     }
 }
 

--- a/Tests/CodexBarTests/MiniMaxProviderTests.swift
+++ b/Tests/CodexBarTests/MiniMaxProviderTests.swift
@@ -192,7 +192,7 @@ struct MiniMaxUsageParserTests {
           "current_subscribe_title": "Max",
           "model_remains": [
             {
-              "model_name": "MiniMax-M1",
+              "model_name": "M2.7-highspeed",
               "current_interval_total_count": 1000,
               "current_interval_usage_count": 250,
               "start_time": \(start),
@@ -242,7 +242,9 @@ struct MiniMaxUsageParserTests {
         let snapshot = try MiniMaxUsageParser.parseCodingPlanRemains(data: Data(json.utf8), now: now)
         let services = try #require(snapshot.services)
         #expect(services.count == 2)
+        #expect(services[0].serviceType == "Text Generation")
         #expect(services[0].windowType == "5 hours")
+        #expect(services[1].serviceType == "Text Generation")
         #expect(services[1].windowType == "Weekly")
         #expect(services[1].usage == 624)
         #expect(services[1].limit == 6000)

--- a/Tests/CodexBarTests/MiniMaxProviderTests.swift
+++ b/Tests/CodexBarTests/MiniMaxProviderTests.swift
@@ -215,6 +215,67 @@ struct MiniMaxUsageParserTests {
     }
 
     @Test
+    func `text generation includes weekly window when provided`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let start = 1_700_000_000_000
+        let end = start + 5 * 60 * 60 * 1000
+        let weekStart = start - 2 * 24 * 60 * 60 * 1000
+        let weekEnd = weekStart + 7 * 24 * 60 * 60 * 1000
+        let json = """
+        {
+          "base_resp": { "status_code": 0 },
+          "model_remains": [
+            {
+              "model_name": "MiniMax-M1",
+              "current_interval_total_count": 1000,
+              "current_interval_usage_count": 250,
+              "start_time": \(start),
+              "end_time": \(end),
+              "current_weekly_total_count": 6000,
+              "current_weekly_usage_count": 5376,
+              "weekly_start_time": \(weekStart),
+              "weekly_end_time": \(weekEnd)
+            }
+          ]
+        }
+        """
+        let snapshot = try MiniMaxUsageParser.parseCodingPlanRemains(data: Data(json.utf8), now: now)
+        let services = try #require(snapshot.services)
+        #expect(services.count == 2)
+        #expect(services[0].windowType == "5 hours")
+        #expect(services[1].windowType == "Weekly")
+        #expect(services[1].usage == 624)
+        #expect(services[1].limit == 6000)
+    }
+
+    @Test
+    func `legacy plan hides weekly when weekly total is missing or zero`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let start = 1_700_000_000_000
+        let end = start + 5 * 60 * 60 * 1000
+        let json = """
+        {
+          "base_resp": { "status_code": 0 },
+          "model_remains": [
+            {
+              "model_name": "MiniMax-M1",
+              "current_interval_total_count": 1000,
+              "current_interval_usage_count": 250,
+              "start_time": \(start),
+              "end_time": \(end),
+              "current_weekly_total_count": 0,
+              "current_weekly_usage_count": 0
+            }
+          ]
+        }
+        """
+        let snapshot = try MiniMaxUsageParser.parseCodingPlanRemains(data: Data(json.utf8), now: now)
+        let services = try #require(snapshot.services)
+        #expect(services.count == 1)
+        #expect(services[0].windowType == "5 hours")
+    }
+
+    @Test
     func `parses multi service payload and utc offset reset`() throws {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = try #require(TimeZone(secondsFromGMT: 8 * 3600))

--- a/Tests/CodexBarTests/MiniMaxProviderTests.swift
+++ b/Tests/CodexBarTests/MiniMaxProviderTests.swift
@@ -246,6 +246,9 @@ struct MiniMaxUsageParserTests {
         #expect(services[1].windowType == "Weekly")
         #expect(services[1].usage == 624)
         #expect(services[1].limit == 6000)
+        #expect(services[1].timeRange.contains("/"))
+        #expect(services[1].timeRange.contains("UTC+8"))
+        #expect(!services[1].timeRange.hasPrefix("10:00-10:00"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

This PR improves MiniMax token plan usage presentation and fixes remains-field semantics.

### What changed

- Corrected MiniMax remains semantics:
  - `current_interval_usage_count` is treated as interval remaining
  - `current_weekly_usage_count` is treated as weekly remaining
  - used is computed as `max(0, total - remaining)`
  - progress percent is computed from `used / total`

- Added text-generation dual window support:
  - Show both `5h` and `Weekly` entries when weekly quota is valid.
  - Hide weekly entry when weekly total is missing/zero.

- Filtered invalid placeholder rows:
  - Skip quota rows with invalid totals (`total <= 0`) so 0/0 placeholders do not render.

- Updated MiniMax menu metric presentation within the existing SwiftUI menu layout:
  - `Usage: used / total`
  - `Used xx%`
  - progress bar
  - time range and reset text
  - lightweight card-style row background

- Expanded MiniMax service display-name normalization for common service labels.

### Scope and safety

- No changes to MiniMax auth flow, endpoint selection, polling cadence, or provider registration.
- No new dependencies.
- No behavior changes intended for non-MiniMax providers.

## Tests

Ran and passed:

- `swift build`
- `swift test --filter MiniMax`

MiniMax-related tests now cover:
1. Text Generation with both 5-hour and weekly quotas.
2. Legacy/no-weekly case hides weekly row.
3. `current_interval_usage_count` / `current_weekly_usage_count` handled as remaining.
4. `used = total - remaining` calculation.
5. Invalid zero-total rows ignored.
6. MiniMax menu metric copy/card assertions.
