### PR TITLE
UsageStore: preserve snapshots for more network failures

### DIFF
--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -1,6 +1,24 @@
 import CodexBarCore
 import Foundation
 
+/// Internal for testing: classifies transport-layer errors that should preserve the prior snapshot.
+func isPreservableNetworkTransportError(_ error: Error) -> Bool {
+    let nsError = error as NSError
+    guard nsError.domain == NSURLErrorDomain else { return false }
+    switch nsError.code {
+    case NSURLErrorTimedOut,
+         NSURLErrorCancelled,
+         NSURLErrorNetworkConnectionLost,
+         NSURLErrorNotConnectedToInternet,
+         NSURLErrorCannotFindHost,
+         NSURLErrorCannotConnectToHost,
+         NSURLErrorDNSLookupFailed:
+        return true
+    default:
+        return false
+    }
+}
+
 extension UsageStore {
     func prepareRefreshState(for provider: UsageProvider? = nil) {
         guard provider == nil || provider == .codex else { return }
@@ -320,19 +338,7 @@ extension UsageStore {
     private static func shouldPreservePriorSnapshot(after error: Error, hadPriorData: Bool) -> Bool {
         guard hadPriorData else { return false }
         if error is CancellationError { return true }
-
-        let nsError = error as NSError
-        if nsError.domain == NSURLErrorDomain {
-            switch nsError.code {
-            case NSURLErrorTimedOut,
-                 NSURLErrorCancelled,
-                 NSURLErrorNetworkConnectionLost,
-                 NSURLErrorNotConnectedToInternet:
-                return true
-            default:
-                break
-            }
-        }
+        if isPreservableNetworkTransportError(error) { return true }
 
         let message = error.localizedDescription.lowercased()
         return message.contains("timed out") ||

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -1,24 +1,6 @@
 import CodexBarCore
 import Foundation
 
-/// Internal for testing: classifies transport-layer errors that should preserve the prior snapshot.
-func isPreservableNetworkTransportError(_ error: Error) -> Bool {
-    let nsError = error as NSError
-    guard nsError.domain == NSURLErrorDomain else { return false }
-    switch nsError.code {
-    case NSURLErrorTimedOut,
-         NSURLErrorCancelled,
-         NSURLErrorNetworkConnectionLost,
-         NSURLErrorNotConnectedToInternet,
-         NSURLErrorCannotFindHost,
-         NSURLErrorCannotConnectToHost,
-         NSURLErrorDNSLookupFailed:
-        return true
-    default:
-        return false
-    }
-}
-
 extension UsageStore {
     func prepareRefreshState(for provider: UsageProvider? = nil) {
         guard provider == nil || provider == .codex else { return }
@@ -338,7 +320,7 @@ extension UsageStore {
     private static func shouldPreservePriorSnapshot(after error: Error, hadPriorData: Bool) -> Bool {
         guard hadPriorData else { return false }
         if error is CancellationError { return true }
-        if isPreservableNetworkTransportError(error) { return true }
+        if self.isPreservableNetworkTransportError(error) { return true }
 
         let message = error.localizedDescription.lowercased()
         return message.contains("timed out") ||
@@ -346,6 +328,23 @@ extension UsageStore {
             message.contains("cancelled") ||
             message.contains("network connection was lost") ||
             message.contains("not connected to the internet")
+    }
+
+    static func isPreservableNetworkTransportError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        guard nsError.domain == NSURLErrorDomain else { return false }
+        switch nsError.code {
+        case NSURLErrorTimedOut,
+             NSURLErrorCancelled,
+             NSURLErrorNetworkConnectionLost,
+             NSURLErrorNotConnectedToInternet,
+             NSURLErrorCannotFindHost,
+             NSURLErrorCannotConnectToHost,
+             NSURLErrorDNSLookupFailed:
+            return true
+        default:
+            return false
+        }
     }
 
     private static func isClaudeUsageProbeTimeout(_ error: Error) -> Bool {

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -411,6 +411,36 @@ struct UsageStoreCoverageTests {
         #expect(store.tokenAccountErrorMessage(ProviderFetchError.noAvailableStrategy(.copilot)) != nil)
     }
 
+    @Test
+    func `isPreservableNetworkTransportError classifies transport failures correctly`() {
+        // Regression test: transport-layer errors should be classified as preservable so the
+        // prior snapshot survives a failed refresh. We test the classifier directly rather
+        // than through refreshProvider to keep the test focused and independent of provider
+        // setup complexity.
+
+        // New cases for issue #1097
+        #expect(isPreservableNetworkTransportError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotFindHost)))
+        #expect(isPreservableNetworkTransportError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost)))
+        #expect(isPreservableNetworkTransportError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorDNSLookupFailed)))
+
+        // Previously covered cases
+        #expect(isPreservableNetworkTransportError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)))
+        #expect(isPreservableNetworkTransportError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)))
+        #expect(isPreservableNetworkTransportError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorNetworkConnectionLost)))
+        #expect(isPreservableNetworkTransportError(
+            NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)))
+
+        // Non-URL errors are not classified as transport-preservable
+        #expect(!isPreservableNetworkTransportError(
+            NSError(domain: NSCocoaErrorDomain, code: 0)))
+    }
+
     private static func makeSettingsStore(
         suite: String,
         zaiTokenStore: any ZaiTokenStoring = NoopZaiTokenStore(),

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -413,31 +413,21 @@ struct UsageStoreCoverageTests {
 
     @Test
     func `isPreservableNetworkTransportError classifies transport failures correctly`() {
-        // Regression test: transport-layer errors should be classified as preservable so the
-        // prior snapshot survives a failed refresh. We test the classifier directly rather
-        // than through refreshProvider to keep the test focused and independent of provider
-        // setup complexity.
-
-        // New cases for issue #1097
-        #expect(isPreservableNetworkTransportError(
+        #expect(UsageStore.isPreservableNetworkTransportError(
             NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotFindHost)))
-        #expect(isPreservableNetworkTransportError(
+        #expect(UsageStore.isPreservableNetworkTransportError(
             NSError(domain: NSURLErrorDomain, code: NSURLErrorCannotConnectToHost)))
-        #expect(isPreservableNetworkTransportError(
+        #expect(UsageStore.isPreservableNetworkTransportError(
             NSError(domain: NSURLErrorDomain, code: NSURLErrorDNSLookupFailed)))
-
-        // Previously covered cases
-        #expect(isPreservableNetworkTransportError(
+        #expect(UsageStore.isPreservableNetworkTransportError(
             NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut)))
-        #expect(isPreservableNetworkTransportError(
+        #expect(UsageStore.isPreservableNetworkTransportError(
             NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)))
-        #expect(isPreservableNetworkTransportError(
+        #expect(UsageStore.isPreservableNetworkTransportError(
             NSError(domain: NSURLErrorDomain, code: NSURLErrorNetworkConnectionLost)))
-        #expect(isPreservableNetworkTransportError(
+        #expect(UsageStore.isPreservableNetworkTransportError(
             NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled)))
-
-        // Non-URL errors are not classified as transport-preservable
-        #expect(!isPreservableNetworkTransportError(
+        #expect(!UsageStore.isPreservableNetworkTransportError(
             NSError(domain: NSCocoaErrorDomain, code: 0)))
     }
 


### PR DESCRIPTION
## Fixes

Fixes #1097 — Preserve last successful quota snapshots when network refresh fails.

This PR implements the shared UsageStore behavior requested in #1097: when quota refresh fails due to additional URL transport/network failures, CodexBar preserves the last successful snapshot instead of clearing it.

## Summary

- Preserve the last successful quota snapshot for additional URL transport failures:
  - `cannotFindHost`
  - `cannotConnectToHost`
  - `dnsLookupFailed`
- Keep `shouldPreservePriorSnapshot(after:hadPriorData:)` private
- Extract transport-error classification into `isPreservableNetworkTransportError(_:)` for focused regression coverage
- Add regression coverage for existing and newly supported transport error codes

## Scope

- Shared UsageStore refresh/error handling only
- No provider-specific fallback logic
- No OpenCode/OpenCodeGo changes
- No Kimi changes
- No MiniMax changes

## Validation

- `swift test --filter UsageStoreCoverageTests`
- `swift test --filter Refresh`
- `make check`
- `git diff --check`