### PR TITLE
Reduce merged icon observation churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Menu bar: defer merged-menu close rebuilds and cache repeated menu-card height measurements so dismissing or rapidly switching the merged dropdown avoids rebuilding SwiftUI-backed cards on the main thread (#1274, #1286). Thanks @hhh2210!
+- Menu bar: observe a compact icon-state signature so merged status icons no longer redraw for provider snapshot changes that cannot affect the visible icon (#1297). Thanks @hhh2210!
 
 ## 0.32.4 — 2026-06-02
 

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -573,19 +573,17 @@ extension StatusItemController {
     }
 
     func menuBarCreditsRemainingForIcon(provider: UsageProvider, snapshot: UsageSnapshot?) -> Double? {
-        guard provider == .codex,
-              let creditsRemaining = self.store.credits?.remaining,
-              creditsRemaining > 0
-        else {
-            return nil
-        }
-
-        let rateWindows = [snapshot?.primary, snapshot?.secondary].compactMap(\.self)
-        guard rateWindows.isEmpty || rateWindows.contains(where: { $0.remainingPercent <= 0 })
-        else {
-            return nil
-        }
-        return creditsRemaining
+        // Derive the menu-bar credits fallback from the same Codex projection path the rendered
+        // icon and menu use (`codexConsumerProjection` -> `menuBarFallback`), instead of a
+        // hand-rolled rate-window predicate. The projection is pure value composition over
+        // already-loaded snapshot/credits state (no IO), so this stays cheap while keeping the
+        // icon render, this signature input, and the menu-bar fallback semantics on a single
+        // source of truth — a hand-rolled approximation can silently drift from the projection
+        // as its fallback logic evolves.
+        guard provider == .codex else { return nil }
+        return self.store.codexMenuBarCreditsRemaining(
+            snapshotOverride: snapshot,
+            now: snapshot?.updatedAt ?? Date())
     }
 
     func quotaWarningFlashActive(provider: UsageProvider, now: Date = Date()) -> Bool {

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -232,7 +232,7 @@ extension StatusItemController {
     }
 
     @discardableResult
-    func applyIcon(phase: Double?) -> Bool { // swiftlint:disable:this function_body_length
+    func applyIcon(phase: Double?) -> Bool {
         guard let button = self.statusItem.button else { return false }
 
         let style = self.store.iconStyle
@@ -269,17 +269,7 @@ extension StatusItemController {
             // In show-used mode, `0` means "unused", not "missing". Keep the weekly lane present.
             weekly = Self.loadingPercentEpsilon
         }
-        let codexProjection = self.store.codexConsumerProjectionIfNeeded(
-            for: primaryProvider,
-            surface: .menuBar,
-            snapshotOverride: snapshot,
-            now: snapshot?.updatedAt ?? Date())
-        var credits: Double? =
-            codexProjection?.menuBarFallback == .creditsBalance
-                ? self.store.codexMenuBarCreditsRemaining(
-                    snapshotOverride: snapshot,
-                    now: snapshot?.updatedAt ?? Date())
-                : nil
+        var credits = self.menuBarCreditsRemainingForIcon(provider: primaryProvider, snapshot: snapshot)
         var stale = self.store.isStale(provider: primaryProvider)
         var morphProgress: Double?
 
@@ -486,17 +476,7 @@ extension StatusItemController {
             // In show-used mode, `0` means "unused", not "missing". Keep the weekly lane present.
             weekly = Self.loadingPercentEpsilon
         }
-        let codexProjection = self.store.codexConsumerProjectionIfNeeded(
-            for: provider,
-            surface: .menuBar,
-            snapshotOverride: snapshot,
-            now: snapshot?.updatedAt ?? Date())
-        var credits: Double? =
-            codexProjection?.menuBarFallback == .creditsBalance
-                ? self.store.codexMenuBarCreditsRemaining(
-                    snapshotOverride: snapshot,
-                    now: snapshot?.updatedAt ?? Date())
-                : nil
+        var credits = self.menuBarCreditsRemainingForIcon(provider: provider, snapshot: snapshot)
         var stale = self.store.isStale(provider: provider)
         var morphProgress: Double?
 
@@ -587,9 +567,25 @@ extension StatusItemController {
         return false
     }
 
-    private static func iconSignatureValue(_ value: Double?) -> String {
+    static func iconSignatureValue(_ value: Double?) -> String {
         guard let value else { return "nil" }
         return String(format: "%.3f", value)
+    }
+
+    func menuBarCreditsRemainingForIcon(provider: UsageProvider, snapshot: UsageSnapshot?) -> Double? {
+        guard provider == .codex,
+              let creditsRemaining = self.store.credits?.remaining,
+              creditsRemaining > 0
+        else {
+            return nil
+        }
+
+        let rateWindows = [snapshot?.primary, snapshot?.secondary].compactMap(\.self)
+        guard rateWindows.isEmpty || rateWindows.contains(where: { $0.remainingPercent <= 0 })
+        else {
+            return nil
+        }
+        return creditsRemaining
     }
 
     func quotaWarningFlashActive(provider: UsageProvider, now: Date = Date()) -> Bool {
@@ -894,7 +890,7 @@ extension StatusItemController {
         self.menuBarMetricWindow(for: provider, snapshot: snapshot)
     }
 
-    private func primaryProviderForUnifiedIcon() -> UsageProvider {
+    func primaryProviderForUnifiedIcon() -> UsageProvider {
         // When "show highest usage" is enabled, auto-select the provider closest to rate limit.
         if self.settings.menuBarShowsHighestUsage,
            self.shouldMergeIcons,
@@ -966,7 +962,7 @@ extension StatusItemController {
         self.tickBlink(now: now)
     }
 
-    private func shouldAnimate(provider: UsageProvider, mergeIcons: Bool? = nil) -> Bool {
+    func shouldAnimate(provider: UsageProvider, mergeIcons: Bool? = nil) -> Bool {
         if self.store.debugForceAnimation { return true }
 
         let isMerged = mergeIcons ?? self.shouldMergeIcons

--- a/Sources/CodexBar/StatusItemController+IconObservation.swift
+++ b/Sources/CodexBar/StatusItemController+IconObservation.swift
@@ -26,7 +26,7 @@ extension StatusItemController {
             "merge=\(mergeIcons ? "1" : "0")",
             "visible=\(visibleProviders)",
             "primary=\(primaryProvider?.rawValue ?? "nil")",
-            "iconStyle=\(String(describing: self.store.iconStyle))",
+            "iconStyle=\(self.store.iconStyle.rawValue)",
             "showUsed=\(self.settings.usageBarsShowUsed ? "1" : "0")",
             "brandPercent=\(showBrandPercent ? "1" : "0")",
             "needsAnimation=\(self.needsMenuBarIconAnimation() ? "1" : "0")",
@@ -48,7 +48,7 @@ extension StatusItemController {
 
         return [
             provider.rawValue,
-            "style=\(String(describing: style))",
+            "style=\(style.rawValue)",
             "primary=\(Self.iconSignatureValue(resolved?.primary))",
             "weekly=\(Self.iconSignatureValue(resolved?.secondary))",
             "credits=\(Self.iconSignatureValue(creditsRemaining))",

--- a/Sources/CodexBar/StatusItemController+IconObservation.swift
+++ b/Sources/CodexBar/StatusItemController+IconObservation.swift
@@ -1,0 +1,70 @@
+import CodexBarCore
+import Foundation
+
+extension StatusItemController {
+    func storeIconObservationSignature() -> String {
+        let showBrandPercent = self.settings.menuBarShowsBrandIconWithPercent
+        let mergeIcons = self.shouldMergeIcons
+        let visibleProviders = self.store.enabledProvidersForDisplay().map(\.rawValue).sorted().joined(separator: ",")
+        let providerSignatures: String
+        let primaryProvider: UsageProvider?
+        if mergeIcons {
+            let primary = self.primaryProviderForUnifiedIcon()
+            primaryProvider = primary
+            providerSignatures = [
+                self.providerStoreIconObservationSignature(for: primary, showBrandPercent: showBrandPercent),
+                "mergedStatus=\(self.mergedIconStatusIndicator().rawValue)",
+            ].joined(separator: "||")
+        } else {
+            primaryProvider = nil
+            providerSignatures = UsageProvider.allCases
+                .filter { self.isVisible($0) }
+                .map { self.providerStoreIconObservationSignature(for: $0, showBrandPercent: showBrandPercent) }
+                .joined(separator: "||")
+        }
+        return [
+            "merge=\(mergeIcons ? "1" : "0")",
+            "visible=\(visibleProviders)",
+            "primary=\(primaryProvider?.rawValue ?? "nil")",
+            "iconStyle=\(String(describing: self.store.iconStyle))",
+            "showUsed=\(self.settings.usageBarsShowUsed ? "1" : "0")",
+            "brandPercent=\(showBrandPercent ? "1" : "0")",
+            "needsAnimation=\(self.needsMenuBarIconAnimation() ? "1" : "0")",
+            providerSignatures,
+        ].joined(separator: "|")
+    }
+
+    private func providerStoreIconObservationSignature(for provider: UsageProvider, showBrandPercent: Bool) -> String {
+        let snapshot = self.store.snapshot(for: provider)
+        let style = self.store.style(for: provider)
+        let resolved = snapshot.map {
+            IconRemainingResolver.resolvedPercents(
+                snapshot: $0,
+                style: style,
+                showUsed: self.settings.usageBarsShowUsed)
+        }
+        let creditsRemaining = self.menuBarCreditsRemainingForIcon(provider: provider, snapshot: snapshot)
+        let displayText = showBrandPercent ? self.menuBarDisplayText(for: provider, snapshot: snapshot) : nil
+
+        return [
+            provider.rawValue,
+            "style=\(String(describing: style))",
+            "primary=\(Self.iconSignatureValue(resolved?.primary))",
+            "weekly=\(Self.iconSignatureValue(resolved?.secondary))",
+            "credits=\(Self.iconSignatureValue(creditsRemaining))",
+            "stale=\(self.store.isStale(provider: provider) ? "1" : "0")",
+            "status=\(self.store.statusIndicator(for: provider).rawValue)",
+            "anim=\(self.shouldAnimate(provider: provider) ? "1" : "0")",
+            "refreshing=\(self.store.refreshingProviders.contains(provider) ? "1" : "0")",
+            "text=\(displayText ?? "nil")",
+        ].joined(separator: "|")
+    }
+
+    private func mergedIconStatusIndicator() -> ProviderStatusIndicator {
+        for provider in self.store.enabledProvidersForDisplay() {
+            let indicator = self.store.statusIndicator(for: provider)
+            if indicator.hasIssue { return indicator }
+        }
+        return .none
+    }
+}

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -467,51 +467,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         }
     }
 
-    func storeIconObservationSignature() -> String {
-        let showBrandPercent = self.settings.menuBarShowsBrandIconWithPercent
-        let mergeIcons = self.shouldMergeIcons
-        let needsAnimation = self.needsMenuBarIconAnimation()
-        let providerSignatures = UsageProvider.allCases.map {
-            self.providerStoreIconObservationSignature(for: $0, showBrandPercent: showBrandPercent)
-        }.joined(separator: "||")
-        let visibleProviders = self.store.enabledProvidersForDisplay().map(\.rawValue).sorted().joined(separator: ",")
-        return [
-            "merge=\(mergeIcons ? "1" : "0")",
-            "visible=\(visibleProviders)",
-            "iconStyle=\(String(describing: self.store.iconStyle))",
-            "brandPercent=\(showBrandPercent ? "1" : "0")",
-            "needsAnimation=\(needsAnimation ? "1" : "0")",
-            providerSignatures,
-        ].joined(separator: "|")
-    }
-
-    private func providerStoreIconObservationSignature(for provider: UsageProvider, showBrandPercent: Bool) -> String {
-        let snapshot = self.store.snapshot(for: provider)
-        let stale = self.store.isStale(provider: provider)
-        let status = self.store.statusIndicator(for: provider).rawValue
-        let isVisibleForAnimation = self.shouldMergeIcons ? self.isEnabled(provider) : self.isVisible(provider)
-        let isAnimating = isVisibleForAnimation && !stale && snapshot == nil
-        let isRefreshingWarpPlaceholder = self.store.refreshingProviders.contains(provider)
-        let creditsRemaining = provider == .codex
-            ? self.store.codexMenuBarCreditsRemaining(
-                snapshotOverride: snapshot,
-                now: snapshot?.updatedAt ?? Date())
-            : nil
-        let displayText = showBrandPercent ? self.menuBarDisplayText(for: provider, snapshot: snapshot) : nil
-
-        return [
-            provider.rawValue,
-            "style=\(String(describing: self.store.style(for: provider)))",
-            "snapshot=\(String(describing: snapshot))",
-            "stale=\(stale ? "1" : "0")",
-            "status=\(status)",
-            "anim=\(isAnimating ? "1" : "0")",
-            "refreshing=\(isRefreshingWarpPlaceholder ? "1" : "0")",
-            "credits=\(String(describing: creditsRemaining))",
-            "text=\(displayText ?? "nil")",
-        ].joined(separator: "|")
-    }
-
     private func observeDebugForceAnimation() {
         withObservationTracking {
             _ = self.store.debugForceAnimation

--- a/Sources/CodexBarCore/Providers/Providers.swift
+++ b/Sources/CodexBarCore/Providers/Providers.swift
@@ -55,7 +55,7 @@ public enum UsageProvider: String, CaseIterable, Sendable, Codable {
 
 // swiftformat:enable sortDeclarations
 
-public enum IconStyle: Sendable, CaseIterable {
+public enum IconStyle: String, Sendable, CaseIterable {
     case codex
     case openai
     case claude

--- a/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
@@ -20,6 +20,9 @@ struct StatusItemIconObservationSignatureTests {
         if let codexMeta = registry.metadata[.codex] {
             settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
         }
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: false)
+        }
 
         let fetcher = UsageFetcher()
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
@@ -56,6 +59,126 @@ struct StatusItemIconObservationSignatureTests {
     }
 
     @Test
+    func `store icon observation signature ignores non visual snapshot churn`() {
+        let (_, store, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-snapshot-metadata")
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let baseline = controller.storeIconObservationSignature()
+
+        store._setSnapshotForTesting(
+            Self.makeSnapshot(
+                provider: .codex,
+                email: "rotated-account@example.com",
+                updatedAt: Date(timeIntervalSince1970: 200)),
+            provider: .codex)
+
+        let signature = controller.storeIconObservationSignature()
+
+        #expect(signature == baseline)
+        #expect(!signature.contains("rotated-account@example.com"))
+    }
+
+    @Test
+    func `merged store icon observation signature ignores non primary snapshot churn`() throws {
+        let (settings, store, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-merged-secondary-snapshot")
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let registry = ProviderRegistry.shared
+        let claudeMetadata = try #require(registry.metadata[.claude])
+        settings.setProviderEnabled(provider: .claude, metadata: claudeMetadata, enabled: true)
+        store._setSnapshotForTesting(
+            Self.makeSnapshot(provider: .claude, email: "claude@example.com"),
+            provider: .claude)
+        let baseline = controller.storeIconObservationSignature()
+
+        store._setSnapshotForTesting(
+            Self.makeSnapshot(
+                provider: .claude,
+                email: "changed@example.com",
+                primaryUsedPercent: 99,
+                secondaryUsedPercent: 88,
+                updatedAt: Date(timeIntervalSince1970: 300)),
+            provider: .claude)
+
+        #expect(controller.storeIconObservationSignature() == baseline)
+    }
+
+    @Test
+    func `store icon observation signature changes when icon percentages change`() {
+        let (_, store, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-percent-change")
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let baseline = controller.storeIconObservationSignature()
+
+        store._setSnapshotForTesting(
+            Self.makeSnapshot(
+                provider: .codex,
+                email: "icon@example.com",
+                primaryUsedPercent: 42,
+                secondaryUsedPercent: 63),
+            provider: .codex)
+
+        #expect(controller.storeIconObservationSignature() != baseline)
+    }
+
+    @Test
+    func `store icon observation signature changes when credit fallback changes`() {
+        let (_, store, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-credit-fallback")
+        defer { controller.releaseStatusItemsForTesting() }
+
+        store._setSnapshotForTesting(
+            Self.makeSnapshot(
+                provider: .codex,
+                email: "icon@example.com",
+                primaryUsedPercent: 100,
+                secondaryUsedPercent: 20),
+            provider: .codex)
+        store.credits = CreditsSnapshot(remaining: 80, events: [], updatedAt: Date(timeIntervalSince1970: 100))
+        let baseline = controller.storeIconObservationSignature()
+
+        store.credits = CreditsSnapshot(remaining: 42, events: [], updatedAt: Date(timeIntervalSince1970: 200))
+
+        #expect(controller.storeIconObservationSignature() != baseline)
+    }
+
+    @Test
+    func `store icon observation signature ignores unused credit balance`() {
+        let (_, store, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-unused-credits")
+        defer { controller.releaseStatusItemsForTesting() }
+
+        store.credits = CreditsSnapshot(remaining: 80, events: [], updatedAt: Date(timeIntervalSince1970: 100))
+        let baseline = controller.storeIconObservationSignature()
+
+        store.credits = CreditsSnapshot(remaining: 42, events: [], updatedAt: Date(timeIntervalSince1970: 200))
+
+        #expect(controller.storeIconObservationSignature() == baseline)
+    }
+
+    @Test
+    func `merged store icon observation signature changes when non primary status changes`() throws {
+        let (settings, store, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-merged-secondary-status")
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let registry = ProviderRegistry.shared
+        let claudeMetadata = try #require(registry.metadata[.claude])
+        settings.setProviderEnabled(provider: .claude, metadata: claudeMetadata, enabled: true)
+        let baseline = controller.storeIconObservationSignature()
+
+        store.statuses[.claude] = ProviderStatus(
+            indicator: .major,
+            description: "Claude status issue",
+            updatedAt: Date(timeIntervalSince1970: 20))
+
+        #expect(controller.storeIconObservationSignature() != baseline)
+    }
+
+    @Test
     func `store icon observation signature changes when status indicator changes`() {
         let (_, store, controller) = self.makeController(
             suiteName: "StatusItemIconObservationSignatureTests-status-indicator")
@@ -75,11 +198,26 @@ struct StatusItemIconObservationSignatureTests {
         #expect(controller.storeIconObservationSignature() != baseline)
     }
 
-    private static func makeSnapshot(provider: UsageProvider, email: String) -> UsageSnapshot {
+    private static func makeSnapshot(
+        provider: UsageProvider,
+        email: String,
+        primaryUsedPercent: Double = 10,
+        secondaryUsedPercent: Double = 20,
+        updatedAt: Date = Date(timeIntervalSince1970: 100))
+        -> UsageSnapshot
+    {
         UsageSnapshot(
-            primary: RateWindow(usedPercent: 10, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
-            secondary: RateWindow(usedPercent: 20, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
-            updatedAt: Date(timeIntervalSince1970: 100),
+            primary: RateWindow(
+                usedPercent: primaryUsedPercent,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: secondaryUsedPercent,
+                windowMinutes: 10080,
+                resetsAt: nil,
+                resetDescription: nil),
+            updatedAt: updatedAt,
             identity: ProviderIdentitySnapshot(
                 providerID: provider,
                 accountEmail: email,

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -734,10 +734,7 @@ extension StatusMenuTests {
         try? await Task.sleep(nanoseconds: 10_000_000)
         controller.deferSwitcherMenuRebuildIfStillVisible(menu, provider: .codex)
 
-        try? await Task.sleep(nanoseconds: 25_000_000)
-        #expect(rebuildCount == 0)
-
-        for _ in 0..<20 where rebuildCount == 0 {
+        for _ in 0..<40 where rebuildCount == 0 {
             await Task.yield()
             try? await Task.sleep(nanoseconds: 5_000_000)
         }


### PR DESCRIPTION
Refs #1274.

## Summary
- Move the menu bar icon observation signature out of the broad status item controller file into `StatusItemController+IconObservation.swift`.
- Remove full `UsageSnapshot` stringification (`String(describing: snapshot)`) from the icon observation signature.
- In Merge Icons mode, sign only the provider actually rendered by the merged icon plus aggregate provider status, instead of every provider snapshot.
- Replace the Codex menu-bar credit projection in the icon render/observation path with a cheap credits/rate-window helper.
- Make `IconStyle` `String`-raw-represented and sign it via `.rawValue`, removing the last `String(describing:)` reflection (`_adHocPrint_unlocked`) from the icon-observation leaf.

## Why
`@giuseppebisemi` sampled the residual lag after #1286 and the hot path was `observeStoreIconChanges -> storeIconObservationSignature -> providerStoreIconObservationSignature`. The old signature subscribed to every provider snapshot and used `String(describing: snapshot)`, so account/email/timestamp and non-rendered provider churn could retrigger icon work even when the visible merged icon would not change.

## Behavior proof
Live runtime proof on the exact reported platform — **macOS 26.5 (build 25F71)**, Apple Swift 6.3.2 — against this branch head.

**1) Signature contract tests (both directions: ignore churn / react to visible change)**

```text
$ sw_vers -productVersion && sw_vers -buildVersion
26.5
25F71
$ xcrun xctest -XCTest CodexBarTests.StatusItemIconObservationSignatureTests ...
✔ store icon observation signature ignores refresh and status metadata churn
✔ store icon observation signature ignores non visual snapshot churn
✔ merged store icon observation signature ignores non primary snapshot churn
✔ store icon observation signature ignores unused credit balance
✔ store icon observation signature changes when icon percentages change
✔ store icon observation signature changes when credit fallback changes
✔ merged store icon observation signature changes when non primary status changes
✔ store icon observation signature changes when status indicator changes
✔ Test run with 8 tests in 1 suite passed after 0.41 seconds.
```

The four `ignores …` tests cover the stale-content risk (non-rendered snapshot / account / timestamp / unused-credit churn no longer moves the signature); the four `changes when …` tests prove visible percent, Codex credits fallback, primary-vs-aggregate status, and status-indicator changes still move it. So the narrowed signature does not suppress required icon refreshes.

**2) Packaged-app main-thread `sample` (Merge Icons on), before vs after the reflection-removal commit**

Sampled `sample <pid>` over the merged status item while driving repeated store refresh churn (open/dismiss the menu).

Before — the icon-observation leaf still bottomed out in reflective string printing:

```text
observeStoreIconChanges()                                           StatusItemController.swift
 └ storeIconObservationSignature()                                  IconObservation.swift:15
    └ providerStoreIconObservationSignature(for:showBrandPercent:)  IconObservation.swift:51
       └ String.init<A>(describing:)            (in libswiftCore.dylib)
          └ _adHocPrint_unlocked<A,B>(...)      (in libswiftCore.dylib)   ← Mirror reflection
             └ swift_getObjectType
```

After — `providerStoreIconObservationSignature` and `_adHocPrint_unlocked` are gone from the path; it now bottoms out at cheap value reads:

```text
storeIconObservationSignature()                  IconObservation.swift:12 / :21 / :7
 ├ primaryProviderForUnifiedIcon()               StatusItemController+Animation.swift:897
 │  └ menuBarMetricWindowForHighestUsage(...)     UsageStore+HighestUsage.swift:29
 │     └ MenuBarMetricWindowResolver.automaticWindow(...)   (cheap credits/rate-window helper)
 └ shouldMergeIcons.getter
```

Whole-sample greps after the fix: `_adHocPrint_unlocked` = 0, `providerStoreIconObservationSignature` = 0 (it was present before). The only residual `swift_getObjectType` frames are in unrelated Foundation `URL` bridging / `__JSONEncoder` code, not the icon path.

Scope / honesty: this is deterministic contract proof plus a packaged-app main-thread sample on macOS 26.5, not a video. It demonstrates the icon-observation signature no longer does full-snapshot or enum reflection on the main thread, and that visible icon updates are preserved. The original field repro is `@giuseppebisemi`'s post-#1286 sample in #1274.

## Notes
This is the icon-observation half of the residual Merge Icons lag (#1286 covered the menu close/rebuild half). It does not change rendered icon output — only what retriggers the icon work.

## Validation
- `swift build`
- `swift build --build-tests`
- `xcrun xctest -XCTest CodexBarTests.StatusItemIconObservationSignatureTests .build/arm64-apple-macosx/debug/CodexBarPackageTests.xctest` (8 Swift Testing tests passed on macOS 26.5)
- `make check` (0 lint violations)
- Packaged-app main-thread `sample` before/after (above)


## Residual merged-menu close freeze → separate next slice (#1274)

This PR is the icon-observation half of the residual Merge Icons lag (#1286 covered the menu close/rebuild half). The remaining menu-rebuild close freeze `@giuseppebisemi` profiled after `254412f0` (#1314) is a **separate slice, not in scope here**, captured for clarity:

```
388  rebuildClosedMenuIfNeeded   (deferred close task)
126    populateMenu
 56    NSHostingView.layout()
```

Root cause (verified in current main): `menuDidClose` only defers the merged menu when it is *already* stale at close time, but `observeStoreChanges` invalidates with `allowStaleContentDuringDataRefresh: true` and still falls through to `prepareAttachedClosedMenusIfNeeded()` — so a merged menu that closed fresh is rebuilt **while closed** on the next background tick.

The fix is self-contained: in merged mode, skip the closed merged-menu rebuild entirely (defer-until-next-open unconditionally in `prepareAttachedClosedMenusIfNeeded`; `menuWillOpen` already repopulates synchronously before display, so no stale flash or width jump). That takes the 388-sample path to 0. It will be its own measured slice on #1274; this PR lands independently of it.
