### PR TITLE
docs(cli): document serve request timeout

### DIFF
--- a/Sources/CodexBarCLI/CLIHelp.swift
+++ b/Sources/CodexBarCLI/CLIHelp.swift
@@ -78,6 +78,7 @@ extension CodexBarCLI {
 
         Usage:
           codexbar serve [--port <port>] [--refresh-interval <seconds>]
+                         [--request-timeout <seconds>]
                          [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>]
                          [-v|--verbose]
 
@@ -95,7 +96,7 @@ extension CodexBarCLI {
 
         Examples:
           codexbar serve
-          codexbar serve --port 8080 --refresh-interval 60
+          codexbar serve --port 8080 --refresh-interval 60 --request-timeout 30
           curl http://127.0.0.1:8080/usage?provider=all
         """
     }
@@ -209,6 +210,7 @@ extension CodexBarCLI {
                        [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>] [-v|--verbose]
                        [--provider \(ProviderHelp.list)] [--no-color] [--pretty] [--refresh]
           codexbar serve [--port <port>] [--refresh-interval <seconds>]
+                       [--request-timeout <seconds>]
                        [--json-output] [--log-level <trace|verbose|debug|info|warning|error|critical>] [-v|--verbose]
           codexbar config <validate|dump|providers> [--format text|json]
                                         [--json]

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -129,6 +129,16 @@ struct CLIServeRouterTests {
     }
 
     @Test
+    func `serve help documents request timeout option`() {
+        let serve = CodexBarCLI.serveHelp(version: "0.0.0")
+        let root = CodexBarCLI.rootHelp(version: "0.0.0")
+
+        #expect(serve.contains("--request-timeout <seconds>"))
+        #expect(serve.contains("codexbar serve --port 8080 --refresh-interval 60 --request-timeout 30"))
+        #expect(root.contains("--request-timeout <seconds>"))
+    }
+
+    @Test
     func `serve cache skips provider error payloads`() {
         let success = CLILocalHTTPResponse(
             status: .ok,


### PR DESCRIPTION
## Summary\n- Include --request-timeout in codexbar serve help output\n- Add a regression test covering serve/root help text\n\n## Testing\n- swift test --filter CLIServeRouterTests