### PR TITLE
Add configurable terminal app for Open Terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.32.6 — Unreleased
 
+### Added
+- Settings: choose Terminal.app or iTerm for Open Terminal actions, including Vertex AI login commands (#1225, fixes #1147). Thanks @Yuxin-Qiao!
+
 ### Fixed
 - Doubao: confirm zero-remaining HTTP 200 request limits before falling back, preserving genuine exhaustion and avoiding false 100% usage (#1383). Thanks @LeoLin990405 and @foobra!
 - Menu bar: defer pasteboard writes and copy feedback outside the `NSMenu` tracking callback so in-menu copy buttons no longer beachball on macOS 26 (#1388). Thanks @LeoLin990405!

--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -74,6 +74,26 @@ struct GeneralPane: View {
                         }
                     }
 
+                    HStack(alignment: .top, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(L("terminal_app_title"))
+                                .font(.body)
+                            Text(L("terminal_app_subtitle"))
+                                .font(.footnote)
+                                .foregroundStyle(.tertiary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        Spacer()
+                        Picker(L("terminal_app_title"), selection: self.$settings.terminalApp) {
+                            ForEach(TerminalApp.allCases) { option in
+                                Text(option.label).tag(option)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                        .frame(maxWidth: 200)
+                    }
+
                     PreferenceToggleRow(
                         title: L("start_at_login_title"),
                         subtitle: L("start_at_login_subtitle"),

--- a/Sources/CodexBar/Providers/VertexAI/VertexAILoginFlow.swift
+++ b/Sources/CodexBar/Providers/VertexAI/VertexAILoginFlow.swift
@@ -16,7 +16,8 @@ extension StatusItemController {
         let response = alert.runModal()
 
         if response == .alertFirstButtonReturn {
-            Self.openTerminalWithGcloudCommand()
+            self.openTerminal(
+                command: "gcloud auth application-default login --scopes=openid,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform")
         }
 
         // Refresh after user may have logged in
@@ -24,25 +25,6 @@ extension StatusItemController {
         Task { @MainActor in
             try? await Task.sleep(for: .seconds(2))
             await self.store.refresh()
-        }
-    }
-
-    private static func openTerminalWithGcloudCommand() {
-        let script = """
-        tell application "Terminal"
-            activate
-            do script "gcloud auth application-default login --scopes=openid,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform"
-        end tell
-        """
-
-        if let appleScript = NSAppleScript(source: script) {
-            var error: NSDictionary?
-            appleScript.executeAndReturnError(&error)
-            if let error {
-                CodexBarLog.logger(LogCategories.terminal).error(
-                    "Failed to open Terminal",
-                    metadata: ["error": String(describing: error)])
-            }
         }
     }
 }

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -305,6 +305,8 @@
 "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar." = "Symlink CodexBarCLI to /usr/local/bin and /opt/homebrew/bin as codexbar.";
 "System" = "System";
 "Temporarily shows the loading animation after the next refresh." = "Temporarily shows the loading animation after the next refresh.";
+"terminal_app_subtitle" = "Terminal used by the Open Terminal action";
+"terminal_app_title" = "Default Terminal";
 "Tertiary (\\(label))" = "Tertiary (\\(label))";
 "Tertiary (\\(tertiaryTitle))" = "Tertiary (\\(tertiaryTitle))";
 "The default Codex account on this Mac." = "The default Codex account on this Mac.";

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -662,6 +662,14 @@ extension SettingsStore {
         get { self.debugLoadingPatternRaw.flatMap(LoadingPattern.init(rawValue:)) }
         set { self.debugLoadingPatternRaw = newValue?.rawValue }
     }
+
+    var terminalApp: TerminalApp {
+        get { TerminalApp(rawValue: self.defaultsState.terminalAppRaw ?? "") ?? .terminal }
+        set {
+            self.defaultsState.terminalAppRaw = newValue.rawValue
+            self.userDefaults.set(newValue.rawValue, forKey: "terminalApp")
+        }
+    }
 }
 
 extension SettingsStore {

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -399,7 +399,6 @@ extension SettingsStore {
         let selectedMenuProviderRaw = userDefaults.string(forKey: "selectedMenuProvider")
         let providerDetectionCompleted = userDefaults.object(forKey: "providerDetectionCompleted") as? Bool ?? false
         let appLanguageRaw = userDefaults.string(forKey: "appLanguage")
-
         return SettingsDefaultsState(
             refreshFrequency: refreshFrequency,
             launchAtLogin: launchAtLogin,
@@ -449,7 +448,8 @@ extension SettingsStore {
             mergedOverviewSelectedProvidersRaw: mergedOverviewSelectedProvidersRaw,
             selectedMenuProviderRaw: selectedMenuProviderRaw,
             providerDetectionCompleted: providerDetectionCompleted,
-            appLanguageRaw: appLanguageRaw)
+            appLanguageRaw: appLanguageRaw,
+            terminalAppRaw: userDefaults.string(forKey: "terminalApp"))
     }
 
     private static func loadMenuBarMetricPreferences(userDefaults: UserDefaults) -> [String: String] {

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -50,4 +50,5 @@ struct SettingsDefaultsState {
     var selectedMenuProviderRaw: String?
     var providerDetectionCompleted: Bool
     var appLanguageRaw: String?
+    var terminalAppRaw: String?
 }

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -351,7 +351,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         }
     }
 
-    private func openTerminal(command: String) {
+    func openTerminal(command: String) {
         let terminal = self.settings.terminalApp
         let escaped = command
             .replacingOccurrences(of: "\\", with: "\\\\")

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -187,7 +187,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
 
     @objc func openTerminalCommand(_ sender: NSMenuItem) {
         let command = sender.representedObject as? String ?? "claude"
-        Self.openTerminal(command: command)
+        self.openTerminal(command: command)
     }
 
     @objc func openLoginToProvider(_ sender: NSMenuItem) {
@@ -351,25 +351,73 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         }
     }
 
-    private static func openTerminal(command: String) {
+    private func openTerminal(command: String) {
+        let terminal = self.settings.terminalApp
         let escaped = command
-            .replacingOccurrences(of: "\\\\", with: "\\\\\\\\")
+            .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
+
+        if terminal == .iTerm, !terminal.isInstalled {
+            CodexBarLog.logger(LogCategories.terminal).warning(
+                "iTerm is not installed, falling back to Terminal.app",
+                metadata: ["terminal": terminal.rawValue])
+            Self.openTerminalInDefaultTerminal(escaped: escaped)
+            return
+        }
+
+        let script = switch terminal {
+        case .terminal:
+            """
+            tell application "Terminal"
+                activate
+                do script "\(escaped)"
+            end tell
+            """
+        case .iTerm:
+            """
+            tell application "iTerm"
+                activate
+                set newWindow to (create window with default profile)
+                tell current session of newWindow
+                    write text "\(escaped)"
+                end tell
+            end tell
+            """
+        }
+
+        if !Self.executeAppleScript(script) {
+            CodexBarLog.logger(LogCategories.terminal).warning(
+                "\(terminal.label) AppleScript failed, falling back to Terminal.app",
+                metadata: ["terminal": terminal.rawValue])
+            Self.openTerminalInDefaultTerminal(escaped: escaped)
+        }
+    }
+
+    private static func openTerminalInDefaultTerminal(escaped: String) {
         let script = """
         tell application "Terminal"
             activate
             do script "\(escaped)"
         end tell
         """
-        if let appleScript = NSAppleScript(source: script) {
+        Self.executeAppleScript(script)
+    }
+
+    /// Executes an AppleScript and returns `true` on success, `false` on failure.
+    @discardableResult
+    private static func executeAppleScript(_ source: String) -> Bool {
+        if let appleScript = NSAppleScript(source: source) {
             var error: NSDictionary?
             appleScript.executeAndReturnError(&error)
             if let error {
                 CodexBarLog.logger(LogCategories.terminal).error(
-                    "Failed to open Terminal",
+                    "Failed to execute AppleScript",
                     metadata: ["error": String(describing: error)])
+                return false
             }
+            return true
         }
+        return false
     }
 
     private func resolvedShortcutProvider() -> UsageProvider {

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -353,54 +353,28 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
 
     func openTerminal(command: String) {
         let terminal = self.settings.terminalApp
-        let escaped = command
-            .replacingOccurrences(of: "\\", with: "\\\\")
-            .replacingOccurrences(of: "\"", with: "\\\"")
 
         if terminal == .iTerm, !terminal.isInstalled {
             CodexBarLog.logger(LogCategories.terminal).warning(
                 "iTerm is not installed, falling back to Terminal.app",
                 metadata: ["terminal": terminal.rawValue])
-            Self.openTerminalInDefaultTerminal(escaped: escaped)
+            Self.openTerminalInDefaultTerminal(command: command)
             return
         }
 
-        let script = switch terminal {
-        case .terminal:
-            """
-            tell application "Terminal"
-                activate
-                do script "\(escaped)"
-            end tell
-            """
-        case .iTerm:
-            """
-            tell application "iTerm"
-                activate
-                set newWindow to (create window with default profile)
-                tell current session of newWindow
-                    write text "\(escaped)"
-                end tell
-            end tell
-            """
+        if Self.executeAppleScript(terminal.appleScript(command: command)) {
+            return
         }
+        guard terminal != .terminal else { return }
 
-        if !Self.executeAppleScript(script) {
-            CodexBarLog.logger(LogCategories.terminal).warning(
-                "\(terminal.label) AppleScript failed, falling back to Terminal.app",
-                metadata: ["terminal": terminal.rawValue])
-            Self.openTerminalInDefaultTerminal(escaped: escaped)
-        }
+        CodexBarLog.logger(LogCategories.terminal).warning(
+            "\(terminal.label) AppleScript failed, falling back to Terminal.app",
+            metadata: ["terminal": terminal.rawValue])
+        Self.openTerminalInDefaultTerminal(command: command)
     }
 
-    private static func openTerminalInDefaultTerminal(escaped: String) {
-        let script = """
-        tell application "Terminal"
-            activate
-            do script "\(escaped)"
-        end tell
-        """
-        Self.executeAppleScript(script)
+    private static func openTerminalInDefaultTerminal(command: String) {
+        self.executeAppleScript(TerminalApp.terminal.appleScript(command: command))
     }
 
     /// Executes an AppleScript and returns `true` on success, `false` on failure.
@@ -417,6 +391,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             }
             return true
         }
+        CodexBarLog.logger(LogCategories.terminal).error("Failed to compile AppleScript")
         return false
     }
 

--- a/Sources/CodexBar/TerminalApp.swift
+++ b/Sources/CodexBar/TerminalApp.swift
@@ -1,0 +1,28 @@
+import AppKit
+
+enum TerminalApp: String, CaseIterable, Identifiable {
+    case terminal
+    case iTerm
+
+    var id: String {
+        self.rawValue
+    }
+
+    var label: String {
+        switch self {
+        case .terminal: "Terminal"
+        case .iTerm: "iTerm"
+        }
+    }
+
+    var bundleIdentifier: String {
+        switch self {
+        case .terminal: "com.apple.Terminal"
+        case .iTerm: "com.googlecode.iterm2"
+        }
+    }
+
+    var isInstalled: Bool {
+        NSWorkspace.shared.urlForApplication(withBundleIdentifier: self.bundleIdentifier) != nil
+    }
+}

--- a/Sources/CodexBar/TerminalApp.swift
+++ b/Sources/CodexBar/TerminalApp.swift
@@ -25,4 +25,33 @@ enum TerminalApp: String, CaseIterable, Identifiable {
     var isInstalled: Bool {
         NSWorkspace.shared.urlForApplication(withBundleIdentifier: self.bundleIdentifier) != nil
     }
+
+    func appleScript(command: String) -> String {
+        let escaped = Self.escapeForAppleScript(command)
+        return switch self {
+        case .terminal:
+            """
+            tell application "Terminal"
+                activate
+                do script "\(escaped)"
+            end tell
+            """
+        case .iTerm:
+            """
+            tell application "iTerm"
+                activate
+                set newWindow to (create window with default profile)
+                tell current session of newWindow
+                    write text "\(escaped)"
+                end tell
+            end tell
+            """
+        }
+    }
+
+    static func escapeForAppleScript(_ command: String) -> String {
+        command
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
 }

--- a/Tests/CodexBarTests/TerminalAppTests.swift
+++ b/Tests/CodexBarTests/TerminalAppTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+@Suite("TerminalApp")
+struct TerminalAppTests {
+    @Test
+    @MainActor
+    func `default is terminal`() throws {
+        let suite = "TerminalAppTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        #expect(store.terminalApp == .terminal)
+    }
+
+    @Test
+    @MainActor
+    func `setting terminal app persists it`() throws {
+        let suite = "TerminalAppTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        store.terminalApp = .iTerm
+        #expect(store.terminalApp == .iTerm)
+        #expect(defaults.string(forKey: "terminalApp") == "iTerm")
+    }
+
+    @Test
+    @MainActor
+    func `invalid stored value falls back to terminal`() throws {
+        let suite = "TerminalAppTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.set("nonexistent", forKey: "terminalApp")
+        let store = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        #expect(store.terminalApp == .terminal)
+    }
+
+    @Test
+    func `only two cases exist`() {
+        #expect(TerminalApp.allCases.count == 2)
+    }
+
+    @Test
+    func `all cases have unique bundle identifiers`() {
+        let ids = TerminalApp.allCases.map(\.bundleIdentifier)
+        #expect(Set(ids).count == TerminalApp.allCases.count)
+    }
+
+    @Test
+    func `all cases have non-empty labels`() {
+        for app in TerminalApp.allCases {
+            #expect(!app.label.isEmpty)
+        }
+    }
+
+    @Test
+    func `round-trip all cases through raw value`() {
+        for app in TerminalApp.allCases {
+            #expect(TerminalApp(rawValue: app.rawValue) == app)
+        }
+    }
+}

--- a/Tests/CodexBarTests/TerminalAppTests.swift
+++ b/Tests/CodexBarTests/TerminalAppTests.swift
@@ -72,4 +72,23 @@ struct TerminalAppTests {
             #expect(TerminalApp(rawValue: app.rawValue) == app)
         }
     }
+
+    @Test
+    func `escapes commands embedded in AppleScript strings`() {
+        let escaped = TerminalApp.escapeForAppleScript(#"echo "C:\tmp""#)
+
+        #expect(escaped == #"echo \"C:\\tmp\""#)
+    }
+
+    @Test
+    func `builds terminal-specific launch scripts`() {
+        let command = #"echo "hello""#
+        let terminalScript = TerminalApp.terminal.appleScript(command: command)
+        let iTermScript = TerminalApp.iTerm.appleScript(command: command)
+
+        #expect(terminalScript.contains(#"tell application "Terminal""#))
+        #expect(terminalScript.contains(#"do script "echo \"hello\"""#))
+        #expect(iTermScript.contains(#"tell application "iTerm""#))
+        #expect(iTermScript.contains(#"write text "echo \"hello\"""#))
+    }
 }


### PR DESCRIPTION
Summary:
- Add a General preference for choosing the terminal used by Open Terminal.
- Support Terminal.app and iTerm as reliable command-launch targets.
- Keep Terminal.app as the default and fall back when iTerm is unavailable or AppleScript execution fails.

Fixes #1147

Validation:
- swift build
- swift test --filter Terminal
- swift test --filter OpenTerminal
- swift test --filter Preferences