### PR TITLE
feat: add Burn Down widgets (single window + 5h & 7d combined)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.36.2 — Unreleased
 
 ### Added
+- Widgets: add single-window and combined burn-down charts for Codex and Claude session/weekly limits. Thanks @StevanusPangau!
 - Cursor: show personal on-demand spend alongside the shared team pool. Thanks @yashiels!
 - Documentation: link the community KDE Plasma panel integration. Thanks @tylxr59!
 - Codex: show available manual rate-limit reset credits and their next expiry for signed-in OAuth accounts. Thanks @rogdex24!

--- a/Sources/CodexBarWidget/BurnDownWidgetProvider.swift
+++ b/Sources/CodexBarWidget/BurnDownWidgetProvider.swift
@@ -75,13 +75,23 @@ struct CombinedBurnDownEntry: TimelineEntry {
 }
 
 struct BurnDownState {
+    private static let sessionWindowMinutes = 5 * 60
+    private static let weeklyWindowMinutes = 7 * 24 * 60
+
     let entry: WidgetSnapshot.ProviderEntry
     let selection: BurnWindowChoice
+    let now: Date
 
-    init?(snapshot: WidgetSnapshot, provider: UsageProvider, selection: BurnWindowChoice) {
+    init?(
+        snapshot: WidgetSnapshot,
+        provider: UsageProvider,
+        selection: BurnWindowChoice,
+        now: Date = Date())
+    {
         guard let entry = snapshot.entries.first(where: { $0.provider == provider }) else { return nil }
         self.entry = entry
         self.selection = selection
+        self.now = now
     }
 
     var secondaryGloballyCapsPrimary: Bool {
@@ -92,12 +102,13 @@ struct BurnDownState {
     }
 
     var secondaryExhausted: Bool {
-        guard self.secondaryGloballyCapsPrimary, let secondary = self.entry.secondary else { return false }
-        return secondary.remainingPercent <= 0
+        guard self.secondaryGloballyCapsPrimary, let secondary = self.secondaryWindow else { return false }
+        guard secondary.remainingPercent <= 0 else { return false }
+        return secondary.resetsAt.map { $0 > self.now } ?? true
     }
 
     var primaryWindow: RateWindow? {
-        guard let primary = self.entry.primary else { return nil }
+        guard let primary = self.window(minutes: Self.sessionWindowMinutes) else { return nil }
         guard self.secondaryExhausted, primary.remainingPercent > 0 else { return primary }
         return RateWindow(
             usedPercent: 100,
@@ -108,7 +119,7 @@ struct BurnDownState {
     }
 
     var secondaryWindow: RateWindow? {
-        self.entry.secondary
+        self.window(minutes: Self.weeklyWindowMinutes)
     }
 
     var selectedWindow: RateWindow? {
@@ -119,11 +130,19 @@ struct BurnDownState {
     }
 
     var blankPrimaryChart: Bool {
-        self.selection == .session && self.secondaryExhausted && self.entry.primary != nil
+        self.selection == .session
+            && self.secondaryExhausted
+            && self.window(minutes: Self.sessionWindowMinutes) != nil
     }
 
     var selectedResetOverride: Date? {
         self.blankPrimaryChart ? self.secondaryWindow?.resetsAt : nil
+    }
+
+    private func window(minutes: Int) -> RateWindow? {
+        [self.entry.primary, self.entry.secondary]
+            .compactMap(\.self)
+            .first { $0.windowMinutes == minutes }
     }
 }
 

--- a/Sources/CodexBarWidget/BurnDownWidgetProvider.swift
+++ b/Sources/CodexBarWidget/BurnDownWidgetProvider.swift
@@ -1,0 +1,209 @@
+import AppIntents
+import CodexBarCore
+import WidgetKit
+
+enum BurnProviderChoice: String, AppEnum {
+    case codex
+    case claude
+
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Provider")
+
+    static let caseDisplayRepresentations: [BurnProviderChoice: DisplayRepresentation] = [
+        .codex: DisplayRepresentation(title: "Codex"),
+        .claude: DisplayRepresentation(title: "Claude"),
+    ]
+
+    var provider: UsageProvider {
+        switch self {
+        case .codex: .codex
+        case .claude: .claude
+        }
+    }
+}
+
+enum BurnWindowChoice: String, AppEnum {
+    case session
+    case weekly
+
+    static let typeDisplayRepresentation = TypeDisplayRepresentation(name: "Usage window")
+
+    static let caseDisplayRepresentations: [BurnWindowChoice: DisplayRepresentation] = [
+        .session: DisplayRepresentation(title: "Session (5-hour)"),
+        .weekly: DisplayRepresentation(title: "Weekly (7-day)"),
+    ]
+}
+
+struct BurnDownSelectionIntent: AppIntent, WidgetConfigurationIntent {
+    static let title: LocalizedStringResource = "Burn Down"
+    static let description = IntentDescription("Select the provider and usage window to display.")
+
+    @Parameter(title: "Provider", default: .codex)
+    var provider: BurnProviderChoice
+
+    @Parameter(title: "Usage window", default: .session)
+    var window: BurnWindowChoice
+
+    init() {
+        self.provider = .codex
+        self.window = .session
+    }
+}
+
+struct BurnProviderSelectionIntent: AppIntent, WidgetConfigurationIntent {
+    static let title: LocalizedStringResource = "Burn Down Provider"
+    static let description = IntentDescription("Select the provider to display.")
+
+    @Parameter(title: "Provider", default: .codex)
+    var provider: BurnProviderChoice
+
+    init() {
+        self.provider = .codex
+    }
+}
+
+struct BurnDownEntry: TimelineEntry {
+    let date: Date
+    let provider: UsageProvider
+    let window: BurnWindowChoice
+    let snapshot: WidgetSnapshot
+}
+
+struct CombinedBurnDownEntry: TimelineEntry {
+    let date: Date
+    let provider: UsageProvider
+    let snapshot: WidgetSnapshot
+}
+
+struct BurnDownState {
+    let entry: WidgetSnapshot.ProviderEntry
+    let selection: BurnWindowChoice
+
+    init?(snapshot: WidgetSnapshot, provider: UsageProvider, selection: BurnWindowChoice) {
+        guard let entry = snapshot.entries.first(where: { $0.provider == provider }) else { return nil }
+        self.entry = entry
+        self.selection = selection
+    }
+
+    var secondaryGloballyCapsPrimary: Bool {
+        switch self.entry.provider {
+        case .codex, .claude: true
+        default: false
+        }
+    }
+
+    var secondaryExhausted: Bool {
+        guard self.secondaryGloballyCapsPrimary, let secondary = self.entry.secondary else { return false }
+        return secondary.remainingPercent <= 0
+    }
+
+    var primaryWindow: RateWindow? {
+        guard let primary = self.entry.primary else { return nil }
+        guard self.secondaryExhausted, primary.remainingPercent > 0 else { return primary }
+        return RateWindow(
+            usedPercent: 100,
+            windowMinutes: primary.windowMinutes,
+            resetsAt: primary.resetsAt,
+            resetDescription: primary.resetDescription,
+            nextRegenPercent: primary.nextRegenPercent)
+    }
+
+    var secondaryWindow: RateWindow? {
+        self.entry.secondary
+    }
+
+    var selectedWindow: RateWindow? {
+        switch self.selection {
+        case .session: self.primaryWindow ?? self.secondaryWindow
+        case .weekly: self.secondaryWindow ?? self.primaryWindow
+        }
+    }
+
+    var blankPrimaryChart: Bool {
+        self.selection == .session && self.secondaryExhausted && self.entry.primary != nil
+    }
+
+    var selectedResetOverride: Date? {
+        self.blankPrimaryChart ? self.secondaryWindow?.resetsAt : nil
+    }
+}
+
+enum BurnDownRefreshSchedule {
+    private static let maximumInterval: TimeInterval = 30 * 60
+
+    static func nextRefresh(
+        snapshot: WidgetSnapshot,
+        provider: UsageProvider,
+        now: Date = Date()) -> Date
+    {
+        let fallback = now.addingTimeInterval(self.maximumInterval)
+        guard let entry = snapshot.entries.first(where: { $0.provider == provider }) else { return fallback }
+        let nextReset = [entry.primary?.resetsAt, entry.secondary?.resetsAt]
+            .compactMap(\.self)
+            .filter { $0 > now }
+            .min()?
+            .addingTimeInterval(1)
+        return min(fallback, nextReset ?? fallback)
+    }
+}
+
+struct BurnDownTimelineProvider: AppIntentTimelineProvider {
+    func placeholder(in context: Context) -> BurnDownEntry {
+        BurnDownEntry(
+            date: Date(),
+            provider: .codex,
+            window: .session,
+            snapshot: WidgetPreviewData.snapshot())
+    }
+
+    func snapshot(for configuration: BurnDownSelectionIntent, in context: Context) async -> BurnDownEntry {
+        BurnDownEntry(
+            date: Date(),
+            provider: configuration.provider.provider,
+            window: configuration.window,
+            snapshot: WidgetSnapshotStore.load() ?? WidgetPreviewData.snapshot())
+    }
+
+    func timeline(
+        for configuration: BurnDownSelectionIntent,
+        in context: Context) async -> Timeline<BurnDownEntry>
+    {
+        let entry = BurnDownEntry(
+            date: Date(),
+            provider: configuration.provider.provider,
+            window: configuration.window,
+            snapshot: WidgetSnapshotStore.load() ?? WidgetPreviewData.emptySnapshot())
+        let refresh = BurnDownRefreshSchedule.nextRefresh(snapshot: entry.snapshot, provider: entry.provider)
+        return Timeline(entries: [entry], policy: .after(refresh))
+    }
+}
+
+struct CombinedBurnDownTimelineProvider: AppIntentTimelineProvider {
+    func placeholder(in context: Context) -> CombinedBurnDownEntry {
+        CombinedBurnDownEntry(
+            date: Date(),
+            provider: .codex,
+            snapshot: WidgetPreviewData.snapshot())
+    }
+
+    func snapshot(
+        for configuration: BurnProviderSelectionIntent,
+        in context: Context) async -> CombinedBurnDownEntry
+    {
+        CombinedBurnDownEntry(
+            date: Date(),
+            provider: configuration.provider.provider,
+            snapshot: WidgetSnapshotStore.load() ?? WidgetPreviewData.snapshot())
+    }
+
+    func timeline(
+        for configuration: BurnProviderSelectionIntent,
+        in context: Context) async -> Timeline<CombinedBurnDownEntry>
+    {
+        let entry = CombinedBurnDownEntry(
+            date: Date(),
+            provider: configuration.provider.provider,
+            snapshot: WidgetSnapshotStore.load() ?? WidgetPreviewData.emptySnapshot())
+        let refresh = BurnDownRefreshSchedule.nextRefresh(snapshot: entry.snapshot, provider: entry.provider)
+        return Timeline(entries: [entry], policy: .after(refresh))
+    }
+}

--- a/Sources/CodexBarWidget/BurnDownWidgetProvider.swift
+++ b/Sources/CodexBarWidget/BurnDownWidgetProvider.swift
@@ -113,8 +113,8 @@ struct BurnDownState {
 
     var selectedWindow: RateWindow? {
         switch self.selection {
-        case .session: self.primaryWindow ?? self.secondaryWindow
-        case .weekly: self.secondaryWindow ?? self.primaryWindow
+        case .session: self.primaryWindow
+        case .weekly: self.secondaryWindow
         }
     }
 

--- a/Sources/CodexBarWidget/BurnDownWidgetViews.swift
+++ b/Sources/CodexBarWidget/BurnDownWidgetViews.swift
@@ -1,0 +1,664 @@
+import AppKit
+import CodexBarCore
+import SwiftUI
+import WidgetKit
+
+// MARK: - Entry View
+
+struct BurnDownWidgetView: View {
+    let entry: BurnDownEntry
+
+    var body: some View {
+        let state = BurnDownState(
+            snapshot: self.entry.snapshot,
+            provider: self.entry.provider,
+            selection: self.entry.window)
+
+        Group {
+            if let state, let window = state.selectedWindow {
+                BurnDownLayout(
+                    window: window,
+                    provider: self.entry.provider,
+                    blankChart: state.blankPrimaryChart,
+                    resetsAtOverride: state.selectedResetOverride)
+            } else {
+                self.emptyState
+            }
+        }
+        .containerBackground(for: .widget) {
+            BurnWidgetBackground()
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 6) {
+            Text("Open CodexBar")
+                .font(.body)
+                .fontWeight(.semibold)
+            Text("Usage data will appear once the app refreshes.")
+                .font(.caption)
+                .multilineTextAlignment(.center)
+                .opacity(0.55)
+        }
+        .padding(12)
+    }
+}
+
+// MARK: - Main Layout
+
+private struct BurnDownLayout: View {
+    @Environment(\.widgetRenderingMode) private var renderingMode
+    @Environment(\.colorScheme) private var colorScheme
+
+    let window: RateWindow
+    let provider: UsageProvider
+    /// True when the session window is blocked because the weekly budget is exhausted:
+    /// suppress the chart and retarget "Resets in" to the weekly reset.
+    var blankChart = false
+    /// When set, "Resets in" counts down to this date (the weekly reset) instead of the
+    /// session window's own reset.
+    var resetsAtOverride: Date?
+
+    var body: some View {
+        let dark = self.colorScheme == .dark
+        let isMonochrome = self.renderingMode != .fullColor
+        let geom = BurnGeom(window: self.window)
+        let theme = BurnTheme(provider: self.provider, geom: geom, dark: dark, isMonochrome: isMonochrome)
+        let windowMins = self.window.windowMinutes ?? 300
+        let isDailyWindow = windowMins >= 1440
+        let resetsIn: Double = if self.blankChart {
+            self.resetsAtOverride.map { max(0, $0.timeIntervalSinceNow / 60) } ?? 0
+        } else if let override = self.resetsAtOverride {
+            max(0, override.timeIntervalSinceNow / 60)
+        } else {
+            geom.tNow < 1 ? (1 - geom.tNow) * Double(windowMins) : 0
+        }
+        let effectiveResetAt: Date? = if self.blankChart {
+            self.resetsAtOverride
+        } else if let override = self.resetsAtOverride {
+            override
+        } else if let reset = self.window.resetsAt, reset > Date() {
+            reset
+        } else if resetsIn > 0 {
+            Date().addingTimeInterval(resetsIn * 60)
+        } else {
+            nil
+        }
+        let outInMins = geom.slope < -0.01 ? (geom.vNow / -geom.slope) * Double(windowMins) : Double.infinity
+        // Very early in the window a single sample can't forecast a credible run-out: a
+        // tiny burst right after reset extrapolates to "runs dry in minutes" even at ~99%
+        // remaining. Match the design's fresh-window behaviour ("Runs out: after reset")
+        // and only surface the estimate once enough of the window has elapsed to trust the
+        // average burn rate.
+        let windowEstablished = geom.tNow >= 0.08
+        let runsDryBefore = geom.runsOut && outInMins < resetsIn && windowEstablished
+
+        let sign = geom.margin >= 0 ? "+" : "−"
+        let badgeNum = "\(sign)\(abs(Int(geom.margin.rounded())))%"
+        // Per the design's edge states, "fresh" and "spent" show only the glyph + word
+        // (◆ full / ■ spent) with no pace number — the margin is meaningless once the
+        // budget is full or gone.
+        let showBadgeNumber = !geom.depleted && !geom.fresh
+        let statusWord: String = geom.depleted ? "spent" : geom.fresh ? "full"
+            : geom.status == .ahead ? "conserving" : geom.status == .behind ? "over pace" : "on pace"
+        let arrow: String = geom.depleted ? "■" : geom.fresh ? "◆"
+            : geom.status == .ahead ? "▲" : geom.status == .behind ? "▼" : "●"
+
+        let startDate = (self.window.resetsAt ?? Date()).addingTimeInterval(-Double(windowMins) * 60)
+        let startLabel = burnAxisLabel(startDate, isDailyWindow: isDailyWindow)
+        let resetLabel = burnAxisLabel(self.window.resetsAt ?? Date(), isDailyWindow: isDailyWindow)
+
+        VStack(spacing: 0) {
+            // Header: brand + pace badge
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(theme.brandDot)
+                            .frame(width: 7, height: 7)
+                            .shadow(color: theme.brandDot.opacity(0.7), radius: 3.5)
+                        Text(burnProviderName(self.provider))
+                            .font(.system(size: 14.5, weight: .semibold))
+                            .foregroundStyle(theme.text)
+                            .lineLimit(1)
+                    }
+                    Text(burnWindowLabel(self.window.windowMinutes))
+                        .font(.system(size: 11))
+                        .foregroundStyle(theme.sub)
+                        .kerning(0.2)
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 1) {
+                    if showBadgeNumber {
+                        Text(badgeNum)
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(theme.statusColor)
+                            .monospacedDigit()
+                    }
+                    HStack(spacing: 3) {
+                        Text(arrow)
+                            .font(.system(size: 8))
+                            .foregroundStyle(theme.statusColor)
+                        Text(statusWord)
+                            .font(.system(size: 10.5))
+                            .foregroundStyle(theme.sub)
+                    }
+                }
+            }
+
+            // Body: stats + hero / chart
+            HStack(alignment: .bottom, spacing: 13) {
+                // Left: stats + hero %
+                VStack(alignment: .leading, spacing: 0) {
+                    VStack(spacing: 5) {
+                        BurnResetStatRow(resetAt: effectiveResetAt, theme: theme)
+                        BurnStatRow(
+                            label: geom.depleted ? "Ran out" : runsDryBefore ? "Runs out in" : "Runs out",
+                            value: geom
+                                .depleted ? "budget spent" : runsDryBefore ? "~\(burnFmtDuration(outInMins))" :
+                                "after reset",
+                            theme: theme,
+                            danger: geom.depleted || runsDryBefore)
+                    }
+                    .padding(.top, 8)
+
+                    Spacer()
+
+                    HStack(alignment: .lastTextBaseline, spacing: 5) {
+                        Text("\(Int(geom.vNow.rounded()))")
+                            .font(.system(size: 41, weight: .semibold))
+                            .foregroundStyle(geom.depleted ? theme.danger : theme.text)
+                            .monospacedDigit()
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
+                        Text("%")
+                            .font(.system(size: 19, weight: .medium))
+                            .foregroundStyle(theme.sub)
+                        Text("left")
+                            .font(.system(size: 11))
+                            .foregroundStyle(theme.sub)
+                    }
+                }
+                .frame(width: 143, alignment: .leading)
+
+                // Right: chart + axis. Blanked when the session window is blocked by the
+                // weekly cap — there's no session burn to chart until the weekly resets.
+                VStack(spacing: 2) {
+                    if self.blankChart {
+                        Color.clear.frame(height: 84)
+                        Color.clear.frame(height: 13)
+                    } else {
+                        BurnChartCanvas(
+                            geom: geom,
+                            theme: theme)
+                            .frame(height: 84)
+
+                        BurnAxisRow(
+                            startLabel: startLabel,
+                            resetLabel: resetLabel,
+                            tNow: geom.tNow,
+                            theme: theme)
+                            .frame(height: 13)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(.horizontal, 15)
+        .padding(.top, 13)
+        .padding(.bottom, 12)
+    }
+}
+
+// MARK: - Stat Row
+
+private struct BurnStatRow: View {
+    let label: String
+    let value: String
+    let theme: BurnTheme
+    let danger: Bool
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(self.label)
+                .font(.system(size: 11.5))
+                .foregroundStyle(self.theme.sub)
+            Spacer()
+            Text(self.value)
+                .font(.system(size: 12.5, weight: .semibold))
+                .foregroundStyle(self.danger ? self.theme.danger : self.theme.text)
+                .monospacedDigit()
+                .lineLimit(1)
+        }
+    }
+}
+
+private struct BurnResetStatRow: View {
+    let resetAt: Date?
+    let theme: BurnTheme
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("Resets in")
+                .font(.system(size: 11.5))
+                .foregroundStyle(self.theme.sub)
+            Spacer()
+            if let resetAt {
+                Text(resetAt, style: .relative)
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundStyle(self.theme.text)
+                    .monospacedDigit()
+                    .lineLimit(1)
+            } else {
+                Text("—")
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundStyle(self.theme.text)
+            }
+        }
+    }
+}
+
+// MARK: - Axis Row
+
+private struct BurnAxisRow: View {
+    let startLabel: String
+    let resetLabel: String
+    let tNow: Double
+    let theme: BurnTheme
+
+    var body: some View {
+        GeometryReader { geo in
+            // Hide "now" when it would collide with the start/reset labels. The edge labels
+            // are anchored to the ends, so estimate their widths (≈9.5pt monospaced digits)
+            // and only show "now" when it clears both with a small gap — otherwise the
+            // now-dot on the chart already conveys position. Matches the design's rule that
+            // "now" hides near an end label.
+            let w = geo.size.width
+            let approxChar: CGFloat = 5.8
+            let nowX = self.tNow * w
+            let nowHalf: CGFloat = 13
+            let gap: CGFloat = 6
+            let clearsStart = nowX - nowHalf > CGFloat(self.startLabel.count) * approxChar + gap
+            let clearsReset = nowX + nowHalf < w - CGFloat(self.resetLabel.count) * approxChar - gap
+            let showNow = self.tNow > 0.05 && self.tNow < 0.95 && clearsStart && clearsReset
+
+            ZStack(alignment: .leading) {
+                Text(self.startLabel)
+                    .font(.system(size: 9.5))
+                    .foregroundStyle(self.theme.sub)
+                    .monospacedDigit()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if showNow {
+                    Text("now")
+                        .font(.system(size: 9.5, weight: .semibold))
+                        .foregroundStyle(self.theme.text)
+                        .position(x: nowX, y: geo.size.height / 2)
+                }
+
+                Text(self.resetLabel)
+                    .font(.system(size: 9.5))
+                    .foregroundStyle(self.theme.sub)
+                    .monospacedDigit()
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+        }
+    }
+}
+
+// MARK: - Chart Canvas
+
+private struct BurnChartCanvas: View {
+    let geom: BurnGeom
+    let theme: BurnTheme
+
+    var body: some View {
+        Canvas { context, size in
+            let w = size.width
+            let h = size.height
+            let padT: CGFloat = 8
+            let padB: CGFloat = 2
+            let padL: CGFloat = 1
+            let padR: CGFloat = 1
+
+            func X(_ t: Double) -> CGFloat {
+                padL + CGFloat(t) * (w - padL - padR)
+            }
+            func Y(_ v: Double) -> CGFloat {
+                padT + CGFloat(1 - v / 100) * (h - padT - padB)
+            }
+
+            let tNow = self.geom.tNow
+            let vNow = self.geom.vNow
+
+            // --- Now vertical hairline ---
+            do {
+                var p = Path()
+                p.move(to: CGPoint(x: X(tNow), y: Y(100)))
+                p.addLine(to: CGPoint(x: X(tNow), y: Y(0)))
+                context.stroke(p, with: .color(self.theme.chartGrid), lineWidth: 1)
+            }
+
+            // --- Baseline ---
+            do {
+                var p = Path()
+                p.move(to: CGPoint(x: X(0), y: Y(0)))
+                p.addLine(to: CGPoint(x: X(1), y: Y(0)))
+                context.stroke(p, with: .color(self.theme.chartGrid), lineWidth: 1)
+            }
+
+            // --- Area fill (gradient from actual line down to baseline) ---
+            do {
+                var p = Path()
+                p.move(to: CGPoint(x: X(0), y: Y(100)))
+                p.addLine(to: CGPoint(x: X(tNow), y: Y(vNow)))
+                p.addLine(to: CGPoint(x: X(tNow), y: Y(0)))
+                p.addLine(to: CGPoint(x: X(0), y: Y(0)))
+                p.closeSubpath()
+
+                let gradient = Gradient(stops: [
+                    .init(color: self.theme.chartFillTop.opacity(self.theme.chartFillTopOpacity), location: 0),
+                    .init(color: self.theme.chartFillTop.opacity(0), location: 0.92),
+                ])
+                context.fill(
+                    p,
+                    with: .linearGradient(
+                        gradient,
+                        startPoint: CGPoint(x: 0, y: padT),
+                        endPoint: CGPoint(x: 0, y: h)))
+            }
+
+            // --- Ideal line (dashed, knocked back) ---
+            do {
+                var p = Path()
+                p.move(to: CGPoint(x: X(0), y: Y(100)))
+                p.addLine(to: CGPoint(x: X(1), y: Y(0)))
+                context.stroke(
+                    p,
+                    with: .color(self.theme.chartIdeal),
+                    style: StrokeStyle(lineWidth: 1.4, lineCap: .round, dash: [2.5, 3]))
+            }
+
+            // --- Projection (fine dotted) ---
+            if self.geom.slope < -0.01 {
+                var p = Path()
+                p.move(to: CGPoint(x: X(tNow), y: Y(vNow)))
+                p.addLine(to: CGPoint(x: X(self.geom.projT), y: Y(self.geom.projV)))
+                context.stroke(
+                    p,
+                    with: .color(self.theme.chartProj.opacity(0.95)),
+                    style: StrokeStyle(lineWidth: 1.6, lineCap: .round, dash: [0.5, 3.5]))
+            }
+
+            // --- Actual line (solid, hero) ---
+            do {
+                var p = Path()
+                p.move(to: CGPoint(x: X(0), y: Y(100)))
+                p.addLine(to: CGPoint(x: X(tNow), y: Y(vNow)))
+                context.stroke(
+                    p,
+                    with: .color(self.theme.chartLine),
+                    style: StrokeStyle(lineWidth: 2.4, lineCap: .round, lineJoin: .round))
+            }
+
+            // --- Now dot (filled, with ring punched in bg color) ---
+            let dotCenter = CGPoint(x: X(tNow), y: Y(vNow))
+            let ringPath = Path(ellipseIn: CGRect(
+                x: dotCenter.x - 5.4, y: dotCenter.y - 5.4, width: 10.8, height: 10.8))
+            context.fill(ringPath, with: .color(self.theme.chartNowRing))
+            let dotPath = Path(ellipseIn: CGRect(
+                x: dotCenter.x - 3.4, y: dotCenter.y - 3.4, width: 6.8, height: 6.8))
+            context.fill(dotPath, with: .color(self.theme.chartNowDot))
+        }
+    }
+}
+
+// MARK: - Background
+
+struct BurnWidgetBackground: View {
+    @Environment(\.widgetRenderingMode) private var renderingMode
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        if self.renderingMode == .fullColor {
+            let dark = self.colorScheme == .dark
+            LinearGradient(
+                colors: dark
+                    ? [BurnPalette.darkBgTop, BurnPalette.darkBgBottom]
+                    : [BurnPalette.lightBgTop, BurnPalette.lightBgBottom],
+                startPoint: .init(x: 0.15, y: 0),
+                endPoint: .init(x: 0.85, y: 1))
+                .overlay(alignment: .top) {
+                    LinearGradient(
+                        colors: [
+                            Color.white.opacity(dark ? 0.04 : 0.60),
+                            Color.white.opacity(0),
+                        ],
+                        startPoint: .top,
+                        endPoint: .center)
+                }
+        } else {
+            Color.clear
+        }
+    }
+}
+
+// MARK: - Theme
+
+struct BurnTheme {
+    let text: Color
+    let sub: Color
+    let hair: Color
+    let accent: Color
+    let statusColor: Color
+    let danger: Color
+    let brandDot: Color
+    let chartLine: Color
+    let chartFillTop: Color
+    let chartFillTopOpacity: Double
+    let chartIdeal: Color
+    let chartProj: Color
+    let chartGrid: Color
+    let chartNowDot: Color
+    let chartNowRing: Color
+
+    init(provider: UsageProvider, geom: BurnGeom, dark: Bool, isMonochrome: Bool) {
+        if isMonochrome {
+            let fg = dark ? Color.white : Color.black
+            self.text = fg.opacity(dark ? 0.95 : 0.90)
+            self.sub = fg.opacity(dark ? 0.50 : 0.46)
+            self.hair = fg.opacity(dark ? 0.13 : 0.11)
+            self.accent = fg.opacity(dark ? 0.95 : 0.85)
+            self.statusColor = fg.opacity(dark ? 0.90 : 0.80)
+            self.danger = fg.opacity(dark ? 0.95 : 0.85)
+            self.brandDot = fg.opacity(dark ? 0.85 : 0.72)
+            self.chartLine = fg.opacity(dark ? 0.95 : 0.85)
+            self.chartFillTop = fg.opacity(dark ? 0.95 : 0.85)
+            self.chartFillTopOpacity = dark ? 0.20 : 0.16
+            self.chartIdeal = fg.opacity(dark ? 0.36 : 0.30)
+            self.chartProj = fg.opacity(dark ? 0.60 : 0.48)
+            self.chartGrid = fg.opacity(dark ? 0.12 : 0.10)
+            self.chartNowDot = fg.opacity(dark ? 1.0 : 0.92)
+            self.chartNowRing = dark
+                ? Color(red: 0.10, green: 0.10, blue: 0.12).opacity(0.92)
+                : Color(red: 0.96, green: 0.96, blue: 0.97).opacity(0.95)
+        } else {
+            let accentColor = Self.accentColor(geom.status, dark: dark)
+            self.accent = accentColor
+            self.statusColor = accentColor
+            self.text = dark ? Color.white.opacity(0.98) : Color(white: 0.20)
+            self.sub = dark ? Color(white: 0.60) : Color(white: 0.45)
+            self.hair = dark ? Color.white.opacity(0.10) : Color.black.opacity(0.09)
+            self.danger = BurnPalette.behindDark
+            self.brandDot = Self.brandDotColor(provider)
+            self.chartLine = accentColor
+            self.chartFillTop = accentColor
+            self.chartFillTopOpacity = dark ? 0.30 : 0.22
+            self.chartIdeal = dark ? Color.white.opacity(0.45) : Color.black.opacity(0.50)
+            // Projection goes red when behind (the one allowed color cue in full-color mode)
+            self.chartProj = geom.status == .behind ? BurnPalette.behindDark : accentColor
+            self.chartGrid = dark ? Color.white.opacity(0.10) : Color.black.opacity(0.09)
+            self.chartNowDot = accentColor
+            self.chartNowRing = dark ? BurnPalette.darkBgBottom : BurnPalette.lightBgBottom
+        }
+    }
+
+    private static func accentColor(_ status: BurnGeom.Status, dark: Bool) -> Color {
+        switch status {
+        case .ahead: dark ? BurnPalette.aheadDark : BurnPalette.aheadLight
+        case .onpace: dark ? BurnPalette.onpaceDark : BurnPalette.onpaceLight
+        case .behind: dark ? BurnPalette.behindDark : BurnPalette.behindLight
+        }
+    }
+
+    private static func brandDotColor(_ provider: UsageProvider) -> Color {
+        switch provider {
+        case .claude: BurnPalette.claudeDot
+        case .codex: BurnPalette.codexDot
+        case .gemini: BurnPalette.geminiDot
+        default: BurnPalette.genericDot
+        }
+    }
+}
+
+// MARK: - Palette
+
+enum BurnPalette {
+    // Status accents — approximated from OKLCH (L=0.80 dark, L=0.62 light)
+    // oklch(0.80 0.15 152) / oklch(0.62 0.15 152) — green
+    static let aheadDark = Color(red: 0.306, green: 0.800, blue: 0.506)
+    static let aheadLight = Color(red: 0.192, green: 0.620, blue: 0.376)
+    // oklch(0.80 0.11 236) / oklch(0.62 0.11 236) — blue
+    static let onpaceDark = Color(red: 0.408, green: 0.668, blue: 0.910)
+    static let onpaceLight = Color(red: 0.264, green: 0.474, blue: 0.712)
+    // oklch(0.72 0.19 26) / oklch(0.60 0.19 26) — red-orange
+    static let behindDark = Color(red: 0.922, green: 0.420, blue: 0.227)
+    static let behindLight = Color(red: 0.762, green: 0.294, blue: 0.137)
+
+    // Brand identity dots — always the LLM's hue
+    static let claudeDot = Color(red: 0.880, green: 0.580, blue: 0.180) // clay/amber, hue 48
+    static let codexDot = Color(red: 0.120, green: 0.780, blue: 0.598) // teal, hue 168
+    static let geminiDot = Color(red: 0.420, green: 0.440, blue: 0.900) // indigo, hue 268
+    static let genericDot = Color(white: 0.60)
+
+    // Backgrounds
+    static let darkBgTop = Color(red: 0.108, green: 0.108, blue: 0.132)
+    static let darkBgBottom = Color(red: 0.132, green: 0.132, blue: 0.156)
+    static let lightBgTop = Color(white: 0.990)
+    static let lightBgBottom = Color(red: 0.940, green: 0.940, blue: 0.960)
+}
+
+// MARK: - Geometry
+
+struct BurnGeom {
+    enum Status { case ahead, onpace, behind }
+
+    let vNow: Double // % remaining (0..100)
+    let tNow: Double // position in window (0..1)
+    let idealNow: Double // what you should have left = 100 * (1 - tNow)
+    let margin: Double // vNow - idealNow; + = conserving, − = over pace
+    let slope: Double // %/unit-t (negative = burning)
+    let projT: Double // t where projection ends
+    let projV: Double // v where projection ends
+    let runsOut: Bool // projection hits 0 inside the window
+
+    var status: Status {
+        self.margin > 4 ? .ahead : self.margin < -4 ? .behind : .onpace
+    }
+
+    var depleted: Bool {
+        self.vNow <= 0.5
+    }
+
+    var fresh: Bool {
+        self.vNow >= 99.5
+    }
+
+    init(window: RateWindow) {
+        let remaining = max(0, min(100, window.remainingPercent))
+        self.vNow = remaining
+
+        let t: Double
+        if let resetsAt = window.resetsAt, let windowMins = window.windowMinutes, windowMins > 0 {
+            let minutesUntilReset = max(0, resetsAt.timeIntervalSinceNow / 60)
+            let minutesElapsed = Double(windowMins) - minutesUntilReset
+            t = max(0.001, min(0.999, minutesElapsed / Double(windowMins)))
+        } else {
+            t = max(0.001, min(0.999, window.usedPercent / 100.0))
+        }
+        self.tNow = t
+        self.idealNow = 100.0 * (1.0 - t)
+        self.margin = remaining - self.idealNow
+
+        let slope = t > 0.001 ? (remaining - 100.0) / t : -remaining
+        self.slope = slope
+
+        if slope < -0.01 {
+            let tOut = t + remaining / -slope
+            if tOut <= 1.0 {
+                self.projT = tOut
+                self.projV = 0
+                self.runsOut = true
+            } else {
+                self.projT = 1.0
+                self.projV = max(0, remaining + slope * (1.0 - t))
+                self.runsOut = false
+            }
+        } else {
+            self.projT = 1.0
+            self.projV = remaining
+            self.runsOut = false
+        }
+    }
+}
+
+// MARK: - Helpers
+
+func burnWindowLabel(_ windowMinutes: Int?) -> String {
+    guard let mins = windowMinutes else { return "Usage limit" }
+    if mins < 60 { return "\(mins)-minute limit" }
+    let hours = mins / 60
+    if hours < 24 { return "\(hours)-hour limit" }
+    return "\(hours / 24)-day limit"
+}
+
+func burnCompactWindowLabel(_ windowMinutes: Int?, fallback: String) -> String {
+    guard let minutes = windowMinutes else { return fallback }
+    if minutes < 60 { return "\(minutes)M" }
+    let hours = minutes / 60
+    if hours < 24 { return "\(hours)H" }
+    return "\(hours / 24)D"
+}
+
+func burnFmtDuration(_ minutes: Double) -> String {
+    guard minutes.isFinite, minutes > 0 else { return "—" }
+    if minutes >= 1440 {
+        let d = Int(minutes / 1440)
+        let h = Int(minutes / 60) % 24
+        return "\(d)d \(h)h"
+    }
+    let h = Int(minutes / 60)
+    let m = Int(minutes) % 60
+    if h <= 0 { return "\(max(1, m))m" }
+    return "\(h)h \(String(format: "%02d", m))m"
+}
+
+func burnAxisLabel(_ date: Date, isDailyWindow: Bool) -> String {
+    let f = DateFormatter()
+    if isDailyWindow {
+        // A rolling multi-day window's start and reset fall on the same weekday, so "EEE"
+        // would print the same label at both ends ("Sat … Sat"). Use a numeric date so the
+        // two ends are distinguishable.
+        f.setLocalizedDateFormatFromTemplate("Md")
+    } else {
+        f.dateStyle = .none
+        f.timeStyle = .short
+    }
+    return f.string(from: date)
+}
+
+func burnProviderName(_ provider: UsageProvider) -> String {
+    ProviderDefaults.metadata[provider]?.displayName ?? provider.rawValue.capitalized
+}

--- a/Sources/CodexBarWidget/BurnDownWidgetViews.swift
+++ b/Sources/CodexBarWidget/BurnDownWidgetViews.swift
@@ -66,24 +66,18 @@ private struct BurnDownLayout: View {
         let theme = BurnTheme(provider: self.provider, geom: geom, dark: dark, isMonochrome: isMonochrome)
         let windowMins = self.window.windowMinutes ?? 300
         let isDailyWindow = windowMins >= 1440
-        let resetsIn: Double = if self.blankChart {
-            self.resetsAtOverride.map { max(0, $0.timeIntervalSinceNow / 60) } ?? 0
-        } else if let override = self.resetsAtOverride {
-            max(0, override.timeIntervalSinceNow / 60)
-        } else {
-            geom.tNow < 1 ? (1 - geom.tNow) * Double(windowMins) : 0
-        }
-        let effectiveResetAt: Date? = if self.blankChart {
-            self.resetsAtOverride
-        } else if let override = self.resetsAtOverride {
-            override
-        } else if let reset = self.window.resetsAt, reset > Date() {
-            reset
-        } else if resetsIn > 0 {
-            Date().addingTimeInterval(resetsIn * 60)
-        } else {
-            nil
-        }
+        let now = Date()
+        let estimatedResetMinutes = self.blankChart || geom.tNow >= 1
+            ? nil
+            : (1 - geom.tNow) * Double(windowMins)
+        let explicitReset = self.blankChart
+            ? self.resetsAtOverride
+            : self.resetsAtOverride ?? self.window.resetsAt
+        let effectiveResetAt = burnEffectiveResetDate(
+            explicitResetAt: explicitReset,
+            estimatedResetMinutes: estimatedResetMinutes,
+            now: now)
+        let resetsIn = effectiveResetAt.map { max(0, $0.timeIntervalSince(now) / 60) } ?? 0
         let outInMins = geom.slope < -0.01 ? (geom.vNow / -geom.slope) * Double(windowMins) : Double.infinity
         // Very early in the window a single sample can't forecast a credible run-out: a
         // tiny burst right after reset extrapolates to "runs dry in minutes" even at ~99%
@@ -622,6 +616,18 @@ func burnWindowLabel(_ windowMinutes: Int?) -> String {
     let hours = mins / 60
     if hours < 24 { return "\(hours)-hour limit" }
     return "\(hours / 24)-day limit"
+}
+
+func burnEffectiveResetDate(
+    explicitResetAt: Date?,
+    estimatedResetMinutes: Double?,
+    now: Date) -> Date?
+{
+    if let explicitResetAt {
+        return explicitResetAt > now ? explicitResetAt : nil
+    }
+    guard let estimatedResetMinutes, estimatedResetMinutes > 0 else { return nil }
+    return now.addingTimeInterval(estimatedResetMinutes * 60)
 }
 
 func burnCompactWindowLabel(_ windowMinutes: Int?, fallback: String) -> String {

--- a/Sources/CodexBarWidget/BurnDownWidgetViews.swift
+++ b/Sources/CodexBarWidget/BurnDownWidgetViews.swift
@@ -98,9 +98,12 @@ private struct BurnDownLayout: View {
         let arrow: String = geom.depleted ? "■" : geom.fresh ? "◆"
             : geom.status == .ahead ? "▲" : geom.status == .behind ? "▼" : "●"
 
-        let startDate = (self.window.resetsAt ?? Date()).addingTimeInterval(-Double(windowMins) * 60)
-        let startLabel = burnAxisLabel(startDate, isDailyWindow: isDailyWindow)
-        let resetLabel = burnAxisLabel(self.window.resetsAt ?? Date(), isDailyWindow: isDailyWindow)
+        let axisDates = burnAxisDateRange(
+            effectiveResetAt: effectiveResetAt,
+            windowMinutes: windowMins,
+            now: now)
+        let startLabel = burnAxisLabel(axisDates.start, isDailyWindow: isDailyWindow)
+        let resetLabel = burnAxisLabel(axisDates.reset, isDailyWindow: isDailyWindow)
 
         VStack(spacing: 0) {
             // Header: brand + pace badge
@@ -628,6 +631,15 @@ func burnEffectiveResetDate(
     }
     guard let estimatedResetMinutes, estimatedResetMinutes > 0 else { return nil }
     return now.addingTimeInterval(estimatedResetMinutes * 60)
+}
+
+func burnAxisDateRange(
+    effectiveResetAt: Date?,
+    windowMinutes: Int,
+    now: Date) -> (start: Date, reset: Date)
+{
+    let reset = effectiveResetAt ?? now
+    return (reset.addingTimeInterval(-Double(windowMinutes) * 60), reset)
 }
 
 func burnCompactWindowLabel(_ windowMinutes: Int?, fallback: String) -> String {

--- a/Sources/CodexBarWidget/CodexBarWidgetBundle.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetBundle.swift
@@ -8,6 +8,8 @@ struct CodexBarWidgetBundle: WidgetBundle {
         CodexBarUsageWidget()
         CodexBarHistoryWidget()
         CodexBarCompactWidget()
+        CodexBarBurnDownWidget()
+        CodexBarCombinedBurnDownWidget()
     }
 }
 
@@ -75,5 +77,39 @@ struct CodexBarCompactWidget: Widget {
         .configurationDisplayName("CodexBar Metric")
         .description("Compact widget for credits or cost.")
         .supportedFamilies([.systemSmall])
+    }
+}
+
+struct CodexBarBurnDownWidget: Widget {
+    private let kind = "CodexBarBurnDownWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: self.kind,
+            intent: BurnDownSelectionIntent.self,
+            provider: BurnDownTimelineProvider())
+        { entry in
+            BurnDownWidgetView(entry: entry)
+        }
+        .configurationDisplayName("CodexBar Burn Down")
+        .description("Remaining budget compared with an ideal steady burn rate.")
+        .supportedFamilies([.systemMedium])
+    }
+}
+
+struct CodexBarCombinedBurnDownWidget: Widget {
+    private let kind = "CodexBarCombinedBurnDownWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: self.kind,
+            intent: BurnProviderSelectionIntent.self,
+            provider: CombinedBurnDownTimelineProvider())
+        { entry in
+            CombinedBurnDownWidgetView(entry: entry)
+        }
+        .configurationDisplayName("CodexBar Burn Down (Combined)")
+        .description("Session and weekly burn-down charts in one tile.")
+        .supportedFamilies([.systemMedium])
     }
 }

--- a/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetProvider.swift
@@ -311,8 +311,12 @@ enum WidgetPreviewData {
     }
 
     static func snapshot() -> WidgetSnapshot {
-        let primary = RateWindow(usedPercent: 35, windowMinutes: nil, resetsAt: nil, resetDescription: "Resets in 4h")
-        let secondary = RateWindow(usedPercent: 60, windowMinutes: nil, resetsAt: nil, resetDescription: "Resets in 3d")
+        let primary = RateWindow(usedPercent: 35, windowMinutes: 300, resetsAt: nil, resetDescription: "Resets in 4h")
+        let secondary = RateWindow(
+            usedPercent: 60,
+            windowMinutes: 10080,
+            resetsAt: nil,
+            resetDescription: "Resets in 3d")
         let entry = WidgetSnapshot.ProviderEntry(
             provider: .codex,
             updatedAt: Date(),

--- a/Sources/CodexBarWidget/CombinedBurnDownWidgetViews.swift
+++ b/Sources/CodexBarWidget/CombinedBurnDownWidgetViews.swift
@@ -1,0 +1,485 @@
+import AppKit
+import CodexBarCore
+import SwiftUI
+import WidgetKit
+
+// MARK: - Entry View
+
+struct CombinedBurnDownWidgetView: View {
+    let entry: CombinedBurnDownEntry
+
+    var body: some View {
+        let state = BurnDownState(
+            snapshot: self.entry.snapshot,
+            provider: self.entry.provider,
+            selection: .session)
+
+        Group {
+            if let state {
+                CombinedBurnDownLayout(state: state, provider: self.entry.provider)
+            } else {
+                self.emptyState
+            }
+        }
+        .containerBackground(for: .widget) {
+            BurnWidgetBackground()
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 6) {
+            Text("Open CodexBar")
+                .font(.body)
+                .fontWeight(.semibold)
+            Text("Usage data will appear once the app refreshes.")
+                .font(.caption)
+                .multilineTextAlignment(.center)
+                .opacity(0.55)
+        }
+        .padding(12)
+    }
+}
+
+// MARK: - Layout
+
+private struct CombinedBurnDownLayout: View {
+    @Environment(\.widgetRenderingMode) private var renderingMode
+    @Environment(\.colorScheme) private var colorScheme
+
+    let state: BurnDownState
+    let provider: UsageProvider
+
+    var body: some View {
+        let dark = self.colorScheme == .dark
+        let isMonochrome = self.renderingMode != .fullColor
+
+        let sessionWindow = self.state.primaryWindow
+        let weeklyWindow = self.state.secondaryWindow
+
+        let sessionGeom = sessionWindow.map { BurnGeom(window: $0) }
+        let weeklyGeom = weeklyWindow.map { BurnGeom(window: $0) }
+
+        // Use a neutral baseline theme for the header/hairline colors
+        let baseGeom = sessionGeom ?? weeklyGeom ?? BurnGeom(
+            window: RateWindow(
+                usedPercent: 50,
+                windowMinutes: 300,
+                resetsAt: Date().addingTimeInterval(2.5 * 3600),
+                resetDescription: nil))
+        let baseTheme = BurnTheme(
+            provider: self.provider,
+            geom: baseGeom,
+            dark: dark,
+            isMonochrome: isMonochrome)
+
+        VStack(spacing: 0) {
+            // Header
+            HStack(alignment: .center) {
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(baseTheme.brandDot)
+                        .frame(width: 7, height: 7)
+                        .shadow(color: baseTheme.brandDot.opacity(0.7), radius: 3.5)
+                    Text(burnProviderName(self.provider))
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(baseTheme.text)
+                        .lineLimit(1)
+                }
+                Spacer()
+                Text("Session & weekly limits")
+                    .font(.system(size: 10))
+                    .foregroundStyle(baseTheme.sub)
+                    .kerning(0.3)
+            }
+
+            // Two rows
+            VStack(spacing: 0) {
+                // 5H row — shows % remaining by default
+                if let win = sessionWindow, let geom = sessionGeom {
+                    CombinedBurnRow(
+                        window: win,
+                        geom: geom,
+                        theme: BurnTheme(
+                            provider: self.provider,
+                            geom: geom,
+                            dark: dark,
+                            isMonochrome: isMonochrome),
+                        tag: burnCompactWindowLabel(win.windowMinutes, fallback: "S"),
+                        periods: 5,
+                        metric: .remaining,
+                        dark: dark,
+                        blankChart: self.state.blankPrimaryChart,
+                        resetsAtOverride: self.state.selectedResetOverride)
+                } else {
+                    CombinedEmptyRow(tag: "S", theme: baseTheme)
+                }
+
+                Rectangle()
+                    .fill(baseTheme.hair)
+                    .frame(height: 1)
+
+                // 7D row — shows % off pace by default
+                if let win = weeklyWindow, let geom = weeklyGeom {
+                    CombinedBurnRow(
+                        window: win,
+                        geom: geom,
+                        theme: BurnTheme(
+                            provider: self.provider,
+                            geom: geom,
+                            dark: dark,
+                            isMonochrome: isMonochrome),
+                        tag: burnCompactWindowLabel(win.windowMinutes, fallback: "W"),
+                        periods: 7,
+                        metric: .pace,
+                        dark: dark)
+                } else {
+                    CombinedEmptyRow(tag: "W", theme: baseTheme)
+                }
+            }
+            .frame(maxHeight: .infinity)
+            .padding(.top, 6)
+        }
+        .padding(.horizontal, 15)
+        .padding(.top, 12)
+        .padding(.bottom, 11)
+    }
+}
+
+// MARK: - Metric
+
+private enum CombinedMetric {
+    case remaining // % left (default for 5H)
+    case pace // % off ideal pace (default for 7D)
+    case used // % consumed
+}
+
+// MARK: - Row
+
+private struct CombinedBurnRow: View {
+    let window: RateWindow
+    let geom: BurnGeom
+    let theme: BurnTheme
+    let tag: String
+    let periods: Int
+    let metric: CombinedMetric
+    let dark: Bool
+    var blankChart = false
+    var resetsAtOverride: Date?
+
+    var body: some View {
+        let windowMins = self.window.windowMinutes ?? 300
+        let isDailyWindow = windowMins >= 1440
+
+        let heroNum = self.metric == .pace ? abs(Int(self.geom.margin.rounded()))
+            : self.metric == .used ? Int((100 - self.geom.vNow).rounded())
+            : Int(self.geom.vNow.rounded())
+        let suffix = self.metric == .remaining ? "left" : self.metric == .used ? "used" : ""
+        let prefixArrow = self.metric == .pace
+
+        let paceWord: String = self.geom.depleted ? "spent" : self.geom.fresh ? "full"
+            : self.geom.status == .ahead ? "under pace"
+            : self.geom.status == .behind ? "over pace" : "on pace"
+        let arrow: String = self.geom.depleted ? "■" : self.geom.fresh ? "◆"
+            : self.geom.status == .ahead ? "▲" : self.geom.status == .behind ? "▼" : "●"
+
+        let explicitReset = self.blankChart
+            ? self.resetsAtOverride
+            : self.resetsAtOverride ?? self.window.resetsAt
+        let resetSeconds = explicitReset?.timeIntervalSinceNow
+        let resetsInMins = self.blankChart && explicitReset == nil
+            ? 0
+            : resetSeconds.map { $0 > 0 } == true
+            ? resetSeconds! / 60
+            : (self.geom.tNow < 1 ? (1 - self.geom.tNow) * Double(windowMins) : 0)
+        let effectiveResetDate: Date? = if self.blankChart, explicitReset == nil {
+            nil
+        } else if resetSeconds.map({ $0 > 0 }) == true {
+            explicitReset
+        } else {
+            Date().addingTimeInterval(resetsInMins * 60)
+        }
+        let heroColor = self.geom.depleted ? self.theme.danger : self.theme.statusColor
+
+        HStack(alignment: .center, spacing: 12) {
+            // Label column
+            VStack(alignment: .leading, spacing: 0) {
+                // Line 1: tag + (arrow for non-pace metrics) + pace word
+                // For remaining/used: "5H ▼ over pace". For pace: "7D on pace" (arrow is on hero line).
+                HStack(alignment: .firstTextBaseline, spacing: 5) {
+                    Text(self.tag)
+                        .font(.system(size: 9.5, weight: .heavy))
+                        .foregroundStyle(self.theme.sub)
+                        .kerning(1)
+                    HStack(alignment: .firstTextBaseline, spacing: 2) {
+                        if !prefixArrow {
+                            Text(arrow)
+                                .font(.system(size: 8))
+                                .foregroundStyle(self.theme.statusColor)
+                        }
+                        Text(paceWord)
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(self.theme.statusColor)
+                    }
+                    .lineLimit(1)
+                }
+
+                // Line 2: hero number. Pace metric prefixes an arrow glyph.
+                HStack(alignment: .lastTextBaseline, spacing: 2) {
+                    if prefixArrow {
+                        Text(arrow)
+                            .font(.system(size: 13, weight: .bold))
+                            .foregroundStyle(heroColor)
+                    }
+                    Text("\(heroNum)")
+                        .font(.system(size: 27, weight: .semibold))
+                        .foregroundStyle(heroColor)
+                        .monospacedDigit()
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                    Text("%")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(self.theme.sub)
+                    if !suffix.isEmpty {
+                        Text(suffix)
+                            .font(.system(size: 10))
+                            .foregroundStyle(self.theme.sub)
+                    }
+                }
+                .padding(.top, 1)
+
+                // Line 3: reset line — refresh glyph + countdown + compact time
+                HStack(spacing: 4) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 9))
+                        .foregroundStyle(self.theme.sub.opacity(0.85))
+                    if let effectiveResetDate {
+                        Text(effectiveResetDate, style: .relative)
+                            .font(.system(size: 9.5, weight: .medium))
+                            .foregroundStyle(self.theme.text)
+                            .monospacedDigit()
+                        Text("· \(combinedCompactResetTime(effectiveResetDate, isDailyWindow: isDailyWindow))")
+                            .font(.system(size: 9.5, weight: .medium))
+                            .foregroundStyle(self.theme.text)
+                    } else {
+                        Text("—")
+                            .font(.system(size: 9.5, weight: .medium))
+                            .foregroundStyle(self.theme.text)
+                    }
+                }
+                .padding(.top, 2)
+                .lineLimit(1)
+            }
+            .frame(width: 112, alignment: .leading)
+
+            // Chart column — blanked when the session window is blocked by an exhausted
+            // weekly cap; there is no session burn to chart until the weekly resets.
+            if self.blankChart {
+                Color.clear
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+            } else {
+                CombinedBurnChartCanvas(geom: self.geom, theme: self.theme, periods: self.periods, dark: self.dark)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 50)
+            }
+        }
+        .frame(maxHeight: .infinity)
+    }
+}
+
+// MARK: - Empty Row
+
+private struct CombinedEmptyRow: View {
+    let tag: String
+    let theme: BurnTheme
+
+    var body: some View {
+        HStack {
+            Text(self.tag)
+                .font(.system(size: 9.5, weight: .heavy))
+                .foregroundStyle(self.theme.sub)
+                .kerning(1)
+            Text("No data")
+                .font(.system(size: 10))
+                .foregroundStyle(self.theme.sub)
+            Spacer()
+        }
+        .frame(maxHeight: .infinity)
+    }
+}
+
+// MARK: - Mini Chart Canvas
+
+private struct CombinedBurnChartCanvas: View {
+    let geom: BurnGeom
+    let theme: BurnTheme
+    let periods: Int
+    let dark: Bool
+
+    var body: some View {
+        Canvas { context, size in
+            let w = size.width
+            let h = size.height
+            let padT: CGFloat = 5
+            let padB: CGFloat = 2
+            let padL: CGFloat = 1
+            let padR: CGFloat = 1
+
+            func X(_ t: Double) -> CGFloat {
+                padL + CGFloat(t) * (w - padL - padR)
+            }
+            func Y(_ v: Double) -> CGFloat {
+                padT + CGFloat(1 - v / 100) * (h - padT - padB)
+            }
+
+            let tNow = self.geom.tNow
+            let vNow = self.geom.vNow
+            let barColor = self.dark ? Color.white : Color.black
+
+            // --- Usage bars (background texture) ---
+            // Drawn first so the actual line renders on top.
+            // Heights are relative-to-ideal: idealPerPeriod maps to ~46% of plot height.
+            let plotH = h - padT - padB
+            let refH = 0.46 * plotH // reference height = ideal-pace bar height
+            let idealPerPeriod = 100.0 / Double(self.periods)
+            let burnRate = tNow > 0.001 ? (100.0 - vNow) / tNow : 0.0 // %/unit-t
+            let slotW = (w - padL - padR) / CGFloat(self.periods)
+
+            for i in 0..<self.periods {
+                let slotStart = Double(i) / Double(self.periods)
+                let slotEnd = Double(i + 1) / Double(self.periods)
+                let slotX = padL + CGFloat(slotStart) * (w - padL - padR)
+
+                if slotEnd <= tNow {
+                    // Completed period — full-width bar
+                    let consumed = burnRate * (slotEnd - slotStart)
+                    let ratio = consumed / idealPerPeriod
+                    let totalBarH = CGFloat(ratio) * refH
+                    let baseH = min(totalBarH, refH)
+
+                    if baseH > 0 {
+                        let rect = CGRect(
+                            x: slotX,
+                            y: h - padB - baseH,
+                            width: slotW - 1,
+                            height: baseH)
+                        context.fill(Path(rect), with: .color(barColor.opacity(0.17)))
+                    }
+                    // Overage segment — above ideal reference line
+                    if totalBarH > refH {
+                        let overH = totalBarH - refH
+                        let rect = CGRect(
+                            x: slotX,
+                            y: h - padB - totalBarH,
+                            width: slotW - 1,
+                            height: overH)
+                        context.fill(Path(rect), with: .color(barColor.opacity(0.34)))
+                    }
+                } else if slotStart < tNow {
+                    // Current (partial) period — narrower bar ending at tNow
+                    let partialFrac = (tNow - slotStart) / (slotEnd - slotStart)
+                    let consumed = burnRate * (tNow - slotStart)
+                    let ratio = consumed / idealPerPeriod
+                    let totalBarH = CGFloat(ratio) * refH
+                    let baseH = min(totalBarH, refH)
+                    let barW = CGFloat(partialFrac) * (slotW - 1)
+
+                    if baseH > 0 {
+                        let rect = CGRect(
+                            x: slotX,
+                            y: h - padB - baseH,
+                            width: barW,
+                            height: baseH)
+                        context.fill(Path(rect), with: .color(barColor.opacity(0.13)))
+                    }
+                    if totalBarH > refH {
+                        let overH = totalBarH - refH
+                        let rect = CGRect(
+                            x: slotX,
+                            y: h - padB - totalBarH,
+                            width: barW,
+                            height: overH)
+                        context.fill(Path(rect), with: .color(barColor.opacity(0.26)))
+                    }
+                } else {
+                    // Future period — faint full-height placeholder
+                    let rect = CGRect(
+                        x: slotX,
+                        y: h - padB - refH,
+                        width: slotW - 1,
+                        height: refH)
+                    context.fill(Path(rect), with: .color(barColor.opacity(0.045)))
+                }
+            }
+
+            // --- Now vertical hairline ---
+            do {
+                var p = Path()
+                p.move(to: CGPoint(x: X(tNow), y: Y(100)))
+                p.addLine(to: CGPoint(x: X(tNow), y: Y(0)))
+                context.stroke(p, with: .color(self.theme.chartGrid), lineWidth: 1)
+            }
+
+            // --- Baseline ---
+            do {
+                var p = Path()
+                p.move(to: CGPoint(x: X(0), y: Y(0)))
+                p.addLine(to: CGPoint(x: X(1), y: Y(0)))
+                context.stroke(p, with: .color(self.theme.chartGrid), lineWidth: 1)
+            }
+
+            // --- Ideal line (dashed, recedes) ---
+            do {
+                var p = Path()
+                p.move(to: CGPoint(x: X(0), y: Y(100)))
+                p.addLine(to: CGPoint(x: X(1), y: Y(0)))
+                context.stroke(
+                    p,
+                    with: .color(self.theme.chartIdeal),
+                    style: StrokeStyle(lineWidth: 1.4, lineCap: .round, dash: [2.5, 3]))
+            }
+
+            // --- Projection (fine dotted) ---
+            if self.geom.slope < -0.01 {
+                var p = Path()
+                p.move(to: CGPoint(x: X(tNow), y: Y(vNow)))
+                p.addLine(to: CGPoint(x: X(self.geom.projT), y: Y(self.geom.projV)))
+                context.stroke(
+                    p,
+                    with: .color(self.theme.chartProj.opacity(0.95)),
+                    style: StrokeStyle(lineWidth: 1.6, lineCap: .round, dash: [0.5, 3.5]))
+            }
+
+            // --- Actual line (solid, dominant) ---
+            do {
+                var p = Path()
+                p.move(to: CGPoint(x: X(0), y: Y(100)))
+                p.addLine(to: CGPoint(x: X(tNow), y: Y(vNow)))
+                context.stroke(
+                    p,
+                    with: .color(self.theme.chartLine),
+                    style: StrokeStyle(lineWidth: 2.4, lineCap: .round, lineJoin: .round))
+            }
+
+            // --- Now dot (filled, ringed) ---
+            let dotCenter = CGPoint(x: X(tNow), y: Y(vNow))
+            let ringPath = Path(ellipseIn: CGRect(
+                x: dotCenter.x - 5.4, y: dotCenter.y - 5.4, width: 10.8, height: 10.8))
+            context.fill(ringPath, with: .color(self.theme.chartNowRing))
+            let dotPath = Path(ellipseIn: CGRect(
+                x: dotCenter.x - 3.4, y: dotCenter.y - 3.4, width: 6.8, height: 6.8))
+            context.fill(dotPath, with: .color(self.theme.chartNowDot))
+        }
+    }
+}
+
+// MARK: - Compact reset time helper
+
+/// Formats a reset date compactly: "4:30p", "5p", "Sun 9a".
+/// Weekday prefix is added for the 7-day window or when the reset is ≥20h away.
+private func combinedCompactResetTime(_ date: Date, isDailyWindow: Bool) -> String {
+    let includeDay = isDailyWindow || date.timeIntervalSinceNow >= 20 * 3600
+    let formatter = DateFormatter()
+    formatter.setLocalizedDateFormatFromTemplate(includeDay ? "EEEjm" : "jm")
+    return formatter.string(from: date)
+}

--- a/Sources/CodexBarWidget/CombinedBurnDownWidgetViews.swift
+++ b/Sources/CodexBarWidget/CombinedBurnDownWidgetViews.swift
@@ -185,19 +185,14 @@ private struct CombinedBurnRow: View {
         let explicitReset = self.blankChart
             ? self.resetsAtOverride
             : self.resetsAtOverride ?? self.window.resetsAt
-        let resetSeconds = explicitReset?.timeIntervalSinceNow
-        let resetsInMins = self.blankChart && explicitReset == nil
-            ? 0
-            : resetSeconds.map { $0 > 0 } == true
-            ? resetSeconds! / 60
-            : (self.geom.tNow < 1 ? (1 - self.geom.tNow) * Double(windowMins) : 0)
-        let effectiveResetDate: Date? = if self.blankChart, explicitReset == nil {
-            nil
-        } else if resetSeconds.map({ $0 > 0 }) == true {
-            explicitReset
-        } else {
-            Date().addingTimeInterval(resetsInMins * 60)
-        }
+        let now = Date()
+        let estimatedResetMinutes = self.blankChart || self.geom.tNow >= 1
+            ? nil
+            : (1 - self.geom.tNow) * Double(windowMins)
+        let effectiveResetDate = burnEffectiveResetDate(
+            explicitResetAt: explicitReset,
+            estimatedResetMinutes: estimatedResetMinutes,
+            now: now)
         let heroColor = self.geom.depleted ? self.theme.danger : self.theme.statusColor
 
         HStack(alignment: .center, spacing: 12) {

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -519,6 +519,23 @@ struct CodexBarWidgetProviderTests {
     }
 
     @Test
+    func `burn down axis shares the effective estimated reset`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let effectiveReset = try #require(burnEffectiveResetDate(
+            explicitResetAt: nil,
+            estimatedResetMinutes: 90,
+            now: now))
+
+        let axis = burnAxisDateRange(
+            effectiveResetAt: effectiveReset,
+            windowMinutes: 300,
+            now: now)
+
+        #expect(axis.reset == effectiveReset)
+        #expect(axis.start == effectiveReset.addingTimeInterval(-5 * 60 * 60))
+    }
+
+    @Test
     func `burn down refreshes immediately after the earliest future reset`() {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let snapshot = Self.burnSnapshot(

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -421,6 +421,57 @@ struct CodexBarWidgetProviderTests {
     }
 
     @Test
+    func `burn down selection does not fall back to another window`() throws {
+        let weeklyOnly = Self.burnSnapshot(provider: .codex, primaryUsed: nil, secondaryUsed: 30)
+        let sessionOnly = Self.burnSnapshot(provider: .codex, primaryUsed: 20, secondaryUsed: nil)
+
+        let weeklyOnlySession = try #require(BurnDownState(
+            snapshot: weeklyOnly,
+            provider: .codex,
+            selection: .session))
+        let weeklyOnlyWeekly = try #require(BurnDownState(
+            snapshot: weeklyOnly,
+            provider: .codex,
+            selection: .weekly))
+        let sessionOnlySession = try #require(BurnDownState(
+            snapshot: sessionOnly,
+            provider: .codex,
+            selection: .session))
+        let sessionOnlyWeekly = try #require(BurnDownState(
+            snapshot: sessionOnly,
+            provider: .codex,
+            selection: .weekly))
+
+        #expect(weeklyOnlySession.selectedWindow == nil)
+        #expect(weeklyOnlyWeekly.selectedWindow == weeklyOnlyWeekly.secondaryWindow)
+        #expect(sessionOnlySession.selectedWindow == sessionOnlySession.primaryWindow)
+        #expect(sessionOnlyWeekly.selectedWindow == nil)
+    }
+
+    @Test
+    func `explicit reset takes precedence over estimated reset`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let future = now.addingTimeInterval(600)
+
+        #expect(burnEffectiveResetDate(
+            explicitResetAt: now.addingTimeInterval(-1),
+            estimatedResetMinutes: 5,
+            now: now) == nil)
+        #expect(burnEffectiveResetDate(
+            explicitResetAt: future,
+            estimatedResetMinutes: 5,
+            now: now) == future)
+        #expect(burnEffectiveResetDate(
+            explicitResetAt: nil,
+            estimatedResetMinutes: 5,
+            now: now) == now.addingTimeInterval(300))
+        #expect(burnEffectiveResetDate(
+            explicitResetAt: nil,
+            estimatedResetMinutes: nil,
+            now: now) == nil)
+    }
+
+    @Test
     func `burn down refreshes immediately after the earliest future reset`() {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let snapshot = Self.burnSnapshot(
@@ -451,24 +502,28 @@ struct CodexBarWidgetProviderTests {
 
     private static func burnSnapshot(
         provider: UsageProvider,
-        primaryUsed: Double,
-        secondaryUsed: Double,
+        primaryUsed: Double?,
+        secondaryUsed: Double?,
         primaryReset: Date? = nil,
         secondaryReset: Date? = nil) -> WidgetSnapshot
     {
         let entry = WidgetSnapshot.ProviderEntry(
             provider: provider,
             updatedAt: Date(timeIntervalSince1970: 1_700_000_000),
-            primary: RateWindow(
-                usedPercent: primaryUsed,
-                windowMinutes: 5 * 60,
-                resetsAt: primaryReset,
-                resetDescription: nil),
-            secondary: RateWindow(
-                usedPercent: secondaryUsed,
-                windowMinutes: 7 * 24 * 60,
-                resetsAt: secondaryReset,
-                resetDescription: nil),
+            primary: primaryUsed.map {
+                RateWindow(
+                    usedPercent: $0,
+                    windowMinutes: 5 * 60,
+                    resetsAt: primaryReset,
+                    resetDescription: nil)
+            },
+            secondary: secondaryUsed.map {
+                RateWindow(
+                    usedPercent: $0,
+                    windowMinutes: 7 * 24 * 60,
+                    resetsAt: secondaryReset,
+                    resetDescription: nil)
+            },
             tertiary: nil,
             creditsRemaining: nil,
             codeReviewRemainingPercent: nil,

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -421,6 +421,17 @@ struct CodexBarWidgetProviderTests {
     }
 
     @Test
+    func `burn down preview includes session and weekly windows`() throws {
+        let snapshot = WidgetPreviewData.snapshot()
+
+        let session = try #require(BurnDownState(snapshot: snapshot, provider: .codex, selection: .session))
+        let weekly = try #require(BurnDownState(snapshot: snapshot, provider: .codex, selection: .weekly))
+
+        #expect(session.selectedWindow?.windowMinutes == 300)
+        #expect(weekly.selectedWindow?.windowMinutes == 10080)
+    }
+
+    @Test
     func `burn down selection does not fall back to another window`() throws {
         let weeklyOnly = Self.burnSnapshot(provider: .codex, primaryUsed: nil, secondaryUsed: 30)
         let sessionOnly = Self.burnSnapshot(provider: .codex, primaryUsed: 20, secondaryUsed: nil)

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -424,6 +424,11 @@ struct CodexBarWidgetProviderTests {
     func `burn down selection does not fall back to another window`() throws {
         let weeklyOnly = Self.burnSnapshot(provider: .codex, primaryUsed: nil, secondaryUsed: 30)
         let sessionOnly = Self.burnSnapshot(provider: .codex, primaryUsed: 20, secondaryUsed: nil)
+        let weeklyStoredInPrimary = Self.burnSnapshot(
+            provider: .claude,
+            primaryUsed: 30,
+            secondaryUsed: nil,
+            primaryWindowMinutes: 7 * 24 * 60)
 
         let weeklyOnlySession = try #require(BurnDownState(
             snapshot: weeklyOnly,
@@ -441,11 +446,42 @@ struct CodexBarWidgetProviderTests {
             snapshot: sessionOnly,
             provider: .codex,
             selection: .weekly))
+        let weeklyPrimarySession = try #require(BurnDownState(
+            snapshot: weeklyStoredInPrimary,
+            provider: .claude,
+            selection: .session))
+        let weeklyPrimaryWeekly = try #require(BurnDownState(
+            snapshot: weeklyStoredInPrimary,
+            provider: .claude,
+            selection: .weekly))
 
         #expect(weeklyOnlySession.selectedWindow == nil)
         #expect(weeklyOnlyWeekly.selectedWindow == weeklyOnlyWeekly.secondaryWindow)
         #expect(sessionOnlySession.selectedWindow == sessionOnlySession.primaryWindow)
         #expect(sessionOnlyWeekly.selectedWindow == nil)
+        #expect(weeklyPrimarySession.selectedWindow == nil)
+        #expect(weeklyPrimaryWeekly.selectedWindow?.usedPercent == 30)
+    }
+
+    @Test
+    func `expired weekly reset no longer blocks the session chart`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = Self.burnSnapshot(
+            provider: .codex,
+            primaryUsed: 20,
+            secondaryUsed: 100,
+            primaryReset: now.addingTimeInterval(300),
+            secondaryReset: now.addingTimeInterval(-1))
+        let state = try #require(BurnDownState(
+            snapshot: snapshot,
+            provider: .codex,
+            selection: .session,
+            now: now))
+
+        #expect(!state.secondaryExhausted)
+        #expect(state.primaryWindow?.remainingPercent == 80)
+        #expect(!state.blankPrimaryChart)
+        #expect(state.selectedResetOverride == nil)
     }
 
     @Test
@@ -505,7 +541,9 @@ struct CodexBarWidgetProviderTests {
         primaryUsed: Double?,
         secondaryUsed: Double?,
         primaryReset: Date? = nil,
-        secondaryReset: Date? = nil) -> WidgetSnapshot
+        secondaryReset: Date? = nil,
+        primaryWindowMinutes: Int = 5 * 60,
+        secondaryWindowMinutes: Int = 7 * 24 * 60) -> WidgetSnapshot
     {
         let entry = WidgetSnapshot.ProviderEntry(
             provider: provider,
@@ -513,14 +551,14 @@ struct CodexBarWidgetProviderTests {
             primary: primaryUsed.map {
                 RateWindow(
                     usedPercent: $0,
-                    windowMinutes: 5 * 60,
+                    windowMinutes: primaryWindowMinutes,
                     resetsAt: primaryReset,
                     resetDescription: nil)
             },
             secondary: secondaryUsed.map {
                 RateWindow(
                     usedPercent: $0,
-                    windowMinutes: 7 * 24 * 60,
+                    windowMinutes: secondaryWindowMinutes,
                     resetsAt: secondaryReset,
                     resetDescription: nil)
             },

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -352,9 +352,128 @@ struct CodexBarWidgetProviderTests {
     func `widget configuration intents default to codex and credits`() {
         let providerIntent = ProviderSelectionIntent()
         let compactIntent = CompactMetricSelectionIntent()
+        let burnIntent = BurnDownSelectionIntent()
+        let combinedBurnIntent = BurnProviderSelectionIntent()
 
         #expect(providerIntent.provider == .codex)
         #expect(compactIntent.provider == .codex)
         #expect(compactIntent.metric == .credits)
+        #expect(burnIntent.provider == .codex)
+        #expect(burnIntent.window == .session)
+        #expect(combinedBurnIntent.provider == .codex)
+    }
+
+    @Test
+    func `burn down uses an exact provider entry`() {
+        let snapshot = Self.burnSnapshot(provider: .claude, primaryUsed: 20, secondaryUsed: 30)
+
+        #expect(BurnDownState(snapshot: snapshot, provider: .codex, selection: .session) == nil)
+        #expect(BurnDownState(snapshot: snapshot, provider: .claude, selection: .session) != nil)
+    }
+
+    @Test
+    func `codex exhausted weekly cap blocks the session chart until weekly reset`() throws {
+        let weeklyReset = Date(timeIntervalSince1970: 1_800_000_000)
+        let snapshot = Self.burnSnapshot(
+            provider: .codex,
+            primaryUsed: 80,
+            secondaryUsed: 100,
+            primaryReset: weeklyReset.addingTimeInterval(-3600),
+            secondaryReset: weeklyReset)
+        let state = try #require(BurnDownState(snapshot: snapshot, provider: .codex, selection: .session))
+
+        #expect(state.secondaryGloballyCapsPrimary)
+        #expect(state.primaryWindow?.remainingPercent == 0)
+        #expect(state.blankPrimaryChart)
+        #expect(state.selectedResetOverride == weeklyReset)
+    }
+
+    @Test
+    func `gemini exhausted secondary window does not block the independent primary`() throws {
+        let primaryReset = Date(timeIntervalSince1970: 1_800_000_000)
+        let snapshot = Self.burnSnapshot(
+            provider: .gemini,
+            primaryUsed: 20,
+            secondaryUsed: 100,
+            primaryReset: primaryReset,
+            secondaryReset: primaryReset.addingTimeInterval(-3600))
+        let state = try #require(BurnDownState(snapshot: snapshot, provider: .gemini, selection: .session))
+
+        #expect(!state.secondaryGloballyCapsPrimary)
+        #expect(state.primaryWindow?.remainingPercent == 80)
+        #expect(!state.blankPrimaryChart)
+        #expect(state.selectedResetOverride == nil)
+    }
+
+    @Test
+    func `independent secondary reset never overrides primary reset`() throws {
+        let primaryReset = Date(timeIntervalSince1970: 1_800_000_000)
+        let snapshot = Self.burnSnapshot(
+            provider: .gemini,
+            primaryUsed: 20,
+            secondaryUsed: 30,
+            primaryReset: primaryReset,
+            secondaryReset: primaryReset.addingTimeInterval(-3600))
+        let state = try #require(BurnDownState(snapshot: snapshot, provider: .gemini, selection: .session))
+
+        #expect(state.selectedWindow?.resetsAt == primaryReset)
+        #expect(state.selectedResetOverride == nil)
+    }
+
+    @Test
+    func `burn down refreshes immediately after the earliest future reset`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = Self.burnSnapshot(
+            provider: .codex,
+            primaryUsed: 20,
+            secondaryUsed: 30,
+            primaryReset: now.addingTimeInterval(60),
+            secondaryReset: now.addingTimeInterval(120))
+
+        #expect(BurnDownRefreshSchedule.nextRefresh(snapshot: snapshot, provider: .codex, now: now)
+            == now.addingTimeInterval(61))
+    }
+
+    @Test
+    func `burn down refresh ignores past resets and unrelated provider entries`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = Self.burnSnapshot(
+            provider: .claude,
+            primaryUsed: 20,
+            secondaryUsed: 30,
+            primaryReset: now.addingTimeInterval(-60),
+            secondaryReset: now.addingTimeInterval(-30))
+        let fallback = now.addingTimeInterval(30 * 60)
+
+        #expect(BurnDownRefreshSchedule.nextRefresh(snapshot: snapshot, provider: .claude, now: now) == fallback)
+        #expect(BurnDownRefreshSchedule.nextRefresh(snapshot: snapshot, provider: .codex, now: now) == fallback)
+    }
+
+    private static func burnSnapshot(
+        provider: UsageProvider,
+        primaryUsed: Double,
+        secondaryUsed: Double,
+        primaryReset: Date? = nil,
+        secondaryReset: Date? = nil) -> WidgetSnapshot
+    {
+        let entry = WidgetSnapshot.ProviderEntry(
+            provider: provider,
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            primary: RateWindow(
+                usedPercent: primaryUsed,
+                windowMinutes: 5 * 60,
+                resetsAt: primaryReset,
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: secondaryUsed,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: secondaryReset,
+                resetDescription: nil),
+            tertiary: nil,
+            creditsRemaining: nil,
+            codeReviewRemainingPercent: nil,
+            tokenUsage: nil,
+            dailyUsage: [])
+        return WidgetSnapshot(entries: [entry], generatedAt: entry.updatedAt)
     }
 }

--- a/WidgetExtension/CodexBarWidgetExtension.xcodeproj/project.pbxproj
+++ b/WidgetExtension/CodexBarWidgetExtension.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		7A3A654DC5A5B85C9C41EA02 /* CodexBarCore in Frameworks */ = {isa = PBXBuildFile; productRef = 140C60DAC1DE9A8AE19E58FE /* CodexBarCore */; };
 		7F0E34471853E41206F690FB /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 02F15F392AF9D502F0503F8F /* SwiftUI.framework */; };
 		882A41814588292DD631F525 /* CodexBarWidgetViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84672F595D2C0B83323E2C54 /* CodexBarWidgetViews.swift */; };
+		B2C3D4E5F6071829A3B4C5D6 /* BurnDownWidgetViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6071829A3B4C5D7 /* BurnDownWidgetViews.swift */; };
+		C3D4E5F607182930B4C5D6E7 /* CombinedBurnDownWidgetViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3D4E5F607182930B4C5D6E8 /* CombinedBurnDownWidgetViews.swift */; };
+		D4E5F60718293041C5D6E7F8 /* BurnDownWidgetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F60718293041C5D6E7F9 /* BurnDownWidgetProvider.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -20,6 +23,9 @@
 		50E5C7D39315A8DA5DC9D18A /* CodexBarWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexBarWidgetBundle.swift; sourceTree = "<group>"; };
 		549C61629C144C190B18EAD9 /* CodexBarWidgetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexBarWidgetProvider.swift; sourceTree = "<group>"; };
 		84672F595D2C0B83323E2C54 /* CodexBarWidgetViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexBarWidgetViews.swift; sourceTree = "<group>"; };
+		B2C3D4E5F6071829A3B4C5D7 /* BurnDownWidgetViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BurnDownWidgetViews.swift; sourceTree = "<group>"; };
+		C3D4E5F607182930B4C5D6E8 /* CombinedBurnDownWidgetViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombinedBurnDownWidgetViews.swift; sourceTree = "<group>"; };
+		D4E5F60718293041C5D6E7F9 /* BurnDownWidgetProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BurnDownWidgetProvider.swift; sourceTree = "<group>"; };
 		E430B27E4F28973A5E77EA3F /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
 		E7789C4095C40CF60759F2B7 /* CodexBarWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = CodexBarWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		EFBE36CB6481E7133E2A5CF3 /* CodexBar */ = {isa = PBXFileReference; lastKnownFileType = folder; name = CodexBar; path = ..; sourceTree = SOURCE_ROOT; };
@@ -63,6 +69,9 @@
 				50E5C7D39315A8DA5DC9D18A /* CodexBarWidgetBundle.swift */,
 				549C61629C144C190B18EAD9 /* CodexBarWidgetProvider.swift */,
 				84672F595D2C0B83323E2C54 /* CodexBarWidgetViews.swift */,
+				B2C3D4E5F6071829A3B4C5D7 /* BurnDownWidgetViews.swift */,
+				C3D4E5F607182930B4C5D6E8 /* CombinedBurnDownWidgetViews.swift */,
+				D4E5F60718293041C5D6E7F9 /* BurnDownWidgetProvider.swift */,
 			);
 			name = CodexBarWidget;
 			path = ../Sources/CodexBarWidget;
@@ -148,6 +157,9 @@
 				0972D036B563954337344F35 /* CodexBarWidgetBundle.swift in Sources */,
 				49DB3749D8E8748409CDC4FE /* CodexBarWidgetProvider.swift in Sources */,
 				882A41814588292DD631F525 /* CodexBarWidgetViews.swift in Sources */,
+				B2C3D4E5F6071829A3B4C5D6 /* BurnDownWidgetViews.swift in Sources */,
+				C3D4E5F607182930B4C5D6E7 /* CombinedBurnDownWidgetViews.swift in Sources */,
+				D4E5F60718293041C5D6E7F8 /* BurnDownWidgetProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -24,12 +24,16 @@ read_when:
 - **CodexBar Usage** (`CodexBarUsageWidget`): configurable provider usage widget, small/medium/large.
 - **CodexBar History** (`CodexBarHistoryWidget`): configurable usage-history chart, medium/large.
 - **CodexBar Metric** (`CodexBarCompactWidget`): compact credits/today-cost/30-day-cost widget, small only.
+- **CodexBar Burn Down** (`CodexBarBurnDownWidget`): configurable session or weekly burn-down chart, medium only.
+- **CodexBar Burn Down (Combined)** (`CodexBarCombinedBurnDownWidget`): session and weekly burn-down charts, medium only.
 
 ## Provider picker support
 The configurable provider widgets currently expose:
 Codex, Claude, Gemini, Alibaba, Antigravity, z.ai, Copilot, MiniMax, Kilo, OpenCode, and OpenCode Go.
 
 Providers without a `ProviderChoice` case can still be present in the app snapshot, but they are not selectable from the widget configuration UI yet.
+
+Burn-down widgets currently support Codex and Claude. Their dedicated configuration intents keep existing Usage and History widget configurations unchanged.
 
 ## Visibility troubleshooting (macOS 14+)
 When widgets do not appear in the gallery at all, the issue is almost always


### PR DESCRIPTION
Two new medium widgets plot a provider's remaining budget against the ideal steady-burn rate.

## Summary

- Add a medium single-window Burn Down widget and a combined 5h + 7d Burn Down widget.
- Use dedicated burn intents limited to Codex and Claude, so existing Usage/History configurations and the `WidgetSnapshot` schema stay unchanged.
- Model global weekly-cap blocking explicitly, so independent Gemini lanes cannot cap or retarget the primary lane.
- Use WidgetKit relative countdown text and refresh immediately after the earliest reset.
- Resolve session and weekly data by 5-hour/7-day cadence without falling back to another window.
- Treat expired explicit resets as stale and release session blocking after an expired weekly cap.
- Derive countdown and chart-axis dates from the same effective reset.

## Screenshots

These are visual references from the original contribution. The current exact rewrite preserves the widget layout but limits the Burn Down provider picker to Codex and Claude; the Gemini example in the combined image is not selectable in this candidate.

**Burn Down (single window)**

Selectable between the 5-hour session window and the 7-day weekly window. Shows remaining percentage, pace, a compact burn chart with ideal pace and projection, and the reset countdown.

<img width="355" height="165" alt="Single burn down widget" src="https://github.com/user-attachments/assets/6070208b-46d7-498d-aa6a-b050d01c0730" />

**Burn Down (5h + 7d)**

Stacks both windows in one medium tile so session and weekly pace stay visible together.

<img width="350" height="526" alt="Combined 5h and 7d burn down widget" src="https://github.com/user-attachments/assets/b6d1275e-db29-4066-9a2f-748f676f9b32" />

## Scope and credit

This is a narrow current-main rewrite of @jamesjlopez's original contribution. The rewritten commit preserves contributor co-authorship.

## Tests

- Exact head: `2fc6730ac9ba727ccaf0114a86154dd66fa632a0`.
- `swift test --filter CodexBarWidgetProviderTests` — green.
- `make check` — green.
- `make test` — all 41 shards green.
- Universal unsigned real WidgetExtension `xcodebuild` — success.
- Final whole-branch autoreview — clean (0.79).
