### PR TITLE
Avoid closed menu rebuilds during data refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Menu bar: keep z.ai overview rows with detail submenus in Overview so hovering quota details no longer recurses into a nested provider menu (#1279, fixes #1246). Thanks @RajvardhanPatil07!
 - Codex: backfill visible-account reset timestamps and missing 5-hour/weekly window metadata from same-workspace plan history so segmented multi-account JSON keeps machine-readable reset data (#1283). Thanks @callmepopo!
 - Antigravity: detect CLI local language-server processes and allow empty CSRF tokens only for explicit CLI matches so Antigravity CLI quota usage renders without weakening IDE CSRF detection (#1341). Thanks @oyaah!
+- Menu bar: skip closed attached-menu rebuilds during stale background data-refresh ticks so closed dropdowns are not pre-warmed while the user is not interacting (#1291). Thanks @Nicolas0315!
 - Cursor: show deficit and run-out pace details for 30-day Total, Auto, and API billing-cycle usage rows (#1336). Thanks @dhruv-anand-aintech!
 - Codex: time out stalled managed `codex login` processes so account switches no longer stay stuck in progress after OAuth completes (#1330). Thanks @dhruv-anand-aintech!
 - Codex Spark: show the same deficit and run-out pace details as the core Codex quota lanes for 5-hour and weekly model limits (#1335). Thanks @dhruv-anand-aintech!

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -45,6 +45,7 @@ extension StatusItemController {
                 deferParentRebuildDuringTracking: deferOpenParentMenuRebuild)
             return
         }
+        guard !allowStaleContentDuringDataRefresh else { return }
         self.prepareAttachedClosedMenusIfNeeded()
     }
 
@@ -148,6 +149,7 @@ extension StatusItemController {
         guard !self.isMenuDataRefreshInFlight else { return }
         let key = ObjectIdentifier(menu)
         let provider = self.menuProvider(for: menu)
+        let requiredMenuVersion = self.latestRequiredMenuRebuildVersion
         self.closedMenuRebuildTokenCounter &+= 1
         let rebuildToken = self.closedMenuRebuildTokenCounter
         self.closedMenuRebuildTokens[key] = rebuildToken
@@ -172,7 +174,7 @@ extension StatusItemController {
             guard !self.hasPreparedForAppShutdown else { return }
             guard !self.isMenuDataRefreshInFlight else { return }
             guard self.openMenus[ObjectIdentifier(menu)] == nil else { return }
-            guard self.menuNeedsRefresh(menu) else { return }
+            guard (self.menuVersions[key] ?? -1) < requiredMenuVersion else { return }
             self.populateMenu(menu, provider: provider)
             self.markMenuFresh(menu)
             #if DEBUG

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -53,6 +53,8 @@ extension StatusItemController {
         guard self.isMenuRefreshEnabled else { return }
         guard self.openMenus.isEmpty else { return }
         guard !self.isMenuDataRefreshInFlight else { return }
+        // Stale data-refresh invalidations should not pre-warm closed menus from any caller.
+        guard self.menuContentVersion <= self.latestRequiredMenuRebuildVersion else { return }
         for menu in self.attachedMenusForClosedPreparation() {
             let key = ObjectIdentifier(menu)
             guard !self.closedMenusDeferredUntilNextOpen.contains(key) else { continue }

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -45,7 +45,6 @@ extension StatusItemController {
                 deferParentRebuildDuringTracking: deferOpenParentMenuRebuild)
             return
         }
-        guard !allowStaleContentDuringDataRefresh else { return }
         self.prepareAttachedClosedMenusIfNeeded()
     }
 
@@ -53,9 +52,15 @@ extension StatusItemController {
         guard self.isMenuRefreshEnabled else { return }
         guard self.openMenus.isEmpty else { return }
         guard !self.isMenuDataRefreshInFlight else { return }
-        // Stale data-refresh invalidations should not pre-warm closed menus from any caller.
-        guard self.menuContentVersion <= self.latestRequiredMenuRebuildVersion else { return }
-        for menu in self.attachedMenusForClosedPreparation() {
+        let menus = self.attachedMenusForClosedPreparation()
+        if self.menuContentVersion > self.latestRequiredMenuRebuildVersion {
+            let hasRequiredClosedMenu = menus.contains { menu in
+                let key = ObjectIdentifier(menu)
+                return (self.menuVersions[key] ?? -1) < self.latestRequiredMenuRebuildVersion
+            }
+            guard self.latestRequiredMenuRebuildVersion > 0, hasRequiredClosedMenu else { return }
+        }
+        for menu in menus {
             let key = ObjectIdentifier(menu)
             guard !self.closedMenusDeferredUntilNextOpen.contains(key) else { continue }
             // Pre-warming the merged menu while it is closed runs a full main-thread populateMenu

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -53,16 +53,24 @@ extension StatusItemController {
         guard self.openMenus.isEmpty else { return }
         guard !self.isMenuDataRefreshInFlight else { return }
         let menus = self.attachedMenusForClosedPreparation()
+        let requiredClosedPreparationVersion: Int?
         if self.menuContentVersion > self.latestRequiredMenuRebuildVersion {
+            guard self.latestRequiredMenuRebuildVersion > 0 else { return }
             let hasRequiredClosedMenu = menus.contains { menu in
                 let key = ObjectIdentifier(menu)
                 return (self.menuVersions[key] ?? -1) < self.latestRequiredMenuRebuildVersion
             }
-            guard self.latestRequiredMenuRebuildVersion > 0, hasRequiredClosedMenu else { return }
+            guard hasRequiredClosedMenu else { return }
+            requiredClosedPreparationVersion = self.latestRequiredMenuRebuildVersion
+        } else {
+            requiredClosedPreparationVersion = nil
         }
         for menu in menus {
             let key = ObjectIdentifier(menu)
             guard !self.closedMenusDeferredUntilNextOpen.contains(key) else { continue }
+            if let requiredClosedPreparationVersion {
+                guard (self.menuVersions[key] ?? -1) < requiredClosedPreparationVersion else { continue }
+            }
             // Pre-warming the merged menu while it is closed runs a full main-thread populateMenu
             // (incl. SwiftUI hosting-view layout) that menuWillOpen redoes synchronously on display
             // anyway. In Merge Icons mode it is the only attached menu, so this just relocates that
@@ -156,7 +164,6 @@ extension StatusItemController {
         guard !self.isMenuDataRefreshInFlight else { return }
         let key = ObjectIdentifier(menu)
         let provider = self.menuProvider(for: menu)
-        let requiredMenuVersion = self.latestRequiredMenuRebuildVersion
         self.closedMenuRebuildTokenCounter &+= 1
         let rebuildToken = self.closedMenuRebuildTokenCounter
         self.closedMenuRebuildTokens[key] = rebuildToken
@@ -181,7 +188,7 @@ extension StatusItemController {
             guard !self.hasPreparedForAppShutdown else { return }
             guard !self.isMenuDataRefreshInFlight else { return }
             guard self.openMenus[ObjectIdentifier(menu)] == nil else { return }
-            guard (self.menuVersions[key] ?? -1) < requiredMenuVersion else { return }
+            guard self.menuNeedsRefresh(menu) else { return }
             self.populateMenu(menu, provider: provider)
             self.markMenuFresh(menu)
             #if DEBUG

--- a/Tests/CodexBarTests/StatusMenuClosedPreparationTests.swift
+++ b/Tests/CodexBarTests/StatusMenuClosedPreparationTests.swift
@@ -52,4 +52,61 @@ extension StatusMenuTests {
 
         #expect(controller.menuVersions[key] == controller.menuContentVersion)
     }
+
+    @Test
+    func `stale refresh completion requeues required closed menu preparation blocked by refresh`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            if let metadata = registry.metadata[provider] {
+                settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
+            }
+        }
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.fallbackMenu = menu
+        controller.statusItem.menu = menu
+
+        controller.populateMenu(menu, provider: nil)
+        controller.markMenuFresh(menu)
+        let key = ObjectIdentifier(menu)
+        let openedVersion = controller.menuVersions[key]
+
+        controller.invalidateMenus()
+        let requiredVersion = controller.latestRequiredMenuRebuildVersion
+        store.isRefreshing = true
+        for _ in 0..<40 where controller.closedMenuRebuildTasks[key] != nil {
+            await Task.yield()
+        }
+
+        #expect(requiredVersion > (openedVersion ?? -1))
+        #expect(controller.closedMenuRebuildTasks[key] == nil)
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        store.isRefreshing = false
+        controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
+        for _ in 0..<40 where controller.menuVersions[key] == openedVersion {
+            await Task.yield()
+        }
+
+        #expect(controller.openMenus.isEmpty)
+        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+    }
 }

--- a/Tests/CodexBarTests/StatusMenuClosedPreparationTests.swift
+++ b/Tests/CodexBarTests/StatusMenuClosedPreparationTests.swift
@@ -109,4 +109,53 @@ extension StatusMenuTests {
         #expect(controller.openMenus.isEmpty)
         #expect(controller.menuVersions[key] == controller.menuContentVersion)
     }
+
+    @Test
+    func `data refresh while persistent menu is open rebuilds on close`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            if let metadata = registry.metadata[provider] {
+                settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
+            }
+        }
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.fallbackMenu = menu
+        controller.statusItem.menu = menu
+
+        controller.menuWillOpen(menu)
+        let key = ObjectIdentifier(menu)
+        let openedVersion = controller.menuVersions[key]
+
+        controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
+        #expect(controller.menuContentVersion != openedVersion)
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        controller.menuDidClose(menu)
+        for _ in 0..<40 where controller.menuVersions[key] == openedVersion {
+            await Task.yield()
+        }
+
+        #expect(controller.openMenus.isEmpty)
+        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+        #expect(controller.menuVersions[key] != openedVersion)
+    }
 }

--- a/Tests/CodexBarTests/StatusMenuClosedPreparationTests.swift
+++ b/Tests/CodexBarTests/StatusMenuClosedPreparationTests.swift
@@ -1,0 +1,55 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+extension StatusMenuTests {
+    @Test
+    func `stale data refresh suppresses icon attached closed menu preparation`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            if let metadata = registry.metadata[provider] {
+                settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
+            }
+        }
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        // Simulate a closed menu that was attached by an icon update but has never been opened.
+        controller.fallbackMenu = menu
+        controller.statusItem.menu = menu
+        let key = ObjectIdentifier(menu)
+
+        controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
+        controller.prepareAttachedClosedMenusIfNeeded()
+        for _ in 0..<40 {
+            await Task.yield()
+        }
+
+        #expect(controller.openMenus.isEmpty)
+        #expect(controller.menuVersions[key] == nil)
+
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -225,6 +225,95 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `data refresh invalidation does not rebuild closed attached menu`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        self.enableOnlyCodex(settings)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.mergedMenu = menu
+        controller.statusItem.menu = menu
+
+        controller.populateMenu(menu, provider: nil)
+        controller.markMenuFresh(menu)
+        let key = ObjectIdentifier(menu)
+        let openedVersion = controller.menuVersions[key]
+
+        controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
+        for _ in 0..<40 {
+            await Task.yield()
+        }
+
+        #expect(controller.openMenus.isEmpty)
+        #expect(controller.menuContentVersion != openedVersion)
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+    }
+
+    @Test
+    func `required closed menu preparation survives later data refresh invalidation`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        self.enableOnlyCodex(settings)
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.mergedMenu = menu
+        controller.statusItem.menu = menu
+
+        controller.populateMenu(menu, provider: nil)
+        controller.markMenuFresh(menu)
+        let key = ObjectIdentifier(menu)
+        let openedVersion = controller.menuVersions[key]
+
+        controller.invalidateMenus()
+        let requiredVersion = controller.latestRequiredMenuRebuildVersion
+        controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
+        for _ in 0..<40 where controller.menuVersions[key] == openedVersion {
+            await Task.yield()
+        }
+
+        #expect(controller.openMenus.isEmpty)
+        #expect(requiredVersion > (openedVersion ?? -1))
+        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+    }
+
+    @Test
     func `closed attached menu preparation waits for store refresh to finish`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -199,7 +199,8 @@ extension StatusMenuTests {
         let key = ObjectIdentifier(menu)
         let openedVersion = controller.menuVersions[key]
 
-        // Background data-refresh tick (stale allowed): the closed merged menu must not be pre-warmed.
+        // Background data-refresh tick (stale allowed): closed prep is skipped entirely, so
+        // the closed merged menu must not be pre-warmed or marked deferred.
         controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
         for _ in 0..<40 {
             await Task.yield()
@@ -207,7 +208,7 @@ extension StatusMenuTests {
         #expect(controller.openMenus.isEmpty)
         #expect(controller.menuContentVersion != openedVersion)
         #expect(controller.menuVersions[key] == openedVersion)
-        #expect(controller.closedMenusDeferredUntilNextOpen.contains(key))
+        #expect(!controller.closedMenusDeferredUntilNextOpen.contains(key))
 
         // A required (non-stale) invalidation must also leave the closed merged menu deferred.
         controller.invalidateMenus()
@@ -225,7 +226,7 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `data refresh invalidation does not rebuild closed attached menu`() async {
+    func `data refresh invalidation does not rebuild closed non merged attached menu`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -247,7 +248,9 @@ extension StatusMenuTests {
 
         controller.menuRefreshEnabledOverrideForTesting = true
         let menu = controller.makeMenu()
-        controller.mergedMenu = menu
+        // Use a non-merged attached menu: stale data-refresh invalidations should not pre-warm any
+        // closed attached menu, while required invalidations still may prepare non-merged menus.
+        controller.fallbackMenu = menu
         controller.statusItem.menu = menu
 
         controller.populateMenu(menu, provider: nil)
@@ -271,7 +274,7 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `required closed menu preparation survives later data refresh invalidation`() async {
+    func `required non merged closed menu preparation survives later data refresh invalidation`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -293,7 +296,9 @@ extension StatusMenuTests {
 
         controller.menuRefreshEnabledOverrideForTesting = true
         let menu = controller.makeMenu()
-        controller.mergedMenu = menu
+        // Use a non-merged attached menu so this covers the delayed closed-menu rebuild path. Merged
+        // menus are intentionally deferred until next open on current main (#1274).
+        controller.fallbackMenu = menu
         controller.statusItem.menu = menu
 
         controller.populateMenu(menu, provider: nil)


### PR DESCRIPTION
## Summary
- skip closed attached menu preparation for data-refresh invalidations that allow stale menu content
- cancel pending closed-menu rebuilds in that path so background refreshes do not spend CPU measuring SwiftUI menu cards
- keep open-time rebuild behavior covered with a regression test

## Evidence
- Pre-fix local `sample` of CodexBar 0.32.4 showed CPU under `StatusItemController.rebuildClosedMenuIfNeeded` -> `populateMenu` -> SwiftUI menu card height measurement while the menu was closed.

## After-fix profiler proof
- Built PR head `c0d5952a04eb60860747436724b84481c89cf98b` locally with `swift build --product CodexBar`.
- Local build note: this machine has only Command Line Tools, so the proof build used a local-only, uncommitted compile workaround that removed dependency `#Preview` declarations from `KeyboardShortcuts` and replaced SwiftUI `@Entry` with the equivalent `EnvironmentKey` implementation. The app/menu refresh code under review was unchanged, and the working tree was restored afterward.
- Ran the PR-built app with Keychain/OpenAI Web disabled via runtime defaults: `.build/arm64-apple-macosx/debug/CodexBar -debugDisableKeychainAccess YES -openAIWebAccessEnabled NO -refreshFrequency oneMinute -debugLogLevel debug`.
- Waited 70 seconds to cross the `oneMinute` refresh cadence with the menu closed, then captured `sample <pid> 20 -file pr1291-afterfix-idle-after-refresh.sample.txt`.
- Sample result: process CPU was `0.0%` before and after the sample window, and the sample contained zero occurrences of the pre-fix hot-path symbols:
  - `rebuildClosedMenuIfNeeded`: 0
  - `populateMenu`: 0
  - `NSHostingController`: 0
  - `sizeThatFits`: 0
  - `closed menu rebuild completed`: 0
- The sample call graph was dominated by AppKit/CFRunLoop waiting for events; no closed menu rebuild or SwiftUI menu card measurement appeared after the refresh cadence elapsed.

## Tests
- `git diff --check`
- `swift test --filter StatusMenuTests` attempted, but local Command Line Tools environment failed while compiling dependency `KeyboardShortcuts` because `PreviewsMacros` for `#Preview` was unavailable.
- `swift build --product CodexBar` passed for the local proof build with the macro-only compile workaround described above.

## Local limitations
- `xcode-select -p` is `/Library/Developer/CommandLineTools`; this machine has no `/Applications/Xcode*.app`, and `home-mac-main` also has no full Xcode install.
- Exact-source macOS app build/tests still need CI or a full-Xcode machine because CLT lacks the SwiftUI macro plugins needed by dependencies.