### PR TITLE
Avoid redundant storage refresh scheduling during provider-switcher m…

### DIFF
--- a/Sources/CodexBar/UsageStore+ProviderStorage.swift
+++ b/Sources/CodexBar/UsageStore+ProviderStorage.swift
@@ -29,6 +29,14 @@ extension UsageStore {
     }
 
     func refreshStorageFootprintsForOverview() {
+        // This method is called during menu rebuilds; keep it cheap to avoid
+        // repeated main-thread file reads when users rapidly switch providers.
+        if self.storageRefreshTask != nil { return }
+        if let lastStorageRefreshAt,
+           Date().timeIntervalSince(lastStorageRefreshAt) < Self.automaticStorageRefreshInterval
+        {
+            return
+        }
         self.scheduleStorageFootprintRefresh(for: self.enabledProvidersForDisplay())
     }
 


### PR DESCRIPTION
## Summary
Add a small performance guard to avoid redundant storage-refresh scheduling during frequent provider-switcher menu rebuilds.

## Change
In `refreshStorageFootprintsForOverview()`, return early when:
1. a storage refresh task is already in flight
2. the previous refresh is still within the automatic refresh interval

## Why
Switching providers can trigger repeated menu rebuilds. This keeps the overview-triggered storage refresh path cheap and reduces potential UI jank risk.

## Scope
- 1 file changed
- 8 lines added
- no intended behavior change
- If helpful, I can follow up with a focused regression test for this guard path.