### PR TITLE
Add default terminal preference

### DIFF
--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -70,6 +70,28 @@ struct GeneralPane: View {
                         title: L("start_at_login_title"),
                         subtitle: L("start_at_login_subtitle"),
                         binding: self.$settings.launchAtLogin)
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack(alignment: .top, spacing: 12) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(L("default_terminal_title"))
+                                    .font(.body)
+                                Text(L("default_terminal_subtitle"))
+                                    .font(.footnote)
+                                    .foregroundStyle(.tertiary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                            Spacer()
+                            Picker(L("default_terminal_title"), selection: self.$settings.preferredTerminalApp) {
+                                ForEach(PreferredTerminalApp.availableApps()) { app in
+                                    Text(app.label).tag(app)
+                                }
+                            }
+                            .labelsHidden()
+                            .pickerStyle(.menu)
+                            .frame(maxWidth: 200)
+                        }
+                    }
                 }
 
                 Divider()

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -106,6 +106,8 @@
 "Daily Routines" = "Daily Routines";
 "Debug" = "Debug";
 "Default" = "Default";
+"default_terminal_subtitle" = "Used by provider Open Terminal menu commands.";
+"default_terminal_title" = "Open Terminal app";
 "Disable Keychain access" = "Disable Keychain access";
 "Disabled" = "Disabled";
 "Dismiss" = "Dismiss";

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -71,6 +71,18 @@ extension SettingsStore {
         }
     }
 
+    var preferredTerminalApp: PreferredTerminalApp {
+        get {
+            let raw = self.userDefaults.string(forKey: "preferredTerminalApp")
+                ?? self.defaultsState.preferredTerminalAppRaw
+            return PreferredTerminalApp(rawValue: raw) ?? .terminal
+        }
+        set {
+            self.defaultsState.preferredTerminalAppRaw = newValue.rawValue
+            self.userDefaults.set(newValue.rawValue, forKey: "preferredTerminalApp")
+        }
+    }
+
     var isVerboseLoggingEnabled: Bool {
         self.debugLogLevel.rank <= CodexBarLog.Level.verbose.rank
     }

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -9,6 +9,7 @@ struct SettingsDefaultsState {
     var debugLogLevelRaw: String?
     var debugLoadingPatternRaw: String?
     var debugKeepCLISessionsAlive: Bool
+    var preferredTerminalAppRaw: String = "terminal"
     var statusChecksEnabled: Bool
     var sessionQuotaNotificationsEnabled: Bool
     var quotaWarningNotificationsEnabled: Bool

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -169,7 +169,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
 
     @objc func openTerminalCommand(_ sender: NSMenuItem) {
         let command = sender.representedObject as? String ?? "claude"
-        Self.openTerminal(command: command)
+        TerminalCommandLauncher.open(command: command, preferredApp: self.settings.preferredTerminalApp)
     }
 
     @objc func openLoginToProvider(_ sender: NSMenuItem) {
@@ -321,27 +321,6 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             let pb = NSPasteboard.general
             pb.clearContents()
             pb.setString(err, forType: .string)
-        }
-    }
-
-    private static func openTerminal(command: String) {
-        let escaped = command
-            .replacingOccurrences(of: "\\\\", with: "\\\\\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
-        let script = """
-        tell application "Terminal"
-            activate
-            do script "\(escaped)"
-        end tell
-        """
-        if let appleScript = NSAppleScript(source: script) {
-            var error: NSDictionary?
-            appleScript.executeAndReturnError(&error)
-            if let error {
-                CodexBarLog.logger(LogCategories.terminal).error(
-                    "Failed to open Terminal",
-                    metadata: ["error": String(describing: error)])
-            }
         }
     }
 

--- a/Sources/CodexBar/TerminalCommandLauncher.swift
+++ b/Sources/CodexBar/TerminalCommandLauncher.swift
@@ -1,0 +1,117 @@
+import AppKit
+import CodexBarCore
+import Foundation
+
+enum PreferredTerminalApp: String, CaseIterable, Identifiable, Sendable {
+    case terminal
+    case iTerm2 = "iterm2"
+
+    var id: String {
+        self.rawValue
+    }
+
+    var label: String {
+        switch self {
+        case .terminal: "Terminal"
+        case .iTerm2: "iTerm2"
+        }
+    }
+
+    var bundleIdentifier: String {
+        switch self {
+        case .terminal: "com.apple.Terminal"
+        case .iTerm2: "com.googlecode.iterm2"
+        }
+    }
+
+    @MainActor
+    static func availableApps() -> [PreferredTerminalApp] {
+        self.availableApps {
+            NSWorkspace.shared.urlForApplication(withBundleIdentifier: $0)
+        }
+    }
+
+    static func availableApps(applicationURL: (String) -> URL?) -> [PreferredTerminalApp] {
+        let installed = Self.allCases.filter { applicationURL($0.bundleIdentifier) != nil }
+        return installed.isEmpty ? [.terminal] : installed
+    }
+
+    @MainActor
+    static func resolved(_ preferred: PreferredTerminalApp) -> PreferredTerminalApp {
+        self.resolved(preferred) {
+            NSWorkspace.shared.urlForApplication(withBundleIdentifier: $0)
+        }
+    }
+
+    static func resolved(
+        _ preferred: PreferredTerminalApp,
+        applicationURL: (String) -> URL?)
+        -> PreferredTerminalApp
+    {
+        applicationURL(preferred.bundleIdentifier) == nil ? .terminal : preferred
+    }
+}
+
+@MainActor
+enum TerminalCommandLauncher {
+    static func open(command: String, preferredApp: PreferredTerminalApp) {
+        self.open(
+            command: command,
+            preferredApp: preferredApp,
+            applicationURL: {
+                NSWorkspace.shared.urlForApplication(withBundleIdentifier: $0)
+            },
+            runAppleScript: self.runAppleScript)
+    }
+
+    static func open(
+        command: String,
+        preferredApp: PreferredTerminalApp,
+        applicationURL: (String) -> URL?,
+        runAppleScript: (String) -> NSDictionary?)
+    {
+        let app = PreferredTerminalApp.resolved(preferredApp, applicationURL: applicationURL)
+        let script = self.appleScript(command: command, app: app)
+        if let error = runAppleScript(script) {
+            CodexBarLog.logger(LogCategories.terminal).error(
+                "Failed to open terminal",
+                metadata: ["app": app.rawValue, "error": String(describing: error)])
+        }
+    }
+
+    static func appleScript(command: String, app: PreferredTerminalApp) -> String {
+        let escaped = self.escapeForAppleScript(command)
+        switch app {
+        case .terminal:
+            """
+            tell application "Terminal"
+                activate
+                do script "\(escaped)"
+            end tell
+            """
+        case .iTerm2:
+            """
+            tell application "iTerm2"
+                activate
+                create window with default profile
+                tell current session of current window
+                    write text "\(escaped)"
+                end tell
+            end tell
+            """
+        }
+    }
+
+    nonisolated static func escapeForAppleScript(_ command: String) -> String {
+        command
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    private static func runAppleScript(_ script: String) -> NSDictionary? {
+        guard let appleScript = NSAppleScript(source: script) else { return nil }
+        var error: NSDictionary?
+        appleScript.executeAndReturnError(&error)
+        return error
+    }
+}

--- a/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
@@ -135,9 +135,43 @@ struct SettingsStoreAdditionalTests {
         #expect(SettingsStore.hasAnyTokenCostUsageSources(env: env, fileManager: fm))
     }
 
-    private static func makeSettingsStore(suite: String) -> SettingsStore {
-        let defaults = UserDefaults(suiteName: suite)!
+    @Test
+    func `preferred terminal app persists in defaults`() {
+        let suite = "SettingsStoreAdditionalTests-preferred-terminal"
+        let settings = Self.makeSettingsStore(suite: suite)
+
+        #expect(settings.preferredTerminalApp == .terminal)
+
+        settings.preferredTerminalApp = .iTerm2
+
+        let reloaded = Self.makeSettingsStorePreservingDefaults(suite: suite)
+        #expect(reloaded.preferredTerminalApp == .iTerm2)
+    }
+
+    @Test
+    func `invalid preferred terminal app defaults to Terminal`() throws {
+        let suite = "SettingsStoreAdditionalTests-invalid-terminal"
+        let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
+        defaults.set("missing", forKey: "preferredTerminalApp")
+
+        let settings = Self.makeSettingsStorePreservingDefaults(suite: suite)
+
+        #expect(settings.preferredTerminalApp == .terminal)
+    }
+
+    private static func makeSettingsStore(suite: String) -> SettingsStore {
+        let defaults = UserDefaults(suiteName: suite) ?? .standard
+        defaults.removePersistentDomain(forName: suite)
+        return self.makeSettingsStore(defaults: defaults, suite: suite)
+    }
+
+    private static func makeSettingsStorePreservingDefaults(suite: String) -> SettingsStore {
+        let defaults = UserDefaults(suiteName: suite) ?? .standard
+        return self.makeSettingsStore(defaults: defaults, suite: suite)
+    }
+
+    private static func makeSettingsStore(defaults: UserDefaults, suite: String) -> SettingsStore {
         let configStore = testConfigStore(suiteName: suite)
 
         return SettingsStore(

--- a/Tests/CodexBarTests/TerminalCommandLauncherTests.swift
+++ b/Tests/CodexBarTests/TerminalCommandLauncherTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct TerminalCommandLauncherTests {
+    @Test
+    func `escapes commands for AppleScript strings`() {
+        let escaped = TerminalCommandLauncher.escapeForAppleScript(#"echo "hi" && cd C:\tmp"#)
+
+        #expect(escaped == #"echo \"hi\" && cd C:\\tmp"#)
+    }
+
+    @Test
+    func `builds Terminal AppleScript`() {
+        let script = TerminalCommandLauncher.appleScript(command: #"claude "hello""#, app: .terminal)
+
+        #expect(script.contains(#"tell application "Terminal""#))
+        #expect(script.contains(#"do script "claude \"hello\"""#))
+    }
+
+    @Test
+    func `builds iTerm2 AppleScript`() {
+        let script = TerminalCommandLauncher.appleScript(command: "claude", app: .iTerm2)
+
+        #expect(script.contains(#"tell application "iTerm2""#))
+        #expect(script.contains("create window with default profile"))
+        #expect(script.contains(#"write text "claude""#))
+    }
+
+    @Test
+    func `falls back to Terminal when preferred app is unavailable`() {
+        var receivedScript: String?
+
+        TerminalCommandLauncher.open(
+            command: "claude",
+            preferredApp: .iTerm2,
+            applicationURL: { _ in nil },
+            runAppleScript: { script in
+                receivedScript = script
+                return nil
+            })
+
+        #expect(receivedScript?.contains(#"tell application "Terminal""#) == true)
+    }
+
+    @Test
+    func `lists only installed terminal apps`() {
+        let apps = PreferredTerminalApp.availableApps { bundleID in
+            bundleID == PreferredTerminalApp.iTerm2.bundleIdentifier
+                ? URL(fileURLWithPath: "/Applications/iTerm.app")
+                : nil
+        }
+
+        #expect(apps == [.iTerm2])
+    }
+}


### PR DESCRIPTION
## Summary
- add a persisted default terminal preference for menu-launched provider commands
- support Terminal and installed iTerm2, falling back to Terminal when the selected app is unavailable
- route the Open Terminal menu action through a testable launcher and cover script generation/settings persistence

Fixes #1147

## Testing
- Not run: local Windows environment does not have the Swift toolchain installed (swift command not found).