### PR TITLE
test: add Codex JSONL shape benchmark

### DIFF
--- a/Scripts/cost_jsonl_shape_survey.swift
+++ b/Scripts/cost_jsonl_shape_survey.swift
@@ -1,0 +1,289 @@
+#!/usr/bin/env swift
+
+import Foundation
+
+struct SurveyOptions {
+    var root: URL = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".codex", isDirectory: true)
+        .appendingPathComponent("sessions", isDirectory: true)
+    var days: Double = 30
+}
+
+struct Survey {
+    var files = 0
+    var totalBytes: Int64 = 0
+    var lines = 0
+    var relevantLines = 0
+    var lineLengths: [Int] = []
+    var linesOver32KiB = 0
+    var linesOver256KiB = 0
+    var turnContextLines = 0
+    var turnContextOver32KiB = 0
+    var turnContextOver256KiB = 0
+    var turnContextModelOffsets: [Int] = []
+    var turnContextModelOffsetUnder32KiB = 0
+    var turnContextModelOffsetUnder256KiB = 0
+    var tokenCountLines = 0
+    var tokenCountMissingExplicitModel = 0
+
+    mutating func recordFile(byteCount: Int64) {
+        self.files += 1
+        self.totalBytes += byteCount
+    }
+
+    mutating func recordLine(_ line: Data) {
+        guard !line.isEmpty else { return }
+
+        let length = line.count
+        self.lines += 1
+        self.lineLengths.append(length)
+        if length > 32 * 1024 {
+            self.linesOver32KiB += 1
+        }
+        if length > 256 * 1024 {
+            self.linesOver256KiB += 1
+        }
+
+        let isRelevant = line.contains(Marker.eventMessage)
+            || line.contains(Marker.turnContext)
+            || line.contains(Marker.sessionMetadata)
+        if isRelevant {
+            self.relevantLines += 1
+        }
+
+        if line.contains(Marker.turnContext) {
+            self.turnContextLines += 1
+            if length > 32 * 1024 {
+                self.turnContextOver32KiB += 1
+            }
+            if length > 256 * 1024 {
+                self.turnContextOver256KiB += 1
+            }
+            if let offset = line.firstOffset(of: Marker.modelField)
+                ?? line.firstOffset(of: Marker.modelNameField)
+            {
+                self.turnContextModelOffsets.append(offset)
+                if offset < 32 * 1024 {
+                    self.turnContextModelOffsetUnder32KiB += 1
+                }
+                if offset < 256 * 1024 {
+                    self.turnContextModelOffsetUnder256KiB += 1
+                }
+            }
+        }
+
+        if line.contains(Marker.tokenCount) {
+            self.tokenCountLines += 1
+            if !line.contains(Marker.modelField), !line.contains(Marker.modelNameField) {
+                self.tokenCountMissingExplicitModel += 1
+            }
+        }
+    }
+}
+
+enum Marker {
+    static let eventMessage = Data(#""type":"event_msg""#.utf8)
+    static let turnContext = Data(#""type":"turn_context""#.utf8)
+    static let sessionMetadata = Data(#""type":"session_meta""#.utf8)
+    static let tokenCount = Data(#""token_count""#.utf8)
+    static let modelField = Data(#""model""#.utf8)
+    static let modelNameField = Data(#""model_name""#.utf8)
+}
+
+extension Data {
+    func contains(_ marker: Data) -> Bool {
+        self.range(of: marker) != nil
+    }
+
+    func firstOffset(of marker: Data) -> Int? {
+        guard let range = self.range(of: marker) else { return nil }
+        return self.distance(from: self.startIndex, to: range.lowerBound)
+    }
+}
+
+func parseOptions(arguments: [String]) throws -> SurveyOptions {
+    var options = SurveyOptions()
+    var index = 1
+    while index < arguments.count {
+        switch arguments[index] {
+        case "--root":
+            index += 1
+            guard index < arguments.count else {
+                throw UsageError.message("--root requires a path")
+            }
+            options.root = URL(fileURLWithPath: expandTilde(arguments[index]), isDirectory: true)
+        case "--days":
+            index += 1
+            guard index < arguments.count, let days = Double(arguments[index]) else {
+                throw UsageError.message("--days requires a number")
+            }
+            options.days = days
+        case "--help", "-h":
+            printUsage()
+            Foundation.exit(0)
+        default:
+            throw UsageError.message("unknown argument: \(arguments[index])")
+        }
+        index += 1
+    }
+    return options
+}
+
+func expandTilde(_ path: String) -> String {
+    guard path == "~" || path.hasPrefix("~/") else { return path }
+    let home = FileManager.default.homeDirectoryForCurrentUser.path
+    if path == "~" {
+        return home
+    }
+    return home + String(path.dropFirst())
+}
+
+enum UsageError: Error, CustomStringConvertible {
+    case message(String)
+
+    var description: String {
+        switch self {
+        case let .message(text):
+            text
+        }
+    }
+}
+
+func printUsage() {
+    print(
+        """
+        Usage: Scripts/cost_jsonl_shape_survey.swift [--root PATH] [--days N]
+
+        Scans local Codex JSONL logs and prints aggregate shape only. It does not
+        print prompts, tool payloads, model values, file paths, or raw log lines.
+        """)
+}
+
+func jsonlFiles(root: URL, modifiedSince cutoff: Date) -> [URL] {
+    guard let enumerator = FileManager.default.enumerator(
+        at: root,
+        includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey, .fileSizeKey],
+        options: [.skipsHiddenFiles]) else { return [] }
+
+    var files: [URL] = []
+    for case let fileURL as URL in enumerator {
+        guard fileURL.pathExtension == "jsonl" else { continue }
+        let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .contentModificationDateKey])
+        guard values?.isRegularFile == true else { continue }
+        guard let modifiedAt = values?.contentModificationDate, modifiedAt >= cutoff else { continue }
+        files.append(fileURL)
+    }
+    return files.sorted { $0.path < $1.path }
+}
+
+func validateRoot(_ root: URL) throws {
+    var isDirectory: ObjCBool = false
+    let exists = FileManager.default.fileExists(atPath: root.path, isDirectory: &isDirectory)
+    guard exists, isDirectory.boolValue else {
+        throw UsageError.message("root does not exist or is not a directory")
+    }
+}
+
+func scan(fileURL: URL, into survey: inout Survey) throws {
+    let values = try fileURL.resourceValues(forKeys: [.fileSizeKey])
+    survey.recordFile(byteCount: Int64(values.fileSize ?? 0))
+
+    let handle = try FileHandle(forReadingFrom: fileURL)
+    defer { try? handle.close() }
+
+    var current = Data()
+    current.reserveCapacity(4 * 1024)
+
+    while true {
+        let chunk = try handle.read(upToCount: 256 * 1024) ?? Data()
+        if chunk.isEmpty {
+            survey.recordLine(current)
+            break
+        }
+
+        var segmentStart = chunk.startIndex
+        while let newline = chunk[segmentStart...].firstIndex(of: 0x0A) {
+            current.append(contentsOf: chunk[segmentStart..<newline])
+            survey.recordLine(current)
+            current.removeAll(keepingCapacity: true)
+            segmentStart = chunk.index(after: newline)
+        }
+
+        if segmentStart < chunk.endIndex {
+            current.append(contentsOf: chunk[segmentStart..<chunk.endIndex])
+        }
+    }
+}
+
+func percentile(_ values: [Int], _ percentile: Double) -> Int {
+    guard !values.isEmpty else { return 0 }
+    let sorted = values.sorted()
+    let index = Int((percentile * Double(sorted.count - 1)).rounded())
+    return sorted[max(0, min(index, sorted.count - 1))]
+}
+
+func printSummary(_ survey: Survey, options: SurveyOptions) {
+    print("root: \(redactedRootDescription(options.root))")
+    print("window days: \(Int(options.days))")
+    print("files: \(survey.files)")
+    print("total bytes: \(survey.totalBytes)")
+    print("lines: \(survey.lines)")
+    print("relevant Codex scanner lines: \(survey.relevantLines)")
+    print(
+        "line length p50/p90/p95/p99/max: " +
+            "\(percentile(survey.lineLengths, 0.50)) / " +
+            "\(percentile(survey.lineLengths, 0.90)) / " +
+            "\(percentile(survey.lineLengths, 0.95)) / " +
+            "\(percentile(survey.lineLengths, 0.99)) / " +
+            "\(percentile(survey.lineLengths, 1.00)) bytes")
+    print("lines > 32 KiB: \(survey.linesOver32KiB)")
+    print("lines > 256 KiB: \(survey.linesOver256KiB)")
+    print("turn_context lines: \(survey.turnContextLines)")
+    print("turn_context lines > 32 KiB: \(survey.turnContextOver32KiB)")
+    print("turn_context lines > 256 KiB: \(survey.turnContextOver256KiB)")
+    print(
+        "turn_context model offset p50/p95/max: " +
+            "\(percentile(survey.turnContextModelOffsets, 0.50)) / " +
+            "\(percentile(survey.turnContextModelOffsets, 0.95)) / " +
+            "\(percentile(survey.turnContextModelOffsets, 1.00)) bytes")
+    print(
+        "turn_context model offset < 32 KiB: " +
+            "\(survey.turnContextModelOffsetUnder32KiB) / \(survey.turnContextLines)")
+    print(
+        "turn_context model offset < 256 KiB: " +
+            "\(survey.turnContextModelOffsetUnder256KiB) / \(survey.turnContextLines)")
+    print(
+        "token_count rows missing an explicit model: " +
+            "\(survey.tokenCountMissingExplicitModel) / \(survey.tokenCountLines)")
+}
+
+func redactedRootDescription(_ root: URL) -> String {
+    let defaultRoot = SurveyOptions().root.standardizedFileURL.path
+    let currentRoot = root.standardizedFileURL.path
+    if currentRoot == defaultRoot {
+        return "default Codex sessions"
+    }
+    return "custom root (redacted)"
+}
+
+do {
+    let options = try parseOptions(arguments: CommandLine.arguments)
+    try validateRoot(options.root)
+    let cutoff = Date().addingTimeInterval(-options.days * 24 * 60 * 60)
+    let files = jsonlFiles(root: options.root, modifiedSince: cutoff)
+    guard !files.isEmpty else {
+        throw UsageError.message("no .jsonl files found in the selected time window")
+    }
+    var survey = Survey()
+    for fileURL in files {
+        try scan(fileURL: fileURL, into: &survey)
+    }
+    printSummary(survey, options: options)
+} catch let error as UsageError {
+    fputs("error: \(error.description)\n\n", stderr)
+    printUsage()
+    Foundation.exit(2)
+} catch {
+    fputs("error: \(error.localizedDescription)\n", stderr)
+    Foundation.exit(1)
+}

--- a/Tests/CodexBarTests/CostUsageJsonlShapeBenchmarkTests.swift
+++ b/Tests/CodexBarTests/CostUsageJsonlShapeBenchmarkTests.swift
@@ -1,0 +1,407 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct CostUsageJsonlShapeBenchmarkTests {
+    @Test
+    func `scanner benchmark covers codex session history shape`() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "codexbar-cost-jsonl-shape-\(UUID().uuidString)",
+            isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let divisor = Self.shapeDivisor()
+        let plan = CodexJsonlShapePlan.localThirtyDaySample.scaled(divisor: divisor)
+        let fileURL = root.appendingPathComponent("codex-shape.jsonl", isDirectory: false)
+        let fixture = try CodexJsonlShapeFixture.write(plan: plan, to: fileURL)
+
+        let maxLineBytes = 256 * 1024
+        let prefixBytes = 32 * 1024
+
+        let currentSummary = try self.summarizeScan(
+            fileURL: fileURL,
+            maxLineBytes: maxLineBytes,
+            prefixBytes: prefixBytes,
+            scanner: CostUsageJsonl.scan)
+        let baselineSummary = try self.summarizeScan(
+            fileURL: fileURL,
+            maxLineBytes: maxLineBytes,
+            prefixBytes: prefixBytes,
+            scanner: self.scanWithFrontBufferBaseline)
+
+        #expect(currentSummary.lineCount == fixture.lineCount)
+        #expect(currentSummary.truncatedCount == fixture.truncatedLineCount)
+        #expect(currentSummary.endOffset == fixture.byteCount)
+        #expect(baselineSummary.lineCount == currentSummary.lineCount)
+        #expect(baselineSummary.truncatedCount == currentSummary.truncatedCount)
+        #expect(baselineSummary.endOffset == currentSummary.endOffset)
+
+        _ = try self.summarizeScan(
+            fileURL: fileURL,
+            maxLineBytes: maxLineBytes,
+            prefixBytes: prefixBytes,
+            scanner: CostUsageJsonl.scan)
+        _ = try self.summarizeScan(
+            fileURL: fileURL,
+            maxLineBytes: maxLineBytes,
+            prefixBytes: prefixBytes,
+            scanner: self.scanWithFrontBufferBaseline)
+
+        let currentFastest = try self.fastestScanDurationNanoseconds(
+            runs: 3,
+            fileURL: fileURL,
+            maxLineBytes: maxLineBytes,
+            prefixBytes: prefixBytes,
+            scanner: CostUsageJsonl.scan)
+        let baselineFastest = try self.fastestScanDurationNanoseconds(
+            runs: 3,
+            fileURL: fileURL,
+            maxLineBytes: maxLineBytes,
+            prefixBytes: prefixBytes,
+            scanner: self.scanWithFrontBufferBaseline)
+
+        let currentMBps = Self.megabytesPerSecond(byteCount: fixture.byteCount, nanoseconds: currentFastest)
+        let baselineMBps = Self.megabytesPerSecond(byteCount: fixture.byteCount, nanoseconds: baselineFastest)
+        let speedup = Double(baselineFastest) / Double(currentFastest)
+        print(
+            "Codex JSONL shape benchmark: divisor=\(divisor) " +
+                "bytes=\(fixture.byteCount) lines=\(fixture.lineCount) " +
+                "truncated=\(fixture.truncatedLineCount) " +
+                "current=\(Self.format(currentMBps))MB/s " +
+                "baseline=\(Self.format(baselineMBps))MB/s " +
+                "speedup=\(Self.format(speedup))x")
+    }
+
+    @Test
+    func `synthetic codex rows preserve model attribution`() throws {
+        let env = try CostUsageTestEnvironment()
+        defer { env.cleanup() }
+
+        let day = try env.makeLocalNoon(year: 2026, month: 5, day: 18)
+        let iso0 = env.isoString(for: day)
+        let iso1 = env.isoString(for: day.addingTimeInterval(1))
+        let iso2 = env.isoString(for: day.addingTimeInterval(2))
+        let model = "openai/gpt-5.5"
+        let turnContext: [String: Any] = [
+            "type": "turn_context",
+            "timestamp": iso0,
+            "payload": [
+                "model": model,
+                "instructions": "synthetic",
+            ],
+        ]
+        let firstTokenCount = self.tokenCountWithoutModel(
+            timestamp: iso1,
+            input: 100,
+            cached: 40,
+            output: 10)
+        let secondTokenCount = self.tokenCountWithoutModel(
+            timestamp: iso2,
+            input: 50,
+            cached: 20,
+            output: 5)
+        let fileURL = try env.writeCodexSessionFile(
+            day: day,
+            filename: "synthetic-attribution.jsonl",
+            contents: env.jsonl([turnContext, firstTokenCount, secondTokenCount]))
+
+        let parsed = CostUsageScanner.parseCodexFile(
+            fileURL: fileURL,
+            range: CostUsageScanner.CostUsageDayRange(since: day, until: day))
+        let dayKey = CostUsageScanner.CostUsageDayRange.dayKey(from: day)
+
+        #expect(parsed.days[dayKey]?["gpt-5.5"] == [150, 60, 15])
+        #expect(parsed.days[dayKey]?["gpt-5"] == nil)
+    }
+
+    private static func shapeDivisor() -> Int {
+        let value = ProcessInfo.processInfo.environment["CODEXBAR_COST_JSONL_SHAPE_DIVISOR"] ?? "20"
+        return max(1, Int(value) ?? 20)
+    }
+
+    private static func megabytesPerSecond(byteCount: Int64, nanoseconds: UInt64) -> Double {
+        let seconds = Double(nanoseconds) / 1_000_000_000
+        guard seconds > 0 else { return 0 }
+        return (Double(byteCount) / 1_000_000) / seconds
+    }
+
+    private static func format(_ value: Double) -> String {
+        String(format: "%.1f", value)
+    }
+
+    private func tokenCountWithoutModel(timestamp: String, input: Int, cached: Int, output: Int) -> [String: Any] {
+        [
+            "type": "event_msg",
+            "timestamp": timestamp,
+            "payload": [
+                "type": "token_count",
+                "info": [
+                    "last_token_usage": [
+                        "input_tokens": input,
+                        "cached_input_tokens": cached,
+                        "output_tokens": output,
+                    ],
+                ],
+            ],
+        ]
+    }
+
+    private func summarizeScan(
+        fileURL: URL,
+        maxLineBytes: Int,
+        prefixBytes: Int,
+        scanner: JsonlShapeScanner) throws -> JsonlShapeScanSummary
+    {
+        var lineCount = 0
+        var truncatedCount = 0
+        let endOffset = try scanner(fileURL, 0, maxLineBytes, prefixBytes) { line in
+            lineCount += 1
+            if line.wasTruncated {
+                truncatedCount += 1
+            }
+        }
+
+        return JsonlShapeScanSummary(
+            lineCount: lineCount,
+            truncatedCount: truncatedCount,
+            endOffset: endOffset)
+    }
+
+    private func fastestScanDurationNanoseconds(
+        runs: Int,
+        fileURL: URL,
+        maxLineBytes: Int,
+        prefixBytes: Int,
+        scanner: JsonlShapeScanner) throws -> UInt64
+    {
+        var fastest = UInt64.max
+        for _ in 0..<runs {
+            let startedAt = DispatchTime.now().uptimeNanoseconds
+            _ = try self.summarizeScan(
+                fileURL: fileURL,
+                maxLineBytes: maxLineBytes,
+                prefixBytes: prefixBytes,
+                scanner: scanner)
+            let elapsed = DispatchTime.now().uptimeNanoseconds - startedAt
+            fastest = min(fastest, elapsed)
+        }
+        return fastest
+    }
+
+    @discardableResult
+    private func scanWithFrontBufferBaseline(
+        fileURL: URL,
+        offset: Int64 = 0,
+        maxLineBytes: Int,
+        prefixBytes: Int,
+        onLine: (CostUsageJsonl.Line) -> Void) throws
+        -> Int64
+    {
+        let handle = try FileHandle(forReadingFrom: fileURL)
+        defer { try? handle.close() }
+
+        let startOffset = max(0, offset)
+        if startOffset > 0 {
+            try handle.seek(toOffset: UInt64(startOffset))
+        }
+
+        var buffer = Data()
+        buffer.reserveCapacity(64 * 1024)
+
+        var current = Data()
+        current.reserveCapacity(4 * 1024)
+        var lineBytes = 0
+        var truncated = false
+        var bytesRead: Int64 = 0
+
+        func flushLine() {
+            guard lineBytes > 0 else { return }
+            onLine(.init(bytes: current, wasTruncated: truncated))
+            current.removeAll(keepingCapacity: true)
+            lineBytes = 0
+            truncated = false
+        }
+
+        while true {
+            let chunk = try handle.read(upToCount: 256 * 1024) ?? Data()
+            if chunk.isEmpty {
+                flushLine()
+                break
+            }
+
+            bytesRead += Int64(chunk.count)
+            buffer.append(chunk)
+
+            while true {
+                guard let nl = buffer.firstIndex(of: 0x0A) else { break }
+                let linePart = buffer[..<nl]
+                buffer.removeSubrange(...nl)
+
+                lineBytes += linePart.count
+                if !truncated {
+                    if lineBytes > maxLineBytes || lineBytes > prefixBytes {
+                        truncated = true
+                        current.removeAll(keepingCapacity: true)
+                    } else {
+                        current.append(contentsOf: linePart)
+                    }
+                }
+
+                flushLine()
+            }
+        }
+
+        return startOffset + bytesRead
+    }
+}
+
+private typealias JsonlShapeScanner = (
+    _ fileURL: URL,
+    _ offset: Int64,
+    _ maxLineBytes: Int,
+    _ prefixBytes: Int,
+    _ onLine: (CostUsageJsonl.Line) -> Void) throws -> Int64
+
+private struct JsonlShapeScanSummary: Equatable {
+    let lineCount: Int
+    let truncatedCount: Int
+    let endOffset: Int64
+}
+
+private struct CodexJsonlShapePlan {
+    static let localThirtyDaySample = CodexJsonlShapePlan(
+        totalLines: 145_797,
+        relevantLines: 57063,
+        tokenCountWithoutModelLines: 22235,
+        turnContextLines: 1935,
+        longTurnContextLines: 207,
+        linesOver32KiB: 2584,
+        linesOver256KiB: 697)
+
+    let totalLines: Int
+    let relevantLines: Int
+    let tokenCountWithoutModelLines: Int
+    let turnContextLines: Int
+    let longTurnContextLines: Int
+    let linesOver32KiB: Int
+    let linesOver256KiB: Int
+
+    func scaled(divisor: Int) -> CodexJsonlShapePlan {
+        CodexJsonlShapePlan(
+            totalLines: self.scaled(self.totalLines, divisor: divisor),
+            relevantLines: self.scaled(self.relevantLines, divisor: divisor),
+            tokenCountWithoutModelLines: self.scaled(self.tokenCountWithoutModelLines, divisor: divisor),
+            turnContextLines: self.scaled(self.turnContextLines, divisor: divisor),
+            longTurnContextLines: self.scaled(self.longTurnContextLines, divisor: divisor),
+            linesOver32KiB: self.scaled(self.linesOver32KiB, divisor: divisor),
+            linesOver256KiB: self.scaled(self.linesOver256KiB, divisor: divisor))
+    }
+
+    private func scaled(_ value: Int, divisor: Int) -> Int {
+        max(1, Int((Double(value) / Double(divisor)).rounded()))
+    }
+}
+
+private struct CodexJsonlShapeFixture {
+    let byteCount: Int64
+    let lineCount: Int
+    let truncatedLineCount: Int
+
+    static func write(plan: CodexJsonlShapePlan, to fileURL: URL) throws -> CodexJsonlShapeFixture {
+        FileManager.default.createFile(atPath: fileURL.path, contents: nil)
+        let handle = try FileHandle(forWritingTo: fileURL)
+        defer { try? handle.close() }
+
+        var byteCount: Int64 = 0
+        var lineCount = 0
+
+        func writeLine(_ line: String) throws {
+            let data = Data((line + "\n").utf8)
+            try handle.write(contentsOf: data)
+            byteCount += Int64(data.count)
+            lineCount += 1
+        }
+
+        let longTurnContextCount = min(plan.longTurnContextLines, plan.turnContextLines)
+        let shortTurnContextCount = plan.turnContextLines - longTurnContextCount
+        let largeIrrelevantOver256Count = plan.linesOver256KiB
+        let largeIrrelevantOver32Count = max(
+            0,
+            plan.linesOver32KiB - longTurnContextCount - largeIrrelevantOver256Count)
+        let otherRelevantCount = max(
+            0,
+            plan.relevantLines - plan.tokenCountWithoutModelLines - plan.turnContextLines)
+        let writtenBeforeSmallIrrelevant = plan.tokenCountWithoutModelLines
+            + shortTurnContextCount
+            + longTurnContextCount
+            + otherRelevantCount
+            + largeIrrelevantOver32Count
+            + largeIrrelevantOver256Count
+        let smallIrrelevantCount = max(0, plan.totalLines - writtenBeforeSmallIrrelevant)
+
+        try self.writeRepeated(
+            count: plan.tokenCountWithoutModelLines,
+            line: self.tokenCountWithoutModelLine,
+            writer: writeLine)
+        try self.writeRepeated(
+            count: shortTurnContextCount,
+            line: self.turnContextLine(fillerBytes: 2048),
+            writer: writeLine)
+        try self.writeRepeated(
+            count: longTurnContextCount,
+            line: self.turnContextLine(fillerBytes: 40 * 1024),
+            writer: writeLine)
+        try self.writeRepeated(
+            count: otherRelevantCount,
+            line: self.taskStartedLine,
+            writer: writeLine)
+        try self.writeRepeated(
+            count: largeIrrelevantOver32Count,
+            line: self.irrelevantLine(fillerBytes: 64 * 1024),
+            writer: writeLine)
+        try self.writeRepeated(
+            count: largeIrrelevantOver256Count,
+            line: self.irrelevantLine(fillerBytes: 300 * 1024),
+            writer: writeLine)
+        try self.writeRepeated(
+            count: smallIrrelevantCount,
+            line: self.irrelevantLine(fillerBytes: 512),
+            writer: writeLine)
+
+        return CodexJsonlShapeFixture(
+            byteCount: byteCount,
+            lineCount: lineCount,
+            truncatedLineCount: longTurnContextCount + largeIrrelevantOver32Count + largeIrrelevantOver256Count)
+    }
+
+    private static let tokenCountWithoutModelLine =
+        #"{"type":"event_msg","timestamp":"2026-05-18T00:00:00Z","payload":{"type":"token_count","info":"#
+            + #"{"last_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":10}}}}"#
+
+    private static let taskStartedLine =
+        #"{"type":"event_msg","timestamp":"2026-05-18T00:00:00Z","payload":"#
+            + #"{"type":"task_started","turn_id":"turn-0001"}}"#
+
+    private static func turnContextLine(fillerBytes: Int) -> String {
+        #"{"type":"turn_context","timestamp":"2026-05-18T00:00:00Z","payload":"#
+            + #"{"model":"openai/gpt-5.5","instructions":""#
+            + String(repeating: "x", count: fillerBytes)
+            + #""}}"#
+    }
+
+    private static func irrelevantLine(fillerBytes: Int) -> String {
+        #"{"type":"response_item","payload":""# + String(repeating: "x", count: fillerBytes) + #""}"#
+    }
+
+    private static func writeRepeated(
+        count: Int,
+        line: String,
+        writer: (String) throws -> Void) throws
+    {
+        for _ in 0..<count {
+            try writer(line)
+        }
+    }
+}


### PR DESCRIPTION
Refs #1016.

This adds an RFC benchmark/survey harness for the Codex JSONL scanner workload:

- `CostUsageJsonlShapeBenchmarkTests` builds a synthetic JSONL file shaped after a local 30-day Codex sessions sample, then compares the current streaming scanner with a front-buffer baseline.
- `Scripts/cost_jsonl_shape_survey.swift` lets maintainers collect the same aggregate shape numbers locally without printing prompts, tool payloads, model values, file paths, or raw JSONL rows.
- A small end-to-end parser assertion covers the relevant attribution shape: a `turn_context` row followed by `token_count` rows that do not carry an explicit model.

The benchmark intentionally does not assert a speed threshold. It is meant to make scanner tradeoffs reproducible without making CI sensitive to runner noise. The long `turn_context` correctness fix is separate in #1014; this PR only provides measurement and workload-shape coverage for #1016.

Local aggregate survey from my default Codex sessions over 30 days:

```text
files: 532
total bytes: 1202851897
lines: 146748
relevant Codex scanner lines: 57418
line length p50/p90/p95/p99/max: 651 / 5065 / 12080 / 52701 / 6904210 bytes
lines > 32 KiB: 2602
lines > 256 KiB: 697
turn_context lines: 1945
turn_context lines > 32 KiB: 208
turn_context lines > 256 KiB: 0
turn_context model offset p50/p95/max: 443 / 2255 / 2382 bytes
turn_context model offset < 32 KiB: 1945 / 1945
turn_context model offset < 256 KiB: 1945 / 1945
token_count rows missing an explicit model: 22381 / 22381
```

Local benchmark sample:

```text
Codex JSONL shape benchmark: divisor=20 bytes=19621792 lines=7290 truncated=129 current=113.9MB/s baseline=46.9MB/s speedup=2.4x
```

Validation:

- `swift test --filter CostUsageJsonlShapeBenchmarkTests`
- `Scripts/cost_jsonl_shape_survey.swift --days 30`
- `./Scripts/lint.sh lint`
- `git diff --check`
