### PR TITLE
Refresh displaced menu bar items on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.29.2 — Unreleased
 
 ### Fixed
+- Menu bar: refresh live status items at startup when macOS places them outside the current menu bar screen frame (#1169). Thanks @kieranmcshane!
 - Release: prevent manual CLI artifact builds from publishing or clobbering release assets (#1154). Thanks @jskoiz!
 - Cost history: route OpenAI and Mistral API spend through the shared cost-history cards, including OpenAI request counts (#1163). Thanks @LeoLin990405!
 - Alibaba Token Plan: update usage refreshes to the Bailian subscription-summary endpoint (#1142). Thanks @YanxinXue!

--- a/Sources/CodexBar/MenuBarVisibilityWatcher.swift
+++ b/Sources/CodexBar/MenuBarVisibilityWatcher.swift
@@ -7,6 +7,7 @@ struct StatusItemVisibilitySnapshot: Equatable {
     let hasWindow: Bool
     let hasScreen: Bool
     let isOnCurrentScreen: Bool
+    let isWithinCurrentScreenFrame: Bool
     let buttonWidth: CGFloat
 
     init(
@@ -15,6 +16,7 @@ struct StatusItemVisibilitySnapshot: Equatable {
         hasWindow: Bool,
         hasScreen: Bool,
         isOnCurrentScreen: Bool = true,
+        isWithinCurrentScreenFrame: Bool = true,
         buttonWidth: CGFloat)
     {
         self.isVisible = isVisible
@@ -22,6 +24,7 @@ struct StatusItemVisibilitySnapshot: Equatable {
         self.hasWindow = hasWindow
         self.hasScreen = hasScreen
         self.isOnCurrentScreen = isOnCurrentScreen
+        self.isWithinCurrentScreenFrame = isWithinCurrentScreenFrame
         self.buttonWidth = buttonWidth
     }
 }
@@ -30,6 +33,7 @@ extension StatusItemVisibilitySnapshot: CustomStringConvertible {
     var description: String {
         "visible=\(self.isVisible),button=\(self.hasButton),window=\(self.hasWindow),"
             + "screen=\(self.hasScreen),currentScreen=\(self.isOnCurrentScreen),"
+            + "withinScreenFrame=\(self.isWithinCurrentScreenFrame),"
             + "width=\(String(format: "%.1f", Double(self.buttonWidth)))"
     }
 }
@@ -52,14 +56,33 @@ enum MenuBarVisibilityWatcher {
 
     @MainActor
     static func visibilitySnapshot(_ item: NSStatusItem) -> StatusItemVisibilitySnapshot {
-        let screen = item.button?.window?.screen
+        let button = item.button
+        let window = button?.window
+        let screen = window?.screen
+        let buttonFrame = self.buttonFrameInScreen(button)
         return StatusItemVisibilitySnapshot(
             isVisible: item.isVisible,
-            hasButton: item.button != nil,
-            hasWindow: item.button?.window != nil,
+            hasButton: button != nil,
+            hasWindow: window != nil,
             hasScreen: screen != nil,
             isOnCurrentScreen: screen.map(self.isCurrentScreen) ?? false,
-            buttonWidth: item.button?.frame.size.width ?? 0)
+            isWithinCurrentScreenFrame: buttonFrame.map(self.isWithinCurrentScreenFrame) ?? false,
+            buttonWidth: button?.frame.size.width ?? 0)
+    }
+
+    @MainActor
+    private static func buttonFrameInScreen(_ button: NSStatusBarButton?) -> CGRect? {
+        guard let button, let window = button.window else { return nil }
+        let frameInWindow = button.convert(button.bounds, to: nil)
+        guard !frameInWindow.isEmpty else { return nil }
+        return window.convertToScreen(frameInWindow)
+    }
+
+    @MainActor
+    private static func isWithinCurrentScreenFrame(_ rect: CGRect) -> Bool {
+        NSScreen.screens.contains { screen in
+            screen.frame.contains(rect)
+        }
     }
 
     @MainActor
@@ -89,7 +112,7 @@ enum MenuBarVisibilityWatcher {
         guard snapshot.isVisible, snapshot.hasButton, snapshot.hasWindow, snapshot.buttonWidth > 0 else {
             return false
         }
-        return !snapshot.hasScreen || !snapshot.isOnCurrentScreen
+        return !snapshot.hasScreen || !snapshot.isOnCurrentScreen || !snapshot.isWithinCurrentScreenFrame
     }
 
     static func hasBlockedVisibleSnapshots(_ snapshots: [StatusItemVisibilitySnapshot]) -> Bool {
@@ -132,6 +155,16 @@ enum MenuBarVisibilityWatcher {
     {
         guard now.timeIntervalSince(appLaunchedAt) <= self.startupFreshnessInterval else { return false }
         return self.hasAnyBlockedVisibleSnapshot(snapshots)
+    }
+
+    static func shouldRefreshStartupPlacement(
+        appLaunchedAt: Date,
+        now: Date = Date(),
+        snapshots: [StatusItemVisibilitySnapshot])
+        -> Bool
+    {
+        guard now.timeIntervalSince(appLaunchedAt) <= self.startupFreshnessInterval else { return false }
+        return self.hasAnyDisplacedVisibleSnapshot(snapshots)
     }
 
     static func shouldRefreshScreenChangePlacement(
@@ -207,6 +240,10 @@ extension StatusItemController {
             now: now,
             snapshots: snapshots)
         else {
+            self.refreshDisplacedStartupStatusItemsIfNeeded(
+                appLaunchedAt: appLaunchedAt,
+                now: now,
+                snapshots: snapshots)
             return
         }
 
@@ -236,6 +273,41 @@ extension StatusItemController {
             return
         }
         MenuBarVisibilityWatcher.presentGuidance(defaults: self.settings.userDefaults, now: now)
+    }
+
+    private func refreshDisplacedStartupStatusItemsIfNeeded(
+        appLaunchedAt: Date,
+        now: Date,
+        snapshots: [StatusItemVisibilitySnapshot])
+    {
+        guard MenuBarVisibilityWatcher.shouldRefreshStartupPlacement(
+            appLaunchedAt: appLaunchedAt,
+            now: now,
+            snapshots: snapshots)
+        else {
+            return
+        }
+
+        self.menuLogger.info(
+            "Status item launched outside the current menu bar; refreshing existing status items",
+            metadata: ["snapshots": snapshots.map(\.description).joined(separator: " | ")])
+        self.refreshExistingStatusItemsForVisibilityRecovery()
+
+        let recoveredSnapshots = MenuBarVisibilityWatcher.visibilitySnapshots(self.startupVisibilityStatusItems)
+        guard MenuBarVisibilityWatcher.shouldRefreshStartupPlacement(
+            appLaunchedAt: appLaunchedAt,
+            now: now,
+            snapshots: recoveredSnapshots)
+        else {
+            self.menuLogger.info(
+                "Status item placement recovered after startup refresh",
+                metadata: ["snapshots": recoveredSnapshots.map(\.description).joined(separator: " | ")])
+            return
+        }
+
+        self.menuLogger.error(
+            "Status item still outside the current menu bar after startup refresh",
+            metadata: ["snapshots": recoveredSnapshots.map(\.description).joined(separator: " | ")])
     }
 
     @objc func handleScreenParametersDidChange(_: Notification) {

--- a/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
+++ b/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
@@ -105,6 +105,21 @@ struct MenuBarVisibilityWatcherTests {
     }
 
     @Test
+    func `classifies offscreen live item as displaced but not blocked`() {
+        let snapshot = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: true,
+            isOnCurrentScreen: true,
+            isWithinCurrentScreenFrame: false,
+            buttonWidth: 18)
+
+        #expect(!MenuBarVisibilityWatcher.isBlockedSnapshot(snapshot: snapshot))
+        #expect(MenuBarVisibilityWatcher.isDisplacedSnapshot(snapshot: snapshot))
+    }
+
+    @Test
     func `guidance shows once then repeats after a day`() throws {
         let defaults = try #require(UserDefaults(suiteName: "MenuBarVisibilityWatcherTests"))
         defaults.removePersistentDomain(forName: "MenuBarVisibilityWatcherTests")
@@ -190,6 +205,75 @@ struct MenuBarVisibilityWatcherTests {
             appLaunchedAt: launchedAt,
             now: launchedAt.addingTimeInterval(2),
             snapshots: [healthy]))
+    }
+
+    @Test
+    func `startup recovery ignores displaced live item`() {
+        let launchedAt = Date(timeIntervalSince1970: 1000)
+        let displaced = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: false,
+            isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(!MenuBarVisibilityWatcher.shouldAttemptStartupRecovery(
+            appLaunchedAt: launchedAt,
+            now: launchedAt.addingTimeInterval(2),
+            snapshots: [displaced]))
+    }
+
+    @Test
+    func `startup placement refresh triggers for displaced live item`() {
+        let launchedAt = Date(timeIntervalSince1970: 1000)
+        let displaced = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: false,
+            isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(MenuBarVisibilityWatcher.shouldRefreshStartupPlacement(
+            appLaunchedAt: launchedAt,
+            now: launchedAt.addingTimeInterval(2),
+            snapshots: [displaced]))
+    }
+
+    @Test
+    func `startup placement refresh triggers for offscreen live item`() {
+        let launchedAt = Date(timeIntervalSince1970: 1000)
+        let displaced = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: true,
+            isOnCurrentScreen: true,
+            isWithinCurrentScreenFrame: false,
+            buttonWidth: 18)
+
+        #expect(MenuBarVisibilityWatcher.shouldRefreshStartupPlacement(
+            appLaunchedAt: launchedAt,
+            now: launchedAt.addingTimeInterval(2),
+            snapshots: [displaced]))
+    }
+
+    @Test
+    func `startup placement refresh ignores stale checks`() {
+        let launchedAt = Date(timeIntervalSince1970: 1000)
+        let displaced = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: false,
+            isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(!MenuBarVisibilityWatcher.shouldRefreshStartupPlacement(
+            appLaunchedAt: launchedAt,
+            now: launchedAt.addingTimeInterval(MenuBarVisibilityWatcher.startupFreshnessInterval + 1),
+            snapshots: [displaced]))
     }
 
     @Test
@@ -289,6 +373,23 @@ struct MenuBarVisibilityWatcherTests {
             hasWindow: true,
             hasScreen: true,
             isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(MenuBarVisibilityWatcher.shouldRefreshScreenChangePlacement(
+            previousScreenCount: 2,
+            currentScreenCount: 2,
+            snapshots: [displaced]))
+    }
+
+    @Test
+    func `screen change placement refresh triggers for offscreen live item`() {
+        let displaced = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: true,
+            isOnCurrentScreen: true,
+            isWithinCurrentScreenFrame: false,
             buttonWidth: 18)
 
         #expect(MenuBarVisibilityWatcher.shouldRefreshScreenChangePlacement(


### PR DESCRIPTION
Refs #1169.

## Summary

- include screen-frame placement in status-item visibility snapshots and recovery logs
- classify live status items outside the current screen frame as displaced, not destructively blocked
- refresh existing displaced status items during the startup materialization check instead of waiting for a display-change notification
- add focused watcher tests for startup/offscreen placement recovery

## Why

#1169 reports a normal-launch failure on macOS 26.5 where CodexBar is alive and the status item exists, but ControlCenter moves it from `.menuBar` to `.ephemeral` / not visible. The existing #1122 recovery split handles displaced live status items after display changes, but the startup check only handled destructive blocked states such as missing button/window or zero width.

This keeps destructive recreation limited to truly broken AppKit status items. For live displaced items, startup now uses the same non-destructive refresh path already used for display-change placement recovery. The new `withinScreenFrame` snapshot field also gives maintainers/reporter logs a clearer signal for cases where AppKit reports a live item but its button frame is outside the usable menu bar screen frame.

## Validation

```text
$ swift test --filter MenuBarVisibilityWatcherTests
Test run with 30 tests in 1 suite passed

$ swift test --filter StatusItemControllerSplitLifecycleTests
Test run with 7 tests in 1 suite passed

$ git diff --check
# no output

$ make check
Done linting! Found 0 violations, 0 serious in 952 files.
```

## Proof and remaining risk

I could not reproduce the macOS 26.5 ControlCenter `.ephemeral` state locally. This PR is therefore framed as a targeted startup recovery/diagnostic improvement, not as final affected-machine proof. The right next proof is a freshly built bundle on a machine that reproduces #1169, checking whether the startup log now includes `withinScreenFrame=false` and whether the non-destructive startup refresh restores the visible item.

## CI note

This commit uses `[skip ci]` to avoid triggering fork push/PR checks on the contributor's personal GitHub Actions budget. Upstream/org-budget macOS CI is fine if a maintainer chooses to run it.
