### PR TITLE
Antigravity: expose full per-model quotas via extraRateWindows

### DIFF
--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1095,27 +1095,10 @@ extension UsageMenuCardView.Model {
                     thresholds: input.quotaWarningThresholds[.weekly],
                     showUsed: input.usageBarsShowUsed)))
         }
-        if let extraRateWindows = snapshot.extraRateWindows {
-            metrics.append(contentsOf: extraRateWindows.map { namedWindow in
-                Metric(
-                    id: namedWindow.id,
-                    title: namedWindow.title,
-                    percent: Self.clamped(
-                        input.usageBarsShowUsed
-                            ? namedWindow.window.usedPercent
-                            : namedWindow.window.remainingPercent),
-                    percentStyle: percentStyle,
-                    resetText: Self.resetText(
-                        for: namedWindow.window,
-                        style: input.resetTimeDisplayStyle,
-                        now: input.now),
-                    detailText: nil,
-                    detailLeftText: nil,
-                    detailRightText: nil,
-                    pacePercent: nil,
-                    paceOnTop: true)
-            })
-        }
+        metrics.append(contentsOf: Self.extraRateWindowMetrics(
+            snapshot: snapshot,
+            input: input,
+            percentStyle: percentStyle))
         if input.provider == .kilo,
            metrics.contains(where: { $0.id == "primary" }),
            metrics.contains(where: { $0.id == "secondary" })
@@ -1441,7 +1424,7 @@ extension UsageMenuCardView.Model {
 
     private static func antigravityMetrics(input: Input, snapshot: UsageSnapshot) -> [Metric] {
         let percentStyle: PercentStyle = input.usageBarsShowUsed ? .used : .left
-        return [
+        var metrics = [
             Self.antigravityMetric(
                 id: "primary",
                 title: input.metadata.sessionLabel,
@@ -1461,6 +1444,38 @@ extension UsageMenuCardView.Model {
                 input: input,
                 percentStyle: percentStyle),
         ]
+        metrics.append(contentsOf: Self.extraRateWindowMetrics(
+            snapshot: snapshot,
+            input: input,
+            percentStyle: percentStyle))
+        return metrics
+    }
+
+    private static func extraRateWindowMetrics(
+        snapshot: UsageSnapshot,
+        input: Input,
+        percentStyle: PercentStyle) -> [Metric]
+    {
+        guard let extraRateWindows = snapshot.extraRateWindows else { return [] }
+        return extraRateWindows.map { namedWindow in
+            Metric(
+                id: namedWindow.id,
+                title: namedWindow.title,
+                percent: Self.clamped(
+                    input.usageBarsShowUsed
+                        ? namedWindow.window.usedPercent
+                        : namedWindow.window.remainingPercent),
+                percentStyle: percentStyle,
+                resetText: Self.resetText(
+                    for: namedWindow.window,
+                    style: input.resetTimeDisplayStyle,
+                    now: input.now),
+                detailText: nil,
+                detailLeftText: nil,
+                detailRightText: nil,
+                pacePercent: nil,
+                paceOnTop: true)
+        }
     }
 
     private static func antigravityMetric(

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -79,6 +79,15 @@ public struct AntigravityStatusSnapshot: Sendable {
         let secondary = secondaryQuota.map(Self.rateWindow(for:))
         let tertiary = tertiaryQuota.map(Self.rateWindow(for:))
 
+        // primary/secondary/tertiary keep the 3-family representative summary for
+        // back-compat. extraRateWindows carries EVERY model quota loss-free —
+        // including families with no dedicated slot (e.g. GPT-OSS) and the
+        // per-effort variants the representative selection collapses — so a
+        // consumer can render the complete per-model breakdown the IDE shows.
+        let extraWindows = self.modelQuotas.map { quota in
+            NamedRateWindow(id: quota.modelId, title: quota.label, window: Self.rateWindow(for: quota))
+        }
+
         let identity = ProviderIdentitySnapshot(
             providerID: .antigravity,
             accountEmail: self.accountEmail,
@@ -88,6 +97,7 @@ public struct AntigravityStatusSnapshot: Sendable {
             primary: primary,
             secondary: secondary,
             tertiary: tertiary,
+            extraRateWindows: extraWindows.isEmpty ? nil : extraWindows,
             updatedAt: Date(),
             identity: identity)
     }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -79,14 +79,14 @@ public struct AntigravityStatusSnapshot: Sendable {
         let secondary = secondaryQuota.map(Self.rateWindow(for:))
         let tertiary = tertiaryQuota.map(Self.rateWindow(for:))
 
-        // primary/secondary/tertiary keep the 3-family representative summary for
-        // back-compat. extraRateWindows carries EVERY model quota loss-free —
-        // including families with no dedicated slot (e.g. GPT-OSS) and the
-        // per-effort variants the representative selection collapses — so a
-        // consumer can render the complete per-model breakdown the IDE shows.
-        let extraWindows = self.modelQuotas.map { quota in
-            NamedRateWindow(id: quota.modelId, title: quota.label, window: Self.rateWindow(for: quota))
-        }
+        // primary/secondary/tertiary keep the 3-family summary for back-compat.
+        // extraRateWindows carries every model quota loss-free, including families
+        // with no dedicated slot and variants the representative selection collapses.
+        let extraWindows = self.modelQuotas
+            .sorted(by: Self.modelQuotaSortPrecedes)
+            .map { quota in
+                NamedRateWindow(id: quota.modelId, title: quota.label, window: Self.rateWindow(for: quota))
+            }
 
         let identity = ProviderIdentitySnapshot(
             providerID: .antigravity,
@@ -108,6 +108,14 @@ public struct AntigravityStatusSnapshot: Sendable {
             windowMinutes: nil,
             resetsAt: quota.resetTime,
             resetDescription: quota.resetDescription)
+    }
+
+    private static func modelQuotaSortPrecedes(_ lhs: AntigravityModelQuota, _ rhs: AntigravityModelQuota) -> Bool {
+        let labelOrder = lhs.label.caseInsensitiveCompare(rhs.label)
+        if labelOrder != .orderedSame {
+            return labelOrder == .orderedAscending
+        }
+        return lhs.modelId.caseInsensitiveCompare(rhs.modelId) == .orderedAscending
     }
 
     private static func normalizedModels(_ models: [AntigravityModelQuota]) -> [AntigravityNormalizedModel] {

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -803,6 +803,58 @@ struct AntigravityStatusProbeTests {
     }
 
     @Test
+    func `extra rate windows preserve all model quotas in stable label order`() throws {
+        let resetTime = Date(timeIntervalSince1970: 1_775_000_000)
+        let snapshot = AntigravityStatusSnapshot(
+            modelQuotas: [
+                AntigravityModelQuota(
+                    label: "GPT-OSS 120B (Medium)",
+                    modelId: "MODEL_PLACEHOLDER_M55",
+                    remainingFraction: 0.25,
+                    resetTime: resetTime,
+                    resetDescription: "tomorrow"),
+                AntigravityModelQuota(
+                    label: "Gemini 3 Pro (Low)",
+                    modelId: "MODEL_PLACEHOLDER_M53",
+                    remainingFraction: 0.5,
+                    resetTime: resetTime,
+                    resetDescription: nil),
+                AntigravityModelQuota(
+                    label: "Claude Opus 4.6 (Thinking)",
+                    modelId: "MODEL_PLACEHOLDER_M50",
+                    remainingFraction: 0.75,
+                    resetTime: resetTime,
+                    resetDescription: nil),
+                AntigravityModelQuota(
+                    label: "Gemini 3 Pro (High)",
+                    modelId: "MODEL_PLACEHOLDER_M52",
+                    remainingFraction: 1,
+                    resetTime: resetTime,
+                    resetDescription: nil),
+            ],
+            accountEmail: nil,
+            accountPlan: nil)
+
+        let usage = try snapshot.toUsageSnapshot()
+        let extraWindows = try #require(usage.extraRateWindows)
+
+        #expect(extraWindows.map(\.id) == [
+            "MODEL_PLACEHOLDER_M50",
+            "MODEL_PLACEHOLDER_M52",
+            "MODEL_PLACEHOLDER_M53",
+            "MODEL_PLACEHOLDER_M55",
+        ])
+        #expect(extraWindows.map(\.title) == [
+            "Claude Opus 4.6 (Thinking)",
+            "Gemini 3 Pro (High)",
+            "Gemini 3 Pro (Low)",
+            "GPT-OSS 120B (Medium)",
+        ])
+        #expect(extraWindows.map { $0.window.remainingPercent.rounded() } == [75, 100, 50, 25])
+        #expect(extraWindows.last?.window.resetDescription == "tomorrow")
+    }
+
+    @Test
     func `model without remaining fraction keeps reset time`() throws {
         let resetTime = Date(timeIntervalSince1970: 1_735_000_000)
         let snapshot = AntigravityStatusSnapshot(

--- a/Tests/CodexBarTests/MenuCardAntigravityTests.swift
+++ b/Tests/CodexBarTests/MenuCardAntigravityTests.swift
@@ -112,6 +112,79 @@ struct MenuCardAntigravityTests {
     }
 
     @Test
+    func `antigravity metrics include complete per model quota windows`() throws {
+        let now = Date(timeIntervalSince1970: 1_735_000_000)
+        let resetTime = now.addingTimeInterval(3600)
+        let antigravitySnapshot = AntigravityStatusSnapshot(
+            modelQuotas: [
+                AntigravityModelQuota(
+                    label: "GPT-OSS 120B (Medium)",
+                    modelId: "MODEL_PLACEHOLDER_M55",
+                    remainingFraction: 0.25,
+                    resetTime: resetTime,
+                    resetDescription: nil),
+                AntigravityModelQuota(
+                    label: "Gemini 3 Pro (Low)",
+                    modelId: "MODEL_PLACEHOLDER_M53",
+                    remainingFraction: 0.5,
+                    resetTime: resetTime,
+                    resetDescription: nil),
+                AntigravityModelQuota(
+                    label: "Claude Opus 4.6 (Thinking)",
+                    modelId: "MODEL_PLACEHOLDER_M50",
+                    remainingFraction: 0.75,
+                    resetTime: resetTime,
+                    resetDescription: nil),
+                AntigravityModelQuota(
+                    label: "Gemini 3 Pro (High)",
+                    modelId: "MODEL_PLACEHOLDER_M52",
+                    remainingFraction: 1,
+                    resetTime: resetTime,
+                    resetDescription: nil),
+            ],
+            accountEmail: nil,
+            accountPlan: "Pro")
+        let snapshot = try antigravitySnapshot.toUsageSnapshot()
+        let metadata = try #require(ProviderDefaults.metadata[.antigravity])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .antigravity,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.metrics.map(\.title) == [
+            "Claude",
+            "Gemini Pro",
+            "Gemini Flash",
+            "Claude Opus 4.6 (Thinking)",
+            "Gemini 3 Pro (High)",
+            "Gemini 3 Pro (Low)",
+            "GPT-OSS 120B (Medium)",
+        ])
+        #expect(model.metrics.suffix(4).map(\.percentLabel) == [
+            "75% left",
+            "100% left",
+            "50% left",
+            "25% left",
+        ])
+    }
+
+    @Test
     func `antigravity missing families show full usage in used mode`() throws {
         let now = Date()
         let identity = ProviderIdentitySnapshot(


### PR DESCRIPTION
## What

`AntigravityStatusSnapshot.toUsageSnapshot()` currently collapses antigravity's 8+ per-model quotas into a 3-family representative summary (`primary`/`secondary`/`tertiary` = Claude / Gemini Pro / Gemini Flash). This PR additionally fills `extraRateWindows` with **every** model quota, so consumers can render the complete per-model breakdown the Antigravity IDE itself shows.

## Why

The 3-slot summary loses information that's available from the API:

- **Models with no family slot are dropped entirely.** GPT-OSS 120B classifies as `unknown` in `family(from:)`, so it never appears anywhere.
- **Per-effort variants are folded together.** Gemini 3.5 Flash (Medium/High/Low) and Gemini 3.1 Pro (Low/High) collapse to one representative each; Claude Sonnet vs Opus collapse to one "Claude".

There was no way for a consumer to recover the full list, even though `GetUserStatus` already returns all of it in `modelQuotas`.

## Change

10 lines in `toUsageSnapshot()`: map every `modelQuota` into a `NamedRateWindow` (`id`=modelId, `title`=label, window via the existing `rateWindow(for:)` helper) and pass it as `extraRateWindows`.

- **Purely additive.** `primary`/`secondary`/`tertiary` are unchanged, so the menubar's existing summary view and any current consumer keep working.
- Reuses the same `extraRateWindows` channel Claude already uses for its "Designs"/"Daily Routines" buckets — no schema or payload changes.

## Effect

Any surface that renders `extraRateWindows` (the CLI `serve`/`usage` JSON, and the menubar's expanded view) will now show antigravity's full per-model quota list. Example `serve --port … /usage?provider=antigravity` now emits 8 windows including `GPT-OSS 120B (Medium)`.

## Testing

- Built `CodexBarCLI` (release) and ran `serve` against a live, logged-in Antigravity instance: `/usage?provider=antigravity` returns all 8 model windows (Gemini 3.5 Flash Med/High/Low, Gemini 3.1 Pro Low/High, Claude Sonnet 4.6, Claude Opus 4.6, GPT-OSS 120B) with `usedPercent` matching the IDE's quota panel.
- `primary`/`secondary`/`tertiary` summary values unchanged.