### PR TITLE
Reduce idle menu power usage

### DIFF
--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -375,9 +375,9 @@ extension SettingsStore {
             userDefaults.set(false, forKey: "openAIWebAccessEnabled")
         }
         let openAIWebBatterySaverDefault = userDefaults.object(forKey: "openAIWebBatterySaverEnabled") as? Bool
-        let openAIWebBatterySaverEnabled = openAIWebBatterySaverDefault ?? false
+        let openAIWebBatterySaverEnabled = openAIWebBatterySaverDefault ?? true
         if Self.isRunningTests, openAIWebBatterySaverDefault == nil {
-            userDefaults.set(false, forKey: "openAIWebBatterySaverEnabled")
+            userDefaults.set(true, forKey: "openAIWebBatterySaverEnabled")
         }
         let providerStorageFootprintsDefault = userDefaults.object(forKey: "providerStorageFootprintsEnabled") as? Bool
         let providerStorageFootprintsEnabled = providerStorageFootprintsDefault ?? false

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -375,9 +375,9 @@ extension SettingsStore {
             userDefaults.set(false, forKey: "openAIWebAccessEnabled")
         }
         let openAIWebBatterySaverDefault = userDefaults.object(forKey: "openAIWebBatterySaverEnabled") as? Bool
-        let openAIWebBatterySaverEnabled = openAIWebBatterySaverDefault ?? true
+        let openAIWebBatterySaverEnabled = openAIWebBatterySaverDefault ?? false
         if Self.isRunningTests, openAIWebBatterySaverDefault == nil {
-            userDefaults.set(true, forKey: "openAIWebBatterySaverEnabled")
+            userDefaults.set(false, forKey: "openAIWebBatterySaverEnabled")
         }
         let providerStorageFootprintsDefault = userDefaults.object(forKey: "providerStorageFootprintsEnabled") as? Bool
         let providerStorageFootprintsEnabled = providerStorageFootprintsDefault ?? false

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -165,7 +165,7 @@ extension StatusItemController {
         if !isPersistentMenu {
             self.menuProviders.removeValue(forKey: key)
             self.menuVersions.removeValue(forKey: key)
-        } else if self.menuNeedsRefresh(menu) {
+        } else if Self.isClosedMenuPreparationEnabled, self.menuNeedsRefresh(menu) {
             self.rebuildClosedMenuIfNeeded(menu)
         }
         self.parentMenuRebuildsDeferredDuringTracking.remove(key)

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -3,15 +3,26 @@ import CodexBarCore
 
 extension StatusItemController {
     private static let defaultClosedMenuPreparationDelay: Duration = .milliseconds(350)
+    private static let defaultClosedMenuPreparationEnabled = false // Avoid idle SwiftUI layout work.
 
     #if DEBUG
     private static var closedMenuPreparationDelayForTesting: Duration = defaultClosedMenuPreparationDelay
+    private static var closedMenuPreparationEnabledForTesting = defaultClosedMenuPreparationEnabled
+
     static func setClosedMenuPreparationDelayForTesting(_ delay: Duration) {
         self.closedMenuPreparationDelayForTesting = delay
     }
 
     static func resetClosedMenuPreparationDelayForTesting() {
         self.closedMenuPreparationDelayForTesting = self.defaultClosedMenuPreparationDelay
+    }
+
+    static func setClosedMenuPreparationEnabledForTesting(_ enabled: Bool) {
+        self.closedMenuPreparationEnabledForTesting = enabled
+    }
+
+    static func resetClosedMenuPreparationEnabledForTesting() {
+        self.closedMenuPreparationEnabledForTesting = self.defaultClosedMenuPreparationEnabled
     }
     #endif
 
@@ -20,6 +31,14 @@ extension StatusItemController {
         closedMenuPreparationDelayForTesting
         #else
         defaultClosedMenuPreparationDelay
+        #endif
+    }
+
+    static var isClosedMenuPreparationEnabled: Bool {
+        #if DEBUG
+        closedMenuPreparationEnabledForTesting
+        #else
+        defaultClosedMenuPreparationEnabled
         #endif
     }
 
@@ -49,6 +68,7 @@ extension StatusItemController {
 
     func prepareAttachedClosedMenusIfNeeded() {
         guard self.isMenuRefreshEnabled else { return }
+        guard Self.isClosedMenuPreparationEnabled else { return }
         guard self.openMenus.isEmpty else { return }
         guard !self.isMenuDataRefreshInFlight else { return }
         for menu in self.attachedMenusForClosedPreparation() {

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -63,7 +63,7 @@ struct ProviderSettingsDescriptorTests {
     }
 
     @Test
-    func `codex exposes open AI web extras toggle as default off opt in`() throws {
+    func `codex exposes open AI web extras toggle as default off with battery saver on`() throws {
         let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-codex-openai-toggle")
         let context = fixture.settingsContext(provider: .codex)
 
@@ -74,7 +74,7 @@ struct ProviderSettingsDescriptorTests {
         #expect(extrasToggle.subtitle.contains("Turn this on"))
 
         let batterySaverToggle = try #require(toggles.first(where: { $0.id == "codex-openai-web-battery-saver" }))
-        #expect(batterySaverToggle.binding.wrappedValue == false)
+        #expect(batterySaverToggle.binding.wrappedValue == true)
         #expect(batterySaverToggle.isVisible?() == false)
 
         fixture.settings.openAIWebAccessEnabled = true

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -63,7 +63,7 @@ struct ProviderSettingsDescriptorTests {
     }
 
     @Test
-    func `codex exposes open AI web extras toggle as default off with battery saver on`() throws {
+    func `codex exposes open AI web extras toggle as default off with battery saver off`() throws {
         let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-codex-openai-toggle")
         let context = fixture.settingsContext(provider: .codex)
 
@@ -74,7 +74,7 @@ struct ProviderSettingsDescriptorTests {
         #expect(extrasToggle.subtitle.contains("Turn this on"))
 
         let batterySaverToggle = try #require(toggles.first(where: { $0.id == "codex-openai-web-battery-saver" }))
-        #expect(batterySaverToggle.binding.wrappedValue == true)
+        #expect(batterySaverToggle.binding.wrappedValue == false)
         #expect(batterySaverToggle.isVisible?() == false)
 
         fixture.settings.openAIWebAccessEnabled = true

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -880,8 +880,8 @@ struct SettingsStoreTests {
 
         #expect(store.openAIWebAccessEnabled == false)
         #expect(defaults.bool(forKey: "openAIWebAccessEnabled") == false)
-        #expect(store.openAIWebBatterySaverEnabled == true)
-        #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == true)
+        #expect(store.openAIWebBatterySaverEnabled == false)
+        #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == false)
         #expect(store.codexCookieSource == .off)
     }
 
@@ -905,8 +905,8 @@ struct SettingsStoreTests {
 
         #expect(store.openAIWebAccessEnabled == true)
         #expect(defaults.bool(forKey: "openAIWebAccessEnabled") == true)
-        #expect(store.openAIWebBatterySaverEnabled == true)
-        #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == true)
+        #expect(store.openAIWebBatterySaverEnabled == false)
+        #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == false)
         #expect(store.codexCookieSource == .auto)
     }
 
@@ -953,8 +953,8 @@ struct SettingsStoreTests {
 
         #expect(store.openAIWebAccessEnabled == true)
         #expect(defaults.bool(forKey: "openAIWebAccessEnabled") == true)
-        #expect(store.openAIWebBatterySaverEnabled == true)
-        #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == true)
+        #expect(store.openAIWebBatterySaverEnabled == false)
+        #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == false)
         #expect(store.codexCookieSource == .auto)
     }
 
@@ -998,13 +998,13 @@ struct SettingsStoreTests {
             zaiTokenStore: NoopZaiTokenStore(),
             syntheticTokenStore: NoopSyntheticTokenStore())
 
-        #expect(store.openAIWebBatterySaverEnabled == true)
+        #expect(store.openAIWebBatterySaverEnabled == false)
 
-        store.openAIWebBatterySaverEnabled = false
-        #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == false)
+        store.openAIWebBatterySaverEnabled = true
+        #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == true)
 
         store.openAIWebAccessEnabled = true
-        #expect(store.openAIWebBatterySaverEnabled == false)
+        #expect(store.openAIWebBatterySaverEnabled == true)
     }
 
     @Test

--- a/Tests/CodexBarTests/SettingsStoreTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreTests.swift
@@ -880,8 +880,8 @@ struct SettingsStoreTests {
 
         #expect(store.openAIWebAccessEnabled == false)
         #expect(defaults.bool(forKey: "openAIWebAccessEnabled") == false)
-        #expect(store.openAIWebBatterySaverEnabled == false)
-        #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == false)
+        #expect(store.openAIWebBatterySaverEnabled == true)
+        #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == true)
         #expect(store.codexCookieSource == .off)
     }
 
@@ -905,8 +905,8 @@ struct SettingsStoreTests {
 
         #expect(store.openAIWebAccessEnabled == true)
         #expect(defaults.bool(forKey: "openAIWebAccessEnabled") == true)
-        #expect(store.openAIWebBatterySaverEnabled == false)
-        #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == false)
+        #expect(store.openAIWebBatterySaverEnabled == true)
+        #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == true)
         #expect(store.codexCookieSource == .auto)
     }
 
@@ -953,8 +953,8 @@ struct SettingsStoreTests {
 
         #expect(store.openAIWebAccessEnabled == true)
         #expect(defaults.bool(forKey: "openAIWebAccessEnabled") == true)
-        #expect(store.openAIWebBatterySaverEnabled == false)
-        #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == false)
+        #expect(store.openAIWebBatterySaverEnabled == true)
+        #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == true)
         #expect(store.codexCookieSource == .auto)
     }
 
@@ -998,7 +998,7 @@ struct SettingsStoreTests {
             zaiTokenStore: NoopZaiTokenStore(),
             syntheticTokenStore: NoopSyntheticTokenStore())
 
-        #expect(store.openAIWebBatterySaverEnabled == false)
+        #expect(store.openAIWebBatterySaverEnabled == true)
 
         store.openAIWebBatterySaverEnabled = false
         #expect(defaults.bool(forKey: "openAIWebBatterySaverEnabled") == false)

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -169,7 +169,7 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `closed attached menu is prepared before next open after invalidation`() async {
+    func `closed attached menu stays stale after invalidation until next open`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -200,11 +200,17 @@ extension StatusMenuTests {
         let openedVersion = controller.menuVersions[key]
 
         controller.invalidateMenus()
-        for _ in 0..<40 where controller.menuVersions[key] == openedVersion {
+        for _ in 0..<40 {
             await Task.yield()
         }
 
         #expect(controller.openMenus.isEmpty)
+        #expect(controller.closedMenuRebuildTasks[key] == nil)
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
         #expect(controller.menuVersions[key] == controller.menuContentVersion)
     }
 
@@ -228,6 +234,8 @@ extension StatusMenuTests {
         defer { controller.releaseStatusItemsForTesting() }
         StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
         defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+        StatusItemController.setClosedMenuPreparationEnabledForTesting(true)
+        defer { StatusItemController.resetClosedMenuPreparationEnabledForTesting() }
 
         controller.menuRefreshEnabledOverrideForTesting = true
         let menu = controller.makeMenu()
@@ -261,6 +269,8 @@ extension StatusMenuTests {
     func `closed attached menu preparation waits for token refresh to finish`() async {
         StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
         defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+        StatusItemController.setClosedMenuPreparationEnabledForTesting(true)
+        defer { StatusItemController.resetClosedMenuPreparationEnabledForTesting() }
 
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()


### PR DESCRIPTION
## Summary
- Stop eager prewarming for closed menus by default so idle invalidations do not spend SwiftUI layout work on menu cards.
- Keep the closed-menu rebuild path covered behind the existing DEBUG-only test hooks, and update the main behavior test to refresh stale content on next open.
- Preserve the existing OpenAI Web battery saver absent-key behavior for upgrades; this PR no longer flips users without a stored `openAIWebBatterySaverEnabled` value into battery saver mode.

## Background
A local pre-fix CPU sample of the running menu bar app showed idle CPU dominated by `StatusItemController.rebuildClosedMenuIfNeeded(_:)` -> `populateMenu(_:provider:)` -> SwiftUI `NSHostingController.sizeThatFits(in:)`, while the menu was closed. WebKit helper processes were not the hot path in that sample.

## Review updates
- Addressed the ClawSweeper P1 compatibility finding in `3f907011` by restoring the `openAIWebBatterySaverEnabled` fallback to `false` and matching tests to that upgrade-safe behavior.
- Existing installs with OpenAI Web extras enabled but no stored battery saver key keep their previous effective regular background refresh behavior.

## After-fix profiler proof
- Built the PR head `3f9070117d350e73c6e90c784c670a7bbdafe953` locally with `swift build --product CodexBar`.
- Local build note: this machine has only Command Line Tools, so the proof build used a local-only, uncommitted compile workaround that removed dependency `#Preview` declarations from `KeyboardShortcuts` and replaced SwiftUI `@Entry` with the equivalent `EnvironmentKey` implementation. The app/menu refresh code under review was unchanged, and the working tree was restored afterward.
- Ran the PR-built app with Keychain/OpenAI Web disabled via runtime defaults: `.build/arm64-apple-macosx/debug/CodexBar -debugDisableKeychainAccess YES -openAIWebAccessEnabled NO -refreshFrequency oneMinute -debugLogLevel debug`.
- Captured an idle closed-menu sample: `sample <pid> 15 -file pr1292-afterfix-idle.sample.txt`.
- Sample result: process CPU was `0.0%` before and after the 15s sample window, and the sample contained zero occurrences of the pre-fix hot-path symbols:
  - `rebuildClosedMenuIfNeeded`: 0
  - `populateMenu`: 0
  - `NSHostingController`: 0
  - `sizeThatFits`: 0
  - `closed menu rebuild completed`: 0
- The sample call graph was dominated by the AppKit event loop waiting for events; the only CodexBar activity observed was status icon observation/update work, not closed menu rebuild or SwiftUI menu card measurement.

## Verification
- `git diff --check` passed
- `.build/lint-tools/bin/swiftformat --lint .` passed: `0/1003 files require formatting`, `87 files skipped`
- `swift build --product CodexBarCLI` passed
- `swift build --product CodexBar` passed for the local proof build with the macro-only compile workaround described above

## Local limitations
- `xcode-select -p` is `/Library/Developer/CommandLineTools`; this machine has no `/Applications/Xcode*.app`, and `home-mac-main` also has no full Xcode install.
- Exact-source `swift build --product CodexBar` is blocked before this change by dependency SwiftUI preview macros under CLT-only setup: `PreviewsMacros` is unavailable in `KeyboardShortcuts`.
- Exact-source `swift test --filter SettingsStoreTests` is blocked before the target tests by the same `PreviewsMacros` issue plus the local CLT test compile not finding module `Testing` for `TestsLinux`.
- `make check` ran SwiftFormat successfully, then SwiftLint failed locally because SourceKitten could not load `sourcekitdInProc` under the CLT-only setup.
- Maintainer CI or a full-Xcode validation run is still useful for exact-source macOS tests.