### PR TITLE
Repair hidden status item defaults repeatedly

### DIFF
--- a/Sources/CodexBar/MenuBarStatusItemDefaultsRepair.swift
+++ b/Sources/CodexBar/MenuBarStatusItemDefaultsRepair.swift
@@ -6,8 +6,6 @@ enum MenuBarStatusItemDefaultsRepair {
     private static let legacyAutosavePrefix = "codexbar-"
 
     static func repairHiddenVisibilityDefaultsIfNeeded(defaults: UserDefaults) -> [String] {
-        guard !defaults.bool(forKey: self.didRepairKey) else { return [] }
-
         let repairedKeys = defaults.dictionaryRepresentation().keys
             .filter { key in
                 self.shouldRepair(key: key, value: defaults.object(forKey: key))
@@ -17,7 +15,9 @@ enum MenuBarStatusItemDefaultsRepair {
         for key in repairedKeys {
             defaults.removeObject(forKey: key)
         }
-        defaults.set(true, forKey: self.didRepairKey)
+        if !defaults.bool(forKey: self.didRepairKey) {
+            defaults.set(true, forKey: self.didRepairKey)
+        }
         return repairedKeys
     }
 

--- a/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerSplitLifecycleTests.swift
@@ -329,15 +329,13 @@ struct StatusItemControllerSplitLifecycleTests {
     }
 
     @Test
-    func `status item defaults repair removes stale hidden Control Center keys once`() throws {
-        let suite = "StatusItemControllerSplitLifecycleTests-repair-\(UUID().uuidString)"
+    func `status item defaults repair removes stale hidden Control Center keys repeatedly`() throws {
+        let suite = "StatusItemControllerSplitLifecycleTests-repair-repeated-\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
         defaults.set(false, forKey: "NSStatusItem VisibleCC Item-0")
         defaults.set(0, forKey: "NSStatusItem VisibleCC Item-12")
         defaults.set(false, forKey: "NSStatusItem VisibleCC codexbar-merged")
-        defaults.set(true, forKey: "NSStatusItem VisibleCC Item-1")
-        defaults.set(false, forKey: "NSStatusItem VisibleCC com.apple.clock")
         defer {
             defaults.removePersistentDomain(forName: suite)
         }
@@ -352,12 +350,53 @@ struct StatusItemControllerSplitLifecycleTests {
         #expect(defaults.object(forKey: "NSStatusItem VisibleCC Item-0") == nil)
         #expect(defaults.object(forKey: "NSStatusItem VisibleCC Item-12") == nil)
         #expect(defaults.object(forKey: "NSStatusItem VisibleCC codexbar-merged") == nil)
-        #expect(defaults.bool(forKey: "NSStatusItem VisibleCC Item-1"))
-        #expect(defaults.object(forKey: "NSStatusItem VisibleCC com.apple.clock") != nil)
+        #expect(defaults.bool(forKey: MenuBarStatusItemDefaultsRepair.didRepairKey))
 
         defaults.set(false, forKey: "NSStatusItem VisibleCC Item-2")
+        defaults.set(false, forKey: "NSStatusItem VisibleCC codexbar-codex")
+
+        #expect(MenuBarStatusItemDefaultsRepair.repairHiddenVisibilityDefaultsIfNeeded(defaults: defaults) == [
+            "NSStatusItem VisibleCC Item-2",
+            "NSStatusItem VisibleCC codexbar-codex",
+        ])
+        #expect(defaults.object(forKey: "NSStatusItem VisibleCC Item-2") == nil)
+        #expect(defaults.object(forKey: "NSStatusItem VisibleCC codexbar-codex") == nil)
+    }
+
+    @Test
+    func `status item defaults repair preserves true CodexBar keys`() throws {
+        let suite = "StatusItemControllerSplitLifecycleTests-repair-true-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set(true, forKey: "NSStatusItem VisibleCC Item-1")
+        defaults.set(1, forKey: "NSStatusItem VisibleCC codexbar-codex")
+        defer {
+            defaults.removePersistentDomain(forName: suite)
+        }
+
         #expect(MenuBarStatusItemDefaultsRepair.repairHiddenVisibilityDefaultsIfNeeded(defaults: defaults).isEmpty)
-        #expect(defaults.object(forKey: "NSStatusItem VisibleCC Item-2") != nil)
+        #expect(defaults.bool(forKey: "NSStatusItem VisibleCC Item-1"))
+        #expect(defaults.bool(forKey: "NSStatusItem VisibleCC codexbar-codex"))
+    }
+
+    @Test
+    func `status item defaults repair preserves unrelated hidden keys`() throws {
+        let suite = "StatusItemControllerSplitLifecycleTests-repair-unrelated-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set(false, forKey: "NSStatusItem VisibleCC com.apple.clock")
+        defaults.set(false, forKey: "NSStatusItem VisibleCC OtherApp")
+        defaults.set(false, forKey: "NSStatusItem VisibleCC codexbuddy")
+        defaults.set(false, forKey: "NSStatusItem VisibleCC Item-X")
+        defer {
+            defaults.removePersistentDomain(forName: suite)
+        }
+
+        #expect(MenuBarStatusItemDefaultsRepair.repairHiddenVisibilityDefaultsIfNeeded(defaults: defaults).isEmpty)
+        #expect(defaults.object(forKey: "NSStatusItem VisibleCC com.apple.clock") != nil)
+        #expect(defaults.object(forKey: "NSStatusItem VisibleCC OtherApp") != nil)
+        #expect(defaults.object(forKey: "NSStatusItem VisibleCC codexbuddy") != nil)
+        #expect(defaults.object(forKey: "NSStatusItem VisibleCC Item-X") != nil)
     }
 
     @Test


### PR DESCRIPTION
## Why?

CodexBar randomly disappearing after updates, external screen disconnections, or when interacting with Bartender, is a major pain. Restarting the app would be a logical recovery method, but it currently doesn't work b/c the repair doesn't happen on repair. This PR fixes it.

## Summary
- remove the one-shot gate from hidden macOS status-item visibility defaults repair
- keep the existing repair marker as historical state, but continue scanning current defaults on each startup
- preserve the CodexBar-owned key filter so unrelated apps' `NSStatusItem VisibleCC ...` keys and true values are left intact

## Related
- #1109
- #1169
- #861

## Tests
- `swift test --filter StatusItemControllerSplitLifecycleTests`
