### PR TITLE
Add Ollama API key support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.28.0 — Unreleased
 
 ### Added
+- Ollama: add API key authentication as an alternative to browser cookies for validating Cloud access (#1044). Thanks @nandorocker!
 - Azure OpenAI: add deployment-status validation via API key, endpoint, and deployment settings (#1045). Thanks @ZenoRewn!
 - Localizations: add Spanish and Catalan language packs and fill missing localization keys (#1041). Thanks @seifreed!
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ See [CLI configuration](docs/cli-configuration.md) for the full flow.
 - [Vertex AI](docs/vertexai.md) — Google Cloud gcloud OAuth with token cost tracking from local Claude logs.
 - [Augment](docs/augment.md) — Augment CLI or browser cookies for credits tracking and usage monitoring.
 - [Amp](docs/amp.md) — Browser cookie-based authentication with Amp Free usage tracking.
-- [Ollama](docs/ollama.md) — Browser cookies for Ollama Cloud usage windows.
+- [Ollama](docs/ollama.md) — API key access plus browser cookies for Ollama Cloud usage windows.
 - [JetBrains AI](docs/jetbrains.md) — Local XML-based quota from JetBrains IDE configuration; monthly credits tracking.
 - [Warp](docs/warp.md) — API token for GraphQL request limits and monthly credits.
 - [ElevenLabs](docs/elevenlabs.md) — API key for character credits and voice slot usage.

--- a/Sources/CodexBar/InlineUsageDashboardContent.swift
+++ b/Sources/CodexBar/InlineUsageDashboardContent.swift
@@ -52,6 +52,12 @@ extension UsageMenuCardView.Model {
             ]
         }
 
+        if input.provider == .ollama,
+           input.snapshot?.identity?.loginMethod == "API key"
+        {
+            return ["API key verified. Ollama does not expose Cloud quota limits through the API."]
+        }
+
         return nil
     }
 

--- a/Sources/CodexBar/Providers/Ollama/OllamaProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Ollama/OllamaProviderImplementation.swift
@@ -10,8 +10,27 @@ struct OllamaProviderImplementation: ProviderImplementation {
 
     @MainActor
     func observeSettings(_ settings: SettingsStore) {
+        _ = settings.ollamaUsageDataSource
+        _ = settings.ollamaAPIToken
         _ = settings.ollamaCookieSource
         _ = settings.ollamaCookieHeader
+    }
+
+    @MainActor
+    func sourceMode(context: ProviderSourceModeContext) -> ProviderSourceMode {
+        context.settings.ollamaUsageDataSource
+    }
+
+    @MainActor
+    func isAvailable(context: ProviderAvailabilityContext) -> Bool {
+        if OllamaAPISettingsReader.apiKey(environment: context.environment) != nil {
+            return true
+        }
+        context.settings.ensureOllamaAPITokenLoaded()
+        if !context.settings.ollamaAPIToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return true
+        }
+        return context.settings.ollamaCookieSource != .off
     }
 
     @MainActor
@@ -35,6 +54,16 @@ struct OllamaProviderImplementation: ProviderImplementation {
 
     @MainActor
     func settingsPickers(context: ProviderSettingsContext) -> [ProviderSettingsPickerDescriptor] {
+        let sourceBinding = Binding(
+            get: { context.settings.ollamaUsageDataSource.rawValue },
+            set: { raw in
+                context.settings.ollamaUsageDataSource = ProviderSourceMode(rawValue: raw) ?? .auto
+            })
+        let sourceOptions: [ProviderSettingsPickerOption] = [
+            ProviderSettingsPickerOption(id: ProviderSourceMode.auto.rawValue, title: "Auto"),
+            ProviderSettingsPickerOption(id: ProviderSourceMode.web.rawValue, title: "Browser cookies"),
+            ProviderSettingsPickerOption(id: ProviderSourceMode.api.rawValue, title: "API key"),
+        ]
         let cookieBinding = Binding(
             get: { context.settings.ollamaCookieSource.rawValue },
             set: { raw in
@@ -55,6 +84,14 @@ struct OllamaProviderImplementation: ProviderImplementation {
 
         return [
             ProviderSettingsPickerDescriptor(
+                id: "ollama-usage-source",
+                title: "Usage source",
+                subtitle: "API key verifies Ollama Cloud access; cookies still expose quota limits.",
+                binding: sourceBinding,
+                options: sourceOptions,
+                isVisible: nil,
+                onChange: nil),
+            ProviderSettingsPickerDescriptor(
                 id: "ollama-cookie-source",
                 title: "Cookie source",
                 subtitle: "Automatic imports browser cookies.",
@@ -69,6 +106,27 @@ struct OllamaProviderImplementation: ProviderImplementation {
     @MainActor
     func settingsFields(context: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {
         [
+            ProviderSettingsFieldDescriptor(
+                id: "ollama-api-key",
+                title: "API key",
+                subtitle: "Stored in ~/.codexbar/config.json. Get your key from Ollama settings.",
+                kind: .secure,
+                placeholder: "ollama-...",
+                binding: context.stringBinding(\.ollamaAPIToken),
+                actions: [
+                    ProviderSettingsActionDescriptor(
+                        id: "ollama-open-api-keys",
+                        title: "Open Ollama API Keys",
+                        style: .link,
+                        isVisible: nil,
+                        perform: {
+                            if let url = URL(string: "https://ollama.com/settings/keys") {
+                                NSWorkspace.shared.open(url)
+                            }
+                        }),
+                ],
+                isVisible: nil,
+                onActivate: { context.settings.ensureOllamaAPITokenLoaded() }),
             ProviderSettingsFieldDescriptor(
                 id: "ollama-cookie",
                 title: "",

--- a/Sources/CodexBar/Providers/Ollama/OllamaSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Ollama/OllamaSettingsStore.swift
@@ -2,6 +2,29 @@ import CodexBarCore
 import Foundation
 
 extension SettingsStore {
+    var ollamaUsageDataSource: ProviderSourceMode {
+        get {
+            let source = self.configSnapshot.providerConfig(for: .ollama)?.source
+            return source ?? .auto
+        }
+        set {
+            self.updateProviderConfig(provider: .ollama) { entry in
+                entry.source = newValue == .auto ? nil : newValue
+            }
+            self.logProviderModeChange(provider: .ollama, field: "source", value: newValue.rawValue)
+        }
+    }
+
+    var ollamaAPIToken: String {
+        get { self.configSnapshot.providerConfig(for: .ollama)?.sanitizedAPIKey ?? "" }
+        set {
+            self.updateProviderConfig(provider: .ollama) { entry in
+                entry.apiKey = self.normalizedConfigValue(newValue)
+            }
+            self.logSecretUpdate(provider: .ollama, field: "apiKey", value: newValue)
+        }
+    }
+
     var ollamaCookieHeader: String {
         get { self.configSnapshot.providerConfig(for: .ollama)?.sanitizedCookieHeader ?? "" }
         set {
@@ -21,6 +44,8 @@ extension SettingsStore {
             self.logProviderModeChange(provider: .ollama, field: "cookieSource", value: newValue.rawValue)
         }
     }
+
+    func ensureOllamaAPITokenLoaded() {}
 
     func ensureOllamaCookieLoaded() {}
 }

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -99,21 +99,6 @@ extension CodexBarCLI {
             }
         }
 
-        #if !os(macOS)
-        if let parsedSourceMode {
-            let requiresWeb = providerList.contains { selectedProvider in
-                Self.sourceModeRequiresWebSupport(parsedSourceMode, provider: selectedProvider)
-            }
-            if requiresWeb {
-                Self.exit(
-                    code: .failure,
-                    message: "Error: selected source requires web support and is only supported on macOS.",
-                    output: output,
-                    kind: .runtime)
-            }
-        }
-        #endif
-
         let browserDetection = BrowserDetection()
         let fetcher = UsageFetcher()
         let claudeFetcher = ClaudeUsageFetcher(browserDetection: browserDetection)
@@ -277,7 +262,12 @@ extension CodexBarCLI {
             account: account)
 
         #if !os(macOS)
-        if Self.sourceModeRequiresWebSupport(effectiveSourceMode, provider: provider) {
+        if Self.sourceModeRequiresWebSupport(
+            effectiveSourceMode,
+            provider: provider,
+            environment: env,
+            settings: settings)
+        {
             return Self.webSourceUnsupportedOutput(
                 provider: provider,
                 account: account?.label ?? codexVisibleAccount?.menuDisplayName,
@@ -459,8 +449,20 @@ extension CodexBarCLI {
         return output
     }
 
-    static func sourceModeRequiresWebSupport(_ sourceMode: ProviderSourceMode, provider: UsageProvider) -> Bool {
+    static func sourceModeRequiresWebSupport(
+        _ sourceMode: ProviderSourceMode,
+        provider: UsageProvider,
+        environment: [String: String]? = nil,
+        settings: ProviderSettingsSnapshot? = nil) -> Bool
+    {
         guard provider != .grok else {
+            return false
+        }
+        if provider == .ollama,
+           sourceMode == .auto,
+           settings?.ollama?.cookieSource == .off
+           || environment.map({ ProviderTokenResolver.ollamaToken(environment: $0) != nil }) == true
+        {
             return false
         }
         return switch sourceMode {

--- a/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
+++ b/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
@@ -95,6 +95,8 @@ public enum ProviderConfigEnvironment {
             ElevenLabsSettingsReader.apiKeyEnvironmentKey
         case .moonshot:
             MoonshotSettingsReader.apiKeyEnvironmentKeys.first
+        case .ollama:
+            OllamaAPISettingsReader.apiKeyEnvironmentKeys.first
         case .venice:
             VeniceSettingsReader.apiKeyEnvironmentKey
         case .deepgram:

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
@@ -54,7 +54,7 @@ public enum OllamaProviderDescriptor {
             return [OllamaAPIFetchStrategy()]
         }
         if ProviderTokenResolver.ollamaToken(environment: context.env) != nil {
-            return [OllamaAPIFetchStrategy(), OllamaStatusFetchStrategy()]
+            return [OllamaStatusFetchStrategy(), OllamaAPIFetchStrategy()]
         }
         return [OllamaStatusFetchStrategy()]
     }
@@ -85,8 +85,9 @@ struct OllamaStatusFetchStrategy: ProviderFetchStrategy {
             sourceLabel: "web")
     }
 
-    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
-        false
+    func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {
+        context.sourceMode == .auto
+            && ProviderTokenResolver.ollamaToken(environment: context.env) != nil
     }
 
     private static func manualCookieHeader(from context: ProviderFetchContext) -> String? {

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaProviderDescriptor.swift
@@ -32,11 +32,31 @@ public enum OllamaProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "Ollama cost summary is not supported." }),
             fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .web],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [OllamaStatusFetchStrategy()] })),
+                sourceModes: [.auto, .web, .api],
+                pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "ollama",
                 versionDetector: nil))
+    }
+
+    private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {
+        switch context.sourceMode {
+        case .web:
+            return [OllamaStatusFetchStrategy()]
+        case .api:
+            return [OllamaAPIFetchStrategy()]
+        case .cli, .oauth:
+            return []
+        case .auto:
+            break
+        }
+        if context.settings?.ollama?.cookieSource == .off {
+            return [OllamaAPIFetchStrategy()]
+        }
+        if ProviderTokenResolver.ollamaToken(environment: context.env) != nil {
+            return [OllamaAPIFetchStrategy(), OllamaStatusFetchStrategy()]
+        }
+        return [OllamaStatusFetchStrategy()]
     }
 }
 
@@ -72,5 +92,32 @@ struct OllamaStatusFetchStrategy: ProviderFetchStrategy {
     private static func manualCookieHeader(from context: ProviderFetchContext) -> String? {
         guard context.settings?.ollama?.cookieSource == .manual else { return nil }
         return CookieHeaderNormalizer.normalize(context.settings?.ollama?.manualCookieHeader)
+    }
+}
+
+struct OllamaAPIFetchStrategy: ProviderFetchStrategy {
+    let id: String = "ollama.api"
+    let kind: ProviderFetchKind = .apiToken
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        Self.resolveToken(environment: context.env) != nil
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        guard let apiKey = Self.resolveToken(environment: context.env) else {
+            throw OllamaUsageError.missingAPIKey
+        }
+        let snapshot = try await OllamaAPIUsageFetcher.fetchUsage(apiKey: apiKey)
+        return self.makeResult(
+            usage: snapshot.toUsageSnapshot(),
+            sourceLabel: "api")
+    }
+
+    func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {
+        context.sourceMode == .auto
+    }
+
+    private static func resolveToken(environment: [String: String]) -> String? {
+        ProviderTokenResolver.ollamaToken(environment: environment)
     }
 }

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
@@ -30,18 +30,24 @@ private func hasRecognizedOllamaSessionCookie(in header: String) -> Bool {
 }
 
 public enum OllamaUsageError: LocalizedError, Sendable {
+    case missingAPIKey
     case notLoggedIn
     case invalidCredentials
+    case apiUnauthorized
     case parseFailed(String)
     case networkError(String)
     case noSessionCookie
 
     public var errorDescription: String? {
         switch self {
+        case .missingAPIKey:
+            "Missing Ollama API key. Set apiKey in ~/.codexbar/config.json or OLLAMA_API_KEY."
         case .notLoggedIn:
             "Not logged in to Ollama. Please log in via ollama.com/settings."
         case .invalidCredentials:
             "Ollama session cookie expired. Please log in again."
+        case .apiUnauthorized:
+            "Ollama API key is invalid or expired."
         case let .parseFailed(message):
             "Could not parse Ollama usage: \(message)"
         case let .networkError(message):
@@ -618,4 +624,119 @@ public struct OllamaUsageFetcher: Sendable {
         if host == "ollama.com" || host == "www.ollama.com" { return true }
         return host.hasSuffix(".ollama.com")
     }
+}
+
+public struct OllamaAPISettingsReader: Sendable {
+    public static let apiKeyEnvironmentKeys = [
+        "OLLAMA_API_KEY",
+        "OLLAMA_KEY",
+    ]
+
+    public static func apiKey(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
+    {
+        for key in self.apiKeyEnvironmentKeys {
+            guard let value = self.cleaned(environment[key]), !value.isEmpty else { continue }
+            return value
+        }
+        return nil
+    }
+
+    private static func cleaned(_ raw: String?) -> String? {
+        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty
+        else {
+            return nil
+        }
+        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
+            (value.hasPrefix("'") && value.hasSuffix("'"))
+        {
+            value.removeFirst()
+            value.removeLast()
+        }
+        return value.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+public struct OllamaAPIUsageSnapshot: Sendable {
+    public let modelCount: Int
+    public let updatedAt: Date
+
+    public init(modelCount: Int, updatedAt: Date) {
+        self.modelCount = modelCount
+        self.updatedAt = updatedAt
+    }
+
+    public func toUsageSnapshot() -> UsageSnapshot {
+        UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            providerCost: nil,
+            updatedAt: self.updatedAt,
+            identity: ProviderIdentitySnapshot(
+                providerID: .ollama,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "API key"))
+    }
+}
+
+public enum OllamaAPIUsageFetcher {
+    public static let tagsURL = URL(string: "https://ollama.com/api/tags")!
+    private static let timeoutSeconds: TimeInterval = 20
+
+    public static func fetchUsage(
+        apiKey: String,
+        tagsURL: URL = Self.tagsURL,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
+        now: Date = Date()) async throws -> OllamaAPIUsageSnapshot
+    {
+        let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw OllamaUsageError.missingAPIKey
+        }
+
+        var request = URLRequest(url: tagsURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = Self.timeoutSeconds
+        request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("CodexBar/1.0", forHTTPHeaderField: "User-Agent")
+
+        let response: ProviderHTTPResponse
+        do {
+            response = try await transport.response(for: request)
+        } catch {
+            throw OllamaUsageError.networkError(error.localizedDescription)
+        }
+
+        switch response.statusCode {
+        case 200:
+            return try Self.parseTags(data: response.data, now: now)
+        case 401, 403:
+            throw OllamaUsageError.apiUnauthorized
+        default:
+            throw OllamaUsageError.networkError("HTTP \(response.statusCode)")
+        }
+    }
+
+    static func _parseTagsForTesting(_ data: Data, now: Date = Date()) throws -> OllamaAPIUsageSnapshot {
+        try self.parseTags(data: data, now: now)
+    }
+
+    private static func parseTags(data: Data, now: Date) throws -> OllamaAPIUsageSnapshot {
+        do {
+            let response = try JSONDecoder().decode(TagsResponse.self, from: data)
+            return OllamaAPIUsageSnapshot(modelCount: response.models.count, updatedAt: now)
+        } catch {
+            throw OllamaUsageError.parseFailed(error.localizedDescription)
+        }
+    }
+
+    private struct TagsResponse: Decodable {
+        let models: [Model]
+    }
+
+    private struct Model: Decodable {}
 }

--- a/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
+++ b/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
@@ -72,6 +72,10 @@ public enum ProviderTokenResolver {
         self.moonshotResolution(environment: environment)?.token
     }
 
+    public static func ollamaToken(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        self.ollamaResolution(environment: environment)?.token
+    }
+
     public static func kiloToken(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         authFileURL: URL? = nil) -> String?
@@ -267,6 +271,12 @@ public enum ProviderTokenResolver {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
     {
         self.resolveEnv(MoonshotSettingsReader.apiKey(environment: environment))
+    }
+
+    public static func ollamaResolution(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
+    {
+        self.resolveEnv(OllamaAPISettingsReader.apiKey(environment: environment))
     }
 
     public static func kiloResolution(

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -283,5 +283,14 @@ final class CLIEntryTests: XCTestCase {
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .grok))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .grok))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.api, provider: .kilo))
+        XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .ollama,
+            environment: ["OLLAMA_API_KEY": "ollama-test"]))
+        XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .ollama,
+            settings: ProviderSettingsSnapshot.make(
+                ollama: .init(cookieSource: .off, manualCookieHeader: nil))))
     }
 }

--- a/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
@@ -4,6 +4,26 @@ import Testing
 
 @Suite(.serialized)
 struct OllamaUsageFetcherRetryMappingTests {
+    private func makeContext(
+        sourceMode: ProviderSourceMode,
+        env: [String: String] = [:],
+        settings: ProviderSettingsSnapshot? = nil) -> ProviderFetchContext
+    {
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        return ProviderFetchContext(
+            runtime: .cli,
+            sourceMode: sourceMode,
+            includeCredits: false,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: env,
+            settings: settings,
+            fetcher: UsageFetcher(),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+            browserDetection: browserDetection)
+    }
+
     @Test
     func `api key reader trims configured environment key`() {
         let token = OllamaAPISettingsReader.apiKey(environment: ["OLLAMA_API_KEY": " 'ollama-test' "])
@@ -24,6 +44,44 @@ struct OllamaUsageFetcherRetryMappingTests {
         #expect(usage.identity?.providerID == .ollama)
         #expect(usage.identity?.loginMethod == "API key")
         #expect(usage.updatedAt == now)
+    }
+
+    @Test
+    func `auto mode keeps web quota strategy before api key verification`() async {
+        let descriptor = OllamaProviderDescriptor.makeDescriptor()
+        let context = self.makeContext(
+            sourceMode: .auto,
+            env: ["OLLAMA_API_KEY": "ollama-test"],
+            settings: ProviderSettingsSnapshot.make(
+                ollama: .init(cookieSource: .auto, manualCookieHeader: nil)))
+
+        let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(context)
+
+        #expect(strategies.map(\.id) == ["ollama.web", "ollama.api"])
+    }
+
+    @Test
+    func `auto mode uses api only when ollama cookies are off`() async {
+        let descriptor = OllamaProviderDescriptor.makeDescriptor()
+        let context = self.makeContext(
+            sourceMode: .auto,
+            env: ["OLLAMA_API_KEY": "ollama-test"],
+            settings: ProviderSettingsSnapshot.make(
+                ollama: .init(cookieSource: .off, manualCookieHeader: nil)))
+
+        let strategies = await descriptor.fetchPlan.pipeline.resolveStrategies(context)
+
+        #expect(strategies.map(\.id) == ["ollama.api"])
+    }
+
+    @Test
+    func `web strategy falls back to api key in auto mode`() {
+        let context = self.makeContext(
+            sourceMode: .auto,
+            env: ["OLLAMA_API_KEY": "ollama-test"])
+        let strategy = OllamaStatusFetchStrategy()
+
+        #expect(strategy.shouldFallback(on: OllamaUsageError.parseFailed("missing"), context: context))
     }
 
     @Test

--- a/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageFetcherRetryMappingTests.swift
@@ -5,6 +5,55 @@ import Testing
 @Suite(.serialized)
 struct OllamaUsageFetcherRetryMappingTests {
     @Test
+    func `api key reader trims configured environment key`() {
+        let token = OllamaAPISettingsReader.apiKey(environment: ["OLLAMA_API_KEY": " 'ollama-test' "])
+
+        #expect(token == "ollama-test")
+    }
+
+    @Test
+    func `api tags response maps to API key identity`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = try OllamaAPIUsageFetcher._parseTagsForTesting(
+            Data(#"{"models":[{"name":"gpt-oss:120b"}]}"#.utf8),
+            now: now)
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(snapshot.modelCount == 1)
+        #expect(usage.primary == nil)
+        #expect(usage.identity?.providerID == .ollama)
+        #expect(usage.identity?.loginMethod == "API key")
+        #expect(usage.updatedAt == now)
+    }
+
+    @Test
+    func `api fetch sends bearer token and rejects unauthorized key`() async throws {
+        let url = try #require(URL(string: "https://ollama.com/api/tags"))
+        let transport = ProviderHTTPTransportHandler { request in
+            #expect(request.url == url)
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer ollama-test")
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 401,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil)!
+            return (Data("{}".utf8), response)
+        }
+
+        do {
+            _ = try await OllamaAPIUsageFetcher.fetchUsage(apiKey: "ollama-test", transport: transport)
+            Issue.record("Expected unauthorized API error")
+        } catch let error as OllamaUsageError {
+            guard case .apiUnauthorized = error else {
+                Issue.record("Expected apiUnauthorized, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("Expected OllamaUsageError.apiUnauthorized, got \(error)")
+        }
+    }
+
+    @Test
     func `missing usage shape surfaces public parse failed message`() async {
         defer { OllamaRetryMappingStubURLProtocol.handler = nil }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -69,7 +69,7 @@ See `docs/configuration.md` for the schema.
     - `web` (macOS only): web-only where that provider exposes an explicit web source; no CLI/API fallback.
     - `cli`: CLI/local-helper source where the provider exposes one (for example Codex RPC/PTy, Claude PTY, Kilo CLI fallback, Kiro CLI, local probes).
     - `oauth`: OAuth-backed source where supported (Codex, Claude, Vertex AI).
-    - `api`: API-key/token flow when the provider supports it (OpenAI, Claude Admin API, z.ai, Gemini, Alibaba, Copilot, Kilo, Kimi K2, MiniMax, Warp, OpenRouter, ElevenLabs, Deepgram, Synthetic, DeepSeek, Moonshot, Doubao, Codebuff, Crof, Venice, AWS Bedrock).
+    - `api`: API-key/token flow when the provider supports it (OpenAI, Claude Admin API, z.ai, Gemini, Alibaba, Copilot, Kilo, Kimi K2, MiniMax, Ollama, Warp, OpenRouter, ElevenLabs, Deepgram, Synthetic, DeepSeek, Moonshot, Doubao, Codebuff, Crof, Venice, AWS Bedrock).
     - Output `source` reflects the strategy actually used (`openai-web`, `web`, `oauth`, `api`, `local`, `cli`, or provider CLI label).
     - Codex web: OpenAI web dashboard (usage limits, credits remaining, code review remaining, usage breakdown).
         - `--web-timeout <seconds>` (default: 60)

--- a/docs/index.html
+++ b/docs/index.html
@@ -155,7 +155,7 @@
           <img class="chip-logo" src="./logos/amp.svg" alt="" width="20" height="20" /><span class="meta"><span class="name">Amp</span><span class="auth">Cookies</span></span>
         </a></li>
         <li><a class="provider" style="--brand:#888888" href="https://github.com/steipete/CodexBar/blob/main/docs/ollama.md">
-          <img class="chip-logo" src="./logos/ollama.svg" alt="" width="20" height="20" /><span class="meta"><span class="name">Ollama</span><span class="auth">Cookies</span></span>
+          <img class="chip-logo" src="./logos/ollama.svg" alt="" width="20" height="20" /><span class="meta"><span class="name">Ollama</span><span class="auth">API key + Cookies</span></span>
         </a></li>
         <li><a class="provider" style="--brand:#141414" href="https://github.com/steipete/CodexBar/blob/main/docs/providers.md#fetch-strategies-current">
           <img class="chip-logo" src="./logos/synthetic.svg" data-dark-src="./logos/synthetic-dark.svg" alt="" width="20" height="20" /><span class="meta"><span class="name">Synthetic</span><span class="auth">API key</span></span>

--- a/docs/ollama.md
+++ b/docs/ollama.md
@@ -1,5 +1,5 @@
 ---
-summary: "Ollama provider notes: settings scrape, cookie auth, and Cloud Usage parsing."
+summary: "Ollama provider notes: API key auth, settings scrape, cookie auth, and Cloud Usage parsing."
 read_when:
   - Adding or modifying the Ollama provider
   - Debugging Ollama cookie import or settings parsing
@@ -8,20 +8,24 @@ read_when:
 
 # Ollama Provider
 
-The Ollama provider scrapes the **Plan & Billing** page to extract Cloud Usage limits for session and weekly windows.
+The Ollama provider can verify Ollama Cloud API-key access and scrape the **Plan & Billing** page to extract Cloud
+Usage limits for session and weekly windows.
 
 ## Features
 
 - **Plan badge**: Reads the plan tier (Free/Pro/Max) from the Cloud Usage header.
 - **Session + weekly usage**: Parses the percent-used values shown in the usage bars.
 - **Reset timestamps**: Uses the `data-time` attribute on the “Resets in …” elements.
-- **Browser cookie auth**: No API keys required.
+- **API key auth**: Verifies direct `https://ollama.com/api` access with `OLLAMA_API_KEY` or a configured key.
+- **Browser cookie auth**: Required for Cloud Usage quota windows because Ollama does not expose those limits through
+  the documented API.
 
 ## Setup
 
 1. Open **Settings → Providers**.
 2. Enable **Ollama**.
-3. Leave **Cookie source** on **Auto** (recommended, imports Chrome cookies by default).
+3. For API-key mode, paste an API key from `https://ollama.com/settings/keys` or set `OLLAMA_API_KEY`.
+4. For quota bars, leave **Cookie source** on **Auto** (recommended, imports Chrome cookies by default).
 
 ### Manual cookie import (optional)
 
@@ -31,7 +35,8 @@ The Ollama provider scrapes the **Plan & Billing** page to extract Cloud Usage l
 
 ## How it works
 
-- Fetches `https://ollama.com/settings` using browser cookies.
+- API-key mode fetches `https://ollama.com/api/tags` with `Authorization: Bearer <key>` to verify Cloud API access.
+- Cookie mode fetches `https://ollama.com/settings` using browser cookies.
 - Parses:
   - Plan badge under **Cloud Usage**.
   - **Session usage** and **Weekly usage** percentages.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -47,7 +47,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 | Warp | API token (config/env) → GraphQL request limits (`api`). |
 | ElevenLabs | API key from config/env → subscription usage API (`api`). |
 | Windsurf | Web session bundle from browser localStorage (`web`) → local SQLite cache (`local`). |
-| Ollama | Web settings page via browser cookies (`web`). |
+| Ollama | API key verifies Cloud API access (`api`); browser cookies expose Cloud quota windows (`web`). |
 | Synthetic | API key from config/env → quota API (`api`). |
 | OpenRouter | API token (config, overrides env) → credits API (`api`). |
 | Perplexity | Browser cookies/manual cookie/env session token → credits API (`web`). |


### PR DESCRIPTION
## Summary
- Add Ollama API-key source alongside browser-cookie quota scraping.
- Wire stored/env API keys into provider fetch planning, Settings, CLI/config environment, and docs.
- Keep auto mode preferring browser cookies for quota windows, with API-key fallback when web auth fails or cookies are off.

Fixes #1044.

## Verification
- `swift test --filter OllamaUsageFetcherRetryMappingTests`
- `swift test --filter CLIEntryTests/test_sourceModeRequiresWebSupportIsProviderAware`
- `make check`
- Live web: `swift run CodexBarCLI usage --provider ollama --source web --format json --pretty` returned Ollama Cloud quota windows for the signed-in account.
- Live API: temporary Ollama key verified via `--source api`; output reported API-key login with no quota windows, then the temporary key was revoked.
- `codex review --base origin/main` clean; nested full `swift test` was blocked by the review sandbox's SwiftPM cache permissions, but local tests above passed.
