### PR TITLE
fix: add Opus 4.8 to built-in Claude pricing table

### DIFF
--- a/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
+++ b/Sources/CodexBarCore/Vendored/CostUsage/CostUsagePricing.swift
@@ -275,6 +275,16 @@ enum CostUsagePricing {
             outputCostPerTokenAboveThreshold: nil,
             cacheCreationInputCostPerTokenAboveThreshold: nil,
             cacheReadInputCostPerTokenAboveThreshold: nil),
+        "claude-opus-4-8": ClaudePricing(
+            inputCostPerToken: 5e-6,
+            outputCostPerToken: 2.5e-5,
+            cacheCreationInputCostPerToken: 6.25e-6,
+            cacheReadInputCostPerToken: 5e-7,
+            thresholdTokens: nil,
+            inputCostPerTokenAboveThreshold: nil,
+            outputCostPerTokenAboveThreshold: nil,
+            cacheCreationInputCostPerTokenAboveThreshold: nil,
+            cacheReadInputCostPerTokenAboveThreshold: nil),
         "claude-sonnet-4-5": ClaudePricing(
             inputCostPerToken: 3e-6,
             outputCostPerToken: 1.5e-5,

--- a/Tests/CodexBarTests/CostUsagePricingTests.swift
+++ b/Tests/CodexBarTests/CostUsagePricingTests.swift
@@ -361,6 +361,18 @@ struct CostUsagePricingTests {
     }
 
     @Test
+    func `claude cost supports opus48`() {
+        let cost = CostUsagePricing.claudeCostUSD(
+            model: "claude-opus-4-8",
+            inputTokens: 10,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            outputTokens: 5)
+        let expected = (10.0 * 5e-6) + (5.0 * 2.5e-5)
+        #expect(cost == expected)
+    }
+
+    @Test
     func `claude cost returns nil for unknown models`() {
         let cost = CostUsagePricing.claudeCostUSD(
             model: "glm-4.6",


### PR DESCRIPTION
Fixes #1210.

## Problem
In v0.31.0, cost for Opus 4.8 tokens is never calculated — it always shows empty.

`claudeCostUSD` first tries the models.dev cache, then falls back to the built-in Claude pricing map. That map had entries for Opus 4.5/4.6/4.7 but **no `claude-opus-4-8` entry**, so when the models.dev cache is missing or stale (e.g. right after a new model ships) the lookup returns `nil` and the cost renders empty.

## Fix
- Add a `claude-opus-4-8` entry to the built-in Claude pricing table, using the same rates as Opus 4.5/4.6/4.7 ($5/M input, $25/M output, $6.25/M cache write, $0.50/M cache read — matching current models.dev pricing for Opus 4.8).
- Add a regression test (`claude cost supports opus48`) mirroring the existing opus47 test.

## Testing
```
swift test --filter CostUsagePricingTests
```
All 24 tests pass, including the new `opus48` case.