### PR TITLE
Add optional reset time menu bar metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Devin: add daily and weekly quota tracking from the signed-in Chrome session or a manual Bearer token (#1264, fixes #800). Thanks @coygeek!
+- Menu bar: add an optional reset-time display for the selected quota metric, with percent fallback when reset metadata is unavailable (#1223, fixes #1185). Thanks @Yuxin-Qiao!
 - Menu bar: move the highlighted Overview provider with trackpad or mouse-wheel scrolling while preserving native submenu and keyboard behavior (#1436). Thanks @joshuavial!
 
 ### Fixed

--- a/Sources/CodexBar/MenuBarDisplayMode.swift
+++ b/Sources/CodexBar/MenuBarDisplayMode.swift
@@ -5,6 +5,7 @@ enum MenuBarDisplayMode: String, CaseIterable, Identifiable {
     case percent
     case pace
     case both
+    case resetTime
 
     var id: String {
         self.rawValue
@@ -15,6 +16,7 @@ enum MenuBarDisplayMode: String, CaseIterable, Identifiable {
         case .percent: L("display_mode_percent")
         case .pace: L("display_mode_pace")
         case .both: L("display_mode_both")
+        case .resetTime: L("display_mode_reset_time")
         }
     }
 
@@ -23,6 +25,7 @@ enum MenuBarDisplayMode: String, CaseIterable, Identifiable {
         case .percent: L("display_mode_percent_desc")
         case .pace: L("display_mode_pace_desc")
         case .both: L("display_mode_both_desc")
+        case .resetTime: L("display_mode_reset_time_desc")
         }
     }
 }

--- a/Sources/CodexBar/MenuBarDisplayText.swift
+++ b/Sources/CodexBar/MenuBarDisplayText.swift
@@ -20,7 +20,9 @@ enum MenuBarDisplayText {
         mode: MenuBarDisplayMode,
         percentWindow: RateWindow?,
         pace: UsagePace? = nil,
-        showUsed: Bool) -> String?
+        showUsed: Bool,
+        resetTimeDisplayStyle: ResetTimeDisplayStyle = .countdown,
+        now: Date = .init()) -> String?
     {
         switch mode {
         case .percent:
@@ -32,6 +34,39 @@ enum MenuBarDisplayText {
             // Fall back to percent-only when pace is unavailable (e.g. Copilot)
             guard let paceText = Self.paceText(pace: pace) else { return percent }
             return "\(percent) · \(paceText)"
+        case .resetTime:
+            guard let percentWindow else { return nil }
+            if let resetsAt = percentWindow.resetsAt {
+                let description = switch resetTimeDisplayStyle {
+                case .countdown:
+                    UsageFormatter.resetCountdownDescription(from: resetsAt, now: now)
+                case .absolute:
+                    UsageFormatter.resetDescription(from: resetsAt, now: now)
+                }
+                return "↻ \(description)"
+            }
+            if let resetDescription = self.resetMetadataText(percentWindow.resetDescription) {
+                return "↻ \(resetDescription)"
+            }
+            return self.percentText(window: percentWindow, showUsed: showUsed)
         }
+    }
+
+    private static func resetMetadataText(_ description: String?) -> String? {
+        guard let description else { return nil }
+        let trimmed = description.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        // RateWindow.resetDescription predates provider-specific detail fields and is also used for
+        // request/token summaries. Only trust phrases that explicitly describe reset timing.
+        let normalized = trimmed.lowercased()
+        let resetPrefixes = [
+            "reset ", "resets ", "in ", "today ", "today,", "tomorrow ", "tomorrow,", "next ",
+            "expire ", "expires ", "refill ", "refills ",
+        ]
+        let exactResetDescriptions = ["today", "tomorrow", "expired", "now", "soon"]
+        return exactResetDescriptions.contains(normalized) || resetPrefixes.contains(where: normalized.hasPrefix)
+            ? trimmed
+            : nil
     }
 }

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -611,9 +611,11 @@
 "display_mode_percent" = "Percentatge";
 "display_mode_pace" = "Ritme";
 "display_mode_both" = "Tots dos";
+"display_mode_reset_time" = "Temps de reinici";
 "display_mode_percent_desc" = "Mostra el percentatge restant/usat (p. ex. 45 %)";
 "display_mode_pace_desc" = "Mostra l'indicador de ritme (p. ex. +5 %)";
 "display_mode_both_desc" = "Mostra el percentatge i el ritme (p. ex. 45 % · +5 %)";
+"display_mode_reset_time_desc" = "Mostra l'hora de reinici de la mètrica seleccionada (p. ex. ↻ 3:56 PM)";
 
 /* Provider status */
 "status_operational" = "Operatiu";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -624,9 +624,11 @@
 "display_mode_percent" = "Percent";
 "display_mode_pace" = "Pace";
 "display_mode_both" = "Both";
+"display_mode_reset_time" = "Reset time";
 "display_mode_percent_desc" = "Show remaining/used percentage (e.g. 45%)";
 "display_mode_pace_desc" = "Show pace indicator (e.g. +5%)";
 "display_mode_both_desc" = "Show both percentage and pace (e.g. 45% · +5%)";
+"display_mode_reset_time_desc" = "Show the reset time for the selected metric (e.g. ↻ 3:56 PM)";
 
 /* Provider status */
 "status_operational" = "Operational";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -611,9 +611,11 @@
 "display_mode_percent" = "Porcentaje";
 "display_mode_pace" = "Ritmo";
 "display_mode_both" = "Ambos";
+"display_mode_reset_time" = "Tiempo de restablecimiento";
 "display_mode_percent_desc" = "Mostrar el porcentaje restante/usado (p. ej. 45 %)";
 "display_mode_pace_desc" = "Mostrar el indicador de ritmo (p. ej. +5 %)";
 "display_mode_both_desc" = "Mostrar porcentaje y ritmo (p. ej. 45 % · +5 %)";
+"display_mode_reset_time_desc" = "Mostrar el tiempo de restablecimiento de la métrica seleccionada (p. ej. ↻ 3:56 PM)";
 
 /* Provider status */
 "status_operational" = "Operativo";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -623,9 +623,11 @@
 "display_mode_percent" = "Pourcentage";
 "display_mode_pace" = "Rythme";
 "display_mode_both" = "Les deux";
+"display_mode_reset_time" = "Heure de réinitialisation";
 "display_mode_percent_desc" = "Afficher le pourcentage restant/utilisé (par exemple 45 %)";
 "display_mode_pace_desc" = "Afficher l'indicateur d'allure (par exemple +5 %)";
 "display_mode_both_desc" = "Afficher à la fois le pourcentage et le rythme (par exemple 45 % · +5 %)";
+"display_mode_reset_time_desc" = "Afficher l'heure de réinitialisation de la métrique sélectionnée (par exemple ↻ 15:56)";
 
 /* Provider status */
 "status_operational" = "Opérationnel";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -622,9 +622,11 @@
 "display_mode_percent" = "パーセント";
 "display_mode_pace" = "ペース";
 "display_mode_both" = "両方";
+"display_mode_reset_time" = "リセット時刻";
 "display_mode_percent_desc" = "残り/使用済みのパーセンテージを表示（例: 45%）";
 "display_mode_pace_desc" = "ペースインジケータを表示（例: +5%）";
 "display_mode_both_desc" = "パーセンテージとペースの両方を表示（例: 45% · +5%）";
+"display_mode_reset_time_desc" = "選択した指標のリセット時刻を表示（例: ↻ 15:56）";
 
 /* Provider status */
 "status_operational" = "正常稼働中";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -623,9 +623,11 @@
 "display_mode_percent" = "Procent";
 "display_mode_pace" = "Tempo";
 "display_mode_both" = "Beide";
+"display_mode_reset_time" = "Resettijd";
 "display_mode_percent_desc" = "Toon resterend/gebruikt percentage (bijvoorbeeld 45%)";
 "display_mode_pace_desc" = "Toon tempo-indicator (bijv. +5%)";
 "display_mode_both_desc" = "Toon zowel percentage als tempo (bijvoorbeeld 45% · +5%)";
+"display_mode_reset_time_desc" = "Toon de resettijd voor de geselecteerde metriek (bijvoorbeeld ↻ 15:56)";
 
 /* Provider status */
 "status_operational" = "Operationeel";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -622,9 +622,11 @@
 "display_mode_percent" = "Porcentagem";
 "display_mode_pace" = "Ritmo";
 "display_mode_both" = "Ambos";
+"display_mode_reset_time" = "Tempo de redefinição";
 "display_mode_percent_desc" = "Mostra a porcentagem restante/usada (ex.: 45%)";
 "display_mode_pace_desc" = "Mostra o indicador de ritmo (ex.: +5%)";
 "display_mode_both_desc" = "Mostra porcentagem e ritmo (ex.: 45% · +5%)";
+"display_mode_reset_time_desc" = "Mostra o tempo de redefinição da métrica selecionada (ex.: ↻ 3:56 PM)";
 
 /* Provider status */
 "status_operational" = "Operacional";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -622,9 +622,11 @@
 "display_mode_percent" = "Procent";
 "display_mode_pace" = "Takt";
 "display_mode_both" = "Båda";
+"display_mode_reset_time" = "Återställningstid";
 "display_mode_percent_desc" = "Visa återstående/förbrukad procent (t.ex. 45 %)";
 "display_mode_pace_desc" = "Visa taktindikator (t.ex. +5 %)";
 "display_mode_both_desc" = "Visa både procent och takt (t.ex. 45 % · +5 %)";
+"display_mode_reset_time_desc" = "Visa återställningstiden för valt mått (t.ex. ↻ 3:56 PM)";
 
 /* Provider status */
 "status_operational" = "Fungerar normalt";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -623,9 +623,11 @@
 "display_mode_percent" = "Відсоток";
 "display_mode_pace" = "Темп";
 "display_mode_both" = "Обидва";
+"display_mode_reset_time" = "Час скидання";
 "display_mode_percent_desc" = "Показати залишок/використаний відсоток (наприклад, 45%)";
 "display_mode_pace_desc" = "Показати індикатор темпу (наприклад, +5%)";
 "display_mode_both_desc" = "Показати відсоток і темп (наприклад, 45% · +5%)";
+"display_mode_reset_time_desc" = "Показувати час скидання для вибраного показника (наприклад, ↻ 15:56)";
 
 /* Provider status */
 "status_operational" = "Працює";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -622,9 +622,11 @@
 "display_mode_percent" = "Phần trăm";
 "display_mode_pace" = "Tốc độ";
 "display_mode_both" = "Cả hai";
+"display_mode_reset_time" = "Thời gian đặt lại";
 "display_mode_percent_desc" = "Hiển thị phần trăm còn lại/đã sử dụng (ví dụ: 45%)";
 "display_mode_pace_desc" = "Hiển thị chỉ báo tốc độ (ví dụ: +5%)";
 "display_mode_both_desc" = "Hiển thị cả phần trăm và tốc độ (ví dụ: 45% · +5%)";
+"display_mode_reset_time_desc" = "Hiển thị thời gian đặt lại của chỉ số đã chọn (ví dụ: ↻ 15:56)";
 
 /* Provider status */
 "status_operational" = "Hoạt động";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -601,9 +601,11 @@
 "display_mode_percent" = "百分比";
 "display_mode_pace" = "进度";
 "display_mode_both" = "两者";
+"display_mode_reset_time" = "重置时间";
 "display_mode_percent_desc" = "显示剩余/已使用百分比（例如 45%）";
 "display_mode_pace_desc" = "显示进度指示器（例如 +5%）";
 "display_mode_both_desc" = "同时显示百分比和进度（例如 45% · +5%）";
+"display_mode_reset_time_desc" = "显示所选指标的重置时间（例如 ↻ 3:56 PM）";
 "status_operational" = "正常运行";
 "status_partial_outage" = "部分中断";
 "status_major_outage" = "重大中断";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -612,9 +612,11 @@
 "display_mode_percent" = "百分比";
 "display_mode_pace" = "進度";
 "display_mode_both" = "兩者";
+"display_mode_reset_time" = "重置時間";
 "display_mode_percent_desc" = "顯示剩餘/已使用百分比（例如 45%）";
 "display_mode_pace_desc" = "顯示進度指示器（例如 +5%）";
 "display_mode_both_desc" = "同時顯示百分比和進度（例如 45% · +5%）";
+"display_mode_reset_time_desc" = "顯示所選指標的重置時間（例如 ↻ 3:56 PM）";
 "status_operational" = "運作正常";
 "status_partial_outage" = "部分服務中斷";
 "status_major_outage" = "重大服務中斷";

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -691,6 +691,7 @@ extension StatusItemController {
     }
 
     func menuBarDisplayText(for provider: UsageProvider, snapshot: UsageSnapshot?) -> String? {
+        let mode = self.settings.menuBarDisplayMode
         if provider == .openrouter,
            self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot) == .automatic,
            let balance = snapshot?.openRouterUsage?.balance
@@ -723,14 +724,14 @@ extension StatusItemController {
                 mode: self.settings.kiroMenuBarDisplayMode,
                 showUsed: self.settings.usageBarsShowUsed)
         }
-        if self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot) == .extraUsage,
+        if mode != .resetTime,
+           self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot) == .extraUsage,
            let spend = Self.extraUsageSpendDisplayText(snapshot: snapshot)
         {
             return spend
         }
 
         let percentWindow = self.menuBarPercentWindow(for: provider, snapshot: snapshot)
-        let mode = self.settings.menuBarDisplayMode
         let now = Date()
         let codexProjection = self.store.codexConsumerProjectionIfNeeded(
             for: provider,
@@ -753,6 +754,13 @@ extension StatusItemController {
             pace = paceWindow.flatMap { window in
                 self.store.weeklyPace(provider: provider, window: window, now: now)
             }
+        case .resetTime:
+            return MenuBarDisplayText.displayText(
+                mode: mode,
+                percentWindow: percentWindow,
+                showUsed: self.settings.usageBarsShowUsed,
+                resetTimeDisplayStyle: self.settings.resetTimeDisplayStyle,
+                now: now)
         }
         let displayText = MenuBarDisplayText.displayText(
             mode: mode,

--- a/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
+++ b/Sources/CodexBar/StatusItemController+CountdownRefresh.swift
@@ -1,0 +1,67 @@
+import CodexBarCore
+import Foundation
+
+extension StatusItemController {
+    private nonisolated static let menuBarCountdownRefreshEpsilon: TimeInterval = 0.05
+
+    func scheduleMenuBarCountdownRefreshIfNeeded(now: Date = .init()) {
+        self.menuBarCountdownRefreshTask?.cancel()
+        self.menuBarCountdownRefreshTask = nil
+
+        guard self.settings.menuBarShowsBrandIconWithPercent,
+              self.settings.menuBarDisplayMode == .resetTime,
+              self.settings.resetTimeDisplayStyle == .countdown
+        else {
+            return
+        }
+
+        let resetDates = self.menuBarCountdownProviders().compactMap { provider in
+            self.menuBarMetricWindow(
+                for: provider,
+                snapshot: self.store.snapshot(for: provider))?.resetsAt
+        }
+        guard let delay = Self.menuBarCountdownRefreshDelay(resetDates: resetDates, now: now) else {
+            return
+        }
+
+        self.menuBarCountdownRefreshTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: .seconds(delay))
+            } catch {
+                return
+            }
+            guard let self, !Task.isCancelled else { return }
+            self.menuBarCountdownRefreshTask = nil
+            self.updateIcons()
+        }
+    }
+
+    nonisolated static func menuBarCountdownRefreshDelay(
+        resetDates: [Date],
+        now: Date)
+        -> TimeInterval?
+    {
+        resetDates.compactMap { resetDate -> TimeInterval? in
+            let remaining = resetDate.timeIntervalSince(now)
+            guard remaining > 0 else { return nil }
+            let displayedMinutes = ceil(remaining / 60)
+            let nextBoundaryRemaining = max(0, displayedMinutes - 1) * 60
+            return max(
+                self.menuBarCountdownRefreshEpsilon,
+                remaining - nextBoundaryRemaining + self.menuBarCountdownRefreshEpsilon)
+        }.min()
+    }
+
+    private func menuBarCountdownProviders() -> [UsageProvider] {
+        if self.shouldMergeIcons {
+            return [self.primaryProviderForUnifiedIcon()]
+        }
+        return UsageProvider.allCases.filter(self.isVisible)
+    }
+
+    #if DEBUG
+    func _test_isMenuBarCountdownRefreshScheduled() -> Bool {
+        self.menuBarCountdownRefreshTask != nil
+    }
+    #endif
+}

--- a/Sources/CodexBar/StatusItemController+Shutdown.swift
+++ b/Sources/CodexBar/StatusItemController+Shutdown.swift
@@ -24,6 +24,8 @@ extension StatusItemController {
     private func cancelShutdownTasks() {
         self.blinkTask?.cancel()
         self.blinkTask = nil
+        self.menuBarCountdownRefreshTask?.cancel()
+        self.menuBarCountdownRefreshTask = nil
         self.loginTask?.cancel()
         self.loginTask = nil
         self.screenChangeVisibilityTask?.cancel()

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -183,6 +183,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         (@MainActor (TimeInterval) async -> CodexLoginRunner.Result)?
     #endif
     var blinkTask: Task<Void, Never>?
+    var menuBarCountdownRefreshTask: Task<Void, Never>?
     var loginTask: Task<Void, Never>? {
         didSet { self.refreshMenusForLoginStateChange() }
     }
@@ -660,6 +661,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         #if DEBUG
         guard !self.isReleasedForTesting else { return }
         #endif
+        self.scheduleMenuBarCountdownRefreshIfNeeded()
         self.lastObservedStoreIconWorkSignature = self.storeIconObservationSignature()
         self.beginIconPerfUpdatePass()
         defer { self.endIconPerfUpdatePass() }
@@ -893,6 +895,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             animationDriver?.stop()
         }
         self.blinkTask?.cancel()
+        self.menuBarCountdownRefreshTask?.cancel()
         self.loginTask?.cancel()
         self.screenChangeVisibilityTask?.cancel()
         self.pendingScreenChangePreviousCount = nil

--- a/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
+++ b/Tests/CodexBarTests/MenuBarCountdownRefreshTests.swift
@@ -1,0 +1,102 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct MenuBarCountdownRefreshTests {
+    @Test
+    func `countdown refresh delay follows the next displayed minute boundary`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+        let delay = StatusItemController.menuBarCountdownRefreshDelay(
+            resetDates: [
+                now.addingTimeInterval(2 * 3600 + 15 * 60 + 30),
+                now.addingTimeInterval(45),
+            ],
+            now: now)
+
+        #expect(abs((delay ?? 0) - 30.05) < 0.001)
+    }
+
+    @Test
+    func `countdown refresh ignores elapsed reset dates`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+        let delay = StatusItemController.menuBarCountdownRefreshDelay(
+            resetDates: [now.addingTimeInterval(-1)],
+            now: now)
+
+        #expect(delay == nil)
+    }
+
+    @Test
+    func `status item schedules countdown refresh only for countdown reset dates`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "MenuBarCountdownRefreshTests-scheduling"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.menuBarShowsBrandIconWithPercent = true
+        settings.menuBarDisplayMode = .resetTime
+        settings.resetTimesShowAbsolute = false
+        if let metadata = ProviderRegistry.shared.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: metadata, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 42,
+                    windowMinutes: 300,
+                    resetsAt: Date().addingTimeInterval(90),
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()),
+            provider: .codex)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        #expect(controller._test_isMenuBarCountdownRefreshScheduled())
+
+        settings.resetTimesShowAbsolute = true
+        controller.updateIcons()
+        #expect(!controller._test_isMenuBarCountdownRefreshScheduled())
+
+        settings.resetTimesShowAbsolute = false
+        store._setSnapshotForTesting(nil, provider: .codex)
+        controller.updateIcons()
+        #expect(!controller._test_isMenuBarCountdownRefreshScheduled())
+
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 42,
+                    windowMinutes: 300,
+                    resetsAt: Date().addingTimeInterval(90),
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()),
+            provider: .codex)
+        controller.updateIcons()
+        #expect(controller._test_isMenuBarCountdownRefreshScheduled())
+
+        controller.prepareForAppShutdown()
+        #expect(!controller._test_isMenuBarCountdownRefreshScheduled())
+    }
+}

--- a/Tests/CodexBarTests/MenuBarResetTimeDisplayTests.swift
+++ b/Tests/CodexBarTests/MenuBarResetTimeDisplayTests.swift
@@ -1,0 +1,136 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct MenuBarResetTimeDisplayTests {
+    @Test
+    func `reset time mode formats the selected window reset`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let resetsAt = now.addingTimeInterval(2 * 3600)
+        let window = RateWindow(
+            usedPercent: 42,
+            windowMinutes: 300,
+            resetsAt: resetsAt,
+            resetDescription: nil)
+
+        let text = MenuBarDisplayText.displayText(
+            mode: .resetTime,
+            percentWindow: window,
+            showUsed: true,
+            resetTimeDisplayStyle: .absolute,
+            now: now)
+
+        #expect(text == "↻ \(UsageFormatter.resetDescription(from: resetsAt, now: now))")
+    }
+
+    @Test
+    func `reset time mode uses countdown preference`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let resetsAt = now.addingTimeInterval(2 * 3600 + 15 * 60)
+        let window = RateWindow(
+            usedPercent: 42,
+            windowMinutes: 300,
+            resetsAt: resetsAt,
+            resetDescription: nil)
+
+        let text = MenuBarDisplayText.displayText(
+            mode: .resetTime,
+            percentWindow: window,
+            showUsed: true,
+            resetTimeDisplayStyle: .countdown,
+            now: now)
+
+        #expect(text == "↻ in 2h 15m")
+    }
+
+    @Test
+    func `reset time mode falls back to used percent without reset metadata`() {
+        let window = RateWindow(
+            usedPercent: 42,
+            windowMinutes: 300,
+            resetsAt: nil,
+            resetDescription: nil)
+
+        let text = MenuBarDisplayText.displayText(
+            mode: .resetTime,
+            percentWindow: window,
+            showUsed: true)
+
+        #expect(text == "42%")
+    }
+
+    @Test
+    func `reset time mode uses text reset metadata`() {
+        let window = RateWindow(
+            usedPercent: 42,
+            windowMinutes: 300,
+            resetsAt: nil,
+            resetDescription: "in 2h 15m")
+
+        let text = MenuBarDisplayText.displayText(
+            mode: .resetTime,
+            percentWindow: window,
+            showUsed: true)
+
+        #expect(text == "↻ in 2h 15m")
+    }
+
+    @Test(arguments: [
+        "Resets in 2h",
+        "tomorrow, 3:00 PM",
+        "next week",
+        "expires in 4d",
+    ])
+    func `reset time mode accepts reset timing phrases`(_ description: String) {
+        let window = RateWindow(
+            usedPercent: 42,
+            windowMinutes: 300,
+            resetsAt: nil,
+            resetDescription: description)
+
+        let text = MenuBarDisplayText.displayText(
+            mode: .resetTime,
+            percentWindow: window,
+            showUsed: true)
+
+        #expect(text == "↻ \(description)")
+    }
+
+    @Test(arguments: [
+        "250/1000 requests",
+        "160 requests",
+        "5 hours window",
+        "$10.00 available",
+    ])
+    func `reset time mode rejects non-reset provider summaries`(_ description: String) {
+        let window = RateWindow(
+            usedPercent: 42,
+            windowMinutes: 300,
+            resetsAt: nil,
+            resetDescription: description)
+
+        let text = MenuBarDisplayText.displayText(
+            mode: .resetTime,
+            percentWindow: window,
+            showUsed: true)
+
+        #expect(text == "42%")
+    }
+
+    @Test
+    func `reset time mode falls back to remaining percent without reset metadata`() {
+        let window = RateWindow(
+            usedPercent: 42,
+            windowMinutes: 300,
+            resetsAt: nil,
+            resetDescription: nil)
+
+        let text = MenuBarDisplayText.displayText(
+            mode: .resetTime,
+            percentWindow: window,
+            showUsed: false)
+
+        #expect(text == "58%")
+    }
+}

--- a/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
+++ b/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
@@ -32,6 +32,49 @@ struct StatusItemBalanceDisplayTests {
     }
 
     @Test
+    func `reset time mode preserves automatic open router balance`() {
+        let settings = self.makeSettings(
+            suiteName: "StatusItemBalanceDisplayTests-openrouter-reset-time",
+            provider: .openrouter)
+        settings.menuBarDisplayMode = .resetTime
+        settings.setMenuBarMetricPreference(.automatic, for: .openrouter)
+        let (store, controller) = self.makeStoreAndController(settings: settings)
+        let snapshot = Self.openRouterSnapshot()
+
+        store._setSnapshotForTesting(snapshot, provider: .openrouter)
+        store._setErrorForTesting(nil, provider: .openrouter)
+
+        let displayText = controller.menuBarDisplayText(for: .openrouter, snapshot: snapshot)
+
+        #expect(displayText == "$12.34")
+    }
+
+    @Test
+    func `reset time mode preserves balance when provider has no quota window`() {
+        let settings = self.makeSettings(
+            suiteName: "StatusItemBalanceDisplayTests-moonshot-reset-time",
+            provider: .moonshot)
+        settings.menuBarDisplayMode = .resetTime
+        let (store, controller) = self.makeStoreAndController(settings: settings)
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .moonshot,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "Balance: $49.58 · $0.42 in deficit"))
+
+        store._setSnapshotForTesting(snapshot, provider: .moonshot)
+        store._setErrorForTesting(nil, provider: .moonshot)
+
+        let displayText = controller.menuBarDisplayText(for: .moonshot, snapshot: snapshot)
+
+        #expect(displayText == "$49.58")
+    }
+
+    @Test
     func `menu bar display text respects open router primary metric preference`() {
         let settings = self.makeSettings(
             suiteName: "StatusItemBalanceDisplayTests-openrouter-primary-metric",

--- a/Tests/CodexBarTests/StatusItemExtraUsageMetricTests.swift
+++ b/Tests/CodexBarTests/StatusItemExtraUsageMetricTests.swift
@@ -125,11 +125,45 @@ struct StatusItemExtraUsageMetricTests {
         #expect(displayText == "72%")
     }
 
+    @Test
+    func `reset time mode uses extra usage reset instead of spend`() {
+        let resetsAt = Date().addingTimeInterval(2 * 24 * 3600)
+        let (store, controller) = self.makeController(
+            suiteName: "StatusItemExtraUsageMetricTests-reset-time",
+            provider: .cursor,
+            displayMode: .resetTime,
+            resetTimesShowAbsolute: true)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 12.34,
+                limit: 100,
+                currencyCode: "USD",
+                period: "Monthly",
+                resetsAt: resetsAt,
+                updatedAt: Date()),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .cursor)
+        store._setErrorForTesting(nil, provider: .cursor)
+
+        let displayText = controller.menuBarDisplayText(for: .cursor, snapshot: snapshot)
+
+        #expect(displayText == "↻ \(UsageFormatter.resetDescription(from: resetsAt))")
+    }
+
     private func makeCursorController(suiteName: String) -> (UsageStore, StatusItemController) {
         self.makeController(suiteName: suiteName, provider: .cursor)
     }
 
-    private func makeController(suiteName: String, provider: UsageProvider) -> (UsageStore, StatusItemController) {
+    private func makeController(
+        suiteName: String,
+        provider: UsageProvider,
+        displayMode: MenuBarDisplayMode = .percent,
+        resetTimesShowAbsolute: Bool = false) -> (UsageStore, StatusItemController)
+    {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: suiteName),
             zaiTokenStore: NoopZaiTokenStore())
@@ -137,7 +171,8 @@ struct StatusItemExtraUsageMetricTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
         settings.selectedMenuProvider = provider
-        settings.menuBarDisplayMode = .percent
+        settings.menuBarDisplayMode = displayMode
+        settings.resetTimesShowAbsolute = resetTimesShowAbsolute
         settings.usageBarsShowUsed = true
         settings.setMenuBarMetricPreference(.extraUsage, for: provider)
 


### PR DESCRIPTION
Related issue: #1185 — Shows reset time in menu bar

Summary:
- Add an opt-in menu bar metric for displaying the current reset time.
- Reuse existing reset metadata and fall back cleanly when no reset time is available.
- Keep the change display-only without adding provider fetching or network behavior.
- Align Reset time support with the reset-bearing lane used for display.
- Add the Reset time picker label to all bundled localizations.

Validation:
- ./Scripts/lint.sh lint
- swift build
- swift test --filter StatusItemResetTimeDisplayTests
- swift test --filter "StatusItemBalanceDisplayTests|StatusItemExtraUsageMetricTests|MenuBarMetricWindowResolverTests"
- swift test --filter Preferences

Proof:
- Local validation passed.
- CI will rerun on the amended commit.
- Visual app proof still to be added separately.