### PR TITLE
Add Noctalia Linux desktop integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ CLI install:
 ## Linux desktop integration?
 - [codexbar-waybar](https://github.com/Marouan-chak/codexbar-waybar) — Waybar custom module + GTK4 popover for Hyprland / Sway / other Wayland compositors, built on top of the bundled Linux CLI.
 - [Codexbar GNOME](https://extensions.gnome.org/extension/9841/codexbar/) — GNOME Shell extension that brings CodexBar usage into the desktop panel.
+- [noctalia-codex-usage](https://github.com/rayoplateado/noctalia-codex-usage) — Noctalia/Quickshell plugin that shows Codex 5-hour and weekly usage limits, built on top of the bundled Linux CLI.
 
 
 ## Credits


### PR DESCRIPTION
## Summary
- Add `noctalia-codex-usage` to the Linux desktop integrations list

## Context
This is a small Noctalia/Quickshell plugin that displays Codex 5-hour and weekly usage limits in the Noctalia bar, with a native attached details panel.

It uses the bundled Linux CLI via:

```bash
codexbar usage --provider codex --source cli --format json
```

Thanks for exposing the CLI — it made this integration straightforward.

## Test plan
- Documentation-only change
- Ran `git diff --check`
