### PR TITLE
docs: add DeepSeek API key example to cli-configuration

### DIFF
--- a/docs/cli-configuration.md
+++ b/docs/cli-configuration.md
@@ -54,6 +54,7 @@ printf '%s' "$OPENAI_ADMIN_KEY" | codexbar config set-api-key --provider openai 
 printf '%s' "$ANTHROPIC_ADMIN_KEY" | codexbar config set-api-key --provider claude --stdin
 printf '%s' "$DEEPGRAM_API_KEY" | codexbar config set-api-key --provider deepgram --stdin
 printf '%s' "$Z_AI_API_KEY" | codexbar config set-api-key --provider zai --stdin
+printf '%s' "$DEEPSEEK_API_KEY" | codexbar config set-api-key --provider deepseek --stdin
 ```
 
 Only providers that consume config-backed API keys accept this command. Admin API providers may require a key with


### PR DESCRIPTION
## Summary

- DeepSeek is already a fully implemented provider in CodexBar (with its own fetcher, descriptor, and settings reader), but `docs/cli-configuration.md` was missing it from the API key examples.
- Adds `printf '%s' "$DEEPSEEK_API_KEY" | codexbar config set-api-key --provider deepseek --stdin` to the *Useful examples* block, consistent with the other API-key-based providers.

## Notes

- DeepSeek supports both `DEEPSEEK_API_KEY` and `DEEPSEEK_KEY` env vars (per `DeepSeekSettingsReader.swift`); the example uses the primary one.
- No code changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)