### PR TITLE
feat: show Xiaomi MiMo balance breakdown and token usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.1 — Unreleased
 
+- Xiaomi MiMo: show paid and granted balance components alongside token-plan usage without requiring a duplicate provider (#1309). Thanks @AdrianSimionov!
 - Settings: keep the native tab toolbar in sync when macOS switches appearance while the window is open (#1484). Thanks @hhh2210!
 - Menu bar: avoid starting a duplicate background provider refresh when the menu closes while its initial missing-data refresh is still in flight.
 - Menu bar: rebuild merged provider content inside AppKit's active tracking run loop so provider switches no longer wait for the menu to close or the default run loop to resume.

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -45,6 +45,28 @@ extension UsageMenuCardView.Model {
         return Color(red: color.red, green: color.green, blue: color.blue)
     }
 
+    static func rateWindowLabels(
+        input: Input,
+        snapshot: UsageSnapshot) -> (primary: String, secondary: String, tertiary: String, showsTertiary: Bool)
+    {
+        if input.provider == .factory, snapshot.tertiary != nil {
+            return ("5-hour", L("Weekly"), L("Monthly"), true)
+        }
+        // Legacy request-based Cursor plans track a request quota, not the token-based "Total" pool.
+        let primaryLabel = if input.provider == .cursor, snapshot.cursorRequests != nil {
+            "Requests"
+        } else if input.provider == .grok {
+            GrokProviderDescriptor.primaryLabel(window: snapshot.primary) ?? input.metadata.sessionLabel
+        } else {
+            input.metadata.sessionLabel
+        }
+        return (
+            L(primaryLabel),
+            L(input.metadata.weeklyLabel),
+            input.metadata.opusLabel.map(L) ?? L("Sonnet"),
+            input.metadata.supportsOpus)
+    }
+
     static func resetText(
         for window: RateWindow,
         style: ResetTimeDisplayStyle,

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1217,6 +1217,20 @@ extension UsageMenuCardView.Model {
                 title: labels.secondary,
                 zaiTimeDetail: zaiTimeDetail))
         }
+        if input.provider == .mimo, let mimoUsage = snapshot.mimoUsage {
+            metrics.append(Metric(
+                id: "mimo-balance",
+                title: L("Balance"),
+                percent: 0,
+                percentStyle: percentStyle,
+                statusText: mimoUsage.balanceDetail,
+                resetText: nil,
+                detailText: nil,
+                detailLeftText: nil,
+                detailRightText: nil,
+                pacePercent: nil,
+                paceOnTop: true))
+        }
         if labels.showsTertiary, let opus = snapshot.tertiary {
             var tertiaryDetailText: String?
             if input.provider == .alibaba || input.provider == .alibabatokenplan,
@@ -1286,30 +1300,6 @@ extension UsageMenuCardView.Model {
                 paceOnTop: true))
         }
         return metrics
-    }
-
-    private static func rateWindowLabels(
-        input: Input,
-        snapshot: UsageSnapshot) -> (primary: String, secondary: String, tertiary: String, showsTertiary: Bool)
-    {
-        if input.provider == .factory, snapshot.tertiary != nil {
-            return ("5-hour", L("Weekly"), L("Monthly"), true)
-        }
-        // Legacy request-based Cursor plans track a request quota, not the token-based "Total" pool —
-        // relabel the primary bar so it reads as a request count instead of a dollar percentage.
-        let primaryLabel = if input.provider == .cursor, snapshot.cursorRequests != nil {
-            "Requests"
-        } else if input.provider == .grok {
-            GrokProviderDescriptor.primaryLabel(window: snapshot.primary) ?? input.metadata
-                .sessionLabel
-        } else {
-            input.metadata.sessionLabel
-        }
-        return (
-            L(primaryLabel),
-            L(input.metadata.weeklyLabel),
-            input.metadata.opusLabel.map(L) ?? L("Sonnet"),
-            input.metadata.supportsOpus)
     }
 
     private static func primaryMetric(
@@ -1547,6 +1537,7 @@ extension UsageMenuCardView.Model {
             title: title ?? L(input.metadata.weeklyLabel),
             percent: Self.clamped(input.usageBarsShowUsed ? weekly.usedPercent : weekly.remainingPercent),
             percentStyle: percentStyle,
+            statusText: nil,
             resetText: weeklyResetText,
             detailText: weeklyDetailText,
             detailLeftText: paceDetail?.leftLabel,

--- a/Sources/CodexBar/MenuDescriptor.swift
+++ b/Sources/CodexBar/MenuDescriptor.swift
@@ -150,10 +150,10 @@ struct MenuDescriptor {
             let resetStyle = settings.resetTimeDisplayStyle
             let labels = Self.rateWindowLabels(provider: provider, metadata: meta, snapshot: snap)
             if let primary = snap.primary {
-                let primaryWindow = if provider == .warp || provider == .kilo || provider == .mimo || provider ==
-                    .abacus ||
-                    provider == .deepseek || provider == .azureopenai
-                {
+                let primaryDetail = primary.resetDescription?.trimmingCharacters(in: .whitespacesAndNewlines)
+                let primaryDescriptionIsDetail = provider == .warp || provider == .kilo || provider == .abacus ||
+                    provider == .deepseek || provider == .azureopenai || provider == .mimo
+                let primaryWindow = if primaryDescriptionIsDetail {
                     // Some providers use resetDescription for non-reset detail
                     // (e.g., "Unlimited", "X/Y credits"). Avoid rendering it as a "Resets ..." line.
                     RateWindow(
@@ -170,12 +170,11 @@ struct MenuDescriptor {
                     window: primaryWindow,
                     resetStyle: resetStyle,
                     showUsed: settings.usageBarsShowUsed)
-                if provider == .warp || provider == .kilo || provider == .mimo || provider == .abacus || provider ==
-                    .deepseek || provider == .azureopenai,
-                    let detail = primary.resetDescription?.trimmingCharacters(in: .whitespacesAndNewlines),
-                    !detail.isEmpty
+                if primaryDescriptionIsDetail,
+                   let primaryDetail,
+                   !primaryDetail.isEmpty
                 {
-                    entries.append(.text(detail, .secondary))
+                    entries.append(.text(primaryDetail, .secondary))
                 }
                 if provider == .crof,
                    primary.resetsAt != nil,
@@ -277,6 +276,9 @@ struct MenuDescriptor {
         }
         if let mistralUsage = snapshot.mistralUsage, !mistralUsage.daily.isEmpty {
             Self.appendMistralUsageSummary(entries: &entries, usage: mistralUsage)
+        }
+        if let mimoUsage = snapshot.mimoUsage {
+            entries.append(.text("\(L("Balance")): \(mimoUsage.balanceDetail)", .primary))
         }
     }
 

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -95,6 +95,9 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
                 return (label: L("Balance"), value: trimmedValue)
             }
         }
+        if provider == .mimo {
+            return (label: L("Plan"), value: rawPlan)
+        }
         return (label: L("Balance"), value: rawPlan)
     }
 

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -526,6 +526,20 @@ struct ProvidersPane: View {
             options = [
                 ProviderSettingsPickerOption(id: MenuBarMetricPreference.automatic.rawValue, title: L("Automatic")),
             ]
+        } else if provider == .mimo {
+            let snapshot = self.store.snapshot(for: provider)
+            var metricOptions = [
+                ProviderSettingsPickerOption(id: MenuBarMetricPreference.automatic.rawValue, title: L("automatic")),
+            ]
+            if snapshot?.primary != nil, snapshot?.mimoUsage != nil {
+                metricOptions.append(ProviderSettingsPickerOption(
+                    id: MenuBarMetricPreference.primary.rawValue,
+                    title: String(format: L("metric_primary"), L("Credits"))))
+                metricOptions.append(ProviderSettingsPickerOption(
+                    id: MenuBarMetricPreference.secondary.rawValue,
+                    title: String(format: L("metric_secondary"), L("Balance"))))
+            }
+            options = metricOptions
         } else if provider == .abacus {
             let metadata = self.store.metadata(for: provider)
             options = [

--- a/Sources/CodexBar/SessionQuotaNotifications.swift
+++ b/Sources/CodexBar/SessionQuotaNotifications.swift
@@ -129,6 +129,28 @@ enum QuotaWarningNotificationLogic {
 }
 
 @MainActor
+extension UsageStore {
+    func sessionQuotaWindow(
+        provider: UsageProvider,
+        snapshot: UsageSnapshot) -> (window: RateWindow, source: SessionQuotaWindowSource)?
+    {
+        guard provider != .mimo else { return nil }
+        if let primary = snapshot.primary, Self.isSessionWindow(primary) {
+            return (primary, .primary)
+        }
+        if provider == .copilot, let secondary = snapshot.secondary {
+            return (secondary, .copilotSecondaryFallback)
+        }
+        return nil
+    }
+
+    private static func isSessionWindow(_ window: RateWindow) -> Bool {
+        guard let minutes = window.windowMinutes else { return true }
+        return minutes <= 6 * 60
+    }
+}
+
+@MainActor
 protocol SessionQuotaNotifying: AnyObject {
     func post(transition: SessionQuotaTransition, provider: UsageProvider, badge: NSNumber?)
     func postQuotaWarning(event: QuotaWarningEvent, provider: UsageProvider, soundEnabled: Bool)

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -705,6 +705,13 @@ extension StatusItemController {
         {
             return balance
         }
+        if provider == .mimo,
+           let balance = Self.miMoBalanceDisplayText(
+               snapshot: snapshot,
+               preference: self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot))
+        {
+            return balance
+        }
         if provider == .moonshot,
            let balance = Self.moonshotBalanceDisplayText(snapshot: snapshot)
         {
@@ -798,6 +805,16 @@ extension StatusItemController {
 
         let balance = rawValue.split(separator: " ", maxSplits: 1).first
         return balance.map(String.init)
+    }
+
+    nonisolated static func miMoBalanceDisplayText(
+        snapshot: UsageSnapshot?,
+        preference: MenuBarMetricPreference) -> String?
+    {
+        guard let snapshot, let mimoUsage = snapshot.mimoUsage else { return nil }
+        if snapshot.primary != nil, preference != .secondary { return nil }
+        let detail = mimoUsage.balanceDetail
+        return detail.components(separatedBy: " (Paid:").first
     }
 
     nonisolated static func moonshotBalanceDisplayText(snapshot: UsageSnapshot?) -> String? {

--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -119,7 +119,6 @@ extension UsageStore {
                     percentLeft: window.remainingPercent)
             }
         }
-
         let primaryTitle: String = {
             if provider == .grok,
                let dyn = GrokProviderDescriptor.primaryLabel(window: snapshot.primary)

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -768,24 +768,6 @@ final class UsageStore {
         var firedThresholds: Set<Int> = []
     }
 
-    private func sessionQuotaWindow(
-        provider: UsageProvider,
-        snapshot: UsageSnapshot) -> (window: RateWindow, source: SessionQuotaWindowSource)?
-    {
-        if let primary = snapshot.primary, Self.isSessionWindow(primary) {
-            return (primary, .primary)
-        }
-        if provider == .copilot, let secondary = snapshot.secondary {
-            return (secondary, .copilotSecondaryFallback)
-        }
-        return nil
-    }
-
-    private static func isSessionWindow(_ window: RateWindow) -> Bool {
-        guard let minutes = window.windowMinutes else { return true }
-        return minutes <= 6 * 60
-    }
-
     func handleSessionQuotaTransition(provider: UsageProvider, snapshot: UsageSnapshot) {
         // Session quota notifications are tied to the primary session window. Copilot free plans can
         // expose only chat quota, so allow Copilot to fall back to secondary for transition tracking.
@@ -867,15 +849,17 @@ final class UsageStore {
         guard self.settings.quotaWarningNotificationsEnabled else { return }
 
         let accountDisplayName = self.quotaWarningAccountDisplayName(provider: provider, snapshot: snapshot)
+        let primaryWindow = provider == .mimo ? nil : snapshot.primary
+        let secondaryWindow = provider == .mimo ? nil : snapshot.secondary
         self.handleQuotaWarningTransition(
             provider: provider,
             window: .session,
-            rateWindow: snapshot.primary,
+            rateWindow: primaryWindow,
             accountDisplayName: accountDisplayName)
         self.handleQuotaWarningTransition(
             provider: provider,
             window: .weekly,
-            rateWindow: snapshot.secondary,
+            rateWindow: secondaryWindow,
             accountDisplayName: accountDisplayName)
     }
 

--- a/Sources/CodexBarCLI/CLIRenderer.swift
+++ b/Sources/CodexBarCLI/CLIRenderer.swift
@@ -34,6 +34,7 @@ enum CLIRenderer {
             now: now,
             lines: &lines)
         self.appendTertiaryLines(snapshot: snapshot, labels: labels, context: context, now: now, lines: &lines)
+        self.appendMiMoBalanceLine(snapshot: snapshot, useColor: context.useColor, lines: &lines)
         self.appendDeepgramLines(snapshot: snapshot, useColor: context.useColor, lines: &lines)
         self.appendAmpBalanceLines(snapshot: snapshot, useColor: context.useColor, lines: &lines)
         self.appendLimitsUnavailableLine(
@@ -114,6 +115,15 @@ enum CLIRenderer {
             lines: &lines)
     }
 
+    private static func appendMiMoBalanceLine(
+        snapshot: UsageSnapshot,
+        useColor: Bool,
+        lines: inout [String])
+    {
+        guard let usage = snapshot.mimoUsage else { return }
+        lines.append(self.labelValueLine("Balance", value: usage.balanceDetail, useColor: useColor))
+    }
+
     private static func appendTertiaryLines(
         snapshot: UsageSnapshot,
         labels: RateWindowLabels,
@@ -186,7 +196,6 @@ enum CLIRenderer {
                 tertiary: "Monthly",
                 showsTertiary: true)
         }
-
         let primaryLabel = provider == .grok
             ? GrokProviderDescriptor.primaryLabel(window: snapshot.primary) ?? metadata.sessionLabel
             : metadata.sessionLabel
@@ -239,7 +248,10 @@ enum CLIRenderer {
             for detail in kiloLogin.details {
                 lines.append(self.labelValueLine("Activity", value: detail, useColor: context.useColor))
             }
-        } else if let plan = snapshot.loginMethod(for: provider), !plan.isEmpty {
+        } else if let plan = snapshot.loginMethod(for: provider),
+                  !plan.isEmpty,
+                  provider != .mimo || !plan.localizedCaseInsensitiveContains("balance:")
+        {
             let displayPlan = if provider == .codex {
                 CodexPlanFormatting.displayName(plan) ?? plan
             } else {

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoUsageFetcher.swift
@@ -143,6 +143,8 @@ public enum MiMoUsageFetcher {
         return MiMoUsageSnapshot(
             balance: balanceSnapshot.balance,
             currency: balanceSnapshot.currency,
+            cashBalance: balanceSnapshot.cashBalance,
+            giftBalance: balanceSnapshot.giftBalance,
             planCode: planDetail.planCode,
             planPeriodEnd: planDetail.periodEnd,
             planExpired: planDetail.expired,
@@ -173,13 +175,20 @@ public enum MiMoUsageFetcher {
         guard let balance = Double(data.balance) else {
             throw MiMoUsageError.parseFailed("Invalid balance value")
         }
+        let cashBalance = data.cashBalance.flatMap(Double.init)
+        let giftBalance = data.giftBalance.flatMap(Double.init)
 
         let currency = data.currency.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !currency.isEmpty else {
             throw MiMoUsageError.parseFailed("Missing currency")
         }
 
-        return MiMoUsageSnapshot(balance: balance, currency: currency, updatedAt: now)
+        return MiMoUsageSnapshot(
+            balance: balance,
+            currency: currency,
+            cashBalance: cashBalance,
+            giftBalance: giftBalance,
+            updatedAt: now)
     }
 
     static func parseTokenPlanDetail(from data: Data) throws -> (planCode: String?, periodEnd: Date?, expired: Bool) {
@@ -227,6 +236,8 @@ public enum MiMoUsageFetcher {
     private struct BalancePayload: Decodable {
         let balance: String
         let currency: String
+        let cashBalance: String?
+        let giftBalance: String?
     }
 
     private struct TokenPlanDetailResponse: Decodable {

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoUsageSnapshot.swift
@@ -1,8 +1,10 @@
 import Foundation
 
-public struct MiMoUsageSnapshot: Sendable {
+public struct MiMoUsageSnapshot: Codable, Sendable {
     public let balance: Double
     public let currency: String
+    public let cashBalance: Double?
+    public let giftBalance: Double?
     public let planCode: String?
     public let planPeriodEnd: Date?
     public let planExpired: Bool
@@ -14,6 +16,8 @@ public struct MiMoUsageSnapshot: Sendable {
     public init(
         balance: Double,
         currency: String,
+        cashBalance: Double? = nil,
+        giftBalance: Double? = nil,
         planCode: String? = nil,
         planPeriodEnd: Date? = nil,
         planExpired: Bool = false,
@@ -24,6 +28,8 @@ public struct MiMoUsageSnapshot: Sendable {
     {
         self.balance = balance
         self.currency = currency
+        self.cashBalance = cashBalance
+        self.giftBalance = giftBalance
         self.planCode = planCode
         self.planPeriodEnd = planPeriodEnd
         self.planExpired = planExpired
@@ -35,11 +41,19 @@ public struct MiMoUsageSnapshot: Sendable {
 }
 
 extension MiMoUsageSnapshot {
-    public func toUsageSnapshot() -> UsageSnapshot {
+    public var balanceDetail: String {
         let trimmedCurrency = self.currency.trimmingCharacters(in: .whitespacesAndNewlines)
         let balanceText = UsageFormatter.currencyString(self.balance, currencyCode: trimmedCurrency)
+        guard let cashBalance = self.cashBalance, let giftBalance = self.giftBalance else {
+            return balanceText
+        }
+        let paid = UsageFormatter.currencyString(cashBalance, currencyCode: trimmedCurrency)
+        let granted = UsageFormatter.currencyString(giftBalance, currencyCode: trimmedCurrency)
+        return "\(balanceText) (Paid: \(paid) / Granted: \(granted))"
+    }
 
-        let primary: RateWindow? = {
+    public func toUsageSnapshot() -> UsageSnapshot {
+        let tokenWindow: RateWindow? = {
             guard self.tokenLimit > 0 else { return nil }
             let usedPercent = max(0, min(100, self.tokenPercent * 100))
             let usedText = Self.fullCountString(self.tokenUsed)
@@ -61,13 +75,13 @@ extension MiMoUsageSnapshot {
             providerID: .mimo,
             accountEmail: nil,
             accountOrganization: nil,
-            loginMethod: planLabel ?? "Balance: \(balanceText)")
+            loginMethod: planLabel)
 
         return UsageSnapshot(
-            primary: primary,
+            primary: tokenWindow,
             secondary: nil,
             tertiary: nil,
-            providerCost: nil,
+            mimoUsage: self,
             updatedAt: self.updatedAt,
             identity: identity)
     }

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -128,6 +128,7 @@ public struct UsageSnapshot: Codable, Sendable {
     public let zaiUsage: ZaiUsageSnapshot?
     public let minimaxUsage: MiniMaxUsageSnapshot?
     public let deepseekUsage: DeepSeekUsageSummary?
+    public let mimoUsage: MiMoUsageSnapshot?
     public let openRouterUsage: OpenRouterUsageSnapshot?
     public let openAIAPIUsage: OpenAIAPIUsageSnapshot?
     public let claudeAdminAPIUsage: ClaudeAdminAPIUsageSnapshot?
@@ -147,6 +148,7 @@ public struct UsageSnapshot: Codable, Sendable {
         case providerCost
         case kiroUsage
         case ampUsage
+        case mimoUsage
         case openRouterUsage
         case openAIAPIUsage
         case claudeAdminAPIUsage
@@ -172,6 +174,7 @@ public struct UsageSnapshot: Codable, Sendable {
         zaiUsage: ZaiUsageSnapshot? = nil,
         minimaxUsage: MiniMaxUsageSnapshot? = nil,
         deepseekUsage: DeepSeekUsageSummary? = nil,
+        mimoUsage: MiMoUsageSnapshot? = nil,
         openRouterUsage: OpenRouterUsageSnapshot? = nil,
         openAIAPIUsage: OpenAIAPIUsageSnapshot? = nil,
         claudeAdminAPIUsage: ClaudeAdminAPIUsageSnapshot? = nil,
@@ -193,6 +196,7 @@ public struct UsageSnapshot: Codable, Sendable {
         self.zaiUsage = zaiUsage
         self.minimaxUsage = minimaxUsage
         self.deepseekUsage = deepseekUsage
+        self.mimoUsage = mimoUsage
         self.openRouterUsage = openRouterUsage
         self.openAIAPIUsage = openAIAPIUsage
         self.claudeAdminAPIUsage = claudeAdminAPIUsage
@@ -217,6 +221,7 @@ public struct UsageSnapshot: Codable, Sendable {
             zaiUsage: self.zaiUsage,
             minimaxUsage: self.minimaxUsage,
             deepseekUsage: self.deepseekUsage,
+            mimoUsage: self.mimoUsage,
             openRouterUsage: self.openRouterUsage,
             openAIAPIUsage: self.openAIAPIUsage,
             claudeAdminAPIUsage: self.claudeAdminAPIUsage,
@@ -241,6 +246,7 @@ public struct UsageSnapshot: Codable, Sendable {
         self.zaiUsage = nil // Not persisted, fetched fresh each time
         self.minimaxUsage = nil // Not persisted, fetched fresh each time
         self.deepseekUsage = nil // Not persisted, fetched fresh each time
+        self.mimoUsage = try container.decodeIfPresent(MiMoUsageSnapshot.self, forKey: .mimoUsage)
         self.openRouterUsage = try container.decodeIfPresent(OpenRouterUsageSnapshot.self, forKey: .openRouterUsage)
         self.openAIAPIUsage = try container.decodeIfPresent(OpenAIAPIUsageSnapshot.self, forKey: .openAIAPIUsage)
         self.claudeAdminAPIUsage = try container.decodeIfPresent(
@@ -280,6 +286,7 @@ public struct UsageSnapshot: Codable, Sendable {
         try container.encodeIfPresent(self.providerCost, forKey: .providerCost)
         try container.encodeIfPresent(self.kiroUsage, forKey: .kiroUsage)
         try container.encodeIfPresent(self.ampUsage, forKey: .ampUsage)
+        try container.encodeIfPresent(self.mimoUsage, forKey: .mimoUsage)
         try container.encodeIfPresent(self.openRouterUsage, forKey: .openRouterUsage)
         try container.encodeIfPresent(self.openAIAPIUsage, forKey: .openAIAPIUsage)
         try container.encodeIfPresent(self.claudeAdminAPIUsage, forKey: .claudeAdminAPIUsage)
@@ -385,6 +392,7 @@ public struct UsageSnapshot: Codable, Sendable {
             zaiUsage: self.zaiUsage,
             minimaxUsage: self.minimaxUsage,
             deepseekUsage: self.deepseekUsage,
+            mimoUsage: self.mimoUsage,
             openRouterUsage: self.openRouterUsage,
             openAIAPIUsage: self.openAIAPIUsage,
             claudeAdminAPIUsage: self.claudeAdminAPIUsage,
@@ -424,6 +432,7 @@ public struct UsageSnapshot: Codable, Sendable {
             zaiUsage: self.zaiUsage,
             minimaxUsage: self.minimaxUsage,
             deepseekUsage: self.deepseekUsage,
+            mimoUsage: self.mimoUsage,
             openRouterUsage: self.openRouterUsage,
             openAIAPIUsage: self.openAIAPIUsage,
             claudeAdminAPIUsage: self.claudeAdminAPIUsage,

--- a/Tests/CodexBarTests/CLIOutputTests.swift
+++ b/Tests/CodexBarTests/CLIOutputTests.swift
@@ -95,4 +95,58 @@ struct CLIOutputTests {
         #expect(text.contains("Account: paid@example.com"))
         #expect(!text.contains("Amp Free:"))
     }
+
+    @Test
+    func `text renderer shows mimo balance without quota or reset text`() {
+        let snapshot = MiMoUsageSnapshot(
+            balance: 25.51,
+            currency: "USD",
+            cashBalance: 20,
+            giftBalance: 5.51,
+            updatedAt: Date(timeIntervalSince1970: 0))
+            .toUsageSnapshot()
+
+        let text = CLIRenderer.renderText(
+            provider: .mimo,
+            snapshot: snapshot,
+            credits: nil,
+            context: RenderContext(
+                header: "Xiaomi MiMo (web)",
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown))
+
+        #expect(text.contains("Balance: $25.51 (Paid: $20.00 / Granted: $5.51)"))
+        #expect(!text.contains("100%"))
+        #expect(!text.contains("Resets"))
+        #expect(!text.contains("Plan: Balance"))
+    }
+
+    @Test
+    func `text renderer shows mimo token credits and balance`() {
+        let snapshot = MiMoUsageSnapshot(
+            balance: 25.51,
+            currency: "USD",
+            planCode: "standard",
+            tokenUsed: 10,
+            tokenLimit: 100,
+            tokenPercent: 0.1,
+            updatedAt: Date(timeIntervalSince1970: 0))
+            .toUsageSnapshot()
+
+        let text = CLIRenderer.renderText(
+            provider: .mimo,
+            snapshot: snapshot,
+            credits: nil,
+            context: RenderContext(
+                header: "Xiaomi MiMo (web)",
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown))
+
+        #expect(text.contains("Credits: 90% left"))
+        #expect(text.contains("Balance: $25.51"))
+        #expect(text.contains("Plan: Standard"))
+        #expect(!text.contains("Window: 100%"))
+    }
 }

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -160,7 +160,7 @@ struct MiMoProviderTests {
     }
 
     @Test
-    func `usage snapshot exposes balance through identity plan text`() {
+    func `usage snapshot exposes balance without duplicating identity`() {
         let snapshot = MiMoUsageSnapshot(
             balance: 25.51,
             currency: "USD",
@@ -170,7 +170,24 @@ struct MiMoProviderTests {
 
         #expect(usage.primary == nil)
         #expect(usage.secondary == nil)
-        #expect(usage.loginMethod(for: .mimo) == "Balance: $25.51")
+        #expect(usage.mimoUsage?.balanceDetail == "$25.51")
+        #expect(usage.loginMethod(for: .mimo) == nil)
+    }
+
+    @Test
+    func `usage snapshot exposes paid and granted balance components`() {
+        let snapshot = MiMoUsageSnapshot(
+            balance: 25.51,
+            currency: "USD",
+            cashBalance: 20,
+            giftBalance: 5.51,
+            updatedAt: Date(timeIntervalSince1970: 1_742_771_200))
+
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(usage.primary == nil)
+        #expect(usage.mimoUsage?.balanceDetail == "$25.51 (Paid: $20.00 / Granted: $5.51)")
+        #expect(usage.loginMethod(for: .mimo) == nil)
     }
 
     @Test
@@ -193,7 +210,42 @@ struct MiMoProviderTests {
         #expect(abs((usage.primary?.usedPercent ?? .nan) - 5.05) < 0.0001)
         #expect(usage.primary?.resetDescription == "10,100,158 / 200,000,000 Credits")
         #expect(usage.primary?.resetsAt == resetDate)
+        #expect(usage.secondary == nil)
+        #expect(usage.mimoUsage?.balanceDetail == "$25.51")
         #expect(usage.loginMethod(for: .mimo) == "Standard")
+    }
+
+    @Test
+    func `menu card shows balance as status text with and without token plan`() throws {
+        let now = Date(timeIntervalSince1970: 1_742_771_200)
+        let metadata = try #require(ProviderDefaults.metadata[.mimo])
+        let balanceOnly = MiMoUsageSnapshot(
+            balance: 25.51,
+            currency: "USD",
+            cashBalance: 20,
+            giftBalance: 5.51,
+            updatedAt: now)
+            .toUsageSnapshot()
+        let withPlan = MiMoUsageSnapshot(
+            balance: 25.51,
+            currency: "USD",
+            cashBalance: 20,
+            giftBalance: 5.51,
+            planCode: "standard",
+            tokenUsed: 10,
+            tokenLimit: 100,
+            tokenPercent: 0.1,
+            updatedAt: now)
+            .toUsageSnapshot()
+
+        let balanceModel = Self.makeMenuCardModel(snapshot: balanceOnly, metadata: metadata, now: now)
+        let planModel = Self.makeMenuCardModel(snapshot: withPlan, metadata: metadata, now: now)
+
+        #expect(balanceModel.metrics.first?.title == "Balance")
+        #expect(balanceModel.metrics.first?.statusText == "$25.51 (Paid: $20.00 / Granted: $5.51)")
+        #expect(planModel.metrics.first?.title == "Credits")
+        #expect(planModel.metrics.last?.title == "Balance")
+        #expect(planModel.metrics.last?.statusText == "$25.51 (Paid: $20.00 / Granted: $5.51)")
     }
 
     @Test
@@ -212,7 +264,58 @@ struct MiMoProviderTests {
         let usage = snapshot.toUsageSnapshot()
 
         #expect(usage.primary == nil)
-        #expect(usage.loginMethod(for: .mimo) == "Balance: $0.00")
+        #expect(usage.mimoUsage?.balanceDetail == "$0.00")
+        #expect(usage.loginMethod(for: .mimo) == nil)
+    }
+
+    @Test
+    func `usage snapshot persists mimo balance details`() throws {
+        let usage = MiMoUsageSnapshot(
+            balance: 25.51,
+            currency: "USD",
+            cashBalance: 20,
+            giftBalance: 5.51,
+            updatedAt: Date(timeIntervalSince1970: 1_742_771_200))
+            .toUsageSnapshot()
+
+        let decoded = try JSONDecoder().decode(UsageSnapshot.self, from: JSONEncoder().encode(usage))
+
+        #expect(decoded.primary == nil)
+        #expect(decoded.mimoUsage?.balanceDetail == "$25.51 (Paid: $20.00 / Granted: $5.51)")
+    }
+
+    @Test
+    func `balance does not participate in icon or switcher quota percentages`() {
+        let balanceOnly = MiMoUsageSnapshot(
+            balance: 25.51,
+            currency: "USD",
+            updatedAt: Date())
+            .toUsageSnapshot()
+        let withPlan = MiMoUsageSnapshot(
+            balance: 25.51,
+            currency: "USD",
+            planCode: "standard",
+            tokenUsed: 10,
+            tokenLimit: 100,
+            tokenPercent: 0.1,
+            updatedAt: Date())
+            .toUsageSnapshot()
+
+        let balanceIcon = IconRemainingResolver.resolvedRemaining(snapshot: balanceOnly, style: .mimo)
+        let planIcon = IconRemainingResolver.resolvedRemaining(snapshot: withPlan, style: .mimo)
+
+        #expect(balanceIcon.primary == nil)
+        #expect(balanceIcon.secondary == nil)
+        #expect(StatusItemController.switcherWeeklyMetricPercent(
+            for: .mimo,
+            snapshot: balanceOnly,
+            showUsed: false) == nil)
+        #expect(planIcon.primary == 90)
+        #expect(planIcon.secondary == nil)
+        #expect(StatusItemController.switcherWeeklyMetricPercent(
+            for: .mimo,
+            snapshot: withPlan,
+            showUsed: false) == 90)
     }
 
     @Test
@@ -235,7 +338,58 @@ struct MiMoProviderTests {
 
         #expect(snapshot.balance == 25.51)
         #expect(snapshot.currency == "USD")
+        #expect(snapshot.cashBalance == nil)
+        #expect(snapshot.giftBalance == nil)
         #expect(snapshot.updatedAt == now)
+    }
+
+    @Test
+    func `parses paid and granted balance fields when available`() throws {
+        let now = Date(timeIntervalSince1970: 1_742_771_200)
+        let json = """
+        {
+          "code": 0,
+          "message": "",
+          "data": {
+            "balance": "50.00",
+            "frozenBalance": null,
+            "currency": "USD",
+            "overdraftLimit": null,
+            "remainingOverdraftLimit": null,
+            "giftBalance": "20.00",
+            "cashBalance": "30.00"
+          }
+        }
+        """
+
+        let snapshot = try MiMoUsageFetcher.parseUsageSnapshot(from: Data(json.utf8), now: now)
+
+        #expect(snapshot.balance == 50)
+        #expect(snapshot.cashBalance == 30)
+        #expect(snapshot.giftBalance == 20)
+        #expect(snapshot.currency == "USD")
+    }
+
+    @Test
+    func `ignores malformed optional balance components`() throws {
+        let json = """
+        {
+          "code": 0,
+          "message": "",
+          "data": {
+            "balance": "25.51",
+            "currency": "USD",
+            "giftBalance": "",
+            "cashBalance": "unknown"
+          }
+        }
+        """
+
+        let snapshot = try MiMoUsageFetcher.parseUsageSnapshot(from: Data(json.utf8))
+
+        #expect(snapshot.balance == 25.51)
+        #expect(snapshot.cashBalance == nil)
+        #expect(snapshot.giftBalance == nil)
     }
 
     @Test
@@ -292,7 +446,7 @@ struct MiMoProviderTests {
     func `combined snapshot merges balance and token plan`() throws {
         let now = Date(timeIntervalSince1970: 1_742_771_200)
         let balanceJSON = """
-        {"code":0,"message":"","data":{"balance":"25.51","currency":"USD"}}
+        {"code":0,"message":"","data":{"balance":"25.51","currency":"USD","cashBalance":"20","giftBalance":"5.51"}}
         """
         let detailJSON = """
         {"code":0,"message":"","data":{"planCode":"standard","currentPeriodEnd":"2026-05-04 23:59:59","expired":false}}
@@ -325,6 +479,8 @@ struct MiMoProviderTests {
 
         #expect(snapshot.balance == 25.51)
         #expect(snapshot.currency == "USD")
+        #expect(snapshot.cashBalance == 20)
+        #expect(snapshot.giftBalance == 5.51)
         #expect(snapshot.planCode == "standard")
         #expect(snapshot.tokenUsed == 10_100_158)
         #expect(snapshot.tokenLimit == 200_000_000)
@@ -374,15 +530,20 @@ struct MiMoProviderTests {
         #expect(snapshot.currency == "USD")
         #expect(requestedPaths.contains("/api/v1/balance"))
     }
+}
 
+extension MiMoProviderTests {
     @Test
     @MainActor
     func `provider detail plan row formats mimo as balance`() {
         CodexBarLocalizationOverride.$appLanguage.withValue("en") {
-            let row = ProviderDetailView<Text>.planRow(provider: .mimo, planText: "Balance: $25.51")
+            let legacyBalance = ProviderDetailView<Text>.planRow(provider: .mimo, planText: "Balance: $25.51")
+            let tokenPlan = ProviderDetailView<Text>.planRow(provider: .mimo, planText: "Standard")
 
-            #expect(row?.label == "Balance")
-            #expect(row?.value == "$25.51")
+            #expect(legacyBalance?.label == "Balance")
+            #expect(legacyBalance?.value == "$25.51")
+            #expect(tokenPlan?.label == "Plan")
+            #expect(tokenPlan?.value == "Standard")
         }
     }
 
@@ -423,6 +584,56 @@ struct MiMoProviderTests {
 
         #expect(lines.contains("Balance: $25.51"))
         #expect(!lines.contains("Balance: Balance: $25.51"))
+        if provider == .mimo {
+            #expect(!lines.contains(where: { $0.hasPrefix("Balance: 100%") }))
+        }
+    }
+
+    @Test
+    @MainActor
+    func `menu descriptor renders mimo token detail without reset date`() throws {
+        let suite = "MiMoProviderTests-menu-token-detail"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let snapshot = MiMoUsageSnapshot(
+            balance: 25.51,
+            currency: "USD",
+            planCode: "standard",
+            tokenUsed: 10,
+            tokenLimit: 100,
+            tokenPercent: 0.1,
+            updatedAt: Date(timeIntervalSince1970: 1_742_771_200))
+            .toUsageSnapshot()
+        store._setSnapshotForTesting(snapshot, provider: .mimo)
+
+        let descriptor = MenuDescriptor.build(
+            provider: .mimo,
+            store: store,
+            settings: settings,
+            account: AccountInfo(email: nil, plan: nil),
+            updateReady: false,
+            includeContextualActions: false)
+        let lines = descriptor.sections
+            .flatMap(\.entries)
+            .compactMap { entry -> String? in
+                guard case let .text(text, _) = entry else { return nil }
+                return text
+            }
+
+        #expect(lines.contains("10 / 100 Credits"))
+        #expect(!lines.contains("Resets 10 / 100 Credits"))
     }
 
     @Test
@@ -577,7 +788,7 @@ struct MiMoProviderTests {
         #expect(requestedCookies.count == 6)
         #expect(requestedCookies.contains(where: { $0.contains("expired-token") }))
         #expect(requestedCookies.contains(where: { $0.contains("valid-token") }))
-        #expect(result.usage.loginMethod(for: .mimo) == "Balance: $25.51")
+        #expect(result.usage.mimoUsage?.balanceDetail == "$25.51")
         #expect(CookieHeaderCache.load(provider: .mimo)?.sourceLabel == "Active Chrome")
     }
 
@@ -639,6 +850,32 @@ struct MiMoProviderTests {
             httpVersion: "HTTP/1.1",
             headerFields: ["Content-Type": "application/json"])!
         return (response, Data(body.utf8))
+    }
+
+    private static func makeMenuCardModel(
+        snapshot: UsageSnapshot,
+        metadata: ProviderMetadata,
+        now: Date) -> UsageMenuCardView.Model
+    {
+        UsageMenuCardView.Model.make(.init(
+            provider: .mimo,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
     }
 
     private func makeBalanceSnapshot(provider: UsageProvider) -> UsageSnapshot {

--- a/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
+++ b/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
@@ -115,6 +115,53 @@ struct StatusItemBalanceDisplayTests {
     }
 
     @Test
+    func `menu bar display text uses mimo balance without token plan`() {
+        let settings = self.makeSettings(
+            suiteName: "StatusItemBalanceDisplayTests-mimo-balance",
+            provider: .mimo)
+        let (store, controller) = self.makeStoreAndController(settings: settings)
+        let snapshot = MiMoUsageSnapshot(
+            balance: 25.51,
+            currency: "USD",
+            cashBalance: 20,
+            giftBalance: 5.51,
+            updatedAt: Date())
+            .toUsageSnapshot()
+
+        store._setSnapshotForTesting(snapshot, provider: .mimo)
+        store._setErrorForTesting(nil, provider: .mimo)
+
+        let displayText = controller.menuBarDisplayText(for: .mimo, snapshot: snapshot)
+
+        #expect(displayText == "$25.51")
+    }
+
+    @Test
+    func `menu bar display text uses selected mimo balance with token plan`() {
+        let settings = self.makeSettings(
+            suiteName: "StatusItemBalanceDisplayTests-mimo-token-plan",
+            provider: .mimo)
+        settings.setMenuBarMetricPreference(.secondary, for: .mimo)
+        let (store, controller) = self.makeStoreAndController(settings: settings)
+        let snapshot = MiMoUsageSnapshot(
+            balance: 25.51,
+            currency: "USD",
+            planCode: "standard",
+            tokenUsed: 10,
+            tokenLimit: 100,
+            tokenPercent: 0.1,
+            updatedAt: Date())
+            .toUsageSnapshot()
+
+        store._setSnapshotForTesting(snapshot, provider: .mimo)
+        store._setErrorForTesting(nil, provider: .mimo)
+
+        let displayText = controller.menuBarDisplayText(for: .mimo, snapshot: snapshot)
+
+        #expect(displayText == "$25.51")
+    }
+
+    @Test
     func `menu bar display text uses moonshot balance`() {
         let settings = self.makeSettings(
             suiteName: "StatusItemBalanceDisplayTests-moonshot-balance",

--- a/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
+++ b/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
@@ -160,6 +160,45 @@ struct UsageStoreSessionQuotaTransitionTests {
     }
 
     @Test
+    func `mimo balance and monthly credits do not emit quota notifications`() {
+        let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-mimo-balance")
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.sessionQuotaNotificationsEnabled = true
+        settings.quotaWarningNotificationsEnabled = true
+        settings.quotaWarningThresholds = [50, 20]
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+        let balanceSnapshot = MiMoUsageSnapshot(
+            balance: 0,
+            currency: "USD",
+            updatedAt: Date())
+            .toUsageSnapshot()
+        let tokenPlanSnapshot = MiMoUsageSnapshot(
+            balance: 25.51,
+            currency: "USD",
+            planCode: "standard",
+            tokenUsed: 100,
+            tokenLimit: 100,
+            tokenPercent: 1,
+            updatedAt: Date())
+            .toUsageSnapshot()
+
+        for snapshot in [balanceSnapshot, tokenPlanSnapshot] {
+            store.handleSessionQuotaTransition(provider: .mimo, snapshot: snapshot)
+            store.handleQuotaWarningTransitions(provider: .mimo, snapshot: snapshot)
+        }
+
+        #expect(notifier.posts.isEmpty)
+        #expect(notifier.quotaWarningPosts.isEmpty)
+    }
+
+    @Test
     func `claude five hour primary still emits session quota notifications`() {
         let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-claude-session")
         settings.refreshFrequency = .manual

--- a/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
+++ b/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
@@ -47,4 +47,41 @@ struct UsageStoreWidgetSnapshotTests {
         #expect(entry.usageRows?.map(\.title) == ["Claude", "Gemini Pro", "Gemini Flash"])
         #expect(entry.usageRows?.compactMap(\.percentLeft) == [90, 80, 70])
     }
+
+    @Test
+    func `widget snapshot excludes mimo balance from quota rows`() async throws {
+        let suite = "UsageStoreWidgetSnapshotTests-mimo-balance"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let snapshot = MiMoUsageSnapshot(
+            balance: 25.51,
+            currency: "USD",
+            updatedAt: Date())
+            .toUsageSnapshot()
+        store._setSnapshotForTesting(snapshot, provider: .mimo)
+
+        var widgetSnapshots: [WidgetSnapshot] = []
+        store._test_widgetSnapshotSaveOverride = { widgetSnapshots.append($0) }
+        defer { store._test_widgetSnapshotSaveOverride = nil }
+
+        store.persistWidgetSnapshot(reason: "mimo-balance-test")
+        await store.widgetSnapshotPersistTask?.value
+
+        let entry = try #require(widgetSnapshots.last?.entries.first { $0.provider == .mimo })
+        #expect(entry.primary == nil)
+        #expect(entry.secondary == nil)
+        #expect(entry.usageRows?.isEmpty == true)
+    }
 }

--- a/docs/mimo.md
+++ b/docs/mimo.md
@@ -12,7 +12,8 @@ The Xiaomi MiMo provider tracks your current balance from the Xiaomi MiMo consol
 
 ## Features
 
-- **Balance display**: Shows the current MiMo balance as provider identity text.
+- **Balance display**: Shows total balance plus paid and granted components when MiMo returns them.
+- **Token plan usage**: Shows current token-plan credits while retaining balance as a second metric.
 - **Cookie-based auth**: Uses browser cookies or a pasted `Cookie:` header.
 - **Near-real-time updates**: Balance usually reflects within a few minutes.
 
@@ -34,15 +35,15 @@ Safari cookie import may require granting CodexBar Full Disk Access in **System 
 
 ## How it works
 
-- Fetches `GET https://platform.xiaomimimo.com/api/v1/balance`
+- Fetches balance and token-plan detail/usage endpoints under `https://platform.xiaomimimo.com/api/v1`
 - Requires the `api-platform_serviceToken` and `userId` cookies
 - Accepts optional MiMo cookies like `api-platform_ph` and `api-platform_slh` when present
 - Supports `MIMO_API_URL` to override the base API URL for testing
 
 ## Limitations
 
-- MiMo currently exposes **balance only**
-- Token cost, status polling, debug log output, and widgets are not supported yet
+- Token cost, status polling, and debug log output are not supported yet
+- Widgets show token-plan usage but omit balance details
 - Auto import covers Safari, Chrome variants, Firefox, and Edge only; other browsers use **Manual** mode
 
 ## Troubleshooting

--- a/docs/mimo.md
+++ b/docs/mimo.md
@@ -43,7 +43,7 @@ Safari cookie import may require granting CodexBar Full Disk Access in **System 
 ## Limitations
 
 - Token cost, status polling, and debug log output are not supported yet
-- Widgets show token-plan usage but omit balance details
+- Widgets do not support Xiaomi MiMo yet
 - Auto import covers Safari, Chrome variants, Firefox, and Edge only; other browsers use **Manual** mode
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

- Extend the existing Xiaomi MiMo provider instead of adding a duplicate provider.
- Show total prepaid balance with paid and granted components when available.
- Keep token-plan credits as the real quota window and persist balance as provider-specific data.
- Render balance consistently in the menu card, native menu, CLI, settings, and menu bar metric.
- Exclude prepaid balance and monthly token credits from session-quota alerts and fake quota percentages.

## Review fixes

- Avoid treating balance as a 100% or 0% rate window in icons, switcher rows, and widgets.
- Avoid session-quota notifications for MiMo monthly credits.
- Render token detail as plain usage text when the period-end date is unavailable.
- Preserve MiMo balance through snapshot encoding and reset-time backfill copies.

## Validation

- `make check`
- `swift test --filter MiMoProviderTests`
- Focused CLI, status item, notification, and widget tests
- Autoreview: no accepted/actionable findings
- Full-suite flaky failures reproduced only under parallel execution; each affected suite passes in isolation
