### PR TITLE
docs: surface 'Disable Keychain Access' toggle as escape hatch for repeating prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Wondering if CodexBar scans your disk? It doesn’t crawl your filesystem; it re
     - Find the browser’s “Safe Storage” key (e.g., “Chrome Safe Storage”, “Brave Safe Storage”, “Microsoft Edge Safe Storage”).
     - Open the item → **Access Control** → add `CodexBar.app` under “Always allow access by these applications”.
     - This removes the prompt when CodexBar decrypts cookies for that browser.
+  - **Last resort — stop all Keychain reads entirely**: if "Always Allow" doesn't stick (e.g., macOS resets the ACL after a Chromium update or a `partition_id` reset), open **CodexBar → Settings → Advanced → Keychain access** and enable **Disable Keychain access**. CodexBar will no longer touch the Keychain. Browser-cookie-based providers will be skipped, but Claude/Codex OAuth via the CLI still works (it reads `~/.codex` / `~/.claude` config files, not the Keychain).
 - **Files & Folders prompts (folder/volume access)**: CodexBar launches provider CLIs and local probes for some providers. If those helpers read a project directory or external drive, macOS may ask CodexBar for that folder/volume (e.g., Desktop or an external volume). This is driven by the helper’s working directory, not background disk scanning.
 - **What we do not request in the background**: no Screen Recording or Accessibility permissions; user-triggered helper actions may ask macOS for Automation permission to open Terminal. No passwords are stored (browser cookies are reused when you opt in).
 

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -528,7 +528,7 @@
 "show_provider_storage_usage_title" = "Show provider storage usage";
 "show_provider_storage_usage_subtitle" = "Show local disk usage in menus. Scans known provider-owned paths in the background.";
 "section_keychain_access" = "Keychain access";
-"keychain_access_caption" = "Disable all Keychain reads and writes. Browser cookie import is unavailable; paste Cookie headers manually in Providers.";
+"keychain_access_caption" = "Disable all Keychain reads and writes. Use this if macOS keeps prompting for 'Chrome/Brave/Edge Safe Storage' even after clicking Always Allow. Browser cookie import is unavailable while enabled; paste Cookie headers manually in Providers. Claude/Codex OAuth via the CLI still works.";
 "disable_keychain_access_title" = "Disable Keychain access";
 "disable_keychain_access_subtitle" = "Prevents any Keychain access while enabled.";
 


### PR DESCRIPTION
## Summary

- Document the existing `Settings → Advanced → Disable Keychain Access` toggle as the supported way out when macOS keeps re-prompting for "Chrome/Brave/Edge Safe Storage" even after clicking **Always Allow** (closed-but-recurring issues #84, #186, #243, #340, and most recently #1056).
- README: add one "Last resort" bullet under the existing **How do I prevent those keychain alerts?** section. Names the trade-off (browser cookie import off, Claude/Codex OAuth via CLI still works).
- `Localizable.strings` (en only): rewrite `keychain_access_caption` so the symptom ("macOS keeps prompting for Safe Storage even after Always Allow") and the trade-off are right next to the toggle.

No code or behavior changes — the toggle (`debugDisableKeychainAccess`) already exists and already short-circuits `KeychainAccessGate` / `BrowserCookieAccessGate`. This PR just makes it findable.

## Why docs-only

The repeating-prompt behavior has multiple upstream root causes (Chromium ACL resets after browser updates, Claude CLI `partition_id` resets per #367, code-signing changes between builds). Trying to fix them in-app is a moving target. But there is already a one-click escape hatch shipped in `PreferencesAdvancedPane.swift:95` — it just isn't discoverable. Pointing users at it closes the loop for everyone who only uses Claude/Codex OAuth and doesn't care about web-cookie providers.

## Non-English localizations

Only `en.lproj` is updated in this PR to avoid machine-translating the other 8 locales (`zh-Hans`, `es`, `ca`, `pt-BR`, …). Happy to follow up if a preferred translation workflow exists.

## Test plan

- [ ] `swift build` passes (no source changes, but verifies resources still bundle).
- [ ] Visually confirm caption wraps cleanly in the Advanced pane at default window width.
- [ ] Confirm README renders correctly on github.com.

Related issue: #1056

🤖 Generated with [Claude Code](https://claude.com/claude-code)