### PR TITLE
Enable pace prediction for Ollama usage windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Release: prevent manual CLI artifact builds from publishing or clobbering release assets (#1154). Thanks @jskoiz!
 - Cost history: route OpenAI and Mistral API spend through the shared cost-history cards, including OpenAI request counts (#1163). Thanks @LeoLin990405!
 - Alibaba Token Plan: update usage refreshes to the Bailian subscription-summary endpoint (#1142). Thanks @YanxinXue!
+- Ollama: show pace projections for documented 5-hour session and 7-day weekly usage windows (#1136). Thanks @bdamokos!
 - Localization: improve Traditional Chinese wording and localize notification copy (#1158). Thanks @jack24254029!
 - Localization: improve Simplified Chinese visible menu, dashboard, and usage labels (#1145). Thanks @Yuxin-Qiao!
 

--- a/Sources/CodexBar/UsagePaceText.swift
+++ b/Sources/CodexBar/UsagePaceText.swift
@@ -81,7 +81,7 @@ enum UsagePaceText {
     }
 
     static func sessionPace(provider: UsageProvider, window: RateWindow, now: Date) -> UsagePace? {
-        guard provider == .codex || provider == .claude else { return nil }
+        guard provider == .codex || provider == .claude || provider == .ollama else { return nil }
         guard window.remainingPercent > 0 else { return nil }
         guard let pace = UsagePace.weekly(window: window, now: now, defaultWindowMinutes: 300) else { return nil }
         guard pace.expectedUsedPercent >= 3 else { return nil }

--- a/Sources/CodexBar/UsagePaceText.swift
+++ b/Sources/CodexBar/UsagePaceText.swift
@@ -82,6 +82,7 @@ enum UsagePaceText {
 
     static func sessionPace(provider: UsageProvider, window: RateWindow, now: Date) -> UsagePace? {
         guard provider == .codex || provider == .claude || provider == .ollama else { return nil }
+        if provider == .ollama, window.windowMinutes == nil { return nil }
         guard window.remainingPercent > 0 else { return nil }
         guard let pace = UsagePace.weekly(window: window, now: now, defaultWindowMinutes: 300) else { return nil }
         guard pace.expectedUsedPercent >= 3 else { return nil }

--- a/Sources/CodexBarCLI/CLIRenderer.swift
+++ b/Sources/CodexBarCLI/CLIRenderer.swift
@@ -368,7 +368,10 @@ enum CLIRenderer {
         useColor: Bool,
         now: Date) -> String?
     {
-        guard provider == .codex || provider == .claude || provider == .opencode else { return nil }
+        guard provider == .codex || provider == .claude || provider == .opencode || provider == .ollama else {
+            return nil
+        }
+        if provider == .ollama, window.windowMinutes == nil { return nil }
         guard window.remainingPercent > 0 else { return nil }
         guard let pace = UsagePace.weekly(window: window, now: now, defaultWindowMinutes: 10080) else { return nil }
         guard pace.expectedUsedPercent >= Self.paceMinimumExpectedPercent else { return nil }

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaUsageParser.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaUsageParser.swift
@@ -2,6 +2,7 @@ import Foundation
 
 enum OllamaUsageParser {
     private static let primaryUsageLabels = ["Session usage", "Hourly usage"]
+    private static let usageLabels = primaryUsageLabels + ["Weekly usage"]
 
     enum ParseFailure: Equatable {
         case notLoggedIn
@@ -74,7 +75,7 @@ enum OllamaUsageParser {
     private static func parseUsageBlock(label: String, html: String) -> UsageBlock? {
         guard let labelRange = html.range(of: label) else { return nil }
         let tail = String(html[labelRange.upperBound...])
-        let window = String(tail.prefix(800))
+        let window = self.usageBlockWindow(after: label, in: tail)
 
         guard let usedPercent = self.parsePercent(in: window) else { return nil }
         let resetsAt = self.parseISODate(in: window)
@@ -92,6 +93,16 @@ enum OllamaUsageParser {
             }
         }
         return nil
+    }
+
+    private static func usageBlockWindow(after label: String, in tail: String) -> String {
+        let maxLength = 4000
+        let boundary = self.usageLabels
+            .filter { $0 != label }
+            .compactMap { tail.range(of: $0)?.lowerBound }
+            .min()
+        let bounded = boundary.map { String(tail[..<$0]) } ?? String(tail.prefix(maxLength))
+        return String(bounded.prefix(maxLength))
     }
 
     private static func parsePercent(in text: String) -> Double? {

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaUsageParser.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaUsageParser.swift
@@ -44,12 +44,14 @@ enum OllamaUsageParser {
             weeklyUsedPercent: weekly?.usedPercent,
             sessionResetsAt: session?.resetsAt,
             weeklyResetsAt: weekly?.resetsAt,
+            sessionWindowMinutes: session?.windowMinutes,
             updatedAt: now))
     }
 
     private struct UsageBlock {
         let usedPercent: Double
         let resetsAt: Date?
+        let windowMinutes: Int?
     }
 
     private static func parsePlanName(_ html: String) -> String? {
@@ -76,7 +78,11 @@ enum OllamaUsageParser {
 
         guard let usedPercent = self.parsePercent(in: window) else { return nil }
         let resetsAt = self.parseISODate(in: window)
-        return UsageBlock(usedPercent: usedPercent, resetsAt: resetsAt)
+        let windowMinutes = label == "Session usage" ? 5 * 60 : nil
+        return UsageBlock(
+            usedPercent: usedPercent,
+            resetsAt: resetsAt,
+            windowMinutes: windowMinutes)
     }
 
     private static func parseUsageBlock(labels: [String], html: String) -> UsageBlock? {

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaUsageSnapshot.swift
@@ -7,6 +7,7 @@ public struct OllamaUsageSnapshot: Sendable {
     public let weeklyUsedPercent: Double?
     public let sessionResetsAt: Date?
     public let weeklyResetsAt: Date?
+    public let sessionWindowMinutes: Int?
     public let updatedAt: Date
 
     public init(
@@ -16,6 +17,7 @@ public struct OllamaUsageSnapshot: Sendable {
         weeklyUsedPercent: Double?,
         sessionResetsAt: Date?,
         weeklyResetsAt: Date?,
+        sessionWindowMinutes: Int? = nil,
         updatedAt: Date)
     {
         self.planName = planName
@@ -24,16 +26,17 @@ public struct OllamaUsageSnapshot: Sendable {
         self.weeklyUsedPercent = weeklyUsedPercent
         self.sessionResetsAt = sessionResetsAt
         self.weeklyResetsAt = weeklyResetsAt
+        self.sessionWindowMinutes = sessionWindowMinutes
         self.updatedAt = updatedAt
     }
 }
 
 extension OllamaUsageSnapshot {
     public func toUsageSnapshot() -> UsageSnapshot {
-        let sessionWindow = self.makeWindow(
+        let sessionWindow = self.makeSessionWindow(
             usedPercent: self.sessionUsedPercent,
             resetsAt: self.sessionResetsAt)
-        let weeklyWindow = self.makeWindow(
+        let weeklyWindow = self.makeWeeklyWindow(
             usedPercent: self.weeklyUsedPercent,
             resetsAt: self.weeklyResetsAt)
 
@@ -54,12 +57,22 @@ extension OllamaUsageSnapshot {
             identity: identity)
     }
 
-    private func makeWindow(usedPercent: Double?, resetsAt: Date?) -> RateWindow? {
+    private func makeSessionWindow(usedPercent: Double?, resetsAt: Date?) -> RateWindow? {
         guard let usedPercent else { return nil }
         let clamped = min(100, max(0, usedPercent))
         return RateWindow(
             usedPercent: clamped,
-            windowMinutes: nil,
+            windowMinutes: self.sessionWindowMinutes,
+            resetsAt: resetsAt,
+            resetDescription: nil)
+    }
+
+    private func makeWeeklyWindow(usedPercent: Double?, resetsAt: Date?) -> RateWindow? {
+        guard let usedPercent else { return nil }
+        let clamped = min(100, max(0, usedPercent))
+        return RateWindow(
+            usedPercent: clamped,
+            windowMinutes: 7 * 24 * 60,
             resetsAt: resetsAt,
             resetDescription: nil)
     }

--- a/Tests/CodexBarTests/CLISnapshotTests.swift
+++ b/Tests/CodexBarTests/CLISnapshotTests.swift
@@ -379,6 +379,64 @@ struct CLISnapshotTests {
     }
 
     @Test
+    func `renders Ollama weekly pace line when weekly window has reset`() {
+        let now = Date()
+        let snap = UsageSnapshot(
+            primary: .init(
+                usedPercent: 0,
+                windowMinutes: nil,
+                resetsAt: now.addingTimeInterval(4 * 3600),
+                resetDescription: nil),
+            secondary: .init(
+                usedPercent: 23,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(5 * 24 * 3600),
+                resetDescription: nil),
+            tertiary: nil,
+            updatedAt: now)
+
+        let output = CLIRenderer.renderText(
+            provider: .ollama,
+            snapshot: snap,
+            credits: nil,
+            context: RenderContext(
+                header: "Ollama (web)",
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown))
+
+        #expect(output.contains("Weekly: 77% left"))
+        #expect(output.contains("Pace: 6% in reserve | Expected 29% used | Lasts until reset"))
+    }
+
+    @Test
+    func `hides Ollama weekly pace when weekly duration is missing`() {
+        let now = Date()
+        let snap = UsageSnapshot(
+            primary: nil,
+            secondary: .init(
+                usedPercent: 23,
+                windowMinutes: nil,
+                resetsAt: now.addingTimeInterval(5 * 24 * 3600),
+                resetDescription: nil),
+            tertiary: nil,
+            updatedAt: now)
+
+        let output = CLIRenderer.renderText(
+            provider: .ollama,
+            snapshot: snap,
+            credits: nil,
+            context: RenderContext(
+                header: "Ollama (web)",
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown))
+
+        #expect(output.contains("Weekly: 77% left"))
+        #expect(!output.contains("Pace:"))
+    }
+
+    @Test
     func `renders JSON payload`() throws {
         let snap = UsageSnapshot(
             primary: .init(usedPercent: 50, windowMinutes: 300, resetsAt: nil, resetDescription: nil),

--- a/Tests/CodexBarTests/OllamaUsageParserTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageParserTests.swift
@@ -162,6 +162,31 @@ struct OllamaUsageParserTests {
     }
 
     @Test
+    func `weekly usage parser finds reset timestamp in long usage block`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let filler = String(repeating: "<span class=\"grid-cell\"></span>", count: 40)
+        let html = """
+        <div>
+          <span>Session usage</span>
+          <span>0.1% used</span>
+          <span>Weekly usage</span>
+          <span>0.7% used</span>
+          \(filler)
+          <div class=\"local-time\" data-time=\"2026-02-02T00:00:00Z\">Resets in 2 days</div>
+        </div>
+        """
+
+        let snapshot = try OllamaUsageParser.parse(html: html, now: now)
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        let expectedWeekly = formatter.date(from: "2026-02-02T00:00:00Z")
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.resetsAt == nil)
+        #expect(usage.secondary?.resetsAt == expectedWeekly)
+    }
+
+    @Test
     func `parses usage when used is capitalized`() throws {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let html = """

--- a/Tests/CodexBarTests/OllamaUsageParserTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageParserTests.swift
@@ -43,6 +43,8 @@ struct OllamaUsageParserTests {
         let usage = snapshot.toUsageSnapshot()
         #expect(usage.identity?.loginMethod == "free")
         #expect(usage.identity?.accountEmail == "user@example.com")
+        #expect(usage.primary?.windowMinutes == 5 * 60)
+        #expect(usage.secondary?.windowMinutes == 7 * 24 * 60)
     }
 
     @Test
@@ -153,6 +155,10 @@ struct OllamaUsageParserTests {
 
         #expect(snapshot.sessionUsedPercent == 2.5)
         #expect(snapshot.weeklyUsedPercent == 4.2)
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary?.windowMinutes == nil)
+        #expect(usage.secondary?.windowMinutes == 7 * 24 * 60)
     }
 
     @Test

--- a/Tests/CodexBarTests/UsagePaceTextTests.swift
+++ b/Tests/CodexBarTests/UsagePaceTextTests.swift
@@ -137,6 +137,21 @@ struct UsagePaceTextTests {
     }
 
     @Test
+    func `session pace detail supports Ollama five hour window`() {
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 80,
+            windowMinutes: 300,
+            resetsAt: now.addingTimeInterval(2 * 3600),
+            resetDescription: nil)
+
+        let detail = UsagePaceText.sessionDetail(provider: .ollama, window: window, now: now)
+
+        #expect(detail?.leftLabel == "20% in deficit")
+        #expect(detail?.rightLabel == "Projected empty in 45m")
+    }
+
+    @Test
     func `session pace detail hides for unsupported provider`() {
         let now = Date(timeIntervalSince1970: 0)
         let window = RateWindow(

--- a/Tests/CodexBarTests/UsagePaceTextTests.swift
+++ b/Tests/CodexBarTests/UsagePaceTextTests.swift
@@ -152,6 +152,20 @@ struct UsagePaceTextTests {
     }
 
     @Test
+    func `session pace detail hides Ollama window without explicit duration`() {
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 80,
+            windowMinutes: nil,
+            resetsAt: now.addingTimeInterval(2 * 3600),
+            resetDescription: nil)
+
+        let detail = UsagePaceText.sessionDetail(provider: .ollama, window: window, now: now)
+
+        #expect(detail == nil)
+    }
+
+    @Test
     func `session pace detail hides for unsupported provider`() {
         let now = Date(timeIntervalSince1970: 0)
         let window = RateWindow(


### PR DESCRIPTION
  ## Summary

  - Set Ollama session windows to 5 hours and weekly windows to 7 days.
  - Enable session and weekly pace rendering for Ollama in the menu.
  - Enable Ollama weekly pace rendering in the CLI.
  - Add regression coverage for Ollama window durations, pace text, parser
  behavior, and CLI snapshot output.

  ## Notes

  Ollama documents that each plan has session limits that reset every 5 hours and
  weekly limits that reset every 7 days:
  https://ollama.com/pricing

  This keeps the session pace allowlist explicit for now by adding Ollama
  alongside Codex and Claude. Longer term, session pace should probably be
  generalized the same way weekly pace was, so any provider with an explicit reset
  time and window duration can use the shared pace calculation without provider-
  specific gating.

  ## Screenshot
<img width="301" height="460" alt="image" src="https://github.com/user-attachments/assets/9c2b1961-70ff-4e12-bd4f-d45e82795b4c" />

  ## CLI proof

  Local debug CLI from this branch:

  ```text
  == Ollama (web) ==
  Session: 100% left [============]
  Resets in 3h 8m
  Weekly: 100% left [===========-]
  Pace: 12% in reserve | Expected 12% used | Lasts until reset
  Resets in 6d 4h
  Account: <redacted>  
```

  ## Tests

  - swift build --product CodexBarCLI
  - swift test --filter OllamaUsageParserTests passed, 9 tests
  - swift test --filter UsagePaceTextTests passed, 11 tests
  - swift test --filter CLISnapshotTests passed, 24 tests
  - make check passed: SwiftFormat clean, SwiftLint found 0 violations
  - Full `swift test` rerun: failed with 7 issues in unrelated async/background
  suites (`ClaudeOAuthCredentialsStoreTests`, `SubprocessRunnerTests`, and
  `CodexManagedOpenAIWebRefreshTests`); focused Ollama/CLI checks passed.