### PR TITLE
Make Augment keepalive stop idempotent

### DIFF
--- a/Sources/CodexBar/Providers/Augment/AugmentProviderRuntime.swift
+++ b/Sources/CodexBar/Providers/Augment/AugmentProviderRuntime.swift
@@ -83,7 +83,8 @@ final class AugmentProviderRuntime: ProviderRuntime {
 
     private func stopKeepalive(context: ProviderRuntimeContext, reason: String) {
         #if os(macOS)
-        self.keepalive?.stop()
+        guard let keepalive = self.keepalive else { return }
+        keepalive.stop()
         self.keepalive = nil
         context.store.augmentLogger.info("Augment keepalive stopped (\(reason))")
         #endif

--- a/Sources/CodexBar/Providers/Augment/AugmentProviderRuntime.swift
+++ b/Sources/CodexBar/Providers/Augment/AugmentProviderRuntime.swift
@@ -5,6 +5,12 @@ import Foundation
 final class AugmentProviderRuntime: ProviderRuntime {
     let id: UsageProvider = .augment
     private var keepalive: AugmentSessionKeepalive?
+    #if DEBUG
+    private(set) var _test_keepaliveStopCount = 0
+    var _test_isKeepaliveRunning: Bool {
+        self.keepalive != nil
+    }
+    #endif
 
     func start(context: ProviderRuntimeContext) {
         self.updateKeepalive(context: context)
@@ -86,6 +92,9 @@ final class AugmentProviderRuntime: ProviderRuntime {
         guard let keepalive = self.keepalive else { return }
         keepalive.stop()
         self.keepalive = nil
+        #if DEBUG
+        self._test_keepaliveStopCount += 1
+        #endif
         context.store.augmentLogger.info("Augment keepalive stopped (\(reason))")
         #endif
     }

--- a/Tests/CodexBarTests/AugmentProviderRuntimeTests.swift
+++ b/Tests/CodexBarTests/AugmentProviderRuntimeTests.swift
@@ -1,16 +1,15 @@
 import CodexBarCore
 import Foundation
-import XCTest
+import Testing
 @testable import CodexBar
 
 @MainActor
-final class AugmentProviderRuntimeTests: XCTestCase {
-    func test_disabledStopDoesNotLogWithoutKeepalive() throws {
-        CodexBarLog.bootstrapIfNeeded(.init(destination: .discard, level: .info, json: false))
-        CodexBarLog.setLogLevel(.info)
-
+@Suite(.serialized)
+struct AugmentProviderRuntimeTests {
+    @Test
+    func `repeated stop only reports a running keepalive once`() throws {
         let suite = "AugmentProviderRuntimeTests-\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
+        let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
         let settings = SettingsStore(
             userDefaults: defaults,
@@ -18,72 +17,26 @@ final class AugmentProviderRuntimeTests: XCTestCase {
             zaiTokenStore: NoopZaiTokenStore(),
             syntheticTokenStore: NoopSyntheticTokenStore(),
             augmentCookieStore: InMemoryCookieHeaderStore())
-        if let metadata = ProviderRegistry.shared.metadata[.augment] {
-            settings.setProviderEnabled(provider: .augment, metadata: metadata, enabled: false)
-        }
+        let metadata = try #require(ProviderRegistry.shared.metadata[.augment])
+        settings.setProviderEnabled(provider: .augment, metadata: metadata, enabled: true)
+
         let store = UsageStore(
             fetcher: UsageFetcher(environment: [:]),
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings,
             startupBehavior: .testing)
-
-        CodexBarLog.setFileLoggingEnabled(true)
-        defer { CodexBarLog.setFileLoggingEnabled(false) }
-
-        let logURL = CodexBarLog.fileLogURL
-        let beforeMarker = "Augment stop idempotency before \(UUID().uuidString)"
-        let afterMarker = "Augment stop idempotency after \(UUID().uuidString)"
-
         let runtime = AugmentProviderRuntime()
         let context = ProviderRuntimeContext(provider: .augment, settings: settings, store: store)
+        defer { runtime.stop(context: context) }
 
-        store.augmentLogger.info(beforeMarker)
-        _ = try Self.waitForLogContaining(beforeMarker, at: logURL)
-
+        runtime.start(context: context)
+        #expect(runtime._test_isKeepaliveRunning)
         runtime.stop(context: context)
+        settings.setProviderEnabled(provider: .augment, metadata: metadata, enabled: false)
         runtime.stop(context: context)
         runtime.settingsDidChange(context: context)
 
-        store.augmentLogger.info(afterMarker)
-        let log = try Self.waitForLogContaining(afterMarker, at: logURL)
-        let stopLogSlice = Self.logSlice(log, between: beforeMarker, and: afterMarker)
-
-        XCTAssertFalse(
-            stopLogSlice.contains("Augment keepalive stopped"),
-            "Disabled stop calls should not emit stopped logs when no keepalive exists:\n\(stopLogSlice)")
-    }
-
-    private static func waitForLogContaining(
-        _ marker: String,
-        at url: URL,
-        timeout: TimeInterval = 2) throws -> String
-    {
-        let deadline = Date().addingTimeInterval(timeout)
-        var latest = ""
-        repeat {
-            latest = try Self.readLog(at: url)
-            if latest.contains(marker) {
-                return latest
-            }
-            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
-        } while Date() < deadline
-
-        XCTFail("Timed out waiting for log marker: \(marker)")
-        return latest
-    }
-
-    private static func readLog(at url: URL) throws -> String {
-        guard FileManager.default.fileExists(atPath: url.path) else { return "" }
-        let data = try Data(contentsOf: url)
-        return String(decoding: data, as: UTF8.self)
-    }
-
-    private static func logSlice(_ log: String, between beforeMarker: String, and afterMarker: String) -> String {
-        guard let beforeRange = log.range(of: beforeMarker, options: .backwards),
-              let afterRange = log.range(of: afterMarker, options: .backwards),
-              beforeRange.upperBound <= afterRange.lowerBound else {
-            return log
-        }
-        return String(log[beforeRange.upperBound..<afterRange.lowerBound])
+        #expect(!runtime._test_isKeepaliveRunning)
+        #expect(runtime._test_keepaliveStopCount == 1)
     }
 }

--- a/Tests/CodexBarTests/AugmentProviderRuntimeTests.swift
+++ b/Tests/CodexBarTests/AugmentProviderRuntimeTests.swift
@@ -1,0 +1,34 @@
+import CodexBarCore
+import XCTest
+@testable import CodexBar
+
+@MainActor
+final class AugmentProviderRuntimeTests: XCTestCase {
+    func test_disabledStopIsIdempotent() {
+        let suite = "AugmentProviderRuntimeTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore())
+        if let metadata = ProviderRegistry.shared.metadata[.augment] {
+            settings.setProviderEnabled(provider: .augment, metadata: metadata, enabled: false)
+        }
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing)
+        let runtime = AugmentProviderRuntime()
+        let context = ProviderRuntimeContext(provider: .augment, settings: settings, store: store)
+
+        runtime.stop(context: context)
+        runtime.stop(context: context)
+        runtime.settingsDidChange(context: context)
+
+        XCTAssertFalse(store.isEnabled(.augment))
+    }
+}

--- a/Tests/CodexBarTests/AugmentProviderRuntimeTests.swift
+++ b/Tests/CodexBarTests/AugmentProviderRuntimeTests.swift
@@ -1,10 +1,14 @@
 import CodexBarCore
+import Foundation
 import XCTest
 @testable import CodexBar
 
 @MainActor
 final class AugmentProviderRuntimeTests: XCTestCase {
-    func test_disabledStopIsIdempotent() {
+    func test_disabledStopDoesNotLogWithoutKeepalive() throws {
+        CodexBarLog.bootstrapIfNeeded(.init(destination: .discard, level: .info, json: false))
+        CodexBarLog.setLogLevel(.info)
+
         let suite = "AugmentProviderRuntimeTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
         defaults.removePersistentDomain(forName: suite)
@@ -22,13 +26,64 @@ final class AugmentProviderRuntimeTests: XCTestCase {
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings,
             startupBehavior: .testing)
+
+        CodexBarLog.setFileLoggingEnabled(true)
+        defer { CodexBarLog.setFileLoggingEnabled(false) }
+
+        let logURL = CodexBarLog.fileLogURL
+        let beforeMarker = "Augment stop idempotency before \(UUID().uuidString)"
+        let afterMarker = "Augment stop idempotency after \(UUID().uuidString)"
+
         let runtime = AugmentProviderRuntime()
         let context = ProviderRuntimeContext(provider: .augment, settings: settings, store: store)
+
+        store.augmentLogger.info(beforeMarker)
+        _ = try Self.waitForLogContaining(beforeMarker, at: logURL)
 
         runtime.stop(context: context)
         runtime.stop(context: context)
         runtime.settingsDidChange(context: context)
 
-        XCTAssertFalse(store.isEnabled(.augment))
+        store.augmentLogger.info(afterMarker)
+        let log = try Self.waitForLogContaining(afterMarker, at: logURL)
+        let stopLogSlice = Self.logSlice(log, between: beforeMarker, and: afterMarker)
+
+        XCTAssertFalse(
+            stopLogSlice.contains("Augment keepalive stopped"),
+            "Disabled stop calls should not emit stopped logs when no keepalive exists:\n\(stopLogSlice)")
+    }
+
+    private static func waitForLogContaining(
+        _ marker: String,
+        at url: URL,
+        timeout: TimeInterval = 2) throws -> String
+    {
+        let deadline = Date().addingTimeInterval(timeout)
+        var latest = ""
+        repeat {
+            latest = try Self.readLog(at: url)
+            if latest.contains(marker) {
+                return latest
+            }
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        } while Date() < deadline
+
+        XCTFail("Timed out waiting for log marker: \(marker)")
+        return latest
+    }
+
+    private static func readLog(at url: URL) throws -> String {
+        guard FileManager.default.fileExists(atPath: url.path) else { return "" }
+        let data = try Data(contentsOf: url)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private static func logSlice(_ log: String, between beforeMarker: String, and afterMarker: String) -> String {
+        guard let beforeRange = log.range(of: beforeMarker, options: .backwards),
+              let afterRange = log.range(of: afterMarker, options: .backwards),
+              beforeRange.upperBound <= afterRange.lowerBound else {
+            return log
+        }
+        return String(log[beforeRange.upperBound..<afterRange.lowerBound])
     }
 }


### PR DESCRIPTION
## Summary
Skip Augment keepalive stop work when no keepalive is active, avoiding repeated stop logs for already-stopped runtimes.

## Context
Part of the UI hang/lag cleanup set: this removes redundant disabled-provider runtime work and log churn from repeated stop paths.

## Validation
- `swift test --filter AugmentProviderRuntimeTests`
- `swift test --filter AugmentStatusProbeTests`
- `git diff --check`

## Runtime Proof
Fixed-branch test proof at `d0b2082d`:

```text
$ swift test --filter AugmentProviderRuntimeTests
Test Case '-[CodexBarTests.AugmentProviderRuntimeTests test_disabledStopDoesNotLogWithoutKeepalive]' passed (0.165 seconds).
Executed 1 test, with 0 failures
```

Negative proof against `main` using a temporary worktree with only the new test file applied:

```text
$ swift test --filter AugmentProviderRuntimeTests
... XCTAssertFalse failed - Disabled stop calls should not emit stopped logs when no keepalive exists:

[2026-06-01T06:49:15.230Z] [INFO] com.steipete.codexbar.augment: Augment keepalive stopped (provider disabled)
[2026-06-01T06:49:15.230Z] [INFO] com.steipete.codexbar.augment: Augment keepalive stopped (provider disabled)
Executed 1 test, with 1 failure
```

Live app runtime proof from a freshly packaged debug app at `d0b2082d`, captured June 1, 2026 at 00:12 PDT with unified logging. App startup exercises the disabled-provider runtime path (`stop` followed by `settingsDidChange`). The log is redacted to startup/provider state only:

```text
$ CODEXBAR_SIGNING=adhoc CODEXBAR_ALLOW_LLDB=1 Scripts/package_app.sh debug
Created /Users/alec/Dev/CodexBar/CodexBar.app

$ log stream --info --style compact --predicate 'process == "CodexBar" && subsystem == "com.steipete.codexbar"'
2026-06-01 00:12:49.251 I CodexBar[...] [com.steipete.codexbar:app] CodexBar starting (git=d0b2082d version=0.32.3)
2026-06-01 00:12:49.565 I CodexBar[...] [com.steipete.codexbar:providers] Provider enablement at startup (enabled=claude,codex states=...,augment=0,...)

$ rg -c "Augment keepalive stopped" oslog.txt
0
```

Compatibility check already run for this PR:

```text
$ swift test --filter AugmentStatusProbeTests
Executed 17 tests, with 0 failures
```

Also ran `git diff --check`; it passed with no output. The runtime proof does not include account, token, cookie, or host data.
