### PR TITLE
fix(augment): parse current auggie CLI output and restore cookie detection

### DIFF
--- a/Sources/CodexBar/Providers/Augment/AugmentProviderRuntime.swift
+++ b/Sources/CodexBar/Providers/Augment/AugmentProviderRuntime.swift
@@ -92,6 +92,7 @@ final class AugmentProviderRuntime: ProviderRuntime {
     private func forceRefresh(context: ProviderRuntimeContext) async {
         #if os(macOS)
         context.store.augmentLogger.info("Augment force refresh requested")
+        CookieHeaderCache.clear(provider: .augment)
         guard let keepalive = self.keepalive else {
             context.store.augmentLogger.warning("Augment keepalive not running; starting")
             self.startKeepalive(context: context)

--- a/Sources/CodexBarCore/Providers/Augment/AuggieCLIProbe.swift
+++ b/Sources/CodexBarCore/Providers/Augment/AuggieCLIProbe.swift
@@ -52,11 +52,16 @@ public struct AuggieCLIProbe: Sendable {
         return output
     }
 
-    private func parse(_ output: String) throws -> AugmentStatusSnapshot {
-        // Parse output like:
+    func parse(_ output: String) throws -> AugmentStatusSnapshot {
+        // Legacy output:
         // Max Plan 450,000 credits / month
         // 11,657 remaining · 953,170 / 964,827 credits used
         // 2 days remaining in this billing cycle (ends 1/8/2026)
+        //
+        // Current output (2026+):
+        // 319,054 credits remaining                     Max Plan
+        // 450,000 credits / month
+        // 9 days remaining in this billing cycle (ends 6/9/2026)
 
         var maxCredits: Int?
         var remaining: Int?
@@ -67,8 +72,15 @@ public struct AuggieCLIProbe: Sendable {
         for line in output.split(separator: "\n") {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
 
-            // Parse "Max Plan 450,000 credits / month"
-            if trimmed.contains("Max Plan"), trimmed.contains("credits") {
+            if trimmed.contains("credits / month") {
+                if let match = trimmed.range(of: #"([\d,]+)\s+credits\s*/\s*month"#, options: .regularExpression) {
+                    let numberStr = String(trimmed[match]).replacingOccurrences(of: ",", with: "")
+                        .replacingOccurrences(of: " credits", with: "")
+                        .replacingOccurrences(of: " / month", with: "")
+                    maxCredits = Int(numberStr)
+                    total = total ?? Int(numberStr)
+                }
+            } else if trimmed.contains("Max Plan"), trimmed.contains("credits"), !trimmed.contains("remaining") {
                 if let match = trimmed.range(of: #"([\d,]+)\s+credits"#, options: .regularExpression) {
                     let numberStr = String(trimmed[match]).replacingOccurrences(of: ",", with: "")
                         .replacingOccurrences(of: " credits", with: "")
@@ -76,9 +88,17 @@ public struct AuggieCLIProbe: Sendable {
                 }
             }
 
+            if trimmed.contains("credits remaining"), !trimmed.contains("billing cycle") {
+                if let match = trimmed.range(of: #"([\d,]+)\s+credits\s+remaining"#, options: .regularExpression) {
+                    let numberStr = String(trimmed[match]).replacingOccurrences(of: ",", with: "")
+                        .replacingOccurrences(of: " credits", with: "")
+                        .replacingOccurrences(of: " remaining", with: "")
+                    remaining = Int(numberStr)
+                }
+            }
+
             // Parse "11,657 remaining · 953,170 / 964,827 credits used"
             if trimmed.contains("remaining"), trimmed.contains("credits used") {
-                // Extract remaining
                 if let remMatch = trimmed.range(of: #"([\d,]+)\s+remaining"#, options: .regularExpression) {
                     let numStr = String(trimmed[remMatch])
                         .replacingOccurrences(of: ",", with: "")
@@ -86,7 +106,6 @@ public struct AuggieCLIProbe: Sendable {
                     remaining = Int(numStr)
                 }
 
-                // Extract used / total
                 if let usedMatch = trimmed.range(
                     of: #"([\d,]+)\s*/\s*([\d,]+)\s+credits used"#,
                     options: .regularExpression)
@@ -103,15 +122,12 @@ public struct AuggieCLIProbe: Sendable {
                 }
             }
 
-            // Parse "2 days remaining in this billing cycle (ends 1/8/2026)"
             if trimmed.contains("billing cycle"), trimmed.contains("ends") {
-                // Extract date from "(ends 1/8/2026)"
                 if let dateMatch = trimmed.range(of: #"ends\s+([\d/]+)"#, options: .regularExpression) {
                     let dateStr = String(trimmed[dateMatch])
                         .replacingOccurrences(of: "ends", with: "")
                         .trimmingCharacters(in: .whitespaces)
 
-                    // Parse date like "1/8/2026"
                     let formatter = DateFormatter()
                     formatter.dateFormat = "M/d/yyyy"
                     formatter.locale = Locale(identifier: "en_US_POSIX")
@@ -121,10 +137,18 @@ public struct AuggieCLIProbe: Sendable {
             }
         }
 
-        guard let finalRemaining = remaining, let finalUsed = used, let finalTotal = total else {
+        guard let finalRemaining = remaining else {
             Self.log.error("Failed to parse auggie output: \(output)")
             throw AuggieCLIError.parseError("Could not extract credits from output")
         }
+
+        let finalTotal = total ?? maxCredits
+        guard let finalTotal else {
+            Self.log.error("Failed to parse auggie output: \(output)")
+            throw AuggieCLIError.parseError("Could not extract credits from output")
+        }
+
+        let finalUsed = used ?? max(0, finalTotal - finalRemaining)
 
         return AugmentStatusSnapshot(
             creditsRemaining: Double(finalRemaining),

--- a/Sources/CodexBarCore/Providers/Augment/AugmentProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Augment/AugmentProviderDescriptor.swift
@@ -95,10 +95,8 @@ struct AugmentCLIFetchStrategy: ProviderFetchStrategy {
         // Fallback to web if CLI fails (not authenticated, etc.)
         if let cliError = error as? AuggieCLIError {
             switch cliError {
-            case .notAuthenticated, .noOutput:
+            case .notAuthenticated, .noOutput, .parseError:
                 return true
-            case .parseError:
-                return false // Don't fallback on parse errors - something is wrong
             }
         }
         return true

--- a/Sources/CodexBarCore/Providers/Augment/AugmentSessionKeepalive.swift
+++ b/Sources/CodexBarCore/Providers/Augment/AugmentSessionKeepalive.swift
@@ -212,6 +212,12 @@ public final class AugmentSessionKeepalive {
                 try await Task.sleep(for: .seconds(1)) // Brief delay for browser to update cookies
                 let newSession = try AugmentCookieImporter.importSession(logger: self.logger)
 
+                await AugmentSessionStore.shared.setCookies(newSession.cookies)
+                CookieHeaderCache.store(
+                    provider: .augment,
+                    cookieHeader: newSession.cookieHeader,
+                    sourceLabel: newSession.sourceLabel)
+
                 self.log(
                     "✅ Session refresh successful - imported \(newSession.cookies.count) cookies " +
                         "from \(newSession.sourceLabel)")
@@ -220,6 +226,11 @@ public final class AugmentSessionKeepalive {
                 // Reset failure tracking on success
                 self.consecutiveFailures = 0
                 self.hasGivenUp = false
+
+                if let callback = self.onSessionRecovered {
+                    self.log("🔄 Triggering usage refresh after session refresh")
+                    await callback()
+                }
             } else {
                 self.log("⚠️ Session refresh returned no new cookies")
                 self.consecutiveFailures += 1

--- a/Sources/CodexBarCore/Providers/Augment/AugmentStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Augment/AugmentStatusProbe.swift
@@ -15,12 +15,15 @@ public enum AugmentCookieImporter {
     /// NOTE: This list may not be exhaustive. If authentication fails with cookies present,
     /// check debug logs for cookie names and report them.
     private static let sessionCookieNames: Set<String> = [
-        "_session", // Legacy session cookie
+        "session", // Augment auth session (auth.augmentcode.com)
+        "_session", // Legacy session cookie (app.augmentcode.com)
+        "web_rpc_proxy_session", // Augment RPC proxy session
         "auth0", // Auth0 session
         "auth0.is.authenticated", // Auth0 authentication flag
         "a0.spajs.txs", // Auth0 SPA transaction state
         "__Secure-next-auth.session-token", // NextAuth secure session
         "next-auth.session-token", // NextAuth session
+        "__Secure-authjs.session-token", // AuthJS secure session
         "__Host-authjs.csrf-token", // AuthJS CSRF token
         "authjs.session-token", // AuthJS session
     ]

--- a/Tests/CodexBarTests/AuggieCLIProbeParseTests.swift
+++ b/Tests/CodexBarTests/AuggieCLIProbeParseTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+#if os(macOS)
+
+struct AuggieCLIProbeParseTests {
+    private let probe = AuggieCLIProbe()
+
+    @Test
+    func `parses current auggie account status output`() throws {
+        let output = """
+        ╭ Account ───────────────────────────────────────────────╮
+        │                                                        │
+        │ 319,054 credits remaining                     Max Plan │
+        │                                450,000 credits / month │
+        │                                                        │
+        ╰────────────────────────────────────────────────────────╯
+
+         9 days remaining in this billing cycle (ends 6/9/2026)
+         For more detail, visit https://app.augmentcode.com/account
+        """
+
+        let snapshot = try probe.parse(output)
+
+        #expect(snapshot.creditsRemaining == 319_054)
+        #expect(snapshot.creditsLimit == 450_000)
+        #expect(snapshot.creditsUsed == 130_946)
+        #expect(snapshot.accountPlan == "450,000 credits/month")
+        #expect(snapshot.billingCycleEnd != nil)
+    }
+
+    @Test
+    func `parses legacy auggie account status output`() throws {
+        let output = """
+        Max Plan 450,000 credits / month
+        11,657 remaining · 953,170 / 964,827 credits used
+        2 days remaining in this billing cycle (ends 1/8/2026)
+        """
+
+        let snapshot = try probe.parse(output)
+
+        #expect(snapshot.creditsRemaining == 11_657)
+        #expect(snapshot.creditsUsed == 953_170)
+        #expect(snapshot.creditsLimit == 964_827)
+        #expect(snapshot.accountPlan == "450,000 credits/month")
+    }
+}
+
+#endif

--- a/Tests/CodexBarTests/AugmentCLIFetchStrategyFallbackTests.swift
+++ b/Tests/CodexBarTests/AugmentCLIFetchStrategyFallbackTests.swift
@@ -79,10 +79,10 @@ struct AugmentCLIFetchStrategyFallbackTests {
     }
 
     @Test
-    func `parse error does not fall back`() {
+    func `parse error falls back to web`() {
         let strategy = AugmentCLIFetchStrategy()
         let context = self.makeContext()
-        #expect(strategy.shouldFallback(on: AuggieCLIError.parseError("bad data"), context: context) == false)
+        #expect(strategy.shouldFallback(on: AuggieCLIError.parseError("bad data"), context: context) == true)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Update `AuggieCLIProbe` to parse the current `auggie account status` output format (credits remaining + credits/month), while keeping legacy output support
- Fall back to browser cookie fetch when CLI parsing fails, instead of stopping with a parse error
- Restore `session` and `web_rpc_proxy_session` to Augment session cookie detection
- Persist imported cookies after session refresh and clear stale cookie cache on force refresh

## Test plan
- [x] `swift test --filter 'AuggieCLIProbeParseTests|AugmentCLIFetchStrategyFallbackTests'`
- [x] `swift run CodexBarCLI usage augment` returns Augment credits via CLI on a machine with `auggie` installed and authenticated

Made with [Cursor](https://cursor.com)