### PR TITLE
Antigravity: improve OAuth client setup diagnostics

### DIFF
--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
@@ -132,8 +132,11 @@ public enum AntigravityOAuthConfig {
 
     public static let missingCredentialsMessage =
         """
-        Antigravity OAuth client is not configured. Install Antigravity.app or set \
-        ANTIGRAVITY_OAUTH_CLIENT_ID and ANTIGRAVITY_OAUTH_CLIENT_SECRET before logging in.
+        CodexBar could not discover Antigravity.app's OAuth client. \
+        Please install Antigravity.app or set both ANTIGRAVITY_OAUTH_CLIENT_ID and \
+        ANTIGRAVITY_OAUTH_CLIENT_SECRET before logging in. \
+        If you are using the Antigravity CLI after migrating from Gemini CLI, note \
+        that the CLI alone may not provide the OAuth client metadata CodexBar needs.
         """
 
     public static func resolvedClient() -> AntigravityOAuthClient? {

--- a/Tests/CodexBarTests/AntigravityOAuthCredentialsStoreTests.swift
+++ b/Tests/CodexBarTests/AntigravityOAuthCredentialsStoreTests.swift
@@ -84,6 +84,15 @@ struct AntigravityOAuthCredentialsStoreTests {
                 applicationRoots: [root]) == standaloneClient)
     }
 
+    @Test
+    func `missing credentials message contains key diagnostic hints`() {
+        let msg = AntigravityOAuthConfig.missingCredentialsMessage
+        #expect(msg.contains("CodexBar could not discover Antigravity.app's OAuth client"))
+        #expect(msg.contains("ANTIGRAVITY_OAUTH_CLIENT_ID"))
+        #expect(msg.contains("ANTIGRAVITY_OAUTH_CLIENT_SECRET"))
+        #expect(msg.contains("Antigravity CLI after migrating from Gemini CLI"))
+    }
+
     private func writeAntigravityApp(
         named name: String,
         under root: URL,


### PR DESCRIPTION
## Summary

Improves the Antigravity OAuth setup diagnostic shown when CodexBar cannot discover the Antigravity OAuth client.

The updated message clarifies that CodexBar expects OAuth client metadata from `Antigravity.app` or explicit `ANTIGRAVITY_OAUTH_CLIENT_ID` / `ANTIGRAVITY_OAUTH_CLIENT_SECRET` environment variables, and notes that the Antigravity CLI alone may not provide the client metadata needed by CodexBar after the Gemini CLI migration.

## Scope

- Antigravity only
- diagnostics/message only
- no auth behavior changes
- no quota parsing changes
- no Gemini provider changes
- no CLI discovery changes

## Testing

- `swift test --filter AntigravityOAuthCredentialsStoreTests`
- `make check`
- `git diff --check`