### PR TITLE
Claude: classify CLI subscription usage notice separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Display: add optional workday markers for weekly progress bars (#1102). Thanks @Yuxin-Qiao!
 
 ### Fixed
+- Claude: classify Claude CLI 2.1 subscription-only `/usage` output separately and fall back to direct CLI usage when the PTY panel fails to load (#1121, fixes #1116). Thanks @Yuxin-Qiao!
 - Groq: show a distinct Groq provider icon instead of reusing the Grok glyph (#1112). Thanks @kiankyars!
 - Claude: normalize OAuth extra-usage spend limits from minor units so Enterprise spend displays as currency instead of 100x too high (#1114, fixes #1111). Thanks @Yuxin-Qiao!
 - OpenAI: retry transient Admin API usage failures once before surfacing an access error (#1117).

--- a/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
+++ b/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
@@ -158,6 +158,8 @@ public enum SubprocessRunner {
         arguments: [String],
         environment: [String: String],
         timeout: TimeInterval,
+        standardInput: Any? = nil,
+        currentDirectoryURL: URL? = nil,
         label: String) async throws -> SubprocessResult
     {
         guard FileManager.default.isExecutableFile(atPath: binary) else {
@@ -174,12 +176,13 @@ public enum SubprocessRunner {
         process.executableURL = URL(fileURLWithPath: binary)
         process.arguments = arguments
         process.environment = environment
+        process.currentDirectoryURL = currentDirectoryURL
 
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
-        process.standardInput = nil
+        process.standardInput = standardInput
 
         let termination = ProcessTermination()
         process.terminationHandler = { process in

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeCLISession.swift
@@ -300,8 +300,7 @@ actor ClaudeCLISession {
 
         let workingDirectory = ClaudeStatusProbe.preparedProbeWorkingDirectoryURL()
         proc.currentDirectoryURL = workingDirectory
-        var env = TTYCommandRunner.enrichedEnvironment()
-        env = Self.scrubbedClaudeEnvironment(from: env)
+        var env = Self.launchEnvironment()
         env["PWD"] = workingDirectory.path
         proc.environment = env
 
@@ -342,6 +341,10 @@ actor ClaudeCLISession {
         self.processGroup = processGroup
         self.binaryPath = binary
         self.startedAt = Date()
+    }
+
+    static func launchEnvironment(baseEnv: [String: String] = ProcessInfo.processInfo.environment) -> [String: String] {
+        self.scrubbedClaudeEnvironment(from: TTYCommandRunner.enrichedEnvironment(baseEnv: baseEnv))
     }
 
     private static func scrubbedClaudeEnvironment(from base: [String: String]) -> [String: String] {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -317,6 +317,7 @@ public struct ClaudeStatusProbe: Sendable {
             || normalized.contains("currentweek")
             || normalized.contains("loadingusage")
             || normalized.contains("failedtoloadusagedata")
+            || self.usageCaptureHasSubscriptionNotice(normalized)
     }
 
     private static func extractPercent(labelSubstrings: [String], context: LabelSearchContext) -> Int? {
@@ -892,6 +893,7 @@ public struct ClaudeStatusProbe: Sendable {
         let stopWhenNormalized: (@Sendable (String) -> Bool)? = subcommand == "/usage"
             ? { @Sendable normalizedScan in
                 Self.usageCaptureHasSessionValue(normalizedScan)
+                    || Self.usageCaptureHasSubscriptionNotice(normalizedScan)
             }
             : nil
         do {
@@ -922,5 +924,10 @@ public struct ClaudeStatusProbe: Sendable {
         guard let labelRange = normalizedText.range(of: "currentsession") else { return false }
         let tail = normalizedText[labelRange.upperBound...]
         return tail.range(of: #"[0-9]{1,3}(?:\.[0-9]+)?%"#, options: .regularExpression) != nil
+    }
+
+    private static func usageCaptureHasSubscriptionNotice(_ normalizedText: String) -> Bool {
+        normalizedText.contains("currentlyusingyoursubscription")
+            && normalizedText.contains("claudecodeusage")
     }
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeStatusProbe.swift
@@ -453,6 +453,9 @@ public struct ClaudeStatusProbe: Sendable {
         {
             return "Claude CLI usage endpoint is rate limited right now. Please try again later."
         }
+        if self.isSubscriptionNoticeOnly(text: text) {
+            return "Claude CLI /usage returned a subscription notice without session quota data."
+        }
         if lower.contains("failed to load usage data") {
             return "Claude CLI could not load usage data. Open the CLI and retry `/usage`."
         }
@@ -466,6 +469,24 @@ public struct ClaudeStatusProbe: Sendable {
         let normalized = TextParsing.stripANSICodes(text).lowercased().filter { !$0.isWhitespace }
         guard normalized.contains("loadingusage") else { return false }
         return !self.usageCaptureHasSessionValue(normalized) && self.allPercents(text).isEmpty
+    }
+
+    /// Returns true when the text contains only a subscription notice with no session/weekly quota data.
+    /// CLI 2.1+ can return "You are currently using your subscription to power your Claude Code usage"
+    /// which lacks the "Current session" / "Current week" labels and percentage values needed for quota display.
+    /// A PTY capture may contain both an intermediate "Loading usage data…" panel and the final subscription
+    /// notice; `loadingusage` is not treated as quota data in this check so mixed captures surface correctly.
+    private static func isSubscriptionNoticeOnly(text: String) -> Bool {
+        let normalized = text.lowercased().filter { !$0.isWhitespace }
+        guard normalized.contains("currentlyusingyoursubscription") else { return false }
+        guard normalized.contains("claudecodeusage") else { return false }
+        // Only real session/week labels and actual percentage values count as quota data.
+        // `loadingusage` is not quota data — a mixed loading+subscription PTY capture should
+        // surface the subscription error, not a still-loading stall.
+        let hasQuotaData = normalized.contains("currentsession") || normalized.contains("currentweek")
+            || normalized.contains("%used") || normalized.contains("%left") || normalized.contains("%remaining")
+            || normalized.contains("%available")
+        return !hasQuotaData
     }
 
     /// Collect remaining percentages in the order they appear; used as a backup when labels move/rename.

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeUsageFetcher.swift
@@ -569,9 +569,48 @@ public struct ClaudeUsageFetcher: ClaudeUsageFetching, Sendable {
         }
 
         private func loadViaCLI(model: String, timeout: TimeInterval) async throws -> ClaudeUsageSnapshot {
-            var snapshot = try await self.fetcher.loadViaPTY(model: model, timeout: timeout)
+            var snapshot: ClaudeUsageSnapshot
+            do {
+                snapshot = try await self.fetcher.loadViaPTY(model: model, timeout: timeout)
+            } catch {
+                if error is CancellationError { throw error }
+                guard Self.shouldTryDirectCLIUsage(after: error) else { throw error }
+                let ptyError = error
+                do {
+                    snapshot = try await self.fetcher.loadViaDirectCLI(
+                        timeout: Self.directCLIUsageTimeout(for: timeout))
+                } catch let directError {
+                    if directError is CancellationError { throw directError }
+                    guard Self.directCLIErrorShouldReplacePTYError(directError) else { throw ptyError }
+                    throw directError
+                }
+            }
             snapshot = await self.fetcher.applyWebExtrasIfNeeded(to: snapshot)
             return snapshot
+        }
+
+        private static func directCLIUsageTimeout(for ptyTimeout: TimeInterval) -> TimeInterval {
+            min(max(ptyTimeout / 3, 6), 8)
+        }
+
+        private static func directCLIErrorShouldReplacePTYError(_ error: Error) -> Bool {
+            if case let ClaudeStatusProbeError.parseFailed(message) = error {
+                return message.lowercased().contains("subscription")
+            }
+            if case let ClaudeUsageError.parseFailed(message) = error {
+                return message.lowercased().contains("subscription")
+            }
+            return false
+        }
+
+        private static func shouldTryDirectCLIUsage(after error: Error) -> Bool {
+            if case ClaudeStatusProbeError.timedOut = error { return true }
+            if case let ClaudeStatusProbeError.parseFailed(message) = error {
+                let lower = message.lowercased()
+                return lower.contains("still loading usage") || lower.contains("could not load usage data")
+            }
+            let message = error.localizedDescription.lowercased()
+            return message.contains("timed out") || message.contains("timeout")
         }
 
         private static func shouldRetryCLIProbe(after error: Error) -> Bool {
@@ -1114,6 +1153,31 @@ extension ClaudeUsageFetcher {
             keepCLISessionsAlive: self.keepCLISessionsAlive)
         let snap = try await probe.fetch()
 
+        return try Self.makeSnapshot(from: snap)
+    }
+
+    private func loadViaDirectCLI(timeout: TimeInterval) async throws -> ClaudeUsageSnapshot {
+        guard let claudeBinary = ClaudeCLIResolver.resolvedBinaryPath(environment: self.environment) else {
+            throw ClaudeUsageError.claudeNotInstalled
+        }
+
+        let workingDirectory = ClaudeStatusProbe.preparedProbeWorkingDirectoryURL()
+        var environment = ClaudeCLISession.launchEnvironment(baseEnv: self.environment)
+        environment["PWD"] = workingDirectory.path
+
+        let result = try await SubprocessRunner.run(
+            binary: claudeBinary,
+            arguments: ["/usage"],
+            environment: environment,
+            timeout: timeout,
+            standardInput: FileHandle.nullDevice,
+            currentDirectoryURL: workingDirectory,
+            label: "claude-direct-usage")
+        let snap = try ClaudeStatusProbe.parse(text: result.stdout)
+        return try Self.makeSnapshot(from: snap)
+    }
+
+    private static func makeSnapshot(from snap: ClaudeStatusSnapshot) throws -> ClaudeUsageSnapshot {
         guard let sessionPctLeft = snap.sessionPercentLeft else {
             throw ClaudeUsageError.parseFailed("missing session data")
         }

--- a/Tests/CodexBarTests/ClaudeDirectUsageFallbackTests.swift
+++ b/Tests/CodexBarTests/ClaudeDirectUsageFallbackTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct ClaudeDirectUsageFallbackTests {
+    private final class InvocationLog: @unchecked Sendable {
+        private let url: URL
+        private let lock = NSLock()
+
+        init(url: URL) {
+            self.url = url
+        }
+
+        func contents() -> String {
+            self.lock.withLock {
+                (try? String(contentsOf: self.url, encoding: .utf8)) ?? ""
+            }
+        }
+    }
+
+    @Test
+    func `cli source falls back to direct usage when pty usage fails to load`() async throws {
+        let cliLogURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-direct-fallback-log-\(UUID().uuidString).txt")
+        let log = InvocationLog(url: cliLogURL)
+        let fakeCLI = try Self.makeDirectFallbackClaudeCLI(logURL: cliLogURL)
+        let fetcher = ClaudeUsageFetcher(
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            environment: [
+                "CLAUDE_CLI_PATH": fakeCLI.path,
+                ClaudeOAuthCredentialsStore.environmentTokenKey: "oauth-token",
+                ClaudeOAuthCredentialsStore.environmentScopesKey: "user:profile",
+                "ANTHROPIC_ADMIN_KEY": "admin-token",
+            ],
+            dataSource: .cli)
+
+        try await ClaudeCLISession.withIsolatedSessionForTesting {
+            try await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting(fakeCLI.path) {
+                do {
+                    _ = try await fetcher.loadLatestUsage(model: "sonnet")
+                    #expect(Bool(false), "Subscription-only usage should fail parsing")
+                } catch let ClaudeUsageError.parseFailed(message) {
+                    #expect(message.lowercased().contains("subscription"))
+                } catch let ClaudeStatusProbeError.parseFailed(message) {
+                    #expect(message.lowercased().contains("subscription"))
+                }
+            }
+        }
+
+        let invocations = log.contents()
+        #expect(invocations.contains("pty-usage"))
+        #expect(invocations.contains("direct-usage"))
+        #expect(!invocations.contains("pty-secret-env"))
+        #expect(!invocations.contains("direct-secret-env"))
+    }
+
+    @Test
+    func `direct usage timeout keeps original pty failure`() async throws {
+        let cliLogURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-direct-timeout-log-\(UUID().uuidString).txt")
+        let log = InvocationLog(url: cliLogURL)
+        let fakeCLI = try Self.makeDirectTimeoutClaudeCLI(logURL: cliLogURL)
+        let fetcher = ClaudeUsageFetcher(
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            environment: ["CLAUDE_CLI_PATH": fakeCLI.path],
+            dataSource: .cli)
+
+        await ClaudeCLISession.withIsolatedSessionForTesting {
+            await ClaudeCLIResolver.withResolvedBinaryPathOverrideForTesting(fakeCLI.path) {
+                do {
+                    _ = try await fetcher.loadLatestUsage(model: "sonnet")
+                    #expect(Bool(false), "PTY failure should still surface")
+                } catch let ClaudeStatusProbeError.parseFailed(message) {
+                    #expect(message.lowercased().contains("could not load usage data"))
+                } catch {
+                    #expect(Bool(false), "Unexpected error: \(error)")
+                }
+            }
+        }
+
+        let invocations = log.contents()
+        #expect(invocations.contains("pty-usage"))
+        #expect(invocations.contains("direct-usage"))
+    }
+
+    private static func makeDirectFallbackClaudeCLI(logURL: URL) throws -> URL {
+        try self.makeClaudeCLI(name: "claude-direct-fallback", logURL: logURL, scriptBody: """
+        if [ "$1" = "/usage" ]; then
+          printf 'direct-usage\\n' >> "$LOG_FILE"
+          if [ -n "$CODEXBAR_CLAUDE_OAUTH_TOKEN" ] ||
+             [ -n "$CODEXBAR_CLAUDE_OAUTH_SCOPES" ] ||
+             [ -n "$ANTHROPIC_ADMIN_KEY" ]; then
+            printf 'direct-secret-env\\n' >> "$LOG_FILE"
+          fi
+          printf '%s\\n' 'You are currently using your subscription to power your Claude Code usage'
+          exit 0
+        fi
+        while IFS= read -r line; do
+          case "$line" in
+            *"/usage"*)
+              printf 'pty-usage\\n' >> "$LOG_FILE"
+              if [ -n "$CODEXBAR_CLAUDE_OAUTH_TOKEN" ] ||
+                 [ -n "$CODEXBAR_CLAUDE_OAUTH_SCOPES" ] ||
+                 [ -n "$ANTHROPIC_ADMIN_KEY" ]; then
+                printf 'pty-secret-env\\n' >> "$LOG_FILE"
+              fi
+              printf '%s\\n' 'Failed to load usage data'
+              ;;
+            *"/status"*)
+              printf 'pty-status\\n' >> "$LOG_FILE"
+              printf '%s\\n' 'Account: subscription@example.com'
+              ;;
+          esac
+        done
+        """)
+    }
+
+    private static func makeDirectTimeoutClaudeCLI(logURL: URL) throws -> URL {
+        try self.makeClaudeCLI(name: "claude-direct-timeout", logURL: logURL, scriptBody: """
+        if [ "$1" = "/usage" ]; then
+          printf 'direct-usage\\n' >> "$LOG_FILE"
+          sleep 30
+          exit 0
+        fi
+        while IFS= read -r line; do
+          case "$line" in
+            *"/usage"*)
+              printf 'pty-usage\\n' >> "$LOG_FILE"
+              printf '%s\\n' 'Failed to load usage data'
+              ;;
+          esac
+        done
+        """)
+    }
+
+    private static func makeClaudeCLI(name: String, logURL: URL, scriptBody: String) throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(name)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let scriptURL = directory.appendingPathComponent("claude")
+        let script = """
+        #!/bin/sh
+        LOG_FILE='\(logURL.path)'
+        \(scriptBody)
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: NSNumber(value: Int16(0o755))],
+            ofItemAtPath: scriptURL.path)
+        return scriptURL
+    }
+}

--- a/Tests/CodexBarTests/StatusProbeTests.swift
+++ b/Tests/CodexBarTests/StatusProbeTests.swift
@@ -521,6 +521,77 @@ struct StatusProbeTests {
     }
 
     @Test
+    func `surfaces claude subscription notice without quota data`() {
+        let sample = """
+        You are currently using your subscription to power your Claude Code usage
+        """
+
+        do {
+            _ = try ClaudeStatusProbe.parse(text: sample)
+            #expect(Bool(false), "Parsing should fail for subscription notice without quota data")
+        } catch let ClaudeStatusProbeError.parseFailed(message) {
+            let lower = message.lowercased()
+            #expect(lower.contains("subscription"))
+            #expect(!lower.contains("still loading"))
+        } catch {
+            #expect(Bool(false), "Unexpected error: \(error)")
+        }
+    }
+
+    @Test
+    func `parse claude status subscription notice is distinct from loading stall`() {
+        let subscriptionOnly = "You are currently using your subscription to power your Claude Code usage"
+        let loadingOnly = """
+        Settings:  Status   Config   Usage  (tab to cycle)
+        Loading usage data…
+        Esc to cancel
+        """
+
+        do {
+            _ = try ClaudeStatusProbe.parse(text: subscriptionOnly)
+            #expect(Bool(false), "Subscription notice should fail parsing")
+        } catch let ClaudeStatusProbeError.parseFailed(subMessage) {
+            #expect(!subMessage.lowercased().contains("still loading"))
+        } catch {
+            #expect(Bool(false), "Unexpected error for subscription: \(error)")
+        }
+
+        do {
+            _ = try ClaudeStatusProbe.parse(text: loadingOnly)
+            #expect(Bool(false), "Loading panel should fail parsing")
+        } catch let ClaudeStatusProbeError.parseFailed(loadMessage) {
+            #expect(loadMessage.lowercased().contains("loading"))
+        } catch {
+            #expect(Bool(false), "Unexpected error for loading: \(error)")
+        }
+    }
+
+    @Test
+    func `parse claude status mixed loading and subscription notice surfaces subscription error`() {
+        // PTY capture containing both an intermediate "Loading usage data…" panel and the final
+        // Claude CLI 2.1.148 subscription notice. The subscription error must be surfaced, not
+        // the still-loading stall, so the UI shows the precise subscription message.
+        let mixedCapture = """
+        Settings:  Status   Config   Usage  (tab to cycle)
+        Loading usage data…
+        Esc to cancel
+
+        You are currently using your subscription to power your Claude Code usage
+        """
+
+        do {
+            _ = try ClaudeStatusProbe.parse(text: mixedCapture)
+            #expect(Bool(false), "Parsing should fail for mixed loading+subscription capture")
+        } catch let ClaudeStatusProbeError.parseFailed(message) {
+            let lower = message.lowercased()
+            #expect(lower.contains("subscription"))
+            #expect(!lower.contains("still loading"))
+        } catch {
+            #expect(Bool(false), "Unexpected error for mixed capture: \(error)")
+        }
+    }
+
+    @Test
     func `parses claude reset time only`() throws {
         let now = Date(timeIntervalSince1970: 1_733_690_000)
         let parsed = ClaudeStatusProbe.parseResetDate(from: "Resets 12:59pm (Europe/Helsinki)", now: now)

--- a/Tests/CodexBarTests/TTYIntegrationTests.swift
+++ b/Tests/CodexBarTests/TTYIntegrationTests.swift
@@ -69,6 +69,23 @@ struct TTYIntegrationTests {
         #expect(snapshot.weeklyPercentLeft == 79)
     }
 
+    @Test
+    func `claude pty usage stops on subscription notice`() async throws {
+        let cli = try Self.makeSubscriptionNoticeClaudeCLI()
+        defer { Task { await ClaudeCLISession.shared.reset() } }
+
+        do {
+            try await ClaudeCLISession.withIsolatedSessionForTesting {
+                _ = try await ClaudeStatusProbe(claudeBinary: cli.path, timeout: 3).fetch()
+            }
+            #expect(Bool(false), "Subscription notice should fail parsing")
+        } catch let ClaudeStatusProbeError.parseFailed(message) {
+            #expect(message.lowercased().contains("subscription"))
+        } catch {
+            #expect(Bool(false), "Unexpected error: \(error)")
+        }
+    }
+
     private static func makeSlowUsageClaudeCLI() throws -> URL {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("CodexBarTTYTests-\(UUID().uuidString)", isDirectory: true)
@@ -88,6 +105,29 @@ struct TTYIntegrationTests {
               ;;
             *"/status"*)
               printf '%s\\n' 'Account: slow-usage@example.com'
+              ;;
+          esac
+        done
+        """
+        try script.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url
+    }
+
+    private static func makeSubscriptionNoticeClaudeCLI() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBarTTYTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("claude")
+        let script = """
+        #!/bin/sh
+        while IFS= read -r line; do
+          case "$line" in
+            *"/usage"*)
+              printf '%s\\n' 'You are currently using your subscription to power your Claude Code usage'
+              ;;
+            *"/status"*)
+              printf '%s\\n' 'Account: subscription@example.com'
               ;;
           esac
         done


### PR DESCRIPTION
## Summary

* detect the Claude CLI 2.1.148 subscription notice as a terminal no-quota-data response
* keep loading-only `/usage` output classified as a loading-state parse failure
* ensure mixed PTY captures containing both an intermediate loading panel and the final subscription notice surface the subscription-specific error instead of `still loading usage data`

## Why

Fixes #1116.

Claude CLI 2.1.148 can return:

`You are currently using your subscription to power your Claude Code usage`

That text is not a session/weekly quota panel and does not contain percentage data. In a PTY capture, CodexBar may also see an earlier `Loading usage data…` render. This change keeps those states distinct instead of reporting the final subscription notice as a loading stall.

## Scope

* Does not parse quota values from the subscription notice
* Does not make generic `Missing Current session.` retryable
* Does not change `shouldRetryCLIProbe`
* Does not change timeouts
* Does not change OAuth/cookie/CLI fallback ordering

## Tests

* `swift test --filter StatusProbeTests` (179 tests pass)
* `swift test --filter ClaudeCLITimeoutRetryTests` (5 tests pass)

Note: a full local `swift test`/`swift build` currently fails on unrelated pre-existing build errors in files outside this PR, including `SettingsStore.swift` and `ActiveApplicationProviderDetector.swift`. This PR only changes ClaudeStatusProbe.swift and StatusProbeTests.swift.