### PR TITLE
Skip redundant closed-menu rebuilds when displayed content is unchanged

### DIFF
--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -67,6 +67,7 @@ extension StatusItemController {
         self.menuProviders.removeValue(forKey: key)
         self.menuVersions.removeValue(forKey: key)
         self.closedMenusDeferredUntilNextOpen.remove(key)
+        self.closedMenuPreparedSignatures.removeValue(forKey: key)
     }
 
     func handleClosedPersistentMenuNeedingRefresh(_ menu: NSMenu) {
@@ -134,6 +135,37 @@ extension StatusItemController {
         return max(measuredWidth, Self.menuCardBaseWidth)
     }
 
+    /// Signature of everything a closed menu would display. Used to skip eager rebuilds of
+    /// invisible menus when a store-observation change does not actually alter the rendered
+    /// content (e.g. probe logs, internal revision counters, in-flight flags). Correctness does
+    /// not depend on this being exhaustive: `menuWillOpen` always rebuilds, so an incomplete
+    /// signature can only skip a pre-warm, never show stale content to the user.
+    func closedMenuContentSignature() -> String {
+        var parts = [self.menuAdjunctReadinessSignature()]
+        for provider in self.store.enabledProvidersForDisplay() {
+            var providerParts = [provider.rawValue]
+            if let snapshot = self.store.snapshot(for: provider) {
+                providerParts.append("p=\(Self.rateWindowSignature(snapshot.primary))")
+                providerParts.append("s=\(Self.rateWindowSignature(snapshot.secondary))")
+                providerParts.append("t=\(Self.rateWindowSignature(snapshot.tertiary))")
+                providerParts.append("u=\(Int(snapshot.updatedAt.timeIntervalSince1970))")
+            } else {
+                providerParts.append("none")
+            }
+            if let error = self.store.error(for: provider) {
+                providerParts.append("e=\(error)")
+            }
+            parts.append(providerParts.joined(separator: ":"))
+        }
+        return parts.joined(separator: "||")
+    }
+
+    private static func rateWindowSignature(_ window: RateWindow?) -> String {
+        guard let window else { return "nil" }
+        return "\(window.usedPercent):\(window.windowMinutes ?? -1):"
+            + "\(window.resetsAt?.timeIntervalSince1970 ?? -1)"
+    }
+
     func rebuildClosedMenuIfNeeded(_ menu: NSMenu) {
         guard !self.hasPreparedForAppShutdown else { return }
         guard !self.isMenuDataRefreshInFlight else { return }
@@ -164,9 +196,24 @@ extension StatusItemController {
             guard !self.isMenuDataRefreshInFlight else { return }
             guard self.openMenus[ObjectIdentifier(menu)] == nil else { return }
             guard self.menuNeedsRefresh(menu) else { return }
+            let contentSignature = self.closedMenuContentSignature()
+            if self.closedMenuPreparedSignatures[key] == contentSignature {
+                // The displayed content has not changed since this closed (invisible) menu was
+                // last pre-warmed, so skip the expensive rebuild. The menu is intentionally left
+                // marked stale so `menuWillOpen` still rebuilds it fresh on the next open.
+                self.menuLogger.debug(
+                    "closed-menu prewarm skipped (content unchanged)",
+                    metadata: ["provider": provider?.rawValue ?? "nil"])
+                return
+            }
             self.populateMenu(menu, provider: provider)
             self.markMenuFresh(menu)
+            self.closedMenuPreparedSignatures[key] = contentSignature
+            self.menuLogger.debug(
+                "closed-menu prewarm performed (content changed)",
+                metadata: ["provider": provider?.rawValue ?? "nil"])
             #if DEBUG
+            self._test_closedMenuRebuildObserver?(menu)
             if self.lastLoggedClosedMenuRebuildVersion != self.menuContentVersion {
                 self.lastLoggedClosedMenuRebuildVersion = self.menuContentVersion
                 self.menuLogger.debug(
@@ -322,6 +369,7 @@ extension StatusItemController {
             self.menuProviders.removeValue(forKey: key)
             self.menuVersions.removeValue(forKey: key)
             self.parentMenuRebuildsDeferredDuringTracking.remove(key)
+            self.closedMenuPreparedSignatures.removeValue(forKey: key)
         }
     }
 }

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -128,6 +128,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var closedMenuRebuildTokens: [ObjectIdentifier: Int] = [:]
     var closedMenuRebuildTokenCounter = 0
     var closedMenusDeferredUntilNextOpen: Set<ObjectIdentifier> = []
+    var closedMenuPreparedSignatures: [ObjectIdentifier: String] = [:]
     var openMenuRebuildTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
     var openMenuRebuildTokens: [ObjectIdentifier: Int] = [:]
     var openMenuRebuildTokenCounter = 0
@@ -149,6 +150,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var lastLoggedClosedMenuRebuildVersion: Int?
     var _test_openMenuRefreshYieldOverride: (@MainActor () async -> Void)?
     var _test_openMenuRebuildObserver: (@MainActor (NSMenu) -> Void)?
+    var _test_closedMenuRebuildObserver: (@MainActor (NSMenu) -> Void)?
     var _test_providerSwitcherMenuRebuildDebounceNanoseconds: UInt64?
     var _test_codexAmbientLoginRunnerOverride:
         (@MainActor (TimeInterval) async -> CodexLoginRunner.Result)?

--- a/Tests/CodexBarTests/StatusMenuClosedRebuildCoalesceTests.swift
+++ b/Tests/CodexBarTests/StatusMenuClosedRebuildCoalesceTests.swift
@@ -1,0 +1,186 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+extension StatusMenuTests {
+    private func makeCoalesceController(
+        _ settings: SettingsStore,
+        store: UsageStore) -> StatusItemController
+    {
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        controller.menuRefreshEnabledOverrideForTesting = true
+        return controller
+    }
+
+    /// Reproduces the closed-menu rebuild storm: store observation churns the menu content
+    /// version continuously, but a closed (invisible) menu whose displayed content is unchanged
+    /// must converge — additional churn ticks must not keep re-populating it. Before the fix this
+    /// rebuilt once per tick (dozens of full main-thread rebuilds).
+    @Test
+    func `closed menu rebuild converges when displayed content is unchanged`() async {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = false
+        defer { StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = self.makeCoalesceController(settings, store: store)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuProviders[ObjectIdentifier(menu)] = .codex
+
+        var closedRebuilds = 0
+        controller._test_closedMenuRebuildObserver = { _ in closedRebuilds += 1 }
+        defer { controller._test_closedMenuRebuildObserver = nil }
+
+        func churnOnce() async {
+            controller.menuContentVersion &+= 1
+            controller.rebuildClosedMenuIfNeeded(menu)
+            for _ in 0..<12 {
+                await Task.yield()
+            }
+        }
+
+        // Let the content settle (the first real populate plus its one-shot self-perturbation).
+        for _ in 0..<5 {
+            await churnOnce()
+        }
+        let settledCount = closedRebuilds
+
+        // Many more observation ticks with identical displayed content must add no rebuilds.
+        for _ in 0..<20 {
+            await churnOnce()
+        }
+
+        #expect(closedRebuilds == settledCount, "unchanged content kept rebuilding the closed menu")
+        #expect(settledCount <= 2, "settling should be bounded, not per-tick (got \(settledCount))")
+    }
+
+    /// Guards against the gate over-suppressing: once content is stable, a genuine change to the
+    /// displayed usage must still re-populate the closed menu.
+    @Test
+    func `closed menu rebuilds again when displayed content changes`() async {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = false
+        defer { StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = self.makeCoalesceController(settings, store: store)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuProviders[ObjectIdentifier(menu)] = .codex
+
+        var closedRebuilds = 0
+        controller._test_closedMenuRebuildObserver = { _ in closedRebuilds += 1 }
+        defer { controller._test_closedMenuRebuildObserver = nil }
+
+        func churnOnce() async {
+            controller.menuContentVersion &+= 1
+            controller.rebuildClosedMenuIfNeeded(menu)
+            for _ in 0..<12 {
+                await Task.yield()
+            }
+        }
+
+        for _ in 0..<5 {
+            await churnOnce()
+        }
+        let beforeChange = closedRebuilds
+
+        // Displayed usage genuinely changes (22% -> 91%).
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 91,
+                    windowMinutes: 300,
+                    resetsAt: Date().addingTimeInterval(1800),
+                    resetDescription: nil),
+                secondary: nil,
+                tertiary: nil,
+                updatedAt: Date(),
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "codex@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Plus Plan")),
+            provider: .codex)
+        await churnOnce()
+
+        #expect(closedRebuilds > beforeChange, "a real content change must rebuild the closed menu")
+    }
+
+    /// End-to-end: drives the real production entry point (`invalidateMenus`, as fired by
+    /// `observeStoreChanges` on every `menuObservationToken` change) against an attached, closed
+    /// menu. A stream of observation changes with unchanged displayed content must not keep
+    /// re-populating the menu.
+    @Test
+    func `invalidateMenus does not storm a closed attached menu on unchanged content`() async {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = false
+        defer { StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = self.makeCoalesceController(settings, store: store)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        StatusItemController.setClosedMenuPreparationDelayForTesting(.zero)
+        defer { StatusItemController.resetClosedMenuPreparationDelayForTesting() }
+
+        // Attach a closed provider menu so prepareAttachedClosedMenusIfNeeded considers it.
+        let menu = controller.makeMenu()
+        controller.menuProviders[ObjectIdentifier(menu)] = .codex
+        controller.providerMenus[.codex] = menu
+
+        var rebuilds = 0
+        controller._test_closedMenuRebuildObserver = { _ in rebuilds += 1 }
+        defer { controller._test_closedMenuRebuildObserver = nil }
+
+        func observationTick() async {
+            controller.invalidateMenus()
+            for _ in 0..<12 {
+                await Task.yield()
+            }
+        }
+
+        for _ in 0..<10 {
+            await observationTick()
+        }
+        let settled = rebuilds
+
+        for _ in 0..<20 {
+            await observationTick()
+        }
+
+        #expect(rebuilds == settled, "invalidateMenus kept rebuilding the closed attached menu")
+        #expect(settled <= 4, "settling should be bounded, not per-observation (got \(settled))")
+    }
+}


### PR DESCRIPTION
## Problem

CodexBar pre-warms closed (invisible) persistent menus so they open instantly. `observeStoreChanges` fires `invalidateMenus()` on every change of `store.menuObservationToken`, and for closed menus that runs `prepareAttachedClosedMenusIfNeeded()` → a full main-thread `populateMenu()` for **every** attached menu (status item, merged, fallback, each provider menu).

`menuObservationToken` is a signature over ~25 store properties (probe logs, in-flight refresh flags, revision counters, fetch metadata, dashboard timestamps…). Many of these change frequently — e.g. while you're actively using codex/claude and CodexBar is observing their data — but **don't change what the menu displays**. So the whole SwiftUI menu hierarchy rebuilds on the main thread continuously with no visible change.

Observed on a real 0.32.4 install during active use: sustained ~12% "idle" CPU, with `sample` showing `rebuildClosedMenuIfNeeded → populateMenu` as the dominant main-thread stack, worsening over time as usage history grows. It's independent of refresh-interval and token-cost settings (confirmed by changing both with no effect), since it's driven by store observation, not the refresh timer.

## Fix

Gate the closed-menu rebuild on a content signature (the existing `menuAdjunctReadinessSignature` plus the per-provider usage snapshot). When the displayed content is unchanged since the menu was last pre-warmed, skip the expensive `populateMenu` and leave the menu marked stale so `menuWillOpen` still rebuilds it fresh.

Safe by construction: the open path (`refreshMenuForOpenIfNeeded`) is untouched and always rebuilds on `menuWillOpen`, so an incomplete signature can only skip a pre-warm — never show stale content to the user.

A `.debug` signpost (`closed-menu prewarm skipped/performed`) makes the behavior observable: set the log level to debug to watch it.

## Runtime evidence

**Before — real 0.32.4 install, `sample` during active use (redacted):** the closed-menu rebuild is the dominant main-thread stack behind the ~12% idle CPU:

```
1056  closure #1 in StatusItemController.rebuildClosedMenuIfNeeded(_:)  (in CodexBar)
 761    StatusItemController.populateMenu(_:provider:)
 646      closure #1 in StatusItemController.updateMenuContentPreservingSwitcher(_:context:)
 463        StatusItemController.addOverviewRows(...) -> MenuCardItemHostingView.measuredHeight(width:)
 462          NSHostingController.sizeThatFits(in:) -> ViewGraph.sizeThatFits(...)
```

**After (controlled) — new test, exercising the real `invalidateMenus` path:** with the gate removed, unchanged-content observation churn produces **39** full closed-menu rebuilds; with the gate it **converges to ≤2 and stops** (20+ further ticks add none). A genuine content change still rebuilds.

**After (live) — adhoc release build, debug logging, ~150s real session:** the new signpost shows the gate skipping redundant rebuilds in a real running build:

```
[..Z] [DEBUG] com.steipete.codexbar.app: closed-menu prewarm performed (content changed) provider=codex
[..Z] [DEBUG] com.steipete.codexbar.app: closed-menu prewarm skipped (content unchanged) provider=codex
...
skipped: 5   performed: 5
```

Each `skipped` is a full closed-menu rebuild that was prevented. The skip ratio scales with churn intensity: this window had only refresh-paced churn (~50% prevented); under the heavy non-display churn that produces the storm (the controlled test above), the gate eliminates ~95%.

**Note on an idle before/after:** a freshly launched idle build does not reproduce the storm — it requires live store churn from active codex/claude usage that CodexBar observes — so an idle CPU A/B reads ~0% either way. The evidence above (production sample + controlled test + live signpost) is used instead of an idle CPU delta.

## Tests added

- `closed menu rebuild converges when displayed content is unchanged`
- `closed menu rebuilds again when displayed content changes`
- `invalidateMenus does not storm a closed attached menu on unchanged content`

Full test suite green (3241 tests).
