### PR TITLE
fix: use Cursor app auth as fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Antigravity: detect current hyphenated IDE language-server processes inside Antigravity app bundles so local quota refreshes no longer report the IDE as unavailable (#1405). Thanks @lfmundim!
 - Menu bar: avoid republishing unchanged provider storage footprints so background scans no longer trigger unnecessary menu observation work (#1416). Thanks @soohanpark!
 - Cursor: show capped team Extra usage when no individual cap exists, and honor percent used/remaining menu bar display settings instead of always showing currency spend (#1426). Thanks @lpc-eol!
+- Cursor: use the signed-in Cursor.app session as a final usage fallback after configured cookie and browser sources fail, while preserving existing account precedence (#1295). Thanks @Jackie-Qin!
 - Claude: explain that an unauthorized Web session requires signing in at claude.ai or refreshing imported cookies (#1287). Thanks @LeoLin990405!
 - CLI server: reload provider config for every usage and cost request, invalidate config-dependent cache entries, and prune expired config variants without restarting `codexbar serve`. Thanks @enieuwy!
 - Menu bar: reserve quota-bar space consistently across Overview and provider switcher segments so selection no longer changes segment height (#1445). Thanks @Zihao-Qi!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Antigravity: detect current hyphenated IDE language-server processes inside Antigravity app bundles so local quota refreshes no longer report the IDE as unavailable (#1405). Thanks @lfmundim!
 - Menu bar: avoid republishing unchanged provider storage footprints so background scans no longer trigger unnecessary menu observation work (#1416). Thanks @soohanpark!
 - Cursor: show capped team Extra usage when no individual cap exists, and honor percent used/remaining menu bar display settings instead of always showing currency spend (#1426). Thanks @lpc-eol!
-- Cursor: use the signed-in Cursor.app session as a final usage fallback after configured cookie and browser sources fail, while preserving existing account precedence (#1295). Thanks @Jackie-Qin!
+- Cursor: derive a first-party web session from the signed-in Cursor.app as a final fallback, preserving account precedence and legacy request quotas (#1295). Thanks @Jackie-Qin!
 - Claude: explain that an unauthorized Web session requires signing in at claude.ai or refreshing imported cookies (#1287). Thanks @LeoLin990405!
 - CLI server: reload provider config for every usage and cost request, invalidate config-dependent cache entries, and prune expired config variants without restarting `codexbar serve`. Thanks @enieuwy!
 - Menu bar: reserve quota-bar space consistently across Overview and provider switcher segments so selection no longer changes segment height (#1445). Thanks @Zihao-Qi!

--- a/Sources/CodexBar/CursorLoginRunner.swift
+++ b/Sources/CodexBar/CursorLoginRunner.swift
@@ -56,7 +56,9 @@ final class CursorLoginRunner {
         self.resetSessionCache = resetSessionCache
         self.loadSnapshot = loadSnapshot ?? {
             let probe = CursorStatusProbe(browserDetection: browserDetection)
-            return try await probe.fetch(allowCachedSessions: false)
+            return try await probe.fetch(
+                allowCachedSessions: false,
+                allowAppAuthFallback: false)
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -344,7 +344,13 @@ struct CursorAppAuthSession: Equatable {
     let accessToken: String
 
     var isUsable: Bool {
-        !self.accessToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        guard !self.accessToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              (try? self.userID()) != nil,
+              let expiresAt = try? self.expiresAt()
+        else {
+            return false
+        }
+        return expiresAt.timeIntervalSinceNow > 60
     }
 
     func cookieHeader() throws -> String {
@@ -352,19 +358,8 @@ struct CursorAppAuthSession: Equatable {
     }
 
     func userID() throws -> String {
-        let parts = self.accessToken.split(separator: ".", omittingEmptySubsequences: false)
-        guard parts.count >= 2 else {
-            throw CursorStatusProbeError.parseFailed("Cursor.app access token is not a JWT")
-        }
-
-        var payload = String(parts[1])
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-        payload += String(repeating: "=", count: (4 - payload.count % 4) % 4)
-
-        guard let data = Data(base64Encoded: payload),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let subject = json["sub"] as? String,
+        let json = try self.payload()
+        guard let subject = json["sub"] as? String,
               let userID = subject.split(separator: "|", omittingEmptySubsequences: true).last.map(String.init),
               !userID.isEmpty
         else {
@@ -377,6 +372,34 @@ struct CursorAppAuthSession: Equatable {
         }
 
         return userID
+    }
+
+    private func expiresAt() throws -> Date {
+        let json = try self.payload()
+        guard let expiration = json["exp"] as? NSNumber else {
+            throw CursorStatusProbeError.parseFailed("Cursor.app access token is missing an expiration")
+        }
+        return Date(timeIntervalSince1970: expiration.doubleValue)
+    }
+
+    private func payload() throws -> [String: Any] {
+        let parts = self.accessToken.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count >= 2 else {
+            throw CursorStatusProbeError.parseFailed("Cursor.app access token is not a JWT")
+        }
+
+        var payload = String(parts[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        payload += String(repeating: "=", count: (4 - payload.count % 4) % 4)
+
+        guard let data = Data(base64Encoded: payload),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw CursorStatusProbeError.parseFailed("Cursor.app access token has an invalid payload")
+        }
+
+        return json
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -437,18 +437,16 @@ public struct CursorDashboardCurrentPeriodUsage: Codable, Sendable {
     public let planUsage: CursorDashboardPlanUsage?
     public let enabled: Bool?
     public let displayMessage: String?
-    public let autoModelSelectedDisplayMessage: String?
-    public let namedModelSelectedDisplayMessage: String?
 }
 
 public struct CursorDashboardPlanUsage: Codable, Sendable {
     public let totalSpend: Double?
     public let includedSpend: Double?
     public let bonusSpend: Double?
+    public let remaining: Double?
     public let limit: Double?
-    public let autoPercentUsed: Double?
-    public let apiPercentUsed: Double?
-    public let totalPercentUsed: Double?
+    public let remainingBonus: Bool?
+    public let bonusTooltip: String?
 }
 
 public struct CursorDashboardMe: Codable, Sendable {
@@ -1287,27 +1285,14 @@ public struct CursorStatusProbe: Sendable {
             throw CursorStatusProbeError.parseFailed("DashboardService GetCurrentPeriodUsage missing planUsage")
         }
 
-        func normPct(_ value: Double?) -> Double? {
-            guard let value else { return nil }
-            if value < 0 { return 0 }
-            if value > 100 { return 100 }
-            return value
-        }
+        let includedSpend = max(0, plan.includedSpend ?? 0)
+        let limit = max(0, plan.limit ?? 0)
+        // Cursor's own usage UI derives the plan percentage from included spend, not total/bonus spend.
+        let planPercentUsed = limit > 0
+            ? min(100, includedSpend / limit * 100)
+            : 0
 
-        let autoPercent = normPct(plan.autoPercentUsed)
-        let apiPercent = normPct(plan.apiPercentUsed)
-        let planPercentUsed: Double = if let totalPercent = normPct(plan.totalPercentUsed) {
-            totalPercent
-        } else if let autoPercent, let apiPercent {
-            max(0, min(100, (autoPercent + apiPercent) / 2))
-        } else if let autoPercent {
-            autoPercent
-        } else if let apiPercent {
-            apiPercent
-        } else {
-            0
-        }
-
+        let billingCycleStart = Self.parseEpochMillisDate(usage.billingCycleStart)
         let billingCycleEnd = Self.parseEpochMillisDate(usage.billingCycleEnd)
         let rawJSON: String? = {
             let encoder = JSONEncoder()
@@ -1318,14 +1303,15 @@ public struct CursorStatusProbe: Sendable {
 
         return CursorStatusSnapshot(
             planPercentUsed: planPercentUsed,
-            autoPercentUsed: autoPercent,
-            apiPercentUsed: apiPercent,
-            planUsedUSD: (plan.totalSpend ?? 0) / 100.0,
-            planLimitUSD: (plan.limit ?? 0) / 100.0,
+            autoPercentUsed: nil,
+            apiPercentUsed: nil,
+            planUsedUSD: includedSpend / 100.0,
+            planLimitUSD: limit / 100.0,
             onDemandUsedUSD: 0,
             onDemandLimitUSD: nil,
             teamOnDemandUsedUSD: nil,
             teamOnDemandLimitUSD: nil,
+            billingCycleStart: billingCycleStart,
             billingCycleEnd: billingCycleEnd,
             membershipType: appSession.membershipType,
             accountEmail: account?.email ?? appSession.cachedEmail,

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -435,6 +435,7 @@ public struct CursorDashboardCurrentPeriodUsage: Codable, Sendable {
     public let billingCycleStart: String?
     public let billingCycleEnd: String?
     public let planUsage: CursorDashboardPlanUsage?
+    public let spendLimitUsage: CursorDashboardSpendLimitUsage?
     public let enabled: Bool?
     public let displayMessage: String?
 }
@@ -447,6 +448,17 @@ public struct CursorDashboardPlanUsage: Codable, Sendable {
     public let limit: Double?
     public let remainingBonus: Bool?
     public let bonusTooltip: String?
+}
+
+public struct CursorDashboardSpendLimitUsage: Codable, Sendable {
+    public let totalSpend: Double?
+    public let pooledLimit: Double?
+    public let pooledUsed: Double?
+    public let pooledRemaining: Double?
+    public let individualLimit: Double?
+    public let individualUsed: Double?
+    public let individualRemaining: Double?
+    public let limitType: String?
 }
 
 public struct CursorDashboardMe: Codable, Sendable {
@@ -1287,6 +1299,11 @@ public struct CursorStatusProbe: Sendable {
 
         let includedSpend = max(0, plan.includedSpend ?? 0)
         let limit = max(0, plan.limit ?? 0)
+        let spendLimit = usage.spendLimitUsage
+        let individualUsed = max(0, spendLimit?.individualUsed ?? 0)
+        let individualLimit = spendLimit?.individualLimit.map { max(0, $0) }
+        let pooledUsed = spendLimit?.pooledUsed.map { max(0, $0) }
+        let pooledLimit = spendLimit?.pooledLimit.map { max(0, $0) }
         // Cursor's own usage UI derives the plan percentage from included spend, not total/bonus spend.
         let planPercentUsed = limit > 0
             ? min(100, includedSpend / limit * 100)
@@ -1307,10 +1324,10 @@ public struct CursorStatusProbe: Sendable {
             apiPercentUsed: nil,
             planUsedUSD: includedSpend / 100.0,
             planLimitUSD: limit / 100.0,
-            onDemandUsedUSD: 0,
-            onDemandLimitUSD: nil,
-            teamOnDemandUsedUSD: nil,
-            teamOnDemandLimitUSD: nil,
+            onDemandUsedUSD: individualUsed / 100.0,
+            onDemandLimitUSD: individualLimit.map { $0 / 100.0 },
+            teamOnDemandUsedUSD: pooledUsed.map { $0 / 100.0 },
+            teamOnDemandLimitUSD: pooledLimit.map { $0 / 100.0 },
             billingCycleStart: billingCycleStart,
             billingCycleEnd: billingCycleEnd,
             membershipType: appSession.membershipType,

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -340,7 +340,7 @@ public struct CursorUserInfo: Codable, Sendable {
 
 // MARK: - Cursor App Auth + Dashboard API Models
 
-struct CursorAppAuthSession: Equatable, Sendable {
+struct CursorAppAuthSession: Equatable {
     let accessToken: String
     let membershipType: String?
     let subscriptionStatus: String?
@@ -870,7 +870,7 @@ public struct CursorStatusProbe: Sendable {
     func fetchWithAppAuthSession(_ session: CursorAppAuthSession) async throws -> CursorStatusSnapshot {
         let usage = try await self.fetchDashboardCurrentPeriodUsage(bearerToken: session.accessToken)
         let account = try? await self.fetchDashboardMe(bearerToken: session.accessToken)
-        return self.parseDashboardCurrentPeriodUsage(
+        return try self.parseDashboardCurrentPeriodUsage(
             usage,
             appSession: session,
             account: account)
@@ -1112,6 +1112,7 @@ public struct CursorStatusProbe: Sendable {
         request.timeoutInterval = self.timeout
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("1", forHTTPHeaderField: "Connect-Protocol-Version")
         request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
         request.httpBody = Data("{}".utf8)
 
@@ -1277,8 +1278,12 @@ public struct CursorStatusProbe: Sendable {
     func parseDashboardCurrentPeriodUsage(
         _ usage: CursorDashboardCurrentPeriodUsage,
         appSession: CursorAppAuthSession,
-        account: CursorDashboardMe?) -> CursorStatusSnapshot
+        account: CursorDashboardMe?) throws -> CursorStatusSnapshot
     {
+        guard let plan = usage.planUsage else {
+            throw CursorStatusProbeError.parseFailed("DashboardService GetCurrentPeriodUsage missing planUsage")
+        }
+
         func normPct(_ value: Double?) -> Double? {
             guard let value else { return nil }
             if value < 0 { return 0 }
@@ -1286,10 +1291,9 @@ public struct CursorStatusProbe: Sendable {
             return value
         }
 
-        let plan = usage.planUsage
-        let autoPercent = normPct(plan?.autoPercentUsed)
-        let apiPercent = normPct(plan?.apiPercentUsed)
-        let planPercentUsed: Double = if let totalPercent = normPct(plan?.totalPercentUsed) {
+        let autoPercent = normPct(plan.autoPercentUsed)
+        let apiPercent = normPct(plan.apiPercentUsed)
+        let planPercentUsed: Double = if let totalPercent = normPct(plan.totalPercentUsed) {
             totalPercent
         } else if let autoPercent, let apiPercent {
             max(0, min(100, (autoPercent + apiPercent) / 2))
@@ -1313,8 +1317,8 @@ public struct CursorStatusProbe: Sendable {
             planPercentUsed: planPercentUsed,
             autoPercentUsed: autoPercent,
             apiPercentUsed: apiPercent,
-            planUsedUSD: (plan?.totalSpend ?? 0) / 100.0,
-            planLimitUSD: (plan?.limit ?? 0) / 100.0,
+            planUsedUSD: (plan.totalSpend ?? 0) / 100.0,
+            planLimitUSD: (plan.limit ?? 0) / 100.0,
             onDemandUsedUSD: 0,
             onDemandLimitUSD: nil,
             teamOnDemandUsedUSD: nil,

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -982,6 +982,11 @@ public struct CursorStatusProbe: Sendable {
             }
         }
 
+        // A transient failure for an explicitly selected session must not switch to Cursor.app's account.
+        if let firstRecoverableError {
+            throw firstRecoverableError
+        }
+
         // Last fallback: derive Cursor's first-party web session from the app token in its global state DB.
         // Reusing the web flow preserves modern billing, legacy request quotas, and account-scoped identity.
         if allowAppAuthFallback,
@@ -1000,10 +1005,6 @@ public struct CursorStatusProbe: Sendable {
             } catch {
                 firstRecoverableError = firstRecoverableError ?? .networkError(error.localizedDescription)
             }
-        }
-
-        if let firstRecoverableError {
-            throw firstRecoverableError
         }
 
         throw CursorStatusProbeError.noSessionCookie

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -831,6 +831,7 @@ public struct CursorStatusProbe: Sendable {
     public let dashboardBaseURL: URL
     public var timeout: TimeInterval = 15.0
     private let browserDetection: BrowserDetection
+    private let browserCookieImportOrder: BrowserCookieImportOrder
     private let urlSession: any ProviderHTTPTransport
     private let appAuthStore: any CursorAppAuthSessionProviding
 
@@ -846,6 +847,7 @@ public struct CursorStatusProbe: Sendable {
             dashboardBaseURL: dashboardBaseURL,
             timeout: timeout,
             browserDetection: browserDetection,
+            browserCookieImportOrder: cursorCookieImportOrder,
             urlSession: urlSession,
             appAuthStore: CursorAppAuthStore())
     }
@@ -855,6 +857,7 @@ public struct CursorStatusProbe: Sendable {
         dashboardBaseURL: URL = URL(string: "https://api2.cursor.sh")!,
         timeout: TimeInterval = 15.0,
         browserDetection: BrowserDetection,
+        browserCookieImportOrder: BrowserCookieImportOrder = cursorCookieImportOrder,
         urlSession: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         appAuthStore: any CursorAppAuthSessionProviding)
     {
@@ -862,6 +865,7 @@ public struct CursorStatusProbe: Sendable {
         self.dashboardBaseURL = dashboardBaseURL
         self.timeout = timeout
         self.browserDetection = browserDetection
+        self.browserCookieImportOrder = browserCookieImportOrder
         self.urlSession = urlSession
         self.appAuthStore = appAuthStore
     }
@@ -914,27 +918,9 @@ public struct CursorStatusProbe: Sendable {
             }
         }
 
-        // Cursor.app keeps a first-party bearer token in its VS Code-style global state DB.
-        // The browser login page can report an already-signed-in state without minting a cursor.com cookie,
-        // so use the local app session before falling back to browser-cookie scraping.
-        if let appSession = try? self.appAuthStore.loadSession(), appSession.isUsable {
-            log("Using Cursor.app local auth")
-            do {
-                return try await self.fetchWithAppAuthSession(appSession)
-            } catch let error as CursorStatusProbeError {
-                if case .notLoggedIn = error {
-                    log("Cursor.app local auth was rejected; falling back to browser cookies")
-                } else {
-                    firstRecoverableError = firstRecoverableError ?? error
-                }
-            } catch {
-                firstRecoverableError = firstRecoverableError ?? .networkError(error.localizedDescription)
-            }
-        }
-
         // Try each browser in order. The first browser that *has* session cookie names is not always valid
         // (e.g. stale Chrome tokens); keep trying until the API accepts a session or we run out of browsers.
-        let browserCandidates = cursorCookieImportOrder.cookieImportCandidates(using: self.browserDetection)
+        let browserCandidates = self.browserCookieImportOrder.cookieImportCandidates(using: self.browserDetection)
         switch await self.scanBrowsers(
             browserCandidates,
             importSessions: { browser in
@@ -992,6 +978,23 @@ public struct CursorStatusProbe: Sendable {
                     log("Stored session failed: \(error.localizedDescription)")
                     firstRecoverableError = firstRecoverableError ?? .networkError(error.localizedDescription)
                 }
+            }
+        }
+
+        // Last fallback: Cursor.app keeps a first-party bearer token in its VS Code-style global state DB.
+        // Use it only after the documented cookie/session sources fail so account precedence stays stable.
+        if let appSession = try? self.appAuthStore.loadSession(), appSession.isUsable {
+            log("Using Cursor.app local auth fallback")
+            do {
+                return try await self.fetchWithAppAuthSession(appSession)
+            } catch let error as CursorStatusProbeError {
+                if case .notLoggedIn = error {
+                    log("Cursor.app local auth was rejected")
+                } else {
+                    firstRecoverableError = firstRecoverableError ?? error
+                }
+            } catch {
+                firstRecoverableError = firstRecoverableError ?? .networkError(error.localizedDescription)
             }
         }
 

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -1007,6 +1007,10 @@ public struct CursorStatusProbe: Sendable {
             }
         }
 
+        if let firstRecoverableError {
+            throw firstRecoverableError
+        }
+
         throw CursorStatusProbeError.noSessionCookie
     }
 

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -899,6 +899,7 @@ public struct CursorStatusProbe: Sendable {
     public func fetch(
         cookieHeaderOverride: String? = nil,
         allowCachedSessions: Bool = true,
+        allowAppAuthFallback: Bool = true,
         logger: ((String) -> Void)? = nil)
         async throws -> CursorStatusSnapshot
     {
@@ -993,7 +994,10 @@ public struct CursorStatusProbe: Sendable {
 
         // Last fallback: Cursor.app keeps a first-party bearer token in its VS Code-style global state DB.
         // Use it only after the documented cookie/session sources fail so account precedence stays stable.
-        if let appSession = try? self.appAuthStore.loadSession(), appSession.isUsable {
+        if allowAppAuthFallback,
+           let appSession = try? self.appAuthStore.loadSession(),
+           appSession.isUsable
+        {
             log("Using Cursor.app local auth fallback")
             do {
                 return try await self.fetchWithAppAuthSession(appSession)
@@ -1293,6 +1297,9 @@ public struct CursorStatusProbe: Sendable {
         appSession: CursorAppAuthSession,
         account: CursorDashboardMe?) throws -> CursorStatusSnapshot
     {
+        guard usage.enabled != false else {
+            throw CursorStatusProbeError.parseFailed("DashboardService GetCurrentPeriodUsage is disabled")
+        }
         guard let plan = usage.planUsage else {
             throw CursorStatusProbeError.parseFailed("DashboardService GetCurrentPeriodUsage missing planUsage")
         }

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -3,6 +3,9 @@ import Foundation
 import FoundationNetworking
 #endif
 import SweetCookieKit
+#if canImport(SQLite3)
+import SQLite3
+#endif
 
 #if os(macOS)
 
@@ -332,6 +335,140 @@ public struct CursorUserInfo: Codable, Sendable {
         case createdAt = "created_at"
         case updatedAt = "updated_at"
         case picture
+    }
+}
+
+// MARK: - Cursor App Auth + Dashboard API Models
+
+struct CursorAppAuthSession: Equatable, Sendable {
+    let accessToken: String
+    let membershipType: String?
+    let subscriptionStatus: String?
+    let cachedEmail: String?
+
+    var isUsable: Bool {
+        !self.accessToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+}
+
+protocol CursorAppAuthSessionProviding: Sendable {
+    func loadSession() throws -> CursorAppAuthSession?
+}
+
+struct CursorAppAuthStore: CursorAppAuthSessionProviding {
+    private static let defaultDBPath: String = {
+        let home = NSHomeDirectory()
+        return "\(home)/Library/Application Support/Cursor/User/globalStorage/state.vscdb"
+    }()
+
+    private let dbPath: String
+
+    init(dbPath: String? = nil) {
+        self.dbPath = dbPath ?? Self.defaultDBPath
+    }
+
+    func loadSession() throws -> CursorAppAuthSession? {
+        guard FileManager.default.fileExists(atPath: self.dbPath) else { return nil }
+
+        guard let accessToken = try self.value(for: "cursorAuth/accessToken"),
+              !accessToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return nil
+        }
+
+        return try CursorAppAuthSession(
+            accessToken: accessToken,
+            membershipType: self.value(for: "cursorAuth/stripeMembershipType") ?? self
+                .value(for: "cursorAuth/membershipType"),
+            subscriptionStatus: self.value(for: "cursorAuth/stripeSubscriptionStatus"),
+            cachedEmail: self.value(for: "cursorAuth/cachedEmail"))
+    }
+
+    private func value(for key: String) throws -> String? {
+        var db: OpaquePointer?
+        guard sqlite3_open_v2(self.dbPath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else {
+            let message = db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown error"
+            sqlite3_close(db)
+            throw CursorStatusProbeError.networkError("SQLite error reading Cursor app auth: \(message)")
+        }
+        defer { sqlite3_close(db) }
+        sqlite3_busy_timeout(db, 250)
+
+        let query = "SELECT value FROM ItemTable WHERE key = ? LIMIT 1;"
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else {
+            let message = db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown error"
+            throw CursorStatusProbeError.networkError("SQLite error preparing Cursor app auth read: \(message)")
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        sqlite3_bind_text(stmt, 1, key, -1, SQLITE_TRANSIENT)
+        let stepResult = sqlite3_step(stmt)
+        guard stepResult == SQLITE_ROW else {
+            if stepResult == SQLITE_DONE { return nil }
+            let message = db.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown error"
+            throw CursorStatusProbeError.networkError("SQLite error reading Cursor app auth: \(message)")
+        }
+
+        return Self.decodeSQLiteValue(stmt: stmt, index: 0)
+    }
+
+    private static func decodeSQLiteValue(stmt: OpaquePointer?, index: Int32) -> String? {
+        switch sqlite3_column_type(stmt, index) {
+        case SQLITE_TEXT:
+            guard let c = sqlite3_column_text(stmt, index) else { return nil }
+            return String(cString: c)
+        case SQLITE_BLOB:
+            guard let bytes = sqlite3_column_blob(stmt, index) else { return nil }
+            let data = Data(bytes: bytes, count: Int(sqlite3_column_bytes(stmt, index)))
+            return String(data: data, encoding: .utf8)
+                ?? String(data: data, encoding: .utf16LittleEndian)
+        default:
+            return nil
+        }
+    }
+}
+
+private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+public struct CursorDashboardCurrentPeriodUsage: Codable, Sendable {
+    public let billingCycleStart: String?
+    public let billingCycleEnd: String?
+    public let planUsage: CursorDashboardPlanUsage?
+    public let enabled: Bool?
+    public let displayMessage: String?
+    public let autoModelSelectedDisplayMessage: String?
+    public let namedModelSelectedDisplayMessage: String?
+}
+
+public struct CursorDashboardPlanUsage: Codable, Sendable {
+    public let totalSpend: Double?
+    public let includedSpend: Double?
+    public let bonusSpend: Double?
+    public let limit: Double?
+    public let autoPercentUsed: Double?
+    public let apiPercentUsed: Double?
+    public let totalPercentUsed: Double?
+}
+
+public struct CursorDashboardMe: Codable, Sendable {
+    public let email: String?
+    public let firstName: String?
+    public let lastName: String?
+    public let isEnterpriseUser: Bool?
+
+    public var displayName: String? {
+        [self.firstName, self.lastName]
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .nilIfEmpty
+    }
+}
+
+extension String {
+    fileprivate var nilIfEmpty: String? {
+        self.isEmpty ? nil : self
     }
 }
 
@@ -691,20 +828,52 @@ public actor CursorSessionStore {
 
 public struct CursorStatusProbe: Sendable {
     public let baseURL: URL
+    public let dashboardBaseURL: URL
     public var timeout: TimeInterval = 15.0
     private let browserDetection: BrowserDetection
     private let urlSession: any ProviderHTTPTransport
+    private let appAuthStore: any CursorAppAuthSessionProviding
 
     public init(
         baseURL: URL = URL(string: "https://cursor.com")!,
+        dashboardBaseURL: URL = URL(string: "https://api2.cursor.sh")!,
         timeout: TimeInterval = 15.0,
         browserDetection: BrowserDetection,
         urlSession: any ProviderHTTPTransport = ProviderHTTPClient.shared)
     {
+        self.init(
+            baseURL: baseURL,
+            dashboardBaseURL: dashboardBaseURL,
+            timeout: timeout,
+            browserDetection: browserDetection,
+            urlSession: urlSession,
+            appAuthStore: CursorAppAuthStore())
+    }
+
+    init(
+        baseURL: URL = URL(string: "https://cursor.com")!,
+        dashboardBaseURL: URL = URL(string: "https://api2.cursor.sh")!,
+        timeout: TimeInterval = 15.0,
+        browserDetection: BrowserDetection,
+        urlSession: any ProviderHTTPTransport = ProviderHTTPClient.shared,
+        appAuthStore: any CursorAppAuthSessionProviding)
+    {
         self.baseURL = baseURL
+        self.dashboardBaseURL = dashboardBaseURL
         self.timeout = timeout
         self.browserDetection = browserDetection
         self.urlSession = urlSession
+        self.appAuthStore = appAuthStore
+    }
+
+    /// Fetch Cursor usage using the access token already stored by Cursor.app.
+    func fetchWithAppAuthSession(_ session: CursorAppAuthSession) async throws -> CursorStatusSnapshot {
+        let usage = try await self.fetchDashboardCurrentPeriodUsage(bearerToken: session.accessToken)
+        let account = try? await self.fetchDashboardMe(bearerToken: session.accessToken)
+        return self.parseDashboardCurrentPeriodUsage(
+            usage,
+            appSession: session,
+            account: account)
     }
 
     /// Fetch Cursor usage with manual cookie header (for debugging).
@@ -742,6 +911,24 @@ public struct CursorStatusProbe: Sendable {
                 }
             } catch {
                 throw error
+            }
+        }
+
+        // Cursor.app keeps a first-party bearer token in its VS Code-style global state DB.
+        // The browser login page can report an already-signed-in state without minting a cursor.com cookie,
+        // so use the local app session before falling back to browser-cookie scraping.
+        if let appSession = try? self.appAuthStore.loadSession(), appSession.isUsable {
+            log("Using Cursor.app local auth")
+            do {
+                return try await self.fetchWithAppAuthSession(appSession)
+            } catch let error as CursorStatusProbeError {
+                if case .notLoggedIn = error {
+                    log("Cursor.app local auth was rejected; falling back to browser cookies")
+                } else {
+                    firstRecoverableError = firstRecoverableError ?? error
+                }
+            } catch {
+                firstRecoverableError = firstRecoverableError ?? .networkError(error.localizedDescription)
             }
         }
 
@@ -898,6 +1085,58 @@ public struct CursorStatusProbe: Sendable {
         }
     }
 
+    private func fetchDashboardCurrentPeriodUsage(bearerToken: String) async throws
+    -> CursorDashboardCurrentPeriodUsage {
+        try await self.fetchDashboard(
+            method: "GetCurrentPeriodUsage",
+            bearerToken: bearerToken,
+            as: CursorDashboardCurrentPeriodUsage.self)
+    }
+
+    private func fetchDashboardMe(bearerToken: String) async throws -> CursorDashboardMe {
+        try await self.fetchDashboard(
+            method: "GetMe",
+            bearerToken: bearerToken,
+            as: CursorDashboardMe.self)
+    }
+
+    private func fetchDashboard<T: Decodable>(
+        method: String,
+        bearerToken: String,
+        as type: T.Type) async throws -> T
+    {
+        let url = self.dashboardBaseURL
+            .appendingPathComponent("/aiserver.v1.DashboardService/\(method)")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = self.timeout
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
+        request.httpBody = Data("{}".utf8)
+
+        let (data, response) = try await self.urlSession.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw CursorStatusProbeError.networkError("Invalid DashboardService response")
+        }
+        if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+            throw CursorStatusProbeError.notLoggedIn
+        }
+        guard httpResponse.statusCode == 200 else {
+            throw CursorStatusProbeError.networkError("DashboardService \(method) HTTP \(httpResponse.statusCode)")
+        }
+
+        do {
+            return try JSONDecoder().decode(type, from: data)
+        } catch {
+            let rawJSON = String(data: data, encoding: .utf8) ?? "<binary>"
+            let snippet = rawJSON.prefix(200)
+            throw CursorStatusProbeError
+                .parseFailed(
+                    "DashboardService \(method) JSON decode failed: \(error.localizedDescription). Raw: \(snippet)")
+        }
+    }
+
     private func fetchWithCookieHeader(_ cookieHeader: String) async throws -> CursorStatusSnapshot {
         enum FetchPart: Sendable {
             case usageSummary((CursorUsageSummary, String))
@@ -1033,6 +1272,65 @@ public struct CursorStatusProbe: Sendable {
         let decoder = JSONDecoder()
         let usage = try decoder.decode(CursorUsageResponse.self, from: data)
         return (usage, rawJSON)
+    }
+
+    func parseDashboardCurrentPeriodUsage(
+        _ usage: CursorDashboardCurrentPeriodUsage,
+        appSession: CursorAppAuthSession,
+        account: CursorDashboardMe?) -> CursorStatusSnapshot
+    {
+        func normPct(_ value: Double?) -> Double? {
+            guard let value else { return nil }
+            if value < 0 { return 0 }
+            if value > 100 { return 100 }
+            return value
+        }
+
+        let plan = usage.planUsage
+        let autoPercent = normPct(plan?.autoPercentUsed)
+        let apiPercent = normPct(plan?.apiPercentUsed)
+        let planPercentUsed: Double = if let totalPercent = normPct(plan?.totalPercentUsed) {
+            totalPercent
+        } else if let autoPercent, let apiPercent {
+            max(0, min(100, (autoPercent + apiPercent) / 2))
+        } else if let autoPercent {
+            autoPercent
+        } else if let apiPercent {
+            apiPercent
+        } else {
+            0
+        }
+
+        let billingCycleEnd = Self.parseEpochMillisDate(usage.billingCycleEnd)
+        let rawJSON: String? = {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            guard let data = try? encoder.encode(usage) else { return nil }
+            return String(data: data, encoding: .utf8)
+        }()
+
+        return CursorStatusSnapshot(
+            planPercentUsed: planPercentUsed,
+            autoPercentUsed: autoPercent,
+            apiPercentUsed: apiPercent,
+            planUsedUSD: (plan?.totalSpend ?? 0) / 100.0,
+            planLimitUSD: (plan?.limit ?? 0) / 100.0,
+            onDemandUsedUSD: 0,
+            onDemandLimitUSD: nil,
+            teamOnDemandUsedUSD: nil,
+            teamOnDemandLimitUSD: nil,
+            billingCycleEnd: billingCycleEnd,
+            membershipType: appSession.membershipType,
+            accountEmail: account?.email ?? appSession.cachedEmail,
+            accountName: account?.displayName,
+            rawJSON: rawJSON)
+    }
+
+    private static func parseEpochMillisDate(_ value: String?) -> Date? {
+        guard let value,
+              let milliseconds = Double(value)
+        else { return nil }
+        return Date(timeIntervalSince1970: milliseconds / 1000.0)
     }
 
     func parseUsageSummary(

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -910,12 +910,10 @@ public struct CursorStatusProbe: Sendable {
                 if case .notLoggedIn = error {
                     CookieHeaderCache.clear(provider: .cursor)
                 } else {
-                    log("Cached session failed: \(error.localizedDescription)")
-                    firstRecoverableError = firstRecoverableError ?? error
+                    throw error
                 }
             } catch {
-                log("Cached session failed: \(error.localizedDescription)")
-                firstRecoverableError = firstRecoverableError ?? .networkError(error.localizedDescription)
+                throw error
             }
         }
 

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -338,16 +338,45 @@ public struct CursorUserInfo: Codable, Sendable {
     }
 }
 
-// MARK: - Cursor App Auth + Dashboard API Models
+// MARK: - Cursor App Auth
 
 struct CursorAppAuthSession: Equatable {
     let accessToken: String
-    let membershipType: String?
-    let subscriptionStatus: String?
-    let cachedEmail: String?
 
     var isUsable: Bool {
         !self.accessToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    func cookieHeader() throws -> String {
+        try "WorkosCursorSessionToken=\(self.userID())%3A%3A\(self.accessToken)"
+    }
+
+    func userID() throws -> String {
+        let parts = self.accessToken.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count >= 2 else {
+            throw CursorStatusProbeError.parseFailed("Cursor.app access token is not a JWT")
+        }
+
+        var payload = String(parts[1])
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        payload += String(repeating: "=", count: (4 - payload.count % 4) % 4)
+
+        guard let data = Data(base64Encoded: payload),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let subject = json["sub"] as? String,
+              let userID = subject.split(separator: "|", omittingEmptySubsequences: true).last.map(String.init),
+              !userID.isEmpty
+        else {
+            throw CursorStatusProbeError.parseFailed("Cursor.app access token is missing a user ID")
+        }
+
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        guard userID.unicodeScalars.allSatisfy(allowed.contains) else {
+            throw CursorStatusProbeError.parseFailed("Cursor.app access token has an invalid user ID")
+        }
+
+        return userID
     }
 }
 
@@ -376,12 +405,7 @@ struct CursorAppAuthStore: CursorAppAuthSessionProviding {
             return nil
         }
 
-        return try CursorAppAuthSession(
-            accessToken: accessToken,
-            membershipType: self.value(for: "cursorAuth/stripeMembershipType") ?? self
-                .value(for: "cursorAuth/membershipType"),
-            subscriptionStatus: self.value(for: "cursorAuth/stripeSubscriptionStatus"),
-            cachedEmail: self.value(for: "cursorAuth/cachedEmail"))
+        return CursorAppAuthSession(accessToken: accessToken)
     }
 
     private func value(for key: String) throws -> String? {
@@ -430,57 +454,6 @@ struct CursorAppAuthStore: CursorAppAuthSessionProviding {
 }
 
 private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
-
-public struct CursorDashboardCurrentPeriodUsage: Codable, Sendable {
-    public let billingCycleStart: String?
-    public let billingCycleEnd: String?
-    public let planUsage: CursorDashboardPlanUsage?
-    public let spendLimitUsage: CursorDashboardSpendLimitUsage?
-    public let enabled: Bool?
-    public let displayMessage: String?
-}
-
-public struct CursorDashboardPlanUsage: Codable, Sendable {
-    public let totalSpend: Double?
-    public let includedSpend: Double?
-    public let bonusSpend: Double?
-    public let remaining: Double?
-    public let limit: Double?
-    public let remainingBonus: Bool?
-    public let bonusTooltip: String?
-}
-
-public struct CursorDashboardSpendLimitUsage: Codable, Sendable {
-    public let totalSpend: Double?
-    public let pooledLimit: Double?
-    public let pooledUsed: Double?
-    public let pooledRemaining: Double?
-    public let individualLimit: Double?
-    public let individualUsed: Double?
-    public let individualRemaining: Double?
-    public let limitType: String?
-}
-
-public struct CursorDashboardMe: Codable, Sendable {
-    public let email: String?
-    public let firstName: String?
-    public let lastName: String?
-    public let isEnterpriseUser: Bool?
-
-    public var displayName: String? {
-        [self.firstName, self.lastName]
-            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: " ")
-            .nilIfEmpty
-    }
-}
-
-extension String {
-    fileprivate var nilIfEmpty: String? {
-        self.isEmpty ? nil : self
-    }
-}
 
 // MARK: - Cursor Status Snapshot
 
@@ -838,7 +811,6 @@ public actor CursorSessionStore {
 
 public struct CursorStatusProbe: Sendable {
     public let baseURL: URL
-    public let dashboardBaseURL: URL
     public var timeout: TimeInterval = 15.0
     private let browserDetection: BrowserDetection
     private let browserCookieImportOrder: BrowserCookieImportOrder
@@ -847,14 +819,12 @@ public struct CursorStatusProbe: Sendable {
 
     public init(
         baseURL: URL = URL(string: "https://cursor.com")!,
-        dashboardBaseURL: URL = URL(string: "https://api2.cursor.sh")!,
         timeout: TimeInterval = 15.0,
         browserDetection: BrowserDetection,
         urlSession: any ProviderHTTPTransport = ProviderHTTPClient.shared)
     {
         self.init(
             baseURL: baseURL,
-            dashboardBaseURL: dashboardBaseURL,
             timeout: timeout,
             browserDetection: browserDetection,
             browserCookieImportOrder: cursorCookieImportOrder,
@@ -864,7 +834,6 @@ public struct CursorStatusProbe: Sendable {
 
     init(
         baseURL: URL = URL(string: "https://cursor.com")!,
-        dashboardBaseURL: URL = URL(string: "https://api2.cursor.sh")!,
         timeout: TimeInterval = 15.0,
         browserDetection: BrowserDetection,
         browserCookieImportOrder: BrowserCookieImportOrder = cursorCookieImportOrder,
@@ -872,7 +841,6 @@ public struct CursorStatusProbe: Sendable {
         appAuthStore: any CursorAppAuthSessionProviding)
     {
         self.baseURL = baseURL
-        self.dashboardBaseURL = dashboardBaseURL
         self.timeout = timeout
         self.browserDetection = browserDetection
         self.browserCookieImportOrder = browserCookieImportOrder
@@ -880,14 +848,11 @@ public struct CursorStatusProbe: Sendable {
         self.appAuthStore = appAuthStore
     }
 
-    /// Fetch Cursor usage using the access token already stored by Cursor.app.
+    /// Fetch Cursor usage using a first-party web session derived from Cursor.app's access token.
     func fetchWithAppAuthSession(_ session: CursorAppAuthSession) async throws -> CursorStatusSnapshot {
-        let usage = try await self.fetchDashboardCurrentPeriodUsage(bearerToken: session.accessToken)
-        let account = try? await self.fetchDashboardMe(bearerToken: session.accessToken)
-        return try self.parseDashboardCurrentPeriodUsage(
-            usage,
-            appSession: session,
-            account: account)
+        try await self.fetchWithCookieHeader(
+            session.cookieHeader(),
+            requestUsageUserIDFallback: session.userID())
     }
 
     /// Fetch Cursor usage with manual cookie header (for debugging).
@@ -922,10 +887,12 @@ public struct CursorStatusProbe: Sendable {
                 if case .notLoggedIn = error {
                     CookieHeaderCache.clear(provider: .cursor)
                 } else {
-                    throw error
+                    log("Cached session failed: \(error.localizedDescription)")
+                    firstRecoverableError = firstRecoverableError ?? error
                 }
             } catch {
-                throw error
+                log("Cached session failed: \(error.localizedDescription)")
+                firstRecoverableError = firstRecoverableError ?? .networkError(error.localizedDescription)
             }
         }
 
@@ -992,8 +959,8 @@ public struct CursorStatusProbe: Sendable {
             }
         }
 
-        // Last fallback: Cursor.app keeps a first-party bearer token in its VS Code-style global state DB.
-        // Use it only after the documented cookie/session sources fail so account precedence stays stable.
+        // Last fallback: derive Cursor's first-party web session from the app token in its global state DB.
+        // Reusing the web flow preserves modern billing, legacy request quotas, and account-scoped identity.
         if allowAppAuthFallback,
            let appSession = try? self.appAuthStore.loadSession(),
            appSession.isUsable
@@ -1102,60 +1069,10 @@ public struct CursorStatusProbe: Sendable {
         }
     }
 
-    private func fetchDashboardCurrentPeriodUsage(bearerToken: String) async throws
-    -> CursorDashboardCurrentPeriodUsage {
-        try await self.fetchDashboard(
-            method: "GetCurrentPeriodUsage",
-            bearerToken: bearerToken,
-            as: CursorDashboardCurrentPeriodUsage.self)
-    }
-
-    private func fetchDashboardMe(bearerToken: String) async throws -> CursorDashboardMe {
-        try await self.fetchDashboard(
-            method: "GetMe",
-            bearerToken: bearerToken,
-            as: CursorDashboardMe.self)
-    }
-
-    private func fetchDashboard<T: Decodable>(
-        method: String,
-        bearerToken: String,
-        as type: T.Type) async throws -> T
+    private func fetchWithCookieHeader(
+        _ cookieHeader: String,
+        requestUsageUserIDFallback: String? = nil) async throws -> CursorStatusSnapshot
     {
-        let url = self.dashboardBaseURL
-            .appendingPathComponent("/aiserver.v1.DashboardService/\(method)")
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.timeoutInterval = self.timeout
-        request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("1", forHTTPHeaderField: "Connect-Protocol-Version")
-        request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
-        request.httpBody = Data("{}".utf8)
-
-        let (data, response) = try await self.urlSession.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw CursorStatusProbeError.networkError("Invalid DashboardService response")
-        }
-        if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
-            throw CursorStatusProbeError.notLoggedIn
-        }
-        guard httpResponse.statusCode == 200 else {
-            throw CursorStatusProbeError.networkError("DashboardService \(method) HTTP \(httpResponse.statusCode)")
-        }
-
-        do {
-            return try JSONDecoder().decode(type, from: data)
-        } catch {
-            let rawJSON = String(data: data, encoding: .utf8) ?? "<binary>"
-            let snippet = rawJSON.prefix(200)
-            throw CursorStatusProbeError
-                .parseFailed(
-                    "DashboardService \(method) JSON decode failed: \(error.localizedDescription). Raw: \(snippet)")
-        }
-    }
-
-    private func fetchWithCookieHeader(_ cookieHeader: String) async throws -> CursorStatusSnapshot {
         enum FetchPart: Sendable {
             case usageSummary((CursorUsageSummary, String))
             case userInfo(Result<CursorUserInfo, Error>)
@@ -1196,7 +1113,7 @@ public struct CursorStatusProbe: Sendable {
         // Uses try? to avoid breaking the flow for users where this endpoint fails or returns unexpected data.
         var requestUsage: CursorUsageResponse?
         var requestUsageRawJSON: String?
-        if let userId = userInfo?.sub {
+        if let userId = userInfo?.sub ?? requestUsageUserIDFallback {
             do {
                 let (usage, usageRawJSON) = try await self.fetchRequestUsage(userId: userId, cookieHeader: cookieHeader)
                 requestUsage = usage
@@ -1290,64 +1207,6 @@ public struct CursorStatusProbe: Sendable {
         let decoder = JSONDecoder()
         let usage = try decoder.decode(CursorUsageResponse.self, from: data)
         return (usage, rawJSON)
-    }
-
-    func parseDashboardCurrentPeriodUsage(
-        _ usage: CursorDashboardCurrentPeriodUsage,
-        appSession: CursorAppAuthSession,
-        account: CursorDashboardMe?) throws -> CursorStatusSnapshot
-    {
-        guard usage.enabled != false else {
-            throw CursorStatusProbeError.parseFailed("DashboardService GetCurrentPeriodUsage is disabled")
-        }
-        guard let plan = usage.planUsage else {
-            throw CursorStatusProbeError.parseFailed("DashboardService GetCurrentPeriodUsage missing planUsage")
-        }
-
-        let includedSpend = max(0, plan.includedSpend ?? 0)
-        let limit = max(0, plan.limit ?? 0)
-        let spendLimit = usage.spendLimitUsage
-        let individualUsed = max(0, spendLimit?.individualUsed ?? 0)
-        let individualLimit = spendLimit?.individualLimit.map { max(0, $0) }
-        let pooledUsed = spendLimit?.pooledUsed.map { max(0, $0) }
-        let pooledLimit = spendLimit?.pooledLimit.map { max(0, $0) }
-        // Cursor's own usage UI derives the plan percentage from included spend, not total/bonus spend.
-        let planPercentUsed = limit > 0
-            ? min(100, includedSpend / limit * 100)
-            : 0
-
-        let billingCycleStart = Self.parseEpochMillisDate(usage.billingCycleStart)
-        let billingCycleEnd = Self.parseEpochMillisDate(usage.billingCycleEnd)
-        let rawJSON: String? = {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.sortedKeys]
-            guard let data = try? encoder.encode(usage) else { return nil }
-            return String(data: data, encoding: .utf8)
-        }()
-
-        return CursorStatusSnapshot(
-            planPercentUsed: planPercentUsed,
-            autoPercentUsed: nil,
-            apiPercentUsed: nil,
-            planUsedUSD: includedSpend / 100.0,
-            planLimitUSD: limit / 100.0,
-            onDemandUsedUSD: individualUsed / 100.0,
-            onDemandLimitUSD: individualLimit.map { $0 / 100.0 },
-            teamOnDemandUsedUSD: pooledUsed.map { $0 / 100.0 },
-            teamOnDemandLimitUSD: pooledLimit.map { $0 / 100.0 },
-            billingCycleStart: billingCycleStart,
-            billingCycleEnd: billingCycleEnd,
-            membershipType: appSession.membershipType,
-            accountEmail: account?.email ?? appSession.cachedEmail,
-            accountName: account?.displayName,
-            rawJSON: rawJSON)
-    }
-
-    private static func parseEpochMillisDate(_ value: String?) -> Date? {
-        guard let value,
-              let milliseconds = Double(value)
-        else { return nil }
-        return Date(timeIntervalSince1970: milliseconds / 1000.0)
     }
 
     func parseUsageSummary(

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -1304,6 +1304,34 @@ extension CursorStatusProbeTests {
         #expect(throws: CursorStatusProbeError.self) {
             _ = try session.cookieHeader()
         }
+        #expect(!session.isUsable)
+    }
+
+    @Test
+    func `expired Cursor app auth token is skipped before network access`() async throws {
+        defer {
+            CursorStatusProbeStubURLProtocol.reset()
+        }
+        CursorStatusProbeStubURLProtocol.reset()
+        CursorStatusProbeStubURLProtocol.setHandler { request in
+            Issue.record("Expired app auth unexpectedly requested \(request.url?.path ?? "<unknown>")")
+            throw URLError(.badURL)
+        }
+
+        let accessToken = try makeCursorAppAuthToken(expiration: Date(timeIntervalSinceNow: -60))
+        let baseURL = try #require(URL(string: "https://cursor-web.test"))
+        let probe = CursorStatusProbe(
+            baseURL: baseURL,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            browserCookieImportOrder: [],
+            urlSession: makeCursorStatusProbeSession(),
+            appAuthStore: CursorAppAuthSessionProviderStub(session: CursorAppAuthSession(
+                accessToken: accessToken)))
+
+        await #expect(throws: CursorStatusProbeError.self) {
+            _ = try await probe.fetch(allowCachedSessions: false)
+        }
+        #expect(CursorStatusProbeStubURLProtocol.requestCount == 0)
     }
 
     @Test
@@ -1368,8 +1396,16 @@ extension CursorStatusProbeTests {
     }
 }
 
-private func makeCursorAppAuthToken(subject: String = "auth0|user_test") throws -> String {
-    let payload = try JSONSerialization.data(withJSONObject: ["sub": subject], options: [.sortedKeys])
+private func makeCursorAppAuthToken(
+    subject: String = "auth0|user_test",
+    expiration: Date = Date(timeIntervalSinceNow: 3600)) throws -> String
+{
+    let payload = try JSONSerialization.data(
+        withJSONObject: [
+            "exp": Int(expiration.timeIntervalSince1970),
+            "sub": subject,
+        ],
+        options: [.sortedKeys])
     let encodedPayload = payload.base64EncodedString()
         .replacingOccurrences(of: "+", with: "-")
         .replacingOccurrences(of: "/", with: "_")

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -1039,6 +1039,7 @@ extension CursorStatusProbeTests {
         CursorStatusProbeStubURLProtocol.setHandler { request in
             let requestURL = try #require(request.url)
             #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer app-token")
+            #expect(request.value(forHTTPHeaderField: "Connect-Protocol-Version") == "1")
             #expect(request.httpMethod == "POST")
 
             switch requestURL.path {
@@ -1108,6 +1109,65 @@ extension CursorStatusProbeTests {
             "/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
             "/aiserver.v1.DashboardService/GetMe",
         ])
+    }
+
+    @Test
+    func `fetch with Cursor app auth rejects dashboard payload without plan usage`() async throws {
+        defer {
+            CursorStatusProbeStubURLProtocol.reset()
+        }
+        CursorStatusProbeStubURLProtocol.reset()
+
+        CursorStatusProbeStubURLProtocol.setHandler { request in
+            let requestURL = try #require(request.url)
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer app-token")
+            #expect(request.value(forHTTPHeaderField: "Connect-Protocol-Version") == "1")
+            #expect(request.httpMethod == "POST")
+
+            switch requestURL.path {
+            case "/aiserver.v1.DashboardService/GetCurrentPeriodUsage":
+                return makeCursorStatusProbeResponse(
+                    url: requestURL,
+                    body: """
+                    {
+                      "billingCycleStart": "1779536824000",
+                      "billingCycleEnd": "1782215224000",
+                      "enabled": true
+                    }
+                    """,
+                    statusCode: 200)
+            case "/aiserver.v1.DashboardService/GetMe":
+                return makeCursorStatusProbeResponse(
+                    url: requestURL,
+                    body: #"{"email":"user@example.com"}"#,
+                    statusCode: 200)
+            default:
+                throw URLError(.badURL)
+            }
+        }
+
+        let dashboardBaseURL = try #require(URL(string: "https://cursor-api.test"))
+        let probe = CursorStatusProbe(
+            dashboardBaseURL: dashboardBaseURL,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            urlSession: makeCursorStatusProbeSession())
+
+        do {
+            _ = try await probe.fetchWithAppAuthSession(CursorAppAuthSession(
+                accessToken: "app-token",
+                membershipType: "enterprise",
+                subscriptionStatus: "active",
+                cachedEmail: "cached@example.com"))
+            Issue.record("Expected missing Dashboard planUsage to fail instead of returning a zero snapshot")
+        } catch let error as CursorStatusProbeError {
+            guard case let .parseFailed(message) = error else {
+                Issue.record("Expected parseFailed for missing Dashboard planUsage, got: \(error)")
+                return
+            }
+            #expect(message == "DashboardService GetCurrentPeriodUsage missing planUsage")
+        } catch {
+            Issue.record("Expected CursorStatusProbeError, got: \(error)")
+        }
     }
 }
 

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -1335,7 +1335,7 @@ extension CursorStatusProbeTests {
     }
 
     @Test
-    func `cached session failure continues to Cursor app auth fallback`() async throws {
+    func `cached session transient failure does not switch to Cursor app auth`() async throws {
         CookieHeaderCache.store(provider: .cursor, cookieHeader: "cached=bad", sourceLabel: "test")
         defer {
             CookieHeaderCache.clear(provider: .cursor)
@@ -1354,45 +1354,28 @@ extension CursorStatusProbeTests {
                     url: requestURL,
                     body: #"{"error":"temporary"}"#,
                     statusCode: 500)
-            case "/api/usage-summary" where cookie == appCookie:
-                return makeCursorStatusProbeResponse(
-                    url: requestURL,
-                    body: """
-                    {
-                      "membershipType": "pro",
-                      "individualUsage": {
-                        "plan": {
-                          "used": 100,
-                          "limit": 1000,
-                          "totalPercentUsed": 10
-                        }
-                      }
-                    }
-                    """,
-                    statusCode: 200)
-            case "/api/auth/me":
-                return makeCursorStatusProbeResponse(
-                    url: requestURL,
-                    body: #"{"email":"user@example.com"}"#,
-                    statusCode: 200)
+            case _ where cookie == appCookie:
+                Issue.record("Transient cached-session failure unexpectedly switched to Cursor.app auth")
+                throw URLError(.userAuthenticationRequired)
             default:
                 throw URLError(.badURL)
             }
         }
 
         let baseURL = try #require(URL(string: "https://cursor-web.test"))
-        let snapshot = try await CursorStatusProbe(
+        let probe = CursorStatusProbe(
             baseURL: baseURL,
             browserDetection: BrowserDetection(cacheTTL: 0),
             browserCookieImportOrder: [],
             urlSession: makeCursorStatusProbeSession(),
             appAuthStore: CursorAppAuthSessionProviderStub(session: CursorAppAuthSession(
-                accessToken: accessToken))).fetch()
+                accessToken: accessToken)))
 
-        #expect(snapshot.planPercentUsed == 10)
-        #expect(snapshot.accountEmail == "user@example.com")
+        await #expect(throws: CursorStatusProbeError.self) {
+            _ = try await probe.fetch()
+        }
         #expect(CursorStatusProbeStubURLProtocol.requestCookies.contains("cached=bad"))
-        #expect(CursorStatusProbeStubURLProtocol.requestCookies.contains(appCookie))
+        #expect(!CursorStatusProbeStubURLProtocol.requestCookies.contains(appCookie))
     }
 }
 

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SQLite3
 import Testing
 @testable import CodexBarCore
 
@@ -930,6 +931,35 @@ private func makeCursorStatusProbeResponse(
 
 extension CursorStatusProbeTests {
     @Test
+    func `app auth store reads Cursor global state database`() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cursor-app-auth-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let dbURL = directory.appendingPathComponent("state.vscdb")
+        var db: OpaquePointer?
+        try #require(sqlite3_open(dbURL.path, &db) == SQLITE_OK)
+        defer { sqlite3_close(db) }
+
+        let sql = """
+        CREATE TABLE ItemTable(key TEXT PRIMARY KEY, value BLOB);
+        INSERT INTO ItemTable VALUES('cursorAuth/accessToken', 'app-token');
+        INSERT INTO ItemTable VALUES('cursorAuth/stripeMembershipType', 'pro');
+        INSERT INTO ItemTable VALUES('cursorAuth/stripeSubscriptionStatus', 'active');
+        INSERT INTO ItemTable VALUES('cursorAuth/cachedEmail', 'user@example.com');
+        """
+        try #require(sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK)
+
+        let session = try #require(try CursorAppAuthStore(dbPath: dbURL.path).loadSession())
+        #expect(session == CursorAppAuthSession(
+            accessToken: "app-token",
+            membershipType: "pro",
+            subscriptionStatus: "active",
+            cachedEmail: "user@example.com"))
+    }
+
+    @Test
     func `fetch ignores user info failure when usage summary succeeds`() async throws {
         defer {
             CursorStatusProbeStubURLProtocol.reset()
@@ -1052,17 +1082,15 @@ extension CursorStatusProbeTests {
                       "billingCycleEnd": "1782215224000",
                       "planUsage": {
                         "totalSpend": 3783,
-                        "includedSpend": 2000,
-                        "bonusSpend": 1783,
+                        "includedSpend": 388,
+                        "bonusSpend": 3395,
+                        "remaining": 1612,
                         "limit": 2000,
-                        "autoPercentUsed": 25.013333333333332,
-                        "apiPercentUsed": 0.6888888888888889,
-                        "totalPercentUsed": 19.4
+                        "remainingBonus": true,
+                        "bonusTooltip": "Bonus usage remains"
                       },
                       "enabled": true,
-                      "displayMessage": "You've hit your usage limit",
-                      "autoModelSelectedDisplayMessage": "You've used 19% of your included total usage",
-                      "namedModelSelectedDisplayMessage": "You've used 1% of your included API usage"
+                      "displayMessage": "You've used 19% of your included usage"
                     }
                     """,
                     statusCode: 200)
@@ -1097,11 +1125,12 @@ extension CursorStatusProbeTests {
                 subscriptionStatus: "active",
                 cachedEmail: "cached@example.com"))).fetch(allowCachedSessions: false)
 
-        #expect(snapshot.planPercentUsed == 19.4)
-        #expect(snapshot.autoPercentUsed == 25.013333333333332)
-        #expect(snapshot.apiPercentUsed == 0.6888888888888889)
-        #expect(snapshot.planUsedUSD == 37.83)
+        #expect(abs(snapshot.planPercentUsed - 19.4) < 0.0001)
+        #expect(snapshot.autoPercentUsed == nil)
+        #expect(snapshot.apiPercentUsed == nil)
+        #expect(snapshot.planUsedUSD == 3.88)
         #expect(snapshot.planLimitUSD == 20.0)
+        #expect(snapshot.billingCycleStart == Date(timeIntervalSince1970: 1_779_536_824_000 / 1000.0))
         #expect(snapshot.billingCycleEnd == Date(timeIntervalSince1970: 1_782_215_224_000 / 1000.0))
         #expect(snapshot.membershipType == "pro")
         #expect(snapshot.accountEmail == "user@example.com")

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -1089,6 +1089,16 @@ extension CursorStatusProbeTests {
                         "remainingBonus": true,
                         "bonusTooltip": "Bonus usage remains"
                       },
+                      "spendLimitUsage": {
+                        "totalSpend": 450,
+                        "pooledLimit": 5000,
+                        "pooledUsed": 1200,
+                        "pooledRemaining": 3800,
+                        "individualLimit": 1000,
+                        "individualUsed": 450,
+                        "individualRemaining": 550,
+                        "limitType": "hard"
+                      },
                       "enabled": true,
                       "displayMessage": "You've used 19% of your included usage"
                     }
@@ -1130,6 +1140,10 @@ extension CursorStatusProbeTests {
         #expect(snapshot.apiPercentUsed == nil)
         #expect(snapshot.planUsedUSD == 3.88)
         #expect(snapshot.planLimitUSD == 20.0)
+        #expect(snapshot.onDemandUsedUSD == 4.5)
+        #expect(snapshot.onDemandLimitUSD == 10.0)
+        #expect(snapshot.teamOnDemandUsedUSD == 12.0)
+        #expect(snapshot.teamOnDemandLimitUSD == 50.0)
         #expect(snapshot.billingCycleStart == Date(timeIntervalSince1970: 1_779_536_824_000 / 1000.0))
         #expect(snapshot.billingCycleEnd == Date(timeIntervalSince1970: 1_782_215_224_000 / 1000.0))
         #expect(snapshot.membershipType == "pro")

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -1089,6 +1089,7 @@ extension CursorStatusProbeTests {
             baseURL: baseURL,
             dashboardBaseURL: dashboardBaseURL,
             browserDetection: BrowserDetection(cacheTTL: 0),
+            browserCookieImportOrder: [],
             urlSession: makeCursorStatusProbeSession(),
             appAuthStore: CursorAppAuthSessionProviderStub(session: CursorAppAuthSession(
                 accessToken: "app-token",
@@ -1108,6 +1109,83 @@ extension CursorStatusProbeTests {
         #expect(CursorStatusProbeStubURLProtocol.requestPaths.sorted() == [
             "/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
             "/aiserver.v1.DashboardService/GetMe",
+        ])
+    }
+
+    @Test
+    func `fetch prefers stored session cookies before Cursor app auth fallback`() async throws {
+        let store = CursorSessionStore.shared
+        await store.clearCookies()
+        defer {
+            CursorStatusProbeStubURLProtocol.reset()
+            Task { await store.clearCookies() }
+        }
+        CursorStatusProbeStubURLProtocol.reset()
+
+        guard let cookie = HTTPCookie(properties: [
+            .name: "WorkosCursorSessionToken",
+            .value: "stored-session",
+            .domain: "cursor.com",
+            .path: "/",
+            .secure: true,
+        ]) else {
+            Issue.record("Failed to create stored Cursor session cookie")
+            return
+        }
+        await store.setCookies([cookie])
+
+        CursorStatusProbeStubURLProtocol.setHandler { request in
+            let requestURL = try #require(request.url)
+            #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+            #expect(request.value(forHTTPHeaderField: "Cookie") == "WorkosCursorSessionToken=stored-session")
+
+            switch requestURL.path {
+            case "/api/usage-summary":
+                return makeCursorStatusProbeResponse(
+                    url: requestURL,
+                    body: """
+                    {
+                      "membershipType": "pro",
+                      "individualUsage": {
+                        "plan": {
+                          "used": 1500,
+                          "limit": 5000,
+                          "totalPercentUsed": 30.0
+                        }
+                      }
+                    }
+                    """,
+                    statusCode: 200)
+            case "/api/auth/me":
+                return makeCursorStatusProbeResponse(
+                    url: requestURL,
+                    body: #"{"email":"stored@example.com","name":"Stored User"}"#,
+                    statusCode: 200)
+            default:
+                Issue.record("Stored-session precedence test unexpectedly requested \(requestURL.path)")
+                throw URLError(.badURL)
+            }
+        }
+
+        let baseURL = try #require(URL(string: "https://cursor.test"))
+        let dashboardBaseURL = try #require(URL(string: "https://cursor-api.test"))
+        let snapshot = try await CursorStatusProbe(
+            baseURL: baseURL,
+            dashboardBaseURL: dashboardBaseURL,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            browserCookieImportOrder: [],
+            urlSession: makeCursorStatusProbeSession(),
+            appAuthStore: CursorAppAuthSessionProviderStub(session: CursorAppAuthSession(
+                accessToken: "app-token",
+                membershipType: "enterprise",
+                subscriptionStatus: "active",
+                cachedEmail: "cached@example.com"))).fetch()
+
+        #expect(snapshot.planPercentUsed == 30.0)
+        #expect(snapshot.accountEmail == "stored@example.com")
+        #expect(CursorStatusProbeStubURLProtocol.requestPaths.sorted() == [
+            "/api/auth/me",
+            "/api/usage-summary",
         ])
     }
 

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -1028,6 +1028,95 @@ extension CursorStatusProbeTests {
             Issue.record("Expected CursorStatusProbeError, got: \(error)")
         }
     }
+
+    @Test
+    func `fetch uses Cursor app local auth when browser cookies are unavailable`() async throws {
+        defer {
+            CursorStatusProbeStubURLProtocol.reset()
+        }
+        CursorStatusProbeStubURLProtocol.reset()
+
+        CursorStatusProbeStubURLProtocol.setHandler { request in
+            let requestURL = try #require(request.url)
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer app-token")
+            #expect(request.httpMethod == "POST")
+
+            switch requestURL.path {
+            case "/aiserver.v1.DashboardService/GetCurrentPeriodUsage":
+                return makeCursorStatusProbeResponse(
+                    url: requestURL,
+                    body: """
+                    {
+                      "billingCycleStart": "1779536824000",
+                      "billingCycleEnd": "1782215224000",
+                      "planUsage": {
+                        "totalSpend": 3783,
+                        "includedSpend": 2000,
+                        "bonusSpend": 1783,
+                        "limit": 2000,
+                        "autoPercentUsed": 25.013333333333332,
+                        "apiPercentUsed": 0.6888888888888889,
+                        "totalPercentUsed": 19.4
+                      },
+                      "enabled": true,
+                      "displayMessage": "You've hit your usage limit",
+                      "autoModelSelectedDisplayMessage": "You've used 19% of your included total usage",
+                      "namedModelSelectedDisplayMessage": "You've used 1% of your included API usage"
+                    }
+                    """,
+                    statusCode: 200)
+            case "/aiserver.v1.DashboardService/GetMe":
+                return makeCursorStatusProbeResponse(
+                    url: requestURL,
+                    body: """
+                    {
+                      "email": "user@example.com",
+                      "firstName": "Test",
+                      "lastName": "User",
+                      "isEnterpriseUser": false
+                    }
+                    """,
+                    statusCode: 200)
+            default:
+                throw URLError(.badURL)
+            }
+        }
+
+        let baseURL = try #require(URL(string: "https://cursor-web.test"))
+        let dashboardBaseURL = try #require(URL(string: "https://cursor-api.test"))
+        let snapshot = try await CursorStatusProbe(
+            baseURL: baseURL,
+            dashboardBaseURL: dashboardBaseURL,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            urlSession: makeCursorStatusProbeSession(),
+            appAuthStore: CursorAppAuthSessionProviderStub(session: CursorAppAuthSession(
+                accessToken: "app-token",
+                membershipType: "pro",
+                subscriptionStatus: "active",
+                cachedEmail: "cached@example.com"))).fetch(allowCachedSessions: false)
+
+        #expect(snapshot.planPercentUsed == 19.4)
+        #expect(snapshot.autoPercentUsed == 25.013333333333332)
+        #expect(snapshot.apiPercentUsed == 0.6888888888888889)
+        #expect(snapshot.planUsedUSD == 37.83)
+        #expect(snapshot.planLimitUSD == 20.0)
+        #expect(snapshot.billingCycleEnd == Date(timeIntervalSince1970: 1_782_215_224_000 / 1000.0))
+        #expect(snapshot.membershipType == "pro")
+        #expect(snapshot.accountEmail == "user@example.com")
+        #expect(snapshot.accountName == "Test User")
+        #expect(CursorStatusProbeStubURLProtocol.requestPaths.sorted() == [
+            "/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
+            "/aiserver.v1.DashboardService/GetMe",
+        ])
+    }
+}
+
+private struct CursorAppAuthSessionProviderStub: CursorAppAuthSessionProviding {
+    let session: CursorAppAuthSession?
+
+    func loadSession() throws -> CursorAppAuthSession? {
+        self.session
+    }
 }
 
 final class CursorStatusProbeStubURLProtocol: URLProtocol {

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -1335,6 +1335,42 @@ extension CursorStatusProbeTests {
     }
 
     @Test
+    func `Cursor app auth transient failure is preserved`() async throws {
+        defer {
+            CursorStatusProbeStubURLProtocol.reset()
+        }
+        CursorStatusProbeStubURLProtocol.reset()
+
+        CursorStatusProbeStubURLProtocol.setHandler { request in
+            let requestURL = try #require(request.url)
+            return makeCursorStatusProbeResponse(
+                url: requestURL,
+                body: #"{"error":"temporary"}"#,
+                statusCode: 500)
+        }
+
+        let accessToken = try makeCursorAppAuthToken()
+        let baseURL = try #require(URL(string: "https://cursor-web.test"))
+        let probe = CursorStatusProbe(
+            baseURL: baseURL,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            browserCookieImportOrder: [],
+            urlSession: makeCursorStatusProbeSession(),
+            appAuthStore: CursorAppAuthSessionProviderStub(session: CursorAppAuthSession(
+                accessToken: accessToken)))
+
+        do {
+            _ = try await probe.fetch(allowCachedSessions: false)
+            Issue.record("Expected Cursor.app auth request to fail")
+        } catch let error as CursorStatusProbeError {
+            guard case .networkError = error else {
+                Issue.record("Expected network error, got \(error)")
+                return
+            }
+        }
+    }
+
+    @Test
     func `cached session transient failure does not switch to Cursor app auth`() async throws {
         CookieHeaderCache.store(provider: .cursor, cookieHeader: "cached=bad", sourceLabel: "test")
         defer {

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -945,18 +945,11 @@ extension CursorStatusProbeTests {
         let sql = """
         CREATE TABLE ItemTable(key TEXT PRIMARY KEY, value BLOB);
         INSERT INTO ItemTable VALUES('cursorAuth/accessToken', 'app-token');
-        INSERT INTO ItemTable VALUES('cursorAuth/stripeMembershipType', 'pro');
-        INSERT INTO ItemTable VALUES('cursorAuth/stripeSubscriptionStatus', 'active');
-        INSERT INTO ItemTable VALUES('cursorAuth/cachedEmail', 'user@example.com');
         """
         try #require(sqlite3_exec(db, sql, nil, nil, nil) == SQLITE_OK)
 
         let session = try #require(try CursorAppAuthStore(dbPath: dbURL.path).loadSession())
-        #expect(session == CursorAppAuthSession(
-            accessToken: "app-token",
-            membershipType: "pro",
-            subscriptionStatus: "active",
-            cachedEmail: "user@example.com"))
+        #expect(session == CursorAppAuthSession(accessToken: "app-token"))
     }
 
     @Test
@@ -1066,55 +1059,46 @@ extension CursorStatusProbeTests {
         }
         CursorStatusProbeStubURLProtocol.reset()
 
+        let accessToken = try makeCursorAppAuthToken()
+        let expectedCookie = "WorkosCursorSessionToken=user_test%3A%3A\(accessToken)"
         CursorStatusProbeStubURLProtocol.setHandler { request in
             let requestURL = try #require(request.url)
-            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer app-token")
-            #expect(request.value(forHTTPHeaderField: "Connect-Protocol-Version") == "1")
-            #expect(request.httpMethod == "POST")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+            #expect(request.value(forHTTPHeaderField: "Cookie") == expectedCookie)
+            #expect(request.httpMethod == "GET")
 
             switch requestURL.path {
-            case "/aiserver.v1.DashboardService/GetCurrentPeriodUsage":
+            case "/api/usage-summary":
                 return makeCursorStatusProbeResponse(
                     url: requestURL,
                     body: """
                     {
-                      "billingCycleStart": "1779536824000",
-                      "billingCycleEnd": "1782215224000",
-                      "planUsage": {
-                        "totalSpend": 3783,
-                        "includedSpend": 388,
-                        "bonusSpend": 3395,
-                        "remaining": 1612,
-                        "limit": 2000,
-                        "remainingBonus": true,
-                        "bonusTooltip": "Bonus usage remains"
-                      },
-                      "spendLimitUsage": {
-                        "totalSpend": 450,
-                        "pooledLimit": 5000,
-                        "pooledUsed": 1200,
-                        "pooledRemaining": 3800,
-                        "individualLimit": 1000,
-                        "individualUsed": 450,
-                        "individualRemaining": 550,
-                        "limitType": "hard"
-                      },
-                      "enabled": true,
-                      "displayMessage": "You've used 19% of your included usage"
+                      "membershipType": "pro",
+                      "billingCycleStart": "2026-05-23T10:27:04.000Z",
+                      "billingCycleEnd": "2026-06-23T10:27:04.000Z",
+                      "individualUsage": {
+                        "plan": {
+                          "used": 388,
+                          "limit": 2000,
+                          "totalPercentUsed": 19.4
+                        },
+                        "onDemand": {
+                          "used": 450,
+                          "limit": 1000
+                        }
+                      }
                     }
                     """,
                     statusCode: 200)
-            case "/aiserver.v1.DashboardService/GetMe":
+            case "/api/auth/me":
                 return makeCursorStatusProbeResponse(
                     url: requestURL,
-                    body: """
-                    {
-                      "email": "user@example.com",
-                      "firstName": "Test",
-                      "lastName": "User",
-                      "isEnterpriseUser": false
-                    }
-                    """,
+                    body: #"{"email":"user@example.com","name":"Test User"}"#,
+                    statusCode: 200)
+            case "/api/usage":
+                return makeCursorStatusProbeResponse(
+                    url: requestURL,
+                    body: #"{"gpt-4":{},"startOfMonth":"2026-05-23"}"#,
                     statusCode: 200)
             default:
                 throw URLError(.badURL)
@@ -1122,36 +1106,26 @@ extension CursorStatusProbeTests {
         }
 
         let baseURL = try #require(URL(string: "https://cursor-web.test"))
-        let dashboardBaseURL = try #require(URL(string: "https://cursor-api.test"))
         let snapshot = try await CursorStatusProbe(
             baseURL: baseURL,
-            dashboardBaseURL: dashboardBaseURL,
             browserDetection: BrowserDetection(cacheTTL: 0),
             browserCookieImportOrder: [],
             urlSession: makeCursorStatusProbeSession(),
             appAuthStore: CursorAppAuthSessionProviderStub(session: CursorAppAuthSession(
-                accessToken: "app-token",
-                membershipType: "pro",
-                subscriptionStatus: "active",
-                cachedEmail: "cached@example.com"))).fetch(allowCachedSessions: false)
+                accessToken: accessToken))).fetch(allowCachedSessions: false)
 
         #expect(abs(snapshot.planPercentUsed - 19.4) < 0.0001)
-        #expect(snapshot.autoPercentUsed == nil)
-        #expect(snapshot.apiPercentUsed == nil)
         #expect(snapshot.planUsedUSD == 3.88)
         #expect(snapshot.planLimitUSD == 20.0)
         #expect(snapshot.onDemandUsedUSD == 4.5)
         #expect(snapshot.onDemandLimitUSD == 10.0)
-        #expect(snapshot.teamOnDemandUsedUSD == 12.0)
-        #expect(snapshot.teamOnDemandLimitUSD == 50.0)
-        #expect(snapshot.billingCycleStart == Date(timeIntervalSince1970: 1_779_536_824_000 / 1000.0))
-        #expect(snapshot.billingCycleEnd == Date(timeIntervalSince1970: 1_782_215_224_000 / 1000.0))
         #expect(snapshot.membershipType == "pro")
         #expect(snapshot.accountEmail == "user@example.com")
         #expect(snapshot.accountName == "Test User")
         #expect(CursorStatusProbeStubURLProtocol.requestPaths.sorted() == [
-            "/aiserver.v1.DashboardService/GetCurrentPeriodUsage",
-            "/aiserver.v1.DashboardService/GetMe",
+            "/api/auth/me",
+            "/api/usage",
+            "/api/usage-summary",
         ])
     }
 
@@ -1167,18 +1141,14 @@ extension CursorStatusProbeTests {
         }
 
         let baseURL = try #require(URL(string: "https://cursor-web.test"))
-        let dashboardBaseURL = try #require(URL(string: "https://cursor-api.test"))
+        let accessToken = try makeCursorAppAuthToken()
         let probe = CursorStatusProbe(
             baseURL: baseURL,
-            dashboardBaseURL: dashboardBaseURL,
             browserDetection: BrowserDetection(cacheTTL: 0),
             browserCookieImportOrder: [],
             urlSession: makeCursorStatusProbeSession(),
             appAuthStore: CursorAppAuthSessionProviderStub(session: CursorAppAuthSession(
-                accessToken: "app-token",
-                membershipType: "pro",
-                subscriptionStatus: "active",
-                cachedEmail: "cached@example.com")))
+                accessToken: accessToken)))
 
         await #expect(throws: CursorStatusProbeError.self) {
             _ = try await probe.fetch(
@@ -1244,18 +1214,14 @@ extension CursorStatusProbeTests {
         }
 
         let baseURL = try #require(URL(string: "https://cursor.test"))
-        let dashboardBaseURL = try #require(URL(string: "https://cursor-api.test"))
+        let accessToken = try makeCursorAppAuthToken()
         let snapshot = try await CursorStatusProbe(
             baseURL: baseURL,
-            dashboardBaseURL: dashboardBaseURL,
             browserDetection: BrowserDetection(cacheTTL: 0),
             browserCookieImportOrder: [],
             urlSession: makeCursorStatusProbeSession(),
             appAuthStore: CursorAppAuthSessionProviderStub(session: CursorAppAuthSession(
-                accessToken: "app-token",
-                membershipType: "enterprise",
-                subscriptionStatus: "active",
-                cachedEmail: "cached@example.com"))).fetch()
+                accessToken: accessToken))).fetch()
 
         #expect(snapshot.planPercentUsed == 30.0)
         #expect(snapshot.accountEmail == "stored@example.com")
@@ -1266,88 +1232,117 @@ extension CursorStatusProbeTests {
     }
 
     @Test
-    func `fetch with Cursor app auth rejects dashboard payload without plan usage`() async throws {
+    func `fetch with Cursor app auth preserves legacy request quotas`() async throws {
         defer {
             CursorStatusProbeStubURLProtocol.reset()
         }
         CursorStatusProbeStubURLProtocol.reset()
 
+        let accessToken = try makeCursorAppAuthToken()
+        let expectedCookie = "WorkosCursorSessionToken=user_test%3A%3A\(accessToken)"
         CursorStatusProbeStubURLProtocol.setHandler { request in
             let requestURL = try #require(request.url)
-            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer app-token")
-            #expect(request.value(forHTTPHeaderField: "Connect-Protocol-Version") == "1")
-            #expect(request.httpMethod == "POST")
+            #expect(request.value(forHTTPHeaderField: "Cookie") == expectedCookie)
 
             switch requestURL.path {
-            case "/aiserver.v1.DashboardService/GetCurrentPeriodUsage":
+            case "/api/usage-summary":
                 return makeCursorStatusProbeResponse(
                     url: requestURL,
                     body: """
                     {
-                      "billingCycleStart": "1779536824000",
-                      "billingCycleEnd": "1782215224000",
-                      "enabled": true
+                      "membershipType": "enterprise",
+                      "individualUsage": {}
                     }
                     """,
                     statusCode: 200)
-            case "/aiserver.v1.DashboardService/GetMe":
+            case "/api/auth/me":
                 return makeCursorStatusProbeResponse(
                     url: requestURL,
-                    body: #"{"email":"user@example.com"}"#,
+                    body: #"{"error":"temporary"}"#,
+                    statusCode: 500)
+            case "/api/usage":
+                #expect(URLComponents(url: requestURL, resolvingAgainstBaseURL: false)?
+                    .queryItems?.first(where: { $0.name == "user" })?.value == "user_test")
+                return makeCursorStatusProbeResponse(
+                    url: requestURL,
+                    body: """
+                    {
+                      "gpt-4": {
+                        "numRequests": 200,
+                        "numRequestsTotal": 240,
+                        "maxRequestUsage": 500
+                      }
+                    }
+                    """,
                     statusCode: 200)
             default:
                 throw URLError(.badURL)
             }
         }
 
-        let dashboardBaseURL = try #require(URL(string: "https://cursor-api.test"))
+        let baseURL = try #require(URL(string: "https://cursor.test"))
         let probe = CursorStatusProbe(
-            dashboardBaseURL: dashboardBaseURL,
+            baseURL: baseURL,
             browserDetection: BrowserDetection(cacheTTL: 0),
             urlSession: makeCursorStatusProbeSession())
 
-        do {
-            _ = try await probe.fetchWithAppAuthSession(CursorAppAuthSession(
-                accessToken: "app-token",
-                membershipType: "enterprise",
-                subscriptionStatus: "active",
-                cachedEmail: "cached@example.com"))
-            Issue.record("Expected missing Dashboard planUsage to fail instead of returning a zero snapshot")
-        } catch let error as CursorStatusProbeError {
-            guard case let .parseFailed(message) = error else {
-                Issue.record("Expected parseFailed for missing Dashboard planUsage, got: \(error)")
-                return
-            }
-            #expect(message == "DashboardService GetCurrentPeriodUsage missing planUsage")
-        } catch {
-            Issue.record("Expected CursorStatusProbeError, got: \(error)")
+        let snapshot = try await probe.fetchWithAppAuthSession(CursorAppAuthSession(accessToken: accessToken))
+        #expect(snapshot.requestsUsed == 240)
+        #expect(snapshot.requestsLimit == 500)
+        #expect(snapshot.toUsageSnapshot().primary?.usedPercent == 48)
+        #expect(snapshot.accountEmail == nil)
+        #expect(CursorStatusProbeStubURLProtocol.requestPaths.sorted() == [
+            "/api/auth/me",
+            "/api/usage",
+            "/api/usage-summary",
+        ])
+    }
+
+    @Test
+    func `malformed Cursor app auth token is rejected before network access`() {
+        let session = CursorAppAuthSession(accessToken: "not-a-jwt")
+        #expect(throws: CursorStatusProbeError.self) {
+            _ = try session.cookieHeader()
         }
     }
 
     @Test
-    func `fetch with Cursor app auth rejects disabled dashboard usage`() async throws {
+    func `cached session failure continues to Cursor app auth fallback`() async throws {
+        CookieHeaderCache.store(provider: .cursor, cookieHeader: "cached=bad", sourceLabel: "test")
         defer {
+            CookieHeaderCache.clear(provider: .cursor)
             CursorStatusProbeStubURLProtocol.reset()
         }
         CursorStatusProbeStubURLProtocol.reset()
 
+        let accessToken = try makeCursorAppAuthToken()
+        let appCookie = "WorkosCursorSessionToken=user_test%3A%3A\(accessToken)"
         CursorStatusProbeStubURLProtocol.setHandler { request in
             let requestURL = try #require(request.url)
+            let cookie = request.value(forHTTPHeaderField: "Cookie")
             switch requestURL.path {
-            case "/aiserver.v1.DashboardService/GetCurrentPeriodUsage":
+            case "/api/usage-summary" where cookie == "cached=bad":
+                return makeCursorStatusProbeResponse(
+                    url: requestURL,
+                    body: #"{"error":"temporary"}"#,
+                    statusCode: 500)
+            case "/api/usage-summary" where cookie == appCookie:
                 return makeCursorStatusProbeResponse(
                     url: requestURL,
                     body: """
                     {
-                      "planUsage": {
-                        "includedSpend": 500,
-                        "limit": 2000
-                      },
-                      "enabled": false
+                      "membershipType": "pro",
+                      "individualUsage": {
+                        "plan": {
+                          "used": 100,
+                          "limit": 1000,
+                          "totalPercentUsed": 10
+                        }
+                      }
                     }
                     """,
                     statusCode: 200)
-            case "/aiserver.v1.DashboardService/GetMe":
+            case "/api/auth/me":
                 return makeCursorStatusProbeResponse(
                     url: requestURL,
                     body: #"{"email":"user@example.com"}"#,
@@ -1358,28 +1353,28 @@ extension CursorStatusProbeTests {
         }
 
         let baseURL = try #require(URL(string: "https://cursor-web.test"))
-        let dashboardBaseURL = try #require(URL(string: "https://cursor-api.test"))
-        let probe = CursorStatusProbe(
+        let snapshot = try await CursorStatusProbe(
             baseURL: baseURL,
-            dashboardBaseURL: dashboardBaseURL,
             browserDetection: BrowserDetection(cacheTTL: 0),
-            urlSession: makeCursorStatusProbeSession())
+            browserCookieImportOrder: [],
+            urlSession: makeCursorStatusProbeSession(),
+            appAuthStore: CursorAppAuthSessionProviderStub(session: CursorAppAuthSession(
+                accessToken: accessToken))).fetch()
 
-        do {
-            _ = try await probe.fetchWithAppAuthSession(CursorAppAuthSession(
-                accessToken: "app-token",
-                membershipType: "pro",
-                subscriptionStatus: "active",
-                cachedEmail: nil))
-            Issue.record("Expected disabled usage to fail")
-        } catch let error as CursorStatusProbeError {
-            guard case let .parseFailed(message) = error else {
-                Issue.record("Expected parseFailed, got: \(error)")
-                return
-            }
-            #expect(message == "DashboardService GetCurrentPeriodUsage is disabled")
-        }
+        #expect(snapshot.planPercentUsed == 10)
+        #expect(snapshot.accountEmail == "user@example.com")
+        #expect(CursorStatusProbeStubURLProtocol.requestCookies.contains("cached=bad"))
+        #expect(CursorStatusProbeStubURLProtocol.requestCookies.contains(appCookie))
     }
+}
+
+private func makeCursorAppAuthToken(subject: String = "auth0|user_test") throws -> String {
+    let payload = try JSONSerialization.data(withJSONObject: ["sub": subject], options: [.sortedKeys])
+    let encodedPayload = payload.base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+    return "header.\(encodedPayload).signature"
 }
 
 private struct CursorAppAuthSessionProviderStub: CursorAppAuthSessionProviding {
@@ -1421,6 +1416,12 @@ final class CursorStatusProbeStubURLProtocol: URLProtocol {
         lock.lock()
         defer { Self.lock.unlock() }
         return state.requests.compactMap { $0.url?.path }
+    }
+
+    static var requestCookies: [String] {
+        lock.lock()
+        defer { Self.lock.unlock() }
+        return state.requests.compactMap { $0.value(forHTTPHeaderField: "Cookie") }
     }
 
     override static func canInit(with request: URLRequest) -> Bool {

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -1156,6 +1156,39 @@ extension CursorStatusProbeTests {
     }
 
     @Test
+    func `fetch can disable Cursor app auth during browser login verification`() async throws {
+        defer {
+            CursorStatusProbeStubURLProtocol.reset()
+        }
+        CursorStatusProbeStubURLProtocol.reset()
+        CursorStatusProbeStubURLProtocol.setHandler { request in
+            Issue.record("Disabled app auth unexpectedly requested \(request.url?.path ?? "<unknown>")")
+            throw URLError(.badURL)
+        }
+
+        let baseURL = try #require(URL(string: "https://cursor-web.test"))
+        let dashboardBaseURL = try #require(URL(string: "https://cursor-api.test"))
+        let probe = CursorStatusProbe(
+            baseURL: baseURL,
+            dashboardBaseURL: dashboardBaseURL,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            browserCookieImportOrder: [],
+            urlSession: makeCursorStatusProbeSession(),
+            appAuthStore: CursorAppAuthSessionProviderStub(session: CursorAppAuthSession(
+                accessToken: "app-token",
+                membershipType: "pro",
+                subscriptionStatus: "active",
+                cachedEmail: "cached@example.com")))
+
+        await #expect(throws: CursorStatusProbeError.self) {
+            _ = try await probe.fetch(
+                allowCachedSessions: false,
+                allowAppAuthFallback: false)
+        }
+        #expect(CursorStatusProbeStubURLProtocol.requestCount == 0)
+    }
+
+    @Test
     func `fetch prefers stored session cookies before Cursor app auth fallback`() async throws {
         let store = CursorSessionStore.shared
         await store.clearCookies()
@@ -1288,6 +1321,63 @@ extension CursorStatusProbeTests {
             #expect(message == "DashboardService GetCurrentPeriodUsage missing planUsage")
         } catch {
             Issue.record("Expected CursorStatusProbeError, got: \(error)")
+        }
+    }
+
+    @Test
+    func `fetch with Cursor app auth rejects disabled dashboard usage`() async throws {
+        defer {
+            CursorStatusProbeStubURLProtocol.reset()
+        }
+        CursorStatusProbeStubURLProtocol.reset()
+
+        CursorStatusProbeStubURLProtocol.setHandler { request in
+            let requestURL = try #require(request.url)
+            switch requestURL.path {
+            case "/aiserver.v1.DashboardService/GetCurrentPeriodUsage":
+                return makeCursorStatusProbeResponse(
+                    url: requestURL,
+                    body: """
+                    {
+                      "planUsage": {
+                        "includedSpend": 500,
+                        "limit": 2000
+                      },
+                      "enabled": false
+                    }
+                    """,
+                    statusCode: 200)
+            case "/aiserver.v1.DashboardService/GetMe":
+                return makeCursorStatusProbeResponse(
+                    url: requestURL,
+                    body: #"{"email":"user@example.com"}"#,
+                    statusCode: 200)
+            default:
+                throw URLError(.badURL)
+            }
+        }
+
+        let baseURL = try #require(URL(string: "https://cursor-web.test"))
+        let dashboardBaseURL = try #require(URL(string: "https://cursor-api.test"))
+        let probe = CursorStatusProbe(
+            baseURL: baseURL,
+            dashboardBaseURL: dashboardBaseURL,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            urlSession: makeCursorStatusProbeSession())
+
+        do {
+            _ = try await probe.fetchWithAppAuthSession(CursorAppAuthSession(
+                accessToken: "app-token",
+                membershipType: "pro",
+                subscriptionStatus: "active",
+                cachedEmail: nil))
+            Issue.record("Expected disabled usage to fail")
+        } catch let error as CursorStatusProbeError {
+            guard case let .parseFailed(message) = error else {
+                Issue.record("Expected parseFailed, got: \(error)")
+                return
+            }
+            #expect(message == "DashboardService GetCurrentPeriodUsage is disabled")
         }
     }
 }

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -8,7 +8,7 @@ read_when:
 
 # Cursor provider
 
-Cursor is web-only. Usage is fetched via browser cookies or a stored WebKit session.
+Cursor is primarily web-backed. Usage is fetched via browser cookies or a stored WebKit session, with Cursor.app local auth as a final fallback.
 
 ## Data sources + fallback order
 
@@ -29,6 +29,12 @@ Cursor is web-only. Usage is fetched via browser cookies or a stored WebKit sess
    - Login teardown uses `WebKitTeardown` to avoid Intel WebKit crashes.
    - Stored at: `~/Library/Application Support/CodexBar/cursor-session.json`.
 
+4) **Cursor.app local auth** (last fallback)
+   - Reads Cursor.app's VS Code-style global state DB for the local app bearer token.
+   - File: `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`.
+   - Used only after cookie/session sources fail so existing account-selection precedence stays stable.
+   - Fetches usage from Cursor DashboardService with bearer auth.
+
 Manual option:
 - Preferences → Providers → Cursor → Cookie source → Manual.
 - Paste the `Cookie:` header from a cursor.com request.
@@ -40,6 +46,11 @@ Manual option:
   - User email + name.
 - `GET https://cursor.com/api/usage?user=ID`
   - Legacy request-based plan usage (request counts + limits).
+- `POST https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage`
+  - Cursor.app local-auth fallback usage via bearer token.
+  - Headers include `Content-Type: application/json` and `Connect-Protocol-Version: 1`.
+- `POST https://api2.cursor.sh/aiserver.v1.DashboardService/GetMe`
+  - Cursor.app local-auth fallback account email + name.
 
 ## Cookie file paths
 - Safari: `~/Library/Cookies/Cookies.binarycookies`

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -33,7 +33,8 @@ Cursor is primarily web-backed. Usage is fetched via browser cookies or a stored
    - Reads Cursor.app's VS Code-style global state DB for the local app bearer token.
    - File: `~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`.
    - Used only after cookie/session sources fail so existing account-selection precedence stays stable.
-   - Fetches usage from Cursor DashboardService with bearer auth.
+   - Derives Cursor's first-party web-session cookie, then uses the same usage and account endpoints as browser sessions.
+   - Account identity comes from that authenticated session; cached app profile fields are not mixed across accounts.
 
 Manual option:
 - Preferences → Providers → Cursor → Cookie source → Manual.
@@ -46,11 +47,6 @@ Manual option:
   - User email + name.
 - `GET https://cursor.com/api/usage?user=ID`
   - Legacy request-based plan usage (request counts + limits).
-- `POST https://api2.cursor.sh/aiserver.v1.DashboardService/GetCurrentPeriodUsage`
-  - Cursor.app local-auth fallback usage via bearer token.
-  - Headers include `Content-Type: application/json` and `Connect-Protocol-Version: 1`.
-- `POST https://api2.cursor.sh/aiserver.v1.DashboardService/GetMe`
-  - Cursor.app local-auth fallback account email + name.
 
 ## Cookie file paths
 - Safari: `~/Library/Cookies/Cookies.binarycookies`


### PR DESCRIPTION
## Summary
- Add Cursor.app local auth as the final fallback after manual, cached, browser, and stored cookie sources are absent or rejected as unauthenticated.
- Read and validate Cursor's local access token, derive its first-party web session cookie, and reuse the existing usage-summary, account, and legacy request-quota flow.
- Preserve account boundaries: selected-session transient failures remain authoritative and never silently switch to Cursor.app's account.
- Reject malformed, expired, and near-expiry app tokens before network access; disable app auth during browser login verification.

## Test Plan
- [x] `swift test --filter CursorStatusProbeTests` - 38 tests passed
- [x] `swift test --filter CursorLoginRunnerTests` - 3 tests passed
- [x] `make check` - SwiftFormat clean, SwiftLint 0 violations
- [x] Branch autoreview - no accepted/actionable findings; patch correct
- [x] Original eight-commit series preserved by `git range-diff`; three focused maintainer safety commits added

## Exact-Head Live Validation
Validated commit `aa4a25bae45a66a280c38aa2a3b77bde61a93a62` using the real local Cursor.app session and production Cursor endpoints. The temporary probe printed only redacted booleans and aggregate usage values; no token, account identifier, name, or email was exposed.

```text
CURSOR_APP_AUTH_LIVE_OK plan_percent=0.0 plan_limit_usd=20.0 has_account=true has_reset=true membership_present=true request_quota_present=false
```

This proves successful app-token loading, first-party web-session derivation, authenticated usage retrieval, account metadata retrieval, and billing-cycle parsing on the exact pushed head. The account is not a legacy request-quota plan, so the request-quota field is correctly absent; that path is covered by focused regression tests.
