### PR TITLE
Add config API key CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Claude: add an Anthropic Admin API source and allow `sk-ant-admin...` keys in Claude token accounts for API spend/token tracking (#966).
 - Grok: add xAI Grok provider support with local identity detection and billing decoding for the Grok CLI integration (#965). Thanks @taibaran!
 - ElevenLabs: add API-key usage tracking for subscription credits, reset time, and voice-slot limits.
+- CLI: add `codexbar config set-api-key` for safely storing provider API keys from stdin.
 - Usage charts: reuse the OpenAI API inline dashboard for local Codex/Claude/Vertex/Bedrock cost history, OpenRouter day/week/month spend, z.ai hourly tokens, and Mistral daily spend.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ Or download release tarballs from GitHub Releases:
 - Install/sign in to the provider sources you rely on: CLIs, browser sessions, OAuth/device flow, API keys, local app files, or provider apps depending on the provider.
 - Optional: Settings → Providers → Codex → OpenAI cookies (Automatic or Manual) to add dashboard extras.
 
+### Set API keys from the CLI
+For API-key providers, store a key in `~/.codexbar/config.json` without opening Settings:
+
+```bash
+printf '%s' "$ELEVENLABS_API_KEY" | codexbar config set-api-key --provider elevenlabs --stdin
+```
+
+`set-api-key` trims the piped value, stores it with restrictive config-file permissions, and enables the provider by default. Use `--no-enable` to only save the key, or `--api-key <key>` for one-off local scripts where shell history is not a concern.
+
 ## Providers
 
 - [Codex](docs/codex.md) — OAuth API or local Codex CLI, plus optional OpenAI web dashboard extras.

--- a/Sources/CodexBarCLI/CLIConfigCommand.swift
+++ b/Sources/CodexBarCLI/CLIConfigCommand.swift
@@ -35,6 +35,114 @@ extension CodexBarCLI {
         Self.printJSON(config, pretty: output.pretty)
         Self.exit(code: .success, output: output, kind: .config)
     }
+
+    static func runConfigSetAPIKey(_ values: ParsedValues) {
+        let output = CLIOutputPreferences.from(values: values)
+
+        guard let rawProvider = values.options["provider"]?.last,
+              let provider = ProviderDescriptorRegistry.cliNameMap[rawProvider.lowercased()]
+        else {
+            Self.exit(
+                code: .failure,
+                message: "Unknown or missing provider. Use --provider <name>.",
+                output: output,
+                kind: .args)
+        }
+        guard ProviderConfigEnvironment.supportsAPIKeyOverride(for: provider) else {
+            Self.exit(
+                code: .failure,
+                message: "\(rawProvider) does not support config API keys.",
+                output: output,
+                kind: .args)
+        }
+
+        let apiKey: String
+        do {
+            apiKey = try Self.resolveConfigAPIKeyInput(
+                apiKey: values.options["apiKey"]?.last,
+                readFromStdin: values.flags.contains("stdin"))
+        } catch {
+            Self.exit(code: .failure, message: error.localizedDescription, output: output, kind: .args)
+        }
+
+        let enableProvider = !values.flags.contains("noEnable")
+        let store = CodexBarConfigStore()
+        var config = Self.loadConfig(output: output)
+        config = Self.configSettingAPIKey(
+            config,
+            provider: provider,
+            apiKey: apiKey,
+            enableProvider: enableProvider)
+
+        do {
+            try store.save(config)
+        } catch {
+            Self.exit(code: .failure, message: error.localizedDescription, output: output, kind: .config)
+        }
+
+        let result = ConfigSetAPIKeyResult(
+            provider: provider.rawValue,
+            enabled: config.providerConfig(for: provider)?.enabled ?? false,
+            configPath: store.fileURL.path)
+
+        switch output.format {
+        case .text:
+            let name = ProviderDescriptorRegistry.descriptor(for: provider).metadata.displayName
+            let suffix = result.enabled ? " and enabled" : ""
+            print("Config: stored API key for \(name)\(suffix)")
+        case .json:
+            Self.printJSON(result, pretty: output.pretty)
+        }
+
+        Self.exit(code: .success, output: output, kind: .config)
+    }
+
+    static func resolveConfigAPIKeyInput(apiKey: String?, readFromStdin: Bool) throws -> String {
+        if apiKey != nil, readFromStdin {
+            throw CLIArgumentError("Use either --api-key or --stdin, not both.")
+        }
+
+        let raw: String? = if readFromStdin {
+            String(data: FileHandle.standardInput.readDataToEndOfFile(), encoding: .utf8)
+        } else {
+            apiKey
+        }
+
+        guard let value = Self.cleanConfigSecret(raw) else {
+            throw CLIArgumentError("Missing API key. Pass --api-key <key> or pipe it with --stdin.")
+        }
+        return value
+    }
+
+    static func configSettingAPIKey(
+        _ config: CodexBarConfig,
+        provider: UsageProvider,
+        apiKey: String,
+        enableProvider: Bool) -> CodexBarConfig
+    {
+        var updated = config.normalized()
+        var providerConfig = updated.providerConfig(for: provider) ?? ProviderConfig(id: provider)
+        providerConfig.apiKey = apiKey
+        if enableProvider {
+            providerConfig.enabled = true
+        }
+        updated.setProviderConfig(providerConfig)
+        return updated
+    }
+
+    private static func cleanConfigSecret(_ raw: String?) -> String? {
+        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
+            (value.hasPrefix("'") && value.hasSuffix("'"))
+        {
+            value.removeFirst()
+            value.removeLast()
+        }
+        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
 }
 
 struct ConfigOptions: CommanderParsable {
@@ -58,4 +166,45 @@ struct ConfigOptions: CommanderParsable {
 
     @Flag(name: .long("pretty"), help: "Pretty-print JSON output")
     var pretty: Bool = false
+}
+
+struct ConfigSetAPIKeyOptions: CommanderParsable {
+    @Flag(names: [.short("v"), .long("verbose")], help: "Enable verbose logging")
+    var verbose: Bool = false
+
+    @Flag(name: .long("json-output"), help: "Emit machine-readable logs")
+    var jsonOutput: Bool = false
+
+    @Option(name: .long("log-level"), help: "Set log level (trace|verbose|debug|info|warning|error|critical)")
+    var logLevel: String?
+
+    @Option(name: .long("format"), help: "Output format: text | json")
+    var format: OutputFormat?
+
+    @Flag(name: .long("json"), help: "")
+    var jsonShortcut: Bool = false
+
+    @Flag(name: .long("json-only"), help: "Emit JSON only (suppress non-JSON output)")
+    var jsonOnly: Bool = false
+
+    @Flag(name: .long("pretty"), help: "Pretty-print JSON output")
+    var pretty: Bool = false
+
+    @Option(name: .long("provider"), help: ProviderHelp.optionHelp)
+    var provider: String?
+
+    @Option(name: .long("api-key"), help: "API key to store")
+    var apiKey: String?
+
+    @Flag(name: .long("stdin"), help: "Read API key from stdin")
+    var stdin: Bool = false
+
+    @Flag(name: .long("no-enable"), help: "Store the key without enabling the provider")
+    var noEnable: Bool = false
+}
+
+private struct ConfigSetAPIKeyResult: Encodable {
+    let provider: String
+    let enabled: Bool
+    let configPath: String
 }

--- a/Sources/CodexBarCLI/CLIEntry.swift
+++ b/Sources/CodexBarCLI/CLIEntry.swift
@@ -42,6 +42,8 @@ enum CodexBarCLI {
                 self.runConfigValidate(invocation.parsedValues)
             case ["config", "dump"]:
                 self.runConfigDump(invocation.parsedValues)
+            case ["config", "set-api-key"]:
+                self.runConfigSetAPIKey(invocation.parsedValues)
             case ["cache", "clear"]:
                 self.runCacheClear(invocation.parsedValues)
             default:
@@ -63,6 +65,7 @@ enum CodexBarCLI {
         let costSignature = CommandSignature.describe(CostOptions())
         let serveSignature = CommandSignature.describe(ServeOptions())
         let configSignature = CommandSignature.describe(ConfigOptions())
+        let configSetAPIKeySignature = CommandSignature.describe(ConfigSetAPIKeyOptions())
         let cacheSignature = CommandSignature.describe(CacheOptions())
 
         return [
@@ -97,6 +100,11 @@ enum CodexBarCLI {
                         abstract: "Print normalized config JSON",
                         discussion: nil,
                         signature: configSignature),
+                    CommandDescriptor(
+                        name: "set-api-key",
+                        abstract: "Store a provider API key",
+                        discussion: nil,
+                        signature: configSetAPIKeySignature),
                 ],
                 defaultSubcommandName: "validate"),
             CommandDescriptor(

--- a/Sources/CodexBarCLI/CLIHelp.swift
+++ b/Sources/CodexBarCLI/CLIHelp.swift
@@ -116,13 +116,18 @@ extension CodexBarCLI {
                              [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>]
                              [-v|--verbose]
                              [--pretty]
+          codexbar config set-api-key --provider <name> (--api-key <key>|--stdin)
+                                    [--no-enable]
+                                    [--format text|json] [--json] [--json-only] [--pretty]
 
         Description:
           Validate or print the CodexBar config file (default: validate).
+          set-api-key stores a provider API key in ~/.codexbar/config.json and enables that provider by default.
 
         Examples:
           codexbar config validate --format json --pretty
           codexbar config dump --pretty
+          printf '%s' "$ELEVENLABS_API_KEY" | codexbar config set-api-key --provider elevenlabs --stdin
         """
     }
 
@@ -180,6 +185,7 @@ extension CodexBarCLI {
                                         [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>]
                                         [-v|--verbose]
                                         [--pretty]
+          codexbar config set-api-key --provider <name> (--api-key <key>|--stdin)
           codexbar cache clear <--cookies|--cost|--all> [--provider <name>]
 
         Global flags:
@@ -198,6 +204,7 @@ extension CodexBarCLI {
           codexbar cost --provider claude --format json --pretty
           codexbar serve --port 8080
           codexbar config validate --format json --pretty
+          codexbar config set-api-key --provider elevenlabs --stdin
           codexbar cache clear --cookies
         """
     }

--- a/Sources/CodexBarCLI/CLIHelpers.swift
+++ b/Sources/CodexBarCLI/CLIHelpers.swift
@@ -366,6 +366,10 @@ extension CodexBarCLI {
         CommandSignature.describe(CacheOptions())
     }
 
+    static func _configSetAPIKeySignatureForTesting() -> CommandSignature {
+        CommandSignature.describe(ConfigSetAPIKeyOptions())
+    }
+
     static func _decodeFormatForTesting(from values: ParsedValues) -> OutputFormat {
         self.decodeFormat(from: values)
     }

--- a/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
+++ b/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
@@ -50,6 +50,16 @@ public enum ProviderConfigEnvironment {
         return env
     }
 
+    public static func supportsAPIKeyOverride(for provider: UsageProvider) -> Bool {
+        if self.directAPIKeyEnvironmentKey(for: provider) != nil { return true }
+        switch provider {
+        case .copilot, .kimik2, .warp, .codebuff, .crof, .doubao:
+            return true
+        default:
+            return false
+        }
+    }
+
     private static func directAPIKeyEnvironmentKey(for provider: UsageProvider) -> String? {
         switch provider {
         case .openai:

--- a/Tests/CodexBarTests/CLIConfigCommandTests.swift
+++ b/Tests/CodexBarTests/CLIConfigCommandTests.swift
@@ -1,0 +1,77 @@
+import CodexBarCore
+import Commander
+import Testing
+@testable import CodexBarCLI
+
+struct CLIConfigCommandTests {
+    @Test
+    func `config set api key parses provider stdin and no enable flags`() throws {
+        let parser = CommandParser(signature: CodexBarCLI._configSetAPIKeySignatureForTesting())
+        let parsed = try parser.parse(arguments: [
+            "--provider", "elevenlabs",
+            "--stdin",
+            "--no-enable",
+            "--json",
+        ])
+
+        #expect(parsed.options["provider"] == ["elevenlabs"])
+        #expect(parsed.flags.contains("stdin"))
+        #expect(parsed.flags.contains("noEnable"))
+        #expect(CodexBarCLI._decodeFormatForTesting(from: parsed) == .json)
+    }
+
+    @Test
+    func `config set api key stores key and enables provider`() {
+        let config = CodexBarConfig.makeDefault()
+        let updated = CodexBarCLI.configSettingAPIKey(
+            config,
+            provider: .elevenlabs,
+            apiKey: "xi-test-token",
+            enableProvider: true)
+        let provider = updated.providerConfig(for: .elevenlabs)
+
+        #expect(provider?.sanitizedAPIKey == "xi-test-token")
+        #expect(provider?.enabled == true)
+    }
+
+    @Test
+    func `config set api key only accepts consumed config keys`() {
+        #expect(ProviderConfigEnvironment.supportsAPIKeyOverride(for: .elevenlabs))
+        #expect(ProviderConfigEnvironment.supportsAPIKeyOverride(for: .openai))
+        #expect(!ProviderConfigEnvironment.supportsAPIKeyOverride(for: .bedrock))
+        #expect(!ProviderConfigEnvironment.supportsAPIKeyOverride(for: .deepseek))
+        #expect(!ProviderConfigEnvironment.supportsAPIKeyOverride(for: .cursor))
+    }
+
+    @Test
+    func `config set api key preserves disabled provider when requested`() {
+        var config = CodexBarConfig.makeDefault()
+        config.setProviderConfig(ProviderConfig(id: .elevenlabs, enabled: false))
+
+        let updated = CodexBarCLI.configSettingAPIKey(
+            config,
+            provider: .elevenlabs,
+            apiKey: "xi-test-token",
+            enableProvider: false)
+        let provider = updated.providerConfig(for: .elevenlabs)
+
+        #expect(provider?.sanitizedAPIKey == "xi-test-token")
+        #expect(provider?.enabled == false)
+    }
+
+    @Test
+    func `config set api key rejects ambiguous input`() {
+        #expect(throws: CLIArgumentError.self) {
+            try CodexBarCLI.resolveConfigAPIKeyInput(apiKey: "xi-test-token", readFromStdin: true)
+        }
+    }
+
+    @Test
+    func `config help documents set api key`() {
+        let help = CodexBarCLI.configHelp(version: "0.0.0")
+
+        #expect(help.contains("config set-api-key --provider <name>"))
+        #expect(help.contains("--stdin"))
+        #expect(help.contains("enables that provider by default"))
+    }
+}


### PR DESCRIPTION
## Summary
- add `codexbar config set-api-key` for storing provider API keys from stdin or a direct argument
- gate the command to providers whose saved API key is actually consumed, excluding multi-secret Bedrock and unsupported providers
- document the API-key CLI flow in README and CLI help

## Verification
- `swift test --filter CLIConfigCommandTests`
- `swift test --filter ProviderConfigEnvironmentTests`
- `swift test --filter ElevenLabsUsageFetcherTests`
- `make check`
- `codex-review --full-access --parallel-tests "swift test --filter CLIConfigCommandTests && swift test --filter ProviderConfigEnvironmentTests && swift test --filter ElevenLabsUsageFetcherTests && make check"` clean
- live ElevenLabs API fetch from stored config key returned Pro plan credits
