### PR TITLE
Show Codex CLI login guidance

### DIFF
--- a/Sources/CodexBar/Providers/Codex/CodexConsumerProjection.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexConsumerProjection.swift
@@ -2,6 +2,9 @@ import CodexBarCore
 import Foundation
 
 struct CodexUIErrorMapper {
+    private static let codexCLINotSignedInMessage =
+        "Codex CLI is not signed in. Run `codex login --device-auth`, then refresh."
+
     static func userFacingMessage(_ raw: String?) -> String? {
         guard let raw, !raw.isEmpty else { return nil }
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -18,6 +21,10 @@ struct CodexUIErrorMapper {
 
         if self.looksCodexCLIMissing(lower: lower) {
             return CodexStatusProbeError.codexNotInstalled.localizedDescription
+        }
+
+        if self.looksCodexCLILoginRequired(lower: lower) {
+            return self.codexCLINotSignedInMessage
         }
 
         if self.looksExpired(lower: lower) {
@@ -72,6 +79,7 @@ struct CodexUIErrorMapper {
             || lower.contains("selected managed codex account is unavailable")
             || lower.contains("codex credits are still loading")
             || lower.contains("codex account changed; importing browser cookies")
+            || lower.contains("codex cli is not signed in.")
             || lower.contains("codex session expired. sign in again.")
             || lower.contains("openai web refresh timed out. refresh openai cookies and try again.")
             || lower.contains(
@@ -87,6 +95,12 @@ struct CodexUIErrorMapper {
             || lower.contains("missing cli 'codex'")
             || lower.contains("missing cli \"codex\"")
             || (lower.contains("binary not found") && lower.contains("codex"))
+    }
+
+    private static func looksCodexCLILoginRequired(lower: String) -> Bool {
+        lower.contains("codex account authentication required")
+            || lower.contains("account authentication required to read rate limits")
+            || lower.contains("requiresopenaiauth")
     }
 
     private static func looksExpired(lower: String) -> Bool {

--- a/Tests/CodexBarTests/CodexUserFacingErrorTests.swift
+++ b/Tests/CodexBarTests/CodexUserFacingErrorTests.swift
@@ -15,6 +15,30 @@ struct CodexUserFacingErrorTests {
     }
 
     @Test
+    func `logged out codex CLI guidance is not collapsed to temporary outage`() {
+        let store = self.makeUsageStore(suite: "CodexUserFacingErrorTests-cli-login-required")
+        store.errors[.codex] =
+            "Codex connection failed: codex account authentication required to read rate limits"
+
+        #expect(
+            store.userFacingError(for: .codex) ==
+                "Codex CLI is not signed in. Run `codex login --device-auth`, then refresh.")
+    }
+
+    @Test
+    func `cached logged out codex CLI failure preserves cached suffix`() {
+        let store = self.makeUsageStore(suite: "CodexUserFacingErrorTests-cached-cli-login-required")
+        store.lastCreditsError =
+            "Last Codex credits refresh failed: Codex connection failed: "
+                + "codex account authentication required to read rate limits. Cached values from 2m ago."
+
+        #expect(
+            store.userFacingLastCreditsError ==
+                "Codex CLI is not signed in. Run `codex login --device-auth`, then refresh. "
+                + "Cached values from 2m ago.")
+    }
+
+    @Test
     func `expired codex auth is sanitized`() {
         let store = self.makeUsageStore(suite: "CodexUserFacingErrorTests-expired-auth")
         store.errors[.codex] = """


### PR DESCRIPTION
Fixes #1170.

## Summary

- classify logged-out Codex app-server auth failures before the generic transport-error bucket
- show actionable CLI sign-in guidance for `codex account authentication required to read rate limits`
- add regression coverage for direct and cached Codex CLI logged-out errors

## Why

ClawSweeper confirmed the issue is source-reproducible on current main: the Codex app-server auth-required failure is wrapped as `Codex connection failed`, then the UI mapper collapses it to `Codex usage is temporarily unavailable. Try refreshing.` That message is appropriate for backend/transport/decode failures, but not for a local logged-out CLI state.

This keeps the existing generic wording for real transport and decode failures while surfacing the logged-out state as:

```text
Codex CLI is not signed in. Run `codex login --device-auth`, then refresh.
```

## After-fix runtime proof

Redacted local runtime proof from PR head `e1c60ff11fdf1faf1942a992b61dce892d857381`, using the real Codex CLI (`codex-cli 0.133.0`) with an isolated empty `CODEX_HOME` to reproduce a logged-out CLI refresh without touching my real login. The temporary proof harness exercised the production Codex RPC fetcher and the same provider error display path used by CodexBar, then was removed before pushing.

```text
$ CODEX_CLI_PATH=/Users/jk/.nvm/versions/node/v22.21.0/bin/codex swift test --filter CodexCLILoggedOutRuntimeProofTests
CODEXBAR_RUNTIME_PROOF_PR_HEAD=e1c60ff11fdf1faf1942a992b61dce892d857381
CODEXBAR_RUNTIME_PROOF_CODEX_CLI=/Users/jk/.nvm/versions/node/v22.21.0/bin/codex
CODEXBAR_RUNTIME_PROOF_CODEX_HOME=<isolated logged-out temp dir>
CODEXBAR_RUNTIME_PROOF_RAW=Codex connection failed: codex account authentication required to read rate limits
CODEXBAR_RUNTIME_PROOF_PROVIDER_PREVIEW=Codex CLI is not signed in. Run `codex login --device-auth`, then refresh.
CODEXBAR_RUNTIME_PROOF_PROVIDER_COPY_FULL=Codex connection failed: codex account authentication required to read rate limits
Test run with 1 test in 1 suite passed
```

## Validation

```text
$ git diff --check
# no output

$ swift test --filter CodexUserFacingErrorTests
Test run with 15 tests in 1 suite passed

$ swift test --filter CodexUsageFetcherFallbackTests
Test run with 13 tests passed

$ make check
Done linting! Found 0 violations, 0 serious in 952 files.
```
