### PR TITLE
Add Azure OpenAI provider

### DIFF
--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -152,7 +152,7 @@ struct MenuDescriptor {
             if let primary = snap.primary {
                 let primaryWindow = if provider == .warp || provider == .kilo || provider == .mimo || provider ==
                     .abacus ||
-                    provider == .deepseek
+                    provider == .deepseek || provider == .azureopenai
                 {
                     // Some providers use resetDescription for non-reset detail
                     // (e.g., "Unlimited", "X/Y credits"). Avoid rendering it as a "Resets ..." line.
@@ -171,7 +171,7 @@ struct MenuDescriptor {
                     resetStyle: resetStyle,
                     showUsed: settings.usageBarsShowUsed)
                 if provider == .warp || provider == .kilo || provider == .mimo || provider == .abacus || provider ==
-                    .deepseek,
+                    .deepseek || provider == .azureopenai,
                     let detail = primary.resetDescription?.trimmingCharacters(in: .whitespacesAndNewlines),
                     !detail.isEmpty
                 {

--- a/Sources/CodexBar/Providers/AzureOpenAI/AzureOpenAIProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/AzureOpenAI/AzureOpenAIProviderImplementation.swift
@@ -1,0 +1,69 @@
+import CodexBarCore
+import CodexBarMacroSupport
+import Foundation
+
+@ProviderImplementationRegistration
+struct AzureOpenAIProviderImplementation: ProviderImplementation {
+    let id: UsageProvider = .azureopenai
+
+    @MainActor
+    func presentation(context _: ProviderPresentationContext) -> ProviderPresentation {
+        ProviderPresentation { _ in "api" }
+    }
+
+    @MainActor
+    func observeSettings(_ settings: SettingsStore) {
+        _ = settings.azureOpenAIAPIKey
+        _ = settings.azureOpenAIEndpoint
+        _ = settings.azureOpenAIDeploymentName
+    }
+
+    @MainActor
+    func isAvailable(context: ProviderAvailabilityContext) -> Bool {
+        let environment = context.environment
+        let hasEnvironmentConfig = AzureOpenAISettingsReader.apiKey(environment: environment) != nil &&
+            AzureOpenAISettingsReader.endpoint(environment: environment) != nil &&
+            AzureOpenAISettingsReader.deploymentName(environment: environment) != nil
+        if hasEnvironmentConfig { return true }
+
+        return !context.settings.azureOpenAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            AzureOpenAISettingsReader.endpointURL(from: context.settings.azureOpenAIEndpoint) != nil &&
+            !context.settings.azureOpenAIDeploymentName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    @MainActor
+    func settingsFields(context: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {
+        [
+            ProviderSettingsFieldDescriptor(
+                id: "azure-openai-api-key",
+                title: "API key",
+                subtitle: "Stored in ~/.codexbar/config.json. AZURE_OPENAI_API_KEY is also supported.",
+                kind: .secure,
+                placeholder: "Azure OpenAI key",
+                binding: context.stringBinding(\.azureOpenAIAPIKey),
+                actions: [],
+                isVisible: nil,
+                onActivate: nil),
+            ProviderSettingsFieldDescriptor(
+                id: "azure-openai-endpoint",
+                title: "Endpoint",
+                subtitle: "Azure OpenAI resource endpoint. AZURE_OPENAI_ENDPOINT is also supported.",
+                kind: .plain,
+                placeholder: "https://resource.openai.azure.com",
+                binding: context.stringBinding(\.azureOpenAIEndpoint),
+                actions: [],
+                isVisible: nil,
+                onActivate: nil),
+            ProviderSettingsFieldDescriptor(
+                id: "azure-openai-deployment-name",
+                title: "Deployment",
+                subtitle: "Azure OpenAI deployment name. AZURE_OPENAI_DEPLOYMENT_NAME is also supported.",
+                kind: .plain,
+                placeholder: "gpt-4o-mini",
+                binding: context.stringBinding(\.azureOpenAIDeploymentName),
+                actions: [],
+                isVisible: nil,
+                onActivate: nil),
+        ]
+    }
+}

--- a/Sources/CodexBar/Providers/AzureOpenAI/AzureOpenAISettingsStore.swift
+++ b/Sources/CodexBar/Providers/AzureOpenAI/AzureOpenAISettingsStore.swift
@@ -1,0 +1,32 @@
+import CodexBarCore
+import Foundation
+
+extension SettingsStore {
+    var azureOpenAIAPIKey: String {
+        get { self.configSnapshot.providerConfig(for: .azureopenai)?.sanitizedAPIKey ?? "" }
+        set {
+            self.updateProviderConfig(provider: .azureopenai) { entry in
+                entry.apiKey = self.normalizedConfigValue(newValue)
+            }
+            self.logSecretUpdate(provider: .azureopenai, field: "apiKey", value: newValue)
+        }
+    }
+
+    var azureOpenAIEndpoint: String {
+        get { self.configSnapshot.providerConfig(for: .azureopenai)?.sanitizedEnterpriseHost ?? "" }
+        set {
+            self.updateProviderConfig(provider: .azureopenai) { entry in
+                entry.enterpriseHost = self.normalizedConfigValue(newValue)
+            }
+        }
+    }
+
+    var azureOpenAIDeploymentName: String {
+        get { self.configSnapshot.providerConfig(for: .azureopenai)?.sanitizedWorkspaceID ?? "" }
+        set {
+            self.updateProviderConfig(provider: .azureopenai) { entry in
+                entry.workspaceID = self.normalizedConfigValue(newValue)
+            }
+        }
+    }
+}

--- a/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
+++ b/Sources/CodexBar/Providers/Shared/ProviderImplementationRegistry.swift
@@ -15,6 +15,7 @@ enum ProviderImplementationRegistry {
         switch provider {
         case .codex: CodexProviderImplementation()
         case .openai: OpenAIAPIProviderImplementation()
+        case .azureopenai: AzureOpenAIProviderImplementation()
         case .claude: ClaudeProviderImplementation()
         case .cursor: CursorProviderImplementation()
         case .opencode: OpenCodeProviderImplementation()

--- a/Sources/CodexBar/UsageStore+Accessors.swift
+++ b/Sources/CodexBar/UsageStore+Accessors.swift
@@ -56,6 +56,8 @@ extension UsageStore {
             return ZaiSettingsError.missingToken.errorDescription
         case .openrouter:
             return OpenRouterSettingsError.missingToken.errorDescription
+        case .azureopenai:
+            return AzureOpenAISettingsError.missingAPIKey.errorDescription
         case .elevenlabs:
             return ElevenLabsUsageError.missingCredentials.errorDescription
         case .deepseek:

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -940,6 +940,7 @@ extension UsageStore {
         let ollamaCookieHeader = self.settings.ollamaCookieHeader
         let processEnvironment = self.environmentBase
         let openAIDebugContext = self.openAIAPIKeyDebugContext(processEnvironment: processEnvironment)
+        let azureOpenAIDebugContext = self.azureOpenAIAPIKeyDebugContext(processEnvironment: processEnvironment)
         let openRouterDebugContext = self.openRouterAPIKeyDebugContext(processEnvironment: processEnvironment)
         let elevenLabsDebugContext = self.elevenLabsAPIKeyDebugContext(processEnvironment: processEnvironment)
         let deepSeekHasEnvToken = DeepSeekSettingsReader.apiKey(environment: processEnvironment) != nil
@@ -984,6 +985,8 @@ extension UsageStore {
                     return await codexFetcher.debugRawRateLimits()
                 case .openai:
                     return Self.apiKeyDebugLine(openAIDebugContext)
+                case .azureopenai:
+                    return Self.apiKeyDebugLine(azureOpenAIDebugContext)
                 case .claude:
                     guard let claudeDebugConfiguration else {
                         return "Claude debug log configuration unavailable"
@@ -1191,6 +1194,20 @@ extension UsageStore {
             resolution: ProviderTokenResolver.openAIAPIResolution(environment: environment),
             configToken: config?.sanitizedAPIKey,
             hasEnvToken: OpenAIAPISettingsReader.apiKey(environment: processEnvironment) != nil,
+            hasTokenAccount: false)
+    }
+
+    private func azureOpenAIAPIKeyDebugContext(processEnvironment: [String: String]) -> APIKeyDebugContext {
+        let config = self.settings.providerConfig(for: .azureopenai)
+        let environment = ProviderConfigEnvironment.applyProviderConfigOverrides(
+            base: processEnvironment,
+            provider: .azureopenai,
+            config: config)
+        return APIKeyDebugContext(
+            label: "AZURE_OPENAI_API_KEY",
+            resolution: ProviderTokenResolver.azureOpenAIResolution(environment: environment),
+            configToken: config?.sanitizedAPIKey,
+            hasEnvToken: AzureOpenAISettingsReader.apiKey(environment: processEnvironment) != nil,
             hasTokenAccount: false)
     }
 

--- a/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
+++ b/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
@@ -15,6 +15,9 @@ public enum ProviderConfigEnvironment {
         if provider == .llmproxy {
             return self.applyLLMProxyOverrides(base: base, config: config)
         }
+        if provider == .azureopenai {
+            return self.applyAzureOpenAIOverrides(base: base, config: config)
+        }
         guard let apiKey = config?.sanitizedAPIKey, !apiKey.isEmpty else { return base }
         var env = base
         if let key = self.directAPIKeyEnvironmentKey(for: provider) {
@@ -61,6 +64,8 @@ public enum ProviderConfigEnvironment {
         switch provider {
         case .copilot, .kimik2, .warp, .codebuff, .crof, .doubao:
             return true
+        case .azureopenai:
+            return true
         default:
             return false
         }
@@ -70,6 +75,8 @@ public enum ProviderConfigEnvironment {
         switch provider {
         case .openai:
             OpenAIAPISettingsReader.adminAPIKeyEnvironmentKey
+        case .azureopenai:
+            AzureOpenAISettingsReader.apiKeyEnvironmentKey
         case .claude:
             ClaudeAdminAPISettingsReader.adminAPIKeyEnvironmentKey
         case .zai:
@@ -148,6 +155,24 @@ public enum ProviderConfigEnvironment {
         }
         if let baseURL = config?.sanitizedEnterpriseHost {
             env[LLMProxySettingsReader.baseURLEnvironmentKey] = baseURL
+        }
+        return env
+    }
+
+    private static func applyAzureOpenAIOverrides(
+        base: [String: String],
+        config: ProviderConfig?) -> [String: String]
+    {
+        guard let config else { return base }
+        var env = base
+        if let apiKey = config.sanitizedAPIKey {
+            env[AzureOpenAISettingsReader.apiKeyEnvironmentKey] = apiKey
+        }
+        if let endpoint = config.sanitizedEnterpriseHost {
+            env[AzureOpenAISettingsReader.endpointEnvironmentKey] = endpoint
+        }
+        if let deploymentName = config.sanitizedWorkspaceID {
+            env[AzureOpenAISettingsReader.deploymentNameEnvironmentKey] = deploymentName
         }
         return env
     }

--- a/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIProviderDescriptor.swift
@@ -1,0 +1,91 @@
+import CodexBarMacroSupport
+import Foundation
+
+@ProviderDescriptorRegistration
+@ProviderDescriptorDefinition
+public enum AzureOpenAIProviderDescriptor {
+    static func makeDescriptor() -> ProviderDescriptor {
+        ProviderDescriptor(
+            id: .azureopenai,
+            metadata: ProviderMetadata(
+                id: .azureopenai,
+                displayName: "Azure OpenAI",
+                sessionLabel: "Status",
+                weeklyLabel: "Deployment",
+                opusLabel: nil,
+                supportsOpus: false,
+                supportsCredits: false,
+                creditsHint: "",
+                toggleTitle: "Show Azure OpenAI usage",
+                cliName: "azure-openai",
+                defaultEnabled: false,
+                isPrimaryProvider: false,
+                usesAccountFallback: false,
+                browserCookieOrder: nil,
+                dashboardURL: "https://ai.azure.com",
+                statusPageURL: nil,
+                statusLinkURL: "https://azure.status.microsoft/en-us/status"),
+            branding: ProviderBranding(
+                iconStyle: .openai,
+                iconResourceName: "ProviderIcon-codex",
+                color: ProviderColor(red: 0, green: 120 / 255, blue: 212 / 255)),
+            tokenCost: ProviderTokenCostConfig(
+                supportsTokenCost: false,
+                noDataMessage: { "Azure OpenAI usage history is not exposed by the deployment validation probe." }),
+            fetchPlan: ProviderFetchPlan(
+                sourceModes: [.auto, .api],
+                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [AzureOpenAIAPIFetchStrategy()] })),
+            cli: ProviderCLIConfig(
+                name: "azure-openai",
+                aliases: ["azureopenai", "aoai"],
+                versionDetector: nil))
+    }
+}
+
+struct AzureOpenAIAPIFetchStrategy: ProviderFetchStrategy {
+    let id: String = "azureopenai.api"
+    let kind: ProviderFetchKind = .apiToken
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        Self.resolveAPIKey(environment: context.env) != nil &&
+            Self.resolveEndpoint(environment: context.env) != nil &&
+            Self.resolveDeploymentName(environment: context.env) != nil
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        guard let apiKey = Self.resolveAPIKey(environment: context.env) else {
+            throw AzureOpenAIUsageError.missingAPIKey
+        }
+        guard let endpoint = Self.resolveEndpoint(environment: context.env) else {
+            throw AzureOpenAIUsageError.missingEndpoint
+        }
+        guard let deploymentName = Self.resolveDeploymentName(environment: context.env) else {
+            throw AzureOpenAIUsageError.missingDeploymentName
+        }
+
+        let usage = try await AzureOpenAIUsageFetcher.fetchUsage(
+            apiKey: apiKey,
+            endpoint: endpoint,
+            deploymentName: deploymentName,
+            apiVersion: AzureOpenAISettingsReader.apiVersion(environment: context.env))
+        return self.makeResult(
+            usage: usage.toUsageSnapshot(),
+            sourceLabel: "deployment")
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+
+    private static func resolveAPIKey(environment: [String: String]) -> String? {
+        ProviderTokenResolver.azureOpenAIToken(environment: environment)
+    }
+
+    private static func resolveEndpoint(environment: [String: String]) -> URL? {
+        AzureOpenAISettingsReader.endpoint(environment: environment)
+    }
+
+    private static func resolveDeploymentName(environment: [String: String]) -> String? {
+        AzureOpenAISettingsReader.deploymentName(environment: environment)
+    }
+}

--- a/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAISettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAISettingsReader.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+public enum AzureOpenAISettingsReader {
+    public static let apiKeyEnvironmentKey = "AZURE_OPENAI_API_KEY"
+    public static let endpointEnvironmentKey = "AZURE_OPENAI_ENDPOINT"
+    public static let deploymentNameEnvironmentKey = "AZURE_OPENAI_DEPLOYMENT_NAME"
+    public static let apiVersionEnvironmentKey = "AZURE_OPENAI_API_VERSION"
+    public static let defaultAPIVersion = "2024-10-21"
+
+    public static func apiKey(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        self.cleaned(environment[self.apiKeyEnvironmentKey])
+    }
+
+    public static func endpoint(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL? {
+        guard let rawEndpoint = self.cleaned(environment[self.endpointEnvironmentKey]) else { return nil }
+        return self.endpointURL(from: rawEndpoint)
+    }
+
+    public static func deploymentName(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        self.cleaned(environment[self.deploymentNameEnvironmentKey])
+    }
+
+    public static func apiVersion(environment: [String: String] = ProcessInfo.processInfo.environment) -> String {
+        self.cleaned(environment[self.apiVersionEnvironmentKey]) ?? self.defaultAPIVersion
+    }
+
+    public static func endpointURL(from rawEndpoint: String) -> URL? {
+        let trimmed = rawEndpoint.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let withScheme = trimmed.contains("://") ? trimmed : "https://\(trimmed)"
+        guard let url = URL(string: withScheme),
+              let host = url.host?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !host.isEmpty
+        else {
+            return nil
+        }
+        return url
+    }
+
+    static func cleaned(_ raw: String?) -> String? {
+        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+
+        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
+            (value.hasPrefix("'") && value.hasSuffix("'"))
+        {
+            value.removeFirst()
+            value.removeLast()
+        }
+
+        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}
+
+public enum AzureOpenAISettingsError: LocalizedError, Sendable, Equatable {
+    case missingAPIKey
+    case missingEndpoint
+    case missingDeploymentName
+    case invalidEndpoint
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingAPIKey:
+            "Azure OpenAI API key not configured. Set AZURE_OPENAI_API_KEY or configure an API key in Settings."
+        case .missingEndpoint:
+            "Azure OpenAI endpoint not configured. Set AZURE_OPENAI_ENDPOINT or configure an endpoint in Settings."
+        case .missingDeploymentName:
+            "Azure OpenAI deployment not configured. Set AZURE_OPENAI_DEPLOYMENT_NAME or configure a deployment " +
+                "in Settings."
+        case .invalidEndpoint:
+            "Azure OpenAI endpoint is invalid."
+        }
+    }
+}

--- a/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIUsageFetcher.swift
@@ -1,0 +1,229 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public struct AzureOpenAIUsageSnapshot: Codable, Sendable, Equatable {
+    public let endpointHost: String
+    public let deploymentName: String
+    public let model: String?
+    public let apiVersion: String
+    public let updatedAt: Date
+
+    public init(
+        endpointHost: String,
+        deploymentName: String,
+        model: String?,
+        apiVersion: String,
+        updatedAt: Date)
+    {
+        self.endpointHost = endpointHost
+        self.deploymentName = deploymentName
+        self.model = model
+        self.apiVersion = apiVersion
+        self.updatedAt = updatedAt
+    }
+
+    public func toUsageSnapshot() -> UsageSnapshot {
+        let detail = Self.detailText(deploymentName: self.deploymentName, model: self.model)
+        return UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 0,
+                windowMinutes: nil,
+                resetsAt: nil,
+                resetDescription: detail),
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: self.updatedAt,
+            identity: ProviderIdentitySnapshot(
+                providerID: .azureopenai,
+                accountEmail: nil,
+                accountOrganization: self.endpointHost,
+                loginMethod: "Deployment: \(self.deploymentName)"))
+    }
+
+    private static func detailText(deploymentName: String, model: String?) -> String {
+        let cleanedModel = model?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let cleanedModel, !cleanedModel.isEmpty else {
+            return "Deployment: \(deploymentName)"
+        }
+        return "Deployment: \(deploymentName) · Model: \(cleanedModel)"
+    }
+}
+
+public enum AzureOpenAIUsageError: LocalizedError, Sendable, Equatable {
+    case missingAPIKey
+    case missingEndpoint
+    case missingDeploymentName
+    case invalidEndpoint
+    case invalidURL
+    case networkError(String)
+    case apiError(statusCode: Int, message: String)
+    case parseFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingAPIKey:
+            AzureOpenAISettingsError.missingAPIKey.errorDescription
+        case .missingEndpoint:
+            AzureOpenAISettingsError.missingEndpoint.errorDescription
+        case .missingDeploymentName:
+            AzureOpenAISettingsError.missingDeploymentName.errorDescription
+        case .invalidEndpoint:
+            AzureOpenAISettingsError.invalidEndpoint.errorDescription
+        case .invalidURL:
+            "Azure OpenAI validation URL is invalid."
+        case let .networkError(message):
+            "Azure OpenAI network error: \(message)"
+        case let .apiError(statusCode, message):
+            if message.isEmpty {
+                "Azure OpenAI API error: HTTP \(statusCode)"
+            } else {
+                "Azure OpenAI API error: HTTP \(statusCode): \(message)"
+            }
+        case let .parseFailed(message):
+            "Azure OpenAI response parse error: \(message)"
+        }
+    }
+}
+
+private struct AzureOpenAIChatCompletionResponse: Decodable {
+    let model: String?
+}
+
+public enum AzureOpenAIUsageFetcher {
+    private static let timeoutSeconds: TimeInterval = 20
+    private static let maxErrorBodyLength = 240
+
+    public static func fetchUsage(
+        apiKey: String,
+        endpoint: URL,
+        deploymentName: String,
+        apiVersion: String = AzureOpenAISettingsReader.defaultAPIVersion,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
+        updatedAt: Date = Date()) async throws -> AzureOpenAIUsageSnapshot
+    {
+        let apiKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        let deploymentName = deploymentName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let apiVersion = apiVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !apiKey.isEmpty else { throw AzureOpenAIUsageError.missingAPIKey }
+        guard !deploymentName.isEmpty else { throw AzureOpenAIUsageError.missingDeploymentName }
+        guard endpoint.host?.isEmpty == false else { throw AzureOpenAIUsageError.invalidEndpoint }
+        let effectiveAPIVersion = apiVersion.isEmpty ? AzureOpenAISettingsReader.defaultAPIVersion : apiVersion
+
+        var request = URLRequest(url: try self.chatCompletionsURL(
+            endpoint: endpoint,
+            deploymentName: deploymentName,
+            apiVersion: effectiveAPIVersion))
+        request.httpMethod = "POST"
+        request.timeoutInterval = Self.timeoutSeconds
+        request.setValue(apiKey, forHTTPHeaderField: "api-key")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try self.validationRequestBody(
+            deploymentName: deploymentName,
+            apiVersion: effectiveAPIVersion)
+
+        let response: ProviderHTTPResponse
+        do {
+            response = try await transport.response(for: request)
+        } catch {
+            throw AzureOpenAIUsageError.networkError(error.localizedDescription)
+        }
+
+        guard (200..<300).contains(response.statusCode) else {
+            throw AzureOpenAIUsageError.apiError(
+                statusCode: response.statusCode,
+                message: self.responseSummary(response.data))
+        }
+
+        let model: String?
+        do {
+            model = try JSONDecoder().decode(AzureOpenAIChatCompletionResponse.self, from: response.data).model
+        } catch {
+            throw AzureOpenAIUsageError.parseFailed(error.localizedDescription)
+        }
+
+        return AzureOpenAIUsageSnapshot(
+            endpointHost: endpoint.host ?? endpoint.absoluteString,
+            deploymentName: deploymentName,
+            model: model,
+            apiVersion: effectiveAPIVersion,
+            updatedAt: updatedAt)
+    }
+
+    public static func _chatCompletionsURLForTesting(
+        endpoint: URL,
+        deploymentName: String,
+        apiVersion: String) throws -> URL
+    {
+        try self.chatCompletionsURL(endpoint: endpoint, deploymentName: deploymentName, apiVersion: apiVersion)
+    }
+
+    private static func chatCompletionsURL(
+        endpoint: URL,
+        deploymentName: String,
+        apiVersion: String) throws -> URL
+    {
+        if self.usesV1API(apiVersion) {
+            let base = endpoint
+                .appendingPathComponent("openai")
+                .appendingPathComponent("v1")
+                .appendingPathComponent("chat")
+                .appendingPathComponent("completions")
+            guard let url = URLComponents(url: base, resolvingAgainstBaseURL: false)?.url else {
+                throw AzureOpenAIUsageError.invalidURL
+            }
+            return url
+        }
+
+        let base = endpoint
+            .appendingPathComponent("openai")
+            .appendingPathComponent("deployments")
+            .appendingPathComponent(deploymentName)
+            .appendingPathComponent("chat")
+            .appendingPathComponent("completions")
+        guard var components = URLComponents(url: base, resolvingAgainstBaseURL: false) else {
+            throw AzureOpenAIUsageError.invalidURL
+        }
+        components.queryItems = [URLQueryItem(name: "api-version", value: apiVersion)]
+        guard let url = components.url else { throw AzureOpenAIUsageError.invalidURL }
+        return url
+    }
+
+    private static func validationRequestBody(
+        deploymentName: String,
+        apiVersion: String) throws -> Data
+    {
+        var payload: [String: Any] = [
+            "messages": [
+                ["role": "user", "content": "ping"],
+            ],
+            "temperature": 0,
+        ]
+        if self.usesV1API(apiVersion) {
+            payload["model"] = deploymentName
+            payload["max_completion_tokens"] = 1
+        } else {
+            payload["max_tokens"] = 1
+        }
+        return try JSONSerialization.data(withJSONObject: payload, options: [])
+    }
+
+    private static func usesV1API(_ apiVersion: String) -> Bool {
+        apiVersion.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "v1"
+    }
+
+    private static func responseSummary(_ data: Data) -> String {
+        guard let body = String(data: data, encoding: .utf8)?
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !body.isEmpty
+        else {
+            return ""
+        }
+        guard body.count > Self.maxErrorBodyLength else { return body }
+        let index = body.index(body.startIndex, offsetBy: Self.maxErrorBodyLength)
+        return "\(body[..<index])… [truncated]"
+    }
+}

--- a/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAIUsageFetcher.swift
@@ -199,7 +199,6 @@ public enum AzureOpenAIUsageFetcher {
             "messages": [
                 ["role": "user", "content": "ping"],
             ],
-            "temperature": 0,
         ]
         if self.usesV1API(apiVersion) {
             payload["model"] = deploymentName

--- a/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDescriptor.swift
@@ -55,6 +55,7 @@ public enum ProviderDescriptorRegistry {
     private static let descriptorsByID: [UsageProvider: ProviderDescriptor] = [
         .codex: CodexProviderDescriptor.descriptor,
         .openai: OpenAIAPIProviderDescriptor.descriptor,
+        .azureopenai: AzureOpenAIProviderDescriptor.descriptor,
         .claude: ClaudeProviderDescriptor.descriptor,
         .cursor: CursorProviderDescriptor.descriptor,
         .opencode: OpenCodeProviderDescriptor.descriptor,

--- a/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
+++ b/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
@@ -32,6 +32,12 @@ public enum ProviderTokenResolver {
         self.openAIAPIResolution(environment: environment)?.token
     }
 
+    public static func azureOpenAIToken(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
+    {
+        self.azureOpenAIResolution(environment: environment)?.token
+    }
+
     public static func claudeAdminAPIToken(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
@@ -194,6 +200,12 @@ public enum ProviderTokenResolver {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
     {
         self.resolveEnv(OpenAIAPISettingsReader.apiKey(environment: environment))
+    }
+
+    public static func azureOpenAIResolution(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
+    {
+        self.resolveEnv(AzureOpenAISettingsReader.apiKey(environment: environment))
     }
 
     public static func claudeAdminAPIResolution(

--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -5,6 +5,7 @@ import SweetCookieKit
 public enum UsageProvider: String, CaseIterable, Sendable, Codable {
     case codex
     case openai
+    case azureopenai
     case claude
     case cursor
     case opencode

--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsageScanner.swift
@@ -347,11 +347,11 @@ enum CostUsageScanner {
                 filtered.claudeLogProviderFilter = .vertexAIOnly
             }
             return self.loadClaudeDaily(provider: .vertexai, range: range, now: now, options: filtered)
-        case .openai, .zai, .gemini, .antigravity, .cursor, .opencode, .opencodego, .alibaba, .factory, .copilot,
-             .minimax, .manus, .kilo, .kiro, .kimi, .kimik2, .moonshot, .augment, .jetbrains, .amp, .ollama,
-             .synthetic, .openrouter, .elevenlabs, .warp, .perplexity, .mimo, .doubao, .abacus, .mistral,
-             .deepseek, .codebuff, .crof, .windsurf, .venice, .commandcode, .stepfun, .bedrock, .grok, .groq,
-             .llmproxy, .deepgram:
+        case .openai, .azureopenai, .zai, .gemini, .antigravity, .cursor, .opencode, .opencodego, .alibaba, .factory,
+             .copilot, .minimax, .manus, .kilo, .kiro, .kimi, .kimik2, .moonshot, .augment, .jetbrains, .amp, .ollama,
+             .synthetic, .openrouter, .elevenlabs, .warp, .perplexity, .mimo, .doubao, .abacus, .mistral, .deepseek,
+             .codebuff, .crof, .windsurf, .venice, .commandcode, .stepfun, .bedrock, .grok, .groq, .llmproxy,
+             .deepgram:
             return emptyReport
         }
     }

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -53,6 +53,7 @@ enum ProviderChoice: String, AppEnum {
         switch provider {
         case .codex: self = .codex
         case .openai: return nil // OpenAI not yet supported in widgets
+        case .azureopenai: return nil // Azure OpenAI not yet supported in widgets
         case .claude: self = .claude
         case .gemini: self = .gemini
         case .alibaba: self = .alibaba

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -259,6 +259,7 @@ private struct ProviderSwitchChip: View {
         switch self.provider {
         case .codex: "Codex"
         case .openai: "OpenAI"
+        case .azureopenai: "Azure OpenAI"
         case .claude: "Claude"
         case .gemini: "Gemini"
         case .antigravity: "Anti"
@@ -615,6 +616,8 @@ enum WidgetColors {
             Color(red: 73 / 255, green: 163 / 255, blue: 176 / 255)
         case .openai:
             Color(red: 15 / 255, green: 130 / 255, blue: 110 / 255)
+        case .azureopenai:
+            Color(red: 0, green: 120 / 255, blue: 212 / 255)
         case .claude:
             Color(red: 204 / 255, green: 124 / 255, blue: 94 / 255)
         case .gemini:

--- a/Tests/CodexBarTests/AzureOpenAIUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AzureOpenAIUsageFetcherTests.swift
@@ -1,0 +1,163 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct AzureOpenAIUsageFetcherTests {
+    @Test
+    func `settings reader trims env vars and normalizes endpoint`() throws {
+        let environment = [
+            AzureOpenAISettingsReader.apiKeyEnvironmentKey: " 'azure-key' ",
+            AzureOpenAISettingsReader.endpointEnvironmentKey: "my-resource.openai.azure.com",
+            AzureOpenAISettingsReader.deploymentNameEnvironmentKey: " \"chat-deployment\" ",
+        ]
+
+        #expect(AzureOpenAISettingsReader.apiKey(environment: environment) == "azure-key")
+        #expect(
+            AzureOpenAISettingsReader.endpoint(environment: environment)?.absoluteString ==
+                "https://my-resource.openai.azure.com")
+        #expect(AzureOpenAISettingsReader.deploymentName(environment: environment) == "chat-deployment")
+        #expect(AzureOpenAISettingsReader.apiVersion(environment: [:]) == AzureOpenAISettingsReader.defaultAPIVersion)
+    }
+
+    @Test
+    func `fetcher validates deployment with chat completions request`() async throws {
+        let endpoint = try #require(URL(string: "https://example-resource.openai.azure.com"))
+        let updatedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let transport = ProviderHTTPTransportStub { request in
+            #expect(request.httpMethod == "POST")
+            #expect(request.url?.path == "/openai/deployments/chat-prod/chat/completions")
+            #expect(request.url?.query == "api-version=2024-10-21")
+            #expect(request.value(forHTTPHeaderField: "api-key") == "azure-key")
+            #expect(request.value(forHTTPHeaderField: "Accept") == "application/json")
+            #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+
+            let body = try #require(request.httpBody)
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            #expect(json["max_tokens"] as? Int == 1)
+            let messages = try #require(json["messages"] as? [[String: String]])
+            #expect(messages.first?["content"] == "ping")
+
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"])!
+            return (Data(#"{"id":"cmpl-1","model":"gpt-4o-mini"}"#.utf8), response)
+        }
+
+        let snapshot = try await AzureOpenAIUsageFetcher.fetchUsage(
+            apiKey: "azure-key",
+            endpoint: endpoint,
+            deploymentName: "chat-prod",
+            transport: transport,
+            updatedAt: updatedAt)
+
+        #expect(snapshot.endpointHost == "example-resource.openai.azure.com")
+        #expect(snapshot.deploymentName == "chat-prod")
+        #expect(snapshot.model == "gpt-4o-mini")
+        #expect(snapshot.apiVersion == AzureOpenAISettingsReader.defaultAPIVersion)
+        #expect(snapshot.updatedAt == updatedAt)
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.identity?.providerID == .azureopenai)
+        #expect(usage.identity?.accountOrganization == "example-resource.openai.azure.com")
+        #expect(usage.identity?.loginMethod == "Deployment: chat-prod")
+        #expect(usage.primary?.resetDescription == "Deployment: chat-prod · Model: gpt-4o-mini")
+    }
+
+    @Test
+    func `chat completions URL preserves endpoint path and deployment escaping`() throws {
+        let endpoint = try #require(URL(string: "https://proxy.example.com/base"))
+        let url = try AzureOpenAIUsageFetcher._chatCompletionsURLForTesting(
+            endpoint: endpoint,
+            deploymentName: "chat prod",
+            apiVersion: "2024-10-21")
+
+        #expect(
+            url.absoluteString ==
+                "https://proxy.example.com/base/openai/deployments/chat%20prod/chat/completions?api-version=2024-10-21")
+    }
+
+    @Test
+    func `v1 API validates with OpenAI compatible path and model field`() async throws {
+        let endpoint = try #require(URL(string: "https://example-resource.openai.azure.com"))
+        let transport = ProviderHTTPTransportStub { request in
+            #expect(request.httpMethod == "POST")
+            #expect(
+                request.url?.absoluteString ==
+                    "https://example-resource.openai.azure.com/openai/v1/chat/completions")
+            #expect(request.value(forHTTPHeaderField: "api-key") == "azure-key")
+
+            let body = try #require(request.httpBody)
+            let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            #expect(json["model"] as? String == "chat-prod")
+            #expect(json["max_completion_tokens"] as? Int == 1)
+            #expect(json["max_tokens"] == nil)
+
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"])!
+            return (Data(#"{"id":"cmpl-1","model":"gpt-4o-mini"}"#.utf8), response)
+        }
+
+        let snapshot = try await AzureOpenAIUsageFetcher.fetchUsage(
+            apiKey: "azure-key",
+            endpoint: endpoint,
+            deploymentName: "chat-prod",
+            apiVersion: "v1",
+            transport: transport)
+
+        #expect(snapshot.apiVersion == "v1")
+        #expect(snapshot.deploymentName == "chat-prod")
+        #expect(snapshot.model == "gpt-4o-mini")
+    }
+}
+
+@MainActor
+struct AzureOpenAIMenuDescriptorTests {
+    @Test
+    func `azure openai deployment detail appears in menu`() throws {
+        let suite = "AzureOpenAIMenuDescriptorTests-menu"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let snapshot = AzureOpenAIUsageSnapshot(
+            endpointHost: "example-resource.openai.azure.com",
+            deploymentName: "chat-prod",
+            model: "gpt-4o-mini",
+            apiVersion: "2024-10-21",
+            updatedAt: Date(timeIntervalSince1970: 1_800_000_000))
+        store._setSnapshotForTesting(snapshot.toUsageSnapshot(), provider: .azureopenai)
+
+        let descriptor = MenuDescriptor.build(
+            provider: .azureopenai,
+            store: store,
+            settings: settings,
+            account: AccountInfo(email: nil, plan: nil),
+            updateReady: false,
+            includeContextualActions: false)
+        let lines = descriptor.sections
+            .flatMap(\.entries)
+            .compactMap { entry -> String? in
+                guard case let .text(text, _) = entry else { return nil }
+                return text
+            }
+
+        #expect(lines.contains("Azure OpenAI"))
+        #expect(lines.contains("Deployment: chat-prod · Model: gpt-4o-mini"))
+    }
+}

--- a/Tests/CodexBarTests/AzureOpenAIUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AzureOpenAIUsageFetcherTests.swift
@@ -35,6 +35,7 @@ struct AzureOpenAIUsageFetcherTests {
             let body = try #require(request.httpBody)
             let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
             #expect(json["max_tokens"] as? Int == 1)
+            #expect(json["temperature"] == nil)
             let messages = try #require(json["messages"] as? [[String: String]])
             #expect(messages.first?["content"] == "ping")
 
@@ -94,6 +95,7 @@ struct AzureOpenAIUsageFetcherTests {
             #expect(json["model"] as? String == "chat-prod")
             #expect(json["max_completion_tokens"] as? Int == 1)
             #expect(json["max_tokens"] == nil)
+            #expect(json["temperature"] == nil)
 
             let response = try HTTPURLResponse(
                 url: #require(request.url),

--- a/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
+++ b/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
@@ -122,6 +122,29 @@ struct ProviderConfigEnvironmentTests {
     }
 
     @Test
+    func `applies Azure OpenAI config overrides`() {
+        let config = ProviderConfig(
+            id: .azureopenai,
+            apiKey: "config-azure-token",
+            workspaceID: "chat-prod",
+            enterpriseHost: "https://example-resource.openai.azure.com")
+        let env = ProviderConfigEnvironment.applyProviderConfigOverrides(
+            base: [
+                AzureOpenAISettingsReader.apiKeyEnvironmentKey: "env-azure-token",
+                AzureOpenAISettingsReader.endpointEnvironmentKey: "https://env-resource.openai.azure.com",
+                AzureOpenAISettingsReader.deploymentNameEnvironmentKey: "env-deployment",
+            ],
+            provider: .azureopenai,
+            config: config)
+
+        #expect(env[AzureOpenAISettingsReader.apiKeyEnvironmentKey] == "config-azure-token")
+        #expect(env[AzureOpenAISettingsReader.endpointEnvironmentKey] == "https://example-resource.openai.azure.com")
+        #expect(env[AzureOpenAISettingsReader.deploymentNameEnvironmentKey] == "chat-prod")
+        #expect(ProviderTokenResolver.azureOpenAIToken(environment: env) == "config-azure-token")
+        #expect(AzureOpenAISettingsReader.deploymentName(environment: env) == "chat-prod")
+    }
+
+    @Test
     func `bedrock config maps AWS credential fields`() {
         let config = ProviderConfig(
             id: .bedrock,


### PR DESCRIPTION
Adds Azure OpenAI as a provider with environment/config support for AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT, and AZURE_OPENAI_DEPLOYMENT_NAME. Includes deployment validation via chat completions, v1 API compatibility, settings wiring, menu rendering, and focused tests.

Validation:
- swift build
- swift test --filter AzureOpenAIUsageFetcherTests
- swift test --filter ProviderConfigEnvironmentTests
- git diff --check

Notes:
- Full swift test currently hits an existing local Safari cookie Full Disk Access failure in FactoryStatusProbeFetchTests, unrelated to this provider.
- make check could not be completed locally because lint tool download/network permission was unavailable.