### PR TITLE
fix: update Alibaba Token Plan usage API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Release: prevent manual CLI artifact builds from publishing or clobbering release assets (#1154). Thanks @jskoiz!
 - Cost history: route OpenAI and Mistral API spend through the shared cost-history cards, including OpenAI request counts (#1163). Thanks @LeoLin990405!
+- Alibaba Token Plan: update usage refreshes to the Bailian subscription-summary endpoint (#1142). Thanks @YanxinXue!
 - Localization: improve Traditional Chinese wording and localize notification copy (#1158). Thanks @jack24254029!
 - Localization: improve Simplified Chinese visible menu, dashboard, and usage labels (#1145). Thanks @Yuxin-Qiao!
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ See [CLI configuration](docs/cli-configuration.md) for the full flow.
 - [OpenCode](docs/opencode.md) — Browser cookies for workspace subscription usage.
 - [OpenCode Go](docs/opencode.md) — Browser cookies for Go usage windows.
 - [Alibaba Coding Plan](docs/alibaba-coding-plan.md) — Web cookies or API key for coding-plan quotas.
+- [Alibaba Token Plan](docs/alibaba-token-plan.md) — Bailian browser/manual cookies for token-plan credits.
 - [Gemini](docs/gemini.md) — OAuth-backed quota API using Gemini CLI credentials (no browser cookies).
 - [Antigravity](docs/antigravity.md) — Local language server probe (experimental); no external auth.
 - [Droid](docs/factory.md) — Browser cookies + WorkOS token flows for Factory usage + billing.

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanUsageFetcher.swift
@@ -26,14 +26,14 @@ public enum AlibabaTokenPlanUsageError: LocalizedError, Sendable, Equatable {
     }
 }
 
-// swiftlint:disable:next type_body_length
 public struct AlibabaTokenPlanUsageFetcher: Sendable {
     private static let log = CodexBarLog.logger("alibaba-token-plan")
-    private static let gatewayBaseURLString = "https://bailian-cs.console.aliyun.com"
+    private static let gatewayBaseURLString = "https://bailian.console.aliyun.com"
     private static let dashboardOriginURLString = "https://bailian.console.aliyun.com"
     private static let currentRegionID = "cn-beijing"
-    private static let apiName = "zeldaEasy.bailian-commerce.tokenPlan.queryTokenPlanInstanceInfo"
-    private static let tokenPlanCommodityCode = "sfm_tokenplanteams_dp_cn"
+    private static let bssServiceCode = "BssOpenAPI-V3"
+    private static let subscriptionSummaryAction = "GetSubscriptionSummary"
+    private static let tokenPlanProductCode = "sfm_tokenplanteams_dp_cn"
     private static let browserLikeUserAgent =
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
         "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
@@ -105,14 +105,12 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
             apiCookieHeader: normalizedAPIHeader,
             environment: environment,
             session: dashboardSession)
-        let anonymousID = self.extractCookieValue(name: "cna", from: normalizedAPIHeader)
         Self.log.info(
             "Fetching Alibaba Token Plan usage",
             metadata: [
                 "apiHost": url.host ?? "unknown",
                 "apiCookieNames": self.cookieNamesDescription(from: normalizedAPIHeader),
                 "dashboardCookieNames": self.cookieNamesDescription(from: normalizedDashboardHeader),
-                "hasAnonymousID": anonymousID == nil ? "0" : "1",
                 "hasCSRF": self.hasCSRF(in: normalizedAPIHeader) ? "1" : "0",
                 "secTokenSource": secToken == nil ? "missing" : "resolved",
             ])
@@ -120,7 +118,7 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.timeoutInterval = 20
-        request.httpBody = self.queryTokenPlanRequestBody(secToken: secToken, anonymousID: anonymousID)
+        request.httpBody = self.subscriptionSummaryRequestBody(secToken: secToken)
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.setValue("*/*", forHTTPHeaderField: "Accept")
         request.setValue(normalizedAPIHeader, forHTTPHeaderField: "Cookie")
@@ -202,10 +200,9 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         var components = URLComponents(string: Self.gatewayBaseURLString)!
         components.path = "/data/api.json"
         components.queryItems = [
-            URLQueryItem(name: "action", value: "BroadScopeAspnGateway"),
-            URLQueryItem(name: "product", value: "sfm_bailian"),
-            URLQueryItem(name: "api", value: Self.apiName),
-            URLQueryItem(name: "_v", value: "undefined"),
+            URLQueryItem(name: "action", value: Self.subscriptionSummaryAction),
+            URLQueryItem(name: "product", value: Self.bssServiceCode),
+            URLQueryItem(name: "_tag", value: ""),
         ]
         return components.url!
     }
@@ -231,15 +228,16 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
 
         try self.throwIfErrorPayload(dictionary)
 
-        let instance = self.findTokenPlanInstance(in: dictionary)
-        let planName = self.findPlanName(in: instance ?? [:]) ?? self.findPlanName(in: dictionary)
-        let quotaSource = self.findQuotaInfo(in: instance ?? [:]) ?? self.findQuotaInfo(in: dictionary)
-        let used = quotaSource.flatMap { self.anyDouble(for: Self.usedQuotaKeys, in: $0) }
-        let total = quotaSource.flatMap { self.anyDouble(for: Self.totalQuotaKeys, in: $0) }
-        let remaining = quotaSource.flatMap { self.anyDouble(for: Self.remainingQuotaKeys, in: $0) }
-        let resetsAt = self.findResetDate(in: instance ?? [:]) ?? self.findResetDate(in: dictionary)
+        let summary = self.findSubscriptionSummary(in: dictionary) ?? dictionary
+        let total = self.anyDouble(for: Self.totalQuotaKeys, in: summary)
+        let remaining = self.anyDouble(for: Self.remainingQuotaKeys, in: summary)
+        let used = self.anyDouble(for: Self.usedQuotaKeys, in: summary) ??
+            total.flatMap { total in remaining.map { max(0, total - $0) } }
+        let resetsAt = self.findResetDate(in: summary) ?? self.findResetDate(in: dictionary)
+        let totalCount = self.anyDouble(for: Self.subscriptionCountKeys, in: summary)
+        let planName = self.findPlanName(in: summary) ?? ((totalCount ?? 0) > 0 || total != nil ? "TOKEN PLAN" : nil)
 
-        if planName == nil, total == nil, used == nil, remaining == nil {
+        if planName == nil, total == nil, used == nil, remaining == nil, totalCount == nil {
             let diagnostics = self.payloadDiagnostics(payload: dictionary)
             Self.log.error("Alibaba Token Plan payload missing expected fields: \(diagnostics)")
             throw AlibabaTokenPlanUsageError.parseFailed("Missing token plan data (\(diagnostics))")
@@ -254,36 +252,8 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
             updatedAt: now)
     }
 
-    private static func queryTokenPlanRequestBody(secToken: String?, anonymousID: String?) -> Data {
-        let traceID = UUID().uuidString.lowercased()
-        var cornerstoneParam: [String: Any] = [
-            "feTraceId": traceID,
-            "feURL": Self.dashboardURL.absoluteString,
-            "protocol": "V2",
-            "console": "ONE_CONSOLE",
-            "productCode": "p_efm",
-            "domain": "bailian.console.aliyun.com",
-            "consoleSite": "BAILIAN_ALIYUN",
-            "userNickName": "",
-            "userPrincipalName": "",
-            "xsp_lang": "zh-CN",
-        ]
-        if let anonymousID, !anonymousID.isEmpty {
-            cornerstoneParam["X-Anonymous-Id"] = anonymousID
-        }
-
-        let paramsObject: [String: Any] = [
-            "Api": Self.apiName,
-            "V": "1.0",
-            "Data": [
-                "queryTokenPlanInstanceInfoRequest": [
-                    "commodityCode": Self.tokenPlanCommodityCode,
-                    "onlyLatestOne": true,
-                ],
-                "cornerstoneParam": cornerstoneParam,
-            ],
-        ]
-
+    private static func subscriptionSummaryRequestBody(secToken: String?) -> Data {
+        let paramsObject = ["ProductCode": Self.tokenPlanProductCode]
         guard let paramsData = try? JSONSerialization.data(withJSONObject: paramsObject, options: []),
               let paramsString = String(data: paramsData, encoding: .utf8)
         else {
@@ -292,6 +262,8 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
 
         var components = URLComponents()
         var queryItems = [
+            URLQueryItem(name: "product", value: Self.bssServiceCode),
+            URLQueryItem(name: "action", value: Self.subscriptionSummaryAction),
             URLQueryItem(name: "params", value: paramsString),
             URLQueryItem(name: "region", value: Self.currentRegionID),
         ]
@@ -436,6 +408,16 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
     }
 
     private static func throwIfErrorPayload(_ dictionary: [String: Any]) throws {
+        if self.findBoolValues(forKeys: ["Success", "success"], in: dictionary).contains(false) {
+            let message = self.findFirstString(forKeys: ["Message", "message", "msg", "Code", "code"], in: dictionary)
+                ?? "request was not successful"
+            let lowered = message.lowercased()
+            if lowered.contains("needlogin") || lowered.contains("login") {
+                throw AlibabaTokenPlanUsageError.loginRequired
+            }
+            throw AlibabaTokenPlanUsageError.apiError(message)
+        }
+
         if let statusCode = self.findFirstInt(forKeys: ["statusCode", "status_code", "code"], in: dictionary),
            statusCode != 0,
            statusCode != 200
@@ -473,6 +455,8 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         "instance_name",
         "displayName",
         "display_name",
+        "ProductName",
+        "productName",
         "name",
         "title",
         "planType",
@@ -488,6 +472,10 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         "used",
         "usedAmount",
         "consumeAmount",
+        "usedValue",
+        "UsedValue",
+        "consumedValue",
+        "ConsumedValue",
     ]
     private static let totalQuotaKeys = [
         "totalQuota",
@@ -499,6 +487,8 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         "creditsTotal",
         "monthlyTotalQuota",
         "amount",
+        "totalValue",
+        "TotalValue",
     ]
     private static let remainingQuotaKeys = [
         "remainingQuota",
@@ -510,6 +500,16 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         "remaining",
         "availableAmount",
         "remainAmount",
+        "totalSurplusValue",
+        "TotalSurplusValue",
+        "surplusValue",
+        "SurplusValue",
+    ]
+    private static let subscriptionCountKeys = [
+        "totalCount",
+        "TotalCount",
+        "subscriptionTotalNumber",
+        "SubscriptionTotalNumber",
     ]
     private static let resetDateKeys = [
         "nextRefreshTime",
@@ -522,41 +522,32 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         "endTime",
         "validEndTime",
         "instanceEndTime",
+        "nearestExpireDate",
+        "NearestExpireDate",
     ]
 
-    private static func findTokenPlanInstance(in payload: [String: Any]) -> [String: Any]? {
-        if let direct = self.findFirstDictionary(
-            forKeys: ["tokenPlanInstanceInfo", "token_plan_instance_info", "instanceInfo", "instance_info"],
-            in: payload)
+    private static func findSubscriptionSummary(in payload: [String: Any]) -> [String: Any]? {
+        if let data = self.findFirstDictionary(
+            forKeys: ["Data", "data", "successResponse", "success_response"],
+            in: payload),
+            self.containsSubscriptionSummaryFields(data)
         {
-            return direct
+            return data
         }
-        if let infos = self.findFirstArray(
-            forKeys: ["tokenPlanInstanceInfos", "token_plan_instance_infos", "instanceInfos", "instances"],
+        return self.findFirstDictionary(
+            matchingAnyKey: Self.usedQuotaKeys + Self.totalQuotaKeys + Self.remainingQuotaKeys +
+                Self.subscriptionCountKeys,
             in: payload)
-        {
-            return infos.compactMap { $0 as? [String: Any] }.max {
-                self.activeSignalScore(in: $0) < self.activeSignalScore(in: $1)
-            }
-        }
-        return nil
+    }
+
+    private static func containsSubscriptionSummaryFields(_ payload: [String: Any]) -> Bool {
+        let keys = self.usedQuotaKeys + self.totalQuotaKeys + self.remainingQuotaKeys + self.subscriptionCountKeys
+        return keys.contains { payload[$0] != nil }
     }
 
     private static func findPlanName(in payload: [String: Any]) -> String? {
         self.anyString(for: self.planNameKeys, in: payload) ??
             self.findFirstString(forKeys: self.planNameKeys, in: payload)
-    }
-
-    private static func findQuotaInfo(in payload: [String: Any]) -> [String: Any]? {
-        if let direct = self.findFirstDictionary(
-            forKeys: ["quotaInfo", "quota_info", "tokenPlanQuotaInfo", "token_plan_quota_info"],
-            in: payload)
-        {
-            return direct
-        }
-        return self.findFirstDictionary(
-            matchingAnyKey: Self.usedQuotaKeys + Self.totalQuotaKeys + Self.remainingQuotaKeys,
-            in: payload)
     }
 
     private static func findResetDate(in payload: [String: Any]) -> Date? {
@@ -566,33 +557,17 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
 
     private static func payloadDiagnostics(payload: [String: Any]) -> String {
         let topKeys = payload.keys.sorted()
-        let dataDict = self.findFirstDictionary(forKeys: ["data", "successResponse", "success_response"], in: payload)
+        let dataDict = self.findFirstDictionary(
+            forKeys: ["Data", "data", "successResponse", "success_response"],
+            in: payload)
         let dataKeys = dataDict?.keys.sorted() ?? []
-        let instance = self.findTokenPlanInstance(in: payload)
-        let instanceKeys = instance?.keys.sorted() ?? []
-        return "topKeys=\(topKeys.joined(separator: ",")) dataKeys=\(dataKeys.joined(separator: ",")) " +
-            "instanceKeys=\(instanceKeys.joined(separator: ","))"
+        return "topKeys=\(topKeys.joined(separator: ",")) dataKeys=\(dataKeys.joined(separator: ","))"
     }
 
     private static func isLikelyLoginHTML(_ data: Data) -> Bool {
         guard let text = String(data: data, encoding: .utf8)?.lowercased() else { return false }
         return text.contains("<html") &&
             (text.contains("login") || text.contains("sign in") || text.contains("signin"))
-    }
-
-    private static func activeSignalScore(in source: [String: Any]) -> Int {
-        if let status = self.anyString(for: ["status", "instanceStatus", "state"], in: source)?.uppercased() {
-            if ["VALID", "ACTIVE", "NORMAL"].contains(status) {
-                return 3
-            }
-            if ["EXPIRED", "INVALID", "INACTIVE", "DISABLED", "TERMINATED", "STOPPED"].contains(status) {
-                return -1
-            }
-        }
-        if let isActive = self.anyBool(for: ["isActive", "active"], in: source) {
-            return isActive ? 3 : -1
-        }
-        return 0
     }
 
     private static func findFirstDictionary(forKeys keys: [String], in value: Any) -> [String: Any]? {
@@ -641,30 +616,6 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         return nil
     }
 
-    private static func findFirstArray(forKeys keys: [String], in value: Any) -> [Any]? {
-        if let dict = value as? [String: Any] {
-            for key in keys {
-                if let array = dict[key] as? [Any] {
-                    return array
-                }
-            }
-            for nestedValue in dict.values {
-                if let found = self.findFirstArray(forKeys: keys, in: nestedValue) {
-                    return found
-                }
-            }
-            return nil
-        }
-        if let array = value as? [Any] {
-            for item in array {
-                if let found = self.findFirstArray(forKeys: keys, in: item) {
-                    return found
-                }
-            }
-        }
-        return nil
-    }
-
     private static func findFirstString(forKeys keys: [String], in value: Any) -> String? {
         if let dict = value as? [String: Any] {
             for key in keys {
@@ -687,6 +638,18 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
             }
         }
         return nil
+    }
+
+    private static func findBoolValues(forKeys keys: [String], in value: Any) -> [Bool] {
+        if let dict = value as? [String: Any] {
+            let directValues = keys.compactMap { self.parseBool(dict[$0]) }
+            let nestedValues = dict.values.flatMap { self.findBoolValues(forKeys: keys, in: $0) }
+            return directValues + nestedValues
+        }
+        if let array = value as? [Any] {
+            return array.flatMap { self.findBoolValues(forKeys: keys, in: $0) }
+        }
+        return []
     }
 
     private static func findFirstInt(forKeys keys: [String], in value: Any) -> Int? {
@@ -838,7 +801,7 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
             }
             let dateFormatter = DateFormatter()
             dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-            for format in ["yyyy-MM-dd HH:mm", "yyyy-MM-dd HH:mm:ss"] {
+            for format in ["yyyy-MM-dd", "yyyy-MM-dd HH:mm", "yyyy-MM-dd HH:mm:ss"] {
                 dateFormatter.dateFormat = format
                 if let date = dateFormatter.date(from: string) {
                     return date

--- a/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
@@ -52,11 +52,11 @@ struct AlibabaTokenPlanSettingsReaderTests {
     }
 
     @Test
-    func `default quota URL targets token plan API`() {
+    func `default quota URL targets subscription summary API`() {
         let url = AlibabaTokenPlanUsageFetcher.defaultQuotaURL
-        #expect(url.host == "bailian-cs.console.aliyun.com")
-        #expect(url.absoluteString.contains("queryTokenPlanInstanceInfo"))
-        #expect(url.absoluteString.contains("BroadScopeAspnGateway"))
+        #expect(url.host == "bailian.console.aliyun.com")
+        #expect(url.absoluteString.contains("GetSubscriptionSummary"))
+        #expect(url.absoluteString.contains("BssOpenAPI-V3"))
     }
 }
 
@@ -68,17 +68,17 @@ struct AlibabaTokenPlanCookieHeaderTests {
             self.cookie(name: "login_current_pk", value: "account", domain: ".aliyun.com"),
             self.cookie(name: "sec_token", value: "shared", domain: ".console.aliyun.com"),
             self.cookie(name: "sec_token", value: "dashboard", domain: "bailian.console.aliyun.com"),
-            self.cookie(name: "sec_token", value: "api", domain: "bailian-cs.console.aliyun.com"),
+            self.cookie(name: "modelstudio_only", value: "modelstudio", domain: "modelstudio.console.alibabacloud.com"),
         ]
 
         let headers = try #require(AlibabaTokenPlanCookieHeader.headers(from: cookies))
 
         #expect(headers.apiCookieHeader.contains("login_aliyunid_ticket=ticket"))
         #expect(headers.apiCookieHeader.contains("login_current_pk=account"))
-        #expect(headers.apiCookieHeader.contains("sec_token=api"))
-        #expect(!headers.apiCookieHeader.contains("sec_token=dashboard"))
+        #expect(headers.apiCookieHeader.contains("sec_token=dashboard"))
+        #expect(!headers.apiCookieHeader.contains("modelstudio_only=modelstudio"))
         #expect(headers.dashboardCookieHeader.contains("sec_token=dashboard"))
-        #expect(!headers.dashboardCookieHeader.contains("sec_token=api"))
+        #expect(!headers.dashboardCookieHeader.contains("modelstudio_only=modelstudio"))
     }
 
     @Test
@@ -101,7 +101,7 @@ struct AlibabaTokenPlanCookieHeaderTests {
             self.cookie(name: "login_aliyunid_ticket", value: "ticket", domain: ".token-plan.test"),
             self.cookie(name: "api_only", value: "api", domain: "quota.token-plan.test"),
             self.cookie(name: "dashboard_only", value: "dashboard", domain: "dashboard.token-plan.test"),
-            self.cookie(name: "prod_api_only", value: "prod-api", domain: "bailian-cs.console.aliyun.com"),
+            self.cookie(name: "prod_api_only", value: "prod-api", domain: "bailian.console.aliyun.com"),
             self.cookie(name: "prod_dashboard_only", value: "prod-dashboard", domain: "bailian.console.aliyun.com"),
         ]
 
@@ -178,23 +178,18 @@ struct AlibabaTokenPlanUsageSnapshotTests {
 @Suite(.serialized)
 struct AlibabaTokenPlanUsageParsingTests {
     @Test
-    func `parses token plan payload`() throws {
+    func `parses subscription summary payload`() throws {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let json = """
         {
-          "data": {
-            "tokenPlanInstanceInfo": {
-              "planName": "TOKEN PLAN",
-              "status": "VALID",
-              "quotaInfo": {
-                "usedQuota": 125,
-                "totalQuota": 1000,
-                "remainingQuota": 875
-              },
-              "periodEndTime": 1701000000000
-            }
+          "Success": true,
+          "Data": {
+            "TotalCount": 1,
+            "TotalValue": 1000,
+            "TotalSurplusValue": 875,
+            "NearestExpireDate": 1701000000000
           },
-          "status_code": 0
+          "Code": "200"
         }
         """
 
@@ -209,19 +204,15 @@ struct AlibabaTokenPlanUsageParsingTests {
     }
 
     @Test
-    func `parses remaining and total quota`() throws {
+    func `parses nested subscription summary body`() throws {
         let body = """
         {
+          "success": true,
           "data": {
-            "tokenPlanInstanceInfo": {
-              "packageName": "TOKEN PLAN",
-              "quotaInfo": {
-                "remainingCredits": 750,
-                "totalCredits": 1000
-              }
-            }
-          },
-          "statusCode": 200
+            "totalCount": 1,
+            "totalSurplusValue": 750,
+            "totalValue": 1000
+          }
         }
         """
         let payload = ["successResponse": ["body": body]]
@@ -230,29 +221,26 @@ struct AlibabaTokenPlanUsageParsingTests {
         let snapshot = try AlibabaTokenPlanUsageFetcher.parseUsageSnapshot(from: data)
 
         #expect(snapshot.planName == "TOKEN PLAN")
-        #expect(snapshot.usedQuota == nil)
+        #expect(snapshot.usedQuota == 250)
         #expect(snapshot.remainingQuota == 750)
         #expect(snapshot.totalQuota == 1000)
         #expect(snapshot.toUsageSnapshot().primary?.usedPercent == 25)
     }
 
     @Test
-    func `plan only payload stays visible without quota window`() throws {
+    func `empty subscription summary stays visible without quota window`() throws {
         let json = """
         {
-          "data": {
-            "tokenPlanInstanceInfo": {
-              "planName": "TOKEN PLAN",
-              "status": "VALID"
-            }
-          },
-          "status_code": 0
+          "Success": true,
+          "Data": {
+            "TotalCount": 0
+          }
         }
         """
 
         let snapshot = try AlibabaTokenPlanUsageFetcher.parseUsageSnapshot(from: Data(json.utf8))
 
-        #expect(snapshot.planName == "TOKEN PLAN")
+        #expect(snapshot.planName == nil)
         #expect(snapshot.totalQuota == nil)
         #expect(snapshot.toUsageSnapshot().primary == nil)
     }
@@ -269,6 +257,22 @@ struct AlibabaTokenPlanUsageParsingTests {
 
         #expect(throws: AlibabaTokenPlanUsageError.loginRequired) {
             try AlibabaTokenPlanUsageFetcher.parseUsageSnapshot(from: Data(json.utf8))
+        }
+    }
+
+    @Test
+    func `nested unsuccessful subscription summary maps to API error`() throws {
+        let body = """
+        {
+          "success": false,
+          "message": "Subscription lookup failed"
+        }
+        """
+        let payload = ["successResponse": ["body": body]]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+
+        #expect(throws: AlibabaTokenPlanUsageError.apiError("Subscription lookup failed")) {
+            try AlibabaTokenPlanUsageFetcher.parseUsageSnapshot(from: data)
         }
     }
 
@@ -326,17 +330,18 @@ struct AlibabaTokenPlanUsageParsingTests {
                     .absoluteString)
                 let body = Self.requestBodyString(from: request)
                 #expect(!body.contains("sec_token="))
-                #expect(body.contains("commodityCode"))
+                #expect(body.contains("GetSubscriptionSummary"))
+                #expect(body.contains("BssOpenAPI-V3"))
+                #expect(body.contains("ProductCode"))
                 #expect(body.contains("sfm_tokenplanteams_dp_cn"))
-                #expect(body.contains("onlyLatestOne"))
                 let json = """
                 {
-                  "data": {
-                    "tokenPlanInstanceInfo": {
-                      "planName": "TOKEN PLAN"
-                    }
-                  },
-                  "status_code": 0
+                  "Success": true,
+                  "Data": {
+                    "TotalCount": 1,
+                    "TotalValue": 1000,
+                    "TotalSurplusValue": 900
+                  }
                 }
                 """
                 return Self.makeResponse(url: url, body: json, statusCode: 200)
@@ -374,12 +379,12 @@ struct AlibabaTokenPlanUsageParsingTests {
                 #expect(body.contains("sec_token=session-html-token"))
                 let json = """
                 {
-                  "data": {
-                    "tokenPlanInstanceInfo": {
-                      "planName": "TOKEN PLAN"
-                    }
-                  },
-                  "status_code": 0
+                  "Success": true,
+                  "Data": {
+                    "TotalCount": 1,
+                    "TotalValue": 1000,
+                    "TotalSurplusValue": 900
+                  }
                 }
                 """
                 return Self.makeResponse(url: url, body: json, statusCode: 200)
@@ -405,10 +410,10 @@ struct AlibabaTokenPlanUsageParsingTests {
 
     @Test
     func `redirect preserves cookie only for same host HTTPS requests`() throws {
-        let sourceURL = try #require(URL(string: "https://bailian-cs.console.aliyun.com/data/api.json"))
-        let sameHostURL = try #require(URL(string: "https://bailian-cs.console.aliyun.com/redirected"))
+        let sourceURL = try #require(URL(string: "https://bailian.console.aliyun.com/data/api.json"))
+        let sameHostURL = try #require(URL(string: "https://bailian.console.aliyun.com/redirected"))
         let crossHostURL = try #require(URL(string: "https://signin.aliyun.com/login"))
-        let insecureURL = try #require(URL(string: "http://bailian-cs.console.aliyun.com/redirected"))
+        let insecureURL = try #require(URL(string: "http://bailian.console.aliyun.com/redirected"))
         let response = try #require(HTTPURLResponse(
             url: sourceURL,
             statusCode: 302,
@@ -553,7 +558,7 @@ struct AlibabaTokenPlanWebStrategyTests {
     }
 
     @Test
-    func `auto web strategy imports URL scoped token plan cookies`() throws {
+    func `auto web strategy imports subscription scoped token plan cookies`() throws {
         let strategy = AlibabaTokenPlanWebFetchStrategy()
         let settings = ProviderSettingsSnapshot.make(
             alibabaTokenPlan: ProviderSettingsSnapshot.AlibabaTokenPlanProviderSettings(
@@ -579,7 +584,10 @@ struct AlibabaTokenPlanWebStrategyTests {
                     self.cookie(name: "login_aliyunid_ticket", value: "ticket", domain: ".aliyun.com"),
                     self.cookie(name: "login_current_pk", value: "account", domain: ".aliyun.com"),
                     self.cookie(name: "dashboard_only", value: "dashboard", domain: "bailian.console.aliyun.com"),
-                    self.cookie(name: "api_only", value: "api", domain: "bailian-cs.console.aliyun.com"),
+                    self.cookie(
+                        name: "modelstudio_only",
+                        value: "modelstudio",
+                        domain: "modelstudio.console.alibabacloud.com"),
                     self.cookie(name: "alibabacloud_only", value: "cloud", domain: ".alibabacloud.com"),
                 ],
                 sourceLabel: "Chrome Default")
@@ -591,12 +599,12 @@ struct AlibabaTokenPlanWebStrategyTests {
 
         let headers = try AlibabaTokenPlanWebFetchStrategy.resolveCookieHeaders(context: context, allowCached: false)
 
-        #expect(headers.apiCookieHeader != headers.dashboardCookieHeader)
-        #expect(!headers.apiCookieHeader.contains("dashboard_only=dashboard"))
-        #expect(headers.apiCookieHeader.contains("api_only=api"))
+        #expect(headers.apiCookieHeader == headers.dashboardCookieHeader)
+        #expect(headers.apiCookieHeader.contains("dashboard_only=dashboard"))
+        #expect(!headers.apiCookieHeader.contains("modelstudio_only=modelstudio"))
         #expect(!headers.apiCookieHeader.contains("alibabacloud_only=cloud"))
         #expect(headers.dashboardCookieHeader.contains("dashboard_only=dashboard"))
-        #expect(!headers.dashboardCookieHeader.contains("api_only=api"))
+        #expect(!headers.dashboardCookieHeader.contains("modelstudio_only=modelstudio"))
         #expect(!headers.dashboardCookieHeader.contains("alibabacloud_only=cloud"))
 
         AlibabaCodingPlanCookieImporter.importSessionOverrideForTesting = { _, _ in
@@ -640,7 +648,7 @@ struct AlibabaTokenPlanWebStrategyTests {
                     self.cookie(name: "login_aliyunid_ticket", value: "ticket", domain: ".token-plan.test"),
                     self.cookie(name: "api_only", value: "api", domain: "quota.token-plan.test"),
                     self.cookie(name: "dashboard_only", value: "dashboard", domain: "dashboard.token-plan.test"),
-                    self.cookie(name: "prod_api_only", value: "prod-api", domain: "bailian-cs.console.aliyun.com"),
+                    self.cookie(name: "prod_api_only", value: "prod-api", domain: "bailian.console.aliyun.com"),
                     self.cookie(
                         name: "prod_dashboard_only",
                         value: "prod-dashboard",
@@ -685,7 +693,6 @@ final class AlibabaTokenPlanStubURLProtocol: URLProtocol {
     override static func canInit(with request: URLRequest) -> Bool {
         guard let host = request.url?.host else { return false }
         return host == "bailian.console.aliyun.com" ||
-            host == "bailian-cs.console.aliyun.com" ||
             host == "alibaba-token-plan.test" ||
             host == "session-token.test"
     }

--- a/docs/alibaba-token-plan.md
+++ b/docs/alibaba-token-plan.md
@@ -1,0 +1,61 @@
+---
+summary: "Alibaba Token Plan provider notes: Bailian cookie auth, subscription summary endpoint, and setup."
+read_when:
+  - Adding or modifying the Alibaba Token Plan provider
+  - Debugging Alibaba Token Plan cookie import or subscription summary fetching
+  - Explaining Alibaba Token Plan setup and limitations to users
+---
+
+# Alibaba Token Plan Provider
+
+The Alibaba Token Plan provider tracks Bailian token-plan credits from the Alibaba Cloud console.
+
+## Features
+
+- **Token-plan usage display**: Shows used, total, and remaining token-plan credits when Bailian returns quota totals.
+- **Cookie-based auth**: Uses browser cookies or a pasted `Cookie:` header.
+- **Expiry awareness**: Shows the nearest token-plan expiration date as the reset time when the subscription summary includes it.
+
+## Setup
+
+1. Open **Settings -> Providers**
+2. Enable **Alibaba Token Plan**
+3. Leave **Cookie source** on **Auto** (recommended)
+
+### Manual cookie import (optional)
+
+1. Open `https://bailian.console.aliyun.com/cn-beijing?tab=plan#/efm/subscription/token-plan`
+2. Copy a `Cookie:` header from your browser's Network tab
+3. Paste it into **Alibaba Token Plan -> Cookie source -> Manual**
+
+## How it works
+
+- Fetches `POST https://bailian.console.aliyun.com/data/api.json?action=GetSubscriptionSummary&product=BssOpenAPI-V3&_tag=`
+- Sends form-encoded fields for `product=BssOpenAPI-V3`, `action=GetSubscriptionSummary`, `region=cn-beijing`, and `params={"ProductCode":"sfm_tokenplanteams_dp_cn"}`
+- Uses Alibaba/Bailian login cookies, with `sec_token` added when it can be resolved from the dashboard page
+- Parses `TotalValue`, `TotalSurplusValue`, `TotalCount`, and `NearestExpireDate` from the subscription summary response
+- Supports `ALIBABA_TOKEN_PLAN_HOST` and `ALIBABA_TOKEN_PLAN_QUOTA_URL` for testing endpoint overrides
+
+## Limitations
+
+- Alibaba Token Plan currently supports the Bailian web-cookie path only
+- API-key auth, token cost summaries, and automatic status polling are not supported
+- The default endpoint is the China mainland Bailian token-plan subscription summary
+
+## Troubleshooting
+
+### "No Alibaba Token Plan session cookies found in browsers"
+
+Log in at `https://bailian.console.aliyun.com/cn-beijing?tab=plan#/efm/subscription/token-plan` in Chrome, then refresh CodexBar.
+
+### "Alibaba Token Plan cookie header is invalid"
+
+The pasted header is empty or not a valid Cookie header. Re-copy the request from the Token Plan page after logging in again.
+
+### "Alibaba Token Plan login required"
+
+Your Bailian session is stale. Sign out and back in on the Bailian console, then refresh CodexBar.
+
+### Empty subscription summary
+
+If Bailian returns `TotalCount: 0`, CodexBar keeps the provider visible but does not show a quota window because the account has no active token-plan subscription summary to graph.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -8,7 +8,7 @@ read_when:
 
 # Providers
 
-CodexBar currently registers 47 provider IDs. Some companies expose multiple surfaces, such as Codex vs OpenAI API or
+CodexBar currently registers 48 provider IDs. Some companies expose multiple surfaces, such as Codex vs OpenAI API or
 OpenCode vs OpenCode Go, because the auth source and quota shape differ.
 
 ## Fetch strategies (current)
@@ -31,6 +31,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 | OpenCode | Web dashboard via cookies (`web`). |
 | OpenCode Go | Web dashboard via cookies (`web`); optional workspace ID. |
 | Alibaba Coding Plan | Console RPC via web cookies (auto/manual) with API key fallback (`web`, `api`). |
+| Alibaba Token Plan | Bailian subscription summary API via browser or manual cookies (`web`). |
 | Droid/Factory | Web cookies → stored tokens → local storage → WorkOS cookies (`web`). |
 | z.ai | API token from config/env → quota API (`api`). |
 | Manus | Browser `session_id` cookie (auto/manual/env) → credits API (`web`). |
@@ -178,6 +179,14 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Host overrides: `ALIBABA_CODING_PLAN_HOST` or `ALIBABA_CODING_PLAN_QUOTA_URL`.
 - Status: `https://status.aliyun.com` (link only, no auto-polling).
 - Details: `docs/alibaba-coding-plan.md`.
+
+## Alibaba Token Plan
+- Web mode posts to the Bailian `GetSubscriptionSummary` endpoint with form-encoded params and optional `sec_token`.
+- Cookie sources: browser import (`auto`), manual Cookie header, or `ALIBABA_TOKEN_PLAN_COOKIE`.
+- Default quota URL: `https://bailian.console.aliyun.com/data/api.json?action=GetSubscriptionSummary&product=BssOpenAPI-V3`.
+- Host overrides: `ALIBABA_TOKEN_PLAN_HOST` or `ALIBABA_TOKEN_PLAN_QUOTA_URL`.
+- Status: `https://status.aliyun.com` (link only, no auto-polling).
+- Details: `docs/alibaba-token-plan.md`.
 
 ## Droid (Factory)
 - Web API via Factory cookies, bearer tokens, and WorkOS refresh tokens.


### PR DESCRIPTION
## Summary

- Switch Alibaba Token Plan usage fetching to Bailian `GetSubscriptionSummary`
- Update token-plan parsing for subscription summary quota fields, remaining credits, expiry date, and empty subscription state
- Refresh Alibaba Token Plan tests and provider docs for the new endpoint

## Background

Alibaba Token Plan changed its official usage API during this weekend, so the previous token-plan instance query endpoint is no longer suitable as the source of current usage data. This PR moves the fetcher to the new Bailian subscription summary endpoint to keep Token Plan credit usage working.

## Validation

- `swift test --filter AlibabaTokenPlan`
- `swiftformat Sources Tests --lint`
- `swiftlint lint --strict --no-cache --quiet`

## Proof

Verified against a real Alibaba Token Plan session.

Redacted live API check:

```bash
curl 'https://bailian.console.aliyun.com/data/api.json?action=GetSubscriptionSummary&product=BssOpenAPI-V3&_tag=' \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  -H 'Cookie: <redacted>' \
  --data 'product=BssOpenAPI-V3&action=GetSubscriptionSummary&params=%7B%22ProductCode%22%3A%22sfm_tokenplanteams_dp_cn%22%7D&region=cn-beijing'
```

<img width="1400" height="1141" alt="Alibaba Token Plan API proof" src="https://github.com/user-attachments/assets/ede1456f-1341-4b03-b5ce-e4846df6de6c" />


Note: `make check` reached SwiftFormat/SwiftLint with 0 violations, then failed only because the sandbox blocked a macOS plist cache write.