### PR TITLE
[security] fix(providers): reject sibling HTTP endpoint overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Cursor: present legacy request-based plans as one Requests quota with the raw used/limit count instead of unrelated token-based Auto/API bars (#1420, fixes #1418). Thanks @hhh2210!
 - Cost usage: memoize Codex priority-turn trace metadata incrementally so warm refreshes scan only appended rows instead of rescanning large trace databases (#1404). Thanks @ProspectOre!
 - Security: reject insecure or malformed MiniMax and Alibaba endpoint overrides while preserving valid custom HTTPS deployments (#1269). Thanks @Hinotoi-agent!
+- Security: reject insecure or malformed OpenRouter, Codebuff, Groq, and ElevenLabs endpoint overrides before sending provider credentials (#1256). Thanks @Hinotoi-agent!
 
 ## 0.33.0 — 2026-06-11
 

--- a/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
+++ b/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
@@ -61,6 +61,8 @@ struct ProviderEndpointOverrideValidator: Sendable {
         guard let decodedHost = url.host(percentEncoded: false)?.lowercased(),
               !decodedHost.isEmpty,
               !decodedHost.contains("%"),
+              decodedHost.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
+              decodedHost.rangeOfCharacter(from: .controlCharacters) == nil,
               let encodedHost = url.host(percentEncoded: true)?.lowercased(),
               Self.hostHasNoEncodedDelimiters(encodedHost, decodedHost: decodedHost, url: url)
         else { return nil }

--- a/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
+++ b/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
@@ -58,7 +58,12 @@ struct ProviderEndpointOverrideValidator: Sendable {
         guard let url else { return nil }
         guard let scheme = url.scheme?.lowercased(), scheme == "https" else { return nil }
         guard url.user == nil, url.password == nil else { return nil }
-        guard url.host(percentEncoded: false) != nil else { return nil }
+        guard let decodedHost = url.host(percentEncoded: false)?.lowercased(),
+              !decodedHost.isEmpty,
+              !decodedHost.contains("%"),
+              let encodedHost = url.host(percentEncoded: true)?.lowercased(),
+              Self.hostHasNoEncodedDelimiters(encodedHost, decodedHost: decodedHost, url: url)
+        else { return nil }
         return url
     }
 
@@ -102,7 +107,7 @@ struct ProviderEndpointOverrideValidator: Sendable {
               decodedHost.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
               decodedHost.rangeOfCharacter(from: .controlCharacters) == nil,
               let encodedHost = url.host(percentEncoded: true)?.lowercased(),
-              self.hostHasNoEncodedDelimiters(encodedHost, decodedHost: decodedHost, url: url)
+              Self.hostHasNoEncodedDelimiters(encodedHost, decodedHost: decodedHost, url: url)
         else { return nil }
 
         switch policy {
@@ -118,7 +123,7 @@ struct ProviderEndpointOverrideValidator: Sendable {
         }
     }
 
-    private func hostHasNoEncodedDelimiters(_ encodedHost: String, decodedHost: String, url: URL) -> Bool {
+    private static func hostHasNoEncodedDelimiters(_ encodedHost: String, decodedHost: String, url: URL) -> Bool {
         if decodedHost.contains(":") {
             guard encodedHost == decodedHost,
                   let componentHost = URLComponents(url: url, resolvingAgainstBaseURL: false)?.host,

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffProviderDescriptor.swift
@@ -80,14 +80,17 @@ struct CodebuffAPIFetchStrategy: ProviderFetchStrategy {
 }
 
 /// Errors related to Codebuff settings.
-public enum CodebuffSettingsError: LocalizedError, Sendable {
+public enum CodebuffSettingsError: LocalizedError, Sendable, Equatable {
     case missingToken
+    case invalidEndpointOverride(String)
 
     public var errorDescription: String? {
         switch self {
         case .missingToken:
             "Codebuff API token not configured. Set CODEBUFF_API_KEY or run `codebuff login` to " +
                 "populate ~/.config/manicode/credentials.json."
+        case let .invalidEndpointOverride(key):
+            "Codebuff endpoint override \(key) must use HTTPS or a bare host."
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift
@@ -13,12 +13,18 @@ public enum CodebuffSettingsReader {
 
     /// Returns the API base URL, defaulting to the production endpoint.
     public static func apiURL(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL {
-        if let override = environment["CODEBUFF_API_URL"],
-           let url = URL(string: cleaned(override) ?? "")
-        {
-            return url
+        if let override = self.validAPIURL(environment: environment) {
+            return override
         }
         return URL(string: "https://www.codebuff.com")!
+    }
+
+    public static func validateEndpointOverrides(
+        environment: [String: String] = ProcessInfo.processInfo.environment) throws
+    {
+        if self.hasExplicitNonHTTPSURL(environment["CODEBUFF_API_URL"]) {
+            throw CodebuffSettingsError.invalidEndpointOverride("CODEBUFF_API_URL")
+        }
     }
 
     /// Returns the auth token from the local credentials file if present.
@@ -59,6 +65,21 @@ public enum CodebuffSettingsReader {
 
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value
+    }
+
+    private static func validAPIURL(environment: [String: String]) -> URL? {
+        guard let raw = self.cleaned(environment["CODEBUFF_API_URL"]) else { return nil }
+        if let url = URL(string: raw), let scheme = url.scheme {
+            return scheme.lowercased() == "https" ? url : nil
+        }
+        return URL(string: "https://\(raw)")
+    }
+
+    private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
+        guard let cleaned = self.cleaned(raw),
+              let scheme = URL(string: cleaned)?.scheme
+        else { return false }
+        return scheme.lowercased() != "https"
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift
@@ -69,17 +69,25 @@ public enum CodebuffSettingsReader {
 
     private static func validAPIURL(environment: [String: String]) -> URL? {
         guard let raw = self.cleaned(environment["CODEBUFF_API_URL"]) else { return nil }
-        if let url = URL(string: raw), let scheme = url.scheme {
-            return scheme.lowercased() == "https" ? url : nil
+        if let scheme = self.explicitURLScheme(raw) {
+            return scheme == "https" ? URL(string: raw) : nil
         }
         return URL(string: "https://\(raw)")
     }
 
     private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
         guard let cleaned = self.cleaned(raw),
-              let scheme = URL(string: cleaned)?.scheme
+              let scheme = self.explicitURLScheme(cleaned)
         else { return false }
-        return scheme.lowercased() != "https"
+        return scheme != "https"
+    }
+
+    private static func explicitURLScheme(_ raw: String) -> String? {
+        guard let schemeSeparator = raw.range(
+            of: #"^[A-Za-z][A-Za-z0-9+.-]*://"#,
+            options: .regularExpression)
+        else { return nil }
+        return raw[..<schemeSeparator.upperBound].dropLast(3).lowercased()
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift
@@ -22,9 +22,9 @@ public enum CodebuffSettingsReader {
     public static func validateEndpointOverrides(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        if self.hasExplicitNonHTTPSURL(environment["CODEBUFF_API_URL"]) {
-            throw CodebuffSettingsError.invalidEndpointOverride("CODEBUFF_API_URL")
-        }
+        guard let raw = self.cleaned(environment["CODEBUFF_API_URL"]) else { return }
+        guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil else { return }
+        throw CodebuffSettingsError.invalidEndpointOverride("CODEBUFF_API_URL")
     }
 
     /// Returns the auth token from the local credentials file if present.
@@ -69,25 +69,7 @@ public enum CodebuffSettingsReader {
 
     private static func validAPIURL(environment: [String: String]) -> URL? {
         guard let raw = self.cleaned(environment["CODEBUFF_API_URL"]) else { return nil }
-        if let scheme = self.explicitURLScheme(raw) {
-            return scheme == "https" ? URL(string: raw) : nil
-        }
-        return URL(string: "https://\(raw)")
-    }
-
-    private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
-        guard let cleaned = self.cleaned(raw),
-              let scheme = self.explicitURLScheme(cleaned)
-        else { return false }
-        return scheme != "https"
-    }
-
-    private static func explicitURLScheme(_ raw: String) -> String? {
-        guard let schemeSeparator = raw.range(
-            of: #"^[A-Za-z][A-Za-z0-9+.-]*://"#,
-            options: .regularExpression)
-        else { return nil }
-        return raw[..<schemeSeparator.upperBound].dropLast(3).lowercased()
+        return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
@@ -23,6 +23,7 @@ public enum CodebuffUsageFetcher {
         guard !trimmed.isEmpty else {
             throw CodebuffUsageError.missingCredentials
         }
+        try CodebuffSettingsReader.validateEndpointOverrides(environment: environment)
 
         let baseURL = CodebuffSettingsReader.apiURL(environment: environment)
 

--- a/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsSettingsReader.swift
@@ -46,17 +46,25 @@ public enum ElevenLabsSettingsReader {
 
     private static func validAPIURL(environment: [String: String]) -> URL? {
         guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
-        if let url = URL(string: raw), let scheme = url.scheme {
-            return scheme.lowercased() == "https" ? url : nil
+        if let scheme = self.explicitURLScheme(raw) {
+            return scheme == "https" ? URL(string: raw) : nil
         }
         return URL(string: "https://\(raw)")
     }
 
     private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
         guard let cleaned = self.cleaned(raw),
-              let scheme = URL(string: cleaned)?.scheme
+              let scheme = self.explicitURLScheme(cleaned)
         else { return false }
-        return scheme.lowercased() != "https"
+        return scheme != "https"
+    }
+
+    private static func explicitURLScheme(_ raw: String) -> String? {
+        guard let schemeSeparator = raw.range(
+            of: #"^[A-Za-z][A-Za-z0-9+.-]*://"#,
+            options: .regularExpression)
+        else { return nil }
+        return raw[..<schemeSeparator.upperBound].dropLast(3).lowercased()
     }
 }
 
@@ -66,7 +74,7 @@ public enum ElevenLabsSettingsError: LocalizedError, Sendable, Equatable {
     public var errorDescription: String? {
         switch self {
         case let .invalidEndpointOverride(key):
-            return "ElevenLabs endpoint override \(key) must use HTTPS or a bare host."
+            "ElevenLabs endpoint override \(key) must use HTTPS or a bare host."
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsSettingsReader.swift
@@ -17,12 +17,18 @@ public enum ElevenLabsSettingsReader {
     }
 
     public static func apiURL(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL {
-        if let override = self.cleaned(environment[self.apiURLEnvironmentKey]),
-           let url = URL(string: override)
-        {
-            return url
+        if let override = self.validAPIURL(environment: environment) {
+            return override
         }
         return URL(string: "https://api.elevenlabs.io")!
+    }
+
+    public static func validateEndpointOverrides(
+        environment: [String: String] = ProcessInfo.processInfo.environment) throws
+    {
+        if self.hasExplicitNonHTTPSURL(environment[self.apiURLEnvironmentKey]) {
+            throw ElevenLabsSettingsError.invalidEndpointOverride(self.apiURLEnvironmentKey)
+        }
     }
 
     static func cleaned(_ raw: String?) -> String? {
@@ -36,5 +42,31 @@ public enum ElevenLabsSettingsReader {
         }
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value
+    }
+
+    private static func validAPIURL(environment: [String: String]) -> URL? {
+        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
+        if let url = URL(string: raw), let scheme = url.scheme {
+            return scheme.lowercased() == "https" ? url : nil
+        }
+        return URL(string: "https://\(raw)")
+    }
+
+    private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
+        guard let cleaned = self.cleaned(raw),
+              let scheme = URL(string: cleaned)?.scheme
+        else { return false }
+        return scheme.lowercased() != "https"
+    }
+}
+
+public enum ElevenLabsSettingsError: LocalizedError, Sendable, Equatable {
+    case invalidEndpointOverride(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .invalidEndpointOverride(key):
+            return "ElevenLabs endpoint override \(key) must use HTTPS or a bare host."
+        }
     }
 }

--- a/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsSettingsReader.swift
@@ -26,9 +26,9 @@ public enum ElevenLabsSettingsReader {
     public static func validateEndpointOverrides(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        if self.hasExplicitNonHTTPSURL(environment[self.apiURLEnvironmentKey]) {
-            throw ElevenLabsSettingsError.invalidEndpointOverride(self.apiURLEnvironmentKey)
-        }
+        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
+        guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil else { return }
+        throw ElevenLabsSettingsError.invalidEndpointOverride(self.apiURLEnvironmentKey)
     }
 
     static func cleaned(_ raw: String?) -> String? {
@@ -46,25 +46,7 @@ public enum ElevenLabsSettingsReader {
 
     private static func validAPIURL(environment: [String: String]) -> URL? {
         guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
-        if let scheme = self.explicitURLScheme(raw) {
-            return scheme == "https" ? URL(string: raw) : nil
-        }
-        return URL(string: "https://\(raw)")
-    }
-
-    private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
-        guard let cleaned = self.cleaned(raw),
-              let scheme = self.explicitURLScheme(cleaned)
-        else { return false }
-        return scheme != "https"
-    }
-
-    private static func explicitURLScheme(_ raw: String) -> String? {
-        guard let schemeSeparator = raw.range(
-            of: #"^[A-Za-z][A-Za-z0-9+.-]*://"#,
-            options: .regularExpression)
-        else { return nil }
-        return raw[..<schemeSeparator.upperBound].dropLast(3).lowercased()
+        return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsUsageFetcher.swift
@@ -188,6 +188,7 @@ public struct ElevenLabsUsageFetcher: Sendable {
         guard !trimmed.isEmpty else {
             throw ElevenLabsUsageError.missingCredentials
         }
+        try ElevenLabsSettingsReader.validateEndpointOverrides(environment: environment)
 
         let url = Self.subscriptionURL(baseURL: ElevenLabsSettingsReader.apiURL(environment: environment))
         var request = URLRequest(url: url)

--- a/Sources/CodexBarCore/Providers/Groq/GroqSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Groq/GroqSettingsReader.swift
@@ -22,9 +22,9 @@ public enum GroqSettingsReader {
     public static func validateEndpointOverrides(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        if self.hasExplicitNonHTTPSURL(environment[self.apiURLEnvironmentKey]) {
-            throw GroqSettingsError.invalidEndpointOverride(self.apiURLEnvironmentKey)
-        }
+        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return }
+        guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil else { return }
+        throw GroqSettingsError.invalidEndpointOverride(self.apiURLEnvironmentKey)
     }
 
     static func cleaned(_ raw: String?) -> String? {
@@ -42,25 +42,7 @@ public enum GroqSettingsReader {
 
     private static func validAPIURL(environment: [String: String]) -> URL? {
         guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
-        if let scheme = self.explicitURLScheme(raw) {
-            return scheme == "https" ? URL(string: raw) : nil
-        }
-        return URL(string: "https://\(raw)")
-    }
-
-    private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
-        guard let cleaned = self.cleaned(raw),
-              let scheme = self.explicitURLScheme(cleaned)
-        else { return false }
-        return scheme != "https"
-    }
-
-    private static func explicitURLScheme(_ raw: String) -> String? {
-        guard let schemeSeparator = raw.range(
-            of: #"^[A-Za-z][A-Za-z0-9+.-]*://"#,
-            options: .regularExpression)
-        else { return nil }
-        return raw[..<schemeSeparator.upperBound].dropLast(3).lowercased()
+        return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Groq/GroqSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Groq/GroqSettingsReader.swift
@@ -13,12 +13,18 @@ public enum GroqSettingsReader {
     public static func apiURL(
         environment: [String: String] = ProcessInfo.processInfo.environment) -> URL
     {
-        if let raw = self.cleaned(environment[self.apiURLEnvironmentKey]),
-           let url = URL(string: raw)
-        {
-            return url
+        if let override = self.validAPIURL(environment: environment) {
+            return override
         }
         return URL(string: "https://api.groq.com/v1")!
+    }
+
+    public static func validateEndpointOverrides(
+        environment: [String: String] = ProcessInfo.processInfo.environment) throws
+    {
+        if self.hasExplicitNonHTTPSURL(environment[self.apiURLEnvironmentKey]) {
+            throw GroqSettingsError.invalidEndpointOverride(self.apiURLEnvironmentKey)
+        }
     }
 
     static func cleaned(_ raw: String?) -> String? {
@@ -32,5 +38,31 @@ public enum GroqSettingsReader {
         }
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value
+    }
+
+    private static func validAPIURL(environment: [String: String]) -> URL? {
+        guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
+        if let url = URL(string: raw), let scheme = url.scheme {
+            return scheme.lowercased() == "https" ? url : nil
+        }
+        return URL(string: "https://\(raw)")
+    }
+
+    private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
+        guard let cleaned = self.cleaned(raw),
+              let scheme = URL(string: cleaned)?.scheme
+        else { return false }
+        return scheme.lowercased() != "https"
+    }
+}
+
+public enum GroqSettingsError: LocalizedError, Sendable, Equatable {
+    case invalidEndpointOverride(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .invalidEndpointOverride(key):
+            return "Groq endpoint override \(key) must use HTTPS or a bare host."
+        }
     }
 }

--- a/Sources/CodexBarCore/Providers/Groq/GroqSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Groq/GroqSettingsReader.swift
@@ -42,17 +42,25 @@ public enum GroqSettingsReader {
 
     private static func validAPIURL(environment: [String: String]) -> URL? {
         guard let raw = self.cleaned(environment[self.apiURLEnvironmentKey]) else { return nil }
-        if let url = URL(string: raw), let scheme = url.scheme {
-            return scheme.lowercased() == "https" ? url : nil
+        if let scheme = self.explicitURLScheme(raw) {
+            return scheme == "https" ? URL(string: raw) : nil
         }
         return URL(string: "https://\(raw)")
     }
 
     private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
         guard let cleaned = self.cleaned(raw),
-              let scheme = URL(string: cleaned)?.scheme
+              let scheme = self.explicitURLScheme(cleaned)
         else { return false }
-        return scheme.lowercased() != "https"
+        return scheme != "https"
+    }
+
+    private static func explicitURLScheme(_ raw: String) -> String? {
+        guard let schemeSeparator = raw.range(
+            of: #"^[A-Za-z][A-Za-z0-9+.-]*://"#,
+            options: .regularExpression)
+        else { return nil }
+        return raw[..<schemeSeparator.upperBound].dropLast(3).lowercased()
     }
 }
 
@@ -62,7 +70,7 @@ public enum GroqSettingsError: LocalizedError, Sendable, Equatable {
     public var errorDescription: String? {
         switch self {
         case let .invalidEndpointOverride(key):
-            return "Groq endpoint override \(key) must use HTTPS or a bare host."
+            "Groq endpoint override \(key) must use HTTPS or a bare host."
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Groq/GroqUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Groq/GroqUsageFetcher.swift
@@ -144,6 +144,7 @@ public struct GroqUsageFetcher: Sendable {
         guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw GroqUsageError.missingCredentials
         }
+        try GroqSettingsReader.validateEndpointOverrides(environment: environment)
         let baseURL = GroqSettingsReader.apiURL(environment: environment)
             .appendingPathComponent("metrics")
             .appendingPathComponent("prometheus")

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterProviderDescriptor.swift
@@ -71,13 +71,16 @@ struct OpenRouterAPIFetchStrategy: ProviderFetchStrategy {
 }
 
 /// Errors related to OpenRouter settings
-public enum OpenRouterSettingsError: LocalizedError, Sendable {
+public enum OpenRouterSettingsError: LocalizedError, Sendable, Equatable {
     case missingToken
+    case invalidEndpointOverride(String)
 
     public var errorDescription: String? {
         switch self {
         case .missingToken:
             "OpenRouter API token not configured. Set OPENROUTER_API_KEY environment variable or configure in Settings."
+        case let .invalidEndpointOverride(key):
+            "OpenRouter endpoint override \(key) must use HTTPS or a bare host."
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterSettingsReader.swift
@@ -21,9 +21,9 @@ public enum OpenRouterSettingsReader {
     public static func validateEndpointOverrides(
         environment: [String: String] = ProcessInfo.processInfo.environment) throws
     {
-        if self.hasExplicitNonHTTPSURL(environment["OPENROUTER_API_URL"]) {
-            throw OpenRouterSettingsError.invalidEndpointOverride("OPENROUTER_API_URL")
-        }
+        guard let raw = self.cleaned(environment["OPENROUTER_API_URL"]) else { return }
+        guard ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw) == nil else { return }
+        throw OpenRouterSettingsError.invalidEndpointOverride("OPENROUTER_API_URL")
     }
 
     static func cleaned(_ raw: String?) -> String? {
@@ -43,24 +43,6 @@ public enum OpenRouterSettingsReader {
 
     private static func validAPIURL(environment: [String: String]) -> URL? {
         guard let raw = self.cleaned(environment["OPENROUTER_API_URL"]) else { return nil }
-        if let scheme = self.explicitURLScheme(raw) {
-            return scheme == "https" ? URL(string: raw) : nil
-        }
-        return URL(string: "https://\(raw)")
-    }
-
-    private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
-        guard let cleaned = self.cleaned(raw),
-              let scheme = self.explicitURLScheme(cleaned)
-        else { return false }
-        return scheme != "https"
-    }
-
-    private static func explicitURLScheme(_ raw: String) -> String? {
-        guard let schemeSeparator = raw.range(
-            of: #"^[A-Za-z][A-Za-z0-9+.-]*://"#,
-            options: .regularExpression)
-        else { return nil }
-        return raw[..<schemeSeparator.upperBound].dropLast(3).lowercased()
+        return ProviderEndpointOverrideValidator.normalizedHTTPSURL(from: raw)
     }
 }

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterSettingsReader.swift
@@ -43,18 +43,24 @@ public enum OpenRouterSettingsReader {
 
     private static func validAPIURL(environment: [String: String]) -> URL? {
         guard let raw = self.cleaned(environment["OPENROUTER_API_URL"]) else { return nil }
-        if let url = URL(string: raw), let scheme = url.scheme {
-            return scheme.lowercased() == "https" ? url : nil
+        if let scheme = self.explicitURLScheme(raw) {
+            return scheme == "https" ? URL(string: raw) : nil
         }
         return URL(string: "https://\(raw)")
     }
 
     private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
         guard let cleaned = self.cleaned(raw),
-              let scheme = URL(string: cleaned)?.scheme
+              let scheme = self.explicitURLScheme(cleaned)
         else { return false }
-        return scheme.lowercased() != "https"
+        return scheme != "https"
+    }
+
+    private static func explicitURLScheme(_ raw: String) -> String? {
+        guard let schemeSeparator = raw.range(
+            of: #"^[A-Za-z][A-Za-z0-9+.-]*://"#,
+            options: .regularExpression)
+        else { return nil }
+        return raw[..<schemeSeparator.upperBound].dropLast(3).lowercased()
     }
 }
-
-

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterSettingsReader.swift
@@ -12,12 +12,18 @@ public enum OpenRouterSettingsReader {
 
     /// Returns the API URL, defaulting to production endpoint
     public static func apiURL(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL {
-        if let override = environment["OPENROUTER_API_URL"],
-           let url = URL(string: cleaned(override) ?? "")
-        {
-            return url
+        if let override = self.validAPIURL(environment: environment) {
+            return override
         }
         return URL(string: "https://openrouter.ai/api/v1")!
+    }
+
+    public static func validateEndpointOverrides(
+        environment: [String: String] = ProcessInfo.processInfo.environment) throws
+    {
+        if self.hasExplicitNonHTTPSURL(environment["OPENROUTER_API_URL"]) {
+            throw OpenRouterSettingsError.invalidEndpointOverride("OPENROUTER_API_URL")
+        }
     }
 
     static func cleaned(_ raw: String?) -> String? {
@@ -34,4 +40,21 @@ public enum OpenRouterSettingsReader {
         value = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return value.isEmpty ? nil : value
     }
+
+    private static func validAPIURL(environment: [String: String]) -> URL? {
+        guard let raw = self.cleaned(environment["OPENROUTER_API_URL"]) else { return nil }
+        if let url = URL(string: raw), let scheme = url.scheme {
+            return scheme.lowercased() == "https" ? url : nil
+        }
+        return URL(string: "https://\(raw)")
+    }
+
+    private static func hasExplicitNonHTTPSURL(_ raw: String?) -> Bool {
+        guard let cleaned = self.cleaned(raw),
+              let scheme = URL(string: cleaned)?.scheme
+        else { return false }
+        return scheme.lowercased() != "https"
+    }
 }
+
+

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterUsageStats.swift
@@ -225,6 +225,7 @@ public struct OpenRouterUsageFetcher: Sendable {
         guard !apiKey.isEmpty else {
             throw OpenRouterUsageError.invalidCredentials
         }
+        try OpenRouterSettingsReader.validateEndpointOverrides(environment: environment)
 
         let baseURL = OpenRouterSettingsReader.apiURL(environment: environment)
         let creditsURL = baseURL.appendingPathComponent("credits")

--- a/Tests/CodexBarTests/ProviderEndpointOverrideSecurityTests.swift
+++ b/Tests/CodexBarTests/ProviderEndpointOverrideSecurityTests.swift
@@ -4,6 +4,31 @@ import Testing
 
 struct ProviderEndpointOverrideSecurityTests {
     @Test
+    func `sibling endpoint overrides allow bracketed IPv6 literals`() throws {
+        let endpoint = "https://[::1]:8443/v1"
+
+        try OpenRouterSettingsReader.validateEndpointOverrides(
+            environment: ["OPENROUTER_API_URL": endpoint])
+        #expect(OpenRouterSettingsReader.apiURL(
+            environment: ["OPENROUTER_API_URL": endpoint]).absoluteString == endpoint)
+
+        try CodebuffSettingsReader.validateEndpointOverrides(
+            environment: ["CODEBUFF_API_URL": endpoint])
+        #expect(CodebuffSettingsReader.apiURL(
+            environment: ["CODEBUFF_API_URL": endpoint]).absoluteString == endpoint)
+
+        try GroqSettingsReader.validateEndpointOverrides(
+            environment: [GroqSettingsReader.apiURLEnvironmentKey: endpoint])
+        #expect(GroqSettingsReader.apiURL(
+            environment: [GroqSettingsReader.apiURLEnvironmentKey: endpoint]).absoluteString == endpoint)
+
+        try ElevenLabsSettingsReader.validateEndpointOverrides(
+            environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: endpoint])
+        #expect(ElevenLabsSettingsReader.apiURL(
+            environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: endpoint]).absoluteString == endpoint)
+    }
+
+    @Test
     func `sibling endpoint overrides reject userinfo and encoded host delimiters`() {
         let userInfoURL = "https://user:pass@proxy.test/v1"
         let malformedHostURLs = [

--- a/Tests/CodexBarTests/ProviderEndpointOverrideSecurityTests.swift
+++ b/Tests/CodexBarTests/ProviderEndpointOverrideSecurityTests.swift
@@ -5,12 +5,24 @@ import Testing
 struct ProviderEndpointOverrideSecurityTests {
     @Test
     func `OpenRouter endpoint override must be HTTPS or a bare host`() throws {
-        #expect(OpenRouterSettingsReader.apiURL(environment: ["OPENROUTER_API_URL": "https://router.test/v1"]).absoluteString == "https://router.test/v1")
-        #expect(OpenRouterSettingsReader.apiURL(environment: ["OPENROUTER_API_URL": "router.test/v1"]).absoluteString == "https://router.test/v1")
-        #expect(OpenRouterSettingsReader.apiURL(environment: ["OPENROUTER_API_URL": "http://attacker.test/v1"]).absoluteString == "https://openrouter.ai/api/v1")
+        let httpsURL = OpenRouterSettingsReader.apiURL(
+            environment: ["OPENROUTER_API_URL": "https://router.test/v1"])
+        #expect(httpsURL.absoluteString == "https://router.test/v1")
+
+        let bareURL = OpenRouterSettingsReader.apiURL(environment: ["OPENROUTER_API_URL": "router.test/v1"])
+        #expect(bareURL.absoluteString == "https://router.test/v1")
+
+        let hostPortURL = OpenRouterSettingsReader.apiURL(
+            environment: ["OPENROUTER_API_URL": "localhost:8080/v1"])
+        #expect(hostPortURL.absoluteString == "https://localhost:8080/v1")
+
+        let httpURL = OpenRouterSettingsReader.apiURL(
+            environment: ["OPENROUTER_API_URL": "http://attacker.test/v1"])
+        #expect(httpURL.absoluteString == "https://openrouter.ai/api/v1")
 
         do {
-            try OpenRouterSettingsReader.validateEndpointOverrides(environment: ["OPENROUTER_API_URL": "http://attacker.test/v1"])
+            try OpenRouterSettingsReader.validateEndpointOverrides(
+                environment: ["OPENROUTER_API_URL": "http://attacker.test/v1"])
             Issue.record("Expected OpenRouterSettingsError.invalidEndpointOverride")
         } catch OpenRouterSettingsError.invalidEndpointOverride("OPENROUTER_API_URL") {
             // Expected.
@@ -21,12 +33,21 @@ struct ProviderEndpointOverrideSecurityTests {
 
     @Test
     func `Codebuff endpoint override must be HTTPS or a bare host`() throws {
-        #expect(CodebuffSettingsReader.apiURL(environment: ["CODEBUFF_API_URL": "https://codebuff.test"]).absoluteString == "https://codebuff.test")
-        #expect(CodebuffSettingsReader.apiURL(environment: ["CODEBUFF_API_URL": "codebuff.test"]).absoluteString == "https://codebuff.test")
-        #expect(CodebuffSettingsReader.apiURL(environment: ["CODEBUFF_API_URL": "http://attacker.test"]).absoluteString == "https://www.codebuff.com")
+        let httpsURL = CodebuffSettingsReader.apiURL(environment: ["CODEBUFF_API_URL": "https://codebuff.test"])
+        #expect(httpsURL.absoluteString == "https://codebuff.test")
+
+        let bareURL = CodebuffSettingsReader.apiURL(environment: ["CODEBUFF_API_URL": "codebuff.test"])
+        #expect(bareURL.absoluteString == "https://codebuff.test")
+
+        let hostPortURL = CodebuffSettingsReader.apiURL(environment: ["CODEBUFF_API_URL": "localhost:8080"])
+        #expect(hostPortURL.absoluteString == "https://localhost:8080")
+
+        let httpURL = CodebuffSettingsReader.apiURL(environment: ["CODEBUFF_API_URL": "http://attacker.test"])
+        #expect(httpURL.absoluteString == "https://www.codebuff.com")
 
         do {
-            try CodebuffSettingsReader.validateEndpointOverrides(environment: ["CODEBUFF_API_URL": "http://attacker.test"])
+            try CodebuffSettingsReader.validateEndpointOverrides(
+                environment: ["CODEBUFF_API_URL": "http://attacker.test"])
             Issue.record("Expected CodebuffSettingsError.invalidEndpointOverride")
         } catch CodebuffSettingsError.invalidEndpointOverride("CODEBUFF_API_URL") {
             // Expected.
@@ -37,12 +58,25 @@ struct ProviderEndpointOverrideSecurityTests {
 
     @Test
     func `Groq endpoint override must be HTTPS or a bare host`() throws {
-        #expect(GroqSettingsReader.apiURL(environment: [GroqSettingsReader.apiURLEnvironmentKey: "https://groq.test/v1"]).absoluteString == "https://groq.test/v1")
-        #expect(GroqSettingsReader.apiURL(environment: [GroqSettingsReader.apiURLEnvironmentKey: "groq.test/v1"]).absoluteString == "https://groq.test/v1")
-        #expect(GroqSettingsReader.apiURL(environment: [GroqSettingsReader.apiURLEnvironmentKey: "http://attacker.test/v1"]).absoluteString == "https://api.groq.com/v1")
+        let httpsURL = GroqSettingsReader.apiURL(
+            environment: [GroqSettingsReader.apiURLEnvironmentKey: "https://groq.test/v1"])
+        #expect(httpsURL.absoluteString == "https://groq.test/v1")
+
+        let bareURL = GroqSettingsReader.apiURL(
+            environment: [GroqSettingsReader.apiURLEnvironmentKey: "groq.test/v1"])
+        #expect(bareURL.absoluteString == "https://groq.test/v1")
+
+        let hostPortURL = GroqSettingsReader.apiURL(
+            environment: [GroqSettingsReader.apiURLEnvironmentKey: "localhost:8080/v1"])
+        #expect(hostPortURL.absoluteString == "https://localhost:8080/v1")
+
+        let httpURL = GroqSettingsReader.apiURL(
+            environment: [GroqSettingsReader.apiURLEnvironmentKey: "http://attacker.test/v1"])
+        #expect(httpURL.absoluteString == "https://api.groq.com/v1")
 
         do {
-            try GroqSettingsReader.validateEndpointOverrides(environment: [GroqSettingsReader.apiURLEnvironmentKey: "http://attacker.test/v1"])
+            try GroqSettingsReader.validateEndpointOverrides(
+                environment: [GroqSettingsReader.apiURLEnvironmentKey: "http://attacker.test/v1"])
             Issue.record("Expected GroqSettingsError.invalidEndpointOverride")
         } catch GroqSettingsError.invalidEndpointOverride(GroqSettingsReader.apiURLEnvironmentKey) {
             // Expected.
@@ -53,12 +87,25 @@ struct ProviderEndpointOverrideSecurityTests {
 
     @Test
     func `ElevenLabs endpoint override must be HTTPS or a bare host`() throws {
-        #expect(ElevenLabsSettingsReader.apiURL(environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: "https://eleven.test"]).absoluteString == "https://eleven.test")
-        #expect(ElevenLabsSettingsReader.apiURL(environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: "eleven.test"]).absoluteString == "https://eleven.test")
-        #expect(ElevenLabsSettingsReader.apiURL(environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: "http://attacker.test"]).absoluteString == "https://api.elevenlabs.io")
+        let httpsURL = ElevenLabsSettingsReader.apiURL(
+            environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: "https://eleven.test"])
+        #expect(httpsURL.absoluteString == "https://eleven.test")
+
+        let bareURL = ElevenLabsSettingsReader.apiURL(
+            environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: "eleven.test"])
+        #expect(bareURL.absoluteString == "https://eleven.test")
+
+        let hostPortURL = ElevenLabsSettingsReader.apiURL(
+            environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: "localhost:8080"])
+        #expect(hostPortURL.absoluteString == "https://localhost:8080")
+
+        let httpURL = ElevenLabsSettingsReader.apiURL(
+            environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: "http://attacker.test"])
+        #expect(httpURL.absoluteString == "https://api.elevenlabs.io")
 
         do {
-            try ElevenLabsSettingsReader.validateEndpointOverrides(environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: "http://attacker.test"])
+            try ElevenLabsSettingsReader.validateEndpointOverrides(
+                environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: "http://attacker.test"])
             Issue.record("Expected ElevenLabsSettingsError.invalidEndpointOverride")
         } catch ElevenLabsSettingsError.invalidEndpointOverride(ElevenLabsSettingsReader.apiURLEnvironmentKey) {
             // Expected.

--- a/Tests/CodexBarTests/ProviderEndpointOverrideSecurityTests.swift
+++ b/Tests/CodexBarTests/ProviderEndpointOverrideSecurityTests.swift
@@ -4,6 +4,42 @@ import Testing
 
 struct ProviderEndpointOverrideSecurityTests {
     @Test
+    func `sibling endpoint overrides reject userinfo and encoded host delimiters`() {
+        let userInfoURL = "https://user:pass@proxy.test/v1"
+        let encodedHostURL = "https://proxy.test%2f.attacker.test/v1"
+
+        #expect(OpenRouterSettingsReader.apiURL(
+            environment: ["OPENROUTER_API_URL": userInfoURL]).host == "openrouter.ai")
+        #expect(throws: OpenRouterSettingsError.invalidEndpointOverride("OPENROUTER_API_URL")) {
+            try OpenRouterSettingsReader.validateEndpointOverrides(
+                environment: ["OPENROUTER_API_URL": encodedHostURL])
+        }
+
+        #expect(CodebuffSettingsReader.apiURL(
+            environment: ["CODEBUFF_API_URL": userInfoURL]).host == "www.codebuff.com")
+        #expect(throws: CodebuffSettingsError.invalidEndpointOverride("CODEBUFF_API_URL")) {
+            try CodebuffSettingsReader.validateEndpointOverrides(
+                environment: ["CODEBUFF_API_URL": encodedHostURL])
+        }
+
+        #expect(GroqSettingsReader.apiURL(
+            environment: [GroqSettingsReader.apiURLEnvironmentKey: userInfoURL]).host == "api.groq.com")
+        #expect(throws: GroqSettingsError.invalidEndpointOverride(GroqSettingsReader.apiURLEnvironmentKey)) {
+            try GroqSettingsReader.validateEndpointOverrides(
+                environment: [GroqSettingsReader.apiURLEnvironmentKey: encodedHostURL])
+        }
+
+        #expect(ElevenLabsSettingsReader.apiURL(
+            environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: userInfoURL]).host == "api.elevenlabs.io")
+        #expect(throws: ElevenLabsSettingsError.invalidEndpointOverride(
+            ElevenLabsSettingsReader.apiURLEnvironmentKey))
+        {
+            try ElevenLabsSettingsReader.validateEndpointOverrides(
+                environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: encodedHostURL])
+        }
+    }
+
+    @Test
     func `OpenRouter endpoint override must be HTTPS or a bare host`() throws {
         let httpsURL = OpenRouterSettingsReader.apiURL(
             environment: ["OPENROUTER_API_URL": "https://router.test/v1"])

--- a/Tests/CodexBarTests/ProviderEndpointOverrideSecurityTests.swift
+++ b/Tests/CodexBarTests/ProviderEndpointOverrideSecurityTests.swift
@@ -1,0 +1,69 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct ProviderEndpointOverrideSecurityTests {
+    @Test
+    func `OpenRouter endpoint override must be HTTPS or a bare host`() throws {
+        #expect(OpenRouterSettingsReader.apiURL(environment: ["OPENROUTER_API_URL": "https://router.test/v1"]).absoluteString == "https://router.test/v1")
+        #expect(OpenRouterSettingsReader.apiURL(environment: ["OPENROUTER_API_URL": "router.test/v1"]).absoluteString == "https://router.test/v1")
+        #expect(OpenRouterSettingsReader.apiURL(environment: ["OPENROUTER_API_URL": "http://attacker.test/v1"]).absoluteString == "https://openrouter.ai/api/v1")
+
+        do {
+            try OpenRouterSettingsReader.validateEndpointOverrides(environment: ["OPENROUTER_API_URL": "http://attacker.test/v1"])
+            Issue.record("Expected OpenRouterSettingsError.invalidEndpointOverride")
+        } catch OpenRouterSettingsError.invalidEndpointOverride("OPENROUTER_API_URL") {
+            // Expected.
+        } catch {
+            Issue.record("Expected OpenRouterSettingsError.invalidEndpointOverride, got \(error)")
+        }
+    }
+
+    @Test
+    func `Codebuff endpoint override must be HTTPS or a bare host`() throws {
+        #expect(CodebuffSettingsReader.apiURL(environment: ["CODEBUFF_API_URL": "https://codebuff.test"]).absoluteString == "https://codebuff.test")
+        #expect(CodebuffSettingsReader.apiURL(environment: ["CODEBUFF_API_URL": "codebuff.test"]).absoluteString == "https://codebuff.test")
+        #expect(CodebuffSettingsReader.apiURL(environment: ["CODEBUFF_API_URL": "http://attacker.test"]).absoluteString == "https://www.codebuff.com")
+
+        do {
+            try CodebuffSettingsReader.validateEndpointOverrides(environment: ["CODEBUFF_API_URL": "http://attacker.test"])
+            Issue.record("Expected CodebuffSettingsError.invalidEndpointOverride")
+        } catch CodebuffSettingsError.invalidEndpointOverride("CODEBUFF_API_URL") {
+            // Expected.
+        } catch {
+            Issue.record("Expected CodebuffSettingsError.invalidEndpointOverride, got \(error)")
+        }
+    }
+
+    @Test
+    func `Groq endpoint override must be HTTPS or a bare host`() throws {
+        #expect(GroqSettingsReader.apiURL(environment: [GroqSettingsReader.apiURLEnvironmentKey: "https://groq.test/v1"]).absoluteString == "https://groq.test/v1")
+        #expect(GroqSettingsReader.apiURL(environment: [GroqSettingsReader.apiURLEnvironmentKey: "groq.test/v1"]).absoluteString == "https://groq.test/v1")
+        #expect(GroqSettingsReader.apiURL(environment: [GroqSettingsReader.apiURLEnvironmentKey: "http://attacker.test/v1"]).absoluteString == "https://api.groq.com/v1")
+
+        do {
+            try GroqSettingsReader.validateEndpointOverrides(environment: [GroqSettingsReader.apiURLEnvironmentKey: "http://attacker.test/v1"])
+            Issue.record("Expected GroqSettingsError.invalidEndpointOverride")
+        } catch GroqSettingsError.invalidEndpointOverride(GroqSettingsReader.apiURLEnvironmentKey) {
+            // Expected.
+        } catch {
+            Issue.record("Expected GroqSettingsError.invalidEndpointOverride, got \(error)")
+        }
+    }
+
+    @Test
+    func `ElevenLabs endpoint override must be HTTPS or a bare host`() throws {
+        #expect(ElevenLabsSettingsReader.apiURL(environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: "https://eleven.test"]).absoluteString == "https://eleven.test")
+        #expect(ElevenLabsSettingsReader.apiURL(environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: "eleven.test"]).absoluteString == "https://eleven.test")
+        #expect(ElevenLabsSettingsReader.apiURL(environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: "http://attacker.test"]).absoluteString == "https://api.elevenlabs.io")
+
+        do {
+            try ElevenLabsSettingsReader.validateEndpointOverrides(environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: "http://attacker.test"])
+            Issue.record("Expected ElevenLabsSettingsError.invalidEndpointOverride")
+        } catch ElevenLabsSettingsError.invalidEndpointOverride(ElevenLabsSettingsReader.apiURLEnvironmentKey) {
+            // Expected.
+        } catch {
+            Issue.record("Expected ElevenLabsSettingsError.invalidEndpointOverride, got \(error)")
+        }
+    }
+}

--- a/Tests/CodexBarTests/ProviderEndpointOverrideSecurityTests.swift
+++ b/Tests/CodexBarTests/ProviderEndpointOverrideSecurityTests.swift
@@ -6,36 +6,91 @@ struct ProviderEndpointOverrideSecurityTests {
     @Test
     func `sibling endpoint overrides reject userinfo and encoded host delimiters`() {
         let userInfoURL = "https://user:pass@proxy.test/v1"
-        let encodedHostURL = "https://proxy.test%2f.attacker.test/v1"
+        let malformedHostURLs = [
+            "https://proxy.test%2f.attacker.test/v1",
+            "https://bad host/v1",
+            "https://bad%20host/v1",
+            "https://bad%09host/v1",
+        ]
 
         #expect(OpenRouterSettingsReader.apiURL(
             environment: ["OPENROUTER_API_URL": userInfoURL]).host == "openrouter.ai")
-        #expect(throws: OpenRouterSettingsError.invalidEndpointOverride("OPENROUTER_API_URL")) {
-            try OpenRouterSettingsReader.validateEndpointOverrides(
-                environment: ["OPENROUTER_API_URL": encodedHostURL])
+        for malformedHostURL in malformedHostURLs {
+            #expect(throws: OpenRouterSettingsError.invalidEndpointOverride("OPENROUTER_API_URL")) {
+                try OpenRouterSettingsReader.validateEndpointOverrides(
+                    environment: ["OPENROUTER_API_URL": malformedHostURL])
+            }
         }
 
         #expect(CodebuffSettingsReader.apiURL(
             environment: ["CODEBUFF_API_URL": userInfoURL]).host == "www.codebuff.com")
-        #expect(throws: CodebuffSettingsError.invalidEndpointOverride("CODEBUFF_API_URL")) {
-            try CodebuffSettingsReader.validateEndpointOverrides(
-                environment: ["CODEBUFF_API_URL": encodedHostURL])
+        for malformedHostURL in malformedHostURLs {
+            #expect(throws: CodebuffSettingsError.invalidEndpointOverride("CODEBUFF_API_URL")) {
+                try CodebuffSettingsReader.validateEndpointOverrides(
+                    environment: ["CODEBUFF_API_URL": malformedHostURL])
+            }
         }
 
         #expect(GroqSettingsReader.apiURL(
             environment: [GroqSettingsReader.apiURLEnvironmentKey: userInfoURL]).host == "api.groq.com")
-        #expect(throws: GroqSettingsError.invalidEndpointOverride(GroqSettingsReader.apiURLEnvironmentKey)) {
-            try GroqSettingsReader.validateEndpointOverrides(
-                environment: [GroqSettingsReader.apiURLEnvironmentKey: encodedHostURL])
+        for malformedHostURL in malformedHostURLs {
+            #expect(throws: GroqSettingsError.invalidEndpointOverride(GroqSettingsReader.apiURLEnvironmentKey)) {
+                try GroqSettingsReader.validateEndpointOverrides(
+                    environment: [GroqSettingsReader.apiURLEnvironmentKey: malformedHostURL])
+            }
         }
 
         #expect(ElevenLabsSettingsReader.apiURL(
             environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: userInfoURL]).host == "api.elevenlabs.io")
-        #expect(throws: ElevenLabsSettingsError.invalidEndpointOverride(
-            ElevenLabsSettingsReader.apiURLEnvironmentKey))
-        {
-            try ElevenLabsSettingsReader.validateEndpointOverrides(
-                environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: encodedHostURL])
+        for malformedHostURL in malformedHostURLs {
+            #expect(throws: ElevenLabsSettingsError.invalidEndpointOverride(
+                ElevenLabsSettingsReader.apiURLEnvironmentKey))
+            {
+                try ElevenLabsSettingsReader.validateEndpointOverrides(
+                    environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: malformedHostURL])
+            }
+        }
+    }
+
+    @Test
+    func `credentialed fetchers reject insecure overrides before sending requests`() async {
+        let insecureURL = "http://attacker.test/v1"
+
+        do {
+            _ = try await OpenRouterUsageFetcher.fetchUsage(
+                apiKey: "openrouter-test",
+                environment: ["OPENROUTER_API_URL": insecureURL])
+            Issue.record("Expected OpenRouterSettingsError.invalidEndpointOverride")
+        } catch {
+            #expect(error as? OpenRouterSettingsError == .invalidEndpointOverride("OPENROUTER_API_URL"))
+        }
+
+        do {
+            _ = try await CodebuffUsageFetcher.fetchUsage(
+                apiKey: "codebuff-test",
+                environment: ["CODEBUFF_API_URL": insecureURL])
+            Issue.record("Expected CodebuffSettingsError.invalidEndpointOverride")
+        } catch {
+            #expect(error as? CodebuffSettingsError == .invalidEndpointOverride("CODEBUFF_API_URL"))
+        }
+
+        do {
+            _ = try await GroqUsageFetcher.fetchUsage(
+                apiKey: "groq-test",
+                environment: [GroqSettingsReader.apiURLEnvironmentKey: insecureURL])
+            Issue.record("Expected GroqSettingsError.invalidEndpointOverride")
+        } catch {
+            #expect(error as? GroqSettingsError == .invalidEndpointOverride(GroqSettingsReader.apiURLEnvironmentKey))
+        }
+
+        do {
+            _ = try await ElevenLabsUsageFetcher.fetchUsage(
+                apiKey: "elevenlabs-test",
+                environment: [ElevenLabsSettingsReader.apiURLEnvironmentKey: insecureURL])
+            Issue.record("Expected ElevenLabsSettingsError.invalidEndpointOverride")
+        } catch {
+            #expect(error as? ElevenLabsSettingsError == .invalidEndpointOverride(
+                ElevenLabsSettingsReader.apiURLEnvironmentKey))
         }
     }
 


### PR DESCRIPTION
## Summary
This PR hardens sibling provider API endpoint overrides for credentialed usage calls.

- Rejects explicit non-HTTPS endpoint overrides for OpenRouter, Codebuff, Groq, and ElevenLabs.
- Preserves the existing convenience behavior where bare host/path override values are normalized to HTTPS.
- Adds provider-level validation before credentialed usage fetches construct requests.
- Adds regression coverage for HTTPS acceptance, bare-host normalization, and explicit HTTP rejection.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Credentialed provider endpoint overrides accepted explicit HTTP URLs across OpenRouter, Codebuff, Groq, and ElevenLabs | A local configuration or environment override could direct provider-owned credentialed API calls to plaintext HTTP, exposing bearer/API-key authenticated traffic to network interception or downgrade paths. | Medium |

## Before this PR

- `OPENROUTER_API_URL`, `CODEBUFF_API_URL`, `GROQ_API_URL`, and `ELEVENLABS_API_URL` could be set to explicit `http://...` URLs.
- The corresponding usage fetchers built credentialed requests using the configured base URL.
- The sibling provider paths did not have regression coverage matching the endpoint hardening already added for Alibaba/MiniMax.

## After this PR

- Explicit non-HTTPS endpoint overrides are rejected during provider settings validation.
- Usage fetchers call the validation path before constructing credentialed requests.
- Bare host/path overrides still infer HTTPS for compatibility.
- A shared regression test locks the behavior for OpenRouter, Codebuff, Groq, and ElevenLabs.

## Why this matters

These API URL settings are provider-owned credentialed endpoints. Once a token/API key is present, allowing an explicit HTTP override creates an unnecessary downgrade path for authenticated traffic. Rejecting non-HTTPS overrides keeps the secure default while preserving a safe HTTPS override mechanism for trusted local testing or alternate provider-compatible endpoints.

## How this differs from related issue/PR

This is a sibling-provider follow-up to #1236. That PR covers Alibaba and MiniMax endpoint overrides. This PR applies the same boundary to OpenRouter, Codebuff, Groq, and ElevenLabs, whose settings readers and usage fetchers are separate code paths.

## Attack flow

```text
local configuration/environment sets provider API URL to http://...
    -> provider settings reader accepts the override
        -> usage fetcher builds a credentialed request from that base URL
            -> bearer/API-key authenticated provider traffic can be sent over plaintext HTTP
```

## Root cause

- API URL override readers normalized or accepted caller-controlled base URLs without rejecting explicit non-HTTPS schemes.
- Credentialed usage fetchers trusted those base URLs before sending provider authentication headers.
- Endpoint override validation was inconsistent across providers.

## Changes in this PR

- Adds explicit endpoint override validation to OpenRouter and Codebuff settings errors/descriptors.
- Adds `validateEndpointOverrides(environment:)` guards to OpenRouter, Codebuff, Groq, and ElevenLabs credentialed usage fetchers.
- Keeps HTTPS inference for bare host/path override values.
- Adds `ProviderEndpointOverrideSecurityTests` covering accepted HTTPS, bare-host normalization, rejected HTTP fallback, and thrown validation errors.

## Maintainer impact

- Narrow provider settings/fetcher hardening only.
- No real provider calls or production credentials are required by the new tests.
- Existing HTTPS endpoint overrides and bare-host override values remain supported.
- Explicit plaintext HTTP endpoint overrides are now rejected for credentialed provider-owned API calls.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `swift build --target CodexBarCore`
- [x] Focused standalone Swift smoke for OpenRouter/Codebuff/Groq/ElevenLabs endpoint override behavior with fake test values, including host:port bare overrides
- [x] `swiftformat` lint mode via `make check` reported `0/998 files require formatting`
- [x] Direct SwiftLint on the touched files with the local CommandLineTools SourceKit path reported 0 violations
- [ ] `swift test --filter ProviderEndpointOverrideSecurityTests` — blocked locally by existing `KeyboardShortcuts` `#Preview` macro/plugin build failure before these tests run:
  - `external macro implementation type 'PreviewsMacros.SwiftUIView' could not be found for macro 'Preview(_:body:)'`
- [ ] Full `make check` — blocked locally after SwiftFormat passes because the wrapper SwiftLint invocation traps while loading SourceKit:
  - `Fatal error: Loading sourcekitdInProc.framework/Versions/A/sourcekitdInProc failed`

Executed with redacted/fake endpoint values only; no provider services or real credentials were used.

```bash
$ swift build --target CodexBarCore
Build of target: 'CodexBarCore' complete! (5.46s)

$ swiftc /tmp/codexbar_endpoint_override_smoke.swift \
  Sources/CodexBarCore/Providers/OpenRouter/OpenRouterSettingsReader.swift \
  Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift \
  Sources/CodexBarCore/Providers/Groq/GroqSettingsReader.swift \
  Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsSettingsReader.swift \
  -o /tmp/codexbar_endpoint_override_smoke
$ /tmp/codexbar_endpoint_override_smoke
endpoint override smoke passed: host:port bare overrides normalize to HTTPS; explicit HTTP rejects

$ python3 - <<'PY'
from pathlib import Path
files = [
    'Sources/CodexBarCore/Providers/OpenRouter/OpenRouterSettingsReader.swift',
    'Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift',
    'Sources/CodexBarCore/Providers/Groq/GroqSettingsReader.swift',
    'Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsSettingsReader.swift',
    'Tests/CodexBarTests/ProviderEndpointOverrideSecurityTests.swift',
]
for f in files:
    for i, line in enumerate(Path(f).read_text().splitlines(), 1):
        if len(line) > 120:
            raise SystemExit(f'{f}:{i}: line length {len(line)}')
print('line length <= 120 for endpoint override files')
PY
line length <= 120 for endpoint override files

$ DYLD_FRAMEWORK_PATH=/Library/Developer/CommandLineTools/usr/lib \
  .build/lint-tools/bin/swiftlint --strict --config .swiftlint.yml \
  Tests/CodexBarTests/ProviderEndpointOverrideSecurityTests.swift \
  Sources/CodexBarCore/Providers/OpenRouter/OpenRouterSettingsReader.swift \
  Sources/CodexBarCore/Providers/Codebuff/CodebuffSettingsReader.swift \
  Sources/CodexBarCore/Providers/Groq/GroqSettingsReader.swift \
  Sources/CodexBarCore/Providers/ElevenLabs/ElevenLabsSettingsReader.swift
Done linting! Found 0 violations, 0 serious in 5 files.

$ swift test --filter ProviderEndpointOverrideSecurityTests
/private/tmp/codexbar-main-security-audit/.build/checkouts/KeyboardShortcuts/Sources/KeyboardShortcuts/Recorder.swift:172:1: error: external macro implementation type 'PreviewsMacros.SwiftUIView' could not be found for macro 'Preview(_:body:)'; plugin for module 'PreviewsMacros' not found

$ make check
SwiftFormat completed in 0.16s.
0/998 files require formatting.
SourceKittenFramework/library_wrapper.swift:58: Fatal error: Loading sourcekitdInProc.framework/Versions/A/sourcekitdInProc failed
```

The smoke script asserts:

- `localhost:8080` and `localhost:8080/v1` are treated as bare host/path overrides and normalize to HTTPS.
- `http://attacker.test...` remains rejected by the validation path for OpenRouter, Codebuff, Groq, and ElevenLabs.

## Disclosure notes

- No real credentials were used or included.
- This PR does not claim unauthenticated remote exploitability; the issue is a local/provider endpoint configuration downgrade boundary for credentialed requests.
- Duplicate check found the related open #1236 for Alibaba/MiniMax and historical Alibaba-only hardening (#1104), but no existing OpenRouter/Codebuff/Groq/ElevenLabs endpoint override hardening PR or advisory.