### PR TITLE
Fix the status item missing issue.

### DIFF
--- a/Sources/CodexBar/MenuBarVisibilityWatcher.swift
+++ b/Sources/CodexBar/MenuBarVisibilityWatcher.swift
@@ -83,6 +83,24 @@ enum MenuBarVisibilityWatcher {
         return !snapshot.hasWindow || !snapshot.hasScreen || !snapshot.isOnCurrentScreen || snapshot.buttonWidth <= 0
     }
 
+    /// Only recreate status items when AppKit failed to materialize the item itself. Menu bar managers can keep
+    /// a visible item in an offscreen window; recreating those loses the external manager's item identity.
+    static func isRecreationCandidateSnapshot(snapshot: StatusItemVisibilitySnapshot) -> Bool {
+        guard snapshot.isVisible else { return false }
+        guard snapshot.hasButton else { return true }
+        guard snapshot.hasWindow else { return true }
+        guard snapshot.buttonWidth > 0 else { return true }
+        return false
+    }
+
+    static func isExternallyPositionedVisibleSnapshot(snapshot: StatusItemVisibilitySnapshot) -> Bool {
+        snapshot.isVisible
+            && snapshot.hasButton
+            && snapshot.hasWindow
+            && snapshot.buttonWidth > 0
+            && (!snapshot.hasScreen || !snapshot.isOnCurrentScreen)
+    }
+
     static func hasBlockedVisibleSnapshots(_ snapshots: [StatusItemVisibilitySnapshot]) -> Bool {
         let visibleItems = snapshots.filter(\.isVisible)
         guard !visibleItems.isEmpty else { return false }
@@ -94,6 +112,12 @@ enum MenuBarVisibilityWatcher {
     static func hasAnyBlockedVisibleSnapshot(_ snapshots: [StatusItemVisibilitySnapshot]) -> Bool {
         snapshots.contains { snapshot in
             snapshot.isVisible && self.isBlockedSnapshot(snapshot: snapshot)
+        }
+    }
+
+    static func hasAnyRecreationCandidateSnapshot(_ snapshots: [StatusItemVisibilitySnapshot]) -> Bool {
+        snapshots.contains { snapshot in
+            self.isRecreationCandidateSnapshot(snapshot: snapshot)
         }
     }
 
@@ -116,7 +140,7 @@ enum MenuBarVisibilityWatcher {
         -> Bool
     {
         guard now.timeIntervalSince(appLaunchedAt) <= self.startupFreshnessInterval else { return false }
-        return self.hasAnyBlockedVisibleSnapshot(snapshots)
+        return self.hasAnyRecreationCandidateSnapshot(snapshots)
     }
 
     static func shouldAttemptScreenChangeRecovery(
@@ -125,12 +149,12 @@ enum MenuBarVisibilityWatcher {
         snapshots: [StatusItemVisibilitySnapshot])
         -> Bool
     {
-        if self.hasAnyBlockedVisibleSnapshot(snapshots) {
+        if self.hasAnyRecreationCandidateSnapshot(snapshots) {
             return true
         }
         guard currentScreenCount < previousScreenCount else { return false }
         return snapshots.contains { snapshot in
-            snapshot.isVisible
+            snapshot.isVisible && !self.isExternallyPositionedVisibleSnapshot(snapshot: snapshot)
         }
     }
 
@@ -139,7 +163,7 @@ enum MenuBarVisibilityWatcher {
         snapshots: [StatusItemVisibilitySnapshot])
         -> Bool
     {
-        attempt < self.screenChangeRecoveryRetryLimit && self.hasAnyBlockedVisibleSnapshot(snapshots)
+        attempt < self.screenChangeRecoveryRetryLimit && self.hasAnyRecreationCandidateSnapshot(snapshots)
     }
 
     static func shouldShowGuidance(defaults: UserDefaults, now: Date = Date()) -> Bool {
@@ -293,7 +317,7 @@ extension StatusItemController {
 
     private func verifyScreenChangeRecoveryIfNeeded(attempt: Int) {
         let snapshots = MenuBarVisibilityWatcher.visibilitySnapshots(self.startupVisibilityStatusItems)
-        guard MenuBarVisibilityWatcher.hasAnyBlockedVisibleSnapshot(snapshots) else {
+        guard MenuBarVisibilityWatcher.hasAnyRecreationCandidateSnapshot(snapshots) else {
             self.menuLogger.info(
                 "Status item recovered after display-change recovery",
                 metadata: ["attempt": "\(attempt)", "snapshots": snapshots.map(\.description).joined(separator: " | ")])

--- a/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
+++ b/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
@@ -77,6 +77,21 @@ struct MenuBarVisibilityWatcherTests {
     }
 
     @Test
+    func `does not recreate visible item positioned outside current screens`() {
+        let snapshot = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: false,
+            isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(MenuBarVisibilityWatcher.isBlockedSnapshot(snapshot: snapshot))
+        #expect(MenuBarVisibilityWatcher.isExternallyPositionedVisibleSnapshot(snapshot: snapshot))
+        #expect(!MenuBarVisibilityWatcher.isRecreationCandidateSnapshot(snapshot: snapshot))
+    }
+
+    @Test
     func `guidance shows once then repeats after a day`() throws {
         let defaults = try #require(UserDefaults(suiteName: "MenuBarVisibilityWatcherTests"))
         defaults.removePersistentDomain(forName: "MenuBarVisibilityWatcherTests")
@@ -165,6 +180,23 @@ struct MenuBarVisibilityWatcherTests {
     }
 
     @Test
+    func `startup recovery ignores externally positioned visible snapshot`() {
+        let launchedAt = Date(timeIntervalSince1970: 1000)
+        let externallyPositioned = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: false,
+            isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(!MenuBarVisibilityWatcher.shouldAttemptStartupRecovery(
+            appLaunchedAt: launchedAt,
+            now: launchedAt.addingTimeInterval(2),
+            snapshots: [externallyPositioned]))
+    }
+
+    @Test
     func `screen change recovery triggers when a display is removed with visible status item`() {
         let healthy = StatusItemVisibilitySnapshot(
             isVisible: true,
@@ -192,6 +224,22 @@ struct MenuBarVisibilityWatcherTests {
             previousScreenCount: 2,
             currentScreenCount: 1,
             snapshots: [hidden]))
+    }
+
+    @Test
+    func `screen change recovery ignores display removal when item is externally positioned`() {
+        let externallyPositioned = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: false,
+            isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(!MenuBarVisibilityWatcher.shouldAttemptScreenChangeRecovery(
+            previousScreenCount: 2,
+            currentScreenCount: 1,
+            snapshots: [externallyPositioned]))
     }
 
     @Test
@@ -229,9 +277,8 @@ struct MenuBarVisibilityWatcherTests {
         let blocked = StatusItemVisibilitySnapshot(
             isVisible: true,
             hasButton: true,
-            hasWindow: true,
+            hasWindow: false,
             hasScreen: false,
-            isOnCurrentScreen: false,
             buttonWidth: 18)
 
         #expect(MenuBarVisibilityWatcher.shouldRetryScreenChangeRecovery(
@@ -244,14 +291,28 @@ struct MenuBarVisibilityWatcherTests {
         let blocked = StatusItemVisibilitySnapshot(
             isVisible: true,
             hasButton: true,
+            hasWindow: false,
+            hasScreen: false,
+            buttonWidth: 18)
+
+        #expect(!MenuBarVisibilityWatcher.shouldRetryScreenChangeRecovery(
+            attempt: MenuBarVisibilityWatcher.screenChangeRecoveryRetryLimit,
+            snapshots: [blocked]))
+    }
+
+    @Test
+    func `screen change retry stops when item is externally positioned`() {
+        let externallyPositioned = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
             hasWindow: true,
             hasScreen: false,
             isOnCurrentScreen: false,
             buttonWidth: 18)
 
         #expect(!MenuBarVisibilityWatcher.shouldRetryScreenChangeRecovery(
-            attempt: MenuBarVisibilityWatcher.screenChangeRecoveryRetryLimit,
-            snapshots: [blocked]))
+            attempt: 1,
+            snapshots: [externallyPositioned]))
     }
 
     @Test


### PR DESCRIPTION
I am the developer of **Barbee**, a menu bar management app like Bartender. 
I previously found that icons would often disappear when using Codexbar (due to off-screen issues), and this problem has been fixed.

To reproduce this problem, try installing **Barbee**(https://testflight.apple.com/join/HPKNaKKv), then hiding the CodexBar menu bar icon, and restarting CodexBar. 
****
This commit should resolve the issue of the menu bar icon disappearing.