### PR TITLE
Add missed v0.30.0 release notes entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,14 @@
 - Antigravity: show the complete per-model quota breakdown alongside the existing summary lanes (#1139). Thanks @guhyun9454!
 - Widget: show tertiary usage rows for providers that expose a third quota lane (#1160). Thanks @LeoLin990405!
 - DeepSeek: show optional web-session usage and cost summaries alongside the balance card (#1166). Thanks @Yuxin-Qiao!
+- OpenAI: add project usage scoping via OPENAI_PROJECT_ID or providers[].workspaceID so costs and completions usage can be filtered by project (#1168).
 
 ### Fixed
 - App shutdown: detach status items, close tracked menus, and cancel menu tasks before quit so Dock autohide stays responsive on macOS 26.5 (#1174). Thanks @jskoiz!
 - Widgets: package the macOS widget as a real Xcode app-extension target so WidgetKit descriptors load on macOS 26.5 (#1095). Thanks @jamesjlopez!
 - Menu: render quota-warning markers as subtle inset ticks instead of full-height bars (#1149).
+- Menu: handle provider switcher Cmd-number and left/right shortcuts while the menu is open, keeping the menu open after switching (#1157).
+- Codex: fix forked child session token replay overcounting when inherited token snapshots are present (#1164).
 - Codex: show sign-in guidance when the Codex CLI is logged out instead of reporting a temporary usage outage (#1171, fixes #1170). Thanks @jskoiz!
 - Menu bar: clear stale hidden macOS status-item visibility defaults once before creating CodexBar items (#1169).
 - StepFun: refresh expired Oasis tokens and persist recovered manual sessions. Thanks @LeoLin990405!

--- a/appcast.xml
+++ b/appcast.xml
@@ -16,12 +16,15 @@
 <li>Antigravity: show the complete per-model quota breakdown alongside the existing summary lanes (#1139). Thanks @guhyun9454!</li>
 <li>Widget: show tertiary usage rows for providers that expose a third quota lane (#1160). Thanks @LeoLin990405!</li>
 <li>DeepSeek: show optional web-session usage and cost summaries alongside the balance card (#1166). Thanks @Yuxin-Qiao!</li>
+<li>OpenAI: add project usage scoping via OPENAI_PROJECT_ID or providers[].workspaceID so costs and completions usage can be filtered by project (#1168).</li>
 </ul>
 <h3>Fixed</h3>
 <ul>
 <li>App shutdown: detach status items, close tracked menus, and cancel menu tasks before quit so Dock autohide stays responsive on macOS 26.5 (#1174). Thanks @jskoiz!</li>
 <li>Widgets: package the macOS widget as a real Xcode app-extension target so WidgetKit descriptors load on macOS 26.5 (#1095). Thanks @jamesjlopez!</li>
 <li>Menu: render quota-warning markers as subtle inset ticks instead of full-height bars (#1149).</li>
+<li>Menu: handle provider switcher Cmd-number and left/right shortcuts while the menu is open, keeping the menu open after switching (#1157).</li>
+<li>Codex: fix forked child session token replay overcounting when inherited token snapshots are present (#1164).</li>
 <li>Codex: show sign-in guidance when the Codex CLI is logged out instead of reporting a temporary usage outage (#1171, fixes #1170). Thanks @jskoiz!</li>
 <li>Menu bar: clear stale hidden macOS status-item visibility defaults once before creating CodexBar items (#1169).</li>
 <li>StepFun: refresh expired Oasis tokens and persist recovered manual sessions. Thanks @LeoLin990405!</li>


### PR DESCRIPTION
## Summary

Addresses #1187.

Docs-only update adding missed v0.30.0 changelog/appcast entries for:

- #1157 Handle provider switcher shortcuts in the open menu
- #1164 Fix Codex fork token replay overcount
- #1168 Add OpenAI project usage scoping

## Validation

- git diff --check