### PR TITLE
Add redacted MiniMax diagnostic report CLI

### DIFF
--- a/Sources/CodexBarCLI/CLIEntry.swift
+++ b/Sources/CodexBarCLI/CLIEntry.swift
@@ -52,6 +52,8 @@ enum CodexBarCLI {
                 self.runConfigSetAPIKey(invocation.parsedValues)
             case ["cache", "clear"]:
                 self.runCacheClear(invocation.parsedValues)
+            case ["diagnose"]:
+                await self.runDiagnose(invocation.parsedValues)
             default:
                 Self.exit(
                     code: .failure,
@@ -74,6 +76,7 @@ enum CodexBarCLI {
         let configProviderToggleSignature = CommandSignature.describe(ConfigProviderToggleOptions())
         let configSetAPIKeySignature = CommandSignature.describe(ConfigSetAPIKeyOptions())
         let cacheSignature = CommandSignature.describe(CacheOptions())
+        let diagnoseSignature = CommandSignature.describe(DiagnoseOptions())
 
         return [
             CommandDescriptor(
@@ -142,6 +145,11 @@ enum CodexBarCLI {
                         signature: cacheSignature),
                 ],
                 defaultSubcommandName: "clear"),
+            CommandDescriptor(
+                name: "diagnose",
+                abstract: "Collect provider diagnostic report for GitHub issues",
+                discussion: nil,
+                signature: diagnoseSignature),
         ]
     }
 
@@ -163,5 +171,58 @@ enum CodexBarCLI {
         guard let first = argv.first else { return ["usage"] }
         if first.hasPrefix("-") { return ["usage"] + argv }
         return argv
+    }
+
+    // MARK: - Diagnose Command
+
+    static func runDiagnose(_ values: ParsedValues) async {
+        let provider = values.options["provider"]?.last ?? "minimax"
+        let formatOption = values.options["format"]?.last
+
+        let outputPreferences = CLIOutputPreferences.from(values: values)
+
+        if provider != "minimax" {
+            Self.exit(
+                code: .failure,
+                message: "Only 'minimax' provider is supported for diagnose. Got: \(provider)",
+                output: outputPreferences,
+                kind: .args)
+        }
+
+        let env = ProcessInfo.processInfo.environment
+        let authSources = MiniMaxDiagnosticReport.detectAuthSources(from: env)
+        let fields = MiniMaxDiagnosticReport.suspectedFields
+
+        let report = MiniMaxDiagnosticReport(
+            liveFetch: "notPerformed",
+            authSourcesPresent: authSources,
+            endpointsAttempted: MiniMaxDiagnosticReport.safeEndpoints,
+            responseShape: nil,
+            suspectedPlanFields: fields.plan,
+            suspectedDateFields: fields.date,
+            suspectedSubscriptionFields: fields.subscription,
+            redaction: MiniMaxDiagnosticReport.RedactionSummary())
+
+        let useJSON = formatOption?.lowercased() == "json" || formatOption == nil
+        if useJSON {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            if let data = try? encoder.encode(report),
+               let jsonString = String(data: data, encoding: .utf8)
+            {
+                print(jsonString)
+            }
+        } else {
+            print("Provider: \(report.provider)")
+            print("Schema: \(report.schemaVersion)")
+            print("Generated: \(report.generatedAt)")
+            print("Live Fetch: \(report.liveFetch)")
+            print("Auth Sources - API Token Env: \(report.authSourcesPresent.apiTokenEnv), Coding Plan Token Env: \(report.authSourcesPresent.codingPlanTokenEnv), Cookie Env: \(report.authSourcesPresent.cookieHeaderEnv)")
+            print("Endpoints: \(report.endpointsAttempted.joined(separator: ", "))")
+            print("Plan Fields: \(report.suspectedPlanFields.joined(separator: ", "))")
+            print("Date Fields: \(report.suspectedDateFields.joined(separator: ", "))")
+            print("Subscription Fields: \(report.suspectedSubscriptionFields.joined(separator: ", "))")
+            print("Redaction: cookies=\(report.redaction.cookies), tokens=\(report.redaction.tokens), ids=\(report.redaction.ids), emails=\(report.redaction.emails)")
+        }
     }
 }

--- a/Sources/CodexBarCLI/CLIEntry.swift
+++ b/Sources/CodexBarCLI/CLIEntry.swift
@@ -217,12 +217,15 @@ enum CodexBarCLI {
             print("Schema: \(report.schemaVersion)")
             print("Generated: \(report.generatedAt)")
             print("Live Fetch: \(report.liveFetch)")
-            print("Auth Sources - API Token Env: \(report.authSourcesPresent.apiTokenEnv), Coding Plan Token Env: \(report.authSourcesPresent.codingPlanTokenEnv), Cookie Env: \(report.authSourcesPresent.cookieHeaderEnv)")
+            print("Auth Sources - API Token Env: \(report.authSourcesPresent.apiTokenEnv), " +
+                "Coding Plan Token Env: \(report.authSourcesPresent.codingPlanTokenEnv), " +
+                "Cookie Env: \(report.authSourcesPresent.cookieHeaderEnv)")
             print("Endpoints: \(report.endpointsAttempted.joined(separator: ", "))")
             print("Plan Fields: \(report.suspectedPlanFields.joined(separator: ", "))")
             print("Date Fields: \(report.suspectedDateFields.joined(separator: ", "))")
             print("Subscription Fields: \(report.suspectedSubscriptionFields.joined(separator: ", "))")
-            print("Redaction: cookies=\(report.redaction.cookies), tokens=\(report.redaction.tokens), ids=\(report.redaction.ids), emails=\(report.redaction.emails)")
+            print("Redaction: cookies=\(report.redaction.cookies), tokens=\(report.redaction.tokens), " +
+                "ids=\(report.redaction.ids), emails=(report.redaction.emails)")
         }
     }
 }

--- a/Sources/CodexBarCLI/CLIOptions.swift
+++ b/Sources/CodexBarCLI/CLIOptions.swift
@@ -76,6 +76,20 @@ struct UsageOptions: CommanderParsable {
     var augmentDebug: Bool = false
 }
 
+struct DiagnoseOptions: CommanderParsable {
+    @Flag(names: [.short("v"), .long("verbose")], help: "Enable verbose logging")
+    var verbose: Bool = false
+
+    @Option(name: .long("provider"), help: "Provider to diagnose: minimax (default: minimax)")
+    var provider: String = "minimax"
+
+    @Flag(name: .long("redact"), help: "Redact sensitive fields in output (always on)")
+    var redact: Bool = false
+
+    @Option(name: .long("format"), help: "Output format: text | json (default: json)")
+    var format: OutputFormat?
+}
+
 enum ProviderSelection: ExpressibleFromArgument {
     case single(UsageProvider)
     case both

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxDiagnosticReport.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxDiagnosticReport.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+public struct MiniMaxDiagnosticReport: Codable {
+    public let schemaVersion: String
+    public let generatedAt: Date
+    public let provider: String
+    public let liveFetch: String
+    public let authSourcesPresent: AuthSourcesPresent
+    public let endpointsAttempted: [String]
+    public let responseShape: [String: String]?
+    public let suspectedPlanFields: [String]
+    public let suspectedDateFields: [String]
+    public let suspectedSubscriptionFields: [String]
+    public let redaction: RedactionSummary
+
+    public struct AuthSourcesPresent: Codable, Sendable {
+        public let apiTokenEnv: Bool
+        public let codingPlanTokenEnv: Bool
+        public let cookieHeaderEnv: Bool
+
+        public init(apiTokenEnv: Bool, codingPlanTokenEnv: Bool, cookieHeaderEnv: Bool) {
+            self.apiTokenEnv = apiTokenEnv
+            self.codingPlanTokenEnv = codingPlanTokenEnv
+            self.cookieHeaderEnv = cookieHeaderEnv
+        }
+    }
+
+    public struct RedactionSummary: Codable, Sendable {
+        public let cookies: String
+        public let tokens: String
+        public let ids: String
+        public let emails: String
+
+        public init(cookies: String = "removed", tokens: String = "removed", ids: String = "redacted", emails: String = "redacted") {
+            self.cookies = cookies
+            self.tokens = tokens
+            self.ids = ids
+            self.emails = emails
+        }
+    }
+
+    public init(
+        schemaVersion: String = "1.0",
+        generatedAt: Date = Date(),
+        provider: String = "minimax",
+        liveFetch: String = "notPerformed",
+        authSourcesPresent: AuthSourcesPresent,
+        endpointsAttempted: [String],
+        responseShape: [String: String]? = nil,
+        suspectedPlanFields: [String],
+        suspectedDateFields: [String],
+        suspectedSubscriptionFields: [String] = [],
+        redaction: RedactionSummary = RedactionSummary())
+    {
+        self.schemaVersion = schemaVersion
+        self.generatedAt = generatedAt
+        self.provider = provider
+        self.liveFetch = liveFetch
+        self.authSourcesPresent = authSourcesPresent
+        self.endpointsAttempted = endpointsAttempted
+        self.responseShape = responseShape
+        self.suspectedPlanFields = suspectedPlanFields
+        self.suspectedDateFields = suspectedDateFields
+        self.suspectedSubscriptionFields = suspectedSubscriptionFields
+        self.redaction = redaction
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        try container.encode(formatter.string(from: generatedAt), forKey: .generatedAt)
+        try container.encode(provider, forKey: .provider)
+        try container.encode(liveFetch, forKey: .liveFetch)
+        try container.encode(authSourcesPresent, forKey: .authSourcesPresent)
+        try container.encode(endpointsAttempted, forKey: .endpointsAttempted)
+        if let shape = responseShape {
+            try container.encode(shape, forKey: .responseShape)
+        } else {
+            try container.encodeNil(forKey: .responseShape)
+        }
+        try container.encode(suspectedPlanFields, forKey: .suspectedPlanFields)
+        try container.encode(suspectedDateFields, forKey: .suspectedDateFields)
+        try container.encode(suspectedSubscriptionFields, forKey: .suspectedSubscriptionFields)
+        try container.encode(redaction, forKey: .redaction)
+    }
+}
+
+extension MiniMaxDiagnosticReport {
+    public static func detectAuthSources(from environment: [String: String]) -> AuthSourcesPresent {
+        AuthSourcesPresent(
+            apiTokenEnv: Self.envKeyPresent("MINIMAX_API_KEY", in: environment),
+            codingPlanTokenEnv: Self.envKeyPresent("MINIMAX_CODING_API_KEY", in: environment),
+            cookieHeaderEnv: Self.envKeyPresent("MINIMAX_COOKIE", in: environment))
+    }
+
+    private static func envKeyPresent(_ key: String, in environment: [String: String]) -> Bool {
+        guard let value = environment[key] else { return false }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && trimmed != "\"\""
+    }
+}
+
+extension MiniMaxDiagnosticReport {
+    public static var suspectedFields: (plan: [String], date: [String], subscription: [String]) {
+        (plan: ["planName", "availablePrompts", "currentPrompts", "remainingPrompts", "windowMinutes", "usedPercent"],
+         date: ["resetsAt", "updatedAt"],
+         subscription: [] as [String])
+    }
+
+    public static var safeEndpoints: [String] {
+        ["minimax.api", "minimax.web"]
+    }
+}

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxDiagnosticReport.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxDiagnosticReport.swift
@@ -31,7 +31,12 @@ public struct MiniMaxDiagnosticReport: Codable {
         public let ids: String
         public let emails: String
 
-        public init(cookies: String = "removed", tokens: String = "removed", ids: String = "redacted", emails: String = "redacted") {
+        public init(
+            cookies: String = "removed",
+            tokens: String = "removed",
+            ids: String = "redacted",
+            emails: String = "redacted")
+        {
             self.cookies = cookies
             self.tokens = tokens
             self.ids = ids
@@ -67,32 +72,32 @@ public struct MiniMaxDiagnosticReport: Codable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encode(self.schemaVersion, forKey: .schemaVersion)
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        try container.encode(formatter.string(from: generatedAt), forKey: .generatedAt)
-        try container.encode(provider, forKey: .provider)
-        try container.encode(liveFetch, forKey: .liveFetch)
-        try container.encode(authSourcesPresent, forKey: .authSourcesPresent)
-        try container.encode(endpointsAttempted, forKey: .endpointsAttempted)
+        try container.encode(formatter.string(from: self.generatedAt), forKey: .generatedAt)
+        try container.encode(self.provider, forKey: .provider)
+        try container.encode(self.liveFetch, forKey: .liveFetch)
+        try container.encode(self.authSourcesPresent, forKey: .authSourcesPresent)
+        try container.encode(self.endpointsAttempted, forKey: .endpointsAttempted)
         if let shape = responseShape {
             try container.encode(shape, forKey: .responseShape)
         } else {
             try container.encodeNil(forKey: .responseShape)
         }
-        try container.encode(suspectedPlanFields, forKey: .suspectedPlanFields)
-        try container.encode(suspectedDateFields, forKey: .suspectedDateFields)
-        try container.encode(suspectedSubscriptionFields, forKey: .suspectedSubscriptionFields)
-        try container.encode(redaction, forKey: .redaction)
+        try container.encode(self.suspectedPlanFields, forKey: .suspectedPlanFields)
+        try container.encode(self.suspectedDateFields, forKey: .suspectedDateFields)
+        try container.encode(self.suspectedSubscriptionFields, forKey: .suspectedSubscriptionFields)
+        try container.encode(self.redaction, forKey: .redaction)
     }
 }
 
 extension MiniMaxDiagnosticReport {
     public static func detectAuthSources(from environment: [String: String]) -> AuthSourcesPresent {
         AuthSourcesPresent(
-            apiTokenEnv: Self.envKeyPresent("MINIMAX_API_KEY", in: environment),
-            codingPlanTokenEnv: Self.envKeyPresent("MINIMAX_CODING_API_KEY", in: environment),
-            cookieHeaderEnv: Self.envKeyPresent("MINIMAX_COOKIE", in: environment))
+            apiTokenEnv: self.envKeyPresent("MINIMAX_API_KEY", in: environment),
+            codingPlanTokenEnv: self.envKeyPresent("MINIMAX_CODING_API_KEY", in: environment),
+            cookieHeaderEnv: self.envKeyPresent("MINIMAX_COOKIE", in: environment))
     }
 
     private static func envKeyPresent(_ key: String, in environment: [String: String]) -> Bool {
@@ -104,9 +109,17 @@ extension MiniMaxDiagnosticReport {
 
 extension MiniMaxDiagnosticReport {
     public static var suspectedFields: (plan: [String], date: [String], subscription: [String]) {
-        (plan: ["planName", "availablePrompts", "currentPrompts", "remainingPrompts", "windowMinutes", "usedPercent"],
-         date: ["resetsAt", "updatedAt"],
-         subscription: [] as [String])
+        (
+            plan: [
+                "planName",
+                "availablePrompts",
+                "currentPrompts",
+                "remainingPrompts",
+                "windowMinutes",
+                "usedPercent",
+            ],
+            date: ["resetsAt", "updatedAt"],
+            subscription: [] as [String])
     }
 
     public static var safeEndpoints: [String] {

--- a/Tests/CodexBarTests/MiniMaxDiagnosticReportTests.swift
+++ b/Tests/CodexBarTests/MiniMaxDiagnosticReportTests.swift
@@ -1,0 +1,216 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct MiniMaxDiagnosticReportTests {
+    @Test
+    func `report has correct structure`() {
+        let authSources = MiniMaxDiagnosticReport.AuthSourcesPresent(
+            apiTokenEnv: true,
+            codingPlanTokenEnv: false,
+            cookieHeaderEnv: true)
+
+        let report = MiniMaxDiagnosticReport(
+            authSourcesPresent: authSources,
+            endpointsAttempted: ["minimax.api", "minimax.web"],
+            suspectedPlanFields: ["planName", "availablePrompts"],
+            suspectedDateFields: ["resetsAt"],
+            suspectedSubscriptionFields: [])
+
+        #expect(report.provider == "minimax")
+        #expect(report.schemaVersion == "1.0")
+        #expect(report.liveFetch == "notPerformed")
+        #expect(report.authSourcesPresent.apiTokenEnv == true)
+        #expect(report.authSourcesPresent.codingPlanTokenEnv == false)
+        #expect(report.authSourcesPresent.cookieHeaderEnv == true)
+        #expect(report.endpointsAttempted.count == 2)
+        #expect(report.suspectedPlanFields.contains("planName"))
+        #expect(report.suspectedDateFields.contains("resetsAt"))
+        #expect(report.suspectedSubscriptionFields.isEmpty)
+    }
+
+    @Test
+    func `redaction summary has correct values`() {
+        let redaction = MiniMaxDiagnosticReport.RedactionSummary()
+
+        #expect(redaction.cookies == "removed")
+        #expect(redaction.tokens == "removed")
+        #expect(redaction.ids == "redacted")
+        #expect(redaction.emails == "redacted")
+    }
+
+    @Test
+    func `report serializes to JSON`() {
+        let authSources = MiniMaxDiagnosticReport.AuthSourcesPresent(
+            apiTokenEnv: false,
+            codingPlanTokenEnv: false,
+            cookieHeaderEnv: false)
+
+        let report = MiniMaxDiagnosticReport(
+            authSourcesPresent: authSources,
+            endpointsAttempted: ["minimax.api"],
+            suspectedPlanFields: ["planName"],
+            suspectedDateFields: ["resetsAt", "updatedAt"],
+            suspectedSubscriptionFields: [])
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try? encoder.encode(report)
+        #expect(data != nil)
+
+        let json = data.flatMap { String(data: $0, encoding: .utf8) }
+        #expect(json != nil)
+        #expect(json?.contains("\"provider\"") ?? false)
+        #expect(json?.contains("\"schemaVersion\"") ?? false)
+        #expect(json?.contains("\"liveFetch\"") ?? false)
+        #expect(json?.contains("\"authSourcesPresent\"") ?? false)
+        #expect(json?.contains("\"endpointsAttempted\"") ?? false)
+        #expect(json?.contains("\"suspectedPlanFields\"") ?? false)
+        #expect(json?.contains("\"redaction\"") ?? false)
+        #expect(json?.contains("\"minimax\"") ?? false)
+    }
+
+    @Test
+    func `no live fetch means response shape is explicit null`() {
+        let authSources = MiniMaxDiagnosticReport.AuthSourcesPresent(
+            apiTokenEnv: false,
+            codingPlanTokenEnv: false,
+            cookieHeaderEnv: false)
+
+        let report = MiniMaxDiagnosticReport(
+            authSourcesPresent: authSources,
+            endpointsAttempted: ["minimax.api"],
+            responseShape: nil,
+            suspectedPlanFields: ["planName"],
+            suspectedDateFields: ["resetsAt"],
+            suspectedSubscriptionFields: [])
+
+        #expect(report.responseShape == nil)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try? encoder.encode(report)
+        let json = data.flatMap { String(data: $0, encoding: .utf8) }
+
+        #expect(json != nil)
+        #expect(json?.contains("\"responseShape\"") ?? false)
+        #expect(json?.contains("null") ?? false)
+        #expect(report.suspectedSubscriptionFields.isEmpty)
+    }
+
+    @Test
+    func `generatedAt serializes as ISO8601 string`() {
+        let authSources = MiniMaxDiagnosticReport.AuthSourcesPresent(
+            apiTokenEnv: false,
+            codingPlanTokenEnv: false,
+            cookieHeaderEnv: false)
+
+        let fixedDate = Date(timeIntervalSince1970: 1700000000)
+        let report = MiniMaxDiagnosticReport(
+            generatedAt: fixedDate,
+            authSourcesPresent: authSources,
+            endpointsAttempted: ["minimax.api"],
+            suspectedPlanFields: [],
+            suspectedDateFields: [],
+            suspectedSubscriptionFields: [])
+
+        let encoder = JSONEncoder()
+        let data = try? encoder.encode(report)
+        let json = data.flatMap { String(data: $0, encoding: .utf8) }
+
+        #expect(json != nil)
+        #expect(json?.contains("2023-11-14") ?? false)
+        #expect(json?.contains("T") ?? false)
+        #expect(json?.contains(":") ?? false)
+    }
+
+    @Test
+    func `auth sources detection is boolean only`() {
+        let withValues = MiniMaxDiagnosticReport.detectAuthSources(from: [
+            "MINIMAX_API_KEY": "sk-test",
+            "MINIMAX_CODING_API_KEY": "",
+            "MINIMAX_COOKIE": "   "
+        ])
+
+        #expect(withValues.apiTokenEnv == true)
+        #expect(withValues.codingPlanTokenEnv == false)
+        #expect(withValues.cookieHeaderEnv == false)
+    }
+
+    @Test
+    func `auth sources detection returns false for empty or quoted-empty values`() {
+        let withEmpty = MiniMaxDiagnosticReport.detectAuthSources(from: [
+            "MINIMAX_API_KEY": "",
+            "MINIMAX_CODING_API_KEY": "\"\""
+        ])
+
+        #expect(withEmpty.apiTokenEnv == false)
+        #expect(withEmpty.codingPlanTokenEnv == false)
+    }
+
+    @Test
+    func `safe endpoints returns expected labels`() {
+        let endpoints = MiniMaxDiagnosticReport.safeEndpoints
+        #expect(endpoints == ["minimax.api", "minimax.web"])
+    }
+
+    @Test
+    func `suspected fields returns correct field names`() {
+        let fields = MiniMaxDiagnosticReport.suspectedFields
+        #expect(fields.plan == ["planName", "availablePrompts", "currentPrompts", "remainingPrompts", "windowMinutes", "usedPercent"])
+        #expect(fields.date == ["resetsAt", "updatedAt"])
+        #expect(fields.subscription.isEmpty)
+    }
+
+    @Test
+    func `no sensitive values leak into JSON output`() {
+        let authSources = MiniMaxDiagnosticReport.AuthSourcesPresent(
+            apiTokenEnv: true,
+            codingPlanTokenEnv: true,
+            cookieHeaderEnv: true)
+
+        let report = MiniMaxDiagnosticReport(
+            authSourcesPresent: authSources,
+            endpointsAttempted: ["minimax.api", "minimax.web"],
+            suspectedPlanFields: ["planName"],
+            suspectedDateFields: ["resetsAt"],
+            suspectedSubscriptionFields: [])
+
+        let encoder = JSONEncoder()
+        let data = try? encoder.encode(report)
+        let json = data.flatMap { String(data: $0, encoding: .utf8) }
+
+        #expect(!(json?.contains("sk-test-secret") ?? false))
+        #expect(!(json?.contains("Bearer") ?? false))
+        #expect(!(json?.contains("user@example.com") ?? false))
+        #expect(!(json?.contains("12345678") ?? false))
+        #expect(!(json?.contains("MINIMAX_API_KEY") ?? false))
+        #expect(!(json?.contains("sk-") ?? false))
+    }
+
+    @Test
+    func `safe secrets do not appear in JSON even when auth sources are true`() {
+        let authSources = MiniMaxDiagnosticReport.AuthSourcesPresent(
+            apiTokenEnv: true,
+            codingPlanTokenEnv: true,
+            cookieHeaderEnv: true)
+
+        let report = MiniMaxDiagnosticReport(
+            authSourcesPresent: authSources,
+            endpointsAttempted: ["minimax.api", "minimax.web"],
+            suspectedPlanFields: ["planName"],
+            suspectedDateFields: ["resetsAt"],
+            suspectedSubscriptionFields: [])
+
+        let encoder = JSONEncoder()
+        let data = try? encoder.encode(report)
+        let json = data.flatMap { String(data: $0, encoding: .utf8) }
+
+        #expect(!(json?.contains("sk-") ?? false))
+        #expect(!(json?.contains("Bearer") ?? false))
+        #expect(!(json?.contains("@") ?? false))
+        #expect(!(json?.contains("12345678") ?? false))
+        #expect(!(json?.contains("MINIMAX_") ?? false))
+        #expect(!(json?.contains("secret") ?? false))
+    }
+}

--- a/Tests/CodexBarTests/MiniMaxDiagnosticReportTests.swift
+++ b/Tests/CodexBarTests/MiniMaxDiagnosticReportTests.swift
@@ -105,7 +105,7 @@ struct MiniMaxDiagnosticReportTests {
             codingPlanTokenEnv: false,
             cookieHeaderEnv: false)
 
-        let fixedDate = Date(timeIntervalSince1970: 1700000000)
+        let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)
         let report = MiniMaxDiagnosticReport(
             generatedAt: fixedDate,
             authSourcesPresent: authSources,
@@ -129,7 +129,7 @@ struct MiniMaxDiagnosticReportTests {
         let withValues = MiniMaxDiagnosticReport.detectAuthSources(from: [
             "MINIMAX_API_KEY": "sk-test",
             "MINIMAX_CODING_API_KEY": "",
-            "MINIMAX_COOKIE": "   "
+            "MINIMAX_COOKIE": "   ",
         ])
 
         #expect(withValues.apiTokenEnv == true)
@@ -141,7 +141,7 @@ struct MiniMaxDiagnosticReportTests {
     func `auth sources detection returns false for empty or quoted-empty values`() {
         let withEmpty = MiniMaxDiagnosticReport.detectAuthSources(from: [
             "MINIMAX_API_KEY": "",
-            "MINIMAX_CODING_API_KEY": "\"\""
+            "MINIMAX_CODING_API_KEY": "\"\"",
         ])
 
         #expect(withEmpty.apiTokenEnv == false)
@@ -157,7 +157,14 @@ struct MiniMaxDiagnosticReportTests {
     @Test
     func `suspected fields returns correct field names`() {
         let fields = MiniMaxDiagnosticReport.suspectedFields
-        #expect(fields.plan == ["planName", "availablePrompts", "currentPrompts", "remainingPrompts", "windowMinutes", "usedPercent"])
+        #expect(fields.plan == [
+            "planName",
+            "availablePrompts",
+            "currentPrompts",
+            "remainingPrompts",
+            "windowMinutes",
+            "usedPercent",
+        ])
         #expect(fields.date == ["resetsAt", "updatedAt"])
         #expect(fields.subscription.isEmpty)
     }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -85,6 +85,13 @@ See `docs/configuration.md` for the schema.
   - `--format text|json`, `--pretty`, and `--json-only` are supported.
   - Warnings keep exit code 0; errors exit non-zero.
 - `codexbar config dump` prints the normalized config JSON.
+- `codexbar diagnose` collects a diagnostic report for MiniMax provider issues.
+  - `--provider minimax` (only minimax is supported).
+  - `--redact` flag (always on; included for symmetry with other commands).
+  - `--format json|text` (default: json).
+  - Output includes: schemaVersion, generatedAt, provider, liveFetch, authSourcesPresent, endpointsAttempted, responseShape, suspectedPlanFields, suspectedDateFields, suspectedSubscriptionFields, redaction summary.
+  - Sensitive values (tokens, cookies, emails, IDs) are never included.
+  - Useful for GitHub issue proof collection without exposing private data.
 
 ### Token accounts
 The CLI reads multi-account tokens from `~/.codexbar/config.json` (same file as the app).


### PR DESCRIPTION
This adds a small, MiniMax-only diagnostic report command for safe issue proof collection.

Scope:

* Adds `codexbar diagnose --provider minimax --format json`
* Output is always redacted and contains boolean auth-source presence only
* Does not perform a live fetch yet
* Emits `responseShape: null` when no live/fixture payload shape is available
* Leaves `suspectedSubscriptionFields` empty because no real subscription/renewal/valid-until payload field has been observed yet
* Does not implement paid-plan expiration parsing for #1119
* Does not change menu bar UI or normal usage output

Example output includes:

* `schemaVersion`
* `generatedAt` as ISO8601
* `provider`
* `liveFetch`
* `authSourcesPresent`
* `endpointsAttempted`
* `responseShape`
* `suspectedPlanFields`
* `suspectedDateFields`
* `suspectedSubscriptionFields`
* `redaction`

Validation:

* `swift build --target CodexBarCLI`
* `swift test --filter MiniMaxDiagnostic`
* `swift test --filter CLI`

Related issue:

* #1119