### PR TITLE
Add token-protected dashboard snapshots to the CLI server

### DIFF
--- a/Sources/CodexBarCLI/CLIEntry.swift
+++ b/Sources/CodexBarCLI/CLIEntry.swift
@@ -91,7 +91,7 @@ enum CodexBarCLI {
                 signature: costSignature),
             CommandDescriptor(
                 name: "serve",
-                abstract: "Serve usage and cost JSON over localhost HTTP",
+                abstract: "Serve usage, cost, and dashboard JSON over HTTP",
                 discussion: nil,
                 signature: serveSignature),
             CommandDescriptor(

--- a/Sources/CodexBarCLI/CLIHelp.swift
+++ b/Sources/CodexBarCLI/CLIHelp.swift
@@ -79,14 +79,18 @@ extension CodexBarCLI {
         Usage:
           codexbar serve [--host <host>] [--port <port>] [--refresh-interval <seconds>]
                          [--request-timeout <seconds>]
-                         [--dashboard-token <token>] [--dashboard-identity none|redacted|full]
+                         [--dashboard-token <token>] [--dashboard-pairing]
+                         [--dashboard-identity none|redacted|full]
                          [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>]
                          [-v|--verbose]
 
         Description:
           Start a foreground HTTP server that exposes CLI JSON payloads and a stable dashboard snapshot.
           By default the server binds to 127.0.0.1 only. Non-loopback --host values require
-          --dashboard-token, and data routes require Authorization: Bearer YOUR_TOKEN when configured.
+          --dashboard-token or --dashboard-pairing. Data routes require Authorization: Bearer YOUR_TOKEN
+          when a token is configured. With --dashboard-pairing, enter the server-shown one-time code
+          on the client to receive a generated bearer token. Repeated failures lock pairing until
+          restart, and a successful claim closes pairing.
           Dashboard identity exposure defaults to redacted.
           Redacted identity keeps plan labels and email domains, but hides email local parts.
 
@@ -98,11 +102,14 @@ extension CodexBarCLI {
           GET /cost
           GET /cost?provider=codex
           GET /dashboard/v1/snapshot
+          GET /dashboard/v1/pairing
+          GET /dashboard/v1/pairing/claim?pairingId=<id>&code=<code>
 
         Examples:
           codexbar serve
           codexbar serve --port 8080 --refresh-interval 60 --request-timeout 30
           codexbar serve --host 0.0.0.0 --port 8080 --dashboard-token "$CODEXBAR_DASHBOARD_TOKEN"
+          codexbar serve --host 0.0.0.0 --port 8080 --dashboard-pairing
           curl http://127.0.0.1:8080/usage?provider=all
           curl -H "Authorization: Bearer $CODEXBAR_DASHBOARD_TOKEN" \\
             http://127.0.0.1:8080/dashboard/v1/snapshot
@@ -219,7 +226,8 @@ extension CodexBarCLI {
                        [--provider \(ProviderHelp.list)] [--no-color] [--pretty] [--refresh]
           codexbar serve [--host <host>] [--port <port>] [--refresh-interval <seconds>]
                        [--request-timeout <seconds>]
-                       [--dashboard-token <token>] [--dashboard-identity none|redacted|full]
+                       [--dashboard-token <token>] [--dashboard-pairing]
+                       [--dashboard-identity none|redacted|full]
                        [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>] [-v|--verbose]
           codexbar config <validate|dump|providers> [--format text|json]
                                         [--json]

--- a/Sources/CodexBarCLI/CLIHelp.swift
+++ b/Sources/CodexBarCLI/CLIHelp.swift
@@ -77,14 +77,18 @@ extension CodexBarCLI {
         CodexBar \(version)
 
         Usage:
-          codexbar serve [--port <port>] [--refresh-interval <seconds>]
+          codexbar serve [--host <host>] [--port <port>] [--refresh-interval <seconds>]
                          [--request-timeout <seconds>]
+                         [--dashboard-token <token>] [--dashboard-identity none|redacted|full]
                          [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>]
                          [-v|--verbose]
 
         Description:
-          Start a foreground localhost-only HTTP server that exposes existing CLI JSON payloads.
-          The server binds to 127.0.0.1 only in this initial version.
+          Start a foreground HTTP server that exposes CLI JSON payloads and a stable dashboard snapshot.
+          By default the server binds to 127.0.0.1 only. Non-loopback --host values require
+          --dashboard-token, and data routes require Authorization: Bearer YOUR_TOKEN when configured.
+          Dashboard identity exposure defaults to redacted.
+          Redacted identity keeps plan labels and email domains, but hides email local parts.
 
         Endpoints:
           GET /health
@@ -93,11 +97,15 @@ extension CodexBarCLI {
           GET /usage?provider=all
           GET /cost
           GET /cost?provider=codex
+          GET /dashboard/v1/snapshot
 
         Examples:
           codexbar serve
           codexbar serve --port 8080 --refresh-interval 60 --request-timeout 30
+          codexbar serve --host 0.0.0.0 --port 8080 --dashboard-token "$CODEXBAR_DASHBOARD_TOKEN"
           curl http://127.0.0.1:8080/usage?provider=all
+          curl -H "Authorization: Bearer $CODEXBAR_DASHBOARD_TOKEN" \\
+            http://127.0.0.1:8080/dashboard/v1/snapshot
         """
     }
 
@@ -209,8 +217,9 @@ extension CodexBarCLI {
                        [--json-only]
                        [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>] [-v|--verbose]
                        [--provider \(ProviderHelp.list)] [--no-color] [--pretty] [--refresh]
-          codexbar serve [--port <port>] [--refresh-interval <seconds>]
+          codexbar serve [--host <host>] [--port <port>] [--refresh-interval <seconds>]
                        [--request-timeout <seconds>]
+                       [--dashboard-token <token>] [--dashboard-identity none|redacted|full]
                        [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>] [-v|--verbose]
           codexbar config <validate|dump|providers> [--format text|json]
                                         [--json]

--- a/Sources/CodexBarCLI/CLILocalHTTPServer.swift
+++ b/Sources/CodexBarCLI/CLILocalHTTPServer.swift
@@ -7,14 +7,18 @@ import Glibc
 
 private let requestReadTimeoutMilliseconds: Int32 = 5000
 
-struct CLILocalHTTPRequest {
+struct CLILocalHTTPRequest: Sendable {
     let method: String
     let target: String
     let host: String
     let path: String
     let queryItems: [String: String]
+    let headers: [String: String]
 
-    static func parse(_ data: Data) -> Result<CLILocalHTTPRequest, CLILocalHTTPRequestParseError> {
+    static func parse(
+        _ data: Data,
+        allowNonLoopbackHost: Bool = false) -> Result<CLILocalHTTPRequest, CLILocalHTTPRequestParseError>
+    {
         guard let raw = String(data: data, encoding: .utf8),
               let firstLine = raw.components(separatedBy: "\r\n").first
         else {
@@ -29,15 +33,19 @@ struct CLILocalHTTPRequest {
         guard target.hasPrefix("/") else { return .failure(.invalidRequest) }
 
         let headerResult = Self.parseHeaders(raw)
+        let headerPairs: [(String, String)]
         let host: String
         switch headerResult {
-        case let .success(headers):
-            let hosts = headers.compactMap { name, value in
+        case let .success(parsedHeaders):
+            headerPairs = parsedHeaders
+            let hosts = parsedHeaders.compactMap { name, value in
                 name.lowercased() == "host" ? value : nil
             }
             guard let candidate = hosts.first else { return .failure(.missingHost) }
             guard hosts.count == 1 else { return .failure(.duplicateHost) }
-            guard Self.isAllowedLoopbackHost(candidate) else { return .failure(.disallowedHost) }
+            guard Self.isAllowedHost(candidate, allowNonLoopbackHost: allowNonLoopbackHost) else {
+                return .failure(.disallowedHost)
+            }
             host = candidate
         case let .failure(error):
             return .failure(error)
@@ -52,12 +60,18 @@ struct CLILocalHTTPRequest {
             }
         }
 
+        var headers: [String: String] = [:]
+        for (name, value) in headerPairs {
+            headers[name.lowercased()] = value
+        }
+
         return .success(CLILocalHTTPRequest(
             method: method,
             target: target,
             host: host,
             path: path,
-            queryItems: queryItems))
+            queryItems: queryItems,
+            headers: headers))
     }
 
     private static func parseHeaders(_ raw: String) -> Result<[(String, String)], CLILocalHTTPRequestParseError> {
@@ -78,7 +92,7 @@ struct CLILocalHTTPRequest {
         return .success(headers)
     }
 
-    private static func isAllowedLoopbackHost(_ host: String) -> Bool {
+    private static func isAllowedHost(_ host: String, allowNonLoopbackHost: Bool) -> Bool {
         let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !trimmed.contains(",") else { return false }
 
@@ -105,7 +119,7 @@ struct CLILocalHTTPRequest {
         case "127.0.0.1", "localhost", "localhost.", "[::1]":
             return true
         default:
-            return false
+            return allowNonLoopbackHost
         }
     }
 
@@ -127,10 +141,11 @@ enum CLILocalHTTPRequestParseError: Error, Equatable {
     case disallowedHost
 }
 
-enum CLIHTTPStatus {
+enum CLIHTTPStatus: Sendable {
     case ok
     case badRequest
     case forbidden
+    case unauthorized
     case notFound
     case methodNotAllowed
     case internalServerError
@@ -140,6 +155,7 @@ enum CLIHTTPStatus {
         case .ok: 200
         case .badRequest: 400
         case .forbidden: 403
+        case .unauthorized: 401
         case .notFound: 404
         case .methodNotAllowed: 405
         case .internalServerError: 500
@@ -152,6 +168,7 @@ enum CLIHTTPStatus {
         case .ok: "OK"
         case .badRequest: "Bad Request"
         case .forbidden: "Forbidden"
+        case .unauthorized: "Unauthorized"
         case .notFound: "Not Found"
         case .methodNotAllowed: "Method Not Allowed"
         case .internalServerError: "Internal Server Error"
@@ -160,7 +177,7 @@ enum CLIHTTPStatus {
     }
 }
 
-struct CLILocalHTTPResponse {
+struct CLILocalHTTPResponse: Sendable {
     let status: CLIHTTPStatus
     let body: Data
     let contentType: String
@@ -189,11 +206,18 @@ final class CLILocalHTTPServer {
 
     private let host: String
     private let port: UInt16
+    private let allowNonLoopbackHostHeaders: Bool
     private let handler: Handler
 
-    init(host: String, port: UInt16, handler: @escaping Handler) {
+    init(
+        host: String,
+        port: UInt16,
+        allowNonLoopbackHostHeaders: Bool = false,
+        handler: @escaping Handler)
+    {
         self.host = host
         self.port = port
+        self.allowNonLoopbackHostHeaders = allowNonLoopbackHostHeaders
         self.handler = handler
     }
 
@@ -250,9 +274,13 @@ final class CLILocalHTTPServer {
             let clientFD = accept(serverFD, &clientAddress, &clientLength)
             guard clientFD >= 0 else { continue }
             let handler = self.handler
+            let allowNonLoopbackHostHeaders = self.allowNonLoopbackHostHeaders
             Task {
                 defer { closeSocket(clientFD) }
-                await handleClient(clientFD, handler: handler)
+                await handleClient(
+                    clientFD,
+                    allowNonLoopbackHostHeaders: allowNonLoopbackHostHeaders,
+                    handler: handler)
             }
         }
     }
@@ -260,10 +288,11 @@ final class CLILocalHTTPServer {
 
 private func handleClient(
     _ clientFD: Int32,
+    allowNonLoopbackHostHeaders: Bool,
     handler: @Sendable (CLILocalHTTPRequest) async -> CLILocalHTTPResponse) async
 {
     let request: CLILocalHTTPRequest
-    switch readRequest(clientFD) {
+    switch readRequest(clientFD, allowNonLoopbackHostHeaders: allowNonLoopbackHostHeaders) {
     case let .success(parsedRequest):
         request = parsedRequest
     case .failure(.disallowedHost):
@@ -286,7 +315,10 @@ private func handleClient(
     sendResponse(response, to: clientFD)
 }
 
-private func readRequest(_ fd: Int32) -> Result<CLILocalHTTPRequest, CLILocalHTTPRequestParseError> {
+private func readRequest(
+    _ fd: Int32,
+    allowNonLoopbackHostHeaders: Bool) -> Result<CLILocalHTTPRequest, CLILocalHTTPRequestParseError>
+{
     var data = Data()
     var buffer = [UInt8](repeating: 0, count: 4096)
     let bufferSize = buffer.count
@@ -308,7 +340,7 @@ private func readRequest(_ fd: Int32) -> Result<CLILocalHTTPRequest, CLILocalHTT
     }
 
     guard sawHeaderEnd else { return .failure(.invalidRequest) }
-    return CLILocalHTTPRequest.parse(data)
+    return CLILocalHTTPRequest.parse(data, allowNonLoopbackHost: allowNonLoopbackHostHeaders)
 }
 
 private func sendResponse(_ response: CLILocalHTTPResponse, to fd: Int32) {

--- a/Sources/CodexBarCLI/CLIServeAuth.swift
+++ b/Sources/CodexBarCLI/CLIServeAuth.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+struct CLIServeAuth: Sendable {
+    let token: String?
+
+    init(token: String?) {
+        self.token = token
+    }
+
+    init(dashboardToken: String?) {
+        self.init(token: dashboardToken)
+    }
+
+    func authorizeDataRequest(_ request: CLILocalHTTPRequest) -> Bool {
+        guard let token else { return true }
+        guard let authorization = request.headers["authorization"] else { return false }
+        return authorization.trimmingCharacters(in: .whitespacesAndNewlines) == "Bearer \(token)"
+    }
+
+    func authorizeDashboardRequest(_ request: CLILocalHTTPRequest) -> Bool {
+        self.authorizeDataRequest(request)
+    }
+}
+
+enum CLIServeSecurity {
+    static func bindHost(_ host: String) -> String {
+        host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "localhost" ? "127.0.0.1" : host
+    }
+
+    static func isLoopbackHost(_ host: String) -> Bool {
+        let normalized = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if normalized == "localhost" || normalized == "::1" { return true }
+        if normalized.hasPrefix("127.") { return true }
+        return normalized == "0:0:0:0:0:0:0:1"
+    }
+
+    static func requiresDashboardToken(host: String) -> Bool {
+        !self.isLoopbackHost(host)
+    }
+}

--- a/Sources/CodexBarCLI/CLIServeAuth.swift
+++ b/Sources/CodexBarCLI/CLIServeAuth.swift
@@ -2,19 +2,26 @@ import Foundation
 
 struct CLIServeAuth: Sendable {
     let token: String?
+    let pairing: CLIServePairing?
 
-    init(token: String?) {
+    init(token: String?, pairing: CLIServePairing? = nil) {
         self.token = token
+        self.pairing = pairing
     }
 
-    init(dashboardToken: String?) {
-        self.init(token: dashboardToken)
+    init(dashboardToken: String?, pairing: CLIServePairing? = nil) {
+        self.init(token: dashboardToken, pairing: pairing)
     }
 
     func authorizeDataRequest(_ request: CLILocalHTTPRequest) -> Bool {
-        guard let token else { return true }
+        guard let token else {
+            guard let pairing else { return true }
+            return pairing.authorize(request)
+        }
         guard let authorization = request.headers["authorization"] else { return false }
-        return authorization.trimmingCharacters(in: .whitespacesAndNewlines) == "Bearer \(token)"
+        let normalized = authorization.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized == "Bearer \(token)" { return true }
+        return self.pairing?.authorize(request) == true
     }
 
     func authorizeDashboardRequest(_ request: CLILocalHTTPRequest) -> Bool {
@@ -36,5 +43,144 @@ enum CLIServeSecurity {
 
     static func requiresDashboardToken(host: String) -> Bool {
         !self.isLoopbackHost(host)
+    }
+}
+
+final class CLIServePairing: @unchecked Sendable {
+    struct Challenge: Sendable {
+        let id: String
+        let code: String
+        let token: String
+    }
+
+    struct DiscoveryPayload: Encodable {
+        let schemaVersion: Int
+        let service: String
+        let auth: AuthPayload
+    }
+
+    struct AuthPayload: Encodable {
+        let type: String
+        let pairingId: String
+        let codeLength: Int
+        let expiresInSeconds: Int
+    }
+
+    struct ClaimPayload: Encodable {
+        let schemaVersion: Int
+        let token: String
+        let endpoint: String
+    }
+
+    enum ClaimOutcome: Sendable {
+        case claimed(ClaimPayload)
+        case rejected
+        case unavailable
+    }
+
+    static let maxFailedAttempts = 5
+    static let codeLength = 6
+
+    private let lock = NSLock()
+    private let announce: @Sendable (String) -> Void
+    private var challenge: Challenge
+    private var paired = false
+    private var failedAttempts = 0
+
+    init(announce: @escaping @Sendable (String) -> Void = { _ in }) {
+        self.announce = announce
+        self.challenge = Self.makeChallenge()
+    }
+
+    /// The code to display next to the server, or nil once pairing is closed.
+    func currentCode() -> String? {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        guard self.isOpenLocked else { return nil }
+        return self.challenge.code
+    }
+
+    func discoveryPayload() -> DiscoveryPayload? {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        guard self.isOpenLocked else { return nil }
+        return DiscoveryPayload(
+            schemaVersion: 1,
+            service: "codexbar-dashboard",
+            auth: AuthPayload(
+                type: "code",
+                pairingId: self.challenge.id,
+                codeLength: Self.codeLength,
+                expiresInSeconds: 0))
+    }
+
+    func claim(pairingID: String?, code: String?) -> ClaimOutcome {
+        let outcome: ClaimOutcome
+        var message: String?
+
+        self.lock.lock()
+        if !self.isOpenLocked {
+            outcome = .unavailable
+        } else if pairingID == self.challenge.id,
+                  Self.normalizeCode(code) == self.challenge.code
+        {
+            self.paired = true
+            outcome = .claimed(ClaimPayload(
+                schemaVersion: 1,
+                token: self.challenge.token,
+                endpoint: "/dashboard/v1/snapshot"))
+            message = "Dashboard paired. Pairing is now closed.\n"
+        } else {
+            self.failedAttempts += 1
+            if self.failedAttempts >= Self.maxFailedAttempts {
+                message = "Too many failed pairing attempts. Pairing disabled until restart.\n"
+            } else {
+                message = "Pairing attempt rejected (\(self.failedAttempts)/\(Self.maxFailedAttempts)).\n"
+            }
+            outcome = .rejected
+        }
+        self.lock.unlock()
+
+        if let message {
+            self.announce(message)
+        }
+        return outcome
+    }
+
+    func authorize(_ request: CLILocalHTTPRequest) -> Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        guard self.paired else { return false }
+        guard let authorization = request.headers["authorization"] else { return false }
+        return authorization.trimmingCharacters(in: .whitespacesAndNewlines) == "Bearer \(self.challenge.token)"
+    }
+
+    private var isOpenLocked: Bool {
+        !self.paired && self.failedAttempts < Self.maxFailedAttempts
+    }
+
+    /// Strips separators users may copy from the grouped console output ("481 273").
+    private static func normalizeCode(_ code: String?) -> String? {
+        guard let code else { return nil }
+        let digits = code.filter(\.isNumber)
+        return digits.isEmpty ? nil : digits
+    }
+
+    private static func makeChallenge() -> Challenge {
+        Challenge(
+            id: UUID().uuidString,
+            code: self.randomCode(),
+            token: self.randomToken())
+    }
+
+    private static func randomCode() -> String {
+        (0..<self.codeLength).map { _ in String(Int.random(in: 0...9)) }.joined()
+    }
+
+    private static func randomToken() -> String {
+        [UUID().uuidString, UUID().uuidString]
+            .joined()
+            .replacingOccurrences(of: "-", with: "")
+            .lowercased()
     }
 }

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -15,6 +15,9 @@ struct ServeOptions: CommanderParsable {
     @Option(name: .long("port"), help: "Local HTTP port (default: 8080)")
     var port: Int?
 
+    @Option(name: .long("host"), help: "HTTP bind host (default: 127.0.0.1)")
+    var host: String?
+
     @Option(name: .long("refresh-interval"), help: "Response cache TTL in seconds (default: 60)")
     var refreshInterval: Double?
 
@@ -22,12 +25,19 @@ struct ServeOptions: CommanderParsable {
         name: .long("request-timeout"),
         help: "Total per-request deadline in seconds; 0 disables (default: 30)")
     var requestTimeout: Double?
+
+    @Option(name: .long("dashboard-token"), help: "Bearer token for serve data routes")
+    var dashboardToken: String?
+
+    @Option(name: .long("dashboard-identity"), help: "Dashboard identity exposure: none | redacted | full")
+    var dashboardIdentity: String?
 }
 
 enum CLIServeRoute: Equatable {
     case health
     case usage(provider: String?)
     case cost(provider: String?)
+    case dashboardSnapshot
 }
 
 enum CLIServeRouteError: Error, Equatable {
@@ -51,6 +61,8 @@ enum CLIServeRouter {
             return .usage(provider: normalizedProvider)
         case "/cost":
             return .cost(provider: normalizedProvider)
+        case "/dashboard/v1/snapshot":
+            return .dashboardSnapshot
         default:
             throw CLIServeRouteError.notFound
         }
@@ -187,20 +199,62 @@ actor CLIServeResponseCache {
     }
 }
 
+actor CLIServeDashboardSnapshotCache {
+    private struct Entry {
+        let cacheKey: String
+        let expiresAt: Date
+        let response: CLILocalHTTPResponse
+    }
+
+    private var entry: Entry?
+    private var refreshingKeys: Set<String> = []
+
+    func response(for cacheKey: String, now: Date) -> CLILocalHTTPResponse? {
+        guard let entry, entry.cacheKey == cacheKey, entry.expiresAt > now else { return nil }
+        return entry.response
+    }
+
+    func staleResponse(for cacheKey: String) -> CLILocalHTTPResponse? {
+        guard let entry, entry.cacheKey == cacheKey else { return nil }
+        return entry.response
+    }
+
+    func beginRefresh(for cacheKey: String) -> Bool {
+        guard !self.refreshingKeys.contains(cacheKey) else { return false }
+        self.refreshingKeys.insert(cacheKey)
+        return true
+    }
+
+    func finishRefresh(response: CLILocalHTTPResponse, for cacheKey: String, ttl: TimeInterval, now: Date) {
+        self.refreshingKeys.remove(cacheKey)
+        guard ttl > 0, response.status == .ok else { return }
+        self.entry = Entry(cacheKey: cacheKey, expiresAt: now.addingTimeInterval(ttl), response: response)
+    }
+}
+
 private enum CLIServeArgumentError: LocalizedError {
+    case invalidHost
     case invalidPort
     case invalidRefreshInterval
     case invalidRequestTimeout
+    case invalidDashboardIdentity
+    case missingDashboardToken(String)
     case invalidProvider(String)
 
     var errorDescription: String? {
         switch self {
+        case .invalidHost:
+            "--host must not be empty."
         case .invalidPort:
             "--port must be between 1 and 65535."
         case .invalidRefreshInterval:
             "--refresh-interval must be zero or greater."
         case .invalidRequestTimeout:
             "--request-timeout must be zero or greater."
+        case .invalidDashboardIdentity:
+            "--dashboard-identity must be none, redacted, or full."
+        case let .missingDashboardToken(host):
+            "--dashboard-token is required when --host is non-loopback ('\(host)')."
         case let .invalidProvider(provider):
             "Unknown provider '\(provider)'."
         }
@@ -213,13 +267,24 @@ extension CodexBarCLI {
     static func runServe(_ values: ParsedValues) async {
         let output = CLIOutputPreferences(format: .json, jsonOnly: true, pretty: false)
         let port = Self.decodeServePort(from: values)
+        let host = Self.decodeServeHost(from: values)
         let refreshInterval = Self.decodeServeRefreshInterval(from: values)
         let requestTimeout = Self.decodeServeRequestTimeout(from: values)
+        let dashboardToken = Self.decodeDashboardToken(from: values)
+        let dashboardIdentity = Self.decodeDashboardIdentity(from: values)
 
         guard let port else {
             Self.exit(
                 code: .failure,
                 message: CLIServeArgumentError.invalidPort.localizedDescription,
+                output: output,
+                kind: .args)
+        }
+
+        guard let host else {
+            Self.exit(
+                code: .failure,
+                message: CLIServeArgumentError.invalidHost.localizedDescription,
                 output: output,
                 kind: .args)
         }
@@ -240,24 +305,56 @@ extension CodexBarCLI {
                 kind: .args)
         }
 
-        let config = Self.loadConfig(output: output)
+        guard let dashboardIdentity else {
+            Self.exit(
+                code: .failure,
+                message: CLIServeArgumentError.invalidDashboardIdentity.localizedDescription,
+                output: output,
+                kind: .args)
+        }
+
+        if CLIServeSecurity.requiresDashboardToken(host: host), dashboardToken == nil {
+            Self.exit(
+                code: .failure,
+                message: CLIServeArgumentError.missingDashboardToken(host).localizedDescription,
+                output: output,
+                kind: .args)
+        }
+
         let cache = CLIServeResponseCache()
-        let server = CLILocalHTTPServer(host: "127.0.0.1", port: port) { request in
+        let dashboardCache = CLIServeDashboardSnapshotCache()
+        let auth = CLIServeAuth(dashboardToken: dashboardToken)
+        let bindHost = CLIServeSecurity.bindHost(host)
+        let allowNonLoopbackHostHeaders = !CLIServeSecurity.isLoopbackHost(host)
+        let server = CLILocalHTTPServer(
+            host: bindHost,
+            port: port,
+            allowNonLoopbackHostHeaders: allowNonLoopbackHostHeaders)
+        { request in
             await Self.handleServeRequest(
                 request,
-                config: config,
+                output: output,
                 cache: cache,
+                dashboardCache: dashboardCache,
                 refreshInterval: refreshInterval,
-                requestTimeout: requestTimeout)
+                requestTimeout: requestTimeout,
+                auth: auth,
+                dashboardIdentity: dashboardIdentity)
         }
 
         do {
             try await server.run {
-                Self.writeStderr("CodexBar server listening on http://127.0.0.1:\(port)\n")
+                Self.writeStderr("CodexBar server listening on http://\(bindHost):\(port)\n")
             }
         } catch {
             Self.exit(code: .failure, message: error.localizedDescription, output: output, kind: .runtime)
         }
+    }
+
+    static func decodeServeHost(from values: ParsedValues) -> String? {
+        let raw = values.options["host"]?.last ?? "127.0.0.1"
+        let host = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return host.isEmpty ? nil : host
     }
 
     static func decodeServePort(from values: ParsedValues) -> UInt16? {
@@ -282,7 +379,11 @@ extension CodexBarCLI {
         } else {
             parsed = 60
         }
-        guard parsed >= 0 else { return nil }
+        guard parsed.isFinite, parsed >= 0 else { return nil }
+
+        let staleBase = parsed.rounded(.up)
+        let refreshSeconds = parsed.rounded()
+        guard staleBase <= Double(Int.max / 3), refreshSeconds <= Double(Int.max) else { return nil }
         return parsed
     }
 
@@ -299,12 +400,27 @@ extension CodexBarCLI {
         return parsed
     }
 
+    static func decodeDashboardToken(from values: ParsedValues) -> String? {
+        guard let raw = values.options["dashboardToken"]?.last else { return nil }
+        let token = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return token.isEmpty ? nil : token
+    }
+
+    static func decodeDashboardIdentity(from values: ParsedValues) -> DashboardIdentityMode? {
+        let raw = values.options["dashboardIdentity"]?.last ?? DashboardIdentityMode.redacted.rawValue
+        return DashboardIdentityMode(rawValue: raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())
+    }
+
+    // swiftlint:disable:next function_parameter_count
     private static func handleServeRequest(
         _ request: CLILocalHTTPRequest,
-        config: CodexBarConfig,
+        output: CLIOutputPreferences,
         cache: CLIServeResponseCache,
+        dashboardCache: CLIServeDashboardSnapshotCache,
         refreshInterval: TimeInterval,
-        requestTimeout: TimeInterval) async -> CLILocalHTTPResponse
+        requestTimeout: TimeInterval,
+        auth: CLIServeAuth,
+        dashboardIdentity: DashboardIdentityMode) async -> CLILocalHTTPResponse
     {
         let route: CLIServeRoute
         do {
@@ -322,8 +438,13 @@ extension CodexBarCLI {
         case .health:
             return Self.serveJSON(ServeHealthPayload(status: "ok"))
         case let .usage(provider):
+            guard auth.authorizeDataRequest(request) else {
+                return Self.serveError(status: .unauthorized, message: "unauthorized")
+            }
+            let config = Self.loadConfig(output: output)
+            let configKey = Self.serveConfigCacheKey(config)
             return await Self.cachedServeResponse(
-                key: "usage:\(provider ?? "")",
+                key: "usage:\(configKey):\(provider ?? "")",
                 cache: cache,
                 refreshInterval: refreshInterval,
                 requestTimeout: requestTimeout)
@@ -331,14 +452,29 @@ extension CodexBarCLI {
                 await Self.serveUsage(provider: provider, config: config)
             }
         case let .cost(provider):
+            guard auth.authorizeDataRequest(request) else {
+                return Self.serveError(status: .unauthorized, message: "unauthorized")
+            }
+            let config = Self.loadConfig(output: output)
+            let configKey = Self.serveConfigCacheKey(config)
             return await Self.cachedServeResponse(
-                key: "cost:\(provider ?? "")",
+                key: "cost:\(configKey):\(provider ?? "")",
                 cache: cache,
                 refreshInterval: refreshInterval,
                 requestTimeout: requestTimeout)
             {
                 await Self.serveCost(provider: provider, config: config)
             }
+        case .dashboardSnapshot:
+            guard auth.authorizeDataRequest(request) else {
+                return Self.serveError(status: .unauthorized, message: "unauthorized")
+            }
+            let config = Self.loadConfig(output: output)
+            return await Self.serveCachedDashboardSnapshot(
+                config: config,
+                cache: dashboardCache,
+                refreshInterval: refreshInterval,
+                identityMode: dashboardIdentity)
         }
     }
 
@@ -401,13 +537,94 @@ extension CodexBarCLI {
 
     static func shouldCacheServeResponse(_ response: CLILocalHTTPResponse) -> Bool {
         guard response.status == .ok else { return false }
-        guard let payload = try? JSONSerialization.jsonObject(with: response.body) as? [[String: Any]] else {
+        guard let payload = try? JSONSerialization.jsonObject(with: response.body) else {
             return true
         }
-        return !payload.contains { item in
-            guard let error = item["error"] else { return false }
-            return !(error is NSNull)
+        if let providers = payload as? [[String: Any]] {
+            return !providers.contains { item in
+                guard let error = item["error"] else { return false }
+                return !(error is NSNull)
+            }
         }
+        return true
+    }
+
+    static func serveConfigCacheKey(_ config: CodexBarConfig) -> String {
+        config.enabledProviders().map(\.rawValue).joined(separator: ",")
+    }
+
+    static func serveCachedDashboardSnapshot(
+        config: CodexBarConfig,
+        cache: CLIServeDashboardSnapshotCache,
+        refreshInterval: TimeInterval,
+        identityMode: DashboardIdentityMode) async -> CLILocalHTTPResponse
+    {
+        let cacheKey = "\(identityMode.rawValue):\(Self.serveConfigCacheKey(config))"
+        if let response = await cache.response(for: cacheKey, now: Date()) {
+            return response
+        }
+
+        await Self.startDashboardSnapshotRefresh(
+            config: config,
+            cache: cache,
+            cacheKey: cacheKey,
+            refreshInterval: refreshInterval,
+            identityMode: identityMode)
+
+        if let response = await cache.staleResponse(for: cacheKey) {
+            return response
+        }
+
+        return Self.serveJSON(Self.makeDashboardRefreshingSnapshot(
+            config: config,
+            refreshInterval: refreshInterval,
+            identityMode: identityMode))
+    }
+
+    private static func startDashboardSnapshotRefresh(
+        config: CodexBarConfig,
+        cache: CLIServeDashboardSnapshotCache,
+        cacheKey: String,
+        refreshInterval: TimeInterval,
+        identityMode: DashboardIdentityMode) async
+    {
+        guard await cache.beginRefresh(for: cacheKey) else { return }
+        Task {
+            let response = await Self.serveDashboardSnapshot(
+                config: config,
+                refreshInterval: refreshInterval,
+                identityMode: identityMode)
+            await cache.finishRefresh(response: response, for: cacheKey, ttl: refreshInterval, now: Date())
+        }
+    }
+
+    static func makeDashboardRefreshingSnapshot(
+        config: CodexBarConfig,
+        refreshInterval: TimeInterval,
+        identityMode: DashboardIdentityMode) -> DashboardSnapshotPayload
+    {
+        let generatedAt = Date()
+        let providers = config.enabledProviders().map { provider in
+            ProviderPayload(
+                provider: provider,
+                account: nil,
+                version: nil,
+                source: "refreshing",
+                status: nil,
+                usage: nil,
+                credits: nil,
+                antigravityPlanInfo: nil,
+                openaiDashboard: nil,
+                error: ProviderErrorPayload(code: 0, message: "refreshing", kind: .provider))
+        }
+        return DashboardSnapshotBuilder.makeSnapshot(
+            usagePayloads: providers,
+            costPayloads: [],
+            config: config,
+            identityMode: identityMode,
+            generatedAt: generatedAt,
+            refreshInterval: refreshInterval,
+            codexBarVersion: Self.currentVersion())
     }
 
     private static func serveUsage(
@@ -491,6 +708,100 @@ extension CodexBarCLI {
         }
 
         return Self.serveJSON(payload)
+    }
+
+    private static func serveDashboardSnapshot(
+        config: CodexBarConfig,
+        refreshInterval: TimeInterval,
+        identityMode: DashboardIdentityMode) async -> CLILocalHTTPResponse
+    {
+        let selection = Self.providerSelection(rawOverride: nil, enabled: config.enabledProviders())
+        let usagePayloads = await Self.dashboardUsagePayloads(selection: selection, config: config)
+        let costPayloads = await Self.dashboardCostPayloads(selection: selection)
+        let snapshot = DashboardSnapshotBuilder.makeSnapshot(
+            usagePayloads: usagePayloads,
+            costPayloads: costPayloads,
+            config: config,
+            identityMode: identityMode,
+            generatedAt: Date(),
+            refreshInterval: refreshInterval,
+            codexBarVersion: Self.currentVersion())
+
+        return Self.serveJSON(snapshot)
+    }
+
+    private static func dashboardUsagePayloads(
+        selection: ProviderSelection,
+        config: CodexBarConfig) async -> [ProviderPayload]
+    {
+        let tokenContext: TokenAccountCLIContext
+        do {
+            tokenContext = try TokenAccountCLIContext(
+                selection: TokenAccountCLISelection(label: nil, index: nil, allAccounts: false),
+                config: config,
+                verbose: false)
+        } catch {
+            return [ProviderPayload(
+                providerID: "cli",
+                account: nil,
+                version: nil,
+                source: "cli",
+                status: nil,
+                usage: nil,
+                credits: nil,
+                antigravityPlanInfo: nil,
+                openaiDashboard: nil,
+                error: Self.makeErrorPayload(error, kind: .config))]
+        }
+
+        let browserDetection = BrowserDetection()
+        let command = UsageCommandContext(
+            format: .json,
+            includeCredits: true,
+            sourceModeOverride: nil,
+            antigravityPlanDebug: false,
+            augmentDebug: false,
+            webDebugDumpHTML: false,
+            webTimeout: 60,
+            verbose: false,
+            useColor: false,
+            resetStyle: Self.resetTimeDisplayStyleFromDefaults(),
+            jsonOnly: true,
+            includeAllCodexAccounts: false,
+            fetcher: UsageFetcher(),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+            browserDetection: browserDetection)
+
+        var output = UsageCommandOutput()
+        for provider in selection.asList {
+            let status = await Self.fetchStatus(for: provider)
+            let providerOutput = await ProviderInteractionContext.$current.withValue(.background) {
+                await Self.fetchUsageOutputs(
+                    provider: provider,
+                    status: status,
+                    tokenContext: tokenContext,
+                    command: command)
+            }
+            output.merge(providerOutput)
+        }
+        return output.payload
+    }
+
+    private static func dashboardCostPayloads(selection: ProviderSelection) async -> [CostPayload] {
+        let providers = Self.costProviders(from: selection)
+        guard !providers.isEmpty else { return [] }
+
+        let fetcher = CostUsageFetcher()
+        var payload: [CostPayload] = []
+        for provider in providers {
+            do {
+                let snapshot = try await fetcher.loadTokenSnapshot(provider: provider, forceRefresh: false)
+                payload.append(Self.makeCostPayload(provider: provider, snapshot: snapshot, error: nil))
+            } catch {
+                payload.append(Self.makeCostPayload(provider: provider, snapshot: nil, error: error))
+            }
+        }
+        return payload
     }
 
     private static func serveProviderSelection(

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -29,6 +29,9 @@ struct ServeOptions: CommanderParsable {
     @Option(name: .long("dashboard-token"), help: "Bearer token for serve data routes")
     var dashboardToken: String?
 
+    @Flag(name: .long("dashboard-pairing"), help: "Enable short-code dashboard pairing")
+    var dashboardPairing: Bool = false
+
     @Option(name: .long("dashboard-identity"), help: "Dashboard identity exposure: none | redacted | full")
     var dashboardIdentity: String?
 }
@@ -38,6 +41,8 @@ enum CLIServeRoute: Equatable {
     case usage(provider: String?)
     case cost(provider: String?)
     case dashboardSnapshot
+    case dashboardPairing
+    case dashboardPairingClaim
 }
 
 enum CLIServeRouteError: Error, Equatable {
@@ -63,6 +68,10 @@ enum CLIServeRouter {
             return .cost(provider: normalizedProvider)
         case "/dashboard/v1/snapshot":
             return .dashboardSnapshot
+        case "/dashboard/v1/pairing":
+            return .dashboardPairing
+        case "/dashboard/v1/pairing/claim":
+            return .dashboardPairingClaim
         default:
             throw CLIServeRouteError.notFound
         }
@@ -271,6 +280,7 @@ extension CodexBarCLI {
         let refreshInterval = Self.decodeServeRefreshInterval(from: values)
         let requestTimeout = Self.decodeServeRequestTimeout(from: values)
         let dashboardToken = Self.decodeDashboardToken(from: values)
+        let dashboardPairingEnabled = Self.decodeDashboardPairingEnabled(from: values)
         let dashboardIdentity = Self.decodeDashboardIdentity(from: values)
 
         guard let port else {
@@ -313,7 +323,7 @@ extension CodexBarCLI {
                 kind: .args)
         }
 
-        if CLIServeSecurity.requiresDashboardToken(host: host), dashboardToken == nil {
+        if CLIServeSecurity.requiresDashboardToken(host: host), dashboardToken == nil, !dashboardPairingEnabled {
             Self.exit(
                 code: .failure,
                 message: CLIServeArgumentError.missingDashboardToken(host).localizedDescription,
@@ -323,7 +333,8 @@ extension CodexBarCLI {
 
         let cache = CLIServeResponseCache()
         let dashboardCache = CLIServeDashboardSnapshotCache()
-        let auth = CLIServeAuth(dashboardToken: dashboardToken)
+        let pairing = dashboardPairingEnabled ? CLIServePairing(announce: { Self.writeStderr($0) }) : nil
+        let auth = CLIServeAuth(dashboardToken: dashboardToken, pairing: pairing)
         let bindHost = CLIServeSecurity.bindHost(host)
         let allowNonLoopbackHostHeaders = !CLIServeSecurity.isLoopbackHost(host)
         let server = CLILocalHTTPServer(
@@ -345,6 +356,9 @@ extension CodexBarCLI {
         do {
             try await server.run {
                 Self.writeStderr("CodexBar server listening on http://\(bindHost):\(port)\n")
+                if let pairing, let code = pairing.currentCode() {
+                    Self.writeStderr("Dashboard pairing code: \(code)\n")
+                }
             }
         } catch {
             Self.exit(code: .failure, message: error.localizedDescription, output: output, kind: .runtime)
@@ -406,6 +420,10 @@ extension CodexBarCLI {
         return token.isEmpty ? nil : token
     }
 
+    static func decodeDashboardPairingEnabled(from values: ParsedValues) -> Bool {
+        values.flags.contains("dashboardPairing")
+    }
+
     static func decodeDashboardIdentity(from values: ParsedValues) -> DashboardIdentityMode? {
         let raw = values.options["dashboardIdentity"]?.last ?? DashboardIdentityMode.redacted.rawValue
         return DashboardIdentityMode(rawValue: raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())
@@ -437,6 +455,26 @@ extension CodexBarCLI {
         switch route {
         case .health:
             return Self.serveJSON(ServeHealthPayload(status: "ok"))
+        case .dashboardPairing:
+            guard let pairing = auth.pairing, let payload = pairing.discoveryPayload() else {
+                return Self.serveError(status: .notFound, message: "pairing unavailable")
+            }
+            return Self.serveJSON(payload)
+        case .dashboardPairingClaim:
+            guard let pairing = auth.pairing else {
+                return Self.serveError(status: .notFound, message: "pairing unavailable")
+            }
+            switch pairing.claim(
+                pairingID: request.queryItems["pairingId"],
+                code: request.queryItems["code"])
+            {
+            case let .claimed(payload):
+                return Self.serveJSON(payload)
+            case .rejected:
+                return Self.serveError(status: .unauthorized, message: "invalid pairing code")
+            case .unavailable:
+                return Self.serveError(status: .notFound, message: "pairing unavailable")
+            }
         case let .usage(provider):
             guard auth.authorizeDataRequest(request) else {
                 return Self.serveError(status: .unauthorized, message: "unauthorized")

--- a/Sources/CodexBarCLI/DashboardPayloads.swift
+++ b/Sources/CodexBarCLI/DashboardPayloads.swift
@@ -1,0 +1,165 @@
+import CodexBarCore
+import Foundation
+
+enum DashboardIdentityMode: String, Equatable, Sendable {
+    case none
+    case redacted
+    case full
+}
+
+struct DashboardSnapshotPayload: Encodable {
+    let schemaVersion: Int
+    let generatedAt: Date
+    let staleAfterSeconds: Int
+    let host: DashboardHostPayload
+    let providers: [DashboardProviderPayload]
+}
+
+struct DashboardHostPayload: Encodable {
+    let codexBarVersion: String?
+    let refreshIntervalSeconds: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case codexBarVersion
+        case refreshIntervalSeconds
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.codexBarVersion, forKey: .codexBarVersion)
+        try container.encode(self.refreshIntervalSeconds, forKey: .refreshIntervalSeconds)
+    }
+}
+
+struct DashboardProviderPayload: Encodable {
+    let id: String
+    let name: String
+    let enabled: Bool
+    let source: String
+    let status: DashboardStatusPayload?
+    let identity: DashboardIdentityPayload?
+    let windows: [DashboardWindowPayload]
+    let credits: DashboardCreditsPayload?
+    let cost: DashboardCostPayload?
+    let display: DashboardDisplayPayload
+    let error: ProviderErrorPayload?
+    let updatedAt: Date?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case enabled
+        case source
+        case status
+        case identity
+        case windows
+        case credits
+        case cost
+        case display
+        case error
+        case updatedAt
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.name, forKey: .name)
+        try container.encode(self.enabled, forKey: .enabled)
+        try container.encode(self.source, forKey: .source)
+        try container.encode(self.status, forKey: .status)
+        try container.encode(self.identity, forKey: .identity)
+        try container.encode(self.windows, forKey: .windows)
+        try container.encode(self.credits, forKey: .credits)
+        try container.encode(self.cost, forKey: .cost)
+        try container.encode(self.display, forKey: .display)
+        try container.encode(self.error, forKey: .error)
+        try container.encode(self.updatedAt, forKey: .updatedAt)
+    }
+}
+
+struct DashboardStatusPayload: Encodable {
+    let level: String
+    let label: String
+    let updatedAt: Date?
+
+    private enum CodingKeys: String, CodingKey {
+        case level
+        case label
+        case updatedAt
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.level, forKey: .level)
+        try container.encode(self.label, forKey: .label)
+        try container.encode(self.updatedAt, forKey: .updatedAt)
+    }
+}
+
+struct DashboardIdentityPayload: Encodable {
+    let accountEmail: String?
+    let plan: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case accountEmail
+        case plan
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.accountEmail, forKey: .accountEmail)
+        try container.encode(self.plan, forKey: .plan)
+    }
+}
+
+struct DashboardWindowPayload: Encodable {
+    let kind: String
+    let label: String
+    let usedPercent: Double
+    let remainingPercent: Double
+    let resetAt: Date?
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case label
+        case usedPercent
+        case remainingPercent
+        case resetAt
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.kind, forKey: .kind)
+        try container.encode(self.label, forKey: .label)
+        try container.encode(self.usedPercent, forKey: .usedPercent)
+        try container.encode(self.remainingPercent, forKey: .remainingPercent)
+        try container.encode(self.resetAt, forKey: .resetAt)
+    }
+}
+
+struct DashboardCreditsPayload: Encodable {
+    let remaining: Double
+    let unit: String
+}
+
+struct DashboardCostPayload: Encodable {
+    let todayUSD: Double?
+    let last30DaysUSD: Double?
+
+    private enum CodingKeys: String, CodingKey {
+        case todayUSD
+        case last30DaysUSD
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.todayUSD, forKey: .todayUSD)
+        try container.encode(self.last30DaysUSD, forKey: .last30DaysUSD)
+    }
+}
+
+struct DashboardDisplayPayload: Encodable {
+    let accentColor: String
+    let sortKey: Int
+    let priority: String
+}

--- a/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
+++ b/Sources/CodexBarCLI/DashboardSnapshotBuilder.swift
@@ -1,0 +1,254 @@
+import CodexBarCore
+import Foundation
+
+enum DashboardSnapshotBuilder {
+    // swiftlint:disable:next function_parameter_count
+    static func makeSnapshot(
+        usagePayloads: [ProviderPayload],
+        costPayloads: [CostPayload],
+        config: CodexBarConfig,
+        identityMode: DashboardIdentityMode,
+        generatedAt: Date,
+        refreshInterval: TimeInterval,
+        codexBarVersion: String?) -> DashboardSnapshotPayload
+    {
+        var costByProvider: [String: CostPayload] = [:]
+        for cost in costPayloads {
+            costByProvider[cost.provider] = cost
+        }
+        let enabledProviders = Set(config.enabledProviders())
+        var sortKeys: [String: Int] = [:]
+        for (index, provider) in config.orderedProviders().enumerated() where sortKeys[provider.rawValue] == nil {
+            sortKeys[provider.rawValue] = index * 10
+        }
+
+        let providers = usagePayloads.enumerated().map { index, payload in
+            self.makeProvider(
+                payload: payload,
+                cost: costByProvider[payload.provider],
+                enabledProviders: enabledProviders,
+                sortKey: sortKeys[payload.provider] ?? (10000 + index),
+                identityMode: identityMode,
+                generatedAt: generatedAt)
+        }
+
+        return DashboardSnapshotPayload(
+            schemaVersion: 1,
+            generatedAt: generatedAt,
+            staleAfterSeconds: max(180, Int(refreshInterval.rounded(.up)) * 3),
+            host: DashboardHostPayload(
+                codexBarVersion: codexBarVersion,
+                refreshIntervalSeconds: max(0, Int(refreshInterval.rounded()))),
+            providers: providers)
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    private static func makeProvider(
+        payload: ProviderPayload,
+        cost: CostPayload?,
+        enabledProviders: Set<UsageProvider>,
+        sortKey: Int,
+        identityMode: DashboardIdentityMode,
+        generatedAt: Date) -> DashboardProviderPayload
+    {
+        let provider = UsageProvider(rawValue: payload.provider)
+        let descriptor = provider.map { ProviderDescriptorRegistry.descriptor(for: $0) }
+        let metadata = descriptor?.metadata
+
+        return DashboardProviderPayload(
+            id: payload.provider,
+            name: metadata?.displayName ?? payload.provider,
+            enabled: provider.map { enabledProviders.contains($0) } ?? true,
+            source: self.dashboardSource(from: payload.source),
+            status: self.makeStatus(payload.status),
+            identity: self.makeIdentity(provider: provider, usage: payload.usage, mode: identityMode),
+            windows: self.makeWindows(provider: provider, metadata: metadata, usage: payload.usage),
+            credits: self.makeCredits(payload.credits),
+            cost: self.makeCost(cost),
+            display: DashboardDisplayPayload(
+                accentColor: self.hexColor(descriptor?.branding.color),
+                sortKey: sortKey,
+                priority: "normal"),
+            error: payload.error,
+            updatedAt: self.updatedAt(
+                usage: payload.usage,
+                credits: payload.credits,
+                cost: cost,
+                error: payload.error,
+                generatedAt: generatedAt))
+    }
+
+    private static func dashboardSource(from source: String) -> String {
+        let trimmed = source.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "unknown" : trimmed
+    }
+
+    private static func makeStatus(_ status: ProviderStatusPayload?) -> DashboardStatusPayload? {
+        guard let status else { return nil }
+        return DashboardStatusPayload(
+            level: self.dashboardStatusLevel(status.indicator),
+            label: status.indicator.label,
+            updatedAt: status.updatedAt)
+    }
+
+    private static func dashboardStatusLevel(_ indicator: ProviderStatusPayload.ProviderStatusIndicator) -> String {
+        switch indicator {
+        case .none:
+            "ok"
+        case .minor, .maintenance:
+            "warning"
+        case .major, .critical:
+            "critical"
+        case .unknown:
+            "unknown"
+        }
+    }
+
+    private static func makeIdentity(
+        provider: UsageProvider?,
+        usage: UsageSnapshot?,
+        mode: DashboardIdentityMode) -> DashboardIdentityPayload?
+    {
+        guard mode != .none,
+              let provider,
+              let identity = usage?.identity(for: provider)
+        else {
+            return nil
+        }
+
+        let email = self.dashboardEmail(identity.accountEmail, mode: mode)
+        let plan = self.dashboardPlan(identity.loginMethod, provider: provider)
+        guard email != nil || plan != nil else { return nil }
+        return DashboardIdentityPayload(accountEmail: email, plan: plan)
+    }
+
+    private static func dashboardEmail(_ email: String?, mode: DashboardIdentityMode) -> String? {
+        guard let email = email?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !email.isEmpty
+        else {
+            return nil
+        }
+        guard mode == .redacted else { return email }
+        guard let at = email.firstIndex(of: "@") else { return "redacted" }
+        return "redacted\(email[at...])"
+    }
+
+    private static func dashboardPlan(_ raw: String?, provider: UsageProvider) -> String? {
+        guard let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty
+        else {
+            return nil
+        }
+
+        if provider == .codex {
+            return CodexPlanFormatting.displayName(raw) ?? UsageFormatter.cleanPlanName(raw)
+        }
+        if provider == .kilo {
+            let firstPlanSegment = raw
+                .components(separatedBy: "·")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .first { !$0.isEmpty && !$0.lowercased().hasPrefix("auto top-up:") }
+            return firstPlanSegment.map(UsageFormatter.cleanPlanName)
+        }
+        return UsageFormatter.cleanPlanName(raw)
+    }
+
+    private static func makeWindows(
+        provider: UsageProvider?,
+        metadata: ProviderMetadata?,
+        usage: UsageSnapshot?) -> [DashboardWindowPayload]
+    {
+        guard let usage else { return [] }
+        let labels = self.rateWindowLabels(provider: provider, metadata: metadata, usage: usage)
+        var windows: [DashboardWindowPayload] = []
+
+        if let primary = usage.primary {
+            windows.append(self.makeWindow(kind: "session", label: labels.primary, window: primary))
+        }
+        if let secondary = usage.secondary {
+            windows.append(self.makeWindow(kind: "weekly", label: labels.secondary, window: secondary))
+        }
+        if let tertiary = usage.tertiary {
+            windows.append(self.makeWindow(kind: "tertiary", label: labels.tertiary, window: tertiary))
+        }
+        for extra in usage.extraRateWindows ?? [] {
+            windows.append(self.makeWindow(kind: extra.id, label: extra.title, window: extra.window))
+        }
+
+        return windows
+    }
+
+    private struct RateWindowLabels {
+        let primary: String
+        let secondary: String
+        let tertiary: String
+    }
+
+    private static func rateWindowLabels(
+        provider: UsageProvider?,
+        metadata: ProviderMetadata?,
+        usage: UsageSnapshot) -> RateWindowLabels
+    {
+        if provider == .factory, usage.tertiary != nil {
+            return RateWindowLabels(primary: "5-hour", secondary: "Weekly", tertiary: "Monthly")
+        }
+
+        return RateWindowLabels(
+            primary: metadata?.sessionLabel ?? "Session",
+            secondary: metadata?.weeklyLabel ?? "Weekly",
+            tertiary: metadata?.opusLabel ?? "Tertiary")
+    }
+
+    private static func makeWindow(kind: String, label: String, window: RateWindow) -> DashboardWindowPayload {
+        let used = self.clampedPercent(window.usedPercent)
+        let remaining = self.clampedPercent(100 - used)
+        return DashboardWindowPayload(
+            kind: kind,
+            label: label,
+            usedPercent: used,
+            remainingPercent: remaining,
+            resetAt: window.resetsAt)
+    }
+
+    private static func clampedPercent(_ value: Double) -> Double {
+        min(100, max(0, value))
+    }
+
+    private static func makeCredits(_ credits: CreditsSnapshot?) -> DashboardCreditsPayload? {
+        guard let credits else { return nil }
+        return DashboardCreditsPayload(remaining: credits.remaining, unit: "credits")
+    }
+
+    private static func makeCost(_ cost: CostPayload?) -> DashboardCostPayload? {
+        guard let cost else { return nil }
+        guard cost.sessionCostUSD != nil || cost.last30DaysCostUSD != nil else { return nil }
+        return DashboardCostPayload(
+            todayUSD: cost.sessionCostUSD,
+            last30DaysUSD: cost.last30DaysCostUSD)
+    }
+
+    private static func updatedAt(
+        usage: UsageSnapshot?,
+        credits: CreditsSnapshot?,
+        cost: CostPayload?,
+        error: ProviderErrorPayload?,
+        generatedAt: Date) -> Date?
+    {
+        if let usage { return usage.updatedAt }
+        if let credits { return credits.updatedAt }
+        if let cost { return cost.updatedAt }
+        return error == nil ? nil : generatedAt
+    }
+
+    private static func hexColor(_ color: ProviderColor?) -> String {
+        guard let color else { return "#6E6E6E" }
+        let red = Int((self.clampedColor(color.red) * 255).rounded())
+        let green = Int((self.clampedColor(color.green) * 255).rounded())
+        let blue = Int((self.clampedColor(color.blue) * 255).rounded())
+        return String(format: "#%02X%02X%02X", red, green, blue)
+    }
+
+    private static func clampedColor(_ value: Double) -> Double {
+        min(1, max(0, value))
+    }
+}

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -1,3 +1,4 @@
+import CodexBarCore
 import Commander
 import Foundation
 import Testing
@@ -35,6 +36,24 @@ struct CLIServeRouterTests {
     }
 
     @Test
+    func `local http parser allows non loopback host only when explicitly enabled`() throws {
+        let raw = "GET /dashboard/v1/snapshot HTTP/1.1\r\nHost: 192.168.1.10:8080\r\n\r\n"
+
+        Self.expectParseFailure(raw: raw, .disallowedHost)
+
+        let request = try CLILocalHTTPRequest.parse(
+            Data(raw.utf8),
+            allowNonLoopbackHost: true).get()
+        #expect(request.host == "192.168.1.10:8080")
+        #expect(request.path == "/dashboard/v1/snapshot")
+
+        Self.expectParseFailure(
+            raw: "GET /usage HTTP/1.1\r\nHost: 192.168.1.10, evil.test\r\n\r\n",
+            .disallowedHost,
+            allowNonLoopbackHost: true)
+    }
+
+    @Test
     func `routes health usage and cost endpoints`() throws {
         #expect(try CLIServeRouter.route(method: "GET", path: "/health", queryItems: [:]) == .health)
         #expect(try CLIServeRouter.route(method: "GET", path: "/usage", queryItems: [:]) == .usage(provider: nil))
@@ -48,6 +67,11 @@ struct CLIServeRouterTests {
                 method: "GET",
                 path: "/cost",
                 queryItems: ["provider": "codex"]) == .cost(provider: "codex"))
+        #expect(
+            try CLIServeRouter.route(
+                method: "GET",
+                path: "/dashboard/v1/snapshot",
+                queryItems: [:]) == .dashboardSnapshot)
     }
 
     @Test
@@ -103,6 +127,10 @@ struct CLIServeRouterTests {
             flags: [])) == nil)
         #expect(CodexBarCLI.decodeServeRefreshInterval(from: ParsedValues(
             positional: [],
+            options: ["refreshInterval": ["1e300"]],
+            flags: [])) == nil)
+        #expect(CodexBarCLI.decodeServeRefreshInterval(from: ParsedValues(
+            positional: [],
             options: [:],
             flags: [])) == 60)
 
@@ -139,6 +167,90 @@ struct CLIServeRouterTests {
     }
 
     @Test
+    func `serve host and dashboard options parse and validate defaults`() {
+        #expect(CodexBarCLI.decodeServeHost(from: ParsedValues(
+            positional: [],
+            options: [:],
+            flags: [])) == "127.0.0.1")
+        #expect(CodexBarCLI.decodeServeHost(from: ParsedValues(
+            positional: [],
+            options: ["host": ["  "]],
+            flags: [])) == nil)
+        #expect(CodexBarCLI.decodeDashboardToken(from: ParsedValues(
+            positional: [],
+            options: ["dashboardToken": [" secret "]],
+            flags: [])) == "secret")
+        #expect(CodexBarCLI.decodeDashboardToken(from: ParsedValues(
+            positional: [],
+            options: ["dashboardToken": [" "]],
+            flags: [])) == nil)
+        #expect(CodexBarCLI.decodeDashboardIdentity(from: ParsedValues(
+            positional: [],
+            options: [:],
+            flags: [])) == .redacted)
+        #expect(CodexBarCLI.decodeDashboardIdentity(from: ParsedValues(
+            positional: [],
+            options: ["dashboardIdentity": ["FULL"]],
+            flags: [])) == .full)
+        #expect(CodexBarCLI.decodeDashboardIdentity(from: ParsedValues(
+            positional: [],
+            options: ["dashboardIdentity": ["invalid"]],
+            flags: [])) == nil)
+
+        #expect(!CLIServeSecurity.requiresDashboardToken(host: "127.0.0.1"))
+        #expect(!CLIServeSecurity.requiresDashboardToken(host: "localhost"))
+        #expect(CLIServeSecurity.requiresDashboardToken(host: "0.0.0.0"))
+        #expect(CLIServeSecurity.requiresDashboardToken(host: "192.168.1.10"))
+    }
+
+    @Test
+    func `request parser captures headers case insensitively`() throws {
+        let raw = [
+            "GET /dashboard/v1/snapshot HTTP/1.1",
+            "Host: localhost",
+            "Authorization: Bearer token",
+            "X-Test: value",
+            "",
+            "",
+        ].joined(separator: "\r\n")
+        let request = try CLILocalHTTPRequest.parse(Data(raw.utf8)).get()
+
+        #expect(request.method == "GET")
+        #expect(request.path == "/dashboard/v1/snapshot")
+        #expect(request.headers["authorization"] == "Bearer token")
+        #expect(request.headers["x-test"] == "value")
+    }
+
+    @Test
+    func `serve auth allows no token and requires matching bearer token when configured`() {
+        let request = CLILocalHTTPRequest(
+            method: "GET",
+            target: "/dashboard/v1/snapshot",
+            host: "localhost",
+            path: "/dashboard/v1/snapshot",
+            queryItems: [:],
+            headers: ["authorization": "Bearer secret"])
+        let missingHeader = CLILocalHTTPRequest(
+            method: "GET",
+            target: "/dashboard/v1/snapshot",
+            host: "localhost",
+            path: "/dashboard/v1/snapshot",
+            queryItems: [:],
+            headers: [:])
+
+        #expect(CLIServeAuth(dashboardToken: nil).authorizeDataRequest(missingHeader))
+        #expect(CLIServeAuth(dashboardToken: "secret").authorizeDataRequest(request))
+        #expect(!CLIServeAuth(dashboardToken: "secret").authorizeDataRequest(missingHeader))
+        #expect(!CLIServeAuth(dashboardToken: "secret").authorizeDataRequest(CLILocalHTTPRequest(
+            method: "GET",
+            target: "/dashboard/v1/snapshot",
+            host: "localhost",
+            path: "/dashboard/v1/snapshot",
+            queryItems: [:],
+            headers: ["authorization": "Bearer wrong"])))
+    }
+
+    @Test
     func `serve cache skips provider error payloads`() {
         let success = CLILocalHTTPResponse(
             status: .ok,
@@ -153,6 +265,69 @@ struct CLIServeRouterTests {
         #expect(CodexBarCLI.shouldCacheServeResponse(success))
         #expect(!CodexBarCLI.shouldCacheServeResponse(providerError))
         #expect(!CodexBarCLI.shouldCacheServeResponse(routeError))
+
+        let dashboardSuccess = CLILocalHTTPResponse(
+            status: .ok,
+            body: Data(#"{"providers":[{"id":"codex","error":null}]}"#.utf8))
+        let dashboardProviderError = CLILocalHTTPResponse(
+            status: .ok,
+            body: Data(#"{"providers":[{"id":"codex","error":{"message":"temporary"}}]}"#.utf8))
+
+        #expect(CodexBarCLI.shouldCacheServeResponse(dashboardSuccess))
+        #expect(CodexBarCLI.shouldCacheServeResponse(dashboardProviderError))
+    }
+
+    @Test
+    func `dashboard snapshot cache keeps stale response while expired`() async {
+        let cache = CLIServeDashboardSnapshotCache()
+        let response = CLILocalHTTPResponse(status: .ok, body: Data(#"{"schemaVersion":1}"#.utf8))
+        let now = Date(timeIntervalSince1970: 100)
+
+        await cache.finishRefresh(response: response, for: "codex", ttl: 10, now: now)
+
+        #expect(await cache.response(for: "codex", now: Date(timeIntervalSince1970: 105))?.body == response.body)
+        #expect(await cache.response(for: "codex", now: Date(timeIntervalSince1970: 111)) == nil)
+        #expect(await cache.staleResponse(for: "codex")?.body == response.body)
+        #expect(await cache.staleResponse(for: "claude") == nil)
+    }
+
+    @Test
+    func `dashboard refreshing snapshot describes enabled providers without fetching`() throws {
+        let config = CodexBarConfig(providers: [
+            ProviderConfig(id: .codex, enabled: true),
+            ProviderConfig(id: .claude, enabled: false),
+        ])
+
+        let snapshot = CodexBarCLI.makeDashboardRefreshingSnapshot(
+            config: config,
+            refreshInterval: 60,
+            identityMode: .redacted)
+        let json = try #require(CodexBarCLI.encodeJSON(snapshot, pretty: false))
+        let data = try #require(json.data(using: .utf8))
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let providers = try #require(object["providers"] as? [[String: Any]])
+        let provider = try #require(providers.first)
+        let error = try #require(provider["error"] as? [String: Any])
+
+        #expect(providers.count == 1)
+        #expect(provider["id"] as? String == "codex")
+        #expect(provider["source"] as? String == "refreshing")
+        #expect(error["message"] as? String == "refreshing")
+    }
+
+    @Test
+    func `serve config cache key follows enabled provider set`() {
+        let initial = CodexBarConfig(providers: [
+            ProviderConfig(id: .codex, enabled: true),
+            ProviderConfig(id: .claude, enabled: false),
+        ])
+        let changed = CodexBarConfig(providers: [
+            ProviderConfig(id: .codex, enabled: true),
+            ProviderConfig(id: .claude, enabled: true),
+        ])
+
+        #expect(CodexBarCLI.serveConfigCacheKey(initial) == "codex")
+        #expect(CodexBarCLI.serveConfigCacheKey(changed) == "codex,claude")
     }
 
     @Test
@@ -293,8 +468,12 @@ struct CLIServeRouterTests {
         return try CLILocalHTTPRequest.parse(Data(raw.utf8)).get()
     }
 
-    private static func expectParseFailure(raw: String, _ expected: CLILocalHTTPRequestParseError) {
-        switch CLILocalHTTPRequest.parse(Data(raw.utf8)) {
+    private static func expectParseFailure(
+        raw: String,
+        _ expected: CLILocalHTTPRequestParseError,
+        allowNonLoopbackHost: Bool = false)
+    {
+        switch CLILocalHTTPRequest.parse(Data(raw.utf8), allowNonLoopbackHost: allowNonLoopbackHost) {
         case .success:
             Issue.record("Expected \(expected)")
         case let .failure(error):

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -72,6 +72,16 @@ struct CLIServeRouterTests {
                 method: "GET",
                 path: "/dashboard/v1/snapshot",
                 queryItems: [:]) == .dashboardSnapshot)
+        #expect(
+            try CLIServeRouter.route(
+                method: "GET",
+                path: "/dashboard/v1/pairing",
+                queryItems: [:]) == .dashboardPairing)
+        #expect(
+            try CLIServeRouter.route(
+                method: "GET",
+                path: "/dashboard/v1/pairing/claim",
+                queryItems: [:]) == .dashboardPairingClaim)
     }
 
     @Test
@@ -184,6 +194,14 @@ struct CLIServeRouterTests {
             positional: [],
             options: ["dashboardToken": [" "]],
             flags: [])) == nil)
+        #expect(!CodexBarCLI.decodeDashboardPairingEnabled(from: ParsedValues(
+            positional: [],
+            options: [:],
+            flags: [])))
+        #expect(CodexBarCLI.decodeDashboardPairingEnabled(from: ParsedValues(
+            positional: [],
+            options: [:],
+            flags: ["dashboardPairing"])))
         #expect(CodexBarCLI.decodeDashboardIdentity(from: ParsedValues(
             positional: [],
             options: [:],
@@ -248,6 +266,107 @@ struct CLIServeRouterTests {
             path: "/dashboard/v1/snapshot",
             queryItems: [:],
             headers: ["authorization": "Bearer wrong"])))
+    }
+
+    @Test
+    func `serve pairing keeps code off the wire and authorizes claimed token`() throws {
+        let pairing = CLIServePairing()
+
+        let discovery = try #require(pairing.discoveryPayload())
+        let code = try #require(pairing.currentCode())
+        #expect(discovery.service == "codexbar-dashboard")
+        #expect(discovery.auth.type == "code")
+        #expect(discovery.auth.codeLength == CLIServePairing.codeLength)
+        #expect(discovery.auth.expiresInSeconds == 0)
+        #expect(code.count == CLIServePairing.codeLength)
+        let codeIsNumeric = code.allSatisfy(\.isNumber)
+        #expect(codeIsNumeric)
+
+        let outcome = pairing.claim(pairingID: discovery.auth.pairingId, code: code)
+        guard case let .claimed(claim) = outcome else {
+            Issue.record("expected claim to succeed")
+            return
+        }
+        #expect(claim.endpoint == "/dashboard/v1/snapshot")
+        #expect(!claim.token.isEmpty)
+
+        let request = CLILocalHTTPRequest(
+            method: "GET",
+            target: "/dashboard/v1/snapshot",
+            host: "localhost",
+            path: "/dashboard/v1/snapshot",
+            queryItems: [:],
+            headers: ["authorization": "Bearer \(claim.token)"])
+        #expect(CLIServeAuth(dashboardToken: nil, pairing: pairing).authorizeDataRequest(request))
+    }
+
+    @Test
+    func `serve pairing token does not authorize before claim`() {
+        let pairing = CLIServePairing()
+        let request = CLILocalHTTPRequest(
+            method: "GET",
+            target: "/dashboard/v1/snapshot",
+            host: "localhost",
+            path: "/dashboard/v1/snapshot",
+            queryItems: [:],
+            headers: ["authorization": "Bearer anything"])
+        #expect(!CLIServeAuth(dashboardToken: nil, pairing: pairing).authorizeDataRequest(request))
+    }
+
+    @Test
+    func `serve pairing survives a mistyped code and accepts separators`() throws {
+        let pairing = CLIServePairing()
+
+        let discovery = try #require(pairing.discoveryPayload())
+        let code = try #require(pairing.currentCode())
+
+        // A wrong code counts an attempt but keeps the same challenge,
+        // so a user who mistypes can simply retry the displayed code.
+        let wrongCode = code == "000000" ? "000001" : "000000"
+        guard case .rejected = pairing.claim(pairingID: discovery.auth.pairingId, code: wrongCode) else {
+            Issue.record("expected wrong claim to be rejected")
+            return
+        }
+        #expect(pairing.currentCode() == code)
+
+        // Separators copied from grouped console output are ignored.
+        let middle = code.index(code.startIndex, offsetBy: 3)
+        let grouped = "\(code[..<middle]) \(code[middle...])"
+        guard case .claimed = pairing.claim(pairingID: discovery.auth.pairingId, code: grouped) else {
+            Issue.record("expected grouped-code claim to succeed")
+            return
+        }
+    }
+
+    @Test
+    func `serve pairing locks after repeated wrong claims and closes after success`() throws {
+        let pairing = CLIServePairing()
+        let discovery = try #require(pairing.discoveryPayload())
+        let code = try #require(pairing.currentCode())
+        let wrongCode = code == "000000" ? "000001" : "000000"
+        for _ in 0..<CLIServePairing.maxFailedAttempts {
+            _ = pairing.claim(pairingID: discovery.auth.pairingId, code: wrongCode)
+        }
+        #expect(pairing.discoveryPayload() == nil)
+        #expect(pairing.currentCode() == nil)
+        guard case .unavailable = pairing.claim(pairingID: discovery.auth.pairingId, code: code) else {
+            Issue.record("expected locked pairing to be unavailable")
+            return
+        }
+
+        let paired = CLIServePairing()
+        let pairedDiscovery = try #require(paired.discoveryPayload())
+        let pairedCode = try #require(paired.currentCode())
+        guard case .claimed = paired.claim(pairingID: pairedDiscovery.auth.pairingId, code: pairedCode) else {
+            Issue.record("expected claim to succeed")
+            return
+        }
+        #expect(paired.discoveryPayload() == nil)
+        guard case .unavailable = paired.claim(pairingID: pairedDiscovery.auth.pairingId, code: pairedCode)
+        else {
+            Issue.record("expected second claim to be unavailable")
+            return
+        }
     }
 
     @Test

--- a/Tests/CodexBarTests/DashboardSnapshotBuilderTests.swift
+++ b/Tests/CodexBarTests/DashboardSnapshotBuilderTests.swift
@@ -1,0 +1,194 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBarCLI
+
+struct DashboardSnapshotBuilderTests {
+    @Test
+    func `builds stable display-oriented dashboard snapshot`() throws {
+        let generatedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let updatedAt = Date(timeIntervalSince1970: 1_800_000_010)
+        let resetAt = Date(timeIntervalSince1970: 1_800_003_600)
+        let usage = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 28,
+                windowMinutes: 300,
+                resetsAt: resetAt,
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 59,
+                windowMinutes: 10080,
+                resetsAt: nil,
+                resetDescription: nil),
+            tertiary: nil,
+            updatedAt: updatedAt,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "user@example.com",
+                accountOrganization: nil,
+                loginMethod: "pro"))
+
+        let payload = ProviderPayload(
+            provider: .codex,
+            account: nil,
+            version: nil,
+            source: "oauth",
+            status: ProviderStatusPayload(
+                indicator: .none,
+                description: "Operational",
+                updatedAt: updatedAt,
+                url: "https://status.example.com"),
+            usage: usage,
+            credits: CreditsSnapshot(remaining: 112.4, events: [], updatedAt: updatedAt),
+            antigravityPlanInfo: nil,
+            openaiDashboard: nil,
+            error: nil)
+        let cost = CostPayload(
+            provider: "codex",
+            source: "local",
+            updatedAt: updatedAt,
+            sessionTokens: 1000,
+            sessionCostUSD: 1.04,
+            historyDays: 30,
+            last30DaysTokens: 30000,
+            last30DaysCostUSD: 18.22,
+            daily: [],
+            totals: nil,
+            error: nil)
+        let config = CodexBarConfig(providers: [
+            ProviderConfig(id: .codex, enabled: true),
+            ProviderConfig(id: .claude, enabled: false),
+        ])
+
+        let snapshot = DashboardSnapshotBuilder.makeSnapshot(
+            usagePayloads: [payload],
+            costPayloads: [cost],
+            config: config,
+            identityMode: .redacted,
+            generatedAt: generatedAt,
+            refreshInterval: 60,
+            codexBarVersion: "9.8.7")
+        let object = try self.jsonObject(snapshot)
+        let provider = try #require((object["providers"] as? [[String: Any]])?.first)
+        let host = try #require(object["host"] as? [String: Any])
+        let identity = try #require(provider["identity"] as? [String: Any])
+        let status = try #require(provider["status"] as? [String: Any])
+        let windows = try #require(provider["windows"] as? [[String: Any]])
+        let credits = try #require(provider["credits"] as? [String: Any])
+        let costObject = try #require(provider["cost"] as? [String: Any])
+        let display = try #require(provider["display"] as? [String: Any])
+
+        #expect(object["schemaVersion"] as? Int == 1)
+        #expect(object["staleAfterSeconds"] as? Int == 180)
+        #expect(host["codexBarVersion"] as? String == "9.8.7")
+        #expect(host["refreshIntervalSeconds"] as? Int == 60)
+
+        #expect(provider["id"] as? String == "codex")
+        #expect(provider["name"] as? String == "Codex")
+        #expect(provider["enabled"] as? Bool == true)
+        #expect(provider["source"] as? String == "oauth")
+        #expect(provider["error"] is NSNull)
+        #expect(provider["updatedAt"] as? String == "2027-01-15T08:00:10Z")
+
+        #expect(status["level"] as? String == "ok")
+        #expect(status["label"] as? String == "Operational")
+        #expect(identity["accountEmail"] as? String == "redacted@example.com")
+        #expect(identity["plan"] as? String == "Pro 20x")
+
+        #expect(windows.count == 2)
+        #expect(windows[0]["kind"] as? String == "session")
+        #expect(windows[0]["label"] as? String == "Session")
+        #expect(windows[0]["usedPercent"] as? Double == 28)
+        #expect(windows[0]["remainingPercent"] as? Double == 72)
+        #expect(windows[0]["resetAt"] as? String == "2027-01-15T09:00:00Z")
+        #expect(windows[1]["kind"] as? String == "weekly")
+        #expect(windows[1]["label"] as? String == "Weekly")
+
+        #expect(credits["remaining"] as? Double == 112.4)
+        #expect(credits["unit"] as? String == "credits")
+        #expect(costObject["todayUSD"] as? Double == 1.04)
+        #expect(costObject["last30DaysUSD"] as? Double == 18.22)
+        #expect(display["accentColor"] as? String == "#49A3B0")
+        #expect(display["sortKey"] as? Int == 0)
+        #expect(display["priority"] as? String == "normal")
+    }
+
+    @Test
+    func `dashboard identity mode none emits null identity`() throws {
+        let usage = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: Date(timeIntervalSince1970: 0),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "user@example.com",
+                accountOrganization: nil,
+                loginMethod: "pro"))
+        let payload = ProviderPayload(
+            provider: .claude,
+            account: nil,
+            version: nil,
+            source: "web",
+            status: nil,
+            usage: usage,
+            credits: nil,
+            antigravityPlanInfo: nil,
+            openaiDashboard: nil,
+            error: nil)
+
+        let snapshot = DashboardSnapshotBuilder.makeSnapshot(
+            usagePayloads: [payload],
+            costPayloads: [],
+            config: CodexBarConfig(providers: [ProviderConfig(id: .claude, enabled: true)]),
+            identityMode: .none,
+            generatedAt: Date(timeIntervalSince1970: 0),
+            refreshInterval: 60,
+            codexBarVersion: nil)
+        let object = try self.jsonObject(snapshot)
+        let provider = try #require((object["providers"] as? [[String: Any]])?.first)
+
+        #expect(provider["identity"] is NSNull)
+        #expect(provider["status"] is NSNull)
+        #expect(provider["credits"] is NSNull)
+        #expect(provider["cost"] is NSNull)
+    }
+
+    @Test
+    func `dashboard provider errors are projected without raw usage internals`() throws {
+        let payload = ProviderPayload(
+            provider: .codex,
+            account: nil,
+            version: nil,
+            source: "auto",
+            status: nil,
+            usage: nil,
+            credits: nil,
+            antigravityPlanInfo: nil,
+            openaiDashboard: nil,
+            error: ProviderErrorPayload(code: 1, message: "temporary failure", kind: .provider))
+
+        let snapshot = DashboardSnapshotBuilder.makeSnapshot(
+            usagePayloads: [payload],
+            costPayloads: [],
+            config: CodexBarConfig(providers: [ProviderConfig(id: .codex, enabled: true)]),
+            identityMode: .redacted,
+            generatedAt: Date(timeIntervalSince1970: 0),
+            refreshInterval: 60,
+            codexBarVersion: nil)
+        let object = try self.jsonObject(snapshot)
+        let provider = try #require((object["providers"] as? [[String: Any]])?.first)
+        let error = try #require(provider["error"] as? [String: Any])
+
+        #expect((provider["windows"] as? [Any])?.isEmpty == true)
+        #expect(error["message"] as? String == "temporary failure")
+        #expect(provider["usage"] == nil)
+        #expect(provider["openaiDashboard"] == nil)
+    }
+
+    private func jsonObject(_ payload: some Encodable) throws -> [String: Any] {
+        let json = try #require(CodexBarCLI.encodeJSON(payload, pretty: false))
+        let data = try #require(json.data(using: .utf8))
+        return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,12 +44,22 @@ See `docs/configuration.md` for the schema.
 - `codexbar cost` prints local token cost usage for Claude + Codex without web/CLI access.
   - `--format text|json` (default: text).
   - `--refresh` ignores cached scans.
-- `codexbar serve` starts a foreground localhost-only HTTP server for usage and cost JSON.
+- `codexbar serve` starts a foreground HTTP server for usage, cost, and dashboard JSON.
+  - `--host <host>` defaults to `127.0.0.1`. The default remains localhost-only.
   - `--port <port>` defaults to `8080`.
   - `--refresh-interval <seconds>` defaults to `60` and controls the in-memory response cache TTL.
   - `--request-timeout <seconds>` defaults to `30` and bounds each request before returning `504 Gateway Timeout`; use `0` to keep waiting indefinitely.
-  - v1 binds to `127.0.0.1` only and rejects non-loopback `Host` headers. It does not expose remote bind, auth, CORS, TLS, or daemon mode.
-  - Endpoints: `GET /health`, `GET /usage`, `GET /usage?provider=<id|both|all>`, `GET /cost`, `GET /cost?provider=<id|both|all>`.
+  - `--dashboard-token <token>` enables bearer auth for serve data routes. Non-loopback hosts, such as
+    `0.0.0.0` or a LAN address, require this token.
+  - `--dashboard-identity none|redacted|full` controls identity fields in dashboard payloads. The default is
+    `redacted`, which redacts account email local parts while still showing plan labels.
+    `none` omits identity, `redacted` preserves email domains only, and `full` includes full account emails.
+  - Auth uses `Authorization: Bearer YOUR_TOKEN` for data routes (`/usage`, `/cost`, and `/dashboard/v1/snapshot`)
+    when a token is configured. `/health` remains unauthenticated.
+  - The default localhost mode rejects non-loopback `Host` headers. Non-loopback bind hosts opt into LAN `Host`
+    headers only when `--dashboard-token` is configured.
+  - No CORS, TLS, or daemon mode is provided.
+  - Endpoints: `GET /health`, `GET /usage`, `GET /usage?provider=<id|both|all>`, `GET /cost`, `GET /cost?provider=<id|both|all>`, `GET /dashboard/v1/snapshot`.
   - Codex usage responses include every visible Codex account, matching the menu bar switcher.
 - `codexbar cache clear` clears local CodexBar caches.
   - `--cookies` removes cached browser-cookie headers from the CodexBar Keychain cache.
@@ -110,6 +120,22 @@ payloads include the visible account label in `account`.
 - `daily[]`: `date`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `totalTokens`, `totalCost`, `modelsUsed`, `modelBreakdowns[]` (`modelName`, `cost`)
 - `totals`: `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheCreationTokens`, `totalTokens`, `totalCost`
 
+### Dashboard snapshot payload
+`GET /dashboard/v1/snapshot` emits a stable display-oriented object instead of raw CLI provider models.
+- Top level: `schemaVersion`, `generatedAt`, `staleAfterSeconds`, `host`, `providers`.
+- `host`: `codexBarVersion`, `refreshIntervalSeconds`.
+- Each provider: `id`, `name`, `enabled`, `source`, `status`, `identity`, `windows`, `credits`, `cost`, `display`, `error`, `updatedAt`.
+- `windows[]`: `kind`, `label`, `usedPercent`, `remainingPercent`, `resetAt`.
+- `display`: `accentColor`, `sortKey`, `priority`.
+
+LAN serving requires an explicit host and dashboard token:
+
+```
+codexbar serve --host 0.0.0.0 --port 8080 --dashboard-token "$CODEXBAR_DASHBOARD_TOKEN"
+curl -H "Authorization: Bearer $CODEXBAR_DASHBOARD_TOKEN" \
+  http://127.0.0.1:8080/dashboard/v1/snapshot
+```
+
 ## Example usage
 ```
 codexbar                          # text, respects app toggles
@@ -122,6 +148,7 @@ codexbar cost --days 90           # choose a 1...365 day cost window
 codexbar cost --provider claude --format json --pretty
 codexbar serve --port 8080        # localhost HTTP JSON server
 codexbar serve --request-timeout 0 # disable serve request deadlines
+codexbar serve --host 0.0.0.0 --dashboard-token "$CODEXBAR_DASHBOARD_TOKEN"
 COPILOT_API_TOKEN=... codexbar --provider copilot --format json --pretty
 codexbar --status                 # include status page indicator/description
 codexbar --provider codex --source oauth --format json --pretty

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -1,0 +1,100 @@
+# Dashboard Snapshot API
+
+`codexbar serve` exposes a versioned dashboard snapshot for clients that need a compact, display-oriented view of CodexBar usage data.
+
+```text
+GET /dashboard/v1/snapshot
+```
+
+The endpoint is available from the foreground HTTP server started by `codexbar serve`. The default bind host remains `127.0.0.1`. Serving on a non-loopback host requires `--dashboard-token`, and data routes require `Authorization: Bearer YOUR_TOKEN` when a token is configured. `/health` remains unauthenticated.
+
+Identity exposure is controlled with:
+
+```text
+--dashboard-identity none|redacted|full
+```
+
+The default is `redacted`.
+
+Identity modes:
+
+- `none`: omit the `identity` object entirely.
+- `redacted`: include non-secret plan labels and redact account email local parts while preserving domains, for example `redacted@example.com`. Addresses without a domain become `redacted`.
+- `full`: include the full account email and plan label.
+
+## Payload
+
+The snapshot is a stable display contract, not a raw dump of provider internals.
+
+```json
+{
+  "schemaVersion": 1,
+  "generatedAt": "2026-05-16T12:00:00Z",
+  "staleAfterSeconds": 180,
+  "host": {
+    "codexBarVersion": "0.17.0",
+    "refreshIntervalSeconds": 60
+  },
+  "providers": [
+    {
+      "id": "codex",
+      "name": "Codex",
+      "enabled": true,
+      "source": "oauth",
+      "status": {
+        "level": "ok",
+        "label": "Operational",
+        "updatedAt": "2026-05-16T11:59:00Z"
+      },
+      "identity": {
+        "accountEmail": "redacted@example.com",
+        "plan": "Plus"
+      },
+      "windows": [
+        {
+          "kind": "session",
+          "label": "Session",
+          "usedPercent": 28,
+          "remainingPercent": 72,
+          "resetAt": "2026-05-16T17:15:00Z"
+        }
+      ],
+      "credits": {
+        "remaining": 112.4,
+        "unit": "credits"
+      },
+      "cost": {
+        "todayUSD": 1.04,
+        "last30DaysUSD": 18.22
+      },
+      "display": {
+        "accentColor": "#6E5AFF",
+        "sortKey": 10,
+        "priority": "normal"
+      },
+      "error": null,
+      "updatedAt": "2026-05-16T11:59:45Z"
+    }
+  ]
+}
+```
+
+## Fields
+
+- `schemaVersion`: Dashboard API schema version.
+- `generatedAt`: Snapshot generation timestamp.
+- `staleAfterSeconds`: Client-side staleness hint.
+- `host.codexBarVersion`: CodexBar version when available.
+- `host.refreshIntervalSeconds`: Server response cache interval.
+- `providers[].id`: Provider identifier.
+- `providers[].name`: Provider display name.
+- `providers[].enabled`: Whether the provider is enabled in CodexBar config.
+- `providers[].source`: Source used for the provider data.
+- `providers[].status`: Provider service status when available.
+- `providers[].identity`: Account and plan identity according to the configured identity mode.
+- `providers[].windows`: Session, weekly, tertiary, or provider-specific rate windows.
+- `providers[].credits`: Remaining credits or balance when available.
+- `providers[].cost`: Local cost data when available.
+- `providers[].display`: UI hints for ordering and coloring.
+- `providers[].error`: Provider error payload when the latest fetch failed.
+- `providers[].updatedAt`: Best-known update timestamp for the provider row.

--- a/docs/dashboard-api.md
+++ b/docs/dashboard-api.md
@@ -6,7 +6,63 @@
 GET /dashboard/v1/snapshot
 ```
 
-The endpoint is available from the foreground HTTP server started by `codexbar serve`. The default bind host remains `127.0.0.1`. Serving on a non-loopback host requires `--dashboard-token`, and data routes require `Authorization: Bearer YOUR_TOKEN` when a token is configured. `/health` remains unauthenticated.
+The endpoint is available from the foreground HTTP server started by `codexbar serve`. The default bind host remains `127.0.0.1`. Serving on a non-loopback host requires `--dashboard-token` or `--dashboard-pairing`, and data routes require `Authorization: Bearer YOUR_TOKEN` when a token is configured. `/health` remains unauthenticated.
+
+## Pairing
+
+For keyboard-limited dashboard clients, start the server with:
+
+```text
+codexbar serve --host 0.0.0.0 --dashboard-pairing
+```
+
+The server prints a one-time numeric pairing code (6 digits). The code itself is never sent over the network; clients only learn its length. Clients can discover the challenge with:
+
+```text
+GET /dashboard/v1/pairing
+```
+
+Example response:
+
+```json
+{
+  "schemaVersion": 1,
+  "service": "codexbar-dashboard",
+  "auth": {
+    "type": "code",
+    "pairingId": "9F7A...",
+    "codeLength": 6,
+    "expiresInSeconds": 0
+  }
+}
+```
+
+`expiresInSeconds: 0` means the pairing code does not expire on a timer; it stays valid until claimed, locked out, or the foreground `codexbar serve` process exits.
+
+The client prompts the user to enter the code shown next to the server (a numeric keypad is enough), then claims a generated bearer token. Separators in the code (spaces, dashes) are ignored:
+
+```text
+GET /dashboard/v1/pairing/claim?pairingId=9F7A...&code=481273
+```
+
+Successful claims return:
+
+```json
+{
+  "schemaVersion": 1,
+  "token": "generated-bearer-token",
+  "endpoint": "/dashboard/v1/snapshot"
+}
+```
+
+Persist the token client-side and use it as `Authorization: Bearer generated-bearer-token` for snapshot requests.
+
+Pairing is guarded against guessing:
+
+- The code has one million possible values and is only ever displayed on the server console, so a network observer learns nothing from discovery.
+- After 5 failed claims, pairing locks until the server restarts (worst-case online guess probability 5 in 1,000,000). Discovery and claim both return `404` while locked.
+- A successful claim closes pairing: discovery stops advertising, further claims return `404`, and only the claimed token authorizes data routes. Restart the server to pair another client.
+- Pairing tokens never authorize data routes before they are claimed.
 
 Identity exposure is controlled with:
 


### PR DESCRIPTION
Summary
- Add a typed dashboard snapshot payload for CodexBar provider, session, account, and app state.
- Extend `codexbar serve` with a token-protected dashboard snapshot endpoint.
- Add configurable dashboard identity exposure modes:
  - `none`: omit account identity fields
  - `redacted`: redact sensitive identity values while preserving useful account context such as domains/plans
  - `full`: include full identity values for trusted local/private deployments
- Add opt-in `--dashboard-pairing` for keyboard-light clients: the server prints a one-time 6-digit code that is entered on the client to claim a generated bearer token.
- Document the dashboard API, authentication behavior, CLI flags, identity modes, pairing flow, and example requests.

Rationale
- This lets CodexBar act as the local source of truth for lightweight dashboard hardware.
- Low-powered clients can fetch a compact, already-normalized snapshot instead of reimplementing provider probing, account parsing, session tracking, privacy policy, and auth logic themselves.
- Keeping the aggregation in CodexBar also avoids duplicating sensitive provider/account handling across small devices or local display projects.

Pairing security model (revised per review)
- The previous three-choice pairing flow was correctly flagged as guessable (review: ~87% success probability within the attempt budget). It has been replaced.
- The pairing code now never travels over the network. Discovery advertises only `auth.type: "code"` and `codeLength`; the 6-digit code is printed exclusively on the server console.
- Online guessing budget: 5 failed claims lock pairing until the process restarts, so worst-case guess probability is 5 in 1,000,000.
- A successful claim closes pairing entirely: discovery returns 404, further claims return 404, and only the claimed token authorizes data routes.
- Pairing tokens never authorize data routes before they are claimed.
- Pairing remains opt-in via `--dashboard-pairing`; token-only LAN serving via `--dashboard-token` is unchanged and remains the default requirement for non-loopback hosts.

Implementation notes
- Adds dashboard payload models and snapshot aggregation logic.
- Adds bearer-token authentication for dashboard API requests.
- Keeps protected dashboard responses unavailable without a valid token.
- Covers payload construction, identity redaction, routing, auth handling, pairing lifecycle (claim, lockout, closure, pre-claim denial), and endpoint behavior with tests.
- Uses inert placeholder tokens in docs/examples instead of real or secret-looking credentials.

Live behavior proof (redacted)
- Built `CodexBarCLI` from this branch on Ubuntu 24.04 (Swift 6.2.1, same toolchain as CI) and exercised the full pairing lifecycle against the running server.

Server startup:

```text
$ CodexBarCLI serve --host 0.0.0.0 --port 8085 --dashboard-pairing
CodexBar server listening on http://0.0.0.0:8085
Dashboard pairing code: 5•••••
```

Discovery does not expose the code:

```text
$ curl http://127.0.0.1:8085/dashboard/v1/pairing
{"schemaVersion":1,"service":"codexbar-dashboard","auth":{"expiresInSeconds":0,"type":"code","codeLength":6,"pairingId":"CF23BC8C-…"}}
```

Wrong code is rejected; unauthorized snapshot is denied:

```text
$ curl -w "\nHTTP %{http_code}\n" ".../pairing/claim?pairingId=CF23BC8C-…&code=000000"
{"error":"invalid pairing code"}
HTTP 401

$ curl -w "\nHTTP %{http_code}\n" http://127.0.0.1:8085/dashboard/v1/snapshot
{"error":"unauthorized"}
HTTP 401
```

Correct code claims a token, pairing closes, token authorizes:

```text
$ curl ".../pairing/claim?pairingId=CF23BC8C-…&code=5•••••"
{"schemaVersion":1,"endpoint":"/dashboard/v1/snapshot","token":"80f93c5d…[redacted]"}

$ curl -w "\nHTTP %{http_code}\n" http://127.0.0.1:8085/dashboard/v1/pairing
{"error":"pairing unavailable"}
HTTP 404

$ curl -H "Authorization: Bearer 80f93c5d…[redacted]" http://127.0.0.1:8085/dashboard/v1/snapshot
{"schemaVersion":1,"providers":[{"updatedAt":"2026-06-10T01:02:33Z","name":"Codex","id":"codex", … }]}   (HTTP 200)
```

Server log across the session:

```text
CodexBar server listening on http://0.0.0.0:8085
Dashboard pairing code: 5•••••
Pairing attempt rejected (1/5).
Dashboard paired. Pairing is now closed.
```

Commands run
- `swift build --product CodexBarCLI` (Linux, Swift 6.2.1): builds clean.
- `swift test --parallel` (Linux, via CI `build-linux-cli` jobs on both x64 and arm64): passed, including the new pairing lifecycle tests.
- macOS `lint-build-test` CI job: SwiftFormat/SwiftLint clean, build and tests on the latest head.
- `git diff --check upstream/main...HEAD`: passed.

Screenshots/GIFs
- Not applicable; this is CLI/API behavior with no UI changes. Live request/response transcripts are included above.

Reference
- No linked issue.

Contribution notes
- No `CONTRIBUTING.md` or pull request template was found.
- Followed repository guidance from `AGENTS.md`.
- Branch is rebased onto upstream `main` at `a4f278d9`.
- Published branch contains four scoped commits:
  - `docs: add dashboard snapshot API reference`
  - `feat(cli): add dashboard snapshot payload builder`
  - `feat(cli): serve token-protected dashboard snapshots`
  - `feat(dashboard): add code-based pairing`
