### PR TITLE
Retry failed startup usage refresh once

### DIFF
--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -234,6 +234,9 @@ final class UsageStore {
     @ObservationIgnored var managedCodexAccountsForStorageOverride: [ManagedCodexAccount]?
     @ObservationIgnored private var pathDebugRefreshTask: Task<Void, Never>?
     @ObservationIgnored var codexPlanHistoryBackfillTask: Task<Void, Never>?
+    @ObservationIgnored private(set) var startupRetryTask: Task<Void, Never>?
+    static var startupRetryDelay: Duration = .seconds(30)
+
     @ObservationIgnored let historicalUsageHistoryStore: HistoricalUsageHistoryStore
     @ObservationIgnored let planUtilizationHistoryStore: PlanUtilizationHistoryStore
     @ObservationIgnored let codexAccountUsageSnapshotStore: (any CodexAccountUsageSnapshotStoring)?
@@ -330,7 +333,10 @@ final class UsageStore {
         Task { @MainActor [weak self] in
             await self?.refreshHistoricalDatasetIfNeeded()
         }
-        Task { await self.refresh() }
+        Task { @MainActor [weak self] in
+            await self?.refresh()
+            self?.scheduleStartupRetryIfNeeded()
+        }
         self.startTimer()
         self.startTokenTimer()
     }
@@ -659,6 +665,23 @@ final class UsageStore {
         }
     }
 
+    func scheduleStartupRetryIfNeeded() {
+        guard self.startupRetryTask == nil else { return }
+        let providers = self.enabledProvidersForBackgroundWork()
+        guard providers
+            .contains(where: {
+                self
+                    .errors[$0] != nil ||
+                    (self.statuses[$0]?.indicator == .unknown && self.statuses[$0]?.updatedAt == nil)
+            }) else { return }
+        self.startupRetryTask = Task { @MainActor [weak self] in
+            defer { self?.startupRetryTask = nil }
+            do { try await Task.sleep(for: Self.startupRetryDelay) } catch { return }
+            guard !Task.isCancelled else { return }
+            await self?.refresh()
+        }
+    }
+
     private func scheduleTokenRefresh(force: Bool) {
         if force {
             self.tokenRefreshSequenceTask?.cancel()
@@ -701,6 +724,7 @@ final class UsageStore {
         self.tokenRefreshSequenceTask?.cancel()
         self.storageRefreshTask?.cancel()
         self.codexPlanHistoryBackfillTask?.cancel()
+        self.startupRetryTask?.cancel()
     }
 
     enum SessionQuotaWindowSource: String {

--- a/Tests/CodexBarTests/UsageStoreStartupRetryTests.swift
+++ b/Tests/CodexBarTests/UsageStoreStartupRetryTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import Testing
+@testable import CodexBar
+@testable import CodexBarCore
+
+@MainActor
+@Suite(.serialized)
+struct UsageStoreStartupRetryTests {
+    @Test
+    func `startup refresh failure schedules retry that recovers`() async throws {
+        let settings = try self.makeSettingsStore(
+            suite: "UsageStoreStartupRetryTests-retry-recovers")
+        settings.statusChecksEnabled = false
+        settings.openAIWebAccessEnabled = false
+
+        UsageStore.startupRetryDelay = .milliseconds(10)
+        defer { UsageStore.startupRetryDelay = .seconds(30) }
+
+        let store = self.makeStore(settings: settings)
+
+        store._test_providerRefreshOverride = { [store] _ in
+            store._setErrorForTesting(
+                "The Internet connection appears to be offline.", provider: .codex)
+        }
+        defer { store._test_providerRefreshOverride = nil }
+
+        await store.refresh()
+        #expect(store.errors[.codex] != nil)
+        #expect(store.snapshots[.codex] == nil)
+
+        store._test_providerRefreshOverride = { [store] _ in
+            store._setErrorForTesting(nil, provider: .codex)
+            store._setSnapshotForTesting(
+                UsageSnapshot(
+                    primary: RateWindow(
+                        usedPercent: 10,
+                        windowMinutes: 300,
+                        resetsAt: Date().addingTimeInterval(1800),
+                        resetDescription: nil),
+                    secondary: nil,
+                    tertiary: nil,
+                    updatedAt: Date(),
+                    identity: ProviderIdentitySnapshot(
+                        providerID: .codex,
+                        accountEmail: "test@example.com",
+                        accountOrganization: nil,
+                        loginMethod: "Plus Plan")),
+                provider: .codex)
+        }
+
+        store.scheduleStartupRetryIfNeeded()
+        let retryTask = try #require(store.startupRetryTask)
+        await retryTask.value
+
+        #expect(store.errors[.codex] == nil)
+        #expect(store.snapshots[.codex] != nil)
+    }
+
+    @Test
+    func `startup retry is not scheduled when refresh succeeds`() async throws {
+        let settings = try self.makeSettingsStore(
+            suite: "UsageStoreStartupRetryTests-no-retry-on-success")
+        settings.statusChecksEnabled = false
+        settings.openAIWebAccessEnabled = false
+
+        let store = self.makeStore(settings: settings)
+        store._test_providerRefreshOverride = { _ in }
+        defer { store._test_providerRefreshOverride = nil }
+
+        await store.refresh()
+        store.scheduleStartupRetryIfNeeded()
+        #expect(store.startupRetryTask == nil)
+    }
+
+    @Test
+    func `startup retry is not scheduled twice`() async throws {
+        let settings = try self.makeSettingsStore(
+            suite: "UsageStoreStartupRetryTests-no-duplicate-retry")
+        settings.statusChecksEnabled = false
+        settings.openAIWebAccessEnabled = false
+
+        let store = self.makeStore(settings: settings)
+
+        store._test_providerRefreshOverride = { [store] _ in
+            store._setErrorForTesting("Network error", provider: .codex)
+        }
+        defer { store._test_providerRefreshOverride = nil }
+
+        await store.refresh()
+
+        UsageStore.startupRetryDelay = .milliseconds(50)
+        defer { UsageStore.startupRetryDelay = .seconds(30) }
+
+        store.scheduleStartupRetryIfNeeded()
+        #expect(store.startupRetryTask != nil)
+
+        store.scheduleStartupRetryIfNeeded()
+        #expect(store.startupRetryTask != nil)
+
+        store.startupRetryTask?.cancel()
+    }
+
+    @Test
+    func `startup retry task is cleared after completion`() async throws {
+        let settings = try self.makeSettingsStore(
+            suite: "UsageStoreStartupRetryTests-task-cleared")
+        settings.statusChecksEnabled = false
+        settings.openAIWebAccessEnabled = false
+
+        UsageStore.startupRetryDelay = .milliseconds(10)
+        defer { UsageStore.startupRetryDelay = .seconds(30) }
+
+        let store = self.makeStore(settings: settings)
+
+        store._test_providerRefreshOverride = { [store] _ in
+            store._setErrorForTesting("Network error", provider: .codex)
+        }
+        defer { store._test_providerRefreshOverride = nil }
+
+        await store.refresh()
+
+        store._test_providerRefreshOverride = { _ in }
+
+        store.scheduleStartupRetryIfNeeded()
+        #expect(store.startupRetryTask != nil)
+
+        let retryTask = try #require(store.startupRetryTask)
+        await retryTask.value
+
+        #expect(store.startupRetryTask == nil)
+    }
+
+    private func makeSettingsStore(suite: String) throws -> SettingsStore {
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set(true, forKey: "providerDetectionCompleted")
+        let configStore = testConfigStore(suiteName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        let codexMetadata = try #require(ProviderDescriptorRegistry.metadata[.codex])
+        settings.setProviderEnabled(provider: .codex, metadata: codexMetadata, enabled: true)
+        settings.providerDetectionCompleted = true
+        return settings
+    }
+
+    private func makeStore(settings: SettingsStore) -> UsageStore {
+        UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing)
+    }
+}


### PR DESCRIPTION
Summary:

- Retry the initial usage refresh once after a startup network/status failure.
- Keep the retry scoped to providers that actually run background refresh work.
- Cancel the pending startup retry during UsageStore cancellation.
- Keep the retry bounded to one delayed attempt.

Validation:

- ./Scripts/lint.sh lint
- swift test --filter UsageStoreStartupRetryTests
- swift test --filter UsageStoreManualTokenRefreshTests
- CI / lint-build-test
- CI / build-linux-cli (linux-x64, ubuntu-24.04)
- CI / build-linux-cli (linux-arm64, ubuntu-24.04-arm)
- GitGuardian Security Checks

Proof:

- Local lint and focused tests passed before push.
- CI is green on d6af342ffd0c8545ab3d50b102e553a4a6656a8c.
- Runtime app proof still to be added separately if maintainers require it.