### PR TITLE
[security] fix(providers): require HTTPS for redirect cookies

### DIFF
--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
@@ -371,6 +371,7 @@ public struct AmpUsageFetcher: Sendable {
     }
 
     static func shouldAttachCookie(to url: URL?) -> Bool {
+        guard url?.scheme?.lowercased() == "https" else { return false }
         guard let host = url?.host?.lowercased() else { return false }
         if host == "ampcode.com" || host == "www.ampcode.com" { return true }
         return host.hasSuffix(".ampcode.com")

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
@@ -372,13 +372,17 @@ public struct AmpUsageFetcher: Sendable {
 
     static func shouldAttachCookie(to url: URL?) -> Bool {
         guard url?.scheme?.lowercased() == "https" else { return false }
+        return self.isAmpHost(url)
+    }
+
+    private static func isAmpHost(_ url: URL?) -> Bool {
         guard let host = url?.host?.lowercased() else { return false }
         if host == "ampcode.com" || host == "www.ampcode.com" { return true }
         return host.hasSuffix(".ampcode.com")
     }
 
     static func isLoginRedirect(_ url: URL) -> Bool {
-        guard self.shouldAttachCookie(to: url) else { return false }
+        guard self.isAmpHost(url) else { return false }
 
         let path = url.path.lowercased()
         let components = path.split(separator: "/").map(String.init)

--- a/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift
@@ -620,6 +620,7 @@ public struct OllamaUsageFetcher: Sendable {
     }
 
     static func shouldAttachCookie(to url: URL?) -> Bool {
+        guard url?.scheme?.lowercased() == "https" else { return false }
         guard let host = url?.host?.lowercased() else { return false }
         if host == "ollama.com" || host == "www.ollama.com" { return true }
         return host.hasSuffix(".ollama.com")

--- a/Tests/CodexBarTests/AmpUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AmpUsageFetcherTests.swift
@@ -29,6 +29,10 @@ struct AmpUsageFetcherTests {
         let signIn = try #require(URL(string: "https://ampcode.com/auth/sign-in?returnTo=%2Fsettings"))
         #expect(AmpUsageFetcher.isLoginRedirect(signIn))
 
+        let downgradedSignIn = try #require(URL(string: "http://ampcode.com/auth/sign-in?returnTo=%2Fsettings"))
+        #expect(AmpUsageFetcher.isLoginRedirect(downgradedSignIn))
+        #expect(!AmpUsageFetcher.shouldAttachCookie(to: downgradedSignIn))
+
         let sso = try #require(URL(string: "https://ampcode.com/auth/sso?returnTo=%2Fsettings"))
         #expect(AmpUsageFetcher.isLoginRedirect(sso))
 

--- a/Tests/CodexBarTests/AmpUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AmpUsageFetcherTests.swift
@@ -18,6 +18,13 @@ struct AmpUsageFetcherTests {
     }
 
     @Test
+    func `rejects non https amp urls`() {
+        #expect(!AmpUsageFetcher.shouldAttachCookie(to: URL(string: "http://ampcode.com/settings")))
+        #expect(!AmpUsageFetcher.shouldAttachCookie(to: URL(string: "http://www.ampcode.com")))
+        #expect(!AmpUsageFetcher.shouldAttachCookie(to: URL(string: "http://app.ampcode.com/path")))
+    }
+
+    @Test
     func `detects login redirects`() throws {
         let signIn = try #require(URL(string: "https://ampcode.com/auth/sign-in?returnTo=%2Fsettings"))
         #expect(AmpUsageFetcher.isLoginRedirect(signIn))

--- a/Tests/CodexBarTests/OllamaUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/OllamaUsageFetcherTests.swift
@@ -18,6 +18,13 @@ struct OllamaUsageFetcherTests {
     }
 
     @Test
+    func `rejects non https ollama urls`() {
+        #expect(!OllamaUsageFetcher.shouldAttachCookie(to: URL(string: "http://ollama.com/settings")))
+        #expect(!OllamaUsageFetcher.shouldAttachCookie(to: URL(string: "http://www.ollama.com")))
+        #expect(!OllamaUsageFetcher.shouldAttachCookie(to: URL(string: "http://app.ollama.com/path")))
+    }
+
+    @Test
     func `manual mode without valid header throws no session cookie`() {
         do {
             _ = try OllamaUsageFetcher.resolveManualCookieHeader(


### PR DESCRIPTION
## Summary
This PR tightens the redirect cookie boundary for the Amp and Ollama usage fetchers.

- Prevents imported browser session cookies from being attached when a provider redirect downgrades from HTTPS to HTTP.
- Keeps existing same-provider host checks for `ampcode.com` / `ollama.com` and their subdomains, but now requires the destination URL scheme to remain HTTPS before reattaching cookies.
- Adds regression coverage for HTTP redirects to the provider root, `www`, and subdomain hosts.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Amp/Ollama cookies could be reattached to same-provider HTTP redirect targets | A network attacker or compromised provider-controlled redirect target could receive imported browser session cookies over cleartext HTTP after a redirect | Medium |

## Before this PR
- `AmpUsageFetcher.RedirectDiagnostics` and `OllamaUsageFetcher.RedirectDiagnostics` manually reattached the imported browser cookie header on redirects when `shouldAttachCookie(to:)` accepted the destination host.
- The host check correctly rejected unrelated domains such as `ampcode.com.evil.com` and `ollama.com.evil.com`.
- The host check did not require HTTPS, so `http://ampcode.com/...`, `http://www.ampcode.com/...`, `http://app.ampcode.com/...`, and equivalent Ollama URLs were still treated as valid cookie destinations.

## After this PR
- `shouldAttachCookie(to:)` for both providers returns `false` unless the redirect destination scheme is HTTPS.
- HTTP downgrade redirects still proceed without the sensitive `Cookie` header attached.
- Tests now lock the HTTPS-only behavior for root, `www`, and subdomain provider URLs.

## Why this matters
CodexBar imports browser session cookies for these providers and manually controls whether those cookies are reattached during redirects. That makes the redirect allowlist a credential boundary. A redirect to cleartext HTTP should not carry the imported session cookie, even when the host remains under the provider domain, because the cookie would be exposed to the network path.

## How this differs from related issue/PR
This is the same class of redirect-cookie boundary already fixed for OpenCode Go in https://github.com/steipete/CodexBar/pull/979, but it affects different provider fetchers and a different guard implementation:

- OpenCode Go uses its own redirect guard delegate.
- Amp and Ollama each use `shouldAttachCookie(to:)` inside provider-specific redirect diagnostics.
- Their host checks were present, but the HTTPS scheme check was missing.

## Attack flow
```text
attacker can influence or intercept a provider redirect path
    -> Amp/Ollama usage fetch follows the redirect
        -> redirect destination remains under the provider host but downgrades to http://
            -> CodexBar manually reattaches the imported browser Cookie header
                -> session cookie is exposed over cleartext HTTP
```

## Affected code

| Issue | Files |
|-------|-------|
| HTTPS scheme was not required before reattaching provider cookies | `Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift`, `Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift` |

## Root cause
Amp/Ollama redirect cookie policy checked the destination host but did not check the destination scheme before manually setting the `Cookie` header.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Provider session cookie exposure on HTTP redirect downgrade | 5.9 Medium | `CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:N/A:N` |

Rationale:
- The user must run the provider usage fetch with imported browser cookies.
- Exploitation requires a redirect downgrade condition or network position that can observe cleartext HTTP.
- The primary impact is confidentiality loss of provider session cookies.

## Safe reproduction steps
1. Review the pre-patch `shouldAttachCookie(to:)` implementation for Amp or Ollama.
2. Evaluate it with a same-provider HTTP destination such as `http://app.ampcode.com/path` or `http://app.ollama.com/path`.
3. Observe that the pre-patch policy accepted those URLs because only the host was checked.
4. With this PR, the same HTTP destinations are rejected and the cookie header is not reattached.

## Changes in this PR
- Adds an HTTPS scheme guard to `AmpUsageFetcher.shouldAttachCookie(to:)` while keeping Amp login-redirect detection on the provider-host predicate.
- Adds an HTTPS scheme guard to `OllamaUsageFetcher.shouldAttachCookie(to:)`.
- Adds Amp regression tests for HTTP root, `www`, and subdomain URLs, plus HTTP login redirects that must still be classified as invalid-session redirects without reattaching cookies.
- Adds Ollama regression tests for HTTP root, `www`, and subdomain URLs.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Provider redirect policy | `Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift`, `Sources/CodexBarCore/Providers/Ollama/OllamaUsageFetcher.swift` | Require HTTPS before reattaching cookies |
| Regression tests | `Tests/CodexBarTests/AmpUsageFetcherTests.swift`, `Tests/CodexBarTests/OllamaUsageFetcherTests.swift` | Cover HTTP downgrade rejection |

## Maintainer impact
- Narrow provider-only behavior change.
- No changes to unrelated providers, configuration, UI, or cookie import code.
- Legitimate HTTPS redirects to existing accepted provider hosts remain allowed.
- HTTP downgrade redirects still work as normal network redirects, but without sensitive cookies.

## Fix rationale
The redirect destination scheme is the correct boundary to enforce because the sensitive operation is manually attaching an imported browser cookie to a new request. Keeping host checks and adding HTTPS preserves the existing allowlist while preventing cleartext credential exposure.

## Type of change
- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] `git diff --check`
- [x] Source invariant check confirmed both provider guards require HTTPS and both regression tests cover HTTP provider URLs
- [x] `./Scripts/lint.sh lint` completed SwiftFormat lint: `0/984 files require formatting`
- [ ] `swift test --filter 'AmpUsageFetcherTests|OllamaUsageFetcherTests'`
- [ ] SwiftLint strict pass

Executed with:
- `git diff --check`
- `python3 - <<'PY' ... source invariant checks ... PY`
- `./Scripts/lint.sh lint`
- `swift test --filter 'AmpUsageFetcherTests|OllamaUsageFetcherTests'`

Not completed locally:
- `swift test --filter 'AmpUsageFetcherTests|OllamaUsageFetcherTests'` was blocked before reaching these tests because the local Command Line Tools-only environment cannot load `PreviewsMacros` while compiling the `KeyboardShortcuts` dependency's `#Preview` declarations.
- SwiftLint strict was blocked in the same local environment by SourceKit loading failure: `Loading sourcekitdInProc.framework/Versions/A/sourcekitdInProc failed`.


## Post-review validation evidence
Addressed the review note that Amp login redirect detection must not inherit the HTTPS-only cookie policy. `AmpUsageFetcher` now separates provider host matching from cookie attachment:

- `isAmpHost(_:)` accepts Amp provider hosts independent of scheme for login-redirect classification.
- `shouldAttachCookie(to:)` still requires HTTPS before reattaching the imported Cookie header.
- Added a regression assertion for `http://ampcode.com/auth/sign-in?returnTo=...`: login redirect remains detected, but `shouldAttachCookie` is false.

Local stub redirect proof, with credentials redacted:

```text
redirect_to=http://ampcode.com/auth/sign-in?returnTo=%2Fsettings
  login_redirect=true
  reattach_cookie=false
  outgoing=Cookie: <none>
  action=abort invalid-session redirect
redirect_to=https://app.ampcode.com/settings
  login_redirect=false
  reattach_cookie=true
  outgoing=Cookie: <redacted>
  action=continue redirected request
redirect_to=http://app.ampcode.com/settings
  login_redirect=false
  reattach_cookie=false
  outgoing=Cookie: <none>
  action=continue redirected request
```

## Disclosure notes
- No production provider endpoints were tested.
- No real cookies or credentials are included in this PR.
- This PR only claims the redirect policy fix shown in code review and regression tests.