### PR TITLE
Defer closed menu rebuilds during refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Copilot: treat GitHub Copilot Business token-billing zero-entitlement quotas as unavailable instead of showing misleading 0% used usage (#1258, #1270). Thanks @devYRPauli!
+- Menu bar: prepare closed menus after refresh and only reuse stale dropdown content for data-refresh invalidations so merged menu opens stay responsive without bypassing privacy or structure changes (#1261). Thanks @ProspectOre!
 - OpenAI Web: stop reloading away from login and Cloudflare blocking states so the dashboard WebView does not loop on route corrections (#1259). Thanks @ProspectOre!
 
 ## 0.32.2 — 2026-06-01

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -83,6 +83,7 @@ extension StatusItemController {
         }
 
         self.cancelDeferredMenuInteractionRefreshTask()
+        self.cancelClosedMenuRebuild(menu)
 
         if self.isHostedSubviewMenu(menu) {
             self.hydrateHostedSubviewMenuIfNeeded(menu)
@@ -122,11 +123,7 @@ extension StatusItemController {
             self.deferOpenAIDashboardRefreshUntilMenuCloses(reason: "parent menu open")
         }
 
-        if self.menuNeedsRefresh(menu) {
-            self.populateMenu(menu, provider: provider)
-            self.markMenuFresh(menu)
-            // Heights are already set during populateMenu, no need to remeasure
-        }
+        self.refreshMenuForOpenIfNeeded(menu, provider: provider)
         if self.isMenuRefreshEnabled {
             // Intentionally skip open-menu tracking when refresh is disabled (tests).
             // If refresh is re-enabled while this menu stays open, it will not be backfilled until next open.
@@ -152,6 +149,7 @@ extension StatusItemController {
             self.removeProviderSwitcherShortcutMonitor()
         }
 
+        self.cancelClosedMenuRebuild(menu)
         self.openMenus.removeValue(forKey: key)
         self.menuRefreshTasks.removeValue(forKey: key)?.cancel()
         self.openMenuRebuildTasks.removeValue(forKey: key)?.cancel()

--- a/Sources/CodexBar/StatusItemController+MenuLocalization.swift
+++ b/Sources/CodexBar/StatusItemController+MenuLocalization.swift
@@ -4,6 +4,7 @@ extension StatusItemController {
     func menuLocalizationSignature() -> String {
         [
             codexBarLocalizationSignature(),
+            self.settings.hidePersonalInfo ? "hide-personal-info" : "show-personal-info",
             L("Overview"),
             L("Cost"),
         ].joined(separator: "|")

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -25,12 +25,16 @@ extension StatusItemController {
 
     func invalidateMenus(
         refreshOpenMenus: Bool = false,
-        deferOpenParentMenuRebuild: Bool = false)
+        deferOpenParentMenuRebuild: Bool = false,
+        allowStaleContentDuringDataRefresh: Bool = false)
     {
         #if DEBUG
         guard !self.isReleasedForTesting else { return }
         #endif
         self.menuContentVersion &+= 1
+        if !allowStaleContentDuringDataRefresh {
+            self.latestRequiredMenuRebuildVersion = self.menuContentVersion
+        }
         guard self.isMenuRefreshEnabled else { return }
         if !self.openMenus.isEmpty {
             guard refreshOpenMenus else { return }
@@ -59,7 +63,7 @@ extension StatusItemController {
 
     func refreshMenuForOpenIfNeeded(_ menu: NSMenu, provider: UsageProvider?) {
         guard self.menuNeedsRefresh(menu) else { return }
-        if self.isMenuDataRefreshInFlight, !menu.items.isEmpty {
+        if self.canPreserveStaleMenuContentDuringRefresh(menu) {
             #if DEBUG
             self.menuLogger.debug(
                 "menu open kept existing content during refresh",
@@ -74,6 +78,13 @@ extension StatusItemController {
         }
         self.populateMenu(menu, provider: provider)
         self.markMenuFresh(menu)
+    }
+
+    private func canPreserveStaleMenuContentDuringRefresh(_ menu: NSMenu) -> Bool {
+        guard self.isMenuDataRefreshInFlight, !menu.items.isEmpty else { return false }
+        let key = ObjectIdentifier(menu)
+        guard let menuVersion = self.menuVersions[key] else { return false }
+        return menuVersion >= self.latestRequiredMenuRebuildVersion
     }
 
     private func attachedMenusForClosedPreparation() -> [NSMenu] {

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -5,13 +5,13 @@ extension StatusItemController {
     private static let defaultClosedMenuPreparationDelay: Duration = .milliseconds(350)
 
     #if DEBUG
-    private static var closedMenuPreparationDelayForTesting: Duration = .zero
+    private static var closedMenuPreparationDelayForTesting: Duration = defaultClosedMenuPreparationDelay
     static func setClosedMenuPreparationDelayForTesting(_ delay: Duration) {
         self.closedMenuPreparationDelayForTesting = delay
     }
 
     static func resetClosedMenuPreparationDelayForTesting() {
-        self.closedMenuPreparationDelayForTesting = .zero
+        self.closedMenuPreparationDelayForTesting = self.defaultClosedMenuPreparationDelay
     }
     #endif
 

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -60,6 +60,15 @@ extension StatusItemController {
     func refreshMenuForOpenIfNeeded(_ menu: NSMenu, provider: UsageProvider?) {
         guard self.menuNeedsRefresh(menu) else { return }
         if self.isMenuDataRefreshInFlight, !menu.items.isEmpty {
+            #if DEBUG
+            self.menuLogger.debug(
+                "menu open kept existing content during refresh",
+                metadata: [
+                    "items": "\(menu.items.count)",
+                    "provider": provider?.rawValue ?? "nil",
+                    "storeRefreshing": self.store.isRefreshing ? "1" : "0",
+                ])
+            #endif
             self.deferMenuInteractionRefreshIfNeeded()
             return
         }
@@ -127,6 +136,17 @@ extension StatusItemController {
             guard self.menuNeedsRefresh(menu) else { return }
             self.populateMenu(menu, provider: provider)
             self.markMenuFresh(menu)
+            #if DEBUG
+            if self.lastLoggedClosedMenuRebuildVersion != self.menuContentVersion {
+                self.lastLoggedClosedMenuRebuildVersion = self.menuContentVersion
+                self.menuLogger.debug(
+                    "closed menu rebuild completed",
+                    metadata: [
+                        "items": "\(menu.items.count)",
+                        "provider": provider?.rawValue ?? "nil",
+                    ])
+            }
+            #endif
         }
     }
 

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -112,13 +112,14 @@ extension StatusItemController {
             guard !Task.isCancelled else { return }
             await Task.yield()
             guard !Task.isCancelled else { return }
-            guard let self, let menu else { return }
+            guard let self else { return }
             defer {
                 if self.closedMenuRebuildTokens[key] == rebuildToken {
                     self.closedMenuRebuildTasks.removeValue(forKey: key)
                     self.closedMenuRebuildTokens.removeValue(forKey: key)
                 }
             }
+            guard let menu else { return }
             guard self.closedMenuRebuildTokens[key] == rebuildToken else { return }
             guard !self.hasPreparedForAppShutdown else { return }
             guard !self.isMenuDataRefreshInFlight else { return }

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -2,6 +2,27 @@ import AppKit
 import CodexBarCore
 
 extension StatusItemController {
+    private static let defaultClosedMenuPreparationDelay: Duration = .milliseconds(350)
+
+    #if DEBUG
+    private static var closedMenuPreparationDelayForTesting: Duration = .zero
+    static func setClosedMenuPreparationDelayForTesting(_ delay: Duration) {
+        self.closedMenuPreparationDelayForTesting = delay
+    }
+
+    static func resetClosedMenuPreparationDelayForTesting() {
+        self.closedMenuPreparationDelayForTesting = .zero
+    }
+    #endif
+
+    private static var closedMenuPreparationDelay: Duration {
+        #if DEBUG
+        closedMenuPreparationDelayForTesting
+        #else
+        defaultClosedMenuPreparationDelay
+        #endif
+    }
+
     func invalidateMenus(
         refreshOpenMenus: Bool = false,
         deferOpenParentMenuRebuild: Bool = false)
@@ -19,6 +40,54 @@ extension StatusItemController {
                 deferParentRebuildDuringTracking: deferOpenParentMenuRebuild)
             return
         }
+        self.prepareAttachedClosedMenusIfNeeded()
+    }
+
+    func prepareAttachedClosedMenusIfNeeded() {
+        guard self.isMenuRefreshEnabled else { return }
+        guard self.openMenus.isEmpty else { return }
+        guard !self.isMenuDataRefreshInFlight else { return }
+        for menu in self.attachedMenusForClosedPreparation() {
+            self.rebuildClosedMenuIfNeeded(menu)
+        }
+    }
+
+    var isMenuDataRefreshInFlight: Bool {
+        self.store.isRefreshing ||
+            UsageProvider.allCases.contains { self.store.isTokenRefreshInFlight(for: $0) }
+    }
+
+    func refreshMenuForOpenIfNeeded(_ menu: NSMenu, provider: UsageProvider?) {
+        guard self.menuNeedsRefresh(menu) else { return }
+        if self.isMenuDataRefreshInFlight, !menu.items.isEmpty {
+            self.deferMenuInteractionRefreshIfNeeded()
+            return
+        }
+        self.populateMenu(menu, provider: provider)
+        self.markMenuFresh(menu)
+    }
+
+    private func attachedMenusForClosedPreparation() -> [NSMenu] {
+        var menus: [NSMenu] = []
+        var seen = Set<ObjectIdentifier>()
+
+        func append(_ menu: NSMenu?) {
+            guard let menu else { return }
+            let key = ObjectIdentifier(menu)
+            guard seen.insert(key).inserted else { return }
+            menus.append(menu)
+        }
+
+        append(self.statusItem.menu)
+        append(self.mergedMenu)
+        append(self.fallbackMenu)
+        for item in self.statusItems.values {
+            append(item.menu)
+        }
+        for menu in self.providerMenus.values {
+            append(menu)
+        }
+        return menus
     }
 
     func renderedMenuWidth(for menu: NSMenu) -> CGFloat {
@@ -28,16 +97,50 @@ extension StatusItemController {
 
     func rebuildClosedMenuIfNeeded(_ menu: NSMenu) {
         guard !self.hasPreparedForAppShutdown else { return }
+        guard !self.isMenuDataRefreshInFlight else { return }
+        let key = ObjectIdentifier(menu)
         let provider = self.menuProvider(for: menu)
-        Task { @MainActor [weak self, weak menu] in
+        self.closedMenuRebuildTokenCounter &+= 1
+        let rebuildToken = self.closedMenuRebuildTokenCounter
+        self.closedMenuRebuildTokens[key] = rebuildToken
+        self.closedMenuRebuildTasks[key]?.cancel()
+        self.closedMenuRebuildTasks[key] = Task { @MainActor [weak self, weak menu] in
+            let delay = Self.closedMenuPreparationDelay
+            if delay > .zero {
+                try? await Task.sleep(for: delay)
+            }
+            guard !Task.isCancelled else { return }
             await Task.yield()
+            guard !Task.isCancelled else { return }
             guard let self, let menu else { return }
+            defer {
+                if self.closedMenuRebuildTokens[key] == rebuildToken {
+                    self.closedMenuRebuildTasks.removeValue(forKey: key)
+                    self.closedMenuRebuildTokens.removeValue(forKey: key)
+                }
+            }
+            guard self.closedMenuRebuildTokens[key] == rebuildToken else { return }
             guard !self.hasPreparedForAppShutdown else { return }
+            guard !self.isMenuDataRefreshInFlight else { return }
             guard self.openMenus[ObjectIdentifier(menu)] == nil else { return }
             guard self.menuNeedsRefresh(menu) else { return }
             self.populateMenu(menu, provider: provider)
             self.markMenuFresh(menu)
         }
+    }
+
+    func cancelClosedMenuRebuild(_ menu: NSMenu) {
+        let key = ObjectIdentifier(menu)
+        self.closedMenuRebuildTasks.removeValue(forKey: key)?.cancel()
+        self.closedMenuRebuildTokens.removeValue(forKey: key)
+    }
+
+    func cancelAllClosedMenuRebuilds() {
+        for task in self.closedMenuRebuildTasks.values {
+            task.cancel()
+        }
+        self.closedMenuRebuildTasks.removeAll(keepingCapacity: false)
+        self.closedMenuRebuildTokens.removeAll(keepingCapacity: false)
     }
 
     func menuNeedsRefresh(_ menu: NSMenu) -> Bool {

--- a/Sources/CodexBar/StatusItemController+Shutdown.swift
+++ b/Sources/CodexBar/StatusItemController+Shutdown.swift
@@ -46,6 +46,7 @@ extension StatusItemController {
         for task in self.menuRefreshTasks.values {
             task.cancel()
         }
+        self.cancelAllClosedMenuRebuilds()
         for task in self.openMenuRebuildTasks.values {
             task.cancel()
         }
@@ -56,6 +57,8 @@ extension StatusItemController {
     private func clearShutdownMenuState() {
         self.removeProviderSwitcherShortcutMonitor()
         self.menuRefreshTasks.removeAll(keepingCapacity: false)
+        self.closedMenuRebuildTasks.removeAll(keepingCapacity: false)
+        self.closedMenuRebuildTokens.removeAll(keepingCapacity: false)
         self.openMenuRebuildTasks.removeAll(keepingCapacity: false)
         self.openMenuRebuildTokens.removeAll(keepingCapacity: false)
         self.openMenuRebuildsClosingHostedSubviewMenus.removeAll(keepingCapacity: false)

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -115,6 +115,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var lastMenuProvider: UsageProvider?
     var menuProviders: [ObjectIdentifier: UsageProvider] = [:]
     var menuContentVersion: Int = 0
+    var latestRequiredMenuRebuildVersion: Int = 0
     var menuVersions: [ObjectIdentifier: Int] = [:]
     var lastMenuAdjunctReadinessSignature = ""
     var mergedMenu: NSMenu?
@@ -189,6 +190,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     private var lastMergeIcons: Bool
     private var lastSwitcherShowsIcons: Bool
     private var lastObservedUsageBarsShowUsed: Bool
+    private var lastObservedHidePersonalInfo: Bool
     /// Tracks which `usageBarsShowUsed` mode the provider switcher was built with.
     /// Used to decide whether we can "smart update" menu content without rebuilding the switcher.
     var lastSwitcherUsageBarsShowUsed: Bool
@@ -351,6 +353,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.lastMergeIcons = settings.mergeIcons
         self.lastSwitcherShowsIcons = settings.switcherShowsIcons
         self.lastObservedUsageBarsShowUsed = settings.usageBarsShowUsed
+        self.lastObservedHidePersonalInfo = settings.hidePersonalInfo
         self.lastSwitcherUsageBarsShowUsed = settings.usageBarsShowUsed
         let repairedStatusItemVisibilityKeys = MenuBarStatusItemDefaultsRepair
             .repairHiddenVisibilityDefaultsIfNeeded(defaults: settings.userDefaults)
@@ -442,7 +445,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
                 self.observeStoreChanges()
                 self.invalidateMenus(
                     refreshOpenMenus: self.didMenuAdjunctReadinessChange(),
-                    deferOpenParentMenuRebuild: true)
+                    deferOpenParentMenuRebuild: true,
+                    allowStaleContentDuringDataRefresh: true)
             }
         }
     }
@@ -632,6 +636,11 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         let usageBarsShowUsed = self.settings.usageBarsShowUsed
         if usageBarsShowUsed != self.lastObservedUsageBarsShowUsed {
             self.lastObservedUsageBarsShowUsed = usageBarsShowUsed
+            shouldRefresh = true
+        }
+        let hidePersonalInfo = self.settings.hidePersonalInfo
+        if hidePersonalInfo != self.lastObservedHidePersonalInfo {
+            self.lastObservedHidePersonalInfo = hidePersonalInfo
             shouldRefresh = true
         }
         if self.menuLocalizationSignature() != self.lastMenuLocalizationSignature {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -190,7 +190,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     private var lastMergeIcons: Bool
     private var lastSwitcherShowsIcons: Bool
     private var lastObservedUsageBarsShowUsed: Bool
-    private var lastObservedHidePersonalInfo: Bool
     /// Tracks which `usageBarsShowUsed` mode the provider switcher was built with.
     /// Used to decide whether we can "smart update" menu content without rebuilding the switcher.
     var lastSwitcherUsageBarsShowUsed: Bool
@@ -353,7 +352,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.lastMergeIcons = settings.mergeIcons
         self.lastSwitcherShowsIcons = settings.switcherShowsIcons
         self.lastObservedUsageBarsShowUsed = settings.usageBarsShowUsed
-        self.lastObservedHidePersonalInfo = settings.hidePersonalInfo
         self.lastSwitcherUsageBarsShowUsed = settings.usageBarsShowUsed
         let repairedStatusItemVisibilityKeys = MenuBarStatusItemDefaultsRepair
             .repairHiddenVisibilityDefaultsIfNeeded(defaults: settings.userDefaults)
@@ -636,11 +634,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         let usageBarsShowUsed = self.settings.usageBarsShowUsed
         if usageBarsShowUsed != self.lastObservedUsageBarsShowUsed {
             self.lastObservedUsageBarsShowUsed = usageBarsShowUsed
-            shouldRefresh = true
-        }
-        let hidePersonalInfo = self.settings.hidePersonalInfo
-        if hidePersonalInfo != self.lastObservedHidePersonalInfo {
-            self.lastObservedHidePersonalInfo = hidePersonalInfo
             shouldRefresh = true
         }
         if self.menuLocalizationSignature() != self.lastMenuLocalizationSignature {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -153,6 +153,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var onDeferredMenuInteractionRefreshForTesting: (() -> Void)?
     var onOpenMenuInvalidationRetryForTesting: (() -> Void)?
     var isReleasedForTesting = false
+    var lastLoggedClosedMenuRebuildVersion: Int?
     var _test_openMenuRefreshYieldOverride: (@MainActor () async -> Void)?
     var _test_openMenuRebuildObserver: (@MainActor (NSMenu) -> Void)?
     var _test_codexAmbientLoginRunnerOverride:

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -56,16 +56,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     }
 
     #if DEBUG
-    static func setMenuRefreshEnabledForTesting(_ enabled: Bool) {
-        self.menuRefreshEnabled = enabled
-    }
-
-    static func resetMenuRefreshEnabledForTesting() {
-        self.menuRefreshEnabled = self.defaultMenuRefreshEnabled
-    }
-    #endif
-
-    #if DEBUG
     var menuRefreshEnabledOverrideForTesting: Bool?
     #endif
 
@@ -907,6 +897,18 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         NotificationCenter.default.removeObserver(self)
     }
 }
+
+#if DEBUG
+extension StatusItemController {
+    static func setMenuRefreshEnabledForTesting(_ enabled: Bool) {
+        self.menuRefreshEnabled = enabled
+    }
+
+    static func resetMenuRefreshEnabledForTesting() {
+        self.menuRefreshEnabled = self.defaultMenuRefreshEnabled
+    }
+}
+#endif
 
 extension StatusItemController {
     private func legacyDefaultItemIndex(forNewProvider provider: UsageProvider) -> Int? {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -132,6 +132,9 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var fallbackMenu: NSMenu?
     var openMenus: [ObjectIdentifier: NSMenu] = [:]
     var menuRefreshTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
+    var closedMenuRebuildTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
+    var closedMenuRebuildTokens: [ObjectIdentifier: Int] = [:]
+    var closedMenuRebuildTokenCounter = 0
     var openMenuRebuildTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
     var openMenuRebuildTokens: [ObjectIdentifier: Int] = [:]
     var openMenuRebuildTokenCounter = 0
@@ -797,6 +800,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         if self.statusItem.menu !== self.mergedMenu {
             self.statusItem.menu = self.mergedMenu
         }
+        self.prepareAttachedClosedMenusIfNeeded()
     }
 
     private func attachMenus(fallback: UsageProvider? = nil) {
@@ -827,6 +831,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
                 item.menu = nil
             }
         }
+        self.prepareAttachedClosedMenusIfNeeded()
     }
 
     private func rebuildProviderStatusItems() {

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -114,6 +114,222 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `closed attached menu is prepared before next open after invalidation`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        self.enableOnlyCodex(settings)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.mergedMenu = menu
+        controller.statusItem.menu = menu
+
+        controller.populateMenu(menu, provider: nil)
+        controller.markMenuFresh(menu)
+        let key = ObjectIdentifier(menu)
+        let openedVersion = controller.menuVersions[key]
+
+        controller.invalidateMenus()
+        for _ in 0..<40 where controller.menuVersions[key] == openedVersion {
+            await Task.yield()
+        }
+
+        #expect(controller.openMenus.isEmpty)
+        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+    }
+
+    @Test
+    func `closed attached menu preparation waits for store refresh to finish`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        self.enableOnlyCodex(settings)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.mergedMenu = menu
+        controller.statusItem.menu = menu
+
+        controller.populateMenu(menu, provider: nil)
+        controller.markMenuFresh(menu)
+        let key = ObjectIdentifier(menu)
+        let openedVersion = controller.menuVersions[key]
+
+        store.isRefreshing = true
+        controller.invalidateMenus()
+        for _ in 0..<40 {
+            await Task.yield()
+        }
+
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        store.isRefreshing = false
+        controller.invalidateMenus()
+        for _ in 0..<40 where controller.menuVersions[key] == openedVersion {
+            await Task.yield()
+        }
+
+        #expect(controller.openMenus.isEmpty)
+        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+    }
+
+    @Test
+    func `closed attached menu preparation waits for token refresh to finish`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        self.enableOnlyCodex(settings)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.mergedMenu = menu
+        controller.statusItem.menu = menu
+
+        controller.populateMenu(menu, provider: nil)
+        controller.markMenuFresh(menu)
+        let key = ObjectIdentifier(menu)
+        let openedVersion = controller.menuVersions[key]
+
+        store.tokenRefreshInFlight.insert(.codex)
+        controller.invalidateMenus()
+        for _ in 0..<40 {
+            await Task.yield()
+        }
+
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        store.tokenRefreshInFlight.remove(.codex)
+        controller.invalidateMenus()
+        for _ in 0..<40 where controller.menuVersions[key] == openedVersion {
+            await Task.yield()
+        }
+
+        #expect(controller.openMenus.isEmpty)
+        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+    }
+
+    @Test
+    func `menu open keeps stale nonempty content while store refresh is active`() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        self.enableOnlyCodex(settings)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.mergedMenu = menu
+        controller.statusItem.menu = menu
+
+        controller.populateMenu(menu, provider: nil)
+        controller.markMenuFresh(menu)
+        let key = ObjectIdentifier(menu)
+        let openedVersion = controller.menuVersions[key]
+        let openedItemCount = menu.items.count
+
+        store.isRefreshing = true
+        defer { store.isRefreshing = false }
+        controller.invalidateMenus()
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        #expect(controller.menuVersions[key] == openedVersion)
+        #expect(controller.menuContentVersion != openedVersion)
+        #expect(menu.items.count == openedItemCount)
+        #expect(controller.openMenus[key] === menu)
+    }
+
+    @Test
+    func `menu open keeps stale nonempty content while token refresh is active`() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        self.enableOnlyCodex(settings)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.mergedMenu = menu
+        controller.statusItem.menu = menu
+
+        controller.populateMenu(menu, provider: nil)
+        controller.markMenuFresh(menu)
+        let key = ObjectIdentifier(menu)
+        let openedVersion = controller.menuVersions[key]
+        let openedItemCount = menu.items.count
+
+        store.tokenRefreshInFlight.insert(.codex)
+        defer { store.tokenRefreshInFlight.remove(.codex) }
+        controller.invalidateMenus()
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        #expect(controller.menuVersions[key] == openedVersion)
+        #expect(controller.menuContentVersion != openedVersion)
+        #expect(menu.items.count == openedItemCount)
+        #expect(controller.openMenus[key] === menu)
+    }
+
+    @Test
     func `explicit store actions refresh a visible open menu`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -246,6 +246,41 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `closed menu rebuild cleanup runs when weak menu disappears`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        self.enableOnlyCodex(settings)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        var menu: NSMenu? = NSMenu()
+        let key = ObjectIdentifier(menu!)
+
+        controller.rebuildClosedMenuIfNeeded(menu!)
+        #expect(controller.closedMenuRebuildTasks[key] != nil)
+        #expect(controller.closedMenuRebuildTokens[key] != nil)
+
+        menu = nil
+        for _ in 0..<40 where controller.closedMenuRebuildTasks[key] != nil {
+            await Task.yield()
+        }
+
+        #expect(controller.closedMenuRebuildTasks[key] == nil)
+        #expect(controller.closedMenuRebuildTokens[key] == nil)
+    }
+
+    @Test
     func `menu open keeps stale nonempty content while store refresh is active`() {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -32,6 +32,8 @@ extension StatusMenuTests {
             preferencesSelection: PreferencesSelection(),
             statusBar: self.makeStatusBarForTesting())
         defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
 
         controller.menuRefreshEnabledOverrideForTesting = true
         StatusItemController.setDeferredMenuInteractionRefreshDelayForTesting(.zero)
@@ -131,6 +133,8 @@ extension StatusMenuTests {
             preferencesSelection: PreferencesSelection(),
             statusBar: self.makeStatusBarForTesting())
         defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
 
         controller.menuRefreshEnabledOverrideForTesting = true
         let menu = controller.makeMenu()
@@ -169,6 +173,8 @@ extension StatusMenuTests {
             preferencesSelection: PreferencesSelection(),
             statusBar: self.makeStatusBarForTesting())
         defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
 
         controller.menuRefreshEnabledOverrideForTesting = true
         let menu = controller.makeMenu()
@@ -200,6 +206,9 @@ extension StatusMenuTests {
 
     @Test
     func `closed attached menu preparation waits for token refresh to finish`() async {
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -263,15 +272,18 @@ extension StatusMenuTests {
             preferencesSelection: PreferencesSelection(),
             statusBar: self.makeStatusBarForTesting())
         defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
 
-        var menu: NSMenu? = NSMenu()
-        let key = ObjectIdentifier(menu!)
+        let key: ObjectIdentifier
+        do {
+            let menu = NSMenu()
+            key = ObjectIdentifier(menu)
+            controller.rebuildClosedMenuIfNeeded(menu)
+            #expect(controller.closedMenuRebuildTasks[key] != nil)
+            #expect(controller.closedMenuRebuildTokens[key] != nil)
+        }
 
-        controller.rebuildClosedMenuIfNeeded(menu!)
-        #expect(controller.closedMenuRebuildTasks[key] != nil)
-        #expect(controller.closedMenuRebuildTokens[key] != nil)
-
-        menu = nil
         for _ in 0..<40 where controller.closedMenuRebuildTasks[key] != nil {
             await Task.yield()
         }

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -324,7 +324,7 @@ extension StatusMenuTests {
 
         store.isRefreshing = true
         defer { store.isRefreshing = false }
-        controller.invalidateMenus()
+        controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
         controller.menuWillOpen(menu)
         defer { controller.menuDidClose(menu) }
 
@@ -332,6 +332,47 @@ extension StatusMenuTests {
         #expect(controller.menuContentVersion != openedVersion)
         #expect(menu.items.count == openedItemCount)
         #expect(controller.openMenus[key] === menu)
+    }
+
+    @Test
+    func `menu open rebuilds stale content after privacy setting changes during refresh`() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        self.enableOnlyCodex(settings)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.mergedMenu = menu
+        controller.statusItem.menu = menu
+
+        controller.populateMenu(menu, provider: nil)
+        controller.markMenuFresh(menu)
+        let key = ObjectIdentifier(menu)
+        let openedVersion = controller.menuVersions[key]
+
+        store.isRefreshing = true
+        defer { store.isRefreshing = false }
+        controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
+        settings.hidePersonalInfo = true
+        controller.invalidateMenus()
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+        #expect(controller.menuVersions[key] != openedVersion)
     }
 
     @Test
@@ -366,7 +407,7 @@ extension StatusMenuTests {
 
         store.tokenRefreshInFlight.insert(.codex)
         defer { store.tokenRefreshInFlight.remove(.codex) }
-        controller.invalidateMenus()
+        controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
         controller.menuWillOpen(menu)
         defer { controller.menuDidClose(menu) }
 

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -22,11 +22,13 @@ struct StatusMenuTests {
         let defaults = UserDefaults(suiteName: suite)!
         defaults.removePersistentDomain(forName: suite)
         let configStore = testConfigStore(suiteName: suite)
-        return SettingsStore(
+        let settings = SettingsStore(
             userDefaults: defaults,
             configStore: configStore,
             zaiTokenStore: NoopZaiTokenStore(),
             syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.providerDetectionCompleted = true
+        return settings
     }
 
     func makeCodexStore(settings: SettingsStore, dashboardAuthorized: Bool) -> UsageStore {
@@ -85,7 +87,6 @@ struct StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        settings.providerDetectionCompleted = true
         settings.alibabaCodingPlanAPIRegion = .chinaMainland
 
         let fetcher = UsageFetcher()
@@ -820,7 +821,6 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        settings.providerDetectionCompleted = true
 
         let registry = ProviderRegistry.shared
         if let codexMeta = registry.metadata[.codex] {
@@ -860,7 +860,6 @@ extension StatusMenuTests {
         settings.statusChecksEnabled = false
         settings.refreshFrequency = .manual
         settings.mergeIcons = false
-        settings.providerDetectionCompleted = true
 
         let registry = ProviderRegistry.shared
         try settings.setProviderEnabled(provider: .codex, metadata: #require(registry.metadata[.codex]), enabled: true)


### PR DESCRIPTION
## Summary
Prepare attached closed menus after refresh work settles, and keep stale nonempty menu content on open while store or token refreshes are active.

## Context
Part of the UI hang/lag cleanup set: this keeps refresh-time menu rebuild work off the open-menu path.

## Validation
- `swift test --filter StatusMenuOpenRefreshTests` (25 tests passed)
- `make check`
- `git diff --check`

## Runtime Proof
Runtime proof was captured from a freshly packaged debug build on June 1, 2026 at 00:05 PDT, driven through macOS Accessibility. Logs are redacted to lifecycle state, item counts, provider id, and refresh state only.

```text
[DEBUG] menu open kept existing content during refresh items=13 provider=claude storeRefreshing=1
[DEBUG] closed menu rebuild completed items=17 provider=claude
```

Interpretation: while refresh was active, opening the stale nonempty menu kept the existing 13 items instead of rebuilding synchronously; after close and refresh settle, the closed-menu rebuild path populated the next version with 17 items.
