### PR TITLE
Avoid repeated display-change status item recreation

### DIFF
--- a/Sources/CodexBar/MenuBarVisibilityWatcher.swift
+++ b/Sources/CodexBar/MenuBarVisibilityWatcher.swift
@@ -147,7 +147,11 @@ enum MenuBarVisibilityWatcher {
         self.hasAnyBlockedVisibleSnapshot(snapshots)
     }
 
-    static func shouldRetryScreenChangeRecovery(
+    /// Returns true when a follow-up verification should report "still blocked" for logging/guidance.
+    /// The actual verifyScreenChangeRecoveryIfNeeded is observe-only and never calls
+    /// recreateStatusItemsForVisibilityRecovery — the single allowed recreate happens in
+    /// checkScreenChangeStatusItemVisibility before any follow-up is scheduled.
+    static func shouldObserveBlockedScreenChangeFollowUp(
         attempt: Int,
         snapshots: [StatusItemVisibilitySnapshot])
         -> Bool
@@ -326,29 +330,20 @@ extension StatusItemController {
             return
         }
 
-        guard MenuBarVisibilityWatcher.shouldRetryScreenChangeRecovery(attempt: attempt, snapshots: snapshots) else {
-            self.menuLogger.error(
-                "Status item still blocked after display-change recovery retries",
-                metadata: [
-                    "attempt": "\(attempt)",
-                    "snapshots": snapshots.map(\.description).joined(separator: " | "),
-                ])
-            guard #available(macOS 26.0, *),
-                  MenuBarVisibilityWatcher.shouldShowGuidance(defaults: self.settings.userDefaults)
-            else {
-                return
-            }
-            MenuBarVisibilityWatcher.presentGuidance(defaults: self.settings.userDefaults)
-            return
-        }
+        // Follow-up verification is observe-only: no further destructive recreate.
+        // `checkScreenChangeStatusItemVisibility` already performed the single allowed recreate.
         self.menuLogger.error(
-            "Status item still blocked after display-change recovery; recreating status items again",
+            "Status item still blocked after display-change recovery; follow-up verification, no further recreate",
             metadata: [
                 "attempt": "\(attempt)",
                 "snapshots": snapshots.map(\.description).joined(separator: " | "),
             ])
-        self.recreateStatusItemsForVisibilityRecovery()
-        self.schedulePostScreenChangeRecoveryVerification(attempt: attempt + 1)
+        guard #available(macOS 26.0, *),
+              MenuBarVisibilityWatcher.shouldShowGuidance(defaults: self.settings.userDefaults)
+        else {
+            return
+        }
+        MenuBarVisibilityWatcher.presentGuidance(defaults: self.settings.userDefaults)
     }
 
     private var startupVisibilityStatusItems: [NSStatusItem] {

--- a/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
+++ b/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
@@ -307,7 +307,7 @@ struct MenuBarVisibilityWatcherTests {
             isOnCurrentScreen: false,
             buttonWidth: 18)
 
-        #expect(!MenuBarVisibilityWatcher.shouldRetryScreenChangeRecovery(
+        #expect(!MenuBarVisibilityWatcher.shouldObserveBlockedScreenChangeFollowUp(
             attempt: MenuBarVisibilityWatcher.screenChangeRecoveryRetryLimit - 1,
             snapshots: [blocked]))
     }
@@ -322,7 +322,7 @@ struct MenuBarVisibilityWatcherTests {
             isOnCurrentScreen: false,
             buttonWidth: 18)
 
-        #expect(MenuBarVisibilityWatcher.shouldRetryScreenChangeRecovery(
+        #expect(MenuBarVisibilityWatcher.shouldObserveBlockedScreenChangeFollowUp(
             attempt: MenuBarVisibilityWatcher.screenChangeRecoveryRetryLimit - 1,
             snapshots: [blocked]))
     }
@@ -337,7 +337,7 @@ struct MenuBarVisibilityWatcherTests {
             isOnCurrentScreen: false,
             buttonWidth: 18)
 
-        #expect(!MenuBarVisibilityWatcher.shouldRetryScreenChangeRecovery(
+        #expect(!MenuBarVisibilityWatcher.shouldObserveBlockedScreenChangeFollowUp(
             attempt: MenuBarVisibilityWatcher.screenChangeRecoveryRetryLimit,
             snapshots: [blocked]))
     }
@@ -351,8 +351,70 @@ struct MenuBarVisibilityWatcherTests {
             hasScreen: true,
             buttonWidth: 18)
 
-        #expect(!MenuBarVisibilityWatcher.shouldRetryScreenChangeRecovery(
+        #expect(!MenuBarVisibilityWatcher.shouldObserveBlockedScreenChangeFollowUp(
             attempt: 1,
+            snapshots: [healthy]))
+    }
+
+    // MARK: - At most one recreate per display-change event
+
+    @Test
+    func `initial screen change detection allows recovery for blocked snapshot`() {
+        let blocked = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: false,
+            hasScreen: false,
+            buttonWidth: 18)
+
+        #expect(MenuBarVisibilityWatcher.shouldAttemptScreenChangeRecovery(snapshots: [blocked]))
+    }
+
+    @Test
+    func `initial screen change detection does not allow recovery for healthy snapshot`() {
+        let healthy = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: true,
+            buttonWidth: 18)
+
+        #expect(!MenuBarVisibilityWatcher.shouldAttemptScreenChangeRecovery(snapshots: [healthy]))
+    }
+
+    @Test
+    func `follow-up still reports blocked for logging and guidance purposes`() {
+        let blocked = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: false,
+            hasScreen: false,
+            buttonWidth: 18)
+
+        // Follow-up detection may still report "blocked" for logging/guidance, even though
+        // verifyScreenChangeRecoveryIfNeeded itself will not call recreate.
+        #expect(MenuBarVisibilityWatcher.shouldObserveBlockedScreenChangeFollowUp(
+            attempt: 1,
+            snapshots: [blocked]))
+        #expect(MenuBarVisibilityWatcher.shouldObserveBlockedScreenChangeFollowUp(
+            attempt: 2,
+            snapshots: [blocked]))
+    }
+
+    @Test
+    func `follow-up does not report blocked for healthy snapshot`() {
+        let healthy = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: true,
+            buttonWidth: 18)
+
+        #expect(!MenuBarVisibilityWatcher.shouldObserveBlockedScreenChangeFollowUp(
+            attempt: 1,
+            snapshots: [healthy]))
+        #expect(!MenuBarVisibilityWatcher.shouldObserveBlockedScreenChangeFollowUp(
+            attempt: 2,
             snapshots: [healthy]))
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1175 by making display-change follow-up verification observe-only.

The initial display-change recovery path may still perform the one allowed destructive `NSStatusItem` recreation when a visible item is blocked. Follow-up verification no longer recreates status items or reschedules another retry; it only logs and shows guidance if the item still appears blocked.

This avoids repeatedly destroying/recreating menu bar status items while menu bar managers such as Thaw, Bartender, Ice, or Hidden Bar are re-parking hidden items.

## Tests

- `swift test --filter MenuBarVisibilityWatcherTests`
- `swift test --filter StatusItemControllerSplitLifecycleTests`
- `swift build`

## Manual validation

Manual validation with Thaw/Bartender/Ice/Hidden Bar is still recommended because the original report depends on third-party menu bar manager behavior.