### PR TITLE
[codex] Recover status item after display changes

### DIFF
--- a/Sources/CodexBar/MenuBarVisibilityWatcher.swift
+++ b/Sources/CodexBar/MenuBarVisibilityWatcher.swift
@@ -6,13 +6,31 @@ struct StatusItemVisibilitySnapshot: Equatable {
     let hasButton: Bool
     let hasWindow: Bool
     let hasScreen: Bool
+    let isOnCurrentScreen: Bool
     let buttonWidth: CGFloat
+
+    init(
+        isVisible: Bool,
+        hasButton: Bool,
+        hasWindow: Bool,
+        hasScreen: Bool,
+        isOnCurrentScreen: Bool = true,
+        buttonWidth: CGFloat)
+    {
+        self.isVisible = isVisible
+        self.hasButton = hasButton
+        self.hasWindow = hasWindow
+        self.hasScreen = hasScreen
+        self.isOnCurrentScreen = isOnCurrentScreen
+        self.buttonWidth = buttonWidth
+    }
 }
 
 extension StatusItemVisibilitySnapshot: CustomStringConvertible {
     var description: String {
         "visible=\(self.isVisible),button=\(self.hasButton),window=\(self.hasWindow),"
-            + "screen=\(self.hasScreen),width=\(String(format: "%.1f", Double(self.buttonWidth)))"
+            + "screen=\(self.hasScreen),currentScreen=\(self.isOnCurrentScreen),"
+            + "width=\(String(format: "%.1f", Double(self.buttonWidth)))"
     }
 }
 
@@ -31,18 +49,35 @@ enum MenuBarVisibilityWatcher {
 
     @MainActor
     static func visibilitySnapshot(_ item: NSStatusItem) -> StatusItemVisibilitySnapshot {
+        let screen = item.button?.window?.screen
         StatusItemVisibilitySnapshot(
             isVisible: item.isVisible,
             hasButton: item.button != nil,
             hasWindow: item.button?.window != nil,
-            hasScreen: item.button?.window?.screen != nil,
+            hasScreen: screen != nil,
+            isOnCurrentScreen: screen.map(self.isCurrentScreen) ?? false,
             buttonWidth: item.button?.frame.size.width ?? 0)
+    }
+
+    @MainActor
+    private static func isCurrentScreen(_ screen: NSScreen) -> Bool {
+        let screenNumber = self.screenNumber(screen)
+        return NSScreen.screens.contains { candidate in
+            if let screenNumber, let candidateNumber = self.screenNumber(candidate) {
+                return candidateNumber == screenNumber
+            }
+            return candidate === screen
+        }
+    }
+
+    private static func screenNumber(_ screen: NSScreen) -> NSNumber? {
+        screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber
     }
 
     static func isBlockedSnapshot(snapshot: StatusItemVisibilitySnapshot) -> Bool {
         guard snapshot.isVisible else { return false }
         guard snapshot.hasButton else { return true }
-        return !snapshot.hasWindow || !snapshot.hasScreen || snapshot.buttonWidth <= 0
+        return !snapshot.hasWindow || !snapshot.hasScreen || !snapshot.isOnCurrentScreen || snapshot.buttonWidth <= 0
     }
 
     static func hasBlockedVisibleSnapshots(_ snapshots: [StatusItemVisibilitySnapshot]) -> Bool {
@@ -79,6 +114,21 @@ enum MenuBarVisibilityWatcher {
     {
         guard now.timeIntervalSince(appLaunchedAt) <= self.startupFreshnessInterval else { return false }
         return self.hasAnyBlockedVisibleSnapshot(snapshots)
+    }
+
+    static func shouldAttemptScreenChangeRecovery(
+        previousScreenCount: Int,
+        currentScreenCount: Int,
+        snapshots: [StatusItemVisibilitySnapshot])
+        -> Bool
+    {
+        if self.hasAnyBlockedVisibleSnapshot(snapshots) {
+            return true
+        }
+        guard currentScreenCount < previousScreenCount else { return false }
+        return snapshots.contains { snapshot in
+            snapshot.isVisible
+        }
     }
 
     static func shouldShowGuidance(defaults: UserDefaults, now: Date = Date()) -> Bool {
@@ -162,6 +212,53 @@ extension StatusItemController {
             return
         }
         MenuBarVisibilityWatcher.presentGuidance(defaults: self.settings.userDefaults, now: now)
+    }
+
+    @objc func handleScreenParametersDidChange(_: Notification) {
+        let previousScreenCount = max(
+            self.pendingScreenChangePreviousCount ?? self.lastKnownScreenCount,
+            self.lastKnownScreenCount)
+        let currentScreenCount = NSScreen.screens.count
+        self.pendingScreenChangePreviousCount = previousScreenCount
+        self.lastKnownScreenCount = currentScreenCount
+        self.scheduleScreenChangeStatusItemVisibilityCheck(
+            previousScreenCount: previousScreenCount,
+            currentScreenCount: currentScreenCount)
+    }
+
+    private func scheduleScreenChangeStatusItemVisibilityCheck(
+        previousScreenCount: Int,
+        currentScreenCount: Int)
+    {
+        guard !SettingsStore.isRunningTests else { return }
+        self.screenChangeVisibilityTask?.cancel()
+        self.screenChangeVisibilityTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(750))
+            self?.checkScreenChangeStatusItemVisibility(
+                previousScreenCount: previousScreenCount,
+                currentScreenCount: currentScreenCount)
+        }
+    }
+
+    private func checkScreenChangeStatusItemVisibility(previousScreenCount: Int, currentScreenCount: Int) {
+        self.pendingScreenChangePreviousCount = nil
+        let snapshots = MenuBarVisibilityWatcher.visibilitySnapshots(self.startupVisibilityStatusItems)
+        guard MenuBarVisibilityWatcher.shouldAttemptScreenChangeRecovery(
+            previousScreenCount: previousScreenCount,
+            currentScreenCount: currentScreenCount,
+            snapshots: snapshots)
+        else {
+            return
+        }
+
+        self.menuLogger.error(
+            "Display configuration changed; recreating status items",
+            metadata: [
+                "previousScreenCount": "\(previousScreenCount)",
+                "currentScreenCount": "\(currentScreenCount)",
+                "snapshots": snapshots.map(\.description).joined(separator: " | "),
+            ])
+        self.recreateStatusItemsForVisibilityRecovery()
     }
 
     private var startupVisibilityStatusItems: [NSStatusItem] {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -150,6 +150,9 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     /// Monotonic token used to ignore stale deferred provider-switcher menu rebuilds.
     var providerSwitcherUpdateToken = 0
     var lastAppliedMergedIconRenderSignature: String?
+    var lastKnownScreenCount: Int
+    var pendingScreenChangePreviousCount: Int?
+    var screenChangeVisibilityTask: Task<Void, Never>?
     let loginLogger = CodexBarLog.logger(LogCategories.login)
     let menuLogger = CodexBarLog.logger(LogCategories.app)
     var selectedMenuProvider: UsageProvider? {
@@ -269,6 +272,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.lastSwitcherUsageBarsShowUsed = settings.usageBarsShowUsed
         self.statusBar = statusBar
         self.statusItem = Self.makeStatusItem(statusBar: statusBar)
+        self.lastKnownScreenCount = NSScreen.screens.count
         // Status items for individual providers are now created lazily in updateVisibility()
         super.init()
         self.wireBindings()
@@ -297,6 +301,11 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
                 name: .codexbarProviderConfigDidChange,
                 object: nil)
         }
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.handleScreenParametersDidChange(_:)),
+            name: NSApplication.didChangeScreenParametersNotification,
+            object: nil)
     }
 
     convenience init(
@@ -739,6 +748,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.isReleasedForTesting = true
         self.blinkTask?.cancel()
         self.loginTask?.cancel()
+        self.screenChangeVisibilityTask?.cancel()
+        self.pendingScreenChangePreviousCount = nil
         self.animationDriver?.stop()
         self.animationDriver = nil
         self.animationPhase = 0
@@ -777,6 +788,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         }
         self.blinkTask?.cancel()
         self.loginTask?.cancel()
+        self.screenChangeVisibilityTask?.cancel()
+        self.pendingScreenChangePreviousCount = nil
         NotificationCenter.default.removeObserver(self)
     }
 }

--- a/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
+++ b/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
@@ -64,6 +64,19 @@ struct MenuBarVisibilityWatcherTests {
     }
 
     @Test
+    func `flags visible item attached to a detached screen`() {
+        let snapshot = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: true,
+            isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(MenuBarVisibilityWatcher.isBlockedSnapshot(snapshot: snapshot))
+    }
+
+    @Test
     func `guidance shows once then repeats after a day`() throws {
         let defaults = try #require(UserDefaults(suiteName: "MenuBarVisibilityWatcherTests"))
         defaults.removePersistentDomain(forName: "MenuBarVisibilityWatcherTests")
@@ -148,6 +161,51 @@ struct MenuBarVisibilityWatcherTests {
         #expect(!MenuBarVisibilityWatcher.shouldAttemptStartupRecovery(
             appLaunchedAt: launchedAt,
             now: launchedAt.addingTimeInterval(2),
+            snapshots: [healthy]))
+    }
+
+    @Test
+    func `screen change recovery triggers when a display is removed with visible status item`() {
+        let healthy = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: true,
+            buttonWidth: 18)
+
+        #expect(MenuBarVisibilityWatcher.shouldAttemptScreenChangeRecovery(
+            previousScreenCount: 2,
+            currentScreenCount: 1,
+            snapshots: [healthy]))
+    }
+
+    @Test
+    func `screen change recovery triggers for blocked status item without display count change`() {
+        let blocked = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: false,
+            hasScreen: false,
+            buttonWidth: 18)
+
+        #expect(MenuBarVisibilityWatcher.shouldAttemptScreenChangeRecovery(
+            previousScreenCount: 1,
+            currentScreenCount: 1,
+            snapshots: [blocked]))
+    }
+
+    @Test
+    func `screen change recovery ignores healthy item when display count does not shrink`() {
+        let healthy = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: true,
+            buttonWidth: 18)
+
+        #expect(!MenuBarVisibilityWatcher.shouldAttemptScreenChangeRecovery(
+            previousScreenCount: 1,
+            currentScreenCount: 2,
             snapshots: [healthy]))
     }
 }


### PR DESCRIPTION
Fixes #997.

## Summary

- Detect status items whose backing window is attached to a detached/non-current screen.
- Observe `NSApplication.didChangeScreenParametersNotification` and debounce display-change recovery.
- Recreate status items when a display is removed while a visible item exists, or when a visible item snapshot is blocked.
- Add focused coverage for detached-screen snapshots and display-removal recovery decisions.

## Root Cause

The startup recovery added in `a75d276f` catches status items that fail to materialize shortly after launch, but CodexBar did not observe runtime display topology changes. If the external display hosting the `NSStatusItem` is unplugged, AppKit can leave the app process alive while the status item is still associated with a removed screen/menu bar.

## Validation

- `git diff --check` passes.
- `swift test --filter MenuBarVisibilityWatcherTests` passes with Xcode 26.5 / Apple Swift 6.3.2.

## Notes

This PR intentionally targets the runtime hot-unplug case. It is complementary to the startup recovery in #988, the Tahoe allow-list guidance in #945, and the earlier macOS 26.4 visibility fix in #849.
