### PR TITLE
Add active provider selection for merged icon

### DIFF
--- a/Sources/CodexBar/ActiveApplicationProviderDetector.swift
+++ b/Sources/CodexBar/ActiveApplicationProviderDetector.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CodexBarCore
+import Combine
 import Foundation
 
 /// Detects the active frontmost application and maps its bundle identifier to a UsageProvider.
@@ -50,7 +51,7 @@ final class ActiveApplicationProviderDetector: ObservableObject {
 
     // MARK: - Private State
 
-    private var observer: NSObjectProtocol?
+    private nonisolated(unsafe) var observer: NSObjectProtocol?
     private let observeApplicationChanges: Bool
 
     // MARK: - Initialization
@@ -101,6 +102,11 @@ final class ActiveApplicationProviderDetector: ObservableObject {
                 }
             }
         }
+    }
+
+    deinit {
+        guard let observer else { return }
+        NSWorkspace.shared.notificationCenter.removeObserver(observer)
     }
 
     private func handleApplicationActivation(_ notification: Notification) {

--- a/Sources/CodexBar/ActiveApplicationProviderDetector.swift
+++ b/Sources/CodexBar/ActiveApplicationProviderDetector.swift
@@ -87,8 +87,8 @@ final class ActiveApplicationProviderDetector: ObservableObject {
         self.observer = NSWorkspace.shared.notificationCenter.addObserver(
             forName: NSWorkspace.didActivateApplicationNotification,
             object: nil,
-            queue: .main
-        ) { [weak self] notification in
+            queue: .main)
+        { [weak self] notification in
             guard let self else { return }
             let bundleID = (notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication)?
                 .bundleIdentifier

--- a/Sources/CodexBar/ActiveApplicationProviderDetector.swift
+++ b/Sources/CodexBar/ActiveApplicationProviderDetector.swift
@@ -1,0 +1,115 @@
+import AppKit
+import CodexBarCore
+import Foundation
+
+/// Detects the active frontmost application and maps its bundle identifier to a UsageProvider.
+///
+/// This is used to show the merged menu bar icon for the provider associated with
+/// the currently focused application when "Show active provider" is enabled.
+///
+/// - Note: Bundle identifier mappings are conservative. Only well-established, unambiguous
+///   mappings are included based on verified bundle IDs from installed apps or confirmed
+///   in existing codebase references.
+@preconcurrency @MainActor
+final class ActiveApplicationProviderDetector: ObservableObject {
+    // MARK: - Bundle Identifier Mappings
+
+    /// Known bundle identifiers mapped to their corresponding UsageProvider.
+    ///
+    /// Ambiguous mappings (e.g., VS Code could mean Copilot, Codex, OpenAI, etc.)
+    /// are not included by default to avoid incorrect provider selection.
+    private nonisolated static let bundleIdentifierToProvider: [String: UsageProvider] = [
+        // JetBrains IDEs - maps to jetbrains provider
+        // Confirmed from existing jetbrainsIDEBasePath setting and ProviderImplementationRegistry
+        "com.jetbrains.intellij": .jetbrains,
+        "com.jetbrains.CLion": .jetbrains,
+        "com.jetbrains.AppCode": .jetbrains,
+        "com.jetbrains.GoLand": .jetbrains,
+        "com.jetbrains.DataGrip": .jetbrains,
+        "com.jetbrains.Rider": .jetbrains,
+        "com.jetbrains.PyCharm": .jetbrains,
+        "com.jetbrains.WebStorm": .jetbrains,
+        "com.jetbrains.PhpStorm": .jetbrains,
+        "com.jetbrains.RubyMine": .jetbrains,
+        "com.jetbrains.idea": .jetbrains,
+
+        // Cursor - bundle ID "com.cursorcursor.cursor" is documented in the CursorProviderImplementation
+        "com.cursorcursor.cursor": .cursor,
+
+        // VS Code - NOT mapped: VS Code is used with many providers (Copilot, Codex, OpenAI, etc.)
+        // making the mapping ambiguous. Users can manually select their provider.
+
+        // Xcode - NOT mapped: Xcode is not a provider-specific IDE. While some users may use
+        // Claude via Xcode extension, the mapping would be too ambiguous to be reliable.
+    ]
+
+    // MARK: - Published State
+
+    /// The provider matching the currently active application, if any.
+    @Published private(set) var currentProvider: UsageProvider?
+
+    // MARK: - Private State
+
+    private var observer: NSObjectProtocol?
+    private let observeApplicationChanges: Bool
+
+    // MARK: - Initialization
+
+    /// - Parameter observeApplicationChanges: If false, skips registering for workspace notifications.
+    ///   Useful for testing without triggering actual app activation events.
+    init(observeApplicationChanges: Bool = true) {
+        self.observeApplicationChanges = observeApplicationChanges
+        if observeApplicationChanges {
+            self.observeFrontmostApplicationChanges()
+        }
+    }
+
+    // MARK: - Public Methods
+
+    /// Returns the provider that should be shown for the given bundle identifier.
+    /// Returns nil if the bundle identifier is unknown or maps to a disabled provider.
+    nonisolated func provider(for bundleIdentifier: String?) -> UsageProvider? {
+        guard let bundleIdentifier, let provider = Self.bundleIdentifierToProvider[bundleIdentifier] else {
+            return nil
+        }
+        return provider
+    }
+
+    /// Updates the current provider based on the active frontmost application.
+    func updateFromFrontmostApplication() {
+        let frontmostApp = NSWorkspace.shared.frontmostApplication
+        self.currentProvider = self.provider(for: frontmostApp?.bundleIdentifier)
+    }
+
+    // MARK: - Private Methods
+
+    private func observeFrontmostApplicationChanges() {
+        self.observer = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self else { return }
+            let bundleID = (notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication)?
+                .bundleIdentifier
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if let bundleID {
+                    self.currentProvider = Self.bundleIdentifierToProvider[bundleID]
+                } else {
+                    self.currentProvider = nil
+                }
+            }
+        }
+    }
+
+    private func handleApplicationActivation(_ notification: Notification) {
+        guard let app = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication,
+              let bundleIdentifier = app.bundleIdentifier
+        else {
+            self.currentProvider = nil
+            return
+        }
+        self.currentProvider = Self.bundleIdentifierToProvider[bundleIdentifier]
+    }
+}

--- a/Sources/CodexBar/PreferencesDisplayPane.swift
+++ b/Sources/CodexBar/PreferencesDisplayPane.swift
@@ -38,6 +38,12 @@ struct DisplayPane: View {
                         .disabled(!self.settings.mergeIcons)
                         .opacity(self.settings.mergeIcons ? 1 : 0.5)
                     PreferenceToggleRow(
+                        title: L("show_active_provider_title"),
+                        subtitle: L("show_active_provider_subtitle"),
+                        binding: self.$settings.showActiveProviderEnabled)
+                        .disabled(!self.settings.mergeIcons)
+                        .opacity(self.settings.mergeIcons ? 1 : 0.5)
+                    PreferenceToggleRow(
                         title: L("menu_bar_shows_percent_title"),
                         subtitle: L("menu_bar_shows_percent_subtitle"),
                         binding: self.$settings.menuBarShowsBrandIconWithPercent)

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -473,6 +473,8 @@
 "switcher_shows_icons_subtitle" = "Show provider icons in the switcher (otherwise show a weekly progress line).";
 "show_most_used_provider_title" = "Show most-used provider";
 "show_most_used_provider_subtitle" = "Menu bar auto-shows the provider closest to its rate limit.";
+"show_active_provider_title" = "Show active provider";
+"show_active_provider_subtitle" = "Menu bar auto-shows the provider associated with the focused app when possible.";
 "menu_bar_shows_percent_title" = "Menu bar shows percent";
 "menu_bar_shows_percent_subtitle" = "Replace critter bars with provider branding icons and a percentage.";
 "display_mode_title" = "Display mode";

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -658,6 +658,14 @@ extension SettingsStore {
         }
     }
 
+    var showActiveProviderEnabled: Bool {
+        get { self.defaultsState.showActiveProviderEnabled }
+        set {
+            self.defaultsState.showActiveProviderEnabled = newValue
+            self.userDefaults.set(newValue, forKey: "showActiveProviderEnabled")
+        }
+    }
+
     var debugLoadingPattern: LoadingPattern? {
         get { self.debugLoadingPatternRaw.flatMap(LoadingPattern.init(rawValue:)) }
         set { self.debugLoadingPatternRaw = newValue?.rawValue }

--- a/Sources/CodexBar/SettingsStore+MenuObservation.swift
+++ b/Sources/CodexBar/SettingsStore+MenuObservation.swift
@@ -64,6 +64,7 @@ extension SettingsStore {
         _ = self.switcherShowsIcons
         _ = self.mergedMenuLastSelectedWasOverview
         _ = self.mergedOverviewSelectedProviders
+        _ = self.showActiveProviderEnabled
         _ = self.zaiAPIToken
         _ = self.syntheticAPIToken
         _ = self.codexCookieHeader

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -381,6 +381,7 @@ extension SettingsStore {
         let selectedMenuProviderRaw = userDefaults.string(forKey: "selectedMenuProvider")
         let providerDetectionCompleted = userDefaults.object(forKey: "providerDetectionCompleted") as? Bool ?? false
         let appLanguageRaw = userDefaults.string(forKey: "appLanguage")
+        let showActiveProviderEnabled = userDefaults.object(forKey: "showActiveProviderEnabled") as? Bool ?? false
 
         return SettingsDefaultsState(
             refreshFrequency: refreshFrequency,
@@ -431,7 +432,8 @@ extension SettingsStore {
             mergedOverviewSelectedProvidersRaw: mergedOverviewSelectedProvidersRaw,
             selectedMenuProviderRaw: selectedMenuProviderRaw,
             providerDetectionCompleted: providerDetectionCompleted,
-            appLanguageRaw: appLanguageRaw)
+            appLanguageRaw: appLanguageRaw,
+            showActiveProviderEnabled: showActiveProviderEnabled)
     }
 
     private static func loadMenuBarMetricPreferences(userDefaults: UserDefaults) -> [String: String] {

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -381,7 +381,6 @@ extension SettingsStore {
         let selectedMenuProviderRaw = userDefaults.string(forKey: "selectedMenuProvider")
         let providerDetectionCompleted = userDefaults.object(forKey: "providerDetectionCompleted") as? Bool ?? false
         let appLanguageRaw = userDefaults.string(forKey: "appLanguage")
-        let showActiveProviderEnabled = userDefaults.object(forKey: "showActiveProviderEnabled") as? Bool ?? false
 
         return SettingsDefaultsState(
             refreshFrequency: refreshFrequency,
@@ -433,7 +432,7 @@ extension SettingsStore {
             selectedMenuProviderRaw: selectedMenuProviderRaw,
             providerDetectionCompleted: providerDetectionCompleted,
             appLanguageRaw: appLanguageRaw,
-            showActiveProviderEnabled: showActiveProviderEnabled)
+            showActiveProviderEnabled: userDefaults.object(forKey: "showActiveProviderEnabled") as? Bool ?? false)
     }
 
     private static func loadMenuBarMetricPreferences(userDefaults: UserDefaults) -> [String: String] {

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -50,4 +50,5 @@ struct SettingsDefaultsState {
     var selectedMenuProviderRaw: String?
     var providerDetectionCompleted: Bool
     var appLanguageRaw: String?
+    var showActiveProviderEnabled: Bool
 }

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -895,7 +895,7 @@ extension StatusItemController {
     private func primaryProviderForUnifiedIcon() -> UsageProvider {
         if self.shouldMergeIcons,
            self.settings.showActiveProviderEnabled,
-           let activeProvider = self.activeApplicationDetector?.currentProvider,
+           let activeProvider = self.activeApplicationCurrentProvider,
            self.store.enabledProvidersForDisplay().contains(activeProvider)
         {
             return activeProvider

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -893,6 +893,13 @@ extension StatusItemController {
     }
 
     private func primaryProviderForUnifiedIcon() -> UsageProvider {
+        if self.shouldMergeIcons,
+           self.settings.showActiveProviderEnabled,
+           let activeProvider = self.activeApplicationDetector?.currentProvider,
+           self.store.enabledProvidersForDisplay().contains(activeProvider)
+        {
+            return activeProvider
+        }
         // When "show highest usage" is enabled, auto-select the provider closest to rate limit.
         if self.settings.menuBarShowsHighestUsage,
            self.shouldMergeIcons,

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -135,6 +135,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     private var lastProviderOrder: [UsageProvider]
     private var lastMergeIcons: Bool
     private var lastShowActiveProviderEnabled: Bool
+    private var lastMergedDisplayProviders: [UsageProvider]
     private var lastSwitcherShowsIcons: Bool
     private var lastObservedUsageBarsShowUsed: Bool
     /// Tracks which `usageBarsShowUsed` mode the provider switcher was built with.
@@ -284,6 +285,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.lastMergeIcons = settings.mergeIcons
         self.lastSwitcherShowsIcons = settings.switcherShowsIcons
         self.lastShowActiveProviderEnabled = settings.showActiveProviderEnabled
+        self.lastMergedDisplayProviders = store.enabledProvidersForDisplay()
         self.lastObservedUsageBarsShowUsed = settings.usageBarsShowUsed
         self.lastSwitcherUsageBarsShowUsed = settings.usageBarsShowUsed
         self.statusBar = statusBar
@@ -597,6 +599,11 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         let showActiveProvider = self.settings.showActiveProviderEnabled
         if showActiveProvider != self.lastShowActiveProviderEnabled {
             self.lastShowActiveProviderEnabled = showActiveProvider
+            self.refreshActiveApplicationDetectorLifecycle()
+        }
+        let mergedDisplayProviders = self.store.enabledProvidersForDisplay()
+        if mergedDisplayProviders != self.lastMergedDisplayProviders {
+            self.lastMergedDisplayProviders = mergedDisplayProviders
             self.refreshActiveApplicationDetectorLifecycle()
         }
         let showsIcons = self.settings.switcherShowsIcons

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CodexBarCore
+import Combine
 import Observation
 import QuartzCore
 
@@ -133,6 +134,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     private var lastConfigRevision: Int
     private var lastProviderOrder: [UsageProvider]
     private var lastMergeIcons: Bool
+    private var lastShowActiveProviderEnabled: Bool
     private var lastSwitcherShowsIcons: Bool
     private var lastObservedUsageBarsShowUsed: Bool
     /// Tracks which `usageBarsShowUsed` mode the provider switcher was built with.
@@ -165,6 +167,9 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         get { self.settings.selectedMenuProvider }
         set { self.settings.selectedMenuProvider = newValue }
     }
+
+    var activeApplicationDetector: ActiveApplicationProviderDetector?
+    private var activeApplicationDetectorCancellable: AnyCancellable?
 
     private static func makeStatusItem(statusBar: NSStatusBar) -> NSStatusItem {
         let item = statusBar.statusItem(withLength: NSStatusItem.variableLength)
@@ -277,6 +282,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.lastProviderOrder = settings.providerOrder
         self.lastMergeIcons = settings.mergeIcons
         self.lastSwitcherShowsIcons = settings.switcherShowsIcons
+        self.lastShowActiveProviderEnabled = settings.showActiveProviderEnabled
         self.lastObservedUsageBarsShowUsed = settings.usageBarsShowUsed
         self.lastSwitcherUsageBarsShowUsed = settings.usageBarsShowUsed
         self.statusBar = statusBar
@@ -315,6 +321,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             selector: #selector(self.handleScreenParametersDidChange(_:)),
             name: NSApplication.didChangeScreenParametersNotification,
             object: nil)
+        self.refreshActiveApplicationDetectorLifecycle()
     }
 
     convenience init(
@@ -346,6 +353,34 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.observeSettingsChanges()
         self.observeUpdaterChanges()
         self.observeManagedCodexCoordinatorChanges()
+    }
+
+    private func observeActiveApplicationDetectorChanges() {
+        guard let detector = self.activeApplicationDetector else { return }
+        withObservationTracking {
+            _ = detector.currentProvider
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, self.activeApplicationDetector != nil else { return }
+                self.observeActiveApplicationDetectorChanges()
+                self.updateIcons()
+            }
+        }
+    }
+
+    private func refreshActiveApplicationDetectorLifecycle() {
+        self.activeApplicationDetectorCancellable?.cancel()
+        self.activeApplicationDetectorCancellable = nil
+        self.activeApplicationDetector = nil
+        guard self.shouldMergeIcons, self.settings.showActiveProviderEnabled else { return }
+        let detector = ActiveApplicationProviderDetector(observeApplicationChanges: true)
+        detector.updateFromFrontmostApplication()
+        self.activeApplicationDetector = detector
+        self.activeApplicationDetectorCancellable = detector.objectWillChange
+            .sink { [weak self] _ in
+                guard let self, self.activeApplicationDetector != nil else { return }
+                self.updateIcons()
+            }
     }
 
     private func observeStoreChanges() {
@@ -563,6 +598,12 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         if mergeIcons != self.lastMergeIcons {
             self.lastMergeIcons = mergeIcons
             shouldRefresh = true
+            self.refreshActiveApplicationDetectorLifecycle()
+        }
+        let showActiveProvider = self.settings.showActiveProviderEnabled
+        if showActiveProvider != self.lastShowActiveProviderEnabled {
+            self.lastShowActiveProviderEnabled = showActiveProvider
+            self.refreshActiveApplicationDetectorLifecycle()
         }
         let showsIcons = self.settings.switcherShowsIcons
         if showsIcons != self.lastSwitcherShowsIcons {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -170,6 +170,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
 
     var activeApplicationDetector: ActiveApplicationProviderDetector?
     private var activeApplicationDetectorCancellable: AnyCancellable?
+    var activeApplicationCurrentProvider: UsageProvider?
 
     private static func makeStatusItem(statusBar: NSStatusBar) -> NSStatusItem {
         let item = statusBar.statusItem(withLength: NSStatusItem.variableLength)
@@ -324,6 +325,27 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.refreshActiveApplicationDetectorLifecycle()
     }
 
+    private func refreshActiveApplicationDetectorLifecycle() {
+        self.activeApplicationDetectorCancellable?.cancel()
+        self.activeApplicationDetectorCancellable = nil
+        self.activeApplicationDetector = nil
+        self.activeApplicationCurrentProvider = nil
+        guard self.shouldMergeIcons, self.settings.showActiveProviderEnabled else { return }
+        let detector = ActiveApplicationProviderDetector(observeApplicationChanges: true)
+        self.activeApplicationDetector = detector
+        self.activeApplicationDetectorCancellable = detector.$currentProvider
+            .sink { [weak self] provider in
+                guard let self, self.activeApplicationDetector != nil else { return }
+                self.activeApplicationCurrentProvider = provider
+                self.updateIcons()
+            }
+        detector.updateFromFrontmostApplication()
+        if let initialProvider = detector.currentProvider {
+            self.activeApplicationCurrentProvider = initialProvider
+            self.updateIcons()
+        }
+    }
+
     convenience init(
         store: UsageStore,
         settings: SettingsStore,
@@ -353,34 +375,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.observeSettingsChanges()
         self.observeUpdaterChanges()
         self.observeManagedCodexCoordinatorChanges()
-    }
-
-    private func observeActiveApplicationDetectorChanges() {
-        guard let detector = self.activeApplicationDetector else { return }
-        withObservationTracking {
-            _ = detector.currentProvider
-        } onChange: { [weak self] in
-            Task { @MainActor [weak self] in
-                guard let self, self.activeApplicationDetector != nil else { return }
-                self.observeActiveApplicationDetectorChanges()
-                self.updateIcons()
-            }
-        }
-    }
-
-    private func refreshActiveApplicationDetectorLifecycle() {
-        self.activeApplicationDetectorCancellable?.cancel()
-        self.activeApplicationDetectorCancellable = nil
-        self.activeApplicationDetector = nil
-        guard self.shouldMergeIcons, self.settings.showActiveProviderEnabled else { return }
-        let detector = ActiveApplicationProviderDetector(observeApplicationChanges: true)
-        detector.updateFromFrontmostApplication()
-        self.activeApplicationDetector = detector
-        self.activeApplicationDetectorCancellable = detector.objectWillChange
-            .sink { [weak self] _ in
-                guard let self, self.activeApplicationDetector != nil else { return }
-                self.updateIcons()
-            }
     }
 
     private func observeStoreChanges() {

--- a/Tests/CodexBarTests/ActiveApplicationProviderDetectorTests.swift
+++ b/Tests/CodexBarTests/ActiveApplicationProviderDetectorTests.swift
@@ -1,0 +1,90 @@
+@testable import CodexBar
+import XCTest
+
+@MainActor
+final class ActiveApplicationProviderDetectorTests: XCTestCase {
+    // MARK: - provider(for:) Tests
+
+    func testProviderForKnownJetBrainsBundleIdentifiers() {
+        let detector = ActiveApplicationProviderDetector(observeApplicationChanges: false)
+
+        let bundleIDs: [String] = [
+            "com.jetbrains.intellij",
+            "com.jetbrains.CLion",
+            "com.jetbrains.AppCode",
+            "com.jetbrains.GoLand",
+            "com.jetbrains.DataGrip",
+            "com.jetbrains.Rider",
+            "com.jetbrains.PyCharm",
+            "com.jetbrains.WebStorm",
+            "com.jetbrains.PhpStorm",
+            "com.jetbrains.RubyMine",
+            "com.jetbrains.idea",
+        ]
+
+        for bundleID in bundleIDs {
+            let provider = detector.provider(for: bundleID)
+            XCTAssertEqual(provider, .jetbrains, "Bundle ID \(bundleID) should map to .jetbrains")
+        }
+    }
+
+    func testProviderForKnownCursorBundleIdentifier() {
+        let detector = ActiveApplicationProviderDetector(observeApplicationChanges: false)
+
+        let provider = detector.provider(for: "com.cursorcursor.cursor")
+        XCTAssertEqual(provider, .cursor)
+    }
+
+    func testProviderForUnknownBundleIdentifierReturnsNil() {
+        let detector = ActiveApplicationProviderDetector(observeApplicationChanges: false)
+
+        let unknownBundleIDs = [
+            "com.apple.Safari",
+            "com.apple.Terminal",
+            "com.microsoft.VSCode",
+            "com.sublimetext.4",
+            "com.google.Chrome",
+        ]
+
+        for bundleID in unknownBundleIDs {
+            let provider = detector.provider(for: bundleID)
+            XCTAssertNil(provider, "Unknown bundle ID \(bundleID) should return nil")
+        }
+    }
+
+    func testProviderForNilBundleIdentifierReturnsNil() {
+        let detector = ActiveApplicationProviderDetector(observeApplicationChanges: false)
+
+        let provider = detector.provider(for: nil)
+        XCTAssertNil(provider)
+    }
+
+    func testProviderForEmptyBundleIdentifierReturnsNil() {
+        let detector = ActiveApplicationProviderDetector(observeApplicationChanges: false)
+
+        let provider = detector.provider(for: "")
+        XCTAssertNil(provider)
+    }
+
+    // MARK: - VS Code Ambiguity Documentation
+
+    func testVSCodeIsNotMapped() {
+        // VS Code is intentionally not mapped because it can be used with multiple providers:
+        // Copilot, Codex, OpenAI, and others. The mapping would be ambiguous.
+        let detector = ActiveApplicationProviderDetector(observeApplicationChanges: false)
+
+        let provider = detector.provider(for: "com.microsoft.VSCode")
+        XCTAssertNil(provider, "VS Code should not be mapped to any provider due to ambiguity")
+    }
+
+    // MARK: - Xcode Not Mapped Documentation
+
+    func testXcodeIsNotMapped() {
+        // Xcode is not mapped because it is not a provider-specific IDE.
+        // Users may use Claude via Xcode extension, but the mapping would be too ambiguous.
+        let detector = ActiveApplicationProviderDetector(observeApplicationChanges: false)
+
+        let provider = detector.provider(for: "com.apple.dt.Xcode")
+        XCTAssertNil(provider, "Xcode should not be mapped to any provider")
+    }
+}

--- a/Tests/CodexBarTests/ActiveApplicationProviderDetectorTests.swift
+++ b/Tests/CodexBarTests/ActiveApplicationProviderDetectorTests.swift
@@ -1,5 +1,5 @@
-@testable import CodexBar
 import XCTest
+@testable import CodexBar
 
 @MainActor
 final class ActiveApplicationProviderDetectorTests: XCTestCase {


### PR DESCRIPTION
## Summary

* Add a Display setting, "Show active provider", for Merge Icons mode.
* Detect the focused macOS app with `NSWorkspace.didActivateApplicationNotification`.
* Switch the merged menu bar icon to the mapped active provider when the provider is available in the merged display list.
* Preserve existing fallback behavior when the setting is off, the app is unmapped, or the provider is unavailable.

## Implementation notes

* Adds `ActiveApplicationProviderDetector`.
* Uses a conservative bundle ID mapping for JetBrains IDEs and Cursor.
* Leaves VS Code and Xcode unmapped because they are ambiguous.
* Creates/destroys the detector when `mergeIcons` or `showActiveProviderEnabled` changes.
* Uses Combine `objectWillChange` for `ObservableObject` / `@Published` updates.
* Initializes detector state from the current frontmost app after creation.

## Validation

* `xcodebuild -scheme CodexBar -configuration Debug -destination 'platform=macOS' build`
* `xcodebuild -scheme CodexBar -configuration Debug -destination 'platform=macOS' -only-testing:CodexBarTests/ActiveApplicationProviderDetectorTests test`
* `git diff --check`

## Manual validation still useful

* Enable Merge Icons and Show active provider.
* Focus Cursor or a JetBrains IDE and confirm the merged icon switches when that provider is enabled.
* Focus an unmapped app such as VS Code, Xcode, Safari, or Finder and confirm fallback behavior remains unchanged.
* Disable Merge Icons and confirm the Show active provider toggle is disabled.

Closes #780