### PR TITLE
Fix OpenAI webview route reload loop

### DIFF
--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -275,13 +275,11 @@ public struct OpenAIDashboardFetcher {
                 continue
             }
 
-            if debugDumpHTML,
-               scrape.loginRequired || scrape.cloudflareInterstitial,
-               let html = try? await self.fetchDebugHTML(webView: webView)
-            {
-                Self.writeDebugArtifacts(html: html, bodyText: scrape.bodyText, logger: log)
-            }
-            try Self.throwIfBlockingScrapeState(scrape)
+            try await self.handleBlockingScrapeState(
+                scrape,
+                webView: webView,
+                debugDumpHTML: debugDumpHTML,
+                logger: log)
 
             // The page is a SPA and can land on ChatGPT UI or other routes; keep forcing the usage URL.
             if Self.shouldReloadUsageRoute(scrape) {
@@ -455,10 +453,8 @@ public struct OpenAIDashboardFetcher {
                 continue
             }
 
-            if scrape.loginRequired { throw FetchError.loginRequired }
-            if scrape.cloudflareInterstitial {
-                throw FetchError.noDashboardData(body: "Cloudflare challenge detected in WebView.")
-            }
+            Self.logBlockingStateIfNeeded(scrape, logger: log)
+            try Self.throwIfBlockingScrapeState(scrape)
 
             if Self.shouldReloadUsageRoute(scrape) {
                 usageRouteSeenAt = nil
@@ -978,6 +974,32 @@ extension OpenAIDashboardFetcher {
         guard error != lastError else { return }
         lastError = error
         logger("usage breakdown error: \(error)")
+    }
+}
+
+extension OpenAIDashboardFetcher {
+    private static func logBlockingStateIfNeeded(_ scrape: ScrapeResult, logger: (String) -> Void) {
+        guard scrape.loginRequired || scrape.cloudflareInterstitial else { return }
+        let route = self.isUsageRoute(scrape.href) ? "usage" : "other"
+        logger(
+            "blocking state before route reload route=\(route) " +
+                "login=\(scrape.loginRequired) cloudflare=\(scrape.cloudflareInterstitial)")
+    }
+
+    private func handleBlockingScrapeState(
+        _ scrape: ScrapeResult,
+        webView: WKWebView,
+        debugDumpHTML: Bool,
+        logger: (String) -> Void) async throws
+    {
+        if debugDumpHTML,
+           scrape.loginRequired || scrape.cloudflareInterstitial,
+           let html = try? await self.fetchDebugHTML(webView: webView)
+        {
+            Self.writeDebugArtifacts(html: html, bodyText: scrape.bodyText, logger: logger)
+        }
+        Self.logBlockingStateIfNeeded(scrape, logger: logger)
+        try Self.throwIfBlockingScrapeState(scrape)
     }
 }
 #else

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -275,13 +275,6 @@ public struct OpenAIDashboardFetcher {
                 continue
             }
 
-            // The page is a SPA and can land on ChatGPT UI or other routes; keep forcing the usage URL.
-            if let href = scrape.href, !Self.isUsageRoute(href) {
-                _ = webView.load(Self.usageURLRequest(url: self.usageURL))
-                try await Self.sleepForDashboardPoll(.milliseconds(500))
-                continue
-            }
-
             if debugDumpHTML,
                scrape.loginRequired || scrape.cloudflareInterstitial,
                let html = try? await self.fetchDebugHTML(webView: webView)
@@ -289,6 +282,13 @@ public struct OpenAIDashboardFetcher {
                 Self.writeDebugArtifacts(html: html, bodyText: scrape.bodyText, logger: log)
             }
             try Self.throwIfBlockingScrapeState(scrape)
+
+            // The page is a SPA and can land on ChatGPT UI or other routes; keep forcing the usage URL.
+            if Self.shouldReloadUsageRoute(scrape) {
+                _ = webView.load(Self.usageURLRequest(url: self.usageURL))
+                try await Self.sleepForDashboardPoll(.milliseconds(500))
+                continue
+            }
 
             let dashboardData = Self.parseDashboardScrape(
                 scrape,
@@ -455,17 +455,17 @@ public struct OpenAIDashboardFetcher {
                 continue
             }
 
-            if let href = scrape.href, !Self.isUsageRoute(href) {
+            if scrape.loginRequired { throw FetchError.loginRequired }
+            if scrape.cloudflareInterstitial {
+                throw FetchError.noDashboardData(body: "Cloudflare challenge detected in WebView.")
+            }
+
+            if Self.shouldReloadUsageRoute(scrape) {
                 usageRouteSeenAt = nil
                 dashboardSignalSeenAt = nil
                 _ = webView.load(Self.usageURLRequest(url: self.usageURL))
                 try await Self.sleepForDashboardPoll(.milliseconds(500))
                 continue
-            }
-
-            if scrape.loginRequired { throw FetchError.loginRequired }
-            if scrape.cloudflareInterstitial {
-                throw FetchError.noDashboardData(body: "Cloudflare challenge detected in WebView.")
             }
 
             let normalizedEmail = scrape.signedInEmail?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -674,6 +674,25 @@ public struct OpenAIDashboardFetcher {
             || path.hasSuffix("codex/cloud/settings/usage")
             || path.hasSuffix("codex/settings/analytics")
             || path.hasSuffix("codex/cloud/settings/analytics")
+    }
+
+    nonisolated static func shouldReloadUsageRoute(
+        href: String?,
+        loginRequired: Bool,
+        workspacePicker: Bool,
+        cloudflareInterstitial: Bool) -> Bool
+    {
+        guard !workspacePicker, !loginRequired, !cloudflareInterstitial else { return false }
+        guard let href else { return false }
+        return !self.isUsageRoute(href)
+    }
+
+    private nonisolated static func shouldReloadUsageRoute(_ scrape: ScrapeResult) -> Bool {
+        self.shouldReloadUsageRoute(
+            href: scrape.href,
+            loginRequired: scrape.loginRequired,
+            workspacePicker: scrape.workspacePicker,
+            cloudflareInterstitial: scrape.cloudflareInterstitial)
     }
 
     nonisolated static func usageURLRequest(url: URL) -> URLRequest {

--- a/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardFetcherCreditsWaitTests.swift
@@ -235,6 +235,25 @@ struct OpenAIDashboardFetcherCreditsWaitTests {
         #expect(!OpenAIDashboardFetcher.isUsageRoute(nil))
     }
 
+    @Test(arguments: [
+        ("https://chatgpt.com/#usage", true, false, false, false),
+        ("https://chatgpt.com/", false, false, true, false),
+        ("https://chatgpt.com/", false, false, false, true)
+    ])
+    func `usage route reload skips blocking states`(
+        href: String,
+        loginRequired: Bool,
+        workspacePicker: Bool,
+        cloudflareInterstitial: Bool,
+        expected: Bool)
+    {
+        #expect(OpenAIDashboardFetcher.shouldReloadUsageRoute(
+            href: href,
+            loginRequired: loginRequired,
+            workspacePicker: workspacePicker,
+            cloudflareInterstitial: cloudflareInterstitial) == expected)
+    }
+
     @Test
     func `dashboard requests prefer English localization`() throws {
         let url = try #require(URL(string: "https://chatgpt.com/codex/cloud/settings/analytics#usage"))


### PR DESCRIPTION
## Summary
Fix the OpenAI dashboard route reload logic so blocking states are handled before wrong-route reload.

## Context
Part of the UI hang/lag cleanup set: this stops a WebView reload loop from continuing when the page is already in a login or Cloudflare blocking state.

## Validation
- `swift test --filter OpenAIDashboardFetcherCreditsWaitTests`
- `make check`
- `git diff --check`

## Runtime Proof
Focused route-state proof:

```text
$ swift test --filter OpenAIDashboardFetcherCreditsWaitTests
Test "usage route reload skips blocking states" with 3 test cases passed:
- href=https://chatgpt.com/#usage, loginRequired=true -> expected false
- href=https://chatgpt.com/, cloudflareInterstitial=true -> expected false
- href=https://chatgpt.com/, no blocking state -> expected true
Test run with 29 tests in 1 suite passed
```

Real WebView proof at `64f8282d`, captured June 1, 2026 at 00:30 PDT with a throwaway SwiftPM runner outside the repo. It imports the local `CodexBarCore` product, creates a nonpersistent `WKWebView`, uses no browser cookies, and calls `OpenAIDashboardFetcher.loadLatestDashboard` directly:

```text
$ swift run --package-path /tmp/codexbar-pr1259-webview-runner.PJhUmF OpenAIWebProof
[openai-web] [webview] href=https://chatgpt.com/#usage login=true workspace=false cloudflare=false
[openai-web] [webview] blocking state before route reload route=other login=true cloudflare=false
RESULT loginRequired elapsed=1.23s
```

That proves the login blocking state exits before a route reload attempt. The proof output contains no account, token, cookie, or host data.

`make check` and `git diff --check` both passed after the final patch.
