### PR TITLE
Preserve Claude web usage on transient refresh auth failures

### DIFF
--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -300,9 +300,12 @@ extension UsageStore {
             let shouldSurface =
                 self.failureGates[provider]?
                     .shouldSurfaceError(onFailureWithPriorData: hadPriorData) ?? true
-            if provider == .claude,
-               hadPriorData,
-               Self.isClaudeWebSessionRefreshFailure(error)
+            let preservesClaudeWebSessionFailure =
+                provider == .claude &&
+                hadPriorData &&
+                Self.isClaudeWebSessionRefreshFailure(error)
+            if preservesClaudeWebSessionFailure,
+               !shouldSurface
             {
                 self.errors[provider] = nil
                 return
@@ -320,7 +323,7 @@ extension UsageStore {
             }
             if shouldSurface {
                 self.errors[provider] = error.localizedDescription
-                if !preservesPriorData {
+                if !preservesPriorData, !preservesClaudeWebSessionFailure {
                     self.snapshots.removeValue(forKey: provider)
                 }
             } else {

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -301,6 +301,13 @@ extension UsageStore {
                 self.failureGates[provider]?
                     .shouldSurfaceError(onFailureWithPriorData: hadPriorData) ?? true
             if provider == .claude,
+               hadPriorData,
+               Self.isClaudeWebSessionRefreshFailure(error)
+            {
+                self.errors[provider] = nil
+                return
+            }
+            if provider == .claude,
                preservesPriorData,
                Self.isClaudeUsageProbeTimeout(error)
             {
@@ -397,6 +404,11 @@ extension UsageStore {
     private static func isClaudeUsageProbeTimeout(_ error: Error) -> Bool {
         if case ClaudeStatusProbeError.timedOut = error { return true }
         return error.localizedDescription == ClaudeStatusProbeError.timedOut.localizedDescription
+    }
+
+    private static func isClaudeWebSessionRefreshFailure(_ error: Error) -> Bool {
+        if case ClaudeWebAPIFetcher.FetchError.unauthorized = error { return true }
+        return error.localizedDescription == ClaudeWebAPIFetcher.FetchError.unauthorized.localizedDescription
     }
 
     nonisolated static func isPermissionPromptWaiting(_ error: Error) -> Bool {

--- a/Tests/CodexBarTests/ClaudeWebRefreshResilienceTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebRefreshResilienceTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+struct ClaudeWebRefreshResilienceTests {
+    @Test
+    func `web unauthorized keeps prior Claude snapshot without surfacing refresh failure`() async throws {
+        try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+            let tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            let fileURL = tempDir.appendingPathComponent("missing-credentials.json")
+
+            try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                let prior = Self.makePriorSnapshot()
+                let store = try await MainActor.run {
+                    try Self.makeStore(
+                        suite: "ClaudeWebRefreshResilienceTests-web-unauthorized",
+                        prior: prior)
+                }
+
+                await store.refreshProvider(.claude)
+                let firstResult = await MainActor.run {
+                    (
+                        updatedAt: store.snapshot(for: .claude)?.updatedAt,
+                        hasError: store.error(for: .claude) != nil)
+                }
+
+                #expect(firstResult.updatedAt == prior.updatedAt)
+                #expect(!firstResult.hasError)
+
+                await store.refreshProvider(.claude)
+                let secondResult = await MainActor.run {
+                    (
+                        updatedAt: store.snapshot(for: .claude)?.updatedAt,
+                        hasError: store.error(for: .claude) != nil)
+                }
+
+                #expect(secondResult.updatedAt == prior.updatedAt)
+                #expect(!secondResult.hasError)
+            }
+        }
+    }
+
+    @Test
+    func `web unauthorized without prior Claude snapshot still surfaces failure`() async throws {
+        try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+            let tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            let fileURL = tempDir.appendingPathComponent("missing-credentials.json")
+
+            try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                let store = try await MainActor.run {
+                    try Self.makeStore(
+                        suite: "ClaudeWebRefreshResilienceTests-web-unauthorized-no-prior",
+                        prior: nil)
+                }
+
+                await store.refreshProvider(.claude)
+                let result = await MainActor.run {
+                    (
+                        hasSnapshot: store.snapshot(for: .claude) != nil,
+                        error: store.error(for: .claude))
+                }
+
+                #expect(!result.hasSnapshot)
+                #expect(result.error == ClaudeWebAPIFetcher.FetchError.unauthorized.localizedDescription)
+            }
+        }
+    }
+
+    @MainActor
+    private static func makeStore(suite: String, prior: UsageSnapshot?) throws -> UsageStore {
+        let settings = self.makeSettingsStore(suite: suite)
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.claudeUsageDataSource = .web
+
+        let metadata = ProviderRegistry.shared.metadata
+        for provider in UsageProvider.allCases {
+            try settings.setProviderEnabled(
+                provider: provider,
+                metadata: #require(metadata[provider]),
+                enabled: provider == .claude)
+        }
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: [:])
+        if let prior {
+            store._setSnapshotForTesting(prior, provider: .claude)
+        }
+
+        let baseSpec = try #require(store.providerSpecs[.claude])
+        let descriptor = ProviderDescriptor(
+            id: .claude,
+            metadata: baseSpec.descriptor.metadata,
+            branding: baseSpec.descriptor.branding,
+            tokenCost: baseSpec.descriptor.tokenCost,
+            fetchPlan: ProviderFetchPlan(
+                sourceModes: [.web],
+                pipeline: ProviderFetchPipeline { _ in [ClaudeWebUnauthorizedFetchStrategy()] }),
+            cli: baseSpec.descriptor.cli)
+        store.providerSpecs[.claude] = ProviderSpec(
+            style: baseSpec.style,
+            isEnabled: baseSpec.isEnabled,
+            descriptor: descriptor,
+            makeFetchContext: baseSpec.makeFetchContext)
+        return store
+    }
+
+    private static func makePriorSnapshot() -> UsageSnapshot {
+        UsageSnapshot(
+            primary: RateWindow(usedPercent: 12, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 34,
+                windowMinutes: 10080,
+                resetsAt: nil,
+                resetDescription: nil),
+            updatedAt: Date(timeIntervalSince1970: 1_800_000_000),
+            identity: ProviderIdentitySnapshot(
+                providerID: .claude,
+                accountEmail: "claude@example.com",
+                accountOrganization: nil,
+                loginMethod: "Pro"))
+    }
+
+    @MainActor
+    private static func makeSettingsStore(suite: String) -> SettingsStore {
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            kimiK2TokenStore: InMemoryKimiK2TokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore())
+        settings.providerDetectionCompleted = true
+        return settings
+    }
+}
+
+private struct ClaudeWebUnauthorizedFetchStrategy: ProviderFetchStrategy {
+    let id = "test.claude-web-unauthorized"
+    let kind: ProviderFetchKind = .web
+
+    func isAvailable(_: ProviderFetchContext) async -> Bool {
+        true
+    }
+
+    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+        throw ClaudeWebAPIFetcher.FetchError.unauthorized
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+}

--- a/Tests/CodexBarTests/ClaudeWebRefreshResilienceTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebRefreshResilienceTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 struct ClaudeWebRefreshResilienceTests {
     @Test
-    func `web unauthorized keeps prior Claude snapshot without surfacing refresh failure`() async throws {
+    func `web unauthorized respects failure gate while keeping prior Claude snapshot`() async throws {
         try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
             let tempDir = FileManager.default.temporaryDirectory
                 .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -34,11 +34,11 @@ struct ClaudeWebRefreshResilienceTests {
                 let secondResult = await MainActor.run {
                     (
                         updatedAt: store.snapshot(for: .claude)?.updatedAt,
-                        hasError: store.error(for: .claude) != nil)
+                        error: store.error(for: .claude))
                 }
 
                 #expect(secondResult.updatedAt == prior.updatedAt)
-                #expect(!secondResult.hasError)
+                #expect(secondResult.error == ClaudeWebAPIFetcher.FetchError.unauthorized.localizedDescription)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Preserve the last good Claude Web usage snapshot when a manual/background refresh hits `ClaudeWebAPIFetcher.FetchError.unauthorized`.
- Clear the transient refresh error instead of replacing an otherwise usable Claude card with `Unauthorized`.
- Keep first-run behavior unchanged: if there is no prior Claude snapshot, the Unauthorized error still surfaces.

## Why
Claude Web can return intermittent 401/403 responses during refresh even after a successful usage fetch. Before this change, a later refresh could replace the visible Claude session/weekly usage with `Unauthorized. Your Claude session may have expired.` despite having a fresh prior snapshot.

## Tests
- Added `ClaudeWebRefreshResilienceTests` covering:
  - prior Claude Web snapshot + unauthorized refresh keeps the prior snapshot and hides the transient error
  - no prior Claude Web snapshot + unauthorized refresh still surfaces the error

## Validation
- `swift build --target CodexBarCore` passes locally.
- `.build/lint-tools/bin/swiftformat Sources Tests --lint` passes locally with `0/985 files require formatting`.
- Local `swift test --filter ClaudeWebRefreshResilienceTests` is blocked by the local CommandLineTools environment (`Testing` module / SwiftUI `@Entry` macro plugins are unavailable without full Xcode); CI should be the test signal.
- Verified manually with a local patched app: after a successful Claude Web snapshot, clicking Refresh while Claude Web API returned 403 kept the Claude session/weekly usage visible instead of showing Unauthorized.

## Scope
No provider ordering, settings UI, localization, auth storage, credential reads, token/cookie logging, or package/test target changes.
