### PR TITLE
Fix Claude usage loading stalls

### DIFF
--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -158,6 +158,15 @@ public struct ClaudeStatusProbe: Sendable {
             throw ClaudeStatusProbeError.parseFailed(usageError)
         }
 
+        if self.isUsageStillLoading(text: clean) {
+            Self.dumpIfNeeded(
+                enabled: shouldDump,
+                reason: "usage still loading",
+                usage: clean,
+                status: statusText)
+            throw ClaudeStatusProbeError.parseFailed("Claude CLI /usage is still loading usage data.")
+        }
+
         // Claude CLI renders /usage as a TUI. Our PTY capture includes earlier screen fragments (including a status
         // line
         // with a "0%" context meter) before the usage panel is drawn. To keep parsing stable, trim to the last
@@ -450,6 +459,12 @@ public struct ClaudeStatusProbe: Sendable {
             return "Claude CLI could not load usage data. Open the CLI and retry `/usage`."
         }
         return nil
+    }
+
+    private static func isUsageStillLoading(text: String) -> Bool {
+        let normalized = TextParsing.stripANSICodes(text).lowercased().filter { !$0.isWhitespace }
+        guard normalized.contains("loadingusage") else { return false }
+        return !self.usageCaptureHasSessionValue(normalized) && self.allPercents(text).isEmpty
     }
 
     /// Collect remaining percentages in the order they appear; used as a backup when labels move/rename.

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -477,10 +477,11 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
 
             let executionSteps = plan.executionSteps
             for (index, step) in executionSteps.enumerated() {
+                let isFinalStep = index == executionSteps.count - 1
                 do {
-                    return try await self.execute(step: step, model: model)
+                    return try await self.execute(step: step, model: model, isFinalStep: isFinalStep)
                 } catch {
-                    if index < executionSteps.count - 1 {
+                    if !isFinalStep {
                         ClaudeUsageFetcher.log.debug(
                             "Claude planner step failed; falling back to next step",
                             metadata: [
@@ -531,7 +532,11 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             ClaudeUsageFetcher.log.debug("Claude auto source planner", metadata: metadata)
         }
 
-        private func execute(step: ClaudeFetchPlanStep, model: String) async throws -> ClaudeUsageSnapshot {
+        private func execute(
+            step: ClaudeFetchPlanStep,
+            model: String,
+            isFinalStep: Bool) async throws -> ClaudeUsageSnapshot
+        {
             switch step.dataSource {
             case .api:
                 throw ClaudeUsageError.parseFailed("Planner emitted invalid api execution step.")
@@ -542,9 +547,19 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             case .web:
                 return try await self.fetcher.loadViaWebAPI()
             case .cli:
-                return try await self.loadViaCLI(model: model, timeout: ClaudeUsageFetcher.cliAutoProbeTimeout)
+                return try await self.loadViaAutoCLI(model: model, isFinalStep: isFinalStep)
             case .auto:
                 throw ClaudeUsageError.parseFailed("Planner emitted invalid auto execution step.")
+            }
+        }
+
+        private func loadViaAutoCLI(model: String, isFinalStep: Bool) async throws -> ClaudeUsageSnapshot {
+            do {
+                return try await self.loadViaCLI(model: model, timeout: ClaudeUsageFetcher.cliAutoProbeTimeout)
+            } catch {
+                if error is CancellationError { throw error }
+                guard isFinalStep, Self.shouldRetryCLIProbe(after: error) else { throw error }
+                return try await self.loadViaCLI(model: model, timeout: ClaudeUsageFetcher.cliRetryProbeTimeout)
             }
         }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -71,6 +71,7 @@ public enum ClaudeUsageError: LocalizedError, Sendable {
 public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
     private static let sessionWindowMinutes = 5 * 60
     private static let weeklyWindowMinutes = 7 * 24 * 60
+    private static let cliAutoProbeTimeout: TimeInterval = 12
     private static let cliProbeTimeout: TimeInterval = 24
     private static let cliRetryProbeTimeout: TimeInterval = 60
     private struct Configuration {
@@ -541,7 +542,7 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
             case .web:
                 return try await self.fetcher.loadViaWebAPI()
             case .cli:
-                return try await self.loadViaCLIWithRetry(model: model)
+                return try await self.loadViaCLI(model: model, timeout: ClaudeUsageFetcher.cliAutoProbeTimeout)
             case .auto:
                 throw ClaudeUsageError.parseFailed("Planner emitted invalid auto execution step.")
             }

--- a/Tests/CodexBarTests/ClaudeCLITimeoutRetryTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLITimeoutRetryTests.swift
@@ -60,6 +60,32 @@ struct ClaudeCLITimeoutRetryTests {
     }
 
     @Test
+    func `auto cli usage uses bounded timeout without long retry`() async throws {
+        let attempts = AttemptRecorder()
+        let fetcher = ClaudeUsageFetcher(
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            environment: [:],
+            dataSource: .auto)
+
+        let fetchOverride: ClaudeStatusProbe.FetchOverride = { _, timeout, _ in
+            _ = await attempts.record(timeout: timeout)
+            throw ClaudeStatusProbeError.parseFailed("Claude CLI /usage is still loading usage data.")
+        }
+
+        await #expect(throws: ClaudeStatusProbeError.self) {
+            try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+                try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
+                    try await fetcher.loadLatestUsage(model: "sonnet")
+                }
+            }
+        }
+
+        let recorded = await attempts.snapshot()
+        #expect(recorded.count == 1)
+        #expect(recorded.timeouts == [12])
+    }
+
+    @Test
     func `cli usage does not retry cancelled probe`() async throws {
         let attempts = AttemptRecorder()
         let fetcher = ClaudeUsageFetcher(

--- a/Tests/CodexBarTests/ClaudeCLITimeoutRetryTests.swift
+++ b/Tests/CodexBarTests/ClaudeCLITimeoutRetryTests.swift
@@ -65,7 +65,8 @@ struct ClaudeCLITimeoutRetryTests {
         let fetcher = ClaudeUsageFetcher(
             browserDetection: BrowserDetection(cacheTTL: 0),
             environment: [:],
-            dataSource: .auto)
+            dataSource: .auto,
+            manualCookieHeader: "foo=bar")
 
         let fetchOverride: ClaudeStatusProbe.FetchOverride = { _, timeout, _ in
             _ = await attempts.record(timeout: timeout)
@@ -73,6 +74,48 @@ struct ClaudeCLITimeoutRetryTests {
         }
 
         await #expect(throws: ClaudeStatusProbeError.self) {
+            try await self.withNoOAuthCredentials {
+                try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
+                    try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
+                        try await fetcher.loadLatestUsage(model: "sonnet")
+                    }
+                }
+            }
+        }
+
+        let recorded = await attempts.snapshot()
+        #expect(recorded.count == 1)
+        #expect(recorded.timeouts == [12])
+    }
+
+    @Test
+    func `auto cli usage retries timeout when cli is final source`() async throws {
+        let attempts = AttemptRecorder()
+        let fetcher = ClaudeUsageFetcher(
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            environment: [:],
+            dataSource: .auto,
+            manualCookieHeader: "foo=bar")
+
+        let fetchOverride: ClaudeStatusProbe.FetchOverride = { _, timeout, _ in
+            let attempt = await attempts.record(timeout: timeout)
+            if attempt == 1 {
+                throw ClaudeStatusProbeError.timedOut
+            }
+            return ClaudeStatusSnapshot(
+                sessionPercentLeft: 72,
+                weeklyPercentLeft: 64,
+                opusPercentLeft: nil,
+                accountEmail: "auto-cli@example.com",
+                accountOrganization: "Auto CLI Org",
+                loginMethod: "cli",
+                primaryResetDescription: nil,
+                secondaryResetDescription: nil,
+                opusResetDescription: nil,
+                rawText: "probe raw")
+        }
+
+        let snapshot = try await self.withNoOAuthCredentials {
             try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting("/usr/bin/true") {
                 try await ClaudeStatusProbe.withFetchOverrideForTesting(fetchOverride) {
                     try await fetcher.loadLatestUsage(model: "sonnet")
@@ -81,8 +124,11 @@ struct ClaudeCLITimeoutRetryTests {
         }
 
         let recorded = await attempts.snapshot()
-        #expect(recorded.count == 1)
-        #expect(recorded.timeouts == [12])
+        #expect(recorded.count == 2)
+        #expect(recorded.timeouts == [12, 60])
+        #expect(snapshot.primary.usedPercent == 28)
+        #expect(snapshot.secondary?.usedPercent == 36)
+        #expect(snapshot.accountEmail == "auto-cli@example.com")
     }
 
     @Test
@@ -109,5 +155,28 @@ struct ClaudeCLITimeoutRetryTests {
         let recorded = await attempts.snapshot()
         #expect(recorded.count == 1)
         #expect(recorded.timeouts == [24])
+    }
+
+    private func withNoOAuthCredentials<T>(operation: () async throws -> T) async rethrows -> T {
+        let missingCredentialsURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-claude-creds-\(UUID().uuidString).json")
+        return try await KeychainCacheStore.withServiceOverrideForTesting("rat-107-\(UUID().uuidString)") {
+            KeychainCacheStore.setTestStoreForTesting(true)
+            defer { KeychainCacheStore.setTestStoreForTesting(false) }
+            return try await ClaudeOAuthCredentialsStore.withIsolatedMemoryCacheForTesting {
+                try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+                    try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(missingCredentialsURL) {
+                        try await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+                            try await ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
+                                data: nil,
+                                fingerprint: nil)
+                            {
+                                try await operation()
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/Tests/CodexBarTests/StatusProbeTests.swift
+++ b/Tests/CodexBarTests/StatusProbeTests.swift
@@ -288,7 +288,7 @@ struct StatusProbeTests {
     }
 
     @Test
-    func `parse claude status loading panel does not report zero percent`() {
+    func `parse claude status loading panel surfaces loading stall`() {
         let sample = """
         Claude Code v2.1.29
         22:47 |  | Opus 4.5 | default | ░░░░░░░░░░ 0%  ◯ /ide for Visual Studio Code
@@ -301,7 +301,8 @@ struct StatusProbeTests {
         do {
             _ = try ClaudeStatusProbe.parse(text: sample)
             #expect(Bool(false), "Parsing should fail while /usage is still loading")
-        } catch ClaudeStatusProbeError.parseFailed {
+        } catch let ClaudeStatusProbeError.parseFailed(message) {
+            #expect(message.lowercased().contains("loading"))
             return
         } catch ClaudeStatusProbeError.timedOut {
             return


### PR DESCRIPTION
## Summary
- detect loading-only Claude `/usage` output instead of treating surrounding status meters as usage
- use a bounded single CLI probe in automatic source fallback while preserving the longer explicit CLI retry path
- add focused coverage for the loading-panel parser path and automatic CLI timeout behavior

Closes #1031.

## Tests
- `git diff --check`
- `swift test --filter ClaudeCLITimeoutRetryTests`
- `swift test --filter StatusProbeTests`
- `swift test --filter Claude`
- `swift build`
- `make format`
- `make lint`
- `swift test`
