### PR TITLE
docs: point Linux users at codexbar-waybar companion repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ CLI install:
 ## Looking for a Windows version?
 - [Win-CodexBar](https://github.com/Finesssee/Win-CodexBar)
 
+## Linux desktop integration?
+- [codexbar-waybar](https://github.com/Marouan-chak/codexbar-waybar) — Waybar custom module + GTK4 popover for Hyprland / Sway / other Wayland compositors, built on top of the bundled Linux CLI.
+
 ## Credits
 Inspired by [ccusage](https://github.com/ryoppippi/ccusage) (MIT), specifically the cost usage tracking.
 


### PR DESCRIPTION
## Summary

Adds a single line under the existing "Looking for a Windows version?" pointer in `README.md`, linking to [`codexbar-waybar`](https://github.com/Marouan-chak/codexbar-waybar) — a Waybar custom module + GTK4 popover that surfaces CodexBar usage on Hyprland / Sway / other Wayland compositors.

The companion repo is built on top of the bundled Linux CLI (the prebuilt `CodexBarCLI-linux-*` tarballs you already publish) and lives separately for a few reasons:

- **Different stack** — Python/GTK4 + shell, doesn't belong inside the Swift codebase.
- **Different platform** — Linux-only, with its own test surface (compositors, distros, `gtk4-layer-shell` linking quirks, Arch's `libxml2-legacy`…).
- **Independent iteration** — its own SemVer, releases, CI, and issue tracker, mirroring the pattern of `Win-CodexBar` already linked in the README.

## What it does

- Waybar custom module shows `🤖 27%` (most-constrained provider) with `ok` / `warning` / `critical` / `stale` state classes.
- Left-click opens a GTK4 popover modeled on the macOS menu — provider tab strip with a system-blue active tab, flat sections, thin progress bars, reset countdowns, credit balances. Inline Settings view with per-provider toggle switches that write `~/.codexbar/config.json`.
- Validated on Arch + Hyprland + Waybar (HyDE flavor). Tested fresh-install workflow end-to-end through v0.1.1.

## Why this PR is small

This PR only adds the pointer. No source moved into the CodexBar repo, no new build steps, no Linux-specific code in Swift land — purely a discoverability link, the same way `Win-CodexBar` is currently linked.

## Test plan

- [x] `Marouan-chak/codexbar-waybar` exists and is public.
- [x] README renders correctly (`README.md` diff is one block).