### PR TITLE
Fix Codex model attribution for large turn contexts

### DIFF
--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
@@ -769,7 +769,7 @@ enum CostUsageScanner {
         }
 
         let maxLineBytes = 256 * 1024
-        let prefixBytes = 32 * 1024
+        let prefixBytes = maxLineBytes
 
         if startOffset == 0,
            let metadata = Self.parseCodexSessionMetadata(fileURL: fileURL)

--- a/Tests/CodexBarTests/CostUsageScannerPriorityTests.swift
+++ b/Tests/CodexBarTests/CostUsageScannerPriorityTests.swift
@@ -121,6 +121,49 @@ struct CostUsageScannerPriorityTests {
     }
 
     @Test
+    func `codex daily report keeps model from large turn context`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 5, day: 15)
+        let iso0 = env.isoString(for: day)
+        let iso1 = env.isoString(for: day.addingTimeInterval(1))
+        let largeInstructions = String(repeating: "x", count: 33 * 1024)
+        let entries: [[String: Any]] = [
+            [
+                "type": "turn_context",
+                "timestamp": iso0,
+                "payload": [
+                    "model": "gpt-5.5",
+                    "developer_instructions": largeInstructions,
+                ],
+            ],
+            ["type": "event_msg", "timestamp": iso1, "payload": ["type": "task_started", "turn_id": "subagent-turn"]],
+            self.tokenCount(timestamp: iso1, input: 100, cached: 20, output: 10),
+        ]
+        _ = try env.writeCodexSessionFile(
+            day: day,
+            filename: "subagent-large-turn-context.jsonl",
+            contents: env.jsonl(entries))
+
+        var options = CostUsageScanner.Options(
+            codexSessionsRoot: env.codexSessionsRoot,
+            cacheRoot: env.cacheRoot)
+        options.refreshMinIntervalSeconds = 0
+
+        let report = CostUsageScanner.loadDailyReport(
+            provider: .codex,
+            since: day,
+            until: day,
+            now: day,
+            options: options)
+
+        #expect(report.data.count == 1)
+        #expect(report.data[0].modelsUsed == ["gpt-5.5"])
+        #expect(report.data[0].modelBreakdowns?.map(\.modelName) == ["gpt-5.5"])
+    }
+
+    @Test
     func `codex pricing skips priority surcharge for long context rows`() throws {
         let env = try CostUsageTestEnvironment()
         defer { env.cleanup() }


### PR DESCRIPTION
## Summary
- Keep Codex `turn_context` lines up to the existing 256 KiB scanner limit instead of truncating them at 32 KiB.
- Add a regression test for a large Codex `turn_context` whose model metadata must be used for subsequent token rows.

## Root cause
Codex subagent sessions can write large `turn_context` JSONL lines because the payload includes role instructions, skill context, and other runtime metadata. The Codex cost scanner already allows lines up to 256 KiB, but it only preserved a 32 KiB prefix before parsing.

When a `turn_context` line is larger than 32 KiB, `CostUsageJsonl.scan` marks it as truncated and the scanner skips the line entirely. If later `token_count` rows do not carry their own model metadata, `currentModel` is never populated and the row falls back to `gpt-5`.

## Local reproduction context
I reproduced this with CodexBar 0.26.1 / build 63 on macOS using local Codex Desktop session logs.

Observed environment/details:
- CodexBar CLI: `CodexBar 0.26.1`
- Codex session source: `Codex Desktop`
- Codex CLI recorded in session metadata: `0.131.0-alpha.9`
- Affected rows were subagent sessions under `~/.codex/sessions/2026/05/15/`
- The affected subagent `turn_context.payload.model` was `gpt-5.5`
- The following `token_count` rows had no `info.model` / `info.model_name`
- One representative `turn_context` line was 34,789 bytes, just over the scanner's old 32 KiB prefix limit

After clearing CodexBar's cost cache and refreshing with 0.26.1, the daily cost cache still bucketed the affected 2026-05-15 subagent usage under `gpt-5`:

```json
"2026-05-15": {
  "gpt-5.5": [369490655, 354968960, 1078961],
  "gpt-5": [9847428, 8968960, 98161]
}
```

The `gpt-5` bucket above came from seven subagent session files whose source `turn_context.payload.model` was `gpt-5.5`. This changes the estimated cost because the affected tokens are priced as `gpt-5` instead of `gpt-5.5`.

## Fix
Use the existing `maxLineBytes` value as the preserved prefix for Codex scanner lines. This keeps the current 256 KiB guardrail while allowing large-but-valid `turn_context` rows to be parsed and used for model attribution.

## Validation
- `swift test --filter CostUsageScannerPriorityTests`
- `swift test --filter CostUsageScanner`
