### PR TITLE
Fix CommandCode subscription fallback

### DIFF
--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
@@ -8,6 +8,7 @@ import FoundationNetworking
 public enum CommandCodeUsageFetcher {
     private static let log = CodexBarLog.logger(LogCategories.commandcodeUsage)
     private static let requestTimeoutSeconds: TimeInterval = 15
+    private static let subscriptionGraceSeconds: TimeInterval = 2
     private static let apiBase = URL(string: "https://api.commandcode.ai")!
     private static let creditsPath = "/internal/billing/credits"
     private static let subscriptionsPath = "/internal/billing/subscriptions"
@@ -21,11 +22,36 @@ public enum CommandCodeUsageFetcher {
         session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         now: Date = Date()) async throws -> CommandCodeUsageSnapshot
     {
-        async let creditsResult = self.fetchCredits(cookieHeader: cookieHeader, transport: transport)
-        async let subscriptionResult = self.fetchSubscription(cookieHeader: cookieHeader, transport: transport)
+        try await self.fetchUsage(
+            cookieHeader: cookieHeader,
+            transport: transport,
+            now: now,
+            subscriptionGraceSeconds: self.subscriptionGraceSeconds)
+    }
 
-        let credits = try await creditsResult
-        let subscription = try await subscriptionResult
+    static func fetchUsageForTesting(
+        cookieHeader: String,
+        session transport: any ProviderHTTPTransport,
+        now: Date,
+        subscriptionGraceSeconds: TimeInterval) async throws -> CommandCodeUsageSnapshot
+    {
+        try await self.fetchUsage(
+            cookieHeader: cookieHeader,
+            transport: transport,
+            now: now,
+            subscriptionGraceSeconds: subscriptionGraceSeconds)
+    }
+
+    private static func fetchUsage(
+        cookieHeader: String,
+        transport: any ProviderHTTPTransport,
+        now: Date,
+        subscriptionGraceSeconds: TimeInterval) async throws -> CommandCodeUsageSnapshot
+    {
+        let (credits, subscription) = try await self.fetchPayloads(
+            cookieHeader: cookieHeader,
+            transport: transport,
+            subscriptionGraceSeconds: subscriptionGraceSeconds)
 
         let plan: CommandCodePlanCatalog.Plan? = subscription.flatMap { sub in
             CommandCodePlanCatalog.plan(forID: sub.planID)
@@ -64,6 +90,76 @@ public enum CommandCodeUsageFetcher {
         let currentPeriodEnd: Date?
     }
 
+    private enum FetchResult {
+        case credits(CreditsPayload)
+        case subscription(SubscriptionPayload?)
+        case subscriptionTimeout
+    }
+
+    private static func fetchPayloads(
+        cookieHeader: String,
+        transport: any ProviderHTTPTransport,
+        subscriptionGraceSeconds: TimeInterval) async throws -> (CreditsPayload, SubscriptionPayload?)
+    {
+        try await withThrowingTaskGroup(of: FetchResult.self) { group in
+            group.addTask {
+                try await .credits(self.fetchCredits(cookieHeader: cookieHeader, transport: transport))
+            }
+            group.addTask {
+                do {
+                    let payload = try await self.fetchSubscription(cookieHeader: cookieHeader, transport: transport)
+                    return .subscription(payload)
+                } catch {
+                    self.log.debug("CommandCode subscription enrichment skipped: \(error.localizedDescription)")
+                    return .subscription(nil)
+                }
+            }
+
+            var credits: CreditsPayload?
+            var subscription: SubscriptionPayload?
+            var subscriptionFinished = false
+            var timeoutStarted = false
+
+            while let result = try await group.next() {
+                switch result {
+                case let .credits(payload):
+                    credits = payload
+                    if subscriptionFinished {
+                        group.cancelAll()
+                        return (payload, subscription)
+                    }
+                    if !timeoutStarted {
+                        timeoutStarted = true
+                        group.addTask {
+                            let requestedGrace = subscriptionGraceSeconds.isFinite ? subscriptionGraceSeconds : 0
+                            let maxGrace = TimeInterval((UInt64.max / 1_000_000_000) - 1)
+                            let grace = min(max(0, requestedGrace), maxGrace)
+                            let nanos = UInt64(grace * 1_000_000_000)
+                            try? await Task.sleep(nanoseconds: nanos)
+                            return .subscriptionTimeout
+                        }
+                    }
+
+                case let .subscription(payload):
+                    subscription = payload
+                    subscriptionFinished = true
+                    if let credits {
+                        group.cancelAll()
+                        return (credits, payload)
+                    }
+
+                case .subscriptionTimeout:
+                    if let credits {
+                        group.cancelAll()
+                        return (credits, subscription)
+                    }
+                }
+            }
+
+            throw CommandCodeUsageError.networkError("Credits request did not complete")
+        }
+    }
+
     private static func fetchCredits(
         cookieHeader: String,
         transport: any ProviderHTTPTransport) async throws -> CreditsPayload
@@ -78,14 +174,19 @@ public enum CommandCodeUsageFetcher {
         transport: any ProviderHTTPTransport) async throws -> SubscriptionPayload?
     {
         let url = self.apiBase.appendingPathComponent(self.subscriptionsPath)
-        let data = try await self.send(url: url, cookieHeader: cookieHeader, transport: transport)
+        let data = try await self.send(
+            url: url,
+            cookieHeader: cookieHeader,
+            transport: transport,
+            logFailures: false)
         return try self.parseSubscription(data: data)
     }
 
     private static func send(
         url: URL,
         cookieHeader: String,
-        transport: any ProviderHTTPTransport) async throws -> Data
+        transport: any ProviderHTTPTransport,
+        logFailures: Bool = true) async throws -> Data
     {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
@@ -108,7 +209,9 @@ public enum CommandCodeUsageFetcher {
         }
         guard (200..<300).contains(response.statusCode) else {
             let body = String(data: response.data, encoding: .utf8) ?? ""
-            Self.log.error("CommandCode \(url.path) → \(response.statusCode): \(body)")
+            if logFailures {
+                Self.log.error("CommandCode \(url.path) → \(response.statusCode): \(body)")
+            }
             throw CommandCodeUsageError.apiError(response.statusCode)
         }
         return response.data

--- a/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
@@ -50,6 +50,158 @@ struct CommandCodeUsageFetcherTests {
     }
 
     @Test
+    func `fetch usage keeps credits when subscription endpoint fails`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            switch request.url?.path {
+            case "/internal/billing/credits":
+                Self.httpResponse(status: 200, body: Self.creditsJSON)
+            case "/internal/billing/subscriptions":
+                Self.httpResponse(status: 503, body: #"{"error":"temporarily unavailable"}"#)
+            default:
+                Self.httpResponse(status: 404, body: "{}")
+            }
+        }
+
+        let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
+            cookieHeader: "__Secure-better-auth.session_token=test",
+            session: transport,
+            now: Date(timeIntervalSince1970: 0))
+
+        #expect(snapshot.monthlyCreditsRemaining == 8.7784)
+        #expect(snapshot.plan == nil)
+        #expect(snapshot.billingPeriodEnd == nil)
+        #expect(snapshot.subscriptionStatus == nil)
+    }
+
+    @Test
+    func `fetch usage does not wait for slow subscription endpoint`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            let response: (Data, URLResponse)
+            switch request.url?.path {
+            case "/internal/billing/credits":
+                response = Self.httpResponse(status: 200, body: Self.creditsJSON)
+            case "/internal/billing/subscriptions":
+                try await Task.sleep(nanoseconds: 500_000_000)
+                response = Self.httpResponse(status: 200, body: Self.subscriptionJSON)
+            default:
+                response = Self.httpResponse(status: 404, body: "{}")
+            }
+            return response
+        }
+        let start = Date()
+
+        let snapshot = try await CommandCodeUsageFetcher.fetchUsageForTesting(
+            cookieHeader: "__Secure-better-auth.session_token=test",
+            session: transport,
+            now: Date(timeIntervalSince1970: 0),
+            subscriptionGraceSeconds: 0.05)
+
+        #expect(Date().timeIntervalSince(start) < 0.4)
+        #expect(snapshot.monthlyCreditsRemaining == 8.7784)
+        #expect(snapshot.plan == nil)
+        #expect(snapshot.billingPeriodEnd == nil)
+    }
+
+    @Test
+    func `fetch usage treats nonfinite subscription grace as zero`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            switch request.url?.path {
+            case "/internal/billing/credits":
+                return Self.httpResponse(status: 200, body: Self.creditsJSON)
+            case "/internal/billing/subscriptions":
+                try await Task.sleep(nanoseconds: 500_000_000)
+                return Self.httpResponse(status: 200, body: Self.subscriptionJSON)
+            default:
+                return Self.httpResponse(status: 404, body: "{}")
+            }
+        }
+        let start = Date()
+
+        let snapshot = try await CommandCodeUsageFetcher.fetchUsageForTesting(
+            cookieHeader: "__Secure-better-auth.session_token=test",
+            session: transport,
+            now: Date(timeIntervalSince1970: 0),
+            subscriptionGraceSeconds: .infinity)
+
+        #expect(Date().timeIntervalSince(start) < 0.4)
+        #expect(snapshot.monthlyCreditsRemaining == 8.7784)
+        #expect(snapshot.plan == nil)
+    }
+
+    @Test
+    func `fetch usage includes subscription when it finishes before credits`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            switch request.url?.path {
+            case "/internal/billing/credits":
+                try await Task.sleep(nanoseconds: 50_000_000)
+                return Self.httpResponse(status: 200, body: Self.creditsJSON)
+            case "/internal/billing/subscriptions":
+                return Self.httpResponse(status: 200, body: Self.subscriptionJSON)
+            default:
+                return Self.httpResponse(status: 404, body: "{}")
+            }
+        }
+
+        let snapshot = try await CommandCodeUsageFetcher.fetchUsageForTesting(
+            cookieHeader: "__Secure-better-auth.session_token=test",
+            session: transport,
+            now: Date(timeIntervalSince1970: 0),
+            subscriptionGraceSeconds: 0.05)
+
+        #expect(snapshot.monthlyCreditsRemaining == 8.7784)
+        #expect(snapshot.plan?.displayName == "Go")
+        #expect(snapshot.subscriptionStatus == "active")
+        let isoFormatter = ISO8601DateFormatter()
+        isoFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        #expect(snapshot.billingPeriodEnd == isoFormatter.date(from: "2026-06-06T07:28:50.000Z"))
+    }
+
+    @Test
+    func `fetch usage still fails when credits endpoint fails`() async {
+        let transport = ProviderHTTPTransportStub { request in
+            switch request.url?.path {
+            case "/internal/billing/credits":
+                Self.httpResponse(status: 503, body: #"{"error":"temporarily unavailable"}"#)
+            case "/internal/billing/subscriptions":
+                Self.httpResponse(status: 200, body: Self.subscriptionJSON)
+            default:
+                Self.httpResponse(status: 404, body: "{}")
+            }
+        }
+
+        await #expect(throws: CommandCodeUsageError.apiError(503)) {
+            try await CommandCodeUsageFetcher.fetchUsage(
+                cookieHeader: "__Secure-better-auth.session_token=test",
+                session: transport,
+                now: Date(timeIntervalSince1970: 0))
+        }
+    }
+
+    @Test
+    func `fetch usage still fails for unknown active subscription plan`() async throws {
+        let unknownSubscription = """
+        {"success":true,"data":{"status":"active","planId":"individual-mystery"}}
+        """
+        let transport = ProviderHTTPTransportStub { request in
+            switch request.url?.path {
+            case "/internal/billing/credits":
+                Self.httpResponse(status: 200, body: Self.creditsJSON)
+            case "/internal/billing/subscriptions":
+                Self.httpResponse(status: 200, body: unknownSubscription)
+            default:
+                Self.httpResponse(status: 404, body: "{}")
+            }
+        }
+
+        await #expect(throws: CommandCodeUsageError.unknownPlan("individual-mystery")) {
+            try await CommandCodeUsageFetcher.fetchUsage(
+                cookieHeader: "__Secure-better-auth.session_token=test",
+                session: transport,
+                now: Date(timeIntervalSince1970: 0))
+        }
+    }
+
+    @Test
     func `snapshot derives used and total from plan catalog`() throws {
         let plan = try #require(CommandCodePlanCatalog.plan(forID: "individual-go"))
         let snapshot = CommandCodeUsageSnapshot(
@@ -109,5 +261,15 @@ struct CommandCodeUsageFetcherTests {
         #expect(CommandCodeCookieHeader.override(from: nil) == nil)
         #expect(CommandCodeCookieHeader.override(from: "") == nil)
         #expect(CommandCodeCookieHeader.override(from: "   ") == nil)
+    }
+
+    private static func httpResponse(status: Int, body: String) -> (Data, URLResponse) {
+        let url = URL(string: "https://api.commandcode.ai/test")!
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: status,
+            httpVersion: nil,
+            headerFields: nil)!
+        return (Data(body.utf8), response)
     }
 }


### PR DESCRIPTION
Fixes #1131

## Summary
- keep `/internal/billing/credits` as the required CommandCode usage payload
- treat `/internal/billing/subscriptions` as best-effort enrichment with a short grace window after credits returns
- keep active unknown subscription plans as hard failures so the plan catalog does not silently drift

## Proof
Before the fix, `swift test --filter CommandCodeUsageFetcherTests` failed when credits returned 200 but subscriptions returned 503 because the subscription error bubbled as `apiError(503)`.

The new coverage proves:
- credits 200 + subscriptions 503 still returns a credits-only snapshot
- slow subscriptions do not block the required credits snapshot past the grace window
- subscriptions that finish first are still included
- credits failures still fail closed
- active unknown plans still throw
- non-finite test grace values cannot trap the timer conversion

## Checks
- `swift test --filter CommandCodeUsageFetcherTests`
- `swift test --filter CommandCode`
- focused web-refresh regression test
- `swift build`
- `make check`
- `git diff --check`

Full `swift test` was attempted twice but did not complete because `swiftpm-testing-helper` stopped producing output. The affected provider tests, build, and lint checks above passed.
