### PR TITLE
fix: reload Codex daemon after account promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 ### Fixed
 - Cost history: keep chart date labels aligned with their bars and visible without clipping. Thanks @elijahfriedman!
 - Claude settings: dim and disable Avoid Keychain prompts while global Keychain access is disabled. Thanks @Zihao-Qi!
+- Codex accounts: restart a running app-server daemon after system-account promotion while preserving remote-control mode. Thanks @rendrag-git!
 - Xiaomi MiMo: retry another imported browser session when a stale session redirects API requests to login. Thanks @Yuxin-Qiao!
 - MiniMax: retry the China API region when the global token endpoint reports a structured invalid-key response.
 - Kiro: keep parsed usage available when the optional account probe times out or fails. Thanks @Yuxin-Qiao!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 ### Fixed
 - Cost history: keep chart date labels aligned with their bars and visible without clipping. Thanks @elijahfriedman!
 - Claude settings: dim and disable Avoid Keychain prompts while global Keychain access is disabled. Thanks @Zihao-Qi!
-- Codex accounts: restart a running app-server daemon after system-account promotion while preserving remote-control mode. Thanks @rendrag-git!
+- Codex accounts: restart a managed app-server daemon after system-account promotion while preserving remote-control mode, and request a manual restart for unsupported or unmanaged services. Thanks @rendrag-git!
 - Xiaomi MiMo: retry another imported browser session when a stale session redirects API requests to login. Thanks @Yuxin-Qiao!
 - MiniMax: retry the China API region when the global token endpoint reports a structured invalid-key response.
 - Kiro: keep parsed usage available when the optional account probe times out or fails. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/CodexAccountPromotionCoordinator.swift
+++ b/Sources/CodexBar/CodexAccountPromotionCoordinator.swift
@@ -1,3 +1,4 @@
+import CodexBarCore
 import Foundation
 import Observation
 
@@ -48,7 +49,9 @@ final class CodexAccountPromotionCoordinator {
         defer { self.isPromotingSystemAccount = false }
 
         do {
-            let result = try await self.service.promoteManagedAccount(id: managedAccountID)
+            let result = try await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                try await self.service.promoteManagedAccount(id: managedAccountID)
+            }
             return .success(result)
         } catch {
             let mapped = Self.mapUserFacingError(error)
@@ -78,6 +81,14 @@ final class CodexAccountPromotionCoordinator {
     }
 
     static func mapUserFacingError(_ error: Error) -> CodexSystemAccountPromotionUserFacingError {
+        if let error = error as? CodexAccountPromotionError,
+           case let .appServerDaemonRestartFailed(output) = error
+        {
+            return CodexSystemAccountPromotionUserFacingError(
+                title: L("System account switched"),
+                message: self.appServerDaemonRestartFailedMessage(output: output))
+        }
+
         let title = L("Could not switch system account")
 
         if let error = error as? CodexAccountPromotionError {
@@ -104,11 +115,24 @@ final class CodexAccountPromotionCoordinator {
                 L("CodexBar could not update managed account storage.")
             case .liveAuthSwapFailed:
                 L("CodexBar could not replace the live Codex auth on this Mac.")
+            case .appServerDaemonRestartFailed:
+                self.appServerDaemonRestartFailedMessage(output: "")
             }
 
             return CodexSystemAccountPromotionUserFacingError(title: title, message: message)
         }
 
         return CodexSystemAccountPromotionUserFacingError(title: title, message: error.localizedDescription)
+    }
+
+    private static func appServerDaemonRestartFailedMessage(output: String) -> String {
+        let base = L(
+            "The system account was switched, but CodexBar could not restart the configured Codex " +
+                "background service. " +
+                "If the Codex desktop app is open, quit and reopen it, then restart your configured Codex " +
+                "background service before using app-server-backed sessions.")
+        let trimmedOutput = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedOutput.isEmpty, trimmedOutput != "No output captured." else { return base }
+        return "\(base)\n\n\(L("Error")):\n\(trimmedOutput)"
     }
 }

--- a/Sources/CodexBar/CodexAccountPromotionService.swift
+++ b/Sources/CodexBar/CodexAccountPromotionService.swift
@@ -224,13 +224,15 @@ final class CodexAccountPromotionService {
 
         if let resultingActiveSource = self.convergedActiveSource(for: context) {
             self.activeSourceWriter.writeCodexActiveSource(resultingActiveSource)
+            let daemonReloadOutcome = await self.appServerDaemonReloader.reloadAfterAuthPromotion()
             await self.accountScopedRefresher.refreshCodexAccountScopedState(allowDisabled: true)
+            try Self.throwOnDaemonReloadFailure(daemonReloadOutcome)
             return CodexAccountPromotionResult(
                 targetManagedAccountID: id,
                 outcome: .convergedNoOp,
                 displacedLiveDisposition: .none,
                 didMutateLiveAuth: false,
-                appServerDaemonReloadOutcome: .notNeeded,
+                appServerDaemonReloadOutcome: daemonReloadOutcome,
                 resultingActiveSource: resultingActiveSource)
         }
 
@@ -251,9 +253,7 @@ final class CodexAccountPromotionService {
         self.activeSourceWriter.writeCodexActiveSource(.liveSystem)
         let daemonReloadOutcome = await self.appServerDaemonReloader.reloadAfterAuthPromotion()
         await self.accountScopedRefresher.refreshCodexAccountScopedState(allowDisabled: true)
-        if case let .failed(output) = daemonReloadOutcome {
-            throw CodexAccountPromotionError.appServerDaemonRestartFailed(output)
-        }
+        try Self.throwOnDaemonReloadFailure(daemonReloadOutcome)
 
         return CodexAccountPromotionResult(
             targetManagedAccountID: id,
@@ -266,6 +266,12 @@ final class CodexAccountPromotionService {
 
     nonisolated static func authFileURL(for homeURL: URL) -> URL {
         homeURL.appendingPathComponent("auth.json", isDirectory: false)
+    }
+
+    private static func throwOnDaemonReloadFailure(_ outcome: CodexAppServerDaemonReloadOutcome) throws {
+        if case let .failed(output) = outcome {
+            throw CodexAccountPromotionError.appServerDaemonRestartFailed(output)
+        }
     }
 
     private func convergedActiveSource(for context: PreparedPromotionContext) -> CodexActiveSource? {

--- a/Sources/CodexBar/CodexAccountPromotionService.swift
+++ b/Sources/CodexBar/CodexAccountPromotionService.swift
@@ -226,7 +226,7 @@ final class CodexAccountPromotionService {
             self.activeSourceWriter.writeCodexActiveSource(resultingActiveSource)
             let daemonReloadOutcome = await self.appServerDaemonReloader.reloadAfterAuthPromotion()
             await self.accountScopedRefresher.refreshCodexAccountScopedState(allowDisabled: true)
-            try Self.throwOnDaemonReloadFailure(daemonReloadOutcome)
+            try Self.throwIfDaemonReloadRequiresAttention(daemonReloadOutcome)
             return CodexAccountPromotionResult(
                 targetManagedAccountID: id,
                 outcome: .convergedNoOp,
@@ -253,7 +253,7 @@ final class CodexAccountPromotionService {
         self.activeSourceWriter.writeCodexActiveSource(.liveSystem)
         let daemonReloadOutcome = await self.appServerDaemonReloader.reloadAfterAuthPromotion()
         await self.accountScopedRefresher.refreshCodexAccountScopedState(allowDisabled: true)
-        try Self.throwOnDaemonReloadFailure(daemonReloadOutcome)
+        try Self.throwIfDaemonReloadRequiresAttention(daemonReloadOutcome)
 
         return CodexAccountPromotionResult(
             targetManagedAccountID: id,
@@ -268,9 +268,14 @@ final class CodexAccountPromotionService {
         homeURL.appendingPathComponent("auth.json", isDirectory: false)
     }
 
-    private static func throwOnDaemonReloadFailure(_ outcome: CodexAppServerDaemonReloadOutcome) throws {
-        if case let .failed(output) = outcome {
+    private static func throwIfDaemonReloadRequiresAttention(_ outcome: CodexAppServerDaemonReloadOutcome) throws {
+        switch outcome {
+        case .unavailable, .unmanaged:
+            throw CodexAccountPromotionError.appServerDaemonRestartFailed("")
+        case let .failed(output):
             throw CodexAccountPromotionError.appServerDaemonRestartFailed(output)
+        case .notNeeded, .notRunning, .restarted:
+            break
         }
     }
 

--- a/Sources/CodexBar/CodexAccountPromotionService.swift
+++ b/Sources/CodexBar/CodexAccountPromotionService.swift
@@ -130,6 +130,7 @@ struct CodexAccountPromotionResult: Equatable {
     let outcome: Outcome
     let displacedLiveDisposition: DisplacedLiveDisposition
     let didMutateLiveAuth: Bool
+    let appServerDaemonReloadOutcome: CodexAppServerDaemonReloadOutcome
     let resultingActiveSource: CodexActiveSource
 }
 
@@ -144,6 +145,7 @@ enum CodexAccountPromotionError: Error, Equatable {
     case displacedLiveImportFailed
     case managedStoreCommitFailed
     case liveAuthSwapFailed
+    case appServerDaemonRestartFailed(String)
 }
 
 @MainActor
@@ -155,6 +157,7 @@ final class CodexAccountPromotionService {
     private let snapshotLoader: any CodexAccountReconciliationSnapshotLoading
     private let authMaterialReader: any CodexAuthMaterialReading
     private let liveAuthSwapper: any CodexLiveAuthSwapping
+    private let appServerDaemonReloader: any CodexAppServerDaemonReloading
     private let activeSourceWriter: any CodexActiveSourceWriting
     private let accountScopedRefresher: any CodexAccountScopedRefreshing
     private let baseEnvironment: [String: String]
@@ -168,6 +171,7 @@ final class CodexAccountPromotionService {
         snapshotLoader: any CodexAccountReconciliationSnapshotLoading,
         authMaterialReader: any CodexAuthMaterialReading,
         liveAuthSwapper: any CodexLiveAuthSwapping,
+        appServerDaemonReloader: any CodexAppServerDaemonReloading,
         activeSourceWriter: any CodexActiveSourceWriting,
         accountScopedRefresher: any CodexAccountScopedRefreshing,
         baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
@@ -180,6 +184,7 @@ final class CodexAccountPromotionService {
         self.snapshotLoader = snapshotLoader
         self.authMaterialReader = authMaterialReader
         self.liveAuthSwapper = liveAuthSwapper
+        self.appServerDaemonReloader = appServerDaemonReloader
         self.activeSourceWriter = activeSourceWriter
         self.accountScopedRefresher = accountScopedRefresher
         self.baseEnvironment = baseEnvironment
@@ -200,6 +205,7 @@ final class CodexAccountPromotionService {
             snapshotLoader: SettingsStoreCodexAccountReconciliationSnapshotLoader(settingsStore: settingsStore),
             authMaterialReader: DefaultCodexAuthMaterialReader(),
             liveAuthSwapper: DefaultCodexLiveAuthSwapper(),
+            appServerDaemonReloader: DefaultCodexAppServerDaemonReloader(baseEnvironment: baseEnvironment),
             activeSourceWriter: SettingsStoreCodexActiveSourceWriter(settingsStore: settingsStore),
             accountScopedRefresher: UsageStoreCodexAccountScopedRefresher(usageStore: usageStore),
             baseEnvironment: baseEnvironment,
@@ -224,6 +230,7 @@ final class CodexAccountPromotionService {
                 outcome: .convergedNoOp,
                 displacedLiveDisposition: .none,
                 didMutateLiveAuth: false,
+                appServerDaemonReloadOutcome: .notNeeded,
                 resultingActiveSource: resultingActiveSource)
         }
 
@@ -242,13 +249,18 @@ final class CodexAccountPromotionService {
         }
 
         self.activeSourceWriter.writeCodexActiveSource(.liveSystem)
+        let daemonReloadOutcome = await self.appServerDaemonReloader.reloadAfterAuthPromotion()
         await self.accountScopedRefresher.refreshCodexAccountScopedState(allowDisabled: true)
+        if case let .failed(output) = daemonReloadOutcome {
+            throw CodexAccountPromotionError.appServerDaemonRestartFailed(output)
+        }
 
         return CodexAccountPromotionResult(
             targetManagedAccountID: id,
             outcome: .promoted,
             displacedLiveDisposition: executionResult.displacedLiveDisposition,
             didMutateLiveAuth: true,
+            appServerDaemonReloadOutcome: daemonReloadOutcome,
             resultingActiveSource: .liveSystem)
     }
 

--- a/Sources/CodexBar/CodexAppServerDaemonReloader.swift
+++ b/Sources/CodexBar/CodexAppServerDaemonReloader.swift
@@ -1,0 +1,133 @@
+import CodexBarCore
+import Foundation
+
+enum CodexAppServerDaemonReloadOutcome: Equatable, Sendable {
+    case notNeeded
+    case notRunning
+    case restarted
+    case remoteControlRestarted
+    case unavailable
+    case failed(String)
+}
+
+protocol CodexAppServerDaemonReloading: Sendable {
+    func reloadAfterAuthPromotion() async -> CodexAppServerDaemonReloadOutcome
+}
+
+struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
+    typealias BinaryResolver = @Sendable ([String: String]) -> String?
+    typealias CommandRunner = @Sendable (
+        _ executable: String,
+        _ arguments: [String],
+        _ environment: [String: String],
+        _ timeout: TimeInterval) async throws -> String
+
+    private let baseEnvironment: [String: String]
+    private let commandTimeout: TimeInterval
+    private let binaryResolver: BinaryResolver
+    private let commandRunner: CommandRunner
+
+    init(
+        baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
+        commandTimeout: TimeInterval = 10,
+        binaryResolver: @escaping BinaryResolver = { environment in
+            BinaryLocator.resolveCodexBinary(
+                env: environment,
+                loginPATH: LoginShellPathCache.shared.current)
+        },
+        commandRunner: @escaping CommandRunner = Self.runCommand)
+    {
+        self.baseEnvironment = baseEnvironment
+        self.commandTimeout = commandTimeout
+        self.binaryResolver = binaryResolver
+        self.commandRunner = commandRunner
+    }
+
+    func reloadAfterAuthPromotion() async -> CodexAppServerDaemonReloadOutcome {
+        var environment = self.baseEnvironment
+        environment["PATH"] = PathBuilder.effectivePATH(
+            purposes: [.rpc, .tty, .nodeTooling],
+            env: environment,
+            loginPATH: LoginShellPathCache.shared.current)
+
+        guard let executable = self.binaryResolver(environment) else {
+            return .unavailable
+        }
+
+        do {
+            _ = try await self.commandRunner(
+                executable,
+                ["app-server", "daemon", "version"],
+                environment,
+                self.commandTimeout)
+        } catch {
+            return .notRunning
+        }
+
+        let remoteControlEnabled = Self.remoteControlEnabled(environment: environment)
+        let restartArguments = remoteControlEnabled
+            ? ["remote-control", "start"]
+            : ["app-server", "daemon", "restart"]
+
+        do {
+            _ = try await self.commandRunner(
+                executable,
+                restartArguments,
+                environment,
+                self.commandTimeout)
+            return remoteControlEnabled ? .remoteControlRestarted : .restarted
+        } catch {
+            return .failed(Self.limitedOutput(for: error))
+        }
+    }
+
+    private static func runCommand(
+        executable: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval) async throws -> String
+    {
+        let result = try await SubprocessRunner.run(
+            binary: executable,
+            arguments: arguments,
+            environment: environment,
+            timeout: timeout,
+            label: "Codex app-server daemon reload")
+        return [result.stdout, result.stderr]
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+    }
+
+    private static func remoteControlEnabled(environment: [String: String]) -> Bool {
+        let settingsURL = self.codexHomeURL(environment: environment)
+            .appendingPathComponent("app-server-daemon", isDirectory: true)
+            .appendingPathComponent("settings.json", isDirectory: false)
+        guard let data = try? Data(contentsOf: settingsURL),
+              let settings = try? JSONDecoder().decode(DaemonSettings.self, from: data)
+        else {
+            return false
+        }
+        return settings.remoteControlEnabled == true
+    }
+
+    private static func codexHomeURL(environment: [String: String]) -> URL {
+        if let raw = environment["CODEX_HOME"]?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty {
+            return URL(fileURLWithPath: (raw as NSString).expandingTildeInPath, isDirectory: true)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".codex", isDirectory: true)
+    }
+
+    private static func limitedOutput(for error: Error) -> String {
+        let output = switch error {
+        case let SubprocessRunnerError.nonZeroExit(_, stderr): stderr
+        default: error.localizedDescription
+        }
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "No output captured." : String(trimmed.prefix(1000))
+    }
+}
+
+private struct DaemonSettings: Decodable {
+    let remoteControlEnabled: Bool?
+}

--- a/Sources/CodexBar/CodexAppServerDaemonReloader.swift
+++ b/Sources/CodexBar/CodexAppServerDaemonReloader.swift
@@ -26,7 +26,6 @@ struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
         _ arguments: [String],
         _ environment: [String: String],
         _ timeout: TimeInterval) async throws -> String
-
     private let baseEnvironment: [String: String]
     private let probeTimeout: TimeInterval
     private let restartTimeout: TimeInterval
@@ -71,7 +70,7 @@ struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
                 self.probeTimeout)
         } catch {
             if Self.probeShowsDaemonAbsent(error) {
-                return .notRunning
+                return .failed("Codex daemon state could not be confirmed while its socket was unavailable.")
             }
             if Self.probeShowsCapabilityUnavailable(error) {
                 return .unavailable

--- a/Sources/CodexBar/CodexAppServerDaemonReloader.swift
+++ b/Sources/CodexBar/CodexAppServerDaemonReloader.swift
@@ -5,7 +5,6 @@ enum CodexAppServerDaemonReloadOutcome: Equatable, Sendable {
     case notNeeded
     case notRunning
     case restarted
-    case remoteControlRestarted
     case unavailable
     case failed(String)
 }
@@ -29,7 +28,7 @@ struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
 
     init(
         baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
-        commandTimeout: TimeInterval = 10,
+        commandTimeout: TimeInterval = 90,
         binaryResolver: @escaping BinaryResolver = { environment in
             BinaryLocator.resolveCodexBinary(
                 env: environment,
@@ -61,21 +60,19 @@ struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
                 environment,
                 self.commandTimeout)
         } catch {
-            return .notRunning
+            if Self.probeShowsDaemonAbsent(error) {
+                return .notRunning
+            }
+            return .failed(Self.limitedOutput(for: error))
         }
-
-        let remoteControlEnabled = Self.remoteControlEnabled(environment: environment)
-        let restartArguments = remoteControlEnabled
-            ? ["remote-control", "start"]
-            : ["app-server", "daemon", "restart"]
 
         do {
             _ = try await self.commandRunner(
                 executable,
-                restartArguments,
+                ["app-server", "daemon", "restart"],
                 environment,
                 self.commandTimeout)
-            return remoteControlEnabled ? .remoteControlRestarted : .restarted
+            return .restarted
         } catch {
             return .failed(Self.limitedOutput(for: error))
         }
@@ -98,24 +95,10 @@ struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
             .joined(separator: "\n")
     }
 
-    private static func remoteControlEnabled(environment: [String: String]) -> Bool {
-        let settingsURL = self.codexHomeURL(environment: environment)
-            .appendingPathComponent("app-server-daemon", isDirectory: true)
-            .appendingPathComponent("settings.json", isDirectory: false)
-        guard let data = try? Data(contentsOf: settingsURL),
-              let settings = try? JSONDecoder().decode(DaemonSettings.self, from: data)
-        else {
-            return false
-        }
-        return settings.remoteControlEnabled == true
-    }
-
-    private static func codexHomeURL(environment: [String: String]) -> URL {
-        if let raw = environment["CODEX_HOME"]?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty {
-            return URL(fileURLWithPath: (raw as NSString).expandingTildeInPath, isDirectory: true)
-        }
-        return FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".codex", isDirectory: true)
+    private static func probeShowsDaemonAbsent(_ error: Error) -> Bool {
+        guard case let SubprocessRunnerError.nonZeroExit(_, stderr) = error else { return false }
+        let normalized = stderr.lowercased()
+        return normalized.contains("no such file or directory") || normalized.contains("connection refused")
     }
 
     private static func limitedOutput(for error: Error) -> String {
@@ -126,8 +109,4 @@ struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
         let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "No output captured." : String(trimmed.prefix(1000))
     }
-}
-
-private struct DaemonSettings: Decodable {
-    let remoteControlEnabled: Bool?
 }

--- a/Sources/CodexBar/CodexAppServerDaemonReloader.swift
+++ b/Sources/CodexBar/CodexAppServerDaemonReloader.swift
@@ -16,6 +16,7 @@ protocol CodexAppServerDaemonReloading: Sendable {
 
 struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
     private struct DaemonVersionResponse: Decodable {
+        let status: String
         let backend: String?
     }
 
@@ -58,7 +59,7 @@ struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
             loginPATH: LoginShellPathCache.shared.current)
 
         guard let executable = self.binaryResolver(environment) else {
-            return .notNeeded
+            return .unavailable
         }
 
         let versionOutput: String
@@ -82,6 +83,9 @@ struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
               let response = try? JSONDecoder().decode(DaemonVersionResponse.self, from: data)
         else {
             return .failed("Codex daemon returned an invalid version response.")
+        }
+        guard response.status == "running" else {
+            return .notRunning
         }
         guard response.backend != nil else {
             return .unmanaged

--- a/Sources/CodexBar/CodexAppServerDaemonReloader.swift
+++ b/Sources/CodexBar/CodexAppServerDaemonReloader.swift
@@ -22,13 +22,15 @@ struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
         _ timeout: TimeInterval) async throws -> String
 
     private let baseEnvironment: [String: String]
-    private let commandTimeout: TimeInterval
+    private let probeTimeout: TimeInterval
+    private let restartTimeout: TimeInterval
     private let binaryResolver: BinaryResolver
     private let commandRunner: CommandRunner
 
     init(
         baseEnvironment: [String: String] = ProcessInfo.processInfo.environment,
-        commandTimeout: TimeInterval = 90,
+        probeTimeout: TimeInterval = 10,
+        restartTimeout: TimeInterval = 120,
         binaryResolver: @escaping BinaryResolver = { environment in
             BinaryLocator.resolveCodexBinary(
                 env: environment,
@@ -37,7 +39,8 @@ struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
         commandRunner: @escaping CommandRunner = Self.runCommand)
     {
         self.baseEnvironment = baseEnvironment
-        self.commandTimeout = commandTimeout
+        self.probeTimeout = probeTimeout
+        self.restartTimeout = restartTimeout
         self.binaryResolver = binaryResolver
         self.commandRunner = commandRunner
     }
@@ -58,7 +61,7 @@ struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
                 executable,
                 ["app-server", "daemon", "version"],
                 environment,
-                self.commandTimeout)
+                self.probeTimeout)
         } catch {
             if Self.probeShowsDaemonAbsent(error) {
                 return .notRunning
@@ -71,7 +74,7 @@ struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
                 executable,
                 ["app-server", "daemon", "restart"],
                 environment,
-                self.commandTimeout)
+                self.restartTimeout)
             return .restarted
         } catch {
             return .failed(Self.limitedOutput(for: error))

--- a/Sources/CodexBar/CodexAppServerDaemonReloader.swift
+++ b/Sources/CodexBar/CodexAppServerDaemonReloader.swift
@@ -6,6 +6,7 @@ enum CodexAppServerDaemonReloadOutcome: Equatable, Sendable {
     case notRunning
     case restarted
     case unavailable
+    case unmanaged
     case failed(String)
 }
 
@@ -14,6 +15,10 @@ protocol CodexAppServerDaemonReloading: Sendable {
 }
 
 struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
+    private struct DaemonVersionResponse: Decodable {
+        let backend: String?
+    }
+
     typealias BinaryResolver = @Sendable ([String: String]) -> String?
     typealias CommandRunner = @Sendable (
         _ executable: String,
@@ -53,11 +58,12 @@ struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
             loginPATH: LoginShellPathCache.shared.current)
 
         guard let executable = self.binaryResolver(environment) else {
-            return .unavailable
+            return .notNeeded
         }
 
+        let versionOutput: String
         do {
-            _ = try await self.commandRunner(
+            versionOutput = try await self.commandRunner(
                 executable,
                 ["app-server", "daemon", "version"],
                 environment,
@@ -66,7 +72,19 @@ struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
             if Self.probeShowsDaemonAbsent(error) {
                 return .notRunning
             }
+            if Self.probeShowsCapabilityUnavailable(error) {
+                return .unavailable
+            }
             return .failed(Self.limitedOutput(for: error))
+        }
+
+        guard let data = versionOutput.data(using: .utf8),
+              let response = try? JSONDecoder().decode(DaemonVersionResponse.self, from: data)
+        else {
+            return .failed("Codex daemon returned an invalid version response.")
+        }
+        guard response.backend != nil else {
+            return .unmanaged
         }
 
         do {
@@ -93,15 +111,18 @@ struct DefaultCodexAppServerDaemonReloader: CodexAppServerDaemonReloading {
             environment: environment,
             timeout: timeout,
             label: "Codex app-server daemon reload")
-        return [result.stdout, result.stderr]
-            .filter { !$0.isEmpty }
-            .joined(separator: "\n")
+        return result.stdout
     }
 
     private static func probeShowsDaemonAbsent(_ error: Error) -> Bool {
         guard case let SubprocessRunnerError.nonZeroExit(_, stderr) = error else { return false }
         let normalized = stderr.lowercased()
         return normalized.contains("no such file or directory") || normalized.contains("connection refused")
+    }
+
+    private static func probeShowsCapabilityUnavailable(_ error: Error) -> Bool {
+        guard case let SubprocessRunnerError.nonZeroExit(code, _) = error else { return false }
+        return code == 2
     }
 
     private static func limitedOutput(for error: Error) -> String {

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -1108,3 +1108,6 @@
 "byte_unit_megabytes" = "ميغابايتات";
 "byte_unit_gigabyte" = "غيغابايت";
 "byte_unit_gigabytes" = "غيغابايتات";
+"System account switched" = "تم تبديل حساب النظام";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "تم تغيير حساب نظام Codex CLI فورًا. إذا كان تطبيق Codex لسطح المكتب مفتوحًا، فأغلقه وأعد فتحه ليستخدم الحساب الجديد.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "تم تبديل حساب النظام، لكن CodexBar لم يتمكن من إعادة تشغيل خدمة Codex المكوّنة في الخلفية. إذا كان تطبيق Codex لسطح المكتب مفتوحًا، فأغلقه وأعد فتحه، ثم أعد تشغيل خدمة Codex المكوّنة في الخلفية قبل استخدام الجلسات المعتمدة على app-server.";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -963,3 +963,6 @@
 "byte_unit_megabytes" = "megabytes";
 "byte_unit_gigabyte" = "gigabyte";
 "byte_unit_gigabytes" = "gigabytes";
+"System account switched" = "Compte del sistema canviat";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "El compte del sistema de la CLI de Codex ha canviat immediatament. Si l'aplicació d'escriptori Codex està oberta, tanqueu-la i torneu-la a obrir perquè utilitzi el compte nou.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "El compte del sistema s'ha canviat, però CodexBar no ha pogut reiniciar el servei en segon pla de Codex configurat. Si l'aplicació d'escriptori Codex està oberta, tanqueu-la i torneu-la a obrir i, després, reinicieu el servei abans d'utilitzar sessions basades en app-server.";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -1105,3 +1105,6 @@
 "byte_unit_megabytes" = "Megabyte";
 "byte_unit_gigabyte" = "Gigabyte";
 "byte_unit_gigabytes" = "Gigabyte";
+"System account switched" = "Systemkonto gewechselt";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "Das Systemkonto der Codex-CLI wurde sofort geändert. Falls die Codex-Desktop-App geöffnet ist, beenden und öffnen Sie sie erneut, damit sie das neue Konto übernimmt.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "Das Systemkonto wurde gewechselt, aber CodexBar konnte den konfigurierten Codex-Hintergrunddienst nicht neu starten. Falls die Codex-Desktop-App geöffnet ist, beenden und öffnen Sie sie erneut. Starten Sie anschließend den konfigurierten Codex-Hintergrunddienst neu, bevor Sie App-Server-Sitzungen verwenden.";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1108,3 +1108,6 @@
 "byte_unit_megabytes" = "megabytes";
 "byte_unit_gigabyte" = "gigabyte";
 "byte_unit_gigabytes" = "gigabytes";
+"System account switched" = "System account switched";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions.";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -963,3 +963,6 @@
 "byte_unit_megabytes" = "megabytes";
 "byte_unit_gigabyte" = "gigabyte";
 "byte_unit_gigabytes" = "gigabytes";
+"System account switched" = "Cuenta del sistema cambiada";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "La cuenta del sistema de la CLI de Codex cambió de inmediato. Si la aplicación de escritorio Codex está abierta, ciérrala y vuelve a abrirla para que use la cuenta nueva.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "La cuenta del sistema se cambió, pero CodexBar no pudo reiniciar el servicio de Codex en segundo plano configurado. Si la aplicación de escritorio Codex está abierta, ciérrala y vuelve a abrirla; después, reinicia el servicio antes de usar sesiones basadas en app-server.";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -1108,3 +1108,6 @@
 "byte_unit_megabytes" = "مگابایت";
 "byte_unit_gigabyte" = "گیگابایت";
 "byte_unit_gigabytes" = "گیگابایت";
+"System account switched" = "حساب سیستم تغییر کرد";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "حساب سیستم Codex CLI بلافاصله تغییر کرد. اگر برنامه دسکتاپ Codex باز است، آن را ببندید و دوباره باز کنید تا حساب جدید را دریافت کند.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "حساب سیستم تغییر کرد، اما CodexBar نتوانست سرویس پس‌زمینه پیکربندی‌شده Codex را دوباره راه‌اندازی کند. اگر برنامه دسکتاپ Codex باز است، آن را ببندید و دوباره باز کنید، سپس پیش از استفاده از نشست‌های مبتنی بر app-server سرویس پس‌زمینه را دوباره راه‌اندازی کنید.";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1103,3 +1103,6 @@
 "byte_unit_megabytes" = "mégaoctets";
 "byte_unit_gigabyte" = "gigaoctet";
 "byte_unit_gigabytes" = "gigaoctets";
+"System account switched" = "Compte système changé";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "Le compte système de la CLI Codex a changé immédiatement. Si l'app Codex pour ordinateur est ouverte, quittez-la puis rouvrez-la afin qu'elle utilise le nouveau compte.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "Le compte système a été changé, mais CodexBar n'a pas pu redémarrer le service Codex en arrière-plan configuré. Si l'app Codex pour ordinateur est ouverte, quittez-la puis rouvrez-la, puis redémarrez le service avant d'utiliser des sessions basées sur app-server.";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -1107,3 +1107,6 @@
 "byte_unit_megabytes" = "megabyte";
 "byte_unit_gigabyte" = "gigabyte";
 "byte_unit_gigabytes" = "gigabyte";
+"System account switched" = "Akun sistem dialihkan";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "Akun sistem Codex CLI langsung berubah. Jika aplikasi desktop Codex terbuka, tutup lalu buka kembali agar menggunakan akun baru.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "Akun sistem telah dialihkan, tetapi CodexBar tidak dapat memulai ulang layanan latar belakang Codex yang dikonfigurasi. Jika aplikasi desktop Codex terbuka, tutup lalu buka kembali, kemudian mulai ulang layanan sebelum menggunakan sesi berbasis app-server.";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -1107,3 +1107,6 @@
 "byte_unit_megabytes" = "megabyte";
 "byte_unit_gigabyte" = "gigabyte";
 "byte_unit_gigabytes" = "gigabyte";
+"System account switched" = "Account di sistema cambiato";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "L'account di sistema della CLI Codex è cambiato immediatamente. Se l'app desktop Codex è aperta, chiudila e riaprila affinché usi il nuovo account.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "L'account di sistema è stato cambiato, ma CodexBar non ha potuto riavviare il servizio Codex in background configurato. Se l'app desktop Codex è aperta, chiudila e riaprila, quindi riavvia il servizio prima di usare sessioni basate su app-server.";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -1104,3 +1104,6 @@
 "byte_unit_megabytes" = "メガバイト";
 "byte_unit_gigabyte" = "ギガバイト";
 "byte_unit_gigabytes" = "ギガバイト";
+"System account switched" = "システムアカウントを切り替えました";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "Codex CLI のシステムアカウントはすぐに変更されました。Codex デスクトップアプリが開いている場合は、終了して再度開き、新しいアカウントを反映してください。";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "システムアカウントは切り替わりましたが、CodexBar は設定済みの Codex バックグラウンドサービスを再起動できませんでした。Codex デスクトップアプリを終了して再度開き、app-server ベースのセッションを使う前にバックグラウンドサービスを再起動してください。";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -1074,3 +1074,6 @@
 "byte_unit_megabytes" = "메가바이트";
 "byte_unit_gigabyte" = "기가바이트";
 "byte_unit_gigabytes" = "기가바이트";
+"System account switched" = "시스템 계정 전환됨";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "Codex CLI 시스템 계정이 즉시 변경되었습니다. Codex 데스크톱 앱이 열려 있으면 종료한 후 다시 열어 새 계정을 적용하세요.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "시스템 계정은 전환되었지만 CodexBar가 구성된 Codex 백그라운드 서비스를 다시 시작하지 못했습니다. Codex 데스크톱 앱을 종료한 후 다시 열고, app-server 기반 세션을 사용하기 전에 백그라운드 서비스를 다시 시작하세요.";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1103,3 +1103,6 @@
 "byte_unit_megabytes" = "megabytes";
 "byte_unit_gigabyte" = "gigabyte";
 "byte_unit_gigabytes" = "gigabytes";
+"System account switched" = "Systeemaccount gewisseld";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "Het systeemaccount van de Codex-CLI is direct gewijzigd. Als de Codex-desktopapp open is, sluit en open deze dan opnieuw zodat het nieuwe account wordt gebruikt.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "Het systeemaccount is gewisseld, maar CodexBar kon de geconfigureerde Codex-achtergrondservice niet herstarten. Sluit en open de Codex-desktopapp opnieuw en herstart daarna de achtergrondservice voordat u app-server-sessies gebruikt.";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -1107,3 +1107,6 @@
 "byte_unit_megabytes" = "megabajty";
 "byte_unit_gigabyte" = "gigabajt";
 "byte_unit_gigabytes" = "gigabajty";
+"System account switched" = "Przełączono konto systemowe";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "Konto systemowe Codex CLI zostało zmienione natychmiast. Jeśli aplikacja Codex jest otwarta, zamknij ją i uruchom ponownie, aby użyła nowego konta.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "Konto systemowe zostało przełączone, ale CodexBar nie mógł ponownie uruchomić skonfigurowanej usługi Codex w tle. Zamknij i ponownie otwórz aplikację Codex, a następnie uruchom ponownie usługę przed użyciem sesji opartych na app-server.";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1104,3 +1104,6 @@
 "byte_unit_megabytes" = "megabytes";
 "byte_unit_gigabyte" = "gigabyte";
 "byte_unit_gigabytes" = "gigabytes";
+"System account switched" = "Conta do sistema trocada";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "A conta do sistema da CLI do Codex mudou imediatamente. Se o app Codex para desktop estiver aberto, feche-o e abra-o novamente para que use a nova conta.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "A conta do sistema foi trocada, mas o CodexBar não conseguiu reiniciar o serviço do Codex em segundo plano configurado. Feche e reabra o app Codex e reinicie o serviço antes de usar sessões baseadas em app-server.";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1102,3 +1102,6 @@
 "byte_unit_megabytes" = "megabyte";
 "byte_unit_gigabyte" = "gigabyte";
 "byte_unit_gigabytes" = "gigabyte";
+"System account switched" = "Systemkontot har bytts";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "Systemkontot för Codex CLI ändrades omedelbart. Om Codex-skrivbordsappen är öppen avslutar du den och öppnar den igen så att det nya kontot används.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "Systemkontot byttes, men CodexBar kunde inte starta om den konfigurerade Codex-bakgrundstjänsten. Avsluta och öppna Codex-skrivbordsappen igen och starta sedan om bakgrundstjänsten innan du använder app-server-baserade sessioner.";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -1108,3 +1108,6 @@
 "byte_unit_megabytes" = "เมกะไบต์";
 "byte_unit_gigabyte" = "กิกะไบต์";
 "byte_unit_gigabytes" = "กิกะไบต์";
+"System account switched" = "สลับบัญชีระบบแล้ว";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "บัญชีระบบของ Codex CLI เปลี่ยนทันที หากแอป Codex บนเดสก์ท็อปเปิดอยู่ ให้ปิดแล้วเปิดใหม่เพื่อให้ใช้บัญชีใหม่";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "สลับบัญชีระบบแล้ว แต่ CodexBar ไม่สามารถเริ่มบริการ Codex เบื้องหลังที่กำหนดค่าไว้ใหม่ได้ ให้ปิดและเปิดแอป Codex บนเดสก์ท็อปใหม่ แล้วเริ่มบริการเบื้องหลังใหม่ก่อนใช้เซสชันที่อาศัย app-server";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1105,3 +1105,6 @@
 "byte_unit_megabytes" = "megabayt";
 "byte_unit_gigabyte" = "gigabayt";
 "byte_unit_gigabytes" = "gigabayt";
+"System account switched" = "Sistem hesabı değiştirildi";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "Codex CLI sistem hesabı hemen değiştirildi. Codex masaüstü uygulaması açıksa yeni hesabı kullanması için kapatıp yeniden açın.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "Sistem hesabı değiştirildi ancak CodexBar yapılandırılmış Codex arka plan hizmetini yeniden başlatamadı. Codex masaüstü uygulamasını kapatıp yeniden açın, ardından app-server tabanlı oturumları kullanmadan önce arka plan hizmetini yeniden başlatın.";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1103,3 +1103,6 @@
 "byte_unit_megabytes" = "мегабайти";
 "byte_unit_gigabyte" = "гігабайт";
 "byte_unit_gigabytes" = "гігабайти";
+"System account switched" = "Системний обліковий запис змінено";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "Системний обліковий запис Codex CLI змінено негайно. Якщо програму Codex відкрито, закрийте й відкрийте її знову, щоб вона використала новий обліковий запис.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "Системний обліковий запис змінено, але CodexBar не вдалося перезапустити налаштовану фонову службу Codex. Закрийте й відкрийте програму Codex знову, а потім перезапустіть службу перед використанням сеансів на основі app-server.";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1104,3 +1104,6 @@
 "byte_unit_megabytes" = "megabyte";
 "byte_unit_gigabyte" = "gigabyte";
 "byte_unit_gigabytes" = "gigabyte";
+"System account switched" = "Đã chuyển tài khoản hệ thống";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "Tài khoản hệ thống Codex CLI đã thay đổi ngay lập tức. Nếu ứng dụng Codex trên máy tính đang mở, hãy thoát và mở lại để ứng dụng dùng tài khoản mới.";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "Tài khoản hệ thống đã được chuyển, nhưng CodexBar không thể khởi động lại dịch vụ Codex nền đã cấu hình. Hãy thoát và mở lại ứng dụng Codex, rồi khởi động lại dịch vụ trước khi dùng các phiên dựa trên app-server.";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1080,3 +1080,6 @@
 "byte_unit_megabytes" = "兆字节";
 "byte_unit_gigabyte" = "吉字节";
 "byte_unit_gigabytes" = "吉字节";
+"System account switched" = "系统账户已切换";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "Codex CLI 系统账户已立即更改。如果 Codex 桌面应用已打开，请退出并重新打开，使其使用新账户。";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "系统账户已切换，但 CodexBar 无法重新启动已配置的 Codex 后台服务。请退出并重新打开 Codex 桌面应用，然后在使用基于 app-server 的会话前重新启动后台服务。";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -976,3 +976,6 @@
 "byte_unit_megabytes" = "百萬位元組";
 "byte_unit_gigabyte" = "十億位元組";
 "byte_unit_gigabytes" = "十億位元組";
+"System account switched" = "系統帳號已切換";
+"The Codex CLI system account changed immediately. If the Codex desktop app is open, quit and reopen it so it picks up the new account." = "Codex CLI 系統帳號已立即變更。如果 Codex 桌面 App 已開啟，請結束並重新開啟，讓它使用新帳號。";
+"The system account was switched, but CodexBar could not restart the configured Codex background service. If the Codex desktop app is open, quit and reopen it, then restart your configured Codex background service before using app-server-backed sessions." = "系統帳號已切換，但 CodexBar 無法重新啟動已設定的 Codex 背景服務。請結束並重新開啟 Codex 桌面 App，然後在使用以 app-server 為基礎的工作階段前重新啟動背景服務。";

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -301,13 +301,28 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             return
         }
 
+        self.closeMenuHierarchyForAction(sender.menu)
         Task { @MainActor [weak self] in
             guard let self else { return }
             let result = await self.codexAccountPromotionCoordinator.promote(managedAccountID: managedAccountID)
-            if case let .failure(error) = result {
+            self.applyIcon(phase: nil)
+            switch result {
+            case .success:
+                let info = Self.codexSystemPromotionSuccessAlertInfo()
+                self.presentLoginAlert(title: info.title, message: info.message)
+            case let .failure(error):
+                await Task.yield()
                 self.presentLoginAlert(title: error.title, message: error.message)
             }
         }
+    }
+
+    static func codexSystemPromotionSuccessAlertInfo() -> LoginAlertInfo {
+        LoginAlertInfo(
+            title: L("System account switched"),
+            message: L(
+                "The Codex CLI system account changed immediately. If the Codex desktop app is open, " +
+                    "quit and reopen it so it picks up the new account."))
     }
 
     @objc func runSwitchAccount(_ sender: NSMenuItem) {

--- a/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
+++ b/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
@@ -32,16 +32,16 @@ extension StatusItemController {
         case .refresh:
             self.refreshNow()
         case .installUpdate:
-            self.closeMenuForPersistentAction(menu)
+            self.closeMenuHierarchyForAction(menu)
             self.installUpdate()
         case .settings:
-            self.closeMenuForPersistentAction(menu)
+            self.closeMenuHierarchyForAction(menu)
             self.showSettingsGeneral()
         case .about:
-            self.closeMenuForPersistentAction(menu)
+            self.closeMenuHierarchyForAction(menu)
             self.showSettingsAbout()
         case .quit:
-            self.closeMenuForPersistentAction(menu)
+            self.closeMenuHierarchyForAction(menu)
             self.quit()
         default:
             break
@@ -58,9 +58,19 @@ extension StatusItemController {
         }
     }
 
-    private func closeMenuForPersistentAction(_ menu: NSMenu?) {
-        guard let menu else { return }
-        menu.cancelTrackingWithoutAnimation()
-        self.forgetClosedMenu(menu)
+    func closeMenuHierarchyForAction(_ menu: NSMenu?) {
+        var menus: [NSMenu] = []
+        var current = menu
+        while let menu = current {
+            menus.append(menu)
+            current = menu.supermenu
+        }
+
+        for menu in menus {
+            menu.cancelTrackingWithoutAnimation()
+        }
+        for menu in menus {
+            self.forgetClosedMenu(menu)
+        }
     }
 }

--- a/Tests/CodexBarTests/CodexAccountPromotionServiceTests.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionServiceTests.swift
@@ -20,17 +20,44 @@ struct CodexAccountPromotionServiceTests {
         try container.removeLiveAuthFile()
 
         let targetAuthData = try container.managedAuthData(for: target)
-        let result = try await container.makeService().promoteManagedAccount(id: target.id)
+        let daemonReloader = RecordingCodexAppServerDaemonReloader(outcome: .restarted)
+        let result = try await container.makeService(appServerDaemonReloader: daemonReloader)
+            .promoteManagedAccount(id: target.id)
         let accounts = try container.loadAccounts().accounts
 
         #expect(result.targetManagedAccountID == target.id)
         #expect(result.outcome == .promoted)
         #expect(result.displacedLiveDisposition == .none)
         #expect(result.didMutateLiveAuth)
+        #expect(result.appServerDaemonReloadOutcome == .restarted)
         #expect(result.resultingActiveSource == .liveSystem)
+        #expect(daemonReloader.reloadCallCount == 1)
         #expect(try container.liveAuthData() == targetAuthData)
         #expect(accounts.count == 1)
         #expect(accounts.first?.id == target.id)
+        #expect(container.settings.codexActiveSource == .liveSystem)
+        #expect(container.usageStore.snapshots[.codex]?.accountEmail(for: .codex) == "beta@example.com")
+    }
+
+    @Test
+    func `daemon restart failure reports partial success after refreshing promoted account`() async throws {
+        let container = try CodexAccountPromotionTestContainer(
+            suiteName: "CodexAccountPromotionServiceTests-daemon-restart-failure")
+        defer { container.tearDown() }
+
+        let target = try container.createManagedAccount(
+            persistedEmail: "beta@example.com",
+            authAccountID: "acct-beta")
+        try container.persistAccounts([target])
+        try container.removeLiveAuthFile()
+
+        let daemonReloader = RecordingCodexAppServerDaemonReloader(outcome: .failed("restart failed"))
+        let service = container.makeService(appServerDaemonReloader: daemonReloader)
+
+        await #expect(throws: CodexAccountPromotionError.appServerDaemonRestartFailed("restart failed")) {
+            try await service.promoteManagedAccount(id: target.id)
+        }
+        #expect(daemonReloader.reloadCallCount == 1)
         #expect(container.settings.codexActiveSource == .liveSystem)
         #expect(container.usageStore.snapshots[.codex]?.accountEmail(for: .codex) == "beta@example.com")
     }
@@ -419,6 +446,7 @@ struct CodexAccountPromotionServiceTests {
             snapshotLoader: SettingsStoreCodexAccountReconciliationSnapshotLoader(settingsStore: container.settings),
             authMaterialReader: DefaultCodexAuthMaterialReader(),
             liveAuthSwapper: DefaultCodexLiveAuthSwapper(),
+            appServerDaemonReloader: RecordingCodexAppServerDaemonReloader(outcome: .notNeeded),
             activeSourceWriter: SettingsStoreCodexActiveSourceWriter(settingsStore: container.settings),
             accountScopedRefresher: UsageStoreCodexAccountScopedRefresher(usageStore: container.usageStore),
             baseEnvironment: container.baseEnvironment,

--- a/Tests/CodexBarTests/CodexAccountPromotionServiceTests.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionServiceTests.swift
@@ -63,6 +63,20 @@ struct CodexAccountPromotionServiceTests {
     }
 
     @Test
+    func `unsupported daemon capability reports partial success after promotion`() async throws {
+        try await self.assertManualDaemonRestartOutcome(
+            .unavailable,
+            suiteName: "CodexAccountPromotionServiceTests-daemon-unavailable")
+    }
+
+    @Test
+    func `unmanaged daemon reports partial success after promotion`() async throws {
+        try await self.assertManualDaemonRestartOutcome(
+            .unmanaged,
+            suiteName: "CodexAccountPromotionServiceTests-daemon-unmanaged")
+    }
+
+    @Test
     func `retry after daemon restart failure reloads converged promoted account`() async throws {
         let container = try CodexAccountPromotionTestContainer(
             suiteName: "CodexAccountPromotionServiceTests-daemon-restart-retry")
@@ -89,6 +103,30 @@ struct CodexAccountPromotionServiceTests {
         #expect(retryResult.didMutateLiveAuth == false)
         #expect(retryResult.appServerDaemonReloadOutcome == .restarted)
         #expect(daemonReloader.reloadCallCount == 2)
+        #expect(container.settings.codexActiveSource == .liveSystem)
+        #expect(container.usageStore.snapshots[.codex]?.accountEmail(for: .codex) == "beta@example.com")
+    }
+
+    private func assertManualDaemonRestartOutcome(
+        _ outcome: CodexAppServerDaemonReloadOutcome,
+        suiteName: String) async throws
+    {
+        let container = try CodexAccountPromotionTestContainer(suiteName: suiteName)
+        defer { container.tearDown() }
+
+        let target = try container.createManagedAccount(
+            persistedEmail: "beta@example.com",
+            authAccountID: "acct-beta")
+        try container.persistAccounts([target])
+        try container.removeLiveAuthFile()
+
+        let daemonReloader = RecordingCodexAppServerDaemonReloader(outcome: outcome)
+        let service = container.makeService(appServerDaemonReloader: daemonReloader)
+
+        await #expect(throws: CodexAccountPromotionError.appServerDaemonRestartFailed("")) {
+            try await service.promoteManagedAccount(id: target.id)
+        }
+        #expect(daemonReloader.reloadCallCount == 1)
         #expect(container.settings.codexActiveSource == .liveSystem)
         #expect(container.usageStore.snapshots[.codex]?.accountEmail(for: .codex) == "beta@example.com")
     }

--- a/Tests/CodexBarTests/CodexAccountPromotionServiceTests.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionServiceTests.swift
@@ -63,6 +63,37 @@ struct CodexAccountPromotionServiceTests {
     }
 
     @Test
+    func `retry after daemon restart failure reloads converged promoted account`() async throws {
+        let container = try CodexAccountPromotionTestContainer(
+            suiteName: "CodexAccountPromotionServiceTests-daemon-restart-retry")
+        defer { container.tearDown() }
+
+        let target = try container.createManagedAccount(
+            persistedEmail: "beta@example.com",
+            authAccountID: "acct-beta")
+        try container.persistAccounts([target])
+        try container.removeLiveAuthFile()
+
+        let daemonReloader = RecordingCodexAppServerDaemonReloader(outcomes: [
+            .failed("restart failed"),
+            .restarted,
+        ])
+        let service = container.makeService(appServerDaemonReloader: daemonReloader)
+
+        await #expect(throws: CodexAccountPromotionError.appServerDaemonRestartFailed("restart failed")) {
+            try await service.promoteManagedAccount(id: target.id)
+        }
+        let retryResult = try await service.promoteManagedAccount(id: target.id)
+
+        #expect(retryResult.outcome == .convergedNoOp)
+        #expect(retryResult.didMutateLiveAuth == false)
+        #expect(retryResult.appServerDaemonReloadOutcome == .restarted)
+        #expect(daemonReloader.reloadCallCount == 2)
+        #expect(container.settings.codexActiveSource == .liveSystem)
+        #expect(container.usageStore.snapshots[.codex]?.accountEmail(for: .codex) == "beta@example.com")
+    }
+
+    @Test
     func `displaced live oauth is imported before target auth is promoted`() async throws {
         let container = try CodexAccountPromotionTestContainer(
             suiteName: "CodexAccountPromotionServiceTests-displaced-import",

--- a/Tests/CodexBarTests/CodexAccountPromotionTestSupport.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionTestSupport.swift
@@ -457,15 +457,20 @@ final class RecordingCodexLiveAuthSwapper: CodexLiveAuthSwapping, @unchecked Sen
 
 final class RecordingCodexAppServerDaemonReloader: CodexAppServerDaemonReloading, @unchecked Sendable {
     private(set) var reloadCallCount = 0
-    let outcome: CodexAppServerDaemonReloadOutcome
+    private let outcomes: [CodexAppServerDaemonReloadOutcome]
 
     init(outcome: CodexAppServerDaemonReloadOutcome) {
-        self.outcome = outcome
+        self.outcomes = [outcome]
+    }
+
+    init(outcomes: [CodexAppServerDaemonReloadOutcome]) {
+        precondition(!outcomes.isEmpty)
+        self.outcomes = outcomes
     }
 
     func reloadAfterAuthPromotion() async -> CodexAppServerDaemonReloadOutcome {
         self.reloadCallCount += 1
-        return self.outcome
+        return self.outcomes[min(self.reloadCallCount - 1, self.outcomes.count - 1)]
     }
 }
 

--- a/Tests/CodexBarTests/CodexAccountPromotionTestSupport.swift
+++ b/Tests/CodexBarTests/CodexAccountPromotionTestSupport.swift
@@ -82,6 +82,7 @@ final class CodexAccountPromotionTestContainer {
     func makeService(
         store: (any ManagedCodexAccountStoring)? = nil,
         liveAuthSwapper: (any CodexLiveAuthSwapping)? = nil,
+        appServerDaemonReloader: (any CodexAppServerDaemonReloading)? = nil,
         activeSourceWriter: (any CodexActiveSourceWriting)? = nil,
         snapshotLoader: (any CodexAccountReconciliationSnapshotLoading)? = nil,
         accountScopedRefresher: (any CodexAccountScopedRefreshing)? = nil)
@@ -96,6 +97,8 @@ final class CodexAccountPromotionTestContainer {
                 ?? SettingsStoreCodexAccountReconciliationSnapshotLoader(settingsStore: self.settings),
             authMaterialReader: DefaultCodexAuthMaterialReader(),
             liveAuthSwapper: liveAuthSwapper ?? DefaultCodexLiveAuthSwapper(),
+            appServerDaemonReloader: appServerDaemonReloader
+                ?? RecordingCodexAppServerDaemonReloader(outcome: .notNeeded),
             activeSourceWriter: activeSourceWriter
                 ?? SettingsStoreCodexActiveSourceWriter(settingsStore: self.settings),
             accountScopedRefresher: accountScopedRefresher
@@ -449,6 +452,20 @@ final class RecordingCodexLiveAuthSwapper: CodexLiveAuthSwapping, @unchecked Sen
         self.swappedData.append(data)
         try self.onSwap?(data, liveHomeURL)
         try self.base.swapLiveAuthData(data, liveHomeURL: liveHomeURL)
+    }
+}
+
+final class RecordingCodexAppServerDaemonReloader: CodexAppServerDaemonReloading, @unchecked Sendable {
+    private(set) var reloadCallCount = 0
+    let outcome: CodexAppServerDaemonReloadOutcome
+
+    init(outcome: CodexAppServerDaemonReloadOutcome) {
+        self.outcome = outcome
+    }
+
+    func reloadAfterAuthPromotion() async -> CodexAppServerDaemonReloadOutcome {
+        self.reloadCallCount += 1
+        return self.outcome
     }
 }
 

--- a/Tests/CodexBarTests/CodexAppServerDaemonReloaderTests.swift
+++ b/Tests/CodexBarTests/CodexAppServerDaemonReloaderTests.swift
@@ -1,3 +1,4 @@
+import CodexBarCore
 import Foundation
 import Testing
 @testable import CodexBar
@@ -13,11 +14,26 @@ struct CodexAppServerDaemonReloaderTests {
     }
 
     @Test
-    func `failed version probe does not attempt a restart`() async {
-        let recorder = DaemonCommandRecorder(failingArguments: ["app-server", "daemon", "version"])
+    func `missing daemon socket leaves daemon untouched`() async {
+        let recorder = DaemonCommandRecorder(
+            failingArguments: ["app-server", "daemon", "version"],
+            failure: SubprocessRunnerError.nonZeroExit(
+                code: 1,
+                stderr: "failed to connect: No such file or directory (os error 2)"))
         let reloader = Self.makeReloader(recorder: recorder)
 
         #expect(await reloader.reloadAfterAuthPromotion() == .notRunning)
+        #expect(await recorder.arguments == [["app-server", "daemon", "version"]])
+    }
+
+    @Test
+    func `probe timeout fails instead of accepting stale daemon state`() async {
+        let recorder = DaemonCommandRecorder(
+            failingArguments: ["app-server", "daemon", "version"],
+            failure: SubprocessRunnerError.timedOut("daemon probe"))
+        let reloader = Self.makeReloader(recorder: recorder)
+
+        #expect(await reloader.reloadAfterAuthPromotion() == .failed("Command timed out: daemon probe"))
         #expect(await recorder.arguments == [["app-server", "daemon", "version"]])
     }
 
@@ -31,37 +47,16 @@ struct CodexAppServerDaemonReloaderTests {
             ["app-server", "daemon", "version"],
             ["app-server", "daemon", "restart"],
         ])
-    }
-
-    @Test
-    func `remote control setting preserves remote control mode`() async throws {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("codexbar-daemon-reloader-\(UUID().uuidString)", isDirectory: true)
-        defer { try? FileManager.default.removeItem(at: root) }
-        let settingsDirectory = root.appendingPathComponent("app-server-daemon", isDirectory: true)
-        try FileManager.default.createDirectory(at: settingsDirectory, withIntermediateDirectories: true)
-        try #"{"remoteControlEnabled":true}"#.write(
-            to: settingsDirectory.appendingPathComponent("settings.json"),
-            atomically: true,
-            encoding: .utf8)
-
-        let recorder = DaemonCommandRecorder()
-        let reloader = Self.makeReloader(
-            baseEnvironment: ["CODEX_HOME": root.path],
-            recorder: recorder)
-
-        #expect(await reloader.reloadAfterAuthPromotion() == .remoteControlRestarted)
-        #expect(await recorder.arguments == [
-            ["app-server", "daemon", "version"],
-            ["remote-control", "start"],
-        ])
+        #expect(await recorder.timeouts == [90, 90])
     }
 
     @Test
     func `restart failure returns bounded diagnostic output`() async {
         let output = String(repeating: "x", count: 1200)
         let restart = ["app-server", "daemon", "restart"]
-        let recorder = DaemonCommandRecorder(failingArguments: restart, failureOutput: output)
+        let recorder = DaemonCommandRecorder(
+            failingArguments: restart,
+            failure: DaemonCommandTestError.failed(output))
         let reloader = Self.makeReloader(recorder: recorder)
 
         let outcome = await reloader.reloadAfterAuthPromotion()
@@ -81,26 +76,31 @@ struct CodexAppServerDaemonReloaderTests {
         DefaultCodexAppServerDaemonReloader(
             baseEnvironment: baseEnvironment,
             binaryResolver: { _ in "/usr/bin/true" },
-            commandRunner: { _, arguments, _, _ in
-                try await recorder.run(arguments: arguments)
+            commandRunner: { _, arguments, _, timeout in
+                try await recorder.run(arguments: arguments, timeout: timeout)
             })
     }
 }
 
 private actor DaemonCommandRecorder {
     private(set) var arguments: [[String]] = []
+    private(set) var timeouts: [TimeInterval] = []
     private let failingArguments: [String]?
-    private let failureOutput: String
+    private let failure: Error
 
-    init(failingArguments: [String]? = nil, failureOutput: String = "command failed") {
+    init(
+        failingArguments: [String]? = nil,
+        failure: Error = DaemonCommandTestError.failed("command failed"))
+    {
         self.failingArguments = failingArguments
-        self.failureOutput = failureOutput
+        self.failure = failure
     }
 
-    func run(arguments: [String]) throws -> String {
+    func run(arguments: [String], timeout: TimeInterval) throws -> String {
         self.arguments.append(arguments)
+        self.timeouts.append(timeout)
         if arguments == self.failingArguments {
-            throw DaemonCommandTestError.failed(self.failureOutput)
+            throw self.failure
         }
         return ""
     }

--- a/Tests/CodexBarTests/CodexAppServerDaemonReloaderTests.swift
+++ b/Tests/CodexBarTests/CodexAppServerDaemonReloaderTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct CodexAppServerDaemonReloaderTests {
+    @Test
+    func `missing Codex binary leaves daemon untouched`() async {
+        let reloader = DefaultCodexAppServerDaemonReloader(
+            baseEnvironment: [:],
+            binaryResolver: { _ in nil })
+
+        #expect(await reloader.reloadAfterAuthPromotion() == .unavailable)
+    }
+
+    @Test
+    func `failed version probe does not attempt a restart`() async {
+        let recorder = DaemonCommandRecorder(failingArguments: ["app-server", "daemon", "version"])
+        let reloader = Self.makeReloader(recorder: recorder)
+
+        #expect(await reloader.reloadAfterAuthPromotion() == .notRunning)
+        #expect(await recorder.arguments == [["app-server", "daemon", "version"]])
+    }
+
+    @Test
+    func `running daemon restarts after auth promotion`() async {
+        let recorder = DaemonCommandRecorder()
+        let reloader = Self.makeReloader(recorder: recorder)
+
+        #expect(await reloader.reloadAfterAuthPromotion() == .restarted)
+        #expect(await recorder.arguments == [
+            ["app-server", "daemon", "version"],
+            ["app-server", "daemon", "restart"],
+        ])
+    }
+
+    @Test
+    func `remote control setting preserves remote control mode`() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-daemon-reloader-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let settingsDirectory = root.appendingPathComponent("app-server-daemon", isDirectory: true)
+        try FileManager.default.createDirectory(at: settingsDirectory, withIntermediateDirectories: true)
+        try #"{"remoteControlEnabled":true}"#.write(
+            to: settingsDirectory.appendingPathComponent("settings.json"),
+            atomically: true,
+            encoding: .utf8)
+
+        let recorder = DaemonCommandRecorder()
+        let reloader = Self.makeReloader(
+            baseEnvironment: ["CODEX_HOME": root.path],
+            recorder: recorder)
+
+        #expect(await reloader.reloadAfterAuthPromotion() == .remoteControlRestarted)
+        #expect(await recorder.arguments == [
+            ["app-server", "daemon", "version"],
+            ["remote-control", "start"],
+        ])
+    }
+
+    @Test
+    func `restart failure returns bounded diagnostic output`() async {
+        let output = String(repeating: "x", count: 1200)
+        let restart = ["app-server", "daemon", "restart"]
+        let recorder = DaemonCommandRecorder(failingArguments: restart, failureOutput: output)
+        let reloader = Self.makeReloader(recorder: recorder)
+
+        let outcome = await reloader.reloadAfterAuthPromotion()
+
+        guard case let .failed(message) = outcome else {
+            Issue.record("Expected restart failure, got \(outcome)")
+            return
+        }
+        #expect(message.count == 1000)
+        #expect(message == String(output.prefix(1000)))
+    }
+
+    private static func makeReloader(
+        baseEnvironment: [String: String] = [:],
+        recorder: DaemonCommandRecorder) -> DefaultCodexAppServerDaemonReloader
+    {
+        DefaultCodexAppServerDaemonReloader(
+            baseEnvironment: baseEnvironment,
+            binaryResolver: { _ in "/usr/bin/true" },
+            commandRunner: { _, arguments, _, _ in
+                try await recorder.run(arguments: arguments)
+            })
+    }
+}
+
+private actor DaemonCommandRecorder {
+    private(set) var arguments: [[String]] = []
+    private let failingArguments: [String]?
+    private let failureOutput: String
+
+    init(failingArguments: [String]? = nil, failureOutput: String = "command failed") {
+        self.failingArguments = failingArguments
+        self.failureOutput = failureOutput
+    }
+
+    func run(arguments: [String]) throws -> String {
+        self.arguments.append(arguments)
+        if arguments == self.failingArguments {
+            throw DaemonCommandTestError.failed(self.failureOutput)
+        }
+        return ""
+    }
+}
+
+private enum DaemonCommandTestError: LocalizedError {
+    case failed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .failed(message): message
+        }
+    }
+}

--- a/Tests/CodexBarTests/CodexAppServerDaemonReloaderTests.swift
+++ b/Tests/CodexBarTests/CodexAppServerDaemonReloaderTests.swift
@@ -14,7 +14,7 @@ struct CodexAppServerDaemonReloaderTests {
     }
 
     @Test
-    func `missing daemon socket leaves daemon untouched`() async {
+    func `missing daemon socket requests manual restart`() async {
         let recorder = DaemonCommandRecorder(
             failingArguments: ["app-server", "daemon", "version"],
             failure: SubprocessRunnerError.nonZeroExit(
@@ -22,8 +22,10 @@ struct CodexAppServerDaemonReloaderTests {
                 stderr: "failed to connect: No such file or directory (os error 2)"))
         let reloader = Self.makeReloader(recorder: recorder)
 
-        #expect(await reloader.reloadAfterAuthPromotion() == .notRunning)
+        #expect(await reloader.reloadAfterAuthPromotion() ==
+            .failed("Codex daemon state could not be confirmed while its socket was unavailable."))
         #expect(await recorder.arguments == [["app-server", "daemon", "version"]])
+        #expect(await recorder.timeouts == [10])
     }
 
     @Test
@@ -159,9 +161,7 @@ private actor DaemonCommandRecorder {
     func run(arguments: [String], timeout: TimeInterval) throws -> String {
         self.arguments.append(arguments)
         self.timeouts.append(timeout)
-        if arguments == self.failingArguments {
-            throw self.failure
-        }
+        if arguments == self.failingArguments { throw self.failure }
         return self.successOutput
     }
 }

--- a/Tests/CodexBarTests/CodexAppServerDaemonReloaderTests.swift
+++ b/Tests/CodexBarTests/CodexAppServerDaemonReloaderTests.swift
@@ -47,7 +47,7 @@ struct CodexAppServerDaemonReloaderTests {
             ["app-server", "daemon", "version"],
             ["app-server", "daemon", "restart"],
         ])
-        #expect(await recorder.timeouts == [90, 90])
+        #expect(await recorder.timeouts == [10, 120])
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexAppServerDaemonReloaderTests.swift
+++ b/Tests/CodexBarTests/CodexAppServerDaemonReloaderTests.swift
@@ -10,7 +10,7 @@ struct CodexAppServerDaemonReloaderTests {
             baseEnvironment: [:],
             binaryResolver: { _ in nil })
 
-        #expect(await reloader.reloadAfterAuthPromotion() == .unavailable)
+        #expect(await reloader.reloadAfterAuthPromotion() == .notNeeded)
     }
 
     @Test
@@ -38,6 +38,20 @@ struct CodexAppServerDaemonReloaderTests {
     }
 
     @Test
+    func `unsupported daemon command requests manual restart`() async {
+        let version = ["app-server", "daemon", "version"]
+        let recorder = DaemonCommandRecorder(
+            failingArguments: version,
+            failure: SubprocessRunnerError.nonZeroExit(
+                code: 2,
+                stderr: "unrecognized subcommand 'daemon'"))
+        let reloader = Self.makeReloader(recorder: recorder)
+
+        #expect(await reloader.reloadAfterAuthPromotion() == .unavailable)
+        #expect(await recorder.arguments == [version])
+    }
+
+    @Test
     func `running daemon restarts after auth promotion`() async {
         let recorder = DaemonCommandRecorder()
         let reloader = Self.makeReloader(recorder: recorder)
@@ -48,6 +62,25 @@ struct CodexAppServerDaemonReloaderTests {
             ["app-server", "daemon", "restart"],
         ])
         #expect(await recorder.timeouts == [10, 120])
+    }
+
+    @Test
+    func `unmanaged daemon requests manual restart without invoking restart`() async {
+        let recorder = DaemonCommandRecorder(successOutput: #"{"status":"running","backend":null}"#)
+        let reloader = Self.makeReloader(recorder: recorder)
+
+        #expect(await reloader.reloadAfterAuthPromotion() == .unmanaged)
+        #expect(await recorder.arguments == [["app-server", "daemon", "version"]])
+    }
+
+    @Test
+    func `invalid daemon version response fails without invoking restart`() async {
+        let recorder = DaemonCommandRecorder(successOutput: "not-json")
+        let reloader = Self.makeReloader(recorder: recorder)
+
+        #expect(await reloader.reloadAfterAuthPromotion() ==
+            .failed("Codex daemon returned an invalid version response."))
+        #expect(await recorder.arguments == [["app-server", "daemon", "version"]])
     }
 
     @Test
@@ -87,13 +120,16 @@ private actor DaemonCommandRecorder {
     private(set) var timeouts: [TimeInterval] = []
     private let failingArguments: [String]?
     private let failure: Error
+    private let successOutput: String
 
     init(
         failingArguments: [String]? = nil,
-        failure: Error = DaemonCommandTestError.failed("command failed"))
+        failure: Error = DaemonCommandTestError.failed("command failed"),
+        successOutput: String = #"{"status":"running","backend":"pid"}"#)
     {
         self.failingArguments = failingArguments
         self.failure = failure
+        self.successOutput = successOutput
     }
 
     func run(arguments: [String], timeout: TimeInterval) throws -> String {
@@ -102,7 +138,7 @@ private actor DaemonCommandRecorder {
         if arguments == self.failingArguments {
             throw self.failure
         }
-        return ""
+        return self.successOutput
     }
 }
 

--- a/Tests/CodexBarTests/CodexAppServerDaemonReloaderTests.swift
+++ b/Tests/CodexBarTests/CodexAppServerDaemonReloaderTests.swift
@@ -5,12 +5,12 @@ import Testing
 
 struct CodexAppServerDaemonReloaderTests {
     @Test
-    func `missing Codex binary leaves daemon untouched`() async {
+    func `missing Codex binary requests manual restart`() async {
         let reloader = DefaultCodexAppServerDaemonReloader(
             baseEnvironment: [:],
             binaryResolver: { _ in nil })
 
-        #expect(await reloader.reloadAfterAuthPromotion() == .notNeeded)
+        #expect(await reloader.reloadAfterAuthPromotion() == .unavailable)
     }
 
     @Test
@@ -66,10 +66,19 @@ struct CodexAppServerDaemonReloaderTests {
 
     @Test
     func `unmanaged daemon requests manual restart without invoking restart`() async {
-        let recorder = DaemonCommandRecorder(successOutput: #"{"status":"running","backend":null}"#)
+        let recorder = DaemonCommandRecorder(successOutput: #"{"status":"running"}"#)
         let reloader = Self.makeReloader(recorder: recorder)
 
         #expect(await reloader.reloadAfterAuthPromotion() == .unmanaged)
+        #expect(await recorder.arguments == [["app-server", "daemon", "version"]])
+    }
+
+    @Test
+    func `nonrunning daemon response does not invoke restart`() async {
+        let recorder = DaemonCommandRecorder(successOutput: #"{"status":"notRunning","backend":"pid"}"#)
+        let reloader = Self.makeReloader(recorder: recorder)
+
+        #expect(await reloader.reloadAfterAuthPromotion() == .notRunning)
         #expect(await recorder.arguments == [["app-server", "daemon", "version"]])
     }
 
@@ -100,6 +109,21 @@ struct CodexAppServerDaemonReloaderTests {
         }
         #expect(message.count == 1000)
         #expect(message == String(output.prefix(1000)))
+    }
+
+    @Test
+    func `restart exit code two remains a restart failure`() async {
+        let restart = ["app-server", "daemon", "restart"]
+        let recorder = DaemonCommandRecorder(
+            failingArguments: restart,
+            failure: SubprocessRunnerError.nonZeroExit(code: 2, stderr: "restart unsupported"))
+        let reloader = Self.makeReloader(recorder: recorder)
+
+        #expect(await reloader.reloadAfterAuthPromotion() == .failed("restart unsupported"))
+        #expect(await recorder.arguments == [
+            ["app-server", "daemon", "version"],
+            restart,
+        ])
     }
 
     private static func makeReloader(

--- a/Tests/CodexBarTests/CodexSystemPromotionUITests.swift
+++ b/Tests/CodexBarTests/CodexSystemPromotionUITests.swift
@@ -27,6 +27,16 @@ struct CodexSystemPromotionUITests {
     }
 
     @Test
+    func `manual daemon restart warning omits empty error block`() {
+        let error = CodexAccountPromotionCoordinator.mapUserFacingError(
+            CodexAccountPromotionError.appServerDaemonRestartFailed(""))
+
+        #expect(error.title == "System account switched")
+        #expect(error.message.contains("could not restart"))
+        #expect(!error.message.contains("Error:"))
+    }
+
+    @Test
     func `promotion coordinator promotes immediately`() async throws {
         let container = try CodexAccountPromotionTestContainer(
             suiteName: "CodexSystemPromotionUITests-coordinator-immediate")

--- a/Tests/CodexBarTests/CodexSystemPromotionUITests.swift
+++ b/Tests/CodexBarTests/CodexSystemPromotionUITests.swift
@@ -7,6 +7,26 @@ import Testing
 @MainActor
 struct CodexSystemPromotionUITests {
     @Test
+    func `system promotion success copy explains desktop app restart`() {
+        let info = StatusItemController.codexSystemPromotionSuccessAlertInfo()
+
+        #expect(info.title == "System account switched")
+        #expect(info.message.contains("changed immediately"))
+        #expect(info.message.contains("quit and reopen"))
+    }
+
+    @Test
+    func `daemon restart failure reports switched account and bounded command output`() {
+        let error = CodexAccountPromotionCoordinator.mapUserFacingError(
+            CodexAccountPromotionError.appServerDaemonRestartFailed("restart exploded"))
+
+        #expect(error.title == "System account switched")
+        #expect(error.message.contains("could not restart"))
+        #expect(error.message.contains("quit and reopen"))
+        #expect(error.message.contains("restart exploded"))
+    }
+
+    @Test
     func `promotion coordinator promotes immediately`() async throws {
         let container = try CodexAccountPromotionTestContainer(
             suiteName: "CodexSystemPromotionUITests-coordinator-immediate")

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -96,7 +96,8 @@ Example:
 - The normal Codex account selector changes only which managed account CodexBar displays.
 - Use the **System Account** submenu to promote a managed account into the live Codex home used by Codex CLI.
 - After promotion, Codex CLI sees the new account immediately. Reopen the Codex desktop app if it is running.
-- If a local app-server daemon is running, CodexBar restarts it after promotion. Remote-control mode is preserved.
+- If a managed local app-server daemon is running, CodexBar restarts it after promotion. Remote-control mode is preserved.
+- If the installed CLI lacks daemon lifecycle support, or the running app-server is unmanaged, the account switch still completes and CodexBar asks you to restart the service manually. Runtime capability detection is authoritative; managed lifecycle support first shipped in stable Codex CLI 0.131.0.
 
 ### Codex CLI RPC (automatic CLI source)
 - Launches local RPC server: `codex -s read-only -a untrusted app-server`.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -97,7 +97,7 @@ Example:
 - Use the **System Account** submenu to promote a managed account into the live Codex home used by Codex CLI.
 - After promotion, Codex CLI sees the new account immediately. Reopen the Codex desktop app if it is running.
 - If a managed local app-server daemon is running, CodexBar restarts it after promotion. Remote-control mode is preserved.
-- If the installed CLI lacks daemon lifecycle support, or the running app-server is unmanaged, the account switch still completes and CodexBar asks you to restart the service manually. Runtime capability detection is authoritative; managed lifecycle support first shipped in stable Codex CLI 0.131.0.
+- If the Codex CLI cannot be found, lacks daemon lifecycle support, or the running app-server is unmanaged, the account switch still completes and CodexBar asks you to restart the service manually. Runtime capability detection is authoritative; managed lifecycle support first shipped in stable Codex CLI 0.131.0.
 
 ### Codex CLI RPC (automatic CLI source)
 - Launches local RPC server: `codex -s read-only -a untrusted app-server`.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -92,6 +92,12 @@ Example:
 - Errors surfaced:
   - Login required or Cloudflare interstitial.
 
+### Managed and system accounts
+- The normal Codex account selector changes only which managed account CodexBar displays.
+- Use the **System Account** submenu to promote a managed account into the live Codex home used by Codex CLI.
+- After promotion, Codex CLI sees the new account immediately. Reopen the Codex desktop app if it is running.
+- If a local app-server daemon is running, CodexBar restarts it after promotion. Remote-control mode is preserved.
+
 ### Codex CLI RPC (automatic CLI source)
 - Launches local RPC server: `codex -s read-only -a untrusted app-server`.
 - JSON-RPC over stdin/stdout:


### PR DESCRIPTION
## Summary
- restart a managed, running Codex app-server daemon after System Account promotion
- preserve persisted remote-control mode through the upstream daemon lifecycle command
- finish the account switch but request a manual restart when the CLI is missing/unsupported or the running app-server is unmanaged
- retry daemon reload when promotion is already converged, allowing recovery after partial restart failure
- use separate 10-second probe and 120-second restart timeouts

## Why
Promoting a managed account atomically replaces live `auth.json`, but an already-running app-server retains the previous identity until it is restarted.

The account switch is already committed before daemon reload. Reload failures therefore remain partial success: Codex CLI uses the new account, account-scoped state is refreshed, and the UI reports that the configured background service still needs attention.

## Upstream lifecycle contract
Current Codex daemon restart behavior:
- loads persisted daemon settings
- stops the managed backend
- starts the replacement backend with `remote_control_enabled` from those settings

Sources:
- https://github.com/openai/codex/blob/04483f4ce5694d471e471583d4ca286908d7c8b7/codex-rs/app-server-daemon/src/lib.rs#L332-L357
- https://github.com/openai/codex/blob/04483f4ce5694d471e471583d4ca286908d7c8b7/codex-rs/app-server-daemon/src/lib.rs#L689-L703

## Current-main rewrite
The original branch predated the current managed-account architecture. This rewrite retains only the remaining daemon-reload behavior while preserving contributor credit.

Normal account selection remains display-only. Only the existing **System Account** submenu mutates live auth.

## Failure behavior
- missing or unsupported Codex CLI daemon command: auth promotion remains successful; request manual restart
- missing/refused daemon socket: state is unconfirmed because managed startup can expose the same result; request manual restart
- version response must explicitly report `status: running`; a missing backend is treated as unmanaged and is never restarted
- unexpected probe failure or timeout: partial-success error
- restart failure or timeout: partial-success error
- retry after partial failure: converged promotion retries daemon reload
- probe timeout: 10 seconds
- restart timeout: 120 seconds

## Proof
- exact candidate: `44fc0903`
- `swift test --filter 'Codex(AppServerDaemonReloader|AccountPromotionService|AccountPromotionExecution|SystemPromotionUI)Tests'`: 49 tests passed
- `make check`: green; SwiftFormat clean; SwiftLint 0 violations
- `git diff --check`: green
- local follow-up autoreview: clean (0.87)
- final lifecycle-aware whole-branch autoreview: clean (0.88)
- `make test`: all 41 shards passed on the rebased exact candidate
- public CI: pending exact-head run

Focused coverage includes:
- real restart command selection
- persisted remote-control preservation through the upstream lifecycle contract
- missing/refused socket fails closed instead of being mistaken for a stopped daemon during managed startup
- missing CLI, unsupported command, unmanaged backend, and non-running status handling
- restart exit-code classification remains distinct from probe capability detection
- fail-closed probe timeout
- 10-second probe and 120-second restart bounds
- partial-success state refresh
- empty manual-restart diagnostics do not render an empty error block
- successful retry through the converged promotion path

## Live boundary
Runtime daemon commands are covered through the injected command runner. Exact-head validation did not mutate production auth or a live account-backed daemon.

Before merge, this still requires authorized redacted live proof with two actual accounts and a managed daemon. Until then, the PR remains held even if CI is green.
