### PR TITLE
[security] fix(release): isolate notarization temp files

### DIFF
--- a/Scripts/sign-and-notarize.sh
+++ b/Scripts/sign-and-notarize.sh
@@ -17,8 +17,18 @@ if [[ -z "${APP_STORE_CONNECT_API_KEY_P8:-}" || -z "${APP_STORE_CONNECT_KEY_ID:-
   echo "Missing APP_STORE_CONNECT_* env vars (API key, key id, issuer id)." >&2
   exit 1
 fi
-echo "$APP_STORE_CONNECT_API_KEY_P8" | sed 's/\\n/\n/g' > /tmp/codexbar-api-key.p8
-trap 'rm -f /tmp/codexbar-api-key.p8 /tmp/${APP_NAME}Notarize.zip' EXIT
+
+NOTARIZATION_TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/codexbar-notarize.XXXXXX")
+chmod 700 "$NOTARIZATION_TEMP_DIR"
+API_KEY_PATH="$NOTARIZATION_TEMP_DIR/codexbar-api-key.p8"
+NOTARIZATION_ZIP="$NOTARIZATION_TEMP_DIR/${APP_NAME}Notarize.zip"
+trap 'rm -rf "$NOTARIZATION_TEMP_DIR"' EXIT
+
+(
+  umask 077
+  printf '%s' "$APP_STORE_CONNECT_API_KEY_P8" | sed 's/\\n/\n/g' > "$API_KEY_PATH"
+)
+chmod 600 "$API_KEY_PATH"
 
 ARCH_LIST=( ${ARCHES_VALUE} )
 for ARCH in "${ARCH_LIST[@]}"; do
@@ -52,11 +62,11 @@ codesign --force --timestamp --options runtime --sign "$APP_IDENTITY" \
   "$APP_BUNDLE"
 
 DITTO_BIN=${DITTO_BIN:-/usr/bin/ditto}
-"$DITTO_BIN" --norsrc -c -k --keepParent "$APP_BUNDLE" "/tmp/${APP_NAME}Notarize.zip"
+"$DITTO_BIN" --norsrc -c -k --keepParent "$APP_BUNDLE" "$NOTARIZATION_ZIP"
 
 echo "Submitting for notarization"
-xcrun notarytool submit "/tmp/${APP_NAME}Notarize.zip" \
-  --key /tmp/codexbar-api-key.p8 \
+xcrun notarytool submit "$NOTARIZATION_ZIP" \
+  --key "$API_KEY_PATH" \
   --key-id "$APP_STORE_CONNECT_KEY_ID" \
   --issuer "$APP_STORE_CONNECT_ISSUER_ID" \
   --wait


### PR DESCRIPTION
## Summary
This PR hardens the release notarization temporary-file boundary in `Scripts/sign-and-notarize.sh`.

- Replaces the predictable `/tmp/codexbar-api-key.p8` App Store Connect key path with a per-run `mktemp -d` workspace.
- Stores the notarization upload ZIP in the same private workspace instead of predictable `/tmp/${APP_NAME}Notarize.zip`.
- Creates the private key file under `umask 077`, explicitly keeps it `0600`, and removes the whole workspace on exit.
- Validates the behavior with a stubbed local notarization run that pre-creates the historical `/tmp` paths as symlinks and confirms they are not touched.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Predictable App Store Connect notarization key path in `/tmp` | A same-host process on a release machine can race or pre-place `/tmp/codexbar-api-key.p8` to read or capture the notarization private key used during release signing/notarization. | High |
| Predictable notarization ZIP path in `/tmp` | A same-host process can interfere with or capture the transient notarization archive path used before `notarytool submit`. | Medium |

## Before this PR

- The release script wrote `APP_STORE_CONNECT_API_KEY_P8` to `/tmp/codexbar-api-key.p8`.
- The key file was created at a fixed public path before cleanup ran.
- The notarization ZIP was also created at a predictable `/tmp/${APP_NAME}Notarize.zip` path.
- A pre-existing symlink or same-host watcher could target those names during a privileged release workflow.

## After this PR

- Each release run creates a fresh `codexbar-notarize.XXXXXX` directory with `0700` permissions.
- The notary API key is written only inside that private directory and is kept `0600`.
- The notarization ZIP is written inside the same private directory.
- The EXIT trap removes the private workspace instead of deleting fixed public paths.

## Why this matters

Release notarization runs with App Store Connect credentials that should not be exposed to other local users or untrusted same-host processes. Predictable names in a shared temporary directory are a common source of symlink and race issues; on a CI or release host, that can turn a transient secret into a durable credential leak.

The exposed credential is not the Developer ID signing certificate itself, so this PR does not claim a complete signing-key compromise. It does protect the notarization API key and the release archive staging path from predictable shared-directory access.

## Attack flow

```text
same-host process on release machine
    -> pre-creates or watches /tmp/codexbar-api-key.p8
        -> release script writes APP_STORE_CONNECT_API_KEY_P8 to that fixed path
            -> process captures the notary API private key before cleanup
```

## Affected code

| Issue | Files |
|-------|-------|
| Predictable notarization key and ZIP temporary paths | `Scripts/sign-and-notarize.sh` |

## Root cause

Predictable notarization key path:
- The script wrote a sensitive API key to a fixed path in a shared temporary directory.
- Cleanup happened only after the path had already been created and used.

Predictable notarization ZIP path:
- The script staged the notarization archive at a fixed shared-directory path.
- The path was not scoped to a per-run private workspace.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Predictable App Store Connect notarization key path | 7.3 High | `CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:N` |

Rationale:
- The attacker must already have local execution on the release host or CI runner, but the vulnerable path crosses into release credentials that are outside the attacker's normal authority.
- Confidentiality is high because the transient private key value can be captured.
- Integrity is limited because the leaked notary credential supports release/notarization workflows but is not, by itself, the Developer ID signing certificate.

## Safe reproduction steps

1. On the vulnerable version, pre-create a symlink at the historical key path:
   ```bash
   ln -sf /tmp/codexbar-captured-key /tmp/codexbar-api-key.p8
   ```
2. Run the release script with stubbed `swift`, `codesign`, `ditto`, `xcrun`, `spctl`, `stapler`, and `xattr` commands so no real Apple service is contacted.
3. Observe that the vulnerable script writes the fake `APP_STORE_CONNECT_API_KEY_P8` content through the predictable `/tmp/codexbar-api-key.p8` path.
4. On this patched branch, run the same harness with the same symlink already present.
5. Observe that `notarytool` receives a key path under a fresh `codexbar-notarize.XXXXXX` directory, the key is `0600`, the directory is `0700`, and the historical `/tmp` symlink remains untouched.

## Expected vulnerable behavior

- The vulnerable script creates or follows `/tmp/codexbar-api-key.p8` while handling `APP_STORE_CONNECT_API_KEY_P8`.
- A same-host process can target that fixed path before or during the release run.
- Cleanup does not prevent the key from being exposed during the release window.

## Changes in this PR

- Creates `NOTARIZATION_TEMP_DIR` with `mktemp -d` under `${TMPDIR:-/tmp}`.
- Applies `chmod 700` to the temporary workspace.
- Writes `API_KEY_PATH` inside that workspace under `umask 077` and explicitly keeps it `chmod 600`.
- Moves `NOTARIZATION_ZIP` into the same private workspace.
- Updates `xcrun notarytool submit` to use the private key and ZIP paths.
- Replaces fixed-path cleanup with removal of the per-run workspace.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Release hardening | `Scripts/sign-and-notarize.sh` | Uses a private per-run temporary directory for notarization key and ZIP staging. |

## Maintainer impact

- The patch is limited to the notarization release script.
- Signing, packaging, stapling, dSYM packaging, and final release artifact names are unchanged.
- Operators still provide the same `APP_STORE_CONNECT_*` environment variables.
- The temporary notary key and upload ZIP are now isolated from shared `/tmp` names.

## Fix rationale

A per-run private temporary directory is the narrowest durable boundary for this script: it removes predictable names, avoids symlink reuse at shared paths, keeps permissions explicit, and keeps the rest of the release workflow unchanged.

Using `mktemp -d` also lets the script clean up a single generated workspace rather than relying on fixed file names that could be attacker-controlled.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `bash -n Scripts/sign-and-notarize.sh`
- [x] Stubbed full-script release/notarization run with fake external tools and pre-existing historical `/tmp` symlinks.
- [x] Verified the notary key path is under `codexbar-notarize.XXXXXX`, key mode is `0600`, directory mode is `0700`, and `/tmp/codexbar-api-key.p8` is not created or followed.
- [x] Verified the script no longer contains references to the historical fixed `/tmp` key or notarization ZIP paths.
- [x] `git diff --check`

Executed with:
- `bash -n Scripts/sign-and-notarize.sh`
- Stubbed local harness for `Scripts/sign-and-notarize.sh` with `ARCHES=arm64`, fake Apple/tooling commands, and pre-created historical `/tmp` symlinks.
- `git grep -n -E '/tmp/(codexbar-api-key\.p8|\$\{APP_NAME\}Notarize\.zip|CodexBarNotarize\.zip)' -- Scripts/sign-and-notarize.sh`
- `git diff --check`

A real Apple notarization submission was not run because that would require live project release credentials and external service access.


## Redacted harness proof

The stubbed notarization harness uses fake `APP_STORE_CONNECT_*` values, fake Apple/tooling commands, and pre-created historical `/tmp` symlinks. No live Apple notarization service or real credentials are used.

```text
### stubbed notarization harness
$ ARCHES=arm64 APP_STORE_CONNECT_*=(fake values) DITTO_BIN=$FAKE_DITTO TMPDIR=$PRIVATE_TMP bash Scripts/sign-and-notarize.sh
stub swift build --arch arm64
stub package_app release
Signing with Developer ID Application: Peter Steinberger (Y5PE65HELJ)
stub codesign CodexBar.app/Contents/Helpers/CodexBarCLI
stub codesign CodexBar.app/Contents/Helpers/CodexBarClaudeWatchdog
stub codesign CodexBar.app
notarization_zip_path=$TMPDIR/codexbar-notarize.DWVZdi/CodexBarNotarize.zip
stub ditto wrote $TMPDIR/codexbar-notarize.DWVZdi/CodexBarNotarize.zip
Submitting for notarization
notarytool_key_path=$TMPDIR/codexbar-notarize.DWVZdi/codexbar-api-key.p8
notarytool_key_mode=600
notarytool_temp_dir_mode=700
notarytool_key_content=<redacted>_PRIVATE_KEY_LINE_1
<redacted>_PRIVATE_KEY_LINE_2
stub notarytool submit ok
Stapling ticket
stub xcrun stapler staple CodexBar.app
stub xattr -cr CodexBar.app
stub ditto wrote CodexBar-1.2.3-arm64.zip
stub spctl -a -t exec -vv CodexBar.app
stub stapler validate CodexBar.app
Packaging dSYM
stub ditto wrote CodexBar-1.2.3-arm64.dSYM.zip
Done: CodexBar-1.2.3-arm64.zip

### historical fixed-path symlink checks
historical_key_symlink_target_content=untouched-key-marker
historical_zip_symlink_target_content=untouched-zip-marker
historical_key_symlink_still_exists=true
historical_zip_symlink_still_exists=true
### cleanup check
private_temp_dirs_after_exit=0

### static validation
bash_n=ok
git_diff_check=ok
```

## Disclosure notes

- This PR is intentionally bounded to local release-host temporary-file handling.
- It does not claim remote code execution or Developer ID signing certificate compromise.
- It protects transient App Store Connect notarization credentials and release ZIP staging from predictable shared temporary paths.
- No unrelated files were changed.

