### PR TITLE
Copilot: drop zero-entitlement quotas instead of showing "0% used" (#1258)

### DIFF
--- a/Sources/CodexBarCore/CopilotUsageModels.swift
+++ b/Sources/CodexBarCore/CopilotUsageModels.swift
@@ -31,7 +31,12 @@ public struct CopilotUsageResponse: Sendable, Decodable {
         }
 
         public var isPlaceholder: Bool {
-            self.entitlement == 0 && self.remaining == 0 && self.percentRemaining == 0 && self.quotaId.isEmpty
+            // A zero-entitlement, zero-remaining snapshot carries no usable quota signal.
+            // GitHub returns this shape for token-based billing / Copilot Business seats,
+            // sometimes as percent_remaining=100 with a non-empty quota_id, which would
+            // otherwise render as a misleading "0% used" (100 - 100). Treat it as a
+            // placeholder so the usual handling drops it instead of showing fake usage.
+            self.entitlement == 0 && self.remaining == 0
         }
 
         private enum CodingKeys: String, CodingKey {

--- a/Sources/CodexBarCore/CopilotUsageModels.swift
+++ b/Sources/CodexBarCore/CopilotUsageModels.swift
@@ -22,6 +22,8 @@ public struct CopilotUsageResponse: Sendable, Decodable {
         public let percentRemaining: Double
         public let quotaId: String
         public let hasPercentRemaining: Bool
+        private let entitlementWasDecoded: Bool
+        private let remainingWasDecoded: Bool
         public var usedPercent: Double {
             max(0, 100 - self.percentRemaining)
         }
@@ -31,12 +33,20 @@ public struct CopilotUsageResponse: Sendable, Decodable {
         }
 
         public var isPlaceholder: Bool {
-            // A zero-entitlement, zero-remaining snapshot carries no usable quota signal.
+            if self.entitlement == 0,
+               self.remaining == 0,
+               self.percentRemaining == 0,
+               !self.hasPercentRemaining
+            {
+                return true
+            }
+
+            // An explicit zero-entitlement, zero-remaining snapshot carries no usable quota signal.
             // GitHub returns this shape for token-based billing / Copilot Business seats,
             // sometimes as percent_remaining=100 with a non-empty quota_id, which would
             // otherwise render as a misleading "0% used" (100 - 100). Treat it as a
             // placeholder so the usual handling drops it instead of showing fake usage.
-            self.entitlement == 0 && self.remaining == 0
+            return self.entitlementWasDecoded && self.remainingWasDecoded && self.entitlement == 0 && self.remaining == 0
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -58,6 +68,8 @@ public struct CopilotUsageResponse: Sendable, Decodable {
             self.percentRemaining = percentRemaining
             self.quotaId = quotaId
             self.hasPercentRemaining = hasPercentRemaining
+            self.entitlementWasDecoded = true
+            self.remainingWasDecoded = true
         }
 
         public init(from decoder: any Decoder) throws {
@@ -66,6 +78,8 @@ public struct CopilotUsageResponse: Sendable, Decodable {
             let decodedRemaining = Self.decodeNumberIfPresent(container: container, key: .remaining)
             self.entitlement = decodedEntitlement ?? 0
             self.remaining = decodedRemaining ?? 0
+            self.entitlementWasDecoded = decodedEntitlement != nil
+            self.remainingWasDecoded = decodedRemaining != nil
             let decodedPercent = Self.decodeNumberIfPresent(container: container, key: .percentRemaining)
             if let decodedPercent {
                 self.percentRemaining = decodedPercent

--- a/Sources/CodexBarCore/CopilotUsageModels.swift
+++ b/Sources/CodexBarCore/CopilotUsageModels.swift
@@ -46,7 +46,8 @@ public struct CopilotUsageResponse: Sendable, Decodable {
             // sometimes as percent_remaining=100 with a non-empty quota_id, which would
             // otherwise render as a misleading "0% used" (100 - 100). Treat it as a
             // placeholder so the usual handling drops it instead of showing fake usage.
-            return self.entitlementWasDecoded && self.remainingWasDecoded && self.entitlement == 0 && self.remaining == 0
+            return self.entitlementWasDecoded && self.remainingWasDecoded && self.entitlement == 0 && self
+                .remaining == 0
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -232,12 +233,14 @@ public struct CopilotUsageResponse: Sendable, Decodable {
 
     public let quotaSnapshots: QuotaSnapshots
     public let copilotPlan: String
+    public let tokenBasedBilling: Bool
     public let assignedDate: String?
     public let quotaResetDate: String?
 
     private enum CodingKeys: String, CodingKey {
         case quotaSnapshots = "quota_snapshots"
         case copilotPlan = "copilot_plan"
+        case tokenBasedBilling = "token_based_billing"
         case assignedDate = "assigned_date"
         case quotaResetDate = "quota_reset_date"
         case monthlyQuotas = "monthly_quotas"
@@ -247,11 +250,13 @@ public struct CopilotUsageResponse: Sendable, Decodable {
     public init(
         quotaSnapshots: QuotaSnapshots,
         copilotPlan: String,
+        tokenBasedBilling: Bool = false,
         assignedDate: String?,
         quotaResetDate: String?)
     {
         self.quotaSnapshots = quotaSnapshots
         self.copilotPlan = copilotPlan
+        self.tokenBasedBilling = tokenBasedBilling
         self.assignedDate = assignedDate
         self.quotaResetDate = quotaResetDate
     }
@@ -272,6 +277,7 @@ public struct CopilotUsageResponse: Sendable, Decodable {
             self.quotaSnapshots = directSnapshots ?? QuotaSnapshots(premiumInteractions: nil, chat: nil)
         }
         self.copilotPlan = try container.decodeIfPresent(String.self, forKey: .copilotPlan) ?? "unknown"
+        self.tokenBasedBilling = try container.decodeIfPresent(Bool.self, forKey: .tokenBasedBilling) ?? false
         self.assignedDate = try container.decodeIfPresent(String.self, forKey: .assignedDate)
         self.quotaResetDate = try container.decodeIfPresent(String.self, forKey: .quotaResetDate)
     }

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
@@ -16,10 +16,16 @@ public struct CopilotUsageFetcher: Sendable {
 
     private let token: String
     private let enterpriseHost: String?
+    private let transport: any ProviderHTTPTransport
 
-    public init(token: String, enterpriseHost: String? = nil) {
+    public init(
+        token: String,
+        enterpriseHost: String? = nil,
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared)
+    {
         self.token = token
         self.enterpriseHost = enterpriseHost
+        self.transport = transport
     }
 
     public static func apiHost(enterpriseHost: String?) -> String {
@@ -49,7 +55,7 @@ public struct CopilotUsageFetcher: Sendable {
         request.setValue("token \(self.token)", forHTTPHeaderField: "Authorization")
         self.addCommonHeaders(to: &request)
 
-        let response = try await ProviderHTTPClient.shared.response(for: request)
+        let response = try await self.transport.response(for: request)
 
         if response.statusCode == 401 || response.statusCode == 403 {
             throw URLError(.userAuthenticationRequired)
@@ -73,6 +79,11 @@ public struct CopilotUsageFetcher: Sendable {
             // ("Premium" for primary, "Chat" for secondary) on chat-only plans.
             primary = nil
             secondary = chatWindow
+        } else if usage.tokenBasedBilling {
+            // Copilot Business token-based billing currently exposes zero-entitlement
+            // placeholder quotas on this endpoint, so surface the plan without fake usage.
+            primary = nil
+            secondary = nil
         } else {
             throw URLError(.cannotDecodeRawData)
         }

--- a/Tests/CodexBarTests/CopilotUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CopilotUsageFetcherTests.swift
@@ -27,6 +27,47 @@ struct CopilotUsageFetcherTests {
     }
 
     @Test
+    func `fetch returns unavailable snapshot for business token billing placeholders`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "token gh-token")
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"])!
+            let data = Data(
+                """
+                {
+                  "copilot_plan": "business",
+                  "token_based_billing": true,
+                  "quota_snapshots": {
+                    "premium_interactions": {
+                      "entitlement": 0,
+                      "remaining": 0,
+                      "percent_remaining": 100,
+                      "quota_id": "premium_interactions"
+                    },
+                    "chat": {
+                      "entitlement": 0,
+                      "remaining": 0,
+                      "percent_remaining": 100,
+                      "quota_id": "chat"
+                    }
+                  }
+                }
+                """.utf8)
+            return (data, response)
+        }
+        let fetcher = CopilotUsageFetcher(token: "gh-token", transport: transport)
+
+        let snapshot = try await fetcher.fetch()
+
+        #expect(snapshot.primary == nil)
+        #expect(snapshot.secondary == nil)
+        #expect(snapshot.identity?.loginMethod == "Business")
+    }
+
+    @Test
     func `makeRateWindow drops business token billing placeholder quota`() {
         // entitlement=0/remaining=0/percent_remaining=100 must not become a "0% used"
         // rate window for Copilot Business token-based billing accounts. (#1258)

--- a/Tests/CodexBarTests/CopilotUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CopilotUsageFetcherTests.swift
@@ -25,4 +25,27 @@ struct CopilotUsageFetcherTests {
         #expect(requests.count == 1)
         #expect(requests.first?.url?.host == "api.github.com")
     }
+
+    @Test
+    func `makeRateWindow drops business token billing placeholder quota`() {
+        // entitlement=0/remaining=0/percent_remaining=100 must not become a "0% used"
+        // rate window for Copilot Business token-based billing accounts. (#1258)
+        let placeholder = CopilotUsageResponse.QuotaSnapshot(
+            entitlement: 0,
+            remaining: 0,
+            percentRemaining: 100,
+            quotaId: "premium_interactions")
+        #expect(CopilotUsageFetcher.makeRateWindow(from: placeholder) == nil)
+    }
+
+    @Test
+    func `makeRateWindow keeps real quota window`() {
+        let real = CopilotUsageResponse.QuotaSnapshot(
+            entitlement: 500,
+            remaining: 125,
+            percentRemaining: 25,
+            quotaId: "premium_interactions")
+        let window = CopilotUsageFetcher.makeRateWindow(from: real)
+        #expect(window?.usedPercent == 75)
+    }
 }

--- a/Tests/CodexBarTests/CopilotUsageModelsTests.swift
+++ b/Tests/CodexBarTests/CopilotUsageModelsTests.swift
@@ -496,6 +496,26 @@ struct CopilotUsageModelsTests {
         #expect(snapshot.usedPercent == 100)
     }
 
+    @Test
+    func `keeps percent only quota snapshots available`() throws {
+        let response = try Self.decodeFixture(
+            """
+            {
+              "copilot_plan": "business",
+              "quota_snapshots": {
+                "chat": {
+                  "percent_remaining": 40,
+                  "quota_id": "chat"
+                }
+              }
+            }
+            """)
+
+        #expect(response.quotaSnapshots.chat?.percentRemaining == 40)
+        #expect(response.quotaSnapshots.chat?.usedPercent == 60)
+        #expect(response.quotaSnapshots.chat?.isPlaceholder == false)
+    }
+
     private static func decodeFixture(_ fixture: String) throws -> CopilotUsageResponse {
         try JSONDecoder().decode(CopilotUsageResponse.self, from: Data(fixture.utf8))
     }

--- a/Tests/CodexBarTests/CopilotUsageModelsTests.swift
+++ b/Tests/CodexBarTests/CopilotUsageModelsTests.swift
@@ -437,6 +437,65 @@ struct CopilotUsageModelsTests {
         #expect(response.quotaSnapshots.chat == nil)
     }
 
+    @Test
+    func `treats business token billing zero entitlement quotas as unavailable`() throws {
+        // GitHub Copilot Business token-based billing reports every quota as
+        // entitlement=0, remaining=0, percent_remaining=100. That previously rendered as a
+        // misleading "0% used" (100 - 100). A zero-entitlement quota carries no usage signal,
+        // so the snapshots must drop out instead of showing as usage. (#1258)
+        let response = try Self.decodeFixture(
+            """
+            {
+              "copilot_plan": "business",
+              "quota_snapshots": {
+                "premium_interactions": {
+                  "entitlement": 0,
+                  "remaining": 0,
+                  "percent_remaining": 100,
+                  "quota_id": "premium_interactions"
+                },
+                "chat": {
+                  "entitlement": 0,
+                  "remaining": 0,
+                  "percent_remaining": 100,
+                  "quota_id": "chat"
+                },
+                "completions": {
+                  "entitlement": 0,
+                  "remaining": 0,
+                  "percent_remaining": 100,
+                  "quota_id": "completions"
+                }
+              }
+            }
+            """)
+
+        #expect(response.quotaSnapshots.premiumInteractions == nil)
+        #expect(response.quotaSnapshots.chat == nil)
+    }
+
+    @Test
+    func `flags zero entitlement snapshot as placeholder`() {
+        let snapshot = CopilotUsageResponse.QuotaSnapshot(
+            entitlement: 0,
+            remaining: 0,
+            percentRemaining: 100,
+            quotaId: "chat")
+        #expect(snapshot.isPlaceholder)
+    }
+
+    @Test
+    func `keeps fully consumed quota with positive entitlement`() {
+        // entitlement > 0 with remaining 0 is a real "100% used" window, not a placeholder.
+        let snapshot = CopilotUsageResponse.QuotaSnapshot(
+            entitlement: 500,
+            remaining: 0,
+            percentRemaining: 0,
+            quotaId: "premium_interactions")
+        #expect(!snapshot.isPlaceholder)
+        #expect(snapshot.usedPercent == 100)
+    }
+
     private static func decodeFixture(_ fixture: String) throws -> CopilotUsageResponse {
         try JSONDecoder().decode(CopilotUsageResponse.self, from: Data(fixture.utf8))
     }

--- a/Tests/CodexBarTests/CopilotUsageModelsTests.swift
+++ b/Tests/CodexBarTests/CopilotUsageModelsTests.swift
@@ -447,6 +447,7 @@ struct CopilotUsageModelsTests {
             """
             {
               "copilot_plan": "business",
+              "token_based_billing": true,
               "quota_snapshots": {
                 "premium_interactions": {
                   "entitlement": 0,
@@ -470,6 +471,7 @@ struct CopilotUsageModelsTests {
             }
             """)
 
+        #expect(response.tokenBasedBilling)
         #expect(response.quotaSnapshots.premiumInteractions == nil)
         #expect(response.quotaSnapshots.chat == nil)
     }


### PR DESCRIPTION
Fixes #1258.

**Problem.** GitHub Copilot Business token-based billing returns every quota as `entitlement: 0, remaining: 0, percent_remaining: 100`. CodexBar computes used percent as `100 - percent_remaining`, so these accounts showed a misleading "0% used" instead of recognizing the endpoint exposes no usable quota. The placeholder guard only caught the all-zero shape with an empty `quota_id`, so the `percent_remaining: 100` variant slipped through as a real window.

**Fix.** A zero-entitlement / zero-remaining snapshot carries no usage signal, so treat it as a placeholder (`entitlement == 0 && remaining == 0`). These now drop out the same way other empty/placeholder Copilot responses already do, so the account no longer shows a fake "0% used". Quotas with a positive entitlement are unchanged, including the genuine "100% used" case (guarded by a test).

**Tests.** Added parser + fetcher regression tests for the reported payload. The three new assertions fail on `main` (the fetcher test shows `RateWindow(usedPercent: 0.0)`) and pass after the change.

**Real-behavior proof.** Running the production decode + rate-window path (`CopilotUsageResponse` decode → `CopilotUsageFetcher.makeRateWindow`) on the exact token-billing payload reported in #1258:

Before (`main`):
```
premium -> RateWindow(usedPercent: 0.0)  -> shown as "0% used"
chat    -> RateWindow(usedPercent: 0.0)  -> shown as "0% used"
```

After (this PR):
```
premium -> no window (unavailable)
chat    -> no window (unavailable)
```

I don't have a live Copilot Business account, so this drives the real parsing/window code with the issue's verbatim payload rather than a live credentialed probe.

**Verification.** `swift test --filter CopilotUsageModelsTests` and `CopilotUsageFetcherTests` pass; `make check` clean (parser hash current); full `swift test` (3219 tests) passes.

Used the Claude CLI while working on this.
