### PR TITLE
Fix length-1 quote trap in shared settings-reader cleaned() helper

### DIFF
--- a/Sources/CodexBarCLI/CLIConfigCommand.swift
+++ b/Sources/CodexBarCLI/CLIConfigCommand.swift
@@ -221,8 +221,7 @@ extension CodexBarCLI {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -157,8 +157,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanSettingsReader.swift
@@ -52,8 +52,7 @@ public struct AlibabaCodingPlanSettingsReader: Sendable {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanSettingsReader.swift
@@ -34,8 +34,7 @@ public struct AlibabaTokenPlanSettingsReader: Sendable {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value

--- a/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAISettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/AzureOpenAI/AzureOpenAISettingsReader.swift
@@ -46,8 +46,7 @@ public enum AzureOpenAISettingsReader {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockSettingsReader.swift
@@ -59,8 +59,7 @@ public enum BedrockSettingsReader {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeAdminAPISettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeAdminAPISettingsReader.swift
@@ -23,8 +23,7 @@ public enum ClaudeAdminAPISettingsReader {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift
@@ -54,8 +54,7 @@ public enum CodebuffSettingsReader {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/Crof/CrofSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Crof/CrofSettingsReader.swift
@@ -19,8 +19,7 @@ public enum CrofSettingsReader {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value

--- a/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekSettingsReader.swift
@@ -26,8 +26,7 @@ public struct DeepSeekSettingsReader: Sendable {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
         return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Sources/CodexBarCore/Providers/Deepgram/DeepgramSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Deepgram/DeepgramSettingsReader.swift
@@ -24,8 +24,7 @@ public struct DeepgramSettingsReader: Sendable {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/Doubao/DoubaoSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Doubao/DoubaoSettingsReader.swift
@@ -29,8 +29,7 @@ public struct DoubaoSettingsReader: Sendable {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
         return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsSettingsReader.swift
@@ -32,8 +32,7 @@ public enum ElevenLabsSettingsReader {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value

--- a/Sources/CodexBarCore/Providers/Groq/GroqSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Groq/GroqSettingsReader.swift
@@ -28,8 +28,7 @@ public enum GroqSettingsReader {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value

--- a/Sources/CodexBarCore/Providers/Kilo/KiloSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Kilo/KiloSettingsReader.swift
@@ -44,8 +44,7 @@ public enum KiloSettingsReader {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
@@ -14,8 +14,7 @@ public enum KimiSettingsReader {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/KimiK2/KimiK2SettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/KimiK2/KimiK2SettingsReader.swift
@@ -29,8 +29,7 @@ public struct KimiK2SettingsReader: Sendable {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
         return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Sources/CodexBarCore/Providers/LLMProxy/LLMProxySettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/LLMProxy/LLMProxySettingsReader.swift
@@ -24,8 +24,7 @@ public enum LLMProxySettingsReader {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value

--- a/Sources/CodexBarCore/Providers/Manus/ManusSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Manus/ManusSettingsReader.swift
@@ -22,8 +22,7 @@ public enum ManusSettingsReader {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxAPISettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxAPISettingsReader.swift
@@ -44,8 +44,7 @@ public struct MiniMaxAPISettingsReader: Sendable {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxSettingsReader.swift
@@ -56,8 +56,7 @@ public struct MiniMaxSettingsReader: Sendable {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/Moonshot/MoonshotSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Moonshot/MoonshotSettingsReader.swift
@@ -40,8 +40,7 @@ public struct MoonshotSettingsReader: Sendable {
         if (value.hasPrefix("\"") && value.hasSuffix("\""))
             || (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
         return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
@@ -651,8 +651,7 @@ public struct OllamaAPISettingsReader: Sendable {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
         return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPISettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPISettingsReader.swift
@@ -23,8 +23,7 @@ public enum OpenAIAPISettingsReader {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterSettingsReader.swift
@@ -28,8 +28,7 @@ public enum OpenRouterSettingsReader {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/Perplexity/PerplexitySettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Perplexity/PerplexitySettingsReader.swift
@@ -29,8 +29,7 @@ public enum PerplexitySettingsReader {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
+++ b/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
@@ -380,8 +380,7 @@ public enum ProviderTokenResolver {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/StepFun/StepFunSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/StepFun/StepFunSettingsReader.swift
@@ -30,8 +30,7 @@ public struct StepFunSettingsReader: Sendable {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value

--- a/Sources/CodexBarCore/Providers/Synthetic/SyntheticSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Synthetic/SyntheticSettingsReader.swift
@@ -18,8 +18,7 @@ public struct SyntheticSettingsReader: Sendable {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/Venice/VeniceSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Venice/VeniceSettingsReader.swift
@@ -26,8 +26,7 @@ public struct VeniceSettingsReader: Sendable {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
         return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Sources/CodexBarCore/Providers/Warp/WarpSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Warp/WarpSettingsReader.swift
@@ -28,8 +28,7 @@ public struct WarpSettingsReader: Sendable {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
         return value.trimmingCharacters(in: .whitespacesAndNewlines)
     }

--- a/Sources/CodexBarCore/Providers/Zai/ZaiSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiSettingsReader.swift
@@ -38,8 +38,7 @@ public struct ZaiSettingsReader: Sendable {
         if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
             (value.hasPrefix("'") && value.hasSuffix("'"))
         {
-            value.removeFirst()
-            value.removeLast()
+            value = String(value.dropFirst().dropLast())
         }
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/TestsLinux/SettingsReaderQuoteUnwrapTrapTests.swift
+++ b/TestsLinux/SettingsReaderQuoteUnwrapTrapTests.swift
@@ -1,0 +1,75 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+/// Regression tests for a copy-pasted quote-unwrap helper that traps on length-1 input.
+///
+/// 32 provider settings readers (plus `CodexBarConfig` and `CLIConfigCommand`) share a
+/// `cleaned(_:)` helper of the form:
+///
+///     if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
+///         (value.hasPrefix("'") && value.hasSuffix("'"))
+///     {
+///         value.removeFirst()
+///         value.removeLast()
+///     }
+///
+/// For a value of length 1 (the single character `"` or `'`), both `hasPrefix` and
+/// `hasSuffix` return true, `removeFirst()` empties the string, and `removeLast()` then
+/// traps with "Can't remove last element from empty collection." This is reachable from
+/// a misconfigured env var (e.g. `ALIBABA_TOKEN_PLAN_COOKIE='"'`) and from quoted JSON
+/// values in `~/.codexbar/config.json`, both of which are user-controllable.
+///
+/// These tests exercise two representative public readers — Alibaba Token Plan (the
+/// newest addition in #1098) and the Ollama API key reader (added in #1087) — by
+/// passing the trap-inducing single-quote inputs and asserting the readers return nil
+/// instead of crashing. The patch swaps `removeFirst()/removeLast()` for
+/// `String(value.dropFirst().dropLast())`, which is empty-safe.
+@Suite
+struct SettingsReaderQuoteUnwrapTrapTests {
+    @Test
+    func alibabaTokenPlanCookieHeader_returnsNilForLoneDoubleQuoteValue() {
+        let env = [AlibabaTokenPlanSettingsReader.cookieHeaderKey: "\""]
+        #expect(AlibabaTokenPlanSettingsReader.cookieHeader(environment: env) == nil)
+    }
+
+    @Test
+    func alibabaTokenPlanCookieHeader_returnsNilForLoneApostropheValue() {
+        let env = [AlibabaTokenPlanSettingsReader.cookieHeaderKey: "'"]
+        #expect(AlibabaTokenPlanSettingsReader.cookieHeader(environment: env) == nil)
+    }
+
+    @Test
+    func alibabaTokenPlanCookieHeader_unwrapsProperlyDoubleQuotedValue() {
+        let env = [AlibabaTokenPlanSettingsReader.cookieHeaderKey: "\"abc=def\""]
+        #expect(AlibabaTokenPlanSettingsReader.cookieHeader(environment: env) == "abc=def")
+    }
+
+    @Test
+    func alibabaTokenPlanCookieHeader_unwrapsProperlySingleQuotedValue() {
+        let env = [AlibabaTokenPlanSettingsReader.cookieHeaderKey: "'abc=def'"]
+        #expect(AlibabaTokenPlanSettingsReader.cookieHeader(environment: env) == "abc=def")
+    }
+
+    @Test
+    func ollamaAPIKey_returnsNilForLoneDoubleQuoteValue() {
+        for key in OllamaAPISettingsReader.apiKeyEnvironmentKeys {
+            let env = [key: "\""]
+            #expect(OllamaAPISettingsReader.apiKey(environment: env) == nil)
+        }
+    }
+
+    @Test
+    func ollamaAPIKey_returnsNilForLoneApostropheValue() {
+        for key in OllamaAPISettingsReader.apiKeyEnvironmentKeys {
+            let env = [key: "'"]
+            #expect(OllamaAPISettingsReader.apiKey(environment: env) == nil)
+        }
+    }
+
+    @Test
+    func ollamaAPIKey_unwrapsProperlyQuotedValue() {
+        let env = [OllamaAPISettingsReader.apiKeyEnvironmentKeys[0]: "\"sk-token\""]
+        #expect(OllamaAPISettingsReader.apiKey(environment: env) == "sk-token")
+    }
+}


### PR DESCRIPTION
PROBLEM

The provider settings readers in CodexBarCore (29 of them, plus
CodexBarConfig, CLIConfigCommand, and ProviderTokenResolver -- 32 files
total) share a copy-pasted cleaned() helper that strips one layer of
wrapping quotes:

    if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
        (value.hasPrefix("'") && value.hasSuffix("'"))
    {
        value.removeFirst()
        value.removeLast()
    }

When value is exactly one character (a lone " or '), both hasPrefix and
hasSuffix return true, removeFirst() empties the string, and removeLast()
then traps the process with:

    Swift/RangeReplaceableCollection.swift:867: Fatal error:
    Can't remove last element from an empty collection

The trap fires deep inside libswiftCore.so's
RangeReplaceableCollection.removeLast() and is not catchable. The whole
process dies (menu bar app or CLI command). Restarting with the same bad
env var or config value crashes again on next probe.

REACHABILITY

Triggered by these user-controllable inputs:

  - env var set to a lone quote (e.g. OLLAMA_API_KEY='"' from a
    misquoted shell script, launchd plist, systemd unit, or paste error)
  - apiKey / cookieHeader values in ~/.codexbar/config.json
  - codexbar config set-api-key --api-key '"' on the CLI

VERIFIED REPRODUCTION

Ubuntu 24.04 x86_64 with Swift 6.2.4, against upstream HEAD 123fe84e
(no patches applied). The PR 1098 follow-up fix for FoundationNetworking
was applied first so CodexBarCore could compile, but the cleaned()
helpers were left unpatched. Then a single test:

    @Test
    func alibabaTokenPlanCookieHeader_lonelyDoubleQuote_shouldNotCrash() {
        let env = ["ALIBABA_TOKEN_PLAN_COOKIE": "\""]
        let result = AlibabaTokenPlanSettingsReader.cookieHeader(
            environment: env)
        #expect(result == nil)
    }

Output:

    Swift/RangeReplaceableCollection.swift:867: Fatal error:
    Can't remove last element from an empty collection
    *** Program crashed: Illegal instruction at 0x00007eab486e2d76 ***
    Thread 2 crashed:
      1 [ra] 0x00007eab485ee6ac
        RangeReplaceableCollection<>.removeLast() + 443
        in libswiftCore.so

After applying this patch, the same test passes in 0.001s.

FIX

Replace the two-line removeFirst() + removeLast() pair in all 32
locations with:

    value = String(value.dropFirst().dropLast())

dropFirst() and dropLast() are empty-safe (they return an empty
Substring on empty input). For value.count >= 2 the result is
byte-identical to the old code. For the single trap case
(value.count == 1 with matching quote prefix/suffix), the new code
returns "" which the surrounding .isEmpty guards convert to nil --
strictly better than a process crash.

REGRESSION COVERAGE

New TestsLinux/SettingsReaderQuoteUnwrapTrapTests.swift exercises two
representative public readers (Alibaba Token Plan, Ollama API key) with
lone-quote and properly-quoted inputs across 7 test cases. 7/7 pass on
the fixed code; the lone-quote tests would have killed the test process
before this patch.

  swift build  ->  Build complete!
  swift test   ->  21 tests in 4 suites passed (was 14 before this PR)
  make check   ->  no new lint violations introduced by this PR

NOTES

  1. The trigger (lone " or ' as a config value) is unusual but well
     within "user provides unexpected input" territory. The
     disproportion of the consequence (full process crash, repeated on
     restart while the bad value persists) justifies the fix even
     though the trigger is rare.

  2. I chose dropFirst/dropLast over a length guard or a shared helper
     because the diff per file is the smallest possible (2 lines
     removed, 1 line added) and the idiom is natively empty-safe.
     Happy to rework to a different shape (value.count >= 2 guard, or
     extracted CodexBarCore helper) if you prefer either approach.

  3. Scope is 32 files because the pattern is copy-pasted that many
     times. Patching only one copy would leave the other 31 still
     crashable. A future refactor to a shared CodexBarCore helper
     would prevent future copy-paste of the pattern.