### PR TITLE
Fix CI trigger for slash branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["*"]
+    branches: ["**"]
   pull_request:
 
 concurrency:


### PR DESCRIPTION
## Summary
- update the CI push branch filter from `*` to `**`
- allow push CI to run for branch names containing `/`

## Why
The current `branches: ["*"]` pattern only matches single-segment branch names. It does not match common slash-named branches such as `feature/foo`, `fix/foo`, or `codex/test/foo`.

`branches: ["**"]` keeps the apparent current intent - run CI on all pushed branches - while including nested branch names.

## Verification
- tested in fork PR tsh-third-party/CodexBar#2
- push CI and pull_request CI both started for `codex/test/ci-double-star-branch-filter`
- Linux CI jobs passed
- macOS CI proceeded into the normal Swift test suite; one existing AppKit/status-menu test failed after CI scheduling, unrelated to this workflow glob change