### PR TITLE
feat: add opt-in MiMo local usage fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.34.1 — Unreleased
 
 - Xiaomi MiMo: show paid and granted balance components alongside token-plan usage without requiring a duplicate provider (#1309). Thanks @AdrianSimionov!
+- Xiaomi MiMo: add an opt-in local session-log fallback for token accounting when browser quota authentication is unavailable (#1284). Thanks @LeoLin990405!
 - Settings: keep the native tab toolbar in sync when macOS switches appearance while the window is open (#1484). Thanks @hhh2210!
 - Menu bar: avoid starting a duplicate background provider refresh when the menu closes while its initial missing-data refresh is still in flight.
 - Menu bar: rebuild merged provider content inside AppKit's active tracking run loop so provider switches no longer wait for the menu to close or the default run loop to resume.

--- a/Scripts/mimo-usage.py
+++ b/Scripts/mimo-usage.py
@@ -43,10 +43,9 @@ def parse_session_usage(jsonl_path: Path):
                     if not ts:
                         continue
                     message_id = msg.get("id")
-                    request_id = d.get("requestId") or d.get("request_id")
                     identity = None
-                    if isinstance(message_id, str) and isinstance(request_id, str):
-                        identity = (message_id, request_id)
+                    if isinstance(message_id, str):
+                        identity = (str(jsonl_path), message_id)
                     yield identity, ts, usage
                 except (json.JSONDecodeError, ValueError):
                     continue

--- a/Scripts/mimo-usage.py
+++ b/Scripts/mimo-usage.py
@@ -16,13 +16,14 @@ Usage:
 import json
 import os
 import sys
-import time
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
 
-MIMO_HOME = Path.home() / ".claude-envs" / "mimo"
+MIMO_HOME = Path(os.environ.get("MIMO_CLAUDE_HOME", Path.home() / ".claude-envs" / "mimo")).expanduser()
 PROJECTS_DIR = MIMO_HOME / ".claude" / "projects"
-CACHE_PATH = Path.home() / ".codexbar" / "mimo-local-usage.json"
+CACHE_PATH = Path(
+    os.environ.get("MIMO_LOCAL_USAGE_PATH", Path.home() / ".codexbar" / "mimo-local-usage.json")
+).expanduser()
 
 
 def parse_session_usage(jsonl_path: Path):
@@ -139,7 +140,7 @@ def fmt_tokens(n: int) -> str:
 def short_status(payload):
     """1-line status line."""
     w = payload["windows"]["week"]
-    total = w["input"] + w["output"] + w["cache_read"]
+    total = w["input"] + w["output"] + w["cache_read"] + w["cache_create"]
     return f"mimo: {fmt_tokens(total)} tok this week ({w['messages']} msg)"
 
 
@@ -175,7 +176,7 @@ def human_summary(payload):
         out_t = fmt_tokens(w["output"])
         cr_t = fmt_tokens(w["cache_read"])
         cc_t = fmt_tokens(w["cache_create"])
-        total = w["input"] + w["output"] + w["cache_read"]
+        total = w["input"] + w["output"] + w["cache_read"] + w["cache_create"]
         lines.append(f"{label:>10}: {fmt_tokens(total):>8} total | in={in_t} out={out_t} cache_r={cr_t} cache_c={cc_t} | msg={w['messages']}")
     lines.append("")
     lines.append("Note: this is local accounting from cc-mimo session jsonl.")

--- a/Scripts/mimo-usage.py
+++ b/Scripts/mimo-usage.py
@@ -42,10 +42,26 @@ def parse_session_usage(jsonl_path: Path):
                         continue
                     if not ts:
                         continue
+                    metadata = d.get("metadata")
+                    message_metadata = msg.get("metadata")
+                    session_id = d.get("sessionId") or d.get("session_id")
+                    if not session_id and isinstance(metadata, dict):
+                        session_id = metadata.get("sessionId")
+                    if not session_id and isinstance(message_metadata, dict):
+                        session_id = message_metadata.get("sessionId")
                     message_id = msg.get("id")
+                    request_id = d.get("requestId") or d.get("request_id")
                     identity = None
-                    if isinstance(message_id, str):
-                        identity = (str(jsonl_path), message_id)
+                    if all(isinstance(value, str) and value for value in (message_id, request_id)):
+                        identity = ("request", message_id, request_id)
+                    elif (
+                        request_id is None
+                        and isinstance(session_id, str)
+                        and session_id
+                        and isinstance(message_id, str)
+                        and message_id
+                    ):
+                        identity = ("legacy", session_id, message_id)
                     yield identity, ts, usage
                 except (json.JSONDecodeError, ValueError):
                     continue

--- a/Scripts/mimo-usage.py
+++ b/Scripts/mimo-usage.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+mimo-usage — local token usage tracker for cc-mimo
+
+Scans ~/.claude-envs/mimo/.claude/projects/**/*.jsonl session files,
+sums input/output/cache tokens per time window (today/week/all),
+writes to ~/.codexbar/mimo-local-usage.json, and prints a human-readable
+summary by default.
+
+Usage:
+  mimo-usage              # show summary (also refreshes cache)
+  mimo-usage --update     # refresh cache only, no output (for LaunchAgent/wrapper)
+  mimo-usage --json       # JSON output
+  mimo-usage --short      # 1-line status (for status line / widget)
+"""
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from datetime import datetime, timedelta, timezone
+
+MIMO_HOME = Path.home() / ".claude-envs" / "mimo"
+PROJECTS_DIR = MIMO_HOME / ".claude" / "projects"
+CACHE_PATH = Path.home() / ".codexbar" / "mimo-local-usage.json"
+
+
+def parse_session_usage(jsonl_path: Path):
+    """Yield (timestamp_iso, usage_dict) for each assistant message with usage."""
+    try:
+        with jsonl_path.open() as f:
+            for line in f:
+                try:
+                    d = json.loads(line)
+                    ts = d.get("timestamp")
+                    msg = d.get("message")
+                    if not isinstance(msg, dict):
+                        continue
+                    usage = msg.get("usage")
+                    if not isinstance(usage, dict):
+                        continue
+                    if not ts:
+                        continue
+                    yield ts, usage
+                except (json.JSONDecodeError, ValueError):
+                    continue
+    except (OSError, IOError):
+        return
+
+
+def aggregate_usage():
+    """Scan all mimo session jsonls and return windowed token sums."""
+    now = datetime.now(timezone.utc)
+    today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    # Week starts on Monday 00:00 UTC
+    week_start = today_start - timedelta(days=today_start.weekday())
+
+    windows = {
+        "today": {"input": 0, "output": 0, "cache_read": 0, "cache_create": 0, "messages": 0},
+        "week": {"input": 0, "output": 0, "cache_read": 0, "cache_create": 0, "messages": 0},
+        "all_time": {"input": 0, "output": 0, "cache_read": 0, "cache_create": 0, "messages": 0},
+    }
+    sessions_scanned = 0
+    last_activity = None
+
+    if not PROJECTS_DIR.exists():
+        return windows, sessions_scanned, last_activity
+
+    for jsonl in PROJECTS_DIR.rglob("*.jsonl"):
+        sessions_scanned += 1
+        for ts_str, usage in parse_session_usage(jsonl):
+            try:
+                # Parse ISO timestamp (may end with Z)
+                ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+            except (ValueError, TypeError):
+                continue
+
+            input_t = int(usage.get("input_tokens", 0) or 0)
+            output_t = int(usage.get("output_tokens", 0) or 0)
+            cache_read_t = int(usage.get("cache_read_input_tokens", 0) or 0)
+            cache_create_t = int(usage.get("cache_creation_input_tokens", 0) or 0)
+
+            if last_activity is None or ts > last_activity:
+                last_activity = ts
+
+            # all_time
+            w = windows["all_time"]
+            w["input"] += input_t
+            w["output"] += output_t
+            w["cache_read"] += cache_read_t
+            w["cache_create"] += cache_create_t
+            w["messages"] += 1
+
+            if ts >= week_start:
+                w = windows["week"]
+                w["input"] += input_t
+                w["output"] += output_t
+                w["cache_read"] += cache_read_t
+                w["cache_create"] += cache_create_t
+                w["messages"] += 1
+
+            if ts >= today_start:
+                w = windows["today"]
+                w["input"] += input_t
+                w["output"] += output_t
+                w["cache_read"] += cache_read_t
+                w["cache_create"] += cache_create_t
+                w["messages"] += 1
+
+    return windows, sessions_scanned, last_activity
+
+
+def write_cache(windows, sessions_scanned, last_activity):
+    CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "last_activity": last_activity.isoformat() if last_activity else None,
+        "sessions_scanned": sessions_scanned,
+        "windows": windows,
+        "source": "local-jsonl-scan",
+        "note": "Local token accounting from cc-mimo session jsonl. Not a quota; mimo platform.xiaomimimo.com SSO cookie required for real quota.",
+    }
+    tmp = CACHE_PATH.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, indent=2))
+    tmp.replace(CACHE_PATH)
+    return payload
+
+
+def fmt_tokens(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+def short_status(payload):
+    """1-line status line."""
+    w = payload["windows"]["week"]
+    total = w["input"] + w["output"] + w["cache_read"]
+    return f"mimo: {fmt_tokens(total)} tok this week ({w['messages']} msg)"
+
+
+def human_summary(payload):
+    """Multi-line human-readable summary."""
+    last = payload.get("last_activity")
+    if last:
+        try:
+            last_dt = datetime.fromisoformat(last)
+            ago = datetime.now(timezone.utc) - last_dt
+            if ago.total_seconds() < 60:
+                ago_str = "just now"
+            elif ago.total_seconds() < 3600:
+                ago_str = f"{int(ago.total_seconds() / 60)}m ago"
+            elif ago.total_seconds() < 86400:
+                ago_str = f"{int(ago.total_seconds() / 3600)}h ago"
+            else:
+                ago_str = f"{ago.days}d ago"
+        except (ValueError, TypeError):
+            ago_str = last
+    else:
+        ago_str = "never"
+
+    lines = [
+        "== MiMo (local tracker) ==",
+        f"Sessions scanned: {payload['sessions_scanned']}",
+        f"Last activity: {ago_str}",
+        "",
+    ]
+    for window_name, label in [("today", "Today"), ("week", "This week"), ("all_time", "All time")]:
+        w = payload["windows"][window_name]
+        in_t = fmt_tokens(w["input"])
+        out_t = fmt_tokens(w["output"])
+        cr_t = fmt_tokens(w["cache_read"])
+        cc_t = fmt_tokens(w["cache_create"])
+        total = w["input"] + w["output"] + w["cache_read"]
+        lines.append(f"{label:>10}: {fmt_tokens(total):>8} total | in={in_t} out={out_t} cache_r={cr_t} cache_c={cc_t} | msg={w['messages']}")
+    lines.append("")
+    lines.append("Note: this is local accounting from cc-mimo session jsonl.")
+    lines.append("Real platform quota requires Chrome cookie (cookieSource=manual).")
+    return "\n".join(lines)
+
+
+def main():
+    args = sys.argv[1:]
+    quiet = "--update" in args
+    json_out = "--json" in args
+    short = "--short" in args
+
+    windows, sessions_scanned, last_activity = aggregate_usage()
+    payload = write_cache(windows, sessions_scanned, last_activity)
+
+    if quiet:
+        return 0
+    if json_out:
+        print(json.dumps(payload, indent=2))
+        return 0
+    if short:
+        print(short_status(payload))
+        return 0
+
+    print(human_summary(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Scripts/mimo-usage.py
+++ b/Scripts/mimo-usage.py
@@ -27,7 +27,7 @@ CACHE_PATH = Path(
 
 
 def parse_session_usage(jsonl_path: Path):
-    """Yield (timestamp_iso, usage_dict) for each assistant message with usage."""
+    """Yield (identity, timestamp_iso, usage_dict) for each assistant message with usage."""
     try:
         with jsonl_path.open() as f:
             for line in f:
@@ -42,7 +42,12 @@ def parse_session_usage(jsonl_path: Path):
                         continue
                     if not ts:
                         continue
-                    yield ts, usage
+                    message_id = msg.get("id")
+                    request_id = d.get("requestId") or d.get("request_id")
+                    identity = None
+                    if isinstance(message_id, str) and isinstance(request_id, str):
+                        identity = (message_id, request_id)
+                    yield identity, ts, usage
                 except (json.JSONDecodeError, ValueError):
                     continue
     except (OSError, IOError):
@@ -63,13 +68,15 @@ def aggregate_usage():
     }
     sessions_scanned = 0
     last_activity = None
+    keyed_rows = {}
+    unkeyed_rows = []
 
     if not PROJECTS_DIR.exists():
         return windows, sessions_scanned, last_activity
 
     for jsonl in PROJECTS_DIR.rglob("*.jsonl"):
         sessions_scanned += 1
-        for ts_str, usage in parse_session_usage(jsonl):
+        for identity, ts_str, usage in parse_session_usage(jsonl):
             try:
                 # Parse ISO timestamp (may end with Z)
                 ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
@@ -78,37 +85,46 @@ def aggregate_usage():
             except (ValueError, TypeError):
                 continue
 
-            input_t = int(usage.get("input_tokens", 0) or 0)
-            output_t = int(usage.get("output_tokens", 0) or 0)
-            cache_read_t = int(usage.get("cache_read_input_tokens", 0) or 0)
-            cache_create_t = int(usage.get("cache_creation_input_tokens", 0) or 0)
+            row = (ts, usage)
+            if identity is None:
+                unkeyed_rows.append(row)
+            else:
+                previous = keyed_rows.get(identity)
+                if previous is None or ts >= previous[0]:
+                    keyed_rows[identity] = row
 
-            if last_activity is None or ts > last_activity:
-                last_activity = ts
+    for ts, usage in [*keyed_rows.values(), *unkeyed_rows]:
+        input_t = int(usage.get("input_tokens", 0) or 0)
+        output_t = int(usage.get("output_tokens", 0) or 0)
+        cache_read_t = int(usage.get("cache_read_input_tokens", 0) or 0)
+        cache_create_t = int(usage.get("cache_creation_input_tokens", 0) or 0)
 
-            # all_time
-            w = windows["all_time"]
+        if last_activity is None or ts > last_activity:
+            last_activity = ts
+
+        # all_time
+        w = windows["all_time"]
+        w["input"] += input_t
+        w["output"] += output_t
+        w["cache_read"] += cache_read_t
+        w["cache_create"] += cache_create_t
+        w["messages"] += 1
+
+        if ts >= week_start:
+            w = windows["week"]
             w["input"] += input_t
             w["output"] += output_t
             w["cache_read"] += cache_read_t
             w["cache_create"] += cache_create_t
             w["messages"] += 1
 
-            if ts >= week_start:
-                w = windows["week"]
-                w["input"] += input_t
-                w["output"] += output_t
-                w["cache_read"] += cache_read_t
-                w["cache_create"] += cache_create_t
-                w["messages"] += 1
-
-            if ts >= today_start:
-                w = windows["today"]
-                w["input"] += input_t
-                w["output"] += output_t
-                w["cache_read"] += cache_read_t
-                w["cache_create"] += cache_create_t
-                w["messages"] += 1
+        if ts >= today_start:
+            w = windows["today"]
+            w["input"] += input_t
+            w["output"] += output_t
+            w["cache_read"] += cache_read_t
+            w["cache_create"] += cache_create_t
+            w["messages"] += 1
 
     return windows, sessions_scanned, last_activity
 

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -104,6 +104,17 @@ extension UsageMenuCardView.Model {
         return error
     }
 
+    static func mimoUsageNotes(input: Input, subscriptionNotes: [String]) -> [String] {
+        let source = input.sourceLabel?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard source != "local" else { return [] }
+        return [
+            L("Balance updates in near-real time (up to 5 min lag)"),
+            L("Daily billing data finalizes at 07:00 UTC"),
+        ] + subscriptionNotes
+    }
+
     private static func hasLocalCodexTokenUsage(_ input: Input) -> Bool {
         input.provider == .codex &&
             input.tokenCostUsageEnabled &&

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -942,18 +942,7 @@ extension UsageMenuCardView.Model {
         }
 
         if input.provider == .mimo, input.snapshot != nil {
-            // Local fallback (cc-mimo session jsonl scan) has no platform billing —
-            // suppress the misleading "balance updates / daily billing" footer.
-            let resolvedSource = input.sourceLabel?
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .lowercased()
-            if resolvedSource == "local" {
-                return []
-            }
-            return [
-                L("Balance updates in near-real time (up to 5 min lag)"),
-                L("Daily billing data finalizes at 07:00 UTC"),
-            ] + subscriptionNotes
+            return Self.mimoUsageNotes(input: input, subscriptionNotes: subscriptionNotes)
         }
 
         if let notes = apiProviderUsageNotes(input: input) {

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -942,6 +942,14 @@ extension UsageMenuCardView.Model {
         }
 
         if input.provider == .mimo, input.snapshot != nil {
+            // Local fallback (cc-mimo session jsonl scan) has no platform billing —
+            // suppress the misleading "balance updates / daily billing" footer.
+            let resolvedSource = input.sourceLabel?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            if resolvedSource == "local" {
+                return []
+            }
             return [
                 L("Balance updates in near-real time (up to 5 min lag)"),
                 L("Daily billing data finalizes at 07:00 UTC"),

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -564,6 +564,14 @@ extension CodexBarCLI {
         {
             return false
         }
+        if provider == .mimo,
+           sourceMode == .auto,
+           let environment,
+           MiMoLocalUsageFallback.snapshot(
+               cachePath: MiMoLocalUsageFallback.cachePath(environment: environment)) != nil
+        {
+            return false
+        }
         return switch sourceMode {
         case .web:
             true

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -567,8 +567,7 @@ extension CodexBarCLI {
         if provider == .mimo,
            sourceMode == .auto,
            let environment,
-           MiMoLocalUsageFallback.snapshot(
-               cachePath: MiMoLocalUsageFallback.cachePath(environment: environment)) != nil
+           MiMoLocalUsageFallback.cacheExists(environment: environment)
         {
             return false
         }

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoLocalUsageFallback.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoLocalUsageFallback.swift
@@ -27,6 +27,10 @@ public enum MiMoLocalUsageFallback {
         return NSString(string: override).expandingTildeInPath
     }
 
+    public static func cacheExists(environment: [String: String]) -> Bool {
+        FileManager.default.fileExists(atPath: self.cachePath(environment: environment))
+    }
+
     public static func snapshot(now: Date = Date()) -> MiMoUsageSnapshot? {
         self.snapshot(cachePath: self.defaultCachePath(), now: now)
     }

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoLocalUsageFallback.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoLocalUsageFallback.swift
@@ -1,0 +1,91 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Local tracker fallback for MiMo when Xiaomi platform.xiaomimimo.com cookie is unavailable.
+///
+/// Reads the JSON cache produced by `Scripts/mimo-usage.py` which scans
+/// `~/.claude-envs/mimo/.claude/projects/**/*.jsonl` and aggregates token usage
+/// per time window. This is local accounting only — not real platform quota —
+/// but gives users a useful view when SSO cookie access is blocked (keychain,
+/// Chrome session-cookie expiry, etc.).
+///
+/// **Implicit opt-in**: this fallback only triggers when the cache file exists;
+/// users who do not run `Scripts/mimo-usage.py` see no behavior change.
+///
+/// See `docs/mimo.md` "Local fallback (opt-in)" for setup instructions.
+public enum MiMoLocalUsageFallback {
+    public static func defaultCachePath() -> String {
+        "\(NSHomeDirectory())/.codexbar/mimo-local-usage.json"
+    }
+
+    public static func snapshot(now: Date = Date()) -> MiMoUsageSnapshot? {
+        self.snapshot(cachePath: self.defaultCachePath(), now: now)
+    }
+
+    public static func snapshot(cachePath: String, now: Date) -> MiMoUsageSnapshot? {
+        let url = URL(fileURLWithPath: cachePath)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+
+        let windows = json["windows"] as? [String: Any] ?? [:]
+        let week = windows["week"] as? [String: Any] ?? [:]
+        let today = windows["today"] as? [String: Any] ?? [:]
+        let allTime = windows["all_time"] as? [String: Any] ?? [:]
+        let sessionsScanned = json["sessions_scanned"] as? Int ?? 0
+
+        let weekInput = Self.intValue(week["input"])
+        let weekOutput = Self.intValue(week["output"])
+        let weekCacheRead = Self.intValue(week["cache_read"])
+        let weekTotal = weekInput + weekOutput + weekCacheRead
+
+        let todayInput = Self.intValue(today["input"])
+        let todayOutput = Self.intValue(today["output"])
+        let todayCacheRead = Self.intValue(today["cache_read"])
+        let todayTotal = todayInput + todayOutput + todayCacheRead
+
+        let allInput = Self.intValue(allTime["input"])
+        let allOutput = Self.intValue(allTime["output"])
+        let allCacheRead = Self.intValue(allTime["cache_read"])
+        let allTotal = allInput + allOutput + allCacheRead
+
+        // planCode shows today/week/lifetime/sessions in the loginMethod row.
+        var parts: [String] = []
+        if todayTotal > 0 { parts.append("\(Self.fmtTokens(todayTotal)) today") }
+        if weekTotal > 0 { parts.append("\(Self.fmtTokens(weekTotal)) week") }
+        if allTotal > 0 { parts.append("\(Self.fmtTokens(allTotal)) total") }
+        parts.append("\(sessionsScanned) sessions")
+        let planCode = parts.joined(separator: " · ")
+
+        // Progress bar: weekly usage vs lifetime baseline (this-week vs all-time activity ratio).
+        // Idle (week=0) → bar empty, lifetime as baseline so the bar is meaningful once user resumes cc-mimo.
+        let tokenLimit = max(allTotal, weekTotal + 1)
+        let tokenUsed = weekTotal
+        let tokenPercent = tokenLimit > 0 ? Double(tokenUsed) / Double(tokenLimit) : 0
+
+        return MiMoUsageSnapshot(
+            balance: 0,
+            currency: "",
+            planCode: planCode,
+            planPeriodEnd: nil,
+            planExpired: false,
+            tokenUsed: tokenUsed,
+            tokenLimit: tokenLimit,
+            tokenPercent: tokenPercent,
+            updatedAt: now)
+    }
+
+    private static func fmtTokens(_ n: Int) -> String {
+        if n >= 1_000_000 { return String(format: "%.1fM", Double(n) / 1_000_000) }
+        if n >= 1_000 { return String(format: "%.1fk", Double(n) / 1_000) }
+        return "\(n)"
+    }
+
+    private static func intValue(_ raw: Any?) -> Int {
+        if let i = raw as? Int { return i }
+        if let d = raw as? Double { return Int(d) }
+        if let s = raw as? String, let i = Int(s) { return i }
+        return 0
+    }
+}

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoLocalUsageFallback.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoLocalUsageFallback.swift
@@ -1,7 +1,4 @@
 import Foundation
-#if canImport(FoundationNetworking)
-import FoundationNetworking
-#endif
 
 /// Local tracker fallback for MiMo when Xiaomi platform.xiaomimimo.com cookie is unavailable.
 ///
@@ -24,7 +21,7 @@ public enum MiMoLocalUsageFallback {
         self.snapshot(cachePath: self.defaultCachePath(), now: now)
     }
 
-    public static func snapshot(cachePath: String, now: Date) -> MiMoUsageSnapshot? {
+    public static func snapshot(cachePath: String, now: Date = Date()) -> MiMoUsageSnapshot? {
         let url = URL(fileURLWithPath: cachePath)
         guard let data = try? Data(contentsOf: url) else { return nil }
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
@@ -33,36 +30,17 @@ public enum MiMoLocalUsageFallback {
         let week = windows["week"] as? [String: Any] ?? [:]
         let today = windows["today"] as? [String: Any] ?? [:]
         let allTime = windows["all_time"] as? [String: Any] ?? [:]
-        let sessionsScanned = json["sessions_scanned"] as? Int ?? 0
+        let sessionsScanned = Self.intValue(json["sessions_scanned"])
+        let weekTotal = Self.total(for: week)
+        let todayTotal = Self.total(for: today)
+        let allTotal = Self.total(for: allTime)
 
-        let weekInput = Self.intValue(week["input"])
-        let weekOutput = Self.intValue(week["output"])
-        let weekCacheRead = Self.intValue(week["cache_read"])
-        let weekTotal = weekInput + weekOutput + weekCacheRead
-
-        let todayInput = Self.intValue(today["input"])
-        let todayOutput = Self.intValue(today["output"])
-        let todayCacheRead = Self.intValue(today["cache_read"])
-        let todayTotal = todayInput + todayOutput + todayCacheRead
-
-        let allInput = Self.intValue(allTime["input"])
-        let allOutput = Self.intValue(allTime["output"])
-        let allCacheRead = Self.intValue(allTime["cache_read"])
-        let allTotal = allInput + allOutput + allCacheRead
-
-        // planCode shows today/week/lifetime/sessions in the loginMethod row.
-        var parts: [String] = []
+        var parts = ["Local"]
         if todayTotal > 0 { parts.append("\(Self.fmtTokens(todayTotal)) today") }
         if weekTotal > 0 { parts.append("\(Self.fmtTokens(weekTotal)) week") }
         if allTotal > 0 { parts.append("\(Self.fmtTokens(allTotal)) total") }
         parts.append("\(sessionsScanned) sessions")
         let planCode = parts.joined(separator: " · ")
-
-        // Progress bar: weekly usage vs lifetime baseline (this-week vs all-time activity ratio).
-        // Idle (week=0) → bar empty, lifetime as baseline so the bar is meaningful once user resumes cc-mimo.
-        let tokenLimit = max(allTotal, weekTotal + 1)
-        let tokenUsed = weekTotal
-        let tokenPercent = tokenLimit > 0 ? Double(tokenUsed) / Double(tokenLimit) : 0
 
         return MiMoUsageSnapshot(
             balance: 0,
@@ -70,10 +48,10 @@ public enum MiMoLocalUsageFallback {
             planCode: planCode,
             planPeriodEnd: nil,
             planExpired: false,
-            tokenUsed: tokenUsed,
-            tokenLimit: tokenLimit,
-            tokenPercent: tokenPercent,
-            updatedAt: now)
+            tokenUsed: 0,
+            tokenLimit: 0,
+            tokenPercent: 0,
+            updatedAt: Self.updatedAt(json: json, url: url, fallback: now))
     }
 
     private static func fmtTokens(_ n: Int) -> String {
@@ -82,10 +60,34 @@ public enum MiMoLocalUsageFallback {
         return "\(n)"
     }
 
+    private static func total(for window: [String: Any]) -> Int {
+        ["input", "output", "cache_read", "cache_create"].reduce(into: 0) { total, key in
+            let (sum, overflow) = total.addingReportingOverflow(Self.intValue(window[key]))
+            total = overflow ? Int.max : sum
+        }
+    }
+
     private static func intValue(_ raw: Any?) -> Int {
-        if let i = raw as? Int { return i }
-        if let d = raw as? Double { return Int(d) }
-        if let s = raw as? String, let i = Int(s) { return i }
+        if let i = raw as? Int { return max(0, i) }
+        if let d = raw as? Double,
+           d.isFinite,
+           d >= 0,
+           d <= Double(Int.max)
+        {
+            return Int(d)
+        }
+        if let s = raw as? String, let i = Int(s) { return max(0, i) }
         return 0
+    }
+
+    private static func updatedAt(json: [String: Any], url: URL, fallback: Date) -> Date {
+        if let raw = json["updated_at"] as? String {
+            let fractional = ISO8601DateFormatter()
+            fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let parsed = fractional.date(from: raw) ?? ISO8601DateFormatter().date(from: raw) {
+                return parsed
+            }
+        }
+        return (try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? fallback
     }
 }

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoLocalUsageFallback.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoLocalUsageFallback.swift
@@ -78,7 +78,7 @@ public enum MiMoLocalUsageFallback {
 
     private static func fmtTokens(_ n: Int) -> String {
         if n >= 1_000_000 { return String(format: "%.1fM", Double(n) / 1_000_000) }
-        if n >= 1_000 { return String(format: "%.1fk", Double(n) / 1_000) }
+        if n >= 1000 { return String(format: "%.1fk", Double(n) / 1000) }
         return "\(n)"
     }
 

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoLocalUsageFallback.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoLocalUsageFallback.swift
@@ -25,11 +25,13 @@ public enum MiMoLocalUsageFallback {
         let url = URL(fileURLWithPath: cachePath)
         guard let data = try? Data(contentsOf: url) else { return nil }
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
-
-        let windows = json["windows"] as? [String: Any] ?? [:]
-        let week = windows["week"] as? [String: Any] ?? [:]
-        let today = windows["today"] as? [String: Any] ?? [:]
-        let allTime = windows["all_time"] as? [String: Any] ?? [:]
+        guard let windows = json["windows"] as? [String: Any],
+              let week = windows["week"] as? [String: Any],
+              let today = windows["today"] as? [String: Any],
+              let allTime = windows["all_time"] as? [String: Any]
+        else {
+            return nil
+        }
         let sessionsScanned = Self.intValue(json["sessions_scanned"])
         let weekTotal = Self.total(for: week)
         let todayTotal = Self.total(for: today)

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoLocalUsageFallback.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoLocalUsageFallback.swift
@@ -17,6 +17,16 @@ public enum MiMoLocalUsageFallback {
         "\(NSHomeDirectory())/.codexbar/mimo-local-usage.json"
     }
 
+    public static func cachePath(environment: [String: String]) -> String {
+        guard let override = environment["MIMO_LOCAL_USAGE_PATH"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !override.isEmpty
+        else {
+            return self.defaultCachePath()
+        }
+        return NSString(string: override).expandingTildeInPath
+    }
+
     public static func snapshot(now: Date = Date()) -> MiMoUsageSnapshot? {
         self.snapshot(cachePath: self.defaultCachePath(), now: now)
     }

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
@@ -185,7 +185,7 @@ struct MiMoLocalFetchStrategy: ProviderFetchStrategy {
     let kind: ProviderFetchKind = .localProbe
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        FileManager.default.fileExists(atPath: Self.cachePath(context: context))
+        MiMoLocalUsageFallback.cacheExists(environment: context.env)
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
@@ -193,7 +193,7 @@ struct MiMoLocalFetchStrategy: ProviderFetchStrategy {
         guard let snapshot = MiMoLocalUsageFallback.snapshot(cachePath: path) else {
             throw MiMoLocalUsageError.invalidCache(path)
         }
-        return self.makeResult(usage: snapshot.toUsageSnapshot(), sourceLabel: "local")
+        return self.makeResult(usage: snapshot.toUsageSnapshot(includeBalance: false), sourceLabel: "local")
     }
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
@@ -33,8 +33,11 @@ public enum MiMoProviderDescriptor {
                 noDataMessage: { "Xiaomi MiMo cost summary is not supported." }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in
-                    [MiMoWebFetchStrategy(), MiMoLocalFetchStrategy()]
+                pipeline: ProviderFetchPipeline(resolveStrategies: { context in
+                    if context.sourceMode == .web {
+                        return [MiMoWebFetchStrategy()]
+                    }
+                    return [MiMoWebFetchStrategy(), MiMoLocalFetchStrategy()]
                 })),
             cli: ProviderCLIConfig(
                 name: "mimo",

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
@@ -33,7 +33,9 @@ public enum MiMoProviderDescriptor {
                 noDataMessage: { "Xiaomi MiMo cost summary is not supported." }),
             fetchPlan: ProviderFetchPlan(
                 sourceModes: [.auto, .web],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [MiMoWebFetchStrategy()] })),
+                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in
+                    [MiMoWebFetchStrategy(), MiMoLocalFetchStrategy()]
+                })),
             cli: ProviderCLIConfig(
                 name: "mimo",
                 aliases: ["xiaomi-mimo"],
@@ -55,20 +57,7 @@ struct MiMoWebFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        do {
-            return try await self.fetchFromWeb(context)
-        } catch {
-            // Local tracker fallback: when platform cookie/SSO is unavailable
-            // (missingCookie / invalidCookie / loginRequired / invalidCredentials),
-            // fall back to local jsonl token accounting via ~/.codexbar/mimo-local-usage.json
-            // (populated by `~/bin/mimo-usage`, scanning ~/.claude-envs/mimo session jsonl).
-            if Self.shouldFallbackToLocal(error: error),
-               let local = MiMoLocalUsageFallback.snapshot()
-            {
-                return self.makeResult(usage: local.toUsageSnapshot(), sourceLabel: "local")
-            }
-            throw error
-        }
+        try await self.fetchFromWeb(context)
     }
 
     private static func shouldFallbackToLocal(error: Error) -> Bool {
@@ -152,8 +141,8 @@ struct MiMoWebFetchStrategy: ProviderFetchStrategy {
         #endif
     }
 
-    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
-        false
+    func shouldFallback(on error: Error, context _: ProviderFetchContext) -> Bool {
+        Self.shouldFallbackToLocal(error: error)
     }
 
     private static func resolveManualCookieHeader(context: ProviderFetchContext) -> String? {
@@ -174,5 +163,47 @@ struct MiMoWebFetchStrategy: ProviderFetchStrategy {
         case .networkError:
             return false
         }
+    }
+}
+
+enum MiMoLocalUsageError: LocalizedError {
+    case invalidCache(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidCache(path):
+            "Xiaomi MiMo local usage cache is unreadable or malformed: \(path)"
+        }
+    }
+}
+
+struct MiMoLocalFetchStrategy: ProviderFetchStrategy {
+    let id: String = "mimo.local"
+    let kind: ProviderFetchKind = .localProbe
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        FileManager.default.fileExists(atPath: Self.cachePath(context: context))
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        let path = Self.cachePath(context: context)
+        guard let snapshot = MiMoLocalUsageFallback.snapshot(cachePath: path) else {
+            throw MiMoLocalUsageError.invalidCache(path)
+        }
+        return self.makeResult(usage: snapshot.toUsageSnapshot(), sourceLabel: "local")
+    }
+
+    func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
+        false
+    }
+
+    private static func cachePath(context: ProviderFetchContext) -> String {
+        guard let override = context.env["MIMO_LOCAL_USAGE_PATH"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !override.isEmpty
+        else {
+            return MiMoLocalUsageFallback.defaultCachePath()
+        }
+        return NSString(string: override).expandingTildeInPath
     }
 }

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
@@ -201,12 +201,6 @@ struct MiMoLocalFetchStrategy: ProviderFetchStrategy {
     }
 
     private static func cachePath(context: ProviderFetchContext) -> String {
-        guard let override = context.env["MIMO_LOCAL_USAGE_PATH"]?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-            !override.isEmpty
-        else {
-            return MiMoLocalUsageFallback.defaultCachePath()
-        }
-        return NSString(string: override).expandingTildeInPath
+        MiMoLocalUsageFallback.cachePath(environment: context.env)
     }
 }

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoProviderDescriptor.swift
@@ -55,6 +55,32 @@ struct MiMoWebFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        do {
+            return try await self.fetchFromWeb(context)
+        } catch {
+            // Local tracker fallback: when platform cookie/SSO is unavailable
+            // (missingCookie / invalidCookie / loginRequired / invalidCredentials),
+            // fall back to local jsonl token accounting via ~/.codexbar/mimo-local-usage.json
+            // (populated by `~/bin/mimo-usage`, scanning ~/.claude-envs/mimo session jsonl).
+            if Self.shouldFallbackToLocal(error: error),
+               let local = MiMoLocalUsageFallback.snapshot()
+            {
+                return self.makeResult(usage: local.toUsageSnapshot(), sourceLabel: "local")
+            }
+            throw error
+        }
+    }
+
+    private static func shouldFallbackToLocal(error: Error) -> Bool {
+        if error is MiMoSettingsError { return true }
+        guard let mimoError = error as? MiMoUsageError else { return false }
+        switch mimoError {
+        case .invalidCredentials, .loginRequired: return true
+        case .parseFailed, .networkError: return false
+        }
+    }
+
+    private func fetchFromWeb(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
         guard context.settings?.mimo?.cookieSource != .off else {
             throw MiMoSettingsError.missingCookie()
         }

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoUsageSnapshot.swift
@@ -52,7 +52,7 @@ extension MiMoUsageSnapshot {
         return "\(balanceText) (Paid: \(paid) / Granted: \(granted))"
     }
 
-    public func toUsageSnapshot() -> UsageSnapshot {
+    public func toUsageSnapshot(includeBalance: Bool = true) -> UsageSnapshot {
         let tokenWindow: RateWindow? = {
             guard self.tokenLimit > 0 else { return nil }
             let usedPercent = max(0, min(100, self.tokenPercent * 100))
@@ -81,7 +81,7 @@ extension MiMoUsageSnapshot {
             primary: tokenWindow,
             secondary: nil,
             tertiary: nil,
-            mimoUsage: self,
+            mimoUsage: includeBalance ? self : nil,
             updatedAt: self.updatedAt,
             identity: identity)
     }

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -349,7 +349,7 @@ final class CLIEntryTests: XCTestCase {
             .web,
             provider: .mimo,
             environment: ["MIMO_LOCAL_USAGE_PATH": validMiMoCache.path]))
-        XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(
+        XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(
             .auto,
             provider: .mimo,
             environment: ["MIMO_LOCAL_USAGE_PATH": invalidMiMoCache.path]))

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -299,7 +299,24 @@ final class CLIEntryTests: XCTestCase {
             attempts: attempts))
     }
 
-    func test_sourceModeRequiresWebSupportIsProviderAware() {
+    func test_sourceModeRequiresWebSupportIsProviderAware() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mimo-cli-source-mode-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let validMiMoCache = directory.appendingPathComponent("valid.json")
+        let invalidMiMoCache = directory.appendingPathComponent("invalid.json")
+        let payload: [String: Any] = [
+            "sessions_scanned": 1,
+            "windows": [
+                "today": [:],
+                "week": [:],
+                "all_time": [:],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: payload).write(to: validMiMoCache)
+        try Data("{}".utf8).write(to: invalidMiMoCache)
+
         XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .kilo))
         XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .codex))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .kilo))
@@ -324,5 +341,21 @@ final class CLIEntryTests: XCTestCase {
             .auto,
             provider: .kimi,
             environment: ["KIMI_CODE_API_KEY": "kimi-test"]))
+        XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .mimo,
+            environment: ["MIMO_LOCAL_USAGE_PATH": validMiMoCache.path]))
+        XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(
+            .web,
+            provider: .mimo,
+            environment: ["MIMO_LOCAL_USAGE_PATH": validMiMoCache.path]))
+        XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .mimo,
+            environment: ["MIMO_LOCAL_USAGE_PATH": invalidMiMoCache.path]))
+        XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .mimo,
+            environment: ["MIMO_LOCAL_USAGE_PATH": directory.appendingPathComponent("missing.json").path]))
     }
 }

--- a/Tests/CodexBarTests/MiMoLocalUsageFallbackTests.swift
+++ b/Tests/CodexBarTests/MiMoLocalUsageFallbackTests.swift
@@ -81,7 +81,9 @@ struct MiMoLocalUsageFallbackTests {
         #expect(snap.tokenUsed == 0)
         #expect(snap.tokenLimit == 0)
         #expect(snap.tokenPercent == 0)
-        #expect(snap.toUsageSnapshot().primary == nil)
+        let usage = snap.toUsageSnapshot(includeBalance: false)
+        #expect(usage.primary == nil)
+        #expect(usage.mimoUsage == nil)
 
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -109,6 +111,7 @@ struct MiMoLocalUsageFallbackTests {
         #expect(snap.tokenUsed == 0)
         #expect(snap.tokenLimit == 0)
         #expect(snap.tokenPercent == 0)
+        #expect(snap.toUsageSnapshot(includeBalance: false).mimoUsage == nil)
         let plan = try #require(snap.planCode)
         #expect(plan.hasPrefix("Local"))
         #expect(!plan.contains("today"))

--- a/Tests/CodexBarTests/MiMoLocalUsageFallbackTests.swift
+++ b/Tests/CodexBarTests/MiMoLocalUsageFallbackTests.swift
@@ -2,7 +2,6 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
-@Suite
 struct MiMoLocalUsageFallbackTests {
     @Test
     func `returns nil when cache file is missing`() {
@@ -26,22 +25,30 @@ struct MiMoLocalUsageFallbackTests {
     }
 
     @Test
-    func `parses cache and surfaces lifetime + planCode + progress`() throws {
+    func `parses all token buckets without fabricating a quota window`() throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("mimo-fallback-test-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
         let file = dir.appendingPathComponent("usage.json")
+        let updatedAt = "2026-06-03T05:04:03.123456+00:00"
         let payload: [String: Any] = [
+            "updated_at": updatedAt,
             "sessions_scanned": 1296,
             "windows": [
-                "today": ["input": 1500, "output": 500, "cache_read": 0, "cache_create": 0, "messages": 3],
-                "week": ["input": 30000, "output": 10000, "cache_read": 60000, "cache_create": 0, "messages": 25],
+                "today": ["input": 1500, "output": 500, "cache_read": 0, "cache_create": 250, "messages": 3],
+                "week": [
+                    "input": 30000,
+                    "output": 10000,
+                    "cache_read": 60000,
+                    "cache_create": 10000,
+                    "messages": 25,
+                ],
                 "all_time": [
                     "input": 3_600_000,
                     "output": 1_100_000,
                     "cache_read": 16_100_000,
-                    "cache_create": 0,
+                    "cache_create": 2_000_000,
                     "messages": 1315,
                 ],
             ],
@@ -56,18 +63,20 @@ struct MiMoLocalUsageFallbackTests {
         #expect(plan.contains("week"))
         #expect(plan.contains("total"))
         #expect(plan.contains("1296 sessions"))
+        #expect(plan.contains("110.0k week"))
+        #expect(plan.contains("22.8M total"))
+        #expect(snap.tokenUsed == 0)
+        #expect(snap.tokenLimit == 0)
+        #expect(snap.tokenPercent == 0)
+        #expect(snap.toUsageSnapshot().primary == nil)
 
-        // Progress bar: tokenUsed = week, tokenLimit = max(allTotal, week+1) → bar ~0.2% used.
-        let weekSum = 30000 + 10000 + 60000 // 100k
-        #expect(snap.tokenUsed == weekSum)
-        let allSum = 3_600_000 + 1_100_000 + 16_100_000 // 20.8M
-        #expect(snap.tokenLimit == max(allSum, weekSum + 1))
-        #expect(snap.tokenPercent > 0)
-        #expect(snap.tokenPercent < 0.01) // ~0.5% of lifetime
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        #expect(snap.updatedAt == formatter.date(from: updatedAt))
     }
 
     @Test
-    func `idle week surfaces empty progress with lifetime baseline`() throws {
+    func `idle week keeps local accounting in the plan summary`() throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("mimo-fallback-test-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -85,10 +94,10 @@ struct MiMoLocalUsageFallbackTests {
 
         let snap = try #require(MiMoLocalUsageFallback.snapshot(cachePath: file.path, now: Date()))
         #expect(snap.tokenUsed == 0)
-        #expect(snap.tokenLimit == 2_000_000) // allTotal as baseline
+        #expect(snap.tokenLimit == 0)
         #expect(snap.tokenPercent == 0)
-        // planCode skips today/week (both zero) but keeps total + sessions.
         let plan = try #require(snap.planCode)
+        #expect(plan.hasPrefix("Local"))
         #expect(!plan.contains("today"))
         #expect(!plan.contains("week"))
         #expect(plan.contains("total"))

--- a/Tests/CodexBarTests/MiMoLocalUsageFallbackTests.swift
+++ b/Tests/CodexBarTests/MiMoLocalUsageFallbackTests.swift
@@ -35,9 +35,15 @@ struct MiMoLocalUsageFallbackTests {
         let payload: [String: Any] = [
             "sessions_scanned": 1296,
             "windows": [
-                "today": ["input": 1_500, "output": 500, "cache_read": 0, "cache_create": 0, "messages": 3],
-                "week": ["input": 30_000, "output": 10_000, "cache_read": 60_000, "cache_create": 0, "messages": 25],
-                "all_time": ["input": 3_600_000, "output": 1_100_000, "cache_read": 16_100_000, "cache_create": 0, "messages": 1_315],
+                "today": ["input": 1500, "output": 500, "cache_read": 0, "cache_create": 0, "messages": 3],
+                "week": ["input": 30000, "output": 10000, "cache_read": 60000, "cache_create": 0, "messages": 25],
+                "all_time": [
+                    "input": 3_600_000,
+                    "output": 1_100_000,
+                    "cache_read": 16_100_000,
+                    "cache_create": 0,
+                    "messages": 1315,
+                ],
             ],
         ]
         try JSONSerialization.data(withJSONObject: payload).write(to: file)
@@ -52,12 +58,12 @@ struct MiMoLocalUsageFallbackTests {
         #expect(plan.contains("1296 sessions"))
 
         // Progress bar: tokenUsed = week, tokenLimit = max(allTotal, week+1) → bar ~0.2% used.
-        let weekSum = 30_000 + 10_000 + 60_000  // 100k
+        let weekSum = 30000 + 10000 + 60000 // 100k
         #expect(snap.tokenUsed == weekSum)
-        let allSum = 3_600_000 + 1_100_000 + 16_100_000  // 20.8M
+        let allSum = 3_600_000 + 1_100_000 + 16_100_000 // 20.8M
         #expect(snap.tokenLimit == max(allSum, weekSum + 1))
         #expect(snap.tokenPercent > 0)
-        #expect(snap.tokenPercent < 0.01)  // ~0.5% of lifetime
+        #expect(snap.tokenPercent < 0.01) // ~0.5% of lifetime
     }
 
     @Test
@@ -79,7 +85,7 @@ struct MiMoLocalUsageFallbackTests {
 
         let snap = try #require(MiMoLocalUsageFallback.snapshot(cachePath: file.path, now: Date()))
         #expect(snap.tokenUsed == 0)
-        #expect(snap.tokenLimit == 2_000_000)  // allTotal as baseline
+        #expect(snap.tokenLimit == 2_000_000) // allTotal as baseline
         #expect(snap.tokenPercent == 0)
         // planCode skips today/week (both zero) but keeps total + sessions.
         let plan = try #require(snap.planCode)

--- a/Tests/CodexBarTests/MiMoLocalUsageFallbackTests.swift
+++ b/Tests/CodexBarTests/MiMoLocalUsageFallbackTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite
+struct MiMoLocalUsageFallbackTests {
+    @Test
+    func `returns nil when cache file is missing`() {
+        let snap = MiMoLocalUsageFallback.snapshot(
+            cachePath: "/nonexistent/path/that/should/never/exist.json",
+            now: Date())
+        #expect(snap == nil)
+    }
+
+    @Test
+    func `returns nil when cache file is malformed JSON`() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mimo-fallback-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("malformed.json")
+        try "{not json".write(to: file, atomically: true, encoding: .utf8)
+
+        let snap = MiMoLocalUsageFallback.snapshot(cachePath: file.path, now: Date())
+        #expect(snap == nil)
+    }
+
+    @Test
+    func `parses cache and surfaces lifetime + planCode + progress`() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mimo-fallback-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("usage.json")
+        let payload: [String: Any] = [
+            "sessions_scanned": 1296,
+            "windows": [
+                "today": ["input": 1_500, "output": 500, "cache_read": 0, "cache_create": 0, "messages": 3],
+                "week": ["input": 30_000, "output": 10_000, "cache_read": 60_000, "cache_create": 0, "messages": 25],
+                "all_time": ["input": 3_600_000, "output": 1_100_000, "cache_read": 16_100_000, "cache_create": 0, "messages": 1_315],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: payload).write(to: file)
+
+        let snap = try #require(MiMoLocalUsageFallback.snapshot(cachePath: file.path, now: Date()))
+
+        // planCode packs today/week/total/sessions in one row.
+        let plan = try #require(snap.planCode)
+        #expect(plan.contains("today"))
+        #expect(plan.contains("week"))
+        #expect(plan.contains("total"))
+        #expect(plan.contains("1296 sessions"))
+
+        // Progress bar: tokenUsed = week, tokenLimit = max(allTotal, week+1) → bar ~0.2% used.
+        let weekSum = 30_000 + 10_000 + 60_000  // 100k
+        #expect(snap.tokenUsed == weekSum)
+        let allSum = 3_600_000 + 1_100_000 + 16_100_000  // 20.8M
+        #expect(snap.tokenLimit == max(allSum, weekSum + 1))
+        #expect(snap.tokenPercent > 0)
+        #expect(snap.tokenPercent < 0.01)  // ~0.5% of lifetime
+    }
+
+    @Test
+    func `idle week surfaces empty progress with lifetime baseline`() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mimo-fallback-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("idle.json")
+        let payload: [String: Any] = [
+            "sessions_scanned": 100,
+            "windows": [
+                "today": ["input": 0, "output": 0, "cache_read": 0],
+                "week": ["input": 0, "output": 0, "cache_read": 0],
+                "all_time": ["input": 500_000, "output": 250_000, "cache_read": 1_250_000],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: payload).write(to: file)
+
+        let snap = try #require(MiMoLocalUsageFallback.snapshot(cachePath: file.path, now: Date()))
+        #expect(snap.tokenUsed == 0)
+        #expect(snap.tokenLimit == 2_000_000)  // allTotal as baseline
+        #expect(snap.tokenPercent == 0)
+        // planCode skips today/week (both zero) but keeps total + sessions.
+        let plan = try #require(snap.planCode)
+        #expect(!plan.contains("today"))
+        #expect(!plan.contains("week"))
+        #expect(plan.contains("total"))
+        #expect(plan.contains("100 sessions"))
+    }
+}

--- a/Tests/CodexBarTests/MiMoLocalUsageFallbackTests.swift
+++ b/Tests/CodexBarTests/MiMoLocalUsageFallbackTests.swift
@@ -25,6 +25,19 @@ struct MiMoLocalUsageFallbackTests {
     }
 
     @Test
+    func `returns nil when cache schema is incomplete`() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mimo-fallback-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("incomplete.json")
+        try Data("{}".utf8).write(to: file)
+
+        let snap = MiMoLocalUsageFallback.snapshot(cachePath: file.path, now: Date())
+        #expect(snap == nil)
+    }
+
+    @Test
     func `parses all token buckets without fabricating a quota window`() throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("mimo-fallback-test-\(UUID().uuidString)")

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -658,6 +658,50 @@ extension MiMoProviderTests {
     }
 
     @Test
+    func `mimo local strategy works when web cookies are disabled or invalid`() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mimo-local-strategy-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("usage.json")
+        let payload: [String: Any] = [
+            "updated_at": "2026-06-03T05:04:03+00:00",
+            "sessions_scanned": 2,
+            "windows": [
+                "today": ["input": 100, "output": 50, "cache_read": 0, "cache_create": 0],
+                "week": ["input": 100, "output": 50, "cache_read": 0, "cache_create": 0],
+                "all_time": ["input": 100, "output": 50, "cache_read": 0, "cache_create": 0],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: payload).write(to: file)
+
+        let settings = [
+            ProviderSettingsSnapshot.make(mimo: .init(cookieSource: .off, manualCookieHeader: nil)),
+            ProviderSettingsSnapshot.make(
+                mimo: .init(cookieSource: .manual, manualCookieHeader: "Cookie: userId=123")),
+        ]
+
+        for setting in settings {
+            let context = self.makeContext(
+                settings: setting,
+                environment: ["MIMO_LOCAL_USAGE_PATH": file.path])
+            let outcome = await MiMoProviderDescriptor.descriptor.fetchPlan.fetchOutcome(
+                context: context,
+                provider: .mimo)
+
+            switch outcome.result {
+            case let .success(result):
+                #expect(result.sourceLabel == "local")
+                #expect(result.strategyID == "mimo.local")
+                #expect(result.usage.primary == nil)
+                #expect(result.usage.loginMethod(for: .mimo)?.contains("Local") == true)
+            case let .failure(error):
+                Issue.record("Expected local MiMo fallback, got \(error)")
+            }
+        }
+    }
+
+    @Test
     func `mimo manual mode does not report available from cached browser session`() async {
         KeychainCacheStore.setTestStoreForTesting(true)
         defer { KeychainCacheStore.setTestStoreForTesting(false) }

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -703,6 +703,24 @@ extension MiMoProviderTests {
     }
 
     @Test
+    func `mimo malformed local cache stays available and reports its cache error`() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mimo-invalid-local-strategy-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("usage.json")
+        try Data("{}".utf8).write(to: file)
+
+        let context = self.makeContext(environment: ["MIMO_LOCAL_USAGE_PATH": file.path])
+        let strategy = MiMoLocalFetchStrategy()
+
+        #expect(await strategy.isAvailable(context))
+        await #expect(throws: MiMoLocalUsageError.self) {
+            try await strategy.fetch(context)
+        }
+    }
+
+    @Test
     func `mimo explicit web mode does not use local fallback`() async throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("mimo-web-mode-test-\(UUID().uuidString)")

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -702,6 +702,41 @@ extension MiMoProviderTests {
     }
 
     @Test
+    func `mimo explicit web mode does not use local fallback`() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mimo-web-mode-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let file = dir.appendingPathComponent("usage.json")
+        let payload: [String: Any] = [
+            "updated_at": "2026-06-03T05:04:03+00:00",
+            "sessions_scanned": 1,
+            "windows": [
+                "today": ["input": 100, "output": 50, "cache_read": 0, "cache_create": 0],
+                "week": ["input": 100, "output": 50, "cache_read": 0, "cache_create": 0],
+                "all_time": ["input": 100, "output": 50, "cache_read": 0, "cache_create": 0],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: payload).write(to: file)
+
+        let context = self.makeContext(
+            sourceMode: .web,
+            settings: ProviderSettingsSnapshot.make(
+                mimo: .init(cookieSource: .off, manualCookieHeader: nil)),
+            environment: ["MIMO_LOCAL_USAGE_PATH": file.path])
+        let outcome = await MiMoProviderDescriptor.descriptor.fetchPlan.fetchOutcome(
+            context: context,
+            provider: .mimo)
+
+        switch outcome.result {
+        case let .success(result):
+            Issue.record("Expected explicit web mode to reject local fallback, got \(result.strategyID)")
+        case .failure:
+            break
+        }
+    }
+
+    @Test
     func `mimo manual mode does not report available from cached browser session`() async {
         KeychainCacheStore.setTestStoreForTesting(true)
         defer { KeychainCacheStore.setTestStoreForTesting(false) }
@@ -952,13 +987,14 @@ extension MiMoProviderTests {
     }
 
     private func makeContext(
+        sourceMode: ProviderSourceMode = .auto,
         settings: ProviderSettingsSnapshot? = nil,
         environment: [String: String] = [:]) -> ProviderFetchContext
     {
         let browserDetection = BrowserDetection(cacheTTL: 0)
         return ProviderFetchContext(
             runtime: .app,
-            sourceMode: .auto,
+            sourceMode: sourceMode,
             includeCredits: false,
             webTimeout: 1,
             webDebugDumpHTML: false,

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -694,6 +694,7 @@ extension MiMoProviderTests {
                 #expect(result.sourceLabel == "local")
                 #expect(result.strategyID == "mimo.local")
                 #expect(result.usage.primary == nil)
+                #expect(result.usage.mimoUsage == nil)
                 #expect(result.usage.loginMethod(for: .mimo)?.contains("Local") == true)
             case let .failure(error):
                 Issue.record("Expected local MiMo fallback, got \(error)")

--- a/Tests/CodexBarTests/MiMoUsageScriptTests.swift
+++ b/Tests/CodexBarTests/MiMoUsageScriptTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+
+@Suite
+struct MiMoUsageScriptTests {
+    @Test
+    func `script keeps final cumulative streaming usage`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mimo-usage-script-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let mimoHome = root.appendingPathComponent("mimo")
+        let projects = mimoHome
+            .appendingPathComponent(".claude")
+            .appendingPathComponent("projects")
+            .appendingPathComponent("project-a")
+        try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
+
+        let now = ISO8601DateFormatter().string(from: Date())
+        let rows = [
+            self.assistantRow(timestamp: now, outputTokens: 10),
+            self.assistantRow(timestamp: now, outputTokens: 40),
+            self.assistantRow(timestamp: now, outputTokens: 90),
+        ]
+        let session = projects.appendingPathComponent("session.jsonl")
+        let jsonl = try rows
+            .map { try JSONSerialization.data(withJSONObject: $0) }
+            .map { try #require(String(bytes: $0, encoding: .utf8)) }
+            .joined(separator: "\n")
+        try jsonl.write(to: session, atomically: true, encoding: .utf8)
+
+        let cache = root.appendingPathComponent("usage.json")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["python3", self.scriptURL.path, "--update"]
+        process.environment = ProcessInfo.processInfo.environment.merging([
+            "MIMO_CLAUDE_HOME": mimoHome.path,
+            "MIMO_LOCAL_USAGE_PATH": cache.path,
+        ]) { _, new in new }
+        let stderr = Pipe()
+        process.standardError = stderr
+
+        try process.run()
+        process.waitUntilExit()
+
+        let errorText = try #require(String(
+            bytes: stderr.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8))
+        #expect(process.terminationStatus == 0, Comment(rawValue: errorText))
+
+        let payload = try #require(
+            JSONSerialization.jsonObject(with: Data(contentsOf: cache)) as? [String: Any])
+        let windows = try #require(payload["windows"] as? [String: Any])
+        let allTime = try #require(windows["all_time"] as? [String: Any])
+        #expect(allTime["input"] as? Int == 120)
+        #expect(allTime["cache_create"] as? Int == 10)
+        #expect(allTime["cache_read"] as? Int == 5)
+        #expect(allTime["output"] as? Int == 90)
+        #expect(allTime["messages"] as? Int == 1)
+    }
+
+    private var scriptURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Scripts/mimo-usage.py")
+    }
+
+    private func assistantRow(timestamp: String, outputTokens: Int) -> [String: Any] {
+        [
+            "type": "assistant",
+            "timestamp": timestamp,
+            "requestId": "req_stream",
+            "message": [
+                "id": "msg_stream",
+                "usage": [
+                    "input_tokens": 120,
+                    "cache_creation_input_tokens": 10,
+                    "cache_read_input_tokens": 5,
+                    "output_tokens": outputTokens,
+                ],
+            ],
+        ]
+    }
+}

--- a/Tests/CodexBarTests/MiMoUsageScriptTests.swift
+++ b/Tests/CodexBarTests/MiMoUsageScriptTests.swift
@@ -5,6 +5,15 @@ import Testing
 struct MiMoUsageScriptTests {
     @Test
     func `script keeps final cumulative streaming usage`() throws {
+        try self.assertFinalStreamingUsage(includeRequestID: true)
+    }
+
+    @Test
+    func `script deduplicates streaming usage without request id`() throws {
+        try self.assertFinalStreamingUsage(includeRequestID: false)
+    }
+
+    private func assertFinalStreamingUsage(includeRequestID: Bool) throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("mimo-usage-script-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: root) }
@@ -18,9 +27,9 @@ struct MiMoUsageScriptTests {
 
         let now = ISO8601DateFormatter().string(from: Date())
         let rows = [
-            self.assistantRow(timestamp: now, outputTokens: 10),
-            self.assistantRow(timestamp: now, outputTokens: 40),
-            self.assistantRow(timestamp: now, outputTokens: 90),
+            self.assistantRow(timestamp: now, outputTokens: 10, includeRequestID: includeRequestID),
+            self.assistantRow(timestamp: now, outputTokens: 40, includeRequestID: includeRequestID),
+            self.assistantRow(timestamp: now, outputTokens: 90, includeRequestID: includeRequestID),
         ]
         let session = projects.appendingPathComponent("session.jsonl")
         let jsonl = try rows
@@ -67,11 +76,14 @@ struct MiMoUsageScriptTests {
             .appendingPathComponent("Scripts/mimo-usage.py")
     }
 
-    private func assistantRow(timestamp: String, outputTokens: Int) -> [String: Any] {
-        [
+    private func assistantRow(
+        timestamp: String,
+        outputTokens: Int,
+        includeRequestID: Bool) -> [String: Any]
+    {
+        var row: [String: Any] = [
             "type": "assistant",
             "timestamp": timestamp,
-            "requestId": "req_stream",
             "message": [
                 "id": "msg_stream",
                 "usage": [
@@ -82,5 +94,9 @@ struct MiMoUsageScriptTests {
                 ],
             ],
         ]
+        if includeRequestID {
+            row["requestId"] = "req_stream"
+        }
+        return row
     }
 }

--- a/Tests/CodexBarTests/MiMoUsageScriptTests.swift
+++ b/Tests/CodexBarTests/MiMoUsageScriptTests.swift
@@ -5,15 +5,99 @@ import Testing
 struct MiMoUsageScriptTests {
     @Test
     func `script keeps final cumulative streaming usage`() throws {
-        try self.assertFinalStreamingUsage(includeRequestID: true)
+        let rows = [
+            self.assistantRow(outputTokens: 10),
+            self.assistantRow(outputTokens: 40),
+            self.assistantRow(outputTokens: 90),
+        ]
+        let allTime = try self.runScript(files: ["session.jsonl": rows])
+
+        self.assertUsage(
+            allTime,
+            expected: .init(input: 120, cacheCreate: 10, cacheRead: 5, output: 90, messages: 1))
     }
 
     @Test
-    func `script deduplicates streaming usage without request id`() throws {
-        try self.assertFinalStreamingUsage(includeRequestID: false)
+    func `script keeps final cumulative streaming usage without session id`() throws {
+        let rows = [
+            self.assistantRow(outputTokens: 10, sessionID: nil),
+            self.assistantRow(outputTokens: 40, sessionID: nil),
+            self.assistantRow(outputTokens: 90, sessionID: nil),
+        ]
+        let allTime = try self.runScript(files: ["session.jsonl": rows])
+
+        self.assertUsage(
+            allTime,
+            expected: .init(input: 120, cacheCreate: 10, cacheRead: 5, output: 90, messages: 1))
     }
 
-    private func assertFinalStreamingUsage(includeRequestID: Bool) throws {
+    @Test
+    func `script keeps final cumulative usage without request id`() throws {
+        let rows = [
+            self.assistantRow(outputTokens: 10, requestID: nil),
+            self.assistantRow(outputTokens: 40, requestID: nil),
+            self.assistantRow(outputTokens: 90, requestID: nil),
+        ]
+        let allTime = try self.runScript(files: ["session.jsonl": rows])
+
+        self.assertUsage(
+            allTime,
+            expected: .init(input: 120, cacheCreate: 10, cacheRead: 5, output: 90, messages: 1))
+    }
+
+    @Test
+    func `script counts rows without session identity conservatively`() throws {
+        let rows = [
+            self.assistantRow(outputTokens: 10, sessionID: nil, requestID: nil),
+            self.assistantRow(outputTokens: 40, sessionID: nil, requestID: nil),
+            self.assistantRow(outputTokens: 90, sessionID: nil, requestID: nil),
+        ]
+        let allTime = try self.runScript(files: ["session.jsonl": rows])
+
+        self.assertUsage(
+            allTime,
+            expected: .init(input: 360, cacheCreate: 30, cacheRead: 15, output: 140, messages: 3))
+    }
+
+    @Test
+    func `script keeps distinct requests sharing a message id`() throws {
+        let rows = [
+            self.assistantRow(outputTokens: 40, requestID: "req_one"),
+            self.assistantRow(outputTokens: 90, requestID: "req_two"),
+        ]
+        let allTime = try self.runScript(files: ["session.jsonl": rows])
+
+        self.assertUsage(
+            allTime,
+            expected: .init(input: 240, cacheCreate: 20, cacheRead: 10, output: 130, messages: 2))
+    }
+
+    @Test
+    func `script deduplicates copied rows from the same session`() throws {
+        let rows = [self.assistantRow(outputTokens: 90)]
+        let allTime = try self.runScript(files: [
+            "session.jsonl": rows,
+            "session-copy.jsonl": rows,
+        ])
+
+        self.assertUsage(
+            allTime,
+            expected: .init(input: 120, cacheCreate: 10, cacheRead: 5, output: 90, messages: 1))
+    }
+
+    @Test
+    func `script deduplicates copied requests from different sessions`() throws {
+        let allTime = try self.runScript(files: [
+            "session-a.jsonl": [self.assistantRow(outputTokens: 90, sessionID: "session_a")],
+            "session-b.jsonl": [self.assistantRow(outputTokens: 90, sessionID: "session_b")],
+        ])
+
+        self.assertUsage(
+            allTime,
+            expected: .init(input: 120, cacheCreate: 10, cacheRead: 5, output: 90, messages: 1))
+    }
+
+    private func runScript(files: [String: [[String: Any]]]) throws -> [String: Any] {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("mimo-usage-script-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: root) }
@@ -25,18 +109,14 @@ struct MiMoUsageScriptTests {
             .appendingPathComponent("project-a")
         try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
 
-        let now = ISO8601DateFormatter().string(from: Date())
-        let rows = [
-            self.assistantRow(timestamp: now, outputTokens: 10, includeRequestID: includeRequestID),
-            self.assistantRow(timestamp: now, outputTokens: 40, includeRequestID: includeRequestID),
-            self.assistantRow(timestamp: now, outputTokens: 90, includeRequestID: includeRequestID),
-        ]
-        let session = projects.appendingPathComponent("session.jsonl")
-        let jsonl = try rows
-            .map { try JSONSerialization.data(withJSONObject: $0) }
-            .map { try #require(String(bytes: $0, encoding: .utf8)) }
-            .joined(separator: "\n")
-        try jsonl.write(to: session, atomically: true, encoding: .utf8)
+        for (name, rows) in files {
+            let session = projects.appendingPathComponent(name)
+            let jsonl = try rows
+                .map { try JSONSerialization.data(withJSONObject: $0) }
+                .map { try #require(String(bytes: $0, encoding: .utf8)) }
+                .joined(separator: "\n")
+            try jsonl.write(to: session, atomically: true, encoding: .utf8)
+        }
 
         let cache = root.appendingPathComponent("usage.json")
         let process = Process()
@@ -60,12 +140,15 @@ struct MiMoUsageScriptTests {
         let payload = try #require(
             JSONSerialization.jsonObject(with: Data(contentsOf: cache)) as? [String: Any])
         let windows = try #require(payload["windows"] as? [String: Any])
-        let allTime = try #require(windows["all_time"] as? [String: Any])
-        #expect(allTime["input"] as? Int == 120)
-        #expect(allTime["cache_create"] as? Int == 10)
-        #expect(allTime["cache_read"] as? Int == 5)
-        #expect(allTime["output"] as? Int == 90)
-        #expect(allTime["messages"] as? Int == 1)
+        return try #require(windows["all_time"] as? [String: Any])
+    }
+
+    private func assertUsage(_ allTime: [String: Any], expected: UsageExpectation) {
+        #expect(allTime["input"] as? Int == expected.input)
+        #expect(allTime["cache_create"] as? Int == expected.cacheCreate)
+        #expect(allTime["cache_read"] as? Int == expected.cacheRead)
+        #expect(allTime["output"] as? Int == expected.output)
+        #expect(allTime["messages"] as? Int == expected.messages)
     }
 
     private var scriptURL: URL {
@@ -77,13 +160,13 @@ struct MiMoUsageScriptTests {
     }
 
     private func assistantRow(
-        timestamp: String,
         outputTokens: Int,
-        includeRequestID: Bool) -> [String: Any]
+        sessionID: String? = "session_stream",
+        requestID: String? = "req_stream") -> [String: Any]
     {
         var row: [String: Any] = [
             "type": "assistant",
-            "timestamp": timestamp,
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
             "message": [
                 "id": "msg_stream",
                 "usage": [
@@ -94,9 +177,20 @@ struct MiMoUsageScriptTests {
                 ],
             ],
         ]
-        if includeRequestID {
-            row["requestId"] = "req_stream"
+        if let sessionID {
+            row["sessionId"] = sessionID
+        }
+        if let requestID {
+            row["requestId"] = requestID
         }
         return row
+    }
+
+    private struct UsageExpectation {
+        let input: Int
+        let cacheCreate: Int
+        let cacheRead: Int
+        let output: Int
+        let messages: Int
     }
 }

--- a/docs/mimo.md
+++ b/docs/mimo.md
@@ -59,3 +59,39 @@ The pasted header or imported browser session is missing required cookies. Re-co
 ### “Xiaomi MiMo browser session expired”
 
 Your MiMo login is stale. Sign out and back in on the MiMo site, then refresh CodexBar.
+
+## Local fallback (opt-in)
+
+When the platform.xiaomimimo.com cookie path is unavailable — Chrome session cookies expire on Chrome relaunch, Chrome Safe Storage keychain access blocked, no SSO login from this machine, etc. — and you drive MiMo inference through a local wrapper such as `cc-mimo` (Claude Code CLI with `ANTHROPIC_BASE_URL=https://token-plan-sgp.xiaomimimo.com/anthropic`), CodexBar can surface **local token accounting** from that wrapper’s session jsonl as graceful degradation — the MiMo card shows lifetime/weekly token sums instead of `login required`.
+
+This fallback is **implicit opt-in**: it only activates when `~/.codexbar/mimo-local-usage.json` exists. Users who do not run a local wrapper see no change.
+
+### Setup (optional)
+
+1. Drop `Scripts/mimo-usage.py` (shipped with this repo) into your `PATH`:
+
+   ```bash
+   ln -sf "$(pwd)/Scripts/mimo-usage.py" ~/.local/bin/mimo-usage
+   chmod +x ~/.local/bin/mimo-usage
+   ```
+
+2. Run `mimo-usage --update` once to populate `~/.codexbar/mimo-local-usage.json`. The tracker scans `~/.claude-envs/mimo/.claude/projects/**/*.jsonl` (default path for a `cc-mimo`-style wrapper) and aggregates `input_tokens` / `output_tokens` / `cache_read_input_tokens` per time window (today / this week / all time).
+
+3. Trigger updates either on each wrapper invocation (recommended — call `mimo-usage --update` post-exec from your MiMo CLI launcher) or via a `launchd` / `cron` job every 5 minutes.
+
+4. CodexBar picks up the file on its next refresh. The MiMo card displays `Xiaomi MiMo (local)` with progress bar showing weekly tokens vs lifetime baseline and a `<today> · <week> · <lifetime> · <sessions>` plan label. The `Balance updates / Daily billing finalizes` footer is suppressed for `local` source since neither applies.
+
+### Wrapper integration example
+
+```bash
+"$CLAUDE_CLI" "$@"
+_exit=$?
+mimo-usage --update 2>/dev/null || true
+exit $_exit
+```
+
+### Limitations
+
+- **Local accounting only** — this is not real platform quota. The Xiaomi platform may rate-limit your account before your local counter reflects it.
+- The session jsonl scan root (`~/.claude-envs/mimo/.claude/projects`) is hard-coded at the top of `Scripts/mimo-usage.py` (`MIMO_HOME`). Users with a different `HOME` override for their wrapper should edit that constant.
+- Cache schema (`~/.codexbar/mimo-local-usage.json`) is internal; do not rely on the JSON shape for external tooling.

--- a/docs/mimo.md
+++ b/docs/mimo.md
@@ -75,11 +75,11 @@ This fallback is **implicit opt-in**: it only activates when `~/.codexbar/mimo-l
    chmod +x ~/.local/bin/mimo-usage
    ```
 
-2. Run `mimo-usage --update` once to populate `~/.codexbar/mimo-local-usage.json`. The tracker scans `~/.claude-envs/mimo/.claude/projects/**/*.jsonl` (default path for a `cc-mimo`-style wrapper) and aggregates `input_tokens` / `output_tokens` / `cache_read_input_tokens` per time window (today / this week / all time).
+2. Run `mimo-usage --update` once to populate `~/.codexbar/mimo-local-usage.json`. The tracker scans `~/.claude-envs/mimo/.claude/projects/**/*.jsonl` (default path for a `cc-mimo`-style wrapper) and aggregates input, output, cache-read, and cache-creation tokens per time window (today / this week / all time).
 
 3. Trigger updates either on each wrapper invocation (recommended — call `mimo-usage --update` post-exec from your MiMo CLI launcher) or via a `launchd` / `cron` job every 5 minutes.
 
-4. CodexBar picks up the file on its next refresh. The MiMo card displays `Xiaomi MiMo (local)` with progress bar showing weekly tokens vs lifetime baseline and a `<today> · <week> · <lifetime> · <sessions>` plan label. The `Balance updates / Daily billing finalizes` footer is suppressed for `local` source since neither applies.
+4. CodexBar picks up the file on its next refresh. The MiMo card displays `Xiaomi MiMo (local)` with a `Local · <today> · <week> · <lifetime> · <sessions>` summary and the cache's actual update time. Local activity is not rendered as a quota percentage. The `Balance updates / Daily billing finalizes` footer is suppressed for `local` source since neither applies.
 
 ### Wrapper integration example
 
@@ -93,5 +93,5 @@ exit $_exit
 ### Limitations
 
 - **Local accounting only** — this is not real platform quota. The Xiaomi platform may rate-limit your account before your local counter reflects it.
-- The session jsonl scan root (`~/.claude-envs/mimo/.claude/projects`) is hard-coded at the top of `Scripts/mimo-usage.py` (`MIMO_HOME`). Users with a different `HOME` override for their wrapper should edit that constant.
+- Override the session root with `MIMO_CLAUDE_HOME` and the cache path with `MIMO_LOCAL_USAGE_PATH` when a wrapper uses non-default locations.
 - Cache schema (`~/.codexbar/mimo-local-usage.json`) is internal; do not rely on the JSON shape for external tooling.


### PR DESCRIPTION
## Summary
- Add an opt-in local MiMo usage source backed by `~/.codexbar/mimo-local-usage.json`.
- Keep explicit web mode web-only; in auto mode, try web first and use local data only when the cache exists and web authentication/settings fail.
- Support the same local source from the CLI, including non-macOS hosts where web cookie import is unavailable.
- Show local token accounting without presenting it as Xiaomi balance or quota data.
- Add `Scripts/mimo-usage.py` and setup documentation for generating the cache from local session JSONL files.

## Behavior
The cache file is the opt-in boundary. Users without it retain the existing web-only behavior. An existing malformed cache remains an available local source and reports a specific unreadable/malformed-cache error instead of a generic web-support error.

Local data is accounting derived from session logs, not authoritative Xiaomi quota or billing data. The UI labels it as local, suppresses web-only balance copy, and does not feed local values into balance identity or quota percentages.

## Validation
- Focused MiMo suites: 37 tests passed.
- Provider-aware CLI regression: passed.
- `make check`: SwiftFormat clean; SwiftLint 0 violations.
- Local diff autoreview: clean.
- Full branch autoreview against `origin/main`: clean.
- Exact-head GitHub CI required before merge.

## Scope
No new dependency. No change to explicit web mode, Xiaomi API authentication, or other providers.
