### PR TITLE
Fix startup status retry after offline launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Codex: cancel OpenAI WebKit dashboard refreshes promptly and avoid an immediate second background WebView retry after timeouts, reducing launch-time Web Content CPU spikes (#1217).
+- Status: retry startup refreshes a few times after transient offline/network failures so provider status can recover after macOS brings the network online (#1211).
 
 ## 0.31.0 — 2026-05-28
 

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -148,6 +148,7 @@ extension UsageStore {
             {
                 return
             }
+            self.recordStartupConnectivityRetryableFailure(error)
             if claudeCredentialsChanged {
                 await self.clearClaudeCredentialDerivedStateForCredentialSwap()
             }
@@ -357,6 +358,40 @@ extension UsageStore {
         default:
             return false
         }
+    }
+
+    static func startupConnectivityRetryDelay(forAttempt attempt: Int) -> TimeInterval? {
+        let delays: [TimeInterval] = [15, 45, 120, 300]
+        guard attempt >= 1, attempt <= delays.count else { return nil }
+        return delays[attempt - 1]
+    }
+
+    static func isStartupConnectivityRetryableError(_ error: Error) -> Bool {
+        if error is CancellationError { return false }
+
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain {
+            switch nsError.code {
+            case NSURLErrorTimedOut,
+                 NSURLErrorNetworkConnectionLost,
+                 NSURLErrorNotConnectedToInternet,
+                 NSURLErrorCannotFindHost,
+                 NSURLErrorCannotConnectToHost,
+                 NSURLErrorDNSLookupFailed:
+                return true
+            default:
+                return false
+            }
+        }
+
+        let message = error.localizedDescription.lowercased()
+        return message.contains("timed out") ||
+            message.contains("timeout") ||
+            message.contains("network connection was lost") ||
+            message.contains("not connected to the internet") ||
+            message.contains("cannot find host") ||
+            message.contains("cannot connect to host") ||
+            message.contains("dns lookup")
     }
 
     private static func isClaudeUsageProbeTimeout(_ error: Error) -> Bool {

--- a/Sources/CodexBar/UsageStore+StartupConnectivityRetry.swift
+++ b/Sources/CodexBar/UsageStore+StartupConnectivityRetry.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+extension UsageStore {
+    enum StartupBehavior {
+        case automatic
+        case full
+        case testing
+
+        var automaticallyStartsBackgroundWork: Bool {
+            switch self {
+            case .automatic, .full:
+                true
+            case .testing:
+                false
+            }
+        }
+
+        func resolved(isRunningTests: Bool) -> StartupBehavior {
+            switch self {
+            case .automatic:
+                isRunningTests ? .testing : .full
+            case .full, .testing:
+                self
+            }
+        }
+    }
+
+    func recordStartupConnectivityRetryableFailure(_ error: Error) {
+        guard self.startupConnectivityRetryRefreshActive else { return }
+        guard Self.isStartupConnectivityRetryableError(error) else { return }
+        self.startupConnectivityRetryNeeded = true
+    }
+
+    func completeStartupConnectivityRetryPass(currentAttempt: Int) {
+        guard self.startupConnectivityRetryNeeded else {
+            self.cancelStartupConnectivityRetry()
+            return
+        }
+
+        let nextAttempt = currentAttempt + 1
+        guard let delay = Self.startupConnectivityRetryDelay(forAttempt: nextAttempt) else {
+            self.cancelStartupConnectivityRetry()
+            return
+        }
+
+        self.scheduleStartupConnectivityRetry(attempt: nextAttempt, delay: delay)
+    }
+
+    private func scheduleStartupConnectivityRetry(attempt: Int, delay: TimeInterval) {
+        guard self.startupBehavior.automaticallyStartsBackgroundWork ||
+            self._test_startupConnectivityRetryScheduled != nil ||
+            self._test_startupConnectivityRetrySleepOverride != nil
+        else {
+            return
+        }
+
+        self.startupConnectivityRetryTask?.cancel()
+        self._test_startupConnectivityRetryScheduled?(attempt, delay)
+        self.startupConnectivityRetryTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await self.sleepForStartupConnectivityRetry(delay)
+                guard !Task.isCancelled else { return }
+                await self.runRefresh(startupConnectivityRetryAttempt: attempt)
+            } catch {
+                return
+            }
+        }
+    }
+
+    private func cancelStartupConnectivityRetry() {
+        self.startupConnectivityRetryTask?.cancel()
+        self.startupConnectivityRetryTask = nil
+    }
+
+    private func sleepForStartupConnectivityRetry(_ delay: TimeInterval) async throws {
+        if let override = self._test_startupConnectivityRetrySleepOverride {
+            try await override(delay)
+            return
+        }
+        try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+    }
+}

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -115,30 +115,6 @@ final class UsageStore {
         case dashboardWeb
     }
 
-    enum StartupBehavior {
-        case automatic
-        case full
-        case testing
-
-        var automaticallyStartsBackgroundWork: Bool {
-            switch self {
-            case .automatic, .full:
-                true
-            case .testing:
-                false
-            }
-        }
-
-        func resolved(isRunningTests: Bool) -> StartupBehavior {
-            switch self {
-            case .automatic:
-                isRunningTests ? .testing : .full
-            case .full, .testing:
-                self
-            }
-        }
-    }
-
     var snapshots: [UsageProvider: UsageSnapshot] = [:]
     var errors: [UsageProvider: String] = [:]
     var lastSourceLabels: [UsageProvider: String] = [:]
@@ -201,6 +177,11 @@ final class UsageStore {
     @ObservationIgnored var _test_widgetSnapshotSaveOverride: (@MainActor (WidgetSnapshot) async -> Void)?
     @ObservationIgnored var _test_providerRefreshOverride: (@MainActor (UsageProvider) async -> Void)?
     @ObservationIgnored var _test_tokenUsageRefreshOverride: (@MainActor (UsageProvider, Bool) async -> Void)?
+    @ObservationIgnored var _test_providerStatusFetchOverride: (@MainActor (
+        UsageProvider) async throws -> ProviderStatus)?
+    @ObservationIgnored var _test_startupConnectivityRetryScheduled: (@MainActor (Int, TimeInterval) -> Void)?
+    @ObservationIgnored var _test_startupConnectivityRetrySleepOverride: (@MainActor (
+        TimeInterval) async throws -> Void)?
     @ObservationIgnored var widgetSnapshotPersistTask: Task<Void, Never>?
 
     @ObservationIgnored let codexFetcher: UsageFetcher
@@ -226,6 +207,9 @@ final class UsageStore {
     @ObservationIgnored private var timerTask: Task<Void, Never>?
     @ObservationIgnored private var tokenTimerTask: Task<Void, Never>?
     @ObservationIgnored private var tokenRefreshSequenceTask: Task<Void, Never>?
+    @ObservationIgnored var startupConnectivityRetryTask: Task<Void, Never>?
+    @ObservationIgnored var startupConnectivityRetryNeeded = false
+    @ObservationIgnored var startupConnectivityRetryRefreshActive = false
     @ObservationIgnored var storageRefreshTask: Task<Void, Never>?
     @ObservationIgnored var storageRefreshGeneration: UInt64 = 0
     @ObservationIgnored var storageRefreshInFlightSignature: String?
@@ -252,7 +236,7 @@ final class UsageStore {
     @ObservationIgnored private let providerAvailabilityCacheTTL: TimeInterval = 1
     @ObservationIgnored private let tokenFetchTTL: TimeInterval = 60 * 60
     @ObservationIgnored private let tokenFetchTimeout: TimeInterval = 10 * 60
-    @ObservationIgnored private let startupBehavior: StartupBehavior
+    @ObservationIgnored let startupBehavior: StartupBehavior
     @ObservationIgnored let planUtilizationPersistenceCoordinator: PlanUtilizationHistoryPersistenceCoordinator
 
     init(
@@ -530,9 +514,20 @@ final class UsageStore {
     }
 
     func refresh(forceTokenUsage: Bool = false) async {
+        await self.runRefresh(forceTokenUsage: forceTokenUsage, startupConnectivityRetryAttempt: nil)
+    }
+
+    func runRefresh(
+        forceTokenUsage: Bool = false,
+        startupConnectivityRetryAttempt: Int?)
+        async
+    {
         guard !self.isRefreshing else { return }
         self.prepareRefreshState()
         let refreshPhase: ProviderRefreshPhase = self.hasCompletedInitialRefresh ? .regular : .startup
+        let allowsStartupConnectivityRetry = refreshPhase == .startup || startupConnectivityRetryAttempt != nil
+        self.startupConnectivityRetryRefreshActive = allowsStartupConnectivityRetry
+        self.startupConnectivityRetryNeeded = false
         let displayEnabledProviders = self.enabledProvidersForDisplay()
         let enabledProviderSet = Set(displayEnabledProviders)
         let refreshProviders = self.enabledProvidersForBackgroundWork()
@@ -544,6 +539,7 @@ final class UsageStore {
             defer {
                 self.isRefreshing = false
                 self.hasCompletedInitialRefresh = true
+                self.startupConnectivityRetryRefreshActive = false
             }
 
             self.clearDisabledProviderState(enabledProviders: enabledProviderSet)
@@ -612,6 +608,10 @@ final class UsageStore {
             }
 
             self.persistWidgetSnapshot(reason: "refresh")
+        }
+
+        if allowsStartupConnectivityRetry {
+            self.completeStartupConnectivityRetryPass(currentAttempt: startupConnectivityRetryAttempt ?? 0)
         }
     }
 
@@ -699,6 +699,7 @@ final class UsageStore {
         self.timerTask?.cancel()
         self.tokenTimerTask?.cancel()
         self.tokenRefreshSequenceTask?.cancel()
+        self.startupConnectivityRetryTask?.cancel()
         self.storageRefreshTask?.cancel()
         self.codexPlanHistoryBackfillTask?.cancel()
     }
@@ -890,7 +891,9 @@ final class UsageStore {
 
         do {
             let status: ProviderStatus
-            if let urlString = meta.statusPageURL, let baseURL = URL(string: urlString) {
+            if let override = self._test_providerStatusFetchOverride {
+                status = try await override(provider)
+            } else if let urlString = meta.statusPageURL, let baseURL = URL(string: urlString) {
                 status = try await Self.fetchStatus(from: baseURL)
             } else if let productID = meta.statusWorkspaceProductID {
                 status = try await Self.fetchWorkspaceStatus(productID: productID)
@@ -899,6 +902,7 @@ final class UsageStore {
             }
             await MainActor.run { self.statuses[provider] = status }
         } catch {
+            self.recordStartupConnectivityRetryableFailure(error)
             // Keep the previous status to avoid flapping when the API hiccups.
             await MainActor.run {
                 if self.statuses[provider] == nil {

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -471,6 +471,90 @@ struct UsageStoreCoverageTests {
             NSError(domain: NSCocoaErrorDomain, code: 0)))
     }
 
+    @Test
+    func `startup status network failure schedules bounded retry`() async throws {
+        let settings = Self.makeSettingsStore(suite: "UsageStoreCoverageTests-startup-status-retry")
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = true
+        try Self.enableOnly(.codex, settings: settings)
+
+        let store = Self.makeUsageStore(settings: settings)
+        store._test_providerRefreshOverride = { _ in }
+        defer { store._test_providerRefreshOverride = nil }
+        store._test_providerStatusFetchOverride = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+        defer { store._test_providerStatusFetchOverride = nil }
+
+        var scheduled: [(attempt: Int, delay: TimeInterval)] = []
+        store._test_startupConnectivityRetryScheduled = { attempt, delay in
+            scheduled.append((attempt, delay))
+        }
+        defer { store._test_startupConnectivityRetryScheduled = nil }
+
+        await store.refresh()
+        defer {
+            store.startupConnectivityRetryTask?.cancel()
+            store.startupConnectivityRetryTask = nil
+        }
+
+        #expect(scheduled.map(\.attempt) == [1])
+        #expect(scheduled.map(\.delay) == [15])
+        #expect(store.statuses[.codex]?.indicator == .unknown)
+        #expect(store.statuses[.codex]?.description?.isEmpty == false)
+    }
+
+    @Test
+    func `startup connectivity retry refreshes status and clears retry task after recovery`() async throws {
+        let settings = Self.makeSettingsStore(suite: "UsageStoreCoverageTests-startup-status-recovery")
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = true
+        try Self.enableOnly(.codex, settings: settings)
+
+        let store = Self.makeUsageStore(settings: settings)
+        store._test_providerRefreshOverride = { _ in }
+        defer { store._test_providerRefreshOverride = nil }
+
+        var statusAttempts = 0
+        store._test_providerStatusFetchOverride = { _ in
+            statusAttempts += 1
+            if statusAttempts == 1 {
+                throw URLError(.cannotFindHost)
+            }
+            return ProviderStatus(indicator: .none, description: "Operational", updatedAt: Date())
+        }
+        defer { store._test_providerStatusFetchOverride = nil }
+
+        let sleepGate = StartupConnectivityRetrySleepGate()
+        store._test_startupConnectivityRetrySleepOverride = { delay in
+            try await sleepGate.sleep(delay)
+        }
+        defer { store._test_startupConnectivityRetrySleepOverride = nil }
+
+        await store.refresh()
+        await sleepGate.waitUntilSleeping()
+        let retryTask = try #require(store.startupConnectivityRetryTask)
+
+        await sleepGate.resume()
+        await retryTask.value
+
+        #expect(statusAttempts == 2)
+        #expect(store.statuses[.codex]?.indicator == ProviderStatusIndicator.none)
+        #expect(store.statuses[.codex]?.description == "Operational")
+        #expect(store.startupConnectivityRetryTask == nil)
+    }
+
+    @Test
+    func `startup connectivity retry classification is bounded and excludes cancellation`() {
+        #expect(UsageStore.startupConnectivityRetryDelay(forAttempt: 1) == 15)
+        #expect(UsageStore.startupConnectivityRetryDelay(forAttempt: 4) == 300)
+        #expect(UsageStore.startupConnectivityRetryDelay(forAttempt: 5) == nil)
+        #expect(UsageStore.isStartupConnectivityRetryableError(URLError(.timedOut)))
+        #expect(UsageStore.isStartupConnectivityRetryableError(URLError(.notConnectedToInternet)))
+        #expect(!UsageStore.isStartupConnectivityRetryableError(URLError(.cancelled)))
+        #expect(!UsageStore.isStartupConnectivityRetryableError(CancellationError()))
+    }
+
     private static func makeSettingsStore(
         suite: String,
         zaiTokenStore: any ZaiTokenStoring = NoopZaiTokenStore(),
@@ -509,6 +593,49 @@ struct UsageStoreCoverageTests {
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings,
             environmentBase: [:])
+    }
+
+    private static func enableOnly(_ enabledProvider: UsageProvider, settings: SettingsStore) throws {
+        let metadata = ProviderRegistry.shared.metadata
+        for provider in UsageProvider.allCases {
+            try settings.setProviderEnabled(
+                provider: provider,
+                metadata: #require(metadata[provider]),
+                enabled: provider == enabledProvider)
+        }
+    }
+}
+
+private actor StartupConnectivityRetrySleepGate {
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func sleep(_ delay: TimeInterval) async throws {
+        #expect(delay == 15)
+        try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            self.resumeWaiters()
+        }
+    }
+
+    func waitUntilSleeping() async {
+        if self.continuation != nil { return }
+        await withCheckedContinuation { continuation in
+            self.waiters.append(continuation)
+        }
+    }
+
+    func resume() {
+        self.continuation?.resume()
+        self.continuation = nil
+    }
+
+    private func resumeWaiters() {
+        let waiters = self.waiters
+        self.waiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Retry startup refreshes after transient offline/status network failures with a bounded 15s/45s/120s/300s backoff.
- Keep retry state scoped to startup/retry passes and cancel scheduled retry work during teardown or after recovery.
- Add stubbed status/retry tests; no live auth or real provider probes.

Fixes #1211.

## Proof
- `swift test --filter UsageStoreCoverageTests`
- `make check`
- `swift test`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local` -> clean, no accepted/actionable findings
