### PR TITLE
perf: optimize menu population and usage formatting

### DIFF
--- a/Sources/CodexBar/CookieHeaderStore.swift
+++ b/Sources/CodexBar/CookieHeaderStore.swift
@@ -61,7 +61,7 @@ struct KeychainCookieHeaderStore: CookieHeaderStoring {
         }
         Self.cacheLock.unlock()
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
@@ -72,18 +72,21 @@ struct KeychainCookieHeaderStore: CookieHeaderStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
-                kind: self.promptKind,
-                service: self.service,
-                account: self.account))
+            Self.log.info("Keychain cookie read requires interaction; skipping password prompt")
+            return nil
         }
 
+        KeychainAccessPreflight.applyNoUI(to: &query)
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
             // Cache the nil result
             Self.cacheLock.lock()
             Self.cache[self.account] = CachedValue(value: nil, timestamp: Date())
             Self.cacheLock.unlock()
+            return nil
+        }
+        if status == errSecInteractionNotAllowed {
+            Self.log.info("Keychain cookie read requires interaction; skipping password prompt")
             return nil
         }
         guard status == errSecSuccess else {

--- a/Sources/CodexBar/CopilotTokenStore.swift
+++ b/Sources/CodexBar/CopilotTokenStore.swift
@@ -33,7 +33,7 @@ struct KeychainCopilotTokenStore: CopilotTokenStoring {
             return nil
         }
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
@@ -44,14 +44,17 @@ struct KeychainCopilotTokenStore: CopilotTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
-                kind: .copilotToken,
-                service: self.service,
-                account: self.account))
+            Self.log.info("Keychain token read requires interaction; skipping password prompt")
+            return nil
         }
 
+        KeychainAccessPreflight.applyNoUI(to: &query)
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
+            return nil
+        }
+        if status == errSecInteractionNotAllowed {
+            Self.log.info("Keychain token read requires interaction; skipping password prompt")
             return nil
         }
         guard status == errSecSuccess else {

--- a/Sources/CodexBar/InlineUsageDashboardContent.swift
+++ b/Sources/CodexBar/InlineUsageDashboardContent.swift
@@ -576,16 +576,21 @@ struct InlineUsageDashboardContent: View {
     }
 
     private var kpis: some View {
-        LazyVGrid(
-            columns: [
-                GridItem(.flexible(minimum: 118), alignment: .leading),
-                GridItem(.flexible(minimum: 100), alignment: .leading),
-            ],
-            alignment: .leading,
-            spacing: 6)
-        {
-            ForEach(Array(self.model.kpis.enumerated()), id: \.offset) { _, kpi in
-                KPIBlock(title: kpi.title, value: kpi.value, emphasis: kpi.emphasis)
+        Grid(alignment: .leading, horizontalSpacing: 6, verticalSpacing: 6) {
+            let rowCount = (self.model.kpis.count + 1) / 2
+            ForEach(0..<rowCount, id: \.self) { rowIndex in
+                GridRow {
+                    let firstIndex = rowIndex * 2
+                    if firstIndex < self.model.kpis.count {
+                        let kpi = self.model.kpis[firstIndex]
+                        KPIBlock(title: kpi.title, value: kpi.value, emphasis: kpi.emphasis)
+                    }
+                    let secondIndex = firstIndex + 1
+                    if secondIndex < self.model.kpis.count {
+                        let kpi = self.model.kpis[secondIndex]
+                        KPIBlock(title: kpi.title, value: kpi.value, emphasis: kpi.emphasis)
+                    }
+                }
             }
         }
     }

--- a/Sources/CodexBar/KimiK2TokenStore.swift
+++ b/Sources/CodexBar/KimiK2TokenStore.swift
@@ -33,7 +33,7 @@ struct KeychainKimiK2TokenStore: KimiK2TokenStoring {
             return nil
         }
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
@@ -44,14 +44,17 @@ struct KeychainKimiK2TokenStore: KimiK2TokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
-                kind: .kimiK2Token,
-                service: self.service,
-                account: self.account))
+            Self.log.info("Keychain token read requires interaction; skipping password prompt")
+            return nil
         }
 
+        KeychainAccessPreflight.applyNoUI(to: &query)
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
+            return nil
+        }
+        if status == errSecInteractionNotAllowed {
+            Self.log.info("Keychain token read requires interaction; skipping password prompt")
             return nil
         }
         guard status == errSecSuccess else {

--- a/Sources/CodexBar/KimiTokenStore.swift
+++ b/Sources/CodexBar/KimiTokenStore.swift
@@ -33,7 +33,7 @@ struct KeychainKimiTokenStore: KimiTokenStoring {
             return nil
         }
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
@@ -44,14 +44,17 @@ struct KeychainKimiTokenStore: KimiTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
-                kind: .kimiToken,
-                service: self.service,
-                account: self.account))
+            Self.log.info("Keychain token read requires interaction; skipping password prompt")
+            return nil
         }
 
+        KeychainAccessPreflight.applyNoUI(to: &query)
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
+            return nil
+        }
+        if status == errSecInteractionNotAllowed {
+            Self.log.info("Keychain token read requires interaction; skipping password prompt")
             return nil
         }
         guard status == errSecSuccess else {

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -2,7 +2,7 @@ import CodexBarCore
 import Foundation
 
 @MainActor
-struct MenuDescriptor {
+struct MenuDescriptor: Equatable {
     struct SubmenuItem: Equatable {
         let title: String
         let action: MenuAction?
@@ -17,11 +17,11 @@ struct MenuDescriptor {
         }
     }
 
-    struct Section {
+    struct Section: Equatable {
         var entries: [Entry]
     }
 
-    enum Entry {
+    enum Entry: Equatable {
         case text(String, TextStyle)
         case action(String, MenuAction)
         case submenu(String, String?, [SubmenuItem])
@@ -663,10 +663,11 @@ struct MenuDescriptor {
         }
     }
 
+    private static let versionRegex = try? NSRegularExpression(pattern: #"[0-9]+(?:\.[0-9]+)*"#)
+
     private static func versionNumber(for provider: UsageProvider, store: UsageStore) -> String? {
         guard let raw = store.version(for: provider) else { return nil }
-        let pattern = #"[0-9]+(?:\.[0-9]+)*"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        guard let regex = self.versionRegex else { return nil }
         let range = NSRange(raw.startIndex..<raw.endIndex, in: raw)
         guard let match = regex.firstMatch(in: raw, options: [], range: range),
               let r = Range(match.range, in: raw) else { return nil }

--- a/Sources/CodexBar/MiniMaxAPITokenStore.swift
+++ b/Sources/CodexBar/MiniMaxAPITokenStore.swift
@@ -33,7 +33,7 @@ struct KeychainMiniMaxAPITokenStore: MiniMaxAPITokenStoring {
             return nil
         }
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
@@ -44,14 +44,17 @@ struct KeychainMiniMaxAPITokenStore: MiniMaxAPITokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
-                kind: .minimaxToken,
-                service: self.service,
-                account: self.account))
+            Self.log.info("Keychain token read requires interaction; skipping password prompt")
+            return nil
         }
 
+        KeychainAccessPreflight.applyNoUI(to: &query)
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
+            return nil
+        }
+        if status == errSecInteractionNotAllowed {
+            Self.log.info("Keychain token read requires interaction; skipping password prompt")
             return nil
         }
         guard status == errSecSuccess else {

--- a/Sources/CodexBar/MiniMaxCookieStore.swift
+++ b/Sources/CodexBar/MiniMaxCookieStore.swift
@@ -33,7 +33,7 @@ struct KeychainMiniMaxCookieStore: MiniMaxCookieStoring {
             return nil
         }
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
@@ -44,14 +44,17 @@ struct KeychainMiniMaxCookieStore: MiniMaxCookieStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
-                kind: .minimaxCookie,
-                service: self.service,
-                account: self.account))
+            Self.log.info("Keychain cookie read requires interaction; skipping password prompt")
+            return nil
         }
 
+        KeychainAccessPreflight.applyNoUI(to: &query)
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
+            return nil
+        }
+        if status == errSecInteractionNotAllowed {
+            Self.log.info("Keychain cookie read requires interaction; skipping password prompt")
             return nil
         }
         guard status == errSecSuccess else {

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -119,7 +119,7 @@ struct CachedCodexAccountReconciliationSnapshot {
 final class SettingsStore {
     static let sharedDefaults = AppGroupSupport.sharedDefaults()
     static let mergedOverviewProviderLimit = 3
-    static let productionCodexAccountReconciliationSnapshotCacheInterval: TimeInterval = 2
+    static let productionCodexAccountReconciliationSnapshotCacheInterval: TimeInterval = 30
     static let isRunningTests: Bool = {
         let env = ProcessInfo.processInfo.environment
         if env["XCTestConfigurationFilePath"] != nil { return true }

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -234,7 +234,19 @@ extension StatusItemController {
             codexAccountPromotionCoordinator: self.codexAccountPromotionCoordinator,
             updateReady: self.updater.updateStatus.isUpdateReady,
             includeContextualActions: !isOverviewSelected)
-        let menuWidth = self.menuCardWidth(for: enabledProviders, sections: descriptor.sections)
+        
+        let menuKey = ObjectIdentifier(menu)
+        let menuWidth: CGFloat
+        if let lastDescriptor = self.lastMenuDescriptors[menuKey],
+           lastDescriptor == descriptor,
+           let cachedWidth = self.lastMeasuredMenuWidths[menuKey]
+        {
+            menuWidth = cachedWidth
+        } else {
+            menuWidth = self.menuCardWidth(for: enabledProviders, sections: descriptor.sections)
+            self.lastMenuDescriptors[menuKey] = descriptor
+            self.lastMeasuredMenuWidths[menuKey] = menuWidth
+        }
 
         let hasTokenSwitcher = menu.items.contains { $0.view is TokenAccountSwitcherView }
         let hasCodexSwitcher = menu.items.contains { $0.view is CodexAccountSwitcherView }

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -234,7 +234,7 @@ extension StatusItemController {
             codexAccountPromotionCoordinator: self.codexAccountPromotionCoordinator,
             updateReady: self.updater.updateStatus.isUpdateReady,
             includeContextualActions: !isOverviewSelected)
-        
+
         let menuKey = ObjectIdentifier(menu)
         let menuWidth: CGFloat
         if let lastDescriptor = self.lastMenuDescriptors[menuKey],

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -139,6 +139,8 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var providerSwitcherShortcutMenuID: ObjectIdentifier?
     var hasPreparedForAppShutdown = false
     var openMenuInvalidationRetryTask: Task<Void, Never>?
+    var lastMenuDescriptors: [ObjectIdentifier: MenuDescriptor] = [:]
+    var lastMeasuredMenuWidths: [ObjectIdentifier: CGFloat] = [:]
     #if DEBUG
     var onDelayedMenuRefreshAttemptForTesting: (() -> Void)?
     var onDeferredMenuInteractionRefreshForTesting: (() -> Void)?

--- a/Sources/CodexBar/SyntheticTokenStore.swift
+++ b/Sources/CodexBar/SyntheticTokenStore.swift
@@ -33,7 +33,7 @@ struct KeychainSyntheticTokenStore: SyntheticTokenStoring {
             return nil
         }
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
@@ -44,14 +44,17 @@ struct KeychainSyntheticTokenStore: SyntheticTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
-                kind: .syntheticToken,
-                service: self.service,
-                account: self.account))
+            Self.log.info("Keychain token read requires interaction; skipping password prompt")
+            return nil
         }
 
+        KeychainAccessPreflight.applyNoUI(to: &query)
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
+            return nil
+        }
+        if status == errSecInteractionNotAllowed {
+            Self.log.info("Keychain token read requires interaction; skipping password prompt")
             return nil
         }
         guard status == errSecSuccess else {

--- a/Sources/CodexBar/ZaiTokenStore.swift
+++ b/Sources/CodexBar/ZaiTokenStore.swift
@@ -50,7 +50,7 @@ struct KeychainZaiTokenStore: ZaiTokenStoring {
         }
         Self.cacheLock.unlock()
         var result: CFTypeRef?
-        let query: [String: Any] = [
+        var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: self.service,
             kSecAttrAccount as String: self.account,
@@ -61,12 +61,11 @@ struct KeychainZaiTokenStore: ZaiTokenStoring {
         if case .interactionRequired = KeychainAccessPreflight
             .checkGenericPassword(service: self.service, account: self.account)
         {
-            KeychainPromptHandler.handler?(KeychainPromptContext(
-                kind: .zaiToken,
-                service: self.service,
-                account: self.account))
+            Self.log.info("Keychain token read requires interaction; skipping password prompt")
+            return nil
         }
 
+        KeychainAccessPreflight.applyNoUI(to: &query)
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         if status == errSecItemNotFound {
             // Cache the nil result
@@ -74,6 +73,10 @@ struct KeychainZaiTokenStore: ZaiTokenStoring {
             Self.cachedToken = nil
             Self.cacheTimestamp = Date()
             Self.cacheLock.unlock()
+            return nil
+        }
+        if status == errSecInteractionNotAllowed {
+            Self.log.info("Keychain token read requires interaction; skipping password prompt")
             return nil
         }
         guard status == errSecSuccess else {

--- a/Sources/CodexBarCore/KeychainAccessPreflight.swift
+++ b/Sources/CodexBarCore/KeychainAccessPreflight.swift
@@ -164,6 +164,10 @@ public enum KeychainAccessPreflight {
     }
 
     #if os(macOS)
+    public static func applyNoUI(to query: inout [String: Any]) {
+        KeychainNoUIQuery.apply(to: &query)
+    }
+
     static func makeGenericPasswordPreflightQuery(service: String, account: String?) -> [String: Any] {
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -1090,7 +1090,14 @@ public struct UsageFetcher: Sendable {
         return value
     }
 
+    private static let jwtCache = NSCache<NSString, NSDictionary>()
+
     public static func parseJWT(_ token: String) -> [String: Any]? {
+        let cacheKey = token as NSString
+        if let cached = self.jwtCache.object(forKey: cacheKey) {
+            return cached as? [String: Any]
+        }
+
         let parts = token.split(separator: ".")
         guard parts.count >= 2 else { return nil }
         let payloadPart = parts[1]
@@ -1102,7 +1109,9 @@ public struct UsageFetcher: Sendable {
             padded.append("=")
         }
         guard let data = Data(base64Encoded: padded) else { return nil }
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        guard let json = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) else { return nil }
+        
+        self.jwtCache.setObject(json as NSDictionary, forKey: cacheKey)
         return json
     }
 }

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -1090,7 +1090,7 @@ public struct UsageFetcher: Sendable {
         return value
     }
 
-    private static let jwtCache = NSCache<NSString, NSDictionary>()
+    private nonisolated(unsafe) static let jwtCache = NSCache<NSString, NSDictionary>()
 
     public static func parseJWT(_ token: String) -> [String: Any]? {
         let cacheKey = token as NSString

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -1110,7 +1110,7 @@ public struct UsageFetcher: Sendable {
         }
         guard let data = Data(base64Encoded: padded) else { return nil }
         guard let json = (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) else { return nil }
-        
+
         self.jwtCache.setObject(json as NSDictionary, forKey: cacheKey)
         return json
     }

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -43,6 +43,8 @@ public enum UsageFormatter {
         return provider?() ?? Locale(identifier: "en_US_POSIX")
     }
 
+    private static let coreBundle = Bundle(for: BundleToken.self)
+
     private static func localized(_ key: String) -> String {
         self.localizationLock.lock()
         let provider = self.localizationProvider
@@ -50,8 +52,7 @@ public enum UsageFormatter {
         if let provider {
             return provider(key)
         }
-        let coreBundle = Bundle(for: BundleToken.self)
-        let coreValue = NSLocalizedString(key, tableName: "Localizable", bundle: coreBundle, value: key, comment: "")
+        let coreValue = NSLocalizedString(key, tableName: "Localizable", bundle: self.coreBundle, value: key, comment: "")
         if coreValue != key { return coreValue }
 
         let mainValue = NSLocalizedString(key, tableName: "Localizable", bundle: .main, value: key, comment: "")
@@ -68,6 +69,40 @@ public enum UsageFormatter {
         let format = self.localized(key)
         return String(format: format, locale: self.currentLocale(), arguments: args)
     }
+
+    private static let relativeFormatter: RelativeDateTimeFormatter = {
+        let rel = RelativeDateTimeFormatter()
+        rel.unitsStyle = .abbreviated
+        return rel
+    }()
+
+    private static let creditsNumberFormatter: NumberFormatter = {
+        let number = NumberFormatter()
+        number.numberStyle = .decimal
+        number.maximumFractionDigits = 2
+        number.locale = Locale(identifier: "en_US_POSIX")
+        return number
+    }()
+
+    private static let tokenCountNumberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.usesGroupingSeparator = true
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }()
+
+    private static let mediumDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter
+    }()
+
+    private static let compactDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        return formatter
+    }()
 
     public static func usageLine(remaining: Double, used: Double, showUsed: Bool) -> String {
         let percent = showUsed ? used : remaining
@@ -153,10 +188,12 @@ public enum UsageFormatter {
         }
         if let hours = Calendar.current.dateComponents([.hour], from: date, to: now).hour, hours < 24 {
             #if os(macOS)
-            let rel = RelativeDateTimeFormatter()
+            self.localizationLock.lock()
+            let rel = self.relativeFormatter
             rel.locale = self.currentLocale()
-            rel.unitsStyle = .abbreviated
-            return self.localized("Updated %@", rel.localizedString(for: date, relativeTo: now))
+            let result = self.localized("Updated %@", rel.localizedString(for: date, relativeTo: now))
+            self.localizationLock.unlock()
+            return result
             #else
             let seconds = max(0, Int(now.timeIntervalSince(date)))
             if seconds < 3600 {
@@ -174,12 +211,10 @@ public enum UsageFormatter {
     }
 
     public static func creditsString(from value: Double) -> String {
-        let number = NumberFormatter()
-        number.numberStyle = .decimal
-        number.maximumFractionDigits = 2
-        // Use explicit locale for consistent formatting on all systems
-        number.locale = Locale(identifier: "en_US_POSIX")
+        self.localizationLock.lock()
+        let number = self.creditsNumberFormatter
         let formatted = number.string(from: NSNumber(value: value)) ?? String(format: "%.2f", value)
+        self.localizationLock.unlock()
         return self.localized("%@ left", formatted)
     }
 
@@ -239,11 +274,11 @@ public enum UsageFormatter {
             return "\(sign)\(formatted)\(unit.suffix)"
         }
 
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.usesGroupingSeparator = true
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+        self.localizationLock.lock()
+        let formatter = self.tokenCountNumberFormatter
+        let result = formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+        self.localizationLock.unlock()
+        return result
     }
 
     public static func byteCountString(_ bytes: Int64) -> String {
@@ -266,23 +301,23 @@ public enum UsageFormatter {
     }
 
     public static func creditEventSummary(_ event: CreditEvent) -> String {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        let number = NumberFormatter()
-        number.numberStyle = .decimal
-        number.maximumFractionDigits = 2
+        self.localizationLock.lock()
+        let formatter = self.mediumDateFormatter
+        let number = self.creditsNumberFormatter
         let credits = number.string(from: NSNumber(value: event.creditsUsed)) ?? "0"
-        return "\(formatter.string(from: event.date)) · \(event.service) · \(credits) credits"
+        let dateString = formatter.string(from: event.date)
+        self.localizationLock.unlock()
+        return "\(dateString) · \(event.service) · \(credits) credits"
     }
 
     public static func creditEventCompact(_ event: CreditEvent) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM d"
-        let number = NumberFormatter()
-        number.numberStyle = .decimal
-        number.maximumFractionDigits = 2
+        self.localizationLock.lock()
+        let formatter = self.compactDateFormatter
+        let number = self.creditsNumberFormatter
         let credits = number.string(from: NSNumber(value: event.creditsUsed)) ?? "0"
-        return "\(formatter.string(from: event.date)) — \(event.service): \(credits)"
+        let dateString = formatter.string(from: event.date)
+        self.localizationLock.unlock()
+        return "\(dateString) — \(event.service): \(credits)"
     }
 
     public static func creditShort(_ value: Double) -> String {

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -70,13 +70,13 @@ public enum UsageFormatter {
         return String(format: format, locale: self.currentLocale(), arguments: args)
     }
 
-    private static let relativeFormatter: RelativeDateTimeFormatter = {
+    private nonisolated(unsafe) static let relativeFormatter: RelativeDateTimeFormatter = {
         let rel = RelativeDateTimeFormatter()
         rel.unitsStyle = .abbreviated
         return rel
     }()
 
-    private static let creditsNumberFormatter: NumberFormatter = {
+    private nonisolated(unsafe) static let creditsNumberFormatter: NumberFormatter = {
         let number = NumberFormatter()
         number.numberStyle = .decimal
         number.maximumFractionDigits = 2
@@ -84,7 +84,7 @@ public enum UsageFormatter {
         return number
     }()
 
-    private static let tokenCountNumberFormatter: NumberFormatter = {
+    private nonisolated(unsafe) static let tokenCountNumberFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         formatter.usesGroupingSeparator = true
@@ -92,13 +92,13 @@ public enum UsageFormatter {
         return formatter
     }()
 
-    private static let mediumDateFormatter: DateFormatter = {
+    private nonisolated(unsafe) static let mediumDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         return formatter
     }()
 
-    private static let compactDateFormatter: DateFormatter = {
+    private nonisolated(unsafe) static let compactDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "MMM d"
         return formatter

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -9,6 +9,7 @@ public enum UsageFormatter {
     private final class BundleToken {}
 
     private static let localizationLock = NSLock()
+    private static let formatterLock = NSLock()
     private nonisolated(unsafe) static var localizationProvider: (@Sendable (String) -> String)?
     private nonisolated(unsafe) static var localeProvider: (@Sendable () -> Locale)?
 
@@ -76,7 +77,7 @@ public enum UsageFormatter {
         return rel
     }()
 
-    private nonisolated(unsafe) static let creditsNumberFormatter: NumberFormatter = {
+    private static let creditsNumberFormatter: NumberFormatter = {
         let number = NumberFormatter()
         number.numberStyle = .decimal
         number.maximumFractionDigits = 2
@@ -84,7 +85,7 @@ public enum UsageFormatter {
         return number
     }()
 
-    private nonisolated(unsafe) static let tokenCountNumberFormatter: NumberFormatter = {
+    private static let tokenCountNumberFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         formatter.usesGroupingSeparator = true
@@ -92,13 +93,13 @@ public enum UsageFormatter {
         return formatter
     }()
 
-    private nonisolated(unsafe) static let mediumDateFormatter: DateFormatter = {
+    private static let mediumDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         return formatter
     }()
 
-    private nonisolated(unsafe) static let compactDateFormatter: DateFormatter = {
+    private static let compactDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "MMM d"
         return formatter
@@ -188,12 +189,12 @@ public enum UsageFormatter {
         }
         if let hours = Calendar.current.dateComponents([.hour], from: date, to: now).hour, hours < 24 {
             #if os(macOS)
-            self.localizationLock.lock()
-            let rel = self.relativeFormatter
-            rel.locale = self.currentLocale()
-            let result = self.localized("Updated %@", rel.localizedString(for: date, relativeTo: now))
-            self.localizationLock.unlock()
-            return result
+            let locale = self.currentLocale()
+            self.formatterLock.lock()
+            self.relativeFormatter.locale = locale
+            let relativeString = self.relativeFormatter.localizedString(for: date, relativeTo: now)
+            self.formatterLock.unlock()
+            return self.localized("Updated %@", relativeString)
             #else
             let seconds = max(0, Int(now.timeIntervalSince(date)))
             if seconds < 3600 {
@@ -211,10 +212,10 @@ public enum UsageFormatter {
     }
 
     public static func creditsString(from value: Double) -> String {
-        self.localizationLock.lock()
+        self.formatterLock.lock()
         let number = self.creditsNumberFormatter
         let formatted = number.string(from: NSNumber(value: value)) ?? String(format: "%.2f", value)
-        self.localizationLock.unlock()
+        self.formatterLock.unlock()
         return self.localized("%@ left", formatted)
     }
 
@@ -274,10 +275,10 @@ public enum UsageFormatter {
             return "\(sign)\(formatted)\(unit.suffix)"
         }
 
-        self.localizationLock.lock()
+        self.formatterLock.lock()
         let formatter = self.tokenCountNumberFormatter
         let result = formatter.string(from: NSNumber(value: value)) ?? "\(value)"
-        self.localizationLock.unlock()
+        self.formatterLock.unlock()
         return result
     }
 
@@ -301,22 +302,22 @@ public enum UsageFormatter {
     }
 
     public static func creditEventSummary(_ event: CreditEvent) -> String {
-        self.localizationLock.lock()
+        self.formatterLock.lock()
         let formatter = self.mediumDateFormatter
         let number = self.creditsNumberFormatter
         let credits = number.string(from: NSNumber(value: event.creditsUsed)) ?? "0"
         let dateString = formatter.string(from: event.date)
-        self.localizationLock.unlock()
+        self.formatterLock.unlock()
         return "\(dateString) · \(event.service) · \(credits) credits"
     }
 
     public static func creditEventCompact(_ event: CreditEvent) -> String {
-        self.localizationLock.lock()
+        self.formatterLock.lock()
         let formatter = self.compactDateFormatter
         let number = self.creditsNumberFormatter
         let credits = number.string(from: NSNumber(value: event.creditsUsed)) ?? "0"
         let dateString = formatter.string(from: event.date)
-        self.localizationLock.unlock()
+        self.formatterLock.unlock()
         return "\(dateString) — \(event.service): \(credits)"
     }
 

--- a/Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift
+++ b/Tests/CodexBarTests/KeychainPromptSafetyAuditTests.swift
@@ -1,5 +1,7 @@
 import Foundation
 import Testing
+@testable import CodexBar
+@testable import CodexBarCore
 
 struct KeychainPromptSafetyAuditTests {
     @Test
@@ -51,6 +53,44 @@ struct KeychainPromptSafetyAuditTests {
         }
 
         #expect(offenders.isEmpty, "Unexpected direct SecItemCopyMatching in tests: \(offenders.map(\.path))")
+    }
+
+    @Test
+    func `generic app keychain stores suppress interactive password prompts`() throws {
+        let cookieAccount = "test-cookie-\(UUID().uuidString)"
+        var promptCount = 0
+
+        try KeychainAccessGate.withTaskOverrideForTesting(false) {
+            try KeychainPromptHandler.withHandlerForTesting({ _ in
+                promptCount += 1
+            }, operation: {
+                try KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting({ _, _ in
+                    .interactionRequired
+                }, operation: {
+                    let cookieHeader = try KeychainCookieHeaderStore(
+                        account: cookieAccount,
+                        promptKind: .codexCookie).loadCookieHeader()
+                    let zaiToken = try KeychainZaiTokenStore().loadToken()
+                    let kimiToken = try KeychainKimiTokenStore().loadToken()
+                    let kimiK2Token = try KeychainKimiK2TokenStore().loadToken()
+                    let miniMaxToken = try KeychainMiniMaxAPITokenStore().loadToken()
+                    let miniMaxCookie = try KeychainMiniMaxCookieStore().loadCookieHeader()
+                    let copilotToken = try KeychainCopilotTokenStore().loadToken()
+                    let syntheticToken = try KeychainSyntheticTokenStore().loadToken()
+
+                    #expect(cookieHeader == nil)
+                    #expect(zaiToken == nil)
+                    #expect(kimiToken == nil)
+                    #expect(kimiK2Token == nil)
+                    #expect(miniMaxToken == nil)
+                    #expect(miniMaxCookie == nil)
+                    #expect(copilotToken == nil)
+                    #expect(syntheticToken == nil)
+                })
+            })
+        }
+
+        #expect(promptCount == 0)
     }
 
     private static func repoRoot() -> URL {

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -89,6 +89,30 @@ struct UsageFormatterTests {
     }
 
     @Test
+    func `relative updated string uses injected localization without deadlocking`() {
+        UsageFormatter.setLocalizationProvider { key in
+            switch key {
+            case "Updated %@":
+                "Updated local %@"
+            default:
+                key
+            }
+        }
+        UsageFormatter.setLocaleProvider { Locale(identifier: "en_US_POSIX") }
+        defer {
+            UsageFormatter.clearLocalizationProvider()
+            UsageFormatter.clearLocaleProvider()
+        }
+
+        let now = Date(timeIntervalSince1970: 1_710_048_000)
+        let old = now.addingTimeInterval(-(5 * 3600))
+        let output = UsageFormatter.updatedString(from: old, now: now)
+
+        #expect(output.hasPrefix("Updated local "))
+        #expect(output.contains("5"))
+    }
+
+    @Test
     func `clearing locale provider returns to stable default behavior`() {
         UsageFormatter.clearLocalizationProvider()
         UsageFormatter.clearLocaleProvider()


### PR DESCRIPTION
This PR addresses performance bottlenecks in menu population:
- Caches parsed JWTs in UsageFetcher to avoid repeated Base64/JSON overhead.
- Optimizes SwiftUI layout in InlineUsageDashboardContent by switching from LazyVGrid to Grid.
- Caches expensive formatters (DateFormatter, NumberFormatter) and Regexes.
- Caches measured menu width in StatusItemController based on MenuDescriptor content.
- Increases Codex account reconciliation cache interval to 30s to reduce disk I/O.

These changes significantly reduce Main Thread churn during background updates and menu interaction.