### PR TITLE
Fix Alibaba token plan SEC token fallback

### DIFF
--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanUsageFetcher.swift
@@ -26,6 +26,7 @@ public enum AlibabaTokenPlanUsageError: LocalizedError, Sendable, Equatable {
     }
 }
 
+// swiftlint:disable:next type_body_length
 public struct AlibabaTokenPlanUsageFetcher: Sendable {
     private static let log = CodexBarLog.logger("alibaba-token-plan")
     private static let gatewayBaseURLString = "https://bailian.console.aliyun.com"
@@ -306,6 +307,14 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
             return token
         }
 
+        if let token = await self.fetchSECTokenFromUserInfo(
+            cookieHeader: dashboardCookieHeader,
+            environment: environment,
+            session: session)
+        {
+            return token
+        }
+
         if let cookieSECToken, !cookieSECToken.isEmpty {
             Self.log.info("Resolved Alibaba Token Plan sec_token from cookies")
             return cookieSECToken
@@ -318,6 +327,55 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
                 "apiCookieNames": self.cookieNamesDescription(from: apiCookieHeader),
             ])
         return nil
+    }
+
+    private static func fetchSECTokenFromUserInfo(
+        cookieHeader: String,
+        environment: [String: String],
+        session: URLSession) async -> String?
+    {
+        let baseURL = self.consoleBaseURL(environment: environment)
+        let userInfoURL = baseURL.appendingPathComponent("tool/user/info.json")
+        var request = URLRequest(url: userInfoURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 10
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue(Self.safariLikeUserAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue("application/json, text/plain, */*", forHTTPHeaderField: "Accept")
+        let referer = baseURL.absoluteString.hasSuffix("/") ? baseURL.absoluteString : "\(baseURL.absoluteString)/"
+        request.setValue(referer, forHTTPHeaderField: "Referer")
+
+        guard let (data, response) = try? await session.data(for: request),
+              let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200,
+              let object = try? JSONSerialization.jsonObject(with: data, options: [])
+        else {
+            return nil
+        }
+
+        let expanded = self.expandedJSON(object)
+        guard let token = self.findFirstString(forKeys: ["secToken", "sec_token"], in: expanded),
+              !token.isEmpty
+        else {
+            return nil
+        }
+
+        Self.log.info(
+            "Resolved Alibaba Token Plan sec_token from user info",
+            metadata: [
+                "userInfoHost": userInfoURL.host ?? "unknown",
+                "bodyBytes": "\(data.count)",
+            ])
+        return token
+    }
+
+    private static func consoleBaseURL(environment: [String: String]) -> URL {
+        let dashboard = self.dashboardURL(environment: environment)
+        var components = URLComponents()
+        components.scheme = dashboard.scheme
+        components.host = dashboard.host
+        components.port = dashboard.port
+        return components.url ?? URL(string: Self.dashboardOriginURLString)!
     }
 
     private static func quotaURL(from rawHost: String) -> URL? {
@@ -408,11 +466,22 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
     }
 
     private static func throwIfErrorPayload(_ dictionary: [String: Any]) throws {
+        if self.parseBool(dictionary["successResponse"]) == false {
+            let code = self.findFirstString(forKeys: ["code", "status", "statusCode"], in: dictionary)
+            let message = self.findFirstString(forKeys: ["message", "msg", "statusMessage"], in: dictionary) ??
+                code ??
+                "request was not successful"
+            if self.isLoginOrTokenError(code: code, message: message) {
+                throw AlibabaTokenPlanUsageError.loginRequired
+            }
+            throw AlibabaTokenPlanUsageError.apiError(message)
+        }
+
         if self.findBoolValues(forKeys: ["Success", "success"], in: dictionary).contains(false) {
+            let code = self.findFirstString(forKeys: ["Code", "code"], in: dictionary)
             let message = self.findFirstString(forKeys: ["Message", "message", "msg", "Code", "code"], in: dictionary)
                 ?? "request was not successful"
-            let lowered = message.lowercased()
-            if lowered.contains("needlogin") || lowered.contains("login") {
+            if self.isLoginOrTokenError(code: code, message: message) {
                 throw AlibabaTokenPlanUsageError.loginRequired
             }
             throw AlibabaTokenPlanUsageError.apiError(message)
@@ -435,13 +504,22 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
         let codeText = self.findFirstString(forKeys: ["code", "status", "statusCode"], in: dictionary)?.lowercased()
         let messageText = self.findFirstString(forKeys: ["message", "msg", "statusMessage"], in: dictionary)?
             .lowercased()
-        if codeText?.contains("needlogin") == true ||
-            codeText?.contains("login") == true ||
-            messageText?.contains("log in") == true ||
-            messageText?.contains("login") == true
-        {
+        if self.isLoginOrTokenError(code: codeText, message: messageText) {
             throw AlibabaTokenPlanUsageError.loginRequired
         }
+    }
+
+    private static func isLoginOrTokenError(code: String?, message: String?) -> Bool {
+        let combined = [code, message]
+            .compactMap { $0?.lowercased() }
+            .joined(separator: " ")
+        return combined.contains("needlogin") ||
+            combined.contains("login") ||
+            combined.contains("postonlyortokenerror") ||
+            combined.contains("tokenerror") ||
+            combined.contains("request has expired") ||
+            combined.contains("refresh page") ||
+            combined.contains("请求已经过期")
     }
 
     private static let planNameKeys = [

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaTokenPlanUsageFetcher.swift
@@ -467,6 +467,11 @@ public struct AlibabaTokenPlanUsageFetcher: Sendable {
 
     private static func throwIfErrorPayload(_ dictionary: [String: Any]) throws {
         if self.parseBool(dictionary["successResponse"]) == false {
+            if let statusCode = self.findFirstInt(forKeys: ["statusCode", "status_code", "code"], in: dictionary),
+               statusCode == 401 || statusCode == 403
+            {
+                throw AlibabaTokenPlanUsageError.invalidCredentials
+            }
             let code = self.findFirstString(forKeys: ["code", "status", "statusCode"], in: dictionary)
             let message = self.findFirstString(forKeys: ["message", "msg", "statusMessage"], in: dictionary) ??
                 code ??

--- a/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
@@ -261,6 +261,21 @@ struct AlibabaTokenPlanUsageParsingTests {
     }
 
     @Test
+    func `post only token payload maps to login required`() {
+        let json = """
+        {
+          "code": "PostonlyOrTokenError",
+          "message": "Your request has expired. Please refresh the page.",
+          "successResponse": false
+        }
+        """
+
+        #expect(throws: AlibabaTokenPlanUsageError.loginRequired) {
+            try AlibabaTokenPlanUsageFetcher.parseUsageSnapshot(from: Data(json.utf8))
+        }
+    }
+
+    @Test
     func `nested unsuccessful subscription summary maps to API error`() throws {
         let body = """
         {
@@ -311,7 +326,7 @@ struct AlibabaTokenPlanUsageParsingTests {
     }
 
     @Test
-    func `cookie only request continues without SEC token`() async throws {
+    func `SEC token preflight falls back to user info`() async throws {
         defer {
             AlibabaTokenPlanStubURLProtocol.handler = nil
         }
@@ -319,8 +334,31 @@ struct AlibabaTokenPlanUsageParsingTests {
         AlibabaTokenPlanStubURLProtocol.handler = { request in
             guard let url = request.url else { throw URLError(.badURL) }
 
-            if url.host == "alibaba-token-plan.test", request.httpMethod == "GET" {
+            if url.host == "alibaba-token-plan.test",
+               url.path == "/cn-beijing",
+               request.httpMethod == "GET"
+            {
+                #expect(url.port == 9443)
                 return Self.makeResponse(url: url, body: "<html></html>", statusCode: 200)
+            }
+
+            if url.host == "alibaba-token-plan.test",
+               url.path == "/tool/user/info.json",
+               request.httpMethod == "GET"
+            {
+                #expect(url.port == 9443)
+                #expect(request.value(forHTTPHeaderField: "Cookie") == "login_aliyunid_ticket=ticket; raw_only=keep")
+                #expect(request.value(forHTTPHeaderField: "Accept") == "application/json, text/plain, */*")
+                let json = """
+                {
+                  "code": "200",
+                  "data": {
+                    "secToken": "user-info-token"
+                  },
+                  "successResponse": true
+                }
+                """
+                return Self.makeResponse(url: url, body: json, statusCode: 200)
             }
 
             if url.host == "alibaba-token-plan.test", request.httpMethod == "POST" {
@@ -329,7 +367,7 @@ struct AlibabaTokenPlanUsageParsingTests {
                 #expect(request.value(forHTTPHeaderField: "Referer") == AlibabaTokenPlanUsageFetcher.dashboardURL
                     .absoluteString)
                 let body = Self.requestBodyString(from: request)
-                #expect(!body.contains("sec_token="))
+                #expect(body.contains("sec_token=user-info-token"))
                 #expect(body.contains("GetSubscriptionSummary"))
                 #expect(body.contains("BssOpenAPI-V3"))
                 #expect(body.contains("ProductCode"))
@@ -356,7 +394,7 @@ struct AlibabaTokenPlanUsageParsingTests {
         let snapshot = try await AlibabaTokenPlanUsageFetcher.fetchUsage(
             apiCookieHeader: "login_aliyunid_ticket=ticket; raw_only=keep",
             dashboardCookieHeader: "login_aliyunid_ticket=ticket; raw_only=keep",
-            environment: [AlibabaTokenPlanSettingsReader.hostKey: "https://alibaba-token-plan.test"],
+            environment: [AlibabaTokenPlanSettingsReader.hostKey: "https://alibaba-token-plan.test:9443"],
             session: session)
 
         #expect(snapshot.planName == "TOKEN PLAN")

--- a/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaTokenPlanProviderTests.swift
@@ -306,6 +306,21 @@ struct AlibabaTokenPlanUsageParsingTests {
     }
 
     @Test
+    func `failed forbidden payload maps to invalid credentials`() {
+        let json = """
+        {
+          "successResponse": false,
+          "statusCode": 403,
+          "message": "Forbidden"
+        }
+        """
+
+        #expect(throws: AlibabaTokenPlanUsageError.invalidCredentials) {
+            try AlibabaTokenPlanUsageFetcher.parseUsageSnapshot(from: Data(json.utf8))
+        }
+    }
+
+    @Test
     func `html login payload maps to login required`() {
         let html = """
         <html>


### PR DESCRIPTION
## Summary

- Add a user info JSON fallback for resolving Alibaba Token Plan `sec_token`
- Treat `PostonlyOrTokenError` / expired token payloads as `loginRequired`
- Cover the new SEC token fallback and token-expired error mapping in tests

## Why

Alibaba Token Plan requests can fail when the dashboard HTML preflight does not expose `sec_token`, even though the authenticated user info endpoint can still return it.

The API can also return expired-token payloads as `successResponse: false`. Those should prompt login/token refresh instead of surfacing as a generic API error.

## Proof

Tested the packaged app from PR head against a real Alibaba Token Plan session.

- Commit: `44bcfc07`
- App version: `0.32.2 (77)`
- Result: Alibaba Token Plan usage loaded successfully
- Evidence: 
<img width="310" height="383" alt="截屏2026-06-01 12 35 07" src="https://github.com/user-attachments/assets/0aac2372-a292-4c3a-a867-a669a66ef15d" />


The screenshot shows the Token Plan provider loading usage successfully from a real authenticated session after this change. Sensitive values are redacted:

- Cookies
- `secToken`
- Account identifiers
- Private request details

Additional runtime proof:

Captured from a real Alibaba Token Plan session using the packaged app from commit `44bcfc07`:

```text
Resolved Alibaba Token Plan sec_token from user info
Fetching Alibaba Token Plan usage
Alibaba Token Plan HTTP response status=200
```
Sensitive values were redacted, including cookies, secToken, account identifiers, and private request details.


## Validation

- `swift test --filter AlibabaTokenPlan`
- `swiftlint --strict --no-cache`