### PR TITLE
fix: set explicit HTTP timeouts to prevent OOM when network is blocked

### DIFF
--- a/Sources/CodexBarCore/ProviderHTTPClient.swift
+++ b/Sources/CodexBarCore/ProviderHTTPClient.swift
@@ -57,7 +57,9 @@ public final class ProviderHTTPClient: ProviderHTTPTransport, @unchecked Sendabl
             let configuration = URLSessionConfiguration.default
             configuration.timeoutIntervalForRequest = 30
             configuration.timeoutIntervalForResource = 90
+            #if !canImport(FoundationNetworking)
             configuration.waitsForConnectivity = false
+            #endif
             self.session = URLSession(configuration: configuration)
         }
     }

--- a/Sources/CodexBarCore/ProviderHTTPClient.swift
+++ b/Sources/CodexBarCore/ProviderHTTPClient.swift
@@ -50,8 +50,16 @@ public final class ProviderHTTPClient: ProviderHTTPTransport, @unchecked Sendabl
 
     private let session: URLSession
 
-    public init(session: URLSession = .shared) {
-        self.session = session
+    public init(session: URLSession? = nil) {
+        if let session {
+            self.session = session
+        } else {
+            let configuration = URLSessionConfiguration.default
+            configuration.timeoutIntervalForRequest = 30
+            configuration.timeoutIntervalForResource = 90
+            configuration.waitsForConnectivity = false
+            self.session = URLSession(configuration: configuration)
+        }
     }
 
     public func data(for request: URLRequest) async throws -> (Data, URLResponse) {


### PR DESCRIPTION
## Summary

- Set `timeoutIntervalForRequest = 30s` and `timeoutIntervalForResource = 90s` on `ProviderHTTPClient`'s URLSession
- Set `waitsForConnectivity = false` so blocked connections fail immediately instead of waiting

## Problem

`URLSession.shared` defaults to `timeoutIntervalForResource = 604800` (7 days). When a firewall blocks `CodexBarCLI` (e.g. LuLu on macOS blocks unsigned/new CLI binaries by default), every provider fetch hangs indefinitely. With the `usage` command spawning concurrent tasks for all enabled providers, the process accumulates **28 GB+ of memory per instance**, triggering Jetsam and crashing the system.

Observed on v0.26.1 with LuLu firewall on macOS 15. Two stuck `CodexBarCLI` processes totaling 56 GB crashed the machine.

## Fix

One-line change to `ProviderHTTPClient.init`: use a custom `URLSessionConfiguration` with sane timeouts instead of `URLSession.shared`.

Fixes #1004

## Test plan

- [ ] Run `codexbar usage` with network blocked → should fail within 30s with timeout error instead of hanging
- [ ] Run `codexbar usage` with network allowed → should work as before
- [ ] Existing tests pass (timeout doesn't affect normal response times)