### PR TITLE
Add GNOME Shell extension link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ CLI install:
 
 ## Linux desktop integration?
 - [codexbar-waybar](https://github.com/Marouan-chak/codexbar-waybar) — Waybar custom module + GTK4 popover for Hyprland / Sway / other Wayland compositors, built on top of the bundled Linux CLI.
+## For GNOME Shell users (Linux DE):  
+- [Codexbar-gnome](https://extensions.gnome.org/extension/9841/codexbar/)- Same as the MacOS version, but integrated into the GNOME environment
+
 
 ## Credits
 Inspired by [ccusage](https://github.com/ryoppippi/ccusage) (MIT), specifically the cost usage tracking.

--- a/README.md
+++ b/README.md
@@ -212,8 +212,7 @@ CLI install:
 
 ## Linux desktop integration?
 - [codexbar-waybar](https://github.com/Marouan-chak/codexbar-waybar) — Waybar custom module + GTK4 popover for Hyprland / Sway / other Wayland compositors, built on top of the bundled Linux CLI.
-## For GNOME Shell users (Linux DE):  
-- [Codexbar-gnome](https://extensions.gnome.org/extension/9841/codexbar/)- Same as the MacOS version, but integrated into the GNOME environment
+- [Codexbar GNOME](https://extensions.gnome.org/extension/9841/codexbar/) — GNOME Shell extension that brings CodexBar usage into the desktop panel.
 
 
 ## Credits


### PR DESCRIPTION
Hello!
I've implemented a GNOME Extension for Codexbar, using Codexbar CLI for Linux as data provider.  
Gnome is one of the most used desktop environments for Linux and the extension has now 102 downloads on the official [Extensions Gnome Store](https://extensions.gnome.org/extension/9841/codexbar/).  
This extension does the same as the Macos version does, ported for GNOME.  
The source code is here -> [InledGroup/codexbar-gnome](https://github.com/InledGroup/codexbar-gnome).  
Documentation can be found [here](https://help.inled.es/codexbar-gnome) for newcomers.
If anyone can review this, thank you for your time.