### PR TITLE
feat(grok): add web billing fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Usage charts: reuse the OpenAI API inline dashboard for local Codex/Claude/Vertex/Bedrock cost history, OpenRouter day/week/month spend, z.ai hourly tokens, and Mistral daily spend.
 
 ### Fixed
+- Grok: fall back to grok.com's billing endpoint when `grok agent stdio` omits the xAI billing method (#984). Thanks @bcharleson!
 - Codex: prefer per-event token usage over divergent total counters when scanning local cost history, preventing large false cost spikes (#968). Thanks @Ifan24!
 - Codex: improve managed account login recovery guidance when macOS blocks or moves a stale `codex` CLI to Trash (#977).
 - Kimi K2: label the legacy provider as unofficial and remove links that presented the legacy endpoint as an official Kimi account surface (#967, fixes #473). Thanks @mturac!

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -432,7 +432,10 @@ extension CodexBarCLI {
     }
 
     static func sourceModeRequiresWebSupport(_ sourceMode: ProviderSourceMode, provider: UsageProvider) -> Bool {
-        switch sourceMode {
+        guard provider != .grok else {
+            return false
+        }
+        return switch sourceMode {
         case .web:
             true
         case .auto:

--- a/Sources/CodexBarCore/Providers/Grok/GrokCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokCookieImporter.swift
@@ -1,0 +1,213 @@
+import Foundation
+
+#if os(macOS)
+import SweetCookieKit
+
+public enum GrokCookieImporter {
+    private static let importSessionCacheTTL: TimeInterval = 5
+    private static let importSessionCache = ImportSessionCache(ttl: importSessionCacheTTL)
+    private static let log = CodexBarLog.logger(LogCategories.providers)
+    private static let cookieClient = BrowserCookieClient()
+    private static let cookieDomains = ["grok.com"]
+    private static let cookieImportOrder: BrowserCookieImportOrder =
+        ProviderDefaults.metadata[.grok]?.browserCookieOrder ?? Browser.defaultImportOrder
+
+    public struct SessionInfo: Sendable {
+        public let cookies: [HTTPCookie]
+        public let sourceLabel: String
+
+        public init(cookies: [HTTPCookie], sourceLabel: String) {
+            self.cookies = cookies
+            self.sourceLabel = sourceLabel
+        }
+
+        public var cookieHeader: String {
+            self.cookies.map { "\($0.name)=\($0.value)" }.joined(separator: "; ")
+        }
+    }
+
+    public static func importSessions(
+        browserDetection: BrowserDetection = BrowserDetection(),
+        logger: ((String) -> Void)? = nil) throws -> [SessionInfo]
+    {
+        if let cached = self.cachedImportSessions() {
+            return cached
+        }
+
+        var sessions: [SessionInfo] = []
+        let candidates = self.cookieImportOrder.cookieImportCandidates(using: browserDetection)
+        for browserSource in candidates {
+            do {
+                let perSource = try self.importSessions(from: browserSource, logger: logger)
+                sessions.append(contentsOf: perSource)
+            } catch {
+                BrowserCookieAccessGate.recordIfNeeded(error)
+                self.emit(
+                    "\(browserSource.displayName) cookie import failed: \(error.localizedDescription)",
+                    logger: logger)
+            }
+        }
+
+        guard !sessions.isEmpty else { throw GrokWebBillingError.missingCredentials }
+        self.storeImportSessions(sessions)
+        return sessions
+    }
+
+    public static func importSessions(
+        from browserSource: Browser,
+        logger: ((String) -> Void)? = nil) throws -> [SessionInfo]
+    {
+        let query = BrowserCookieQuery(domains: self.cookieDomains)
+        let log: (String) -> Void = { msg in self.emit(msg, logger: logger) }
+        let sources = try Self.cookieClient.codexBarRecords(
+            matching: query,
+            in: browserSource,
+            logger: log)
+
+        var sessions: [SessionInfo] = []
+        let grouped = Dictionary(grouping: sources, by: { $0.store.profile.id })
+        let sortedGroups = grouped.values.sorted { lhs, rhs in
+            self.mergedLabel(for: lhs) < self.mergedLabel(for: rhs)
+        }
+
+        for group in sortedGroups where !group.isEmpty {
+            let label = self.mergedLabel(for: group)
+            let mergedRecords = self.mergeRecords(group)
+            guard mergedRecords.contains(where: { $0.name == "sso" || $0.name == "sso-rw" }) else { continue }
+            let httpCookies = BrowserCookieClient.makeHTTPCookies(mergedRecords, origin: query.origin)
+            guard !httpCookies.isEmpty else { continue }
+            log("Found Grok session cookies in \(label)")
+            sessions.append(SessionInfo(cookies: httpCookies, sourceLabel: label))
+        }
+        return sessions
+    }
+
+    public static func importSession(
+        browserDetection: BrowserDetection = BrowserDetection(),
+        logger: ((String) -> Void)? = nil) throws -> SessionInfo
+    {
+        let sessions = try self.importSessions(browserDetection: browserDetection, logger: logger)
+        guard let first = sessions.first else { throw GrokWebBillingError.missingCredentials }
+        return first
+    }
+
+    public static func hasSession(
+        browserDetection: BrowserDetection = BrowserDetection(),
+        logger: ((String) -> Void)? = nil) -> Bool
+    {
+        do {
+            _ = try self.importSession(browserDetection: browserDetection, logger: logger)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    static func invalidateImportSessionCache() {
+        self.importSessionCache.invalidate()
+    }
+
+    private static func emit(_ message: String, logger: ((String) -> Void)?) {
+        logger?("[grok-cookie] \(message)")
+        self.log.debug("\(message)")
+    }
+
+    private static func cachedImportSessions(now: Date = Date()) -> [SessionInfo]? {
+        self.importSessionCache.load(now: now)
+    }
+
+    private static func storeImportSessions(_ sessions: [SessionInfo], now: Date = Date()) {
+        self.importSessionCache.store(sessions, now: now)
+    }
+
+    private static func mergedLabel(for sources: [BrowserCookieStoreRecords]) -> String {
+        guard let base = sources.map(\.label).min() else { return "Unknown" }
+        if base.hasSuffix(" (Network)") {
+            return String(base.dropLast(" (Network)".count))
+        }
+        return base
+    }
+
+    private static func mergeRecords(_ sources: [BrowserCookieStoreRecords]) -> [BrowserCookieRecord] {
+        let sortedSources = sources.sorted { lhs, rhs in
+            self.storePriority(lhs.store.kind) < self.storePriority(rhs.store.kind)
+        }
+        var mergedByKey: [String: BrowserCookieRecord] = [:]
+        for source in sortedSources {
+            for record in source.records {
+                let key = self.recordKey(record)
+                if let existing = mergedByKey[key] {
+                    if self.shouldReplace(existing: existing, candidate: record) {
+                        mergedByKey[key] = record
+                    }
+                } else {
+                    mergedByKey[key] = record
+                }
+            }
+        }
+        return Array(mergedByKey.values)
+    }
+
+    private static func storePriority(_ kind: BrowserCookieStoreKind) -> Int {
+        switch kind {
+        case .network: 0
+        case .primary: 1
+        case .safari: 2
+        }
+    }
+
+    private static func recordKey(_ record: BrowserCookieRecord) -> String {
+        "\(record.name)|\(record.domain)|\(record.path)"
+    }
+
+    private static func shouldReplace(existing: BrowserCookieRecord, candidate: BrowserCookieRecord) -> Bool {
+        switch (existing.expires, candidate.expires) {
+        case let (lhs?, rhs?): rhs > lhs
+        case (nil, .some): true
+        case (.some, nil): false
+        case (nil, nil): false
+        }
+    }
+
+    private final class ImportSessionCache: @unchecked Sendable {
+        private let ttl: TimeInterval
+        private let lock = NSLock()
+        private var entry: (sessions: [SessionInfo], expiresAt: Date)?
+
+        init(ttl: TimeInterval) {
+            self.ttl = ttl
+        }
+
+        func load(now: Date) -> [SessionInfo]? {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            guard let entry = self.entry, entry.expiresAt > now else {
+                self.entry = nil
+                return nil
+            }
+            return entry.sessions
+        }
+
+        func store(_ sessions: [SessionInfo], now: Date) {
+            self.lock.lock()
+            self.entry = (sessions, now.addingTimeInterval(self.ttl))
+            self.lock.unlock()
+        }
+
+        func invalidate() {
+            self.lock.lock()
+            self.entry = nil
+            self.lock.unlock()
+        }
+    }
+}
+#else
+public enum GrokCookieImporter {
+    public static func hasSession(
+        browserDetection _: BrowserDetection = BrowserDetection(),
+        logger _: ((String) -> Void)? = nil) -> Bool
+    {
+        false
+    }
+}
+#endif

--- a/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift
@@ -21,6 +21,7 @@ public enum GrokProviderDescriptor {
                 defaultEnabled: false,
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
+                browserCookieOrder: ProviderBrowserCookieDefaults.grokCookieImportOrder,
                 dashboardURL: "https://grok.com/?_s=usage",
                 changelogURL: "https://x.ai/news",
                 statusPageURL: nil,
@@ -33,11 +34,24 @@ public enum GrokProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "Grok cost summary is not supported yet." }),
             fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .cli],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [GrokCLIFetchStrategy()] })),
+                sourceModes: [.auto, .cli, .web],
+                pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "grok",
                 versionDetector: { _ in GrokStatusProbe.detectVersion() }))
+    }
+
+    private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {
+        switch context.sourceMode {
+        case .auto:
+            [GrokCLIFetchStrategy(), GrokWebFetchStrategy()]
+        case .cli:
+            [GrokCLIFetchStrategy()]
+        case .web:
+            [GrokWebFetchStrategy()]
+        case .api, .oauth:
+            []
+        }
     }
 }
 
@@ -45,18 +59,114 @@ struct GrokCLIFetchStrategy: ProviderFetchStrategy {
     let id: String = "grok.cli"
     let kind: ProviderFetchKind = .cli
 
-    func isAvailable(_: ProviderFetchContext) async -> Bool {
-        BinaryLocator.resolveGrokBinary() != nil
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        BinaryLocator.resolveGrokBinary(env: context.env) != nil
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
         let probe = GrokStatusProbe()
         let snap = try await probe.fetch(env: context.env)
-        let sourceLabel = snap.billing != nil ? "grok-cli" : "grok-local"
         return self.makeResult(
             usage: snap.toUsageSnapshot(),
+            sourceLabel: "grok-cli")
+    }
+
+    func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {
+        context.sourceMode == .auto
+    }
+}
+
+struct GrokWebFetchStrategy: ProviderFetchStrategy {
+    let id: String = "grok.web"
+    let kind: ProviderFetchKind = .web
+
+    static func canImportBrowserCookies(runtime: ProviderRuntime, env: [String: String]) -> Bool {
+        runtime == .app || env["CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT"] == "1"
+    }
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        #if os(macOS)
+        if Self.canImportBrowserCookies(runtime: context.runtime, env: context.env),
+           GrokCookieImporter.hasSession(browserDetection: context.browserDetection)
+        {
+            return true
+        }
+        #endif
+        return FileManager.default.fileExists(atPath: GrokCredentialsStore.authFileURL(env: context.env).path)
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        let (webBilling, sourceLabel, authenticatedByAuthFile) = try await self.fetchWebBilling(context: context)
+        let credentials = Self.credentialsForWebBillingSnapshot(
+            credentials: try? GrokCredentialsStore.load(env: context.env),
+            authenticatedByAuthFile: authenticatedByAuthFile)
+        let snapshot = GrokUsageSnapshot(
+            billing: nil,
+            webBilling: webBilling,
+            credentials: GrokStatusProbe.credentialsForSnapshot(
+                credentials: credentials,
+                billing: nil,
+                webBilling: webBilling),
+            localSummary: GrokLocalSessionScanner.summarize(env: context.env),
+            cliVersion: GrokStatusProbe.detectVersion(env: context.env),
+            updatedAt: Date())
+        return self.makeResult(
+            usage: snapshot.toUsageSnapshot(),
             sourceLabel: sourceLabel)
     }
+
+    private func fetchWebBilling(context: ProviderFetchContext) async throws -> (
+        snapshot: GrokWebBillingSnapshot,
+        sourceLabel: String,
+        authenticatedByAuthFile: Bool)
+    {
+        #if os(macOS)
+        if Self.canImportBrowserCookies(runtime: context.runtime, env: context.env) {
+            var lastCookieError: Error?
+            do {
+                let sessions = try GrokCookieImporter.importSessions(browserDetection: context.browserDetection)
+                let (snapshot, sourceLabel) = try await Self.fetchFirstValidCookieSession(sessions)
+                return (snapshot, sourceLabel, false)
+            } catch {
+                lastCookieError = error
+            }
+            if !FileManager.default.fileExists(atPath: GrokCredentialsStore.authFileURL(env: context.env).path) {
+                throw lastCookieError ?? GrokWebBillingError.missingCredentials
+            }
+        }
+        #endif
+
+        let credentials = try GrokCredentialsStore.load(env: context.env)
+        let snapshot = try await GrokWebBillingFetcher.fetch(credentials: credentials)
+        return (snapshot, "grok-web", true)
+    }
+
+    static func credentialsForWebBillingSnapshot(
+        credentials: GrokCredentials?,
+        authenticatedByAuthFile: Bool) -> GrokCredentials?
+    {
+        authenticatedByAuthFile ? credentials : nil
+    }
+
+    #if os(macOS)
+    static func fetchFirstValidCookieSession(
+        _ sessions: [GrokCookieImporter.SessionInfo],
+        fetch: (String) async throws -> GrokWebBillingSnapshot = { cookieHeader in
+            try await GrokWebBillingFetcher.fetch(cookieHeader: cookieHeader)
+        }) async throws -> (GrokWebBillingSnapshot, String)
+    {
+        var lastError: Error?
+        for session in sessions {
+            do {
+                let snapshot = try await fetch(session.cookieHeader)
+                return (snapshot, session.sourceLabel)
+            } catch {
+                lastError = error
+            }
+        }
+        throw lastError ?? GrokWebBillingError.missingCredentials
+    }
+    #endif
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
         false

--- a/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public struct GrokUsageSnapshot: Sendable {
     public let billing: GrokBillingResponse?
+    public let webBilling: GrokWebBillingSnapshot?
     public let credentials: GrokCredentials?
     public let localSummary: GrokLocalSessionSummary?
     public let cliVersion: String?
@@ -9,12 +10,14 @@ public struct GrokUsageSnapshot: Sendable {
 
     public init(
         billing: GrokBillingResponse?,
+        webBilling: GrokWebBillingSnapshot? = nil,
         credentials: GrokCredentials?,
         localSummary: GrokLocalSessionSummary?,
         cliVersion: String?,
         updatedAt: Date)
     {
         self.billing = billing
+        self.webBilling = webBilling
         self.credentials = credentials
         self.localSummary = localSummary
         self.cliVersion = cliVersion
@@ -22,7 +25,8 @@ public struct GrokUsageSnapshot: Sendable {
     }
 
     public func toUsageSnapshot() -> UsageSnapshot {
-        // Primary window: monthly credit usage from billing config (preferred), otherwise nil.
+        // Primary window: monthly credit usage from the CLI RPC, falling back to
+        // the web billing RPC used by grok.com when the agent surface lacks billing.
         var primary: RateWindow?
         if let billing,
            let percent = billing.monthlyUsedPercent
@@ -31,6 +35,14 @@ public struct GrokUsageSnapshot: Sendable {
                 usedPercent: percent,
                 windowMinutes: nil,
                 resetsAt: billing.billingPeriodEndDate,
+                resetDescription: nil)
+        } else if let webBilling,
+                  let percent = webBilling.usedPercent
+        {
+            primary = RateWindow(
+                usedPercent: percent,
+                windowMinutes: nil,
+                resetsAt: webBilling.resetsAt,
                 resetDescription: nil)
         }
 
@@ -100,24 +112,21 @@ public struct GrokStatusProbe: Sendable {
         let localSummary = GrokLocalSessionScanner.summarize(env: env)
         let cliVersion = Self.detectVersion(env: env)
 
-        // Grok session tokens expire after ~7 days. An expired record on disk
-        // must be treated like a missing credential when deciding whether to
-        // mask the RPC auth error: otherwise we render a snapshot with stale
-        // identity and no `grok login` hint while billing silently 401s.
-        let activeCredentials = credentials.flatMap { $0.isExpired ? nil : $0 }
-
         // `localSummary` is *not* currently projected into a visible RateWindow or
         // identity field, so a stale `~/.grok/sessions/` directory must not
-        // suppress the auth-required hint. Only swallow the RPC error when we
-        // actually have something renderable for the user — fresh credentials
-        // or a billing response.
-        if billing == nil, activeCredentials == nil {
+        // suppress the auth-required hint. CLI-only fetches need a billing
+        // response; the provider pipeline owns the separate web fallback.
+        if billing == nil {
             throw rpcError ?? GrokRPCError.notAuthenticated
         }
 
         return GrokUsageSnapshot(
             billing: billing,
-            credentials: Self.credentialsForSnapshot(credentials: credentials, billing: billing),
+            webBilling: nil,
+            credentials: Self.credentialsForSnapshot(
+                credentials: credentials,
+                billing: billing,
+                webBilling: nil),
             localSummary: localSummary,
             cliVersion: cliVersion,
             updatedAt: Date())
@@ -125,11 +134,24 @@ public struct GrokStatusProbe: Sendable {
 
     static func credentialsForSnapshot(
         credentials: GrokCredentials?,
-        billing: GrokBillingResponse?) -> GrokCredentials?
+        billing: GrokBillingResponse?,
+        webBilling: GrokWebBillingSnapshot? = nil) -> GrokCredentials?
     {
-        // If billing succeeded, the CLI accepted/refreshed auth and the local
+        // If remote usage succeeded, xAI accepted auth and the local
         // identity is still useful even when the persisted expires_at is stale.
-        if billing != nil { return credentials }
+        if billing != nil || webBilling != nil { return credentials }
         return credentials.flatMap { $0.isExpired ? nil : $0 }
+    }
+
+    static func shouldSurfaceRemoteAuthError(_ error: Error?) -> Bool {
+        guard let error = error as? GrokWebBillingError else { return false }
+        switch error {
+        case let .requestFailed(status, _):
+            return status == 401 || status == 403
+        case let .rpcFailed(status, _):
+            return status == 16
+        case .missingCredentials, .emptyResponse, .invalidResponse, .parseFailed:
+            return false
+        }
     }
 }

--- a/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift
@@ -1,0 +1,343 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public struct GrokWebBillingSnapshot: Sendable, Equatable {
+    public let usedPercent: Double?
+    public let resetsAt: Date?
+
+    public init(usedPercent: Double?, resetsAt: Date?) {
+        self.usedPercent = usedPercent
+        self.resetsAt = resetsAt
+    }
+}
+
+public enum GrokWebBillingError: LocalizedError, Sendable {
+    case missingCredentials
+    case emptyResponse
+    case invalidResponse
+    case requestFailed(Int, String)
+    case rpcFailed(Int, String)
+    case parseFailed
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingCredentials:
+            "Grok web billing requires a signed-in grok.com browser session or `grok login`."
+        case .emptyResponse:
+            "Grok web billing returned no protobuf payload."
+        case .invalidResponse:
+            "Grok web billing returned an invalid response."
+        case let .requestFailed(status, body):
+            if status == 401 || status == 403 {
+                "Grok web billing rejected credentials. Run `grok login` to refresh xAI auth."
+            } else {
+                "Grok web billing request failed with HTTP \(status): \(body)"
+            }
+        case let .rpcFailed(status, message):
+            if status == 16 {
+                "Grok web billing rejected credentials. Run `grok login` to refresh xAI auth."
+            } else {
+                "Grok web billing RPC failed with status \(status): \(message)"
+            }
+        case .parseFailed:
+            "Could not parse Grok web billing usage."
+        }
+    }
+}
+
+public enum GrokWebBillingFetcher {
+    public static let defaultEndpoint =
+        URL(string: "https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig")!
+
+    public static func fetch(
+        credentials: GrokCredentials,
+        session: URLSession = .shared,
+        endpoint: URL = Self.defaultEndpoint) async throws -> GrokWebBillingSnapshot
+    {
+        try await self.fetch(
+            authorizationHeader: "Bearer \(credentials.accessToken)",
+            cookieHeader: nil,
+            session: session,
+            endpoint: endpoint)
+    }
+
+    public static func fetch(
+        cookieHeader: String,
+        session: URLSession = .shared,
+        endpoint: URL = Self.defaultEndpoint) async throws -> GrokWebBillingSnapshot
+    {
+        try await self.fetch(
+            authorizationHeader: nil,
+            cookieHeader: cookieHeader,
+            session: session,
+            endpoint: endpoint)
+    }
+
+    private static func fetch(
+        authorizationHeader: String?,
+        cookieHeader: String?,
+        session: URLSession,
+        endpoint: URL) async throws -> GrokWebBillingSnapshot
+    {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 8
+        request.httpBody = Data([0x00, 0x00, 0x00, 0x00, 0x00])
+        if let authorizationHeader {
+            request.setValue(authorizationHeader, forHTTPHeaderField: "Authorization")
+        }
+        if let cookieHeader {
+            request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        }
+        request.setValue("https://grok.com", forHTTPHeaderField: "Origin")
+        request.setValue("https://grok.com/?_s=usage", forHTTPHeaderField: "Referer")
+        request.setValue("*/*", forHTTPHeaderField: "Accept")
+        request.setValue("application/grpc-web+proto", forHTTPHeaderField: "Content-Type")
+        request.setValue("1", forHTTPHeaderField: "x-grpc-web")
+        request.setValue("connect-es/2.1.1", forHTTPHeaderField: "x-user-agent")
+        request.setValue("CodexBar", forHTTPHeaderField: "User-Agent")
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw GrokWebBillingError.invalidResponse
+        }
+        guard http.statusCode == 200 else {
+            let body = String(data: data.prefix(400), encoding: .utf8) ?? ""
+            throw GrokWebBillingError.requestFailed(http.statusCode, body)
+        }
+        try Self.validateGRPCStatusFields(Self.grpcHeaderFields(from: http.allHeaderFields))
+        try Self.validateGRPCWebTrailers(data)
+
+        return try Self.parseGRPCWebResponse(data)
+    }
+
+    static func parseGRPCWebResponse(_ data: Data, now: Date = Date()) throws -> GrokWebBillingSnapshot {
+        let payloads = Self.grpcWebDataFrames(from: data)
+        guard !payloads.isEmpty else { throw GrokWebBillingError.emptyResponse }
+
+        var scan = ProtobufScan()
+        for payload in payloads {
+            scan.merge(Self.scanProtobuf(payload, depth: 0))
+        }
+
+        let parsedPercent = scan.fixed32Fields
+            .filter { field in
+                field.path.last == 1 && field.value.isFinite && field.value >= 0 && field.value <= 100
+            }
+            .min { lhs, rhs in
+                lhs.path.count == rhs.path.count ? lhs.order < rhs.order : lhs.path.count < rhs.path.count
+            }
+            .map { Double($0.value) }
+
+        let resetFields = scan.varintFields.compactMap { field -> (path: [UInt64], date: Date)? in
+            let raw = field.value
+            guard raw >= 1_700_000_000, raw <= 2_100_000_000 else { return nil }
+            return (field.path, Date(timeIntervalSince1970: TimeInterval(raw)))
+        }
+        let futureResetFields = resetFields.filter { $0.date > now }
+        let reset = futureResetFields
+            .filter { $0.path == [1, 5, 1] }
+            .map(\.date)
+            .min() ?? futureResetFields
+            .map(\.date)
+            .min()
+
+        let noUsageYet = parsedPercent == nil &&
+            scan.fixed32Fields.isEmpty &&
+            reset != nil &&
+            scan.varintFields.contains { $0.path.starts(with: [1, 6]) }
+        guard let percent = parsedPercent ?? (noUsageYet ? 0 : nil) else {
+            throw GrokWebBillingError.parseFailed
+        }
+        return GrokWebBillingSnapshot(usedPercent: percent, resetsAt: reset)
+    }
+
+    static func grpcWebDataFrames(from data: Data) -> [Data] {
+        let bytes = [UInt8](data)
+        var frames: [Data] = []
+        var index = 0
+        while index + 5 <= bytes.count {
+            let flags = bytes[index]
+            let length = (Int(bytes[index + 1]) << 24)
+                | (Int(bytes[index + 2]) << 16)
+                | (Int(bytes[index + 3]) << 8)
+                | Int(bytes[index + 4])
+            let start = index + 5
+            let end = start + length
+            guard length >= 0, end <= bytes.count else { break }
+            if flags & 0x80 == 0 {
+                frames.append(Data(bytes[start..<end]))
+            }
+            index = end
+        }
+        return frames
+    }
+
+    static func validateGRPCWebTrailers(_ data: Data) throws {
+        try self.validateGRPCStatusFields(self.grpcWebTrailerFields(from: data))
+    }
+
+    static func validateGRPCStatusFields(_ fields: [String: String]) throws {
+        guard let rawStatus = fields["grpc-status"],
+              let status = Int(rawStatus),
+              status != 0
+        else {
+            return
+        }
+        throw GrokWebBillingError.rpcFailed(status, fields["grpc-message"] ?? "")
+    }
+
+    static func grpcHeaderFields(from headers: [AnyHashable: Any]) -> [String: String] {
+        var fields: [String: String] = [:]
+        for (key, value) in headers {
+            let normalizedKey = String(describing: key)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            guard normalizedKey.hasPrefix("grpc-") else { continue }
+            fields[normalizedKey] = String(describing: value)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .removingPercentEncoding ?? ""
+        }
+        return fields
+    }
+
+    static func grpcWebTrailerFields(from data: Data) -> [String: String] {
+        let bytes = [UInt8](data)
+        var fields: [String: String] = [:]
+        var index = 0
+        while index + 5 <= bytes.count {
+            let flags = bytes[index]
+            let length = (Int(bytes[index + 1]) << 24)
+                | (Int(bytes[index + 2]) << 16)
+                | (Int(bytes[index + 3]) << 8)
+                | Int(bytes[index + 4])
+            let start = index + 5
+            let end = start + length
+            guard length >= 0, end <= bytes.count else { break }
+            if flags & 0x80 != 0, let text = String(data: Data(bytes[start..<end]), encoding: .utf8) {
+                for line in text.components(separatedBy: .newlines) where !line.isEmpty {
+                    guard let separator = line.firstIndex(of: ":") else { continue }
+                    let key = line[..<separator]
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .lowercased()
+                    let value = line[line.index(after: separator)...]
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .removingPercentEncoding ?? ""
+                    fields[key] = value
+                }
+            }
+            index = end
+        }
+        return fields
+    }
+
+    private struct ProtobufScan {
+        struct Fixed32Field {
+            var path: [UInt64]
+            var value: Float
+            var order: Int
+        }
+
+        struct VarintField {
+            var path: [UInt64]
+            var value: UInt64
+        }
+
+        var fixed32Fields: [Fixed32Field] = []
+        var varintFields: [VarintField] = []
+
+        mutating func merge(_ other: ProtobufScan) {
+            self.fixed32Fields.append(contentsOf: other.fixed32Fields)
+            self.varintFields.append(contentsOf: other.varintFields)
+        }
+    }
+
+    private static func scanProtobuf(_ data: Data, depth: Int) -> ProtobufScan {
+        self.scanProtobuf(data, depth: depth, path: [], order: 0).scan
+    }
+
+    private static func scanProtobuf(
+        _ data: Data,
+        depth: Int,
+        path: [UInt64],
+        order: Int) -> (scan: ProtobufScan, order: Int)
+    {
+        let bytes = [UInt8](data)
+        var scan = ProtobufScan()
+        var index = 0
+        var nextOrder = order
+
+        while index < bytes.count {
+            let fieldStart = index
+            guard let key = Self.readVarint(bytes, index: &index), key != 0 else {
+                index = fieldStart + 1
+                continue
+            }
+            let fieldNumber = key >> 3
+            let wireType = key & 0x07
+            let fieldPath = path + [fieldNumber]
+
+            switch wireType {
+            case 0:
+                if let value = Self.readVarint(bytes, index: &index) {
+                    scan.varintFields.append(ProtobufScan.VarintField(path: fieldPath, value: value))
+                } else {
+                    index = fieldStart + 1
+                }
+            case 1:
+                guard index + 8 <= bytes.count else { return (scan, nextOrder) }
+                index += 8
+            case 2:
+                guard let length = Self.readVarint(bytes, index: &index),
+                      length <= UInt64(bytes.count - index)
+                else {
+                    index = fieldStart + 1
+                    continue
+                }
+                let start = index
+                let end = index + Int(length)
+                if depth < 4 {
+                    let nested = Self.scanProtobuf(
+                        Data(bytes[start..<end]),
+                        depth: depth + 1,
+                        path: fieldPath,
+                        order: nextOrder)
+                    scan.merge(nested.scan)
+                    nextOrder = nested.order
+                }
+                index = end
+            case 5:
+                guard index + 4 <= bytes.count else { return (scan, nextOrder) }
+                let bitPattern = UInt32(bytes[index])
+                    | (UInt32(bytes[index + 1]) << 8)
+                    | (UInt32(bytes[index + 2]) << 16)
+                    | (UInt32(bytes[index + 3]) << 24)
+                scan.fixed32Fields.append(ProtobufScan.Fixed32Field(
+                    path: fieldPath,
+                    value: Float(bitPattern: bitPattern),
+                    order: nextOrder))
+                nextOrder += 1
+                index += 4
+            default:
+                index = fieldStart + 1
+            }
+        }
+
+        return (scan, nextOrder)
+    }
+
+    private static func readVarint(_ bytes: [UInt8], index: inout Int) -> UInt64? {
+        var value: UInt64 = 0
+        var shift: UInt64 = 0
+        while index < bytes.count, shift < 64 {
+            let byte = bytes[index]
+            index += 1
+            value |= UInt64(byte & 0x7F) << shift
+            if byte & 0x80 == 0 { return value }
+            shift += 7
+        }
+        return nil
+    }
+}

--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -200,4 +200,14 @@ public enum ProviderBrowserCookieDefaults {
         nil
         #endif
     }
+
+    /// Grok is normally signed in through Chrome; keep this narrow so CLI/live probes do not touch
+    /// unrelated browser keychains.
+    public static var grokCookieImportOrder: BrowserCookieImportOrder? {
+        #if os(macOS)
+        [.chrome]
+        #else
+        nil
+        #endif
+    }
 }

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -272,6 +272,8 @@ final class CLIEntryTests: XCTestCase {
         XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .kilo))
         XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .codex))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .kilo))
+        XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .grok))
+        XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .grok))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.api, provider: .kilo))
     }
 }

--- a/Tests/CodexBarTests/GrokAuthTests.swift
+++ b/Tests/CodexBarTests/GrokAuthTests.swift
@@ -124,10 +124,23 @@ struct GrokAuthTests {
         """#
         let expired = try GrokCredentialsStore.parse(data: Data(pastJson.utf8))
         let billing = try JSONDecoder().decode(GrokBillingResponse.self, from: Data(#"{}"#.utf8))
+        let webBilling = GrokWebBillingSnapshot(
+            usedPercent: 42,
+            resetsAt: Date(timeIntervalSince1970: 1_800_000_000))
 
         #expect(GrokStatusProbe.credentialsForSnapshot(credentials: expired, billing: nil) == nil)
         #expect(GrokStatusProbe.credentialsForSnapshot(credentials: expired, billing: billing)?
             .email == "grok@example.com")
+        #expect(GrokStatusProbe.credentialsForSnapshot(credentials: expired, billing: nil, webBilling: webBilling)?
+            .email == "grok@example.com")
+    }
+
+    @Test
+    func `remote auth failures surface even with fresh local credentials`() {
+        #expect(GrokStatusProbe.shouldSurfaceRemoteAuthError(GrokWebBillingError.requestFailed(401, "unauthorized")))
+        #expect(GrokStatusProbe.shouldSurfaceRemoteAuthError(GrokWebBillingError.requestFailed(403, "forbidden")))
+        #expect(GrokStatusProbe.shouldSurfaceRemoteAuthError(GrokWebBillingError.rpcFailed(16, "token expired")))
+        #expect(!GrokStatusProbe.shouldSurfaceRemoteAuthError(GrokWebBillingError.parseFailed))
     }
 
     @Test

--- a/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
+++ b/Tests/CodexBarTests/GrokWebBillingFetcherTests.swift
@@ -1,0 +1,477 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct GrokWebBillingFetcherTests {
+    @Test
+    func `provider exposes cli and web source modes`() {
+        #expect(GrokProviderDescriptor.descriptor.fetchPlan.sourceModes == [.auto, .cli, .web])
+    }
+
+    @Test
+    func `cli runtime does not import browser cookies unless explicitly enabled`() {
+        #expect(GrokWebFetchStrategy.canImportBrowserCookies(runtime: .app, env: [:]))
+        #expect(!GrokWebFetchStrategy.canImportBrowserCookies(runtime: .cli, env: [:]))
+        #expect(GrokWebFetchStrategy.canImportBrowserCookies(
+            runtime: .cli,
+            env: ["CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT": "1"]))
+    }
+
+    @Test
+    func `web strategy tries later browser session when first cookie is stale`() async throws {
+        let stale = try #require(Self.cookie(name: "sso", value: "stale"))
+        let valid = try #require(Self.cookie(name: "sso", value: "valid"))
+        let sessions = [
+            GrokCookieImporter.SessionInfo(cookies: [stale], sourceLabel: "Chrome Profile 1"),
+            GrokCookieImporter.SessionInfo(cookies: [valid], sourceLabel: "Chrome Profile 2"),
+        ]
+        var attemptedHeaders: [String] = []
+
+        let result = try await GrokWebFetchStrategy.fetchFirstValidCookieSession(sessions) { cookieHeader in
+            attemptedHeaders.append(cookieHeader)
+            guard cookieHeader.contains("valid") else {
+                throw GrokWebBillingError.requestFailed(401, "stale")
+            }
+            return GrokWebBillingSnapshot(
+                usedPercent: 12,
+                resetsAt: Date(timeIntervalSince1970: 1_800_000_000))
+        }
+
+        #expect(attemptedHeaders == ["sso=stale", "sso=valid"])
+        #expect(result.0.usedPercent == 12)
+        #expect(result.1 == "Chrome Profile 2")
+    }
+
+    @Test
+    func `cookie authenticated web billing does not reuse auth file identity`() {
+        #expect(GrokWebFetchStrategy.credentialsForWebBillingSnapshot(
+            credentials: Self.credentials,
+            authenticatedByAuthFile: false) == nil)
+        #expect(GrokWebFetchStrategy.credentialsForWebBillingSnapshot(
+            credentials: Self.credentials,
+            authenticatedByAuthFile: true)?
+            .email == "grok@example.com")
+    }
+
+    @Test
+    func `parses grok grpc web billing frame`() throws {
+        let reset = UInt64(1_800_000_000)
+        let payload = Self.protobufPayload(usedPercent: 42.5, resetEpoch: reset)
+        let data = Self.grpcFrame(payload)
+
+        let snapshot = try GrokWebBillingFetcher.parseGRPCWebResponse(
+            data,
+            now: Date(timeIntervalSince1970: 1_799_000_000))
+
+        #expect(snapshot.usedPercent == 42.5)
+        #expect(snapshot.resetsAt == Date(timeIntervalSince1970: TimeInterval(reset)))
+    }
+
+    @Test
+    func `ignores grpc web trailer frames`() {
+        let payload = Self.protobufPayload(usedPercent: 12.25, resetEpoch: 1_800_000_001)
+        let trailer = Data("grpc-status: 0\r\n".utf8)
+        let data = Self.grpcFrame(payload) + Self.grpcFrame(trailer, flags: 0x80)
+
+        let frames = GrokWebBillingFetcher.grpcWebDataFrames(from: data)
+
+        #expect(frames == [payload])
+    }
+
+    @Test
+    func `web fetch turns grpc unauthenticated trailer into reauth guidance`() async throws {
+        defer {
+            GrokWebBillingStubURLProtocol.requests = []
+            GrokWebBillingStubURLProtocol.requestBodies = []
+            GrokWebBillingStubURLProtocol.handler = nil
+        }
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [GrokWebBillingStubURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let endpoint = try #require(URL(string: "https://grok.test/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig"))
+        let body = Self.grpcFrame(Data("grpc-status: 16\r\ngrpc-message: token%20expired\r\n".utf8), flags: 0x80)
+
+        #expect(GrokWebBillingFetcher.grpcWebTrailerFields(from: body)["grpc-status"] == "16")
+
+        GrokWebBillingStubURLProtocol.requests = []
+        GrokWebBillingStubURLProtocol.requestBodies = []
+        GrokWebBillingStubURLProtocol.handler = { request in
+            let url = try #require(request.url)
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/grpc-web+proto"])!
+            return (response, body)
+        }
+
+        await #expect {
+            _ = try await GrokWebBillingFetcher.fetch(
+                credentials: Self.credentials,
+                session: session,
+                endpoint: endpoint)
+        } throws: { error in
+            error.localizedDescription.contains("grok login")
+        }
+    }
+
+    @Test
+    func `web fetch turns grpc unauthenticated headers into reauth guidance`() async throws {
+        defer {
+            GrokWebBillingStubURLProtocol.requests = []
+            GrokWebBillingStubURLProtocol.requestBodies = []
+            GrokWebBillingStubURLProtocol.handler = nil
+        }
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [GrokWebBillingStubURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let endpoint = try #require(URL(string: "https://grok.test/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig"))
+
+        GrokWebBillingStubURLProtocol.requests = []
+        GrokWebBillingStubURLProtocol.requestBodies = []
+        GrokWebBillingStubURLProtocol.handler = { request in
+            let url = try #require(request.url)
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: [
+                    "Content-Type": "application/grpc-web+proto",
+                    "grpc-status": "16",
+                    "grpc-message": "Invalid%20bearer%20token.",
+                ])!
+            return (response, Data())
+        }
+
+        await #expect {
+            _ = try await GrokWebBillingFetcher.fetch(
+                credentials: Self.credentials,
+                session: session,
+                endpoint: endpoint)
+        } throws: { error in
+            error.localizedDescription.contains("grok login")
+        }
+    }
+
+    @Test
+    func `rejects reset only billing because it cannot render usage`() {
+        var payload = Data()
+        payload.append(0x10) // field 2, varint reset timestamp
+        payload.append(contentsOf: Self.varint(1_800_000_001))
+
+        #expect {
+            _ = try GrokWebBillingFetcher.parseGRPCWebResponse(Self.grpcFrame(payload))
+        } throws: { error in
+            guard case GrokWebBillingError.parseFailed = error else { return false }
+            return true
+        }
+    }
+
+    @Test
+    func `parses grok no usage yet billing response as zero percent`() throws {
+        let data = Data([
+            0x00, 0x00, 0x00, 0x00, 0x37, 0x0A, 0x35, 0x12,
+            0x00, 0x1A, 0x00, 0x22, 0x06, 0x08, 0x80, 0xDA,
+            0xCF, 0xCF, 0x06, 0x2A, 0x06, 0x08, 0x80, 0x97,
+            0xF3, 0xD0, 0x06, 0x32, 0x09, 0x0A, 0x05, 0x08,
+            0xEA, 0x0F, 0x10, 0x04, 0x12, 0x00, 0x32, 0x09,
+            0x0A, 0x05, 0x08, 0xEA, 0x0F, 0x10, 0x03, 0x12,
+            0x00, 0x32, 0x09, 0x0A, 0x05, 0x08, 0xEA, 0x0F,
+            0x10, 0x02, 0x12, 0x00, 0x80, 0x00, 0x00, 0x00,
+            0x0F, 0x67, 0x72, 0x70, 0x63, 0x2D, 0x73, 0x74,
+            0x61, 0x74, 0x75, 0x73, 0x3A, 0x30, 0x0D, 0x0A,
+        ])
+
+        let snapshot = try GrokWebBillingFetcher.parseGRPCWebResponse(
+            data,
+            now: Date(timeIntervalSince1970: 1_768_000_000))
+
+        #expect(snapshot.usedPercent == 0)
+        #expect(snapshot.resetsAt == Date(timeIntervalSince1970: 1_780_272_000))
+    }
+
+    @Test
+    func `uses billing field one instead of earlier unrelated float`() throws {
+        var payload = Data()
+        payload.append(0x4D) // field 9, fixed32 unrelated in-range float
+        var unrelatedBits = Float(7).bitPattern.littleEndian
+        withUnsafeBytes(of: &unrelatedBits) { payload.append(contentsOf: $0) }
+        payload.append(0x0D) // field 1, fixed32 billing usage percent
+        var usageBits = Float(42).bitPattern.littleEndian
+        withUnsafeBytes(of: &usageBits) { payload.append(contentsOf: $0) }
+        payload.append(0x10) // field 2, varint reset timestamp
+        payload.append(contentsOf: Self.varint(1_800_000_001))
+
+        let snapshot = try GrokWebBillingFetcher.parseGRPCWebResponse(Self.grpcFrame(payload))
+
+        #expect(snapshot.usedPercent == 42)
+    }
+
+    @Test
+    func `chooses future billing end instead of recent billing start`() throws {
+        let recentStart = UInt64(1_800_000_000)
+        let billingEnd = UInt64(1_802_592_000)
+        var payload = Data()
+        payload.append(0x0D) // field 1, fixed32 usage percent
+        var percentBits = Float(33).bitPattern.littleEndian
+        withUnsafeBytes(of: &percentBits) { payload.append(contentsOf: $0) }
+        payload.append(0x10) // field 2, varint billing start
+        payload.append(contentsOf: Self.varint(recentStart))
+        payload.append(0x18) // field 3, varint billing end
+        payload.append(contentsOf: Self.varint(billingEnd))
+
+        let snapshot = try GrokWebBillingFetcher.parseGRPCWebResponse(
+            Self.grpcFrame(payload),
+            now: Date(timeIntervalSince1970: TimeInterval(recentStart + 1800)))
+
+        #expect(snapshot.resetsAt == Date(timeIntervalSince1970: TimeInterval(billingEnd)))
+    }
+
+    @Test
+    func `web fetch posts grpc web request with bearer token`() async throws {
+        defer {
+            GrokWebBillingStubURLProtocol.requests = []
+            GrokWebBillingStubURLProtocol.requestBodies = []
+            GrokWebBillingStubURLProtocol.handler = nil
+        }
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [GrokWebBillingStubURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let endpoint = try #require(URL(string: "https://grok.test/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig"))
+        let reset = UInt64(1_800_000_002)
+
+        GrokWebBillingStubURLProtocol.requests = []
+        GrokWebBillingStubURLProtocol.requestBodies = []
+        GrokWebBillingStubURLProtocol.handler = { request in
+            let url = try #require(request.url)
+            #expect(url == endpoint)
+            #expect(request.httpMethod == "POST")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer token-123")
+            #expect(request.value(forHTTPHeaderField: "Origin") == "https://grok.com")
+            #expect(request.value(forHTTPHeaderField: "Referer") == "https://grok.com/?_s=usage")
+            #expect(request.value(forHTTPHeaderField: "Accept") == "*/*")
+            #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/grpc-web+proto")
+            #expect(request.value(forHTTPHeaderField: "x-grpc-web") == "1")
+            #expect(request.timeoutInterval == 8)
+
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/grpc-web+proto"])!
+            let body = Self.grpcFrame(Self.protobufPayload(usedPercent: 55.5, resetEpoch: reset))
+            return (response, body)
+        }
+
+        let snapshot = try await GrokWebBillingFetcher.fetch(
+            credentials: Self.credentials,
+            session: session,
+            endpoint: endpoint)
+
+        #expect(GrokWebBillingStubURLProtocol.requests.count == 1)
+        #expect(GrokWebBillingStubURLProtocol.requestBodies == [Data([0x00, 0x00, 0x00, 0x00, 0x00])])
+        #expect(snapshot.usedPercent == 55.5)
+        #expect(snapshot.resetsAt == Date(timeIntervalSince1970: TimeInterval(reset)))
+    }
+
+    @Test
+    func `web fetch can authenticate with browser cookies`() async throws {
+        defer {
+            GrokWebBillingStubURLProtocol.requests = []
+            GrokWebBillingStubURLProtocol.requestBodies = []
+            GrokWebBillingStubURLProtocol.handler = nil
+        }
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [GrokWebBillingStubURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let endpoint = try #require(URL(string: "https://grok.test/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig"))
+
+        GrokWebBillingStubURLProtocol.requests = []
+        GrokWebBillingStubURLProtocol.requestBodies = []
+        GrokWebBillingStubURLProtocol.handler = { request in
+            #expect(request.value(forHTTPHeaderField: "Cookie") == "sso=session; sso-rw=session")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+            #expect(request.value(forHTTPHeaderField: "x-user-agent") == "connect-es/2.1.1")
+            let response = HTTPURLResponse(
+                url: endpoint,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/grpc-web+proto"])!
+            let body = Self.grpcFrame(Self.protobufPayload(usedPercent: 9, resetEpoch: 1_800_000_004))
+            return (response, body)
+        }
+
+        let snapshot = try await GrokWebBillingFetcher.fetch(
+            cookieHeader: "sso=session; sso-rw=session",
+            session: session,
+            endpoint: endpoint)
+
+        #expect(snapshot.usedPercent == 9)
+    }
+
+    @Test
+    func `web fetch turns unauthorized response into reauth guidance`() async throws {
+        defer {
+            GrokWebBillingStubURLProtocol.requests = []
+            GrokWebBillingStubURLProtocol.requestBodies = []
+            GrokWebBillingStubURLProtocol.handler = nil
+        }
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [GrokWebBillingStubURLProtocol.self]
+        let session = URLSession(configuration: config)
+        let endpoint = try #require(URL(string: "https://grok.test/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig"))
+
+        GrokWebBillingStubURLProtocol.requests = []
+        GrokWebBillingStubURLProtocol.requestBodies = []
+        GrokWebBillingStubURLProtocol.handler = { request in
+            let url = try #require(request.url)
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 401,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "text/plain"])!
+            return (response, Data("unauthorized".utf8))
+        }
+
+        await #expect {
+            _ = try await GrokWebBillingFetcher.fetch(
+                credentials: Self.credentials,
+                session: session,
+                endpoint: endpoint)
+        } throws: { error in
+            error.localizedDescription.contains("grok login")
+        }
+    }
+
+    @Test
+    func `usage snapshot maps web billing when cli billing is absent`() {
+        let snapshot = GrokUsageSnapshot(
+            billing: nil,
+            webBilling: GrokWebBillingSnapshot(
+                usedPercent: 67.25,
+                resetsAt: Date(timeIntervalSince1970: 1_800_000_003)),
+            credentials: Self.credentials,
+            localSummary: nil,
+            cliVersion: nil,
+            updatedAt: Date(timeIntervalSince1970: 1_799_000_000))
+
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(usage.primary?.usedPercent == 67.25)
+        #expect(usage.primary?.resetsAt == Date(timeIntervalSince1970: 1_800_000_003))
+        #expect(usage.accountEmail(for: .grok) == "grok@example.com")
+        #expect(usage.loginMethod(for: .grok) == "SuperGrok")
+    }
+
+    private static let credentials = GrokCredentials(
+        accessToken: "token-123",
+        refreshToken: "refresh-123",
+        scope: "https://auth.x.ai::client",
+        authMode: "oidc",
+        userId: "user-123",
+        email: "grok@example.com",
+        firstName: "G",
+        lastName: "Rok",
+        teamId: "team-123",
+        oidcIssuer: "https://auth.x.ai",
+        oidcClientId: "client",
+        expiresAt: Date(timeIntervalSince1970: 1_900_000_000),
+        createTime: Date(timeIntervalSince1970: 1_799_000_000))
+
+    private static func protobufPayload(usedPercent: Float, resetEpoch: UInt64) -> Data {
+        var data = Data()
+        data.append(0x0D) // field 1, fixed32
+        var percentBits = usedPercent.bitPattern.littleEndian
+        withUnsafeBytes(of: &percentBits) { data.append(contentsOf: $0) }
+        data.append(0x10) // field 2, varint
+        data.append(contentsOf: Self.varint(resetEpoch))
+        return data
+    }
+
+    private static func grpcFrame(_ payload: Data, flags: UInt8 = 0x00) -> Data {
+        var data = Data([flags])
+        let length = UInt32(payload.count).bigEndian
+        withUnsafeBytes(of: length) { data.append(contentsOf: $0) }
+        data.append(payload)
+        return data
+    }
+
+    private static func varint(_ value: UInt64) -> [UInt8] {
+        var remaining = value
+        var bytes: [UInt8] = []
+        repeat {
+            var byte = UInt8(remaining & 0x7F)
+            remaining >>= 7
+            if remaining != 0 { byte |= 0x80 }
+            bytes.append(byte)
+        } while remaining != 0
+        return bytes
+    }
+
+    private static func cookie(name: String, value: String) -> HTTPCookie? {
+        HTTPCookie(properties: [
+            .domain: "grok.com",
+            .path: "/",
+            .name: name,
+            .value: value,
+        ])
+    }
+}
+
+final class GrokWebBillingStubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var requests: [URLRequest] = []
+    nonisolated(unsafe) static var requestBodies: [Data?] = []
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override static func canInit(with _: URLRequest) -> Bool {
+        true
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.requests.append(self.request)
+        Self.requestBodies.append(Self.readBody(from: self.request))
+        guard let handler = Self.handler else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+
+        do {
+            let (response, data) = try handler(self.request)
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            self.client?.urlProtocol(self, didLoad: data)
+            self.client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            self.client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+
+    private static func readBody(from request: URLRequest) -> Data? {
+        if let body = request.httpBody { return body }
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 1024)
+        while stream.hasBytesAvailable {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count > 0 {
+                data.append(buffer, count: count)
+            } else {
+                break
+            }
+        }
+        return data
+    }
+}

--- a/docs/grok.md
+++ b/docs/grok.md
@@ -1,5 +1,5 @@
 ---
-summary: "Grok provider data sources: ACP JSON-RPC over `grok agent stdio`, OAuth credentials, and local session signals."
+summary: "Grok provider data sources: ACP JSON-RPC, grok.com billing fallback, OAuth credentials, and local session signals."
 read_when:
   - Debugging Grok billing/usage parsing
   - Updating `grok agent stdio` JSON-RPC integration
@@ -9,8 +9,9 @@ read_when:
 # Grok provider
 
 Grok uses xAI's official Grok Build CLI (`grok`, released 2026-05-14). Usage data is
-fetched via the ACP JSON-RPC `x.ai/billing` extension method over `grok agent stdio`.
-No browser cookies, no direct REST calls.
+fetched via the ACP JSON-RPC `x.ai/billing` extension method over `grok agent stdio`
+when available, then via grok.com's billing gRPC-web endpoint using the signed-in
+browser session when the CLI surface does not expose billing.
 
 ## Data sources + fallback order
 
@@ -29,7 +30,20 @@ No browser cookies, no direct REST calls.
      slashes, so payloads must be re-encoded with `\/` → `/` before being
      written to stdin or grok will silently drop them (12s client-side
      timeout instead of the expected error response).
-3) **Local session signals** (informational fallback)
+3) **grok.com billing gRPC-web fallback** (best-effort)
+   - POSTs an empty gRPC-web protobuf request to
+     `https://grok.com/grok_api_v2.GrokBuildBilling/GetGrokCreditsConfig`.
+   - Uses grok.com browser session cookies. CodexBar imports Chrome only by
+     default to avoid unrelated browser Keychain prompts.
+   - CLI/test runtime does not import browser cookies unless
+     `CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT=1` is set.
+   - `~/.grok/auth.json` is still used for identity and as a last best-effort
+     bearer probe, but the production grok.com billing endpoint currently
+     authenticates browser sessions.
+   - Parses the returned protobuf enough to recover monthly used percent and
+     reset timestamp. This keeps billing visible when `grok agent stdio` returns
+     `Method not found`.
+4) **Local session signals** (informational fallback)
    - Walks `~/.grok/sessions/<encoded-cwd>/<session-id>/signals.json` files (last 30 days).
    - Aggregates `totalTokensBeforeCompaction`, `contextTokensUsed`, `modelsUsed`,
      and the most recent session timestamp.
@@ -84,8 +98,10 @@ No browser cookies, no direct REST calls.
 ## Mapping to `UsageSnapshot`
 
 - **Primary window** = monthly credit usage:
-  - `usedPercent` = `usage.totalUsed.val / monthlyLimit.val * 100`.
-  - `resetsAt` = `billingCycle.billingPeriodEnd`.
+  - CLI RPC: `usedPercent` = `usage.totalUsed.val / monthlyLimit.val * 100`;
+    `resetsAt` = `billingCycle.billingPeriodEnd`.
+  - grok.com fallback: `usedPercent` and `resetsAt` parsed from the gRPC-web
+    billing protobuf.
 - **Identity**:
   - `accountEmail` from credential `email`.
   - `accountOrganization` from credential `team_id`.
@@ -121,6 +137,7 @@ points to `https://status.x.ai`.
 - `Sources/CodexBarCore/Providers/Grok/GrokProviderDescriptor.swift`
 - `Sources/CodexBarCore/Providers/Grok/GrokAuth.swift`
 - `Sources/CodexBarCore/Providers/Grok/GrokRPCClient.swift`
+- `Sources/CodexBarCore/Providers/Grok/GrokWebBillingFetcher.swift`
 - `Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift`
 - `Sources/CodexBarCore/Providers/Grok/GrokLocalSessionScanner.swift`
 - `Sources/CodexBar/Providers/Grok/GrokProviderImplementation.swift`

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -54,7 +54,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 | Crof | API key from config/env → credit balance + requests quota API (`api`). |
 | Venice | API key from config/env → DIEM/USD balance API (`api`). |
 | Command Code | Web billing API via Command Code session cookies (`web`). |
-| Grok | `grok agent stdio` JSON-RPC `x.ai/billing` (`cli`); local `~/.grok/sessions` signals as fallback. |
+| Grok | `grok agent stdio` JSON-RPC `x.ai/billing` (`cli`) → grok.com billing gRPC-web via Chrome session cookies (`web`); local `~/.grok/sessions` signals as fallback. |
 
 ## Codex
 - App Auto: OAuth API first; falls back to CLI only when OAuth credentials are missing or auth/refresh is invalid.
@@ -300,6 +300,8 @@ headers, source selection, provider ordering, and token accounts are stored in `
 ## Grok
 - `grok agent stdio` (ACP) JSON-RPC `x.ai/billing` method; requires `grok login` (SuperGrok OAuth/OIDC).
 - Reads cached credentials from `~/.grok/auth.json` for identity (email, team).
+- Falls back to grok.com's billing gRPC-web endpoint via Chrome session cookies when the CLI does not expose billing.
+- CLI/test runs do not import browser cookies unless `CODEXBAR_ALLOW_BROWSER_COOKIE_IMPORT=1` is set.
 - Local fallback aggregates `~/.grok/sessions/**/signals.json` token counts when the RPC is unavailable.
 - Status: link only to `https://status.x.ai` (no auto-polling yet).
 - Details: `docs/grok.md`.


### PR DESCRIPTION
## Summary
- add Grok web billing fallback against grok.com's billing endpoint when `grok agent stdio` omits xAI billing
- use the Grok CLI OAuth token for CLI/live probes, with browser cookies available only where explicitly allowed
- prevent CLI/test runs from importing browser cookies by default so Keychain prompts do not appear
- add Grok parser/provider regression coverage and docs/changelog credit for #984

## Verification
- CodexBar review skill: clean, `make check` exit 0
- `CLANG_MODULE_CACHE_PATH="$PWD/.build/module-cache-local" swift test --filter Grok`
- `PATH="$HOME/.grok/bin:$PATH" timeout 30s swift run CodexBarCLI usage --provider grok --source web --format json`
- `PATH="$HOME/.grok/bin:$PATH" timeout 45s swift run CodexBarCLI usage --provider grok --format json`
