### PR TITLE
Add native Turkish localization support

### DIFF
--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -15,6 +15,7 @@ enum AppLanguage: String, CaseIterable, Identifiable {
     case dutch = "nl"
     case ukrainian = "uk"
     case vietnamese = "vi"
+    case turkish = "tr"
 
     var id: String {
         self.rawValue
@@ -34,6 +35,7 @@ enum AppLanguage: String, CaseIterable, Identifiable {
         case .dutch: L("language_dutch")
         case .ukrainian: L("language_ukrainian")
         case .vietnamese: L("language_vietnamese")
+        case .turkish: L("language_turkish")
         }
     }
 }

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -403,6 +403,7 @@
 "language_dutch" = "Nederlands";
 "language_french" = "Francès";
 "language_ukrainian" = "Ucraïnès";
+"language_turkish" = "Türkçe";
 "start_at_login_title" = "Obrir en iniciar la sessió";
 "start_at_login_subtitle" = "Obre el CodexBar automàticament en iniciar el Mac.";
 "show_cost_summary" = "Mostra el resum de cost";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -403,6 +403,7 @@
 "language_dutch" = "Nederlands";
 "language_french" = "Francés";
 "language_ukrainian" = "Ucraniano";
+"language_turkish" = "Türkçe";
 "start_at_login_title" = "Abrir al iniciar sesión";
 "start_at_login_subtitle" = "Abre CodexBar automáticamente al iniciar tu Mac.";
 "show_cost_summary" = "Mostrar resumen de coste";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -404,6 +404,7 @@
 "language_dutch" = "Néerlandais";
 "language_ukrainian" = "Ukrainien";
 "language_vietnamese" = "Vietnamien";
+"language_turkish" = "Turc";
 "start_at_login_title" = "Lancer à l'ouverture de session";
 "start_at_login_subtitle" = "Ouvre automatiquement CodexBar au démarrage de votre Mac.";
 "show_cost_summary" = "Afficher le récapitulatif des coûts";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -404,6 +404,7 @@
 "language_ukrainian" = "Oekraïens";
 "language_swedish" = "Zweeds";
 "language_vietnamese" = "Vietnamees";
+"language_turkish" = "Turks";
 "start_at_login_title" = "Begin bij Inloggen";
 "start_at_login_subtitle" = "Opent automatisch CodexBar wanneer u uw Mac start.";
 "show_cost_summary" = "Kostenoverzicht weergeven";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -403,6 +403,7 @@
 "language_dutch" = "Nederlands";
 "language_french" = "Francês";
 "language_ukrainian" = "Ucraniano";
+"language_turkish" = "Türkçe";
 "start_at_login_title" = "Iniciar ao fazer login";
 "start_at_login_subtitle" = "Abre o CodexBar automaticamente ao iniciar o Mac.";
 "show_cost_summary" = "Mostrar resumo de custos";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -401,6 +401,7 @@
 "language_chinese_traditional" = "繁體中文";
 "language_portuguese_brazilian" = "Português (Brasil)";
 "language_dutch" = "Nederlands";
+"language_turkish" = "Türkçe";
 "language_swedish" = "Svenska";
 "language_french" = "Franska";
 "language_ukrainian" = "Ukrainska";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* English localization for CodexBar (base/fallback) */
+/* Turkish localization for CodexBar */
 
 " providers" = " providers";
 "(System)" = "(System)";
@@ -390,20 +390,21 @@
 "section_system" = "System";
 "section_usage" = "Usage";
 "section_automation" = "Automation";
-"language_title" = "Language";
-"language_subtitle" = "Change the display language. Requires app restart to take full effect.";
-"language_system" = "System";
-"language_english" = "English";
-"language_spanish" = "Español";
-"language_catalan" = "Català";
-"language_chinese_simplified" = "简体中文";
-"language_chinese_traditional" = "繁體中文";
-"language_portuguese_brazilian" = "Português (Brasil)";
-"language_dutch" = "Nederlands";
-"language_turkish" = "Türkçe";
-"language_swedish" = "Svenska";
-"language_french" = "French";
-"language_ukrainian" = "Українська";
+"language_title" = "Dil";
+"language_subtitle" = "Goruntuleme dilini degistirir. Tam olarak uygulanmasi icin uygulamayi yeniden baslatmaniz gerekir.";
+"language_system" = "Sistem";
+"language_english" = "Ingilizce";
+"language_spanish" = "Ispanyolca";
+"language_catalan" = "Katalanca";
+"language_chinese_simplified" = "Basitlestirilmis Cince";
+"language_chinese_traditional" = "Geleneksel Cince";
+"language_portuguese_brazilian" = "Portekizce (Brezilya)";
+"language_turkish" = "Turkce";
+"language_swedish" = "Isvecce";
+"language_french" = "Fransizca";
+"language_ukrainian" = "Ukraynaca";
+"language_dutch" = "Felemenkce";
+"language_vietnamese" = "Vietnamca";
 "start_at_login_title" = "Start at Login";
 "start_at_login_subtitle" = "Automatically opens CodexBar when you start your Mac.";
 "show_cost_summary" = "Show cost summary";
@@ -1064,5 +1065,3 @@
 "Clear" = "Clear";
 "No matching providers" = "No matching providers";
 "Search providers" = "Search providers";
-
-"language_vietnamese" = "Vietnamese";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -404,6 +404,7 @@
 "language_dutch" = "Нідерландська";
 "language_ukrainian" = "Українська";
 "language_vietnamese" = "В'єтнамська";
+"language_turkish" = "Турецька";
 "start_at_login_title" = "Почніть із входу";
 "start_at_login_subtitle" = "Автоматично відкриває CodexBar під час запуску Mac.";
 "show_cost_summary" = "Показати підсумок витрат";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -403,6 +403,7 @@
 "language_french" = "Tiếng Pháp";
 "language_dutch" = "Tiếng Hà Lan";
 "language_ukrainian" = "Tiếng Ukraina";
+"language_turkish" = "Tiếng Thổ Nhĩ Kỳ";
 "start_at_login_title" = "Bắt đầu khi đăng nhập";
 "start_at_login_subtitle" = "Tự động mở CodexBar khi bạn khởi động máy Mac.";
 "show_cost_summary" = "Hiển thị tóm tắt chi phí";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -410,6 +410,7 @@
 "language_dutch" = "Nederlands";
 "language_french" = "法语";
 "language_ukrainian" = "乌克兰语";
+"language_turkish" = "Türkçe";
 "start_at_login_title" = "开机启动";
 "start_at_login_subtitle" = "启动 Mac 时自动打开 CodexBar。";
 "show_cost_summary" = "显示费用摘要";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -410,6 +410,7 @@
 "language_dutch" = "Nederlands";
 "language_french" = "法語";
 "language_ukrainian" = "烏克蘭語";
+"language_turkish" = "Türkçe";
 "start_at_login_title" = "登入時啟動";
 "start_at_login_subtitle" = "登入 Mac 時自動開啟 CodexBar。";
 "show_cost_summary" = "顯示費用摘要";

--- a/Tests/CodexBarTests/LocalizationLanguageCatalogTests.swift
+++ b/Tests/CodexBarTests/LocalizationLanguageCatalogTests.swift
@@ -16,6 +16,7 @@ struct LocalizationLanguageCatalogTests {
         "language_dutch",
         "language_ukrainian",
         "language_vietnamese",
+        "language_turkish",
     ]
 
     @Test

--- a/Tests/CodexBarTests/TurkishLocalizationCoverageTests.swift
+++ b/Tests/CodexBarTests/TurkishLocalizationCoverageTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+
+struct TurkishLocalizationCoverageTests {
+    @Test
+    func `turkish localization keys and placeholders match english`() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        let enURL = root.appendingPathComponent("Sources/CodexBar/Resources/en.lproj/Localizable.strings")
+        let trURL = root.appendingPathComponent("Sources/CodexBar/Resources/tr.lproj/Localizable.strings")
+
+        let en = try Self.parseStrings(from: enURL)
+        let tr = try Self.parseStrings(from: trURL)
+
+        let missing = en.keys.filter { tr[$0] == nil }.sorted()
+        let extra = tr.keys.filter { en[$0] == nil }.sorted()
+        #expect(missing.isEmpty, "Missing Turkish keys: \(missing)")
+        #expect(extra.isEmpty, "Extra Turkish keys: \(extra)")
+
+        var placeholderMismatches: [String] = []
+        for key in en.keys.sorted() {
+            guard let trValue = tr[key] else { continue }
+            if Self.placeholders(in: en[key] ?? "") != Self.placeholders(in: trValue) {
+                placeholderMismatches.append(key)
+            }
+        }
+        #expect(
+            placeholderMismatches.isEmpty,
+            "Turkish placeholder mismatches: \(placeholderMismatches)")
+    }
+
+    private static func parseStrings(from url: URL) throws -> [String: String] {
+        let content = try String(contentsOf: url, encoding: .utf8)
+        var result: [String: String] = [:]
+        let pattern = #"^\s*"((?:\\.|[^"\\])*)"\s*=\s*"((?:\\.|[^"\\])*)";\s*$"#
+        let regex = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
+        let ns = content as NSString
+        let range = NSRange(location: 0, length: ns.length)
+        for match in regex.matches(in: content, options: [], range: range) {
+            guard match.numberOfRanges == 3 else { continue }
+            let key = ns.substring(with: match.range(at: 1))
+            let value = ns.substring(with: match.range(at: 2))
+            result[key] = value
+        }
+        return result
+    }
+
+    private static func placeholders(in value: String) -> [String] {
+        let pattern = #"(\\\([^)]*\)|%\d*\$?[sd@]|%@|%d|%f|\\n|\\u\{[0-9a-fA-F]+\})"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let ns = value as NSString
+        let range = NSRange(location: 0, length: ns.length)
+        return regex.matches(in: value, range: range).map { ns.substring(with: $0.range(at: 1)) }
+    }
+}


### PR DESCRIPTION
## Summary
- add `tr` to the app language picker
- add `Sources/CodexBar/Resources/tr.lproj/Localizable.strings`
- add `language_turkish` label to existing locale files
- add Turkish localization parity test vs English (keys + placeholders)

## Test
- `swift test -c debug --filter PreferencesPaneSmokeTests`
- `swift test -c debug --filter TurkishLocalizationCoverageTests`