### PR TITLE
OpenCode: surface workspace renewal date via NamedRateWindow

### DIFF
--- a/Sources/CodexBarCore/Providers/OpenCode/OpenCodeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCode/OpenCodeUsageFetcher.swift
@@ -62,6 +62,10 @@ public struct OpenCodeUsageFetcher: Sendable {
         "renewAt",
         "renew_at",
     ]
+    private static let renewAtKeys = [
+        "renewAt",
+        "renew_at",
+    ]
     private static func makeISO8601Formatter() -> ISO8601DateFormatter {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -502,24 +506,33 @@ public struct OpenCodeUsageFetcher: Sendable {
 
     private static func parseUsageJSON(object: Any, now: Date) -> OpenCodeUsageSnapshot? {
         guard let dict = object as? [String: Any] else { return nil }
-        if let snapshot = self.parseUsageDictionary(dict, now: now) {
+        let renewsAt = self.dateValue(from: self.value(from: dict, keys: self.renewAtKeys))
+        if let snapshot = self.parseUsageDictionary(dict, now: now, inheritedRenewsAt: renewsAt) {
             return snapshot
         }
 
         for key in ["data", "result", "usage", "billing", "payload"] {
             if let nested = dict[key] as? [String: Any],
-               let snapshot = self.parseUsageDictionary(nested, now: now)
+               let snapshot = self.parseUsageDictionary(nested, now: now, inheritedRenewsAt: renewsAt)
             {
                 return snapshot
             }
         }
 
-        return self.parseUsageNested(dict, now: now, depth: 0)
+        if let snapshot = self.parseUsageNested(dict, now: now, depth: 0, inheritedRenewsAt: renewsAt) {
+            return snapshot
+        }
+        return self.parseUsageFromCandidates(object: object, now: now, inheritedRenewsAt: renewsAt)
     }
 
-    private static func parseUsageDictionary(_ dict: [String: Any], now: Date) -> OpenCodeUsageSnapshot? {
+    private static func parseUsageDictionary(
+        _ dict: [String: Any],
+        now: Date,
+        inheritedRenewsAt: Date?) -> OpenCodeUsageSnapshot?
+    {
+        let renewsAt = self.dateValue(from: self.value(from: dict, keys: self.renewAtKeys)) ?? inheritedRenewsAt
         if let usage = dict["usage"] as? [String: Any],
-           let snapshot = self.parseUsageDictionary(usage, now: now)
+           let snapshot = self.parseUsageDictionary(usage, now: now, inheritedRenewsAt: renewsAt)
         {
             return snapshot
         }
@@ -531,14 +544,20 @@ public struct OpenCodeUsageFetcher: Sendable {
         let weekly = weeklyKeys.compactMap { dict[$0] as? [String: Any] }.first
 
         if let rolling, let weekly {
-            return self.buildSnapshot(rolling: rolling, weekly: weekly, now: now)
+            return self.buildSnapshot(rolling: rolling, weekly: weekly, now: now, renewsAt: renewsAt)
         }
 
         return nil
     }
 
-    private static func parseUsageNested(_ dict: [String: Any], now: Date, depth: Int) -> OpenCodeUsageSnapshot? {
+    private static func parseUsageNested(
+        _ dict: [String: Any],
+        now: Date,
+        depth: Int,
+        inheritedRenewsAt: Date?) -> OpenCodeUsageSnapshot?
+    {
         if depth > 3 { return nil }
+        let renewsAt = self.dateValue(from: self.value(from: dict, keys: self.renewAtKeys)) ?? inheritedRenewsAt
         var rolling: [String: Any]?
         var weekly: [String: Any]?
 
@@ -552,15 +571,18 @@ public struct OpenCodeUsageFetcher: Sendable {
             }
         }
 
-        if let rolling, let weekly,
-           let snapshot = self.buildSnapshot(rolling: rolling, weekly: weekly, now: now)
-        {
-            return snapshot
+        if let rolling, let weekly {
+            let snapshot = self.buildSnapshot(rolling: rolling, weekly: weekly, now: now, renewsAt: renewsAt)
+            if let snapshot { return snapshot }
         }
 
         for value in dict.values {
             if let sub = value as? [String: Any],
-               let snapshot = self.parseUsageNested(sub, now: now, depth: depth + 1)
+               let snapshot = self.parseUsageNested(
+                   sub,
+                   now: now,
+                   depth: depth + 1,
+                   inheritedRenewsAt: renewsAt)
             {
                 return snapshot
             }
@@ -569,7 +591,11 @@ public struct OpenCodeUsageFetcher: Sendable {
         return nil
     }
 
-    private static func parseUsageFromCandidates(object: Any, now: Date) -> OpenCodeUsageSnapshot? {
+    private static func parseUsageFromCandidates(
+        object: Any,
+        now: Date,
+        inheritedRenewsAt: Date? = nil) -> OpenCodeUsageSnapshot?
+    {
         let candidates = self.collectWindowCandidates(object: object, now: now)
         guard !candidates.isEmpty else { return nil }
 
@@ -596,11 +622,14 @@ public struct OpenCodeUsageFetcher: Sendable {
 
         guard let rolling, let weekly else { return nil }
 
+        let renewsAt = self.dateValue(from: self.value(from: object as? [String: Any] ?? [:], keys: self.renewAtKeys))
+            ?? inheritedRenewsAt
         return OpenCodeUsageSnapshot(
             rollingUsagePercent: rolling.percent,
             weeklyUsagePercent: weekly.percent,
             rollingResetInSec: rolling.resetInSec,
             weeklyResetInSec: weekly.resetInSec,
+            renewsAt: renewsAt,
             updatedAt: now)
     }
 
@@ -679,7 +708,8 @@ public struct OpenCodeUsageFetcher: Sendable {
     private static func buildSnapshot(
         rolling: [String: Any],
         weekly: [String: Any],
-        now: Date) -> OpenCodeUsageSnapshot?
+        now: Date,
+        renewsAt: Date? = nil) -> OpenCodeUsageSnapshot?
     {
         guard let rollingWindow = self.parseWindow(rolling, now: now),
               let weeklyWindow = self.parseWindow(weekly, now: now)
@@ -692,6 +722,7 @@ public struct OpenCodeUsageFetcher: Sendable {
             weeklyUsagePercent: weeklyWindow.percent,
             rollingResetInSec: rollingWindow.resetInSec,
             weeklyResetInSec: weeklyWindow.resetInSec,
+            renewsAt: renewsAt,
             updatedAt: now)
     }
 

--- a/Sources/CodexBarCore/Providers/OpenCode/OpenCodeUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/OpenCode/OpenCodeUsageSnapshot.swift
@@ -5,6 +5,7 @@ public struct OpenCodeUsageSnapshot: Sendable {
     public let weeklyUsagePercent: Double
     public let rollingResetInSec: Int
     public let weeklyResetInSec: Int
+    public let renewsAt: Date?
     public let updatedAt: Date
 
     public init(
@@ -12,12 +13,14 @@ public struct OpenCodeUsageSnapshot: Sendable {
         weeklyUsagePercent: Double,
         rollingResetInSec: Int,
         weeklyResetInSec: Int,
+        renewsAt: Date? = nil,
         updatedAt: Date)
     {
         self.rollingUsagePercent = rollingUsagePercent
         self.weeklyUsagePercent = weeklyUsagePercent
         self.rollingResetInSec = rollingResetInSec
         self.weeklyResetInSec = weeklyResetInSec
+        self.renewsAt = renewsAt
         self.updatedAt = updatedAt
     }
 
@@ -36,9 +39,20 @@ public struct OpenCodeUsageSnapshot: Sendable {
             resetsAt: weeklyReset,
             resetDescription: nil)
 
+        var extraWindows: [NamedRateWindow]?
+        if let renewsAt = self.renewsAt {
+            let renewalWindow = RateWindow(
+                usedPercent: 0,
+                windowMinutes: nil,
+                resetsAt: renewsAt,
+                resetDescription: nil)
+            extraWindows = [NamedRateWindow(id: "renewal", title: "Renews", window: renewalWindow)]
+        }
+
         return UsageSnapshot(
             primary: primary,
             secondary: secondary,
+            extraRateWindows: extraWindows,
             updatedAt: self.updatedAt,
             identity: nil)
     }

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -92,6 +92,10 @@ public struct OpenCodeGoUsageFetcher: Sendable {
         "renewAt",
         "renew_at",
     ]
+    private static let renewAtKeys = [
+        "renewAt",
+        "renew_at",
+    ]
     private static let redirectGuardDelegate = RedirectGuardDelegate()
     private static let redirectGuardSession: URLSession = {
         let configuration = URLSessionConfiguration.ephemeral
@@ -350,25 +354,31 @@ public struct OpenCodeGoUsageFetcher: Sendable {
             return nil
         }
 
-        if let snapshot = self.parseUsageDictionary(dict, now: now) {
+        let renewsAt = self.dateValue(from: self.value(from: dict, keys: self.renewAtKeys))
+        if let snapshot = self.parseUsageDictionary(dict, now: now, inheritedRenewsAt: renewsAt) {
             return snapshot
         }
         for key in ["data", "result", "usage", "billing", "payload"] {
             if let nested = dict[key] as? [String: Any],
-               let snapshot = self.parseUsageDictionary(nested, now: now)
+               let snapshot = self.parseUsageDictionary(nested, now: now, inheritedRenewsAt: renewsAt)
             {
                 return snapshot
             }
         }
-        if let snapshot = self.parseUsageNested(dict, now: now, depth: 0) {
+        if let snapshot = self.parseUsageNested(dict, now: now, depth: 0, inheritedRenewsAt: renewsAt) {
             return snapshot
         }
-        return self.parseUsageFromCandidates(object: object, now: now)
+        return self.parseUsageFromCandidates(object: object, now: now, inheritedRenewsAt: renewsAt)
     }
 
-    private static func parseUsageDictionary(_ dict: [String: Any], now: Date) -> OpenCodeGoUsageSnapshot? {
+    private static func parseUsageDictionary(
+        _ dict: [String: Any],
+        now: Date,
+        inheritedRenewsAt: Date?) -> OpenCodeGoUsageSnapshot?
+    {
+        let renewsAt = self.dateValue(from: self.value(from: dict, keys: self.renewAtKeys)) ?? inheritedRenewsAt
         if let usage = dict["usage"] as? [String: Any],
-           let snapshot = self.parseUsageDictionary(usage, now: now)
+           let snapshot = self.parseUsageDictionary(usage, now: now, inheritedRenewsAt: renewsAt)
         {
             return snapshot
         }
@@ -383,11 +393,17 @@ public struct OpenCodeGoUsageFetcher: Sendable {
 
         guard let rolling, let weekly else { return nil }
 
-        return self.buildSnapshot(rolling: rolling, weekly: weekly, monthly: monthly, now: now)
+        return self.buildSnapshot(rolling: rolling, weekly: weekly, monthly: monthly, now: now, renewsAt: renewsAt)
     }
 
-    private static func parseUsageNested(_ dict: [String: Any], now: Date, depth: Int) -> OpenCodeGoUsageSnapshot? {
+    private static func parseUsageNested(
+        _ dict: [String: Any],
+        now: Date,
+        depth: Int,
+        inheritedRenewsAt: Date?) -> OpenCodeGoUsageSnapshot?
+    {
         if depth > 3 { return nil }
+        let renewsAt = self.dateValue(from: self.value(from: dict, keys: self.renewAtKeys)) ?? inheritedRenewsAt
         var rolling: [String: Any]?
         var weekly: [String: Any]?
         var monthly: [String: Any]?
@@ -404,15 +420,23 @@ public struct OpenCodeGoUsageFetcher: Sendable {
             }
         }
 
-        if let rolling, let weekly,
-           let snapshot = self.buildSnapshot(rolling: rolling, weekly: weekly, monthly: monthly, now: now)
-        {
-            return snapshot
+        if let rolling, let weekly {
+            let snapshot = self.buildSnapshot(
+                rolling: rolling,
+                weekly: weekly,
+                monthly: monthly,
+                now: now,
+                renewsAt: renewsAt)
+            if let snapshot { return snapshot }
         }
 
         for value in dict.values {
             if let sub = value as? [String: Any],
-               let snapshot = self.parseUsageNested(sub, now: now, depth: depth + 1)
+               let snapshot = self.parseUsageNested(
+                   sub,
+                   now: now,
+                   depth: depth + 1,
+                   inheritedRenewsAt: renewsAt)
             {
                 return snapshot
             }
@@ -421,7 +445,11 @@ public struct OpenCodeGoUsageFetcher: Sendable {
         return nil
     }
 
-    private static func parseUsageFromCandidates(object: Any, now: Date) -> OpenCodeGoUsageSnapshot? {
+    private static func parseUsageFromCandidates(
+        object: Any,
+        now: Date,
+        inheritedRenewsAt: Date? = nil) -> OpenCodeGoUsageSnapshot?
+    {
         let candidates = self.collectWindowCandidates(object: object, now: now)
         guard !candidates.isEmpty else { return nil }
 
@@ -457,6 +485,8 @@ public struct OpenCodeGoUsageFetcher: Sendable {
 
         guard let rolling, let weekly else { return nil }
 
+        let renewsAt = self.dateValue(from: self.value(from: object as? [String: Any] ?? [:], keys: self.renewAtKeys))
+            ?? inheritedRenewsAt
         return OpenCodeGoUsageSnapshot(
             hasMonthlyUsage: monthly != nil,
             rollingUsagePercent: rolling.percent,
@@ -465,6 +495,7 @@ public struct OpenCodeGoUsageFetcher: Sendable {
             rollingResetInSec: rolling.resetInSec,
             weeklyResetInSec: weekly.resetInSec,
             monthlyResetInSec: monthly?.resetInSec ?? 0,
+            renewsAt: renewsAt,
             updatedAt: now)
     }
 
@@ -553,7 +584,8 @@ public struct OpenCodeGoUsageFetcher: Sendable {
         rolling: [String: Any],
         weekly: [String: Any],
         monthly: [String: Any]?,
-        now: Date) -> OpenCodeGoUsageSnapshot?
+        now: Date,
+        renewsAt: Date? = nil) -> OpenCodeGoUsageSnapshot?
     {
         guard let rollingWindow = self.parseWindow(rolling, now: now),
               let weeklyWindow = self.parseWindow(weekly, now: now)
@@ -571,6 +603,7 @@ public struct OpenCodeGoUsageFetcher: Sendable {
             rollingResetInSec: rollingWindow.resetInSec,
             weeklyResetInSec: weeklyWindow.resetInSec,
             monthlyResetInSec: monthlyWindow?.resetInSec ?? 0,
+            renewsAt: renewsAt,
             updatedAt: now)
     }
 
@@ -813,6 +846,15 @@ public struct OpenCodeGoUsageFetcher: Sendable {
         default:
             nil
         }
+    }
+
+    private static func value(from dict: [String: Any], keys: [String]) -> Any? {
+        for key in keys {
+            if let value = dict[key] {
+                return value
+            }
+        }
+        return nil
     }
 
     private static func dateValue(from value: Any?) -> Date? {

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageSnapshot.swift
@@ -9,6 +9,7 @@ public struct OpenCodeGoUsageSnapshot: Sendable {
     public let weeklyResetInSec: Int
     public let monthlyResetInSec: Int
     public let zenBalanceUSD: Double?
+    public let renewsAt: Date?
     public let updatedAt: Date
 
     public init(
@@ -20,6 +21,7 @@ public struct OpenCodeGoUsageSnapshot: Sendable {
         weeklyResetInSec: Int,
         monthlyResetInSec: Int,
         zenBalanceUSD: Double? = nil,
+        renewsAt: Date? = nil,
         updatedAt: Date)
     {
         self.hasMonthlyUsage = hasMonthlyUsage
@@ -30,6 +32,7 @@ public struct OpenCodeGoUsageSnapshot: Sendable {
         self.weeklyResetInSec = weeklyResetInSec
         self.monthlyResetInSec = monthlyResetInSec
         self.zenBalanceUSD = zenBalanceUSD
+        self.renewsAt = renewsAt
         self.updatedAt = updatedAt
     }
 
@@ -59,10 +62,21 @@ public struct OpenCodeGoUsageSnapshot: Sendable {
             tertiary = nil
         }
 
+        var extraWindows: [NamedRateWindow]?
+        if let renewsAt = self.renewsAt {
+            let renewalWindow = RateWindow(
+                usedPercent: 0,
+                windowMinutes: nil,
+                resetsAt: renewsAt,
+                resetDescription: nil)
+            extraWindows = [NamedRateWindow(id: "renewal", title: "Renews", window: renewalWindow)]
+        }
+
         return UsageSnapshot(
             primary: primary,
             secondary: secondary,
             tertiary: tertiary,
+            extraRateWindows: extraWindows,
             providerCost: self.zenBalanceUSD.map {
                 ProviderCostSnapshot(
                     used: $0,
@@ -85,6 +99,7 @@ public struct OpenCodeGoUsageSnapshot: Sendable {
             weeklyResetInSec: self.weeklyResetInSec,
             monthlyResetInSec: self.monthlyResetInSec,
             zenBalanceUSD: balance,
+            renewsAt: self.renewsAt,
             updatedAt: self.updatedAt)
     }
 }

--- a/Tests/CodexBarTests/OpenCodeGoUsageParserTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageParserTests.swift
@@ -292,4 +292,155 @@ struct OpenCodeGoUsageParserTests {
             _ = try OpenCodeGoUsageFetcher.parseSubscription(text: text, now: now)
         }
     }
+
+    @Test
+    func `renewsAt parses from ISO8601 renewAt key`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let renewAt = now.addingTimeInterval(86400 * 30)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let payload: [String: Any] = [
+            "rollingUsage": ["usagePercent": 10, "resetInSec": 600],
+            "weeklyUsage": ["usagePercent": 50, "resetInSec": 3600],
+            "monthlyUsage": ["usagePercent": 25, "resetInSec": 7200],
+            "renewAt": formatter.string(from: renewAt),
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let text = String(data: data, encoding: .utf8) ?? ""
+
+        let snapshot = try OpenCodeGoUsageFetcher.parseSubscription(text: text, now: now)
+
+        #expect(snapshot.renewsAt != nil)
+        #expect(snapshot.renewsAt == renewAt)
+    }
+
+    @Test
+    func `renewsAt parses from renew_at key`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let renewAt = now.addingTimeInterval(86400 * 30)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let payload: [String: Any] = [
+            "rollingUsage": ["usagePercent": 10, "resetInSec": 600],
+            "weeklyUsage": ["usagePercent": 50, "resetInSec": 3600],
+            "monthlyUsage": ["usagePercent": 25, "resetInSec": 7200],
+            "renew_at": formatter.string(from: renewAt),
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let text = String(data: data, encoding: .utf8) ?? ""
+
+        let snapshot = try OpenCodeGoUsageFetcher.parseSubscription(text: text, now: now)
+
+        #expect(snapshot.renewsAt != nil)
+        #expect(snapshot.renewsAt == renewAt)
+    }
+
+    @Test
+    func `renewsAt is nil when absent`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let payload: [String: Any] = [
+            "rollingUsage": ["usagePercent": 10, "resetInSec": 600],
+            "weeklyUsage": ["usagePercent": 50, "resetInSec": 3600],
+            "monthlyUsage": ["usagePercent": 25, "resetInSec": 7200],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let text = String(data: data, encoding: .utf8) ?? ""
+
+        let snapshot = try OpenCodeGoUsageFetcher.parseSubscription(text: text, now: now)
+
+        #expect(snapshot.renewsAt == nil)
+    }
+
+    @Test
+    func `top level renewAt is preserved for nested usage object`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let renewAt = now.addingTimeInterval(86400 * 30)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let payload: [String: Any] = [
+            "renewAt": formatter.string(from: renewAt),
+            "usage": [
+                "rollingUsage": ["usagePercent": 10, "resetInSec": 600],
+                "weeklyUsage": ["usagePercent": 50, "resetInSec": 3600],
+                "monthlyUsage": ["usagePercent": 25, "resetInSec": 7200],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let text = String(data: data, encoding: .utf8) ?? ""
+
+        let snapshot = try OpenCodeGoUsageFetcher.parseSubscription(text: text, now: now)
+
+        #expect(snapshot.renewsAt == renewAt)
+    }
+
+    @Test
+    func `top level renew_at is preserved for nested usage object`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let renewAt = now.addingTimeInterval(86400 * 30)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let payload: [String: Any] = [
+            "renew_at": formatter.string(from: renewAt),
+            "usage": [
+                "rollingUsage": ["usagePercent": 10, "resetInSec": 600],
+                "weeklyUsage": ["usagePercent": 50, "resetInSec": 3600],
+                "monthlyUsage": ["usagePercent": 25, "resetInSec": 7200],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let text = String(data: data, encoding: .utf8) ?? ""
+
+        let snapshot = try OpenCodeGoUsageFetcher.parseSubscription(text: text, now: now)
+
+        #expect(snapshot.renewsAt == renewAt)
+    }
+
+    @Test
+    func `child renewAt overrides parent renewAt`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let parentRenewAt = now.addingTimeInterval(86400 * 30)
+        let childRenewAt = now.addingTimeInterval(86400 * 45)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let payload: [String: Any] = [
+            "renewAt": formatter.string(from: parentRenewAt),
+            "usage": [
+                "renewAt": formatter.string(from: childRenewAt),
+                "rollingUsage": ["usagePercent": 10, "resetInSec": 600],
+                "weeklyUsage": ["usagePercent": 50, "resetInSec": 3600],
+                "monthlyUsage": ["usagePercent": 25, "resetInSec": 7200],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let text = String(data: data, encoding: .utf8) ?? ""
+
+        let snapshot = try OpenCodeGoUsageFetcher.parseSubscription(text: text, now: now)
+
+        #expect(snapshot.renewsAt == childRenewAt)
+    }
+
+    @Test
+    func `toUsageSnapshot includes renewal NamedRateWindow when renewsAt present`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let renewAt = now.addingTimeInterval(86400 * 30)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let payload: [String: Any] = [
+            "rollingUsage": ["usagePercent": 10, "resetInSec": 600],
+            "weeklyUsage": ["usagePercent": 50, "resetInSec": 3600],
+            "monthlyUsage": ["usagePercent": 25, "resetInSec": 7200],
+            "renewAt": formatter.string(from: renewAt),
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let text = String(data: data, encoding: .utf8) ?? ""
+
+        let snapshot = try OpenCodeGoUsageFetcher.parseSubscription(text: text, now: now)
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(usage.extraRateWindows != nil)
+        #expect(usage.extraRateWindows?.count == 1)
+        #expect(usage.extraRateWindows?[0].id == "renewal")
+        #expect(usage.extraRateWindows?[0].title == "Renews")
+        #expect(usage.extraRateWindows?[0].window.resetsAt == renewAt)
+    }
 }

--- a/Tests/CodexBarTests/OpenCodeUsageParserTests.swift
+++ b/Tests/CodexBarTests/OpenCodeUsageParserTests.swift
@@ -112,4 +112,148 @@ struct OpenCodeUsageParserTests {
             _ = try OpenCodeUsageFetcher.parseSubscription(text: text, now: now)
         }
     }
+
+    @Test
+    func `renewsAt parses from ISO8601 renewAt key`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let renewAt = now.addingTimeInterval(86400 * 30)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let payload: [String: Any] = [
+            "rollingUsage": ["usagePercent": 10, "resetInSec": 600],
+            "weeklyUsage": ["usagePercent": 50, "resetInSec": 3600],
+            "renewAt": formatter.string(from: renewAt),
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let text = String(data: data, encoding: .utf8) ?? ""
+
+        let snapshot = try OpenCodeUsageFetcher.parseSubscription(text: text, now: now)
+
+        #expect(snapshot.renewsAt != nil)
+        #expect(snapshot.renewsAt == renewAt)
+    }
+
+    @Test
+    func `renewsAt parses from renew_at key`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let renewAt = now.addingTimeInterval(86400 * 30)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let payload: [String: Any] = [
+            "rollingUsage": ["usagePercent": 10, "resetInSec": 600],
+            "weeklyUsage": ["usagePercent": 50, "resetInSec": 3600],
+            "renew_at": formatter.string(from: renewAt),
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let text = String(data: data, encoding: .utf8) ?? ""
+
+        let snapshot = try OpenCodeUsageFetcher.parseSubscription(text: text, now: now)
+
+        #expect(snapshot.renewsAt != nil)
+        #expect(snapshot.renewsAt == renewAt)
+    }
+
+    @Test
+    func `renewsAt is nil when absent`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let payload: [String: Any] = [
+            "rollingUsage": ["usagePercent": 10, "resetInSec": 600],
+            "weeklyUsage": ["usagePercent": 50, "resetInSec": 3600],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let text = String(data: data, encoding: .utf8) ?? ""
+
+        let snapshot = try OpenCodeUsageFetcher.parseSubscription(text: text, now: now)
+
+        #expect(snapshot.renewsAt == nil)
+    }
+
+    @Test
+    func `top level renewAt is preserved for nested usage object`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let renewAt = now.addingTimeInterval(86400 * 30)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let payload: [String: Any] = [
+            "renewAt": formatter.string(from: renewAt),
+            "usage": [
+                "rollingUsage": ["usagePercent": 10, "resetInSec": 600],
+                "weeklyUsage": ["usagePercent": 50, "resetInSec": 3600],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let text = String(data: data, encoding: .utf8) ?? ""
+
+        let snapshot = try OpenCodeUsageFetcher.parseSubscription(text: text, now: now)
+
+        #expect(snapshot.renewsAt == renewAt)
+    }
+
+    @Test
+    func `top level renew_at is preserved for nested usage object`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let renewAt = now.addingTimeInterval(86400 * 30)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let payload: [String: Any] = [
+            "renew_at": formatter.string(from: renewAt),
+            "usage": [
+                "rollingUsage": ["usagePercent": 10, "resetInSec": 600],
+                "weeklyUsage": ["usagePercent": 50, "resetInSec": 3600],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let text = String(data: data, encoding: .utf8) ?? ""
+
+        let snapshot = try OpenCodeUsageFetcher.parseSubscription(text: text, now: now)
+
+        #expect(snapshot.renewsAt == renewAt)
+    }
+
+    @Test
+    func `child renewAt overrides parent renewAt`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let parentRenewAt = now.addingTimeInterval(86400 * 30)
+        let childRenewAt = now.addingTimeInterval(86400 * 45)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let payload: [String: Any] = [
+            "renewAt": formatter.string(from: parentRenewAt),
+            "usage": [
+                "renewAt": formatter.string(from: childRenewAt),
+                "rollingUsage": ["usagePercent": 10, "resetInSec": 600],
+                "weeklyUsage": ["usagePercent": 50, "resetInSec": 3600],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let text = String(data: data, encoding: .utf8) ?? ""
+
+        let snapshot = try OpenCodeUsageFetcher.parseSubscription(text: text, now: now)
+
+        #expect(snapshot.renewsAt == childRenewAt)
+    }
+
+    @Test
+    func `toUsageSnapshot includes renewal NamedRateWindow when renewsAt present`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let renewAt = now.addingTimeInterval(86400 * 30)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let payload: [String: Any] = [
+            "rollingUsage": ["usagePercent": 10, "resetInSec": 600],
+            "weeklyUsage": ["usagePercent": 50, "resetInSec": 3600],
+            "renewAt": formatter.string(from: renewAt),
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let text = String(data: data, encoding: .utf8) ?? ""
+
+        let snapshot = try OpenCodeUsageFetcher.parseSubscription(text: text, now: now)
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(usage.extraRateWindows != nil)
+        #expect(usage.extraRateWindows?.count == 1)
+        #expect(usage.extraRateWindows?[0].id == "renewal")
+        #expect(usage.extraRateWindows?[0].title == "Renews")
+        #expect(usage.extraRateWindows?[0].window.resetsAt == renewAt)
+    }
 }


### PR DESCRIPTION
## Summary
- Preserve OpenCode/OpenCodeGo renewAt/renew_at as renewsAt: Date?
- Surface renewal timing via NamedRateWindow(title: "Renews")
- Keep provider-specific scope; no shared lifecycle model or global RateWindow semantic changes

## Risk
Provider-local only. No new API calls, no shared model changes, and no global UI changes.

## Validation
- swift test --filter OpenCode
- swift test --filter OpenCodeGo