### PR TITLE
fix(elevenlabs): improve progress contrast in light mode

### DIFF
--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -30,6 +30,10 @@ extension UsageMenuCardView.Model {
     }
 
     static func progressColor(for provider: UsageProvider) -> Color {
+        if provider == .elevenlabs {
+            return Color(nsColor: .labelColor)
+        }
+
         let color = ProviderDescriptorRegistry.descriptor(for: provider).branding.color
         return Color(red: color.red, green: color.green, blue: color.blue)
     }

--- a/Tests/CodexBarTests/MenuCardProviderRegressionTests.swift
+++ b/Tests/CodexBarTests/MenuCardProviderRegressionTests.swift
@@ -1,9 +1,15 @@
 import CodexBarCore
 import Foundation
+import SwiftUI
 import Testing
 @testable import CodexBar
 
 struct MenuCardProviderRegressionTests {
+    @Test
+    func `elevenlabs progress color stays visible in light menus`() {
+        #expect(UsageMenuCardView.Model.progressColor(for: .elevenlabs) == Color(nsColor: .labelColor))
+    }
+
     @Test
     func `open router model shows daily and weekly key spend`() throws {
         let now = Date()


### PR DESCRIPTION
## Summary

- Fix the ElevenLabs progress fill being too close to the light menu background, which made quota progress hard to read at a glance.
- Use the adaptive system label color for ElevenLabs progress bars instead of the near-white ElevenLabs brand color.
- Keep the existing dark-mode appearance intact while making the bar visible in light mode.
- Add a focused regression test for the ElevenLabs progress tint.

## Visual Verification

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Light mode before: ElevenLabs progress is nearly invisible](https://quiet-wisdom-stvd.here.now/droppie-2026-05-20T03-52-49Z.png) | ![Light mode after: ElevenLabs progress is dark and visible](https://bitter-hazel-mvr8.here.now/droppie-2026-05-20T03-53-00Z.png) |
| Dark | ![Dark mode before](https://steady-paddle-rpk4.here.now/droppie-2026-05-20T03-52-42Z.png) | <div align="center">Remains the same</div> |

## Validation

- `swiftformat Sources/CodexBar/MenuCardView+ModelHelpers.swift Tests/CodexBarTests/MenuCardProviderRegressionTests.swift`
- `swift test --filter MenuCardProviderRegressionTests`
- `make check`
- `CODEXBAR_SIGNING=adhoc CODEXBAR_WIDGET_METADATA_MODE=skip ./Scripts/package_app.sh debug`
- Manual: built and launched `CodexBar.app`; verified ElevenLabs progress remains visible in light mode and unchanged in dark mode.
- `codex review --uncommitted`
