### PR TITLE
Add Chinese localization for Codex menu text

### DIFF
--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -177,7 +177,7 @@ extension UsageMenuCardView.Model {
         return extraRateWindows.map { namedWindow in
             Metric(
                 id: namedWindow.id,
-                title: namedWindow.title,
+                title: Self.extraRateWindowTitle(namedWindow, provider: input.provider),
                 percent: Self.clamped(
                     input.usageBarsShowUsed
                         ? namedWindow.window.usedPercent
@@ -192,6 +192,18 @@ extension UsageMenuCardView.Model {
                 detailRightText: nil,
                 pacePercent: nil,
                 paceOnTop: true)
+        }
+    }
+
+    private static func extraRateWindowTitle(_ namedWindow: NamedRateWindow, provider: UsageProvider) -> String {
+        guard provider == .codex else { return namedWindow.title }
+        switch namedWindow.id {
+        case "codex-spark":
+            return L("Codex Spark 5-hour")
+        case "codex-spark-weekly":
+            return L("Codex Spark Weekly")
+        default:
+            return namedWindow.title
         }
     }
 

--- a/Sources/CodexBar/Providers/Codex/CodexConsumerProjection.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexConsumerProjection.swift
@@ -24,28 +24,29 @@ struct CodexUIErrorMapper {
         }
 
         if self.looksCodexCLILoginRequired(lower: lower) {
-            return self.codexCLINotSignedInMessage
+            return L(self.codexCLINotSignedInMessage)
         }
 
         if self.looksExpired(lower: lower) {
-            return "Codex session expired. Sign in again."
+            return L("Codex session expired. Sign in again.")
         }
 
         if lower.contains("frame load interrupted") {
-            return "OpenAI web refresh was interrupted. Refresh OpenAI cookies and try again."
+            return L("OpenAI web refresh was interrupted. Refresh OpenAI cookies and try again.")
         }
 
         if self.looksOpenAIWebTimeout(lower: lower) {
-            return "OpenAI web refresh timed out. Refresh OpenAI cookies and try again."
+            return L("OpenAI web refresh timed out. Refresh OpenAI cookies and try again.")
         }
 
         if self.looksOpenAIWebNetworkError(lower: lower) {
-            return "OpenAI web refresh hit a network error. "
-                + "Check your connection, then refresh OpenAI cookies and try again."
+            return L(
+                "OpenAI web refresh hit a network error. "
+                    + "Check your connection, then refresh OpenAI cookies and try again.")
         }
 
         if self.looksInternalTransport(lower: lower) {
-            return "Codex usage is temporarily unavailable. Try refreshing."
+            return L("Codex usage is temporarily unavailable. Try refreshing.")
         }
 
         return trimmed
@@ -56,6 +57,7 @@ struct CodexUIErrorMapper {
         guard let suffixRange = raw.range(of: cachedMarker) else { return nil }
 
         let suffix = String(raw[suffixRange.lowerBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+
         if lower.hasPrefix("last codex credits refresh failed:"),
            let base = self.userFacingMessage(String(raw[..<suffixRange.lowerBound]))
         {

--- a/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
@@ -219,7 +219,7 @@ struct CodexProviderImplementation: ProviderImplementation {
     func loginMenuAction(context _: ProviderMenuLoginContext)
         -> (label: String, action: MenuDescriptor.MenuAction)?
     {
-        ("Add Account...", .addCodexAccount)
+        (L("Add Account..."), .addCodexAccount)
     }
 
     @MainActor
@@ -246,7 +246,7 @@ struct CodexProviderImplementation: ProviderImplementation {
         }
 
         entries.append(.submenu(
-            "System Account",
+            L("System Account"),
             MenuDescriptor.MenuActionSystemImage.systemAccount.rawValue,
             submenuItems))
     }

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1057,3 +1057,12 @@
 "Cookie: …\n\nor paste the __Secure-next-auth.session-token value" = "Cookie: …\n\nor paste the __Secure-next-auth.session-token value";
 "Cookie: …\n\nor paste the kimi-auth token value" = "Cookie: …\n\nor paste the kimi-auth token value";
 "session_id=...\n\nor paste just the session_id value" = "session_id=...\n\nor paste just the session_id value";
+"Codex CLI is not signed in. Run `codex login --device-auth`, then refresh." = "Codex CLI is not signed in. Run `codex login --device-auth`, then refresh.";
+"Codex session expired. Sign in again." = "Codex session expired. Sign in again.";
+"Codex Spark 5-hour" = "Codex Spark 5-hour";
+"Codex Spark Weekly" = "Codex Spark Weekly";
+"Codex usage is temporarily unavailable. Try refreshing." = "Codex usage is temporarily unavailable. Try refreshing.";
+"OpenAI web refresh hit a network error. Check your connection, then refresh OpenAI cookies and try again." = "OpenAI web refresh hit a network error. Check your connection, then refresh OpenAI cookies and try again.";
+"OpenAI web refresh timed out. Refresh OpenAI cookies and try again." = "OpenAI web refresh timed out. Refresh OpenAI cookies and try again.";
+"OpenAI web refresh was interrupted. Refresh OpenAI cookies and try again." = "OpenAI web refresh was interrupted. Refresh OpenAI cookies and try again.";
+"System Account" = "System Account";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1030,3 +1030,12 @@
 "Cookie: …\n\nor paste the __Secure-next-auth.session-token value" = "Cookie: …\n\n或粘贴 __Secure-next-auth.session-token 值";
 "Cookie: …\n\nor paste the kimi-auth token value" = "Cookie: …\n\n或粘贴 kimi-auth token 值";
 "session_id=...\n\nor paste just the session_id value" = "session_id=...\n\n或只粘贴 session_id 值";
+"Codex CLI is not signed in. Run `codex login --device-auth`, then refresh." = "Codex CLI 尚未登录。请运行 `codex login --device-auth`，然后刷新。";
+"Codex session expired. Sign in again." = "Codex 会话已过期。请重新登录。";
+"Codex Spark 5-hour" = "Codex Spark 5 小时";
+"Codex Spark Weekly" = "Codex Spark 每周";
+"Codex usage is temporarily unavailable. Try refreshing." = "Codex 用量暂时不可用。请尝试刷新。";
+"OpenAI web refresh hit a network error. Check your connection, then refresh OpenAI cookies and try again." = "OpenAI 网页刷新遇到网络错误。请检查连接，然后刷新 OpenAI Cookie 后重试。";
+"OpenAI web refresh timed out. Refresh OpenAI cookies and try again." = "OpenAI 网页刷新超时。请刷新 OpenAI Cookie 后重试。";
+"OpenAI web refresh was interrupted. Refresh OpenAI cookies and try again." = "OpenAI 网页刷新被中断。请刷新 OpenAI Cookie 后重试。";
+"System Account" = "系统账户";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -926,3 +926,12 @@
 "Cookie: …\n\nor paste the __Secure-next-auth.session-token value" = "Cookie: …\n\n或貼上 __Secure-next-auth.session-token 值";
 "Cookie: …\n\nor paste the kimi-auth token value" = "Cookie: …\n\n或貼上 kimi-auth token 值";
 "session_id=...\n\nor paste just the session_id value" = "session_id=...\n\n或只貼上 session_id 值";
+"Codex CLI is not signed in. Run `codex login --device-auth`, then refresh." = "Codex CLI 尚未登入。請執行 `codex login --device-auth`，然後重新整理。";
+"Codex session expired. Sign in again." = "Codex 工作階段已過期。請重新登入。";
+"Codex Spark 5-hour" = "Codex Spark 5 小時";
+"Codex Spark Weekly" = "Codex Spark 每週";
+"Codex usage is temporarily unavailable. Try refreshing." = "Codex 使用量暫時無法取得。請嘗試重新整理。";
+"OpenAI web refresh hit a network error. Check your connection, then refresh OpenAI cookies and try again." = "OpenAI 網頁重新整理遇到網路錯誤。請檢查連線，然後重新整理 OpenAI Cookie 後重試。";
+"OpenAI web refresh timed out. Refresh OpenAI cookies and try again." = "OpenAI 網頁重新整理逾時。請重新整理 OpenAI Cookie 後重試。";
+"OpenAI web refresh was interrupted. Refresh OpenAI cookies and try again." = "OpenAI 網頁重新整理被中斷。請重新整理 OpenAI Cookie 後重試。";
+"System Account" = "系統帳號";

--- a/Tests/CodexBarTests/CodexMenuLocalizationTests.swift
+++ b/Tests/CodexBarTests/CodexMenuLocalizationTests.swift
@@ -1,0 +1,192 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct CodexMenuLocalizationTests {
+    @Test
+    func `codex login and account submenu labels localize in menu actions`() throws {
+        try CodexBarLocalizationOverride.$appLanguage.withValue("zh-Hans") {
+            let settings = self.makeSettings(suite: "CodexMenuLocalizationTests-actions")
+            let managedAccount = ManagedCodexAccount(
+                id: UUID(),
+                email: "managed@example.com",
+                managedHomePath: "/tmp/managed-home",
+                createdAt: 1,
+                updatedAt: 2,
+                lastAuthenticatedAt: 2)
+            let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+            defer {
+                settings._test_managedCodexAccountStoreURL = nil
+                settings._test_liveSystemCodexAccount = nil
+                try? FileManager.default.removeItem(at: storeURL)
+            }
+
+            settings._test_managedCodexAccountStoreURL = storeURL
+            settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+                email: "live@example.com",
+                codexHomePath: "/Users/test/.codex",
+                observedAt: Date())
+            settings.codexActiveSource = .liveSystem
+
+            let store = UsageStore(
+                fetcher: UsageFetcher(),
+                browserDetection: BrowserDetection(cacheTTL: 0),
+                settings: settings)
+            let implementation = CodexProviderImplementation()
+            let login = implementation.loginMenuAction(context: ProviderMenuLoginContext(
+                provider: .codex,
+                store: store,
+                settings: settings,
+                account: AccountInfo(email: nil, plan: nil)))
+            #expect(login?.label == "添加账户…")
+
+            var entries: [ProviderMenuEntry] = []
+            implementation.appendActionMenuEntries(context: ProviderMenuActionContext(
+                provider: .codex,
+                store: store,
+                settings: settings,
+                account: AccountInfo(email: nil, plan: nil),
+                managedCodexAccountCoordinator: nil,
+                codexAccountPromotionCoordinator: nil), entries: &entries)
+
+            let submenuTitle = entries.compactMap { entry -> String? in
+                guard case let .submenu(title, _, _) = entry else { return nil }
+                return title
+            }.first
+            #expect(submenuTitle == "系统账户")
+        }
+    }
+
+    @Test
+    func `codex card model localizes known codex-owned menu text`() throws {
+        try CodexBarLocalizationOverride.$appLanguage.withValue("zh-Hans") {
+            let now = Date(timeIntervalSince1970: 1_800_000_000)
+            let metadata = try #require(ProviderDefaults.metadata[.codex])
+            let snapshot = UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 2,
+                    windowMinutes: 300,
+                    resetsAt: now.addingTimeInterval(4 * 60 * 60),
+                    resetDescription: nil),
+                secondary: RateWindow(
+                    usedPercent: 4,
+                    windowMinutes: 10080,
+                    resetsAt: now.addingTimeInterval(6 * 24 * 60 * 60),
+                    resetDescription: nil),
+                tertiary: nil,
+                extraRateWindows: [
+                    NamedRateWindow(
+                        id: "codex-spark",
+                        title: "Codex Spark 5-hour",
+                        window: RateWindow(
+                            usedPercent: 30,
+                            windowMinutes: 300,
+                            resetsAt: now.addingTimeInterval(60 * 60),
+                            resetDescription: nil)),
+                ],
+                updatedAt: now,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "user@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Pro"))
+            let projection = CodexConsumerProjection.make(
+                surface: .liveCard,
+                context: CodexConsumerProjection.Context(
+                    snapshot: snapshot,
+                    rawUsageError: nil,
+                    liveCredits: nil,
+                    rawCreditsError: nil,
+                    liveDashboard: nil,
+                    rawDashboardError: nil,
+                    dashboardAttachmentAuthorized: false,
+                    dashboardRequiresLogin: false,
+                    now: now))
+
+            let model = UsageMenuCardView.Model.make(.init(
+                provider: .codex,
+                metadata: metadata,
+                snapshot: snapshot,
+                codexProjection: projection,
+                credits: nil,
+                creditsError: nil,
+                dashboard: nil,
+                dashboardError: nil,
+                tokenSnapshot: nil,
+                tokenError: nil,
+                account: AccountInfo(email: "user@example.com", plan: "Pro"),
+                isRefreshing: false,
+                lastError: nil,
+                usageBarsShowUsed: false,
+                resetTimeDisplayStyle: .countdown,
+                tokenCostUsageEnabled: false,
+                showOptionalCreditsAndExtraUsage: true,
+                hidePersonalInfo: false,
+                now: now))
+
+            #expect(model.metrics.first { $0.id == "primary" }?.title == "会话")
+            #expect(model.metrics.first { $0.id == "secondary" }?.title == "每周")
+            #expect(model.metrics.first { $0.id == "codex-spark" }?.title == "Codex Spark 5 小时")
+            #expect(model.email == "user@example.com")
+            #expect(model.planText == "Pro 20x")
+        }
+    }
+
+    @Test
+    func `codex sanitized menu errors preserve cached suffix`() {
+        CodexBarLocalizationOverride.$appLanguage.withValue("zh-Hans") {
+            let message = CodexUIErrorMapper.userFacingMessage(
+                "Last Codex credits refresh failed: Codex connection failed: failed to fetch codex rate limits: " +
+                    "GET https://chatgpt.com/backend-api/wham/usage failed: 500; body={} " +
+                    "Cached values from 2m ago.")
+
+            #expect(message == "Codex 用量暂时不可用。请尝试刷新。 Cached values from 2m ago.")
+        }
+    }
+
+    @Test
+    func `codex menu text falls back to original english when language is unavailable`() {
+        CodexBarLocalizationOverride.$appLanguage.withValue("fr") {
+            let settings = self.makeSettings(suite: "CodexMenuLocalizationTests-fallback")
+            let store = UsageStore(
+                fetcher: UsageFetcher(),
+                browserDetection: BrowserDetection(cacheTTL: 0),
+                settings: settings)
+            let implementation = CodexProviderImplementation()
+            let login = implementation.loginMenuAction(context: ProviderMenuLoginContext(
+                provider: .codex,
+                store: store,
+                settings: settings,
+                account: AccountInfo(email: nil, plan: nil)))
+            #expect(login?.label == "Add Account...")
+
+            let message = CodexUIErrorMapper.userFacingMessage(
+                "Last Codex credits refresh failed: Codex connection failed: failed to fetch codex rate limits: " +
+                    "GET https://chatgpt.com/backend-api/wham/usage failed: 500; body={} " +
+                    "Cached values from 2m ago.")
+
+            #expect(message == "Codex usage is temporarily unavailable. Try refreshing. Cached values from 2m ago.")
+        }
+    }
+
+    private func makeSettings(suite: String) -> SettingsStore {
+        let defaults = UserDefaults(suiteName: "\(suite)-\(UUID().uuidString)")!
+        defaults.removePersistentDomain(forName: suite)
+        return SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+    }
+
+    private func makeManagedAccountStoreURL(accounts: [ManagedCodexAccount]) throws -> URL {
+        let storeURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let store = FileManagedCodexAccountStore(fileURL: storeURL)
+        try store.storeAccounts(ManagedCodexAccountSet(
+            version: FileManagedCodexAccountStore.currentVersion,
+            accounts: accounts))
+        return storeURL
+    }
+}


### PR DESCRIPTION
## Summary
- Add Simplified Chinese and Traditional Chinese localization for Codex-owned menu labels.
- Localize known Codex rate-limit titles and existing Codex menu error messages.
- Preserve existing fallback behavior when a localization is unavailable.

## Proof

#### Simplified Chinese

<img width="356" height="829" alt="image" src="https://github.com/user-attachments/assets/1d935976-6ae1-4fc8-8372-b45a150d918a" />

<img width="356" height="611" alt="image" src="https://github.com/user-attachments/assets/e2f23d93-7c42-45ce-9637-36124ff8465f" />

#### Traditional Chinese

<img width="356" height="829" alt="image" src="https://github.com/user-attachments/assets/8ce15964-cb9c-4d89-9a2c-022cf4851ea4" />

<img width="356" height="611" alt="image" src="https://github.com/user-attachments/assets/349bae19-4438-4d2e-b934-193221371e62" />


#### Traditional Chinese with  fallback

<img width="356" height="829" alt="image" src="https://github.com/user-attachments/assets/23970c0d-3c71-4e94-aea1-b754e36f0791" />

<img width="356" height="611" alt="image" src="https://github.com/user-attachments/assets/53cf4cbe-f6f7-47a8-bef5-44eab1b26208" />

## Verification
- `swift test --filter CodexMenuLocalizationTests` passed
- `make check` passed