### PR TITLE
MiniMax: add tests for coding plan title propagation

### DIFF
--- a/Tests/CodexBarTests/MiniMaxMenuCardModelPlanTests.swift
+++ b/Tests/CodexBarTests/MiniMaxMenuCardModelPlanTests.swift
@@ -1,0 +1,101 @@
+import CodexBarCore
+import Foundation
+import SwiftUI
+import Testing
+@testable import CodexBar
+
+struct MiniMaxMenuCardModelPlanTests {
+    @Test
+    func `minimax loginMethod maps to planText in MenuCardModel`() throws {
+        let now = Date()
+        let minimax = MiniMaxUsageSnapshot(
+            planName: "MiniMax Star",
+            availablePrompts: nil,
+            currentPrompts: nil,
+            remainingPrompts: nil,
+            windowMinutes: nil,
+            usedPercent: nil,
+            resetsAt: nil,
+            updatedAt: now)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            minimaxUsage: minimax,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .minimax,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "MiniMax Star"))
+        let metadata = try #require(ProviderDefaults.metadata[.minimax])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .minimax,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: true,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.planText == "MiniMax Star")
+    }
+
+    @Test
+    func `minimax nil loginMethod results in nil planText`() throws {
+        let now = Date()
+        let minimax = MiniMaxUsageSnapshot(
+            planName: nil,
+            availablePrompts: nil,
+            currentPrompts: nil,
+            remainingPrompts: nil,
+            windowMinutes: nil,
+            usedPercent: nil,
+            resetsAt: nil,
+            updatedAt: now)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            minimaxUsage: minimax,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .minimax,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: nil))
+        let metadata = try #require(ProviderDefaults.metadata[.minimax])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .minimax,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: true,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.planText == nil)
+    }
+}

--- a/Tests/CodexBarTests/MiniMaxProviderTests.swift
+++ b/Tests/CodexBarTests/MiniMaxProviderTests.swift
@@ -171,6 +171,94 @@ struct MiniMaxUsageParserTests {
     }
 
     @Test
+    func `parses planName from concrete fields in remains response`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+        // 1. plan_name
+        let jsonPlanName = """
+        {
+          "base_resp": { "status_code": 0 },
+          "plan_name": "MiniMax Star",
+          "model_remains": [{"model_name": "abab6.5"}]
+        }
+        """
+        let snapshot1 = try MiniMaxUsageParser.parseCodingPlanRemains(data: Data(jsonPlanName.utf8), now: now)
+        #expect(snapshot1.planName == "MiniMax Star")
+
+        // 2. current_plan_title
+        let jsonCurrentPlan = """
+        {
+          "base_resp": { "status_code": 0 },
+          "current_plan_title": "Coding Plan Pro",
+          "model_remains": [{"model_name": "abab6.5"}]
+        }
+        """
+        let snapshot2 = try MiniMaxUsageParser.parseCodingPlanRemains(data: Data(jsonCurrentPlan.utf8), now: now)
+        #expect(snapshot2.planName == "Coding Plan Pro")
+
+        // 3. current_subscribe_title
+        let jsonSubscribe = """
+        {
+          "base_resp": { "status_code": 0 },
+          "current_subscribe_title": "Max",
+          "model_remains": [{"model_name": "abab6.5"}]
+        }
+        """
+        let snapshot3 = try MiniMaxUsageParser.parseCodingPlanRemains(data: Data(jsonSubscribe.utf8), now: now)
+        #expect(snapshot3.planName == "Max")
+
+        // 4. combo_title
+        let jsonCombo = """
+        {
+          "base_resp": { "status_code": 0 },
+          "combo_title": "Combo Star",
+          "model_remains": [{"model_name": "abab6.5"}]
+        }
+        """
+        let snapshot4 = try MiniMaxUsageParser.parseCodingPlanRemains(data: Data(jsonCombo.utf8), now: now)
+        #expect(snapshot4.planName == "Combo Star")
+
+        // 5. current_combo_card.title
+        let jsonComboCard = """
+        {
+          "base_resp": { "status_code": 0 },
+          "current_combo_card": { "title": "Card Title" },
+          "model_remains": [{"model_name": "abab6.5"}]
+        }
+        """
+        let snapshot5 = try MiniMaxUsageParser.parseCodingPlanRemains(data: Data(jsonComboCard.utf8), now: now)
+        #expect(snapshot5.planName == "Card Title")
+    }
+
+    @Test
+    func `toUsageSnapshot maps planName to loginMethod`() {
+        let now = Date()
+        let snapshot1 = MiniMaxUsageSnapshot(
+            planName: "MiniMax Star",
+            availablePrompts: nil,
+            currentPrompts: nil,
+            remainingPrompts: nil,
+            windowMinutes: nil,
+            usedPercent: nil,
+            resetsAt: nil,
+            updatedAt: now)
+        let usage1 = snapshot1.toUsageSnapshot()
+        #expect(usage1.identity?.loginMethod == "MiniMax Star")
+
+        let snapshot2 = MiniMaxUsageSnapshot(
+            planName: nil,
+            availablePrompts: nil,
+            currentPrompts: nil,
+            remainingPrompts: nil,
+            windowMinutes: nil,
+            usedPercent: nil,
+            resetsAt: nil,
+            updatedAt: now)
+        let usage2 = snapshot2.toUsageSnapshot()
+        #expect(usage2.identity?.loginMethod == nil)
+    }
+
+    @Test
     func `parses coding plan snapshot`() throws {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let html = """


### PR DESCRIPTION
## Summary

Adds focused coverage for MiniMax coding-plan title propagation from parser output to the shared menu model.

This verifies that concrete MiniMax plan names exposed by provider responses flow through:

- `MiniMaxUsageSnapshot.planName`
- `ProviderIdentitySnapshot.loginMethod`
- `UsageMenuCardView.Model.planText`

The tests also verify that missing MiniMax plan metadata does not create a fake plan label.

## Scope

- tests only
- no production code changes
- no quota calculation changes
- no generic `Coding Plan` fallback
- no account/email fallback changes

## Testing

- `swift test --filter MiniMax`
- `swift test --filter MenuCardModel`
- `git diff --check`
- `make check` partially completed:
  - SwiftFormat passed (`0/926 files require formatting`)
  - SwiftLint passed (`Found 0 violations, 0 serious in 925 files`)
  - stopped on a local missing plist folder error unrelated to the diff:
    `The folder “7030ca5bcc3ed9e5a33a37b69280775f7f9ac4a760295f3a996ae326a0b1bd78.plist” doesn’t exist.`