### PR TITLE
Fix Antigravity OAuth client discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Localizations: add Spanish and Catalan language packs and fill missing localization keys (#1041). Thanks @seifreed!
 
 ### Fixed
+- Antigravity: discover OAuth credentials from the bundled extension language server in newer IDE builds so Add Account works again (#1076). Thanks @xARSENICx!
 - Menu bar: wait for display changes to settle before recovering status items and retry if macOS still leaves the icon detached (#1074). Thanks @yipjunkai!
 - Menu: keep lower action rows stable when Refresh is highlighted or pressed (#1071). Thanks @MadanChaollaPark!
 - Linux CLI: avoid linking JetBrains provider parsing against `libxml2.so.2`, improving compatibility with newer distros that ship libxml2 2.15+ (#1046). Thanks @semsemyonoff!

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
@@ -185,6 +185,9 @@ public enum AntigravityOAuthConfig {
             fileManager: fileManager)
         let relativePaths = [
             "Contents/Resources/app/out/main.js",
+            "Contents/Resources/app/extensions/antigravity/bin/language_server_macos_arm",
+            "Contents/Resources/app/extensions/antigravity/bin/language_server_macos_x64",
+            "Contents/Resources/app/extensions/antigravity/bin/language_server_macos",
             "Contents/Resources/bin/language_server",
             "Contents/Resources/bin/language_server_macos",
         ]

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
@@ -184,10 +184,10 @@ public enum AntigravityOAuthConfig {
             applicationRoots: applicationRoots,
             fileManager: fileManager)
         let relativePaths = [
-            "Contents/Resources/app/out/main.js",
             "Contents/Resources/app/extensions/antigravity/bin/language_server_macos_arm",
             "Contents/Resources/app/extensions/antigravity/bin/language_server_macos_x64",
             "Contents/Resources/app/extensions/antigravity/bin/language_server_macos",
+            "Contents/Resources/app/out/main.js",
             "Contents/Resources/bin/language_server",
             "Contents/Resources/bin/language_server_macos",
         ]

--- a/Tests/CodexBarTests/AntigravityOAuthCredentialsStoreTests.swift
+++ b/Tests/CodexBarTests/AntigravityOAuthCredentialsStoreTests.swift
@@ -66,6 +66,19 @@ struct AntigravityOAuthCredentialsStoreTests {
         let extensionClient = AntigravityOAuthClient(
             clientID: self.googleClientID("extension"),
             clientSecret: self.googleClientSecret(repeating: "d"))
+        let staleClient = AntigravityOAuthClient(
+            clientID: self.googleClientID("stale"),
+            clientSecret: self.googleClientSecret(repeating: "e"))
+        try self.writeAntigravityApp(
+            named: "Antigravity IDE.app",
+            under: root,
+            bundleIdentifier: "com.google.antigravity-ide",
+            artifactRelativePath: "Contents/Resources/app/out/main.js",
+            artifactData: Data("""
+            out-build/vs/platform/cloudCode/common/oauthClient.js
+            clientId="\(staleClient.clientID)";
+            clientSecret="\(staleClient.clientSecret)";
+            """.utf8))
         var artifactData = Data([0xFF])
         artifactData.append(Data(
             """

--- a/Tests/CodexBarTests/AntigravityOAuthCredentialsStoreTests.swift
+++ b/Tests/CodexBarTests/AntigravityOAuthCredentialsStoreTests.swift
@@ -58,6 +58,32 @@ struct AntigravityOAuthCredentialsStoreTests {
     }
 
     @Test
+    func `oauth client discovery reads antigravity extension language server`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let extensionClient = AntigravityOAuthClient(
+            clientID: self.googleClientID("extension"),
+            clientSecret: self.googleClientSecret(repeating: "d"))
+        var artifactData = Data([0xFF])
+        artifactData.append(Data(
+            """
+            \u{0}\(extensionClient.clientSecret)\u{0}oauth_data\u{0}\(extensionClient.clientID)\u{0}
+            """.utf8))
+        try self.writeAntigravityApp(
+            named: "Antigravity IDE.app",
+            under: root,
+            bundleIdentifier: "com.google.antigravity-ide",
+            artifactRelativePath: "Contents/Resources/app/extensions/antigravity/bin/language_server_macos_arm",
+            artifactData: artifactData)
+
+        #expect(
+            AntigravityOAuthConfig.discoverClientFromInstalledApp(
+                applicationRoots: [root]) == extensionClient)
+    }
+
+    @Test
     func `oauth client discovery pairs lone binary secret with trailing client id`() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
## Summary
- Prefer Antigravity IDE's bundled extension language server when discovering OAuth client credentials.
- Keep the existing main.js and top-level language_server fallbacks for older bundles.
- Add regression coverage where main.js has stale credentials and the extension binary must win.

Fixes #1076.

## Verification
- swift test --filter AntigravityOAuthCredentialsStoreTests
- make check
- Live installed bundle: /Applications/Antigravity IDE.app/Contents/Resources/app/extensions/antigravity/bin/language_server_macos_arm and /Applications/Antigravity IDE.app/Contents/Resources/app/out/main.js both exist and contain OAuth markers.
- codex review --base origin/main
