### PR TITLE
Harden menu bar status item placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Codex: cancel OpenAI WebKit dashboard refreshes promptly and avoid an immediate second background WebView retry after timeouts, reducing launch-time Web Content CPU spikes (#1217).
+- Menu bar: give CodexBar status items stable placement identities while preserving existing upgrade placement state (#1216). Thanks @pdurlej!
 - Status: retry startup refreshes a few times after transient offline/network failures so provider status can recover after macOS brings the network online (#1211).
 
 ## 0.31.0 — 2026-05-28

--- a/Sources/CodexBar/MenuBarStatusItemPlacementPreflight.swift
+++ b/Sources/CodexBar/MenuBarStatusItemPlacementPreflight.swift
@@ -10,9 +10,16 @@ enum MenuBarStatusItemPlacementPreflight {
     }
 
     @discardableResult
-    static func prepare(defaults: UserDefaults, autosaveName: String) -> Bool {
+    static func prepare(defaults: UserDefaults, autosaveName: String, legacyDefaultItemIndex: Int? = nil) -> Bool {
         let key = self.preferredPositionKey(autosaveName: autosaveName)
-        guard self.shouldSetPreferredPosition(defaults.object(forKey: key)) else { return false }
+        let value = defaults.object(forKey: key)
+        guard value != nil || !self.shouldPreserveMissingStableKey(
+            defaults: defaults,
+            legacyDefaultItemIndex: legacyDefaultItemIndex)
+        else {
+            return false
+        }
+        guard self.shouldSetPreferredPosition(value) else { return false }
         defaults.set(self.lowPreferredPosition, forKey: key)
         return true
     }
@@ -21,5 +28,42 @@ enum MenuBarStatusItemPlacementPreflight {
         guard let value else { return true }
         guard let number = value as? NSNumber else { return true }
         return number.doubleValue > self.suspiciousPreferredPositionThreshold
+    }
+
+    static func shouldPreserveMissingStableKey(defaults: UserDefaults, legacyDefaultItemIndex: Int?) -> Bool {
+        guard let legacyDefaultItemIndex else { return false }
+        return self.legacyPreferredPositions(defaults: defaults).contains { position in
+            position.itemIndex == legacyDefaultItemIndex && !self.shouldSetPreferredPosition(position.value)
+        }
+    }
+
+    static func isLegacyPreferredPositionKey(_ key: String) -> Bool {
+        guard key.hasPrefix(self.preferredPositionPrefix) else { return false }
+        return self.isDefaultStatusItemName(String(key.dropFirst(self.preferredPositionPrefix.count)))
+    }
+
+    private static func legacyPreferredPositions(defaults: UserDefaults) -> [LegacyPreferredPosition] {
+        defaults.dictionaryRepresentation().compactMap { key, value -> LegacyPreferredPosition? in
+            guard key.hasPrefix(self.preferredPositionPrefix) else { return nil }
+            let itemName = String(key.dropFirst(self.preferredPositionPrefix.count))
+            guard let itemIndex = self.defaultStatusItemIndex(itemName) else { return nil }
+            return LegacyPreferredPosition(itemIndex: itemIndex, value: value)
+        }
+    }
+
+    private struct LegacyPreferredPosition {
+        var itemIndex: Int
+        var value: Any
+    }
+
+    private static func isDefaultStatusItemName(_ itemName: String) -> Bool {
+        self.defaultStatusItemIndex(itemName) != nil
+    }
+
+    private static func defaultStatusItemIndex(_ itemName: String) -> Int? {
+        guard itemName.hasPrefix("Item-") else { return nil }
+        let suffix = itemName.dropFirst("Item-".count)
+        guard suffix.allSatisfy(\.isNumber) else { return nil }
+        return Int(suffix)
     }
 }

--- a/Sources/CodexBar/MenuBarStatusItemPlacementPreflight.swift
+++ b/Sources/CodexBar/MenuBarStatusItemPlacementPreflight.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum MenuBarStatusItemPlacementPreflight {
+    static let preferredPositionPrefix = "NSStatusItem Preferred Position "
+    static let lowPreferredPosition: Double = 0
+    static let suspiciousPreferredPositionThreshold: Double = 100
+
+    static func preferredPositionKey(autosaveName: String) -> String {
+        "\(self.preferredPositionPrefix)\(autosaveName)"
+    }
+
+    @discardableResult
+    static func prepare(defaults: UserDefaults, autosaveName: String) -> Bool {
+        let key = self.preferredPositionKey(autosaveName: autosaveName)
+        guard self.shouldSetPreferredPosition(defaults.object(forKey: key)) else { return false }
+        defaults.set(self.lowPreferredPosition, forKey: key)
+        return true
+    }
+
+    static func shouldSetPreferredPosition(_ value: Any?) -> Bool {
+        guard let value else { return true }
+        guard let number = value as? NSNumber else { return true }
+        return number.doubleValue > self.suspiciousPreferredPositionThreshold
+    }
+}

--- a/Sources/CodexBar/MenuBarStatusItemWindowProbe.swift
+++ b/Sources/CodexBar/MenuBarStatusItemWindowProbe.swift
@@ -1,0 +1,100 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+struct MenuBarStatusItemWindowSnapshot: Equatable, CustomStringConvertible {
+    let name: String
+    let ownerName: String
+    let bounds: CGRect
+    let isOnscreen: Bool
+    let displayBounds: CGRect?
+
+    var isWithinDisplayBounds: Bool {
+        guard let displayBounds else { return false }
+        return displayBounds.contains(self.bounds)
+    }
+
+    var description: String {
+        let display = self.displayBounds.map {
+            "display=\(Int($0.minX)),\(Int($0.minY)) \(Int($0.width))x\(Int($0.height))"
+        } ?? "display=nil"
+        return "name=\(self.name),owner=\(self.ownerName),x=\(Int(self.bounds.minX)),"
+            + "w=\(Int(self.bounds.width)),onscreen=\(self.isOnscreen),"
+            + "withinDisplay=\(self.isWithinDisplayBounds),\(display)"
+    }
+}
+
+enum MenuBarStatusItemWindowProbe {
+    static func snapshots(matching names: Set<String>) -> [MenuBarStatusItemWindowSnapshot] {
+        self.snapshots(
+            matching: names,
+            windowInfo: self.windowInfo(),
+            displayBounds: NSScreen.screens.map(\.frame))
+    }
+
+    static func snapshots(
+        matching names: Set<String>,
+        windowInfo: [[String: Any]],
+        displayBounds: [CGRect])
+        -> [MenuBarStatusItemWindowSnapshot]
+    {
+        guard !names.isEmpty else { return [] }
+        return windowInfo.compactMap { record in
+            self.snapshot(record: record, matching: names, displayBounds: displayBounds)
+        }
+    }
+
+    private static func windowInfo() -> [[String: Any]] {
+        guard let windows = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]] else {
+            return []
+        }
+        return windows
+    }
+
+    private static func snapshot(
+        record: [String: Any],
+        matching names: Set<String>,
+        displayBounds: [CGRect])
+        -> MenuBarStatusItemWindowSnapshot?
+    {
+        guard let name = record[kCGWindowName as String] as? String,
+              names.contains(name),
+              let bounds = self.bounds(record[kCGWindowBounds as String])
+        else { return nil }
+        let ownerName = record[kCGWindowOwnerName as String] as? String ?? "unknown"
+        let isOnscreen = (record[kCGWindowIsOnscreen as String] as? NSNumber)?.boolValue
+            ?? record[kCGWindowIsOnscreen as String] as? Bool
+            ?? false
+        return MenuBarStatusItemWindowSnapshot(
+            name: name,
+            ownerName: ownerName,
+            bounds: bounds,
+            isOnscreen: isOnscreen,
+            displayBounds: displayBounds.first { $0.intersects(bounds) })
+    }
+
+    private static func bounds(_ value: Any?) -> CGRect? {
+        guard let dictionary = value as? [String: Any],
+              let x = self.double(dictionary["X"]),
+              let y = self.double(dictionary["Y"]),
+              let width = self.double(dictionary["Width"]),
+              let height = self.double(dictionary["Height"])
+        else { return nil }
+        return CGRect(x: x, y: y, width: width, height: height)
+    }
+
+    private static func double(_ value: Any?) -> Double? {
+        switch value {
+        case let number as NSNumber:
+            number.doubleValue
+        case let double as Double:
+            double
+        case let int as Int:
+            Double(int)
+        case let cgFloat as CGFloat:
+            Double(cgFloat)
+        default:
+            nil
+        }
+    }
+}

--- a/Sources/CodexBar/MenuBarVisibilityWatcher.swift
+++ b/Sources/CodexBar/MenuBarVisibilityWatcher.swift
@@ -203,7 +203,10 @@ extension StatusItemController {
 
         self.menuLogger.error(
             "Status item failed to materialize; recreating status items",
-            metadata: ["snapshots": snapshots.map(\.description).joined(separator: " | ")])
+            metadata: [
+                "snapshots": snapshots.map(\.description).joined(separator: " | "),
+                "windows": self.statusItemWindowDiagnosticsDescription(),
+            ])
         self.recreateStatusItemsForVisibilityRecovery()
 
         let recoveredSnapshots = MenuBarVisibilityWatcher.visibilitySnapshots(self.startupVisibilityStatusItems)
@@ -220,7 +223,10 @@ extension StatusItemController {
 
         self.menuLogger.error(
             "Status item still failed to materialize after recreation",
-            metadata: ["snapshots": recoveredSnapshots.map(\.description).joined(separator: " | ")])
+            metadata: [
+                "snapshots": recoveredSnapshots.map(\.description).joined(separator: " | "),
+                "windows": self.statusItemWindowDiagnosticsDescription(),
+            ])
         guard #available(macOS 26.0, *),
               MenuBarVisibilityWatcher.shouldShowGuidance(defaults: self.settings.userDefaults, now: now)
         else {
@@ -272,6 +278,7 @@ extension StatusItemController {
                     "currentScreenCount": "\(settledCurrentScreenCount)",
                     "capturedScreenCount": "\(currentScreenCount)",
                     "snapshots": snapshots.map(\.description).joined(separator: " | "),
+                    "windows": self.statusItemWindowDiagnosticsDescription(),
                 ])
             self.recreateStatusItemsForVisibilityRecovery()
             self.schedulePostScreenChangeRecoveryVerification(attempt: 1)
@@ -322,6 +329,7 @@ extension StatusItemController {
             metadata: [
                 "attempt": "\(attempt)",
                 "snapshots": snapshots.map(\.description).joined(separator: " | "),
+                "windows": self.statusItemWindowDiagnosticsDescription(),
             ])
         self.recreateStatusItemsForVisibilityRecovery()
         // No further async retries: a menu bar manager may park the newly recreated item in a state
@@ -331,7 +339,10 @@ extension StatusItemController {
         guard MenuBarVisibilityWatcher.hasAnyBlockedVisibleSnapshot(finalSnapshots) else { return }
         self.menuLogger.error(
             "Status item still blocked after display-change recovery recreation",
-            metadata: ["snapshots": finalSnapshots.map(\.description).joined(separator: " | ")])
+            metadata: [
+                "snapshots": finalSnapshots.map(\.description).joined(separator: " | "),
+                "windows": self.statusItemWindowDiagnosticsDescription(),
+            ])
         guard #available(macOS 26.0, *),
               MenuBarVisibilityWatcher.shouldShowGuidance(defaults: self.settings.userDefaults)
         else { return }
@@ -340,5 +351,14 @@ extension StatusItemController {
 
     private var startupVisibilityStatusItems: [NSStatusItem] {
         [self.statusItem] + Array(self.statusItems.values)
+    }
+
+    private func statusItemWindowDiagnosticsDescription() -> String {
+        let names = Set(self.startupVisibilityStatusItems.compactMap { item in
+            item.autosaveName.isEmpty ? nil : item.autosaveName
+        })
+        let snapshots = MenuBarStatusItemWindowProbe.snapshots(matching: names)
+        guard !snapshots.isEmpty else { return "none" }
+        return snapshots.map(\.description).joined(separator: " | ")
     }
 }

--- a/Sources/CodexBar/ProviderBrandIcon.swift
+++ b/Sources/CodexBar/ProviderBrandIcon.swift
@@ -6,6 +6,9 @@ enum ProviderBrandIcon {
 
     /// Lazy-loaded resource bundle for provider icons.
     private static let resourceBundle: Bundle? = {
+        guard Bundle.main.bundleURL.pathExtension == "app" else {
+            return Bundle.module
+        }
         // SwiftPM creates a CodexBar_CodexBar.bundle for resources in the CodexBar target.
         if let bundleURL = Bundle.main.url(forResource: "CodexBar_CodexBar", withExtension: "bundle"),
            let bundle = Bundle(url: bundleURL)

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -10,7 +10,6 @@ extension StatusItemController {
     static let loadingAnimationPhaseIncrement: Double =
         2.7 / StatusItemController.loadingAnimationFPS
     private static let loadingAnimationMaxContinuousDuration: TimeInterval = 30.0
-
     func needsMenuBarIconAnimation() -> Bool {
         if self.shouldMergeIcons {
             let primaryProvider = self.primaryProviderForUnifiedIcon()
@@ -338,6 +337,9 @@ extension StatusItemController {
                 "anim=\(needsAnimation ? "1" : "0")",
             ].joined(separator: "|")
             if self.shouldSkipMergedIconRender(signature) {
+                // AppKit can lose button title/image-position state independently of the cached render signature.
+                // Keep the cheap title path self-healing even when the icon image itself can be skipped.
+                self.setButtonTitle(displayText, for: button)
                 self.noteIconPerfRender(skipped: true)
                 return true
             }
@@ -915,7 +917,7 @@ extension StatusItemController {
         {
             return selected
         }
-        for provider in UsageProvider.allCases {
+        for provider in self.store.enabledProviders() {
             if self.store.isEnabled(provider), self.store.snapshot(for: provider) != nil {
                 return provider
             }

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -30,6 +30,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     static let quotaWarningFlashDuration: TimeInterval = 60
     private nonisolated static let statusItemAccessibilityTitle = "CodexBar"
     private nonisolated static let statusItemAccessibilityIdentifierPrefix = "CodexBar.StatusItem"
+    private nonisolated static let mergedLegacyDefaultItemIndex = 0
 
     enum StatusItemIdentity {
         case merged
@@ -38,9 +39,9 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         var autosaveName: String {
             switch self {
             case .merged:
-                return "codexbar-merged"
+                "codexbar-merged"
             case let .provider(provider):
-                return "codexbar-\(provider.rawValue)"
+                "codexbar-\(provider.rawValue)"
             }
         }
 
@@ -209,10 +210,14 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     private static func makeStatusItem(
         statusBar: NSStatusBar,
         identity: StatusItemIdentity,
-        defaults: UserDefaults)
+        defaults: UserDefaults,
+        legacyDefaultItemIndex: Int?)
         -> NSStatusItem
     {
-        MenuBarStatusItemPlacementPreflight.prepare(defaults: defaults, autosaveName: identity.autosaveName)
+        MenuBarStatusItemPlacementPreflight.prepare(
+            defaults: defaults,
+            autosaveName: identity.autosaveName,
+            legacyDefaultItemIndex: legacyDefaultItemIndex)
         let item = statusBar.statusItem(withLength: NSStatusItem.variableLength)
         item.autosaveName = identity.autosaveName
         if let button = item.button {
@@ -337,7 +342,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.statusItem = Self.makeStatusItem(
             statusBar: statusBar,
             identity: .merged,
-            defaults: settings.userDefaults)
+            defaults: settings.userDefaults,
+            legacyDefaultItemIndex: Self.mergedLegacyDefaultItemIndex)
         self.lastKnownScreenCount = NSScreen.screens.count
         // Status items for individual providers are now created lazily in updateVisibility()
         super.init()
@@ -705,7 +711,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         let item = Self.makeStatusItem(
             statusBar: self.statusBar,
             identity: .provider(provider),
-            defaults: self.settings.userDefaults)
+            defaults: self.settings.userDefaults,
+            legacyDefaultItemIndex: self.legacyDefaultItemIndex(forNewProvider: provider))
         self.statusItems[provider] = item
         return item
     }
@@ -719,7 +726,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.statusItem = Self.makeStatusItem(
             statusBar: self.statusBar,
             identity: .merged,
-            defaults: self.settings.userDefaults)
+            defaults: self.settings.userDefaults,
+            legacyDefaultItemIndex: Self.mergedLegacyDefaultItemIndex)
         for provider in Array(self.statusItems.keys) {
             self.removeProviderStatusItem(for: provider)
         }
@@ -896,6 +904,12 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
 }
 
 extension StatusItemController {
+    private func legacyDefaultItemIndex(forNewProvider provider: UsageProvider) -> Int? {
+        let visibleProviders = self.settings.orderedProviders().filter { self.isVisible($0) }
+        guard let providerOffset = visibleProviders.firstIndex(of: provider) else { return nil }
+        return Self.mergedLegacyDefaultItemIndex + 1 + providerOffset
+    }
+
     func refreshExistingStatusItemsForVisibilityRecovery() {
         #if DEBUG
         guard !self.isReleasedForTesting else { return }

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -31,9 +31,18 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     private nonisolated static let statusItemAccessibilityTitle = "CodexBar"
     private nonisolated static let statusItemAccessibilityIdentifierPrefix = "CodexBar.StatusItem"
 
-    private enum StatusItemIdentity {
+    enum StatusItemIdentity {
         case merged
         case provider(UsageProvider)
+
+        var autosaveName: String {
+            switch self {
+            case .merged:
+                return "codexbar-merged"
+            case let .provider(provider):
+                return "codexbar-\(provider.rawValue)"
+            }
+        }
 
         var accessibilityIdentifier: String {
             switch self {
@@ -197,8 +206,15 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         set { self.settings.selectedMenuProvider = newValue }
     }
 
-    private static func makeStatusItem(statusBar: NSStatusBar, identity: StatusItemIdentity) -> NSStatusItem {
+    private static func makeStatusItem(
+        statusBar: NSStatusBar,
+        identity: StatusItemIdentity,
+        defaults: UserDefaults)
+        -> NSStatusItem
+    {
+        MenuBarStatusItemPlacementPreflight.prepare(defaults: defaults, autosaveName: identity.autosaveName)
         let item = statusBar.statusItem(withLength: NSStatusItem.variableLength)
+        item.autosaveName = identity.autosaveName
         if let button = item.button {
             // Ensure the icon is rendered at 1:1 without resampling (crisper edges for template images).
             button.imageScaling = .scaleNone
@@ -318,7 +334,10 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         let repairedStatusItemVisibilityKeys = MenuBarStatusItemDefaultsRepair
             .repairHiddenVisibilityDefaultsIfNeeded(defaults: settings.userDefaults)
         self.statusBar = statusBar
-        self.statusItem = Self.makeStatusItem(statusBar: statusBar, identity: .merged)
+        self.statusItem = Self.makeStatusItem(
+            statusBar: statusBar,
+            identity: .merged,
+            defaults: settings.userDefaults)
         self.lastKnownScreenCount = NSScreen.screens.count
         // Status items for individual providers are now created lazily in updateVisibility()
         super.init()
@@ -683,7 +702,10 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         if let existing = self.statusItems[provider] {
             return existing
         }
-        let item = Self.makeStatusItem(statusBar: self.statusBar, identity: .provider(provider))
+        let item = Self.makeStatusItem(
+            statusBar: self.statusBar,
+            identity: .provider(provider),
+            defaults: self.settings.userDefaults)
         self.statusItems[provider] = item
         return item
     }
@@ -694,7 +716,10 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         #endif
         self.statusItem.menu = nil
         self.statusBar.removeStatusItem(self.statusItem)
-        self.statusItem = Self.makeStatusItem(statusBar: self.statusBar, identity: .merged)
+        self.statusItem = Self.makeStatusItem(
+            statusBar: self.statusBar,
+            identity: .merged,
+            defaults: self.settings.userDefaults)
         for provider in Array(self.statusItems.keys) {
             self.removeProviderStatusItem(for: provider)
         }

--- a/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
+++ b/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreGraphics
 import Testing
 @testable import CodexBar
 
@@ -61,6 +62,52 @@ struct MenuBarVisibilityWatcherTests {
             buttonWidth: 18)
 
         #expect(!MenuBarVisibilityWatcher.isBlockedSnapshot(snapshot: snapshot))
+    }
+
+    @Test
+    func `window probe matches autosave name and reports display bounds`() {
+        let snapshots = MenuBarStatusItemWindowProbe.snapshots(
+            matching: ["codexbar-merged"],
+            windowInfo: [[
+                kCGWindowName as String: "codexbar-merged",
+                kCGWindowOwnerName as String: "Control Center",
+                kCGWindowIsOnscreen as String: true,
+                kCGWindowBounds as String: [
+                    "X": 1680,
+                    "Y": 0,
+                    "Width": 70,
+                    "Height": 24,
+                ],
+            ]],
+            displayBounds: [CGRect(x: 0, y: 0, width: 2056, height: 1329)])
+
+        #expect(snapshots.count == 1)
+        #expect(snapshots.first?.name == "codexbar-merged")
+        #expect(snapshots.first?.ownerName == "Control Center")
+        #expect(snapshots.first?.isOnscreen == true)
+        #expect(snapshots.first?.isWithinDisplayBounds == true)
+    }
+
+    @Test
+    func `window probe detects offscreen status item by bounds`() {
+        let snapshots = MenuBarStatusItemWindowProbe.snapshots(
+            matching: ["codexbar-merged"],
+            windowInfo: [[
+                kCGWindowName as String: "codexbar-merged",
+                kCGWindowOwnerName as String: "Control Center",
+                kCGWindowIsOnscreen as String: true,
+                kCGWindowBounds as String: [
+                    "X": 2023,
+                    "Y": 0,
+                    "Width": 71,
+                    "Height": 24,
+                ],
+            ]],
+            displayBounds: [CGRect(x: 0, y: 0, width: 2056, height: 1329)])
+
+        #expect(snapshots.count == 1)
+        #expect(snapshots.first?.isOnscreen == true)
+        #expect(snapshots.first?.isWithinDisplayBounds == false)
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
+++ b/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CoreGraphics
+import Foundation
 import Testing
 @testable import CodexBar
 

--- a/Tests/CodexBarTests/StatusItemAnimationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationSignatureTests.swift
@@ -78,6 +78,115 @@ struct StatusItemAnimationSignatureTests {
     }
 
     @Test
+    func `merged brand percent reapplies title when cached render is skipped`() throws {
+        let suite = "StatusItemAnimationSignatureTests-merged-brand-percent-title-restore"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        settings.menuBarShowsBrandIconWithPercent = true
+        settings.menuBarDisplayMode = .percent
+        settings.usageBarsShowUsed = false
+        settings.syntheticAPIToken = "synthetic-test-token"
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let syntheticMeta = registry.metadata[.synthetic] {
+            settings.setProviderEnabled(provider: .synthetic, metadata: syntheticMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 23, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+
+        let displayText = try #require(controller.menuBarDisplayText(for: .codex, snapshot: snapshot))
+        let expectedTitle = StatusItemController.buttonTitle(displayText, hasImage: true)
+        controller.applyIcon(phase: nil)
+        let button = try #require(controller.statusItem.button)
+        #expect(button.title == expectedTitle)
+        #expect(button.imagePosition == .imageLeft)
+
+        button.title = ""
+        button.imagePosition = .imageOnly
+
+        let skipped = controller.applyIcon(phase: nil)
+
+        #expect(skipped)
+        #expect(button.title == expectedTitle)
+        #expect(button.imagePosition == .imageLeft)
+    }
+
+    @Test
+    func `merged fallback provider follows enabled provider order`() throws {
+        let suite = "StatusItemAnimationSignatureTests-merged-provider-order"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.menuBarShowsBrandIconWithPercent = false
+        settings.syntheticAPIToken = "synthetic-test-token"
+        settings.setProviderOrder([.synthetic, .codex])
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let syntheticMeta = registry.metadata[.synthetic] {
+            settings.setProviderEnabled(provider: .synthetic, metadata: syntheticMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 50, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        store._setSnapshotForTesting(snapshot, provider: .codex)
+        store._setSnapshotForTesting(snapshot, provider: .synthetic)
+
+        controller.applyIcon(phase: nil)
+
+        #expect(store.enabledProviders().prefix(2) == [.synthetic, .codex])
+        #expect(controller.lastAppliedMergedIconRenderSignature?.contains("provider=synthetic") == true)
+    }
+
+    @Test
     func `merged icon follows overview provider order when first overview provider is loading`() {
         let suite = "StatusItemAnimationSignatureTests-merged-overview-provider-order"
         let defaults = UserDefaults(suiteName: suite)

--- a/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
@@ -124,7 +124,7 @@ struct StatusItemControllerSplitLifecycleTests {
     }
 
     @Test
-    func `status item placement preflight writes low position when missing`() throws {
+    func `status item placement preflight writes low position on fresh install`() throws {
         let suite = "StatusItemControllerSplitLifecycleTests-placement-missing-\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
@@ -134,6 +134,120 @@ struct StatusItemControllerSplitLifecycleTests {
 
         let key = MenuBarStatusItemPlacementPreflight.preferredPositionKey(autosaveName: "codexbar-merged")
         #expect(defaults.double(forKey: key) == 0)
+    }
+
+    @Test
+    func `status item placement preflight preserves missing new key when legacy item placement exists`() throws {
+        let suite = "StatusItemControllerSplitLifecycleTests-placement-legacy-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(42, forKey: "NSStatusItem Preferred Position Item-0")
+        let key = MenuBarStatusItemPlacementPreflight.preferredPositionKey(autosaveName: "codexbar-merged")
+
+        #expect(!MenuBarStatusItemPlacementPreflight.prepare(
+            defaults: defaults,
+            autosaveName: "codexbar-merged",
+            legacyDefaultItemIndex: 0))
+
+        #expect(defaults.object(forKey: key) == nil)
+        #expect(defaults.double(forKey: "NSStatusItem Preferred Position Item-0") == 42)
+    }
+
+    @Test
+    func `status item placement preflight repairs missing new key when legacy item placement is suspicious`() throws {
+        let suite = "StatusItemControllerSplitLifecycleTests-placement-legacy-high-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(11298, forKey: "NSStatusItem Preferred Position Item-0")
+        let key = MenuBarStatusItemPlacementPreflight.preferredPositionKey(autosaveName: "codexbar-merged")
+
+        #expect(MenuBarStatusItemPlacementPreflight.prepare(
+            defaults: defaults,
+            autosaveName: "codexbar-merged",
+            legacyDefaultItemIndex: 0))
+
+        #expect(defaults.double(forKey: key) == 0)
+        #expect(defaults.double(forKey: "NSStatusItem Preferred Position Item-0") == 11298)
+    }
+
+    @Test
+    func `status item placement preflight preserves missing new key when mixed legacy placements exist`() throws {
+        let suite = "StatusItemControllerSplitLifecycleTests-placement-legacy-mixed-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(42, forKey: "NSStatusItem Preferred Position Item-0")
+        defaults.set(11298, forKey: "NSStatusItem Preferred Position Item-1")
+        let key = MenuBarStatusItemPlacementPreflight.preferredPositionKey(autosaveName: "codexbar-merged")
+
+        #expect(!MenuBarStatusItemPlacementPreflight.prepare(
+            defaults: defaults,
+            autosaveName: "codexbar-merged",
+            legacyDefaultItemIndex: 0))
+
+        #expect(defaults.object(forKey: key) == nil)
+        #expect(defaults.double(forKey: "NSStatusItem Preferred Position Item-0") == 42)
+        #expect(defaults.double(forKey: "NSStatusItem Preferred Position Item-1") == 11298)
+    }
+
+    @Test
+    func `status item placement preflight repairs provider new key when mixed legacy placements exist`() throws {
+        let suite = "StatusItemControllerSplitLifecycleTests-placement-provider-mixed-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(42, forKey: "NSStatusItem Preferred Position Item-0")
+        defaults.set(11298, forKey: "NSStatusItem Preferred Position Item-1")
+        let key = MenuBarStatusItemPlacementPreflight.preferredPositionKey(autosaveName: "codexbar-codex")
+
+        #expect(MenuBarStatusItemPlacementPreflight.prepare(
+            defaults: defaults,
+            autosaveName: "codexbar-codex",
+            legacyDefaultItemIndex: 1))
+
+        #expect(defaults.double(forKey: key) == 0)
+        #expect(defaults.double(forKey: "NSStatusItem Preferred Position Item-0") == 42)
+        #expect(defaults.double(forKey: "NSStatusItem Preferred Position Item-1") == 11298)
+    }
+
+    @Test
+    func `status item placement preflight repairs provider new key when only merged legacy placement exists`() throws {
+        let suite = "StatusItemControllerSplitLifecycleTests-placement-provider-single-legacy-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(42, forKey: "NSStatusItem Preferred Position Item-0")
+        let key = MenuBarStatusItemPlacementPreflight.preferredPositionKey(autosaveName: "codexbar-codex")
+
+        #expect(MenuBarStatusItemPlacementPreflight.prepare(
+            defaults: defaults,
+            autosaveName: "codexbar-codex",
+            legacyDefaultItemIndex: 1))
+
+        #expect(defaults.double(forKey: key) == 0)
+        #expect(defaults.double(forKey: "NSStatusItem Preferred Position Item-0") == 42)
+    }
+
+    @Test
+    func `status item placement preflight preserves provider key with matching legacy placement`() throws {
+        let suite = "StatusItemControllerSplitLifecycleTests-placement-provider-matching-legacy-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(42, forKey: "NSStatusItem Preferred Position Item-0")
+        defaults.set(58, forKey: "NSStatusItem Preferred Position Item-1")
+        let key = MenuBarStatusItemPlacementPreflight.preferredPositionKey(autosaveName: "codexbar-codex")
+
+        #expect(!MenuBarStatusItemPlacementPreflight.prepare(
+            defaults: defaults,
+            autosaveName: "codexbar-codex",
+            legacyDefaultItemIndex: 1))
+
+        #expect(defaults.object(forKey: key) == nil)
+        #expect(defaults.double(forKey: "NSStatusItem Preferred Position Item-0") == 42)
+        #expect(defaults.double(forKey: "NSStatusItem Preferred Position Item-1") == 58)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
@@ -98,22 +98,70 @@ struct StatusItemControllerSplitLifecycleTests {
     }
 
     @Test
-    func `status items publish stable non persistent manager identity`() throws {
+    func `status items publish stable manager identity`() throws {
         let (_, controller) = try self.makeSplitController()
         defer { controller.releaseStatusItemsForTesting() }
 
         let codexButton = try #require(controller.statusItems[.codex]?.button)
         let claudeButton = try #require(controller.statusItems[.claude]?.button)
 
-        #expect(!controller.statusItem.autosaveName.hasPrefix("CodexBar."))
-        #expect(controller.statusItems[.codex]?.autosaveName.hasPrefix("CodexBar.") == false)
-        #expect(controller.statusItems[.claude]?.autosaveName.hasPrefix("CodexBar.") == false)
+        #expect(controller.statusItem.autosaveName == "codexbar-merged")
+        #expect(controller.statusItems[.codex]?.autosaveName == "codexbar-codex")
+        #expect(controller.statusItems[.claude]?.autosaveName == "codexbar-claude")
         #expect(controller.statusItem.button?.accessibilityIdentifier() == "CodexBar.StatusItem")
         #expect(codexButton.accessibilityIdentifier() == "CodexBar.StatusItem.codex")
         #expect(claudeButton.accessibilityIdentifier() == "CodexBar.StatusItem.claude")
         #expect(controller.statusItem.button?.accessibilityTitle() == "CodexBar")
         #expect(codexButton.accessibilityTitle() == "CodexBar")
         #expect(claudeButton.accessibilityTitle() == "CodexBar")
+    }
+
+    @Test
+    func `status item identity returns stable autosave names`() {
+        #expect(StatusItemController.StatusItemIdentity.merged.autosaveName == "codexbar-merged")
+        #expect(StatusItemController.StatusItemIdentity.provider(.codex).autosaveName == "codexbar-codex")
+        #expect(StatusItemController.StatusItemIdentity.provider(.claude).autosaveName == "codexbar-claude")
+    }
+
+    @Test
+    func `status item placement preflight writes low position when missing`() throws {
+        let suite = "StatusItemControllerSplitLifecycleTests-placement-missing-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        #expect(MenuBarStatusItemPlacementPreflight.prepare(defaults: defaults, autosaveName: "codexbar-merged"))
+
+        let key = MenuBarStatusItemPlacementPreflight.preferredPositionKey(autosaveName: "codexbar-merged")
+        #expect(defaults.double(forKey: key) == 0)
+    }
+
+    @Test
+    func `status item placement preflight replaces suspicious high position`() throws {
+        let suite = "StatusItemControllerSplitLifecycleTests-placement-high-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let key = MenuBarStatusItemPlacementPreflight.preferredPositionKey(autosaveName: "codexbar-merged")
+        defaults.set(11298, forKey: key)
+
+        #expect(MenuBarStatusItemPlacementPreflight.prepare(defaults: defaults, autosaveName: "codexbar-merged"))
+
+        #expect(defaults.double(forKey: key) == 0)
+    }
+
+    @Test
+    func `status item placement preflight preserves reasonable position`() throws {
+        let suite = "StatusItemControllerSplitLifecycleTests-placement-preserve-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let key = MenuBarStatusItemPlacementPreflight.preferredPositionKey(autosaveName: "codexbar-merged")
+        defaults.set(42, forKey: key)
+
+        #expect(!MenuBarStatusItemPlacementPreflight.prepare(defaults: defaults, autosaveName: "codexbar-merged"))
+
+        #expect(defaults.double(forKey: key) == 42)
     }
 
     @Test
@@ -164,7 +212,7 @@ struct StatusItemControllerSplitLifecycleTests {
         #expect(newCodexItem === oldCodexItem)
         #expect(newClaudeItem === oldClaudeItem)
         #expect(newCodexItem.button === oldCodexButton)
-        #expect(!newCodexItem.autosaveName.hasPrefix("CodexBar."))
+        #expect(newCodexItem.autosaveName == "codexbar-codex")
         #expect(newCodexItem.button?.accessibilityIdentifier() == "CodexBar.StatusItem.codex")
     }
 
@@ -182,7 +230,7 @@ struct StatusItemControllerSplitLifecycleTests {
 
         #expect(controller.statusItem === oldMergedItem)
         #expect(controller.statusItem.button === oldMergedButton)
-        #expect(!controller.statusItem.autosaveName.hasPrefix("CodexBar."))
+        #expect(controller.statusItem.autosaveName == "codexbar-merged")
         #expect(controller.statusItem.button?.accessibilityIdentifier() == "CodexBar.StatusItem")
     }
 
@@ -214,7 +262,7 @@ struct StatusItemControllerSplitLifecycleTests {
 
         let newCodexItem = try #require(controller.statusItems[.codex])
         #expect(newCodexItem !== oldCodexItem)
-        #expect(!newCodexItem.autosaveName.hasPrefix("CodexBar."))
+        #expect(newCodexItem.autosaveName == "codexbar-codex")
         #expect(newCodexItem.button?.accessibilityIdentifier() == "CodexBar.StatusItem.codex")
     }
 
@@ -232,7 +280,7 @@ struct StatusItemControllerSplitLifecycleTests {
 
         let mergedButton = try #require(controller.statusItem.button)
         #expect(mergedButton.image != nil)
-        #expect(!controller.statusItem.autosaveName.hasPrefix("CodexBar."))
+        #expect(controller.statusItem.autosaveName == "codexbar-merged")
         #expect(mergedButton.accessibilityIdentifier() == "CodexBar.StatusItem")
     }
 }

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -884,8 +884,8 @@ extension StatusMenuTests {
             statusBar: self.makeStatusBarForTesting())
 
         let codexItem = try #require(controller.statusItems[.codex])
-        #expect(!controller.statusItem.autosaveName.hasPrefix("codexbar-"))
-        #expect(!codexItem.autosaveName.hasPrefix("codexbar-"))
+        #expect(controller.statusItem.autosaveName == "codexbar-merged")
+        #expect(codexItem.autosaveName == "codexbar-codex")
 
         try settings.setProviderEnabled(
             provider: .gemini,
@@ -894,8 +894,8 @@ extension StatusMenuTests {
         controller.handleProviderConfigChange(reason: "test")
 
         #expect(controller.statusItems[.codex] === codexItem)
-        #expect(controller.statusItems[.codex]?.autosaveName.hasPrefix("codexbar-") == false)
-        #expect(controller.statusItems[.gemini]?.autosaveName.hasPrefix("codexbar-") == false)
+        #expect(controller.statusItems[.codex]?.autosaveName == "codexbar-codex")
+        #expect(controller.statusItems[.gemini]?.autosaveName == "codexbar-gemini")
     }
 
     @Test


### PR DESCRIPTION
## Summary

Harden CodexBar status item placement on crowded macOS 26 menu bars.

This PR adds stable `NSStatusItem.autosaveName` values, writes a low preferred-position key before status item creation when the saved value is missing or suspiciously high, and adds CGWindowList-based diagnostics for real menu-bar window bounds. It also keeps cached brand-percent renders self-healing by reapplying the button title, and makes merged fallback provider selection follow the configured enabled provider order.

Maintainer follow-up: the placement preflight now preserves reasonable legacy AppKit `Item-N` placement only for the matching new stable identity, so upgrades keep valid existing placement while fresh or suspicious provider identities still get seeded.

## Why

Field debugging on macOS 26 showed cases where `NSStatusBarButton.title` and frame were correct, but the host menu bar placed the status item under/over the clock or off-screen. AX title checks were misleading, so the diagnostics now report CGWindow bounds keyed by the stable autosave/window name.

This does not try to guarantee visibility under active menu-bar managers; it reduces fragility for standalone CodexBar and gives better evidence when the host menu bar is the failing layer.

## Changes

- Add stable autosave names:
  - `codexbar-merged`
  - `codexbar-<provider>`
- Preflight `NSStatusItem Preferred Position <autosaveName>` to `0` before item creation when missing or greater than `100`.
- Preserve reasonable legacy `Item-N` placement for the matching stable identity during upgrade.
- Add `MenuBarStatusItemWindowProbe` using `CGWindowListCopyWindowInfo` for bounds/on-screen diagnostics.
- Include window diagnostics in existing visibility recovery failure logs.
- Reapply title/image-position state when cached merged brand-percent icon rendering is skipped.
- Respect enabled provider order in merged fallback provider selection.
- Use `Bundle.module` for provider icon resources outside app-bundle execution so package tests exercise the brand-percent path.

## Validation

- `swift test --filter StatusItemControllerSplitLifecycleTests` - 19 tests passed.
- `swift test --filter MenuBarVisibilityWatcherTests --filter StatusItemAnimationSignatureTests --filter StatusMenuTests` - 73 tests passed.
- `make check` - SwiftFormat and SwiftLint clean.
- `swift test` - 3157 tests in 378 suites passed.
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` - clean, no accepted/actionable findings.

No full app launch in validation: repo policy avoids live provider/keychain prompts for this path; AppKit proof is via status-item/controller tests and CGWindow-style visibility tests.
