### PR TITLE
Fix Claude CLI token ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.32.1 — Unreleased
 
 ### Fixed
+- Claude: keep Claude CLI-owned OAuth refresh tokens delegated to Claude Code when CLI storage is present, preventing CodexBar from consuming rotating refresh tokens and forcing re-login (#1161, #1239). Thanks @RajvardhanPatil07!
 - Menu bar: reuse short-lived Codex account reconciliation snapshots so repeated menu rebuilds do not reread local auth state on every open.
 - Menu bar: defer automatic provider refreshes until after AppKit menu tracking ends so opening the dropdown no longer starts work that can freeze focus and keyboard input.
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -436,6 +436,7 @@ public enum ClaudeOAuthCredentialsStore {
         private func resolvedCacheOwner(_ owner: ClaudeOAuthCredentialOwner) -> ClaudeOAuthCredentialOwner {
             guard owner == .codexbar else { return owner }
             guard self.hasClaudeCLIStorageWithoutPrompt() else { return owner }
+            // Claude Code rotates refresh tokens; when its storage exists, it owns the refresh lifecycle.
             return .claudeCLI
         }
 

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeOAuth/ClaudeOAuthCredentials.swift
@@ -192,17 +192,19 @@ public enum ClaudeOAuthCredentialsStore {
                    Date().timeIntervalSince(timestamp) < ClaudeOAuthCredentialsStore.memoryCacheValidityDuration,
                    !cachedRecord.credentials.isExpired
                 {
-                    if recovery.shouldAttemptFreshnessSyncFromClaudeKeychain(cached: cachedRecord),
+                    let owner = self.resolvedCacheOwner(cachedRecord.owner)
+                    let record = ClaudeOAuthCredentialRecord(
+                        credentials: cachedRecord.credentials,
+                        owner: owner,
+                        source: .memoryCache)
+                    if recovery.shouldAttemptFreshnessSyncFromClaudeKeychain(cached: record),
                        let synced = recovery.syncWithClaudeKeychainIfChanged(
-                           cached: cachedRecord,
+                           cached: record,
                            respectKeychainPromptCooldown: shouldRespectKeychainPromptCooldownForSilentProbes)
                     {
                         return synced
                     }
-                    return ClaudeOAuthCredentialRecord(
-                        credentials: cachedRecord.credentials,
-                        owner: cachedRecord.owner,
-                        source: .memoryCache)
+                    return record
                 }
 
                 var lastError: Error?
@@ -212,7 +214,7 @@ public enum ClaudeOAuthCredentialsStore {
                 switch KeychainCacheStore.load(key: ClaudeOAuthCredentialsStore.cacheKey, as: CacheEntry.self) {
                 case let .found(entry):
                     if let creds = try? ClaudeOAuthCredentials.parse(data: entry.data) {
-                        let owner = entry.owner ?? .claudeCLI
+                        let owner = self.resolvedCacheOwner(entry.owner ?? .claudeCLI)
                         let record = ClaudeOAuthCredentialRecord(
                             credentials: creds,
                             owner: owner,
@@ -326,9 +328,10 @@ public enum ClaudeOAuthCredentialsStore {
                    Date().timeIntervalSince(timestamp) < ClaudeOAuthCredentialsStore.memoryCacheValidityDuration,
                    !cachedRecord.credentials.isExpired
                 {
+                    let owner = self.resolvedCacheOwner(cachedRecord.owner)
                     return ClaudeOAuthCredentialRecord(
                         credentials: cachedRecord.credentials,
-                        owner: cachedRecord.owner,
+                        owner: owner,
                         source: .memoryCache)
                 }
                 if case let .found(entry) = KeychainCacheStore.load(
@@ -337,9 +340,10 @@ public enum ClaudeOAuthCredentialsStore {
                     let creds = try? ClaudeOAuthCredentials.parse(data: entry.data),
                     !creds.isExpired
                 {
+                    let owner = self.resolvedCacheOwner(entry.owner ?? .claudeCLI)
                     return ClaudeOAuthCredentialRecord(
                         credentials: creds,
-                        owner: entry.owner ?? .claudeCLI,
+                        owner: owner,
                         source: .cacheKeychain)
                 }
 
@@ -427,6 +431,17 @@ public enum ClaudeOAuthCredentialsStore {
                 lastError = error
             }
             return nil
+        }
+
+        private func resolvedCacheOwner(_ owner: ClaudeOAuthCredentialOwner) -> ClaudeOAuthCredentialOwner {
+            guard owner == .codexbar else { return owner }
+            guard self.hasClaudeCLIStorageWithoutPrompt() else { return owner }
+            return .claudeCLI
+        }
+
+        private func hasClaudeCLIStorageWithoutPrompt() -> Bool {
+            if ClaudeOAuthCredentialsStore.currentFileFingerprint() != nil { return true }
+            return ClaudeOAuthCredentialsStore.hasClaudeKeychainItemWithoutPrompt()
         }
 
         @discardableResult
@@ -1289,6 +1304,40 @@ public enum ClaudeOAuthCredentialsStore {
         Repository(context: self.currentCollaboratorContext()).hasClaudeKeychainCredentialsWithoutPrompt()
     }
 
+    private static func hasClaudeKeychainItemWithoutPrompt() -> Bool {
+        #if DEBUG
+        if let store = self.taskClaudeKeychainOverrideStore {
+            if let data = store.data, !data.isEmpty { return true }
+            if store.fingerprint != nil { return true }
+        }
+        if let data = self.taskClaudeKeychainDataOverride ?? self.claudeKeychainDataOverride,
+           !data.isEmpty
+        {
+            return true
+        }
+        if self.taskClaudeKeychainFingerprintOverride ?? self.claudeKeychainFingerprintOverride != nil {
+            return true
+        }
+        #endif
+
+        #if os(macOS)
+        switch self.claudeKeychainCandidatesProbeWithoutPrompt(enforcePromptPolicy: false) {
+        case let .value(candidates) where !candidates.isEmpty:
+            return true
+        case .value, .unavailable:
+            break
+        }
+        switch self.claudeKeychainLegacyCandidateProbeWithoutPrompt(enforcePromptPolicy: false) {
+        case let .value(candidate):
+            return candidate != nil
+        case .unavailable:
+            return false
+        }
+        #else
+        return false
+        #endif
+    }
+
     private static func shouldCheckClaudeKeychainChange(now: Date = Date()) -> Bool {
         #if DEBUG
         // Unit tests can supply TaskLocal overrides for the Claude keychain data/fingerprint. Those tests often run
@@ -1561,12 +1610,17 @@ public enum ClaudeOAuthCredentialsStore {
 
     private static func claudeKeychainCandidatesProbeWithoutPrompt(
         promptMode: ClaudeOAuthKeychainPromptMode = ClaudeOAuthKeychainPromptPreference
-            .current()) -> ClaudeKeychainProbe<[ClaudeKeychainCandidate]>
+            .current(),
+        enforcePromptPolicy: Bool = true) -> ClaudeKeychainProbe<[ClaudeKeychainCandidate]>
     {
-        guard self.shouldAllowClaudeCodeKeychainAccess(mode: promptMode) else { return .unavailable }
-        if self.isPromptPolicyApplicable,
-           ProviderInteractionContext.current == .background,
-           !ClaudeOAuthKeychainAccessGate.shouldAllowPrompt() { return .unavailable }
+        if enforcePromptPolicy {
+            guard self.shouldAllowClaudeCodeKeychainAccess(mode: promptMode) else { return .unavailable }
+            if self.isPromptPolicyApplicable,
+               ProviderInteractionContext.current == .background,
+               !ClaudeOAuthKeychainAccessGate.shouldAllowPrompt() { return .unavailable }
+        } else {
+            guard self.keychainAccessAllowed else { return .unavailable }
+        }
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.claudeKeychainService,
@@ -1617,12 +1671,17 @@ public enum ClaudeOAuthCredentialsStore {
 
     private static func claudeKeychainLegacyCandidateProbeWithoutPrompt(
         promptMode: ClaudeOAuthKeychainPromptMode = ClaudeOAuthKeychainPromptPreference
-            .current()) -> ClaudeKeychainProbe<ClaudeKeychainCandidate?>
+            .current(),
+        enforcePromptPolicy: Bool = true) -> ClaudeKeychainProbe<ClaudeKeychainCandidate?>
     {
-        guard self.shouldAllowClaudeCodeKeychainAccess(mode: promptMode) else { return .unavailable }
-        if self.isPromptPolicyApplicable,
-           ProviderInteractionContext.current == .background,
-           !ClaudeOAuthKeychainAccessGate.shouldAllowPrompt() { return .unavailable }
+        if enforcePromptPolicy {
+            guard self.shouldAllowClaudeCodeKeychainAccess(mode: promptMode) else { return .unavailable }
+            if self.isPromptPolicyApplicable,
+               ProviderInteractionContext.current == .background,
+               !ClaudeOAuthKeychainAccessGate.shouldAllowPrompt() { return .unavailable }
+        } else {
+            guard self.keychainAccessAllowed else { return .unavailable }
+        }
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.claudeKeychainService,

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests {
+    private func makeCredentialsData(accessToken: String, expiresAt: Date, refreshToken: String? = nil) -> Data {
+        let millis = Int(expiresAt.timeIntervalSince1970 * 1000)
+        let refreshField: String = {
+            guard let refreshToken else { return "" }
+            return ",\n            \"refreshToken\": \"\(refreshToken)\""
+        }()
+        let json = """
+        {
+          "claudeAiOauth": {
+            "accessToken": "\(accessToken)",
+            "expiresAt": \(millis),
+            "scopes": ["user:profile"]\(refreshField)
+          }
+        }
+        """
+        return Data(json.utf8)
+    }
+
+    @Test
+    func `load record treats codexbar cache as claude CLI owned when credentials file exists`() throws {
+        let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
+        try KeychainCacheStore.withServiceOverrideForTesting(service) {
+            KeychainCacheStore.setTestStoreForTesting(true)
+            defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+            ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting()
+            defer { ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting() }
+
+            let tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            let fileURL = tempDir.appendingPathComponent("credentials.json")
+            try ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+                try ClaudeOAuthCredentialsStore.withIsolatedMemoryCacheForTesting {
+                    try ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                        try ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+                            ClaudeOAuthCredentialsStore.invalidateCache()
+                            let cacheKey = KeychainCacheStore.Key.oauth(provider: .claude)
+                            defer { KeychainCacheStore.clear(key: cacheKey) }
+
+                            let fileData = self.makeCredentialsData(
+                                accessToken: "claude-cli-file",
+                                expiresAt: Date(timeIntervalSinceNow: 3600),
+                                refreshToken: "cli-refresh-token")
+                            try fileData.write(to: fileURL)
+
+                            let cachedData = self.makeCredentialsData(
+                                accessToken: "codexbar-cache",
+                                expiresAt: Date(timeIntervalSinceNow: 3600),
+                                refreshToken: "cached-refresh-token")
+                            KeychainCacheStore.store(
+                                key: cacheKey,
+                                entry: ClaudeOAuthCredentialsStore.CacheEntry(
+                                    data: cachedData,
+                                    storedAt: Date(timeIntervalSinceNow: 60),
+                                    owner: .codexbar))
+
+                            let record = try ClaudeOAuthCredentialsStore.loadRecord(
+                                environment: [:],
+                                allowKeychainPrompt: false,
+                                respectKeychainPromptCooldown: true,
+                                allowClaudeKeychainRepairWithoutPrompt: false)
+
+                            #expect(record.credentials.accessToken == "codexbar-cache")
+                            #expect(record.owner == .claudeCLI)
+                            #expect(record.source == .cacheKeychain)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    func `load with auto refresh delegates expired codexbar cache when credentials file exists`() async throws {
+        let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
+        try await KeychainCacheStore.withServiceOverrideForTesting(service) {
+            KeychainCacheStore.setTestStoreForTesting(true)
+            defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+            ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting()
+            defer { ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting() }
+
+            let tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            let fileURL = tempDir.appendingPathComponent("credentials.json")
+            try await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+                try await ClaudeOAuthCredentialsStore.withIsolatedMemoryCacheForTesting {
+                    try await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                        try await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+                            ClaudeOAuthCredentialsStore.invalidateCache()
+                            let cacheKey = KeychainCacheStore.Key.oauth(provider: .claude)
+                            defer { KeychainCacheStore.clear(key: cacheKey) }
+
+                            try Data("not valid credentials".utf8).write(to: fileURL)
+
+                            let expiredData = self.makeCredentialsData(
+                                accessToken: "expired-codexbar-with-file",
+                                expiresAt: Date(timeIntervalSinceNow: -3600),
+                                refreshToken: "cached-refresh-token")
+                            KeychainCacheStore.store(
+                                key: cacheKey,
+                                entry: ClaudeOAuthCredentialsStore.CacheEntry(
+                                    data: expiredData,
+                                    storedAt: Date(timeIntervalSinceNow: 60),
+                                    owner: .codexbar))
+
+                            await ClaudeOAuthRefreshFailureGate.$shouldAttemptOverride.withValue(false) {
+                                do {
+                                    _ = try await ClaudeOAuthCredentialsStore.loadWithAutoRefresh(
+                                        environment: [:],
+                                        allowKeychainPrompt: false,
+                                        respectKeychainPromptCooldown: true)
+                                    Issue.record("Expected delegated refresh error when Claude CLI file is present")
+                                } catch let error as ClaudeOAuthCredentialsError {
+                                    guard case .refreshDelegatedToClaudeCLI = error else {
+                                        Issue.record("Expected .refreshDelegatedToClaudeCLI, got \(error)")
+                                        return
+                                    }
+                                } catch {
+                                    Issue.record("Expected ClaudeOAuthCredentialsError, got \(error)")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    func `load record treats codexbar cache as claude CLI owned when Claude keychain item exists`() throws {
+        let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
+        try KeychainCacheStore.withServiceOverrideForTesting(service) {
+            KeychainCacheStore.setTestStoreForTesting(true)
+            defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+            ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting()
+            defer { ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting() }
+
+            let tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            let fileURL = tempDir.appendingPathComponent("credentials.json")
+            try ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+                try ClaudeOAuthCredentialsStore.withIsolatedMemoryCacheForTesting {
+                    try ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                        ClaudeOAuthCredentialsStore.invalidateCache()
+                        let cacheKey = KeychainCacheStore.Key.oauth(provider: .claude)
+                        defer { KeychainCacheStore.clear(key: cacheKey) }
+
+                        let cachedData = self.makeCredentialsData(
+                            accessToken: "codexbar-cache",
+                            expiresAt: Date(timeIntervalSinceNow: 3600),
+                            refreshToken: "cached-refresh-token")
+                        KeychainCacheStore.store(
+                            key: cacheKey,
+                            entry: ClaudeOAuthCredentialsStore.CacheEntry(
+                                data: cachedData,
+                                storedAt: Date(),
+                                owner: .codexbar))
+
+                        let keychainData = self.makeCredentialsData(
+                            accessToken: "claude-keychain",
+                            expiresAt: Date(timeIntervalSinceNow: 3600),
+                            refreshToken: "keychain-refresh-token")
+
+                        let record = try ClaudeOAuthKeychainPromptPreference.withTaskOverrideForTesting(.never) {
+                            try ClaudeOAuthCredentialsStore.withClaudeKeychainOverridesForTesting(
+                                data: keychainData,
+                                fingerprint: nil)
+                            {
+                                try ClaudeOAuthCredentialsStore.loadRecord(
+                                    environment: [:],
+                                    allowKeychainPrompt: false,
+                                    respectKeychainPromptCooldown: true,
+                                    allowClaudeKeychainRepairWithoutPrompt: false)
+                            }
+                        }
+
+                        #expect(record.credentials.accessToken == "codexbar-cache")
+                        #expect(record.owner == .claudeCLI)
+                        #expect(record.source == .cacheKeychain)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests.swift
+++ b/Tests/CodexBarTests/ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests.swift
@@ -136,6 +136,64 @@ struct ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests {
     }
 
     @Test
+    func `load with auto refresh keeps codexbar cache ownership without Claude CLI storage`() async throws {
+        let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
+        try await KeychainCacheStore.withServiceOverrideForTesting(service) {
+            KeychainCacheStore.setTestStoreForTesting(true)
+            defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+            ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting()
+            defer { ClaudeOAuthCredentialsStore._resetCredentialsFileTrackingForTesting() }
+
+            let tempDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: tempDir) }
+            let fileURL = tempDir.appendingPathComponent("missing-credentials.json")
+            await ClaudeOAuthCredentialsStore.withIsolatedCredentialsFileTrackingForTesting {
+                await ClaudeOAuthCredentialsStore.withIsolatedMemoryCacheForTesting {
+                    await ClaudeOAuthCredentialsStore.withCredentialsURLOverrideForTesting(fileURL) {
+                        await ClaudeOAuthCredentialsStore.withKeychainAccessOverrideForTesting(true) {
+                            ClaudeOAuthCredentialsStore.invalidateCache()
+                            let cacheKey = KeychainCacheStore.Key.oauth(provider: .claude)
+                            defer { KeychainCacheStore.clear(key: cacheKey) }
+
+                            let expiredData = self.makeCredentialsData(
+                                accessToken: "expired-codexbar-only",
+                                expiresAt: Date(timeIntervalSinceNow: -3600),
+                                refreshToken: "cached-refresh-token")
+                            KeychainCacheStore.store(
+                                key: cacheKey,
+                                entry: ClaudeOAuthCredentialsStore.CacheEntry(
+                                    data: expiredData,
+                                    storedAt: Date(timeIntervalSinceNow: 60),
+                                    owner: .codexbar))
+
+                            await ClaudeOAuthRefreshFailureGate.$shouldAttemptOverride.withValue(false) {
+                                do {
+                                    _ = try await ClaudeOAuthCredentialsStore.loadWithAutoRefresh(
+                                        environment: [:],
+                                        allowKeychainPrompt: false,
+                                        respectKeychainPromptCooldown: true)
+                                    Issue.record("Expected direct CodexBar refresh failure")
+                                } catch let error as ClaudeOAuthCredentialsError {
+                                    guard case let .refreshFailed(message) = error else {
+                                        Issue.record("Expected .refreshFailed, got \(error)")
+                                        return
+                                    }
+                                    #expect(message.contains("suppressed") || message.contains("backed off"))
+                                } catch {
+                                    Issue.record("Expected ClaudeOAuthCredentialsError, got \(error)")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
     func `load record treats codexbar cache as claude CLI owned when Claude keychain item exists`() throws {
         let service = "com.steipete.codexbar.cache.tests.\(UUID().uuidString)"
         try KeychainCacheStore.withServiceOverrideForTesting(service) {


### PR DESCRIPTION
## Summary
- Treat cached Claude OAuth credentials as Claude CLI-owned whenever Claude CLI storage is present, even if the cache entry was previously marked CodexBar-owned.
- Detect CLI storage via the credentials file fingerprint or a no-prompt Claude Code keychain item probe.
- Keep CodexBar-owned cache entries on the direct refresh path when no Claude CLI storage is present.
- Add regression tests for CLI file ownership, delegated refresh, CodexBar-only refresh ownership, and Claude keychain ownership.

## Why
Claude Code rotates refresh tokens. If CodexBar directly refreshes a token that came from Claude CLI storage, it can desynchronize the CLI's persisted refresh token and force users to log in again. With this change, CLI-backed credentials stay delegated to Claude CLI instead of CodexBar spending the refresh token.

Fixes #1161.

## Maintainer policy
When Claude CLI storage exists, Claude Code owns the refresh lifecycle. CodexBar may read/sync the resulting credentials, but it should not independently spend the same rotating refresh token. If no Claude CLI storage is detectable, existing CodexBar-owned cache behavior is preserved.

## Validation
- `swift test --filter ClaudeOAuthCredentialsStoreCLIStorageOwnershipTests` ✅ 4 tests
- `swift test --filter ClaudeOAuthCredentialsStoreTests` ✅ 17 tests
- `swift test --filter ClaudeUsageTests` ✅ 39 tests
- `make check` ✅ SwiftFormat + SwiftLint, 0 violations
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main` ✅ clean

## Redacted behavior proof
Focused test logs show the mixed-storage path is delegated to Claude CLI, while a CodexBar-only cache still takes the direct refresh path. No real credentials were used.

```text
owner=claudeCLI source=cacheKeychain ... credentials expired; delegating refresh to Claude CLI
owner=codexbar source=cacheKeychain ... Access token expired, attempting auto-refresh
```

## Notes
- Maintainer follow-up added a negative regression test for the CodexBar-only cache path and a changelog entry crediting @RajvardhanPatil07.
