### PR TITLE
Add high usage suggestions

### DIFF
--- a/Sources/CodexBar/HighUsageSuggestionSection.swift
+++ b/Sources/CodexBar/HighUsageSuggestionSection.swift
@@ -1,0 +1,30 @@
+import AppKit
+import CodexBarCore
+import SwiftUI
+
+struct HighUsageSuggestionSection: View {
+    let suggestions: [HighUsageSuggestion]
+    @Environment(\.menuItemHighlighted) private var isHighlighted
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let first = suggestions.first, first.priority == .elevated {
+                Text("High usage detected")
+                    .font(.body)
+                    .fontWeight(.medium)
+            }
+            ForEach(Array(self.suggestions.enumerated()), id: \.offset) { _, suggestion in
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text("•")
+                        .font(.footnote)
+                        .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                    Text(suggestion.body)
+                        .font(.footnote)
+                        .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                        .lineLimit(3)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+}

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -132,4 +132,12 @@ extension UsageMenuCardView.Model {
             pacePercent: pacePercent,
             paceOnTop: paceOnTop)
     }
+
+    static func highUsageSuggestions(input: Input) -> [HighUsageSuggestion] {
+        if let primary = input.snapshot?.primary {
+            let provider = HighUsageSuggestionProvider.usedPercent(primary.usedPercent)
+            return provider.suggestions()
+        }
+        return []
+    }
 }

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -29,6 +29,17 @@ extension UsageMenuCardView.Model {
             self.placeholder != nil
     }
 
+    var hasSuggestions: Bool {
+        self.suggestions?.isEmpty == false
+    }
+
+    var hasDetails: Bool {
+        self.hasUsageContent ||
+            self.tokenUsage != nil ||
+            self.providerCost != nil ||
+            self.hasSuggestions
+    }
+
     static func progressColor(for provider: UsageProvider) -> Color {
         if provider == .elevenlabs {
             return Color(nsColor: .labelColor)

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -131,11 +131,7 @@ struct UsageMenuCardView: View {
         VStack(alignment: .leading, spacing: 6) {
             UsageMenuCardHeaderView(model: self.model)
 
-            if self.model.hasUsageContent ||
-                self.model.tokenUsage != nil ||
-                self.model.providerCost != nil ||
-                self.model.suggestions != nil
-            {
+            if self.model.hasDetails {
                 Divider()
             }
 

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -111,6 +111,7 @@ struct UsageMenuCardView: View {
         let creditsHintCopyText: String?
         let providerCost: ProviderCostSection?
         let tokenUsage: TokenUsageSection?
+        let suggestions: [HighUsageSuggestion]?
         let placeholder: String?
         let progressColor: Color
     }
@@ -130,7 +131,11 @@ struct UsageMenuCardView: View {
         VStack(alignment: .leading, spacing: 6) {
             UsageMenuCardHeaderView(model: self.model)
 
-            if self.hasDetails {
+            if self.model.hasUsageContent ||
+                self.model.tokenUsage != nil ||
+                self.model.providerCost != nil ||
+                self.model.suggestions != nil
+            {
                 Divider()
             }
 
@@ -216,6 +221,9 @@ struct UsageMenuCardView: View {
                             }
                         }
                     }
+                    if let suggestions = self.model.suggestions, !suggestions.isEmpty {
+                        HighUsageSuggestionSection(suggestions: suggestions)
+                    }
                 }
                 .padding(.bottom, self.model.creditsText == nil ? 6 : 0)
             }
@@ -224,12 +232,6 @@ struct UsageMenuCardView: View {
         .padding(.top, 2)
         .padding(.bottom, 2)
         .frame(width: self.width, alignment: .leading)
-    }
-
-    private var hasDetails: Bool {
-        self.model.hasUsageContent ||
-            self.model.tokenUsage != nil ||
-            self.model.providerCost != nil
     }
 }
 
@@ -813,6 +815,7 @@ extension UsageMenuCardView.Model {
             creditsHintCopyText: redacted.creditsHintCopyText,
             providerCost: providerCost,
             tokenUsage: tokenUsage,
+            suggestions: UsageMenuCardView.Model.highUsageSuggestions(input: input),
             placeholder: placeholder,
             progressColor: Self.progressColor(for: input.provider))
     }

--- a/Sources/CodexBarCore/HighUsageSuggestion.swift
+++ b/Sources/CodexBarCore/HighUsageSuggestion.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Provider-neutral suggestion shown when usage or spend is high.
+public struct HighUsageSuggestion: Equatable, Sendable {
+    public enum Priority: Int, Comparable, Sendable {
+        case normal = 0
+        case elevated = 1
+
+        public static func < (lhs: Priority, rhs: Priority) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
+    }
+
+    public let title: String
+    public let body: String
+    public let priority: Priority
+
+    public init(title: String, body: String, priority: Priority = .normal) {
+        self.title = title
+        self.body = body
+        self.priority = priority
+    }
+}
+
+public enum HighUsageSuggestionProvider {
+    case usedPercent(Double)
+
+    public var suggestionThreshold: Double {
+        80
+    }
+
+    public var criticalThreshold: Double {
+        95
+    }
+
+    public func suggestions() -> [HighUsageSuggestion] {
+        switch self {
+        case let .usedPercent(percent):
+            if percent < self.suggestionThreshold {
+                return []
+            }
+            let priority: HighUsageSuggestion.Priority = percent >= self.criticalThreshold ? .elevated : .normal
+            return Self.suggestionsForUsage(percent: percent, priority: priority)
+        }
+    }
+
+    private static func suggestionsForUsage(
+        percent: Double,
+        priority: HighUsageSuggestion.Priority) -> [HighUsageSuggestion]
+    {
+        let title = if priority == .elevated {
+            "Usage is very high"
+        } else {
+            "Usage is high"
+        }
+
+        return [
+            HighUsageSuggestion(
+                title: title,
+                body: "Narrow the prompt scope before starting a large agent run.",
+                priority: priority),
+            HighUsageSuggestion(
+                title: title,
+                body: "Attach only the files or folders needed for the task.",
+                priority: priority),
+            HighUsageSuggestion(
+                title: title,
+                body: "Use a cheaper or smaller model for exploration and reserve premium models for final passes.",
+                priority: priority),
+            HighUsageSuggestion(
+                title: title,
+                body: "Check for background agents or repeated retry loops.",
+                priority: priority),
+        ]
+    }
+}

--- a/Tests/CodexBarTests/HighUsageSuggestionTests.swift
+++ b/Tests/CodexBarTests/HighUsageSuggestionTests.swift
@@ -1,0 +1,64 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct HighUsageSuggestionTests {
+    @Test
+    func `low usage returns no suggestions`() {
+        let provider = HighUsageSuggestionProvider.usedPercent(50)
+        #expect(provider.suggestions().isEmpty)
+    }
+
+    @Test
+    func `usage at threshold returns suggestions`() {
+        let provider = HighUsageSuggestionProvider.usedPercent(80)
+        let suggestions = provider.suggestions()
+        #expect(!suggestions.isEmpty)
+        #expect(suggestions.allSatisfy { $0.priority == .normal })
+    }
+
+    @Test
+    func `usage at critical threshold returns elevated priority`() {
+        let provider = HighUsageSuggestionProvider.usedPercent(95)
+        let suggestions = provider.suggestions()
+        #expect(!suggestions.isEmpty)
+        #expect(suggestions.allSatisfy { $0.priority == .elevated })
+    }
+
+    @Test
+    func `usage above critical threshold returns elevated priority`() {
+        let provider = HighUsageSuggestionProvider.usedPercent(99)
+        let suggestions = provider.suggestions()
+        #expect(!suggestions.isEmpty)
+        #expect(suggestions.allSatisfy { $0.priority == .elevated })
+    }
+
+    @Test
+    func `usage at exactly 100 percent returns suggestions`() {
+        let provider = HighUsageSuggestionProvider.usedPercent(100)
+        let suggestions = provider.suggestions()
+        #expect(!suggestions.isEmpty)
+        #expect(suggestions.allSatisfy { $0.priority == .elevated })
+    }
+
+    @Test
+    func `high usage returns four suggestions`() {
+        let provider = HighUsageSuggestionProvider.usedPercent(85)
+        let suggestions = provider.suggestions()
+        #expect(suggestions.count == 4)
+    }
+
+    @Test
+    func `normal priority title is Usage is high`() {
+        let provider = HighUsageSuggestionProvider.usedPercent(80)
+        let suggestions = provider.suggestions()
+        #expect(suggestions.allSatisfy { $0.title == "Usage is high" })
+    }
+
+    @Test
+    func `elevated priority title is Usage is very high`() {
+        let provider = HighUsageSuggestionProvider.usedPercent(95)
+        let suggestions = provider.suggestions()
+        #expect(suggestions.allSatisfy { $0.title == "Usage is very high" })
+    }
+}


### PR DESCRIPTION
## Summary
- add provider-neutral high-usage suggestions when a primary usage window reaches 80%+
- escalate the suggestion state at 95%+ usage
- render the suggestions as a compact menu-card section without vendor links, tracking, referrals, or external integrations

## Testing
- make check
- swift test --filter HighUsageSuggestionTests
- swift test (known unrelated async/timing failures also reproduce on origin/main: CodexManagedOpenAIWebRefreshTests and CodexBackgroundRefreshCoalescingTests)

Fixes #1066