### PR TITLE
Fix Linux build of AlibabaTokenPlanCookieHeader

### DIFF
--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanCookieHeader.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanCookieHeader.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 struct AlibabaTokenPlanCookieHeaders: Sendable {
     private static let cachedAPIHeaderName = "__codexbar_alibaba_token_plan_api"


### PR DESCRIPTION
AlibabaTokenPlanCookieHeader.swift uses HTTPCookie (lines 79, 94, 95, 97-99, 102, 113, 118, 134, 146) but only imports Foundation. On macOS HTTPCookie lives in Foundation, but on Linux it was moved to FoundationNetworking and is "explicitly marked unavailable" in Foundation -- so the new file added in #1098 (Alibaba Token Plan provider) breaks the Linux build of CodexBarCore outright. Sibling new files in the same PR (AlibabaTokenPlanUsageFetcher, T3ChatUsageFetcher) already use the right conditional import; this one was overlooked.

VERIFICATION

Ubuntu 24.04 x86_64 with Swift 6.2.4:

Before:
    $ swift build
    error: 'HTTPCookie' is unavailable: This type has moved to the
    FoundationNetworking module. Import that module to use it.
    (10+ occurrences across the file, build aborts)

After:
    $ swift build
    Build complete! (72.86s)
    $ swift test
    Test run with 14 tests in 3 suites passed

No source-of-truth change beyond restoring buildability -- adds the same
"#if canImport(FoundationNetworking) / import FoundationNetworking / #endif"
block that already guards GeminiStatusProbe, ManusCookieHeader,
AlibabaTokenPlanUsageFetcher, T3ChatUsageFetcher, and others.