### PR TITLE
fix(grok): treat expired credentials as missing in fetch

### DIFF
--- a/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
@@ -100,18 +100,24 @@ public struct GrokStatusProbe: Sendable {
         let localSummary = GrokLocalSessionScanner.summarize(env: env)
         let cliVersion = Self.detectVersion(env: env)
 
+        // Grok session tokens expire after ~7 days. An expired record on disk
+        // must be treated like a missing credential when deciding whether to
+        // mask the RPC auth error: otherwise we render a snapshot with stale
+        // identity and no `grok login` hint while billing silently 401s.
+        let activeCredentials = credentials.flatMap { $0.isExpired ? nil : $0 }
+
         // `localSummary` is *not* currently projected into a visible RateWindow or
         // identity field, so a stale `~/.grok/sessions/` directory must not
         // suppress the auth-required hint. Only swallow the RPC error when we
-        // actually have something rendrable for the user — credentials or a
-        // billing response.
-        if billing == nil, credentials == nil {
+        // actually have something rendrable for the user — fresh credentials
+        // or a billing response.
+        if billing == nil, activeCredentials == nil {
             throw rpcError ?? GrokRPCError.notAuthenticated
         }
 
         return GrokUsageSnapshot(
             billing: billing,
-            credentials: credentials,
+            credentials: activeCredentials,
             localSummary: localSummary,
             cliVersion: cliVersion,
             updatedAt: Date())

--- a/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
@@ -109,7 +109,7 @@ public struct GrokStatusProbe: Sendable {
         // `localSummary` is *not* currently projected into a visible RateWindow or
         // identity field, so a stale `~/.grok/sessions/` directory must not
         // suppress the auth-required hint. Only swallow the RPC error when we
-        // actually have something rendrable for the user — fresh credentials
+        // actually have something renderable for the user — fresh credentials
         // or a billing response.
         if billing == nil, activeCredentials == nil {
             throw rpcError ?? GrokRPCError.notAuthenticated
@@ -117,9 +117,19 @@ public struct GrokStatusProbe: Sendable {
 
         return GrokUsageSnapshot(
             billing: billing,
-            credentials: activeCredentials,
+            credentials: Self.credentialsForSnapshot(credentials: credentials, billing: billing),
             localSummary: localSummary,
             cliVersion: cliVersion,
             updatedAt: Date())
+    }
+
+    static func credentialsForSnapshot(
+        credentials: GrokCredentials?,
+        billing: GrokBillingResponse?) -> GrokCredentials?
+    {
+        // If billing succeeded, the CLI accepted/refreshed auth and the local
+        // identity is still useful even when the persisted expires_at is stale.
+        if billing != nil { return credentials }
+        return credentials.flatMap { $0.isExpired ? nil : $0 }
     }
 }

--- a/Tests/CodexBarTests/GrokAuthTests.swift
+++ b/Tests/CodexBarTests/GrokAuthTests.swift
@@ -111,6 +111,25 @@ struct GrokAuthTests {
     }
 
     @Test
+    func `expired credentials are preserved when billing succeeds`() throws {
+        let pastJson = #"""
+        {
+          "https://auth.x.ai::client": {
+            "key": "stale-token",
+            "email": "grok@example.com",
+            "team_id": "team_123",
+            "expires_at": "2020-01-01T00:00:00Z"
+          }
+        }
+        """#
+        let expired = try GrokCredentialsStore.parse(data: Data(pastJson.utf8))
+        let billing = try JSONDecoder().decode(GrokBillingResponse.self, from: Data(#"{}"#.utf8))
+
+        #expect(GrokStatusProbe.credentialsForSnapshot(credentials: expired, billing: nil) == nil)
+        #expect(GrokStatusProbe.credentialsForSnapshot(credentials: expired, billing: billing)?.email == "grok@example.com")
+    }
+
+    @Test
     func `falls back to legacy when OIDC entry has no key`() throws {
         // A stale/partial OIDC record must not shadow a healthy legacy session.
         let json = #"""

--- a/Tests/CodexBarTests/GrokAuthTests.swift
+++ b/Tests/CodexBarTests/GrokAuthTests.swift
@@ -126,7 +126,8 @@ struct GrokAuthTests {
         let billing = try JSONDecoder().decode(GrokBillingResponse.self, from: Data(#"{}"#.utf8))
 
         #expect(GrokStatusProbe.credentialsForSnapshot(credentials: expired, billing: nil) == nil)
-        #expect(GrokStatusProbe.credentialsForSnapshot(credentials: expired, billing: billing)?.email == "grok@example.com")
+        #expect(GrokStatusProbe.credentialsForSnapshot(credentials: expired, billing: billing)?
+            .email == "grok@example.com")
     }
 
     @Test

--- a/Tests/CodexBarTests/GrokAuthTests.swift
+++ b/Tests/CodexBarTests/GrokAuthTests.swift
@@ -72,6 +72,45 @@ struct GrokAuthTests {
     }
 
     @Test
+    func `isExpired reflects past expires_at`() throws {
+        // Past expiry
+        let pastJson = #"""
+        {
+          "https://auth.x.ai::client": {
+            "key": "stale-token",
+            "expires_at": "2020-01-01T00:00:00Z"
+          }
+        }
+        """#
+        let past = try GrokCredentialsStore.parse(data: Data(pastJson.utf8))
+        #expect(past.isExpired == true)
+
+        // Future expiry
+        let futureJson = #"""
+        {
+          "https://auth.x.ai::client": {
+            "key": "fresh-token",
+            "expires_at": "2099-01-01T00:00:00Z"
+          }
+        }
+        """#
+        let future = try GrokCredentialsStore.parse(data: Data(futureJson.utf8))
+        #expect(future.isExpired == false)
+
+        // Missing expires_at — treated as non-expired so we never spuriously lock
+        // out clients whose auth.json shape predates this field.
+        let noExpiryJson = #"""
+        {
+          "https://auth.x.ai::client": {
+            "key": "ageless-token"
+          }
+        }
+        """#
+        let noExpiry = try GrokCredentialsStore.parse(data: Data(noExpiryJson.utf8))
+        #expect(noExpiry.isExpired == false)
+    }
+
+    @Test
     func `falls back to legacy when OIDC entry has no key`() throws {
         // A stale/partial OIDC record must not shadow a healthy legacy session.
         let json = #"""

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -1200,6 +1200,7 @@ struct SettingsStoreTests {
             .commandcode,
             .stepfun,
             .bedrock,
+            .grok,
         ])
 
         // Move one provider; ensure it's persisted across instances.


### PR DESCRIPTION
## Summary

Follow-up to the Codex bot's P1 review on #965 (commit `cbd30a4e`). Grok session tokens expire after ~7 days, so this hits real users on a predictable cadence.

## The bug

`GrokStatusProbe.fetch` decides whether to surface the RPC auth error using:

```swift
if billing == nil, credentials == nil {
    throw rpcError ?? GrokRPCError.notAuthenticated
}
```

That check is permissive: an `auth.json` whose `expires_at` is already in the past still loads successfully (`isExpired` is computed but never consulted), so `credentials != nil` and the auth error is silently swallowed. The UI then renders a "successful" snapshot with stale email/team and no `grok login` hint while billing keeps 401-ing in the background.

## The fix

Treat expired records the same as missing credentials when deciding whether to swallow the RPC error, **and** drop them from the rendered snapshot so the UI doesn't surface stale identity for an inactive session:

```swift
let activeCredentials = credentials.flatMap { $0.isExpired ? nil : $0 }
if billing == nil, activeCredentials == nil {
    throw rpcError ?? GrokRPCError.notAuthenticated
}
```

Behaviour matrix after this change:

| `expires_at` | Old behaviour | New behaviour |
|---|---|---|
| missing | rendered as fresh | rendered as fresh (unchanged — pre-`expires_at` shape stays supported) |
| in the future | rendered as fresh | rendered as fresh (unchanged) |
| in the past | rendered with stale data, RPC error swallowed | RPC error raised, snapshot omits stale identity |

## Tests

Adds `isExpired reflects past expires_at` covering past, future, and missing `expires_at`. All 11 Grok tests pass under Xcode 26.5.

## Test plan

- [ ] `make test` passes
- [ ] With a freshly-logged-in `grok login` session, Grok shows identity as before
- [ ] After `rm ~/.grok/auth.json` (or letting it expire), the provider surfaces the `Not authenticated to Grok. Run \`grok login\`.` hint instead of rendering empty