### PR TITLE
Localize provider storage setting

### DIFF
--- a/Sources/CodexBar/PreferencesAdvancedPane.swift
+++ b/Sources/CodexBar/PreferencesAdvancedPane.swift
@@ -78,8 +78,8 @@ struct AdvancedPane: View {
                         subtitle: L("hide_personal_info_subtitle"),
                         binding: self.$settings.hidePersonalInfo)
                     PreferenceToggleRow(
-                        title: "Show provider storage usage",
-                        subtitle: "Show local disk usage in menus. Scans known provider-owned paths in the background.",
+                        title: L("show_provider_storage_usage_title"),
+                        subtitle: L("show_provider_storage_usage_subtitle"),
                         binding: self.$settings.providerStorageFootprintsEnabled)
                 }
 

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -522,6 +522,8 @@
 "weekly_limit_confetti_subtitle" = "Play full-screen confetti when weekly usage resets.";
 "hide_personal_info_title" = "Hide personal information";
 "hide_personal_info_subtitle" = "Obscure email addresses in the menu bar and menu UI.";
+"show_provider_storage_usage_title" = "Show provider storage usage";
+"show_provider_storage_usage_subtitle" = "Show local disk usage in menus. Scans known provider-owned paths in the background.";
 "section_keychain_access" = "Keychain access";
 "keychain_access_caption" = "Disable all Keychain reads and writes. Browser cookie import is unavailable; paste Cookie headers manually in Providers.";
 "disable_keychain_access_title" = "Disable Keychain access";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -522,6 +522,8 @@
 "weekly_limit_confetti_subtitle" = "Mostra confete em tela cheia quando o uso semanal for renovado.";
 "hide_personal_info_title" = "Ocultar informações pessoais";
 "hide_personal_info_subtitle" = "Oculta endereços de e-mail na barra de menus e na UI do menu.";
+"show_provider_storage_usage_title" = "Mostrar uso de armazenamento dos provedores";
+"show_provider_storage_usage_subtitle" = "Mostra o uso de disco local nos menus. Verifica em segundo plano caminhos conhecidos pertencentes aos provedores.";
 "section_keychain_access" = "Acesso ao Keychain";
 "keychain_access_caption" = "Desativa todas as leituras e gravações do Keychain. A importação de cookies do navegador fica indisponível; cole cabeçalhos Cookie manualmente em Provedores.";
 "disable_keychain_access_title" = "Desativar acesso ao Keychain";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -529,6 +529,8 @@
 "weekly_limit_confetti_subtitle" = "当每周用量重置时播放全屏彩纸。";
 "hide_personal_info_title" = "隐藏个人信息";
 "hide_personal_info_subtitle" = "在菜单栏和菜单界面中隐藏电子邮件地址。";
+"show_provider_storage_usage_title" = "显示提供商存储用量";
+"show_provider_storage_usage_subtitle" = "在菜单中显示本地磁盘用量。会在后台扫描已知的提供商自有路径。";
 "section_keychain_access" = "钥匙串访问";
 "keychain_access_caption" = "禁用所有钥匙串读写。浏览器 cookie 导入不可用；在提供商中手动粘贴 Cookie 标头。";
 "disable_keychain_access_title" = "禁用钥匙串访问";

--- a/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
+++ b/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
@@ -76,6 +76,7 @@ struct PreferencesPaneSmokeTests {
         #expect(UserDefaults.standard.string(forKey: "appLanguage") == "zh-Hans")
         #expect(L("tab_general") == "通用")
         #expect(L("quota_warning_notifications_title") == "配额预警通知")
+        #expect(L("show_provider_storage_usage_title") == "显示提供商存储用量")
     }
 
     private static func makeSettingsStore(suite: String) -> SettingsStore {


### PR DESCRIPTION
## Summary
- Route the Advanced pane provider storage toggle through the localization helper.
- Add English, Simplified Chinese, and Brazilian Portuguese strings for the setting title/subtitle.
- Cover the Simplified Chinese title in the preference localization smoke test.

Fixes #971

## Verification
- `git diff --check HEAD~1 HEAD`

