### PR TITLE
feat: add aur package for arch linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Latest release](https://img.shields.io/github/v/release/steipete/CodexBar?style=flat-square&color=0a0a0c)](https://github.com/steipete/CodexBar/releases/latest)
 [![macOS 14+](https://img.shields.io/badge/macOS-14%2B-0a0a0c?style=flat-square)](https://github.com/steipete/CodexBar/releases/latest)
 [![Homebrew](https://img.shields.io/badge/brew-steipete%2Ftap%2Fcodexbar-orange?style=flat-square)](https://github.com/steipete/homebrew-tap)
+[![AUR](https://img.shields.io/aur/version/codexbar-cli?style=flat-square&color=1793d1)](https://aur.archlinux.org/packages/codexbar-cli)
 [![License: MIT](https://img.shields.io/badge/license-MIT-6e5aff?style=flat-square)](LICENSE)
 [![Site](https://img.shields.io/badge/site-codexbar.app-16d3b4?style=flat-square)](https://codexbar.app)
 
@@ -38,6 +39,10 @@ brew install --cask steipete/tap/codexbar
 Homebrew formula (Linux today):
 ```bash
 brew install steipete/tap/codexbar
+```
+Arch Linux AUR package:
+```bash
+yay -S codexbar-cli
 ```
 Or download release tarballs from GitHub Releases:
 - macOS: `CodexBarCLI-v<tag>-macos-arm64.tar.gz`, `CodexBarCLI-v<tag>-macos-x86_64.tar.gz`


### PR DESCRIPTION
 ## Summary
- Add an AUR package for ArchLinux.
- Add an AUR badge for the `codexbar-cli` package.
- Document Arch Linux installation via `yay -S codexbar-cli` in the CLI install section.

  ## Testing
  - Not run; documentation-only change.