### PR TITLE
Fix menu tracking background rebuild stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - CLI: avoid executing a same-user mutable temporary installer script across the macOS administrator privilege boundary (#1222). Thanks @Hinotoi-agent!
 - Codex: cancel OpenAI WebKit dashboard refreshes promptly and avoid an immediate second background WebView retry after timeouts, reducing launch-time Web Content CPU spikes (#1217).
 - Menu: refresh open Codex menu adjuncts as dashboard, credits, token-cost, and plan-history data become ready after cold start (#1150). Thanks @AmrMohamad!
+- Menu bar: defer background parent-menu rebuilds until AppKit menu tracking ends so late-arriving usage data cannot stall dropdown hover on macOS 26.5 (#1227).
 - Menu bar: give CodexBar status items stable placement identities while preserving existing upgrade placement state (#1216). Thanks @pdurlej!
 - Release: isolate notarization API keys and upload ZIPs in a private per-run temporary directory instead of predictable shared /tmp paths (#1228). Thanks @Hinotoi-agent!
 - Status: retry startup refreshes a few times after transient offline/network failures so provider status can recover after macOS brings the network online (#1211).

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -130,7 +130,7 @@ extension StatusItemController {
         let wasHostedSubviewMenu = self.isHostedSubviewMenu(menu)
         self.forgetClosedMenu(menu)
         if wasHostedSubviewMenu {
-            self.refreshOpenMenusAllowingParentRebuild()
+            self.refreshOpenMenusAllowingParentRebuild(deferParentRebuildDuringTracking: true)
         }
     }
 
@@ -156,6 +156,8 @@ extension StatusItemController {
         if !isPersistentMenu {
             self.menuProviders.removeValue(forKey: key)
             self.menuVersions.removeValue(forKey: key)
+        } else if self.menuNeedsRefresh(menu) {
+            self.rebuildClosedMenuIfNeeded(menu)
         }
     }
 
@@ -1073,16 +1075,6 @@ extension StatusItemController {
         return .provider(self.resolvedMenuProvider(enabledProviders: enabledProviders) ?? .codex)
     }
 
-    func menuNeedsRefresh(_ menu: NSMenu) -> Bool {
-        let key = ObjectIdentifier(menu)
-        return self.menuVersions[key] != self.menuContentVersion
-    }
-
-    func markMenuFresh(_ menu: NSMenu) {
-        let key = ObjectIdentifier(menu)
-        self.menuVersions[key] = self.menuContentVersion
-    }
-
     func menuProvider(for menu: NSMenu) -> UsageProvider? {
         if self.shouldMergeIcons {
             return self.resolvedMenuProvider()
@@ -1094,25 +1086,6 @@ extension StatusItemController {
             return nil
         }
         return self.store.enabledProvidersForDisplay().first ?? .codex
-    }
-
-    func hasOpenHostedSubviewMenu() -> Bool {
-        self.openMenus.values.contains { self.isHostedSubviewMenu($0) }
-    }
-
-    func refreshOpenMenuIfStillVisible(_ menu: NSMenu, provider: UsageProvider?) {
-        self.scheduleOpenMenuRebuildIfStillVisible(menu, provider: provider)
-    }
-
-    func rebuildOpenMenuIfStillVisible(_ menu: NSMenu, provider: UsageProvider?) {
-        guard self.openMenus[ObjectIdentifier(menu)] != nil else { return }
-        guard self.isHostedSubviewMenu(menu) || !self.hasOpenHostedSubviewMenu() else { return }
-        self.populateMenu(menu, provider: provider)
-        self.markMenuFresh(menu)
-        self.applyIcon(phase: nil)
-        #if DEBUG
-        self._test_openMenuRebuildObserver?(menu)
-        #endif
     }
 
     private func scheduleOpenMenuRefresh(for menu: NSMenu) {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -130,7 +130,7 @@ extension StatusItemController {
         let wasHostedSubviewMenu = self.isHostedSubviewMenu(menu)
         self.forgetClosedMenu(menu)
         if wasHostedSubviewMenu {
-            self.refreshOpenMenusAllowingParentRebuild(deferParentRebuildDuringTracking: true)
+            self.refreshOpenMenusAfterHostedSubviewClose()
         }
     }
 
@@ -159,6 +159,7 @@ extension StatusItemController {
         } else if self.menuNeedsRefresh(menu) {
             self.rebuildClosedMenuIfNeeded(menu)
         }
+        self.parentMenuRebuildsDeferredDuringTracking.remove(key)
     }
 
     func menu(_ menu: NSMenu, willHighlight item: NSMenuItem?) {

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -79,6 +79,14 @@ extension StatusItemController {
         self.refreshOpenMenusAllowingParentRebuild()
     }
 
+    func refreshOpenMenusAfterHostedSubviewClose() {
+        guard self.isMenuRefreshEnabled else { return }
+        guard !self.openMenus.isEmpty else { return }
+        self.refreshOpenMenusIfNeeded(
+            allowsParentRebuild: true,
+            respectsParentRebuildDeferral: true)
+    }
+
     func refreshOpenMenusAllowingParentRebuild(deferParentRebuildDuringTracking: Bool = false) {
         guard self.isMenuRefreshEnabled else { return }
         guard !self.openMenus.isEmpty else { return }
@@ -104,7 +112,8 @@ extension StatusItemController {
 
     private func refreshOpenMenusIfNeeded(
         allowsParentRebuild: Bool,
-        deferParentRebuildDuringTracking: Bool = false)
+        deferParentRebuildDuringTracking: Bool = false,
+        respectsParentRebuildDeferral: Bool = false)
     {
         var orphanedKeys: [ObjectIdentifier] = []
         let hasOpenHostedSubviewMenu = self.hasOpenHostedSubviewMenu()
@@ -117,6 +126,7 @@ extension StatusItemController {
                 menu,
                 allowsParentRebuild: allowsParentRebuild,
                 deferParentRebuildDuringTracking: deferParentRebuildDuringTracking,
+                respectsParentRebuildDeferral: respectsParentRebuildDeferral,
                 hasOpenHostedSubviewMenu: hasOpenHostedSubviewMenu)
         }
         self.removeOrphanedOpenMenuEntries(orphanedKeys)
@@ -126,6 +136,7 @@ extension StatusItemController {
         _ menu: NSMenu,
         allowsParentRebuild: Bool,
         deferParentRebuildDuringTracking: Bool,
+        respectsParentRebuildDeferral: Bool,
         hasOpenHostedSubviewMenu: Bool)
     {
         if self.isHostedSubviewMenu(menu) {
@@ -133,10 +144,18 @@ extension StatusItemController {
             return
         }
         guard allowsParentRebuild else { return }
-        guard !hasOpenHostedSubviewMenu else { return }
         guard self.menuNeedsRefresh(menu) else { return }
+        let key = ObjectIdentifier(menu)
 
-        guard !deferParentRebuildDuringTracking else { return }
+        if deferParentRebuildDuringTracking {
+            self.parentMenuRebuildsDeferredDuringTracking.insert(key)
+            return
+        }
+        if respectsParentRebuildDeferral, self.parentMenuRebuildsDeferredDuringTracking.contains(key) {
+            return
+        }
+        self.parentMenuRebuildsDeferredDuringTracking.remove(key)
+        guard !hasOpenHostedSubviewMenu else { return }
 
         let provider = self.menuProvider(for: menu)
         self.scheduleOpenMenuRebuildIfStillVisible(menu, provider: provider)
@@ -148,6 +167,7 @@ extension StatusItemController {
             self.menuRefreshTasks.removeValue(forKey: key)?.cancel()
             self.menuProviders.removeValue(forKey: key)
             self.menuVersions.removeValue(forKey: key)
+            self.parentMenuRebuildsDeferredDuringTracking.remove(key)
         }
     }
 }

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -1,9 +1,72 @@
 import AppKit
+import CodexBarCore
 
 extension StatusItemController {
+    func invalidateMenus(
+        refreshOpenMenus: Bool = false,
+        deferOpenParentMenuRebuild: Bool = false)
+    {
+        #if DEBUG
+        guard !self.isReleasedForTesting else { return }
+        #endif
+        self.menuContentVersion &+= 1
+        guard self.isMenuRefreshEnabled else { return }
+        if !self.openMenus.isEmpty {
+            guard refreshOpenMenus else { return }
+            self.refreshOpenMenusAllowingParentRebuild(
+                deferParentRebuildDuringTracking: deferOpenParentMenuRebuild)
+            self.scheduleOpenMenuInvalidationRetry(
+                deferParentRebuildDuringTracking: deferOpenParentMenuRebuild)
+            return
+        }
+    }
+
     func renderedMenuWidth(for menu: NSMenu) -> CGFloat {
         let measuredWidth = ceil(menu.size.width)
         return max(measuredWidth, Self.menuCardBaseWidth)
+    }
+
+    func rebuildClosedMenuIfNeeded(_ menu: NSMenu) {
+        guard !self.hasPreparedForAppShutdown else { return }
+        let provider = self.menuProvider(for: menu)
+        Task { @MainActor [weak self, weak menu] in
+            await Task.yield()
+            guard let self, let menu else { return }
+            guard !self.hasPreparedForAppShutdown else { return }
+            guard self.openMenus[ObjectIdentifier(menu)] == nil else { return }
+            guard self.menuNeedsRefresh(menu) else { return }
+            self.populateMenu(menu, provider: provider)
+            self.markMenuFresh(menu)
+        }
+    }
+
+    func menuNeedsRefresh(_ menu: NSMenu) -> Bool {
+        let key = ObjectIdentifier(menu)
+        return self.menuVersions[key] != self.menuContentVersion
+    }
+
+    func markMenuFresh(_ menu: NSMenu) {
+        let key = ObjectIdentifier(menu)
+        self.menuVersions[key] = self.menuContentVersion
+    }
+
+    func hasOpenHostedSubviewMenu() -> Bool {
+        self.openMenus.values.contains { self.isHostedSubviewMenu($0) }
+    }
+
+    func refreshOpenMenuIfStillVisible(_ menu: NSMenu, provider: UsageProvider?) {
+        self.scheduleOpenMenuRebuildIfStillVisible(menu, provider: provider)
+    }
+
+    func rebuildOpenMenuIfStillVisible(_ menu: NSMenu, provider: UsageProvider?) {
+        guard self.openMenus[ObjectIdentifier(menu)] != nil else { return }
+        guard self.isHostedSubviewMenu(menu) || !self.hasOpenHostedSubviewMenu() else { return }
+        self.populateMenu(menu, provider: provider)
+        self.markMenuFresh(menu)
+        self.applyIcon(phase: nil)
+        #if DEBUG
+        self._test_openMenuRebuildObserver?(menu)
+        #endif
     }
 
     func refreshOpenMenusIfNeeded() {
@@ -16,13 +79,15 @@ extension StatusItemController {
         self.refreshOpenMenusAllowingParentRebuild()
     }
 
-    func refreshOpenMenusAllowingParentRebuild() {
+    func refreshOpenMenusAllowingParentRebuild(deferParentRebuildDuringTracking: Bool = false) {
         guard self.isMenuRefreshEnabled else { return }
         guard !self.openMenus.isEmpty else { return }
-        self.refreshOpenMenusIfNeeded(allowsParentRebuild: true)
+        self.refreshOpenMenusIfNeeded(
+            allowsParentRebuild: true,
+            deferParentRebuildDuringTracking: deferParentRebuildDuringTracking)
     }
 
-    func scheduleOpenMenuInvalidationRetry() {
+    func scheduleOpenMenuInvalidationRetry(deferParentRebuildDuringTracking: Bool = false) {
         self.openMenuInvalidationRetryTask?.cancel()
         self.openMenuInvalidationRetryTask = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -31,12 +96,16 @@ extension StatusItemController {
             #if DEBUG
             self.onOpenMenuInvalidationRetryForTesting?()
             #endif
-            self.refreshOpenMenusAllowingParentRebuild()
+            self.refreshOpenMenusAllowingParentRebuild(
+                deferParentRebuildDuringTracking: deferParentRebuildDuringTracking)
             self.openMenuInvalidationRetryTask = nil
         }
     }
 
-    private func refreshOpenMenusIfNeeded(allowsParentRebuild: Bool) {
+    private func refreshOpenMenusIfNeeded(
+        allowsParentRebuild: Bool,
+        deferParentRebuildDuringTracking: Bool = false)
+    {
         var orphanedKeys: [ObjectIdentifier] = []
         let hasOpenHostedSubviewMenu = self.hasOpenHostedSubviewMenu()
         for (key, menu) in self.openMenus {
@@ -47,6 +116,7 @@ extension StatusItemController {
             self.refreshOpenMenuIfNeeded(
                 menu,
                 allowsParentRebuild: allowsParentRebuild,
+                deferParentRebuildDuringTracking: deferParentRebuildDuringTracking,
                 hasOpenHostedSubviewMenu: hasOpenHostedSubviewMenu)
         }
         self.removeOrphanedOpenMenuEntries(orphanedKeys)
@@ -55,6 +125,7 @@ extension StatusItemController {
     private func refreshOpenMenuIfNeeded(
         _ menu: NSMenu,
         allowsParentRebuild: Bool,
+        deferParentRebuildDuringTracking: Bool,
         hasOpenHostedSubviewMenu: Bool)
     {
         if self.isHostedSubviewMenu(menu) {
@@ -64,6 +135,8 @@ extension StatusItemController {
         guard allowsParentRebuild else { return }
         guard !hasOpenHostedSubviewMenu else { return }
         guard self.menuNeedsRefresh(menu) else { return }
+
+        guard !deferParentRebuildDuringTracking else { return }
 
         let provider = self.menuProvider(for: menu)
         self.scheduleOpenMenuRebuildIfStillVisible(menu, provider: provider)

--- a/Sources/CodexBar/StatusItemController+Shutdown.swift
+++ b/Sources/CodexBar/StatusItemController+Shutdown.swift
@@ -59,6 +59,7 @@ extension StatusItemController {
         self.openMenuRebuildTasks.removeAll(keepingCapacity: false)
         self.openMenuRebuildTokens.removeAll(keepingCapacity: false)
         self.openMenuRebuildsClosingHostedSubviewMenus.removeAll(keepingCapacity: false)
+        self.parentMenuRebuildsDeferredDuringTracking.removeAll(keepingCapacity: false)
         self.openMenus.removeAll(keepingCapacity: false)
         self.highlightedMenuItems.removeAll(keepingCapacity: false)
         self.menuProviders.removeAll(keepingCapacity: false)

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -441,7 +441,9 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.observeStoreChanges()
-                self.invalidateMenus(refreshOpenMenus: self.didMenuAdjunctReadinessChange())
+                self.invalidateMenus(
+                    refreshOpenMenus: self.didMenuAdjunctReadinessChange(),
+                    deferOpenParentMenuRebuild: true)
             }
         }
     }
@@ -603,20 +605,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
                 self.observeManagedCodexCoordinatorChanges()
                 self.refreshMenusForLoginStateChange()
             }
-        }
-    }
-
-    func invalidateMenus(refreshOpenMenus: Bool = false) {
-        #if DEBUG
-        guard !self.isReleasedForTesting else { return }
-        #endif
-        self.menuContentVersion &+= 1
-        guard self.isMenuRefreshEnabled else { return }
-        if !self.openMenus.isEmpty {
-            guard refreshOpenMenus else { return }
-            self.refreshOpenMenusAllowingParentRebuild()
-            self.scheduleOpenMenuInvalidationRetry()
-            return
         }
     }
 

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -136,6 +136,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var openMenuRebuildTokens: [ObjectIdentifier: Int] = [:]
     var openMenuRebuildTokenCounter = 0
     var openMenuRebuildsClosingHostedSubviewMenus: Set<ObjectIdentifier> = []
+    var parentMenuRebuildsDeferredDuringTracking: Set<ObjectIdentifier> = []
     var highlightedMenuItems: [ObjectIdentifier: NSMenuItem] = [:]
     var providerSwitcherShortcutEventMonitor: ProviderSwitcherShortcutEventMonitor?
     var providerSwitcherShortcutMenuID: ObjectIdentifier?
@@ -852,6 +853,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             self.openMenuRebuildTasks.removeValue(forKey: menuID)?.cancel()
             self.openMenuRebuildTokens.removeValue(forKey: menuID)
             self.openMenuRebuildsClosingHostedSubviewMenus.remove(menuID)
+            self.parentMenuRebuildsDeferredDuringTracking.remove(menuID)
             self.highlightedMenuItems.removeValue(forKey: menuID)
         }
 

--- a/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
@@ -59,11 +59,13 @@ struct StatusMenuHostedSubmenuRefreshTests {
         #expect(submenu.items.first?.view != nil)
 
         let oldParentVersion = try #require(controller.menuVersions[parentKey])
-        controller.menuContentVersion &+= 1
-        controller.refreshOpenMenusIfNeeded()
+        controller.invalidateMenus(
+            refreshOpenMenus: true,
+            deferOpenParentMenuRebuild: true)
         #expect(controller.menuVersions[parentKey] == oldParentVersion)
-        controller.menuContentVersion &+= 1
-        controller.refreshOpenMenusIfNeeded()
+        controller.invalidateMenus(
+            refreshOpenMenus: true,
+            deferOpenParentMenuRebuild: true)
         #expect(controller.menuVersions[parentKey] == oldParentVersion)
 
         controller.menuDidClose(submenu)

--- a/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
@@ -7,7 +7,7 @@ import Testing
 @Suite(.serialized)
 struct StatusMenuHostedSubmenuRefreshTests {
     @Test
-    func `open parent menu defers data rebuild until hosted submenu closes`() async throws {
+    func `open parent menu defers data rebuild until parent tracking ends`() async throws {
         let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
         StatusItemController.menuCardRenderingEnabled = true
         defer {
@@ -69,10 +69,21 @@ struct StatusMenuHostedSubmenuRefreshTests {
         controller.menuDidClose(submenu)
         #expect(controller.openMenus[submenuKey] == nil)
 
+        for _ in 0..<40 where controller.menuVersions[parentKey] != oldParentVersion {
+            await Task.yield()
+        }
+        #expect(controller.menuVersions[parentKey] == oldParentVersion)
+
+        controller.menuDidClose(menu)
         for _ in 0..<40 where controller.menuVersions[parentKey] != controller.menuContentVersion {
             await Task.yield()
         }
-
+        if controller.menuVersions[parentKey] != controller.menuContentVersion {
+            controller.menuWillOpen(menu)
+        }
+        for _ in 0..<40 where controller.menuVersions[parentKey] != controller.menuContentVersion {
+            await Task.yield()
+        }
         #expect(controller.menuVersions[parentKey] == controller.menuContentVersion)
     }
 

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -333,7 +333,7 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `credits history arriving after open refreshes parent menu without explicit refresh`() async throws {
+    func `credits history arriving after open rebuilds parent menu after tracking ends`() async throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -370,10 +370,12 @@ extension StatusMenuTests {
             ],
             updatedAt: now.addingTimeInterval(10))
 
-        await self.waitUntilOpenMenuIsFresh(controller, key: key, after: openedVersion)
+        await self.waitUntilOpenMenuStaysStale(controller, key: key, after: openedVersion)
 
         #expect(controller.menuContentVersion != openedVersion)
-        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        await self.closeMenuAndWaitUntilFresh(controller, menu: menu, key: key)
 
         let creditsItem = try #require(self.menuItem(in: menu, id: "menuCardCredits"))
         #expect(
@@ -383,7 +385,7 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `fresh dashboard history with same day count refreshes parent menu`() async throws {
+    func `fresh dashboard history with same day count rebuilds parent menu after tracking ends`() async throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -424,17 +426,20 @@ extension StatusMenuTests {
             ],
             updatedAt: now.addingTimeInterval(10))
 
-        await self.waitUntilOpenMenuIsFresh(controller, key: key, after: openedVersion)
+        await self.waitUntilOpenMenuStaysStale(controller, key: key, after: openedVersion)
 
         #expect(controller.menuContentVersion != openedVersion)
-        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        await self.closeMenuAndWaitUntilFresh(controller, menu: menu, key: key)
+
         let creditsItem = try #require(self.menuItem(in: menu, id: "menuCardCredits"))
         #expect(creditsItem.submenu?.items.first?.representedObject as? String == StatusItemController
             .creditsHistoryChartID)
     }
 
     @Test
-    func `token cost history arriving after open refreshes parent menu without explicit refresh`() async throws {
+    func `token cost history arriving after open rebuilds parent menu after tracking ends`() async throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -464,10 +469,12 @@ extension StatusMenuTests {
 
         store._setTokenSnapshotForTesting(self.makeCodexTokenCostSnapshot(), provider: .codex)
 
-        await self.waitUntilOpenMenuIsFresh(controller, key: key, after: openedVersion)
+        await self.waitUntilOpenMenuStaysStale(controller, key: key, after: openedVersion)
 
         #expect(controller.menuContentVersion != openedVersion)
-        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        await self.closeMenuAndWaitUntilFresh(controller, menu: menu, key: key)
 
         let costItem = try #require(self.menuItem(in: menu, id: "menuCardCost"))
         #expect(costItem.submenu?.items.first?.representedObject as? String == StatusItemController.costHistoryChartID)
@@ -475,7 +482,7 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `fresh token cost history with same day count refreshes parent menu`() async throws {
+    func `fresh token cost history with same day count rebuilds parent menu after tracking ends`() async throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -520,16 +527,19 @@ extension StatusMenuTests {
                 updatedAt: Date(timeIntervalSince1970: 200)),
             provider: .codex)
 
-        await self.waitUntilOpenMenuIsFresh(controller, key: key, after: openedVersion)
+        await self.waitUntilOpenMenuStaysStale(controller, key: key, after: openedVersion)
 
         #expect(controller.menuContentVersion != openedVersion)
-        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        await self.closeMenuAndWaitUntilFresh(controller, menu: menu, key: key)
+
         let costItem = try #require(self.menuItem(in: menu, id: "menuCardCost"))
         #expect(costItem.submenu?.items.first?.representedObject as? String == StatusItemController.costHistoryChartID)
     }
 
     @Test
-    func `plan utilization history arriving after open refreshes parent menu without explicit refresh`() async throws {
+    func `plan utilization history arriving after open rebuilds parent menu after tracking ends`() async throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -564,15 +574,17 @@ extension StatusMenuTests {
             snapshot: self.makeCodexPlanUtilizationSnapshot(),
             now: Date())
 
-        await self.waitUntilOpenMenuIsFresh(controller, key: key, after: openedVersion)
+        await self.waitUntilOpenMenuStaysStale(controller, key: key, after: openedVersion)
 
         #expect(store.planUtilizationHistoryRevision > openedRevision)
         #expect(controller.menuContentVersion != openedVersion)
-        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        await self.closeMenuAndWaitUntilFresh(controller, menu: menu, key: key)
     }
 
     @Test
-    func `dashboard attachment authorization arriving after open refreshes parent menu`() async throws {
+    func `dashboard attachment authorization arriving after open rebuilds parent menu after close`() async throws {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -609,11 +621,13 @@ extension StatusMenuTests {
 
         store.openAIDashboardAttachmentAuthorized = true
 
-        await self.waitUntilOpenMenuIsFresh(controller, key: key, after: openedVersion)
+        await self.waitUntilOpenMenuStaysStale(controller, key: key, after: openedVersion)
 
         #expect(store.openAIDashboardAttachmentRevision == 1)
         #expect(controller.menuContentVersion != openedVersion)
-        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        await self.closeMenuAndWaitUntilFresh(controller, menu: menu, key: key)
     }
 
     private func enableOnlyCodex(_ settings: SettingsStore) {
@@ -637,7 +651,7 @@ extension StatusMenuTests {
         }
     }
 
-    private func waitUntilOpenMenuIsFresh(
+    private func waitUntilOpenMenuStaysStale(
         _ controller: StatusItemController,
         key: ObjectIdentifier,
         after version: Int?) async
@@ -647,12 +661,30 @@ extension StatusMenuTests {
                 await Task.yield()
                 continue
             }
-            guard controller.menuVersions[key] == controller.menuContentVersion else {
+            guard controller.menuVersions[key] == version else {
                 await Task.yield()
                 continue
             }
             return
         }
+    }
+
+    private func closeMenuAndWaitUntilFresh(
+        _ controller: StatusItemController,
+        menu: NSMenu,
+        key: ObjectIdentifier) async
+    {
+        controller.menuDidClose(menu)
+        for _ in 0..<40 where controller.menuVersions[key] != controller.menuContentVersion {
+            await Task.yield()
+        }
+        if controller.menuVersions[key] != controller.menuContentVersion {
+            controller.menuWillOpen(menu)
+        }
+        for _ in 0..<40 where controller.menuVersions[key] != controller.menuContentVersion {
+            await Task.yield()
+        }
+        #expect(controller.menuVersions[key] == controller.menuContentVersion)
     }
 
     private func makeOpenAIDashboard(

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -146,6 +146,59 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `explicit refresh rebuilds stale parent after hosted submenu closes`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        let menuKey = ObjectIdentifier(menu)
+        controller.openMenus[menuKey] = menu
+
+        let submenu = controller.makeHostedSubviewPlaceholderMenu(
+            chartID: StatusItemController.usageBreakdownChartID,
+            provider: .codex)
+        let submenuKey = ObjectIdentifier(submenu)
+        controller.openMenus[submenuKey] = submenu
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let openedVersion = controller.menuVersions[menuKey]
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { _ in
+            rebuildCount += 1
+        }
+        defer { controller._test_openMenuRebuildObserver = nil }
+
+        controller.refreshOpenMenusAfterExplicitStoreAction()
+        for _ in 0..<20 where controller.menuContentVersion == openedVersion {
+            await Task.yield()
+        }
+        #expect(controller.menuVersions[menuKey] == openedVersion)
+
+        controller.menuDidClose(submenu)
+        for _ in 0..<20 where rebuildCount == 0 {
+            await Task.yield()
+        }
+
+        #expect(controller.openMenus[submenuKey] == nil)
+        #expect(rebuildCount == 1)
+        #expect(controller.menuVersions[menuKey] == controller.menuContentVersion)
+    }
+
+    @Test
     func `plain open menu refresh preserves pending switcher hosted submenu cleanup`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()


### PR DESCRIPTION
Fixes #1227

Summary:
- defer background parent menu rebuilds while AppKit menu tracking is active
- keep explicit refresh/provider actions able to refresh visible menus, including after hosted submenus close
- rebuild stale persistent parent menus after close and guard delayed rebuilds during shutdown

Proof:
- make check
- swift test --filter StatusMenuHostedSubmenuRefreshTests --filter StatusMenuOpenRefreshTests --filter StatusItemControllerShutdownTests
- /Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main
