### PR TITLE
Fix OpenAI WebKit refresh cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Settings: add search to the Providers pane so large provider lists can be filtered by name or id (#1184). Thanks @046081-dotcom!
 
+### Fixed
+- Codex: cancel OpenAI WebKit dashboard refreshes promptly and avoid an immediate second background WebView retry after timeouts, reducing launch-time Web Content CPU spikes (#1217).
+
 ## 0.31.0 — 2026-05-28
 
 ### Changed

--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -26,6 +26,7 @@ extension UsageStore {
         let expectedGuard: CodexAccountScopedRefreshGuard?
         let refreshTaskToken: UUID
         let allowCodexUsageBackfill: Bool
+        let force: Bool
     }
 
     private struct OpenAIDashboardCookieImportRequest {
@@ -402,7 +403,8 @@ extension UsageStore {
             allowCurrentSnapshotFallback: allowCurrentSnapshotFallback,
             expectedGuard: expectedGuard,
             refreshTaskToken: taskToken,
-            allowCodexUsageBackfill: allowCodexUsageBackfill)
+            allowCodexUsageBackfill: allowCodexUsageBackfill,
+            force: force)
         let task = Task { [weak self] in
             guard let self else { return }
             await self.performOpenAIDashboardRefreshIfNeeded(context)
@@ -509,6 +511,7 @@ extension UsageStore {
             var dash = try await self.loadLatestOpenAIDashboard(
                 accountEmail: effectiveEmail,
                 logger: log,
+                allowNavigationTimeoutRetry: context.force,
                 timeout: Self.openAIWebDashboardFetchTimeout(didImportCookies: didImportCookiesForRefresh))
             guard self.shouldContinueOpenAIDashboardRefresh(token: context.refreshTaskToken) else { return }
 
@@ -524,6 +527,7 @@ extension UsageStore {
                 dash = try await self.loadLatestOpenAIDashboard(
                     accountEmail: effectiveEmail,
                     logger: log,
+                    allowNavigationTimeoutRetry: context.force,
                     timeout: Self.openAIWebRetryDashboardFetchTimeout(afterCookieImport: true))
                 guard self.shouldContinueOpenAIDashboardRefresh(token: context.refreshTaskToken) else { return }
             }
@@ -573,6 +577,17 @@ extension UsageStore {
         latestCookieImportStatus: inout String?,
         logger: @escaping (String) -> Void) async
     {
+        if !context.force {
+            OpenAIDashboardFetcher.evictAllCachedWebViews()
+            logger("OpenAI web refresh timed out; skipping immediate background retry.")
+            await self.applyOpenAIDashboardFailure(
+                message: "OpenAI web dashboard refresh timed out. CodexBar will retry after the refresh cooldown.",
+                expectedGuard: context.expectedGuard,
+                refreshTaskToken: context.refreshTaskToken,
+                routingTargetEmail: context.targetEmail)
+            return
+        }
+
         let targetEmail = self.currentCodexOpenAIWebTargetEmail(
             allowCurrentSnapshotFallback: context.allowCurrentSnapshotFallback,
             allowLastKnownLiveFallback: context.expectedGuard?.identity != .unresolved)
@@ -599,6 +614,7 @@ extension UsageStore {
             let dash = try await self.loadLatestOpenAIDashboard(
                 accountEmail: effectiveEmail,
                 logger: logger,
+                allowNavigationTimeoutRetry: context.force,
                 timeout: Self.openAIWebRetryDashboardFetchTimeout(afterCookieImport: true))
             guard self.shouldContinueOpenAIDashboardRefresh(token: context.refreshTaskToken) else { return }
             await self.applyOpenAIDashboard(
@@ -650,6 +666,7 @@ extension UsageStore {
             let dash = try await self.loadLatestOpenAIDashboard(
                 accountEmail: effectiveEmail,
                 logger: logger,
+                allowNavigationTimeoutRetry: context.force,
                 timeout: Self.openAIWebRetryDashboardFetchTimeout(afterCookieImport: true))
             guard self.shouldContinueOpenAIDashboardRefresh(token: context.refreshTaskToken) else { return }
             await self.applyOpenAIDashboard(
@@ -713,6 +730,7 @@ extension UsageStore {
             let dash = try await self.loadLatestOpenAIDashboard(
                 accountEmail: effectiveEmail,
                 logger: logger,
+                allowNavigationTimeoutRetry: context.force,
                 timeout: Self.openAIWebRetryDashboardFetchTimeout(afterCookieImport: true))
             guard self.shouldContinueOpenAIDashboardRefresh(token: context.refreshTaskToken) else { return }
             await self.applyOpenAIDashboard(
@@ -914,6 +932,9 @@ extension UsageStore {
     }
 
     func invalidateOpenAIDashboardRefreshTask() {
+        self.openAIDashboardBackgroundRefreshTask?.cancel()
+        self.openAIDashboardBackgroundRefreshTask = nil
+        self.openAIDashboardBackgroundRefreshTaskKey = nil
         self.openAIDashboardRefreshTask?.cancel()
         self.openAIDashboardRefreshTask = nil
         self.openAIDashboardRefreshTaskKey = nil
@@ -927,15 +948,17 @@ extension UsageStore {
     private func loadLatestOpenAIDashboard(
         accountEmail: String?,
         logger: @escaping (String) -> Void,
+        allowNavigationTimeoutRetry: Bool,
         timeout: TimeInterval) async throws -> OpenAIDashboardSnapshot
     {
         if let override = self._test_openAIDashboardLoaderOverride {
-            return try await override(accountEmail, logger, timeout)
+            return try await override(accountEmail, logger, allowNavigationTimeoutRetry, timeout)
         }
         return try await OpenAIDashboardFetcher().loadLatestDashboard(
             accountEmail: accountEmail,
             logger: logger,
             debugDumpHTML: timeout != Self.openAIWebPrimaryFetchTimeout,
+            allowNavigationTimeoutRetry: allowNavigationTimeoutRetry,
             timeout: timeout)
     }
 

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -195,6 +195,7 @@ final class UsageStore {
     @ObservationIgnored var _test_openAIDashboardLoaderOverride: (@MainActor (
         String?,
         @escaping (String) -> Void,
+        Bool,
         TimeInterval) async throws -> OpenAIDashboardSnapshot)?
     @ObservationIgnored var _test_codexCreditsLoaderOverride: (@MainActor () async throws -> CreditsSnapshot)?
     @ObservationIgnored var _test_widgetSnapshotSaveOverride: (@MainActor (WidgetSnapshot) async -> Void)?

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -198,10 +198,16 @@ public struct OpenAIDashboardFetcher {
         return true
     }
 
+    private nonisolated static func sleepForDashboardPoll(_ duration: Duration) async throws {
+        try? await Task.sleep(for: duration)
+        try Task.checkCancellation()
+    }
+
     public func loadLatestDashboard(
         accountEmail: String?,
         logger: ((String) -> Void)? = nil,
         debugDumpHTML: Bool = false,
+        allowNavigationTimeoutRetry: Bool = true,
         timeout: TimeInterval = 60) async throws -> OpenAIDashboardSnapshot
     {
         let store = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: accountEmail)
@@ -209,6 +215,7 @@ public struct OpenAIDashboardFetcher {
             websiteDataStore: store,
             logger: logger,
             debugDumpHTML: debugDumpHTML,
+            allowNavigationTimeoutRetry: allowNavigationTimeoutRetry,
             timeout: timeout)
     }
 
@@ -216,19 +223,21 @@ public struct OpenAIDashboardFetcher {
         websiteDataStore: WKWebsiteDataStore,
         logger: ((String) -> Void)? = nil,
         debugDumpHTML: Bool = false,
+        allowNavigationTimeoutRetry: Bool = true,
         timeout: TimeInterval = 60) async throws -> OpenAIDashboardSnapshot
     {
         let deadline = Self.deadline(startingAt: Date(), timeout: timeout)
         let preflight = await Self.fetchDashboardAPIPreflight(
             websiteDataStore: websiteDataStore,
             logger: { logger?($0) })
-        let apiData = preflight.apiData
-        let verifiedSignedInEmail = preflight.verifiedSignedInEmail
+        try Task.checkCancellation()
+        let (apiData, verifiedSignedInEmail) = (preflight.apiData, preflight.verifiedSignedInEmail)
 
         let lease = try await self.makeWebView(
             websiteDataStore: websiteDataStore,
             logger: logger,
-            timeout: Self.remainingTimeout(until: deadline))
+            timeout: Self.remainingTimeout(until: deadline),
+            allowNavigationTimeoutRetry: allowNavigationTimeoutRetry)
         defer { lease.release() }
         let webView = lease.webView
         let log = lease.log
@@ -244,6 +253,7 @@ public struct OpenAIDashboardFetcher {
         var lastUsageBreakdownError: String?
         var lastCreditsPurchaseURL: String?
         while Date() < deadline {
+            try Task.checkCancellation()
             let scrape = try await self.scrape(webView: webView)
             lastBody = scrape.bodyText ?? lastBody
 
@@ -261,14 +271,14 @@ public struct OpenAIDashboardFetcher {
             }
 
             if scrape.workspacePicker {
-                try? await Task.sleep(for: .milliseconds(500))
+                try await Self.sleepForDashboardPoll(.milliseconds(500))
                 continue
             }
 
             // The page is a SPA and can land on ChatGPT UI or other routes; keep forcing the usage URL.
             if let href = scrape.href, !Self.isUsageRoute(href) {
                 _ = webView.load(Self.usageURLRequest(url: self.usageURL))
-                try? await Task.sleep(for: .milliseconds(500))
+                try await Self.sleepForDashboardPoll(.milliseconds(500))
                 continue
             }
 
@@ -321,7 +331,7 @@ public struct OpenAIDashboardFetcher {
                         "rows=\(scrape.rows.count)")
                 if scrape.didScrollToCredits {
                     log("scrollIntoView(Credits usage history) requested; waiting…")
-                    try? await Task.sleep(for: .milliseconds(600))
+                    try await Self.sleepForDashboardPoll(.milliseconds(600))
                     continue
                 }
 
@@ -338,7 +348,7 @@ public struct OpenAIDashboardFetcher {
                     creditsHeaderInViewport: scrape.creditsHeaderInViewport,
                     didScrollToCredits: scrape.didScrollToCredits))
                 {
-                    try? await Task.sleep(for: .milliseconds(400))
+                    try await Self.sleepForDashboardPoll(.milliseconds(400))
                     continue
                 }
             }
@@ -350,7 +360,7 @@ public struct OpenAIDashboardFetcher {
                        now: Date(),
                        errorFirstSeenAt: usageBreakdownErrorFirstSeenAt))
                 {
-                    try? await Task.sleep(for: .milliseconds(400))
+                    try await Self.sleepForDashboardPoll(.milliseconds(400))
                     continue
                 }
 
@@ -359,7 +369,7 @@ public struct OpenAIDashboardFetcher {
                 if codeReview != nil, usageBreakdown.isEmpty {
                     let elapsed = Date().timeIntervalSince(codeReviewFirstSeenAt ?? Date())
                     if elapsed < 6 {
-                        try? await Task.sleep(for: .milliseconds(400))
+                        try await Self.sleepForDashboardPoll(.milliseconds(400))
                         continue
                     }
                 }
@@ -377,7 +387,7 @@ public struct OpenAIDashboardFetcher {
                     accountPlan: dashboardData.accountPlan))
             }
 
-            try? await Task.sleep(for: .milliseconds(500))
+            try await Self.sleepForDashboardPoll(.milliseconds(500))
         }
 
         if debugDumpHTML, let html = try? await self.fetchDebugHTML(webView: webView) {
@@ -435,12 +445,13 @@ public struct OpenAIDashboardFetcher {
         var dashboardSignalSeenAt: Date?
 
         while Date() < deadline {
+            try Task.checkCancellation()
             let scrape = try await self.scrape(webView: webView)
             lastBody = scrape.bodyText ?? lastBody
             lastHref = scrape.href ?? lastHref
 
             if scrape.workspacePicker {
-                try? await Task.sleep(for: .milliseconds(500))
+                try await Self.sleepForDashboardPoll(.milliseconds(500))
                 continue
             }
 
@@ -448,7 +459,7 @@ public struct OpenAIDashboardFetcher {
                 usageRouteSeenAt = nil
                 dashboardSignalSeenAt = nil
                 _ = webView.load(Self.usageURLRequest(url: self.usageURL))
-                try? await Task.sleep(for: .milliseconds(500))
+                try await Self.sleepForDashboardPoll(.milliseconds(500))
                 continue
             }
 
@@ -482,7 +493,7 @@ public struct OpenAIDashboardFetcher {
                 signedInEmail: normalizedEmail,
                 hasDashboardSignal: hasDashboardSignal))
             {
-                try? await Task.sleep(for: .milliseconds(400))
+                try await Self.sleepForDashboardPoll(.milliseconds(400))
                 continue
             }
 
@@ -630,6 +641,7 @@ public struct OpenAIDashboardFetcher {
         websiteDataStore: WKWebsiteDataStore,
         logger: ((String) -> Void)?,
         timeout: TimeInterval,
+        allowNavigationTimeoutRetry: Bool = true,
         preserveLoadedPageOnRelease: Bool = false) async throws -> OpenAIDashboardWebViewLease
     {
         try await OpenAIDashboardWebViewCache.shared.acquire(
@@ -637,6 +649,7 @@ public struct OpenAIDashboardFetcher {
             usageURL: self.usageURL,
             logger: logger,
             navigationTimeout: timeout,
+            allowTimeoutRetry: allowNavigationTimeoutRetry,
             preserveLoadedPageOnRelease: preserveLoadedPageOnRelease)
     }
 
@@ -973,6 +986,7 @@ public struct OpenAIDashboardFetcher {
         accountEmail _: String?,
         logger _: ((String) -> Void)? = nil,
         debugDumpHTML _: Bool = false,
+        allowNavigationTimeoutRetry _: Bool = true,
         timeout _: TimeInterval = 60) async throws -> OpenAIDashboardSnapshot
     {
         throw FetchError.noDashboardData(body: "OpenAI web dashboard fetch is only supported on macOS.")

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardNavigationDelegate.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardNavigationDelegate.swift
@@ -29,6 +29,10 @@ final class NavigationDelegate: NSObject, WKNavigationDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
 
+    func cancel() {
+        self.completeOnce(.failure(CancellationError()))
+    }
+
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         self.completeOnce(.success(()))
     }

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
@@ -28,6 +28,34 @@ final class OpenAIDashboardWebViewCache {
         let preserveLoadedPageOnRelease: Bool
     }
 
+    @MainActor
+    private final class NavigationCancellationState {
+        private weak var webView: WKWebView?
+        private var delegate: NavigationDelegate?
+        private var isCancelled = false
+
+        func install(webView: WKWebView, delegate: NavigationDelegate) {
+            self.webView = webView
+            self.delegate = delegate
+            if self.isCancelled {
+                self.cancel()
+            }
+        }
+
+        func cancel() {
+            self.isCancelled = true
+            guard let webView, let delegate else { return }
+            delegate.cancel()
+            if webView.codexNavigationDelegate === delegate {
+                webView.stopLoading()
+                webView.navigationDelegate = nil
+                webView.codexNavigationDelegate = nil
+            }
+            self.delegate = nil
+            self.webView = nil
+        }
+    }
+
     private final class Entry {
         let webView: WKWebView
         let host: OffscreenWebViewHost
@@ -237,6 +265,7 @@ final class OpenAIDashboardWebViewCache {
         usageURL: URL,
         logger: ((String) -> Void)?,
         navigationTimeout: TimeInterval = 15,
+        allowTimeoutRetry: Bool = true,
         preserveLoadedPageOnRelease: Bool = false) async throws -> OpenAIDashboardWebViewLease
     {
         let deadline = Date().addingTimeInterval(max(navigationTimeout, 1))
@@ -246,7 +275,7 @@ final class OpenAIDashboardWebViewCache {
             logger: logger,
             deadline: deadline,
             options: .init(
-                allowTimeoutRetry: true,
+                allowTimeoutRetry: allowTimeoutRetry,
                 preserveLoadedPageOnRelease: preserveLoadedPageOnRelease))
     }
 
@@ -497,14 +526,26 @@ final class OpenAIDashboardWebViewCache {
             Self.log.debug("OpenAI preserved page reset failed; reloading usage URL")
         }
 
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            let delegate = NavigationDelegate { result in
-                cont.resume(with: result)
+        try Task.checkCancellation()
+        let cancellationState = NavigationCancellationState()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                let delegate = NavigationDelegate { result in
+                    cont.resume(with: result)
+                }
+                webView.navigationDelegate = delegate
+                webView.codexNavigationDelegate = delegate
+                cancellationState.install(webView: webView, delegate: delegate)
+                delegate.armTimeout(seconds: timeout)
+                _ = webView.load(OpenAIDashboardFetcher.usageURLRequest(url: usageURL))
+                if Task.isCancelled {
+                    cancellationState.cancel()
+                }
             }
-            webView.navigationDelegate = delegate
-            webView.codexNavigationDelegate = delegate
-            delegate.armTimeout(seconds: timeout)
-            _ = webView.load(OpenAIDashboardFetcher.usageURLRequest(url: usageURL))
+        } onCancel: {
+            Task { @MainActor in
+                cancellationState.cancel()
+            }
         }
     }
 

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshDashboardCleanupTests.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshDashboardCleanupTests.swift
@@ -33,7 +33,7 @@ extension CodexAccountScopedRefreshTests {
         defer { store._test_codexCreditsLoaderOverride = nil }
 
         var observedTargetEmail: String?
-        store._test_openAIDashboardLoaderOverride = { accountEmail, _, _ in
+        store._test_openAIDashboardLoaderOverride = { accountEmail, _, _, _ in
             observedTargetEmail = accountEmail
             #expect(store.currentCodexOpenAIWebRefreshGuard().source == .liveSystem)
             #expect(store.currentCodexOpenAIWebRefreshGuard().identity == .unresolved)

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
@@ -338,7 +338,7 @@ struct CodexAccountScopedRefreshTests {
 
         let store = self.makeUsageStore(settings: settings)
         store.lastKnownLiveSystemCodexEmail = nil
-        store._test_openAIDashboardLoaderOverride = { _, _, _ in
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
             self.dashboard(email: "seeded@example.com", creditsRemaining: 33, usedPercent: 12)
         }
         defer { store._test_openAIDashboardLoaderOverride = nil }
@@ -379,7 +379,7 @@ struct CodexAccountScopedRefreshTests {
             self.codexSnapshot(email: "trusted@example.com", usedPercent: 12),
             provider: .codex)
         store.lastSourceLabels[.codex] = "codex-cli"
-        store._test_openAIDashboardLoaderOverride = { _, _, _ in
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
             self.dashboard(email: "trusted@example.com", creditsRemaining: 33, usedPercent: 12)
         }
         defer { store._test_openAIDashboardLoaderOverride = nil }
@@ -613,7 +613,7 @@ struct CodexAccountScopedRefreshTests {
             on: store,
             snapshot: self.codexSnapshot(email: "alpha@example.com", usedPercent: 18))
         let dashboardBlocker = BlockingOpenAIDashboardLoader()
-        store._test_openAIDashboardLoaderOverride = { _, _, _ in
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
             try await dashboardBlocker.awaitResult()
         }
         defer { store._test_openAIDashboardLoaderOverride = nil }

--- a/Tests/CodexBarTests/CodexBackgroundRefreshCoalescingTests.swift
+++ b/Tests/CodexBarTests/CodexBackgroundRefreshCoalescingTests.swift
@@ -158,7 +158,7 @@ struct CodexBackgroundRefreshCoalescingTests {
             CreditsSnapshot(remaining: 25, events: [], updatedAt: Date())
         }
         defer { store._test_codexCreditsLoaderOverride = nil }
-        store._test_openAIDashboardLoaderOverride = { _, _, _ in
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
             try await blocker.awaitResult()
         }
         defer { store._test_openAIDashboardLoaderOverride = nil }

--- a/Tests/CodexBarTests/CodexManagedOpenAIWebRefreshTests.swift
+++ b/Tests/CodexBarTests/CodexManagedOpenAIWebRefreshTests.swift
@@ -45,7 +45,7 @@ struct CodexManagedOpenAIWebRefreshTests {
             CreditsSnapshot(remaining: 25, events: [], updatedAt: Date())
         }
         defer { store._test_codexCreditsLoaderOverride = nil }
-        store._test_openAIDashboardLoaderOverride = { _, _, _ in
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
             try await blocker.awaitResult()
         }
         defer { store._test_openAIDashboardLoaderOverride = nil }
@@ -269,7 +269,7 @@ struct CodexManagedOpenAIWebRefreshTests {
             CreditsSnapshot(remaining: 25, events: [], updatedAt: Date())
         }
         defer { store._test_codexCreditsLoaderOverride = nil }
-        store._test_openAIDashboardLoaderOverride = { _, _, _ in
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
             try await dashboardBlocker.awaitResult()
         }
         defer { store._test_openAIDashboardLoaderOverride = nil }
@@ -341,7 +341,7 @@ struct CodexManagedOpenAIWebRefreshTests {
             settings: settings,
             startupBehavior: .testing)
         let blocker = BlockingManagedOpenAIDashboardLoader()
-        store._test_openAIDashboardLoaderOverride = { _, _, _ in
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
             try await blocker.awaitResult()
         }
         defer { store._test_openAIDashboardLoaderOverride = nil }
@@ -415,7 +415,7 @@ struct CodexManagedOpenAIWebRefreshTests {
             startupBehavior: .testing)
         store.openAIDashboardCookieImportStatus =
             "OpenAI cookies are for other@example.com, not managed@example.com."
-        store._test_openAIDashboardLoaderOverride = { _, _, _ in
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
             throw ManagedDashboardTestError.networkTimeout
         }
         defer { store._test_openAIDashboardLoaderOverride = nil }
@@ -447,8 +447,10 @@ struct CodexManagedOpenAIWebRefreshTests {
             startupBehavior: .testing)
         let blocker = BlockingManagedOpenAIDashboardLoader()
         let importTracker = OpenAIDashboardImportCallTracker()
-        store._test_openAIDashboardLoaderOverride = { _, _, _ in
-            try await blocker.awaitResult()
+        var allowNavigationTimeoutRetries: [Bool] = []
+        store._test_openAIDashboardLoaderOverride = { _, _, allowNavigationTimeoutRetry, _ in
+            allowNavigationTimeoutRetries.append(allowNavigationTimeoutRetry)
+            return try await blocker.awaitResult()
         }
         defer { store._test_openAIDashboardLoaderOverride = nil }
         store._test_openAIDashboardCookieImportOverride = { targetEmail, _, _, _, _ in
@@ -484,8 +486,63 @@ struct CodexManagedOpenAIWebRefreshTests {
         await refreshTask.value
 
         #expect(await blocker.startedCount() == 2)
+        #expect(allowNavigationTimeoutRetries == [true, true])
         #expect(store.openAIDashboard?.creditsRemaining == 25)
         #expect(store.lastOpenAIDashboardError == nil)
+    }
+
+    @Test
+    func `background navigation timeout skips immediate WebKit retry`() async throws {
+        let settings = try self.makeSettingsStore(
+            suite: "CodexManagedOpenAIWebRefreshTests-background-timeout-no-retry")
+        let managedAccount = ManagedCodexAccount(
+            id: UUID(),
+            email: "managed@example.com",
+            managedHomePath: "/tmp/managed-codex-home",
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1)
+        settings._test_activeManagedCodexAccount = managedAccount
+        settings.codexActiveSource = .managedAccount(id: managedAccount.id)
+        defer { settings._test_activeManagedCodexAccount = nil }
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing)
+        let blocker = BlockingManagedOpenAIDashboardLoader()
+        let importTracker = OpenAIDashboardImportCallTracker()
+        var allowNavigationTimeoutRetries: [Bool] = []
+        store._test_openAIDashboardLoaderOverride = { _, _, allowNavigationTimeoutRetry, _ in
+            allowNavigationTimeoutRetries.append(allowNavigationTimeoutRetry)
+            return try await blocker.awaitResult()
+        }
+        defer { store._test_openAIDashboardLoaderOverride = nil }
+        store._test_openAIDashboardCookieImportOverride = { targetEmail, _, _, _, _ in
+            _ = await importTracker.recordCall()
+            return OpenAIDashboardBrowserCookieImporter.ImportResult(
+                sourceLabel: "Chrome",
+                cookieCount: 2,
+                signedInEmail: targetEmail,
+                matchesCodexEmail: true)
+        }
+        defer { store._test_openAIDashboardCookieImportOverride = nil }
+
+        let expectedGuard = store.currentCodexOpenAIWebRefreshGuard()
+        let refreshTask = Task {
+            await store.refreshOpenAIDashboardIfNeeded(force: false, expectedGuard: expectedGuard)
+        }
+        await blocker.waitUntilStarted(count: 1)
+
+        await blocker.resumeNext(with: .failure(URLError(.timedOut)))
+        await refreshTask.value
+
+        #expect(await blocker.startedCount() == 1)
+        #expect(allowNavigationTimeoutRetries == [false])
+        #expect(await importTracker.callCount() == 0)
+        #expect(store.openAIDashboard == nil)
+        #expect(store.lastOpenAIDashboardError?.contains("timed out") == true)
     }
 
     @Test
@@ -508,7 +565,7 @@ struct CodexManagedOpenAIWebRefreshTests {
             settings: settings,
             startupBehavior: .testing)
         let blocker = BlockingManagedOpenAIDashboardLoader()
-        store._test_openAIDashboardLoaderOverride = { _, _, _ in
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
             try await blocker.awaitResult()
         }
         defer { store._test_openAIDashboardLoaderOverride = nil }
@@ -560,7 +617,7 @@ struct CodexManagedOpenAIWebRefreshTests {
             startupBehavior: .testing)
         store.openAIDashboardCookieImportStatus =
             "OpenAI cookies are for other@example.com, not managed@example.com."
-        store._test_openAIDashboardLoaderOverride = { _, _, _ in
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
             throw ManagedDashboardTestError.networkTimeout
         }
         defer { store._test_openAIDashboardLoaderOverride = nil }
@@ -792,6 +849,10 @@ private actor OpenAIDashboardImportCallTracker {
         await withCheckedContinuation { continuation in
             self.waiters.append((count: count, continuation: continuation))
         }
+    }
+
+    func callCount() -> Int {
+        self.calls
     }
 
     private func resumeReadyWaiters() {

--- a/Tests/CodexBarTests/CodexManagedOpenAIWebTestSupport.swift
+++ b/Tests/CodexBarTests/CodexManagedOpenAIWebTestSupport.swift
@@ -33,7 +33,7 @@ extension CodexManagedOpenAIWebTests {
             settings: settings,
             startupBehavior: .testing)
         let blocker = CoalescingManagedOpenAIDashboardLoader()
-        store._test_openAIDashboardLoaderOverride = { _, _, _ in
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
             try await blocker.awaitResult()
         }
         defer { store._test_openAIDashboardLoaderOverride = nil }

--- a/Tests/CodexBarTests/CodexManagedOpenAIWebTests.swift
+++ b/Tests/CodexBarTests/CodexManagedOpenAIWebTests.swift
@@ -304,7 +304,7 @@ struct CodexManagedOpenAIWebTests {
         }
 
         var observedTargetEmail: String?
-        store._test_openAIDashboardLoaderOverride = { accountEmail, _, _ in
+        store._test_openAIDashboardLoaderOverride = { accountEmail, _, _, _ in
             observedTargetEmail = accountEmail
             return OpenAIDashboardSnapshot(
                 signedInEmail: "new@example.com",
@@ -365,7 +365,7 @@ struct CodexManagedOpenAIWebTests {
         store.lastSourceLabels[.codex] = "codex-cli"
 
         var observedTargetEmail: String?
-        store._test_openAIDashboardLoaderOverride = { accountEmail, _, _ in
+        store._test_openAIDashboardLoaderOverride = { accountEmail, _, _, _ in
             observedTargetEmail = accountEmail
             return OpenAIDashboardSnapshot(
                 signedInEmail: "usage@example.com",
@@ -818,7 +818,7 @@ struct CodexManagedOpenAIWebTests {
             startupBehavior: .testing)
 
         var loaderCalls = 0
-        store._test_openAIDashboardLoaderOverride = { _, _, _ in
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
             loaderCalls += 1
             throw OpenAIDashboardFetcher.FetchError.loginRequired
         }
@@ -860,7 +860,7 @@ struct CodexManagedOpenAIWebTests {
             settings: settings,
             startupBehavior: .testing)
 
-        store._test_openAIDashboardLoaderOverride = { _, _, _ in
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
             throw OpenAIDashboardFetcher.FetchError.loginRequired
         }
         defer { store._test_openAIDashboardLoaderOverride = nil }

--- a/Tests/CodexBarTests/OpenAIDashboardNavigationDelegateTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardNavigationDelegateTests.swift
@@ -61,6 +61,22 @@ struct OpenAIDashboardNavigationDelegateTests {
 
     @MainActor
     @Test
+    func `explicit cancel completes with cancellation error`() {
+        var result: Result<Void, Error>?
+        let delegate = NavigationDelegate { result = $0 }
+
+        delegate.cancel()
+
+        switch result {
+        case let .failure(error)?:
+            #expect(error is CancellationError)
+        default:
+            #expect(Bool(false))
+        }
+    }
+
+    @MainActor
+    @Test
     func `commit completes navigation successfully after grace period`() async {
         let webView = WKWebView()
         var result: Result<Void, Error>?


### PR DESCRIPTION
Fixes #1217

Summary:
- cancel OpenAI dashboard WebKit navigation and polling promptly when the refresh task is cancelled
- cancel both foreground and background dashboard refresh tasks during OpenAI web state invalidation
- skip immediate background WebKit retry after navigation timeouts while preserving forced/manual retry behavior

Proof:
- `swift test --filter OpenAIWebRefreshGateTests --filter WebKitTeardownTests --filter CodexManagedOpenAIWebRefreshTests --filter OpenAIDashboardNavigationDelegateTests --filter OpenAIDashboardWebViewCacheTests`
- `make check`
- `swift test` (3140 tests)
- autoreview clean: no accepted/actionable findings

Note: no live auth probe was run because provider/Keychain-prompt validation is avoided for this path; coverage uses stubbed dashboard loaders and WebKit lifecycle tests.
