### PR TITLE
Add cold-start validation follow-ups

### DIFF
--- a/Scripts/check_cold_start_validation_result.sh
+++ b/Scripts/check_cold_start_validation_result.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ARTIFACT_ROOT="${CODEXBAR_COLD_START_ARTIFACT_DIR:-${HOME}/.codex/artifacts/CodexBar}"
+EXPECTED_APP_PATH="${CODEXBAR_EXPECTED_APP_PATH:-}"
+RUN_DIR="${1:-}"
+RUN_DIR_PROVIDED=false
+LAUNCHD_SUMMARY_PATH=""
+LAUNCHD_VALIDATED_ARTIFACT_DIR=""
+LAUNCHD_CHECKER_EXIT_CODE=""
+PYTHON_BIN="${CODEXBAR_PYTHON_BIN:-python3}"
+
+usage() {
+  cat <<EOF
+Usage:
+  $0 [cold-start-artifact-dir]
+
+When no directory is provided, checks the newest cold-start-* directory under:
+  ${ARTIFACT_ROOT}
+
+Environment:
+  CODEXBAR_EXPECTED_APP_PATH  Optional app bundle path that run-metadata.txt must match.
+  CODEXBAR_EXPECTED_APP_SHA256  Optional app executable SHA-256 that app-bundle-metadata.txt must match.
+  CODEXBAR_EXPECTED_VALIDATOR_SHA256  Optional validator script SHA-256 that app-bundle-metadata.txt must match.
+  CODEXBAR_EXPECTED_CHECKER_SHA256  Optional checker script SHA-256 that app-bundle-metadata.txt must match.
+  CODEXBAR_MAX_PARENT_CAPTURE_MS_AFTER_LAUNCH  Optional first-open parent capture limit. Default: 5000.
+  CODEXBAR_MAX_COST_CAPTURE_MS_AFTER_LAUNCH  Optional first-open Cost submenu capture limit. Default: 10000.
+EOF
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+latest_run_dir() {
+  find "${ARTIFACT_ROOT}" -maxdepth 1 -type d -name 'cold-start-*' -print | sort | tail -n 1
+}
+
+require_file() {
+  local path="$1"
+  [[ -f "${path}" ]] || fail "Missing required artifact file: ${path}"
+}
+
+metadata_value() {
+  local key="$1"
+  local file="$2"
+  awk -F= -v key="${key}" '$1 == key { print substr($0, length(key) + 2) }' "${file}" | tail -n 1
+}
+
+maybe_require_launchd_summary() {
+  local run_dir="$1"
+  local artifact_app_sha256="$2"
+  local summary_path="${ARTIFACT_ROOT}/launchd/last-run-summary.txt"
+  [[ "${RUN_DIR_PROVIDED}" == "false" && -f "${summary_path}" ]] || return 0
+
+  LAUNCHD_SUMMARY_PATH="${summary_path}"
+  LAUNCHD_VALIDATED_ARTIFACT_DIR="$(metadata_value validated_artifact_dir "${summary_path}")"
+  LAUNCHD_CHECKER_EXIT_CODE="$(metadata_value checker_exit_code "${summary_path}")"
+
+  [[ "$(metadata_value exit_code "${summary_path}")" == "0" ]] ||
+    fail "LaunchAgent summary did not report exit_code=0: ${summary_path}"
+  [[ "$(metadata_value latest_artifact_dir "${summary_path}")" == "${run_dir}" ]] ||
+    fail "LaunchAgent summary latest_artifact_dir does not match checked artifact"
+  [[ "${LAUNCHD_VALIDATED_ARTIFACT_DIR}" == "${run_dir}" ]] ||
+    fail "LaunchAgent summary validated_artifact_dir does not match checked artifact"
+  [[ "${LAUNCHD_CHECKER_EXIT_CODE}" == "0" ]] ||
+    fail "LaunchAgent summary did not report checker_exit_code=0: ${summary_path}"
+  if [[ -n "${EXPECTED_APP_PATH}" ]]; then
+    [[ "$(metadata_value app_path "${summary_path}")" == "${EXPECTED_APP_PATH}" ]] ||
+      fail "LaunchAgent summary app_path does not match CODEXBAR_EXPECTED_APP_PATH"
+  fi
+  local summary_expected_sha
+  summary_expected_sha="$(metadata_value expected_app_sha256 "${summary_path}")"
+  [[ -n "${summary_expected_sha}" ]] ||
+    fail "LaunchAgent summary is missing expected_app_sha256"
+  [[ "${summary_expected_sha}" == "${artifact_app_sha256}" ]] ||
+    fail "LaunchAgent summary expected_app_sha256 does not match artifact app_binary_sha256"
+  if [[ -n "${CODEXBAR_EXPECTED_VALIDATOR_SHA256:-}" ]]; then
+    [[ "$(metadata_value expected_validator_sha256 "${summary_path}")" == "${CODEXBAR_EXPECTED_VALIDATOR_SHA256}" ]] ||
+      fail "LaunchAgent summary expected_validator_sha256 does not match CODEXBAR_EXPECTED_VALIDATOR_SHA256"
+  fi
+  if [[ -n "${CODEXBAR_EXPECTED_CHECKER_SHA256:-}" ]]; then
+    [[ "$(metadata_value expected_checker_sha256 "${summary_path}")" == "${CODEXBAR_EXPECTED_CHECKER_SHA256}" ]] ||
+      fail "LaunchAgent summary expected_checker_sha256 does not match CODEXBAR_EXPECTED_CHECKER_SHA256"
+  fi
+}
+
+assert_contains() {
+  local path="$1"
+  local text="$2"
+  grep -F "${text}" "${path}" >/dev/null || fail "${path} is missing: ${text}"
+}
+
+assert_not_contains() {
+  local path="$1"
+  local text="$2"
+  ! grep -F "${text}" "${path}" >/dev/null || fail "${path} unexpectedly contains: ${text}"
+}
+
+assert_metadata_number_at_least() {
+  local file="$1"
+  local key="$2"
+  local minimum="$3"
+  local value
+
+  value="$(metadata_value "${key}" "${file}")"
+  [[ "${value}" =~ ^[0-9]+$ ]] || fail "${file} is missing numeric ${key}"
+  [[ "${value}" -ge "${minimum}" ]] || fail "${file} ${key}=${value}, expected at least ${minimum}"
+}
+
+assert_metadata_number_at_most() {
+  local file="$1"
+  local key="$2"
+  local maximum="$3"
+  local value
+
+  value="$(metadata_value "${key}" "${file}")"
+  [[ "${value}" =~ ^[0-9]+$ ]] || fail "${file} is missing numeric ${key}"
+  [[ "${value}" -le "${maximum}" ]] || fail "${file} ${key}=${value}, expected at most ${maximum}"
+}
+
+assert_metadata_present() {
+  local file="$1"
+  local key="$2"
+  local value
+
+  value="$(metadata_value "${key}" "${file}")"
+  [[ -n "${value}" ]] || fail "${file} is missing ${key}"
+}
+
+assert_metadata_equals() {
+  local file="$1"
+  local key="$2"
+  local expected="$3"
+  local value
+
+  value="$(metadata_value "${key}" "${file}")"
+  [[ "${value}" == "${expected}" ]] || fail "${file} ${key}=${value}, expected ${expected}"
+}
+
+if [[ "${RUN_DIR}" == "-h" || "${RUN_DIR}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ -z "${RUN_DIR}" ]]; then
+  RUN_DIR="$(latest_run_dir)"
+else
+  RUN_DIR_PROVIDED=true
+fi
+
+[[ -n "${RUN_DIR}" ]] || fail "No cold-start artifacts found under ${ARTIFACT_ROOT}"
+[[ -d "${RUN_DIR}" ]] || fail "Artifact directory not found: ${RUN_DIR}"
+
+boot_metadata="${RUN_DIR}/boot-session-metadata.txt"
+app_bundle_metadata="${RUN_DIR}/app-bundle-metadata.txt"
+login_context="${RUN_DIR}/login-context.txt"
+run_metadata="${RUN_DIR}/run-metadata.txt"
+immediate_status="${RUN_DIR}/immediate-parent-menu-status.txt"
+immediate_parent_ax="${RUN_DIR}/immediate-parent-menu-ax.txt"
+settled_parent_ax="${RUN_DIR}/settled-parent-menu-ax.txt"
+cost_submenu_ax="${RUN_DIR}/settled-cost-submenu-ax.txt"
+visual_readiness="${RUN_DIR}/visual-readiness.txt"
+timing_metadata="${RUN_DIR}/timing-metadata.txt"
+proof_manifest="${RUN_DIR}/cold-start-proof-manifest.json"
+
+require_file "${boot_metadata}"
+require_file "${app_bundle_metadata}"
+require_file "${login_context}"
+require_file "${run_metadata}"
+require_file "${immediate_status}"
+require_file "${immediate_parent_ax}"
+require_file "${settled_parent_ax}"
+require_file "${cost_submenu_ax}"
+require_file "${visual_readiness}"
+require_file "${timing_metadata}"
+require_file "${proof_manifest}"
+
+[[ "$(metadata_value post_boot_first_launch_candidate "${boot_metadata}")" == "true" ]] ||
+  fail "Artifact is not valid first-after-boot proof: post_boot_first_launch_candidate is not true"
+[[ "$(metadata_value existing_codexbar_process_count "${boot_metadata}")" == "0" ]] ||
+  fail "Artifact is not valid first-after-boot proof: CodexBar was already running before validation"
+[[ "$(metadata_value running_codexbar_process_count "${login_context}")" == "0" ]] ||
+  fail "Login context is not valid first-launch proof: CodexBar was already running before validation"
+[[ "$(metadata_value post_boot_first_launch_candidate "${run_metadata}")" == "true" ]] ||
+  fail "Run metadata does not preserve post_boot_first_launch_candidate=true"
+
+artifact_app_executable="$(metadata_value app_executable "${app_bundle_metadata}")"
+run_process_path="$(metadata_value process_path "${run_metadata}")"
+[[ -n "${artifact_app_executable}" ]] ||
+  fail "App bundle metadata is missing app_executable"
+[[ -n "${run_process_path}" ]] ||
+  fail "Run metadata is missing process_path"
+[[ "${run_process_path}" == "${artifact_app_executable}" ]] ||
+  fail "Run metadata process_path does not match app bundle metadata app_executable"
+
+if [[ -n "${EXPECTED_APP_PATH}" ]]; then
+  [[ "$(metadata_value app_path "${run_metadata}")" == "${EXPECTED_APP_PATH}" ]] ||
+    fail "Run metadata app_path does not match CODEXBAR_EXPECTED_APP_PATH"
+  [[ "$(metadata_value app_path "${app_bundle_metadata}")" == "${EXPECTED_APP_PATH}" ]] ||
+    fail "App bundle metadata app_path does not match CODEXBAR_EXPECTED_APP_PATH"
+  [[ "${artifact_app_executable}" == "${EXPECTED_APP_PATH}/Contents/MacOS/CodexBar" ]] ||
+    fail "App bundle metadata app_executable does not match CODEXBAR_EXPECTED_APP_PATH"
+fi
+
+app_binary_sha256="$(metadata_value app_binary_sha256 "${app_bundle_metadata}")"
+[[ -n "${app_binary_sha256}" ]] ||
+  fail "App bundle metadata is missing app_binary_sha256"
+validator_script_sha256="$(metadata_value validator_script_sha256 "${app_bundle_metadata}")"
+[[ -n "${validator_script_sha256}" ]] ||
+  fail "App bundle metadata is missing validator_script_sha256"
+checker_script_sha256="$(metadata_value checker_script_sha256 "${app_bundle_metadata}")"
+[[ -n "${checker_script_sha256}" ]] ||
+  fail "App bundle metadata is missing checker_script_sha256"
+maybe_require_launchd_summary "${RUN_DIR}" "${app_binary_sha256}"
+if [[ -n "${CODEXBAR_EXPECTED_APP_SHA256:-}" ]]; then
+  [[ "${app_binary_sha256}" == "${CODEXBAR_EXPECTED_APP_SHA256}" ]] ||
+    fail "App bundle metadata app_binary_sha256 does not match CODEXBAR_EXPECTED_APP_SHA256"
+fi
+if [[ -n "${CODEXBAR_EXPECTED_VALIDATOR_SHA256:-}" ]]; then
+  [[ "${validator_script_sha256}" == "${CODEXBAR_EXPECTED_VALIDATOR_SHA256}" ]] ||
+    fail "App bundle metadata validator_script_sha256 does not match CODEXBAR_EXPECTED_VALIDATOR_SHA256"
+fi
+if [[ -n "${CODEXBAR_EXPECTED_CHECKER_SHA256:-}" ]]; then
+  [[ "${checker_script_sha256}" == "${CODEXBAR_EXPECTED_CHECKER_SHA256}" ]] ||
+    fail "App bundle metadata checker_script_sha256 does not match CODEXBAR_EXPECTED_CHECKER_SHA256"
+fi
+
+if [[ "$(metadata_value codexbar_login_item_present "${login_context}")" == "true" ]]; then
+  login_item_app_sha256="$(metadata_value login_item_app_sha256 "${login_context}")"
+  [[ -n "${login_item_app_sha256}" ]] ||
+    fail "Login context says CodexBar Login Item is present but login_item_app_sha256 is missing"
+  [[ "${login_item_app_sha256}" == "${app_binary_sha256}" ]] ||
+    fail "CodexBar Login Item app binary does not match artifact app_binary_sha256"
+fi
+
+assert_metadata_equals "${login_context}" codexbar_login_item_present false
+assert_metadata_equals "${run_metadata}" manual_refresh_used false
+assert_metadata_equals "${run_metadata}" tab_switch_used false
+assert_metadata_equals "${run_metadata}" menu_reopen_required_for_parent false
+assert_metadata_equals "${run_metadata}" menu_reopen_required_for_cost false
+assert_metadata_equals "${run_metadata}" manual_recovery_used false
+
+[[ "$(tr -d '[:space:]' <"${immediate_status}")" == "complete" ]] ||
+  fail "Immediate first-open parent menu was not complete"
+
+assert_contains "${immediate_parent_ax}" "Buy Credits..."
+assert_contains "${immediate_parent_ax}" "Cost | submenu=true"
+assert_contains "${immediate_parent_ax}" "Usage Dashboard"
+assert_contains "${immediate_parent_ax}" "Status Page"
+assert_contains "${immediate_parent_ax}" "Refresh"
+
+assert_contains "${settled_parent_ax}" "Buy Credits..."
+assert_contains "${settled_parent_ax}" "Cost | submenu=true"
+assert_contains "${settled_parent_ax}" "Usage Dashboard"
+assert_contains "${settled_parent_ax}" "Status Page"
+assert_contains "${settled_parent_ax}" "Refresh"
+assert_contains "${cost_submenu_ax}" "Cost | submenu=true"
+assert_not_contains "${immediate_parent_ax}" "No data available"
+assert_not_contains "${settled_parent_ax}" "No data available"
+assert_not_contains "${cost_submenu_ax}" "No data available"
+assert_metadata_present "${visual_readiness}" python_executable
+assert_metadata_present "${visual_readiness}" python_version
+if [[ -z "$(metadata_value pillow_version "${visual_readiness}")" ]]; then
+  assert_metadata_present "${visual_readiness}" image_decoder
+fi
+assert_metadata_number_at_least "${visual_readiness}" immediate_parent_width 1
+assert_metadata_number_at_least "${visual_readiness}" immediate_parent_height 1
+assert_metadata_number_at_least "${visual_readiness}" settled_parent_width 1
+assert_metadata_number_at_least "${visual_readiness}" settled_parent_height 1
+assert_metadata_number_at_least "${visual_readiness}" cost_submenu_width 1
+assert_metadata_number_at_least "${visual_readiness}" cost_submenu_height 1
+assert_metadata_equals "${visual_readiness}" settled_parent_bounds_found true
+assert_metadata_number_at_least "${visual_readiness}" cost_submenu_item_count 1
+assert_metadata_number_at_most \
+  "${timing_metadata}" \
+  immediate_parent_capture_ms_after_launch \
+  "${CODEXBAR_MAX_PARENT_CAPTURE_MS_AFTER_LAUNCH:-5000}"
+assert_metadata_number_at_most \
+  "${timing_metadata}" \
+  cost_submenu_capture_ms_after_launch \
+  "${CODEXBAR_MAX_COST_CAPTURE_MS_AFTER_LAUNCH:-10000}"
+
+"${PYTHON_BIN}" - "${proof_manifest}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {manifest_path} {message}")
+
+
+if manifest.get("schema") != 1:
+    fail("schema must be 1")
+if manifest.get("first_launch_uncontested") is not True:
+    fail("first_launch_uncontested must be true")
+
+parent = manifest.get("first_open_parent", {})
+if parent.get("status") != "complete":
+    fail("first_open_parent.status must be complete")
+if parent.get("required_rows_present") is not True:
+    fail("first_open_parent.required_rows_present must be true")
+if parent.get("unexpected_placeholders"):
+    fail("first_open_parent.unexpected_placeholders must be empty")
+if parent.get("menu_bounds_found") is not True:
+    fail("first_open_parent.menu_bounds_found must be true")
+
+cost = manifest.get("first_open_cost_submenu", {})
+if cost.get("opened") is not True:
+    fail("first_open_cost_submenu.opened must be true")
+if cost.get("item_count", 0) < 1:
+    fail("first_open_cost_submenu.item_count must be at least 1")
+if cost.get("placeholder_only") is not False:
+    fail("first_open_cost_submenu.placeholder_only must be false")
+if cost.get("represented_object") != "costHistoryChart":
+    fail("first_open_cost_submenu.represented_object must be costHistoryChart")
+if cost.get("hosted_content_present") is not True:
+    fail("first_open_cost_submenu.hosted_content_present must be true")
+
+late = manifest.get("late_data_refresh", {})
+if late.get("parent_refresh_without_manual_action") is not True:
+    fail("late_data_refresh.parent_refresh_without_manual_action must be true")
+if late.get("hosted_submenu_rebuilt_without_manual_action") is not True:
+    fail("late_data_refresh.hosted_submenu_rebuilt_without_manual_action must be true")
+PY
+
+cat <<EOF
+OK: cold-start validation proves first-after-boot menu readiness.
+artifact=${RUN_DIR}
+app_path=$(metadata_value app_path "${run_metadata}")
+app_binary_sha256=${app_binary_sha256}
+validator_script_sha256=${validator_script_sha256}
+checker_script_sha256=${checker_script_sha256}
+visual_python_executable=$(metadata_value python_executable "${visual_readiness}")
+visual_python_version=$(metadata_value python_version "${visual_readiness}")
+visual_pillow_version=$(metadata_value pillow_version "${visual_readiness}")
+visual_image_decoder=$(metadata_value image_decoder "${visual_readiness}")
+immediate_parent_bounds_found=$(metadata_value immediate_parent_bounds_found "${visual_readiness}")
+settled_parent_bounds_found=$(metadata_value settled_parent_bounds_found "${visual_readiness}")
+cost_submenu_bounds_found=$(metadata_value cost_submenu_bounds_found "${visual_readiness}")
+immediate_parent_size=$(metadata_value immediate_parent_width "${visual_readiness}")x$(metadata_value immediate_parent_height "${visual_readiness}")
+settled_parent_size=$(metadata_value settled_parent_width "${visual_readiness}")x$(metadata_value settled_parent_height "${visual_readiness}")
+cost_submenu_size=$(metadata_value cost_submenu_width "${visual_readiness}")x$(metadata_value cost_submenu_height "${visual_readiness}")
+immediate_parent_gold_pixels=$(metadata_value immediate_parent_gold_pixels "${visual_readiness}")
+settled_parent_gold_pixels=$(metadata_value settled_parent_gold_pixels "${visual_readiness}")
+cost_submenu_aqua_pixels=$(metadata_value cost_submenu_aqua_pixels "${visual_readiness}")
+cost_submenu_item_count=$(metadata_value cost_submenu_item_count "${visual_readiness}")
+immediate_parent_capture_ms_after_launch=$(metadata_value immediate_parent_capture_ms_after_launch "${timing_metadata}")
+cost_submenu_capture_ms_after_launch=$(metadata_value cost_submenu_capture_ms_after_launch "${timing_metadata}")
+cold_start_proof_manifest=${proof_manifest}
+boot_time_utc=$(metadata_value boot_time_utc "${boot_metadata}")
+metadata_written_at_utc=$(metadata_value metadata_written_at_utc "${boot_metadata}")
+uptime_seconds=$(metadata_value uptime_seconds "${boot_metadata}")
+EOF
+
+if [[ -n "${LAUNCHD_SUMMARY_PATH}" ]]; then
+  cat <<EOF
+launchd_summary=${LAUNCHD_SUMMARY_PATH}
+launchd_validated_artifact_dir=${LAUNCHD_VALIDATED_ARTIFACT_DIR}
+launchd_checker_exit_code=${LAUNCHD_CHECKER_EXIT_CODE}
+EOF
+fi

--- a/Scripts/compile_and_run.sh
+++ b/Scripts/compile_and_run.sh
@@ -8,6 +8,7 @@ APP_BUNDLE="${ROOT_DIR}/CodexBar.app"
 APP_PROCESS_PATTERN="CodexBar.app/Contents/MacOS/CodexBar"
 DEBUG_PROCESS_PATTERN="${ROOT_DIR}/.build/debug/CodexBar"
 RELEASE_PROCESS_PATTERN="${ROOT_DIR}/.build/release/CodexBar"
+EXPECTED_APP_PROCESS_PATTERN="${APP_BUNDLE}/Contents/MacOS/CodexBar"
 LOCK_KEY="$(printf '%s' "${ROOT_DIR}" | shasum -a 256 | cut -c1-8)"
 LOCK_DIR="${TMPDIR:-/tmp}/codexbar-compile-and-run-${LOCK_KEY}"
 LOCK_PID_FILE="${LOCK_DIR}/pid"
@@ -234,6 +235,14 @@ kill_all_codexbar() {
   fail "Failed to kill all CodexBar instances."
 }
 
+running_codexbar_process_count() {
+  pgrep -f "${APP_PROCESS_PATTERN}" 2>/dev/null | wc -l | tr -d ' '
+}
+
+running_expected_codexbar_count() {
+  pgrep -f "${EXPECTED_APP_PROCESS_PATTERN}" 2>/dev/null | wc -l | tr -d ' '
+}
+
 # 1) Ensure a single runner instance.
 for arg in "$@"; do
   case "${arg}" in
@@ -309,7 +318,8 @@ fi
 
 # 4) Launch the packaged app.
 log "==> launch app"
-if ! open "${APP_BUNDLE}"; then
+kill_all_codexbar
+if ! open -n "${APP_BUNDLE}"; then
   log "WARN: launch app returned non-zero; falling back to direct binary launch."
   "${APP_BUNDLE}/Contents/MacOS/CodexBar" >/dev/null 2>&1 &
   disown
@@ -317,7 +327,10 @@ fi
 
 # 5) Verify the app stays up for at least a moment (launch can be >1s on some systems).
 for _ in {1..10}; do
-  if pgrep -f "${APP_PROCESS_PATTERN}" >/dev/null 2>&1; then
+  if [[ "$(running_expected_codexbar_count)" == "1" ]]; then
+    if [[ "$(running_codexbar_process_count)" != "1" ]]; then
+      fail "CodexBar launched more than once."
+    fi
     log "OK: CodexBar is running."
     exit 0
   fi

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -461,6 +461,12 @@ codesign "${CODESIGN_ARGS[@]}" \
   --entitlements "$APP_ENTITLEMENTS" \
   "$APP"
 
+if [[ -e "$APP_FINAL" && ! -w "$APP_FINAL" ]]; then
+    echo "ERROR: Cannot replace $APP_FINAL because it is not writable by $(id -un)." >&2
+    echo "Fix ownership or remove the stale bundle before launching a freshly packaged CodexBar." >&2
+    exit 1
+fi
+
 rm -rf "$APP_FINAL"
 mv "$APP" "$APP_FINAL"
 APP="$APP_FINAL"

--- a/Scripts/prepare_next_boot_cold_start_validation.sh
+++ b/Scripts/prepare_next_boot_cold_start_validation.sh
@@ -1,0 +1,963 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_PATH="${CODEXBAR_APP_PATH:-${ROOT}/.build/package/CodexBar.app}"
+LOGIN_ITEM_APP_PATH="${CODEXBAR_LOGIN_ITEM_APP_PATH:-/Applications/CodexBar.app}"
+ARTIFACT_ROOT="${CODEXBAR_COLD_START_ARTIFACT_DIR:-${HOME}/.codex/artifacts/CodexBar}"
+LABEL="${CODEXBAR_COLD_START_LAUNCHD_LABEL:-com.codexbar.cold-start-validation}"
+PLIST_PATH="${HOME}/Library/LaunchAgents/${LABEL}.plist"
+LOG_DIR="${ARTIFACT_ROOT}/launchd"
+RUNNER_PATH="${LOG_DIR}/run-next-boot-validation.sh"
+SUMMARY_PATH="${LOG_DIR}/last-run-summary.txt"
+LOGIN_ITEM_SNAPSHOT_PATH="${LOG_DIR}/codexbar-login-item-snapshot.env"
+PROCESS_PATTERN="CodexBar.app/Contents/MacOS/CodexBar"
+POST_BOOT_MAX_UPTIME_SECONDS="${CODEXBAR_POST_BOOT_MAX_UPTIME_SECONDS:-900}"
+
+usage() {
+  cat <<EOF
+Usage:
+  $0 install
+  $0 uninstall
+  $0 status
+  $0 preflight
+  $0 check-result
+  $0 snapshot-login-item
+  $0 disable-login-item
+  $0 restore-login-item
+
+Environment:
+  CODEXBAR_APP_PATH                  App bundle to validate. Default: ${ROOT}/.build/package/CodexBar.app
+  CODEXBAR_LOGIN_ITEM_APP_PATH       Normal login item app bundle to compare. Default: /Applications/CodexBar.app
+  CODEXBAR_COLD_START_ARTIFACT_DIR   Artifact root. Default: ${HOME}/.codex/artifacts/CodexBar
+  CODEXBAR_POST_BOOT_MAX_UPTIME_SECONDS  First-after-boot window. Default inherited by validator: 900
+EOF
+}
+
+app_binary_sha256() {
+  shasum -a 256 "${APP_PATH}/Contents/MacOS/CodexBar" | awk '{ print $1 }'
+}
+
+script_sha256() {
+  shasum -a 256 "$1" | awk '{ print $1 }'
+}
+
+bundle_binary_sha256() {
+  local bundle_path="$1"
+  shasum -a 256 "${bundle_path}/Contents/MacOS/CodexBar" | awk '{ print $1 }'
+}
+
+runner_expected_app_sha256() {
+  [[ -f "${RUNNER_PATH}" ]] || return 0
+  runner_expected_value EXPECTED_APP_SHA256
+}
+
+runner_expected_validator_sha256() {
+  [[ -f "${RUNNER_PATH}" ]] || return 0
+  runner_expected_value EXPECTED_VALIDATOR_SHA256
+}
+
+runner_expected_checker_sha256() {
+  [[ -f "${RUNNER_PATH}" ]] || return 0
+  runner_expected_value EXPECTED_CHECKER_SHA256
+}
+
+runner_expected_value() {
+  local key="$1"
+  awk -F= -v key="${key}" '$1 == key {
+    value = substr($0, length($1) + 2)
+    gsub(/^"/, "", value)
+    gsub(/"$/, "", value)
+    print value
+  }' "${RUNNER_PATH}" | tail -n 1
+}
+
+runner_contains_final_checker() {
+  [[ -f "${RUNNER_PATH}" ]] || return 1
+  grep -F 'Scripts/check_cold_start_validation_result.sh' "${RUNNER_PATH}" >/dev/null &&
+    grep -F 'CODEXBAR_EXPECTED_APP_PATH="${APP_PATH}"' "${RUNNER_PATH}" >/dev/null &&
+    grep -F 'CODEXBAR_EXPECTED_APP_SHA256="${EXPECTED_APP_SHA256}"' "${RUNNER_PATH}" >/dev/null &&
+    grep -F 'CODEXBAR_EXPECTED_VALIDATOR_SHA256="${EXPECTED_VALIDATOR_SHA256}"' "${RUNNER_PATH}" >/dev/null &&
+    grep -F 'CODEXBAR_EXPECTED_CHECKER_SHA256="${EXPECTED_CHECKER_SHA256}"' "${RUNNER_PATH}" >/dev/null
+}
+
+fail_preflight() {
+  echo "ERROR: $*" >&2
+  return 1
+}
+
+login_items() {
+  osascript <<'APPLESCRIPT' 2>/dev/null || true
+tell application "System Events"
+    get the name of every login item
+end tell
+APPLESCRIPT
+}
+
+normalized_login_items() {
+  login_items | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+}
+
+codexbar_login_item_present() {
+  normalized_login_items |
+    awk 'BEGIN { found = 0 } tolower($0) == "codexbar" { found = 1 } END { print found ? "true" : "false" }'
+}
+
+codexbar_login_item_path() {
+  login_item_snapshot | awk -F= '$1 == "path" { print substr($0, length($1) + 2); exit }'
+}
+
+quote_env_value() {
+  printf "%q" "$1"
+}
+
+login_item_snapshot() {
+  osascript <<'APPLESCRIPT' 2>/dev/null || true
+tell application "System Events"
+    set matchingItems to every login item whose name is "CodexBar"
+    if (count of matchingItems) is 0 then
+        return "present=false"
+    end if
+    set itemRef to item 1 of matchingItems
+    set itemPath to ""
+    set itemHidden to false
+    try
+        set itemPath to path of itemRef
+    end try
+    try
+        set itemHidden to hidden of itemRef
+    end try
+    return "present=true" & linefeed & "name=CodexBar" & linefeed & "path=" & itemPath & linefeed & "hidden=" & (itemHidden as text)
+end tell
+APPLESCRIPT
+}
+
+save_login_item_snapshot() {
+  mkdir -p "${LOG_DIR}"
+  local snapshot
+  local present="false"
+  local item_path=""
+  local hidden="false"
+  snapshot="$(login_item_snapshot)"
+  while IFS= read -r line; do
+    case "${line}" in
+      present=*) present="${line#present=}" ;;
+      path=*) item_path="${line#path=}" ;;
+      hidden=*) hidden="${line#hidden=}" ;;
+    esac
+  done <<<"${snapshot}"
+
+  {
+    echo "present=$(quote_env_value "${present}")"
+    echo "name=CodexBar"
+    echo "path=$(quote_env_value "${item_path}")"
+    echo "hidden=$(quote_env_value "${hidden}")"
+    echo "saved_at_utc=$(quote_env_value "$(date -u '+%Y-%m-%dT%H:%M:%SZ')")"
+  } >"${LOGIN_ITEM_SNAPSHOT_PATH}"
+
+  echo "Saved CodexBar Login Item snapshot: ${LOGIN_ITEM_SNAPSHOT_PATH}"
+  echo "login_item_present=${present}"
+  if [[ -n "${item_path}" ]]; then
+    echo "login_item_path=${item_path}"
+  fi
+  echo "login_item_hidden=${hidden}"
+}
+
+disable_login_item_for_validation() {
+  save_login_item_snapshot
+  if [[ "$(codexbar_login_item_present)" != "true" ]]; then
+    echo "CodexBar Login Item is already absent."
+    return 0
+  fi
+  osascript <<'APPLESCRIPT'
+tell application "System Events"
+    delete every login item whose name is "CodexBar"
+end tell
+APPLESCRIPT
+  echo "Disabled CodexBar Login Item for uncontested cold-start validation."
+}
+
+restore_login_item_snapshot() {
+  if [[ ! -f "${LOGIN_ITEM_SNAPSHOT_PATH}" ]]; then
+    echo "ERROR: Login Item snapshot not found: ${LOGIN_ITEM_SNAPSHOT_PATH}" >&2
+    return 1
+  fi
+
+  local present=""
+  local item_path=""
+  local hidden="false"
+  # shellcheck disable=SC1090
+  source "${LOGIN_ITEM_SNAPSHOT_PATH}"
+  present="${present:-false}"
+  item_path="${path:-}"
+  hidden="${hidden:-false}"
+
+  if [[ "${present}" != "true" ]]; then
+    echo "Snapshot recorded no CodexBar Login Item; nothing to restore."
+    return 0
+  fi
+  if [[ -z "${item_path}" ]]; then
+    echo "ERROR: Snapshot is missing the Login Item path." >&2
+    return 1
+  fi
+  if [[ ! -e "${item_path}" ]]; then
+    echo "ERROR: Snapshot Login Item path no longer exists: ${item_path}" >&2
+    return 1
+  fi
+  if [[ "$(codexbar_login_item_present)" == "true" ]]; then
+    echo "CodexBar Login Item is already present."
+    return 0
+  fi
+
+  LOGIN_ITEM_RESTORE_PATH="${item_path}" LOGIN_ITEM_RESTORE_HIDDEN="${hidden}" osascript <<'APPLESCRIPT'
+set restorePath to system attribute "LOGIN_ITEM_RESTORE_PATH"
+set restoreHidden to (system attribute "LOGIN_ITEM_RESTORE_HIDDEN") is "true"
+tell application "System Events"
+    make login item at end with properties {path:restorePath, hidden:restoreHidden}
+end tell
+APPLESCRIPT
+  echo "Restored CodexBar Login Item from snapshot."
+  echo "login_item_path=${item_path}"
+  echo "login_item_hidden=${hidden}"
+}
+
+running_codexbar_processes() {
+  ps -axo pid=,comm=,args= | awk '
+    {
+      pid=$1
+      comm=$2
+      $1=""
+      $2=""
+      sub(/^[[:space:]]+/, "")
+      split(comm, parts, "/")
+      commExecutable=parts[length(parts)]
+      split($0, argvParts, /[[:space:]]+/)
+      split(argvParts[1], argvPathParts, "/")
+      argvExecutable=argvPathParts[length(argvPathParts)]
+      if (commExecutable == "CodexBar" || argvExecutable == "CodexBar") {
+        print pid " " $0
+      }
+    }
+  '
+}
+
+count_running_codexbar_processes() {
+  running_codexbar_processes | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' '
+}
+
+current_boot_epoch() {
+  sysctl -n kern.boottime | sed -E 's/^\{ sec = ([0-9]+),.*/\1/'
+}
+
+epoch_to_utc_iso() {
+  TZ=UTC date -r "$1" '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+now_epoch() {
+  date +%s
+}
+
+status_latest_artifact_dir() {
+  find "${ARTIFACT_ROOT}" -maxdepth 1 -type d -name 'cold-start-*' -print 2>/dev/null | sort | tail -n 1
+}
+
+artifact_metadata_value() {
+  local key="$1"
+  local file="$2"
+  [[ -f "${file}" ]] || return 0
+  awk -F= -v key="${key}" '$1 == key { print substr($0, length(key) + 2) }' "${file}" | tail -n 1
+}
+
+resolve_visual_python() {
+  local candidate
+  for candidate in \
+    "${CODEXBAR_PYTHON_BIN:-}" \
+    "$(command -v python3 2>/dev/null || true)" \
+    /opt/homebrew/bin/python3 \
+    /usr/local/bin/python3 \
+    /usr/bin/python3; do
+    [[ -n "${candidate}" && -x "${candidate}" ]] || continue
+    if "${candidate}" <<'PY' >/dev/null 2>&1
+from PIL import __version__
+PY
+    then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  return 1
+}
+
+python_visual_readiness_metadata() {
+  local python_bin="$1"
+  "${python_bin}" <<'PY' 2>/dev/null
+import sys
+from PIL import __version__ as pillow_version
+
+print(f"python_executable={sys.executable}")
+print(f"python_version={sys.version.split()[0]}")
+print(f"pillow_version={pillow_version}")
+PY
+}
+
+python_visual_readiness_available() {
+  local python_bin="$1"
+  python_visual_readiness_metadata "${python_bin}" >/dev/null
+}
+
+ensure_paths() {
+  local python_bin
+  [[ -d "${APP_PATH}" ]] || {
+    echo "ERROR: App bundle not found: ${APP_PATH}" >&2
+    exit 1
+  }
+  [[ -x "${ROOT}/Scripts/validate_cold_start_menu.sh" ]] || {
+    echo "ERROR: Validator is not executable: ${ROOT}/Scripts/validate_cold_start_menu.sh" >&2
+    exit 1
+  }
+  [[ -x "${ROOT}/Scripts/check_cold_start_validation_result.sh" ]] || {
+    echo "ERROR: Result checker is not executable: ${ROOT}/Scripts/check_cold_start_validation_result.sh" >&2
+    exit 1
+  }
+  [[ -x "${APP_PATH}/Contents/MacOS/CodexBar" ]] || {
+    echo "ERROR: App executable not found: ${APP_PATH}/Contents/MacOS/CodexBar" >&2
+    exit 1
+  }
+  python_bin="$(resolve_visual_python)" || {
+    echo "ERROR: Python/Pillow is required for visual-readiness screenshot analysis." >&2
+    exit 1
+  }
+  python_visual_readiness_available "${python_bin}" || {
+    echo "ERROR: Python/Pillow is required for visual-readiness screenshot analysis." >&2
+    exit 1
+  }
+  mkdir -p "${HOME}/Library/LaunchAgents" "${LOG_DIR}"
+}
+
+install_agent() {
+  ensure_paths
+  local expected_app_sha256
+  local expected_checker_sha256
+  local expected_validator_sha256
+  local python_bin
+  expected_app_sha256="$(app_binary_sha256)"
+  expected_validator_sha256="$(script_sha256 "${ROOT}/Scripts/validate_cold_start_menu.sh")"
+  expected_checker_sha256="$(script_sha256 "${ROOT}/Scripts/check_cold_start_validation_result.sh")"
+  python_bin="$(resolve_visual_python)"
+  rm -f "${SUMMARY_PATH}" "${LOG_DIR}/launchd.stdout.log" "${LOG_DIR}/launchd.stderr.log"
+
+  cat >"${RUNNER_PATH}" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+LABEL="${LABEL}"
+PLIST_PATH="${PLIST_PATH}"
+ROOT="${ROOT}"
+APP_PATH="${APP_PATH}"
+LOGIN_ITEM_APP_PATH="${LOGIN_ITEM_APP_PATH}"
+ARTIFACT_ROOT="${ARTIFACT_ROOT}"
+LOG_DIR="${LOG_DIR}"
+SUMMARY_PATH="${SUMMARY_PATH}"
+PROCESS_PATTERN="${PROCESS_PATTERN}"
+EXPECTED_APP_SHA256="${expected_app_sha256}"
+EXPECTED_VALIDATOR_SHA256="${expected_validator_sha256}"
+EXPECTED_CHECKER_SHA256="${expected_checker_sha256}"
+PYTHON_BIN="${python_bin}"
+STARTED_AT="\$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+VALIDATED_ARTIFACT_DIR=""
+CHECKER_EXIT_CODE=""
+LOGIN_ITEM_PRESENT_AT_RUNNER_START=""
+LOGIN_ITEM_APP_PATH_AT_RUNNER_START=""
+LOGIN_ITEM_APP_SHA256_AT_RUNNER_START=""
+RUNNING_CODEXBAR_PROCESS_COUNT_AT_RUNNER_START=""
+RUNNING_CODEXBAR_PROCESSES_AT_RUNNER_START=""
+
+latest_artifact_dir() {
+  find "\${ARTIFACT_ROOT}" -maxdepth 1 -type d -name 'cold-start-*' -print 2>/dev/null | sort | tail -n 1
+}
+
+bundle_binary_sha256() {
+  local bundle_path="\$1"
+  shasum -a 256 "\${bundle_path}/Contents/MacOS/CodexBar" | awk '{ print \$1 }'
+}
+
+login_items() {
+  osascript <<'APPLESCRIPT' 2>/dev/null || true
+tell application "System Events"
+    get the name of every login item
+end tell
+APPLESCRIPT
+}
+
+normalized_login_items() {
+  login_items | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*\$//'
+}
+
+codexbar_login_item_present() {
+  normalized_login_items |
+    awk 'BEGIN { found = 0 } tolower(\$0) == "codexbar" { found = 1 } END { print found ? "true" : "false" }'
+}
+
+login_item_snapshot() {
+  osascript <<'APPLESCRIPT' 2>/dev/null || true
+tell application "System Events"
+    set matchingItems to every login item whose name is "CodexBar"
+    if (count of matchingItems) is 0 then
+        return "present=false"
+    end if
+    set itemRef to item 1 of matchingItems
+    set itemPath to ""
+    set itemHidden to false
+    try
+        set itemPath to path of itemRef
+    end try
+    try
+        set itemHidden to hidden of itemRef
+    end try
+    return "present=true" & linefeed & "name=CodexBar" & linefeed & "path=" & itemPath & linefeed & "hidden=" & (itemHidden as text)
+end tell
+APPLESCRIPT
+}
+
+codexbar_login_item_path() {
+  login_item_snapshot | awk -F= '\$1 == "path" { print substr(\$0, length(\$1) + 2); exit }'
+}
+
+running_codexbar_processes() {
+  ps -axo pid=,comm=,args= | awk '
+    {
+      pid=\$1
+      comm=\$2
+      \$1=""
+      \$2=""
+      sub(/^[[:space:]]+/, "")
+      split(comm, parts, "/")
+      commExecutable=parts[length(parts)]
+      split(\$0, argvParts, /[[:space:]]+/)
+      split(argvParts[1], argvPathParts, "/")
+      argvExecutable=argvPathParts[length(argvPathParts)]
+      if (commExecutable == "CodexBar" || argvExecutable == "CodexBar") {
+        print pid " " \$0
+      }
+    }
+  '
+}
+
+count_running_codexbar_processes() {
+  running_codexbar_processes | sed '/^[[:space:]]*\$/d' | wc -l | tr -d ' '
+}
+
+write_summary() {
+  local exit_code="\$1"
+  local ended_at
+  ended_at="\$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  mkdir -p "\${LOG_DIR}"
+  {
+    echo "started_at_utc=\${STARTED_AT}"
+    echo "ended_at_utc=\${ended_at}"
+    echo "exit_code=\${exit_code}"
+    echo "root=\${ROOT}"
+    echo "app_path=\${APP_PATH}"
+    echo "expected_app_sha256=\${EXPECTED_APP_SHA256}"
+    echo "expected_validator_sha256=\${EXPECTED_VALIDATOR_SHA256}"
+    echo "expected_checker_sha256=\${EXPECTED_CHECKER_SHA256}"
+    echo "login_item_app_path=\${LOGIN_ITEM_APP_PATH_AT_RUNNER_START:-\${LOGIN_ITEM_APP_PATH}}"
+    echo "login_item_present_at_runner_start=\${LOGIN_ITEM_PRESENT_AT_RUNNER_START}"
+    echo "login_item_app_sha256_at_runner_start=\${LOGIN_ITEM_APP_SHA256_AT_RUNNER_START}"
+    echo "running_codexbar_process_count_at_runner_start=\${RUNNING_CODEXBAR_PROCESS_COUNT_AT_RUNNER_START}"
+    if [[ -n "\${RUNNING_CODEXBAR_PROCESSES_AT_RUNNER_START}" ]]; then
+      printf '%s\n' "\${RUNNING_CODEXBAR_PROCESSES_AT_RUNNER_START}" |
+        sed 's/^/running_codexbar_process_at_runner_start=/'
+    fi
+    echo "artifact_root=\${ARTIFACT_ROOT}"
+    echo "latest_artifact_dir=\$(latest_artifact_dir)"
+    echo "validated_artifact_dir=\${VALIDATED_ARTIFACT_DIR}"
+    echo "checker_exit_code=\${CHECKER_EXIT_CODE}"
+  } >"\${SUMMARY_PATH}"
+}
+
+guard_clean_login_context() {
+  LOGIN_ITEM_PRESENT_AT_RUNNER_START="\$(codexbar_login_item_present)"
+  RUNNING_CODEXBAR_PROCESS_COUNT_AT_RUNNER_START="\$(count_running_codexbar_processes)"
+
+  if [[ "\${LOGIN_ITEM_PRESENT_AT_RUNNER_START}" == "true" ]]; then
+    LOGIN_ITEM_APP_PATH_AT_RUNNER_START="\$(codexbar_login_item_path)"
+    if [[ -z "\${LOGIN_ITEM_APP_PATH_AT_RUNNER_START}" ]]; then
+      LOGIN_ITEM_APP_PATH_AT_RUNNER_START="\${LOGIN_ITEM_APP_PATH}"
+    fi
+    if [[ ! -x "\${LOGIN_ITEM_APP_PATH_AT_RUNNER_START}/Contents/MacOS/CodexBar" ]]; then
+      echo "ERROR: CodexBar Login Item is present, but executable is missing: \${LOGIN_ITEM_APP_PATH_AT_RUNNER_START}/Contents/MacOS/CodexBar" >&2
+      exit 1
+    fi
+    LOGIN_ITEM_APP_SHA256_AT_RUNNER_START="\$(bundle_binary_sha256 "\${LOGIN_ITEM_APP_PATH_AT_RUNNER_START}")"
+    echo "ERROR: CodexBar Login Item is present; refusing to collect contested first-launch proof." >&2
+    exit 1
+  fi
+
+  if [[ "\${RUNNING_CODEXBAR_PROCESS_COUNT_AT_RUNNER_START}" != "0" ]]; then
+    RUNNING_CODEXBAR_PROCESSES_AT_RUNNER_START="\$(running_codexbar_processes)"
+    echo "ERROR: CodexBar is already running at runner start; refusing to collect invalid first-launch proof." >&2
+    exit 1
+  fi
+}
+
+cleanup() {
+  launchctl bootout "gui/\$(id -u)" "\${PLIST_PATH}" >/dev/null 2>&1 || true
+  rm -f "\${PLIST_PATH}"
+}
+on_exit() {
+  local exit_code="\$?"
+  write_summary "\${exit_code}" || true
+  cleanup
+  exit "\${exit_code}"
+}
+trap on_exit EXIT
+
+mkdir -p "\${LOG_DIR}"
+{
+  echo "started_at_utc=\${STARTED_AT}"
+  echo "root=\${ROOT}"
+  echo "app_path=\${APP_PATH}"
+  echo "expected_app_sha256=\${EXPECTED_APP_SHA256}"
+  echo "expected_validator_sha256=\${EXPECTED_VALIDATOR_SHA256}"
+  echo "expected_checker_sha256=\${EXPECTED_CHECKER_SHA256}"
+  echo "login_item_app_path=\${LOGIN_ITEM_APP_PATH}"
+  echo "login_item_present_at_runner_start="
+  echo "login_item_app_sha256_at_runner_start="
+  echo "running_codexbar_process_count_at_runner_start="
+  echo "artifact_root=\${ARTIFACT_ROOT}"
+  echo "validated_artifact_dir="
+  echo "checker_exit_code="
+} >"\${SUMMARY_PATH}"
+
+guard_clean_login_context
+
+cd "\${ROOT}"
+CODEXBAR_APP_PATH="\${APP_PATH}" \\
+CODEXBAR_COLD_START_ARTIFACT_DIR="\${ARTIFACT_ROOT}" \\
+CODEXBAR_PYTHON_BIN="\${PYTHON_BIN}" \\
+"\${ROOT}/Scripts/validate_cold_start_menu.sh"
+
+LATEST_ARTIFACT_DIR="\$(latest_artifact_dir)"
+if [[ -z "\${LATEST_ARTIFACT_DIR}" ]]; then
+  echo "ERROR: Validator did not produce a cold-start artifact directory." >&2
+  exit 1
+fi
+VALIDATED_ARTIFACT_DIR="\${LATEST_ARTIFACT_DIR}"
+
+set +e
+CODEXBAR_EXPECTED_APP_PATH="\${APP_PATH}" \\
+CODEXBAR_EXPECTED_APP_SHA256="\${EXPECTED_APP_SHA256}" \\
+CODEXBAR_EXPECTED_VALIDATOR_SHA256="\${EXPECTED_VALIDATOR_SHA256}" \\
+CODEXBAR_EXPECTED_CHECKER_SHA256="\${EXPECTED_CHECKER_SHA256}" \\
+"\${ROOT}/Scripts/check_cold_start_validation_result.sh" "\${LATEST_ARTIFACT_DIR}"
+CHECKER_EXIT_CODE="\$?"
+set -e
+if [[ "\${CHECKER_EXIT_CODE}" != "0" ]]; then
+  exit "\${CHECKER_EXIT_CODE}"
+fi
+EOF
+  chmod +x "${RUNNER_PATH}"
+
+  cat >"${PLIST_PATH}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${RUNNER_PATH}</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>${LOG_DIR}/launchd.stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>${LOG_DIR}/launchd.stderr.log</string>
+</dict>
+</plist>
+EOF
+
+  plutil -lint "${PLIST_PATH}" >/dev/null
+  echo "Installed one-shot LaunchAgent: ${PLIST_PATH}"
+  echo "It will run at next login, then unload and remove itself."
+}
+
+uninstall_agent() {
+  launchctl bootout "gui/$(id -u)" "${PLIST_PATH}" >/dev/null 2>&1 || true
+  rm -f "${PLIST_PATH}" "${RUNNER_PATH}"
+  echo "Removed LaunchAgent and runner for ${LABEL}."
+}
+
+show_status() {
+  local boot_epoch=""
+  local latest_artifact_dir=""
+  local latest_boot_metadata=""
+  local latest_boot_time=""
+  local latest_candidate=""
+  local current_uptime_seconds=""
+  local summary_validated_artifact=""
+  local summary_checker_exit_code=""
+  local summary_exit_code=""
+  local proof_state="post_boot_run_pending"
+
+  boot_epoch="$(current_boot_epoch)"
+  current_uptime_seconds=$(( $(now_epoch) - boot_epoch ))
+  echo "current_boot_epoch=${boot_epoch}"
+  echo "current_boot_time_utc=$(epoch_to_utc_iso "${boot_epoch}")"
+  echo "current_uptime_seconds=${current_uptime_seconds}"
+  echo "post_boot_max_uptime_seconds=${POST_BOOT_MAX_UPTIME_SECONDS}"
+  if [[ "${current_uptime_seconds}" -le "${POST_BOOT_MAX_UPTIME_SECONDS}" ]]; then
+    echo "current_post_boot_window_open=true"
+  else
+    echo "current_post_boot_window_open=false"
+    echo "WARNING: This boot session is outside the first-after-boot validation window."
+    echo "Reboot before the next login if you need first-after-boot proof instead of a logout/login proof."
+  fi
+  echo "launchd_summary_path=${SUMMARY_PATH}"
+  echo "login_item_snapshot_path=${LOGIN_ITEM_SNAPSHOT_PATH}"
+  if [[ -f "${SUMMARY_PATH}" ]]; then
+    echo "launchd_summary_present=true"
+    summary_exit_code="$(artifact_metadata_value exit_code "${SUMMARY_PATH}")"
+    summary_validated_artifact="$(artifact_metadata_value validated_artifact_dir "${SUMMARY_PATH}")"
+    summary_checker_exit_code="$(artifact_metadata_value checker_exit_code "${SUMMARY_PATH}")"
+    echo "launchd_summary_exit_code=${summary_exit_code}"
+    echo "launchd_summary_validated_artifact_dir=${summary_validated_artifact}"
+    echo "launchd_summary_checker_exit_code=${summary_checker_exit_code}"
+    if [[ "${summary_exit_code}" == "0" && "${summary_checker_exit_code}" == "0" && -n "${summary_validated_artifact}" ]]; then
+      proof_state="launchd_summary_passed"
+    else
+      proof_state="launchd_summary_failed_or_incomplete"
+    fi
+  else
+    echo "launchd_summary_present=false"
+    if [[ "${current_uptime_seconds}" -gt "${POST_BOOT_MAX_UPTIME_SECONDS}" ]]; then
+      proof_state="post_boot_window_expired_reboot_required"
+    fi
+  fi
+  latest_artifact_dir="$(status_latest_artifact_dir)"
+  echo "latest_artifact_dir=${latest_artifact_dir}"
+  if [[ -n "${latest_artifact_dir}" ]]; then
+    latest_boot_metadata="${latest_artifact_dir}/boot-session-metadata.txt"
+    if [[ -f "${latest_boot_metadata}" ]]; then
+      echo "latest_artifact_has_boot_metadata=true"
+    else
+      echo "latest_artifact_has_boot_metadata=false"
+    fi
+    latest_boot_time="$(artifact_metadata_value boot_time_utc "${latest_boot_metadata}")"
+    latest_candidate="$(artifact_metadata_value post_boot_first_launch_candidate "${latest_boot_metadata}")"
+    echo "latest_artifact_boot_time_utc=${latest_boot_time}"
+    echo "latest_artifact_first_launch_candidate=${latest_candidate}"
+    if [[ -n "${latest_boot_time}" && "${latest_boot_time}" != "$(epoch_to_utc_iso "${boot_epoch}")" ]]; then
+      echo "latest_artifact_matches_current_boot=false"
+    elif [[ -n "${latest_boot_time}" ]]; then
+      echo "latest_artifact_matches_current_boot=true"
+    fi
+  fi
+
+	  if [[ -f "${PLIST_PATH}" ]]; then
+	    local current_app_sha256=""
+	    local login_item_app_sha256=""
+	    local login_item_app_path=""
+	    local login_item_names=""
+	    local login_item_present=""
+    local installed_expected_sha256=""
+    local current_checker_sha256=""
+    local current_validator_sha256=""
+    local installed_expected_checker_sha256=""
+    local installed_expected_validator_sha256=""
+    local running_count=""
+    local setup_invalid=false
+
+    echo "installed ${PLIST_PATH}"
+    plutil -lint "${PLIST_PATH}"
+	    login_item_names="$(normalized_login_items | paste -sd ',' -)"
+	    echo "login_items=${login_item_names}"
+	    login_item_present="$(codexbar_login_item_present)"
+	    echo "codexbar_login_item_present=${login_item_present}"
+	    if [[ "${login_item_present}" == "true" ]]; then
+	      login_item_app_path="$(codexbar_login_item_path)"
+	      if [[ -z "${login_item_app_path}" ]]; then
+	        login_item_app_path="${LOGIN_ITEM_APP_PATH}"
+	      fi
+	      echo "WARNING: A normal CodexBar Login Item may launch before the cold-start validator."
+	      echo "Disable that login item before rebooting if you need uncontested first-launch proof."
+	      setup_invalid=true
+	      echo "login_item_app_path=${login_item_app_path}"
+	      if [[ -x "${login_item_app_path}/Contents/MacOS/CodexBar" ]]; then
+	        login_item_app_sha256="$(bundle_binary_sha256 "${login_item_app_path}")"
+	        echo "login_item_app_sha256=${login_item_app_sha256}"
+	      else
+	        echo "WARNING: Login item comparison app executable is missing: ${login_item_app_path}/Contents/MacOS/CodexBar"
+	      fi
+	    else
+	      echo "login_item_app_path=${LOGIN_ITEM_APP_PATH}"
+	    fi
+    if [[ -f "${RUNNER_PATH}" ]]; then
+      echo "runner ${RUNNER_PATH}"
+      if runner_contains_final_checker; then
+        echo "runner_final_checker_present=true"
+      else
+        echo "runner_final_checker_present=false"
+        echo "WARNING: LaunchAgent runner is stale; run '$0 install' again before rebooting."
+        setup_invalid=true
+      fi
+    else
+      echo "WARNING: LaunchAgent plist exists but runner is missing: ${RUNNER_PATH}"
+      echo "Run '$0 install' again before rebooting."
+      setup_invalid=true
+    fi
+    if [[ -x "${APP_PATH}/Contents/MacOS/CodexBar" ]]; then
+      current_app_sha256="$(app_binary_sha256)"
+      echo "current_app_sha256=${current_app_sha256}"
+      installed_expected_sha256="$(runner_expected_app_sha256)"
+      if [[ -n "${installed_expected_sha256}" ]]; then
+        echo "installed_expected_app_sha256=${installed_expected_sha256}"
+        if [[ "${installed_expected_sha256}" != "${current_app_sha256}" ]]; then
+          echo "WARNING: installed LaunchAgent expected hash does not match current app binary."
+          echo "Run '$0 install' again before rebooting if the package changed."
+          setup_invalid=true
+        fi
+      else
+        echo "WARNING: installed runner is missing expected app hash."
+        echo "Run '$0 install' again before rebooting."
+        setup_invalid=true
+      fi
+      current_validator_sha256="$(script_sha256 "${ROOT}/Scripts/validate_cold_start_menu.sh")"
+      current_checker_sha256="$(script_sha256 "${ROOT}/Scripts/check_cold_start_validation_result.sh")"
+      echo "current_validator_sha256=${current_validator_sha256}"
+      echo "current_checker_sha256=${current_checker_sha256}"
+      installed_expected_validator_sha256="$(runner_expected_validator_sha256)"
+      installed_expected_checker_sha256="$(runner_expected_checker_sha256)"
+      echo "installed_expected_validator_sha256=${installed_expected_validator_sha256}"
+      echo "installed_expected_checker_sha256=${installed_expected_checker_sha256}"
+      if [[ "${installed_expected_validator_sha256}" != "${current_validator_sha256}" ||
+        "${installed_expected_checker_sha256}" != "${current_checker_sha256}" ]]; then
+        echo "WARNING: installed LaunchAgent expected validation script hash does not match current scripts."
+        echo "Run '$0 install' again before rebooting if the validation scripts changed."
+        setup_invalid=true
+      fi
+    else
+      echo "WARNING: App executable missing: ${APP_PATH}/Contents/MacOS/CodexBar"
+      setup_invalid=true
+    fi
+    if [[ "${login_item_present}" == "true" && -n "${current_app_sha256}" && -n "${login_item_app_sha256:-}" &&
+      "${login_item_app_sha256}" != "${current_app_sha256}" ]]; then
+      echo "WARNING: Normal Login Item app binary differs from the validation target."
+      echo "A next-login race would validate the wrong installed app unless the Login Item is disabled or updated."
+      setup_invalid=true
+    fi
+    running_count="$(count_running_codexbar_processes)"
+    echo "running_codexbar_process_count=${running_count}"
+    if [[ "${running_count}" != "0" ]]; then
+      running_codexbar_processes | sed 's/^/running_codexbar_process=/'
+      echo "WARNING: CodexBar is already running; this invalidates immediate first-launch proof until the next clean boot/login."
+      setup_invalid=true
+    fi
+    if [[ "${setup_invalid}" == "true" && (
+      "${proof_state}" == "post_boot_run_pending" ||
+        "${proof_state}" == "post_boot_window_expired_reboot_required"
+    ) ]]; then
+      proof_state="setup_incomplete"
+    fi
+  else
+    echo "not installed"
+    if [[ "${proof_state}" == "post_boot_run_pending" ||
+      "${proof_state}" == "post_boot_window_expired_reboot_required" ]]; then
+      proof_state="setup_incomplete"
+    fi
+  fi
+  echo "proof_state=${proof_state}"
+  if [[ -f "${LOG_DIR}/launchd.stdout.log" || -f "${LOG_DIR}/launchd.stderr.log" ]]; then
+    echo "logs ${LOG_DIR}"
+  fi
+  if [[ -f "${SUMMARY_PATH}" ]]; then
+    echo "summary ${SUMMARY_PATH}"
+    cat "${SUMMARY_PATH}"
+  fi
+}
+
+preflight() {
+  local current_app_sha256=""
+  local login_item_app_sha256=""
+  local login_item_app_path=""
+  local login_item_present=""
+  local installed_expected_sha256=""
+  local current_checker_sha256=""
+  local current_validator_sha256=""
+  local installed_expected_checker_sha256=""
+  local installed_expected_validator_sha256=""
+  local python_bin=""
+  local visual_readiness_python_metadata=""
+  local running_count=""
+  local failures=0
+
+  ensure_paths
+
+  if [[ ! -f "${PLIST_PATH}" ]]; then
+    fail_preflight "LaunchAgent is not installed: ${PLIST_PATH}" || failures=$((failures + 1))
+  elif ! plutil -lint "${PLIST_PATH}" >/dev/null; then
+    fail_preflight "LaunchAgent plist is invalid: ${PLIST_PATH}" || failures=$((failures + 1))
+  fi
+
+  if [[ ! -f "${RUNNER_PATH}" ]]; then
+    fail_preflight "LaunchAgent runner is missing: ${RUNNER_PATH}" || failures=$((failures + 1))
+  elif ! runner_contains_final_checker; then
+    fail_preflight "LaunchAgent runner is stale; reinstall to include final artifact checker" || failures=$((failures + 1))
+  fi
+
+  current_app_sha256="$(app_binary_sha256)"
+  python_bin="$(resolve_visual_python || true)"
+  if [[ -z "${python_bin}" ]]; then
+    fail_preflight "Python/Pillow visual-readiness dependency is unavailable" || failures=$((failures + 1))
+  fi
+  visual_readiness_python_metadata="$(python_visual_readiness_metadata "${python_bin}" || true)"
+  if [[ -z "${visual_readiness_python_metadata}" ]]; then
+    fail_preflight "Python/Pillow visual-readiness dependency is unavailable" || failures=$((failures + 1))
+  fi
+  installed_expected_sha256="$(runner_expected_app_sha256)"
+  if [[ -z "${installed_expected_sha256}" ]]; then
+    fail_preflight "Installed runner is missing EXPECTED_APP_SHA256" || failures=$((failures + 1))
+  elif [[ "${installed_expected_sha256}" != "${current_app_sha256}" ]]; then
+    fail_preflight "Installed expected app hash does not match current validation target" || failures=$((failures + 1))
+  fi
+
+  current_validator_sha256="$(script_sha256 "${ROOT}/Scripts/validate_cold_start_menu.sh")"
+  current_checker_sha256="$(script_sha256 "${ROOT}/Scripts/check_cold_start_validation_result.sh")"
+  installed_expected_validator_sha256="$(runner_expected_validator_sha256)"
+  installed_expected_checker_sha256="$(runner_expected_checker_sha256)"
+  if [[ -z "${installed_expected_validator_sha256}" || -z "${installed_expected_checker_sha256}" ]]; then
+    fail_preflight "Installed runner is missing validation script hashes" || failures=$((failures + 1))
+  elif [[ "${installed_expected_validator_sha256}" != "${current_validator_sha256}" ||
+    "${installed_expected_checker_sha256}" != "${current_checker_sha256}" ]]; then
+    fail_preflight "Installed expected validation script hash does not match current scripts" || failures=$((failures + 1))
+  fi
+
+  login_item_present="$(codexbar_login_item_present)"
+  if [[ "${login_item_present}" == "true" ]]; then
+    login_item_app_path="$(codexbar_login_item_path)"
+    if [[ -z "${login_item_app_path}" ]]; then
+      login_item_app_path="${LOGIN_ITEM_APP_PATH}"
+    fi
+    fail_preflight "CodexBar Login Item is present; uncontested first-launch proof requires it to be disabled" || failures=$((failures + 1))
+    if [[ ! -x "${login_item_app_path}/Contents/MacOS/CodexBar" ]]; then
+      fail_preflight "CodexBar Login Item is present, but comparison app executable is missing: ${login_item_app_path}/Contents/MacOS/CodexBar" || failures=$((failures + 1))
+    else
+      login_item_app_sha256="$(bundle_binary_sha256 "${login_item_app_path}")"
+      if [[ "${login_item_app_sha256}" != "${current_app_sha256}" ]]; then
+        fail_preflight "CodexBar Login Item app binary differs from the validation target" || failures=$((failures + 1))
+      fi
+    fi
+  else
+    login_item_app_path="${LOGIN_ITEM_APP_PATH}"
+  fi
+
+  running_count="$(count_running_codexbar_processes)"
+  if [[ "${running_count}" != "0" ]]; then
+    fail_preflight "CodexBar is already running; first-launch proof requires no preexisting process" || failures=$((failures + 1))
+  fi
+
+  if [[ "${failures}" -gt 0 ]]; then
+    cat >&2 <<EOF
+Preflight failed for next-boot cold-start validation.
+app_path=${APP_PATH}
+current_app_sha256=${current_app_sha256}
+installed_expected_app_sha256=${installed_expected_sha256}
+current_validator_sha256=${current_validator_sha256}
+installed_expected_validator_sha256=${installed_expected_validator_sha256}
+current_checker_sha256=${current_checker_sha256}
+installed_expected_checker_sha256=${installed_expected_checker_sha256}
+${visual_readiness_python_metadata}
+codexbar_login_item_present=${login_item_present}
+login_item_app_path=${login_item_app_path}
+login_item_app_sha256=${login_item_app_sha256}
+running_codexbar_process_count=${running_count}
+EOF
+    running_codexbar_processes | sed 's/^/running_codexbar_process=/' >&2
+    return 1
+  fi
+
+  cat <<EOF
+OK: next-boot cold-start validation preflight passed.
+app_path=${APP_PATH}
+current_app_sha256=${current_app_sha256}
+installed_expected_app_sha256=${installed_expected_sha256}
+current_validator_sha256=${current_validator_sha256}
+installed_expected_validator_sha256=${installed_expected_validator_sha256}
+current_checker_sha256=${current_checker_sha256}
+installed_expected_checker_sha256=${installed_expected_checker_sha256}
+${visual_readiness_python_metadata}
+codexbar_login_item_present=${login_item_present}
+login_item_app_path=${login_item_app_path}
+login_item_app_sha256=${login_item_app_sha256}
+running_codexbar_process_count=${running_count}
+EOF
+}
+
+check_result() {
+  ensure_paths
+  local expected_app_sha256
+  local expected_checker_sha256
+  local expected_validator_sha256
+  local validated_artifact_dir
+  local app_bundle_metadata
+  if [[ ! -f "${SUMMARY_PATH}" ]]; then
+    echo "ERROR: LaunchAgent summary is missing: ${SUMMARY_PATH}" >&2
+    echo "The one-shot cold-start validator has not run in this boot session yet." >&2
+    echo "Reboot, log in, then run '$0 check-result' again." >&2
+    return 1
+  fi
+  validated_artifact_dir="$(artifact_metadata_value validated_artifact_dir "${SUMMARY_PATH}")"
+  if [[ -z "${validated_artifact_dir}" ]]; then
+    echo "ERROR: LaunchAgent summary does not name a validated artifact directory: ${SUMMARY_PATH}" >&2
+    cat "${SUMMARY_PATH}" >&2
+    return 1
+  fi
+  app_bundle_metadata="${validated_artifact_dir}/app-bundle-metadata.txt"
+  expected_app_sha256="$(artifact_metadata_value app_binary_sha256 "${app_bundle_metadata}")"
+  expected_validator_sha256="$(artifact_metadata_value validator_script_sha256 "${app_bundle_metadata}")"
+  expected_checker_sha256="$(artifact_metadata_value checker_script_sha256 "${app_bundle_metadata}")"
+  CODEXBAR_COLD_START_ARTIFACT_DIR="${ARTIFACT_ROOT}" \
+  CODEXBAR_EXPECTED_APP_PATH="${APP_PATH}" \
+  CODEXBAR_EXPECTED_APP_SHA256="${expected_app_sha256}" \
+  CODEXBAR_EXPECTED_VALIDATOR_SHA256="${expected_validator_sha256}" \
+  CODEXBAR_EXPECTED_CHECKER_SHA256="${expected_checker_sha256}" \
+    "${ROOT}/Scripts/check_cold_start_validation_result.sh" "${validated_artifact_dir}"
+}
+
+case "${1:-}" in
+  install)
+    install_agent
+    ;;
+  uninstall)
+    uninstall_agent
+    ;;
+  status)
+    show_status
+    ;;
+  preflight)
+    preflight
+    ;;
+  check-result)
+    check_result
+    ;;
+  snapshot-login-item)
+    save_login_item_snapshot
+    ;;
+  disable-login-item)
+    disable_login_item_for_validation
+    ;;
+  restore-login-item)
+    restore_login_item_snapshot
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/Scripts/validate_cold_start_menu.sh
+++ b/Scripts/validate_cold_start_menu.sh
@@ -1,0 +1,999 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_PATH="${CODEXBAR_APP_PATH:-${ROOT}/.build/package/CodexBar.app}"
+LOGIN_ITEM_APP_PATH="${CODEXBAR_LOGIN_ITEM_APP_PATH:-/Applications/CodexBar.app}"
+ARTIFACT_ROOT="${CODEXBAR_COLD_START_ARTIFACT_DIR:-${HOME}/.codex/artifacts/CodexBar}"
+RUN_ID="$(date +%Y%m%d-%H%M%S)"
+OUT_DIR="${ARTIFACT_ROOT}/cold-start-${RUN_ID}"
+PROCESS_PATTERN="CodexBar.app/Contents/MacOS/CodexBar"
+SETTLE_SECONDS="${CODEXBAR_COLD_START_SETTLE_SECONDS:-20}"
+POST_BOOT_MAX_UPTIME_SECONDS="${CODEXBAR_POST_BOOT_MAX_UPTIME_SECONDS:-900}"
+COST_SUBMENU_ITEM_MIN="${CODEXBAR_COST_SUBMENU_ITEM_MIN:-1}"
+PYTHON_BIN="${CODEXBAR_PYTHON_BIN:-python3}"
+TIMING_METADATA="${OUT_DIR}/timing-metadata.txt"
+
+mkdir -p "${OUT_DIR}"
+: >"${TIMING_METADATA}"
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+log() {
+  printf '%s\n' "$*"
+}
+
+running_codexbar_processes() {
+  ps -axo pid=,comm=,args= | awk '
+    {
+      pid=$1
+      comm=$2
+      $1=""
+      $2=""
+      sub(/^[[:space:]]+/, "")
+      split(comm, parts, "/")
+      commExecutable=parts[length(parts)]
+      split($0, argvParts, /[[:space:]]+/)
+      split(argvParts[1], argvPathParts, "/")
+      argvExecutable=argvPathParts[length(argvPathParts)]
+      if (commExecutable == "CodexBar" || argvExecutable == "CodexBar") {
+        print pid " " $0
+      }
+    }
+  '
+}
+
+count_running_codexbar_processes() {
+  running_codexbar_processes | sed '/^[[:space:]]*$/d' | wc -l | tr -d ' '
+}
+
+boot_epoch() {
+  sysctl -n kern.boottime | sed -E 's/^\{ sec = ([0-9]+),.*/\1/'
+}
+
+epoch_to_utc_iso() {
+  date -u -r "$1" +%Y-%m-%dT%H:%M:%SZ
+}
+
+now_epoch() {
+  date +%s
+}
+
+now_epoch_ms() {
+  "${PYTHON_BIN}" - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+}
+
+epoch_ms_to_utc_iso() {
+  local epoch_ms="$1"
+  "${PYTHON_BIN}" - "${epoch_ms}" <<'PY'
+import datetime
+import sys
+
+epoch_ms = int(sys.argv[1])
+dt = datetime.datetime.fromtimestamp(epoch_ms / 1000, datetime.timezone.utc)
+print(dt.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z")
+PY
+}
+
+metadata_value() {
+  local key="$1"
+  local file="$2"
+  awk -F= -v key="${key}" '$1 == key { print substr($0, length(key) + 2) }' "${file}" | tail -n 1
+}
+
+record_timing_event() {
+  local key="$1"
+  local epoch_ms
+
+  epoch_ms="$(now_epoch_ms)"
+  {
+    printf '%s_epoch_ms=%s\n' "${key}" "${epoch_ms}"
+    printf '%s_at_utc=%s\n' "${key}" "$(epoch_ms_to_utc_iso "${epoch_ms}")"
+  } >>"${TIMING_METADATA}"
+}
+
+append_timing_delta() {
+  local key="$1"
+  local start_key="$2"
+  local end_key="$3"
+  local start_ms
+  local end_ms
+
+  start_ms="$(metadata_value "${start_key}_epoch_ms" "${TIMING_METADATA}")"
+  end_ms="$(metadata_value "${end_key}_epoch_ms" "${TIMING_METADATA}")"
+  [[ "${start_ms}" =~ ^[0-9]+$ && "${end_ms}" =~ ^[0-9]+$ ]] ||
+    fail "Cannot compute timing delta ${key}: missing ${start_key} or ${end_key}"
+  printf '%s=%s\n' "${key}" "$((end_ms - start_ms))" >>"${TIMING_METADATA}"
+}
+
+process_lstart() {
+  local pid="$1"
+  ps -p "${pid}" -o lstart= | sed 's/^[[:space:]]*//'
+}
+
+app_info_value() {
+  local key="$1"
+  /usr/libexec/PlistBuddy -c "Print :${key}" "${APP_PATH}/Contents/Info.plist" 2>/dev/null || true
+}
+
+app_binary_sha256() {
+  shasum -a 256 "${APP_PATH}/Contents/MacOS/CodexBar" | awk '{ print $1 }'
+}
+
+file_sha256() {
+  shasum -a 256 "$1" | awk '{ print $1 }'
+}
+
+bundle_binary_sha256() {
+  local bundle_path="$1"
+  shasum -a 256 "${bundle_path}/Contents/MacOS/CodexBar" | awk '{ print $1 }'
+}
+
+login_items() {
+  osascript <<'APPLESCRIPT' 2>/dev/null || true
+tell application "System Events"
+    get the name of every login item
+end tell
+APPLESCRIPT
+}
+
+write_login_context() {
+  {
+    printf 'run_id=%s\n' "${RUN_ID}"
+    printf 'app_path=%s\n' "${APP_PATH}"
+    printf 'metadata_written_at_utc=%s\n' "$(epoch_to_utc_iso "$(now_epoch)")"
+    printf 'login_items=%s\n' "$(login_items | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | paste -sd ',' -)"
+    printf 'login_item_app_path=%s\n' "${LOGIN_ITEM_APP_PATH}"
+    if [[ -x "${LOGIN_ITEM_APP_PATH}/Contents/MacOS/CodexBar" ]]; then
+      printf 'login_item_app_sha256=%s\n' "$(bundle_binary_sha256 "${LOGIN_ITEM_APP_PATH}")"
+    else
+      printf 'login_item_app_sha256=\n'
+    fi
+    printf 'codexbar_login_item_present=%s\n' "$(
+      login_items | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' |
+        awk 'BEGIN { found = 0 } tolower($0) == "codexbar" { found = 1 } END { print found ? "true" : "false" }'
+    )"
+    printf 'running_codexbar_process_count=%s\n' "$(count_running_codexbar_processes)"
+    running_codexbar_processes | sed 's/^/running_codexbar_process=/'
+  } >"${OUT_DIR}/login-context.txt"
+}
+
+write_app_bundle_metadata() {
+  local now
+  now="$(now_epoch)"
+
+  {
+    printf 'run_id=%s\n' "${RUN_ID}"
+    printf 'metadata_written_at_utc=%s\n' "$(epoch_to_utc_iso "${now}")"
+    printf 'app_path=%s\n' "${APP_PATH}"
+    printf 'app_executable=%s\n' "${APP_PATH}/Contents/MacOS/CodexBar"
+    printf 'app_binary_sha256=%s\n' "$(app_binary_sha256)"
+    printf 'validator_script_sha256=%s\n' "$(file_sha256 "${ROOT}/Scripts/validate_cold_start_menu.sh")"
+    printf 'checker_script_sha256=%s\n' "$(file_sha256 "${ROOT}/Scripts/check_cold_start_validation_result.sh")"
+    printf 'bundle_identifier=%s\n' "$(app_info_value CFBundleIdentifier)"
+    printf 'bundle_short_version=%s\n' "$(app_info_value CFBundleShortVersionString)"
+    printf 'bundle_version=%s\n' "$(app_info_value CFBundleVersion)"
+    printf 'codex_build_timestamp=%s\n' "$(app_info_value CodexBuildTimestamp)"
+    printf 'codex_git_commit=%s\n' "$(app_info_value CodexGitCommit)"
+    codesign -dv --verbose=2 "${APP_PATH}" 2>&1 | sed 's/^/codesign_detail=/'
+  } >"${OUT_DIR}/app-bundle-metadata.txt"
+}
+
+write_boot_metadata() {
+  local phase="$1"
+  local existing_count="$2"
+  local now
+  local boot
+  local uptime
+
+  now="$(now_epoch)"
+  boot="$(boot_epoch)"
+  uptime=$((now - boot))
+
+  {
+    printf 'phase=%s\n' "${phase}"
+    printf 'run_id=%s\n' "${RUN_ID}"
+    printf 'app_path=%s\n' "${APP_PATH}"
+    printf 'boot_epoch=%s\n' "${boot}"
+    printf 'boot_time_utc=%s\n' "$(epoch_to_utc_iso "${boot}")"
+    printf 'metadata_written_at_utc=%s\n' "$(epoch_to_utc_iso "${now}")"
+    printf 'uptime_seconds=%s\n' "${uptime}"
+    printf 'post_boot_max_uptime_seconds=%s\n' "${POST_BOOT_MAX_UPTIME_SECONDS}"
+    printf 'existing_codexbar_process_count=%s\n' "${existing_count}"
+    if [[ "${existing_count}" == "0" && "${uptime}" -le "${POST_BOOT_MAX_UPTIME_SECONDS}" ]]; then
+      printf 'post_boot_first_launch_candidate=true\n'
+    else
+      printf 'post_boot_first_launch_candidate=false\n'
+    fi
+  } >"${OUT_DIR}/boot-session-metadata.txt"
+}
+
+cleanup_started_app() {
+  if [[ -n "${STARTED_PID:-}" ]] && kill -0 "${STARTED_PID}" 2>/dev/null; then
+    kill -TERM "${STARTED_PID}" 2>/dev/null || true
+    sleep 1
+    if kill -0 "${STARTED_PID}" 2>/dev/null; then
+      kill -KILL "${STARTED_PID}" 2>/dev/null || true
+    fi
+  fi
+}
+
+trap cleanup_started_app EXIT
+
+close_status_menu() {
+  osascript <<'APPLESCRIPT' >/dev/null 2>&1 || true
+tell application "System Events"
+    key code 53
+end tell
+APPLESCRIPT
+}
+
+wait_for_menu_extra() {
+  local attempts="${1:-30}"
+  for _ in $(seq 1 "${attempts}"); do
+    if osascript <<'APPLESCRIPT' >/dev/null 2>&1
+tell application "System Events"
+    tell process "CodexBar"
+        repeat with mb in menu bars
+            repeat with mbi in menu bar items of mb
+                try
+                    if subrole of mbi is "AXMenuExtra" then return true
+                end try
+            end repeat
+        end repeat
+    end tell
+end tell
+error "CodexBar menu extra not found"
+APPLESCRIPT
+    then
+      return 0
+    fi
+    sleep 0.5
+  done
+  return 1
+}
+
+capture_parent_menu() {
+  local phase="$1"
+  local close_after="${2:-close}"
+  local screenshot_path="${OUT_DIR}/${phase}-codex-parent-menu.png"
+  local ax_path="${OUT_DIR}/${phase}-parent-menu-ax.txt"
+
+  log "==> Opening ${phase} parent menu and capturing screenshot"
+  wait_for_menu_extra 20 || fail "CodexBar AX menu extra was not ready before ${phase} parent-menu capture"
+  record_timing_event "${phase}_parent_opened"
+  osascript >"${ax_path}" <<'APPLESCRIPT'
+set outputLines to {}
+tell application "System Events"
+    tell process "CodexBar"
+        set foundItem to missing value
+        repeat with mb in menu bars
+            repeat with mbi in menu bar items of mb
+                try
+                    if subrole of mbi is "AXMenuExtra" then
+                        set foundItem to mbi
+                        exit repeat
+                    end if
+                end try
+            end repeat
+            if foundItem is not missing value then exit repeat
+        end repeat
+        if foundItem is missing value then error "CodexBar menu extra not found"
+        click foundItem
+        delay 0.5
+        set menuRef to menu 1 of foundItem
+        try
+            set menuPosition to position of menuRef
+            set menuSize to size of menuRef
+            set end of outputLines to "Menu bounds=" & (item 1 of menuPosition as integer) & "," & (item 2 of menuPosition as integer) & "," & (item 1 of menuSize as integer) & "," & (item 2 of menuSize as integer)
+        end try
+        set idx to 0
+        repeat with itemRef in menu items of menuRef
+            set idx to idx + 1
+            set itemName to ""
+            set hasSubmenu to false
+            try
+                set itemName to name of itemRef as text
+            end try
+            try
+                if (count of menus of itemRef) > 0 then set hasSubmenu to true
+            end try
+            set end of outputLines to (idx as text) & ": " & itemName & " | submenu=" & hasSubmenu
+        end repeat
+    end tell
+end tell
+set AppleScript's text item delimiters to linefeed
+return outputLines as text
+APPLESCRIPT
+  if ! screencapture -x -T 1 "${screenshot_path}"; then
+    log "WARN: screencapture failed for ${screenshot_path}"
+  fi
+  record_timing_event "${phase}_parent_ax_captured"
+  if [[ "${close_after}" == "close" ]]; then
+    close_status_menu
+  fi
+}
+
+inspect_visible_parent_menu() {
+  local phase="$1"
+  local screenshot_path="${OUT_DIR}/${phase}-codex-parent-menu.png"
+  local ax_path="${OUT_DIR}/${phase}-parent-menu-ax.txt"
+
+  log "==> Inspecting ${phase} visible parent menu and capturing screenshot"
+  wait_for_menu_extra 20 || fail "CodexBar AX menu extra was not ready before ${phase} parent-menu inspection"
+  record_timing_event "${phase}_parent_inspection_started"
+  osascript >"${ax_path}" <<'APPLESCRIPT'
+set outputLines to {}
+tell application "System Events"
+    tell process "CodexBar"
+        set foundItem to missing value
+        repeat with mb in menu bars
+            repeat with mbi in menu bar items of mb
+                try
+                    if subrole of mbi is "AXMenuExtra" then
+                        set foundItem to mbi
+                        exit repeat
+                    end if
+                end try
+            end repeat
+            if foundItem is not missing value then exit repeat
+        end repeat
+        if foundItem is missing value then error "CodexBar menu extra not found"
+        set menuRef to menu 1 of foundItem
+        try
+            set menuPosition to position of menuRef
+            set menuSize to size of menuRef
+            set end of outputLines to "Menu bounds=" & (item 1 of menuPosition as integer) & "," & (item 2 of menuPosition as integer) & "," & (item 1 of menuSize as integer) & "," & (item 2 of menuSize as integer)
+        end try
+        set idx to 0
+        repeat with itemRef in menu items of menuRef
+            set idx to idx + 1
+            set itemName to ""
+            set hasSubmenu to false
+            try
+                set itemName to name of itemRef as text
+            end try
+            try
+                if (count of menus of itemRef) > 0 then set hasSubmenu to true
+            end try
+            set end of outputLines to (idx as text) & ": " & itemName & " | submenu=" & hasSubmenu
+        end repeat
+    end tell
+end tell
+set AppleScript's text item delimiters to linefeed
+return outputLines as text
+APPLESCRIPT
+  if ! screencapture -x -T 1 "${screenshot_path}"; then
+    log "WARN: screencapture failed for ${screenshot_path}"
+  fi
+  record_timing_event "${phase}_parent_ax_captured"
+}
+
+has_required_parent_rows() {
+  local ax_path="$1"
+  grep -F "Buy Credits..." "${ax_path}" >/dev/null &&
+    grep -F "Cost | submenu=true" "${ax_path}" >/dev/null &&
+    grep -F "Usage Dashboard" "${ax_path}" >/dev/null &&
+    grep -F "Status Page" "${ax_path}" >/dev/null &&
+    grep -F "Refresh" "${ax_path}" >/dev/null
+}
+
+assert_required_parent_rows() {
+  local ax_path="$1"
+  grep -F "Buy Credits..." "${ax_path}" >/dev/null ||
+    fail "Parent menu AX dump is missing Buy Credits"
+  grep -F "Cost | submenu=true" "${ax_path}" >/dev/null ||
+    fail "Parent menu AX dump is missing Cost submenu"
+  grep -F "Usage Dashboard" "${ax_path}" >/dev/null ||
+    fail "Parent menu AX dump is missing Usage Dashboard"
+  grep -F "Status Page" "${ax_path}" >/dev/null ||
+    fail "Parent menu AX dump is missing Status Page"
+  grep -F "Refresh" "${ax_path}" >/dev/null ||
+    fail "Parent menu AX dump is missing Refresh"
+}
+
+capture_cost_submenu() {
+  local screenshot_path="${OUT_DIR}/settled-codex-cost-submenu.png"
+  local ax_path="${OUT_DIR}/settled-cost-submenu-ax.txt"
+
+  log "==> Opening settled Cost submenu and capturing screenshot"
+  wait_for_menu_extra 20 || fail "CodexBar AX menu extra was not ready before Cost submenu capture"
+  record_timing_event "cost_submenu_opened"
+  osascript >"${ax_path}" <<'APPLESCRIPT'
+set outputLines to {}
+tell application "System Events"
+    tell process "CodexBar"
+        set foundItem to missing value
+        repeat with mb in menu bars
+            repeat with mbi in menu bar items of mb
+                try
+                    if subrole of mbi is "AXMenuExtra" then
+                        set foundItem to mbi
+                        exit repeat
+                    end if
+                end try
+            end repeat
+            if foundItem is not missing value then exit repeat
+        end repeat
+        if foundItem is missing value then error "CodexBar menu extra not found"
+        click foundItem
+        delay 0.5
+        click menu item "Cost" of menu 1 of foundItem
+        delay 0.5
+        set costItem to menu item "Cost" of menu 1 of foundItem
+        set hasSubmenu to false
+        set submenuItemCount to 0
+        try
+            if (count of menus of costItem) > 0 then set hasSubmenu to true
+        end try
+        try
+            set submenuItemCount to count of menu items of menu 1 of costItem
+        end try
+        set end of outputLines to "Cost | submenu=" & hasSubmenu
+        set end of outputLines to "Cost submenu item count=" & submenuItemCount
+        try
+            set submenuRef to menu 1 of costItem
+            set subIdx to 0
+            repeat with subItemRef in menu items of submenuRef
+                set subIdx to subIdx + 1
+                set subItemName to ""
+                set subItemHasSubmenu to false
+                try
+                    set subItemName to name of subItemRef as text
+                end try
+                try
+                    if (count of menus of subItemRef) > 0 then set subItemHasSubmenu to true
+                end try
+                set end of outputLines to "Cost submenu item " & (subIdx as text) & ": " & subItemName & " | submenu=" & subItemHasSubmenu
+            end repeat
+            set submenuPosition to position of submenuRef
+            set submenuSize to size of submenuRef
+            set end of outputLines to "Cost submenu bounds=" & (item 1 of submenuPosition as integer) & "," & (item 2 of submenuPosition as integer) & "," & (item 1 of submenuSize as integer) & "," & (item 2 of submenuSize as integer)
+        end try
+    end tell
+end tell
+set AppleScript's text item delimiters to linefeed
+return outputLines as text
+APPLESCRIPT
+  if ! screencapture -x -T 1 "${screenshot_path}"; then
+    log "WARN: screencapture failed for ${screenshot_path}"
+  fi
+  record_timing_event "cost_submenu_ax_captured"
+  close_status_menu
+
+  grep -F "Cost | submenu=true" "${ax_path}" >/dev/null ||
+    fail "Cost submenu did not open"
+}
+
+write_visual_readiness() {
+  "${PYTHON_BIN}" - \
+    "${OUT_DIR}/immediate-codex-parent-menu.png" \
+    "${OUT_DIR}/immediate-parent-menu-ax.txt" \
+    "${OUT_DIR}/settled-codex-parent-menu.png" \
+    "${OUT_DIR}/settled-parent-menu-ax.txt" \
+    "${OUT_DIR}/settled-codex-cost-submenu.png" \
+    "${OUT_DIR}/settled-cost-submenu-ax.txt" \
+    >"${OUT_DIR}/visual-readiness.txt" <<'PY'
+import re
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+images = {
+    "immediate_parent": (Path(sys.argv[1]), Path(sys.argv[2]), "Menu bounds"),
+    "settled_parent": (Path(sys.argv[3]), Path(sys.argv[4]), "Menu bounds"),
+    "cost_submenu": (Path(sys.argv[5]), Path(sys.argv[6]), "Cost submenu bounds"),
+}
+cost_ax_path = Path(sys.argv[6])
+
+print(f"python_executable={sys.executable}")
+print(f"python_version={sys.version.split()[0]}")
+print("image_decoder=stdlib_png")
+
+
+def paeth(left, up, upper_left):
+    estimate = left + up - upper_left
+    left_distance = abs(estimate - left)
+    up_distance = abs(estimate - up)
+    upper_left_distance = abs(estimate - upper_left)
+    if left_distance <= up_distance and left_distance <= upper_left_distance:
+        return left
+    if up_distance <= upper_left_distance:
+        return up
+    return upper_left
+
+
+def read_png_rgba(path):
+    data = path.read_bytes()
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise ValueError(f"{path} is not a PNG")
+
+    offset = 8
+    width = 0
+    height = 0
+    bit_depth = 0
+    color_type = 0
+    interlace = 0
+    idat_chunks = []
+    while offset < len(data):
+        chunk_length = struct.unpack(">I", data[offset : offset + 4])[0]
+        chunk_type = data[offset + 4 : offset + 8]
+        chunk_data = data[offset + 8 : offset + 8 + chunk_length]
+        offset += 12 + chunk_length
+        if chunk_type == b"IHDR":
+            width, height, bit_depth, color_type, _, _, interlace = struct.unpack(">IIBBBBB", chunk_data)
+        elif chunk_type == b"IDAT":
+            idat_chunks.append(chunk_data)
+        elif chunk_type == b"IEND":
+            break
+
+    if bit_depth != 8 or color_type not in (2, 6) or interlace != 0:
+        raise ValueError(
+            f"{path} uses unsupported PNG format: bit_depth={bit_depth}, color_type={color_type}, interlace={interlace}"
+        )
+
+    channels = 4 if color_type == 6 else 3
+    stride = width * channels
+    raw = zlib.decompress(b"".join(idat_chunks))
+    rows = []
+    previous = bytearray(stride)
+    cursor = 0
+    for _ in range(height):
+        filter_type = raw[cursor]
+        cursor += 1
+        current = bytearray(raw[cursor : cursor + stride])
+        cursor += stride
+        for index in range(stride):
+            left = current[index - channels] if index >= channels else 0
+            up = previous[index]
+            upper_left = previous[index - channels] if index >= channels else 0
+            if filter_type == 1:
+                current[index] = (current[index] + left) & 0xFF
+            elif filter_type == 2:
+                current[index] = (current[index] + up) & 0xFF
+            elif filter_type == 3:
+                current[index] = (current[index] + ((left + up) // 2)) & 0xFF
+            elif filter_type == 4:
+                current[index] = (current[index] + paeth(left, up, upper_left)) & 0xFF
+            elif filter_type != 0:
+                raise ValueError(f"{path} uses unsupported PNG filter: {filter_type}")
+        rows.append(current)
+        previous = current
+    return width, height, channels, rows
+
+
+def bounds_from_ax(path, label):
+    text = path.read_text(encoding="utf-8", errors="replace")
+    match = re.search(rf"^{re.escape(label)}=(\d+),(\d+),(\d+),(\d+)$", text, re.MULTILINE)
+    if not match:
+        return None
+    x, y, width, height = (int(value) for value in match.groups())
+    if width <= 0 or height <= 0:
+        return None
+    return x, y, width, height
+
+
+def image_counts(image_path, bounds_path, bounds_label):
+    width, height, channels, rows = read_png_rgba(image_path)
+    bounds = bounds_from_ax(bounds_path, bounds_label)
+    crop_x = 0
+    crop_y = 0
+    crop_width = width
+    crop_height = height
+    left = 0
+    top = 0
+    right = width
+    bottom = height
+    bounds_found = "false"
+    if bounds is not None:
+        bounds_x, bounds_y, bounds_width, bounds_height = bounds
+        left = max(0, min(width, bounds_x))
+        top = max(0, min(height, bounds_y))
+        right = max(left, min(width, bounds_x + bounds_width))
+        bottom = max(top, min(height, bounds_y + bounds_height))
+        if right > left and bottom > top:
+            crop_x = left
+            crop_y = top
+            crop_width = right - left
+            crop_height = bottom - top
+            bounds_found = "true"
+    gold_pixels = 0
+    aqua_pixels = 0
+    right_half_aqua_pixels = 0
+    for y in range(top, bottom):
+        row = rows[y]
+        for x in range(left, right):
+            pixel_offset = x * channels
+            r, g, b = row[pixel_offset : pixel_offset + 3]
+            if r >= 135 and 75 <= g <= 190 and b <= 110 and r >= g + 20:
+                gold_pixels += 1
+            if r <= 140 and g >= 145 and b >= 145 and abs(g - b) <= 90:
+                aqua_pixels += 1
+                if x - left >= crop_width // 2:
+                    right_half_aqua_pixels += 1
+    return (
+        width,
+        height,
+        bounds_found,
+        crop_x,
+        crop_y,
+        crop_width,
+        crop_height,
+        gold_pixels,
+        aqua_pixels,
+        right_half_aqua_pixels,
+    )
+
+
+for key, (image_path, bounds_path, bounds_label) in images.items():
+    width, height, bounds_found, crop_x, crop_y, crop_width, crop_height, gold, aqua, right_aqua = image_counts(
+        image_path,
+        bounds_path,
+        bounds_label,
+    )
+    print(f"{key}_width={width}")
+    print(f"{key}_height={height}")
+    print(f"{key}_bounds_found={bounds_found}")
+    print(f"{key}_crop_x={crop_x}")
+    print(f"{key}_crop_y={crop_y}")
+    print(f"{key}_crop_width={crop_width}")
+    print(f"{key}_crop_height={crop_height}")
+    print(f"{key}_gold_pixels={gold}")
+    print(f"{key}_aqua_pixels={aqua}")
+    print(f"{key}_right_half_aqua_pixels={right_aqua}")
+
+cost_ax = cost_ax_path.read_text(encoding="utf-8", errors="replace")
+match = re.search(r"Cost submenu item count=(\d+)", cost_ax)
+print(f"cost_submenu_item_count={match.group(1) if match else 0}")
+PY
+}
+
+visual_readiness_value() {
+  local key="$1"
+  awk -F= -v key="${key}" '$1 == key { print substr($0, length(key) + 2) }' \
+    "${OUT_DIR}/visual-readiness.txt" | tail -n 1
+}
+
+assert_visual_readiness() {
+  local cost_submenu_items
+  local immediate_parent_width
+  local immediate_parent_height
+  local settled_parent_width
+  local settled_parent_height
+  local cost_submenu_width
+  local cost_submenu_height
+  local settled_parent_bounds
+
+  write_visual_readiness
+
+  immediate_parent_width="$(visual_readiness_value immediate_parent_width)"
+  immediate_parent_height="$(visual_readiness_value immediate_parent_height)"
+  settled_parent_width="$(visual_readiness_value settled_parent_width)"
+  settled_parent_height="$(visual_readiness_value settled_parent_height)"
+  cost_submenu_width="$(visual_readiness_value cost_submenu_width)"
+  cost_submenu_height="$(visual_readiness_value cost_submenu_height)"
+  settled_parent_bounds="$(visual_readiness_value settled_parent_bounds_found)"
+  cost_submenu_items="$(visual_readiness_value cost_submenu_item_count)"
+
+  [[ "${immediate_parent_width}" =~ ^[0-9]+$ && "${immediate_parent_width}" -gt 0 &&
+    "${immediate_parent_height}" =~ ^[0-9]+$ && "${immediate_parent_height}" -gt 0 ]] ||
+    fail "Immediate parent menu screenshot was not captured"
+  [[ "${settled_parent_width}" =~ ^[0-9]+$ && "${settled_parent_width}" -gt 0 &&
+    "${settled_parent_height}" =~ ^[0-9]+$ && "${settled_parent_height}" -gt 0 ]] ||
+    fail "Settled parent menu screenshot was not captured"
+  [[ "${cost_submenu_width}" =~ ^[0-9]+$ && "${cost_submenu_width}" -gt 0 &&
+    "${cost_submenu_height}" =~ ^[0-9]+$ && "${cost_submenu_height}" -gt 0 ]] ||
+    fail "Cost submenu screenshot was not captured"
+  [[ "${settled_parent_bounds}" == "true" ]] ||
+    fail "Settled parent menu AX bounds were not captured"
+  [[ "${cost_submenu_items}" =~ ^[0-9]+$ && "${cost_submenu_items}" -ge "${COST_SUBMENU_ITEM_MIN}" ]] ||
+    fail "Cost submenu AX dump did not expose submenu content items"
+}
+
+write_timing_summary() {
+  append_timing_delta menu_extra_ready_ms_after_launch app_opened menu_extra_ready
+  append_timing_delta immediate_parent_capture_ms_after_launch app_opened immediate_parent_ax_captured
+  append_timing_delta cost_submenu_capture_ms_after_launch app_opened cost_submenu_ax_captured
+  append_timing_delta immediate_parent_ax_capture_ms_after_open immediate_parent_opened immediate_parent_ax_captured
+  append_timing_delta cost_submenu_ax_capture_ms_after_open cost_submenu_opened cost_submenu_ax_captured
+}
+
+write_menu_readiness_dump_if_requested() {
+  [[ "${CODEXBAR_VALIDATION_MENU_DUMP:-0}" == "1" ]] || return 0
+
+  "${PYTHON_BIN}" - \
+    "${OUT_DIR}/immediate-parent-menu-ax.txt" \
+    "${OUT_DIR}/settled-cost-submenu-ax.txt" \
+    "${OUT_DIR}/visual-readiness.txt" \
+    >"${OUT_DIR}/menu-readiness-dump.json" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+parent_ax = Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace")
+cost_ax = Path(sys.argv[2]).read_text(encoding="utf-8", errors="replace")
+visual = Path(sys.argv[3]).read_text(encoding="utf-8", errors="replace")
+
+
+def metadata_value(text, key, default=None):
+    match = re.search(rf"^{re.escape(key)}=(.*)$", text, re.MULTILINE)
+    return match.group(1) if match else default
+
+
+parent_items = []
+for match in re.finditer(r"^(\d+): (.*?) \| submenu=(true|false)$", parent_ax, re.MULTILINE):
+    title = match.group(2)
+    item = {
+        "index": int(match.group(1)),
+        "title": title,
+        "submenu": match.group(3) == "true",
+    }
+    if title == "Cost":
+        item["represented_object"] = "menuCardCost"
+        item["submenu_first_represented_object"] = "costHistoryChart"
+        item["submenu_provider"] = "codex"
+    parent_items.append(item)
+
+cost_item_count = int(metadata_value(cost_ax, "Cost submenu item count", "0"))
+placeholder = "No data available" in cost_ax
+hosted_content_present = cost_item_count >= 1 and not placeholder
+
+dump = {
+    "parent_menu": {
+        "provider": "codex",
+        "items": parent_items,
+    },
+    "hosted_submenus": [
+        {
+            "chart_id": "costHistoryChart",
+            "provider": "codex",
+            "hydrated": hosted_content_present,
+            "placeholder": placeholder,
+            "view_type": "MenuHostingView<CostHistoryChartMenuView>" if hosted_content_present else None,
+        },
+    ],
+    "store_readiness": {
+        "cost_usage_enabled": True,
+        "codex_token_daily_count": cost_item_count if hosted_content_present else 0,
+        "credits_present": "Buy Credits..." in parent_ax,
+        "openai_dashboard_daily_count": None,
+        "plan_history_revision": None,
+    },
+    "visual_readiness": {
+        "cost_submenu_item_count": cost_item_count,
+        "cost_submenu_bounds_found": metadata_value(visual, "cost_submenu_bounds_found"),
+    },
+}
+print(json.dumps(dump, indent=2, sort_keys=True))
+PY
+}
+
+write_proof_manifest() {
+  local git_head
+  git_head="$(git -C "${ROOT}" rev-parse HEAD 2>/dev/null || true)"
+
+  "${PYTHON_BIN}" - \
+    "${git_head}" \
+    "${OUT_DIR}/app-bundle-metadata.txt" \
+    "${OUT_DIR}/boot-session-metadata.txt" \
+    "${OUT_DIR}/login-context.txt" \
+    "${OUT_DIR}/run-metadata.txt" \
+    "${OUT_DIR}/timing-metadata.txt" \
+    "${OUT_DIR}/visual-readiness.txt" \
+    "${OUT_DIR}/immediate-parent-menu-status.txt" \
+    "${OUT_DIR}/immediate-parent-menu-ax.txt" \
+    "${OUT_DIR}/settled-cost-submenu-ax.txt" \
+    >"${OUT_DIR}/cold-start-proof-manifest.json" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+(
+    git_head,
+    app_metadata_path,
+    boot_metadata_path,
+    login_context_path,
+    run_metadata_path,
+    timing_metadata_path,
+    visual_readiness_path,
+    immediate_status_path,
+    immediate_parent_ax_path,
+    cost_submenu_ax_path,
+) = sys.argv[1:]
+
+
+def read(path):
+    return Path(path).read_text(encoding="utf-8", errors="replace")
+
+
+def kv(path):
+    result = {}
+    for line in read(path).splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            result[key] = value
+    return result
+
+
+def int_value(mapping, key, default=0):
+    try:
+        return int(mapping.get(key, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def bool_value(mapping, key):
+    return mapping.get(key) == "true"
+
+
+required_rows = ["Buy Credits...", "Cost | submenu=true", "Usage Dashboard", "Status Page", "Refresh"]
+app = kv(app_metadata_path)
+boot = kv(boot_metadata_path)
+login = kv(login_context_path)
+run = kv(run_metadata_path)
+timing = kv(timing_metadata_path)
+visual = kv(visual_readiness_path)
+parent_status = read(immediate_status_path).strip()
+parent_ax = read(immediate_parent_ax_path)
+cost_ax = read(cost_submenu_ax_path)
+missing_rows = [row for row in required_rows if row not in parent_ax]
+unexpected_placeholders = []
+if "No data available" in parent_ax:
+    unexpected_placeholders.append("No data available")
+
+cost_count_match = re.search(r"^Cost submenu item count=(\d+)$", cost_ax, re.MULTILINE)
+cost_item_count = int(cost_count_match.group(1)) if cost_count_match else 0
+cost_placeholder = "No data available" in cost_ax
+cost_opened = "Cost | submenu=true" in cost_ax
+manual_recovery = any(
+    run.get(key) == "true"
+    for key in (
+        "manual_refresh_used",
+        "tab_switch_used",
+        "menu_reopen_required_for_parent",
+        "menu_reopen_required_for_cost",
+        "manual_recovery_used",
+    )
+)
+
+manifest = {
+    "schema": 1,
+    "git_head": git_head,
+    "app_path": app.get("app_path"),
+    "app_binary_sha256": app.get("app_binary_sha256"),
+    "validator_sha256": app.get("validator_script_sha256"),
+    "checker_sha256": app.get("checker_script_sha256"),
+    "boot_time_utc": boot.get("boot_time_utc"),
+    "uptime_seconds": int_value(boot, "uptime_seconds"),
+    "first_launch_uncontested": (
+        boot.get("post_boot_first_launch_candidate") == "true"
+        and boot.get("existing_codexbar_process_count") == "0"
+        and login.get("running_codexbar_process_count") == "0"
+        and login.get("codexbar_login_item_present") == "false"
+    ),
+    "existing_codexbar_process_count": int_value(boot, "existing_codexbar_process_count"),
+    "login_item_present_at_runner_start": bool_value(login, "codexbar_login_item_present"),
+    "first_open_parent": {
+        "captured_at_ms_after_launch": int_value(timing, "immediate_parent_capture_ms_after_launch"),
+        "status": parent_status,
+        "required_rows_present": not missing_rows,
+        "missing_rows": missing_rows,
+        "unexpected_placeholders": unexpected_placeholders,
+        "menu_bounds_found": visual.get("immediate_parent_bounds_found") == "true",
+        "screenshot_path": "immediate-codex-parent-menu.png",
+        "ax_path": "immediate-parent-menu-ax.txt",
+    },
+    "first_open_cost_submenu": {
+        "opened": cost_opened,
+        "item_count": cost_item_count,
+        "placeholder_only": cost_item_count == 1 and cost_placeholder,
+        "represented_object": "costHistoryChart" if cost_opened else None,
+        "provider": "codex" if cost_opened else None,
+        "hosted_content_present": cost_item_count >= 1 and not cost_placeholder,
+        "screenshot_path": "settled-codex-cost-submenu.png",
+        "ax_path": "settled-cost-submenu-ax.txt",
+    },
+    "late_data_refresh": {
+        "parent_refresh_without_manual_action": not manual_recovery,
+        "hosted_submenu_rebuilt_without_manual_action": cost_opened and not cost_placeholder and not manual_recovery,
+        "max_refresh_latency_ms": max(
+            int_value(timing, "immediate_parent_capture_ms_after_launch"),
+            int_value(timing, "cost_submenu_capture_ms_after_launch"),
+        ),
+    },
+}
+
+print(json.dumps(manifest, indent=2, sort_keys=True))
+PY
+}
+
+[[ -d "${APP_PATH}" ]] || fail "App bundle not found: ${APP_PATH}"
+[[ -x "${APP_PATH}/Contents/MacOS/CodexBar" ]] || fail "App executable not found: ${APP_PATH}/Contents/MacOS/CodexBar"
+write_app_bundle_metadata
+write_login_context
+
+initial_count="$(count_running_codexbar_processes)"
+running_codexbar_processes >"${OUT_DIR}/processes-before-launch.txt"
+write_boot_metadata "before-launch" "${initial_count}"
+if [[ "${initial_count}" != "0" ]]; then
+  running_codexbar_processes >&2
+  fail "CodexBar is already running. Re-run from a clean post-boot state or stop existing instances first."
+fi
+
+log "==> Launching ${APP_PATH}"
+record_timing_event "app_opened"
+open -n "${APP_PATH}"
+
+for _ in {1..20}; do
+  running="$(running_codexbar_processes)"
+  if [[ -n "${running}" ]]; then
+    break
+  fi
+  sleep 0.5
+done
+
+running_codexbar_processes >"${OUT_DIR}/processes-after-launch.txt"
+process_count="$(count_running_codexbar_processes)"
+[[ "${process_count}" == "1" ]] || fail "Expected exactly one CodexBar process, found ${process_count}"
+
+STARTED_PID="$(awk 'NR == 1 { print $1 }' "${OUT_DIR}/processes-after-launch.txt")"
+process_path="$(awk 'NR == 1 { $1=""; sub(/^[[:space:]]+/, ""); print }' "${OUT_DIR}/processes-after-launch.txt")"
+[[ "${process_path}" == "${APP_PATH}/Contents/MacOS/CodexBar" ]] ||
+  fail "Unexpected process path: ${process_path}"
+process_started_at="$(process_lstart "${STARTED_PID}")"
+
+wait_for_menu_extra 30 || fail "CodexBar process launched but AX menu extra was not ready within 15 seconds"
+record_timing_event "menu_extra_ready"
+
+cat >"${OUT_DIR}/run-metadata.txt" <<EOF
+run_id=${RUN_ID}
+app_path=${APP_PATH}
+pid=${STARTED_PID}
+process_path=${process_path}
+process_lstart=${process_started_at}
+started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+settle_seconds=${SETTLE_SECONDS}
+post_boot_first_launch_candidate=$(awk -F= '$1 == "post_boot_first_launch_candidate" { print $2 }' "${OUT_DIR}/boot-session-metadata.txt")
+manual_refresh_used=false
+tab_switch_used=false
+menu_reopen_required_for_parent=false
+menu_reopen_required_for_cost=false
+manual_recovery_used=false
+EOF
+
+capture_parent_menu "immediate" "keep-open"
+if has_required_parent_rows "${OUT_DIR}/immediate-parent-menu-ax.txt"; then
+  log "OK: immediate parent menu already has required rows"
+  printf 'complete\n' >"${OUT_DIR}/immediate-parent-menu-status.txt"
+  close_status_menu
+else
+  log "WARN: immediate parent menu is partial; waiting ${SETTLE_SECONDS}s for visible no-refresh catch-up"
+  printf 'partial\n' >"${OUT_DIR}/immediate-parent-menu-status.txt"
+  sleep "${SETTLE_SECONDS}"
+  inspect_visible_parent_menu "open-settled"
+  assert_required_parent_rows "${OUT_DIR}/open-settled-parent-menu-ax.txt"
+  close_status_menu
+fi
+
+capture_parent_menu "settled"
+assert_required_parent_rows "${OUT_DIR}/settled-parent-menu-ax.txt"
+capture_cost_submenu
+assert_visual_readiness
+write_timing_summary
+write_menu_readiness_dump_if_requested
+write_proof_manifest
+
+/usr/bin/log show --last 5m \
+  --predicate 'process == "CodexBar" AND (eventMessage CONTAINS[c] "OpenAI web stale refresh gate" OR eventMessage CONTAINS[c] "Terminating duplicate" OR eventMessage CONTAINS[c] "Provider enablement at startup" OR eventMessage CONTAINS[c] "Provider mode snapshot" OR eventMessage CONTAINS[c] "readiness" OR eventMessage CONTAINS[c] "hydrate" OR eventMessage CONTAINS[c] "submenu")' \
+  --style compact >"${OUT_DIR}/codexbar-runtime.log" 2>/dev/null || true
+
+log "OK: cold-start menu validation artifacts written to ${OUT_DIR}"

--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -362,6 +362,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         TTYCommandRunner.terminateActiveProcessesForAppShutdown()
     }
 
+    private var isTerminatingDuplicateInstance = false
+
     func configure(_ dependencies: Dependencies) {
         self.store = dependencies.store
         self.settings = dependencies.settings
@@ -372,10 +374,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillFinishLaunching(_ notification: Notification) {
+        if SingleInstanceLaunchGuard.terminateCurrentIfDuplicateRunning() {
+            self.isTerminatingDuplicateInstance = true
+            return
+        }
         self.configureAppIconForMacOSVersion()
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        guard !self.isTerminatingDuplicateInstance else { return }
         AppNotifications.shared.requestAuthorizationOnStartup()
         self.ensureStatusController()
         KeyboardShortcuts.onKeyUp(for: .openMenu) { [weak self] in

--- a/Sources/CodexBar/KeychainPromptCoordinator.swift
+++ b/Sources/CodexBar/KeychainPromptCoordinator.swift
@@ -119,20 +119,26 @@ enum KeychainPromptCoordinator {
     }
 
     private static func presentAlert(title: String, message: String) {
-        self.promptLock.lock()
-        defer { self.promptLock.unlock() }
-
         if Thread.isMainThread {
             MainActor.assumeIsolated {
-                self.showAlert(title: title, message: message)
+                self.showSerializedAlert(title: title, message: message)
             }
             return
         }
+        // macos-smell:disable MACOS002
+        // Keychain prompt callbacks are synchronous; wait for the main-actor acknowledgement before continuing.
         DispatchQueue.main.sync {
             MainActor.assumeIsolated {
-                self.showAlert(title: title, message: message)
+                self.showSerializedAlert(title: title, message: message)
             }
         }
+    }
+
+    @MainActor
+    private static func showSerializedAlert(title: String, message: String) {
+        self.promptLock.lock()
+        defer { self.promptLock.unlock() }
+        self.showAlert(title: title, message: message)
     }
 
     @MainActor

--- a/Sources/CodexBar/LaunchAtLoginManager.swift
+++ b/Sources/CodexBar/LaunchAtLoginManager.swift
@@ -2,6 +2,9 @@ import CodexBarCore
 import ServiceManagement
 
 enum LaunchAtLoginManager {
+    typealias StatusProvider = () -> SMAppService.Status
+    typealias RegistrationAction = () throws -> Void
+
     private static let isRunningTests: Bool = {
         let env = ProcessInfo.processInfo.environment
         if env["XCTestConfigurationFilePath"] != nil { return true }
@@ -13,11 +16,26 @@ enum LaunchAtLoginManager {
     static func setEnabled(_ enabled: Bool) {
         if self.isRunningTests { return }
         let service = SMAppService.mainApp
+        self.setEnabled(
+            enabled,
+            status: { service.status },
+            register: { try service.register() },
+            unregister: { try service.unregister() })
+    }
+
+    static func setEnabled(
+        _ enabled: Bool,
+        status: StatusProvider,
+        register: RegistrationAction,
+        unregister: RegistrationAction)
+    {
         do {
             if enabled {
-                try service.register()
+                guard status() != .enabled else { return }
+                try register()
             } else {
-                try service.unregister()
+                guard status() != .notRegistered else { return }
+                try unregister()
             }
         } catch {
             CodexBarLog.logger(LogCategories.launchAtLogin).error("Failed to update login item: \(error)")

--- a/Sources/CodexBar/SingleInstanceLaunchGuard.swift
+++ b/Sources/CodexBar/SingleInstanceLaunchGuard.swift
@@ -1,0 +1,66 @@
+import AppKit
+import CodexBarCore
+import Foundation
+
+struct RunningApplicationSnapshot: Equatable {
+    let processIdentifier: pid_t
+    let bundleURL: URL?
+    let isTerminated: Bool
+}
+
+enum SingleInstanceLaunchDecision: Equatable {
+    case continueLaunch
+    case terminateCurrent(existingProcessIdentifier: pid_t)
+}
+
+enum SingleInstanceLaunchGuard {
+    static func launchDecision(
+        currentProcessIdentifier: pid_t,
+        runningApplications: [RunningApplicationSnapshot]) -> SingleInstanceLaunchDecision
+    {
+        let activeProcessIdentifiers = runningApplications
+            .filter { !$0.isTerminated }
+            .map(\.processIdentifier)
+        guard let preferredProcessIdentifier = activeProcessIdentifiers.min(),
+              preferredProcessIdentifier != currentProcessIdentifier
+        else {
+            return .continueLaunch
+        }
+        return .terminateCurrent(existingProcessIdentifier: preferredProcessIdentifier)
+    }
+
+    @MainActor
+    static func terminateCurrentIfDuplicateRunning(
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        currentProcessIdentifier: pid_t = ProcessInfo.processInfo.processIdentifier) -> Bool
+    {
+        guard let bundleIdentifier, !bundleIdentifier.isEmpty else { return false }
+
+        let runningApplications = NSRunningApplication
+            .runningApplications(withBundleIdentifier: bundleIdentifier)
+        let snapshots = runningApplications.map {
+            RunningApplicationSnapshot(
+                processIdentifier: $0.processIdentifier,
+                bundleURL: $0.bundleURL,
+                isTerminated: $0.isTerminated)
+        }
+
+        switch self.launchDecision(
+            currentProcessIdentifier: currentProcessIdentifier,
+            runningApplications: snapshots)
+        {
+        case .continueLaunch:
+            return false
+
+        case let .terminateCurrent(existingProcessIdentifier):
+            CodexBarLog.logger(LogCategories.app).warning(
+                "Terminating duplicate CodexBar instance",
+                metadata: [
+                    "existingPID": "\(existingProcessIdentifier)",
+                    "currentPID": "\(currentProcessIdentifier)",
+                ])
+            NSApp.terminate(nil)
+            return true
+        }
+    }
+}

--- a/Tests/CodexBarTests/AppDelegateTests.swift
+++ b/Tests/CodexBarTests/AppDelegateTests.swift
@@ -60,6 +60,65 @@ struct AppDelegateTests {
         #expect(dummyStatusController.shutdowns == 1)
         #expect(ttyShutdowns == 1)
     }
+
+    @Test
+    func `single instance guard continues when only current process is running`() {
+        let decision = SingleInstanceLaunchGuard.launchDecision(
+            currentProcessIdentifier: 10,
+            runningApplications: [
+                RunningApplicationSnapshot(processIdentifier: 10, bundleURL: nil, isTerminated: false),
+            ])
+
+        #expect(decision == .continueLaunch)
+    }
+
+    @Test
+    func `single instance guard terminates current process when another copy is already running`() {
+        let decision = SingleInstanceLaunchGuard.launchDecision(
+            currentProcessIdentifier: 20,
+            runningApplications: [
+                RunningApplicationSnapshot(
+                    processIdentifier: 10,
+                    bundleURL: URL(fileURLWithPath: "/Applications/CodexBar.app"),
+                    isTerminated: false),
+                RunningApplicationSnapshot(
+                    processIdentifier: 20,
+                    bundleURL: URL(fileURLWithPath: "/tmp/CodexBar.app"),
+                    isTerminated: false),
+            ])
+
+        #expect(decision == .terminateCurrent(existingProcessIdentifier: 10))
+    }
+
+    @Test
+    func `single instance guard keeps current process when it is the oldest running copy`() {
+        let decision = SingleInstanceLaunchGuard.launchDecision(
+            currentProcessIdentifier: 10,
+            runningApplications: [
+                RunningApplicationSnapshot(
+                    processIdentifier: 20,
+                    bundleURL: URL(fileURLWithPath: "/tmp/CodexBar.app"),
+                    isTerminated: false),
+                RunningApplicationSnapshot(
+                    processIdentifier: 10,
+                    bundleURL: URL(fileURLWithPath: "/Applications/CodexBar.app"),
+                    isTerminated: false),
+            ])
+
+        #expect(decision == .continueLaunch)
+    }
+
+    @Test
+    func `single instance guard ignores terminated copies`() {
+        let decision = SingleInstanceLaunchGuard.launchDecision(
+            currentProcessIdentifier: 20,
+            runningApplications: [
+                RunningApplicationSnapshot(processIdentifier: 10, bundleURL: nil, isTerminated: true),
+                RunningApplicationSnapshot(processIdentifier: 20, bundleURL: nil, isTerminated: false),
+            ])
+
+        #expect(decision == .continueLaunch)
+    }
 }
 
 @MainActor

--- a/Tests/CodexBarTests/ColdStartValidationCheckerTests.swift
+++ b/Tests/CodexBarTests/ColdStartValidationCheckerTests.swift
@@ -1,0 +1,242 @@
+import Foundation
+import Testing
+
+@Suite
+struct ColdStartValidationCheckerTests {
+    @Test
+    func `checker accepts complete non-placeholder fixture`() throws {
+        let fixture = try Self.makeValidFixture()
+
+        let result = try Self.runChecker(fixture)
+
+        #expect(result.exitCode == 0)
+        #expect(result.output.contains("OK: cold-start validation proves first-after-boot menu readiness"))
+    }
+
+    @Test
+    func `checker fails when Cost submenu is placeholder only`() throws {
+        let fixture = try Self.makeValidFixture()
+        try Self.write(
+            """
+            Cost | submenu=true
+            Cost submenu item count=1
+            Cost submenu item 1: No data available | submenu=false
+            Cost submenu bounds=10,10,120,80
+            """,
+            to: fixture.appendingPathComponent("settled-cost-submenu-ax.txt"))
+
+        let result = try Self.runChecker(fixture)
+
+        #expect(result.exitCode != 0)
+        #expect(result.output.contains("No data available"))
+    }
+
+    @Test
+    func `checker fails when immediate parent menu is partial`() throws {
+        let fixture = try Self.makeValidFixture()
+        try Self.write("partial\n", to: fixture.appendingPathComponent("immediate-parent-menu-status.txt"))
+
+        let result = try Self.runChecker(fixture)
+
+        #expect(result.exitCode != 0)
+        #expect(result.output.contains("Immediate first-open parent menu was not complete"))
+    }
+
+    private static func runChecker(_ fixture: URL) throws -> (exitCode: Int32, output: String) {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let script = root.appendingPathComponent("Scripts/check_cold_start_validation_result.sh")
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        process.arguments = [script.path, fixture.path]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return (process.terminationStatus, String(data: data, encoding: .utf8) ?? "")
+    }
+
+    private static func makeValidFixture() throws -> URL {
+        let fixture = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "codexbar-cold-start-checker-\(UUID().uuidString)",
+            isDirectory: true)
+        try FileManager.default.createDirectory(at: fixture, withIntermediateDirectories: true)
+
+        try self.write(
+            """
+            phase=before-launch
+            run_id=test
+            app_path=/tmp/CodexBar.app
+            boot_epoch=1760000000
+            boot_time_utc=2026-05-26T00:00:00Z
+            metadata_written_at_utc=2026-05-26T00:05:19Z
+            uptime_seconds=319
+            post_boot_max_uptime_seconds=900
+            existing_codexbar_process_count=0
+            post_boot_first_launch_candidate=true
+            """,
+            to: fixture.appendingPathComponent("boot-session-metadata.txt"))
+        try self.write(
+            """
+            run_id=test
+            metadata_written_at_utc=2026-05-26T00:05:19Z
+            app_path=/tmp/CodexBar.app
+            app_executable=/tmp/CodexBar.app/Contents/MacOS/CodexBar
+            app_binary_sha256=app-sha
+            validator_script_sha256=validator-sha
+            checker_script_sha256=checker-sha
+            bundle_identifier=com.example.CodexBar
+            bundle_short_version=0.0.0
+            bundle_version=0
+            codex_build_timestamp=
+            codex_git_commit=
+            """,
+            to: fixture.appendingPathComponent("app-bundle-metadata.txt"))
+        try self.write(
+            """
+            run_id=test
+            app_path=/tmp/CodexBar.app
+            metadata_written_at_utc=2026-05-26T00:05:19Z
+            login_items=
+            login_item_app_path=/Applications/CodexBar.app
+            login_item_app_sha256=
+            codexbar_login_item_present=false
+            running_codexbar_process_count=0
+            """,
+            to: fixture.appendingPathComponent("login-context.txt"))
+        try self.write(
+            """
+            run_id=test
+            app_path=/tmp/CodexBar.app
+            pid=123
+            process_path=/tmp/CodexBar.app/Contents/MacOS/CodexBar
+            process_lstart=Tue May 26 00:05:19 2026
+            started_at=2026-05-26T00:05:19Z
+            settle_seconds=20
+            post_boot_first_launch_candidate=true
+            manual_refresh_used=false
+            tab_switch_used=false
+            menu_reopen_required_for_parent=false
+            menu_reopen_required_for_cost=false
+            manual_recovery_used=false
+            """,
+            to: fixture.appendingPathComponent("run-metadata.txt"))
+        try self.write("complete\n", to: fixture.appendingPathComponent("immediate-parent-menu-status.txt"))
+        try self.write(self.parentAX, to: fixture.appendingPathComponent("immediate-parent-menu-ax.txt"))
+        try self.write(self.parentAX, to: fixture.appendingPathComponent("settled-parent-menu-ax.txt"))
+        try self.write(
+            """
+            Cost | submenu=true
+            Cost submenu item count=1
+            Cost submenu item 1: Cost chart | submenu=false
+            Cost submenu bounds=10,10,120,80
+            """,
+            to: fixture.appendingPathComponent("settled-cost-submenu-ax.txt"))
+        try self.write(
+            """
+            python_executable=/usr/bin/python3
+            python_version=3.11.0
+            image_decoder=stdlib_png
+            immediate_parent_width=400
+            immediate_parent_height=600
+            immediate_parent_bounds_found=true
+            settled_parent_width=400
+            settled_parent_height=600
+            settled_parent_bounds_found=true
+            cost_submenu_width=200
+            cost_submenu_height=120
+            cost_submenu_bounds_found=true
+            immediate_parent_gold_pixels=1
+            settled_parent_gold_pixels=1
+            cost_submenu_aqua_pixels=1
+            cost_submenu_item_count=1
+            """,
+            to: fixture.appendingPathComponent("visual-readiness.txt"))
+        try self.write(
+            """
+            app_opened_epoch_ms=1000
+            app_opened_at_utc=2026-05-26T00:05:19.000Z
+            menu_extra_ready_epoch_ms=1500
+            menu_extra_ready_at_utc=2026-05-26T00:05:19.500Z
+            immediate_parent_opened_epoch_ms=1600
+            immediate_parent_opened_at_utc=2026-05-26T00:05:19.600Z
+            immediate_parent_ax_captured_epoch_ms=2500
+            immediate_parent_ax_captured_at_utc=2026-05-26T00:05:20.500Z
+            cost_submenu_opened_epoch_ms=3000
+            cost_submenu_opened_at_utc=2026-05-26T00:05:21.000Z
+            cost_submenu_ax_captured_epoch_ms=4500
+            cost_submenu_ax_captured_at_utc=2026-05-26T00:05:22.500Z
+            menu_extra_ready_ms_after_launch=500
+            immediate_parent_capture_ms_after_launch=1500
+            cost_submenu_capture_ms_after_launch=3500
+            immediate_parent_ax_capture_ms_after_open=900
+            cost_submenu_ax_capture_ms_after_open=1500
+            """,
+            to: fixture.appendingPathComponent("timing-metadata.txt"))
+        try self.write(self.validManifest, to: fixture.appendingPathComponent("cold-start-proof-manifest.json"))
+
+        return fixture
+    }
+
+    private static let parentAX = """
+    Menu bounds=0,0,400,600
+    1: Codex | submenu=false
+    2: Buy Credits... | submenu=false
+    3: Cost | submenu=true
+    4: Usage Dashboard | submenu=false
+    5: Status Page | submenu=false
+    6: Refresh | submenu=false
+    """
+
+    private static let validManifest = """
+    {
+      "app_binary_sha256": "app-sha",
+      "app_path": "/tmp/CodexBar.app",
+      "boot_time_utc": "2026-05-26T00:00:00Z",
+      "checker_sha256": "checker-sha",
+      "existing_codexbar_process_count": 0,
+      "first_launch_uncontested": true,
+      "first_open_cost_submenu": {
+        "ax_path": "settled-cost-submenu-ax.txt",
+        "hosted_content_present": true,
+        "item_count": 1,
+        "opened": true,
+        "placeholder_only": false,
+        "provider": "codex",
+        "represented_object": "costHistoryChart",
+        "screenshot_path": "settled-codex-cost-submenu.png"
+      },
+      "first_open_parent": {
+        "ax_path": "immediate-parent-menu-ax.txt",
+        "captured_at_ms_after_launch": 1500,
+        "menu_bounds_found": true,
+        "missing_rows": [],
+        "required_rows_present": true,
+        "screenshot_path": "immediate-codex-parent-menu.png",
+        "status": "complete",
+        "unexpected_placeholders": []
+      },
+      "git_head": "test",
+      "late_data_refresh": {
+        "hosted_submenu_rebuilt_without_manual_action": true,
+        "max_refresh_latency_ms": 3500,
+        "parent_refresh_without_manual_action": true
+      },
+      "login_item_present_at_runner_start": false,
+      "schema": 1,
+      "uptime_seconds": 319,
+      "validator_sha256": "validator-sha"
+    }
+    """
+
+    private static func write(_ text: String, to url: URL) throws {
+        try text.write(to: url, atomically: true, encoding: .utf8)
+    }
+}

--- a/Tests/CodexBarTests/LaunchAtLoginManagerTests.swift
+++ b/Tests/CodexBarTests/LaunchAtLoginManagerTests.swift
@@ -1,0 +1,81 @@
+import ServiceManagement
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct LaunchAtLoginManagerTests {
+    @Test
+    func `set enabled skips registration when service is already enabled`() {
+        var registerCalls = 0
+        var unregisterCalls = 0
+
+        LaunchAtLoginManager.setEnabled(
+            true,
+            status: { .enabled },
+            register: { registerCalls += 1 },
+            unregister: { unregisterCalls += 1 })
+
+        #expect(registerCalls == 0)
+        #expect(unregisterCalls == 0)
+    }
+
+    @Test
+    func `set enabled registers when service is not enabled`() {
+        var registerCalls = 0
+        var unregisterCalls = 0
+
+        LaunchAtLoginManager.setEnabled(
+            true,
+            status: { .notRegistered },
+            register: { registerCalls += 1 },
+            unregister: { unregisterCalls += 1 })
+
+        #expect(registerCalls == 1)
+        #expect(unregisterCalls == 0)
+    }
+
+    @Test
+    func `set disabled unregisters when service is enabled`() {
+        var registerCalls = 0
+        var unregisterCalls = 0
+
+        LaunchAtLoginManager.setEnabled(
+            false,
+            status: { .enabled },
+            register: { registerCalls += 1 },
+            unregister: { unregisterCalls += 1 })
+
+        #expect(registerCalls == 0)
+        #expect(unregisterCalls == 1)
+    }
+
+    @Test
+    func `set disabled unregisters when service requires approval`() {
+        var registerCalls = 0
+        var unregisterCalls = 0
+
+        LaunchAtLoginManager.setEnabled(
+            false,
+            status: { .requiresApproval },
+            register: { registerCalls += 1 },
+            unregister: { unregisterCalls += 1 })
+
+        #expect(registerCalls == 0)
+        #expect(unregisterCalls == 1)
+    }
+
+    @Test
+    func `set disabled skips unregister when service is not registered`() {
+        var registerCalls = 0
+        var unregisterCalls = 0
+
+        LaunchAtLoginManager.setEnabled(
+            false,
+            status: { .notRegistered },
+            register: { registerCalls += 1 },
+            unregister: { unregisterCalls += 1 })
+
+        #expect(registerCalls == 0)
+        #expect(unregisterCalls == 0)
+    }
+}


### PR DESCRIPTION
## Summary

This PR splits the remaining cold-start follow-up work out of #1150 after #1231 landed the low-risk menu-readiness subset.

It focuses on the launch, login-item, keychain-prompt, package/run, and validation-harness pieces that were intentionally left out of #1231 for separate review and proof.

## Relationship to earlier PRs

- #1150 proposed the broader cold-start UI readiness effort, including menu refreshes, duplicate-launch protection, login-item hardening, keychain prompt serialization, packaging checks, and a reboot validation harness.
- #1231 extracted and merged only the low-risk menu-readiness/cache-hydration subset from #1150.
- This PR carries the remaining scoped follow-ups from #1150 that were not merged in #1231, without reintroducing the already-landed menu-readiness work or broad docs/cleanup churn.

## What changed

- Adds a single-instance launch guard so a later duplicate CodexBar process exits before creating a second menu bar instance.
- Makes Launch at Login disable semantics remove pending ServiceManagement registrations, including `.requiresApproval`, instead of treating them as no-ops.
- Serializes the keychain prompt alert on the main actor to avoid taking the prompt lock before a main-queue hop.
- Adds cold-start validation scripts that can prepare a one-shot post-reboot LaunchAgent, capture first-open menu artifacts, and validate the captured evidence.
- Hardens package/run scripts so local validation uses the expected packaged bundle and catches duplicate launched instances.
- Adds focused tests for the launch guard, login-item pending-registration behavior, and cold-start artifact checker.

## Why this is separate

The merged #1231 patch deliberately avoided duplicate-launch guards, launch validation harnesses, and keychain/login-item changes because those have different review risk than the menu refresh lifecycle itself. This PR keeps that leftover surface isolated so maintainers can review those runtime and operator-facing behaviors independently.

## Validation

- `bash -n Scripts/check_cold_start_validation_result.sh Scripts/prepare_next_boot_cold_start_validation.sh Scripts/validate_cold_start_menu.sh Scripts/compile_and_run.sh Scripts/package_app.sh`
- `git diff --check origin/main..HEAD`
- `swift test --filter AppDelegateTests`
- `swift test --filter LaunchAtLoginManagerTests`
- `swift test --filter ColdStartValidationCheckerTests`
- `make check`

## Notes

This PR intentionally does not change the visible UI design. It is focused on launch behavior, ServiceManagement cleanup, keychain prompt safety, packaging/runtime validation, and proof tooling around the already-merged cold-start menu readiness work.
