### PR TITLE
Fix provider switcher shortcuts

### DIFF
--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -77,6 +77,12 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         }
     }
 
+    nonisolated func performProviderSelection(at index: Int) {
+        Task { @MainActor [weak self] in
+            self?.selectOpenProviderSwitcherSegment(at: index)
+        }
+    }
+
     @objc func refreshAugmentSession() {
         Task {
             await self.store.forceRefreshAugmentSession()

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -131,7 +131,6 @@ extension StatusItemController {
             // Intentionally skip open-menu tracking when refresh is disabled (tests).
             // If refresh is re-enabled while this menu stays open, it will not be backfilled until next open.
             self.openMenus[ObjectIdentifier(menu)] = menu
-            self.installProviderSwitcherShortcutMonitorIfNeeded(for: menu)
             // Only schedule refresh after menu is registered as open - refreshNow is called async
             self.scheduleOpenMenuRefresh(for: menu)
         }
@@ -147,10 +146,6 @@ extension StatusItemController {
 
     func forgetClosedMenu(_ menu: NSMenu) {
         let key = ObjectIdentifier(menu)
-
-        if key == self.providerSwitcherShortcutMenuID {
-            self.removeProviderSwitcherShortcutMonitor()
-        }
 
         self.openMenus.removeValue(forKey: key)
         self.menuRefreshTasks.removeValue(forKey: key)?.cancel()

--- a/Sources/CodexBar/StatusItemController+ProviderSwitcher.swift
+++ b/Sources/CodexBar/StatusItemController+ProviderSwitcher.swift
@@ -1,119 +1,21 @@
 import AppKit
-import CodexBarCore
-
-final class ProviderSwitcherShortcutEventMonitor {
-    private let events: NSEvent.EventTypeMask
-    private let callback: @MainActor (NSEvent) -> Bool
-    private let observer: CFRunLoopObserver
-    private var isActive = false
-
-    init(events: NSEvent.EventTypeMask, callback: @escaping @MainActor (NSEvent) -> Bool) {
-        self.events = events
-        self.callback = callback
-
-        self.observer = CFRunLoopObserverCreateWithHandler(
-            nil,
-            CFRunLoopActivity.beforeSources.rawValue,
-            true,
-            0)
-        { [events, callback] _, _ in
-            MainActor.assumeIsolated {
-                while let event = NSApp.nextEvent(
-                    matching: events,
-                    until: .distantPast,
-                    inMode: .eventTracking,
-                    dequeue: false)
-                {
-                    guard callback(event) else { break }
-                    _ = NSApp.nextEvent(
-                        matching: events,
-                        until: .distantPast,
-                        inMode: .eventTracking,
-                        dequeue: true)
-                }
-            }
-        }
-    }
-
-    deinit {
-        self.stop()
-    }
-
-    func start() {
-        guard !self.isActive else { return }
-        CFRunLoopAddObserver(
-            RunLoop.main.getCFRunLoop(),
-            self.observer,
-            CFRunLoopMode(RunLoop.Mode.eventTracking.rawValue as CFString))
-        self.isActive = true
-    }
-
-    func stop() {
-        guard self.isActive else { return }
-        CFRunLoopRemoveObserver(
-            RunLoop.main.getCFRunLoop(),
-            self.observer,
-            CFRunLoopMode(RunLoop.Mode.eventTracking.rawValue as CFString))
-        self.isActive = false
-    }
-}
 
 extension StatusItemController {
-    func installProviderSwitcherShortcutMonitorIfNeeded(for menu: NSMenu) {
-        guard self.isMenuRefreshEnabled,
-              self.shouldMergeIcons,
-              menu.items.first?.view is ProviderSwitcherView
-        else {
-            return
-        }
-
-        self.removeProviderSwitcherShortcutMonitor()
-        let monitor = ProviderSwitcherShortcutEventMonitor(events: [.keyDown]) { [weak self, weak menu] event in
-            guard let self,
-                  let menu,
-                  self.openMenus[ObjectIdentifier(menu)] != nil,
-                  menu.items.first?.view is ProviderSwitcherView
-            else {
-                return false
-            }
-
-            return self.handleProviderSwitcherShortcut(event, menu: menu)
-        }
-        monitor.start()
-        self.providerSwitcherShortcutEventMonitor = monitor
-        self.providerSwitcherShortcutMenuID = ObjectIdentifier(menu)
-    }
-
-    func removeProviderSwitcherShortcutMonitor() {
-        self.providerSwitcherShortcutEventMonitor?.stop()
-        self.providerSwitcherShortcutEventMonitor = nil
-        self.providerSwitcherShortcutMenuID = nil
-    }
-
     func providerSwitcherContentStartIndex(in menu: NSMenu) -> Int {
         menu.items.first?.view is ProviderSwitcherView ? 2 : 0
     }
 
     @discardableResult
-    func handleProviderSwitcherShortcut(_ event: NSEvent, menu: NSMenu) -> Bool {
-        if let index = StatusItemMenu.providerSelectionIndex(for: event) {
-            return self.selectProviderSwitcherSegment(at: index, menu: menu)
-        }
-        if let direction = StatusItemMenu.providerNavigationDirection(for: event) {
-            self.navigateProviderSwitcher(direction)
+    func selectOpenProviderSwitcherSegment(at index: Int) -> Bool {
+        for menu in self.openMenus.values {
+            guard let switcherView = menu.items.first?.view as? ProviderSwitcherView,
+                  switcherView.handleKeyboardSelection(at: index)
+            else {
+                continue
+            }
+            self.applyIcon(phase: nil)
             return true
         }
         return false
-    }
-
-    @discardableResult
-    private func selectProviderSwitcherSegment(at index: Int, menu: NSMenu) -> Bool {
-        guard let switcherView = menu.items.first?.view as? ProviderSwitcherView,
-              switcherView.handleKeyboardSelection(at: index)
-        else {
-            return false
-        }
-        self.applyIcon(phase: nil)
-        return true
     }
 }

--- a/Sources/CodexBar/StatusItemController+Shutdown.swift
+++ b/Sources/CodexBar/StatusItemController+Shutdown.swift
@@ -54,7 +54,6 @@ extension StatusItemController {
     }
 
     private func clearShutdownMenuState() {
-        self.removeProviderSwitcherShortcutMonitor()
         self.menuRefreshTasks.removeAll(keepingCapacity: false)
         self.openMenuRebuildTasks.removeAll(keepingCapacity: false)
         self.openMenuRebuildTokens.removeAll(keepingCapacity: false)

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -141,8 +141,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var deferredOpenAIDashboardRefreshReason: String?
     var deferredMenuInteractionRefreshTask: Task<Void, Never>?
     var highlightedMenuItems: [ObjectIdentifier: NSMenuItem] = [:]
-    var providerSwitcherShortcutEventMonitor: ProviderSwitcherShortcutEventMonitor?
-    var providerSwitcherShortcutMenuID: ObjectIdentifier?
     var hasPreparedForAppShutdown = false
     var openMenuInvalidationRetryTask: Task<Void, Never>?
     #if DEBUG

--- a/Sources/CodexBar/StatusItemMenu.swift
+++ b/Sources/CodexBar/StatusItemMenu.swift
@@ -10,6 +10,7 @@ protocol StatusItemMenuPersistentActionDelegate: AnyObject {
     func performPersistentSettingsAction()
     func performPersistentQuitAction()
     func performProviderNavigation(_ direction: StatusItemMenuProviderNavigationDirection)
+    func performProviderSelection(at index: Int)
 }
 
 final class StatusItemMenu: NSMenu {
@@ -31,6 +32,12 @@ final class StatusItemMenu: NSMenu {
            self.items.first?.view is ProviderSwitcherView
         {
             self.persistentActionDelegate?.performProviderNavigation(direction)
+            return true
+        }
+        if let index = Self.providerSelectionIndex(for: event),
+           self.items.first?.view is ProviderSwitcherView
+        {
+            self.persistentActionDelegate?.performProviderSelection(at: index)
             return true
         }
 

--- a/Tests/CodexBarTests/StatusItemControllerShutdownTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerShutdownTests.swift
@@ -51,7 +51,6 @@ struct StatusItemControllerShutdownTests {
         #expect(controller.hasPreparedForAppShutdown)
         #expect(controller.openMenus.isEmpty)
         #expect(controller.menuRefreshTasks.isEmpty)
-        #expect(controller.providerSwitcherShortcutEventMonitor == nil)
         #expect(controller.statusItem.menu == nil)
         #expect(controller.statusItems.isEmpty)
         #expect(controller.providerMenus.isEmpty)

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -24,6 +24,8 @@ private final class RefreshShortcutRecorder: StatusItemMenuPersistentActionDeleg
     func performProviderNavigation(_ direction: StatusItemMenuProviderNavigationDirection) {
         self.navigationDirections.append(direction)
     }
+
+    func performProviderSelection(at index: Int) {}
 }
 
 @MainActor

--- a/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
@@ -24,48 +24,6 @@ struct StatusMenuSwitcherClickTests {
             syntheticTokenStore: NoopSyntheticTokenStore())
     }
 
-    private func makeInstalledSwitcherShortcutMonitor() -> (controller: StatusItemController, menu: StatusItemMenu) {
-        let settings = self.makeSettings()
-        settings.statusChecksEnabled = false
-        settings.refreshFrequency = .manual
-        settings.mergeIcons = true
-
-        let registry = ProviderRegistry.shared
-        for provider in UsageProvider.allCases {
-            guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .codex || provider == .claude
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
-        }
-
-        let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
-        let controller = StatusItemController(
-            store: store,
-            settings: settings,
-            account: fetcher.loadAccountInfo(),
-            updater: DisabledUpdaterController(),
-            preferencesSelection: PreferencesSelection(),
-            statusBar: self.makeStatusBarForTesting())
-
-        let menu = StatusItemMenu()
-        let switcher = ProviderSwitcherView(
-            providers: [.codex, .claude],
-            selected: .provider(.codex),
-            includesOverview: true,
-            width: 320,
-            showsIcons: false,
-            iconProvider: { _ in NSImage() },
-            weeklyRemainingProvider: { _ in nil },
-            onSelect: { _ in })
-        let switcherItem = NSMenuItem()
-        switcherItem.view = switcher
-        menu.addItem(switcherItem)
-        menu.addItem(.separator())
-
-        controller.installProviderSwitcherShortcutMonitorIfNeeded(for: menu)
-        return (controller, menu)
-    }
-
     @Test
     func `merged switcher routes runtime clicks after overview round-trip`() throws {
         // Regression test for #867: after Provider → Overview, subsequent runtime clicks on a
@@ -73,7 +31,7 @@ struct StatusMenuSwitcherClickTests {
         let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
         let previousMenuRefresh = StatusItemController.menuRefreshEnabled
         StatusItemController.menuCardRenderingEnabled = false
-        StatusItemController.setMenuRefreshEnabledForTesting(false)
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
         defer {
             StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering
             StatusItemController.setMenuRefreshEnabledForTesting(previousMenuRefresh)
@@ -313,63 +271,29 @@ struct StatusMenuSwitcherClickTests {
 
         let menu = try #require(controller.makeMenu() as? StatusItemMenu)
         controller.menuWillOpen(menu)
+        let menuKey = ObjectIdentifier(menu)
+        controller.openMenus[menuKey] = menu
+        defer { controller.openMenus.removeValue(forKey: menuKey) }
         #expect(menu.items.first?.view is ProviderSwitcherView)
 
-        #expect(try controller.handleProviderSwitcherShortcut(Self.commandKeyEvent("3", keyCode: 20), menu: menu))
-        await Task.yield()
+        #expect(try menu.performKeyEquivalent(with: Self.commandKeyEvent("3", keyCode: 20)))
+        for _ in 0..<100 where settings.selectedMenuProvider != .claude {
+            await Task.yield()
+        }
         #expect(settings.mergedMenuLastSelectedWasOverview == false)
         #expect(settings.selectedMenuProvider == .claude)
 
-        #expect(try controller.handleProviderSwitcherShortcut(Self.commandKeyEvent("1", keyCode: 18), menu: menu))
-        await Task.yield()
+        #expect(try menu.performKeyEquivalent(with: Self.commandKeyEvent("1", keyCode: 18)))
+        for _ in 0..<100 where !settings.mergedMenuLastSelectedWasOverview {
+            await Task.yield()
+        }
         #expect(settings.mergedMenuLastSelectedWasOverview == true)
         #expect(settings.selectedMenuProvider == .claude)
 
-        #expect(try !controller.handleProviderSwitcherShortcut(Self.commandKeyEvent("9", keyCode: 25), menu: menu))
+        #expect(try menu.performKeyEquivalent(with: Self.commandKeyEvent("9", keyCode: 25)))
         await Task.yield()
         #expect(settings.mergedMenuLastSelectedWasOverview == true)
         #expect(settings.selectedMenuProvider == .claude)
-    }
-
-    @Test
-    func `provider shortcut monitor is removed when tracked menu closes after switcher rebuild`() {
-        let previousMenuRefresh = StatusItemController.menuRefreshEnabled
-        StatusItemController.setMenuRefreshEnabledForTesting(true)
-        defer {
-            StatusItemController.setMenuRefreshEnabledForTesting(previousMenuRefresh)
-        }
-
-        let (controller, menu) = self.makeInstalledSwitcherShortcutMonitor()
-        defer { controller.releaseStatusItemsForTesting() }
-
-        #expect(controller.providerSwitcherShortcutEventMonitor != nil)
-        #expect(controller.providerSwitcherShortcutMenuID == ObjectIdentifier(menu))
-
-        menu.removeAllItems()
-        controller.menuDidClose(menu)
-
-        #expect(controller.providerSwitcherShortcutEventMonitor == nil)
-        #expect(controller.providerSwitcherShortcutMenuID == nil)
-    }
-
-    @Test
-    func `switcher shortcut monitor is removed from direct close cleanup`() {
-        let previousMenuRefresh = StatusItemController.menuRefreshEnabled
-        StatusItemController.setMenuRefreshEnabledForTesting(true)
-        defer {
-            StatusItemController.setMenuRefreshEnabledForTesting(previousMenuRefresh)
-        }
-
-        let (controller, menu) = self.makeInstalledSwitcherShortcutMonitor()
-        defer { controller.releaseStatusItemsForTesting() }
-
-        #expect(controller.providerSwitcherShortcutEventMonitor != nil)
-        #expect(controller.providerSwitcherShortcutMenuID == ObjectIdentifier(menu))
-
-        controller.forgetClosedMenu(menu)
-
-        #expect(controller.providerSwitcherShortcutEventMonitor == nil)
-        #expect(controller.providerSwitcherShortcutMenuID == nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary
Route provider switcher command-number shortcuts through `StatusItemMenu` instead of a custom event-tracking monitor.

## Context
Part of the UI hang/lag cleanup set: this removes a custom event-tracking shortcut monitor and uses the normal menu key-equivalent path instead.

## Validation
- `swift test --filter 'StatusMenuSwitcherClickTests|StatusMenuPersistentRefreshTests|StatusItemControllerShutdownTests'`
- `make check`
- `git diff --check`

## Runtime Proof
Built and launched this PR branch from `7d3e97f3990a3a60e8cafacaf6a4b77f2dd0b800` with the PR-built app isolated as the only running CodexBar status-item app.

Redacted live state monitor while the visible menu was operated manually:

```text
23:25:55 PDT selected=codex overview=0
23:26:31 PDT selected=claude overview=0   # after Cmd-3
23:26:35 PDT selected=claude overview=1   # after Cmd-1
23:26:42 PDT selected=cursor overview=0   # extra command-number check
```

No screenshots or raw AX menu dumps were posted because the menu can contain private account/cost data.
