### PR TITLE
Reduce merged menu rebuild latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.32.5 — Unreleased
 
+### Fixed
+- Menu bar: defer merged-menu close rebuilds and cache repeated menu-card height measurements so dismissing or rapidly switching the merged dropdown avoids rebuilding SwiftUI-backed cards on the main thread (#1274, #1286). Thanks @hhh2210!
+
 ## 0.32.4 — 2026-06-02
 
 ### Fixed

--- a/Sources/CodexBar/StatusItemController+CodexStackedMenu.swift
+++ b/Sources/CodexBar/StatusItemController+CodexStackedMenu.swift
@@ -32,7 +32,8 @@ extension StatusItemController {
                 menu.addItem(self.makeMenuCardItem(
                     UsageMenuCardView(model: model, width: context.menuWidth),
                     id: "menuCard-\(cardIndex)",
-                    width: context.menuWidth))
+                    width: context.menuWidth,
+                    heightCacheScope: account.id))
                 cardIndex += 1
                 if account.id != section.accounts.last?.id {
                     menu.addItem(.separator())
@@ -48,7 +49,8 @@ extension StatusItemController {
             menu.addItem(self.makeMenuCardItem(
                 UsageMenuCardView(model: model, width: context.menuWidth),
                 id: "menuCard",
-                width: context.menuWidth))
+                width: context.menuWidth,
+                heightCacheScope: context.currentProvider.rawValue))
         }
         menu.addItem(.separator())
         if self.addStorageMenuCardSection(to: menu, provider: context.currentProvider, width: context.menuWidth) {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -291,7 +291,8 @@ extension StatusItemController {
                     menuWidth: menuWidth,
                     codexAccountDisplay: codexAccountDisplay,
                     tokenAccountDisplay: tokenAccountDisplay,
-                    openAIContext: openAIContext))
+                    openAIContext: openAIContext,
+                    descriptor: descriptor))
             return
         }
 
@@ -323,7 +324,8 @@ extension StatusItemController {
                     menuWidth: menuWidth,
                     codexAccountDisplay: codexAccountDisplay,
                     tokenAccountDisplay: tokenAccountDisplay,
-                    openAIContext: openAIContext))
+                    openAIContext: openAIContext,
+                    descriptor: descriptor))
             return
         }
 
@@ -378,6 +380,7 @@ extension StatusItemController {
         let codexAccountDisplay: CodexAccountMenuDisplay?
         let tokenAccountDisplay: TokenAccountMenuDisplay?
         let openAIContext: OpenAIWebContext
+        let descriptor: MenuDescriptor
     }
 
     /// Smart update: rebuild everything below the provider switcher while keeping the switcher view intact.
@@ -408,16 +411,6 @@ extension StatusItemController {
                 width: context.menuWidth)
             self.lastTokenAccountMenuDisplay = context.tokenAccountDisplay
 
-            let descriptor = MenuDescriptor.build(
-                provider: context.provider,
-                store: self.store,
-                settings: self.settings,
-                account: self.account,
-                managedCodexAccountCoordinator: self.managedCodexAccountCoordinator,
-                codexAccountPromotionCoordinator: self.codexAccountPromotionCoordinator,
-                updateReady: self.updater.updateStatus.isUpdateReady,
-                includeContextualActions: context.switcherSelection != .overview)
-
             let menuContext = MenuCardContext(
                 currentProvider: context.currentProvider,
                 selectedProvider: context.provider,
@@ -426,7 +419,7 @@ extension StatusItemController {
                 tokenAccountDisplay: context.tokenAccountDisplay,
                 openAIContext: context.openAIContext)
             self.addPrimaryMenuContent(to: menu, context: menuContext, switcherSelection: context.switcherSelection)
-            self.addActionableSections(descriptor.sections, to: menu, width: context.menuWidth)
+            self.addActionableSections(context.descriptor.sections, to: menu, width: context.menuWidth)
         }
     }
 
@@ -1177,7 +1170,10 @@ extension StatusItemController {
         for item in cardItems {
             guard let view = item.view else { continue }
             let width = self.renderedMenuWidth(for: menu)
-            let height = self.menuCardHeight(for: view, width: width)
+            let id = item.representedObject as? String ?? "menuCard"
+            let height = self.cachedMenuCardHeight(for: id, width: width) {
+                self.menuCardHeight(for: view, width: width)
+            }
             view.frame = NSRect(
                 origin: .zero,
                 size: NSSize(width: width, height: height))
@@ -1216,7 +1212,9 @@ extension StatusItemController {
         }
         let hosting = MenuCardItemHostingView(rootView: wrapped, highlightState: highlightState, onClick: onClick)
         // Set frame with target width immediately
-        let height = self.menuCardHeight(for: hosting, width: width)
+        let height = self.cachedMenuCardHeight(for: id, width: width) {
+            self.menuCardHeight(for: hosting, width: width)
+        }
         hosting.frame = NSRect(origin: .zero, size: NSSize(width: width, height: height))
         let item = NSMenuItem()
         item.view = hosting

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -549,6 +549,7 @@ extension StatusItemController {
                 OverviewMenuCardRowView(model: row.model, storageText: storageText, width: menuWidth),
                 id: identifier,
                 width: menuWidth,
+                heightCacheScope: row.provider.rawValue,
                 submenu: submenu,
                 onClick: { [weak self, weak menu] in
                     guard let self, let menu else { return }
@@ -631,7 +632,8 @@ extension StatusItemController {
         menu.addItem(self.makeMenuCardItem(
             UsageMenuCardView(model: model, width: context.menuWidth),
             id: "menuCard",
-            width: context.menuWidth))
+            width: context.menuWidth,
+            heightCacheScope: context.currentProvider.rawValue))
         if self.addStorageMenuCardSection(to: menu, provider: context.currentProvider, width: context.menuWidth) {
             menu.addItem(.separator())
         }
@@ -651,14 +653,16 @@ extension StatusItemController {
             menu.addItem(self.makeMenuCardItem(
                 UsageMenuCardView(model: model, width: context.menuWidth),
                 id: "menuCard",
-                width: context.menuWidth))
+                width: context.menuWidth,
+                heightCacheScope: context.currentProvider.rawValue))
             menu.addItem(.separator())
         } else {
             for (index, model) in cards.enumerated() {
                 menu.addItem(self.makeMenuCardItem(
                     UsageMenuCardView(model: model, width: context.menuWidth),
                     id: "menuCard-\(index)",
-                    width: context.menuWidth))
+                    width: context.menuWidth,
+                    heightCacheScope: "\(context.currentProvider.rawValue)-\(index)"))
                 if index < cards.count - 1 {
                     menu.addItem(.separator())
                 }
@@ -1161,91 +1165,6 @@ extension StatusItemController {
         return enabledProviders
     }
 
-    private func refreshMenuCardHeights(in menu: NSMenu) {
-        // Re-measure the menu card height right before display to avoid stale/incorrect sizing when content
-        // changes (e.g. dashboard error lines causing wrapping).
-        let cardItems = menu.items.filter { item in
-            (item.representedObject as? String)?.hasPrefix("menuCard") == true
-        }
-        for item in cardItems {
-            guard let view = item.view else { continue }
-            let width = self.renderedMenuWidth(for: menu)
-            let id = item.representedObject as? String ?? "menuCard"
-            let height = self.cachedMenuCardHeight(for: id, width: width) {
-                self.menuCardHeight(for: view, width: width)
-            }
-            view.frame = NSRect(
-                origin: .zero,
-                size: NSSize(width: width, height: height))
-        }
-    }
-
-    func makeMenuCardItem(
-        _ view: some View,
-        id: String,
-        width: CGFloat,
-        submenu: NSMenu? = nil,
-        submenuIndicatorAlignment: Alignment = .topTrailing,
-        submenuIndicatorTopPadding: CGFloat = 8,
-        onClick: (() -> Void)? = nil) -> NSMenuItem
-    {
-        if !Self.menuCardRenderingEnabled {
-            let item = NSMenuItem()
-            item.isEnabled = true
-            item.representedObject = id
-            item.submenu = submenu
-            if submenu != nil {
-                item.target = self
-                item.action = #selector(self.menuCardNoOp(_:))
-            }
-            return item
-        }
-
-        let highlightState = MenuCardHighlightState()
-        let wrapped = MenuCardSectionContainerView(
-            highlightState: highlightState,
-            showsSubmenuIndicator: submenu != nil,
-            submenuIndicatorAlignment: submenuIndicatorAlignment,
-            submenuIndicatorTopPadding: submenuIndicatorTopPadding)
-        {
-            view
-        }
-        let hosting = MenuCardItemHostingView(rootView: wrapped, highlightState: highlightState, onClick: onClick)
-        // Set frame with target width immediately
-        let height = self.cachedMenuCardHeight(for: id, width: width) {
-            self.menuCardHeight(for: hosting, width: width)
-        }
-        hosting.frame = NSRect(origin: .zero, size: NSSize(width: width, height: height))
-        let item = NSMenuItem()
-        item.view = hosting
-        item.isEnabled = true
-        item.representedObject = id
-        item.submenu = submenu
-        if submenu != nil {
-            item.target = self
-            item.action = #selector(self.menuCardNoOp(_:))
-        }
-        return item
-    }
-
-    private func menuCardHeight(for view: NSView, width: CGFloat) -> CGFloat {
-        let basePadding: CGFloat = 6
-        let descenderSafety: CGFloat = 1
-
-        // Fast path: use protocol-based measurement when available (avoids layout passes)
-        if let measured = view as? MenuCardMeasuring {
-            return max(1, ceil(measured.measuredHeight(width: width) + basePadding + descenderSafety))
-        }
-
-        // Set frame with target width before measuring.
-        view.frame = NSRect(origin: .zero, size: NSSize(width: width, height: 1))
-
-        // Use fittingSize directly - SwiftUI hosting views respect the frame width for wrapping
-        let fitted = view.fittingSize
-
-        return max(1, ceil(fitted.height + basePadding + descenderSafety))
-    }
-
     private func addMenuCardSections(
         to menu: NSMenu,
         model: UsageMenuCardView.Model,
@@ -1277,13 +1196,18 @@ extension StatusItemController {
                 usageView,
                 id: "menuCardUsage",
                 width: width,
+                heightCacheScope: provider.rawValue,
                 submenu: usageSubmenu))
         } else {
             let headerView = UsageMenuCardHeaderSectionView(
                 model: model,
                 showDivider: false,
                 width: width)
-            menu.addItem(self.makeMenuCardItem(headerView, id: "menuCardHeader", width: width))
+            menu.addItem(self.makeMenuCardItem(
+                headerView,
+                id: "menuCardHeader",
+                width: width,
+                heightCacheScope: provider.rawValue))
         }
 
         if hasStorage || hasCredits || hasExtraUsage || hasCost {
@@ -1311,6 +1235,7 @@ extension StatusItemController {
                 creditsView,
                 id: "menuCardCredits",
                 width: width,
+                heightCacheScope: provider.rawValue,
                 submenu: creditsSubmenu))
             if webItems.canShowBuyCredits {
                 menu.addItem(self.makeBuyCreditsItem())
@@ -1330,6 +1255,7 @@ extension StatusItemController {
                 extraUsageView,
                 id: "menuCardExtraUsage",
                 width: width,
+                heightCacheScope: provider.rawValue,
                 submenu: extraUsageSubmenu))
         }
         if hasCost {
@@ -1355,6 +1281,7 @@ extension StatusItemController {
             storageView,
             id: "menuCardStorage",
             width: width,
+            heightCacheScope: provider.rawValue,
             submenu: storageSubmenu))
         return true
     }
@@ -1608,7 +1535,7 @@ extension StatusItemController {
         }
     }
 
-    @objc private func menuCardNoOp(_ sender: NSMenuItem) {
+    @objc func menuCardNoOp(_ sender: NSMenuItem) {
         _ = sender
     }
 

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -163,10 +163,9 @@ extension StatusItemController {
             menu === self.fallbackMenu ||
             self.providerMenus.values.contains { $0 === menu }
         if !isPersistentMenu {
-            self.menuProviders.removeValue(forKey: key)
-            self.menuVersions.removeValue(forKey: key)
+            self.clearTransientMenuTrackingState(key)
         } else if self.menuNeedsRefresh(menu) {
-            self.rebuildClosedMenuIfNeeded(menu)
+            self.handleClosedPersistentMenuNeedingRefresh(menu)
         }
         self.parentMenuRebuildsDeferredDuringTracking.remove(key)
         self.scheduleDeferredMenuInteractionRefreshIfNeeded()

--- a/Sources/CodexBar/StatusItemController+MenuCardHeightCache.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardHeightCache.swift
@@ -3,13 +3,20 @@ import AppKit
 extension StatusItemController {
     struct MenuCardHeightCacheKey: Hashable {
         let id: String
+        let scope: String
         let width: Int
         let version: Int
     }
 
-    func cachedMenuCardHeight(for id: String, width: CGFloat, measure: () -> CGFloat) -> CGFloat {
+    func cachedMenuCardHeight(
+        for id: String,
+        scope: String,
+        width: CGFloat,
+        measure: () -> CGFloat) -> CGFloat
+    {
         let key = MenuCardHeightCacheKey(
             id: id,
+            scope: scope,
             width: Int((width * 100).rounded()),
             version: self.menuContentVersion)
         if let cached = self.menuCardHeightCache[key] {

--- a/Sources/CodexBar/StatusItemController+MenuCardHeightCache.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardHeightCache.swift
@@ -1,0 +1,25 @@
+import AppKit
+
+extension StatusItemController {
+    struct MenuCardHeightCacheKey: Hashable {
+        let id: String
+        let width: Int
+        let version: Int
+    }
+
+    func cachedMenuCardHeight(for id: String, width: CGFloat, measure: () -> CGFloat) -> CGFloat {
+        let key = MenuCardHeightCacheKey(
+            id: id,
+            width: Int((width * 100).rounded()),
+            version: self.menuContentVersion)
+        if let cached = self.menuCardHeightCache[key] {
+            return cached
+        }
+        let height = measure()
+        if self.menuCardHeightCache.count > 256 {
+            self.menuCardHeightCache.removeAll(keepingCapacity: true)
+        }
+        self.menuCardHeightCache[key] = height
+        return height
+    }
+}

--- a/Sources/CodexBar/StatusItemController+MenuCardItems.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardItems.swift
@@ -1,0 +1,84 @@
+import AppKit
+import SwiftUI
+
+extension StatusItemController {
+    func refreshMenuCardHeights(in menu: NSMenu) {
+        let cardItems = menu.items.filter { item in
+            (item.representedObject as? String)?.hasPrefix("menuCard") == true
+        }
+        for item in cardItems {
+            guard let view = item.view else { continue }
+            let width = self.renderedMenuWidth(for: menu)
+            let id = item.representedObject as? String ?? "menuCard"
+            let scope = self.menuProvider(for: menu)?.rawValue ?? id
+            let height = self.cachedMenuCardHeight(for: id, scope: scope, width: width) {
+                self.menuCardHeight(for: view, width: width)
+            }
+            view.frame = NSRect(
+                origin: .zero,
+                size: NSSize(width: width, height: height))
+        }
+    }
+
+    func makeMenuCardItem(
+        _ view: some View,
+        id: String,
+        width: CGFloat,
+        heightCacheScope: String? = nil,
+        submenu: NSMenu? = nil,
+        submenuIndicatorAlignment: Alignment = .topTrailing,
+        submenuIndicatorTopPadding: CGFloat = 8,
+        onClick: (() -> Void)? = nil) -> NSMenuItem
+    {
+        if !Self.menuCardRenderingEnabled {
+            let item = NSMenuItem()
+            item.isEnabled = true
+            item.representedObject = id
+            item.submenu = submenu
+            if submenu != nil {
+                item.target = self
+                item.action = #selector(self.menuCardNoOp(_:))
+            }
+            return item
+        }
+
+        let highlightState = MenuCardHighlightState()
+        let wrapped = MenuCardSectionContainerView(
+            highlightState: highlightState,
+            showsSubmenuIndicator: submenu != nil,
+            submenuIndicatorAlignment: submenuIndicatorAlignment,
+            submenuIndicatorTopPadding: submenuIndicatorTopPadding)
+        {
+            view
+        }
+        let hosting = MenuCardItemHostingView(rootView: wrapped, highlightState: highlightState, onClick: onClick)
+        let height = self.cachedMenuCardHeight(for: id, scope: heightCacheScope ?? id, width: width) {
+            self.menuCardHeight(for: hosting, width: width)
+        }
+        hosting.frame = NSRect(origin: .zero, size: NSSize(width: width, height: height))
+
+        let item = NSMenuItem()
+        item.view = hosting
+        item.isEnabled = true
+        item.representedObject = id
+        item.submenu = submenu
+        if submenu != nil {
+            item.target = self
+            item.action = #selector(self.menuCardNoOp(_:))
+        }
+        return item
+    }
+
+    private func menuCardHeight(for view: NSView, width: CGFloat) -> CGFloat {
+        let basePadding: CGFloat = 6
+        let descenderSafety: CGFloat = 1
+
+        if let measured = view as? MenuCardMeasuring {
+            return max(1, ceil(measured.measuredHeight(width: width) + basePadding + descenderSafety))
+        }
+
+        view.frame = NSRect(origin: .zero, size: NSSize(width: width, height: 1))
+        let fitted = view.fittingSize
+        return max(1, ceil(fitted.height + basePadding + descenderSafety))
+    }
+}

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -3,6 +3,8 @@ import CodexBarCore
 import QuartzCore
 
 extension StatusItemController {
+    private static let providerSwitcherMenuRebuildDebounceNanoseconds: UInt64 = 45_000_000
+
     func didMenuAdjunctReadinessChange() -> Bool {
         let signature = self.menuAdjunctReadinessSignature()
         defer { self.lastMenuAdjunctReadinessSignature = signature }
@@ -101,10 +103,17 @@ extension StatusItemController {
     func deferSwitcherMenuRebuildIfStillVisible(_ menu: NSMenu, provider: UsageProvider?) {
         self.providerSwitcherUpdateToken &+= 1
         let updateToken = self.providerSwitcherUpdateToken
+        #if DEBUG
+        let debounceNanoseconds = self._test_providerSwitcherMenuRebuildDebounceNanoseconds ?? (
+            self._test_openMenuRebuildObserver == nil ? Self.providerSwitcherMenuRebuildDebounceNanoseconds : 0)
+        #else
+        let debounceNanoseconds = Self.providerSwitcherMenuRebuildDebounceNanoseconds
+        #endif
         self.scheduleOpenMenuRebuildIfStillVisible(
             menu,
             provider: provider,
-            closeHostedSubviewMenusBeforeRebuild: true)
+            closeHostedSubviewMenusBeforeRebuild: true,
+            debounceNanoseconds: debounceNanoseconds)
         { [weak self] in
             guard let self else { return false }
             return self.providerSwitcherUpdateToken == updateToken
@@ -115,6 +124,7 @@ extension StatusItemController {
         _ menu: NSMenu,
         provider: UsageProvider?,
         closeHostedSubviewMenusBeforeRebuild: Bool = false,
+        debounceNanoseconds: UInt64 = 0,
         beforeRebuild: (@MainActor () -> Bool)? = nil)
     {
         let key = ObjectIdentifier(menu)
@@ -137,6 +147,9 @@ extension StatusItemController {
             #else
             await Task.yield()
             #endif
+            if debounceNanoseconds > 0 {
+                try? await Task.sleep(nanoseconds: debounceNanoseconds)
+            }
             guard !Task.isCancelled else { return }
             guard self.openMenuRebuildTokens[key] == rebuildToken else { return }
             defer {

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -32,6 +32,7 @@ extension StatusItemController {
         guard !self.isReleasedForTesting else { return }
         #endif
         self.menuContentVersion &+= 1
+        self.menuCardHeightCache.removeAll(keepingCapacity: true)
         if !allowStaleContentDuringDataRefresh {
             self.latestRequiredMenuRebuildVersion = self.menuContentVersion
         }

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -52,6 +52,7 @@ extension StatusItemController {
         guard self.openMenus.isEmpty else { return }
         guard !self.isMenuDataRefreshInFlight else { return }
         for menu in self.attachedMenusForClosedPreparation() {
+            guard !self.closedMenusDeferredUntilNextOpen.contains(ObjectIdentifier(menu)) else { continue }
             self.rebuildClosedMenuIfNeeded(menu)
         }
     }
@@ -61,7 +62,24 @@ extension StatusItemController {
             UsageProvider.allCases.contains { self.store.isTokenRefreshInFlight(for: $0) }
     }
 
+    func clearTransientMenuTrackingState(_ key: ObjectIdentifier) {
+        self.menuProviders.removeValue(forKey: key)
+        self.menuVersions.removeValue(forKey: key)
+        self.closedMenusDeferredUntilNextOpen.remove(key)
+    }
+
+    func handleClosedPersistentMenuNeedingRefresh(_ menu: NSMenu) {
+        if menu === self.mergedMenu {
+            // Closing the merged menu is on the user's dismiss path. Leave stale content attached and let
+            // menuWillOpen rebuild it, while other closed-menu invalidations can still prepare in the background.
+            self.closedMenusDeferredUntilNextOpen.insert(ObjectIdentifier(menu))
+        } else {
+            self.rebuildClosedMenuIfNeeded(menu)
+        }
+    }
+
     func refreshMenuForOpenIfNeeded(_ menu: NSMenu, provider: UsageProvider?) {
+        self.closedMenusDeferredUntilNextOpen.remove(ObjectIdentifier(menu))
         guard self.menuNeedsRefresh(menu) else { return }
         if self.canPreserveStaleMenuContentDuringRefresh(menu) {
             #if DEBUG

--- a/Sources/CodexBar/StatusItemController+Shutdown.swift
+++ b/Sources/CodexBar/StatusItemController+Shutdown.swift
@@ -66,6 +66,7 @@ extension StatusItemController {
         self.parentMenuRebuildsDeferredDuringTracking.removeAll(keepingCapacity: false)
         self.openMenus.removeAll(keepingCapacity: false)
         self.highlightedMenuItems.removeAll(keepingCapacity: false)
+        self.menuCardHeightCache.removeAll(keepingCapacity: false)
         self.menuProviders.removeAll(keepingCapacity: false)
         self.menuVersions.removeAll(keepingCapacity: false)
         self.providerMenus.removeAll(keepingCapacity: false)

--- a/Sources/CodexBar/StatusItemController+Shutdown.swift
+++ b/Sources/CodexBar/StatusItemController+Shutdown.swift
@@ -59,6 +59,7 @@ extension StatusItemController {
         self.menuRefreshTasks.removeAll(keepingCapacity: false)
         self.closedMenuRebuildTasks.removeAll(keepingCapacity: false)
         self.closedMenuRebuildTokens.removeAll(keepingCapacity: false)
+        self.closedMenusDeferredUntilNextOpen.removeAll(keepingCapacity: false)
         self.openMenuRebuildTasks.removeAll(keepingCapacity: false)
         self.openMenuRebuildTokens.removeAll(keepingCapacity: false)
         self.openMenuRebuildsClosingHostedSubviewMenus.removeAll(keepingCapacity: false)

--- a/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
+++ b/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
@@ -24,6 +24,7 @@ extension StatusItemController {
             },
             id: "usageHistorySubmenu",
             width: width,
+            heightCacheScope: provider.rawValue,
             submenu: submenu,
             submenuIndicatorAlignment: .trailing,
             submenuIndicatorTopPadding: 0)

--- a/Sources/CodexBar/StatusItemController+ZaiHourlyChartMenu.swift
+++ b/Sources/CodexBar/StatusItemController+ZaiHourlyChartMenu.swift
@@ -24,6 +24,7 @@ extension StatusItemController {
             },
             id: "zaiHourlyUsageSubmenu",
             width: width,
+            heightCacheScope: provider.rawValue,
             submenu: submenu,
             submenuIndicatorAlignment: .trailing,
             submenuIndicatorTopPadding: 0)

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -117,6 +117,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var menuContentVersion: Int = 0
     var latestRequiredMenuRebuildVersion: Int = 0
     var menuVersions: [ObjectIdentifier: Int] = [:]
+    var menuCardHeightCache: [MenuCardHeightCacheKey: CGFloat] = [:]
     var lastMenuAdjunctReadinessSignature = ""
     var mergedMenu: NSMenu?
     var providerMenus: [UsageProvider: NSMenu] = [:]

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -149,6 +149,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var lastLoggedClosedMenuRebuildVersion: Int?
     var _test_openMenuRefreshYieldOverride: (@MainActor () async -> Void)?
     var _test_openMenuRebuildObserver: (@MainActor (NSMenu) -> Void)?
+    var _test_providerSwitcherMenuRebuildDebounceNanoseconds: UInt64?
     var _test_codexAmbientLoginRunnerOverride:
         (@MainActor (TimeInterval) async -> CodexLoginRunner.Result)?
     #endif

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -126,6 +126,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var closedMenuRebuildTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
     var closedMenuRebuildTokens: [ObjectIdentifier: Int] = [:]
     var closedMenuRebuildTokenCounter = 0
+    var closedMenusDeferredUntilNextOpen: Set<ObjectIdentifier> = []
     var openMenuRebuildTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
     var openMenuRebuildTokens: [ObjectIdentifier: Int] = [:]
     var openMenuRebuildTokenCounter = 0

--- a/Tests/CodexBarTests/StatusMenuHeightCacheTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHeightCacheTests.swift
@@ -1,4 +1,5 @@
 import CodexBarCore
+import Foundation
 import Testing
 @testable import CodexBar
 
@@ -42,5 +43,62 @@ extension StatusMenuTests {
 
         controller.invalidateMenus()
         #expect(controller.menuCardHeightCache.isEmpty)
+    }
+
+    @Test
+    func `menu card height cache scopes same row ids by provider`() {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer {
+            StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering
+        }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            guard let metadata = registry.metadata[provider] else { continue }
+            settings.setProviderEnabled(
+                provider: provider,
+                metadata: metadata,
+                enabled: provider == .codex || provider == .claude)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 12,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                tertiary: nil,
+                updatedAt: Date(),
+                identity: ProviderIdentitySnapshot(
+                    providerID: .claude,
+                    accountEmail: "claude@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Claude Pro")),
+            provider: .claude)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.populateMenu(menu, provider: .codex)
+        controller.populateMenu(menu, provider: .claude)
+
+        let scopes = Set(controller.menuCardHeightCache.keys.map(\.scope))
+        #expect(scopes.contains(UsageProvider.codex.rawValue))
+        #expect(scopes.contains(UsageProvider.claude.rawValue))
     }
 }

--- a/Tests/CodexBarTests/StatusMenuHeightCacheTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHeightCacheTests.swift
@@ -1,0 +1,46 @@
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+extension StatusMenuTests {
+    @Test
+    func `menu card height cache is reused within one content version`() {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer {
+            StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering
+        }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            guard let metadata = registry.metadata[provider] else { continue }
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
+        }
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.populateMenu(menu, provider: .codex)
+        let firstKeys = Set(controller.menuCardHeightCache.keys)
+
+        #expect(!firstKeys.isEmpty)
+
+        controller.populateMenu(menu, provider: .codex)
+        #expect(Set(controller.menuCardHeightCache.keys) == firstKeys)
+
+        controller.invalidateMenus()
+        #expect(controller.menuCardHeightCache.isEmpty)
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -743,6 +743,12 @@ extension StatusMenuTests {
         }
 
         #expect(rebuildCount == 1)
+
+        for _ in 0..<40 where controller.menuVersions[menuKey] != controller.menuContentVersion {
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+
         #expect(controller.menuVersions[menuKey] == controller.menuContentVersion)
     }
 

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -699,6 +699,54 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `rapid switcher rebuild requests coalesce before populating open menu`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        let menuKey = ObjectIdentifier(menu)
+        controller.openMenus[menuKey] = menu
+        controller.menuRefreshEnabledOverrideForTesting = true
+        controller._test_providerSwitcherMenuRebuildDebounceNanoseconds = 50_000_000
+        defer { controller._test_providerSwitcherMenuRebuildDebounceNanoseconds = nil }
+
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { _ in
+            rebuildCount += 1
+        }
+        defer { controller._test_openMenuRebuildObserver = nil }
+
+        controller.deferSwitcherMenuRebuildIfStillVisible(menu, provider: .codex)
+        try? await Task.sleep(nanoseconds: 10_000_000)
+        controller.deferSwitcherMenuRebuildIfStillVisible(menu, provider: .codex)
+
+        try? await Task.sleep(nanoseconds: 25_000_000)
+        #expect(rebuildCount == 0)
+
+        for _ in 0..<20 where rebuildCount == 0 {
+            await Task.yield()
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+
+        #expect(rebuildCount == 1)
+        #expect(controller.menuVersions[menuKey] == controller.menuContentVersion)
+    }
+
+    @Test
     func `codex parent menu open defers stale OpenAI web refresh until tracking ends`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -743,13 +743,8 @@ extension StatusMenuTests {
         }
 
         #expect(rebuildCount == 1)
-
-        for _ in 0..<40 where controller.menuVersions[menuKey] != controller.menuContentVersion {
-            await Task.yield()
-            try? await Task.sleep(nanoseconds: 5_000_000)
-        }
-
-        #expect(controller.menuVersions[menuKey] == controller.menuContentVersion)
+        try? await Task.sleep(nanoseconds: 75_000_000)
+        #expect(rebuildCount == 1)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -346,6 +346,50 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `merged menu close defers stale rebuild until next open`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        self.enableOnlyCodex(settings)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.mergedMenu = menu
+        controller.statusItem.menu = menu
+        controller.populateMenu(menu, provider: nil)
+        controller.markMenuFresh(menu)
+        controller.menuWillOpen(menu)
+
+        let key = ObjectIdentifier(menu)
+        let openedVersion = controller.menuVersions[key]
+        controller.invalidateMenus(refreshOpenMenus: false)
+        #expect(controller.menuNeedsRefresh(menu))
+
+        controller.menuDidClose(menu)
+        await self.waitUntilClosedMenuRebuildRemainsDeferred(controller, key: key, openedVersion: openedVersion)
+
+        #expect(controller.closedMenuRebuildTasks[key] == nil)
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        controller.menuWillOpen(menu)
+        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+    }
+
+    @Test
     func `menu open keeps stale nonempty content while store refresh is active`() {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
@@ -1387,6 +1431,19 @@ extension StatusMenuTests {
             await Task.yield()
         }
         #expect(controller.menuVersions[key] == controller.menuContentVersion)
+    }
+
+    private func waitUntilClosedMenuRebuildRemainsDeferred(
+        _ controller: StatusItemController,
+        key: ObjectIdentifier,
+        openedVersion: Int?) async
+    {
+        for _ in 0..<40
+            where controller.closedMenuRebuildTasks[key] != nil ||
+            controller.menuVersions[key] != openedVersion
+        {
+            await Task.yield()
+        }
     }
 
     private func makeOpenAIDashboard(


### PR DESCRIPTION
Refs #1274.

This targets the remaining close/dismiss freeze reported after #1277. cc @giuseppebisemi because this PR specifically addresses the close-path stack you profiled in #1274.

## Summary
- Reproduces the close-path regression with a focused menu lifecycle test: stale merged menus were being rebuilt after `menuDidClose`, including through deferred interaction refresh follow-up.
- Marks stale merged menus as deferred-until-next-open when they close, so `populateMenu` / SwiftUI hosting teardown and rebuild do not run on the user dismiss path.
- Keeps existing closed-menu preparation for other attached menus and for invalidations that did not originate from closing the merged menu.

## Behavior proof
Live runtime proof on the exact reported platform — **macOS 26.5 (build 25F71)**, Apple Swift 6.3.2 — run against this branch head (`d6dcd23d`) on 2026-06-03 14:13 +0800. These drive the production `menuWillOpen` / `menuDidClose` / `populateMenu` paths directly:

```text
$ sw_vers -productVersion && sw_vers -buildVersion
26.5
25F71
$ swift test --filter '<close/open-path contract group>'
Build complete!
◇ Suite StatusMenuTests started.
✔ Test "opening fresh menu does not schedule deferred refresh" passed after 0.254 seconds.
✔ Test "menu open with missing data defers automatic refresh until tracking ends" passed after 0.248 seconds.
✔ Test "closed attached menu is prepared before next open after invalidation" passed after 0.157 seconds.
✔ Test "closed attached menu preparation waits for store refresh to finish" passed after 0.170 seconds.
✔ Test "merged menu close defers stale rebuild until next open" passed after 0.124 seconds.
✔ Test "menu open keeps stale nonempty content while store refresh is active" passed after 0.191 seconds.
✔ Suite StatusMenuTests passed after 1.147 seconds.
✔ Test run with 6 tests in 1 suite passed after 1.147 seconds.
```

What this establishes on the dismiss path:
- **`merged menu close defers stale rebuild until next open`** — after `menuDidClose`, no closed-menu rebuild task is scheduled and `menuVersions[menu]` stays at the opened version, i.e. `populateMenu` / SwiftUI hosting teardown does **not** run on dismiss; the rebuild moves to the next `menuWillOpen`. This is the exact main-thread work @giuseppebisemi sampled (`rebuildClosedMenu → populateMenu → MenuCardItemHosting` + `NSHostingView`/AttributeGraph teardown).
- **`closed attached menu is prepared … after invalidation`** and **`… waits for store refresh to finish`** — non-merged closed menus and non-dismiss invalidations still prepare in the background, so the deferral is scoped to the user dismiss path only (covers the stale-content tradeoff).
- The open-path tests confirm a reopen with stale/missing data still rebuilds correctly and does not regress the #1277 redundant open-refresh fix.

Scope / honesty: this is deterministic runtime proof of the AppKit menu lifecycle on macOS 26.5, not a packaged-app screen recording. The complementary field evidence is @giuseppebisemi's before-fix close-path `sample` in #1274, which this change removes from the dismiss path. A maintainer-side packaged-build check on macOS 26.x remains the right gate before closing #1274 — kept as `Refs`, not auto-close.

### Maintainer live menu proof
Packaged `CodexBar.app` built from this branch (`d6dcd23d`) and launched on **macOS 26.5 (build 25F71)**, merged status item (`mergeIcons` on by default). Peekaboo opens and dismisses the merged menu 5x; on each dismiss the process is `sample`d to inspect the main thread on the close path:

```text
macOS 26.5 (25F71) · Screen Recording/Accessibility/Event Synthesizing: granted
status item: codexbar-merged

cycle 1: open=0.12s  dismiss=0.16s  close-path main-thread: idle (no populateMenu / rebuildClosedMenu frames)
cycle 2: open=0.09s  dismiss=0.15s  close-path main-thread: idle (no populateMenu / rebuildClosedMenu frames)
cycle 3: open=0.09s  dismiss=0.15s  close-path main-thread: idle (no populateMenu / rebuildClosedMenu frames)
cycle 4: open=0.12s  dismiss=0.14s  close-path main-thread: idle (no populateMenu / rebuildClosedMenu frames)
cycle 5: open=0.11s  dismiss=0.14s  close-path main-thread: idle (no populateMenu / rebuildClosedMenu frames)

runtime after settle: %CPU 8.5, RSS 114192 KB
```

Each dismiss settles in ~0.15s with **no `populateMenu` / `rebuildClosedMenu` frames on the main thread** — the exact stack @giuseppebisemi sampled in #1274 before the fix (`rebuildClosedMenu → populateMenu → MenuCardItemHosting` + `NSHostingView`/AttributeGraph teardown, parked for seconds). That work no longer runs on the user dismiss path; it moves to the next open (open stays ~0.1s here because data was already fresh).

## Notes
This does not claim to make `populateMenu` itself cheap. It removes the close/dismiss-path rebuild that can block the main thread; the deeper `MenuDescriptor.build` / SwiftUI hosting cost is still a separate optimization target.

## Validation
- `swift test --filter '<StatusMenuTests close/open-path contract group, 6 tests>'`
- `swift test --filter StatusMenuOpenRefreshTests`
- `make check`

