### PR TITLE
fix(cli): validate serve Host headers

### DIFF
--- a/Sources/CodexBarCLI/CLILocalHTTPServer.swift
+++ b/Sources/CodexBarCLI/CLILocalHTTPServer.swift
@@ -12,6 +12,7 @@ struct CLILocalHTTPRequest {
     let target: String
     let path: String
     let queryItems: [String: String]
+    let headers: [String: String]
 
     static func parse(_ data: Data) -> CLILocalHTTPRequest? {
         guard let raw = String(data: data, encoding: .utf8),
@@ -35,18 +36,42 @@ struct CLILocalHTTPRequest {
                 queryItems[item.name] = value
             }
         }
+        guard let headers = Self.parseHeaders(raw) else { return nil }
 
         return CLILocalHTTPRequest(
             method: method,
             target: target,
             path: path,
-            queryItems: queryItems)
+            queryItems: queryItems,
+            headers: headers)
+    }
+
+    private static func parseHeaders(_ raw: String) -> [String: String]? {
+        var headers: [String: String] = [:]
+        let lines = raw.components(separatedBy: "\r\n")
+        for line in lines.dropFirst() {
+            if line.isEmpty { break }
+            guard let separator = line.firstIndex(of: ":") else { continue }
+            let name = line[..<separator]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            guard !name.isEmpty else { continue }
+            if name == "host", headers[name] != nil {
+                return nil
+            }
+            let valueStart = line.index(after: separator)
+            let value = line[valueStart...]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            headers[name] = value
+        }
+        return headers
     }
 }
 
 enum CLIHTTPStatus {
     case ok
     case badRequest
+    case forbidden
     case notFound
     case methodNotAllowed
     case internalServerError
@@ -55,6 +80,7 @@ enum CLIHTTPStatus {
         switch self {
         case .ok: 200
         case .badRequest: 400
+        case .forbidden: 403
         case .notFound: 404
         case .methodNotAllowed: 405
         case .internalServerError: 500
@@ -65,6 +91,7 @@ enum CLIHTTPStatus {
         switch self {
         case .ok: "OK"
         case .badRequest: "Bad Request"
+        case .forbidden: "Forbidden"
         case .notFound: "Not Found"
         case .methodNotAllowed: "Method Not Allowed"
         case .internalServerError: "Internal Server Error"

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -30,6 +30,39 @@ enum CLIServeRouteError: Error, Equatable {
     case notFound
 }
 
+enum CLIServeRequestGuard {
+    private static let allowedHosts: Set<String> = [
+        "127.0.0.1",
+        "localhost",
+        "localhost.",
+        "[::1]",
+    ]
+
+    static func isAllowedHost(_ rawHost: String?) -> Bool {
+        guard let rawHost else { return false }
+        let host = rawHost.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !host.isEmpty else { return false }
+        let normalized: String
+        if host.hasPrefix("[") {
+            guard let closingBracket = host.firstIndex(of: "]") else { return false }
+            normalized = String(host[...closingBracket])
+            let remainder = host[host.index(after: closingBracket)...]
+            if !remainder.isEmpty {
+                guard remainder.first == ":",
+                      UInt16(remainder.dropFirst()) != nil
+                else { return false }
+            }
+        } else {
+            let parts = host.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+            normalized = String(parts[0])
+            if parts.count == 2 {
+                guard UInt16(parts[1]) != nil else { return false }
+            }
+        }
+        return self.allowedHosts.contains(normalized)
+    }
+}
+
 enum CLIServeRouter {
     static func route(method: String, path: String, queryItems: [String: String]) throws -> CLIServeRoute {
         guard method.uppercased() == "GET" else {
@@ -60,7 +93,7 @@ private struct ServeHealthPayload: Encodable {
     let status: String
 }
 
-private actor CLIServeResponseCache {
+actor CLIServeResponseCache {
     private struct Entry {
         let expiresAt: Date
         let response: CLILocalHTTPResponse
@@ -167,12 +200,16 @@ extension CodexBarCLI {
         return parsed
     }
 
-    private static func handleServeRequest(
+    static func handleServeRequest(
         _ request: CLILocalHTTPRequest,
         config: CodexBarConfig,
         cache: CLIServeResponseCache,
         refreshInterval: TimeInterval) async -> CLILocalHTTPResponse
     {
+        guard CLIServeRequestGuard.isAllowedHost(request.headers["host"]) else {
+            return self.serveError(status: .forbidden, message: "forbidden host")
+        }
+
         let route: CLIServeRoute
         do {
             route = try CLIServeRouter.route(

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -1,3 +1,4 @@
+import CodexBarCore
 import Commander
 import Foundation
 import Testing
@@ -18,6 +19,83 @@ struct CLIServeRouterTests {
                 method: "GET",
                 path: "/cost",
                 queryItems: ["provider": "codex"]) == .cost(provider: "codex"))
+    }
+
+    @Test
+    func `local request parser preserves host header`() throws {
+        let raw = """
+        GET /usage?provider=codex HTTP/1.1\r
+        Host: 127.0.0.1:8080\r
+        User-Agent: test\r
+        \r
+        """
+        let request = try #require(CLILocalHTTPRequest.parse(Data(raw.utf8)))
+
+        #expect(request.path == "/usage")
+        #expect(request.queryItems["provider"] == "codex")
+        #expect(request.headers["host"] == "127.0.0.1:8080")
+        #expect(request.headers["user-agent"] == "test")
+    }
+
+    @Test
+    func `local request parser rejects duplicate host headers`() {
+        let raw = """
+        GET /usage HTTP/1.1\r
+        Host: attacker.example\r
+        Host: 127.0.0.1\r
+        \r
+        """
+
+        #expect(CLILocalHTTPRequest.parse(Data(raw.utf8)) == nil)
+    }
+
+    @Test
+    func `serve host guard allows only loopback hosts`() {
+        #expect(CLIServeRequestGuard.isAllowedHost("127.0.0.1"))
+        #expect(CLIServeRequestGuard.isAllowedHost("127.0.0.1:8080"))
+        #expect(CLIServeRequestGuard.isAllowedHost("localhost"))
+        #expect(CLIServeRequestGuard.isAllowedHost("LOCALHOST:8080"))
+        #expect(CLIServeRequestGuard.isAllowedHost("localhost."))
+        #expect(CLIServeRequestGuard.isAllowedHost("localhost.:8080"))
+        #expect(CLIServeRequestGuard.isAllowedHost("[::1]"))
+        #expect(CLIServeRequestGuard.isAllowedHost("[::1]:8080"))
+
+        #expect(!CLIServeRequestGuard.isAllowedHost(nil))
+        #expect(!CLIServeRequestGuard.isAllowedHost(""))
+        #expect(!CLIServeRequestGuard.isAllowedHost("attacker.example"))
+        #expect(!CLIServeRequestGuard.isAllowedHost("attacker.example:8080"))
+        #expect(!CLIServeRequestGuard.isAllowedHost("127.0.0.1.attacker.example"))
+        #expect(!CLIServeRequestGuard.isAllowedHost("[::1].attacker.example"))
+    }
+
+    @Test
+    func `serve request handler rejects forbidden or missing host before routing`() async {
+        let forbidden = CLILocalHTTPRequest(
+            method: "GET",
+            target: "/health",
+            path: "/health",
+            queryItems: [:],
+            headers: ["host": "attacker.example"])
+        let missing = CLILocalHTTPRequest(
+            method: "GET",
+            target: "/health",
+            path: "/health",
+            queryItems: [:],
+            headers: [:])
+
+        let forbiddenResponse = await CodexBarCLI.handleServeRequest(
+            forbidden,
+            config: CodexBarConfig.makeDefault(),
+            cache: CLIServeResponseCache(),
+            refreshInterval: 0)
+        let missingResponse = await CodexBarCLI.handleServeRequest(
+            missing,
+            config: CodexBarConfig.makeDefault(),
+            cache: CLIServeResponseCache(),
+            refreshInterval: 0)
+
+        #expect(forbiddenResponse.status == .forbidden)
+        #expect(missingResponse.status == .forbidden)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #995.

This hardens `codexbar serve` by validating the HTTP `Host` header before any route dispatch, cache lookup, or provider fetch work runs.

Changes:
- parse request headers in the local HTTP server
- reject duplicate `Host` headers at parse time
- allow only loopback hosts: `127.0.0.1`, `localhost`, `localhost.`, and `[::1]`, with optional numeric ports
- return 403 for missing, malformed, or non-loopback Host values
- add regression coverage for hostile, missing, duplicate, and loopback Host cases

## Validation

- `swift test --filter CLIServeRouterTests`
- `swift test`
- `make check`
- live smoke: localhost Host succeeds, hostile Host returns 403, duplicate Host returns 400

## Review notes

- Claude review identified the duplicate-Host last-wins edge case in the first patch; this PR rejects duplicate Host headers.
- Two independent review agents found no actionable issues after the duplicate-Host fix.
- A final Claude retry hit a temporary Claude API 500 twice, so it could not complete; the earlier actionable Claude finding was addressed and verified.