### PR TITLE
Fix Codex CLI Gatekeeper assessment

### DIFF
--- a/Sources/CodexBarCore/PathEnvironment.swift
+++ b/Sources/CodexBarCore/PathEnvironment.swift
@@ -324,7 +324,7 @@ public enum CodexLaunchPreflight {
             return !hasQuarantine
         }
 
-        return !self.isExplicitlyBlockedAssessment(assessment)
+        return !self.isExplicitlyBlockedAssessment(assessment, path: native)
     }
 
     private static func nativeCodexExecutableCandidates(for path: String, fileManager: FileManager) -> [String] {
@@ -417,14 +417,39 @@ public enum CodexLaunchPreflight {
         return String(data: data, encoding: .utf8)
     }
 
-    private static func isExplicitlyBlockedAssessment(_ assessment: String) -> Bool {
-        let lower = assessment.lowercased()
-        return lower.contains("rejected") ||
-            lower.contains("denied") ||
+    private static func isExplicitlyBlockedAssessment(_ assessment: String, path: String) -> Bool {
+        let lower = self.assessmentDiagnosticText(assessment, path: path).lowercased()
+        if lower.contains("denied") ||
             lower.contains("cssmerr_tp_cert_revoked") ||
             lower.contains("revoked") ||
             lower.contains("malware") ||
             lower.contains("quarantine")
+        {
+            return true
+        }
+        if lower.contains("rejected") {
+            return !lower.contains("code is valid but does not seem to be an app")
+        }
+        return false
+    }
+
+    private static func assessmentDiagnosticText(_ assessment: String, path: String) -> String {
+        assessment
+            .split(whereSeparator: \.isNewline)
+            .enumerated()
+            .compactMap { offset, line -> String? in
+                var text = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                if offset == 0, text.hasPrefix("\(path):") {
+                    text = String(text.dropFirst(path.count + 1))
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+                let lower = text.lowercased()
+                guard !lower.hasPrefix("source="), !lower.hasPrefix("origin=") else {
+                    return nil
+                }
+                return text
+            }
+            .joined(separator: "\n")
     }
     #endif
 }

--- a/Tests/CodexBarTests/PathBuilderTests.swift
+++ b/Tests/CodexBarTests/PathBuilderTests.swift
@@ -267,6 +267,77 @@ struct PathBuilderTests {
 
         #expect(!allowed)
     }
+
+    @Test
+    func `Codex launch preflight allows valid signed command line binary assessment`() {
+        let allowed = CodexLaunchPreflight.isLaunchCandidateAllowed(
+            path: "/opt/homebrew/bin/codex",
+            fileManager: MockFileManager(executables: []),
+            hasExtendedAttribute: { _, name in name == "com.apple.quarantine" },
+            spctlAssessment: { path in "\(path): rejected (the code is valid but does not seem to be an app)" },
+            isMachOExecutable: { _ in true })
+
+        #expect(allowed)
+    }
+
+    @Test
+    func `Codex launch preflight blocks revoked assessment even with non app rejection text`() {
+        let allowed = CodexLaunchPreflight.isLaunchCandidateAllowed(
+            path: "/opt/homebrew/bin/codex",
+            fileManager: MockFileManager(executables: []),
+            hasExtendedAttribute: { _, name in name == "com.apple.quarantine" },
+            spctlAssessment: { _ in
+                """
+                rejected (the code is valid but does not seem to be an app)
+                CSSMERR_TP_CERT_REVOKED
+                """
+            },
+            isMachOExecutable: { _ in true })
+
+        #expect(!allowed)
+    }
+
+    @Test
+    func `Codex launch preflight ignores benign text in path when verdict is generic rejection`() {
+        let allowed = CodexLaunchPreflight.isLaunchCandidateAllowed(
+            path: "/tmp/code is valid but does not seem to be an app/codex",
+            fileManager: MockFileManager(executables: []),
+            hasExtendedAttribute: { _, name in name == "com.apple.quarantine" },
+            spctlAssessment: { path in "\(path): rejected\nsource=no usable signature" },
+            isMachOExecutable: { _ in true })
+
+        #expect(!allowed)
+    }
+
+    @Test
+    func `Codex launch preflight ignores benign text before verdict separator`() {
+        let allowed = CodexLaunchPreflight.isLaunchCandidateAllowed(
+            path: "/tmp/x: code is valid but does not seem to be an app/codex",
+            fileManager: MockFileManager(executables: []),
+            hasExtendedAttribute: { _, name in name == "com.apple.quarantine" },
+            spctlAssessment: { path in "\(path): rejected\nsource=no usable signature" },
+            isMachOExecutable: { _ in true })
+
+        #expect(!allowed)
+    }
+
+    @Test
+    func `Codex launch preflight ignores blocked words in accepted path and source fields`() {
+        let allowed = CodexLaunchPreflight.isLaunchCandidateAllowed(
+            path: "/tmp/rejected/quarantine/codex",
+            fileManager: MockFileManager(executables: []),
+            hasExtendedAttribute: { _, name in name == "com.apple.quarantine" },
+            spctlAssessment: { path in
+                """
+                \(path): accepted
+                source=revoked quarantine marker
+                origin=malware test fixture
+                """
+            },
+            isMachOExecutable: { _ in true })
+
+        #expect(allowed)
+    }
     #endif
 
     @Test


### PR DESCRIPTION
## Summary

* allow the Homebrew Codex CLI when `spctl` reports `rejected (the code is valid but does not seem to be an app)`
* keep higher-risk Gatekeeper signals (`denied`, revoked certs, malware, quarantine-specific rejection text) blocked before applying the non-app CLI exception
* add regression coverage for both the valid CLI assessment and a mixed non-app/revoked assessment

## Why

Fixes #1133.

The Homebrew Codex cask can install a signed Mach-O CLI at `/opt/homebrew/bin/codex` that still has the quarantine xattr. On macOS, `spctl --assess --type execute --verbose=4 /opt/homebrew/bin/codex` can return:

```text
/opt/homebrew/bin/codex: rejected (the code is valid but does not seem to be an app)
```

Before this change, CodexBar treated any `rejected` assessment as a blocked launch candidate. That made `codex.cli` unavailable even though `codex --version` and `codex login status` worked locally, so auto mode could surface OAuth refresh-token errors instead of falling back to the working CLI.

## Scope

* Does not remove the launch preflight for blocked Codex binaries
* Does not allow revoked, denied, malware, or quarantine-specific blocked assessments
* Does not change OAuth refresh behavior
* Does not change the Codex provider fallback order

## Local validation

* `codex --version` -> `codex-cli 0.133.0`
* `codex login status` -> `Logged in using ChatGPT`
* `xattr /opt/homebrew/bin/codex` includes `com.apple.quarantine`
* `spctl --assess --type execute --verbose=4 /opt/homebrew/bin/codex` -> `rejected (the code is valid but does not seem to be an app)`
* `swift run CodexBarCLI usage --provider codex --source cli --format json --pretty --verbose` -> `codex.cli (cli) available`, source `codex-cli`
* `swift test --filter PathBuilderTests` (33 tests pass)
* `make check` (SwiftFormat clean, SwiftLint 0 violations)
* `./Scripts/compile_and_run.sh` (`OK: CodexBar is running.`)
