### PR TITLE
Fix z.ai overview submenu recursion

### DIFF
--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -558,9 +558,11 @@ extension StatusItemController {
                     guard let self, let menu else { return }
                     self.selectOverviewProvider(row.provider, menu: menu)
                 })
-            // Keep menu item action wired for keyboard activation and accessibility action paths.
-            item.target = self
-            item.action = #selector(self.selectOverviewProvider(_:))
+            if submenu == nil {
+                // Keep plain rows wired for keyboard activation and accessibility action paths.
+                item.target = self
+                item.action = #selector(self.selectOverviewProvider(_:))
+            }
             menu.addItem(item)
             if index < rows.count - 1 {
                 menu.addItem(.separator())

--- a/Tests/CodexBarTests/StatusMenuOverviewSubmenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOverviewSubmenuTests.swift
@@ -61,4 +61,68 @@ extension StatusMenuTests {
             ($0.representedObject as? String) == StatusItemController.costHistoryChartID
         } == true)
     }
+
+    @Test
+    func `overview row submenu action does not switch provider detail`() throws {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.mergedMenuLastSelectedWasOverview = true
+
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            guard let metadata = registry.metadata[provider] else { continue }
+            let shouldEnable = provider == .zai || provider == .claude
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let usage = ZaiUsageSnapshot(
+            tokenLimit: nil,
+            timeLimit: ZaiLimitEntry(
+                type: .timeLimit,
+                unit: .minutes,
+                number: 1,
+                usage: 100,
+                currentValue: 50,
+                remaining: 50,
+                percentage: 50,
+                usageDetails: [ZaiUsageDetail(modelCode: "glm-4.5", usage: 512)],
+                nextResetTime: now.addingTimeInterval(3600)),
+            planName: "Pro",
+            updatedAt: now)
+        store._setSnapshotForTesting(usage.toUsageSnapshot(), provider: .zai)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+
+        let zaiRow = try #require(menu.items.first {
+            ($0.representedObject as? String) == "overviewRow-zai"
+        })
+        #expect(zaiRow.submenu != nil)
+
+        let action = try #require(zaiRow.action)
+        let target = try #require(zaiRow.target as? StatusItemController)
+        _ = target.perform(action, with: zaiRow)
+
+        #expect(settings.mergedMenuLastSelectedWasOverview)
+        #expect(settings.selectedMenuProvider == .claude)
+        #expect(menu.items.contains {
+            ($0.representedObject as? String) == "overviewRow-zai"
+        })
+    }
 }

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -1671,7 +1671,7 @@ extension StatusMenuTests {
         let registry = ProviderRegistry.shared
         for provider in UsageProvider.allCases {
             guard let metadata = registry.metadata[provider] else { continue }
-            let shouldEnable = provider == .codex || provider == .claude
+            let shouldEnable = provider == .codex || provider == .cursor
             settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
         }
 
@@ -1688,15 +1688,15 @@ extension StatusMenuTests {
         let menu = controller.makeMenu()
         controller.menuWillOpen(menu)
 
-        let claudeRow = try #require(menu.items.first {
-            ($0.representedObject as? String) == "overviewRow-claude"
+        let cursorRow = try #require(menu.items.first {
+            ($0.representedObject as? String) == "overviewRow-cursor"
         })
-        let action = try #require(claudeRow.action)
-        let target = try #require(claudeRow.target as? StatusItemController)
-        _ = target.perform(action, with: claudeRow)
+        let action = try #require(cursorRow.action)
+        let target = try #require(cursorRow.target as? StatusItemController)
+        _ = target.perform(action, with: cursorRow)
 
         #expect(settings.mergedMenuLastSelectedWasOverview == false)
-        #expect(settings.selectedMenuProvider == .claude)
+        #expect(settings.selectedMenuProvider == .cursor)
 
         let ids = self.representedIDs(in: menu)
         #expect(ids.contains("menuCard"))


### PR DESCRIPTION
## Summary

- Keep overview rows with detail submenus on the passive submenu action path.
- Add z.ai regression coverage that ensures submenu activation does not switch into provider detail.
- Keep existing provider-selection coverage on a plain overview row fixture.

## Why

Hovering the z.ai overview row could open a nested full menu because the row had both a detail submenu and a provider-selection action. Rows with submenus should let hover open only the detail submenu; plain rows still keep the selection action.

Fixes #1246.

## Reviewer validation

A contributor reviewed and tested this locally on macOS with Swift 6.3.2 / Xcode 26.5.

This PR passed:

```text
PASS overview row submenu action does not switch provider detail (0.092s)
PASS selecting overview row switches to provider detail (0.119s)
PASS Test run with 4 tests in 1 suite (0.594s)
```

Base check, with only the source fix reverted while keeping the new test, failed as expected:

```text
FAIL mergedMenuLastSelectedWasOverview became false
FAIL selectedMenuProvider became .zai instead of staying .claude
FAIL overviewRow-zai disappeared after the rebuild
```

Restoring the fix made the test green again. The test performs the row action on a z.ai overview row with a confirmed non-nil submenu, so it covers the path that previously rebuilt the menu mid-interaction. The reviewer also reported SwiftFormat and SwiftLint clean on the three changed files.

Unrelated note from local validation: `closed attached menu preparation waits for store refresh to finish` failed under a parallel run but passed in isolation; that test is not touched by this PR and appears to be a pre-existing timing flake.

## Validation

- `git diff --check`
- `.build/lint-tools/bin/swiftformat Sources Tests --lint`
- GitHub CI passed: macOS lint/build/test, Linux x64 build, Linux arm64 build, and security.
- `swift test --filter StatusMenuTests/selecting_overview_row_switches_to_provider_detail` was blocked locally before project code compiled: the Command Line Tools install cannot load `PreviewsMacros` for the `KeyboardShortcuts` dependency `#Preview` declarations.
- `make check` ran SwiftFormat successfully, then was blocked when portable SwiftLint trapped loading `sourcekitdInProc.framework` under the local Command Line Tools install.