### PR TITLE
Codex: add reset announcement parser foundation

### DIFF
--- a/Sources/CodexBarCore/CodexResetAnnouncement.swift
+++ b/Sources/CodexBarCore/CodexResetAnnouncement.swift
@@ -28,8 +28,8 @@ public struct CodexResetAnnouncement: Codable, Equatable, Sendable {
         observedAt: Date = Date(),
         announcedResetAt: Date? = nil,
         status: CodexResetAnnouncementStatus,
-        confidence: Double? = nil
-    ) {
+        confidence: Double? = nil)
+    {
         self.sourceName = sourceName
         self.sourceURL = sourceURL
         self.observedAt = observedAt

--- a/Sources/CodexBarCore/CodexResetAnnouncement.swift
+++ b/Sources/CodexBarCore/CodexResetAnnouncement.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// A parsed announcement that a Codex usage-limit reset has been observed from an external source.
+///
+/// This is a pure data container produced by ``CodexResetAnnouncementParser``.
+/// It intentionally carries no ``rawText`` to avoid persisting arbitrary user content
+/// (e.g., DMs or mentions) that may appear alongside an announcement.
+///
+/// - note: This type does not perform network access, mutate quota state, or send notifications.
+///   It is the foundation for phase-1 of #1103: representation and safe parsing only.
+public enum CodexResetAnnouncementStatus: String, Codable, Sendable {
+    case upcoming
+    case completed
+    case ambiguous
+}
+
+public struct CodexResetAnnouncement: Codable, Equatable, Sendable {
+    public let sourceName: String
+    public let sourceURL: String?
+    public let observedAt: Date
+    public let announcedResetAt: Date?
+    public let status: CodexResetAnnouncementStatus
+    public let confidence: Double?
+
+    public init(
+        sourceName: String,
+        sourceURL: String? = nil,
+        observedAt: Date = Date(),
+        announcedResetAt: Date? = nil,
+        status: CodexResetAnnouncementStatus,
+        confidence: Double? = nil
+    ) {
+        self.sourceName = sourceName
+        self.sourceURL = sourceURL
+        self.observedAt = observedAt
+        self.announcedResetAt = announcedResetAt
+        self.status = status
+        self.confidence = confidence
+    }
+}

--- a/Sources/CodexBarCore/CodexResetAnnouncementParser.swift
+++ b/Sources/CodexBarCore/CodexResetAnnouncementParser.swift
@@ -5,7 +5,12 @@ import Foundation
 /// Phase-1 foundation for #1103. This type is:
 /// - pure: no network access, no side effects, no quota mutation
 /// - sendable: thread-safe, no mutable state
-/// - stateless: ``parse(_:)`` and ``announcements(from:sourceName:sourceURL:)`` are both deterministic
+/// - stateless: ``parse(_:)`` is a pure, deterministic function — the same input
+///   always produces the same output with no hidden state or time dependencies.
+///
+/// ``announcements(from:sourceName:sourceURL:observedAt:)`` is deterministic when
+/// ``observedAt`` is supplied; otherwise each call gets its own timestamp via the
+/// default ``Date()``, making results differ across runs.
 ///
 /// The parser recognises three confidence bands:
 ///
@@ -19,6 +24,9 @@ import Foundation
 /// word-boundary guards to prevent false positives from concatenated words
 /// (e.g. "theResetUsageLimits" would not match).  Punctuation at phrase
 /// boundaries is accepted (e.g. "limits." matches "limits").
+///
+/// If a phrase appears multiple times in the text, every occurrence is checked
+/// and the function returns ``true`` if **any** occurrence passes boundary checks.
 public struct CodexResetAnnouncementParser: Sendable {
     public init() {}
 
@@ -49,12 +57,17 @@ public struct CodexResetAnnouncementParser: Sendable {
 
     /// Converts parsed results into domain objects.
     ///
+    /// All ``CodexResetAnnouncement`` instances created in a single call share the
+    /// same ``CodexResetAnnouncement/observedAt`` value, making results reproducible
+    /// when a fixed ``observedAt`` is supplied.
+    ///
     /// ``rawText`` is intentionally omitted from the resulting ``CodexResetAnnouncement``
     /// to avoid persisting arbitrary external content that may contain personal information.
     public func announcements(
         from texts: [String],
         sourceName: String,
-        sourceURL: String? = nil
+        sourceURL: String? = nil,
+        observedAt: Date = Date()
     ) -> [CodexResetAnnouncement] {
         texts.compactMap { text in
             switch parse(text) {
@@ -62,18 +75,21 @@ public struct CodexResetAnnouncementParser: Sendable {
                 return CodexResetAnnouncement(
                     sourceName: sourceName,
                     sourceURL: sourceURL,
+                    observedAt: observedAt,
                     status: .upcoming,
                     confidence: confidence)
             case .completed(let confidence):
                 return CodexResetAnnouncement(
                     sourceName: sourceName,
                     sourceURL: sourceURL,
+                    observedAt: observedAt,
                     status: .completed,
                     confidence: confidence)
             case .ambiguous(let confidence):
                 return CodexResetAnnouncement(
                     sourceName: sourceName,
                     sourceURL: sourceURL,
+                    observedAt: observedAt,
                     status: .ambiguous,
                     confidence: confidence)
             case .none:
@@ -122,18 +138,29 @@ public struct CodexResetAnnouncementParser: Sendable {
         return patterns.contains { Self.containsWithWordBoundaries(text: text, phrase: $0) }
     }
 
-    /// True when ``phrase`` appears in ``text`` with whitespace or sentence-terminal
-    /// punctuation on both sides.  This prevents "theresetusage limits" from matching
-    /// "reset usage limits", while still accepting "reset usage limits." with a trailing period.
+    /// Scans every occurrence of ``phrase`` in ``text`` and returns ``true`` if **any**
+    /// occurrence passes word-boundary checks.  Returns ``false`` only after all occurrences
+    /// have been rejected.
+    ///
+    /// Boundary rules: the character immediately before the phrase and immediately after
+    /// must be whitespace, punctuation, or absent (start/end of string).  This prevents
+    /// "theResetUsageLimits" from matching "reset usage limits" while still accepting
+    /// "reset usage limits." with a trailing period.
     private static func containsWithWordBoundaries(text: String, phrase: String) -> Bool {
-        guard let range = text.range(of: phrase, options: .caseInsensitive) else { return false }
-        let start = range.lowerBound
-        let end = range.upperBound
+        var searchStart = text.startIndex
+        while let range = text.range(of: phrase, options: .caseInsensitive, range: searchStart..<text.endIndex) {
+            let start = range.lowerBound
+            let end = range.upperBound
 
-        let isWordChar: (Character) -> Bool = { !$0.isWhitespace && !$0.isPunctuation }
+            let isWordChar: (Character) -> Bool = { !$0.isWhitespace && !$0.isPunctuation }
+            let charBeforeOK = start == text.startIndex || !isWordChar(text[text.index(before: start)])
+            let charAfterOK = end == text.endIndex || !isWordChar(text[end])
 
-        let charBeforeOK = start == text.startIndex || !isWordChar(text[text.index(before: start)])
-        let charAfterOK = end == text.endIndex || !isWordChar(text[end])
-        return charBeforeOK && charAfterOK
+            if charBeforeOK && charAfterOK {
+                return true
+            }
+            searchStart = range.upperBound
+        }
+        return false
     }
 }

--- a/Sources/CodexBarCore/CodexResetAnnouncementParser.swift
+++ b/Sources/CodexBarCore/CodexResetAnnouncementParser.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+/// Parses external text for Codex usage-limit reset announcements.
+///
+/// Phase-1 foundation for #1103. This type is:
+/// - pure: no network access, no side effects, no quota mutation
+/// - sendable: thread-safe, no mutable state
+/// - stateless: ``parse(_:)`` and ``announcements(from:sourceName:sourceURL:)`` are both deterministic
+///
+/// The parser recognises three confidence bands:
+///
+/// | Status | Confidence | Example |
+/// |---|---|---|
+/// | `.completed` | 1.0 | "usage limits have been reset" |
+/// | `.upcoming` | 0.85 | "I will reset usage limits" |
+/// | `.ambiguous` | 0.5 | "waived usage consumption" |
+///
+/// All matching uses exact-substring containment on lowercased text, with
+/// word-boundary guards to prevent false positives from concatenated words
+/// (e.g. "theResetUsageLimits" would not match).  Punctuation at phrase
+/// boundaries is accepted (e.g. "limits." matches "limits").
+public struct CodexResetAnnouncementParser: Sendable {
+    public init() {}
+
+    public enum ParseResult: Equatable {
+        case upcoming(confidence: Double)
+        case completed(confidence: Double)
+        case ambiguous(confidence: Double)
+        case none
+    }
+
+    public func parse(_ text: String) -> ParseResult {
+        let lowercased = text.lowercased()
+
+        if Self.matchesCompletedReset(lowercased) {
+            return .completed(confidence: 1.0)
+        }
+
+        if Self.matchesUpcomingReset(lowercased) {
+            return .upcoming(confidence: 0.85)
+        }
+
+        if Self.matchesAmbiguousReset(lowercased) {
+            return .ambiguous(confidence: 0.5)
+        }
+
+        return .none
+    }
+
+    /// Converts parsed results into domain objects.
+    ///
+    /// ``rawText`` is intentionally omitted from the resulting ``CodexResetAnnouncement``
+    /// to avoid persisting arbitrary external content that may contain personal information.
+    public func announcements(
+        from texts: [String],
+        sourceName: String,
+        sourceURL: String? = nil
+    ) -> [CodexResetAnnouncement] {
+        texts.compactMap { text in
+            switch parse(text) {
+            case .upcoming(let confidence):
+                return CodexResetAnnouncement(
+                    sourceName: sourceName,
+                    sourceURL: sourceURL,
+                    status: .upcoming,
+                    confidence: confidence)
+            case .completed(let confidence):
+                return CodexResetAnnouncement(
+                    sourceName: sourceName,
+                    sourceURL: sourceURL,
+                    status: .completed,
+                    confidence: confidence)
+            case .ambiguous(let confidence):
+                return CodexResetAnnouncement(
+                    sourceName: sourceName,
+                    sourceURL: sourceURL,
+                    status: .ambiguous,
+                    confidence: confidence)
+            case .none:
+                return nil
+            }
+        }
+    }
+
+    // MARK: - Private patterns
+
+    /// Past-tense statements indicating the reset has already occurred.
+    private static func matchesCompletedReset(_ text: String) -> Bool {
+        let patterns = [
+            "i reset usage limits",
+            "i've reset usage limits",
+            "i have reset usage limits",
+            "usage limits have been reset",
+            "limits have been reset",
+            "limits are back to normal"
+        ]
+        return patterns.contains { Self.containsWithWordBoundaries(text: text, phrase: $0) }
+    }
+
+    /// Future or present-progressive statements indicating a reset is imminent or in progress.
+    private static func matchesUpcomingReset(_ text: String) -> Bool {
+        let patterns = [
+            "i will reset usage limits",
+            "i'll reset usage limits",
+            "will reset usage limits",
+            "i plan to reset usage limits",
+            "i'm resetting usage limits",
+            "resetting usage limits"
+        ]
+        return patterns.contains { Self.containsWithWordBoundaries(text: text, phrase: $0) }
+    }
+
+    /// Phrases that indicate a waiver but are ambiguous about whether a full reset occurred.
+    private static func matchesAmbiguousReset(_ text: String) -> Bool {
+        let patterns = [
+            "waived usage consumption",
+            "usage consumption waived",
+            "limits are waived",
+            "usage limits are waived",
+            "consumption has been waived"
+        ]
+        return patterns.contains { Self.containsWithWordBoundaries(text: text, phrase: $0) }
+    }
+
+    /// True when ``phrase`` appears in ``text`` with whitespace or sentence-terminal
+    /// punctuation on both sides.  This prevents "theresetusage limits" from matching
+    /// "reset usage limits", while still accepting "reset usage limits." with a trailing period.
+    private static func containsWithWordBoundaries(text: String, phrase: String) -> Bool {
+        guard let range = text.range(of: phrase, options: .caseInsensitive) else { return false }
+        let start = range.lowerBound
+        let end = range.upperBound
+
+        let isWordChar: (Character) -> Bool = { !$0.isWhitespace && !$0.isPunctuation }
+
+        let charBeforeOK = start == text.startIndex || !isWordChar(text[text.index(before: start)])
+        let charAfterOK = end == text.endIndex || !isWordChar(text[end])
+        return charBeforeOK && charAfterOK
+    }
+}

--- a/Sources/CodexBarCore/CodexResetAnnouncementParser.swift
+++ b/Sources/CodexBarCore/CodexResetAnnouncementParser.swift
@@ -67,33 +67,33 @@ public struct CodexResetAnnouncementParser: Sendable {
         from texts: [String],
         sourceName: String,
         sourceURL: String? = nil,
-        observedAt: Date = Date()
-    ) -> [CodexResetAnnouncement] {
+        observedAt: Date = Date()) -> [CodexResetAnnouncement]
+    {
         texts.compactMap { text in
-            switch parse(text) {
-            case .upcoming(let confidence):
-                return CodexResetAnnouncement(
+            switch self.parse(text) {
+            case let .upcoming(confidence):
+                CodexResetAnnouncement(
                     sourceName: sourceName,
                     sourceURL: sourceURL,
                     observedAt: observedAt,
                     status: .upcoming,
                     confidence: confidence)
-            case .completed(let confidence):
-                return CodexResetAnnouncement(
+            case let .completed(confidence):
+                CodexResetAnnouncement(
                     sourceName: sourceName,
                     sourceURL: sourceURL,
                     observedAt: observedAt,
                     status: .completed,
                     confidence: confidence)
-            case .ambiguous(let confidence):
-                return CodexResetAnnouncement(
+            case let .ambiguous(confidence):
+                CodexResetAnnouncement(
                     sourceName: sourceName,
                     sourceURL: sourceURL,
                     observedAt: observedAt,
                     status: .ambiguous,
                     confidence: confidence)
             case .none:
-                return nil
+                nil
             }
         }
     }
@@ -108,7 +108,7 @@ public struct CodexResetAnnouncementParser: Sendable {
             "i have reset usage limits",
             "usage limits have been reset",
             "limits have been reset",
-            "limits are back to normal"
+            "limits are back to normal",
         ]
         return patterns.contains { Self.containsWithWordBoundaries(text: text, phrase: $0) }
     }
@@ -121,7 +121,7 @@ public struct CodexResetAnnouncementParser: Sendable {
             "will reset usage limits",
             "i plan to reset usage limits",
             "i'm resetting usage limits",
-            "resetting usage limits"
+            "resetting usage limits",
         ]
         return patterns.contains { Self.containsWithWordBoundaries(text: text, phrase: $0) }
     }
@@ -133,7 +133,7 @@ public struct CodexResetAnnouncementParser: Sendable {
             "usage consumption waived",
             "limits are waived",
             "usage limits are waived",
-            "consumption has been waived"
+            "consumption has been waived",
         ]
         return patterns.contains { Self.containsWithWordBoundaries(text: text, phrase: $0) }
     }
@@ -156,7 +156,7 @@ public struct CodexResetAnnouncementParser: Sendable {
             let charBeforeOK = start == text.startIndex || !isWordChar(text[text.index(before: start)])
             let charAfterOK = end == text.endIndex || !isWordChar(text[end])
 
-            if charBeforeOK && charAfterOK {
+            if charBeforeOK, charAfterOK {
                 return true
             }
             searchStart = range.upperBound

--- a/Tests/CodexBarTests/CodexResetAnnouncementParserTests.swift
+++ b/Tests/CodexBarTests/CodexResetAnnouncementParserTests.swift
@@ -216,13 +216,60 @@ struct CodexResetAnnouncementParserTests {
         // arbitrary external content. The model has no rawText property.
     }
 
+    // MARK: - Timestamp determinism
+
+    @Test
+    func announcements_batchSharesSameObservedAt() {
+        // All announcements in a single batch share the same observedAt.
+        let fixedDate = Date(timeIntervalSince1970: 1_800_000_000)
+        let texts = [
+            "I will reset usage limits",
+            "usage limits have been reset",
+            "Codex is great"
+        ]
+        let results = parser.announcements(from: texts, sourceName: "thsottiaux", sourceURL: nil, observedAt: fixedDate)
+        #expect(results.count == 2)
+        #expect(results[0].observedAt == fixedDate)
+        #expect(results[1].observedAt == fixedDate)
+    }
+
+    @Test
+    func announcements_fixedObservedAtIsStable() {
+        // With a fixed observedAt, repeated calls produce equatable results.
+        let fixedDate = Date(timeIntervalSince1970: 1_800_000_000)
+        let texts = ["I will reset usage limits", "usage limits have been reset"]
+        let results1 = parser.announcements(from: texts, sourceName: "thsottiaux", sourceURL: nil, observedAt: fixedDate)
+        let results2 = parser.announcements(from: texts, sourceName: "thsottiaux", sourceURL: nil, observedAt: fixedDate)
+        #expect(results1 == results2)
+    }
+
+    // MARK: - Multi-occurrence scanning
+
+    @Test
+    func multiOccurrence_invalidBoundaryFollowedByValid() {
+        // "xreset usage limits" fails boundary check but "I reset usage limits" is valid.
+        let result = parser.parse("xreset usage limits but I reset usage limits")
+        #expect(result == .completed(confidence: 1.0))
+    }
+
+    @Test
+    func multiOccurrence_concatenatedPrefixThenValidUpcoming() {
+        // "theResetUsageLimits" is concatenated (no spaces) but "I will reset usage limits" is valid.
+        let result = parser.parse("theResetUsageLimits event fired, then I will reset usage limits")
+        #expect(result == .upcoming(confidence: 0.85))
+    }
+
+    @Test
+    func multiOccurrence_concatenatedStillRejected() {
+        // Pure concatenated text with no valid occurrence should not match.
+        #expect(parser.parse("theResetUsageLimits event fired") == .none)
+        #expect(parser.parse("predefined usage limit template") == .none)
+    }
+
     // MARK: - No quota mutation (pure parser guarantee)
 
     @Test
     func parser_doesNotMutateQuota() {
-        // The parser is a pure function: parse() and announcements() have no side effects
-        // and cannot modify any shared state. Calling them repeatedly with the same input
-        // always produces the same output without touching network, storage, or notifications.
         let result1 = parser.parse("I will reset usage limits")
         let result2 = parser.parse("usage limits have been reset")
         let result3 = parser.parse("limits are back to normal")
@@ -240,8 +287,6 @@ struct CodexResetAnnouncementParserTests {
 
     @Test
     func parser_doesNotRequireNetwork() {
-        // All parse results are local string operations with no URLSession, DataTask, or
-        // other network primitive involved. This is verified by the test running offline.
         let samples: [(String, CodexResetAnnouncementParser.ParseResult)] = [
             ("I will reset usage limits", .upcoming(confidence: 0.85)),
             ("usage limits have been reset", .completed(confidence: 1.0)),
@@ -284,7 +329,6 @@ struct CodexResetAnnouncementParserTests {
 
     @Test
     func edgeCase_substringIsolation() {
-        // A phrase that happens to contain a pattern as a substring should not match
         #expect(parser.parse("theResetUsageLimits event fired") == .none)
         #expect(parser.parse("predefined usage limit template") == .none)
     }

--- a/Tests/CodexBarTests/CodexResetAnnouncementParserTests.swift
+++ b/Tests/CodexBarTests/CodexResetAnnouncementParserTests.swift
@@ -1,0 +1,291 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct CodexResetAnnouncementParserTests {
+    let parser = CodexResetAnnouncementParser()
+
+    // MARK: - Completed reset (past tense)
+
+    @Test
+    func completedReset_pastTenseIEvening() {
+        let result = parser.parse("I reset usage limits this evening")
+        #expect(result == .completed(confidence: 1.0))
+    }
+
+    @Test
+    func completedReset_usageLimitsHaveBeenReset() {
+        let result = parser.parse("usage limits have been reset")
+        #expect(result == .completed(confidence: 1.0))
+    }
+
+    @Test
+    func completedReset_limitsAreBackToNormal() {
+        let result = parser.parse("limits are back to normal")
+        #expect(result == .completed(confidence: 1.0))
+    }
+
+    @Test
+    func completedReset_withContraction() {
+        let result = parser.parse("i've reset usage limits")
+        #expect(result == .completed(confidence: 1.0))
+    }
+
+    @Test
+    func completedReset_withFullStop() {
+        let result = parser.parse("I reset usage limits.")
+        #expect(result == .completed(confidence: 1.0))
+    }
+
+    // MARK: - Upcoming reset (future / present-progressive)
+
+    @Test
+    func upcomingReset_willResetThisEvening() {
+        let result = parser.parse("I will reset usage limits this evening")
+        #expect(result == .upcoming(confidence: 0.85))
+    }
+
+    @Test
+    func upcomingReset_iWillReset() {
+        let result = parser.parse("I will reset usage limits")
+        #expect(result == .upcoming(confidence: 0.85))
+    }
+
+    @Test
+    func upcomingReset_contraction() {
+        let result = parser.parse("I'll reset usage limits")
+        #expect(result == .upcoming(confidence: 0.85))
+    }
+
+    @Test
+    func upcomingReset_iPlanToReset() {
+        let result = parser.parse("I plan to reset usage limits tomorrow")
+        #expect(result == .upcoming(confidence: 0.85))
+    }
+
+    @Test
+    func upcomingReset_presentProgressive() {
+        let result = parser.parse("I'm resetting usage limits now")
+        #expect(result == .upcoming(confidence: 0.85))
+    }
+
+    @Test
+    func upcomingReset_presentParticiple() {
+        let result = parser.parse("Resetting usage limits as we speak")
+        #expect(result == .upcoming(confidence: 0.85))
+    }
+
+    // MARK: - Ambiguous reset (waiver language)
+
+    @Test
+    func ambiguousReset_waivedUsageConsumption() {
+        let result = parser.parse("waived usage consumption")
+        #expect(result == .ambiguous(confidence: 0.5))
+    }
+
+    @Test
+    func ambiguousReset_limitsAreWaived() {
+        let result = parser.parse("limits are waived")
+        #expect(result == .ambiguous(confidence: 0.5))
+    }
+
+    @Test
+    func ambiguousReset_usageLimitsAreWaived() {
+        let result = parser.parse("usage limits are waived")
+        #expect(result == .ambiguous(confidence: 0.5))
+    }
+
+    // MARK: - False positives: password / auth resets
+
+    @Test
+    func falsePositive_passwordReset() {
+        #expect(parser.parse("I will reset my password") == .none)
+        #expect(parser.parse("Please reset your password") == .none)
+        #expect(parser.parse("I forgot my password reset") == .none)
+        #expect(parser.parse("DM me to reset your password") == .none)
+    }
+
+    @Test
+    func falsePositive_tokenRefresh() {
+        #expect(parser.parse("I will reset my API token") == .none)
+        #expect(parser.parse("Please reset your session token") == .none)
+    }
+
+    @Test
+    func falsePositive_settingsReset() {
+        #expect(parser.parse("Reset your settings") == .none)
+        #expect(parser.parse("I will reset settings to default") == .none)
+        #expect(parser.parse("Reset the app settings") == .none)
+    }
+
+    // MARK: - False positives: rate limit changes
+
+    @Test
+    func falsePositive_rateLimitIncrease() {
+        #expect(parser.parse("We increased the rate limits") == .none)
+        #expect(parser.parse("Rate limits are higher now") == .none)
+        #expect(parser.parse("Limits have been increased") == .none)
+    }
+
+    @Test
+    func falsePositive_rateLimitDecrease() {
+        #expect(parser.parse("We decreased the rate limits") == .none)
+        #expect(parser.parse("Limits have been lowered") == .none)
+    }
+
+    @Test
+    func falsePositive_limitChangesWithoutReset() {
+        #expect(parser.parse("usage limits changed") == .none)
+        #expect(parser.parse("usage limits are different now") == .none)
+    }
+
+    // MARK: - False positives: system / cache resets
+
+    @Test
+    func falsePositive_cacheReset() {
+        #expect(parser.parse("I will reset my cache") == .none)
+        #expect(parser.parse("Reset cache to free up space") == .none)
+    }
+
+    @Test
+    func falsePositive_systemReset() {
+        #expect(parser.parse("System reset needed") == .none)
+        #expect(parser.parse("The server will reset tonight") == .none)
+    }
+
+    // MARK: - False positives: usage without reset
+
+    @Test
+    func falsePositive_usageHighNoReset() {
+        #expect(parser.parse("My usage is very high today") == .none)
+        #expect(parser.parse("Codex usage is at 90%") == .none)
+        #expect(parser.parse("I'm hitting usage limits") == .none)
+    }
+
+    @Test
+    func falsePositive_ordinaryTweet() {
+        #expect(parser.parse("Codex is great for coding tasks today") == .none)
+        #expect(parser.parse("Just shipped a new feature to production!") == .none)
+        #expect(parser.parse("Twitter is broken again") == .none)
+    }
+
+    // MARK: - False positives: other reset-like phrases
+
+    @Test
+    func falsePositive_serverRestart() {
+        #expect(parser.parse("Server will reset at midnight") == .none)
+        #expect(parser.parse("Systems are resetting overnight") == .none)
+    }
+
+    @Test
+    func falsePositive_genericReset() {
+        #expect(parser.parse("I'll reset everything") == .none)
+        #expect(parser.parse("Let's reset and start fresh") == .none)
+    }
+
+    // MARK: - Announcements collection
+
+    @Test
+    func announcements_parsesMultipleTexts() {
+        let texts = [
+            "I will reset usage limits",
+            "usage limits have been reset",
+            "Codex is great"
+        ]
+        let results = parser.announcements(from: texts, sourceName: "thsottiaux", sourceURL: "https://twitter.com/thsottiaux")
+        #expect(results.count == 2)
+        #expect(results[0].status == .upcoming)
+        #expect(results[1].status == .completed)
+    }
+
+    @Test
+    func announcements_retainsSourceInfo() {
+        let texts = ["I will reset usage limits"]
+        let results = parser.announcements(from: texts, sourceName: "thsottiaux", sourceURL: "https://twitter.com/thsottiaux/status/123")
+        #expect(results.count == 1)
+        #expect(results[0].sourceName == "thsottiaux")
+        #expect(results[0].sourceURL == "https://twitter.com/thsottiaux/status/123")
+    }
+
+    @Test
+    func announcements_doesNotRetainRawText() {
+        let texts = ["I will reset usage limits"]
+        let results = parser.announcements(from: texts, sourceName: "thsottiaux", sourceURL: nil)
+        #expect(results.count == 1)
+        // rawText is intentionally absent from CodexResetAnnouncement to avoid persisting
+        // arbitrary external content. The model has no rawText property.
+    }
+
+    // MARK: - No quota mutation (pure parser guarantee)
+
+    @Test
+    func parser_doesNotMutateQuota() {
+        // The parser is a pure function: parse() and announcements() have no side effects
+        // and cannot modify any shared state. Calling them repeatedly with the same input
+        // always produces the same output without touching network, storage, or notifications.
+        let result1 = parser.parse("I will reset usage limits")
+        let result2 = parser.parse("usage limits have been reset")
+        let result3 = parser.parse("limits are back to normal")
+
+        #expect(result1 == .upcoming(confidence: 0.85))
+        #expect(result2 == .completed(confidence: 1.0))
+        #expect(result3 == .completed(confidence: 1.0))
+
+        // Calling again proves determinism / no hidden state mutation
+        #expect(parser.parse("I will reset usage limits") == .upcoming(confidence: 0.85))
+        #expect(parser.parse("usage limits have been reset") == .completed(confidence: 1.0))
+    }
+
+    // MARK: - No network dependency
+
+    @Test
+    func parser_doesNotRequireNetwork() {
+        // All parse results are local string operations with no URLSession, DataTask, or
+        // other network primitive involved. This is verified by the test running offline.
+        let samples: [(String, CodexResetAnnouncementParser.ParseResult)] = [
+            ("I will reset usage limits", .upcoming(confidence: 0.85)),
+            ("usage limits have been reset", .completed(confidence: 1.0)),
+            ("limits are back to normal", .completed(confidence: 1.0)),
+            ("waived usage consumption", .ambiguous(confidence: 0.5)),
+            ("Codex is great today", .none),
+            ("Reset your password", .none)
+        ]
+        for (text, expected) in samples {
+            #expect(parser.parse(text) == expected)
+        }
+    }
+
+    // MARK: - Edge cases
+
+    @Test
+    func edgeCase_emptyString() {
+        #expect(parser.parse("") == .none)
+    }
+
+    @Test
+    func edgeCase_caseInsensitive() {
+        #expect(parser.parse("I WILL RESET USAGE LIMITS") == .upcoming(confidence: 0.85))
+        #expect(parser.parse("USAGE LIMITS HAVE BEEN RESET") == .completed(confidence: 1.0))
+        #expect(parser.parse("Waived Usage Consumption") == .ambiguous(confidence: 0.5))
+    }
+
+    @Test
+    func edgeCase_withExtraWhitespace() {
+        #expect(parser.parse("  I will reset usage limits  ") == .upcoming(confidence: 0.85))
+        #expect(parser.parse("\tI will reset usage limits\t") == .upcoming(confidence: 0.85))
+    }
+
+    @Test
+    func edgeCase_multipleResetPhrasesInOneTweet() {
+        // Completed takes priority (first in evaluation order)
+        let result = parser.parse("I will reset usage limits and limits are back to normal")
+        #expect(result == .completed(confidence: 1.0))
+    }
+
+    @Test
+    func edgeCase_substringIsolation() {
+        // A phrase that happens to contain a pattern as a substring should not match
+        #expect(parser.parse("theResetUsageLimits event fired") == .none)
+        #expect(parser.parse("predefined usage limit template") == .none)
+    }
+}

--- a/Tests/CodexBarTests/CodexResetAnnouncementParserTests.swift
+++ b/Tests/CodexBarTests/CodexResetAnnouncementParserTests.swift
@@ -8,209 +8,215 @@ struct CodexResetAnnouncementParserTests {
     // MARK: - Completed reset (past tense)
 
     @Test
-    func completedReset_pastTenseIEvening() {
-        let result = parser.parse("I reset usage limits this evening")
+    func `completed reset past tense I evening`() {
+        let result = self.parser.parse("I reset usage limits this evening")
         #expect(result == .completed(confidence: 1.0))
     }
 
     @Test
-    func completedReset_usageLimitsHaveBeenReset() {
-        let result = parser.parse("usage limits have been reset")
+    func `completed reset usage limits have been reset`() {
+        let result = self.parser.parse("usage limits have been reset")
         #expect(result == .completed(confidence: 1.0))
     }
 
     @Test
-    func completedReset_limitsAreBackToNormal() {
-        let result = parser.parse("limits are back to normal")
+    func `completed reset limits are back to normal`() {
+        let result = self.parser.parse("limits are back to normal")
         #expect(result == .completed(confidence: 1.0))
     }
 
     @Test
-    func completedReset_withContraction() {
-        let result = parser.parse("i've reset usage limits")
+    func `completed reset with contraction`() {
+        let result = self.parser.parse("i've reset usage limits")
         #expect(result == .completed(confidence: 1.0))
     }
 
     @Test
-    func completedReset_withFullStop() {
-        let result = parser.parse("I reset usage limits.")
+    func `completed reset with full stop`() {
+        let result = self.parser.parse("I reset usage limits.")
         #expect(result == .completed(confidence: 1.0))
     }
 
     // MARK: - Upcoming reset (future / present-progressive)
 
     @Test
-    func upcomingReset_willResetThisEvening() {
-        let result = parser.parse("I will reset usage limits this evening")
+    func `upcoming reset will reset this evening`() {
+        let result = self.parser.parse("I will reset usage limits this evening")
         #expect(result == .upcoming(confidence: 0.85))
     }
 
     @Test
-    func upcomingReset_iWillReset() {
-        let result = parser.parse("I will reset usage limits")
+    func `upcoming reset i will reset`() {
+        let result = self.parser.parse("I will reset usage limits")
         #expect(result == .upcoming(confidence: 0.85))
     }
 
     @Test
-    func upcomingReset_contraction() {
-        let result = parser.parse("I'll reset usage limits")
+    func `upcoming reset contraction`() {
+        let result = self.parser.parse("I'll reset usage limits")
         #expect(result == .upcoming(confidence: 0.85))
     }
 
     @Test
-    func upcomingReset_iPlanToReset() {
-        let result = parser.parse("I plan to reset usage limits tomorrow")
+    func `upcoming reset i plan to reset`() {
+        let result = self.parser.parse("I plan to reset usage limits tomorrow")
         #expect(result == .upcoming(confidence: 0.85))
     }
 
     @Test
-    func upcomingReset_presentProgressive() {
-        let result = parser.parse("I'm resetting usage limits now")
+    func `upcoming reset present progressive`() {
+        let result = self.parser.parse("I'm resetting usage limits now")
         #expect(result == .upcoming(confidence: 0.85))
     }
 
     @Test
-    func upcomingReset_presentParticiple() {
-        let result = parser.parse("Resetting usage limits as we speak")
+    func `upcoming reset present participle`() {
+        let result = self.parser.parse("Resetting usage limits as we speak")
         #expect(result == .upcoming(confidence: 0.85))
     }
 
     // MARK: - Ambiguous reset (waiver language)
 
     @Test
-    func ambiguousReset_waivedUsageConsumption() {
-        let result = parser.parse("waived usage consumption")
+    func `ambiguous reset waived usage consumption`() {
+        let result = self.parser.parse("waived usage consumption")
         #expect(result == .ambiguous(confidence: 0.5))
     }
 
     @Test
-    func ambiguousReset_limitsAreWaived() {
-        let result = parser.parse("limits are waived")
+    func `ambiguous reset limits are waived`() {
+        let result = self.parser.parse("limits are waived")
         #expect(result == .ambiguous(confidence: 0.5))
     }
 
     @Test
-    func ambiguousReset_usageLimitsAreWaived() {
-        let result = parser.parse("usage limits are waived")
+    func `ambiguous reset usage limits are waived`() {
+        let result = self.parser.parse("usage limits are waived")
         #expect(result == .ambiguous(confidence: 0.5))
     }
 
     // MARK: - False positives: password / auth resets
 
     @Test
-    func falsePositive_passwordReset() {
-        #expect(parser.parse("I will reset my password") == .none)
-        #expect(parser.parse("Please reset your password") == .none)
-        #expect(parser.parse("I forgot my password reset") == .none)
-        #expect(parser.parse("DM me to reset your password") == .none)
+    func `false positive password reset`() {
+        #expect(self.parser.parse("I will reset my password") == .none)
+        #expect(self.parser.parse("Please reset your password") == .none)
+        #expect(self.parser.parse("I forgot my password reset") == .none)
+        #expect(self.parser.parse("DM me to reset your password") == .none)
     }
 
     @Test
-    func falsePositive_tokenRefresh() {
-        #expect(parser.parse("I will reset my API token") == .none)
-        #expect(parser.parse("Please reset your session token") == .none)
+    func `false positive token refresh`() {
+        #expect(self.parser.parse("I will reset my API token") == .none)
+        #expect(self.parser.parse("Please reset your session token") == .none)
     }
 
     @Test
-    func falsePositive_settingsReset() {
-        #expect(parser.parse("Reset your settings") == .none)
-        #expect(parser.parse("I will reset settings to default") == .none)
-        #expect(parser.parse("Reset the app settings") == .none)
+    func `false positive settings reset`() {
+        #expect(self.parser.parse("Reset your settings") == .none)
+        #expect(self.parser.parse("I will reset settings to default") == .none)
+        #expect(self.parser.parse("Reset the app settings") == .none)
     }
 
     // MARK: - False positives: rate limit changes
 
     @Test
-    func falsePositive_rateLimitIncrease() {
-        #expect(parser.parse("We increased the rate limits") == .none)
-        #expect(parser.parse("Rate limits are higher now") == .none)
-        #expect(parser.parse("Limits have been increased") == .none)
+    func `false positive rate limit increase`() {
+        #expect(self.parser.parse("We increased the rate limits") == .none)
+        #expect(self.parser.parse("Rate limits are higher now") == .none)
+        #expect(self.parser.parse("Limits have been increased") == .none)
     }
 
     @Test
-    func falsePositive_rateLimitDecrease() {
-        #expect(parser.parse("We decreased the rate limits") == .none)
-        #expect(parser.parse("Limits have been lowered") == .none)
+    func `false positive rate limit decrease`() {
+        #expect(self.parser.parse("We decreased the rate limits") == .none)
+        #expect(self.parser.parse("Limits have been lowered") == .none)
     }
 
     @Test
-    func falsePositive_limitChangesWithoutReset() {
-        #expect(parser.parse("usage limits changed") == .none)
-        #expect(parser.parse("usage limits are different now") == .none)
+    func `false positive limit changes without reset`() {
+        #expect(self.parser.parse("usage limits changed") == .none)
+        #expect(self.parser.parse("usage limits are different now") == .none)
     }
 
     // MARK: - False positives: system / cache resets
 
     @Test
-    func falsePositive_cacheReset() {
-        #expect(parser.parse("I will reset my cache") == .none)
-        #expect(parser.parse("Reset cache to free up space") == .none)
+    func `false positive cache reset`() {
+        #expect(self.parser.parse("I will reset my cache") == .none)
+        #expect(self.parser.parse("Reset cache to free up space") == .none)
     }
 
     @Test
-    func falsePositive_systemReset() {
-        #expect(parser.parse("System reset needed") == .none)
-        #expect(parser.parse("The server will reset tonight") == .none)
+    func `false positive system reset`() {
+        #expect(self.parser.parse("System reset needed") == .none)
+        #expect(self.parser.parse("The server will reset tonight") == .none)
     }
 
     // MARK: - False positives: usage without reset
 
     @Test
-    func falsePositive_usageHighNoReset() {
-        #expect(parser.parse("My usage is very high today") == .none)
-        #expect(parser.parse("Codex usage is at 90%") == .none)
-        #expect(parser.parse("I'm hitting usage limits") == .none)
+    func `false positive usage high no reset`() {
+        #expect(self.parser.parse("My usage is very high today") == .none)
+        #expect(self.parser.parse("Codex usage is at 90%") == .none)
+        #expect(self.parser.parse("I'm hitting usage limits") == .none)
     }
 
     @Test
-    func falsePositive_ordinaryTweet() {
-        #expect(parser.parse("Codex is great for coding tasks today") == .none)
-        #expect(parser.parse("Just shipped a new feature to production!") == .none)
-        #expect(parser.parse("Twitter is broken again") == .none)
+    func `false positive ordinary tweet`() {
+        #expect(self.parser.parse("Codex is great for coding tasks today") == .none)
+        #expect(self.parser.parse("Just shipped a new feature to production!") == .none)
+        #expect(self.parser.parse("Twitter is broken again") == .none)
     }
 
     // MARK: - False positives: other reset-like phrases
 
     @Test
-    func falsePositive_serverRestart() {
-        #expect(parser.parse("Server will reset at midnight") == .none)
-        #expect(parser.parse("Systems are resetting overnight") == .none)
+    func `false positive server restart`() {
+        #expect(self.parser.parse("Server will reset at midnight") == .none)
+        #expect(self.parser.parse("Systems are resetting overnight") == .none)
     }
 
     @Test
-    func falsePositive_genericReset() {
-        #expect(parser.parse("I'll reset everything") == .none)
-        #expect(parser.parse("Let's reset and start fresh") == .none)
+    func `false positive generic reset`() {
+        #expect(self.parser.parse("I'll reset everything") == .none)
+        #expect(self.parser.parse("Let's reset and start fresh") == .none)
     }
 
     // MARK: - Announcements collection
 
     @Test
-    func announcements_parsesMultipleTexts() {
+    func `announcements parses multiple texts`() {
         let texts = [
             "I will reset usage limits",
             "usage limits have been reset",
-            "Codex is great"
+            "Codex is great",
         ]
-        let results = parser.announcements(from: texts, sourceName: "thsottiaux", sourceURL: "https://twitter.com/thsottiaux")
+        let results = self.parser.announcements(
+            from: texts,
+            sourceName: "thsottiaux",
+            sourceURL: "https://twitter.com/thsottiaux")
         #expect(results.count == 2)
         #expect(results[0].status == .upcoming)
         #expect(results[1].status == .completed)
     }
 
     @Test
-    func announcements_retainsSourceInfo() {
+    func `announcements retains source info`() {
         let texts = ["I will reset usage limits"]
-        let results = parser.announcements(from: texts, sourceName: "thsottiaux", sourceURL: "https://twitter.com/thsottiaux/status/123")
+        let results = self.parser.announcements(
+            from: texts,
+            sourceName: "thsottiaux",
+            sourceURL: "https://twitter.com/thsottiaux/status/123")
         #expect(results.count == 1)
         #expect(results[0].sourceName == "thsottiaux")
         #expect(results[0].sourceURL == "https://twitter.com/thsottiaux/status/123")
     }
 
     @Test
-    func announcements_doesNotRetainRawText() {
+    func `announcements does not retain raw text`() {
         let texts = ["I will reset usage limits"]
-        let results = parser.announcements(from: texts, sourceName: "thsottiaux", sourceURL: nil)
+        let results = self.parser.announcements(from: texts, sourceName: "thsottiaux", sourceURL: nil)
         #expect(results.count == 1)
         // rawText is intentionally absent from CodexResetAnnouncement to avoid persisting
         // arbitrary external content. The model has no rawText property.
@@ -219,117 +225,129 @@ struct CodexResetAnnouncementParserTests {
     // MARK: - Timestamp determinism
 
     @Test
-    func announcements_batchSharesSameObservedAt() {
+    func `announcements batch shares same observed at`() {
         // All announcements in a single batch share the same observedAt.
         let fixedDate = Date(timeIntervalSince1970: 1_800_000_000)
         let texts = [
             "I will reset usage limits",
             "usage limits have been reset",
-            "Codex is great"
+            "Codex is great",
         ]
-        let results = parser.announcements(from: texts, sourceName: "thsottiaux", sourceURL: nil, observedAt: fixedDate)
+        let results = self.parser.announcements(
+            from: texts,
+            sourceName: "thsottiaux",
+            sourceURL: nil,
+            observedAt: fixedDate)
         #expect(results.count == 2)
         #expect(results[0].observedAt == fixedDate)
         #expect(results[1].observedAt == fixedDate)
     }
 
     @Test
-    func announcements_fixedObservedAtIsStable() {
+    func `announcements fixed observed at is stable`() {
         // With a fixed observedAt, repeated calls produce equatable results.
         let fixedDate = Date(timeIntervalSince1970: 1_800_000_000)
         let texts = ["I will reset usage limits", "usage limits have been reset"]
-        let results1 = parser.announcements(from: texts, sourceName: "thsottiaux", sourceURL: nil, observedAt: fixedDate)
-        let results2 = parser.announcements(from: texts, sourceName: "thsottiaux", sourceURL: nil, observedAt: fixedDate)
+        let results1 = self.parser.announcements(
+            from: texts,
+            sourceName: "thsottiaux",
+            sourceURL: nil,
+            observedAt: fixedDate)
+        let results2 = self.parser.announcements(
+            from: texts,
+            sourceName: "thsottiaux",
+            sourceURL: nil,
+            observedAt: fixedDate)
         #expect(results1 == results2)
     }
 
     // MARK: - Multi-occurrence scanning
 
     @Test
-    func multiOccurrence_invalidBoundaryFollowedByValid() {
+    func `multi occurrence invalid boundary followed by valid`() {
         // "xreset usage limits" fails boundary check but "I reset usage limits" is valid.
-        let result = parser.parse("xreset usage limits but I reset usage limits")
+        let result = self.parser.parse("xreset usage limits but I reset usage limits")
         #expect(result == .completed(confidence: 1.0))
     }
 
     @Test
-    func multiOccurrence_concatenatedPrefixThenValidUpcoming() {
+    func `multi occurrence concatenated prefix then valid upcoming`() {
         // "theResetUsageLimits" is concatenated (no spaces) but "I will reset usage limits" is valid.
-        let result = parser.parse("theResetUsageLimits event fired, then I will reset usage limits")
+        let result = self.parser.parse("theResetUsageLimits event fired, then I will reset usage limits")
         #expect(result == .upcoming(confidence: 0.85))
     }
 
     @Test
-    func multiOccurrence_concatenatedStillRejected() {
+    func `multi occurrence concatenated still rejected`() {
         // Pure concatenated text with no valid occurrence should not match.
-        #expect(parser.parse("theResetUsageLimits event fired") == .none)
-        #expect(parser.parse("predefined usage limit template") == .none)
+        #expect(self.parser.parse("theResetUsageLimits event fired") == .none)
+        #expect(self.parser.parse("predefined usage limit template") == .none)
     }
 
     // MARK: - No quota mutation (pure parser guarantee)
 
     @Test
-    func parser_doesNotMutateQuota() {
-        let result1 = parser.parse("I will reset usage limits")
-        let result2 = parser.parse("usage limits have been reset")
-        let result3 = parser.parse("limits are back to normal")
+    func `parser does not mutate quota`() {
+        let result1 = self.parser.parse("I will reset usage limits")
+        let result2 = self.parser.parse("usage limits have been reset")
+        let result3 = self.parser.parse("limits are back to normal")
 
         #expect(result1 == .upcoming(confidence: 0.85))
         #expect(result2 == .completed(confidence: 1.0))
         #expect(result3 == .completed(confidence: 1.0))
 
         // Calling again proves determinism / no hidden state mutation
-        #expect(parser.parse("I will reset usage limits") == .upcoming(confidence: 0.85))
-        #expect(parser.parse("usage limits have been reset") == .completed(confidence: 1.0))
+        #expect(self.parser.parse("I will reset usage limits") == .upcoming(confidence: 0.85))
+        #expect(self.parser.parse("usage limits have been reset") == .completed(confidence: 1.0))
     }
 
     // MARK: - No network dependency
 
     @Test
-    func parser_doesNotRequireNetwork() {
+    func `parser does not require network`() {
         let samples: [(String, CodexResetAnnouncementParser.ParseResult)] = [
             ("I will reset usage limits", .upcoming(confidence: 0.85)),
             ("usage limits have been reset", .completed(confidence: 1.0)),
             ("limits are back to normal", .completed(confidence: 1.0)),
             ("waived usage consumption", .ambiguous(confidence: 0.5)),
             ("Codex is great today", .none),
-            ("Reset your password", .none)
+            ("Reset your password", .none),
         ]
         for (text, expected) in samples {
-            #expect(parser.parse(text) == expected)
+            #expect(self.parser.parse(text) == expected)
         }
     }
 
     // MARK: - Edge cases
 
     @Test
-    func edgeCase_emptyString() {
-        #expect(parser.parse("") == .none)
+    func `edge case empty string`() {
+        #expect(self.parser.parse("") == .none)
     }
 
     @Test
-    func edgeCase_caseInsensitive() {
-        #expect(parser.parse("I WILL RESET USAGE LIMITS") == .upcoming(confidence: 0.85))
-        #expect(parser.parse("USAGE LIMITS HAVE BEEN RESET") == .completed(confidence: 1.0))
-        #expect(parser.parse("Waived Usage Consumption") == .ambiguous(confidence: 0.5))
+    func `edge case case insensitive`() {
+        #expect(self.parser.parse("I WILL RESET USAGE LIMITS") == .upcoming(confidence: 0.85))
+        #expect(self.parser.parse("USAGE LIMITS HAVE BEEN RESET") == .completed(confidence: 1.0))
+        #expect(self.parser.parse("Waived Usage Consumption") == .ambiguous(confidence: 0.5))
     }
 
     @Test
-    func edgeCase_withExtraWhitespace() {
-        #expect(parser.parse("  I will reset usage limits  ") == .upcoming(confidence: 0.85))
-        #expect(parser.parse("\tI will reset usage limits\t") == .upcoming(confidence: 0.85))
+    func `edge case with extra whitespace`() {
+        #expect(self.parser.parse("  I will reset usage limits  ") == .upcoming(confidence: 0.85))
+        #expect(self.parser.parse("\tI will reset usage limits\t") == .upcoming(confidence: 0.85))
     }
 
     @Test
-    func edgeCase_multipleResetPhrasesInOneTweet() {
+    func `edge case multiple reset phrases in one tweet`() {
         // Completed takes priority (first in evaluation order)
-        let result = parser.parse("I will reset usage limits and limits are back to normal")
+        let result = self.parser.parse("I will reset usage limits and limits are back to normal")
         #expect(result == .completed(confidence: 1.0))
     }
 
     @Test
-    func edgeCase_substringIsolation() {
-        #expect(parser.parse("theResetUsageLimits event fired") == .none)
-        #expect(parser.parse("predefined usage limit template") == .none)
+    func `edge case substring isolation`() {
+        #expect(self.parser.parse("theResetUsageLimits event fired") == .none)
+        #expect(self.parser.parse("predefined usage limit template") == .none)
     }
 }


### PR DESCRIPTION
## Summary

Adds a small, pure parser foundation for Codex reset announcements as a safe phase-1 step toward #1103.

This PR intentionally does not scrape X/Twitter, does not require an X API key, does not send notifications, and does not mutate quota math. It only introduces a conservative representation and parser for external reset-announcement text.

## What changed

- Add `CodexResetAnnouncement` model.
- Add `CodexResetAnnouncementParser`.
- Add parser coverage for:
  - completed reset announcements
  - upcoming reset announcements
  - ambiguous waiver language
  - false positives such as password resets, settings resets, cache resets, rate-limit changes, and unrelated Codex text

## Privacy / safety

- The production model does not retain raw external announcement text.
- The parser is pure and deterministic.
- No network access is added.
- No quota state is mutated.

## Validation

- `swift test --filter CodexResetAnnouncementParserTests`
- `swift build`

## Scope

Phase 1 for #1103 only. Follow-up work can decide the approved announcement source, UI surface, notification behavior, and whether confirmed resets should affect quota calculations.