### PR TITLE
fix(minimax): filter modelRemains to coding-plan-relevant models

### DIFF
--- a/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiniMax/MiniMaxUsageFetcher.swift
@@ -787,9 +787,22 @@ enum MiniMaxUsageParser {
             throw MiniMaxUsageError.parseFailed("Missing coding plan data.")
         }
 
+        // Filter modelRemains to coding-plan-relevant models only (drop auxiliary services
+        // like video/image/music/speech). Order: "general" (main coding plan quota) first,
+        // then text generation models, dropping everything else. This stops the menu from
+        // surfacing e.g. `video 0/3` when the user's primary intent is the coding plan
+        // (auxiliary services are typically a few free-tier extras and clutter the card).
+        let codingPlanRemains = payload.data.modelRemains.filter { item in
+            guard let name = item.modelName?.lowercased() else { return false }
+            if name == "general" { return true }
+            if let raw = item.modelName, Self.isTextGenerationModelName(raw) { return true }
+            return false
+        }
+        let effectiveRemains = codingPlanRemains.isEmpty ? payload.data.modelRemains : codingPlanRemains
+
         // Convert model_remains to services array for multi-service UI display
         var services: [MiniMaxServiceUsage] = []
-        for item in payload.data.modelRemains {
+        for item in effectiveRemains {
             guard let modelName = item.modelName else { continue }
             let serviceTypeIdentifier = self.mapModelNameToServiceType(modelName: modelName)
 
@@ -825,7 +838,7 @@ enum MiniMaxUsageParser {
         }
 
         // Use first service for backward compatibility fields
-        let first = payload.data.modelRemains.first
+        let first = effectiveRemains.first
         let total = first?.currentIntervalTotalCount
         let remaining = first?.currentIntervalUsageCount
         let usedPercent = self.usedPercent(total: total, remaining: remaining)


### PR DESCRIPTION
## Summary
- Filter `model_remains` returned by the MiniMax coding-plan API to coding-plan-relevant models only (`general` + text-generation models), dropping auxiliary services like `video` / `image` / `music` / `speech` before service construction.
- Backward-compatible: when filtering leaves nothing (e.g. an account with only auxiliary services), the original list is used as fallback so the card still surfaces *something*.
- Single-file change in `MiniMaxUsageFetcher.parseMultiService`.

## Why
The MiniMax `coding_plan/remains` API currently returns one `model_remains` entry per accessible model:

```json
{
  "model_remains": [
    {"model_name": "general", "current_interval_total_count": 0, "current_interval_usage_count": 0, "current_interval_remaining_percent": 99},
    {"model_name": "video",   "current_interval_total_count": 3, "current_interval_usage_count": 3, "current_interval_remaining_percent": 100}
  ]
}
```

On a coding-plan account that's idle in the current window (`general` is 0/0) but has used the free-tier `video` quota (3/3), the menu card currently surfaces **only** `video 0/3` because:

1. `general` has `current_interval_total_count: 0`, so `makeServiceUsage` skips it (`guard total > 0`).
2. `video` has a non-zero allowance, so it survives `makeServiceUsage` and becomes the only visible service.

The user picked MiniMax for the coding plan, not video generation — surfacing `video 0/3 · 0% used` as the headline number is confusing and unhelpful.

## Fix
Filter `modelRemains` to coding-plan-relevant models before service construction:

```swift
let codingPlanRemains = payload.data.modelRemains.filter { item in
    guard let name = item.modelName?.lowercased() else { return false }
    if name == "general" { return true }
    if let raw = item.modelName, Self.isTextGenerationModelName(raw) { return true }
    return false
}
let effectiveRemains = codingPlanRemains.isEmpty ? payload.data.modelRemains : codingPlanRemains
```

Then the rest of `parseMultiService` operates on `effectiveRemains`. The fallback to `payload.data.modelRemains` when filtering empties out preserves behavior for accounts that legitimately have only auxiliary services.

## Tests
- Existing MiniMax parsing tests remain green.

## Validation
- `swift build --target CodexBarCore` passes.
- `swift build --target CodexBar` passes.
- Real-behavior probe on a coding-plan account that returns `[general(0/0), video(3/3)]`: menu card now shows the coding plan window as primary (100% remaining placeholder for the idle window) instead of `video 0/3 · 0% used`.
- Local `swift test --filter MiniMaxUsageFetcher` is blocked before reaching focused tests by the local Command Line Tools environment (`KeyboardShortcuts` `#Preview` macro plugins are unavailable without full Xcode); CI should be the test signal.

## Scope
Single-file change in `MiniMaxUsageFetcher.parseMultiService`. No changes to API endpoint, auth, struct decoding, `mapModelNameToServiceType`, settings UI, or non-MiniMax providers.