### PR TITLE
Restore full-width provider switcher quota bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Localizations: add Spanish and Catalan language packs and fill missing localization keys (#1041). Thanks @seifreed!
 
 ### Fixed
+- Menu: restore full-width provider switcher quota bars and refresh them while the menu stays open (#1094). Thanks @bcharleson!
 - Codex: accept the first click in the account switcher inside menu popovers (#1079). Thanks @ptstory!
 - Codex/Claude: terminate PTY child process trees during probe cleanup so wrapper-launched CLI descendants do not linger after sessions finish (#1085). Thanks @mickobizzle!
 - MiniMax: exclude explicitly failed billing-history records from token charts and model/method totals (#1089). Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/ProviderSwitcherButtons.swift
+++ b/Sources/CodexBar/ProviderSwitcherButtons.swift
@@ -21,12 +21,18 @@ final class PaddedToggleButton: NSButton {
     }
 }
 
+@MainActor
+protocol ProviderSwitcherToggleButton: AnyObject {
+    func setQuotaBarReservedHeight(_ height: CGFloat)
+}
+
 final class InlineIconToggleButton: NSButton {
     private let iconView = NSImageView()
     private let titleField = NSTextField(labelWithString: "")
     private let stack = NSStackView()
     private var paddingConstraints: [NSLayoutConstraint] = []
     private var iconSizeConstraints: [NSLayoutConstraint] = []
+    private var quotaBarReservedHeight: CGFloat = 0
     private var isConfiguring = false // Batch invalidation during setup
 
     var contentPadding = NSEdgeInsets(top: 4, left: 7, bottom: 4, right: 7) {
@@ -34,7 +40,8 @@ final class InlineIconToggleButton: NSButton {
             self.paddingConstraints.first { $0.firstAttribute == .top }?.constant = self.contentPadding.top
             self.paddingConstraints.first { $0.firstAttribute == .leading }?.constant = self.contentPadding.left
             self.paddingConstraints.first { $0.firstAttribute == .trailing }?.constant = -self.contentPadding.right
-            self.paddingConstraints.first { $0.firstAttribute == .bottom }?.constant = -self.contentPadding.bottom
+            self.paddingConstraints.first { $0.firstAttribute == .bottom }?.constant =
+                -(self.contentPadding.bottom + self.quotaBarReservedHeight)
             if !self.isConfiguring { self.invalidateIntrinsicContentSize() }
         }
     }
@@ -71,6 +78,14 @@ final class InlineIconToggleButton: NSButton {
         self.titleField.font = NSFont.systemFont(ofSize: size)
     }
 
+    func setQuotaBarReservedHeight(_ height: CGFloat) {
+        guard self.quotaBarReservedHeight != height else { return }
+        self.quotaBarReservedHeight = height
+        self.paddingConstraints.first { $0.firstAttribute == .bottom }?.constant =
+            -(self.contentPadding.bottom + height)
+        if !self.isConfiguring { self.invalidateIntrinsicContentSize() }
+    }
+
     func setAllowsTwoLineTitle(_ allow: Bool) {
         let hasWhitespace = self.titleField.stringValue.rangeOfCharacter(from: .whitespacesAndNewlines) != nil
         let shouldWrap = allow && hasWhitespace
@@ -83,7 +98,7 @@ final class InlineIconToggleButton: NSButton {
         let size = self.stack.fittingSize
         return NSSize(
             width: size.width + self.contentPadding.left + self.contentPadding.right,
-            height: size.height + self.contentPadding.top + self.contentPadding.bottom)
+            height: size.height + self.contentPadding.top + self.contentPadding.bottom + self.quotaBarReservedHeight)
     }
 
     init(title: String, image: NSImage, target: AnyObject?, action: Selector?) {
@@ -152,12 +167,15 @@ final class InlineIconToggleButton: NSButton {
     }
 }
 
+extension InlineIconToggleButton: ProviderSwitcherToggleButton {}
+
 final class StackedToggleButton: NSButton {
     private let iconView = NSImageView()
     private let titleField = NSTextField(labelWithString: "")
     private let stack = NSStackView()
     private var paddingConstraints: [NSLayoutConstraint] = []
     private var iconSizeConstraints: [NSLayoutConstraint] = []
+    private var quotaBarReservedHeight: CGFloat = 0
     private var isConfiguring = false // Batch invalidation during setup
 
     var contentPadding = NSEdgeInsets(top: 2, left: 4, bottom: 2, right: 4) {
@@ -165,7 +183,8 @@ final class StackedToggleButton: NSButton {
             self.paddingConstraints.first { $0.firstAttribute == .top }?.constant = self.contentPadding.top
             self.paddingConstraints.first { $0.firstAttribute == .leading }?.constant = self.contentPadding.left
             self.paddingConstraints.first { $0.firstAttribute == .trailing }?.constant = -self.contentPadding.right
-            self.paddingConstraints.first { $0.firstAttribute == .bottom }?.constant = -self.contentPadding.bottom
+            self.paddingConstraints.first { $0.firstAttribute == .bottom }?.constant =
+                -(self.contentPadding.bottom + self.quotaBarReservedHeight)
             if !self.isConfiguring { self.invalidateIntrinsicContentSize() }
         }
     }
@@ -202,6 +221,14 @@ final class StackedToggleButton: NSButton {
         self.titleField.font = NSFont.systemFont(ofSize: size)
     }
 
+    func setQuotaBarReservedHeight(_ height: CGFloat) {
+        guard self.quotaBarReservedHeight != height else { return }
+        self.quotaBarReservedHeight = height
+        self.paddingConstraints.first { $0.firstAttribute == .bottom }?.constant =
+            -(self.contentPadding.bottom + height)
+        if !self.isConfiguring { self.invalidateIntrinsicContentSize() }
+    }
+
     func setAllowsTwoLineTitle(_ allow: Bool) {
         let hasWhitespace = self.titleField.stringValue.rangeOfCharacter(from: .whitespacesAndNewlines) != nil
         let shouldWrap = allow && hasWhitespace
@@ -214,7 +241,7 @@ final class StackedToggleButton: NSButton {
         let size = self.stack.fittingSize
         return NSSize(
             width: size.width + self.contentPadding.left + self.contentPadding.right,
-            height: size.height + self.contentPadding.top + self.contentPadding.bottom)
+            height: size.height + self.contentPadding.top + self.contentPadding.bottom + self.quotaBarReservedHeight)
     }
 
     init(title: String, image: NSImage, target: AnyObject?, action: Selector?) {
@@ -282,3 +309,5 @@ final class StackedToggleButton: NSButton {
         NSLayoutConstraint.activate(self.paddingConstraints + self.iconSizeConstraints)
     }
 }
+
+extension StackedToggleButton: ProviderSwitcherToggleButton {}

--- a/Sources/CodexBar/ProviderSwitcherButtons.swift
+++ b/Sources/CodexBar/ProviderSwitcherButtons.swift
@@ -1,6 +1,8 @@
 import AppKit
 
 final class PaddedToggleButton: NSButton {
+    private var quotaBarReservedHeight: CGFloat = 0
+
     var contentPadding = NSEdgeInsets(top: 4, left: 7, bottom: 4, right: 7) {
         didSet {
             if oldValue.top != self.contentPadding.top ||
@@ -17,7 +19,13 @@ final class PaddedToggleButton: NSButton {
         let size = super.intrinsicContentSize
         return NSSize(
             width: size.width + self.contentPadding.left + self.contentPadding.right,
-            height: size.height + self.contentPadding.top + self.contentPadding.bottom)
+            height: size.height + self.contentPadding.top + self.contentPadding.bottom + self.quotaBarReservedHeight)
+    }
+
+    func setQuotaBarReservedHeight(_ height: CGFloat) {
+        guard self.quotaBarReservedHeight != height else { return }
+        self.quotaBarReservedHeight = height
+        self.invalidateIntrinsicContentSize()
     }
 }
 
@@ -25,6 +33,8 @@ final class PaddedToggleButton: NSButton {
 protocol ProviderSwitcherToggleButton: AnyObject {
     func setQuotaBarReservedHeight(_ height: CGFloat)
 }
+
+extension PaddedToggleButton: ProviderSwitcherToggleButton {}
 
 final class InlineIconToggleButton: NSButton {
     private let iconView = NSImageView()

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -346,7 +346,10 @@ extension StatusItemController {
     {
         self.performMenuMutationWithoutAnimation {
             let contentStartIndex = menu.items.first?.view is ProviderSwitcherView ? 2 : 0
-            (menu.items.first?.view as? ProviderSwitcherView)?.updateSelection(context.switcherSelection)
+            if let switcherView = menu.items.first?.view as? ProviderSwitcherView {
+                switcherView.updateSelection(context.switcherSelection)
+                switcherView.updateQuotaIndicators()
+            }
             while menu.items.count > contentStartIndex {
                 menu.removeItem(at: contentStartIndex)
             }

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -14,10 +14,11 @@ final class ProviderSwitcherView: NSView {
         let title: String
     }
 
-    private struct QuotaIndicator {
+    fileprivate struct QuotaIndicator {
         let track: NSView
         let fill: NSView
         var fillWidthConstraint: NSLayoutConstraint
+        var fillRatio: CGFloat
     }
 
     private let segments: [Segment]
@@ -101,11 +102,7 @@ final class ProviderSwitcherView: NSView {
             maxAllowedSegmentWidth: initialMaxAllowedSegmentWidth,
             stackedIcons: self.stackedIcons)
         self.rowSpacing = self.stackedIcons ? 4 : 2
-        if self.stackedIcons && self.rowCount >= 3 {
-            self.rowHeight = 40
-        } else {
-            self.rowHeight = self.stackedIcons ? 36 : 30
-        }
+        self.rowHeight = Self.switcherRowHeight(stackedIcons: self.stackedIcons, rowCount: self.rowCount)
         let height: CGFloat = self.rowHeight * CGFloat(self.rowCount)
             + self.rowSpacing * CGFloat(max(0, self.rowCount - 1))
         self.preferredWidth = width
@@ -550,6 +547,15 @@ final class ProviderSwitcherView: NSView {
         return rows
     }
 
+    private static func switcherRowHeight(stackedIcons: Bool, rowCount: Int) -> CGFloat {
+        let baseRowHeight: CGFloat = if stackedIcons, rowCount >= 3 {
+            40
+        } else {
+            stackedIcons ? 36 : 30
+        }
+        return baseRowHeight + self.quotaIndicatorReservedHeight
+    }
+
     private static func switcherOuterPadding(for width: CGFloat, count: Int, minimumGap: CGFloat) -> CGFloat {
         // Align with the card's left/right content grid when possible.
         let preferred: CGFloat = 16
@@ -613,9 +619,10 @@ final class ProviderSwitcherView: NSView {
                 } else {
                     self.addQuotaIndicator(to: button, selection: segment.selection, remainingPercent: remaining)
                 }
-            } else if let indicator = self.quotaIndicators[key] {
-                indicator.track.isHidden = true
-                indicator.fill.isHidden = true
+            } else if let indicator = self.quotaIndicators.removeValue(forKey: key) {
+                Self.applyQuotaBarContentInset(to: button, height: 0)
+                indicator.track.removeFromSuperview()
+                continue
             }
             self.updateQuotaIndicatorVisibility(for: button)
         }
@@ -654,6 +661,10 @@ final class ProviderSwitcherView: NSView {
         self.buttons.map(\.frame)
     }
 
+    func _test_buttonFittingSizes() -> [NSSize] {
+        self.buttons.map(\.fittingSize)
+    }
+
     func _test_setHoveredButtonTag(_ tag: Int?) {
         self.hoveredButtonTag = tag
         self.updateButtonStyles()
@@ -661,7 +672,13 @@ final class ProviderSwitcherView: NSView {
 
     func _test_quotaIndicatorFillRatios() -> [CGFloat] {
         self.buttons.compactMap { button in
-            self.quotaIndicators[ObjectIdentifier(button)]?.fillWidthConstraint.multiplier
+            self.quotaIndicators[ObjectIdentifier(button)]?.fillRatio
+        }
+    }
+
+    func _test_quotaIndicatorFillFrames() -> [NSRect] {
+        self.buttons.compactMap { button in
+            self.quotaIndicators[ObjectIdentifier(button)]?.fill.frame
         }
     }
     #endif
@@ -857,6 +874,19 @@ final class ProviderSwitcherView: NSView {
         return newImage
     }
 
+    private static func overviewIcon() -> NSImage {
+        if let symbol = NSImage(systemSymbolName: "square.grid.2x2", accessibilityDescription: nil) {
+            return symbol
+        }
+        return NSImage(size: NSSize(width: 16, height: 16))
+    }
+
+    private static func switcherTitle(for provider: UsageProvider) -> String {
+        ProviderDescriptorRegistry.descriptor(for: provider).metadata.displayName
+    }
+}
+
+extension ProviderSwitcherView {
     private func addQuotaIndicator(to view: NSView, selection: ProviderSwitcherSelection, remainingPercent: Double?) {
         guard let remainingPercent else { return }
         Self.applyQuotaBarContentInset(to: view)
@@ -880,7 +910,7 @@ final class ProviderSwitcherView: NSView {
         track.addSubview(fill)
 
         let ratio = Self.quotaIndicatorRatio(remainingPercent: remainingPercent)
-        let fillWidthConstraint = fill.widthAnchor.constraint(equalTo: track.widthAnchor, multiplier: ratio)
+        let fillWidthConstraint = Self.quotaIndicatorFillWidthConstraint(fill: fill, track: track, ratio: ratio)
 
         NSLayoutConstraint.activate([
             track.leadingAnchor.constraint(
@@ -902,43 +932,49 @@ final class ProviderSwitcherView: NSView {
         self.quotaIndicators[ObjectIdentifier(view)] = QuotaIndicator(
             track: track,
             fill: fill,
-            fillWidthConstraint: fillWidthConstraint)
+            fillWidthConstraint: fillWidthConstraint,
+            fillRatio: ratio)
         self.updateQuotaIndicatorVisibility(for: view)
     }
 
-    private static func applyQuotaBarContentInset(to view: NSView) {
-        (view as? ProviderSwitcherToggleButton)?.setQuotaBarReservedHeight(self.quotaIndicatorReservedHeight)
+    fileprivate static func applyQuotaBarContentInset(
+        to view: NSView,
+        height: CGFloat = quotaIndicatorReservedHeight)
+    {
+        (view as? ProviderSwitcherToggleButton)?.setQuotaBarReservedHeight(height)
     }
 
     private func updateQuotaIndicatorVisibility(for view: NSView) {
         guard let indicator = self.quotaIndicators[ObjectIdentifier(view)] else { return }
         let isSelected = (view as? NSButton)?.state == .on
         indicator.track.isHidden = isSelected
-        indicator.fill.isHidden = isSelected
+        indicator.fill.isHidden = isSelected || indicator.fillRatio <= 0
     }
 
-    private static func updateQuotaIndicatorFill(
+    fileprivate static func updateQuotaIndicatorFill(
         indicator: inout QuotaIndicator,
         remainingPercent: Double,
         selection: ProviderSwitcherSelection)
     {
         let ratio = Self.quotaIndicatorRatio(remainingPercent: remainingPercent)
         indicator.fillWidthConstraint.isActive = false
-        let fillWidthConstraint = indicator.fill.widthAnchor.constraint(
-            equalTo: indicator.track.widthAnchor,
-            multiplier: ratio)
+        let fillWidthConstraint = Self.quotaIndicatorFillWidthConstraint(
+            fill: indicator.fill,
+            track: indicator.track,
+            ratio: ratio)
         fillWidthConstraint.isActive = true
         indicator.fillWidthConstraint = fillWidthConstraint
+        indicator.fillRatio = ratio
         indicator.fill.layer?.backgroundColor = Self.quotaIndicatorColor(
             for: selection,
             remainingPercent: remainingPercent).cgColor
         indicator.fill.layer?.cornerRadius = Self.quotaIndicatorHeight / 2
         indicator.fill.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
         indicator.track.isHidden = false
-        indicator.fill.isHidden = false
+        indicator.fill.isHidden = ratio <= 0
     }
 
-    private static func quotaIndicatorColor(
+    fileprivate static func quotaIndicatorColor(
         for selection: ProviderSwitcherSelection,
         remainingPercent _: Double) -> NSColor
     {
@@ -951,19 +987,20 @@ final class ProviderSwitcherView: NSView {
         }
     }
 
-    private static func quotaIndicatorRatio(remainingPercent: Double) -> CGFloat {
+    fileprivate static func quotaIndicatorRatio(remainingPercent: Double) -> CGFloat {
         CGFloat(max(0, min(1, remainingPercent / 100)))
     }
 
-    private static func overviewIcon() -> NSImage {
-        if let symbol = NSImage(systemSymbolName: "square.grid.2x2", accessibilityDescription: nil) {
-            return symbol
+    private static func quotaIndicatorFillWidthConstraint(
+        fill: NSView,
+        track: NSView,
+        ratio: CGFloat)
+        -> NSLayoutConstraint
+    {
+        guard ratio > 0 else {
+            return fill.widthAnchor.constraint(equalToConstant: 0)
         }
-        return NSImage(size: NSSize(width: 16, height: 16))
-    }
-
-    private static func switcherTitle(for provider: UsageProvider) -> String {
-        ProviderDescriptorRegistry.descriptor(for: provider).metadata.displayName
+        return fill.widthAnchor.constraint(equalTo: track.widthAnchor, multiplier: ratio)
     }
 }
 

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -15,8 +15,9 @@ final class ProviderSwitcherView: NSView {
     }
 
     private struct QuotaIndicator {
-        let badge: NSView
-        let fillWidthConstraint: NSLayoutConstraint
+        let track: NSView
+        let fill: NSView
+        var fillWidthConstraint: NSLayoutConstraint
     }
 
     private let segments: [Segment]
@@ -39,6 +40,13 @@ final class ProviderSwitcherView: NSView {
     private var hoveredButtonTag: Int?
     private var pressedButtonTag: Int?
     private let lightModeOverlayLayer = CALayer()
+    private static let quotaIndicatorHeight: CGFloat = 3
+    private static let quotaIndicatorBottomInset: CGFloat = 2
+    private static let quotaIndicatorHorizontalInset: CGFloat = 8
+    private static let quotaIndicatorContentGap: CGFloat = 3
+    private static var quotaIndicatorReservedHeight: CGFloat {
+        quotaIndicatorContentGap + quotaIndicatorHeight + quotaIndicatorBottomInset
+    }
 
     init(
         providers: [UsageProvider],
@@ -579,6 +587,40 @@ final class ProviderSwitcherView: NSView {
         self.updateButtonStyles()
     }
 
+    func updateQuotaIndicators() {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        defer { CATransaction.commit() }
+
+        for (index, button) in self.buttons.enumerated() {
+            guard self.segments.indices.contains(index) else { continue }
+            let segment = self.segments[index]
+            let remaining: Double? = switch segment.selection {
+            case let .provider(provider):
+                self.weeklyRemainingProvider(provider)
+            case .overview:
+                nil
+            }
+
+            let key = ObjectIdentifier(button)
+            if let remaining {
+                if var indicator = self.quotaIndicators[key] {
+                    Self.updateQuotaIndicatorFill(
+                        indicator: &indicator,
+                        remainingPercent: remaining,
+                        selection: segment.selection)
+                    self.quotaIndicators[key] = indicator
+                } else {
+                    self.addQuotaIndicator(to: button, selection: segment.selection, remainingPercent: remaining)
+                }
+            } else if let indicator = self.quotaIndicators[key] {
+                indicator.track.isHidden = true
+                indicator.fill.isHidden = true
+            }
+            self.updateQuotaIndicatorVisibility(for: button)
+        }
+    }
+
     @objc private func handleSelection(_ sender: NSButton) {
         let index = sender.tag
         guard self.segments.indices.contains(index) else { return }
@@ -617,9 +659,9 @@ final class ProviderSwitcherView: NSView {
         self.updateButtonStyles()
     }
 
-    func _test_quotaIndicatorFillWidths() -> [CGFloat] {
+    func _test_quotaIndicatorFillRatios() -> [CGFloat] {
         self.buttons.compactMap { button in
-            self.quotaIndicators[ObjectIdentifier(button)]?.fillWidthConstraint.constant
+            self.quotaIndicators[ObjectIdentifier(button)]?.fillWidthConstraint.multiplier
         }
     }
     #endif
@@ -817,51 +859,83 @@ final class ProviderSwitcherView: NSView {
 
     private func addQuotaIndicator(to view: NSView, selection: ProviderSwitcherSelection, remainingPercent: Double?) {
         guard let remainingPercent else { return }
-        let indicatorWidth: CGFloat = 16
-        let fillWidth = Self.quotaIndicatorFillWidth(
-            remainingPercent: remainingPercent,
-            totalWidth: indicatorWidth)
+        Self.applyQuotaBarContentInset(to: view)
 
-        let badge = NSView()
-        badge.wantsLayer = true
-        badge.layer?.backgroundColor = NSColor.secondaryLabelColor.withAlphaComponent(0.18).cgColor
-        badge.layer?.cornerRadius = 1.5
-        badge.layer?.masksToBounds = true
-        badge.translatesAutoresizingMaskIntoConstraints = false
+        let track = NSView()
+        track.wantsLayer = true
+        track.layer?.backgroundColor = NSColor.tertiaryLabelColor.withAlphaComponent(0.22).cgColor
+        track.layer?.cornerRadius = Self.quotaIndicatorHeight / 2
+        track.layer?.masksToBounds = true
+        track.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(track)
 
         let fill = NSView()
         fill.wantsLayer = true
         fill.layer?.backgroundColor = Self.quotaIndicatorColor(
             for: selection,
             remainingPercent: remainingPercent).cgColor
-        fill.layer?.cornerRadius = 1.5
-        fill.layer?.masksToBounds = true
+        fill.layer?.cornerRadius = Self.quotaIndicatorHeight / 2
+        fill.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
         fill.translatesAutoresizingMaskIntoConstraints = false
-        badge.addSubview(fill)
-        view.addSubview(badge)
+        track.addSubview(fill)
 
-        let fillWidthConstraint = fill.widthAnchor.constraint(equalToConstant: fillWidth)
+        let ratio = Self.quotaIndicatorRatio(remainingPercent: remainingPercent)
+        let fillWidthConstraint = fill.widthAnchor.constraint(equalTo: track.widthAnchor, multiplier: ratio)
+
         NSLayoutConstraint.activate([
-            badge.topAnchor.constraint(equalTo: view.topAnchor, constant: 3),
-            badge.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -6),
-            badge.widthAnchor.constraint(equalToConstant: indicatorWidth),
-            badge.heightAnchor.constraint(equalToConstant: 3),
-            fill.leadingAnchor.constraint(equalTo: badge.leadingAnchor),
-            fill.topAnchor.constraint(equalTo: badge.topAnchor),
-            fill.bottomAnchor.constraint(equalTo: badge.bottomAnchor),
+            track.leadingAnchor.constraint(
+                equalTo: view.leadingAnchor,
+                constant: Self.quotaIndicatorHorizontalInset),
+            track.trailingAnchor.constraint(
+                equalTo: view.trailingAnchor,
+                constant: -Self.quotaIndicatorHorizontalInset),
+            track.bottomAnchor.constraint(
+                equalTo: view.bottomAnchor,
+                constant: -Self.quotaIndicatorBottomInset),
+            track.heightAnchor.constraint(equalToConstant: Self.quotaIndicatorHeight),
+            fill.leadingAnchor.constraint(equalTo: track.leadingAnchor),
+            fill.topAnchor.constraint(equalTo: track.topAnchor),
+            fill.bottomAnchor.constraint(equalTo: track.bottomAnchor),
             fillWidthConstraint,
         ])
 
         self.quotaIndicators[ObjectIdentifier(view)] = QuotaIndicator(
-            badge: badge,
+            track: track,
+            fill: fill,
             fillWidthConstraint: fillWidthConstraint)
         self.updateQuotaIndicatorVisibility(for: view)
+    }
+
+    private static func applyQuotaBarContentInset(to view: NSView) {
+        (view as? ProviderSwitcherToggleButton)?.setQuotaBarReservedHeight(self.quotaIndicatorReservedHeight)
     }
 
     private func updateQuotaIndicatorVisibility(for view: NSView) {
         guard let indicator = self.quotaIndicators[ObjectIdentifier(view)] else { return }
         let isSelected = (view as? NSButton)?.state == .on
-        indicator.badge.isHidden = isSelected
+        indicator.track.isHidden = isSelected
+        indicator.fill.isHidden = isSelected
+    }
+
+    private static func updateQuotaIndicatorFill(
+        indicator: inout QuotaIndicator,
+        remainingPercent: Double,
+        selection: ProviderSwitcherSelection)
+    {
+        let ratio = Self.quotaIndicatorRatio(remainingPercent: remainingPercent)
+        indicator.fillWidthConstraint.isActive = false
+        let fillWidthConstraint = indicator.fill.widthAnchor.constraint(
+            equalTo: indicator.track.widthAnchor,
+            multiplier: ratio)
+        fillWidthConstraint.isActive = true
+        indicator.fillWidthConstraint = fillWidthConstraint
+        indicator.fill.layer?.backgroundColor = Self.quotaIndicatorColor(
+            for: selection,
+            remainingPercent: remainingPercent).cgColor
+        indicator.fill.layer?.cornerRadius = Self.quotaIndicatorHeight / 2
+        indicator.fill.layer?.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
+        indicator.track.isHidden = false
+        indicator.fill.isHidden = false
     }
 
     private static func quotaIndicatorColor(
@@ -871,16 +945,14 @@ final class ProviderSwitcherView: NSView {
         switch selection {
         case let .provider(provider):
             let color = ProviderDescriptorRegistry.descriptor(for: provider).branding.color
-            return NSColor(deviceRed: color.red, green: color.green, blue: color.blue, alpha: 0.7)
+            return NSColor(deviceRed: color.red, green: color.green, blue: color.blue, alpha: 1)
         case .overview:
-            return NSColor.secondaryLabelColor.withAlphaComponent(0.7)
+            return NSColor.secondaryLabelColor
         }
     }
 
-    private static func quotaIndicatorFillWidth(remainingPercent: Double, totalWidth: CGFloat) -> CGFloat {
-        let clamped = min(100, max(0, remainingPercent))
-        guard clamped > 0 else { return 0 }
-        return max(3, totalWidth * CGFloat(clamped / 100))
+    private static func quotaIndicatorRatio(remainingPercent: Double) -> CGFloat {
+        CGFloat(max(0, min(1, remainingPercent / 100)))
     }
 
     private static func overviewIcon() -> NSImage {

--- a/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
@@ -322,6 +322,129 @@ struct StatusMenuSwitcherClickTests {
         #expect(updatedHigh < initialHigh)
     }
 
+    @Test
+    func `switcher quota indicator renders zero remaining empty`() {
+        var grokRemaining = 50.0
+        let view = ProviderSwitcherView(
+            providers: [.claude, .grok],
+            selected: .provider(.claude),
+            includesOverview: false,
+            width: 180,
+            showsIcons: true,
+            iconProvider: { _ in NSImage(size: NSSize(width: 16, height: 16)) },
+            weeklyRemainingProvider: { provider in
+                switch provider {
+                case .claude:
+                    100
+                case .grok:
+                    grokRemaining
+                default:
+                    nil
+                }
+            },
+            onSelect: { _ in })
+
+        grokRemaining = 0
+        view.updateQuotaIndicators()
+        view.updateConstraintsForSubtreeIfNeeded()
+        view.layoutSubtreeIfNeeded()
+
+        let fillRatios = view._test_quotaIndicatorFillRatios()
+        let fillFrames = view._test_quotaIndicatorFillFrames()
+        #expect(fillRatios.last == 0)
+        #expect(fillFrames.last?.width == 0)
+    }
+
+    @Test
+    func `switcher quota indicator disappears when remaining becomes unavailable`() throws {
+        var grokRemaining: Double? = 50
+        let noQuotaView = ProviderSwitcherView(
+            providers: [.claude, .grok],
+            selected: .provider(.claude),
+            includesOverview: false,
+            width: 180,
+            showsIcons: true,
+            iconProvider: { _ in NSImage(size: NSSize(width: 16, height: 16)) },
+            weeklyRemainingProvider: { _ in nil },
+            onSelect: { _ in })
+        let view = ProviderSwitcherView(
+            providers: [.claude, .grok],
+            selected: .provider(.claude),
+            includesOverview: false,
+            width: 180,
+            showsIcons: true,
+            iconProvider: { _ in NSImage(size: NSSize(width: 16, height: 16)) },
+            weeklyRemainingProvider: { provider in
+                switch provider {
+                case .claude:
+                    100
+                case .grok:
+                    grokRemaining
+                default:
+                    nil
+                }
+            },
+            onSelect: { _ in })
+        #expect(view._test_quotaIndicatorFillRatios().count == 2)
+        let noQuotaHeight = try #require(noQuotaView._test_buttonFittingSizes().last?.height)
+        let quotaHeight = try #require(view._test_buttonFittingSizes().last?.height)
+        #expect(quotaHeight > noQuotaHeight)
+
+        grokRemaining = nil
+        view.updateQuotaIndicators()
+
+        #expect(view._test_quotaIndicatorFillRatios().count == 1)
+        let removedQuotaHeight = try #require(view._test_buttonFittingSizes().last?.height)
+        #expect(removedQuotaHeight == noQuotaHeight)
+    }
+
+    @Test
+    func `text only switcher quota bars reserve title space`() throws {
+        let providers: [UsageProvider] = [.claude, .grok]
+        let textOnlyWithoutQuota = ProviderSwitcherView(
+            providers: providers,
+            selected: .provider(.claude),
+            includesOverview: false,
+            width: 180,
+            showsIcons: false,
+            iconProvider: { _ in NSImage(size: NSSize(width: 16, height: 16)) },
+            weeklyRemainingProvider: { _ in nil },
+            onSelect: { _ in })
+        let textOnlyWithQuota = ProviderSwitcherView(
+            providers: providers,
+            selected: .provider(.claude),
+            includesOverview: false,
+            width: 180,
+            showsIcons: false,
+            iconProvider: { _ in NSImage(size: NSSize(width: 16, height: 16)) },
+            weeklyRemainingProvider: { _ in 50 },
+            onSelect: { _ in })
+
+        let withoutQuotaHeight = try #require(textOnlyWithoutQuota._test_buttonFittingSizes().first?.height)
+        let withQuotaHeight = try #require(textOnlyWithQuota._test_buttonFittingSizes().first?.height)
+        #expect(withQuotaHeight > withoutQuotaHeight)
+    }
+
+    @Test
+    func `multi row switcher quota bars stay inside bounds`() {
+        let view = ProviderSwitcherView(
+            providers: [.codex, .claude, .cursor, .factory, .zai, .minimax, .alibaba],
+            selected: .provider(.codex),
+            includesOverview: true,
+            width: 300,
+            showsIcons: true,
+            iconProvider: { _ in NSImage(size: NSSize(width: 16, height: 16)) },
+            weeklyRemainingProvider: { _ in 50 },
+            onSelect: { _ in })
+        view.updateConstraintsForSubtreeIfNeeded()
+        view.layoutSubtreeIfNeeded()
+
+        for frame in view._test_buttonFrames() {
+            #expect(frame.minY >= 0)
+            #expect(frame.maxY <= view.bounds.maxY)
+        }
+    }
+
     private static func arrowKeyEvent(keyCode: UInt16) throws -> NSEvent {
         try #require(NSEvent.keyEvent(
             with: .keyDown,

--- a/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
@@ -277,11 +277,49 @@ struct StatusMenuSwitcherClickTests {
             },
             onSelect: { _ in })
 
-        let fillWidths = view._test_quotaIndicatorFillWidths()
-        #expect(fillWidths.count == 2)
-        let lowRemainingWidth = try #require(fillWidths.first)
-        let highRemainingWidth = try #require(fillWidths.last)
-        #expect(lowRemainingWidth < highRemainingWidth)
+        let fillRatios = view._test_quotaIndicatorFillRatios()
+        #expect(fillRatios.count == 2)
+        let lowRemainingRatio = try #require(fillRatios.first)
+        let highRemainingRatio = try #require(fillRatios.last)
+        #expect(lowRemainingRatio < highRemainingRatio)
+    }
+
+    @Test
+    func `switcher quota indicator refresh updates fill ratios`() throws {
+        var claudeRemaining = 5.0
+        var grokRemaining = 95.0
+        let view = ProviderSwitcherView(
+            providers: [.claude, .grok],
+            selected: .provider(.claude),
+            includesOverview: false,
+            width: 180,
+            showsIcons: true,
+            iconProvider: { _ in NSImage(size: NSSize(width: 16, height: 16)) },
+            weeklyRemainingProvider: { provider in
+                switch provider {
+                case .claude:
+                    claudeRemaining
+                case .grok:
+                    grokRemaining
+                default:
+                    nil
+                }
+            },
+            onSelect: { _ in })
+
+        let initialRatios = view._test_quotaIndicatorFillRatios()
+        let initialLow = try #require(initialRatios.first)
+        let initialHigh = try #require(initialRatios.last)
+
+        claudeRemaining = 80
+        grokRemaining = 12
+        view.updateQuotaIndicators()
+
+        let updatedRatios = view._test_quotaIndicatorFillRatios()
+        let updatedLow = try #require(updatedRatios.first)
+        let updatedHigh = try #require(updatedRatios.last)
+        #expect(updatedLow > initialLow)
+        #expect(updatedHigh < initialHigh)
     }
 
     private static func arrowKeyEvent(keyCode: UInt16) throws -> NSEvent {


### PR DESCRIPTION
## Summary

- Reverts the v0.27.0 corner-badge quota indicators back to the pre-0.27 full-width bottom progress bar used through 0.26.1
- Reserves bottom space in stacked/inline switcher buttons so the bar no longer overlaps tab labels in multi-row layouts
- Refreshes switcher quota indicator fill when the open menu preserves the provider switcher during usage updates (⌘R / background refresh)

## Context

In `f9344673` (shipped in v0.27.0), the switcher meter was changed from a full-width bottom bar to a 16px top-trailing badge to keep buttons centered. That badge reads poorly when many providers are enabled and the switcher uses the stacked two-row layout: the meter floats near labels, misaligns, and looks like a broken underline instead of a quota bar.

This restores the readable bar while keeping the centering fix by reserving dedicated space below icon/title content instead of overlaying the badge on button chrome.

## Test plan

- [x] `swift test --filter StatusMenuSwitcherClickTests`
- [ ] Open merged menu with 8+ enabled providers; confirm each unselected tab shows a full-width bottom bar with visible track + fill
- [ ] Press ⌘R while menu is open; confirm switcher bars update without rebuilding the whole switcher
- [ ] Select a provider tab; confirm its quota bar hides while others remain visible
- [ ] Compare against CodexBar 0.26.1 on a second machine for visual parity


Made with [Cursor](https://cursor.com)