### PR TITLE
[security] fix(providers): reject insecure credentialed endpoint overrides

### DIFF
--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanProviderDescriptor.swift
@@ -84,6 +84,9 @@ struct AlibabaCodingPlanWebFetchStrategy: ProviderFetchStrategy {
     let kind: ProviderFetchKind = .web
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        if (try? AlibabaCodingPlanSettingsReader.validateEndpointOverrides(environment: context.env)) == nil {
+            return true
+        }
         guard context.settings?.alibaba?.cookieSource != .off else { return false }
 
         if AlibabaCodingPlanSettingsReader.cookieHeader(environment: context.env) != nil {
@@ -173,8 +176,10 @@ struct AlibabaCodingPlanWebFetchStrategy: ProviderFetchStrategy {
 
         if let settingsError = error as? AlibabaCodingPlanSettingsError {
             switch settingsError {
-            case .missingCookie, .invalidCookie, .invalidEndpointOverride:
+            case .missingCookie, .invalidCookie:
                 return true
+            case .invalidEndpointOverride:
+                return false
             case .missingToken:
                 return false
             }
@@ -242,10 +247,14 @@ struct AlibabaCodingPlanAPIFetchStrategy: ProviderFetchStrategy {
     let kind: ProviderFetchKind = .apiToken
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        Self.resolveToken(environment: context.env) != nil
+        if (try? AlibabaCodingPlanSettingsReader.validateEndpointOverrides(environment: context.env)) == nil {
+            return true
+        }
+        return Self.resolveToken(environment: context.env) != nil
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        try AlibabaCodingPlanSettingsReader.validateEndpointOverrides(environment: context.env)
         guard let apiKey = Self.resolveToken(environment: context.env) else {
             throw AlibabaCodingPlanSettingsError.missingToken
         }

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanProviderDescriptor.swift
@@ -112,6 +112,8 @@ struct AlibabaCodingPlanWebFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        try AlibabaCodingPlanSettingsReader.validateEndpointOverrides(environment: context.env)
+
         let cookieSource = context.settings?.alibaba?.cookieSource ?? .auto
         let cookieHeader = try Self.resolveCookieHeader(context: context, allowCached: true)
         do {
@@ -171,7 +173,7 @@ struct AlibabaCodingPlanWebFetchStrategy: ProviderFetchStrategy {
 
         if let settingsError = error as? AlibabaCodingPlanSettingsError {
             switch settingsError {
-            case .missingCookie, .invalidCookie:
+            case .missingCookie, .invalidCookie, .invalidEndpointOverride:
                 return true
             case .missingToken:
                 return false

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanSettingsReader.swift
@@ -26,10 +26,7 @@ public struct AlibabaCodingPlanSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
         guard let raw = self.cleaned(environment[self.hostKey]) else { return nil }
-        if let scheme = URL(string: raw)?.scheme {
-            return scheme.lowercased() == "https" ? raw : nil
-        }
-        return raw
+        return self.hasExplicitNonHTTPSURL(raw) ? nil : raw
     }
 
     public static func cookieHeader(
@@ -42,8 +39,9 @@ public struct AlibabaCodingPlanSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
         guard let raw = self.cleaned(environment[self.quotaURLKey]) else { return nil }
-        if let url = URL(string: raw), let scheme = url.scheme {
-            return scheme.lowercased() == "https" ? url : nil
+        if self.hasExplicitURLScheme(raw) {
+            guard let url = URL(string: raw), url.scheme?.lowercased() == "https" else { return nil }
+            return url
         }
         return URL(string: "https://\(raw)")
     }
@@ -75,10 +73,23 @@ public struct AlibabaCodingPlanSettingsReader: Sendable {
     }
 
     private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
-        guard let cleaned = self.cleaned(raw),
-              let scheme = URL(string: cleaned)?.scheme
+        guard let cleaned = self.cleaned(raw), self.hasExplicitURLScheme(cleaned) else { return false }
+        return URL(string: cleaned)?.scheme?.lowercased() != "https"
+    }
+
+    static func hasExplicitURLScheme(_ value: String) -> Bool {
+        guard let colonIndex = value.firstIndex(of: ":") else { return false }
+        let scheme = value[..<colonIndex]
+        guard !scheme.isEmpty,
+              scheme.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "+" || $0 == "-" || $0 == "." }),
+              scheme.first?.isLetter == true
         else { return false }
-        return scheme.lowercased() != "https"
+
+        let remainder = value[value.index(after: colonIndex)...]
+        if remainder.hasPrefix("//") { return true }
+
+        let portCandidate = remainder.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false).first ?? ""
+        return portCandidate.isEmpty || !portCandidate.allSatisfy(\.isNumber)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanSettingsReader.swift
@@ -25,7 +25,11 @@ public struct AlibabaCodingPlanSettingsReader: Sendable {
     public static func hostOverride(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> String?
     {
-        self.cleaned(environment[self.hostKey])
+        guard let raw = self.cleaned(environment[self.hostKey]) else { return nil }
+        if let scheme = URL(string: raw)?.scheme {
+            return scheme.lowercased() == "https" ? raw : nil
+        }
+        return raw
     }
 
     public static func cookieHeader(
@@ -38,10 +42,21 @@ public struct AlibabaCodingPlanSettingsReader: Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
     {
         guard let raw = self.cleaned(environment[self.quotaURLKey]) else { return nil }
-        if let url = URL(string: raw), url.scheme != nil {
-            return url
+        if let url = URL(string: raw), let scheme = url.scheme {
+            return scheme.lowercased() == "https" ? url : nil
         }
         return URL(string: "https://\(raw)")
+    }
+
+    public static func validateEndpointOverrides(
+        environment: [String: String] = ProcessInfo.processInfo.environment) throws
+    {
+        if self.hasExplicitNonHTTPSURL(environment[self.quotaURLKey]) {
+            throw AlibabaCodingPlanSettingsError.invalidEndpointOverride(self.quotaURLKey)
+        }
+        if self.hasExplicitNonHTTPSURL(environment[self.hostKey]) {
+            throw AlibabaCodingPlanSettingsError.invalidEndpointOverride(self.hostKey)
+        }
     }
 
     static func cleaned(_ raw: String?) -> String? {
@@ -58,12 +73,20 @@ public struct AlibabaCodingPlanSettingsReader: Sendable {
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value
     }
+
+    private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
+        guard let cleaned = self.cleaned(raw),
+              let scheme = URL(string: cleaned)?.scheme
+        else { return false }
+        return scheme.lowercased() != "https"
+    }
 }
 
-public enum AlibabaCodingPlanSettingsError: LocalizedError, Sendable {
+public enum AlibabaCodingPlanSettingsError: LocalizedError, Sendable, Equatable {
     case missingToken
     case missingCookie(details: String? = nil)
     case invalidCookie
+    case invalidEndpointOverride(String)
 
     public var errorDescription: String? {
         switch self {
@@ -78,6 +101,8 @@ public enum AlibabaCodingPlanSettingsError: LocalizedError, Sendable {
             return "\(base) \(details)"
         case .invalidCookie:
             return "Alibaba Coding Plan cookie header is invalid."
+        case let .invalidEndpointOverride(key):
+            return "Alibaba Coding Plan endpoint override \(key) must use HTTPS or a bare host."
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanUsageFetcher.swift
@@ -22,7 +22,9 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         apiKey: String,
         region: AlibabaCodingPlanAPIRegion = .international,
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        now: Date = Date()) async throws -> AlibabaCodingPlanUsageSnapshot
+        now: Date = Date(),
+        session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared)
+        async throws -> AlibabaCodingPlanUsageSnapshot
     {
         let cleanedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleanedKey.isEmpty else {
@@ -35,7 +37,8 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
                 apiKey: cleanedKey,
                 region: region,
                 environment: environment,
-                now: now)
+                now: now,
+                transport: transport)
         }
 
         do {
@@ -43,7 +46,8 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
                 apiKey: cleanedKey,
                 region: .international,
                 environment: environment,
-                now: now)
+                now: now,
+                transport: transport)
         } catch let error as AlibabaCodingPlanUsageError {
             guard error.shouldRetryOnAlternateRegion else { throw error }
             Self.log.debug("Alibaba Coding Plan request failed on intl host; retrying cn host")
@@ -51,7 +55,8 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
                 apiKey: cleanedKey,
                 region: .chinaMainland,
                 environment: environment,
-                now: now)
+                now: now,
+                transport: transport)
         }
     }
 
@@ -59,7 +64,9 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         cookieHeader: String,
         region: AlibabaCodingPlanAPIRegion = .international,
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        now: Date = Date()) async throws -> AlibabaCodingPlanUsageSnapshot
+        now: Date = Date(),
+        session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared)
+        async throws -> AlibabaCodingPlanUsageSnapshot
     {
         guard let normalizedCookie = CookieHeaderNormalizer.normalize(cookieHeader) else {
             throw AlibabaCodingPlanSettingsError.invalidCookie
@@ -71,7 +78,8 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
                 cookieHeader: normalizedCookie,
                 region: region,
                 environment: environment,
-                now: now)
+                now: now,
+                transport: transport)
         }
 
         do {
@@ -79,7 +87,8 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
                 cookieHeader: normalizedCookie,
                 region: .international,
                 environment: environment,
-                now: now)
+                now: now,
+                transport: transport)
         } catch let error as AlibabaCodingPlanUsageError {
             guard error.shouldRetryOnAlternateRegion else { throw error }
             Self.log.debug("Alibaba Coding Plan cookie request failed on intl host; retrying cn host")
@@ -87,7 +96,8 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
                 cookieHeader: normalizedCookie,
                 region: .chinaMainland,
                 environment: environment,
-                now: now)
+                now: now,
+                transport: transport)
         }
     }
 
@@ -95,7 +105,8 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         apiKey: String,
         region: AlibabaCodingPlanAPIRegion,
         environment: [String: String],
-        now: Date) async throws -> AlibabaCodingPlanUsageSnapshot
+        now: Date,
+        transport: any ProviderHTTPTransport) async throws -> AlibabaCodingPlanUsageSnapshot
     {
         let url = self.resolveQuotaURL(region: region, environment: environment)
         var request = URLRequest(url: url)
@@ -110,7 +121,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         request.setValue(region.gatewayBaseURLString, forHTTPHeaderField: "Origin")
         request.setValue(region.dashboardURL.absoluteString, forHTTPHeaderField: "Referer")
 
-        let response = try await ProviderHTTPClient.shared.response(for: request)
+        let response = try await transport.response(for: request)
         let data = response.data
         guard response.statusCode == 200 else {
             if response.statusCode == 401 || response.statusCode == 403 {
@@ -128,13 +139,15 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         cookieHeader: String,
         region: AlibabaCodingPlanAPIRegion,
         environment: [String: String],
-        now: Date) async throws -> AlibabaCodingPlanUsageSnapshot
+        now: Date,
+        transport: any ProviderHTTPTransport) async throws -> AlibabaCodingPlanUsageSnapshot
     {
         let url = self.resolveConsoleQuotaURL(region: region, environment: environment)
         let secToken = try await self.resolveConsoleSECToken(
             cookieHeader: cookieHeader,
             region: region,
-            environment: environment)
+            environment: environment,
+            transport: transport)
         let anonymousID = self.extractCookieValue(name: "cna", from: cookieHeader)
 
         var request = URLRequest(url: url)
@@ -157,7 +170,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         request.setValue(region.gatewayBaseURLString, forHTTPHeaderField: "Origin")
         request.setValue(region.consoleRefererURL.absoluteString, forHTTPHeaderField: "Referer")
 
-        let response = try await ProviderHTTPClient.shared.response(for: request)
+        let response = try await transport.response(for: request)
         let data = response.data
         guard response.statusCode == 200 else {
             if response.statusCode == 401 || response.statusCode == 403 {
@@ -275,7 +288,10 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         let cleaned = AlibabaCodingPlanSettingsReader.cleaned(rawHost)
         guard let cleaned else { return nil }
 
-        let base: URL? = if let url = URL(string: cleaned), let scheme = url.scheme {
+        let base: URL? = if AlibabaCodingPlanSettingsReader.hasExplicitURLScheme(cleaned),
+                            let url = URL(string: cleaned),
+                            let scheme = url.scheme
+        {
             scheme.lowercased() == "https" ? url : nil
         } else {
             URL(string: "https://\(cleaned)")
@@ -299,7 +315,10 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         let cleaned = AlibabaCodingPlanSettingsReader.cleaned(rawHost)
         guard let cleaned else { return nil }
 
-        let base: URL? = if let url = URL(string: cleaned), let scheme = url.scheme {
+        let base: URL? = if AlibabaCodingPlanSettingsReader.hasExplicitURLScheme(cleaned),
+                            let url = URL(string: cleaned),
+                            let scheme = url.scheme
+        {
             scheme.lowercased() == "https" ? url : nil
         } else {
             URL(string: "https://\(cleaned)")
@@ -320,7 +339,8 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
     private static func resolveConsoleSECToken(
         cookieHeader: String,
         region: AlibabaCodingPlanAPIRegion,
-        environment: [String: String]) async throws -> String
+        environment: [String: String],
+        transport: any ProviderHTTPTransport) async throws -> String
     {
         let cookieSECToken = self.extractCookieValue(name: "sec_token", from: cookieHeader)
 
@@ -346,7 +366,8 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         if let token = try? await self.fetchSECTokenFromUserInfo(
             cookieHeader: cookieHeader,
             region: region,
-            environment: environment)
+            environment: environment,
+            transport: transport)
         {
             return token
         }
@@ -362,7 +383,10 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         let cleaned = AlibabaCodingPlanSettingsReader.cleaned(rawHost)
         guard let cleaned else { return nil }
 
-        let base: URL? = if let url = URL(string: cleaned), let scheme = url.scheme {
+        let base: URL? = if AlibabaCodingPlanSettingsReader.hasExplicitURLScheme(cleaned),
+                            let url = URL(string: cleaned),
+                            let scheme = url.scheme
+        {
             scheme.lowercased() == "https" ? url : nil
         } else {
             URL(string: "https://\(cleaned)")
@@ -386,7 +410,8 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
     private static func fetchSECTokenFromUserInfo(
         cookieHeader: String,
         region: AlibabaCodingPlanAPIRegion,
-        environment: [String: String]) async throws -> String?
+        environment: [String: String],
+        transport: any ProviderHTTPTransport) async throws -> String?
     {
         let gatewayBaseURL = self.resolveConsoleGatewayBaseURL(region: region, environment: environment)
         let userInfoURL = gatewayBaseURL.appendingPathComponent("tool/user/info.json")
@@ -399,7 +424,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
             .absoluteString + "/"
         request.setValue(referer, forHTTPHeaderField: "Referer")
 
-        let response = try await ProviderHTTPClient.shared.response(for: request)
+        let response = try await transport.response(for: request)
         guard response.statusCode == 200 else {
             return nil
         }
@@ -407,6 +432,14 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         let object = try JSONSerialization.jsonObject(with: response.data, options: [])
         let expanded = self.expandedJSON(object)
         return self.findFirstString(forKeys: ["secToken", "sec_token"], in: expanded)
+    }
+
+    static func resolveConsoleUserInfoURL(
+        region: AlibabaCodingPlanAPIRegion,
+        environment: [String: String]) -> URL
+    {
+        self.resolveConsoleGatewayBaseURL(region: region, environment: environment)
+            .appendingPathComponent("tool/user/info.json")
     }
 
     private static func resolveConsoleGatewayBaseURL(
@@ -425,7 +458,10 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         let cleaned = AlibabaCodingPlanSettingsReader.cleaned(rawHost)
         guard let cleaned else { return nil }
 
-        let base: URL? = if let url = URL(string: cleaned), let scheme = url.scheme {
+        let base: URL? = if AlibabaCodingPlanSettingsReader.hasExplicitURLScheme(cleaned),
+                            let url = URL(string: cleaned),
+                            let scheme = url.scheme
+        {
             scheme.lowercased() == "https" ? url : nil
         } else {
             URL(string: "https://\(cleaned)")

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanUsageFetcher.swift
@@ -28,6 +28,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         guard !cleanedKey.isEmpty else {
             throw AlibabaCodingPlanUsageError.invalidCredentials
         }
+        try AlibabaCodingPlanSettingsReader.validateEndpointOverrides(environment: environment)
 
         if region != .international {
             return try await self.fetchUsageOnce(
@@ -63,6 +64,7 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         guard let normalizedCookie = CookieHeaderNormalizer.normalize(cookieHeader) else {
             throw AlibabaCodingPlanSettingsError.invalidCookie
         }
+        try AlibabaCodingPlanSettingsReader.validateEndpointOverrides(environment: environment)
 
         if region != .international {
             return try await self.fetchUsageOnce(
@@ -273,8 +275,8 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         let cleaned = AlibabaCodingPlanSettingsReader.cleaned(rawHost)
         guard let cleaned else { return nil }
 
-        let base: URL? = if let url = URL(string: cleaned), url.scheme != nil {
-            url
+        let base: URL? = if let url = URL(string: cleaned), let scheme = url.scheme {
+            scheme.lowercased() == "https" ? url : nil
         } else {
             URL(string: "https://\(cleaned)")
         }
@@ -297,8 +299,8 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         let cleaned = AlibabaCodingPlanSettingsReader.cleaned(rawHost)
         guard let cleaned else { return nil }
 
-        let base: URL? = if let url = URL(string: cleaned), url.scheme != nil {
-            url
+        let base: URL? = if let url = URL(string: cleaned), let scheme = url.scheme {
+            scheme.lowercased() == "https" ? url : nil
         } else {
             URL(string: "https://\(cleaned)")
         }
@@ -360,8 +362,8 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         let cleaned = AlibabaCodingPlanSettingsReader.cleaned(rawHost)
         guard let cleaned else { return nil }
 
-        let base: URL? = if let url = URL(string: cleaned), url.scheme != nil {
-            url
+        let base: URL? = if let url = URL(string: cleaned), let scheme = url.scheme {
+            scheme.lowercased() == "https" ? url : nil
         } else {
             URL(string: "https://\(cleaned)")
         }
@@ -423,8 +425,8 @@ public struct AlibabaCodingPlanUsageFetcher: Sendable {
         let cleaned = AlibabaCodingPlanSettingsReader.cleaned(rawHost)
         guard let cleaned else { return nil }
 
-        let base: URL? = if let url = URL(string: cleaned), url.scheme != nil {
-            url
+        let base: URL? = if let url = URL(string: cleaned), let scheme = url.scheme {
+            scheme.lowercased() == "https" ? url : nil
         } else {
             URL(string: "https://\(cleaned)")
         }

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxProviderDescriptor.swift
@@ -131,6 +131,8 @@ struct MiniMaxCodingPlanFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        try MiniMaxSettingsReader.validateEndpointOverrides(environment: context.env)
+
         let fetchContext = FetchContext(
             region: context.settings?.minimax?.apiRegion ?? .global,
             environment: context.env,

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxProviderDescriptor.swift
@@ -71,6 +71,9 @@ struct MiniMaxAPIFetchStrategy: ProviderFetchStrategy {
     let kind: ProviderFetchKind = .apiToken
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        if (try? MiniMaxSettingsReader.validateEndpointOverrides(environment: context.env)) == nil {
+            return true
+        }
         let authMode = MiniMaxAuthMode.resolve(
             apiToken: ProviderTokenResolver.minimaxToken(environment: context.env),
             cookieHeader: ProviderTokenResolver.minimaxCookie(environment: context.env))
@@ -83,6 +86,7 @@ struct MiniMaxAPIFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        try MiniMaxSettingsReader.validateEndpointOverrides(environment: context.env)
         guard let apiToken = ProviderTokenResolver.minimaxToken(environment: context.env) else {
             throw MiniMaxAPISettingsError.missingToken
         }
@@ -112,6 +116,9 @@ struct MiniMaxCodingPlanFetchStrategy: ProviderFetchStrategy {
     private static let log = CodexBarLog.logger(LogCategories.minimaxWeb)
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        if (try? MiniMaxSettingsReader.validateEndpointOverrides(environment: context.env)) == nil {
+            return true
+        }
         if Self.resolveCookieOverride(context: context) != nil {
             return true
         }

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxSettingsReader.swift
@@ -28,10 +28,7 @@ public struct MiniMaxSettingsReader: Sendable {
 
     public static func hostOverride(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         guard let raw = self.cleaned(environment[self.hostKey]) else { return nil }
-        if let scheme = URL(string: raw)?.scheme {
-            return scheme.lowercased() == "https" ? raw : nil
-        }
-        return raw
+        return self.hasExplicitNonHTTPSURL(raw) ? nil : raw
     }
 
     public static func codingPlanURL(
@@ -81,17 +78,31 @@ public struct MiniMaxSettingsReader: Sendable {
 
     private static func url(from raw: String?) -> URL? {
         guard let cleaned = self.cleaned(raw) else { return nil }
-        if let url = URL(string: cleaned), let scheme = url.scheme {
-            return scheme.lowercased() == "https" ? url : nil
+        if self.hasExplicitURLScheme(cleaned) {
+            guard let url = URL(string: cleaned), url.scheme?.lowercased() == "https" else { return nil }
+            return url
         }
         return URL(string: "https://\(cleaned)")
     }
 
     private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
-        guard let cleaned = self.cleaned(raw),
-              let scheme = URL(string: cleaned)?.scheme
+        guard let cleaned = self.cleaned(raw), self.hasExplicitURLScheme(cleaned) else { return false }
+        return URL(string: cleaned)?.scheme?.lowercased() != "https"
+    }
+
+    static func hasExplicitURLScheme(_ value: String) -> Bool {
+        guard let colonIndex = value.firstIndex(of: ":") else { return false }
+        let scheme = value[..<colonIndex]
+        guard !scheme.isEmpty,
+              scheme.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "+" || $0 == "-" || $0 == "." }),
+              scheme.first?.isLetter == true
         else { return false }
-        return scheme.lowercased() != "https"
+
+        let remainder = value[value.index(after: colonIndex)...]
+        if remainder.hasPrefix("//") { return true }
+
+        let portCandidate = remainder.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false).first ?? ""
+        return portCandidate.isEmpty || !portCandidate.allSatisfy(\.isNumber)
     }
 }
 
@@ -102,7 +113,8 @@ public enum MiniMaxSettingsError: LocalizedError, Sendable, Equatable {
     public var errorDescription: String? {
         switch self {
         case .missingCookie:
-            "MiniMax session not found. Sign in to platform.minimax.io or platform.minimaxi.com in your browser and try again."
+            "MiniMax session not found. Sign in to platform.minimax.io or platform.minimaxi.com " +
+                "in your browser and try again."
         case let .invalidEndpointOverride(key):
             "MiniMax endpoint override \(key) must use HTTPS or a bare host."
         }

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxSettingsReader.swift
@@ -27,7 +27,11 @@ public struct MiniMaxSettingsReader: Sendable {
     }
 
     public static func hostOverride(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
-        self.cleaned(environment[self.hostKey])
+        guard let raw = self.cleaned(environment[self.hostKey]) else { return nil }
+        if let scheme = URL(string: raw)?.scheme {
+            return scheme.lowercased() == "https" ? raw : nil
+        }
+        return raw
     }
 
     public static func codingPlanURL(
@@ -48,6 +52,18 @@ public struct MiniMaxSettingsReader: Sendable {
         self.url(from: environment[self.billingHistoryURLKey])
     }
 
+    public static func validateEndpointOverrides(
+        environment: [String: String] = ProcessInfo.processInfo.environment) throws
+    {
+        let explicitURLKeys = [self.codingPlanURLKey, self.remainsURLKey, self.billingHistoryURLKey]
+        for key in explicitURLKeys where self.hasExplicitNonHTTPSURL(environment[key]) {
+            throw MiniMaxSettingsError.invalidEndpointOverride(key)
+        }
+        if self.hasExplicitNonHTTPSURL(environment[self.hostKey]) {
+            throw MiniMaxSettingsError.invalidEndpointOverride(self.hostKey)
+        }
+    }
+
     static func cleaned(_ raw: String?) -> String? {
         guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
             return nil
@@ -65,20 +81,30 @@ public struct MiniMaxSettingsReader: Sendable {
 
     private static func url(from raw: String?) -> URL? {
         guard let cleaned = self.cleaned(raw) else { return nil }
-        if let url = URL(string: cleaned), url.scheme != nil {
-            return url
+        if let url = URL(string: cleaned), let scheme = url.scheme {
+            return scheme.lowercased() == "https" ? url : nil
         }
         return URL(string: "https://\(cleaned)")
     }
+
+    private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
+        guard let cleaned = self.cleaned(raw),
+              let scheme = URL(string: cleaned)?.scheme
+        else { return false }
+        return scheme.lowercased() != "https"
+    }
 }
 
-public enum MiniMaxSettingsError: LocalizedError, Sendable {
+public enum MiniMaxSettingsError: LocalizedError, Sendable, Equatable {
     case missingCookie
+    case invalidEndpointOverride(String)
 
     public var errorDescription: String? {
         switch self {
         case .missingCookie:
             "MiniMax session not found. Sign in to platform.minimax.io or platform.minimaxi.com in your browser and try again."
+        case let .invalidEndpointOverride(key):
+            "MiniMax endpoint override \(key) must use HTTPS or a bare host."
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -467,7 +467,10 @@ public struct MiniMaxUsageFetcher: Sendable {
             return components.url
         }
 
-        if let url = URL(string: cleaned), let scheme = url.scheme {
+        if MiniMaxSettingsReader.hasExplicitURLScheme(cleaned),
+           let url = URL(string: cleaned),
+           let scheme = url.scheme
+        {
             guard scheme.lowercased() == "https" else { return nil }
             if let composed = compose(url) { return composed }
             return url

--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -36,6 +36,7 @@ public struct MiniMaxUsageFetcher: Sendable {
         guard let cookie = MiniMaxCookieHeader.normalized(from: cookieHeader) else {
             throw MiniMaxUsageError.invalidCredentials
         }
+        try MiniMaxSettingsReader.validateEndpointOverrides(environment: environment)
 
         let context = WebFetchContext(
             cookie: cookie,
@@ -466,7 +467,8 @@ public struct MiniMaxUsageFetcher: Sendable {
             return components.url
         }
 
-        if let url = URL(string: cleaned), url.scheme != nil {
+        if let url = URL(string: cleaned), let scheme = url.scheme {
+            guard scheme.lowercased() == "https" else { return nil }
             if let composed = compose(url) { return composed }
             return url
         }

--- a/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
@@ -177,6 +177,11 @@ public struct ProviderDiagnosticFetchAttempt: Codable, Sendable {
 
     public static func errorCategoryLabel(_ description: String?) -> String {
         guard let desc = description?.lowercased() else { return "unknown" }
+        if desc.contains("endpoint override") || desc.contains("source") || desc.contains("not supported") ||
+            desc.contains("unavailable")
+        {
+            return "configuration"
+        }
         if desc.contains("network") || desc.contains("timeout") || desc.contains("connection") {
             return "network"
         }
@@ -184,9 +189,6 @@ public struct ProviderDiagnosticFetchAttempt: Codable, Sendable {
             desc.contains("api key") || desc.contains("key not configured") || desc.contains("missing key")
         {
             return "auth"
-        }
-        if desc.contains("source") || desc.contains("not supported") || desc.contains("unavailable") {
-            return "configuration"
         }
         if desc.contains("api") || desc.contains("http") || desc.contains("404") || desc.contains("403") {
             return "api"
@@ -224,7 +226,23 @@ public struct ProviderDiagnosticError: Codable, Sendable {
             case .parseFailed: return "parse"
             }
         }
-        if error is MiniMaxSettingsError || error is MiniMaxAPISettingsError { return "auth" }
+        if let minimaxError = error as? MiniMaxSettingsError {
+            switch minimaxError {
+            case .invalidEndpointOverride:
+                return "configuration"
+            case .missingCookie:
+                return "auth"
+            }
+        }
+        if error is MiniMaxAPISettingsError { return "auth" }
+        if let alibabaError = error as? AlibabaCodingPlanSettingsError {
+            switch alibabaError {
+            case .invalidEndpointOverride:
+                return "configuration"
+            case .missingToken, .missingCookie, .invalidCookie:
+                return "auth"
+            }
+        }
         return ProviderDiagnosticFetchAttempt.errorCategoryLabel(error.localizedDescription)
     }
 

--- a/Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift
@@ -61,6 +61,18 @@ struct AlibabaCodingPlanSettingsReaderTests {
     }
 
     @Test
+    func `quota URL preserves bare host port values`() {
+        let url = AlibabaCodingPlanSettingsReader.quotaURL(environment: [
+            AlibabaCodingPlanSettingsReader.quotaURLKey: "localhost:8443/data/api.json",
+        ])
+
+        #expect(url?.scheme == "https")
+        #expect(url?.host == "localhost")
+        #expect(url?.port == 8443)
+        #expect(url?.path == "/data/api.json")
+    }
+
+    @Test
     func `quota URL rejects non HTTPS schemes`() {
         let httpURL = AlibabaCodingPlanSettingsReader.quotaURL(environment: [
             AlibabaCodingPlanSettingsReader.quotaURLKey: "http://modelstudio.console.alibabacloud.com/data/api.json",
@@ -84,10 +96,14 @@ struct AlibabaCodingPlanSettingsReaderTests {
         let bareHost = AlibabaCodingPlanSettingsReader.hostOverride(environment: [
             AlibabaCodingPlanSettingsReader.hostKey: "modelstudio.console.alibabacloud.com",
         ])
+        let bareHostWithPort = AlibabaCodingPlanSettingsReader.hostOverride(environment: [
+            AlibabaCodingPlanSettingsReader.hostKey: "localhost:8443",
+        ])
 
         #expect(httpHost == nil)
         #expect(httpsHost == "https://modelstudio.console.alibabacloud.com")
         #expect(bareHost == "modelstudio.console.alibabacloud.com")
+        #expect(bareHostWithPort == "localhost:8443")
     }
 
     @Test
@@ -108,6 +124,10 @@ struct AlibabaCodingPlanSettingsReaderTests {
             AlibabaCodingPlanSettingsReader.quotaURLKey:
                 "https://modelstudio.console.alibabacloud.com/data/api.json",
             AlibabaCodingPlanSettingsReader.hostKey: "modelstudio.console.alibabacloud.com",
+        ])
+        try AlibabaCodingPlanSettingsReader.validateEndpointOverrides(environment: [
+            AlibabaCodingPlanSettingsReader.quotaURLKey: "localhost:8443/data/api.json",
+            AlibabaCodingPlanSettingsReader.hostKey: "localhost:8443",
         ])
     }
 
@@ -651,6 +671,42 @@ struct AlibabaCodingPlanFallbackTests {
     }
 
     @Test
+    func `web strategy rejects invalid endpoint override before cookie discovery`() async {
+        let strategy = AlibabaCodingPlanWebFetchStrategy()
+        let context = self.makeContext(
+            sourceMode: .web,
+            env: [AlibabaCodingPlanSettingsReader.quotaURLKey: "http://localhost:8080/data/api.json"])
+
+        #expect(await strategy.isAvailable(context))
+        await #expect(
+            throws: AlibabaCodingPlanSettingsError.invalidEndpointOverride(AlibabaCodingPlanSettingsReader.quotaURLKey))
+        {
+            try await strategy.fetch(context)
+        }
+    }
+
+    @Test
+    func `api key strategy rejects invalid endpoint override as configuration error`() async {
+        let strategy = AlibabaCodingPlanAPIFetchStrategy()
+        let context = self.makeContext(
+            sourceMode: .api,
+            env: [
+                AlibabaCodingPlanSettingsReader.apiTokenKey: "[REDACTED]",
+                AlibabaCodingPlanSettingsReader.quotaURLKey: "http://localhost:8080/data/api.json",
+            ])
+
+        #expect(await strategy.isAvailable(context))
+        await #expect(
+            throws: AlibabaCodingPlanSettingsError.invalidEndpointOverride(AlibabaCodingPlanSettingsReader.quotaURLKey))
+        {
+            try await strategy.fetch(context)
+        }
+        #expect(strategy.shouldFallback(
+            on: AlibabaCodingPlanSettingsError.invalidEndpointOverride(AlibabaCodingPlanSettingsReader.quotaURLKey),
+            context: context) == false)
+    }
+
+    @Test
     func `falls back on TLS failure in auto mode`() {
         let strategy = AlibabaCodingPlanWebFetchStrategy()
         let context = self.makeContext(sourceMode: .auto)
@@ -741,6 +797,23 @@ struct AlibabaCodingPlanRegionTests {
         let url = AlibabaCodingPlanUsageFetcher.resolveQuotaURL(region: .international, environment: env)
         #expect(url.host == "custom.aliyun.com")
         #expect(url.path == "/data/api.json")
+    }
+
+    @Test
+    func `bare host port override is honored by usage URLs`() {
+        let env = [AlibabaCodingPlanSettingsReader.hostKey: "localhost:8443"]
+        let quota = AlibabaCodingPlanUsageFetcher.resolveQuotaURL(region: .international, environment: env)
+        let console = AlibabaCodingPlanUsageFetcher.resolveConsoleDashboardURL(region: .international, environment: env)
+        let userInfo = AlibabaCodingPlanUsageFetcher.resolveConsoleUserInfoURL(region: .international, environment: env)
+
+        for url in [quota, console, userInfo] {
+            #expect(url.scheme == "https")
+            #expect(url.host == "localhost")
+            #expect(url.port == 8443)
+        }
+        #expect(quota.path == "/data/api.json")
+        #expect(console.path == AlibabaCodingPlanAPIRegion.international.dashboardURL.path)
+        #expect(userInfo.path == "/tool/user/info.json")
     }
 
     @Test
@@ -917,6 +990,50 @@ struct AlibabaCodingPlanUsageFetcherRequestTests {
     }
 
     @Test
+    func `bare host port override applies to API key usage request`() async throws {
+        let registered = URLProtocol.registerClass(AlibabaUsageFetcherStubURLProtocol.self)
+        defer {
+            if registered {
+                URLProtocol.unregisterClass(AlibabaUsageFetcherStubURLProtocol.self)
+            }
+            AlibabaUsageFetcherStubURLProtocol.handler = nil
+        }
+
+        AlibabaUsageFetcherStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            #expect(url.scheme == "https")
+            #expect(url.host == "localhost")
+            #expect(url.port == 8443)
+            #expect(url.path == "/data/api.json")
+            let json = """
+            {
+              "data": {
+                "codingPlanInstanceInfos": [
+                  { "planName": "Alibaba Coding Plan Pro", "status": "VALID" }
+                ],
+                "codingPlanQuotaInfo": {
+                  "per5HourUsedQuota": 13,
+                  "per5HourTotalQuota": 1000,
+                  "per5HourQuotaNextRefreshTime": 1700000300000
+                }
+              },
+              "status_code": 0
+            }
+            """
+            return Self.makeResponse(url: url, body: json, statusCode: 200)
+        }
+
+        let snapshot = try await AlibabaCodingPlanUsageFetcher.fetchUsage(
+            apiKey: "[REDACTED]",
+            region: .international,
+            environment: [AlibabaCodingPlanSettingsReader.hostKey: "localhost:8443"],
+            now: Date(timeIntervalSince1970: 1_700_000_000))
+
+        #expect(snapshot.planName == "Alibaba Coding Plan Pro")
+        #expect(snapshot.fiveHourUsedQuota == 13)
+    }
+
+    @Test
     func `console request body uses region specific metadata`() async throws {
         let registered = URLProtocol.registerClass(AlibabaConsoleSECTokenStubURLProtocol.self)
         defer {
@@ -1034,7 +1151,8 @@ final class AlibabaUsageFetcherStubURLProtocol: URLProtocol {
     nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
 
     override static func canInit(with request: URLRequest) -> Bool {
-        request.url?.host == "alibaba-api.test"
+        guard let host = request.url?.host else { return false }
+        return ["alibaba-api.test", "localhost"].contains(host)
     }
 
     override static func canonicalRequest(for request: URLRequest) -> URLRequest {

--- a/Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift
@@ -3,6 +3,20 @@ import Testing
 @testable import CodexBarCore
 
 struct AlibabaCodingPlanSettingsReaderTests {
+    private struct StubClaudeFetcher: ClaudeUsageFetching {
+        func loadLatestUsage(model _: String) async throws -> ClaudeUsageSnapshot {
+            throw ClaudeUsageError.parseFailed("stub")
+        }
+
+        func debugRawProbe(model _: String) async -> String {
+            "stub"
+        }
+
+        func detectVersion() -> String? {
+            nil
+        }
+    }
+
     @Test
     func `api token reads from environment`() {
         let token = AlibabaCodingPlanSettingsReader.apiToken(environment: ["ALIBABA_CODING_PLAN_API_KEY": "abc123"])
@@ -44,6 +58,104 @@ struct AlibabaCodingPlanSettingsReaderTests {
             .quotaURL(environment: [AlibabaCodingPlanSettingsReader
                     .quotaURLKey: "modelstudio.console.alibabacloud.com/data/api.json"])
         #expect(url?.absoluteString == "https://modelstudio.console.alibabacloud.com/data/api.json")
+    }
+
+    @Test
+    func `quota URL rejects non HTTPS schemes`() {
+        let httpURL = AlibabaCodingPlanSettingsReader.quotaURL(environment: [
+            AlibabaCodingPlanSettingsReader.quotaURLKey: "http://modelstudio.console.alibabacloud.com/data/api.json",
+        ])
+        let ftpURL = AlibabaCodingPlanSettingsReader.quotaURL(environment: [
+            AlibabaCodingPlanSettingsReader.quotaURLKey: "ftp://modelstudio.console.alibabacloud.com/data/api.json",
+        ])
+
+        #expect(httpURL == nil)
+        #expect(ftpURL == nil)
+    }
+
+    @Test
+    func `host override rejects non HTTPS schemes`() {
+        let httpHost = AlibabaCodingPlanSettingsReader.hostOverride(environment: [
+            AlibabaCodingPlanSettingsReader.hostKey: "http://modelstudio.console.alibabacloud.com",
+        ])
+        let httpsHost = AlibabaCodingPlanSettingsReader.hostOverride(environment: [
+            AlibabaCodingPlanSettingsReader.hostKey: "https://modelstudio.console.alibabacloud.com",
+        ])
+        let bareHost = AlibabaCodingPlanSettingsReader.hostOverride(environment: [
+            AlibabaCodingPlanSettingsReader.hostKey: "modelstudio.console.alibabacloud.com",
+        ])
+
+        #expect(httpHost == nil)
+        #expect(httpsHost == "https://modelstudio.console.alibabacloud.com")
+        #expect(bareHost == "modelstudio.console.alibabacloud.com")
+    }
+
+    @Test
+    func `validation fails closed for explicit non HTTPS endpoint overrides`() throws {
+        let rejectedOverrides = [
+            AlibabaCodingPlanSettingsReader.quotaURLKey:
+                "http://modelstudio.console.alibabacloud.com/data/api.json",
+            AlibabaCodingPlanSettingsReader.hostKey: "ftp://modelstudio.console.alibabacloud.com",
+        ]
+
+        for (key, value) in rejectedOverrides {
+            #expect(throws: AlibabaCodingPlanSettingsError.invalidEndpointOverride(key)) {
+                try AlibabaCodingPlanSettingsReader.validateEndpointOverrides(environment: [key: value])
+            }
+        }
+
+        try AlibabaCodingPlanSettingsReader.validateEndpointOverrides(environment: [
+            AlibabaCodingPlanSettingsReader.quotaURLKey:
+                "https://modelstudio.console.alibabacloud.com/data/api.json",
+            AlibabaCodingPlanSettingsReader.hostKey: "modelstudio.console.alibabacloud.com",
+        ])
+    }
+
+    @Test
+    func `api fetch rejects non HTTPS endpoint override before sending credentials`() async {
+        await #expect(throws: AlibabaCodingPlanSettingsError.invalidEndpointOverride(
+            AlibabaCodingPlanSettingsReader.quotaURLKey))
+        {
+            try await AlibabaCodingPlanUsageFetcher.fetchUsage(
+                apiKey: "dummy-api-key",
+                environment: [
+                    AlibabaCodingPlanSettingsReader.quotaURLKey: "http://localhost:8080/data/api.json",
+                ])
+        }
+    }
+
+    @Test
+    func `cookie fetch rejects non HTTPS host override before sending credentials`() async {
+        await #expect(throws: AlibabaCodingPlanSettingsError.invalidEndpointOverride(
+            AlibabaCodingPlanSettingsReader.hostKey))
+        {
+            try await AlibabaCodingPlanUsageFetcher.fetchUsage(
+                cookieHeader: "login_aliyunid_ticket=abc; login_aliyunid_pk=123",
+                environment: [AlibabaCodingPlanSettingsReader.hostKey: "http://localhost:8080"])
+        }
+    }
+
+    @Test
+    func `web strategy rejects invalid endpoint override before cookie discovery`() async {
+        let env = [AlibabaCodingPlanSettingsReader.quotaURLKey: "http://localhost:8080/data/api.json"]
+        let context = ProviderFetchContext(
+            runtime: .app,
+            sourceMode: .web,
+            includeCredits: false,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: env,
+            settings: nil,
+            fetcher: UsageFetcher(environment: env),
+            claudeFetcher: StubClaudeFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0))
+
+        await #expect(throws: AlibabaCodingPlanSettingsError.invalidEndpointOverride(
+            AlibabaCodingPlanSettingsReader.quotaURLKey))
+        {
+            try await AlibabaCodingPlanWebFetchStrategy().fetch(context)
+        }
     }
 
     @Test

--- a/Tests/CodexBarTests/MiniMaxProviderTests.swift
+++ b/Tests/CodexBarTests/MiniMaxProviderTests.swift
@@ -133,7 +133,7 @@ struct MiniMaxProviderStrategyTests {
     }
 
     private func makeContext(runtime: ProviderRuntime, env: [String: String] = [:]) -> ProviderFetchContext {
-        return ProviderFetchContext(
+        ProviderFetchContext(
             runtime: runtime,
             sourceMode: .web,
             includeCredits: false,

--- a/Tests/CodexBarTests/MiniMaxProviderTests.swift
+++ b/Tests/CodexBarTests/MiniMaxProviderTests.swift
@@ -25,6 +25,71 @@ struct MiniMaxAPISettingsReaderTests {
     }
 }
 
+struct MiniMaxSettingsReaderTests {
+    @Test
+    func `URL overrides infer HTTPS scheme`() {
+        let url = MiniMaxSettingsReader.codingPlanURL(environment: [
+            MiniMaxSettingsReader.codingPlanURLKey: "platform.minimax.test/account",
+        ])
+
+        #expect(url?.scheme == "https")
+        #expect(url?.host == "platform.minimax.test")
+    }
+
+    @Test
+    func `URL overrides reject non HTTPS schemes`() {
+        let httpURL = MiniMaxSettingsReader.remainsURL(environment: [
+            MiniMaxSettingsReader.remainsURLKey: "http://platform.minimax.test/remains",
+        ])
+        let ftpURL = MiniMaxSettingsReader.billingHistoryURL(environment: [
+            MiniMaxSettingsReader.billingHistoryURLKey: "ftp://platform.minimax.test/billing",
+        ])
+
+        #expect(httpURL == nil)
+        #expect(ftpURL == nil)
+    }
+
+    @Test
+    func `host override rejects non HTTPS schemes`() {
+        let httpHost = MiniMaxSettingsReader.hostOverride(environment: [
+            MiniMaxSettingsReader.hostKey: "http://platform.minimax.test",
+        ])
+        let httpsHost = MiniMaxSettingsReader.hostOverride(environment: [
+            MiniMaxSettingsReader.hostKey: "https://platform.minimax.test",
+        ])
+        let bareHost = MiniMaxSettingsReader.hostOverride(environment: [
+            MiniMaxSettingsReader.hostKey: "platform.minimax.test",
+        ])
+
+        #expect(httpHost == nil)
+        #expect(httpsHost == "https://platform.minimax.test")
+        #expect(bareHost == "platform.minimax.test")
+    }
+
+    @Test
+    func `validation fails closed for explicit non HTTPS endpoint overrides`() throws {
+        let rejectedOverrides = [
+            MiniMaxSettingsReader.codingPlanURLKey: "http://platform.minimax.test/account",
+            MiniMaxSettingsReader.remainsURLKey: "http://platform.minimax.test/remains",
+            MiniMaxSettingsReader.billingHistoryURLKey: "ftp://platform.minimax.test/history",
+            MiniMaxSettingsReader.hostKey: "http://platform.minimax.test",
+        ]
+
+        for (key, value) in rejectedOverrides {
+            #expect(throws: MiniMaxSettingsError.invalidEndpointOverride(key)) {
+                try MiniMaxSettingsReader.validateEndpointOverrides(environment: [key: value])
+            }
+        }
+
+        try MiniMaxSettingsReader.validateEndpointOverrides(environment: [
+            MiniMaxSettingsReader.codingPlanURLKey: "https://platform.minimax.test/account",
+            MiniMaxSettingsReader.remainsURLKey: "https://platform.minimax.test/remains",
+            MiniMaxSettingsReader.billingHistoryURLKey: "https://platform.minimax.test/history",
+            MiniMaxSettingsReader.hostKey: "platform.minimax.test",
+        ])
+    }
+}
+
 struct MiniMaxProviderStrategyTests {
     private struct StubClaudeFetcher: ClaudeUsageFetching {
         func loadLatestUsage(model _: String) async throws -> ClaudeUsageSnapshot {
@@ -54,8 +119,20 @@ struct MiniMaxProviderStrategyTests {
         }
     }
 
-    private func makeContext(runtime: ProviderRuntime) -> ProviderFetchContext {
-        let env: [String: String] = [:]
+    @Test
+    func `web strategy rejects invalid endpoint override before browser credential discovery`() async {
+        let context = self.makeContext(
+            runtime: .app,
+            env: [MiniMaxSettingsReader.remainsURLKey: "http://localhost:8080/remains"])
+
+        await #expect(throws: MiniMaxSettingsError.invalidEndpointOverride(MiniMaxSettingsReader.remainsURLKey)) {
+            try await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                try await MiniMaxCodingPlanFetchStrategy().fetch(context)
+            }
+        }
+    }
+
+    private func makeContext(runtime: ProviderRuntime, env: [String: String] = [:]) -> ProviderFetchContext {
         return ProviderFetchContext(
             runtime: runtime,
             sourceMode: .web,
@@ -766,6 +843,27 @@ struct MiniMaxUsageParserTests {
         #expect(summary.topMethods[0].tokens == 4000)
         #expect(summary.topMethods[1].name == "chat")
         #expect(summary.topMethods[1].tokens == 1000)
+    }
+
+    @Test
+    func `web usage fetch rejects non HTTPS endpoint override before sending credentials`() async throws {
+        let transport = ProviderHTTPTransportStub { _ in
+            Issue.record("request should not be sent for invalid endpoint override")
+            return try Self.httpResponse(
+                url: #require(URL(string: "https://platform.minimax.test/unreachable")),
+                body: "{}",
+                contentType: "application/json")
+        }
+
+        await #expect(throws: MiniMaxSettingsError.invalidEndpointOverride(MiniMaxSettingsReader.remainsURLKey)) {
+            try await MiniMaxUsageFetcher.fetchUsage(
+                cookieHeader: "HERTZ-SESSION=abc",
+                region: .global,
+                environment: [MiniMaxSettingsReader.remainsURLKey: "http://localhost:8080/remains"],
+                session: transport)
+        }
+        let requests = await transport.requests()
+        #expect(requests.isEmpty)
     }
 
     @Test

--- a/Tests/CodexBarTests/MiniMaxProviderTests.swift
+++ b/Tests/CodexBarTests/MiniMaxProviderTests.swift
@@ -846,27 +846,6 @@ struct MiniMaxUsageParserTests {
     }
 
     @Test
-    func `web usage fetch rejects non HTTPS endpoint override before sending credentials`() async throws {
-        let transport = ProviderHTTPTransportStub { _ in
-            Issue.record("request should not be sent for invalid endpoint override")
-            return try Self.httpResponse(
-                url: #require(URL(string: "https://platform.minimax.test/unreachable")),
-                body: "{}",
-                contentType: "application/json")
-        }
-
-        await #expect(throws: MiniMaxSettingsError.invalidEndpointOverride(MiniMaxSettingsReader.remainsURLKey)) {
-            try await MiniMaxUsageFetcher.fetchUsage(
-                cookieHeader: "HERTZ-SESSION=abc",
-                region: .global,
-                environment: [MiniMaxSettingsReader.remainsURLKey: "http://localhost:8080/remains"],
-                session: transport)
-        }
-        let requests = await transport.requests()
-        #expect(requests.isEmpty)
-    }
-
-    @Test
     func `web usage fetch attaches billing history when available`() async throws {
         let now = try #require(ISO8601DateFormatter().date(from: "2026-05-17T12:00:00Z"))
         let transport = ProviderHTTPTransportStub { request in
@@ -1073,6 +1052,43 @@ struct MiniMaxUsageParserTests {
       }
     }
     """
+
+    private static func httpResponse(
+        url: URL,
+        body: String,
+        statusCode: Int = 200,
+        contentType: String) -> (Data, URLResponse)
+    {
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: ["Content-Type": contentType])!
+        return (Data(body.utf8), response)
+    }
+}
+
+struct MiniMaxUsageFetcherSecurityTests {
+    @Test
+    func `web usage fetch rejects non HTTPS endpoint override before sending credentials`() async throws {
+        let transport = ProviderHTTPTransportStub { _ in
+            Issue.record("request should not be sent for invalid endpoint override")
+            return try Self.httpResponse(
+                url: #require(URL(string: "https://platform.minimax.test/unreachable")),
+                body: "{}",
+                contentType: "application/json")
+        }
+
+        await #expect(throws: MiniMaxSettingsError.invalidEndpointOverride(MiniMaxSettingsReader.remainsURLKey)) {
+            try await MiniMaxUsageFetcher.fetchUsage(
+                cookieHeader: "[REDACTED]",
+                region: .global,
+                environment: [MiniMaxSettingsReader.remainsURLKey: "http://localhost:8080/remains"],
+                session: transport)
+        }
+        let requests = await transport.requests()
+        #expect(requests.isEmpty)
+    }
 
     private static func httpResponse(
         url: URL,

--- a/Tests/CodexBarTests/MiniMaxProviderTests.swift
+++ b/Tests/CodexBarTests/MiniMaxProviderTests.swift
@@ -37,6 +37,18 @@ struct MiniMaxSettingsReaderTests {
     }
 
     @Test
+    func `URL overrides preserve bare host port values`() {
+        let url = MiniMaxSettingsReader.codingPlanURL(environment: [
+            MiniMaxSettingsReader.codingPlanURLKey: "localhost:8443/account",
+        ])
+
+        #expect(url?.scheme == "https")
+        #expect(url?.host == "localhost")
+        #expect(url?.port == 8443)
+        #expect(url?.path == "/account")
+    }
+
+    @Test
     func `URL overrides reject non HTTPS schemes`() {
         let httpURL = MiniMaxSettingsReader.remainsURL(environment: [
             MiniMaxSettingsReader.remainsURLKey: "http://platform.minimax.test/remains",
@@ -60,10 +72,14 @@ struct MiniMaxSettingsReaderTests {
         let bareHost = MiniMaxSettingsReader.hostOverride(environment: [
             MiniMaxSettingsReader.hostKey: "platform.minimax.test",
         ])
+        let bareHostWithPort = MiniMaxSettingsReader.hostOverride(environment: [
+            MiniMaxSettingsReader.hostKey: "localhost:8443",
+        ])
 
         #expect(httpHost == nil)
         #expect(httpsHost == "https://platform.minimax.test")
         #expect(bareHost == "platform.minimax.test")
+        #expect(bareHostWithPort == "localhost:8443")
     }
 
     @Test
@@ -86,6 +102,12 @@ struct MiniMaxSettingsReaderTests {
             MiniMaxSettingsReader.remainsURLKey: "https://platform.minimax.test/remains",
             MiniMaxSettingsReader.billingHistoryURLKey: "https://platform.minimax.test/history",
             MiniMaxSettingsReader.hostKey: "platform.minimax.test",
+        ])
+        try MiniMaxSettingsReader.validateEndpointOverrides(environment: [
+            MiniMaxSettingsReader.codingPlanURLKey: "localhost:8443/account",
+            MiniMaxSettingsReader.remainsURLKey: "localhost:8443/remains",
+            MiniMaxSettingsReader.billingHistoryURLKey: "localhost:8443/history",
+            MiniMaxSettingsReader.hostKey: "localhost:8443",
         ])
     }
 }
@@ -125,6 +147,7 @@ struct MiniMaxProviderStrategyTests {
             runtime: .app,
             env: [MiniMaxSettingsReader.remainsURLKey: "http://localhost:8080/remains"])
 
+        #expect(await MiniMaxCodingPlanFetchStrategy().isAvailable(context))
         await #expect(throws: MiniMaxSettingsError.invalidEndpointOverride(MiniMaxSettingsReader.remainsURLKey)) {
             try await ProviderInteractionContext.$current.withValue(.userInitiated) {
                 try await MiniMaxCodingPlanFetchStrategy().fetch(context)
@@ -960,6 +983,35 @@ struct MiniMaxUsageParserTests {
     }
 
     @Test
+    func `bare host port override applies to web usage request`() async throws {
+        let now = try #require(ISO8601DateFormatter().date(from: "2026-05-17T12:00:00Z"))
+        let transport = ProviderHTTPTransportStub { request in
+            let url = try #require(request.url)
+            #expect(url.scheme == "https")
+            #expect(url.host == "localhost")
+            #expect(url.port == 8443)
+            #expect(url.path == "/user-center/payment/coding-plan")
+            return Self.httpResponse(
+                url: url,
+                body: Self.codingPlanJSON,
+                contentType: "application/json")
+        }
+
+        let snapshot = try await MiniMaxUsageFetcher.fetchUsage(
+            cookieHeader: "HERTZ-SESSION=abc",
+            region: .global,
+            environment: [MiniMaxSettingsReader.hostKey: "localhost:8443"],
+            includeBillingHistory: false,
+            session: transport,
+            now: now)
+
+        let requests = await transport.requests()
+        #expect(snapshot.currentPrompts == 2)
+        #expect(snapshot.billingSummary == nil)
+        #expect(requests.count == 1)
+    }
+
+    @Test
     func `web usage fetch keeps quota when billing history is forbidden`() async throws {
         let now = try #require(ISO8601DateFormatter().date(from: "2026-05-17T12:00:00Z"))
         let transport = ProviderHTTPTransportStub { request in
@@ -1130,6 +1182,23 @@ struct MiniMaxAPIRegionTests {
         let remains = MiniMaxUsageFetcher.resolveRemainsURL(region: .global, environment: env)
         #expect(codingPlan.host == "api.minimaxi.com")
         #expect(remains.host == "api.minimaxi.com")
+    }
+
+    @Test
+    func `bare host port override is honored by usage URLs`() {
+        let env = [MiniMaxSettingsReader.hostKey: "localhost:8443"]
+        let codingPlan = MiniMaxUsageFetcher.resolveCodingPlanURL(region: .global, environment: env)
+        let remains = MiniMaxUsageFetcher.resolveRemainsURL(region: .global, environment: env)
+        let billingHistory = MiniMaxUsageFetcher.resolveBillingHistoryURL(region: .global, environment: env)
+
+        for url in [codingPlan, remains, billingHistory] {
+            #expect(url.scheme == "https")
+            #expect(url.host == "localhost")
+            #expect(url.port == 8443)
+        }
+        #expect(codingPlan.path == "/user-center/payment/coding-plan")
+        #expect(remains.path == "/v1/api/openplatform/coding_plan/remains")
+        #expect(billingHistory.path == "/account/amount")
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
+++ b/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
@@ -166,6 +166,34 @@ struct ProviderDiagnosticExportTests {
     }
 
     @Test
+    func `invalid provider endpoint overrides map to configuration diagnostics`() {
+        let alibaba = ProviderDiagnosticError(
+            from: AlibabaCodingPlanSettingsError.invalidEndpointOverride(AlibabaCodingPlanSettingsReader.quotaURLKey),
+            authConfigured: true)
+        #expect(alibaba.category == "configuration")
+        #expect(alibaba.safeDescription == "Configuration issue - check provider source and settings")
+
+        let minimax = ProviderDiagnosticError(
+            from: MiniMaxSettingsError.invalidEndpointOverride(MiniMaxSettingsReader.remainsURLKey),
+            authConfigured: true)
+        #expect(minimax.category == "configuration")
+        #expect(minimax.safeDescription == "Configuration issue - check provider source and settings")
+    }
+
+    @Test
+    func `invalid endpoint override fetch attempt text maps to configuration before auth or api`() {
+        let alibabaDescription = AlibabaCodingPlanSettingsError
+            .invalidEndpointOverride(AlibabaCodingPlanSettingsReader.quotaURLKey)
+            .localizedDescription
+        let minimaxDescription = MiniMaxSettingsError
+            .invalidEndpointOverride(MiniMaxSettingsReader.remainsURLKey)
+            .localizedDescription
+
+        #expect(ProviderDiagnosticFetchAttempt.errorCategoryLabel(alibabaDescription) == "configuration")
+        #expect(ProviderDiagnosticFetchAttempt.errorCategoryLabel(minimaxDescription) == "configuration")
+    }
+
+    @Test
     func `MiniMax details map from MiniMaxUsageSnapshot correctly`() {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let snapshot = MiniMaxUsageSnapshot(


### PR DESCRIPTION
## Summary

This PR hardens the credentialed endpoint override boundary for the MiniMax and Alibaba Coding Plan providers.

- Rejects explicit non-HTTPS endpoint overrides before provider web/API usage requests can resolve or send credentials.
- Preserves trusted HTTPS overrides and bare host/path compatibility by continuing to compose bare values as HTTPS URLs.
- Adds provider-specific validation errors so unsafe endpoint configuration fails closed instead of silently falling through.
- Adds regression coverage for settings readers, URL composition, and web strategy entry points that should reject invalid overrides before credential discovery.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Non-HTTPS credentialed endpoint overrides for MiniMax and Alibaba Coding Plan | A local configuration/environment override could direct browser-derived cookies or authorization headers toward `http://` or another non-HTTPS endpoint during usage fetching. | Moderate |

## Before this PR

- `MINIMAX_*_URL`, `MINIMAX_HOST`, `ALIBABA_CODING_PLAN_QUOTA_URL`, and `ALIBABA_CODING_PLAN_HOST` accepted explicit URL schemes inconsistently across settings readers, URL builders, and fetch strategies.
- Some helper methods returned `nil` for non-HTTPS values, but higher-level fetch paths could still continue into fallback behavior or credential discovery.
- Web strategies did not consistently validate endpoint overrides before resolving cached, manual, or browser-derived cookie material.
- Tests covered normal endpoint construction but did not lock the “reject before credentials” boundary for unsafe explicit schemes.

## After this PR

- Explicit endpoint overrides with `http://`, `ftp://`, or any non-HTTPS scheme fail closed with provider-specific `invalidEndpointOverride` errors.
- Bare host/path override values, including bare `host:port` values, remain supported and continue to be normalized to HTTPS where URL construction is needed.
- MiniMax and Alibaba web strategies validate endpoint overrides before resolving browser/session credentials.
- Regression tests cover invalid explicit schemes, preserved HTTPS/bare-host behavior, and early strategy rejection before credential discovery.

## Compatibility decision: explicit `http://` overrides fail closed

This PR intentionally treats explicit non-HTTPS endpoint override URLs as unsupported for MiniMax and Alibaba Coding Plan credentialed usage fetches. That is a compatibility break for local/debug setups that deliberately set values such as `MINIMAX_REMAINS_URL=http://localhost:8080/remains` or `ALIBABA_CODING_PLAN_QUOTA_URL=http://localhost:8080/data/api.json`.

The supported compatibility paths are:

- explicit `https://...` override URLs;
- bare host/path values, including bare `host:port` values such as `localhost:8443/path`, which are normalized to HTTPS by the application.

The security decision is to fail closed for explicit `http://` or other non-HTTPS schemes before credential discovery or request construction, rather than allowing provider cookies/API keys to be resolved for a plaintext endpoint.

## Why this matters

MiniMax and Alibaba Coding Plan usage fetches can attach sensitive provider session material to outbound requests. Endpoint override variables are useful for trusted local development and deployment customization, but a credentialed request should not proceed when an override explicitly selects plaintext HTTP or another non-HTTPS transport.

Failing closed at the settings and strategy boundary prevents accidental credential delivery to unsafe endpoints while keeping the intended trusted HTTPS override workflow intact.

## Attack flow

```text
Local configuration or environment sets a provider endpoint override to http://localhost:8080/...
    -> CodexBar usage fetch path runs for MiniMax or Alibaba Coding Plan
        -> endpoint override is not rejected before credential discovery
            -> browser, cached, or manual provider credentials can be resolved
                -> request can be composed for the non-HTTPS override
                    -> sensitive provider session material can be sent to an unsafe endpoint
```

## Affected code

| Issue | Files |
|-------|-------|
| Non-HTTPS credentialed endpoint overrides | `Sources/CodexBarCore/Providers/MiniMax/MiniMaxSettingsReader.swift`, `Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift`, `Sources/CodexBarCore/Providers/MiniMax/MiniMaxProviderDescriptor.swift`, `Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanSettingsReader.swift`, `Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanUsageFetcher.swift`, `Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanProviderDescriptor.swift` |

## Root cause

Non-HTTPS credentialed endpoint overrides

- Direct cause: explicit endpoint schemes were parsed or ignored inconsistently instead of being treated as configuration errors when the scheme was not HTTPS.
- Boundary failure: credentialed web-fetch strategies did not validate endpoint override configuration before discovering or using browser/session credentials.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Non-HTTPS credentialed endpoint overrides | 5.5 Medium | `CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:N/A:N` |

Rationale:

- The control point is local configuration or environment influence, and the application/user must execute the affected usage fetch path.
- The impact is bounded to confidentiality of provider session material that could be sent to a non-HTTPS endpoint.
- Scope is unchanged, and this PR does not claim unauthenticated remote reachability.

## Safe reproduction steps

### 1. MiniMax invalid endpoint override

1. Configure a MiniMax web endpoint override with an explicit non-HTTPS URL, for example `MINIMAX_REMAINS_URL=http://localhost:8080/remains`.
2. Trigger the MiniMax web usage fetch strategy.
3. On vulnerable code, the strategy can continue toward credential discovery/fetch behavior instead of rejecting the unsafe override at entry.
4. After this PR, the strategy throws `MiniMaxSettingsError.invalidEndpointOverride("MINIMAX_REMAINS_URL")` before browser credential discovery.

### 2. Alibaba Coding Plan invalid endpoint override

1. Configure an Alibaba Coding Plan endpoint override with an explicit non-HTTPS URL, for example `ALIBABA_CODING_PLAN_QUOTA_URL=http://localhost:8080/data/api.json`.
2. Trigger the Alibaba Coding Plan API or web usage fetch path.
3. On vulnerable code, the fetch path can proceed with inconsistent override handling instead of treating the override as unsafe configuration.
4. After this PR, the path throws `AlibabaCodingPlanSettingsError.invalidEndpointOverride("ALIBABA_CODING_PLAN_QUOTA_URL")` before credentialed request construction.

## Expected vulnerable behavior

- Explicit non-HTTPS endpoint overrides should never be accepted for credentialed provider usage requests.
- Pre-patch behavior allowed invalid override values to be ignored or handled inconsistently across settings readers, URL builders, and strategy boundaries.
- The safe proof signal is the new regression coverage and focused smoke validation asserting that invalid overrides throw before browser/cookie resolution or credentialed request construction.

## Changes in this PR

- Adds `validateEndpointOverrides` helpers for MiniMax and Alibaba Coding Plan settings.
- Rejects explicit non-HTTPS schemes while preserving HTTPS, bare-host, and bare `host:port` compatibility.
- Validates endpoint overrides in web fetch strategies before cookie lookup or credentialed fetch work.
- Keeps URL construction helpers defensive by returning `nil` for explicit non-HTTPS URLs.
- Adds provider-specific `invalidEndpointOverride` errors.
- Adds regression tests for invalid-scheme rejection and preserved HTTPS/bare-host behavior.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Settings validation | `MiniMaxSettingsReader.swift`, `AlibabaCodingPlanSettingsReader.swift` | Added explicit endpoint override validation and provider-specific errors. |
| Request construction | `MiniMaxUsageFetcher.swift`, `AlibabaCodingPlanUsageFetcher.swift` | Preserved HTTPS-only URL composition for override-based requests. |
| Strategy boundary | `MiniMaxProviderDescriptor.swift`, `AlibabaCodingPlanProviderDescriptor.swift` | Validate overrides before resolving cookies or fetching usage. |
| Tests | `MiniMaxProviderTests.swift`, `AlibabaCodingPlanProviderTests.swift` | Added settings, URL composition, and strategy regression coverage. |

## Maintainer impact

- Scope is limited to MiniMax and Alibaba Coding Plan endpoint override handling.
- Existing HTTPS override behavior remains supported.
- Bare host/path override values, including bare `host:port` values, still work and continue to be normalized to HTTPS.
- Local wrappers or debug setups that intentionally use explicit `http://` overrides for these credentialed provider fetches will now fail closed.
- Unrelated providers, UI behavior, storage paths, and non-provider code paths are untouched.

## Fix rationale

- The credential boundary belongs before cookie discovery and request construction, not after a request URL has already been selected.
- Treating explicit non-HTTPS schemes as configuration errors avoids silent fallback behavior that can mask unsafe override configuration.
- Preserving bare host/path support keeps the existing trusted customization workflow while ensuring the transport selected by the application remains HTTPS.
- Covering both settings helpers and strategy entry points protects the low-level parser behavior and the high-level credential boundary.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `git diff --check`
- [x] `swift build --target CodexBarCore`
- [x] Focused endpoint override smoke compiled with `swiftc`: verified bare `host:port` values normalize to HTTPS/preserve host+port+path, and explicit `http://` values reject for Alibaba and MiniMax
- [x] `./Scripts/lint.sh lint` partially completed: Codex parser hash was current, lint tools were pinned/current, SwiftFormat reported `0/991 files require formatting`; SwiftLint then failed in this local CLT environment while loading `sourcekitdInProc`
- [x] Direct touched-file SwiftFormat lint: `0/4 files require formatting`
- [x] GitHub Actions before this follow-up push: `lint-build-test`, `build-linux-cli (linux-x64, ubuntu-24.04)`, `build-linux-cli (linux-arm64, ubuntu-24.04-arm)`, and `GitGuardian Security Checks` passed
- [ ] Local focused `swift test --filter 'AlibabaCodingPlanSettingsReaderTests|MiniMaxSettingsReaderTests'` did not complete in this local toolchain because unrelated dependency/test-target compilation failed before the focused tests ran

Executed with:

```console
$ git diff --check

$ swift build --target CodexBarCore
Build of target: 'CodexBarCore' complete! (7.20s)

$ swiftc Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanSettingsReader.swift Sources/CodexBarCore/Providers/MiniMax/MiniMaxCookieHeader.swift Sources/CodexBarCore/Providers/MiniMax/MiniMaxSettingsReader.swift /tmp/main.swift -o /tmp/codexbar_endpoint_override_smoke
$ /tmp/codexbar_endpoint_override_smoke
PASS expected rejection: Alibaba explicit http quota URL: Alibaba Coding Plan endpoint override ALIBABA_CODING_PLAN_QUOTA_URL must use HTTPS or a bare host.
PASS expected rejection: MiniMax explicit http coding URL: MiniMax endpoint override MINIMAX_CODING_PLAN_URL must use HTTPS or a bare host.
PASS endpoint override smoke: bare host:port normalizes to https; explicit http rejects for Alibaba and MiniMax

$ ./Scripts/lint.sh lint
Codex parser hash is current (c55f8a5a2d69092d)
==> Lint tools already installed (0.59.1, 0.63.2)
SwiftFormat completed in 0.16s.
0/991 files require formatting.
SourceKittenFramework/library_wrapper.swift:58: Fatal error: Loading sourcekitdInProc.framework/Versions/A/sourcekitdInProc failed

$ .build/lint-tools/bin/swiftformat Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanSettingsReader.swift Sources/CodexBarCore/Providers/MiniMax/MiniMaxSettingsReader.swift Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift Tests/CodexBarTests/MiniMaxProviderTests.swift --lint
SwiftFormat completed in 0.02s.
0/4 files require formatting.

$ swift test --filter 'AlibabaCodingPlanSettingsReaderTests|MiniMaxSettingsReaderTests'
.build/checkouts/KeyboardShortcuts/Sources/KeyboardShortcuts/Recorder.swift:172:1: error: external macro implementation type 'PreviewsMacros.SwiftUIView' could not be found for macro 'Preview(_:body:)'
```

The temporary smoke file and binary were removed after the proof run. No real provider credentials were used.

## Disclosure notes

- No production endpoints or real provider credentials were used while validating this patch.
- This PR is bounded to local configuration/environment endpoint override influence and credentialed provider usage-fetch requests.
- This PR does not claim unauthenticated remote code execution, external network reachability, or compromise without local configuration/control conditions.
- No unrelated files are changed.

## Latest validation update (55d63eda)

This follow-up addresses the ClawSweeper host:port resolver and pre-availability validation blockers on the current PR head.

Changes since the previous proof:

- MiniMax and Alibaba usage URL builders now distinguish real explicit URL schemes from bare `host:port` values, so `localhost:8443` is normalized as an HTTPS host override instead of being mistaken for a URL scheme.
- MiniMax and Alibaba invalid endpoint override validation now runs before availability/cookie/keychain/token probes in the normal provider pipeline.
- Invalid endpoint override diagnostics are categorized as `configuration`, including fetch-attempt text that contains endpoint override wording before auth/API keywords.
- Added focused regression coverage for MiniMax and Alibaba `localhost:8443` resolver paths, pre-credential invalid override rejection, and diagnostic categorization.

Real usage-path smoke proof, run through a temporary external SwiftPM harness importing this checkout's `CodexBarCore` product with no real provider credentials:

```text
$ XCTestConfigurationFilePath=/tmp/fake.xctest swift run EndpointSmoke
PASS MiniMax MINIMAX_HOST=localhost:8443 request URL: https://localhost:8443/user-center/payment/coding-plan?cycle_type=3
PASS MiniMax credential header redacted: Cookie=[REDACTED]
PASS MiniMax usage path accepted bare host:port override over HTTPS
PASS Alibaba API ALIBABA_CODING_PLAN_HOST=localhost:8443 request URL: https://localhost:8443/data/api.json?action=zeldaEasy.broadscope-bailian.codingPlan.queryCodingPlanInstanceInfoV2&product=broadscope-bailian&api=queryCodingPlanInstanceInfoV2&currentRegionId=ap-southeast-1
PASS Alibaba API credential headers redacted: Authorization=[REDACTED], x-api-key=[REDACTED]
PASS Alibaba API usage path accepted bare host:port override over HTTPS before controlled rejection
PASS Alibaba cookie rejected invalid explicit override before request: ALIBABA_CODING_PLAN_QUOTA_URL
```

Local validation on the current pushed head:

```text
$ git diff --check
# passed

$ swift build --target CodexBarCore
Build of target: 'CodexBarCore' complete! (6.40s)

$ swift test --filter 'ProviderDiagnosticExportTests|MiniMaxProviderStrategyTests|MiniMaxUsageParserTests|MiniMaxAPIRegionTests|AlibabaCodingPlanFallbackTests|AlibabaCodingPlanRegionTests|AlibabaCodingPlanUsageFetcherRequestTests'
TestsLinux/JetBrainsParserLinuxTests.swift:3:8: error: no such module 'Testing'
```

The focused repository `swift test` command is still blocked before the selected tests execute by this local Command Line Tools test-target/toolchain issue (`TestsLinux` importing `Testing`). The security-relevant behavior above was exercised through the temporary external harness to avoid live credential prompts and avoid importing the repo test targets.
## Latest validation

Current pushed head: `5c0749eb887ec199a7f6b16820d87e7588352f33`

Local validation on this head:
- `git diff --check` ✅
- `swift build --target CodexBarCore` ✅ (`Build of target: 'CodexBarCore' complete! (6.96s)`)
- `./Scripts/lint.sh lint` partially completed: parser hash current, lint tools current, SwiftFormat `0/991 files require formatting`; SwiftLint then fails locally while loading `sourcekitdInProc` from this Command Line Tools environment.
- Direct standalone `swiftformat` is not on this PATH, so repo lint tooling was used for the SwiftFormat signal.
- Focused repository `swift test` remains blocked locally by the existing Command Line Tools / test-target issue documented below.

The latest code change after the prior security proof is formatting-only in the touched fetcher/test files; no real provider credentials were used.
