### PR TITLE
docs: add showy-quota to integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,9 @@ CLI install:
 - [noctalia-codex-usage](https://github.com/rayoplateado/noctalia-codex-usage) — Noctalia/Quickshell plugin that shows Codex 5-hour and weekly usage limits, built on top of the bundled Linux CLI.
 
 
+## Status bar & terminal integration
+- [showy-quota](https://github.com/enieuwy/showy-quota) — always-on AI plan quota strips for SketchyBar, tmux, and Zellij (standalone WASM plugin), built on `codexbar serve` / the bundled CLI.
+
 ## Credits
 Inspired by [ccusage](https://github.com/ryoppippi/ccusage) (MIT), specifically the cost usage tracking.
 


### PR DESCRIPTION
showy-quota surfaces CodexBar's quota data in terminal/menu-bar surfaces — SketchyBar (macOS), tmux, and a standalone Zellij WASM plugin. It consumes `codexbar serve` / `codexbar usage --format json` and owns no auth or provider logic of its own. Mirrors the existing Windows/Linux integration pattern. Happy to reword, fold into an existing section, or drop it.