### PR TITLE
MiniMax: filter failed billing records from history aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 - Codex: accept the first click in the account switcher inside menu popovers (#1079). Thanks @ptstory!
 - Codex/Claude: terminate PTY child process trees during probe cleanup so wrapper-launched CLI descendants do not linger after sessions finish (#1085). Thanks @mickobizzle!
+- MiniMax: exclude explicitly failed billing-history records from token charts and model/method totals (#1089). Thanks @Yuxin-Qiao!
 - OpenAI: parse Wednesday and Saturday dashboard reset lines so rate-limit reset times are not dropped on those days (#1080). Thanks @m1qaweb!
 - Localization: translate provider-detail labels and empty states when Simplified Chinese is selected (#1051). Thanks @wang93wei!
 - Antigravity: discover OAuth credentials from the bundled extension language server in newer IDE builds so Add Account works again (#1076). Thanks @xARSENICx!

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxBillingHistory.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxBillingHistory.swift
@@ -85,6 +85,8 @@ struct MiniMaxBillingRecord: Decodable {
     let consumeTime: String?
     let method: String?
     let model: String?
+    let result: String?
+    let status: String?
 
     private enum CodingKeys: String, CodingKey {
         case consumeToken = "consume_token"
@@ -97,6 +99,8 @@ struct MiniMaxBillingRecord: Decodable {
         case consumeTime = "consume_time"
         case method
         case model
+        case result
+        case status
     }
 
     init(from decoder: Decoder) throws {
@@ -111,6 +115,18 @@ struct MiniMaxBillingRecord: Decodable {
         self.consumeTime = try container.decodeIfPresent(String.self, forKey: .consumeTime)
         self.method = try container.decodeIfPresent(String.self, forKey: .method)
         self.model = try container.decodeIfPresent(String.self, forKey: .model)
+        self.result = try container.decodeIfPresent(String.self, forKey: .result)
+        self.status = try container.decodeIfPresent(String.self, forKey: .status)
+    }
+
+    var recordResult: String? {
+        if let result = self.result?.trimmingCharacters(in: .whitespacesAndNewlines), !result.isEmpty {
+            return result
+        }
+        if let status = self.status?.trimmingCharacters(in: .whitespacesAndNewlines), !status.isEmpty {
+            return status
+        }
+        return nil
     }
 
     var tokenCount: Int {
@@ -159,6 +175,12 @@ enum MiniMaxBillingHistoryParser {
         var modelTotals: [String: (tokens: Int, cash: Double, hasCash: Bool)] = [:]
 
         for record in records {
+            if let recordResult = record.recordResult,
+               recordResult.caseInsensitiveCompare("SUCCESS") != .orderedSame
+            {
+                continue
+            }
+
             guard let date = self.recordDate(record, calendar: calendar),
                   date >= startOf30Days,
                   date <= now

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxBillingHistory.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxBillingHistory.swift
@@ -115,8 +115,8 @@ struct MiniMaxBillingRecord: Decodable {
         self.consumeTime = try container.decodeIfPresent(String.self, forKey: .consumeTime)
         self.method = try container.decodeIfPresent(String.self, forKey: .method)
         self.model = try container.decodeIfPresent(String.self, forKey: .model)
-        self.result = try container.decodeIfPresent(String.self, forKey: .result)
-        self.status = try container.decodeIfPresent(String.self, forKey: .status)
+        self.result = Self.decodeOptionalScalarString(container, forKey: .result)
+        self.status = Self.decodeOptionalScalarString(container, forKey: .status)
     }
 
     var recordResult: String? {
@@ -136,6 +136,25 @@ struct MiniMaxBillingRecord: Decodable {
 
     var cashValue: Double? {
         self.consumeCashAfterVoucher ?? self.consumeCash
+    }
+
+    private static func decodeOptionalScalarString<K: CodingKey>(
+        _ container: KeyedDecodingContainer<K>,
+        forKey key: K) -> String?
+    {
+        if let value = try? container.decodeIfPresent(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? container.decodeIfPresent(Int.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? container.decodeIfPresent(Double.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? container.decodeIfPresent(Bool.self, forKey: key) {
+            return String(value)
+        }
+        return nil
     }
 }
 

--- a/Tests/CodexBarTests/MiniMaxProviderTests.swift
+++ b/Tests/CodexBarTests/MiniMaxProviderTests.swift
@@ -702,6 +702,66 @@ struct MiniMaxUsageParserTests {
     }
 
     @Test
+    func `billing history filters failed records`() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let now = try #require(ISO8601DateFormatter().date(from: "2026-05-17T12:00:00Z"))
+        let json = """
+        {
+          "base_resp": { "status_code": 0 },
+          "total_cnt": 4,
+          "charge_records": [
+            {
+              "consume_token": 1000,
+              "ymd": "2026-05-17",
+              "method": "chat",
+              "model": "MiniMax-M1",
+              "result": "SUCCESS"
+            },
+            {
+              "consume_token": 2000,
+              "ymd": "2026-05-17",
+              "method": "chat",
+              "model": "MiniMax-M1",
+              "result": "FAILED"
+            },
+            {
+              "consume_token": 3000,
+              "ymd": "2026-05-17",
+              "method": "chat",
+              "model": "MiniMax-M1",
+              "status": "fail"
+            },
+            {
+              "consume_token": 4000,
+              "ymd": "2026-05-17",
+              "method": "audio",
+              "model": "speech-2.8"
+            }
+          ]
+        }
+        """
+
+        let summary = try MiniMaxBillingHistoryParser.parse(
+            data: Data(json.utf8),
+            now: now,
+            calendar: calendar)
+
+        // Only SUCCESS (1000) and missing/empty result status (4000) should be included.
+        // FAILED (2000) and status "fail" (3000) should be skipped.
+        #expect(summary.todayTokens == 5000)
+        #expect(summary.last30DaysTokens == 5000)
+        #expect(summary.daily.map(\.day) == ["2026-05-17"])
+
+        // Top methods should aggregate only SUCCESS/missing records.
+        #expect(summary.topMethods.count == 2)
+        #expect(summary.topMethods[0].name == "audio")
+        #expect(summary.topMethods[0].tokens == 4000)
+        #expect(summary.topMethods[1].name == "chat")
+        #expect(summary.topMethods[1].tokens == 1000)
+    }
+
+    @Test
     func `web usage fetch attaches billing history when available`() async throws {
         let now = try #require(ISO8601DateFormatter().date(from: "2026-05-17T12:00:00Z"))
         let transport = ProviderHTTPTransportStub { request in

--- a/Tests/CodexBarTests/MiniMaxProviderTests.swift
+++ b/Tests/CodexBarTests/MiniMaxProviderTests.swift
@@ -709,7 +709,7 @@ struct MiniMaxUsageParserTests {
         let json = """
         {
           "base_resp": { "status_code": 0 },
-          "total_cnt": 4,
+          "total_cnt": 5,
           "charge_records": [
             {
               "consume_token": 1000,
@@ -737,6 +737,13 @@ struct MiniMaxUsageParserTests {
               "ymd": "2026-05-17",
               "method": "audio",
               "model": "speech-2.8"
+            },
+            {
+              "consume_token": 5000,
+              "ymd": "2026-05-17",
+              "method": "video",
+              "model": "video-1",
+              "status": 0
             }
           ]
         }
@@ -748,7 +755,7 @@ struct MiniMaxUsageParserTests {
             calendar: calendar)
 
         // Only SUCCESS (1000) and missing/empty result status (4000) should be included.
-        // FAILED (2000) and status "fail" (3000) should be skipped.
+        // FAILED (2000), status "fail" (3000), and numeric status 0 (5000) should be skipped.
         #expect(summary.todayTokens == 5000)
         #expect(summary.last30DaysTokens == 5000)
         #expect(summary.daily.map(\.day) == ["2026-05-17"])


### PR DESCRIPTION
## Summary

Filters failed MiniMax billing-history records out of local billing aggregation.

MiniMax billing-history rows can include a result/status field, such as `SUCCESS`. CodexBar already aggregates MiniMax billing-history rows into Today / Last 30 days token summaries, charts, and model/method breakdowns. This PR makes aggregation ignore rows with an explicit non-success result while preserving backward compatibility for older payloads where the result/status field is missing.

## Scope

- MiniMax billing-history parser only
- aggregation correctness fix
- no endpoint changes
- no pagination changes
- no quota-card changes
- no UI layout changes
- missing result/status remains backward-compatible and is still included

## Testing

- `swift test --filter MiniMax`
- `make check`
- `git diff --check`