### PR TITLE
Fix Antigravity 2.0 local detection

### DIFF
--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -263,7 +263,6 @@ public enum AntigravityStatusProbeError: LocalizedError, Sendable, Equatable {
 public struct AntigravityStatusProbe: Sendable {
     public var timeout: TimeInterval = 8.0
 
-    private static let processName = "language_server_macos"
     private static let getUserStatusPath = "/exa.language_server_pb.LanguageServerService/GetUserStatus"
     private static let commandModelConfigPath =
         "/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs"
@@ -465,7 +464,7 @@ public struct AntigravityStatusProbe: Sendable {
             let text = String(line)
             guard let match = Self.matchProcessLine(text) else { continue }
             let lower = match.command.lowercased()
-            guard lower.contains(Self.processName) else { continue }
+            guard Self.isLanguageServerCommandLine(lower) else { continue }
             guard Self.isAntigravityCommandLine(lower) else { continue }
             sawAntigravity = true
             guard let token = Self.extractFlag("--csrf_token", from: match.command) else { continue }
@@ -496,6 +495,13 @@ public struct AntigravityStatusProbe: Sendable {
         let parts = trimmed.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true)
         guard parts.count == 2, let pid = Int(parts[0]) else { return nil }
         return ProcessLineMatch(pid: pid, command: String(parts[1]))
+    }
+
+    static func isLanguageServerCommandLine(_ command: String) -> Bool {
+        let executable = command.split(separator: " ", maxSplits: 1, omittingEmptySubsequences: true).first
+            .map(String.init) ?? command
+        let processName = URL(fileURLWithPath: executable).lastPathComponent.lowercased()
+        return processName == "language_server_macos" || processName == "language_server"
     }
 
     private static func isAntigravityCommandLine(_ command: String) -> Bool {

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -22,6 +22,19 @@ private final class AntigravityAttemptRecorder: @unchecked Sendable {
 
 struct AntigravityStatusProbeTests {
     @Test
+    func `language server detection accepts current and legacy Antigravity binaries`() {
+        #expect(
+            AntigravityStatusProbe.isLanguageServerCommandLine(
+                "/Applications/Antigravity.app/Contents/Resources/bin/language_server --standalone"))
+        #expect(
+            AntigravityStatusProbe.isLanguageServerCommandLine(
+                "/Applications/Antigravity.app/Contents/Resources/bin/language_server_macos --standalone"))
+        #expect(
+            !AntigravityStatusProbe.isLanguageServerCommandLine(
+                "/Applications/Antigravity.app/Contents/MacOS/Antigravity"))
+    }
+
+    @Test
     func `localhost trust policy only accepts local server trust challenges`() {
         #expect(
             LocalhostTrustPolicy.shouldAcceptServerTrust(

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -32,7 +32,7 @@ Antigravity supports local IDE probing and Google OAuth-backed remote usage. The
 
 1) **Process detection**
    - Command: `ps -ax -o pid=,command=`.
-   - Match process name: `language_server_macos` plus Antigravity markers:
+   - Match process name: `language_server` or `language_server_macos` plus Antigravity markers:
      - `--app_data_dir antigravity` OR path contains `/antigravity/`.
    - Extract CLI flags:
      - `--csrf_token <token>` (required).


### PR DESCRIPTION
## Summary
- Accept Antigravity 2.0's `language_server` process name in the local Antigravity status probe while keeping legacy `language_server_macos` support.
- Add a focused regression test for current and legacy Antigravity language-server binaries.
- Update `docs/antigravity.md` to document both process names.

Fixes #1049.

## Verification
- `swift test --filter AntigravityStatusProbeTests`
- `./.build/debug/CodexBarCLI usage --provider antigravity --source cli --json --antigravity-plan-debug`
- `make format`
- `make check`
- `TZ=UTC swift test`

## Live repro note
On Antigravity 2.0.0, the running local process is `/Applications/Antigravity.app/Contents/Resources/bin/language_server ... --app_data_dir antigravity ...`. Current `main` only matches `language_server_macos`, so `--source cli` reports `Antigravity language server not detected` and auto mode falls back to OAuth. After this patch, the freshly built CLI returns `source: local` for the same running Antigravity app.