### PR TITLE
Preserve account reset timestamps

### DIFF
--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -69,6 +69,7 @@ extension UsageStore {
         self.lastFetchAttempts.removeValue(forKey: .codex)
         self.accountSnapshots.removeValue(forKey: .codex)
         self.codexAccountSnapshots = []
+        self.lastKnownResetSnapshots.removeValue(forKey: .codex)
         self.failureGates[.codex]?.reset()
         self.lastKnownSessionRemaining.removeValue(forKey: .codex)
         self.lastKnownSessionWindowSource.removeValue(forKey: .codex)

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -508,6 +508,7 @@ extension UsageStore {
         case let .success(result):
             let scoped = result.usage.scoped(to: .codex)
             let labeled = self.applyCodexVisibleAccountLabel(scoped, account: account)
+                .backfillingResetTimes(from: self.lastKnownResetSnapshots[.codex])
             let snapshot = CodexAccountUsageSnapshot(
                 account: account,
                 snapshot: labeled,

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -560,7 +560,7 @@ extension UsageStore {
         priorSnapshot: CodexAccountUsageSnapshot?) -> UsageSnapshot?
     {
         if let priorSnapshot,
-           priorSnapshot.account.selectionSource == account.selectionSource,
+           Self.codexVisibleAccountsMatchForResetBackfill(priorSnapshot.account, account),
            let snapshot = priorSnapshot.snapshot
         {
             return snapshot
@@ -578,6 +578,19 @@ extension UsageStore {
               cachedSnapshot.accountEmail(for: .codex) == account.email
         else { return nil }
         return cachedSnapshot
+    }
+
+    private static func codexVisibleAccountsMatchForResetBackfill(
+        _ prior: CodexVisibleAccount,
+        _ current: CodexVisibleAccount) -> Bool
+    {
+        prior.id == current.id &&
+            prior.email == current.email &&
+            prior.workspaceAccountID == current.workspaceAccountID &&
+            prior.authFingerprint == current.authFingerprint &&
+            prior.storedAccountID == current.storedAccountID &&
+            prior.selectionSource == current.selectionSource &&
+            prior.isLive == current.isLive
     }
 
     private static func shouldPreserveCodexAccountSnapshotOnFailure(_ message: String) -> Bool {

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -507,8 +507,11 @@ extension UsageStore {
         switch outcome.result {
         case let .success(result):
             let scoped = result.usage.scoped(to: .codex)
+            let cachedSnapshot = self.codexVisibleAccountBackfillSnapshot(
+                for: account,
+                priorSnapshot: priorSnapshot)
             let labeled = self.applyCodexVisibleAccountLabel(scoped, account: account)
-                .backfillingResetTimes(from: self.lastKnownResetSnapshots[.codex])
+                .backfillingCodexWindowMetadata(from: cachedSnapshot)
             let snapshot = CodexAccountUsageSnapshot(
                 account: account,
                 snapshot: labeled,
@@ -552,6 +555,31 @@ extension UsageStore {
         }
     }
 
+    private func codexVisibleAccountBackfillSnapshot(
+        for account: CodexVisibleAccount,
+        priorSnapshot: CodexAccountUsageSnapshot?) -> UsageSnapshot?
+    {
+        if let priorSnapshot,
+           priorSnapshot.account.selectionSource == account.selectionSource,
+           let snapshot = priorSnapshot.snapshot
+        {
+            return snapshot
+        }
+        guard account.isActive else { return nil }
+        let priorSameEmailDifferentSource = self.codexAccountSnapshots.contains {
+            $0.account.email == account.email
+        }
+        guard !priorSameEmailDifferentSource else { return nil }
+        let sameEmailAccountCount = self.settings.codexVisibleAccountProjection.visibleAccounts.count {
+            $0.email == account.email
+        }
+        guard sameEmailAccountCount <= 1 else { return nil }
+        guard let cachedSnapshot = self.lastKnownResetSnapshots[.codex],
+              cachedSnapshot.accountEmail(for: .codex) == account.email
+        else { return nil }
+        return cachedSnapshot
+    }
+
     private static func shouldPreserveCodexAccountSnapshotOnFailure(_ message: String) -> Bool {
         guard CodexAccountHealth.status(forError: message) == .unavailable else { return false }
         let normalized = message.lowercased()
@@ -577,19 +605,18 @@ extension UsageStore {
         switch outcome.result {
         case .success:
             guard let snapshot else { return }
-            let backfilled = snapshot.backfillingResetTimes(from: self.lastKnownResetSnapshots[.codex])
-            self.handleSessionQuotaTransition(provider: .codex, snapshot: backfilled)
-            self.lastKnownResetSnapshots[.codex] = backfilled
-            self.snapshots[.codex] = backfilled
+            self.handleSessionQuotaTransition(provider: .codex, snapshot: snapshot)
+            self.lastKnownResetSnapshots[.codex] = snapshot
+            self.snapshots[.codex] = snapshot
             if let sourceLabel {
                 self.lastSourceLabels[.codex] = sourceLabel
             }
             self.errors[.codex] = nil
             self.failureGates[.codex]?.recordSuccess()
-            self.rememberLiveSystemCodexEmailIfNeeded(backfilled.accountEmail(for: .codex))
-            self.seedCodexAccountScopedRefreshGuard(accountEmail: backfilled.accountEmail(for: .codex))
-            await self.recordPlanUtilizationHistorySample(provider: .codex, snapshot: backfilled)
-            self.recordCodexHistoricalSampleIfNeeded(snapshot: backfilled)
+            self.rememberLiveSystemCodexEmailIfNeeded(snapshot.accountEmail(for: .codex))
+            self.seedCodexAccountScopedRefreshGuard(accountEmail: snapshot.accountEmail(for: .codex))
+            await self.recordPlanUtilizationHistorySample(provider: .codex, snapshot: snapshot)
+            self.recordCodexHistoricalSampleIfNeeded(snapshot: snapshot)
         case let .failure(error):
             guard let message = self.tokenAccountErrorMessage(error) else {
                 self.errors[.codex] = nil

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -37,6 +37,39 @@ public struct RateWindow: Codable, Equatable, Sendable {
             resetDescription: self.resetDescription ?? cached?.resetDescription,
             nextRegenPercent: self.nextRegenPercent)
     }
+
+    public func backfillingCodexWindowMetadata(from cached: RateWindow?, now: Date = .init()) -> RateWindow {
+        guard let cached else { return self }
+        let resolvedWindowMinutes = if let windowMinutes = self.windowMinutes, windowMinutes > 0 {
+            windowMinutes
+        } else {
+            cached.windowMinutes
+        }
+        let resolvedResetsAt = if let resetsAt = self.resetsAt {
+            resetsAt
+        } else if let cachedReset = cached.resetsAt, cachedReset > now {
+            cachedReset
+        } else {
+            self.resetsAt
+        }
+        let cachedResetMatchesResolvedReset = cached.resetsAt != nil &&
+            cached.resetsAt == resolvedResetsAt &&
+            (cached.resetsAt.map { $0 > now } ?? false)
+        let resolvedResetDescription = self.resetDescription ??
+            (cachedResetMatchesResolvedReset ? cached.resetDescription : nil)
+        if resolvedWindowMinutes == self.windowMinutes,
+           resolvedResetsAt == self.resetsAt,
+           resolvedResetDescription == self.resetDescription
+        {
+            return self
+        }
+        return RateWindow(
+            usedPercent: self.usedPercent,
+            windowMinutes: resolvedWindowMinutes,
+            resetsAt: resolvedResetsAt,
+            resetDescription: resolvedResetDescription,
+            nextRegenPercent: self.nextRegenPercent)
+    }
 }
 
 public struct NamedRateWindow: Codable, Equatable, Sendable {
@@ -335,6 +368,7 @@ public struct UsageSnapshot: Codable, Sendable {
             secondary: secondary,
             tertiary: tertiary,
             extraRateWindows: self.extraRateWindows,
+            kiroUsage: self.kiroUsage,
             providerCost: self.providerCost,
             zaiUsage: self.zaiUsage,
             minimaxUsage: self.minimaxUsage,
@@ -347,6 +381,42 @@ public struct UsageSnapshot: Codable, Sendable {
             cursorRequests: self.cursorRequests,
             updatedAt: self.updatedAt,
             identity: self.identity)
+    }
+
+    public func backfillingCodexWindowMetadata(from cached: UsageSnapshot?, now: Date = .init()) -> UsageSnapshot {
+        guard let cached else { return self }
+        guard Self.identitiesMatch(self.identity, cached.identity) else { return self }
+        let primary = self.primary?.backfillingCodexWindowMetadata(from: cached.primary, now: now)
+        let secondary = self.secondary?.backfillingCodexWindowMetadata(from: cached.secondary, now: now) ??
+            Self.codexCachedWindowIfUsable(cached.secondary, now: now)
+        let tertiary = self.tertiary?.backfillingCodexWindowMetadata(from: cached.tertiary, now: now)
+        if primary == self.primary, secondary == self.secondary, tertiary == self.tertiary {
+            return self
+        }
+        return UsageSnapshot(
+            primary: primary,
+            secondary: secondary,
+            tertiary: tertiary,
+            extraRateWindows: self.extraRateWindows,
+            kiroUsage: self.kiroUsage,
+            providerCost: self.providerCost,
+            zaiUsage: self.zaiUsage,
+            minimaxUsage: self.minimaxUsage,
+            deepseekUsage: self.deepseekUsage,
+            openRouterUsage: self.openRouterUsage,
+            openAIAPIUsage: self.openAIAPIUsage,
+            claudeAdminAPIUsage: self.claudeAdminAPIUsage,
+            mistralUsage: self.mistralUsage,
+            deepgramUsage: self.deepgramUsage,
+            cursorRequests: self.cursorRequests,
+            updatedAt: self.updatedAt,
+            identity: self.identity)
+    }
+
+    private static func codexCachedWindowIfUsable(_ window: RateWindow?, now: Date) -> RateWindow? {
+        guard let window, let windowMinutes = window.windowMinutes, windowMinutes > 0 else { return nil }
+        guard let resetsAt = window.resetsAt, resetsAt > now else { return nil }
+        return window
     }
 
     private func orderedPerplexityFallbackWindows() -> [RateWindow] {

--- a/Tests/CodexBarTests/CodexAccountResetBackfillTests.swift
+++ b/Tests/CodexBarTests/CodexAccountResetBackfillTests.swift
@@ -645,6 +645,95 @@ extension CodexAccountScopedRefreshTests {
     }
 
     @Test
+    func `visible account refresh does not backfill same id when stable live identity changes`() async throws {
+        let settings = self.makeSettingsStore(suite: "CodexAccountResetBackfillTests-same-id-live-identity")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "shared@example.com",
+            workspaceLabel: "New Live Workspace",
+            workspaceAccountID: "acct-new",
+            authFingerprint: "new-auth",
+            codexHomePath: "/Users/test/.codex-new",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-new"))
+        settings.codexActiveSource = .liveSystem
+
+        let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-999999999997"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "managed@example.com",
+            managedHomePath: "/tmp/managed-home",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+
+        let projection = settings.codexVisibleAccountProjection
+        let currentLive = try #require(projection.visibleAccounts.first { $0.selectionSource == .liveSystem })
+        #expect(currentLive.id == "shared@example.com")
+        #expect(currentLive.workspaceAccountID == "acct-new")
+        let priorLiveSameID = CodexVisibleAccount(
+            id: currentLive.id,
+            email: "shared@example.com",
+            workspaceLabel: "Old Live Workspace",
+            workspaceAccountID: "acct-old",
+            authFingerprint: "old-auth",
+            storedAccountID: nil,
+            selectionSource: .liveSystem,
+            isActive: true,
+            isLive: true,
+            canReauthenticate: true,
+            canRemove: false)
+        let priorSnapshots = [
+            CodexAccountUsageSnapshot(
+                account: priorLiveSameID,
+                snapshot: self.codexSnapshot(
+                    email: "shared@example.com",
+                    usedPercent: 5,
+                    resetsAt: Date().addingTimeInterval(3600)),
+                error: nil,
+                sourceLabel: "cached"),
+        ]
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: priorSnapshots)
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        store.codexAccountSnapshots = priorSnapshots
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 6,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date(),
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "shared@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Pro")))
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        let liveSnapshot = try #require(snapshotStore.storedSnapshots.first { $0.account.id == currentLive.id })
+        #expect(liveSnapshot.account.workspaceAccountID == "acct-new")
+        #expect(liveSnapshot.snapshot?.primary?.resetsAt == nil)
+        #expect(store.snapshots[.codex]?.primary?.resetsAt == nil)
+    }
+
+    @Test
     func `visible account refresh repairs collapsed codex windows from matching cached account`() async throws {
         let settings = self.makeSettingsStore(suite: "CodexAccountResetBackfillTests-collapsed")
         settings.refreshFrequency = .manual
@@ -733,6 +822,37 @@ extension CodexAccountScopedRefreshTests {
         #expect(liveSnapshot.snapshot?.secondary?.resetDescription == "next week")
         #expect(store.snapshots[.codex]?.primary?.resetsAt == sessionReset)
         #expect(store.snapshots[.codex]?.secondary?.resetsAt == weeklyReset)
+
+        if ProcessInfo.processInfo.environment["CODEXBAR_RESET_BACKFILL_PROOF"] == "1" {
+            let formatter = ISO8601DateFormatter()
+            print("""
+
+            Codex visible-account reset backfill proof
+            path=UsageStore.refreshCodexVisibleAccountsForMenu()
+            account=[redacted-live-account]
+            fresh.primary.usedPercent=1
+            fresh.primary.windowMinutes=0
+            fresh.primary.resetsAt=nil
+            fresh.secondary=nil
+            cached.primary.windowMinutes=300
+            cached.primary.resetsAt=\(formatter.string(from: sessionReset))
+            cached.secondary.windowMinutes=10080
+            cached.secondary.resetsAt=\(formatter.string(from: weeklyReset))
+            stored.primary.usedPercent=\(liveSnapshot.snapshot?.primary?.usedPercent ?? -1)
+            stored.primary.windowMinutes=\(liveSnapshot.snapshot?.primary?.windowMinutes ?? -1)
+            stored.primary.resetsAt=\(liveSnapshot.snapshot?.primary?.resetsAt
+                .map { formatter.string(from: $0) } ?? "nil")
+            stored.secondary.usedPercent=\(liveSnapshot.snapshot?.secondary?.usedPercent ?? -1)
+            stored.secondary.windowMinutes=\(liveSnapshot.snapshot?.secondary?.windowMinutes ?? -1)
+            stored.secondary.resetsAt=\(liveSnapshot.snapshot?.secondary?.resetsAt
+                .map { formatter.string(from: $0) } ?? "nil")
+            selected.primary.resetsAt=\(store.snapshots[.codex]?.primary?.resetsAt
+                .map { formatter.string(from: $0) } ?? "nil")
+            selected.secondary.resetsAt=\(store.snapshots[.codex]?.secondary?.resetsAt
+                .map { formatter.string(from: $0) } ?? "nil")
+            result=PASS cached reset/window metadata preserved when fresh visible-account response omitted it
+            """)
+        }
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexAccountResetBackfillTests.swift
+++ b/Tests/CodexBarTests/CodexAccountResetBackfillTests.swift
@@ -62,4 +62,837 @@ extension CodexAccountScopedRefreshTests {
             .resetsAt == knownReset)
         #expect(managedSnapshot.snapshot?.primary?.resetsAt == nil)
     }
+
+    @Test
+    func `visible account refresh does not backfill active cache from different email`() async throws {
+        let settings = self.makeSettingsStore(suite: "CodexAccountResetBackfillTests-different-email-cache")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+        settings._test_liveSystemCodexAccount = self.liveAccount(email: "new@example.com")
+        settings.codexActiveSource = .liveSystem
+
+        let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-111111111111"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "managed@example.com",
+            managedHomePath: "/tmp/managed-home",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        store.lastKnownResetSnapshots[.codex] = self.codexSnapshot(
+            email: "old@example.com",
+            usedPercent: 5,
+            resetsAt: Date().addingTimeInterval(3600))
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 6,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date(),
+                identity: nil))
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        let liveSnapshot = try #require(snapshotStore.storedSnapshots.first { $0.account.email == "new@example.com" })
+        #expect(liveSnapshot.snapshot?.primary?.resetsAt == nil)
+        #expect(store.snapshots[.codex]?.primary?.resetsAt == nil)
+    }
+
+    @Test
+    func `visible account refresh does not backfill same email sibling account from active cache`() async throws {
+        let settings = self.makeSettingsStore(suite: "CodexAccountResetBackfillTests-same-email")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "shared@example.com",
+            identity: .providerAccount(id: "acct-live"))
+        settings.codexActiveSource = .liveSystem
+
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: managedHome) }
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "shared@example.com",
+            plan: "pro",
+            accountId: "acct-managed")
+
+        let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-333333333333"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "shared@example.com",
+            workspaceLabel: "Managed Workspace",
+            workspaceAccountID: "acct-managed",
+            authFingerprint: "managed-auth",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let otherAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-999999999999"))
+        let otherAccount = ManagedCodexAccount(
+            id: otherAccountID,
+            email: "other@example.com",
+            managedHomePath: "/tmp/other-managed-home",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount, otherAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        let knownReset = Date().addingTimeInterval(3600)
+        store.lastKnownResetSnapshots[.codex] = self.codexSnapshot(
+            email: "shared@example.com",
+            usedPercent: 5,
+            resetsAt: knownReset)
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 6,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: "Resets 4:06 PM"),
+                secondary: nil,
+                updatedAt: Date(),
+                identity: nil))
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        let liveSnapshot = try #require(snapshotStore.storedSnapshots.first { $0.account.isLive })
+        let managedSnapshot = try #require(snapshotStore.storedSnapshots.first {
+            !$0.account.isLive && $0.account.email == "shared@example.com"
+        })
+        #expect(liveSnapshot.account.email == "shared@example.com")
+        #expect(managedSnapshot.account.email == "shared@example.com")
+        #expect(liveSnapshot.snapshot?.primary?.resetsAt == nil)
+        #expect(managedSnapshot.snapshot?.primary?.resetsAt == nil)
+        #expect(store.snapshots[.codex]?.primary?.resetsAt == nil)
+    }
+
+    @Test
+    func `visible account refresh does not backfill newly active same email account from previous active cache`()
+        async throws
+    {
+        let settings = self.makeSettingsStore(suite: "CodexAccountResetBackfillTests-same-email-active-switch")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "shared@example.com",
+            identity: .providerAccount(id: "acct-live"))
+
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: managedHome) }
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "shared@example.com",
+            plan: "pro",
+            accountId: "acct-managed")
+
+        let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-555555555555"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "shared@example.com",
+            workspaceLabel: "Managed Workspace",
+            workspaceAccountID: "acct-managed",
+            authFingerprint: "managed-auth",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let otherAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-777777777777"))
+        let otherAccount = ManagedCodexAccount(
+            id: otherAccountID,
+            email: "other@example.com",
+            managedHomePath: "/tmp/other-managed-home",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount, otherAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: managedAccountID)
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        store.lastKnownResetSnapshots[.codex] = self.codexSnapshot(
+            email: "shared@example.com",
+            usedPercent: 5,
+            resetsAt: Date().addingTimeInterval(3600))
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 6,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: "Resets 4:06 PM"),
+                secondary: nil,
+                updatedAt: Date(),
+                identity: nil))
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        let activeSnapshot = try #require(snapshotStore.storedSnapshots.first { $0.account.isActive })
+        #expect(activeSnapshot.account.email == "shared@example.com")
+        #expect(activeSnapshot.snapshot?.primary?.resetsAt == nil)
+        #expect(store.snapshots[.codex]?.primary?.resetsAt == nil)
+    }
+
+    @Test
+    func `single account refresh clears reset cache after same email source switch`() async throws {
+        let settings = self.makeSettingsStore(suite: "CodexAccountResetBackfillTests-single-source-switch")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .segmented
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "shared@example.com",
+            identity: .providerAccount(id: "acct-live"))
+        settings.codexActiveSource = .liveSystem
+
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: managedHome) }
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "shared@example.com",
+            plan: "pro",
+            accountId: "acct-managed")
+
+        let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-555555555556"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "shared@example.com",
+            workspaceLabel: "Managed Workspace",
+            workspaceAccountID: "acct-managed",
+            authFingerprint: "managed-auth",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        defer {
+            settings._test_activeManagedCodexAccount = nil
+            settings._test_liveSystemCodexAccount = nil
+        }
+        settings._test_activeManagedCodexAccount = managedAccount
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing)
+        store.lastCodexAccountScopedRefreshGuard = store.currentCodexAccountScopedRefreshGuard(
+            preferCurrentSnapshot: false,
+            allowLastKnownLiveFallback: false)
+        store.lastKnownResetSnapshots[.codex] = self.codexSnapshot(
+            email: "shared@example.com",
+            usedPercent: 5,
+            resetsAt: Date().addingTimeInterval(3600))
+        settings.codexActiveSource = .managedAccount(id: managedAccountID)
+        #expect(store.prepareCodexAccountScopedRefreshIfNeeded())
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 6,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date(),
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "shared@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Pro")))
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(store.snapshots[.codex]?.primary?.resetsAt == nil)
+        #expect(store.lastKnownResetSnapshots[.codex]?.primary?.resetsAt == nil)
+    }
+
+    @Test
+    func `visible account refresh does not backfill collapsed same email id from prior sibling`() async throws {
+        let settings = self.makeSettingsStore(suite: "CodexAccountResetBackfillTests-same-email-id-collapse")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: managedHome) }
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "shared@example.com",
+            plan: "pro",
+            accountId: "acct-managed")
+
+        let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-888888888888"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "shared@example.com",
+            workspaceLabel: "Managed Workspace",
+            workspaceAccountID: "acct-managed",
+            authFingerprint: "managed-auth",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let otherAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-666666666666"))
+        let otherAccount = ManagedCodexAccount(
+            id: otherAccountID,
+            email: "other@example.com",
+            managedHomePath: "/tmp/other-managed-home",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount, otherAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: managedAccountID)
+
+        let liveSibling = CodexVisibleAccount(
+            id: "live:acct-live",
+            email: "shared@example.com",
+            workspaceLabel: "Live Workspace",
+            workspaceAccountID: "acct-live",
+            storedAccountID: nil,
+            selectionSource: .liveSystem,
+            isActive: true,
+            isLive: true,
+            canReauthenticate: true,
+            canRemove: false)
+        let priorSnapshots = [
+            CodexAccountUsageSnapshot(
+                account: liveSibling,
+                snapshot: self.codexSnapshot(
+                    email: "shared@example.com",
+                    usedPercent: 5,
+                    resetsAt: Date().addingTimeInterval(3600)),
+                error: nil,
+                sourceLabel: "cached"),
+        ]
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: priorSnapshots)
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        store.codexAccountSnapshots = priorSnapshots
+        store.lastKnownResetSnapshots[.codex] = self.codexSnapshot(
+            email: "shared@example.com",
+            usedPercent: 5,
+            resetsAt: Date().addingTimeInterval(3600))
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 6,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date(),
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "shared@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Pro")))
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        let activeSnapshot = try #require(snapshotStore.storedSnapshots.first { $0.account.isActive })
+        #expect(activeSnapshot.account.id == "shared@example.com")
+        #expect(activeSnapshot.account.selectionSource == .managedAccount(id: managedAccountID))
+        #expect(activeSnapshot.snapshot?.primary?.resetsAt == nil)
+        #expect(store.snapshots[.codex]?.primary?.resetsAt == nil)
+    }
+
+    @Test
+    func `visible account refresh does not backfill reused email id from different source`() async throws {
+        let settings = self.makeSettingsStore(suite: "CodexAccountResetBackfillTests-reused-email-id-source")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: managedHome) }
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "shared@example.com",
+            plan: "pro",
+            accountId: "acct-managed")
+
+        let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-999999999997"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "shared@example.com",
+            workspaceLabel: "Managed Workspace",
+            workspaceAccountID: "acct-managed",
+            authFingerprint: "managed-auth",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let otherAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-999999999996"))
+        let otherAccount = ManagedCodexAccount(
+            id: otherAccountID,
+            email: "other@example.com",
+            managedHomePath: "/tmp/other-managed-home",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount, otherAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: managedAccountID)
+
+        let priorLiveSameID = CodexVisibleAccount(
+            id: "shared@example.com",
+            email: "shared@example.com",
+            workspaceLabel: "Live Workspace",
+            workspaceAccountID: nil,
+            storedAccountID: nil,
+            selectionSource: .liveSystem,
+            isActive: true,
+            isLive: true,
+            canReauthenticate: true,
+            canRemove: false)
+        let priorSnapshots = [
+            CodexAccountUsageSnapshot(
+                account: priorLiveSameID,
+                snapshot: self.codexSnapshot(
+                    email: "shared@example.com",
+                    usedPercent: 5,
+                    resetsAt: Date().addingTimeInterval(3600)),
+                error: nil,
+                sourceLabel: "cached"),
+        ]
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: priorSnapshots)
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        store.codexAccountSnapshots = priorSnapshots
+        store.lastKnownResetSnapshots[.codex] = self.codexSnapshot(
+            email: "shared@example.com",
+            usedPercent: 5,
+            resetsAt: Date().addingTimeInterval(3600))
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 6,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date(),
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "shared@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Pro")))
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        let activeSnapshot = try #require(snapshotStore.storedSnapshots.first { $0.account.isActive })
+        #expect(activeSnapshot.account.id == "shared@example.com")
+        #expect(activeSnapshot.account.selectionSource == .managedAccount(id: managedAccountID))
+        #expect(activeSnapshot.snapshot?.primary?.resetsAt == nil)
+        #expect(store.snapshots[.codex]?.primary?.resetsAt == nil)
+    }
+
+    @Test
+    func `visible account refresh does not backfill changed live id from prior live account`() async throws {
+        let settings = self.makeSettingsStore(suite: "CodexAccountResetBackfillTests-live-id-change")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "shared@example.com",
+            identity: .providerAccount(id: "acct-new"))
+        settings.codexActiveSource = .liveSystem
+
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: managedHome) }
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "shared@example.com",
+            plan: "pro",
+            accountId: "acct-managed")
+
+        let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-999999999998"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "shared@example.com",
+            workspaceLabel: "Managed Workspace",
+            workspaceAccountID: "acct-managed",
+            authFingerprint: "managed-auth",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+
+        let projection = settings.codexVisibleAccountProjection
+        let currentLive = try #require(projection.visibleAccounts.first { $0.selectionSource == .liveSystem })
+        #expect(currentLive.id == "live:provider:acct-new")
+        let priorLive = CodexVisibleAccount(
+            id: "live:provider:acct-old",
+            email: "shared@example.com",
+            workspaceLabel: "Old Live Workspace",
+            workspaceAccountID: "acct-old",
+            storedAccountID: nil,
+            selectionSource: .liveSystem,
+            isActive: true,
+            isLive: true,
+            canReauthenticate: true,
+            canRemove: false)
+        let priorSnapshots = [
+            CodexAccountUsageSnapshot(
+                account: priorLive,
+                snapshot: self.codexSnapshot(
+                    email: "shared@example.com",
+                    usedPercent: 5,
+                    resetsAt: Date().addingTimeInterval(3600)),
+                error: nil,
+                sourceLabel: "cached"),
+        ]
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: priorSnapshots)
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        store.codexAccountSnapshots = priorSnapshots
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 6,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date(),
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "shared@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Pro")))
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        let liveSnapshot = try #require(snapshotStore.storedSnapshots.first { $0.account.id == currentLive.id })
+        #expect(liveSnapshot.snapshot?.primary?.resetsAt == nil)
+        #expect(store.snapshots[.codex]?.primary?.resetsAt == nil)
+    }
+
+    @Test
+    func `visible account refresh repairs collapsed codex windows from matching cached account`() async throws {
+        let settings = self.makeSettingsStore(suite: "CodexAccountResetBackfillTests-collapsed")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+        settings._test_liveSystemCodexAccount = self.liveAccount(email: "live@example.com")
+        settings.codexActiveSource = .liveSystem
+
+        let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-444444444444"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "managed@example.com",
+            managedHomePath: "/tmp/managed-home",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+
+        let projection = settings.codexVisibleAccountProjection
+        let liveAccount = try #require(projection.visibleAccounts.first { $0.email == "live@example.com" })
+        let sessionReset = Date().addingTimeInterval(3600)
+        let weeklyReset = Date().addingTimeInterval(7 * 24 * 3600)
+        let cachedSnapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 1,
+                windowMinutes: 300,
+                resetsAt: sessionReset,
+                resetDescription: "4:06 PM"),
+            secondary: RateWindow(
+                usedPercent: 7,
+                windowMinutes: 10080,
+                resetsAt: weeklyReset,
+                resetDescription: "next week"),
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "live@example.com",
+                accountOrganization: nil,
+                loginMethod: "Pro"))
+        let priorSnapshots = [
+            CodexAccountUsageSnapshot(
+                account: liveAccount,
+                snapshot: cachedSnapshot,
+                error: nil,
+                sourceLabel: "cached"),
+        ]
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: priorSnapshots)
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        store.codexAccountSnapshots = priorSnapshots
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 1,
+                    windowMinutes: 0,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date(),
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "live@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Pro")))
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        let liveSnapshot = try #require(snapshotStore.storedSnapshots.first { $0.account.id == liveAccount.id })
+        #expect(liveSnapshot.snapshot?.primary?.usedPercent == 1)
+        #expect(liveSnapshot.snapshot?.primary?.windowMinutes == 300)
+        #expect(liveSnapshot.snapshot?.primary?.resetsAt == sessionReset)
+        #expect(liveSnapshot.snapshot?.primary?.resetDescription == "4:06 PM")
+        #expect(liveSnapshot.snapshot?.secondary?.usedPercent == 7)
+        #expect(liveSnapshot.snapshot?.secondary?.windowMinutes == 10080)
+        #expect(liveSnapshot.snapshot?.secondary?.resetsAt == weeklyReset)
+        #expect(liveSnapshot.snapshot?.secondary?.resetDescription == "next week")
+        #expect(store.snapshots[.codex]?.primary?.resetsAt == sessionReset)
+        #expect(store.snapshots[.codex]?.secondary?.resetsAt == weeklyReset)
+    }
+
+    @Test
+    func `visible account refresh does not promote undated cached secondary window`() async throws {
+        let settings = self.makeSettingsStore(suite: "CodexAccountResetBackfillTests-undated-secondary")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+        settings._test_liveSystemCodexAccount = self.liveAccount(email: "live@example.com")
+        settings.codexActiveSource = .liveSystem
+
+        let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-666666666666"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "managed@example.com",
+            managedHomePath: "/tmp/managed-home",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+
+        let projection = settings.codexVisibleAccountProjection
+        let liveAccount = try #require(projection.visibleAccounts.first { $0.email == "live@example.com" })
+        let cachedSnapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 1,
+                windowMinutes: 300,
+                resetsAt: Date().addingTimeInterval(3600),
+                resetDescription: "4:06 PM"),
+            secondary: RateWindow(
+                usedPercent: 7,
+                windowMinutes: 10080,
+                resetsAt: nil,
+                resetDescription: "next week"),
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "live@example.com",
+                accountOrganization: nil,
+                loginMethod: "Pro"))
+        let priorSnapshots = [
+            CodexAccountUsageSnapshot(
+                account: liveAccount,
+                snapshot: cachedSnapshot,
+                error: nil,
+                sourceLabel: "cached"),
+        ]
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: priorSnapshots)
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        store.codexAccountSnapshots = priorSnapshots
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 1,
+                    windowMinutes: 0,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date(),
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "live@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Pro")))
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        let liveSnapshot = try #require(snapshotStore.storedSnapshots.first { $0.account.id == liveAccount.id })
+        #expect(liveSnapshot.snapshot?.primary?.windowMinutes == 300)
+        #expect(liveSnapshot.snapshot?.secondary == nil)
+    }
+
+    @Test
+    func `visible account refresh does not backfill expired cached reset descriptions`() async throws {
+        let settings = self.makeSettingsStore(suite: "CodexAccountResetBackfillTests-expired-reset-text")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+        settings._test_liveSystemCodexAccount = self.liveAccount(email: "live@example.com")
+        settings.codexActiveSource = .liveSystem
+
+        let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-777777777777"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "managed@example.com",
+            managedHomePath: "/tmp/managed-home",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+
+        let projection = settings.codexVisibleAccountProjection
+        let liveAccount = try #require(projection.visibleAccounts.first { $0.email == "live@example.com" })
+        let cachedSnapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 1,
+                windowMinutes: 300,
+                resetsAt: Date().addingTimeInterval(-3600),
+                resetDescription: "Resets in stale cached text"),
+            secondary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "live@example.com",
+                accountOrganization: nil,
+                loginMethod: "Pro"))
+        let priorSnapshots = [
+            CodexAccountUsageSnapshot(
+                account: liveAccount,
+                snapshot: cachedSnapshot,
+                error: nil,
+                sourceLabel: "cached"),
+        ]
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: priorSnapshots)
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        store.codexAccountSnapshots = priorSnapshots
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 1,
+                    windowMinutes: 0,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date(),
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "live@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Pro")))
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        let liveSnapshot = try #require(snapshotStore.storedSnapshots.first { $0.account.id == liveAccount.id })
+        #expect(liveSnapshot.snapshot?.primary?.windowMinutes == 300)
+        #expect(liveSnapshot.snapshot?.primary?.resetsAt == nil)
+        #expect(liveSnapshot.snapshot?.primary?.resetDescription == nil)
+        #expect(store.snapshots[.codex]?.primary?.resetsAt == nil)
+        #expect(store.snapshots[.codex]?.primary?.resetDescription == nil)
+    }
 }

--- a/Tests/CodexBarTests/CodexAccountResetBackfillTests.swift
+++ b/Tests/CodexBarTests/CodexAccountResetBackfillTests.swift
@@ -1,0 +1,65 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+extension CodexAccountScopedRefreshTests {
+    @Test
+    func `visible account refresh backfills known reset time before storing snapshots`() async throws {
+        let settings = self.makeSettingsStore(suite: "CodexAccountResetBackfillTests-backfill")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+        settings._test_liveSystemCodexAccount = self.liveAccount(email: "live@example.com")
+        settings.codexActiveSource = .liveSystem
+
+        let managedAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-222222222222"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "managed@example.com",
+            managedHomePath: "/tmp/managed-home",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        let knownReset = Date().addingTimeInterval(3600)
+        store.lastKnownResetSnapshots[.codex] = self.codexSnapshot(
+            email: "live@example.com",
+            usedPercent: 5,
+            resetsAt: knownReset)
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 6,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: "Resets 4:06 PM"),
+                secondary: nil,
+                updatedAt: Date(),
+                identity: nil))
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        let liveSnapshot = try #require(snapshotStore.storedSnapshots.first { $0.account.email == "live@example.com" })
+        let managedSnapshot = try #require(snapshotStore.storedSnapshots
+            .first { $0.account.email == "managed@example.com" })
+        #expect(liveSnapshot.snapshot?.primary?.resetsAt == knownReset)
+        #expect(store.codexAccountSnapshots.first { $0.account.email == "live@example.com" }?.snapshot?.primary?
+            .resetsAt == knownReset)
+        #expect(managedSnapshot.snapshot?.primary?.resetsAt == nil)
+    }
+}

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshTestSupport.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshTestSupport.swift
@@ -84,9 +84,13 @@ extension CodexAccountScopedRefreshTests {
             identity: identity)
     }
 
-    func codexSnapshot(email: String, usedPercent: Double) -> UsageSnapshot {
+    func codexSnapshot(email: String, usedPercent: Double, resetsAt: Date? = nil) -> UsageSnapshot {
         UsageSnapshot(
-            primary: RateWindow(usedPercent: usedPercent, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            primary: RateWindow(
+                usedPercent: usedPercent,
+                windowMinutes: 300,
+                resetsAt: resetsAt,
+                resetDescription: nil),
             secondary: nil,
             updatedAt: Date(),
             identity: ProviderIdentitySnapshot(

--- a/Tests/CodexBarTests/ResetTimeBackfillTests.swift
+++ b/Tests/CodexBarTests/ResetTimeBackfillTests.swift
@@ -44,6 +44,27 @@ final class ResetTimeBackfillTests: XCTestCase {
         XCTAssertNil(result.resetDescription)
     }
 
+    func test_codexWindowMetadataDoesNotCopyCachedDescriptionForDifferentFreshReset() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let cachedReset = now.addingTimeInterval(3600)
+        let freshReset = now.addingTimeInterval(7200)
+        let cached = RateWindow(
+            usedPercent: 50,
+            windowMinutes: 300,
+            resetsAt: cachedReset,
+            resetDescription: "Resets in 1h")
+        let fresh = RateWindow(
+            usedPercent: 62,
+            windowMinutes: 300,
+            resetsAt: freshReset,
+            resetDescription: nil)
+
+        let result = fresh.backfillingCodexWindowMetadata(from: cached, now: now)
+
+        XCTAssertEqual(result.resetsAt, freshReset)
+        XCTAssertNil(result.resetDescription)
+    }
+
     func test_snapshotBackfillPreservesCurrentSnapshotFields() {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let reset = now.addingTimeInterval(3600)


### PR DESCRIPTION
Fixes #1283

## Summary
- Backfill missing Codex reset/window metadata before persisting visible per-account usage snapshots.
- Scope cached reset metadata to the same visible account identity so same-email siblings, source switches, reused visible IDs, and stable identity changes do not inherit stale reset times.
- Add regressions for stacked visible accounts, the single-card account-switch path, stale reset descriptions, and same-ID live account identity changes.

## Root cause
The selected/global refresh path already retained missing reset timestamps from the last known snapshot before updating state. The per-account visible refresh path labeled the account snapshot and stored it immediately, so a fresh response that omitted `resetsAt` or `windowMinutes` could persist without the known 5-hour and weekly window metadata.

The original repair also needed stricter identity checks. A prior visible-account snapshot could be reused when only `selectionSource` matched; that left a stale-window risk when an email-based visible ID stayed the same while the underlying live account identity changed.

## Fix
- `codexVisibleAccountBackfillSnapshot` now reuses a prior visible-account snapshot only when the prior/current `CodexVisibleAccount` match on visible ID, email, workspace account ID, auth fingerprint, stored account ID, selection source, and live/managed shape.
- The active global fallback remains constrained to the active account, a single visible account for that email, no prior same-email visible snapshot, and a cached snapshot with the same Codex email.
- The selected/main snapshot uses the scoped repaired result instead of reapplying the unscoped global fallback.

## Real Proof
PR: https://github.com/steipete/CodexBar/pull/1298

Command run after the identity-guard fix:

```sh
CODEXBAR_RESET_BACKFILL_PROOF=1 swift test --filter "visible account refresh repairs collapsed codex windows from matching cached account"
```

Redacted terminal excerpt from that command:

```text
Codex visible-account reset backfill proof
path=UsageStore.refreshCodexVisibleAccountsForMenu()
account=[redacted-live-account]
fresh.primary.usedPercent=1
fresh.primary.windowMinutes=0
fresh.primary.resetsAt=nil
fresh.secondary=nil
cached.primary.windowMinutes=300
cached.primary.resetsAt=2026-06-04T09:59:00Z
cached.secondary.windowMinutes=10080
cached.secondary.resetsAt=2026-06-11T08:59:00Z
stored.primary.usedPercent=1.0
stored.primary.windowMinutes=300
stored.primary.resetsAt=2026-06-04T09:59:00Z
stored.secondary.usedPercent=7.0
stored.secondary.windowMinutes=10080
stored.secondary.resetsAt=2026-06-11T08:59:00Z
selected.primary.resetsAt=2026-06-04T09:59:00Z
selected.secondary.resetsAt=2026-06-11T08:59:00Z
result=PASS cached reset/window metadata preserved when fresh visible-account response omitted it
✔ Test "visible account refresh repairs collapsed codex windows from matching cached account" passed
```

What that proves:
- The affected visible-account refresh path is `UsageStore.refreshCodexVisibleAccountsForMenu()`.
- The fresh provider response intentionally omitted reset metadata: primary reset `nil`, primary window `0`, secondary `nil`.
- The cached same-account snapshot had a 300-minute session reset and a 10080-minute weekly reset.
- After the fix, the stored per-account snapshot and selected/main snapshot preserved the cached reset/window metadata while keeping the fresh primary usage percent.

Identity-guard negative proof:
- Added a regression where prior and current live accounts share the same email-based visible ID and `.liveSystem` source, but differ by workspace account ID/auth fingerprint.
- The fresh omitted-reset response remains `primary.resetsAt == nil` instead of copying the stale prior reset.

Earlier provider proof feasibility: local CLI was installed and authenticated. A redacted live `--all-accounts` refresh returned reset metadata through the installed account path:

```json
{
  "source": "codex-cli",
  "usage": {
    "accountEmail": "[redacted-email]",
    "primary": {
      "resetsAt": "2026-06-04T08:32:42Z",
      "usedPercent": 43,
      "windowMinutes": 300
    },
    "secondary": {
      "resetsAt": "2026-06-11T03:32:42Z",
      "usedPercent": 7,
      "windowMinutes": 10080
    }
  }
}
```

## Checks
- `CODEXBAR_RESET_BACKFILL_PROOF=1 swift test --filter "visible account refresh repairs collapsed codex windows from matching cached account"` passed and printed the redacted omitted-reset proof above.
- `swift test --filter CodexAccountResetBackfill` passed: 12 tests.
- `swift test --filter ResetTimeBackfillTests` passed: 5 tests.
- `swift test --filter UsageStorePlanUtilizationCodexOwnershipTests` passed: 12 tests.
- `swift build` passed.
- `make check` passed: SwiftFormat reported 0/1001 files needing formatting; SwiftLint reported 0 violations in 1000 files.

I also ran the full `swift test` earlier; it hit one unrelated timing failure in `CodexBackgroundRefreshCoalescingTests.swift:43` (`rapid regular refreshes coalesce concurrent Codex credits fetches`). The focused touched-area suites above pass consistently.

Remaining risk: proof is bounded to deterministic UsageStore/RateWindow behavior plus a redacted local CLI feasibility sample; no live credentials or provider transcripts are included.
