### PR TITLE
Stabilize merged provider menu positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Devin: add daily and weekly quota tracking from the signed-in Chrome session or a manual Bearer token (#1264, fixes #800). Thanks @coygeek!
 
 ### Fixed
+- Menu bar: anchor merged provider dropdowns to the status item's trailing edge without marking preserved in-flight refresh content fresh, preventing horizontal drift while keeping deferred updates visible (#1288). Thanks @Yuxin-Qiao!
 - Cost usage: replace repeated Foundation metadata/root checks with one portable file-stat pass so expired Codex history refreshes stay responsive on very large session archives (#1392). Thanks @TheAngryPit and @ProspectOre!
 - Cursor: show the Safari Full Disk Access recovery hint before the long browser login list so permission guidance remains visible when menu errors truncate (#1419, fixes #1417). Thanks @hhh2210!
 - Cursor: present legacy request-based plans as one Requests quota with the raw used/limit count instead of unrelated token-based Auto/API bars (#1420, fixes #1418). Thanks @hhh2210!

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1085,7 +1085,7 @@ extension StatusItemController {
         return true
     }
 
-    private func resolvedMenuProvider(enabledProviders: [UsageProvider]? = nil) -> UsageProvider? {
+    func resolvedMenuProvider(enabledProviders: [UsageProvider]? = nil) -> UsageProvider? {
         let enabled = enabledProviders ?? self.store.enabledProvidersForDisplay()
         if enabled.isEmpty { return .codex }
         if let selected = self.selectedMenuProvider, enabled.contains(selected) {

--- a/Sources/CodexBar/StatusItemController+MergedMenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MergedMenuPresentation.swift
@@ -5,17 +5,21 @@ extension StatusItemController {
 
     @objc func showMergedMenu(_ sender: NSStatusBarButton) {
         guard self.shouldMergeIcons else { return }
-        let menu = self.mergedMenu ?? self.makeMenu()
-        self.mergedMenu = menu
-        let provider = self.resolvedMenuProvider()
-        self.refreshMenuForOpenIfNeeded(menu, provider: provider)
-        self.markMenuFresh(menu)
+        let menu = self.prepareMergedMenuForPresentation()
 
         let popupPoint = Self.trailingAlignedMenuPopupPoint(
             statusButtonBounds: sender.bounds,
             statusButtonIsFlipped: sender.isFlipped,
             menuWidth: self.renderedMenuWidth(for: menu))
         menu.popUp(positioning: nil, at: popupPoint, in: sender)
+    }
+
+    func prepareMergedMenuForPresentation() -> NSMenu {
+        let menu = self.mergedMenu ?? self.makeMenu()
+        self.mergedMenu = menu
+        let provider = self.resolvedMenuProvider()
+        self.refreshMenuForOpenIfNeeded(menu, provider: provider)
+        return menu
     }
 
     static func trailingAlignedMenuPopupPoint(

--- a/Sources/CodexBar/StatusItemController+MergedMenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MergedMenuPresentation.swift
@@ -1,0 +1,36 @@
+import AppKit
+
+extension StatusItemController {
+    private static let mergedMenuVerticalClearance: CGFloat = 8
+
+    @objc func showMergedMenu(_ sender: NSStatusBarButton) {
+        guard self.shouldMergeIcons else { return }
+        let menu = self.mergedMenu ?? self.makeMenu()
+        self.mergedMenu = menu
+        let provider = self.resolvedMenuProvider()
+        self.refreshMenuForOpenIfNeeded(menu, provider: provider)
+        self.markMenuFresh(menu)
+
+        let popupPoint = Self.trailingAlignedMenuPopupPoint(
+            statusButtonBounds: sender.bounds,
+            statusButtonIsFlipped: sender.isFlipped,
+            menuWidth: self.renderedMenuWidth(for: menu))
+        menu.popUp(positioning: nil, at: popupPoint, in: sender)
+    }
+
+    static func trailingAlignedMenuPopupPoint(
+        statusButtonBounds: NSRect,
+        statusButtonIsFlipped: Bool,
+        menuWidth: CGFloat)
+        -> NSPoint
+    {
+        let popupY = if statusButtonIsFlipped {
+            statusButtonBounds.maxY + self.mergedMenuVerticalClearance
+        } else {
+            statusButtonBounds.minY - self.mergedMenuVerticalClearance
+        }
+        return NSPoint(
+            x: statusButtonBounds.maxX - ceil(menuWidth / 2),
+            y: popupY)
+    }
+}

--- a/Sources/CodexBar/StatusItemController+MergedMenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MergedMenuPresentation.swift
@@ -34,7 +34,7 @@ extension StatusItemController {
             statusButtonBounds.minY - self.mergedMenuVerticalClearance
         }
         return NSPoint(
-            x: statusButtonBounds.maxX - ceil(menuWidth / 2),
+            x: statusButtonBounds.maxX - ceil(menuWidth),
             y: popupY)
     }
 }

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -668,8 +668,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             let skippedMergedRender = self.applyIcon(phase: phase)
             if skippedMergedRender,
                !self.deferredMergedIconRenderAfterTracking,
-               let mergedMenu = self.mergedMenu,
-               self.statusItem.menu === mergedMenu
+               self.mergedMenu != nil
             {
                 return
             }
@@ -785,8 +784,12 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         if self.mergedMenu == nil {
             self.mergedMenu = self.makeMenu()
         }
-        if self.statusItem.menu !== self.mergedMenu {
-            self.statusItem.menu = self.mergedMenu
+        if self.statusItem.menu != nil {
+            self.statusItem.menu = nil
+        }
+        if let button = self.statusItem.button {
+            button.target = self
+            button.action = #selector(self.showMergedMenu(_:))
         }
         self.prepareAttachedClosedMenusIfNeeded()
     }

--- a/Tests/CodexBarTests/MergedMenuPositioningTests.swift
+++ b/Tests/CodexBarTests/MergedMenuPositioningTests.swift
@@ -1,0 +1,38 @@
+import AppKit
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct MergedMenuPositioningTests {
+    @Test
+    func `popup point anchors menu center to status item trailing edge`() {
+        let menuWidth: CGFloat = 620
+        let compact = NSRect(x: 0, y: 0, width: 44, height: 22)
+        let expanded = NSRect(x: -92, y: 0, width: 136, height: 22)
+
+        let compactPoint = StatusItemController.trailingAlignedMenuPopupPoint(
+            statusButtonBounds: compact,
+            statusButtonIsFlipped: true,
+            menuWidth: menuWidth)
+        let expandedPoint = StatusItemController.trailingAlignedMenuPopupPoint(
+            statusButtonBounds: expanded,
+            statusButtonIsFlipped: true,
+            menuWidth: menuWidth)
+
+        #expect(compactPoint.x == expandedPoint.x)
+        #expect(compactPoint.x + ceil(menuWidth / 2) == compact.maxX)
+        #expect(expandedPoint.x + ceil(menuWidth / 2) == expanded.maxX)
+        #expect(compactPoint.y == compact.maxY + 8)
+        #expect(expandedPoint.y == expanded.maxY + 8)
+    }
+
+    @Test
+    func `popup point clears status item in non-flipped coordinates`() {
+        let point = StatusItemController.trailingAlignedMenuPopupPoint(
+            statusButtonBounds: NSRect(x: 0, y: 0, width: 44, height: 22),
+            statusButtonIsFlipped: false,
+            menuWidth: 620)
+
+        #expect(point.y == -8)
+    }
+}

--- a/Tests/CodexBarTests/MergedMenuPositioningTests.swift
+++ b/Tests/CodexBarTests/MergedMenuPositioningTests.swift
@@ -5,7 +5,7 @@ import Testing
 @MainActor
 struct MergedMenuPositioningTests {
     @Test
-    func `popup point anchors menu center to status item trailing edge`() {
+    func `popup point anchors menu trailing edge to status item trailing edge`() {
         let menuWidth: CGFloat = 620
         let compact = NSRect(x: 0, y: 0, width: 44, height: 22)
         let expanded = NSRect(x: -92, y: 0, width: 136, height: 22)
@@ -20,8 +20,8 @@ struct MergedMenuPositioningTests {
             menuWidth: menuWidth)
 
         #expect(compactPoint.x == expandedPoint.x)
-        #expect(compactPoint.x + ceil(menuWidth / 2) == compact.maxX)
-        #expect(expandedPoint.x + ceil(menuWidth / 2) == expanded.maxX)
+        #expect(compactPoint.x + ceil(menuWidth) == compact.maxX)
+        #expect(expandedPoint.x + ceil(menuWidth) == expanded.maxX)
         #expect(compactPoint.y == compact.maxY + 8)
         #expect(expandedPoint.y == expanded.maxY + 8)
     }

--- a/Tests/CodexBarTests/StatusItemControllerShutdownTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerShutdownTests.swift
@@ -43,7 +43,10 @@ struct StatusItemControllerShutdownTests {
         controller.menuRefreshTasks[key] = Task { try? await Task.sleep(for: .seconds(30)) }
 
         #expect(controller.openMenus[key] === menu)
-        #expect(controller.statusItem.menu != nil)
+        #expect(controller.mergedMenu != nil)
+        #expect(controller.statusItem.menu == nil)
+        #expect(controller.statusItem.button?.target === controller)
+        #expect(controller.statusItem.button?.action == #selector(StatusItemController.showMergedMenu(_:)))
 
         controller.prepareForAppShutdown()
         controller.prepareForAppShutdown()

--- a/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
+++ b/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
@@ -129,6 +129,56 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `merged presentation during in flight refresh preserves stale menu freshness`() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.costUsageEnabled = true
+        self.enableOnlyCodexForReadinessBaseline(settings)
+
+        let snapshotA = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 111,
+            sessionCostUSD: 1.11,
+            last30DaysTokens: 1111,
+            last30DaysCostUSD: 11.11,
+            updatedAt: Date(timeIntervalSince1970: 100))
+        let snapshotB = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 222,
+            sessionCostUSD: 2.22,
+            last30DaysTokens: 2222,
+            last30DaysCostUSD: 22.22,
+            updatedAt: Date(timeIntervalSince1970: 200))
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._setTokenSnapshotForTesting(snapshotA, provider: .codex)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let menu = controller.prepareMergedMenuForPresentation()
+        let key = ObjectIdentifier(menu)
+        let preparedVersion = controller.menuVersions[key]
+
+        store.isRefreshing = true
+        store._setTokenSnapshotForTesting(snapshotB, provider: .codex)
+        controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
+
+        let presentedMenu = controller.prepareMergedMenuForPresentation()
+
+        #expect(presentedMenu === menu)
+        #expect(controller.menuVersions[key] == preparedVersion)
+        #expect(controller.menuNeedsRefresh(menu))
+    }
+
+    @Test
     func `root open before deferred store observation rebuilds and refreshes matching observer`() {
         // Store observation invalidates menus from a deferred main-actor task. If a closed menu opens after
         // live data changes but before that task runs, it must rebuild from live data and let the matching


### PR DESCRIPTION
## Summary

- Opens the merged-provider menu from the status item button action instead of attaching it directly to `NSStatusItem.menu`.
- Anchors the menu horizontally to the status item trailing edge so the menu stays visually stable when the merged status item label grows leftward or shrinks.
- Adds vertical clearance below the status item button so the merged menu no longer covers the menu bar row.
- Updates shutdown coverage for the action-driven merged menu and adds focused positioning tests.

## Why

In Merge Icons mode, switching between providers with different menu bar label widths can make the menu appear to drift because AppKit's default status-item menu positioning follows the status item center.

The status item trailing edge is the stable side in the menu bar, so anchoring the menu there keeps the lower content aligned while switching providers. The custom popup point also adds an explicit vertical gap below the status item button, preventing the menu from overlapping the menu bar row.

## Validation

- `swift test --filter 'MergedMenuPositioningTests|StatusItemControllerShutdownTests'`

## Evidence

Local release-style testing shows the merged menu staying horizontally stable while clearing the menu bar row.

Antigravity selected:

![Merged menu clears menu bar row with Antigravity selected](https://raw.githubusercontent.com/Yuxin-Qiao/CodexBar/pr-1288-proof-assets/pr-assets/1288/antigravity-overlap.png)

Codex selected:

![Merged menu clears menu bar row with Codex selected](https://raw.githubusercontent.com/Yuxin-Qiao/CodexBar/pr-1288-proof-assets/pr-assets/1288/codex-percent-overlap.png)

Current test build used for the screenshots: `0.32.5` build `80`, release configuration with local ad-hoc signing.
