### PR TITLE
[security] fix(cli): avoid privileged temp installer script

### DIFF
--- a/bin/install-codexbar-cli.sh
+++ b/bin/install-codexbar-cli.sh
@@ -10,23 +10,20 @@ if [[ ! -x "$HELPER" ]]; then
   exit 1
 fi
 
-install_script=$(mktemp)
-cat > "$install_script" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-HELPER="__HELPER__"
-TARGETS=("/usr/local/bin/codexbar" "/opt/homebrew/bin/codexbar")
+osascript - "$HELPER" <<'APPLESCRIPT'
+on run argv
+  set helperPath to item 1 of argv
+  set installCommand to "set -euo pipefail" & linefeed & ¬
+    "HELPER=" & quoted form of helperPath & linefeed & ¬
+    "TARGETS=(\"/usr/local/bin/codexbar\" \"/opt/homebrew/bin/codexbar\")" & linefeed & ¬
+    "for t in \"${TARGETS[@]}\"; do" & linefeed & ¬
+    "  mkdir -p \"$(dirname \"$t\")\"" & linefeed & ¬
+    "  ln -sf \"$HELPER\" \"$t\"" & linefeed & ¬
+    "  echo \"Linked $t -> $HELPER\"" & linefeed & ¬
+    "done"
 
-for t in "${TARGETS[@]}"; do
-  mkdir -p "$(dirname "$t")"
-  ln -sf "$HELPER" "$t"
-  echo "Linked $t -> $HELPER"
-done
-EOF
-
-perl -pi -e "s#__HELPER__#$HELPER#g" "$install_script"
-
-osascript -e "do shell script \"bash '$install_script'\" with administrator privileges"
-rm -f "$install_script"
+  do shell script "bash -c " & quoted form of installCommand with administrator privileges
+end run
+APPLESCRIPT
 
 echo "CodexBar CLI installed. Try: codexbar usage"


### PR DESCRIPTION
## Summary

This PR hardens CodexBar's CLI installer privilege boundary by removing the user-owned temporary shell script that was later executed through the expected macOS administrator prompt.

- Replaces the mutable `mktemp` installer payload with an AppleScript heredoc that passes the helper path as an argument and builds the privileged command in memory.
- Keeps the existing CLI symlink behavior for `/usr/local/bin/codexbar` and `/opt/homebrew/bin/codexbar`.
- Adds validation coverage through shell syntax checking, AppleScript compilation, and static checks that the old temp-script handoff is gone.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| CLI installer executes a same-user mutable temp script as administrator | Same-user local malware can rewrite the installer body before the user approves the expected CodexBar admin prompt, turning the trusted install flow into root command execution. | High, with local/same-user and user-approval prerequisites |

## Before this PR

- `bin/install-codexbar-cli.sh` created an unprivileged `mktemp` file and wrote the privileged install body into it.
- The script then invoked AppleScript with `do shell script "bash '$install_script'" with administrator privileges`.
- The temp file remained owned and mutable by the original user until privileged `bash` opened it.
- A same-user attacker did not need to spoof the admin prompt; they only needed to race/replace the file before the victim approved the legitimate CodexBar prompt.

## After this PR

- The installer no longer writes a root-executed payload to a user-owned temp file.
- AppleScript receives the trusted helper path as an argument and quotes it when composing the privileged command.
- The privileged command is passed directly to `bash -c` by AppleScript instead of by path to a mutable temp script.
- The existing symlink install behavior is preserved.

## Why this matters

This is not a drive-by remote exploit. The realistic attacker is same-user local malware or a compromised developer dependency already running as the logged-in macOS user.

That attacker still benefits from the bug because CodexBar supplies the social and privilege boundary for them: when the victim runs the documented CLI installer and approves the expected administrator prompt, the attacker can swap the unprivileged temp script so their payload is what root executes. In attacker terms, the issue is a plausible local privilege-escalation primitive for same-user malware, not an unauthenticated remote compromise.

## Attack flow

```text
same-user local malware
    -> monitors the victim's temp directory / installer process
        -> rewrites CodexBar's generated install script before admin approval completes
            -> AppleScript runs bash on that mutable file with administrator privileges
                -> attacker-controlled shell commands run as root
```

## Affected code

| Issue | Files |
|-------|-------|
| Mutable temp script crossed the admin boundary | `bin/install-codexbar-cli.sh` |

## Root cause

CLI installer mutable temp script privilege escalation:
- The installer generated privileged shell code in a user-owned temporary file before privilege elevation.
- The trust boundary failed because the file path, not an immutable command body or root-owned payload, was handed to the administrator execution step.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| CLI installer mutable temp script privilege escalation | 7.8 High | `CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H` |

Rationale:
- The attacker already needs local same-user code execution and the victim must approve the legitimate CodexBar administrator prompt.
- If those preconditions are met, the impact is root command execution under that prompt, affecting confidentiality, integrity, and availability.

## Safe reproduction steps

The issue can be validated without executing privileged payloads:

1. Inspect the vulnerable installer flow on the previous revision.
2. Confirm it creates a temp file with `mktemp`, writes the privileged shell payload into that file, and later runs `bash '$install_script'` with administrator privileges.
3. Confirm a `mktemp`-style file is owned by the current user and remains writable by that user before privileged `bash` would open it.
4. Append a harmless marker to the temp file and observe that the file content changes before the privileged execution point.

Safe validation signal from local review:

```text
path_basename codexbar-installer-proof-h3ih2ilh
mode 0o600
same_user_owned True
same_user_can_modify_before_privileged_bash_opens_file True
```

Mode `0600` blocks other Unix users, but it does not block same-user malware, which is the relevant macOS GUI-admin-prompt escalation model.

## Expected vulnerable behavior

On the vulnerable installer:

- The generated install script is mutable by the unprivileged user after creation.
- The admin prompt remains legitimate and expected for CodexBar's CLI install flow.
- If same-user malware rewrites the file during the prompt window, the substituted payload is what administrator `bash` executes.

## Changes in this PR

- Removes the `mktemp` script generation and cleanup path.
- Removes the `perl` substitution pass over the generated root-run script.
- Passes the helper path into AppleScript as an argument.
- Uses AppleScript `quoted form` when building the privileged shell command.
- Keeps the existing symlink creation targets and output messages.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Installer hardening | `bin/install-codexbar-cli.sh` | Replaced the mutable root-run temp script with an in-memory AppleScript-built privileged command. |

## Maintainer impact

- Scope is limited to the CLI installer shell script.
- The app, CLI helper binary, release scripts, and documentation are otherwise untouched.
- Users should see the same expected administrator prompt and the same resulting symlinks.
- The patch removes the prompt-time file race rather than adding a broader installer framework or changing install locations.

## Fix rationale

The privilege boundary should not depend on a user-owned file staying unchanged while the system waits for administrator approval. Passing a fixed command body through AppleScript, with the variable helper path quoted inside AppleScript, removes the mutable file handoff while preserving the small existing install operation.

## Type of change

- [x] Security fix
- [ ] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `bash -n bin/install-codexbar-cli.sh`
- [x] Extracted the embedded AppleScript heredoc and compiled it with `osacompile`.
- [x] Checked that the updated installer no longer contains `mktemp`, `install_script`, or the old `bash '$install_script'` handoff.

Executed with:

```bash
python3 - <<'PY'
from pathlib import Path
import re, tempfile, os, subprocess, sys
path=Path('bin/install-codexbar-cli.sh')
text=path.read_text()
print('bash -n bin/install-codexbar-cli.sh')
r=subprocess.run(['bash','-n',str(path)], text=True, capture_output=True)
print(r.stdout, end='')
print(r.stderr, end='', file=sys.stderr)
print('exit_code', r.returncode)
if r.returncode:
    raise SystemExit(r.returncode)
m=re.search(r"<<'APPLESCRIPT'\n(.*?)\nAPPLESCRIPT", text, re.S)
if not m:
    raise SystemExit('AppleScript heredoc not found')
with tempfile.NamedTemporaryFile('w', suffix='.applescript', delete=False) as f:
    f.write(m.group(1))
    p=f.name
try:
    print('osacompile extracted AppleScript')
    r=subprocess.run(['osacompile','-o','/tmp/codexbar-installer-test.scpt',p], text=True, capture_output=True)
    print(r.stdout, end='')
    print(r.stderr, end='', file=sys.stderr)
    print('exit_code', r.returncode)
    if r.returncode:
        raise SystemExit(r.returncode)
finally:
    os.unlink(p)
    try: os.unlink('/tmp/codexbar-installer-test.scpt')
    except FileNotFoundError: pass
print('no mktemp:', 'mktemp' not in text)
print('no privileged temp script:', "bash '$install_script'" not in text and 'install_script' not in text)
print('osascript uses stdin plus helper arg:', 'osascript - "$HELPER"' in text)
PY
```

Output:

```text
bash -n bin/install-codexbar-cli.sh
exit_code 0
osacompile extracted AppleScript
exit_code 0
no mktemp: True
no privileged temp script: True
osascript uses stdin plus helper arg: True
```


### Live macOS installer smoke test

After the static checks above, I also ran the patched installer through the real macOS administrator prompt. The smoke test used a locally staged `/Applications/CodexBar.app` bundle containing the PR-built `CodexBarCLI` helper plus a test `VERSION` file, so the output below verifies the installer path and symlink behavior without relying on a production install.

Executed with:

```bash
./bin/install-codexbar-cli.sh
ls -l /usr/local/bin/codexbar /opt/homebrew/bin/codexbar
/usr/local/bin/codexbar --version
/opt/homebrew/bin/codexbar --version
```

Output:

```text
Pre-check symlinks:
ls: /opt/homebrew/bin/codexbar: No such file or directory
ls: /usr/local/bin/codexbar: No such file or directory

Running patched installer (approve the macOS administrator dialog when it appears)...
Linked /usr/local/bin/codexbar -> /Applications/CodexBar.app/Contents/Helpers/CodexBarCLI
Linked /opt/homebrew/bin/codexbar -> /Applications/CodexBar.app/Contents/Helpers/CodexBarCLI
CodexBar CLI installed. Try: codexbar usage

Post-check symlinks:
lrwxr-xr-x  1 root  wheel  55 May 30 20:55 /opt/homebrew/bin/codexbar -> /Applications/CodexBar.app/Contents/Helpers/CodexBarCLI
lrwxr-xr-x  1 root  wheel  55 May 30 20:55 /usr/local/bin/codexbar -> /Applications/CodexBar.app/Contents/Helpers/CodexBarCLI

Version checks:
CodexBar 1.6.2-test
CodexBar 1.6.2-test
```

Cleanup after the smoke test removed the temporary staged app and both proof symlinks.

## Disclosure notes

- This PR is intentionally framed as local/same-user privilege escalation through a trusted installer prompt, not unauthenticated remote code execution.
- No production systems were tested.
- No unrelated files were changed.
- I did not find a repository `SECURITY.md` with a preferred private reporting path, so this is opened as a bounded hardening PR with reproduction kept non-destructive.

