### PR TITLE
Fix OpenAI dashboard reset-line parser for Wednesday and Saturday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Localizations: add Spanish and Catalan language packs and fill missing localization keys (#1041). Thanks @seifreed!
 
 ### Fixed
+- OpenAI: parse Wednesday and Saturday dashboard reset lines so rate-limit reset times are not dropped on those days (#1080). Thanks @m1qaweb!
 - Localization: translate provider-detail labels and empty states when Simplified Chinese is selected (#1051). Thanks @wang93wei!
 - Antigravity: discover OAuth credentials from the bundled extension language server in newer IDE builds so Add Account works again (#1076). Thanks @xARSENICx!
 - Menu bar: wait for display changes to settle before recovering status items and retry if macOS still leaves the icon detached (#1074). Thanks @yipjunkai!

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardParser.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardParser.swift
@@ -443,7 +443,12 @@ public enum OpenAIDashboardParser {
     }
 
     private static func weekdayMatch(in text: String) -> WeekdayMatch? {
-        let pattern = #"\b(mon|tue|tues|wed|thu|thur|thurs|fri|sat|sun)(day)?\b"#
+        // The optional "(day)?" suffix requires each alternative to be long enough that
+        // adding "day" reproduces the full weekday name. "wed"+"day"="wedday" and
+        // "sat"+"day"="satday", so the longer prefixes "wednes" and "satur" are needed
+        // to cover the full "Wednesday" and "Saturday" forms — mirroring how the existing
+        // "tue|tues" and "thu|thur|thurs" alternatives layer up to "tuesday"/"thursday".
+        let pattern = #"\b(mon|tue|tues|wed|wednes|thu|thur|thurs|fri|sat|satur|sun)(day)?\b"#
         guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return nil }
         let range = NSRange(text.startIndex..<text.endIndex, in: text)
         guard let match = regex.firstMatch(in: text, options: [], range: range),

--- a/TestsLinux/OpenAIDashboardParserLinuxTests.swift
+++ b/TestsLinux/OpenAIDashboardParserLinuxTests.swift
@@ -1,0 +1,60 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+/// Cross-platform tests for the OpenAI dashboard text parser.
+///
+/// The dashboard renders reset countdowns like "Resets Wednesday at 3pm". The parser
+/// converts a textual weekday into the next occurrence of that weekday so it can be
+/// formatted into a concrete `Date`. These tests pin down full-weekday-name coverage
+/// because the underlying regex previously missed "Wednesday" and "Saturday" (their
+/// abbreviations were not long enough to combine with the optional "day" suffix).
+@Suite
+struct OpenAIDashboardParserLinuxTests {
+    private static func fixedNow() -> Date {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        // 2026-05-21 is a Thursday in the Gregorian calendar; using a fixed anchor keeps
+        // the test deterministic regardless of when it executes.
+        return calendar.date(from: DateComponents(year: 2026, month: 5, day: 21))!
+    }
+
+    private static func body(forWeekday weekday: String) -> String {
+        """
+        5h limit
+        50% remaining
+        Resets \(weekday)
+        """
+    }
+
+    @Test
+    func parsesResetLineForEveryFullWeekdayName() {
+        let now = Self.fixedNow()
+        for weekday in ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"] {
+            let result = OpenAIDashboardParser.parseRateLimits(
+                bodyText: Self.body(forWeekday: weekday),
+                now: now)
+            #expect(
+                result.primary?.resetsAt != nil,
+                "Expected a parsed resetsAt for weekday \(weekday)")
+        }
+    }
+
+    @Test
+    func parsesResetLineForLowercaseWednesday() {
+        let now = Self.fixedNow()
+        let result = OpenAIDashboardParser.parseRateLimits(
+            bodyText: Self.body(forWeekday: "wednesday"),
+            now: now)
+        #expect(result.primary?.resetsAt != nil)
+    }
+
+    @Test
+    func parsesResetLineForLowercaseSaturday() {
+        let now = Self.fixedNow()
+        let result = OpenAIDashboardParser.parseRateLimits(
+            bodyText: Self.body(forWeekday: "saturday"),
+            now: now)
+        #expect(result.primary?.resetsAt != nil)
+    }
+}


### PR DESCRIPTION
OpenAIDashboardParser.weekdayMatch used the regex
"\b(mon|tue|tues|wed|thu|thur|thurs|fri|sat|sun)(day)?\b" which relies on <abbrev> + optional "day" reproducing the full weekday name. That holds for monday/tuesday/thursday/friday/sunday (the layered "tue|tues" and "thu|thur|thurs" alternatives cover the longer ones), but "wed"+"day"="wedday" and "sat"+"day"="satday" — so "Wednesday" and "Saturday" in reset strings produced no match. parseResetDate then fell through to format-string parsing which can't recover bare weekday text either, dropping the reset time silently on 2 of every 7 days.

Add "wednes" and "satur" alongside the existing alternatives, mirroring the same progressive-abbreviation pattern. New TestsLinux suite sweeps all seven full weekday names plus dedicated lowercase Wed/Sat regressions through the public parseRateLimits API; the parameterized test surfaces both regressions on master and goes green with the fix.