### PR TITLE
fix(ui): collapse duplicate utilization tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Permissions: notify when a provider probe detects a macOS/browser permission prompt waiting for user action (#456).
 
 ### Fixed
+- Codex: collapse near-duplicate session and weekly plan-utilization history windows so charts no longer show repeated tabs (#1027). Thanks @ngutman!
 - Multi-account menus: fetch stacked Codex/token-account usage concurrently so account switchers stay responsive with many accounts (#1011).
 
 ## 0.27.0 — 2026-05-17

--- a/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
@@ -184,13 +184,28 @@ struct PlanUtilizationHistoryChartMenuView: View {
     {
         let metadata = ProviderDescriptorRegistry.metadata[provider]
         let allowedNames = self.visibleSeriesNames(provider: provider, snapshot: snapshot)
-        return histories
-            .filter { history in
-                guard !history.entries.isEmpty else { return false }
-                guard history.windowMinutes > 0 else { return false }
-                guard let allowedNames else { return true }
-                return allowedNames.contains(history.name)
+        var historiesBySelection: [SeriesSelection: PlanUtilizationSeriesHistory] = [:]
+        for history in histories {
+            guard !history.entries.isEmpty else { continue }
+            guard history.windowMinutes > 0 else { continue }
+            guard allowedNames?.contains(history.name) ?? true else { continue }
+
+            let canonicalWindowMinutes = history.name.canonicalWindowMinutes(history.windowMinutes)
+            let selection = SeriesSelection(name: history.name, windowMinutes: canonicalWindowMinutes)
+            if let existingHistory = historiesBySelection[selection] {
+                historiesBySelection[selection] = PlanUtilizationSeriesHistory(
+                    name: history.name,
+                    windowMinutes: canonicalWindowMinutes,
+                    entries: Self.mergedEntries(existingHistory.entries + history.entries))
+            } else {
+                historiesBySelection[selection] = PlanUtilizationSeriesHistory(
+                    name: history.name,
+                    windowMinutes: canonicalWindowMinutes,
+                    entries: history.entries)
             }
+        }
+
+        return historiesBySelection.values
             .sorted { lhs, rhs in
                 let lhsOrder = self.seriesSortOrder(lhs.name)
                 let rhsOrder = self.seriesSortOrder(rhs.name)
@@ -208,6 +223,15 @@ struct PlanUtilizationHistoryChartMenuView: View {
                     title: self.seriesTitle(name: history.name, metadata: metadata),
                     history: history)
             }
+    }
+
+    private nonisolated static func mergedEntries(
+        _ entries: [PlanUtilizationHistoryEntry]) -> [PlanUtilizationHistoryEntry]
+    {
+        entries.reduce(into: []) { result, entry in
+            guard !result.contains(entry) else { return }
+            result.append(entry)
+        }
     }
 
     private nonisolated static func visibleSeriesNames(

--- a/Sources/CodexBar/PlanUtilizationHistoryStore.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryStore.swift
@@ -15,6 +15,17 @@ struct PlanUtilizationSeriesName: RawRepresentable, Hashable, Codable, Expressib
     static let session: Self = "session"
     static let weekly: Self = "weekly"
     static let opus: Self = "opus"
+
+    func canonicalWindowMinutes(_ windowMinutes: Int) -> Int {
+        switch self {
+        case .session where (295...305).contains(windowMinutes):
+            300
+        case .weekly where (10070...10090).contains(windowMinutes):
+            10080
+        default:
+            windowMinutes
+        }
+    }
 }
 
 struct PlanUtilizationHistoryEntry: Codable, Equatable {

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -128,13 +128,30 @@ extension UsageStore {
     {
         guard !samples.isEmpty else { return nil }
 
-        var historiesByKey = Dictionary(uniqueKeysWithValues: existingHistories.map {
-            (PlanUtilizationSeriesKey(name: $0.name, windowMinutes: $0.windowMinutes), $0)
-        })
+        var historiesByKey: [PlanUtilizationSeriesKey: PlanUtilizationSeriesHistory] = [:]
         var didChange = false
+        for history in existingHistories {
+            let canonicalWindowMinutes = history.name.canonicalWindowMinutes(history.windowMinutes)
+            let key = PlanUtilizationSeriesKey(name: history.name, windowMinutes: canonicalWindowMinutes)
+            let canonicalHistory = PlanUtilizationSeriesHistory(
+                name: history.name,
+                windowMinutes: canonicalWindowMinutes,
+                entries: history.entries)
+            if let existingHistory = historiesByKey[key] {
+                historiesByKey[key] = PlanUtilizationSeriesHistory(
+                    name: history.name,
+                    windowMinutes: canonicalWindowMinutes,
+                    entries: self.mergedPlanUtilizationEntries(existingHistory.entries + canonicalHistory.entries))
+                didChange = true
+            } else {
+                historiesByKey[key] = canonicalHistory
+                didChange = didChange || canonicalWindowMinutes != history.windowMinutes
+            }
+        }
 
         for sample in samples {
-            let key = PlanUtilizationSeriesKey(name: sample.name, windowMinutes: sample.windowMinutes)
+            let canonicalWindowMinutes = sample.name.canonicalWindowMinutes(sample.windowMinutes)
+            let key = PlanUtilizationSeriesKey(name: sample.name, windowMinutes: canonicalWindowMinutes)
             if let existingHistory = historiesByKey[key] {
                 guard let updatedEntries = self.updatedPlanUtilizationEntries(
                     existingEntries: existingHistory.entries,
@@ -144,12 +161,12 @@ extension UsageStore {
                 }
                 historiesByKey[key] = PlanUtilizationSeriesHistory(
                     name: sample.name,
-                    windowMinutes: sample.windowMinutes,
+                    windowMinutes: canonicalWindowMinutes,
                     entries: updatedEntries)
             } else {
                 historiesByKey[key] = PlanUtilizationSeriesHistory(
                     name: sample.name,
-                    windowMinutes: sample.windowMinutes,
+                    windowMinutes: canonicalWindowMinutes,
                     entries: [sample.entry])
             }
             didChange = true
@@ -161,6 +178,15 @@ extension UsageStore {
                 return lhs.windowMinutes < rhs.windowMinutes
             }
             return lhs.name.rawValue < rhs.name.rawValue
+        }
+    }
+
+    private nonisolated static func mergedPlanUtilizationEntries(
+        _ entries: [PlanUtilizationHistoryEntry]) -> [PlanUtilizationHistoryEntry]
+    {
+        entries.reduce(into: []) { result, entry in
+            guard !result.contains(entry) else { return }
+            result.append(entry)
         }
     }
 
@@ -292,10 +318,11 @@ extension UsageStore {
                 return
             }
 
-            let key = PlanUtilizationSeriesKey(name: name, windowMinutes: windowMinutes)
+            let canonicalWindowMinutes = name.canonicalWindowMinutes(windowMinutes)
+            let key = PlanUtilizationSeriesKey(name: name, windowMinutes: canonicalWindowMinutes)
             samplesByKey[key] = PlanUtilizationSeriesSample(
                 name: name,
-                windowMinutes: windowMinutes,
+                windowMinutes: canonicalWindowMinutes,
                 entry: PlanUtilizationHistoryEntry(
                     capturedAt: capturedAt,
                     usedPercent: usedPercent,

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationResetCoalescingTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationResetCoalescingTests.swift
@@ -5,6 +5,36 @@ import Testing
 
 struct UsageStorePlanUtilizationResetCoalescingTests {
     @Test
+    func `near canonical codex windows merge into canonical history series`() throws {
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+        let existing = [
+            planSeries(name: .session, windowMinutes: 300, entries: [
+                planEntry(at: base, usedPercent: 20),
+            ]),
+            planSeries(name: .weekly, windowMinutes: 10080, entries: [
+                planEntry(at: base, usedPercent: 40),
+            ]),
+        ]
+        let incoming = [
+            planSeries(name: .session, windowMinutes: 299, entries: [
+                planEntry(at: base.addingTimeInterval(3600), usedPercent: 30),
+            ]),
+            planSeries(name: .weekly, windowMinutes: 10079, entries: [
+                planEntry(at: base.addingTimeInterval(3600), usedPercent: 50),
+            ]),
+        ]
+
+        let updated = try #require(
+            UsageStore._updatedPlanUtilizationHistoriesForTesting(
+                existingHistories: existing,
+                samples: incoming))
+
+        #expect(updated.map { "\($0.name.rawValue):\($0.windowMinutes)" } == ["session:300", "weekly:10080"])
+        #expect(findSeries(updated, name: .session, windowMinutes: 300)?.entries.map(\.usedPercent) == [20, 30])
+        #expect(findSeries(updated, name: .weekly, windowMinutes: 10080)?.entries.map(\.usedPercent) == [40, 50])
+    }
+
+    @Test
     func `same hour entry backfills missing reset metadata`() throws {
         let calendar = Calendar(identifier: .gregorian)
         let hourStart = try #require(calendar.date(from: DateComponents(

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
@@ -144,6 +144,32 @@ struct UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
+    func `native chart folds near canonical codex windows into single tabs`() {
+        let histories = [
+            planSeries(name: .session, windowMinutes: 299, entries: [
+                planEntry(at: Date(timeIntervalSince1970: 1_700_000_000), usedPercent: 20),
+            ]),
+            planSeries(name: .session, windowMinutes: 300, entries: [
+                planEntry(at: Date(timeIntervalSince1970: 1_700_003_600), usedPercent: 30),
+            ]),
+            planSeries(name: .weekly, windowMinutes: 10079, entries: [
+                planEntry(at: Date(timeIntervalSince1970: 1_700_086_400), usedPercent: 40),
+            ]),
+            planSeries(name: .weekly, windowMinutes: 10080, entries: [
+                planEntry(at: Date(timeIntervalSince1970: 1_700_172_800), usedPercent: 50),
+            ]),
+        ]
+
+        let model = PlanUtilizationHistoryChartMenuView._modelSnapshotForTesting(
+            histories: histories,
+            provider: .codex)
+
+        #expect(model.visibleSeries == ["session:300", "weekly:10080"])
+        #expect(model.selectedSeries == "session:300")
+    }
+
+    @MainActor
+    @Test
     func `claude history tabs match current snapshot bars`() {
         let histories = [
             planSeries(name: .session, windowMinutes: 300, entries: [


### PR DESCRIPTION
## Summary
- canonicalize near-session and near-weekly plan utilization windows before storing samples
- fold existing persisted near-canonical history series for chart tabs
- add focused tests for storage coalescing and chart tab presentation

## Verification
- swift test --filter UsageStorePlanUtilization
- make check
- ./Scripts/compile_and_run.sh
- bash ~/.codex/skills/codex-review/scripts/codex-review --parallel-tests "swift test --filter UsageStorePlanUtilization"