### PR TITLE
Avoid redundant menu-open refreshes

### DIFF
--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1109,9 +1109,13 @@ extension StatusItemController {
     }
 
     private func scheduleOpenMenuRefresh(for menu: NSMenu) {
-        // Queue refresh work until the menu closes. AppKit menu tracking is modal; starting provider refreshes
-        // while it is active can make the menu feel frozen and can block keyboard focus from returning.
-        self.deferMenuInteractionRefreshIfNeeded()
+        // Queue refresh work only when visible menu data is missing or stale. Here "stale" means the last
+        // provider fetch failed and needs a retry; periodic freshness is handled by the refresh timer.
+        // AppKit menu tracking is modal, so starting provider refreshes while it is active can make the menu
+        // feel frozen and can block keyboard focus from returning.
+        if self.menuNeedsDelayedRefreshRetry(for: menu) {
+            self.deferMenuInteractionRefreshIfNeeded()
+        }
         let key = ObjectIdentifier(menu)
         self.menuRefreshTasks[key]?.cancel()
         self.menuRefreshTasks[key] = Task { @MainActor [weak self, weak menu] in

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -6,7 +6,7 @@ import Testing
 
 extension StatusMenuTests {
     @Test
-    func `menu open defers automatic refresh until tracking ends`() async {
+    func `opening fresh menu does not schedule deferred refresh`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -15,6 +15,59 @@ extension StatusMenuTests {
         self.enableOnlyCodex(settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        var providerRefreshCount = 0
+        var refreshInteractions: [ProviderInteraction] = []
+        store._test_providerRefreshOverride = { provider in
+            guard provider == .codex else { return }
+            refreshInteractions.append(ProviderInteractionContext.current)
+            providerRefreshCount += 1
+        }
+        defer { store._test_providerRefreshOverride = nil }
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        StatusItemController.setDeferredMenuInteractionRefreshDelayForTesting(.zero)
+        defer { StatusItemController.resetDeferredMenuInteractionRefreshDelayForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+        #expect(providerRefreshCount == 0)
+        #expect(!controller.deferredMenuInteractionRefreshPending)
+
+        controller.menuDidClose(menu)
+        for _ in 0..<40 {
+            await Task.yield()
+        }
+
+        #expect(providerRefreshCount == 0)
+        #expect(refreshInteractions.isEmpty)
+    }
+
+    @Test
+    func `menu open with missing data defers automatic refresh until tracking ends`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        self.enableOnlyCodex(settings)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._setSnapshotForTesting(nil, provider: .codex)
         var providerRefreshCount = 0
         var refreshInteractions: [ProviderInteraction] = []
         store._test_providerRefreshOverride = { provider in
@@ -776,6 +829,7 @@ extension StatusMenuTests {
         self.enableOnlyCodex(settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._setSnapshotForTesting(nil, provider: .codex)
         store.openAIDashboard = nil
         store.lastOpenAIDashboardSnapshot = nil
         let providerBlocker = BlockingStatusMenuProviderRefresh()
@@ -832,6 +886,7 @@ extension StatusMenuTests {
         self.enableOnlyCodex(settings)
 
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._setSnapshotForTesting(nil, provider: .codex)
         store.openAIDashboard = nil
         store.lastOpenAIDashboardSnapshot = nil
         let providerBlocker = BlockingStatusMenuProviderRefresh()


### PR DESCRIPTION
## Summary
- Avoids queuing deferred provider refreshes when opening a menu whose visible data is already fresh.
- Keeps the existing stale/missing-data retry path, still deferred until menu tracking ends.
- Adds focused coverage for fresh opens vs missing-data opens.

## Why
Refs #1235. This follows the existing open-menu refresh direction from #923/#1040/#946: menu-open/background refreshes should stay non-blocking and avoid invalidating or rebuilding the visible `NSMenu` unless data is actually stale or missing.

Scope note for #1235: 0.32.3 already cached provider brand icons (#1274), and 0.32.2 capped/sped up Codex token scanning. This PR is a separate, additive path: it removes the redundant deferred refresh that 0.32.1's "defer refresh until tracking ends" change queued unconditionally on every open, even when no data was stale or missing.

## Evidence

### Focused fresh-menu behavior
Command:

```sh
swift test --filter 'CodexBarTests.StatusMenuTests/`opening fresh menu does not schedule deferred refresh`()'
```

Redacted output excerpt:

```text
Build complete! (11.46s)
◇ Test "opening fresh menu does not schedule deferred refresh" started.
✔ Test "opening fresh menu does not schedule deferred refresh" passed after 0.283 seconds.
✔ Test run with 1 test in 1 suite passed after 0.283 seconds.
```

### Missing-data retry behavior preserved
Command:

```sh
swift test --filter 'CodexBarTests.StatusMenuTests/`menu open with missing data defers automatic refresh until tracking ends`()'
```

Redacted output excerpt:

```text
◇ Test "menu open with missing data defers automatic refresh until tracking ends" started.
✔ Test "menu open with missing data defers automatic refresh until tracking ends" passed after 0.343 seconds.
✔ Test run with 1 test in 1 suite passed after 0.344 seconds.
```

### Lint / format gate
Command:

```sh
make check
```

Redacted output excerpt:

```text
SwiftFormat completed in 0.81s.
0/997 files require formatting.
Done linting! Found 0 violations, 0 serious in 996 files.
```

## ClawSweeper status
ClawSweeper's current blocker is real app behavior proof, not patch quality. I kept this PR scoped to the narrow refresh guard and did not push temporary profiling instrumentation or unrelated packaging/widget-project changes. A real macOS app proof should show:

- Fresh menu open: no deferred provider refresh is queued after close.
- Missing-data menu open: deferred refresh is still queued after menu tracking ends.

## Notes
- I did not create a duplicate issue because #1235 is already the active report for this regression.
- This PR should not automatically close #1235; residual closed-menu `populateMenu` cost is a separate performance issue.


### Maintainer live menu proof
Ran against a freshly packaged `CodexBar.app` from this branch on June 2, 2026. Prompt-risk settings were temporarily disabled for the run: keychain access disabled, refresh cadence manual, OpenAI Web off, Claude Web extras off, token-cost scanning off, and storage-footprint scanning off. Defaults were restored afterwards and the test app was stopped.

Packaged CLI smoke:

```text
CodexBar.app/Contents/Helpers/CodexBarCLI config validate
Config: OK
```

Peekaboo proof:

```text
peekaboo menu list-all --json
status item present: codexbar-merged

/usr/bin/time -p peekaboo menu click-extra --title codexbar-merged --json
success: true, clicked_item: codexbar-merged, real 0.16s
```

Visual check: screenshot showed the merged Overview menu rendered with provider rows and no blocking prompt.

Repeated open / click-away proof:

```text
3 merged-menu opens: 0.14s, 0.15s, 0.17s
3 synthetic outside clicks: 0.12s, 0.13s, 0.15s
All 6 Peekaboo actions returned success: true
Final screenshot showed the menu dismissed.
```

Runtime sample after settle:

```text
%CPU 0.1, RSS 119632 KB
```
