### PR TITLE
feat: Add reserve/pace indicator for Xiaomi MiMo token plan

### DIFF
--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1270,6 +1270,21 @@ extension UsageMenuCardView.Model {
                 }
             }
         }
+        if input.provider == .mimo {
+            if let pace = input.weeklyPace {
+                let paceDetail = Self.weeklyPaceDetail(
+                    window: primary,
+                    now: input.now,
+                    pace: pace,
+                    showUsed: input.usageBarsShowUsed)
+                if let paceDetail {
+                    primaryDetailLeft = paceDetail.leftLabel
+                    primaryDetailRight = paceDetail.rightLabel
+                    primaryPacePercent = paceDetail.pacePercent
+                    primaryPaceOnTop = paceDetail.paceOnTop
+                }
+            }
+        }
         if input.provider == .synthetic,
            let regen = Self.syntheticRollingRegenDetail(
                window: primary,

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -638,8 +638,8 @@ struct ProvidersPane: View {
             tokenError = nil
         }
 
-        // Abacus uses primary for monthly credits (no secondary window)
-        let paceWindow = provider == .abacus ? snapshot?.primary : snapshot?.secondary
+        // Abacus and MiMo use primary for monthly credits (no secondary window)
+        let paceWindow = (provider == .abacus || provider == .mimo) ? snapshot?.primary : snapshot?.secondary
         let weeklyPace = if let codexProjection,
                             let weekly = codexProjection.rateWindow(for: .weekly)
         {

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -74,8 +74,8 @@ extension StatusItemController {
 
         let sourceLabel = snapshotOverride == nil ? self.store.sourceLabel(for: target) : nil
         let kiloAutoMode = target == .kilo && self.settings.kiloUsageDataSource == .auto
-        // Abacus uses primary for monthly credits (no secondary window)
-        let paceWindow = target == .abacus ? snapshot?.primary : snapshot?.secondary
+        // Abacus and MiMo use primary for monthly credits (no secondary window)
+        let paceWindow = (target == .abacus || target == .mimo) ? snapshot?.primary : snapshot?.secondary
         let weeklyPace = if let codexProjection,
                             let weekly = codexProjection.rateWindow(for: .weekly)
         {

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoUsageSnapshot.swift
@@ -49,9 +49,15 @@ extension MiMoUsageSnapshot {
                 guard let periodEnd = self.planPeriodEnd else { return nil }
                 let timeUntilReset = periodEnd.timeIntervalSince(self.updatedAt)
                 guard timeUntilReset > 0 else { return nil }
-                // Estimate total monthly period (30 or 31 days) since we only have the end date.
-                let twentyEightDays: TimeInterval = 28 * 24 * 60 * 60
-                return timeUntilReset > twentyEightDays ? 44_640 : 43_200
+                // The reset date marks the end of the billing cycle, so the cycle
+                // started one month before.  This correctly handles mid-month
+                // subscriptions (e.g. reset June 15 → started May 15 → 31 days)
+                // and February resets (28/29 days).
+                let calendar = Calendar.current
+                guard let cycleStart = calendar.date(byAdding: .month, value: -1, to: periodEnd) else { return nil }
+                let windowLength = periodEnd.timeIntervalSince(cycleStart)
+                guard windowLength > 0 else { return nil }
+                return Int(windowLength / 60)
             }()
             return RateWindow(
                 usedPercent: usedPercent,

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoUsageSnapshot.swift
@@ -45,9 +45,17 @@ extension MiMoUsageSnapshot {
             let usedText = Self.fullCountString(self.tokenUsed)
             let limitText = Self.fullCountString(self.tokenLimit)
             let resetDesc = "\(usedText) / \(limitText) Credits"
+            let windowMinutes: Int? = {
+                guard let periodEnd = self.planPeriodEnd else { return nil }
+                let timeUntilReset = periodEnd.timeIntervalSince(self.updatedAt)
+                guard timeUntilReset > 0 else { return nil }
+                // Estimate total monthly period (30 or 31 days) since we only have the end date.
+                let twentyEightDays: TimeInterval = 28 * 24 * 60 * 60
+                return timeUntilReset > twentyEightDays ? 44_640 : 43_200
+            }()
             return RateWindow(
                 usedPercent: usedPercent,
-                windowMinutes: nil,
+                windowMinutes: windowMinutes,
                 resetsAt: self.planPeriodEnd,
                 resetDescription: resetDesc)
         }()

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoUsageSnapshot.swift
@@ -50,11 +50,11 @@ extension MiMoUsageSnapshot {
                 let timeUntilReset = periodEnd.timeIntervalSince(self.updatedAt)
                 guard timeUntilReset > 0 else { return nil }
                 // The reset date marks the end of the billing cycle, so the cycle
-                // started one month before.  This correctly handles mid-month
-                // subscriptions (e.g. reset June 15 → started May 15 → 31 days)
-                // and February resets (28/29 days).
-                let calendar = Calendar.current
-                guard let cycleStart = calendar.date(byAdding: .month, value: -1, to: periodEnd) else { return nil }
+                // started one month before.  Use a UTC calendar so the result is
+                // deterministic regardless of the system timezone.
+                var utcCalendar = Calendar.current
+                utcCalendar.timeZone = TimeZone(secondsFromGMT: 0)!
+                guard let cycleStart = utcCalendar.date(byAdding: .month, value: -1, to: periodEnd) else { return nil }
                 let windowLength = periodEnd.timeIntervalSince(cycleStart)
                 guard windowLength > 0 else { return nil }
                 return Int(windowLength / 60)

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoUsageSnapshot.swift
@@ -50,11 +50,15 @@ extension MiMoUsageSnapshot {
                 let timeUntilReset = periodEnd.timeIntervalSince(self.updatedAt)
                 guard timeUntilReset > 0 else { return nil }
                 // The reset date marks the end of the billing cycle, so the cycle
-                // started one month before.  Use a UTC calendar so the result is
+                // started before that.  Use a UTC calendar so the result is
                 // deterministic regardless of the system timezone.
+                //
+                // Annual plans have periodEnd far in the future (months away);
+                // subtract one year for those, one month otherwise.
                 var utcCalendar = Calendar.current
                 utcCalendar.timeZone = TimeZone(secondsFromGMT: 0)!
-                guard let cycleStart = utcCalendar.date(byAdding: .month, value: -1, to: periodEnd) else { return nil }
+                let component: Calendar.Component = timeUntilReset > 90 * 86_400 ? .year : .month
+                guard let cycleStart = utcCalendar.date(byAdding: component, value: -1, to: periodEnd) else { return nil }
                 let windowLength = periodEnd.timeIntervalSince(cycleStart)
                 guard windowLength > 0 else { return nil }
                 return Int(windowLength / 60)

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoUsageSnapshot.swift
@@ -49,19 +49,17 @@ extension MiMoUsageSnapshot {
                 guard let periodEnd = self.planPeriodEnd else { return nil }
                 let timeUntilReset = periodEnd.timeIntervalSince(self.updatedAt)
                 guard timeUntilReset > 0 else { return nil }
-                // The reset date marks the end of the billing cycle, so the cycle
-                // started before that.  Use a UTC calendar so the result is
-                // deterministic regardless of the system timezone.
-                //
-                // Annual plans have periodEnd far in the future (months away);
-                // subtract one year for those, one month otherwise.
                 var utcCalendar = Calendar.current
                 utcCalendar.timeZone = TimeZone(secondsFromGMT: 0)!
-                let component: Calendar.Component = timeUntilReset > 90 * 86_400 ? .year : .month
-                guard let cycleStart = utcCalendar.date(byAdding: component, value: -1, to: periodEnd) else { return nil }
-                let windowLength = periodEnd.timeIntervalSince(cycleStart)
-                guard windowLength > 0 else { return nil }
-                return Int(windowLength / 60)
+                guard let monthStart = utcCalendar.date(byAdding: .month, value: -1, to: periodEnd) else { return nil }
+                let monthWindow = periodEnd.timeIntervalSince(monthStart)
+                if monthWindow >= timeUntilReset {
+                    return Int(monthWindow / 60)
+                }
+                guard let yearStart = utcCalendar.date(byAdding: .year, value: -1, to: periodEnd) else { return nil }
+                let yearWindow = periodEnd.timeIntervalSince(yearStart)
+                guard yearWindow > 0 else { return nil }
+                return Int(yearWindow / 60)
             }()
             return RateWindow(
                 usedPercent: usedPercent,

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -196,7 +196,7 @@ struct MiMoProviderTests {
         #expect(abs((usage.primary?.usedPercent ?? .nan) - 5.05) < 0.0001)
         #expect(usage.primary?.resetDescription == "10,100,158 / 200,000,000 Credits")
         #expect(usage.primary?.resetsAt == resetDate)
-        #expect(usage.primary?.windowMinutes == 43_200) // May 31 → June 30 = 30 days (Calendar preserves end-of-month)
+        #expect(usage.primary?.windowMinutes == 44_640) // UTC: June 30 − 1 month = May 30 → 31 days
         #expect(usage.loginMethod(for: .mimo) == "Standard")
     }
 

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -175,7 +175,10 @@ struct MiMoProviderTests {
 
     @Test
     func `usage snapshot shows token plan as primary when available`() {
-        let resetDate = Date(timeIntervalSince1970: 1_778_025_599)
+        // June 30, 2026 23:59:59 UTC
+        let resetDate = Date(timeIntervalSince1970: 1_782_863_999)
+        // June 5, 2026 00:00:00 UTC
+        let updatedAt = Date(timeIntervalSince1970: 1_780_704_000)
         let snapshot = MiMoUsageSnapshot(
             balance: 25.51,
             currency: "USD",
@@ -185,7 +188,7 @@ struct MiMoProviderTests {
             tokenUsed: 10_100_158,
             tokenLimit: 200_000_000,
             tokenPercent: 0.0505,
-            updatedAt: Date(timeIntervalSince1970: 1_742_771_200))
+            updatedAt: updatedAt)
 
         let usage = snapshot.toUsageSnapshot()
 
@@ -193,7 +196,38 @@ struct MiMoProviderTests {
         #expect(abs((usage.primary?.usedPercent ?? .nan) - 5.05) < 0.0001)
         #expect(usage.primary?.resetDescription == "10,100,158 / 200,000,000 Credits")
         #expect(usage.primary?.resetsAt == resetDate)
+        #expect(usage.primary?.windowMinutes == 43_200)
         #expect(usage.loginMethod(for: .mimo) == "Standard")
+    }
+
+    @Test
+    func `token plan pace is computed when window and reset date are present`() {
+        // June 30, 2026 23:59:59 UTC
+        let resetDate = Date(timeIntervalSince1970: 1_782_863_999)
+        // June 5, 2026 00:00:00 UTC — about 5 days into a 30-day period
+        let updatedAt = Date(timeIntervalSince1970: 1_780_704_000)
+        let snapshot = MiMoUsageSnapshot(
+            balance: 25.51,
+            currency: "USD",
+            planCode: "standard",
+            planPeriodEnd: resetDate,
+            planExpired: false,
+            tokenUsed: 1_000_000,
+            tokenLimit: 200_000_000,
+            tokenPercent: 0.005,
+            updatedAt: updatedAt)
+
+        let usage = snapshot.toUsageSnapshot()
+        guard let primary = usage.primary else {
+            Issue.record("Expected primary RateWindow")
+            return
+        }
+
+        // ~5 days elapsed out of 30 → expected ~16.7%, actual 0.5% → well in reserve
+        let pace = UsagePace.weekly(window: primary, now: updatedAt, defaultWindowMinutes: 43_200)
+        #expect(pace != nil)
+        #expect(pace?.stage == .farBehind) // behind expected = in reserve
+        #expect(pace?.willLastToReset == true)
     }
 
     @Test

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -196,7 +196,7 @@ struct MiMoProviderTests {
         #expect(abs((usage.primary?.usedPercent ?? .nan) - 5.05) < 0.0001)
         #expect(usage.primary?.resetDescription == "10,100,158 / 200,000,000 Credits")
         #expect(usage.primary?.resetsAt == resetDate)
-        #expect(usage.primary?.windowMinutes == 43_200)
+        #expect(usage.primary?.windowMinutes == 43_200) // May 31 → June 30 = 30 days (Calendar preserves end-of-month)
         #expect(usage.loginMethod(for: .mimo) == "Standard")
     }
 

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -231,6 +231,58 @@ struct MiMoProviderTests {
     }
 
     @Test
+    func `annual plan gets year-length window`() {
+        // June 30, 2027 23:59:59 UTC — annual plan reset
+        let resetDate = Date(timeIntervalSince1970: 1_814_399_999)
+        // July 1, 2026 00:00:00 UTC — 1 day into a 365-day annual cycle
+        let updatedAt = Date(timeIntervalSince1970: 1_782_950_400)
+        let snapshot = MiMoUsageSnapshot(
+            balance: 100.00,
+            currency: "USD",
+            planCode: "annual",
+            planPeriodEnd: resetDate,
+            planExpired: false,
+            tokenUsed: 1_000_000,
+            tokenLimit: 500_000_000,
+            tokenPercent: 0.002,
+            updatedAt: updatedAt)
+
+        let usage = snapshot.toUsageSnapshot()
+        // Annual: June 30, 2027 − 1 year = June 30, 2026 → 365 days = 525,600 minutes
+        #expect(usage.primary?.windowMinutes == 525_600)
+        #expect(usage.primary?.resetsAt == resetDate)
+    }
+
+    @Test
+    func `annual plan pace is computed with year-length window`() {
+        // June 30, 2027 23:59:59 UTC — annual plan reset
+        let resetDate = Date(timeIntervalSince1970: 1_814_399_999)
+        // July 1, 2026 00:00:00 UTC — ~0.27% through a 365-day period
+        let updatedAt = Date(timeIntervalSince1970: 1_782_950_400)
+        let snapshot = MiMoUsageSnapshot(
+            balance: 100.00,
+            currency: "USD",
+            planCode: "annual",
+            planPeriodEnd: resetDate,
+            planExpired: false,
+            tokenUsed: 1_000_000,
+            tokenLimit: 500_000_000,
+            tokenPercent: 0.002,
+            updatedAt: updatedAt)
+
+        let usage = snapshot.toUsageSnapshot()
+        guard let primary = usage.primary else {
+            Issue.record("Expected primary RateWindow")
+            return
+        }
+
+        let pace = UsagePace.weekly(window: primary, now: updatedAt, defaultWindowMinutes: 525_600)
+        #expect(pace != nil)
+        #expect(pace?.stage == .onTrack) // 0.2% actual vs ~0.27% expected → on-track (delta < 2%)
+        #expect(pace?.willLastToReset == true)
+    }
+
+    @Test
     func `usage snapshot falls back to balance when no token plan`() {
         let snapshot = MiMoUsageSnapshot(
             balance: 0,

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -283,6 +283,32 @@ struct MiMoProviderTests {
     }
 
     @Test
+    func `annual plan with 76 days remaining still gets year-length window`() {
+        // June 30, 2027 23:59:59 UTC — annual plan reset
+        let resetDate = Date(timeIntervalSince1970: 1_814_399_999)
+        // April 15, 2027 12:00:00 UTC — 76 days before reset
+        let updatedAt = Date(timeIntervalSince1970: 1_807_843_200)
+        let snapshot = MiMoUsageSnapshot(
+            balance: 100.00,
+            currency: "USD",
+            planCode: "annual",
+            planPeriodEnd: resetDate,
+            planExpired: false,
+            tokenUsed: 400_000_000,
+            tokenLimit: 500_000_000,
+            tokenPercent: 0.80,
+            updatedAt: updatedAt)
+
+        let usage = snapshot.toUsageSnapshot()
+        guard let primary = usage.primary else {
+            Issue.record("Expected primary RateWindow")
+            return
+        }
+
+        #expect(primary.windowMinutes == 525_600)
+    }
+
+    @Test
     func `usage snapshot falls back to balance when no token plan`() {
         let snapshot = MiMoUsageSnapshot(
             balance: 0,


### PR DESCRIPTION
Adds green pace marker and 'X% in reserve' labels when MiMo token usage is below expected linear consumption for the monthly billing period.

- Estimates 30/31-day window from planPeriodEnd for pace calculation
- Uses UsagePace.weekly() via Abacus-style primary window path
- Green stripe on progress bar when in reserve, red when in deficit
- Menu card shows 'X% in reserve · Lasts until reset' detail