### PR TITLE
[codex] Fix OpenAI costs parsing

### DIFF
--- a/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIUsageFetcher.swift
@@ -353,6 +353,17 @@ private struct CostResult: Decodable {
     struct Amount: Decodable {
         let value: Double?
         let currency: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case value
+            case currency
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.value = try container.decodeFlexibleDoubleIfPresent(forKey: .value)
+            self.currency = try container.decodeIfPresent(String.self, forKey: .currency)
+        }
     }
 
     let amount: Amount?
@@ -361,6 +372,31 @@ private struct CostResult: Decodable {
     private enum CodingKeys: String, CodingKey {
         case amount
         case lineItem = "line_item"
+    }
+}
+
+private extension KeyedDecodingContainer {
+    func decodeFlexibleDoubleIfPresent(forKey key: K) throws -> Double? {
+        if try self.decodeNil(forKey: key) {
+            return nil
+        }
+        if let value = try? self.decode(Double.self, forKey: key) {
+            return value
+        }
+        if let value = try? self.decode(Int.self, forKey: key) {
+            return Double(value)
+        }
+        if let stringValue = try? self.decode(String.self, forKey: key) {
+            let trimmed = stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return nil }
+            if let value = Double(trimmed) {
+                return value
+            }
+        }
+        throw DecodingError.dataCorruptedError(
+            forKey: key,
+            in: self,
+            debugDescription: "Expected number or numeric string for \(key.stringValue)")
     }
 }
 

--- a/Tests/CodexBarTests/OpenAIAPICreditBalanceTests.swift
+++ b/Tests/CodexBarTests/OpenAIAPICreditBalanceTests.swift
@@ -133,7 +133,7 @@ struct OpenAIAPICreditBalanceTests {
               "results": [
                 {
                   "object": "organization.costs.result",
-                  "amount": { "value": 12.50, "currency": "usd" },
+                  "amount": { "value": "12.50", "currency": "usd" },
                   "line_item": "Text tokens"
                 },
                 {


### PR DESCRIPTION
## Summary

- Decode OpenAI organization cost `amount.value` when it is returned as a numeric string.
- Keep existing numeric decoding support for documented numeric responses.
- Add a regression fixture covering the string value shape observed from the live API.

Fixes #999

## Root cause

The OpenAI Costs API can return `amount.value` as a string such as `"12.50"`. `OpenAIAPIUsageFetcher` decoded this field as `Double?`, so a successful HTTP 200 costs response failed JSON decoding and OpenAI Admin API usage rendered an error.

## Validation

- Live probe against `/v1/organization/costs` with an Admin API key decoded 31 cost buckets using the tolerant decoder.
- `swift test --filter OpenAIAPICreditBalanceTests` could not complete in this local environment because only Command Line Tools are installed; the macOS test target pulls `KeyboardShortcuts`, whose SwiftUI `#Preview` usage requires `PreviewsMacros` from full Xcode.
