### PR TITLE
Fix fork roadmap upstream strategy link

### DIFF
--- a/docs/FORK_ROADMAP.md
+++ b/docs/FORK_ROADMAP.md
@@ -118,7 +118,7 @@ This document outlines the development roadmap for the CodexBar fork maintained 
 
 **Files to Create:**
 - `Scripts/sync_upstream.sh`
-- `docs/UPSTREAM_SYNC.md`
+- `docs/UPSTREAM_STRATEGY.md`
 - `.github/workflows/upstream-sync-check.yml`
 
 ---
@@ -228,5 +228,5 @@ This document outlines the development roadmap for the CodexBar fork maintained 
 - [Augment Provider](augment.md) - Augment-specific documentation
 - [Development Guide](DEVELOPMENT.md) - Build and test instructions
 - [Provider Authoring](provider.md) - How to create new providers
-- [Upstream Sync](UPSTREAM_SYNC.md) - Syncing with original repository (TBD)
+- [Upstream Strategy](UPSTREAM_STRATEGY.md) - Syncing with original repository
 - [Quotio Analysis](QUOTIO_ANALYSIS.md) - Feature comparison (TBD)


### PR DESCRIPTION
## Summary
- Replace the stale docs/UPSTREAM_SYNC.md reference with the existing docs/UPSTREAM_STRATEGY.md page.
- Update the related-docs label so the roadmap points readers to a valid upstream strategy document.

## Verification
- Ran a local markdown link check across README.md and docs/**/*.md.
- Ran git diff --check for the commit.