### PR TITLE
Document ElevenLabs provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ printf '%s' "$ELEVENLABS_API_KEY" | codexbar config set-api-key --provider eleve
 - [Ollama](docs/ollama.md) — Browser cookies for Ollama Cloud usage windows.
 - [JetBrains AI](docs/jetbrains.md) — Local XML-based quota from JetBrains IDE configuration; monthly credits tracking.
 - [Warp](docs/warp.md) — API token for GraphQL request limits and monthly credits.
+- [ElevenLabs](docs/elevenlabs.md) — API key for character credits and voice slot usage.
 - [OpenRouter](docs/openrouter.md) — API token for credit-based usage tracking across multiple AI providers.
 - Perplexity — Account usage credits from Perplexity usage data.
 - [Abacus AI](docs/abacus.md) — Browser cookie auth for ChatLLM/RouteLLM compute credit tracking.

--- a/docs/elevenlabs.md
+++ b/docs/elevenlabs.md
@@ -1,0 +1,51 @@
+---
+summary: "ElevenLabs provider notes: API key setup and subscription usage fields."
+read_when:
+  - Adding or modifying the ElevenLabs provider
+  - Debugging ElevenLabs API keys or subscription usage parsing
+  - Adjusting ElevenLabs credit or voice-slot labels
+---
+
+# ElevenLabs Provider
+
+The ElevenLabs provider reads subscription usage from the ElevenLabs API using an API key.
+
+## Features
+
+- Character credit usage from the current subscription period.
+- Reset timing when the API returns `next_character_count_reset_unix`.
+- Voice slot and professional voice slot usage when those fields are present.
+- Plan/status text from the subscription response.
+
+## Setup
+
+1. Open **Settings -> Providers**
+2. Enable **ElevenLabs**
+3. Open `https://elevenlabs.io/app/settings/api-keys`
+4. Create or copy an API key
+5. Paste the key into CodexBar's ElevenLabs provider settings
+
+### Environment Variables
+
+CodexBar also accepts these environment variables:
+
+- `ELEVENLABS_API_KEY`
+- `XI_API_KEY`
+
+For tests or self-hosted/proxy setups, override the API base URL with `ELEVENLABS_API_URL`.
+
+## How It Works
+
+- Endpoint: `GET https://api.elevenlabs.io/v1/user/subscription`
+- Auth header: `xi-api-key`
+- Fields used: `character_count`, `character_limit`, `voice_slots_used`, `voice_limit`, `professional_voice_slots_used`, `professional_voice_limit`, `tier`, `status`, `next_character_count_reset_unix`
+
+## Troubleshooting
+
+### "Missing ElevenLabs API key"
+
+Add a key in **Settings -> Providers -> ElevenLabs**, set `ELEVENLABS_API_KEY`, or configure an ElevenLabs token account.
+
+### "ElevenLabs API error"
+
+Confirm the API key is valid and that the current network can reach `api.elevenlabs.io`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
     <title>CodexBar — every AI coding limit in your menu bar</title>
     <meta
       name="description"
-      content="A tiny macOS menu bar app that tracks AI coding-provider usage windows, credits, costs, and resets across 29 providers — Codex, Claude, Cursor, Gemini, Copilot, and 24 more."
+      content="A tiny macOS menu bar app that tracks AI coding-provider usage windows, credits, costs, and resets across 30 providers — Codex, Claude, Cursor, Gemini, Copilot, and 25 more."
     />
     <meta name="theme-color" content="#0a0a0c" />
     <link rel="canonical" href="https://codexbar.app/" />
@@ -14,7 +14,7 @@
     <meta property="og:title" content="CodexBar" />
     <meta
       property="og:description"
-      content="Track usage windows, credits, and resets across 29 AI coding providers from your macOS menu bar."
+      content="Track usage windows, credits, and resets across 30 AI coding providers from your macOS menu bar."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://codexbar.app/" />
@@ -74,7 +74,7 @@
 
       <section class="providers" aria-labelledby="providers-h">
         <header class="section-head">
-          <h2 id="providers-h">29 providers, one menu bar</h2>
+          <h2 id="providers-h">30 providers, one menu bar</h2>
           <p>Each tile becomes a status item with its own usage window, reset countdown, and provider menu.</p>
         </header>
         <ul class="grid">
@@ -146,6 +146,9 @@
         </a></li>
         <li><a class="provider" style="--brand:#7B68EE" href="https://github.com/steipete/CodexBar/blob/main/docs/warp.md">
           <span class="chip">W</span><span class="meta"><span class="name">Warp</span><span class="auth">API key</span></span>
+        </a></li>
+        <li><a class="provider" style="--brand:#EAEAE6;--ink:#0a0a0c" href="https://github.com/steipete/CodexBar/blob/main/docs/elevenlabs.md">
+          <span class="chip">E</span><span class="meta"><span class="name">ElevenLabs</span><span class="auth">API key</span></span>
         </a></li>
         <li><a class="provider" style="--brand:#6467F2" href="https://github.com/steipete/CodexBar/blob/main/docs/openrouter.md">
           <span class="chip">O</span><span class="meta"><span class="name">OpenRouter</span><span class="auth">API key</span></span>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -3,7 +3,7 @@
 CodexBar shows OpenAI Codex and Claude Code usage limits in the macOS menu bar.
 
 Canonical documentation:
-- CodexBar — every AI coding limit in your menu bar: https://codexbar.app/ - A tiny macOS menu bar app that tracks AI coding-provider usage windows, credits, costs, and resets across 29 providers — Codex, Claude, Cursor, Gemini, Copilot, and 24 more.
+- CodexBar — every AI coding limit in your menu bar: https://codexbar.app/ - A tiny macOS menu bar app that tracks AI coding-provider usage windows, credits, costs, and resets across 30 providers — Codex, Claude, Cursor, Gemini, Copilot, and 25 more.
 
 Source: https://github.com/steipete/CodexBar
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -40,6 +40,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 | JetBrains AI | Local XML quota file (`local`). |
 | Amp | Web settings page via browser cookies (`web`). |
 | Warp | API token (config/env) → GraphQL request limits (`api`). |
+| ElevenLabs | API key from config/env → subscription usage API (`api`). |
 | Ollama | Web settings page via browser cookies (`web`). |
 | Synthetic | API key from config/env → quota API (`api`). |
 | OpenRouter | API token (config, overrides env) → credits API (`api`). |
@@ -175,6 +176,14 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Shows monthly credits usage and next refresh time.
 - Status: none yet.
 - Details: `docs/warp.md`.
+
+## ElevenLabs
+- API key from Settings, token accounts, `ELEVENLABS_API_KEY`, or `XI_API_KEY`.
+- Reads `GET /v1/user/subscription` from `api.elevenlabs.io`.
+- Shows character credit usage, reset timing, and voice slot usage when available.
+- Override the API base URL with `ELEVENLABS_API_URL`.
+- Status: `https://status.elevenlabs.io` (link only, no auto-polling).
+- Details: `docs/elevenlabs.md`.
 
 ## Vertex AI
 - OAuth credentials from `gcloud auth application-default login` (ADC).


### PR DESCRIPTION
## Summary
- Add a dedicated ElevenLabs provider documentation page covering API-key setup, environment variables, API endpoint, and displayed usage fields.
- Link ElevenLabs from the README provider list and the provider strategy overview.
- Add ElevenLabs to the static docs homepage provider grid and refresh the provider count metadata.

## Verification
- `node Scripts/docs-list.mjs`
- `git diff --cached --check`