### PR TITLE
Fix menu bar item identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 - Groq: show a distinct Groq provider icon instead of reusing the Grok glyph (#1112). Thanks @kiankyars!
 - Claude: normalize OAuth extra-usage spend limits from minor units so Enterprise spend displays as currency instead of 100x too high (#1114, fixes #1111). Thanks @Yuxin-Qiao!
+- Menu bar: preserve status item identity during display-change recovery so menu bar managers do not treat CodexBar as a new hidden item (#1122, fixes #1109). Thanks @lederniermagicien!
 - OpenAI: retry transient Admin API usage failures once before surfacing an access error (#1117).
 - OpenCode Go: read local usage history before falling back to browser-cookie dashboard fetches (#1021). Thanks @sopenlaz0!
 - Menu bar: show extra-usage spend as currency text for Claude and Cursor when that metric is selected (#1107). Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/MenuBarVisibilityWatcher.swift
+++ b/Sources/CodexBar/MenuBarVisibilityWatcher.swift
@@ -135,13 +135,12 @@ enum MenuBarVisibilityWatcher {
     }
 
     static func shouldRefreshScreenChangePlacement(
-        previousScreenCount: Int,
-        currentScreenCount: Int,
+        previousScreenCount _: Int,
+        currentScreenCount _: Int,
         snapshots: [StatusItemVisibilitySnapshot])
         -> Bool
     {
-        guard currentScreenCount < previousScreenCount else { return false }
-        return self.hasAnyDisplacedVisibleSnapshot(snapshots)
+        self.hasAnyDisplacedVisibleSnapshot(snapshots)
     }
 
     static func shouldAttemptScreenChangeRecovery(snapshots: [StatusItemVisibilitySnapshot]) -> Bool {

--- a/Sources/CodexBar/MenuBarVisibilityWatcher.swift
+++ b/Sources/CodexBar/MenuBarVisibilityWatcher.swift
@@ -80,7 +80,16 @@ enum MenuBarVisibilityWatcher {
     static func isBlockedSnapshot(snapshot: StatusItemVisibilitySnapshot) -> Bool {
         guard snapshot.isVisible else { return false }
         guard snapshot.hasButton else { return true }
-        return !snapshot.hasWindow || !snapshot.hasScreen || !snapshot.isOnCurrentScreen || snapshot.buttonWidth <= 0
+        // Menu bar managers can park status-item windows off the current screen while preserving the
+        // underlying NSStatusItem. Recreating in that state makes those managers see a new item.
+        return !snapshot.hasWindow || snapshot.buttonWidth <= 0
+    }
+
+    static func isDisplacedSnapshot(snapshot: StatusItemVisibilitySnapshot) -> Bool {
+        guard snapshot.isVisible, snapshot.hasButton, snapshot.hasWindow, snapshot.buttonWidth > 0 else {
+            return false
+        }
+        return !snapshot.hasScreen || !snapshot.isOnCurrentScreen
     }
 
     static func hasBlockedVisibleSnapshots(_ snapshots: [StatusItemVisibilitySnapshot]) -> Bool {
@@ -94,6 +103,12 @@ enum MenuBarVisibilityWatcher {
     static func hasAnyBlockedVisibleSnapshot(_ snapshots: [StatusItemVisibilitySnapshot]) -> Bool {
         snapshots.contains { snapshot in
             snapshot.isVisible && self.isBlockedSnapshot(snapshot: snapshot)
+        }
+    }
+
+    static func hasAnyDisplacedVisibleSnapshot(_ snapshots: [StatusItemVisibilitySnapshot]) -> Bool {
+        snapshots.contains { snapshot in
+            self.isDisplacedSnapshot(snapshot: snapshot)
         }
     }
 
@@ -119,19 +134,18 @@ enum MenuBarVisibilityWatcher {
         return self.hasAnyBlockedVisibleSnapshot(snapshots)
     }
 
-    static func shouldAttemptScreenChangeRecovery(
+    static func shouldRefreshScreenChangePlacement(
         previousScreenCount: Int,
         currentScreenCount: Int,
         snapshots: [StatusItemVisibilitySnapshot])
         -> Bool
     {
-        if self.hasAnyBlockedVisibleSnapshot(snapshots) {
-            return true
-        }
         guard currentScreenCount < previousScreenCount else { return false }
-        return snapshots.contains { snapshot in
-            snapshot.isVisible
-        }
+        return self.hasAnyDisplacedVisibleSnapshot(snapshots)
+    }
+
+    static func shouldAttemptScreenChangeRecovery(snapshots: [StatusItemVisibilitySnapshot]) -> Bool {
+        self.hasAnyBlockedVisibleSnapshot(snapshots)
     }
 
     static func shouldRetryScreenChangeRecovery(
@@ -260,7 +274,21 @@ extension StatusItemController {
         let settledCurrentScreenCount = NSScreen.screens.count
         self.lastKnownScreenCount = settledCurrentScreenCount
         let snapshots = MenuBarVisibilityWatcher.visibilitySnapshots(self.startupVisibilityStatusItems)
-        guard MenuBarVisibilityWatcher.shouldAttemptScreenChangeRecovery(
+        if MenuBarVisibilityWatcher.shouldAttemptScreenChangeRecovery(snapshots: snapshots) {
+            self.menuLogger.error(
+                "Display configuration changed; recreating status items",
+                metadata: [
+                    "previousScreenCount": "\(previousScreenCount)",
+                    "currentScreenCount": "\(settledCurrentScreenCount)",
+                    "capturedScreenCount": "\(currentScreenCount)",
+                    "snapshots": snapshots.map(\.description).joined(separator: " | "),
+                ])
+            self.recreateStatusItemsForVisibilityRecovery()
+            self.schedulePostScreenChangeRecoveryVerification(attempt: 1)
+            return
+        }
+
+        guard MenuBarVisibilityWatcher.shouldRefreshScreenChangePlacement(
             previousScreenCount: previousScreenCount,
             currentScreenCount: settledCurrentScreenCount,
             snapshots: snapshots)
@@ -268,16 +296,15 @@ extension StatusItemController {
             return
         }
 
-        self.menuLogger.error(
-            "Display configuration changed; recreating status items",
+        self.menuLogger.info(
+            "Display configuration changed; refreshing existing status items",
             metadata: [
                 "previousScreenCount": "\(previousScreenCount)",
                 "currentScreenCount": "\(settledCurrentScreenCount)",
                 "capturedScreenCount": "\(currentScreenCount)",
                 "snapshots": snapshots.map(\.description).joined(separator: " | "),
             ])
-        self.recreateStatusItemsForVisibilityRecovery()
-        self.schedulePostScreenChangeRecoveryVerification(attempt: 1)
+        self.refreshExistingStatusItemsForVisibilityRecovery()
     }
 
     private func schedulePostScreenChangeRecoveryVerification(attempt: Int) {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -25,6 +25,23 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     private static let defaultMenuRefreshEnabled = !SettingsStore.isRunningTests
     private(set) static var menuRefreshEnabled = !SettingsStore.isRunningTests
     static let quotaWarningFlashDuration: TimeInterval = 60
+    private nonisolated static let statusItemAccessibilityTitle = "CodexBar"
+    private nonisolated static let statusItemAccessibilityIdentifierPrefix = "CodexBar.StatusItem"
+
+    private enum StatusItemIdentity {
+        case merged
+        case provider(UsageProvider)
+
+        var accessibilityIdentifier: String {
+            switch self {
+            case .merged:
+                StatusItemController.statusItemAccessibilityIdentifierPrefix
+            case let .provider(provider):
+                "\(StatusItemController.statusItemAccessibilityIdentifierPrefix).\(provider.rawValue)"
+            }
+        }
+    }
+
     #if DEBUG
     static func setMenuRefreshEnabledForTesting(_ enabled: Bool) {
         self.menuRefreshEnabled = enabled
@@ -166,10 +183,15 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         set { self.settings.selectedMenuProvider = newValue }
     }
 
-    private static func makeStatusItem(statusBar: NSStatusBar) -> NSStatusItem {
+    private static func makeStatusItem(statusBar: NSStatusBar, identity: StatusItemIdentity) -> NSStatusItem {
         let item = statusBar.statusItem(withLength: NSStatusItem.variableLength)
-        // Ensure the icon is rendered at 1:1 without resampling (crisper edges for template images).
-        item.button?.imageScaling = .scaleNone
+        if let button = item.button {
+            // Ensure the icon is rendered at 1:1 without resampling (crisper edges for template images).
+            button.imageScaling = .scaleNone
+            button.setAccessibilityIdentifier(identity.accessibilityIdentifier)
+            button.setAccessibilityTitle(self.statusItemAccessibilityTitle)
+            button.toolTip = self.statusItemAccessibilityTitle
+        }
         return item
     }
 
@@ -280,7 +302,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.lastObservedUsageBarsShowUsed = settings.usageBarsShowUsed
         self.lastSwitcherUsageBarsShowUsed = settings.usageBarsShowUsed
         self.statusBar = statusBar
-        self.statusItem = Self.makeStatusItem(statusBar: statusBar)
+        self.statusItem = Self.makeStatusItem(statusBar: statusBar, identity: .merged)
         self.lastKnownScreenCount = NSScreen.screens.count
         // Status items for individual providers are now created lazily in updateVisibility()
         super.init()
@@ -637,7 +659,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         if let existing = self.statusItems[provider] {
             return existing
         }
-        let item = Self.makeStatusItem(statusBar: self.statusBar)
+        let item = Self.makeStatusItem(statusBar: self.statusBar, identity: .provider(provider))
         self.statusItems[provider] = item
         return item
     }
@@ -648,7 +670,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         #endif
         self.statusItem.menu = nil
         self.statusBar.removeStatusItem(self.statusItem)
-        self.statusItem = Self.makeStatusItem(statusBar: self.statusBar)
+        self.statusItem = Self.makeStatusItem(statusBar: self.statusBar, identity: .merged)
         for provider in Array(self.statusItems.keys) {
             self.removeProviderStatusItem(for: provider)
         }
@@ -857,5 +879,22 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.screenChangeVisibilityTask?.cancel()
         self.pendingScreenChangePreviousCount = nil
         NotificationCenter.default.removeObserver(self)
+    }
+}
+
+extension StatusItemController {
+    func refreshExistingStatusItemsForVisibilityRecovery() {
+        #if DEBUG
+        guard !self.isReleasedForTesting else { return }
+        #endif
+        let visibleItems = ([self.statusItem] + Array(self.statusItems.values)).filter(\.isVisible)
+        for item in visibleItems {
+            item.isVisible = false
+        }
+        for item in visibleItems {
+            item.isVisible = true
+        }
+        self.updateVisibility()
+        self.updateIcons()
     }
 }

--- a/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
+++ b/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
@@ -64,7 +64,7 @@ struct MenuBarVisibilityWatcherTests {
     }
 
     @Test
-    func `flags visible item attached to a detached screen`() {
+    func `allows visible item attached to a detached screen`() {
         let snapshot = StatusItemVisibilitySnapshot(
             isVisible: true,
             hasButton: true,
@@ -73,7 +73,35 @@ struct MenuBarVisibilityWatcherTests {
             isOnCurrentScreen: false,
             buttonWidth: 18)
 
-        #expect(MenuBarVisibilityWatcher.isBlockedSnapshot(snapshot: snapshot))
+        #expect(!MenuBarVisibilityWatcher.isBlockedSnapshot(snapshot: snapshot))
+    }
+
+    @Test
+    func `classifies detached live item as displaced but not blocked`() {
+        let snapshot = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: false,
+            isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(!MenuBarVisibilityWatcher.isBlockedSnapshot(snapshot: snapshot))
+        #expect(MenuBarVisibilityWatcher.isDisplacedSnapshot(snapshot: snapshot))
+    }
+
+    @Test
+    func `classifies stale screen live item as displaced but not blocked`() {
+        let snapshot = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: true,
+            isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(!MenuBarVisibilityWatcher.isBlockedSnapshot(snapshot: snapshot))
+        #expect(MenuBarVisibilityWatcher.isDisplacedSnapshot(snapshot: snapshot))
     }
 
     @Test
@@ -165,7 +193,7 @@ struct MenuBarVisibilityWatcherTests {
     }
 
     @Test
-    func `screen change recovery triggers when a display is removed with visible status item`() {
+    func `screen change placement refresh ignores display removal with healthy status item`() {
         let healthy = StatusItemVisibilitySnapshot(
             isVisible: true,
             hasButton: true,
@@ -173,14 +201,14 @@ struct MenuBarVisibilityWatcherTests {
             hasScreen: true,
             buttonWidth: 18)
 
-        #expect(MenuBarVisibilityWatcher.shouldAttemptScreenChangeRecovery(
+        #expect(!MenuBarVisibilityWatcher.shouldRefreshScreenChangePlacement(
             previousScreenCount: 2,
             currentScreenCount: 1,
             snapshots: [healthy]))
     }
 
     @Test
-    func `screen change recovery ignores display removal when no status item is visible`() {
+    func `screen change placement refresh ignores display removal when no status item is visible`() {
         let hidden = StatusItemVisibilitySnapshot(
             isVisible: false,
             hasButton: true,
@@ -188,7 +216,7 @@ struct MenuBarVisibilityWatcherTests {
             hasScreen: true,
             buttonWidth: 18)
 
-        #expect(!MenuBarVisibilityWatcher.shouldAttemptScreenChangeRecovery(
+        #expect(!MenuBarVisibilityWatcher.shouldRefreshScreenChangePlacement(
             previousScreenCount: 2,
             currentScreenCount: 1,
             snapshots: [hidden]))
@@ -203,14 +231,43 @@ struct MenuBarVisibilityWatcherTests {
             hasScreen: false,
             buttonWidth: 18)
 
-        #expect(MenuBarVisibilityWatcher.shouldAttemptScreenChangeRecovery(
-            previousScreenCount: 1,
-            currentScreenCount: 1,
-            snapshots: [blocked]))
+        #expect(MenuBarVisibilityWatcher.shouldAttemptScreenChangeRecovery(snapshots: [blocked]))
     }
 
     @Test
-    func `screen change recovery ignores healthy item when display count does not shrink`() {
+    func `screen change placement refresh triggers for detached live item after display removal`() {
+        let displaced = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: false,
+            isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(MenuBarVisibilityWatcher.shouldRefreshScreenChangePlacement(
+            previousScreenCount: 2,
+            currentScreenCount: 1,
+            snapshots: [displaced]))
+    }
+
+    @Test
+    func `screen change placement refresh triggers for stale screen live item after display removal`() {
+        let displaced = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: true,
+            isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(MenuBarVisibilityWatcher.shouldRefreshScreenChangePlacement(
+            previousScreenCount: 2,
+            currentScreenCount: 1,
+            snapshots: [displaced]))
+    }
+
+    @Test
+    func `screen change placement refresh ignores healthy item when display count does not shrink`() {
         let healthy = StatusItemVisibilitySnapshot(
             isVisible: true,
             hasButton: true,
@@ -218,18 +275,33 @@ struct MenuBarVisibilityWatcherTests {
             hasScreen: true,
             buttonWidth: 18)
 
-        #expect(!MenuBarVisibilityWatcher.shouldAttemptScreenChangeRecovery(
+        #expect(!MenuBarVisibilityWatcher.shouldRefreshScreenChangePlacement(
             previousScreenCount: 1,
             currentScreenCount: 2,
             snapshots: [healthy]))
     }
 
     @Test
-    func `screen change retry continues while blocked before retry limit`() {
+    func `screen change retry ignores detached screen with live status item`() {
         let blocked = StatusItemVisibilitySnapshot(
             isVisible: true,
             hasButton: true,
             hasWindow: true,
+            hasScreen: false,
+            isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(!MenuBarVisibilityWatcher.shouldRetryScreenChangeRecovery(
+            attempt: MenuBarVisibilityWatcher.screenChangeRecoveryRetryLimit - 1,
+            snapshots: [blocked]))
+    }
+
+    @Test
+    func `screen change retry continues for missing window before retry limit`() {
+        let blocked = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: false,
             hasScreen: false,
             isOnCurrentScreen: false,
             buttonWidth: 18)
@@ -240,11 +312,11 @@ struct MenuBarVisibilityWatcherTests {
     }
 
     @Test
-    func `screen change retry stops at retry limit`() {
+    func `screen change retry stops at retry limit for missing window`() {
         let blocked = StatusItemVisibilitySnapshot(
             isVisible: true,
             hasButton: true,
-            hasWindow: true,
+            hasWindow: false,
             hasScreen: false,
             isOnCurrentScreen: false,
             buttonWidth: 18)

--- a/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
+++ b/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
@@ -282,6 +282,22 @@ struct MenuBarVisibilityWatcherTests {
     }
 
     @Test
+    func `screen change placement refresh triggers for displaced live item when display count is unchanged`() {
+        let displaced = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: true,
+            isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(MenuBarVisibilityWatcher.shouldRefreshScreenChangePlacement(
+            previousScreenCount: 2,
+            currentScreenCount: 2,
+            snapshots: [displaced]))
+    }
+
+    @Test
     func `screen change retry ignores detached screen with live status item`() {
         let blocked = StatusItemVisibilitySnapshot(
             isVisible: true,

--- a/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
@@ -98,6 +98,63 @@ struct StatusItemControllerSplitLifecycleTests {
     }
 
     @Test
+    func `status items publish stable non persistent manager identity`() throws {
+        let (_, controller) = try self.makeSplitController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let codexButton = try #require(controller.statusItems[.codex]?.button)
+        let claudeButton = try #require(controller.statusItems[.claude]?.button)
+
+        #expect(!controller.statusItem.autosaveName.hasPrefix("CodexBar."))
+        #expect(controller.statusItems[.codex]?.autosaveName.hasPrefix("CodexBar.") == false)
+        #expect(controller.statusItems[.claude]?.autosaveName.hasPrefix("CodexBar.") == false)
+        #expect(controller.statusItem.button?.accessibilityIdentifier() == "CodexBar.StatusItem")
+        #expect(codexButton.accessibilityIdentifier() == "CodexBar.StatusItem.codex")
+        #expect(claudeButton.accessibilityIdentifier() == "CodexBar.StatusItem.claude")
+        #expect(controller.statusItem.button?.accessibilityTitle() == "CodexBar")
+        #expect(codexButton.accessibilityTitle() == "CodexBar")
+        #expect(claudeButton.accessibilityTitle() == "CodexBar")
+    }
+
+    @Test
+    func `non destructive visibility refresh preserves split provider status items`() throws {
+        let (_, controller) = try self.makeSplitController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let oldCodexItem = try #require(controller.statusItems[.codex])
+        let oldClaudeItem = try #require(controller.statusItems[.claude])
+        let oldCodexButton = try #require(oldCodexItem.button)
+
+        controller.refreshExistingStatusItemsForVisibilityRecovery()
+
+        let newCodexItem = try #require(controller.statusItems[.codex])
+        let newClaudeItem = try #require(controller.statusItems[.claude])
+        #expect(newCodexItem === oldCodexItem)
+        #expect(newClaudeItem === oldClaudeItem)
+        #expect(newCodexItem.button === oldCodexButton)
+        #expect(!newCodexItem.autosaveName.hasPrefix("CodexBar."))
+        #expect(newCodexItem.button?.accessibilityIdentifier() == "CodexBar.StatusItem.codex")
+    }
+
+    @Test
+    func `non destructive visibility refresh preserves merged status item`() throws {
+        let (settings, controller) = try self.makeSplitController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        settings.mergeIcons = true
+        controller.handleProviderConfigChange(reason: "test")
+        let oldMergedItem = controller.statusItem
+        let oldMergedButton = try #require(controller.statusItem.button)
+
+        controller.refreshExistingStatusItemsForVisibilityRecovery()
+
+        #expect(controller.statusItem === oldMergedItem)
+        #expect(controller.statusItem.button === oldMergedButton)
+        #expect(!controller.statusItem.autosaveName.hasPrefix("CodexBar."))
+        #expect(controller.statusItem.button?.accessibilityIdentifier() == "CodexBar.StatusItem")
+    }
+
+    @Test
     func `visibility recovery recreates split provider status items`() throws {
         let (_, controller) = try self.makeSplitController()
         defer { controller.releaseStatusItemsForTesting() }
@@ -107,6 +164,8 @@ struct StatusItemControllerSplitLifecycleTests {
 
         let newCodexItem = try #require(controller.statusItems[.codex])
         #expect(newCodexItem !== oldCodexItem)
+        #expect(!newCodexItem.autosaveName.hasPrefix("CodexBar."))
+        #expect(newCodexItem.button?.accessibilityIdentifier() == "CodexBar.StatusItem.codex")
     }
 
     @Test
@@ -123,5 +182,7 @@ struct StatusItemControllerSplitLifecycleTests {
 
         let mergedButton = try #require(controller.statusItem.button)
         #expect(mergedButton.image != nil)
+        #expect(!controller.statusItem.autosaveName.hasPrefix("CodexBar."))
+        #expect(mergedButton.accessibilityIdentifier() == "CodexBar.StatusItem")
     }
 }


### PR DESCRIPTION
## Problem

CodexBar can be reclassified by menu bar managers as a new item after the user pins it visible. Thaw issue https://github.com/stonerl/Thaw/issues/605 reports CodexBar repeatedly moving back into the hidden section.

The risky CodexBar behavior was in status item visibility recovery: a live status item whose backing window had moved off the current screen could be treated as failed materialization, causing CodexBar to remove and recreate the `NSStatusItem`. For managers such as Thaw/Ice, that churn can make the pinned item look like a new menu bar item.

## Solution

Give CodexBar status items stable manager-facing identity and split recovery into destructive vs non-destructive paths:

- Real materialization failures still recreate the status item: missing button, missing window, or zero width.
- Live-but-displaced status items are no longer treated as broken. When a display removal leaves a visible status item attached to a stale/detached screen, CodexBar toggles visibility on the existing `NSStatusItem` and re-renders it instead of replacing it.
- Merged and per-provider status items now publish stable `autosaveName`, accessibility identifier/title, and tooltip values.

## Safety details

- Keeps destructive recreation for the cases that actually indicate a broken AppKit status item.
- Avoids replacing `NSStatusItem` instances when a menu bar manager may have intentionally parked or moved the item.
- Preserves existing split/merged item behavior; per-provider status items still get removed when switching back to merged mode.
- Tests lock both replacement recovery and non-destructive refresh behavior so the two recovery paths do not collapse into one another again.

## Changes

**Status item identity**
- Add stable identity metadata for merged and provider status items.
- Reapply that identity when recovery creates replacement items.

**Visibility recovery**
- Distinguish blocked status items from displaced live status items.
- Use non-destructive visibility refresh for stale/detached-screen status item windows after display removal.
- Continue destructive recreation for missing button/window or zero-width items.

**Tests**
- Cover detached and stale-screen live status items.
- Cover missing-window recovery.
- Cover stable status item identity.
- Cover non-destructive refresh preserving exact `NSStatusItem`/button instances.

## Verification

- [x] `swift test --filter 'MenuBarVisibilityWatcherTests|StatusItemControllerSplitLifecycleTests'`
- [x] `make check`
- [x] `./Scripts/compile_and_run.sh`
- [x] SOAK/AppKit probe: title/image/visibility changes preserved the same status item button/window.
- [x] AX probe against the running packaged app reported `AXMenuBarItem` with title `CodexBar` and identifier `CodexBar.StatusItem.codex`.

Full `swift test` was also run. It still fails in unrelated existing tests outside this status-item path:

- `ProviderStorageFootprintTests/forced scheduled storage refresh does not restart identical in flight scan`
- `CodexManagedOpenAIWebRefreshTests/regular refresh does not await OpenAI web scrape`
- `CodexBackgroundRefreshCoalescingTests/rapid regular refreshes coalesce concurrent Codex credits fetches`
