### PR TITLE
Add toggles to hide extra rate windows from menu bar

### DIFF
--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -692,6 +692,7 @@ extension UsageMenuCardView.Model {
         let resetTimeDisplayStyle: ResetTimeDisplayStyle
         let tokenCostUsageEnabled: Bool
         let showOptionalCreditsAndExtraUsage: Bool
+        let hiddenExtraRateWindowIDs: Set<String>
         let sourceLabel: String?
         let kiloAutoMode: Bool
         let hidePersonalInfo: Bool
@@ -718,6 +719,7 @@ extension UsageMenuCardView.Model {
             resetTimeDisplayStyle: ResetTimeDisplayStyle,
             tokenCostUsageEnabled: Bool,
             showOptionalCreditsAndExtraUsage: Bool,
+            hiddenExtraRateWindowIDs: Set<String> = [],
             sourceLabel: String? = nil,
             kiloAutoMode: Bool = false,
             hidePersonalInfo: Bool,
@@ -743,6 +745,7 @@ extension UsageMenuCardView.Model {
             self.resetTimeDisplayStyle = resetTimeDisplayStyle
             self.tokenCostUsageEnabled = tokenCostUsageEnabled
             self.showOptionalCreditsAndExtraUsage = showOptionalCreditsAndExtraUsage
+            self.hiddenExtraRateWindowIDs = hiddenExtraRateWindowIDs
             self.sourceLabel = sourceLabel
             self.kiloAutoMode = kiloAutoMode
             self.hidePersonalInfo = hidePersonalInfo
@@ -1096,7 +1099,8 @@ extension UsageMenuCardView.Model {
                     showUsed: input.usageBarsShowUsed)))
         }
         if let extraRateWindows = snapshot.extraRateWindows {
-            metrics.append(contentsOf: extraRateWindows.map { namedWindow in
+            let visibleWindows = extraRateWindows.filter { !input.hiddenExtraRateWindowIDs.contains($0.id) }
+            metrics.append(contentsOf: visibleWindows.map { namedWindow in
                 Metric(
                     id: namedWindow.id,
                     title: namedWindow.title,

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct ProviderDetailView<SupplementaryContent: View>: View {
     let provider: UsageProvider
     @Bindable var store: UsageStore
+    @Bindable var settings: SettingsStore
     @Binding var isEnabled: Bool
     let subtitle: String
     let model: UsageMenuCardView.Model
@@ -24,6 +25,7 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
     init(
         provider: UsageProvider,
         store: UsageStore,
+        settings: SettingsStore,
         isEnabled: Binding<Bool>,
         subtitle: String,
         model: UsageMenuCardView.Model,
@@ -42,6 +44,7 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
     {
         self.provider = provider
         self.store = store
+        self.settings = settings
         self._isEnabled = isEnabled
         self.subtitle = subtitle
         self.model = model
@@ -99,6 +102,8 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
 
                 ProviderMetricsInlineView(
                     provider: self.provider,
+                    store: self.store,
+                    settings: self.settings,
                     model: self.model,
                     isEnabled: self.isEnabled,
                     labelWidth: labelWidth)
@@ -369,9 +374,15 @@ private struct ProviderDetailInfoRow: View {
 @MainActor
 struct ProviderMetricsInlineView: View {
     let provider: UsageProvider
+    @Bindable var store: UsageStore
+    @Bindable var settings: SettingsStore
     let model: UsageMenuCardView.Model
     let isEnabled: Bool
     let labelWidth: CGFloat
+
+    private var extraRateWindowIDs: Set<String> {
+        Set(self.store.snapshot(for: self.provider)?.extraRateWindows?.map(\.id) ?? [])
+    }
 
     var body: some View {
         let hasMetrics = !self.model.metrics.isEmpty
@@ -379,6 +390,7 @@ struct ProviderMetricsInlineView: View {
         let hasCredits = self.model.creditsText != nil
         let hasProviderCost = self.model.providerCost != nil
         let hasTokenUsage = self.model.tokenUsage != nil
+        let extraIDs = self.extraRateWindowIDs
         ProviderSettingsSection(
             title: L("Usage"),
             spacing: 8,
@@ -391,11 +403,7 @@ struct ProviderMetricsInlineView: View {
                     .foregroundStyle(.secondary)
             } else {
                 ForEach(self.model.metrics, id: \.id) { metric in
-                    ProviderMetricInlineRow(
-                        metric: metric,
-                        title: ProviderDetailView<EmptyView>.metricTitle(provider: self.provider, metric: metric),
-                        progressColor: self.model.progressColor,
-                        labelWidth: self.labelWidth)
+                    self.metricRow(metric, extraIDs: extraIDs)
                 }
 
                 if hasUsageNotes {
@@ -433,6 +441,28 @@ struct ProviderMetricsInlineView: View {
         }
     }
 
+    @ViewBuilder
+    private func metricRow(_ metric: UsageMenuCardView.Model.Metric, extraIDs: Set<String>) -> some View {
+        let isExtra = extraIDs.contains(metric.id)
+        ProviderMetricInlineRow(
+            metric: metric,
+            title: ProviderDetailView<EmptyView>.metricTitle(provider: self.provider, metric: metric),
+            progressColor: self.model.progressColor,
+            labelWidth: self.labelWidth
+        ) {
+            if isExtra {
+                Toggle("", isOn: Binding(
+                    get: { !self.settings.isExtraRateWindowHidden(metric.id, provider: self.provider) },
+                    set: { self.settings.setExtraRateWindowHidden(metric.id, provider: self.provider, hidden: !$0) }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.mini)
+                .help("Show in menu bar")
+            }
+        }
+    }
+
     private var placeholderText: String {
         if !self.isEnabled {
             return L("Disabled — no recent data")
@@ -441,17 +471,18 @@ struct ProviderMetricsInlineView: View {
     }
 }
 
-private struct ProviderMetricInlineRow: View {
+private struct ProviderMetricInlineRow<TrailingContent: View>: View {
     let metric: UsageMenuCardView.Model.Metric
     let title: String
     let progressColor: Color
     let labelWidth: CGFloat
+    @ViewBuilder let trailingContent: () -> TrailingContent
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
             Text(self.title)
                 .font(.subheadline.weight(.semibold))
-                .lineLimit(1)
+                .lineLimit(2)
                 .frame(width: self.labelWidth, alignment: .leading)
 
             VStack(alignment: .leading, spacing: 4) {
@@ -502,6 +533,8 @@ private struct ProviderMetricInlineRow: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+
+            self.trailingContent()
         }
         .padding(.vertical, 2)
     }

--- a/Sources/CodexBar/PreferencesProvidersPane+Testing.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane+Testing.swift
@@ -160,6 +160,7 @@ enum ProvidersPaneTestHarness {
         _ = ProviderDetailView(
             provider: .codex,
             store: store,
+            settings: store.settings,
             isEnabled: enabledBinding,
             subtitle: "Subtitle",
             model: model,

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -58,6 +58,7 @@ struct ProvidersPane: View {
                 ProviderDetailView(
                     provider: provider,
                     store: self.store,
+                    settings: self.settings,
                     isEnabled: self.binding(for: provider),
                     subtitle: self.providerSubtitle(provider),
                     model: self.menuCardModel(for: provider),

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -394,6 +394,30 @@ extension SettingsStore {
         }
     }
 
+    var hiddenExtraRateWindowIDsRaw: [String: [String]] {
+        get { self.defaultsState.hiddenExtraRateWindowIDs }
+        set {
+            self.defaultsState.hiddenExtraRateWindowIDs = newValue
+            self.userDefaults.set(newValue, forKey: "hiddenExtraRateWindowIDs")
+        }
+    }
+
+    func hiddenExtraRateWindowIDs(for provider: UsageProvider) -> Set<String> {
+        Set(self.hiddenExtraRateWindowIDsRaw[provider.rawValue] ?? [])
+    }
+
+    func isExtraRateWindowHidden(_ id: String, provider: UsageProvider) -> Bool {
+        self.hiddenExtraRateWindowIDsRaw[provider.rawValue]?.contains(id) ?? false
+    }
+
+    func setExtraRateWindowHidden(_ id: String, provider: UsageProvider, hidden: Bool) {
+        var raw = self.hiddenExtraRateWindowIDsRaw
+        var ids = Set(raw[provider.rawValue] ?? [])
+        if hidden { ids.insert(id) } else { ids.remove(id) }
+        raw[provider.rawValue] = Array(ids)
+        self.hiddenExtraRateWindowIDsRaw = raw
+    }
+
     var openAIWebAccessEnabled: Bool {
         get { self.defaultsState.openAIWebAccessEnabled }
         set {

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -89,6 +89,7 @@ extension SettingsStore {
         _ = self.debugLoadingPattern
         _ = self.selectedMenuProvider
         _ = self.configRevision
+        _ = self.hiddenExtraRateWindowIDsRaw
         return 0
     }
 }

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -381,6 +381,7 @@ extension SettingsStore {
         let selectedMenuProviderRaw = userDefaults.string(forKey: "selectedMenuProvider")
         let providerDetectionCompleted = userDefaults.object(forKey: "providerDetectionCompleted") as? Bool ?? false
         let appLanguageRaw = userDefaults.string(forKey: "appLanguage")
+        let hiddenExtraRateWindowIDs = userDefaults.dictionary(forKey: "hiddenExtraRateWindowIDs") as? [String: [String]] ?? [:]
 
         return SettingsDefaultsState(
             refreshFrequency: refreshFrequency,
@@ -431,7 +432,8 @@ extension SettingsStore {
             mergedOverviewSelectedProvidersRaw: mergedOverviewSelectedProvidersRaw,
             selectedMenuProviderRaw: selectedMenuProviderRaw,
             providerDetectionCompleted: providerDetectionCompleted,
-            appLanguageRaw: appLanguageRaw)
+            appLanguageRaw: appLanguageRaw,
+            hiddenExtraRateWindowIDs: hiddenExtraRateWindowIDs)
     }
 
     private static func loadMenuBarMetricPreferences(userDefaults: UserDefaults) -> [String: String] {

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -50,4 +50,5 @@ struct SettingsDefaultsState {
     var selectedMenuProviderRaw: String?
     var providerDetectionCompleted: Bool
     var appLanguageRaw: String?
+    var hiddenExtraRateWindowIDs: [String: [String]]
 }

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -99,6 +99,7 @@ extension StatusItemController {
             resetTimeDisplayStyle: self.settings.resetTimeDisplayStyle,
             tokenCostUsageEnabled: self.settings.isCostUsageEffectivelyEnabled(for: target),
             showOptionalCreditsAndExtraUsage: self.settings.showOptionalCreditsAndExtraUsage,
+            hiddenExtraRateWindowIDs: self.settings.hiddenExtraRateWindowIDs(for: target),
             sourceLabel: sourceLabel,
             kiloAutoMode: kiloAutoMode,
             hidePersonalInfo: self.settings.hidePersonalInfo,

--- a/Tests/CodexBarTests/HiddenExtraRateWindowsTests.swift
+++ b/Tests/CodexBarTests/HiddenExtraRateWindowsTests.swift
@@ -1,0 +1,163 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct HiddenExtraRateWindowsTests {
+    @Test
+    func `hide and show extra rate windows per provider`() {
+        let settings = Self.makeSettingsStore()
+        let windowID = "test-window-123"
+        let provider = UsageProvider.codex
+
+        // Initially not hidden
+        #expect(settings.isExtraRateWindowHidden(windowID, provider: provider) == false)
+
+        // Hide the window
+        settings.setExtraRateWindowHidden(windowID, provider: provider, hidden: true)
+        #expect(settings.isExtraRateWindowHidden(windowID, provider: provider) == true)
+
+        // Show the window again
+        settings.setExtraRateWindowHidden(windowID, provider: provider, hidden: false)
+        #expect(settings.isExtraRateWindowHidden(windowID, provider: provider) == false)
+    }
+
+    @Test
+    func `hidden windows persist across app restarts`() throws {
+        let suite = "HiddenExtraRateWindowsTests-persistence"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+
+        var settings = Self.makeSettingsStore(userDefaults: defaults, configStore: configStore)
+        let windowID = "persistent-window-456"
+        let provider = UsageProvider.claude
+
+        // Hide a window
+        settings.setExtraRateWindowHidden(windowID, provider: provider, hidden: true)
+        #expect(settings.isExtraRateWindowHidden(windowID, provider: provider) == true)
+
+        // Create new settings store (simulating app restart)
+        settings = Self.makeSettingsStore(userDefaults: defaults, configStore: configStore)
+
+        // Window should still be hidden
+        #expect(settings.isExtraRateWindowHidden(windowID, provider: provider) == true)
+    }
+
+    @Test
+    func `multiple hidden windows per provider`() {
+        let settings = Self.makeSettingsStore()
+        let provider = UsageProvider.gemini
+        let window1 = "window-1"
+        let window2 = "window-2"
+        let window3 = "window-3"
+
+        // Hide multiple windows
+        settings.setExtraRateWindowHidden(window1, provider: provider, hidden: true)
+        settings.setExtraRateWindowHidden(window2, provider: provider, hidden: true)
+        settings.setExtraRateWindowHidden(window3, provider: provider, hidden: false)
+
+        // Verify correct state
+        #expect(settings.isExtraRateWindowHidden(window1, provider: provider) == true)
+        #expect(settings.isExtraRateWindowHidden(window2, provider: provider) == true)
+        #expect(settings.isExtraRateWindowHidden(window3, provider: provider) == false)
+
+        // Get all hidden IDs for provider
+        let hiddenIDs = settings.hiddenExtraRateWindowIDs(for: provider)
+        #expect(hiddenIDs == [window1, window2])
+    }
+
+    @Test
+    func `hidden windows are provider-specific`() {
+        let settings = Self.makeSettingsStore()
+        let windowID = "shared-window-id"
+        let provider1 = UsageProvider.codex
+        let provider2 = UsageProvider.claude
+
+        // Hide window for provider1
+        settings.setExtraRateWindowHidden(windowID, provider: provider1, hidden: true)
+
+        // Same window ID should not be hidden for provider2
+        #expect(settings.isExtraRateWindowHidden(windowID, provider: provider1) == true)
+        #expect(settings.isExtraRateWindowHidden(windowID, provider: provider2) == false)
+
+        // Hide for provider2
+        settings.setExtraRateWindowHidden(windowID, provider: provider2, hidden: true)
+
+        // Both should now be hidden
+        #expect(settings.isExtraRateWindowHidden(windowID, provider: provider1) == true)
+        #expect(settings.isExtraRateWindowHidden(windowID, provider: provider2) == true)
+    }
+
+    @Test
+    func `hiddenExtraRateWindowIDs returns Set of hidden window IDs`() {
+        let settings = Self.makeSettingsStore()
+        let provider = UsageProvider.openai
+        let ids = ["id-1", "id-2", "id-3"]
+
+        // Hide all windows
+        for id in ids {
+            settings.setExtraRateWindowHidden(id, provider: provider, hidden: true)
+        }
+
+        let hiddenSet = settings.hiddenExtraRateWindowIDs(for: provider)
+        #expect(hiddenSet.count == 3)
+        #expect(hiddenSet.contains("id-1"))
+        #expect(hiddenSet.contains("id-2"))
+        #expect(hiddenSet.contains("id-3"))
+        #expect(!hiddenSet.contains("id-4"))
+    }
+
+    @Test
+    func `filtering extra rate windows in menu card model`() {
+        let settings = Self.makeSettingsStore()
+        let windowID1 = "visible-window"
+        let windowID2 = "hidden-window"
+        let provider = UsageProvider.codex
+
+        // Hide one window
+        settings.setExtraRateWindowHidden(windowID2, provider: provider, hidden: true)
+
+        // Verify the hidden set is correct
+        let hiddenIDs = settings.hiddenExtraRateWindowIDs(for: provider)
+
+        // Simulate filtering (as done in MenuCardView)
+        let allWindowIDs = [windowID1, windowID2]
+        let visibleWindowIDs = allWindowIDs.filter { !hiddenIDs.contains($0) }
+
+        #expect(visibleWindowIDs == [windowID1])
+        #expect(visibleWindowIDs.count == 1)
+    }
+
+    // MARK: - Helpers
+
+    private static func makeSettingsStore(suiteName: String = "HiddenExtraRateWindowsTests") -> SettingsStore {
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults.set(false, forKey: "debugDisableKeychainAccess")
+        let configStore = testConfigStore(suiteName: suiteName)
+        return Self.makeSettingsStore(userDefaults: defaults, configStore: configStore)
+    }
+
+    private static func makeSettingsStore(userDefaults: UserDefaults, configStore: CodexBarConfigStore) -> SettingsStore {
+        SettingsStore(
+            userDefaults: userDefaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            kimiK2TokenStore: InMemoryKimiK2TokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore())
+    }
+}


### PR DESCRIPTION
Adds toggles in the provider preferences to hide individual extra rate windows from the menu bar. Hidden state is persisted per provider.

Screenshots show:
- Toggle visible in preferences
- Extra rate window hidden from menu bar
- Window restored when toggled back on
Test coverage also added: HiddenExtraRateWindowsTests.swift (7 test cases)

<img width="323" height="679" alt="Screenshot 2026-05-23 at 2 07 36 PM" src="https://github.com/user-attachments/assets/b5a66f5e-53d8-4899-a745-e68b465d1073" />
<img width="804" height="738" alt="Screenshot 2026-05-23 at 2 07 50 PM" src="https://github.com/user-attachments/assets/42c27abf-9e85-488f-9d42-63d814bd254d" />
<img width="323" height="581" alt="Screenshot 2026-05-23 at 2 08 04 PM" src="https://github.com/user-attachments/assets/56b36a74-c974-406f-ad83-b239b61ff10f" />
<img width="1311" height="705" alt="Screenshot 2026-05-23 at 2 08 39 PM" src="https://github.com/user-attachments/assets/4ec68173-fafd-4956-9731-8b2e6ebe9ad4" />
<img width="1253" height="711" alt="Screenshot 2026-05-23 at 2 10 38 PM" src="https://github.com/user-attachments/assets/5ad6feda-3d25-4a9b-9158-2ca8cc37c8ff" />

### Testing
1. Open preferences for a provider with extra rate windows
2. Toggle "Show in menu bar" to hide/show them
3. Verify state persists across app restarts