### PR TITLE
Add Antigravity agy CLI fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 - CLI server: reload provider config for every usage and cost request, invalidate config-dependent cache entries, and prune expired config variants without restarting `codexbar serve`. Thanks @enieuwy!
 - Menu bar: anchor merged provider dropdowns to the status item's trailing edge without marking preserved in-flight refresh content fresh, preventing horizontal drift while keeping deferred updates visible (#1288). Thanks @Yuxin-Qiao!
-- Antigravity: fall back to the CLI usage server when the desktop app is closed, while keeping helper sessions owned, bounded, cleanly shut down, and unable to start a hidden sign-in flow (#1313). Thanks @enieuwy!
+- Antigravity: fall back to the CLI usage server when the desktop app is closed, keep helper sessions owned and bounded without hidden sign-in flows, and show model rows with missing usage as unavailable instead of exhausted (#1313). Thanks @enieuwy!
 - Cost usage: replace repeated Foundation metadata/root checks with one portable file-stat pass so expired Codex history refreshes stay responsive on very large session archives (#1392). Thanks @TheAngryPit and @ProspectOre!
 - Cursor: show the Safari Full Disk Access recovery hint before the long browser login list so permission guidance remains visible when menu errors truncate (#1419, fixes #1417). Thanks @hhh2210!
 - Cursor: present legacy request-based plans as one Requests quota with the raw used/limit count instead of unrelated token-based Auto/API bars (#1420, fixes #1418). Thanks @hhh2210!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - CLI server: reload provider config for every usage and cost request, invalidate config-dependent cache entries, and prune expired config variants without restarting `codexbar serve`. Thanks @enieuwy!
 - Menu bar: anchor merged provider dropdowns to the status item's trailing edge without marking preserved in-flight refresh content fresh, preventing horizontal drift while keeping deferred updates visible (#1288). Thanks @Yuxin-Qiao!
+- Antigravity: fall back to the CLI usage server when the desktop app is closed, while keeping helper sessions owned, bounded, and cleanly shut down (#1313). Thanks @enieuwy!
 - Cost usage: replace repeated Foundation metadata/root checks with one portable file-stat pass so expired Codex history refreshes stay responsive on very large session archives (#1392). Thanks @TheAngryPit and @ProspectOre!
 - Cursor: show the Safari Full Disk Access recovery hint before the long browser login list so permission guidance remains visible when menu errors truncate (#1419, fixes #1417). Thanks @hhh2210!
 - Cursor: present legacy request-based plans as one Requests quota with the raw used/limit count instead of unrelated token-based Auto/API bars (#1420, fixes #1418). Thanks @hhh2210!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 - CLI server: reload provider config for every usage and cost request, invalidate config-dependent cache entries, and prune expired config variants without restarting `codexbar serve`. Thanks @enieuwy!
 - Menu bar: anchor merged provider dropdowns to the status item's trailing edge without marking preserved in-flight refresh content fresh, preventing horizontal drift while keeping deferred updates visible (#1288). Thanks @Yuxin-Qiao!
-- Antigravity: fall back to the CLI usage server when the desktop app is closed, while keeping helper sessions owned, bounded, and cleanly shut down (#1313). Thanks @enieuwy!
+- Antigravity: fall back to the CLI usage server when the desktop app is closed, while keeping helper sessions owned, bounded, cleanly shut down, and unable to start a hidden sign-in flow (#1313). Thanks @enieuwy!
 - Cost usage: replace repeated Foundation metadata/root checks with one portable file-stat pass so expired Codex history refreshes stay responsive on very large session archives (#1392). Thanks @TheAngryPit and @ProspectOre!
 - Cursor: show the Safari Full Disk Access recovery hint before the long browser login list so permission guidance remains visible when menu errors truncate (#1419, fixes #1417). Thanks @hhh2210!
 - Cursor: present legacy request-based plans as one Requests quota with the raw used/limit count instead of unrelated token-based Auto/API bars (#1420, fixes #1418). Thanks @hhh2210!

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -211,6 +211,18 @@ extension UsageMenuCardView.Model {
                 provider: input.provider,
                 window: namedWindow.window,
                 input: input)
+            let usageKnown = namedWindow.usageKnown
+            let resetText = Self.resetText(
+                for: namedWindow.window,
+                style: input.resetTimeDisplayStyle,
+                now: input.now)
+            let statusText: String? = if usageKnown {
+                nil
+            } else if let resetText {
+                "\(L("Unavailable")) - \(resetText)"
+            } else {
+                L("Unavailable")
+            }
             return Metric(
                 id: namedWindow.id,
                 title: namedWindow.title,
@@ -219,14 +231,12 @@ extension UsageMenuCardView.Model {
                         ? namedWindow.window.usedPercent
                         : namedWindow.window.remainingPercent),
                 percentStyle: percentStyle,
-                resetText: Self.resetText(
-                    for: namedWindow.window,
-                    style: input.resetTimeDisplayStyle,
-                    now: input.now),
+                statusText: statusText,
+                resetText: usageKnown ? resetText : nil,
                 detailText: nil,
-                detailLeftText: paceDetail?.leftLabel,
-                detailRightText: paceDetail?.rightLabel,
-                pacePercent: paceDetail?.pacePercent,
+                detailLeftText: usageKnown ? paceDetail?.leftLabel : nil,
+                detailRightText: usageKnown ? paceDetail?.rightLabel : nil,
+                pacePercent: usageKnown ? paceDetail?.pacePercent : nil,
                 paceOnTop: paceDetail?.paceOnTop ?? true)
         }
     }

--- a/Sources/CodexBar/PreferencesProviderDetailView.swift
+++ b/Sources/CodexBar/PreferencesProviderDetailView.swift
@@ -1,6 +1,11 @@
 import CodexBarCore
 import SwiftUI
 
+enum ProviderMetricInlinePresentation: Equatable {
+    case progress
+    case status(String)
+}
+
 @MainActor
 struct ProviderDetailView<SupplementaryContent: View>: View {
     let provider: UsageProvider
@@ -61,6 +66,15 @@ struct ProviderDetailView<SupplementaryContent: View>: View {
 
     static func metricTitle(provider: UsageProvider, metric: UsageMenuCardView.Model.Metric) -> String {
         L(UsageMenuCardView.popupMetricTitle(provider: provider, metric: metric))
+    }
+
+    static func metricInlinePresentation(
+        _ metric: UsageMenuCardView.Model.Metric) -> ProviderMetricInlinePresentation
+    {
+        if let statusText = metric.statusText {
+            return .status(statusText)
+        }
+        return .progress
     }
 
     static func planRow(provider: UsageProvider, planText: String?) -> (label: String, value: String)? {
@@ -455,50 +469,57 @@ private struct ProviderMetricInlineRow: View {
                 .frame(width: self.labelWidth, alignment: .leading)
 
             VStack(alignment: .leading, spacing: 4) {
-                UsageProgressBar(
-                    percent: self.metric.percent,
-                    tint: self.progressColor,
-                    accessibilityLabel: self.metric.percentStyle.accessibilityLabel,
-                    pacePercent: self.metric.pacePercent,
-                    paceOnTop: self.metric.paceOnTop,
-                    warningMarkerPercents: self.metric.warningMarkerPercents)
-                    .frame(minWidth: ProviderSettingsMetrics.metricBarWidth, maxWidth: .infinity)
-
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text(self.metric.percentLabel)
+                switch ProviderDetailView<EmptyView>.metricInlinePresentation(self.metric) {
+                case let .status(statusText):
+                    Text(statusText)
                         .font(.footnote)
                         .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                    Spacer(minLength: 8)
-                    if let resetText = self.metric.resetText, !resetText.isEmpty {
-                        Text(resetText)
+                case .progress:
+                    UsageProgressBar(
+                        percent: self.metric.percent,
+                        tint: self.progressColor,
+                        accessibilityLabel: self.metric.percentStyle.accessibilityLabel,
+                        pacePercent: self.metric.pacePercent,
+                        paceOnTop: self.metric.paceOnTop,
+                        warningMarkerPercents: self.metric.warningMarkerPercents)
+                        .frame(minWidth: ProviderSettingsMetrics.metricBarWidth, maxWidth: .infinity)
+
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text(self.metric.percentLabel)
                             .font(.footnote)
                             .foregroundStyle(.secondary)
-                    }
-                }
-
-                let hasLeftDetail = self.metric.detailLeftText?.isEmpty == false
-                let hasRightDetail = self.metric.detailRightText?.isEmpty == false
-                if hasLeftDetail || hasRightDetail {
-                    HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        if let leftDetail = self.metric.detailLeftText, !leftDetail.isEmpty {
-                            Text(leftDetail)
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                        }
+                            .monospacedDigit()
                         Spacer(minLength: 8)
-                        if let rightDetail = self.metric.detailRightText, !rightDetail.isEmpty {
-                            Text(rightDetail)
+                        if let resetText = self.metric.resetText, !resetText.isEmpty {
+                            Text(resetText)
                                 .font(.footnote)
                                 .foregroundStyle(.secondary)
                         }
                     }
-                }
 
-                if let detail = self.detailText, !detail.isEmpty {
-                    Text(detail)
-                        .font(.footnote)
-                        .foregroundStyle(.tertiary)
+                    let hasLeftDetail = self.metric.detailLeftText?.isEmpty == false
+                    let hasRightDetail = self.metric.detailRightText?.isEmpty == false
+                    if hasLeftDetail || hasRightDetail {
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            if let leftDetail = self.metric.detailLeftText, !leftDetail.isEmpty {
+                                Text(leftDetail)
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer(minLength: 8)
+                            if let rightDetail = self.metric.detailRightText, !rightDetail.isEmpty {
+                                Text(rightDetail)
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+
+                    if let detail = self.detailText, !detail.isEmpty {
+                        Text(detail)
+                            .font(.footnote)
+                            .foregroundStyle(.tertiary)
+                    }
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/CodexBar/ProviderRegistry.swift
+++ b/Sources/CodexBar/ProviderRegistry.swift
@@ -81,12 +81,19 @@ struct ProviderRegistry {
                                 }
                             }
                         },
-                        costUsageHistoryDays: settings.costUsageHistoryDays)
+                        costUsageHistoryDays: settings.costUsageHistoryDays,
+                        persistsCLISessions: true,
+                        persistentCLISessionIdleWindow: Self.persistentCLISessionIdleWindow(
+                            refreshInterval: settings.refreshFrequency.seconds))
                 })
             specs[provider] = spec
         }
 
         return specs
+    }
+
+    static func persistentCLISessionIdleWindow(refreshInterval: TimeInterval?) -> TimeInterval {
+        max(180, (refreshInterval ?? 120) + 60)
     }
 
     @MainActor

--- a/Sources/CodexBar/Providers/Antigravity/AntigravityProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Antigravity/AntigravityProviderImplementation.swift
@@ -42,7 +42,7 @@ struct AntigravityProviderImplementation: ProviderImplementation {
             ProviderSettingsPickerDescriptor(
                 id: "antigravity-usage-source",
                 title: "Usage source",
-                subtitle: "Auto uses the local IDE API first, then Google OAuth when the IDE is closed.",
+                subtitle: "Auto uses the desktop local API first, then agy CLI, then Google OAuth.",
                 binding: usageBinding,
                 options: usageOptions,
                 isVisible: nil,

--- a/Sources/CodexBar/UsageStore+HighestUsage.swift
+++ b/Sources/CodexBar/UsageStore+HighestUsage.swift
@@ -9,8 +9,10 @@ extension UsageStore {
         var highest: (provider: UsageProvider, usedPercent: Double)?
         for provider in self.enabledProviders() {
             guard let snapshot = self.snapshots[provider] else { continue }
-            let window = self.menuBarMetricWindowForHighestUsage(provider: provider, snapshot: snapshot)
-            let percent = window?.usedPercent ?? 0
+            guard let window = self.menuBarMetricWindowForHighestUsage(provider: provider, snapshot: snapshot) else {
+                continue
+            }
+            let percent = window.usedPercent
             guard !self.shouldExcludeFromHighestUsage(
                 provider: provider,
                 snapshot: snapshot,
@@ -49,7 +51,7 @@ extension UsageStore {
             // In automatic mode Copilot can have one depleted lane while another still has quota.
             return primary.usedPercent >= 100 && secondary.usedPercent >= 100
         }
-        if provider == .cursor,
+        if provider == .cursor || provider == .antigravity,
            effectivePreference == .automatic
         {
             let percents = [
@@ -60,17 +62,7 @@ extension UsageStore {
             guard !percents.isEmpty else { return true }
             return percents.allSatisfy { $0 >= 100 }
         }
-        if provider == .antigravity,
-           effectivePreference == .automatic
-        {
-            let percents = [
-                snapshot.primary?.usedPercent,
-                snapshot.secondary?.usedPercent,
-                snapshot.tertiary?.usedPercent,
-            ].compactMap(\.self)
-            guard !percents.isEmpty else { return true }
-            return percents.allSatisfy { $0 >= 100 }
-        }
+
         return true
     }
 }

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -680,7 +680,10 @@ extension UsageStore {
                     self.settings.stepfunToken = token
                 }
             },
-            costUsageHistoryDays: self.settings.costUsageHistoryDays)
+            costUsageHistoryDays: self.settings.costUsageHistoryDays,
+            persistsCLISessions: true,
+            persistentCLISessionIdleWindow: ProviderRegistry.persistentCLISessionIdleWindow(
+                refreshInterval: self.settings.refreshFrequency.seconds))
     }
 
     func sourceMode(for provider: UsageProvider) -> ProviderSourceMode {

--- a/Sources/CodexBarCLI/CLIEntry.swift
+++ b/Sources/CodexBarCLI/CLIEntry.swift
@@ -33,6 +33,10 @@ enum CodexBarCLI {
             Self.bootstrapLogging(path: invocation.path, values: invocation.parsedValues)
             switch invocation.path {
             case ["usage"]:
+                let signalMonitor = CLITerminationSignalMonitor { signalNumber in
+                    CLITerminationSignalMonitor.terminateActiveHelpersAndReraise(signalNumber)
+                }
+                defer { signalMonitor.cancel() }
                 await self.runUsage(invocation.parsedValues)
             case ["cost"]:
                 await self.runCost(invocation.parsedValues)
@@ -53,6 +57,10 @@ enum CodexBarCLI {
             case ["cache", "clear"]:
                 self.runCacheClear(invocation.parsedValues)
             case ["diagnose"]:
+                let signalMonitor = CLITerminationSignalMonitor { signalNumber in
+                    CLITerminationSignalMonitor.terminateActiveHelpersAndReraise(signalNumber)
+                }
+                defer { signalMonitor.cancel() }
                 await self.runDiagnose(invocation.parsedValues)
             default:
                 Self.exit(

--- a/Sources/CodexBarCLI/CLIErrorReporting.swift
+++ b/Sources/CodexBarCLI/CLIErrorReporting.swift
@@ -49,6 +49,7 @@ extension CodexBarCLI {
     static func makeProviderErrorPayload(
         provider: UsageProvider,
         account: String?,
+        cacheAccountKey: String? = nil,
         source: String,
         status: ProviderStatusPayload?,
         error: Error,
@@ -57,6 +58,7 @@ extension CodexBarCLI {
         ProviderPayload(
             provider: provider,
             account: account,
+            cacheAccountKey: cacheAccountKey,
             version: nil,
             source: source,
             status: status,

--- a/Sources/CodexBarCLI/CLILocalHTTPServer.swift
+++ b/Sources/CodexBarCLI/CLILocalHTTPServer.swift
@@ -184,17 +184,26 @@ struct CLILocalHTTPResponse {
     }
 }
 
-final class CLILocalHTTPServer {
+final class CLILocalHTTPServer: @unchecked Sendable {
     typealias Handler = @Sendable (CLILocalHTTPRequest) async -> CLILocalHTTPResponse
 
     private let host: String
     private let port: UInt16
     private let handler: Handler
+    private let stateLock = NSLock()
+    private var listeningFD: Int32?
+    private var stopRequested = false
 
     init(host: String, port: UInt16, handler: @escaping Handler) {
         self.host = host
         self.port = port
         self.handler = handler
+    }
+
+    func stop() {
+        self.stateLock.lock()
+        self.stopRequested = true
+        self.stateLock.unlock()
     }
 
     func run(onListening: @Sendable () -> Void = {}) async throws {
@@ -210,7 +219,12 @@ final class CLILocalHTTPServer {
         guard serverFD >= 0 else {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
-        defer { closeSocket(serverFD) }
+        var ownsServerFD = true
+        defer {
+            if ownsServerFD {
+                closeSocket(serverFD)
+            }
+        }
 
         var reuse: Int32 = 1
         setsockopt(
@@ -242,19 +256,60 @@ final class CLILocalHTTPServer {
         guard listen(serverFD, 16) == 0 else {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
+        guard self.installListeningFD(serverFD) else {
+            return
+        }
+        ownsServerFD = false
+        defer {
+            if self.releaseListeningFD(serverFD) {
+                closeSocket(serverFD)
+            }
+        }
         onListening()
 
-        while true {
+        while !self.isStopRequested {
+            guard waitForReadable(serverFD, timeoutMilliseconds: 250) else {
+                continue
+            }
             var clientAddress = sockaddr()
             var clientLength = socklen_t(MemoryLayout<sockaddr>.size)
             let clientFD = accept(serverFD, &clientAddress, &clientLength)
-            guard clientFD >= 0 else { continue }
+            guard clientFD >= 0 else {
+                if self.isStopRequested { return }
+                if errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK || errno == ECONNABORTED {
+                    continue
+                }
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
             let handler = self.handler
             Task {
                 defer { closeSocket(clientFD) }
                 await handleClient(clientFD, handler: handler)
             }
         }
+    }
+
+    private var isStopRequested: Bool {
+        self.stateLock.lock()
+        let value = self.stopRequested
+        self.stateLock.unlock()
+        return value
+    }
+
+    private func installListeningFD(_ fd: Int32) -> Bool {
+        self.stateLock.lock()
+        defer { self.stateLock.unlock() }
+        guard !self.stopRequested else { return false }
+        self.listeningFD = fd
+        return true
+    }
+
+    private func releaseListeningFD(_ fd: Int32) -> Bool {
+        self.stateLock.lock()
+        defer { self.stateLock.unlock() }
+        guard self.listeningFD == fd else { return false }
+        self.listeningFD = nil
+        return true
     }
 }
 

--- a/Sources/CodexBarCLI/CLILocalHTTPServer.swift
+++ b/Sources/CodexBarCLI/CLILocalHTTPServer.swift
@@ -164,11 +164,18 @@ struct CLILocalHTTPResponse {
     let status: CLIHTTPStatus
     let body: Data
     let contentType: String
+    let usageCacheKeys: [String?]?
 
-    init(status: CLIHTTPStatus, body: Data, contentType: String = "application/json; charset=utf-8") {
+    init(
+        status: CLIHTTPStatus,
+        body: Data,
+        contentType: String = "application/json; charset=utf-8",
+        usageCacheKeys: [String?]? = nil)
+    {
         self.status = status
         self.body = body
         self.contentType = contentType
+        self.usageCacheKeys = usageCacheKeys
     }
 
     var serialized: Data {

--- a/Sources/CodexBarCLI/CLIPayloads.swift
+++ b/Sources/CodexBarCLI/CLIPayloads.swift
@@ -7,6 +7,7 @@ import FoundationNetworking
 struct ProviderPayload: Encodable {
     let provider: String
     let account: String?
+    let cacheAccountKey: String?
     let version: String?
     let source: String
     let status: ProviderStatusPayload?
@@ -16,9 +17,23 @@ struct ProviderPayload: Encodable {
     let openaiDashboard: OpenAIDashboardSnapshot?
     let error: ProviderErrorPayload?
 
+    private enum CodingKeys: String, CodingKey {
+        case provider
+        case account
+        case version
+        case source
+        case status
+        case usage
+        case credits
+        case antigravityPlanInfo
+        case openaiDashboard
+        case error
+    }
+
     init(
         provider: UsageProvider,
         account: String?,
+        cacheAccountKey: String? = nil,
         version: String?,
         source: String,
         status: ProviderStatusPayload?,
@@ -30,6 +45,7 @@ struct ProviderPayload: Encodable {
     {
         self.provider = provider.rawValue
         self.account = account
+        self.cacheAccountKey = cacheAccountKey
         self.version = version
         self.source = source
         self.status = status
@@ -43,6 +59,7 @@ struct ProviderPayload: Encodable {
     init(
         providerID: String,
         account: String?,
+        cacheAccountKey: String? = nil,
         version: String?,
         source: String,
         status: ProviderStatusPayload?,
@@ -54,6 +71,7 @@ struct ProviderPayload: Encodable {
     {
         self.provider = providerID
         self.account = account
+        self.cacheAccountKey = cacheAccountKey
         self.version = version
         self.source = source
         self.status = status

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -185,7 +185,7 @@ private final class CLIServeDeadlineState: @unchecked Sendable {
     }
 }
 
-private enum CLIServeCacheLookup {
+enum CLIServeCacheLookup {
     case response(CLILocalHTTPResponse)
     case miss
 }
@@ -208,8 +208,26 @@ actor CLIServeResponseCache {
         let response: CLILocalHTTPResponse
     }
 
+    private struct UsageItemKey: Hashable {
+        let provider: String
+        let accountID: String
+    }
+
+    private struct LastGoodUsageItem {
+        let recordedAt: Date
+        let data: Data
+    }
+
+    private struct UsageMergeResult {
+        let response: CLILocalHTTPResponse
+        let hasFreshSuccess: Bool
+        let fallbackRecordedAt: Date?
+    }
+
     private var entries: [String: Entry] = [:]
     private var lastGood: [String: LastGoodEntry] = [:]
+    private var lastGoodUsageItems: [String: [UsageItemKey: LastGoodUsageItem]] = [:]
+    private var lastGoodUsageOrder: [String: [UsageItemKey]] = [:]
     private var inFlightKeys: Set<String> = []
     private var waiters: [String: [CheckedContinuation<CLIServeCacheLookup, Never>]] = [:]
 
@@ -222,7 +240,7 @@ actor CLIServeResponseCache {
         return entry.response
     }
 
-    fileprivate func responseOrStartFetch(for key: String, now: Date) async -> CLIServeCacheLookup {
+    func responseOrStartFetch(for key: String, now: Date) async -> CLIServeCacheLookup {
         self.pruneExpiredEntries(now: now)
         if let cached = self.response(for: key) {
             return .response(cached)
@@ -243,7 +261,7 @@ actor CLIServeResponseCache {
     /// fall back to the last good response when one was recorded within
     /// `staleTTL`, so transient provider errors do not blank out consumers
     /// that poll this endpoint (status bars hide items on error payloads).
-    fileprivate func completeFetch(
+    func completeFetch(
         _ response: CLILocalHTTPResponse,
         for key: String,
         policy: CachePolicy,
@@ -251,12 +269,26 @@ actor CLIServeResponseCache {
         shouldCache: Bool) -> CLILocalHTTPResponse
     {
         let delivered: CLILocalHTTPResponse
+        let staleResponse = self.staleResponse(for: key, staleTTL: policy.staleTTL, now: now)
+        let usageMerge = self.mergeLastGoodUsageItems(
+            into: response,
+            for: key,
+            staleTTL: policy.staleTTL,
+            now: now,
+            replaceCachedItems: shouldCache)
         if shouldCache {
             self.store(response, for: key, ttl: policy.ttl, now: now)
             self.lastGood[key] = LastGoodEntry(recordedAt: now, response: response)
             delivered = response
+        } else if let usageMerge {
+            delivered = usageMerge.response
+            if let recordedAt = usageMerge.fallbackRecordedAt {
+                self.lastGood[key] = LastGoodEntry(recordedAt: recordedAt, response: delivered)
+            } else if !usageMerge.hasFreshSuccess {
+                self.lastGood[key] = nil
+            }
         } else {
-            delivered = self.staleResponse(for: key, staleTTL: policy.staleTTL, now: now) ?? response
+            delivered = staleResponse ?? response
         }
         self.inFlightKeys.remove(key)
         let waiters = self.waiters.removeValue(forKey: key) ?? []
@@ -271,12 +303,161 @@ actor CLIServeResponseCache {
         staleTTL: TimeInterval,
         now: Date) -> CLILocalHTTPResponse?
     {
-        guard staleTTL > 0, let entry = self.lastGood[key] else { return nil }
-        guard now.timeIntervalSince(entry.recordedAt) <= staleTTL else {
+        guard staleTTL > 0 else { return nil }
+        if let entry = self.lastGood[key],
+           now.timeIntervalSince(entry.recordedAt) <= staleTTL
+        {
+            return entry.response
+        }
+        if self.lastGood[key] != nil {
             self.lastGood[key] = nil
+        }
+        return self.staleUsageResponse(for: key, staleTTL: staleTTL, now: now)
+    }
+
+    private func mergeLastGoodUsageItems(
+        into response: CLILocalHTTPResponse,
+        for key: String,
+        staleTTL: TimeInterval,
+        now: Date,
+        replaceCachedItems: Bool) -> UsageMergeResult?
+    {
+        guard key.hasPrefix("usage:"),
+              response.status == .ok,
+              staleTTL > 0,
+              var items = try? JSONSerialization.jsonObject(with: response.body) as? [[String: Any]]
+        else {
             return nil
         }
-        return entry.response
+
+        var cachedItems = replaceCachedItems ? [:] : self.lastGoodUsageItems[key] ?? [:]
+        if !replaceCachedItems {
+            cachedItems = cachedItems.filter { now.timeIntervalSince($0.value.recordedAt) <= staleTTL }
+        }
+        let itemKeys = items.indices.compactMap { index in
+            Self.usageItemKey(
+                items[index],
+                accountID: Self.cacheAccountKey(at: index, in: response.usageCacheKeys))
+        }
+        let duplicateKeys = Set(
+            Dictionary(grouping: itemKeys, by: { $0 })
+                .filter { $0.value.count > 1 }
+                .map(\.key))
+        self.lastGoodUsageOrder[key] = itemKeys.filter { !duplicateKeys.contains($0) }
+        for duplicateKey in duplicateKeys {
+            cachedItems[duplicateKey] = nil
+        }
+        var hasFreshSuccess = false
+        var fallbackRecordedAt: Date?
+        var replacedError = false
+
+        for index in items.indices {
+            let item = items[index]
+            guard let itemKey = Self.usageItemKey(
+                item,
+                accountID: Self.cacheAccountKey(at: index, in: response.usageCacheKeys))
+            else {
+                if !Self.hasError(item) {
+                    hasFreshSuccess = true
+                    fallbackRecordedAt = Self.earlier(fallbackRecordedAt, now)
+                }
+                continue
+            }
+            guard !duplicateKeys.contains(itemKey) else {
+                if !Self.hasError(item) {
+                    hasFreshSuccess = true
+                    fallbackRecordedAt = Self.earlier(fallbackRecordedAt, now)
+                }
+                continue
+            }
+
+            if Self.hasError(item) {
+                guard let cached = cachedItems[itemKey],
+                      let cachedItem = try? JSONSerialization.jsonObject(with: cached.data) as? [String: Any]
+                else {
+                    continue
+                }
+                items[index] = cachedItem
+                fallbackRecordedAt = Self.earlier(fallbackRecordedAt, cached.recordedAt)
+                replacedError = true
+            } else {
+                hasFreshSuccess = true
+                fallbackRecordedAt = Self.earlier(fallbackRecordedAt, now)
+                if let data = try? JSONSerialization.data(withJSONObject: item, options: [.sortedKeys]) {
+                    cachedItems[itemKey] = LastGoodUsageItem(recordedAt: now, data: data)
+                }
+            }
+        }
+        self.lastGoodUsageItems[key] = cachedItems
+
+        guard replacedError,
+              let body = try? JSONSerialization.data(withJSONObject: items, options: [.sortedKeys])
+        else {
+            return UsageMergeResult(
+                response: response,
+                hasFreshSuccess: hasFreshSuccess,
+                fallbackRecordedAt: fallbackRecordedAt)
+        }
+        return UsageMergeResult(
+            response: CLILocalHTTPResponse(
+                status: response.status,
+                body: body,
+                contentType: response.contentType,
+                usageCacheKeys: response.usageCacheKeys),
+            hasFreshSuccess: hasFreshSuccess,
+            fallbackRecordedAt: fallbackRecordedAt)
+    }
+
+    private static func earlier(_ lhs: Date?, _ rhs: Date) -> Date {
+        lhs.map { min($0, rhs) } ?? rhs
+    }
+
+    private func staleUsageResponse(
+        for key: String,
+        staleTTL: TimeInterval,
+        now: Date) -> CLILocalHTTPResponse?
+    {
+        guard key.hasPrefix("usage:"),
+              let order = self.lastGoodUsageOrder[key],
+              !order.isEmpty
+        else {
+            return nil
+        }
+
+        var cachedItems = self.lastGoodUsageItems[key] ?? [:]
+        cachedItems = cachedItems.filter { now.timeIntervalSince($0.value.recordedAt) <= staleTTL }
+        self.lastGoodUsageItems[key] = cachedItems
+        let items = order.compactMap { itemKey -> [String: Any]? in
+            guard let data = cachedItems[itemKey]?.data else { return nil }
+            return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        }
+        guard !items.isEmpty,
+              let body = try? JSONSerialization.data(withJSONObject: items, options: [.sortedKeys])
+        else {
+            return nil
+        }
+        return CLILocalHTTPResponse(status: .ok, body: body)
+    }
+
+    private static func usageItemKey(_ item: [String: Any], accountID: String?) -> UsageItemKey? {
+        guard let provider = item["provider"] as? String,
+              !provider.isEmpty,
+              let accountID,
+              !accountID.isEmpty
+        else {
+            return nil
+        }
+        return UsageItemKey(provider: provider, accountID: accountID)
+    }
+
+    private static func cacheAccountKey(at index: Int, in keys: [String?]?) -> String? {
+        guard let keys, keys.indices.contains(index) else { return nil }
+        return keys[index]
+    }
+
+    private static func hasError(_ item: [String: Any]) -> Bool {
+        guard let error = item["error"] else { return false }
+        return !(error is NSNull)
     }
 
     private func store(_ response: CLILocalHTTPResponse, for key: String, ttl: TimeInterval, now: Date) {
@@ -631,7 +812,9 @@ extension CodexBarCLI {
             output.merge(providerOutput)
         }
 
-        return Self.serveJSON(output.payload)
+        return Self.serveJSON(
+            output.payload,
+            usageCacheKeys: output.payload.map(\.cacheAccountKey))
     }
 
     private static func serveCost(provider rawProvider: String?, config: CodexBarConfig) async -> CLILocalHTTPResponse {
@@ -676,9 +859,16 @@ extension CodexBarCLI {
         return selection
     }
 
-    private static func serveJSON(_ payload: some Encodable, status: CLIHTTPStatus = .ok) -> CLILocalHTTPResponse {
+    private static func serveJSON(
+        _ payload: some Encodable,
+        status: CLIHTTPStatus = .ok,
+        usageCacheKeys: [String?]? = nil) -> CLILocalHTTPResponse
+    {
         let json = Self.encodeJSON(payload, pretty: false) ?? "{}"
-        return CLILocalHTTPResponse(status: status, body: Data(json.utf8))
+        return CLILocalHTTPResponse(
+            status: status,
+            body: Data(json.utf8),
+            usageCacheKeys: usageCacheKeys)
     }
 
     private static func serveError(status: CLIHTTPStatus, message: String) -> CLILocalHTTPResponse {

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -1,12 +1,6 @@
 import CodexBarCore
 import Commander
-import Dispatch
 import Foundation
-#if canImport(Darwin)
-import Darwin
-#else
-import Glibc
-#endif
 
 struct ServeOptions: CommanderParsable {
     @Flag(names: [.short("v"), .long("verbose")], help: "Enable verbose logging")
@@ -39,55 +33,6 @@ enum CLIServeRoute: Equatable {
 enum CLIServeRouteError: Error, Equatable {
     case methodNotAllowed
     case notFound
-}
-
-private func handleCLIServeTerminationSignal(_: Int32) {}
-
-final class CLIServeSignalMonitor: @unchecked Sendable {
-    private let lock = NSLock()
-    private let signals: [Int32]
-    private let sources: [DispatchSourceSignal]
-    private var isCancelled = false
-
-    init(onSignal: @escaping @Sendable () -> Void) {
-        self.signals = [SIGINT, SIGTERM]
-        self.sources = self.signals.map { signalNumber in
-            #if canImport(Darwin)
-            _ = Darwin.signal(signalNumber, handleCLIServeTerminationSignal)
-            #else
-            _ = Glibc.signal(signalNumber, handleCLIServeTerminationSignal)
-            #endif
-            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global(qos: .utility))
-            source.setEventHandler(handler: onSignal)
-            source.resume()
-            return source
-        }
-    }
-
-    func cancel() {
-        self.lock.lock()
-        guard !self.isCancelled else {
-            self.lock.unlock()
-            return
-        }
-        self.isCancelled = true
-        self.lock.unlock()
-
-        for source in self.sources {
-            source.cancel()
-        }
-        for signalNumber in self.signals {
-            #if canImport(Darwin)
-            _ = Darwin.signal(signalNumber, SIG_DFL)
-            #else
-            _ = Glibc.signal(signalNumber, SIG_DFL)
-            #endif
-        }
-    }
-
-    deinit {
-        self.cancel()
-    }
 }
 
 enum CLIServeRouter {
@@ -497,7 +442,8 @@ extension CodexBarCLI {
                 refreshInterval: refreshInterval,
                 requestTimeout: requestTimeout)
         }
-        let signalMonitor = CLIServeSignalMonitor {
+        let signalMonitor = CLITerminationSignalMonitor { _ in
+            TTYCommandRunner.terminateActiveProcessesForAppShutdown()
             server.stop()
         }
         defer { signalMonitor.cancel() }

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -220,14 +220,11 @@ actor CLIServeResponseCache {
 
     private struct UsageMergeResult {
         let response: CLILocalHTTPResponse
-        let hasFreshSuccess: Bool
-        let fallbackRecordedAt: Date?
     }
 
     private var entries: [String: Entry] = [:]
     private var lastGood: [String: LastGoodEntry] = [:]
     private var lastGoodUsageItems: [String: [UsageItemKey: LastGoodUsageItem]] = [:]
-    private var lastGoodUsageOrder: [String: [UsageItemKey]] = [:]
     private var inFlightKeys: Set<String> = []
     private var waiters: [String: [CheckedContinuation<CLIServeCacheLookup, Never>]] = [:]
 
@@ -257,10 +254,9 @@ actor CLIServeResponseCache {
     }
 
     /// Completes an in-flight fetch and returns the response delivered to
-    /// waiters. Successful responses are cached normally. Failed fetches
-    /// fall back to the last good response when one was recorded within
-    /// `staleTTL`, so transient provider errors do not blank out consumers
-    /// that poll this endpoint (status bars hide items on error payloads).
+    /// waiters. Successful responses are cached normally. Failed non-usage
+    /// fetches may use a whole-response fallback within `staleTTL`; usage
+    /// responses only replace keyed error rows from the same identified account.
     func completeFetch(
         _ response: CLILocalHTTPResponse,
         for key: String,
@@ -278,15 +274,15 @@ actor CLIServeResponseCache {
             replaceCachedItems: shouldCache)
         if shouldCache {
             self.store(response, for: key, ttl: policy.ttl, now: now)
-            self.lastGood[key] = LastGoodEntry(recordedAt: now, response: response)
+            if key.hasPrefix("usage:") {
+                self.lastGood[key] = nil
+            } else {
+                self.lastGood[key] = LastGoodEntry(recordedAt: now, response: response)
+            }
             delivered = response
         } else if let usageMerge {
             delivered = usageMerge.response
-            if let recordedAt = usageMerge.fallbackRecordedAt {
-                self.lastGood[key] = LastGoodEntry(recordedAt: recordedAt, response: delivered)
-            } else if !usageMerge.hasFreshSuccess {
-                self.lastGood[key] = nil
-            }
+            self.lastGood[key] = nil
         } else {
             delivered = staleResponse ?? response
         }
@@ -304,6 +300,10 @@ actor CLIServeResponseCache {
         now: Date) -> CLILocalHTTPResponse?
     {
         guard staleTTL > 0 else { return nil }
+        // A timeout cannot prove which usage account is currently active.
+        if key.hasPrefix("usage:") {
+            return nil
+        }
         if let entry = self.lastGood[key],
            now.timeIntervalSince(entry.recordedAt) <= staleTTL
         {
@@ -312,7 +312,7 @@ actor CLIServeResponseCache {
         if self.lastGood[key] != nil {
             self.lastGood[key] = nil
         }
-        return self.staleUsageResponse(for: key, staleTTL: staleTTL, now: now)
+        return nil
     }
 
     private func mergeLastGoodUsageItems(
@@ -343,12 +343,9 @@ actor CLIServeResponseCache {
             Dictionary(grouping: itemKeys, by: { $0 })
                 .filter { $0.value.count > 1 }
                 .map(\.key))
-        self.lastGoodUsageOrder[key] = itemKeys.filter { !duplicateKeys.contains($0) }
         for duplicateKey in duplicateKeys {
             cachedItems[duplicateKey] = nil
         }
-        var hasFreshSuccess = false
-        var fallbackRecordedAt: Date?
         var replacedError = false
 
         for index in items.indices {
@@ -357,32 +354,20 @@ actor CLIServeResponseCache {
                 item,
                 accountID: Self.cacheAccountKey(at: index, in: response.usageCacheKeys))
             else {
-                if !Self.hasError(item) {
-                    hasFreshSuccess = true
-                    fallbackRecordedAt = Self.earlier(fallbackRecordedAt, now)
-                }
                 continue
             }
             guard !duplicateKeys.contains(itemKey) else {
-                if !Self.hasError(item) {
-                    hasFreshSuccess = true
-                    fallbackRecordedAt = Self.earlier(fallbackRecordedAt, now)
-                }
                 continue
             }
 
             if Self.hasError(item) {
-                guard let cached = cachedItems[itemKey],
-                      let cachedItem = try? JSONSerialization.jsonObject(with: cached.data) as? [String: Any]
-                else {
-                    continue
+                if let cached = cachedItems[itemKey],
+                   let cachedItem = try? JSONSerialization.jsonObject(with: cached.data) as? [String: Any]
+                {
+                    items[index] = cachedItem
+                    replacedError = true
                 }
-                items[index] = cachedItem
-                fallbackRecordedAt = Self.earlier(fallbackRecordedAt, cached.recordedAt)
-                replacedError = true
             } else {
-                hasFreshSuccess = true
-                fallbackRecordedAt = Self.earlier(fallbackRecordedAt, now)
                 if let data = try? JSONSerialization.data(withJSONObject: item, options: [.sortedKeys]) {
                     cachedItems[itemKey] = LastGoodUsageItem(recordedAt: now, data: data)
                 }
@@ -393,50 +378,14 @@ actor CLIServeResponseCache {
         guard replacedError,
               let body = try? JSONSerialization.data(withJSONObject: items, options: [.sortedKeys])
         else {
-            return UsageMergeResult(
-                response: response,
-                hasFreshSuccess: hasFreshSuccess,
-                fallbackRecordedAt: fallbackRecordedAt)
+            return UsageMergeResult(response: response)
         }
         return UsageMergeResult(
             response: CLILocalHTTPResponse(
                 status: response.status,
                 body: body,
                 contentType: response.contentType,
-                usageCacheKeys: response.usageCacheKeys),
-            hasFreshSuccess: hasFreshSuccess,
-            fallbackRecordedAt: fallbackRecordedAt)
-    }
-
-    private static func earlier(_ lhs: Date?, _ rhs: Date) -> Date {
-        lhs.map { min($0, rhs) } ?? rhs
-    }
-
-    private func staleUsageResponse(
-        for key: String,
-        staleTTL: TimeInterval,
-        now: Date) -> CLILocalHTTPResponse?
-    {
-        guard key.hasPrefix("usage:"),
-              let order = self.lastGoodUsageOrder[key],
-              !order.isEmpty
-        else {
-            return nil
-        }
-
-        var cachedItems = self.lastGoodUsageItems[key] ?? [:]
-        cachedItems = cachedItems.filter { now.timeIntervalSince($0.value.recordedAt) <= staleTTL }
-        self.lastGoodUsageItems[key] = cachedItems
-        let items = order.compactMap { itemKey -> [String: Any]? in
-            guard let data = cachedItems[itemKey]?.data else { return nil }
-            return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        }
-        guard !items.isEmpty,
-              let body = try? JSONSerialization.data(withJSONObject: items, options: [.sortedKeys])
-        else {
-            return nil
-        }
-        return CLILocalHTTPResponse(status: .ok, body: body)
+                usageCacheKeys: response.usageCacheKeys))
     }
 
     private static func usageItemKey(_ item: [String: Any], accountID: String?) -> UsageItemKey? {

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -1,6 +1,12 @@
 import CodexBarCore
 import Commander
+import Dispatch
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
 
 struct ServeOptions: CommanderParsable {
     @Flag(names: [.short("v"), .long("verbose")], help: "Enable verbose logging")
@@ -33,6 +39,55 @@ enum CLIServeRoute: Equatable {
 enum CLIServeRouteError: Error, Equatable {
     case methodNotAllowed
     case notFound
+}
+
+private func handleCLIServeTerminationSignal(_: Int32) {}
+
+final class CLIServeSignalMonitor: @unchecked Sendable {
+    private let lock = NSLock()
+    private let signals: [Int32]
+    private let sources: [DispatchSourceSignal]
+    private var isCancelled = false
+
+    init(onSignal: @escaping @Sendable () -> Void) {
+        self.signals = [SIGINT, SIGTERM]
+        self.sources = self.signals.map { signalNumber in
+            #if canImport(Darwin)
+            _ = Darwin.signal(signalNumber, handleCLIServeTerminationSignal)
+            #else
+            _ = Glibc.signal(signalNumber, handleCLIServeTerminationSignal)
+            #endif
+            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global(qos: .utility))
+            source.setEventHandler(handler: onSignal)
+            source.resume()
+            return source
+        }
+    }
+
+    func cancel() {
+        self.lock.lock()
+        guard !self.isCancelled else {
+            self.lock.unlock()
+            return
+        }
+        self.isCancelled = true
+        self.lock.unlock()
+
+        for source in self.sources {
+            source.cancel()
+        }
+        for signalNumber in self.signals {
+            #if canImport(Darwin)
+            _ = Darwin.signal(signalNumber, SIG_DFL)
+            #else
+            _ = Glibc.signal(signalNumber, SIG_DFL)
+            #endif
+        }
+    }
+
+    deinit {
+        self.cancel()
+    }
 }
 
 enum CLIServeRouter {
@@ -297,14 +352,25 @@ extension CodexBarCLI {
                 refreshInterval: refreshInterval,
                 requestTimeout: requestTimeout)
         }
+        let signalMonitor = CLIServeSignalMonitor {
+            server.stop()
+        }
+        defer { signalMonitor.cancel() }
 
         do {
             try await server.run {
                 Self.writeStderr("CodexBar server listening on http://127.0.0.1:\(port)\n")
             }
         } catch {
+            await Self.shutdownServeSessions()
             Self.exit(code: .failure, message: error.localizedDescription, output: output, kind: .runtime)
         }
+        await Self.shutdownServeSessions()
+    }
+
+    private static func shutdownServeSessions() async {
+        await ProviderCLISessionLifecycle.shutdownPersistentSessions()
+        TTYCommandRunner.terminateActiveProcessesForAppShutdown()
     }
 
     static func decodeServePort(from values: ParsedValues) -> UInt16? {
@@ -329,7 +395,7 @@ extension CodexBarCLI {
         } else {
             parsed = 60
         }
-        guard parsed >= 0 else { return nil }
+        guard parsed.isFinite, parsed >= 0 else { return nil }
         return parsed
     }
 
@@ -381,7 +447,10 @@ extension CodexBarCLI {
                 refreshInterval: refreshInterval,
                 requestTimeout: requestTimeout)
             {
-                await Self.serveUsage(provider: provider, config: snapshot.config)
+                await Self.serveUsage(
+                    provider: provider,
+                    config: snapshot.config,
+                    refreshInterval: refreshInterval)
             }
         case let .cost(provider):
             let snapshot: CLIServeConfigSnapshot
@@ -493,6 +562,10 @@ extension CodexBarCLI {
         return max(refreshInterval * 10, 300)
     }
 
+    static func serveCLISessionIdleWindow(refreshInterval: TimeInterval) -> TimeInterval {
+        max(180, refreshInterval + 60)
+    }
+
     static func shouldCacheServeResponse(_ response: CLILocalHTTPResponse) -> Bool {
         guard response.status == .ok else { return false }
         guard let payload = try? JSONSerialization.jsonObject(with: response.body) as? [[String: Any]] else {
@@ -506,7 +579,8 @@ extension CodexBarCLI {
 
     private static func serveUsage(
         provider rawProvider: String?,
-        config: CodexBarConfig) async -> CLILocalHTTPResponse
+        config: CodexBarConfig,
+        refreshInterval: TimeInterval) async -> CLILocalHTTPResponse
     {
         let selection: ProviderSelection
         do {
@@ -542,7 +616,8 @@ extension CodexBarCLI {
             fetcher: UsageFetcher(),
             claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
             browserDetection: browserDetection,
-            persistCLISessions: true)
+            persistCLISessions: true,
+            persistentCLISessionIdleWindow: Self.serveCLISessionIdleWindow(refreshInterval: refreshInterval))
 
         var output = UsageCommandOutput()
         for provider in selection.asList {

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -554,12 +554,12 @@ extension CodexBarCLI {
     }
 
     /// How long a last-good response may be served in place of a failed
-    /// refresh. Bounded so consumers never see hours-stale data: ten refresh
-    /// intervals, with a five-minute floor for short intervals. Zero (stale
-    /// fallback disabled) when response caching is disabled.
+    /// refresh. Ten refresh intervals, with a five-minute floor and one-hour
+    /// ceiling. Zero (stale fallback disabled) when response caching is disabled.
     static func serveStaleTTL(refreshInterval: TimeInterval) -> TimeInterval {
         guard refreshInterval > 0 else { return 0 }
-        return max(refreshInterval * 10, 300)
+        guard refreshInterval.isFinite else { return 3600 }
+        return min(max(refreshInterval * 10, 300), 3600)
     }
 
     static func serveCLISessionIdleWindow(refreshInterval: TimeInterval) -> TimeInterval {

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -141,7 +141,20 @@ actor CLIServeResponseCache {
         let response: CLILocalHTTPResponse
     }
 
+    struct CachePolicy {
+        /// How long a successful response stays fresh.
+        let ttl: TimeInterval
+        /// How long a last-good response may stand in for a failed refresh.
+        let staleTTL: TimeInterval
+    }
+
+    private struct LastGoodEntry {
+        let recordedAt: Date
+        let response: CLILocalHTTPResponse
+    }
+
     private var entries: [String: Entry] = [:]
+    private var lastGood: [String: LastGoodEntry] = [:]
     private var inFlightKeys: Set<String> = []
     private var waiters: [String: [CheckedContinuation<CLIServeCacheLookup, Never>]] = [:]
 
@@ -170,21 +183,45 @@ actor CLIServeResponseCache {
         return .miss
     }
 
+    /// Completes an in-flight fetch and returns the response delivered to
+    /// waiters. Successful responses are cached normally. Failed fetches
+    /// fall back to the last good response when one was recorded within
+    /// `staleTTL`, so transient provider errors do not blank out consumers
+    /// that poll this endpoint (status bars hide items on error payloads).
     fileprivate func completeFetch(
         _ response: CLILocalHTTPResponse,
         for key: String,
-        ttl: TimeInterval,
+        policy: CachePolicy,
         now: Date,
-        shouldCache: Bool)
+        shouldCache: Bool) -> CLILocalHTTPResponse
     {
+        let delivered: CLILocalHTTPResponse
         if shouldCache {
-            self.store(response, for: key, ttl: ttl, now: now)
+            self.store(response, for: key, ttl: policy.ttl, now: now)
+            self.lastGood[key] = LastGoodEntry(recordedAt: now, response: response)
+            delivered = response
+        } else {
+            delivered = self.staleResponse(for: key, staleTTL: policy.staleTTL, now: now) ?? response
         }
         self.inFlightKeys.remove(key)
         let waiters = self.waiters.removeValue(forKey: key) ?? []
         for waiter in waiters {
-            waiter.resume(returning: .response(response))
+            waiter.resume(returning: .response(delivered))
         }
+        return delivered
+    }
+
+    private func staleResponse(
+        for key: String,
+        staleTTL: TimeInterval,
+        now: Date) -> CLILocalHTTPResponse?
+    {
+        guard staleTTL > 0, let entry = self.lastGood[key] else { return nil }
+        guard now.timeIntervalSince(entry.recordedAt) <= staleTTL else {
+            self.lastGood[key] = nil
+            return nil
+        }
+        return entry.response
     }
 
     private func store(_ response: CLILocalHTTPResponse, for key: String, ttl: TimeInterval, now: Date) {
@@ -403,13 +440,14 @@ extension CodexBarCLI {
             let response = await Self.serveResponseWithDeadline(seconds: requestTimeout) {
                 await makeResponse()
             }
-            await cache.completeFetch(
+            return await cache.completeFetch(
                 response,
                 for: key,
-                ttl: refreshInterval,
+                policy: CLIServeResponseCache.CachePolicy(
+                    ttl: refreshInterval,
+                    staleTTL: Self.serveStaleTTL(refreshInterval: refreshInterval)),
                 now: Date(),
                 shouldCache: Self.shouldCacheServeResponse(response))
-            return response
         }
     }
 
@@ -444,6 +482,15 @@ extension CodexBarCLI {
             }
             state.setTimeoutTask(timeoutTask)
         }
+    }
+
+    /// How long a last-good response may be served in place of a failed
+    /// refresh. Bounded so consumers never see hours-stale data: ten refresh
+    /// intervals, with a five-minute floor for short intervals. Zero (stale
+    /// fallback disabled) when response caching is disabled.
+    static func serveStaleTTL(refreshInterval: TimeInterval) -> TimeInterval {
+        guard refreshInterval > 0 else { return 0 }
+        return max(refreshInterval * 10, 300)
     }
 
     static func shouldCacheServeResponse(_ response: CLILocalHTTPResponse) -> Bool {
@@ -494,7 +541,8 @@ extension CodexBarCLI {
             includeAllCodexAccounts: true,
             fetcher: UsageFetcher(),
             claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
-            browserDetection: browserDetection)
+            browserDetection: browserDetection,
+            persistCLISessions: true)
 
         var output = UsageCommandOutput()
         for provider in selection.asList {

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -120,7 +120,7 @@ private struct ServeHealthPayload: Encodable {
     let status: String
 }
 
-struct CLIServeConfigSnapshot: Sendable {
+struct CLIServeConfigSnapshot {
     let config: CodexBarConfig
     let cacheToken: String
 }
@@ -191,6 +191,8 @@ enum CLIServeCacheLookup {
 }
 
 actor CLIServeResponseCache {
+    static let maximumStaleTTL: TimeInterval = 3600
+
     private struct Entry {
         let expiresAt: Date
         let response: CLILocalHTTPResponse
@@ -230,6 +232,15 @@ actor CLIServeResponseCache {
 
     private func pruneExpiredEntries(now: Date) {
         self.entries = self.entries.filter { $0.value.expiresAt > now }
+        self.lastGood = self.lastGood.filter {
+            now.timeIntervalSince($0.value.recordedAt) <= Self.maximumStaleTTL
+        }
+        self.lastGoodUsageItems = self.lastGoodUsageItems.compactMapValues { items in
+            let retained = items.filter {
+                now.timeIntervalSince($0.value.recordedAt) <= Self.maximumStaleTTL
+            }
+            return retained.isEmpty ? nil : retained
+        }
     }
 
     private func response(for key: String) -> CLILocalHTTPResponse? {
@@ -416,6 +427,10 @@ actor CLIServeResponseCache {
 
     func cachedEntryCount() -> Int {
         self.entries.count
+    }
+
+    func cachedStaleVariantCount() -> Int {
+        self.lastGood.count + self.lastGoodUsageItems.count
     }
 }
 
@@ -688,8 +703,8 @@ extension CodexBarCLI {
     /// ceiling. Zero (stale fallback disabled) when response caching is disabled.
     static func serveStaleTTL(refreshInterval: TimeInterval) -> TimeInterval {
         guard refreshInterval > 0 else { return 0 }
-        guard refreshInterval.isFinite else { return 3600 }
-        return min(max(refreshInterval * 10, 300), 3600)
+        guard refreshInterval.isFinite else { return CLIServeResponseCache.maximumStaleTTL }
+        return min(max(refreshInterval * 10, 300), CLIServeResponseCache.maximumStaleTTL)
     }
 
     static func serveCLISessionIdleWindow(refreshInterval: TimeInterval) -> TimeInterval {

--- a/Sources/CodexBarCLI/CLITerminationSignalMonitor.swift
+++ b/Sources/CodexBarCLI/CLITerminationSignalMonitor.swift
@@ -1,0 +1,73 @@
+import CodexBarCore
+import Dispatch
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+private func handleCLITerminationSignal(_: Int32) {}
+
+final class CLITerminationSignalMonitor: @unchecked Sendable {
+    static let signalNumbers = [SIGINT, SIGTERM, SIGHUP]
+
+    private let lock = NSLock()
+    private let sources: [DispatchSourceSignal]
+    private var isCancelled = false
+
+    init(onSignal: @escaping @Sendable (Int32) -> Void) {
+        self.sources = Self.signalNumbers.map { signalNumber in
+            Self.installCaptureHandler(for: signalNumber)
+            let source = DispatchSource.makeSignalSource(signal: signalNumber, queue: .global(qos: .utility))
+            source.setEventHandler {
+                onSignal(signalNumber)
+            }
+            source.resume()
+            return source
+        }
+    }
+
+    func cancel() {
+        self.lock.lock()
+        guard !self.isCancelled else {
+            self.lock.unlock()
+            return
+        }
+        self.isCancelled = true
+        self.lock.unlock()
+
+        for source in self.sources {
+            source.cancel()
+        }
+        for signalNumber in Self.signalNumbers {
+            Self.restoreDefaultHandler(for: signalNumber)
+        }
+    }
+
+    deinit {
+        self.cancel()
+    }
+
+    static func terminateActiveHelpersAndReraise(_ signalNumber: Int32) {
+        TTYCommandRunner.terminateActiveProcessesForAppShutdown()
+        self.restoreDefaultHandler(for: signalNumber)
+        _ = kill(getpid(), signalNumber)
+    }
+
+    private static func installCaptureHandler(for signalNumber: Int32) {
+        #if canImport(Darwin)
+        _ = Darwin.signal(signalNumber, handleCLITerminationSignal)
+        #else
+        _ = Glibc.signal(signalNumber, handleCLITerminationSignal)
+        #endif
+    }
+
+    private static func restoreDefaultHandler(for signalNumber: Int32) {
+        #if canImport(Darwin)
+        _ = Darwin.signal(signalNumber, SIG_DFL)
+        #else
+        _ = Glibc.signal(signalNumber, SIG_DFL)
+        #endif
+    }
+}

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -22,6 +22,7 @@ struct UsageCommandContext {
     /// helper sessions (such as the managed Antigravity `agy` process) alive
     /// between fetches instead of resetting after each one-shot fetch.
     var persistCLISessions: Bool = false
+    var persistentCLISessionIdleWindow: TimeInterval?
 }
 
 struct UsageCommandOutput {
@@ -296,7 +297,8 @@ extension CodexBarCLI {
             selectedTokenAccountID: account?.id,
             tokenAccountTokenUpdater: tokenContext.tokenUpdater(for: account),
             providerManualTokenUpdater: tokenContext.manualTokenUpdater(),
-            persistsCLISessions: command.persistCLISessions)
+            persistsCLISessions: command.persistCLISessions,
+            persistentCLISessionIdleWindow: command.persistentCLISessionIdleWindow)
         let outcome = await Self.fetchProviderUsage(
             provider: provider,
             context: fetchContext)

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -18,6 +18,10 @@ struct UsageCommandContext {
     let fetcher: UsageFetcher
     let claudeFetcher: ClaudeUsageFetcher
     let browserDetection: BrowserDetection
+    /// True for long-lived hosts (`codexbar serve`) that keep warm provider
+    /// helper sessions (such as the managed Antigravity `agy` process) alive
+    /// between fetches instead of resetting after each one-shot fetch.
+    var persistCLISessions: Bool = false
 }
 
 struct UsageCommandOutput {
@@ -291,7 +295,8 @@ extension CodexBarCLI {
             browserDetection: command.browserDetection,
             selectedTokenAccountID: account?.id,
             tokenAccountTokenUpdater: tokenContext.tokenUpdater(for: account),
-            providerManualTokenUpdater: tokenContext.manualTokenUpdater())
+            providerManualTokenUpdater: tokenContext.manualTokenUpdater(),
+            persistsCLISessions: command.persistCLISessions)
         let outcome = await Self.fetchProviderUsage(
             provider: provider,
             context: fetchContext)

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -303,7 +303,7 @@ extension CodexBarCLI {
             selectedTokenAccountID: account?.id,
             tokenAccountTokenUpdater: tokenContext.tokenUpdater(for: account),
             providerManualTokenUpdater: tokenContext.manualTokenUpdater(),
-            persistsCLISessions: command.persistCLISessions,
+            persistsCLISessions: Self.persistsCLISessions(provider: provider, command: command),
             persistentCLISessionIdleWindow: command.persistentCLISessionIdleWindow)
         let outcome = await Self.fetchProviderUsage(
             provider: provider,
@@ -406,6 +406,47 @@ extension CodexBarCLI {
             }
         }
 
+        return await Self.finishUsageOutput(output, provider: provider, command: command)
+    }
+
+    private static func holdsAntigravitySession(
+        provider: UsageProvider,
+        command: UsageCommandContext) -> Bool
+    {
+        self.holdsAntigravityCLISessionForPlanDebug(
+            provider: provider,
+            planDebugEnabled: command.antigravityPlanDebug,
+            jsonOnly: command.jsonOnly,
+            persistsCLISessions: command.persistCLISessions)
+    }
+
+    private static func persistsCLISessions(
+        provider: UsageProvider,
+        command: UsageCommandContext) -> Bool
+    {
+        command.persistCLISessions || self.holdsAntigravitySession(provider: provider, command: command)
+    }
+
+    static func holdsAntigravityCLISessionForPlanDebug(
+        provider: UsageProvider,
+        planDebugEnabled: Bool,
+        jsonOnly: Bool,
+        persistsCLISessions: Bool) -> Bool
+    {
+        provider == .antigravity
+            && planDebugEnabled
+            && !jsonOnly
+            && !persistsCLISessions
+    }
+
+    private static func finishUsageOutput(
+        _ output: UsageCommandOutput,
+        provider: UsageProvider,
+        command: UsageCommandContext) async -> UsageCommandOutput
+    {
+        if self.holdsAntigravitySession(provider: provider, command: command) {
+            await ProviderCLISessionLifecycle.shutdownPersistentSessions()
+        }
         return output
     }
 

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -265,6 +265,10 @@ extension CodexBarCLI {
             base: baseSource,
             provider: provider,
             account: account)
+        let cacheAccountKey = Self.usageCacheAccountKey(
+            provider: provider,
+            account: account,
+            codexVisibleAccount: codexVisibleAccount)
 
         #if !os(macOS)
         if Self.sourceModeRequiresWebSupport(
@@ -275,7 +279,9 @@ extension CodexBarCLI {
         {
             return Self.webSourceUnsupportedOutput(
                 provider: provider,
-                account: account?.label ?? codexVisibleAccount?.menuDisplayName,
+                account: (
+                    label: account?.label ?? codexVisibleAccount?.menuDisplayName,
+                    cacheKey: cacheAccountKey),
                 source: effectiveSourceMode.rawValue,
                 status: status,
                 command: command)
@@ -362,6 +368,7 @@ extension CodexBarCLI {
                 output.payload.append(ProviderPayload(
                     provider: provider,
                     account: account?.label ?? codexVisibleAccount?.menuDisplayName,
+                    cacheAccountKey: cacheAccountKey,
                     version: version,
                     source: source,
                     status: status,
@@ -377,6 +384,7 @@ extension CodexBarCLI {
                 output.payload.append(Self.makeProviderErrorPayload(
                     provider: provider,
                     account: account?.label ?? codexVisibleAccount?.menuDisplayName,
+                    cacheAccountKey: cacheAccountKey,
                     source: effectiveSourceMode.rawValue,
                     status: status,
                     error: error,
@@ -433,7 +441,7 @@ extension CodexBarCLI {
 
     private static func webSourceUnsupportedOutput(
         provider: UsageProvider,
-        account: String?,
+        account: (label: String?, cacheKey: String?),
         source: String,
         status: ProviderStatusPayload?,
         command: UsageCommandContext) -> UsageCommandOutput
@@ -448,7 +456,8 @@ extension CodexBarCLI {
         if command.format == .json {
             output.payload.append(Self.makeProviderErrorPayload(
                 provider: provider,
-                account: account,
+                account: account.label,
+                cacheAccountKey: account.cacheKey,
                 source: source,
                 status: status,
                 error: error,
@@ -457,6 +466,36 @@ extension CodexBarCLI {
             Self.writeStderr("Error: \(error.localizedDescription)\n")
         }
         return output
+    }
+
+    static func usageCacheAccountKey(
+        provider: UsageProvider,
+        account: ProviderTokenAccount?,
+        codexVisibleAccount: CodexVisibleAccount?) -> String?
+    {
+        if let account {
+            return "token:\(account.id.uuidString.lowercased())"
+        }
+        if let codexVisibleAccount {
+            if let workspaceAccountID = codexVisibleAccount.workspaceAccountID?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+                !workspaceAccountID.isEmpty,
+                !codexVisibleAccount.email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                let email = codexVisibleAccount.email
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .lowercased()
+                return "codex:workspace:\(workspaceAccountID):email:\(email)"
+            }
+            if let storedAccountID = codexVisibleAccount.storedAccountID {
+                return "codex:stored:\(storedAccountID.uuidString.lowercased())"
+            }
+            if let authFingerprint = codexVisibleAccount.authFingerprint {
+                return "codex:auth:\(authFingerprint)"
+            }
+            return nil
+        }
+        return "default:\(provider.rawValue)"
     }
 
     static func sourceModeRequiresWebSupport(

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -469,7 +469,7 @@ extension CodexBarCLI {
     }
 
     static func usageCacheAccountKey(
-        provider: UsageProvider,
+        provider _: UsageProvider,
         account: ProviderTokenAccount?,
         codexVisibleAccount: CodexVisibleAccount?) -> String?
     {
@@ -495,7 +495,7 @@ extension CodexBarCLI {
             }
             return nil
         }
-        return "default:\(provider.rawValue)"
+        return nil
     }
 
     static func sourceModeRequiresWebSupport(

--- a/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
+++ b/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
@@ -264,27 +264,6 @@ public struct TTYCommandRunner {
         }
     }
 
-    @discardableResult
-    static func registerActiveProcessForAppShutdown(pid: pid_t, binary: String) -> Bool {
-        TTYCommandRunnerActiveProcessRegistry.register(pid: pid, binary: binary)
-    }
-
-    static func beginActiveProcessLaunchForAppShutdown() -> Bool {
-        TTYCommandRunnerActiveProcessRegistry.beginLaunch()
-    }
-
-    static func endActiveProcessLaunchForAppShutdown() {
-        TTYCommandRunnerActiveProcessRegistry.endLaunch()
-    }
-
-    static func updateActiveProcessGroupForAppShutdown(pid: pid_t, processGroup: pid_t?) {
-        TTYCommandRunnerActiveProcessRegistry.updateProcessGroup(pid: pid, processGroup: processGroup)
-    }
-
-    static func unregisterActiveProcessForAppShutdown(pid: pid_t) {
-        TTYCommandRunnerActiveProcessRegistry.unregister(pid: pid)
-    }
-
     private static func resolveShutdownTargets(
         _ targets: [(pid: pid_t, binary: String, processGroup: pid_t?)],
         hostProcessGroup: pid_t,
@@ -1085,6 +1064,27 @@ public struct TTYCommandRunner {
 }
 
 extension TTYCommandRunner {
+    @discardableResult
+    static func registerActiveProcessForAppShutdown(pid: pid_t, binary: String) -> Bool {
+        TTYCommandRunnerActiveProcessRegistry.register(pid: pid, binary: binary)
+    }
+
+    static func beginActiveProcessLaunchForAppShutdown() -> Bool {
+        TTYCommandRunnerActiveProcessRegistry.beginLaunch()
+    }
+
+    static func endActiveProcessLaunchForAppShutdown() {
+        TTYCommandRunnerActiveProcessRegistry.endLaunch()
+    }
+
+    static func updateActiveProcessGroupForAppShutdown(pid: pid_t, processGroup: pid_t?) {
+        TTYCommandRunnerActiveProcessRegistry.updateProcessGroup(pid: pid, processGroup: processGroup)
+    }
+
+    static func unregisterActiveProcessForAppShutdown(pid: pid_t) {
+        TTYCommandRunnerActiveProcessRegistry.unregister(pid: pid)
+    }
+
     static func _test_resetTrackedProcesses() {
         TTYCommandRunnerActiveProcessRegistry.reset()
     }

--- a/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
+++ b/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
@@ -6,9 +6,10 @@ import Glibc
 import Foundation
 
 private enum TTYCommandRunnerActiveProcessRegistry {
-    private static let lock = NSLock()
+    private static let condition = NSCondition()
     private nonisolated(unsafe) static var processes: [pid_t: ProcessInfo] = [:]
     private nonisolated(unsafe) static var isShuttingDown = false
+    private nonisolated(unsafe) static var launchesInProgress = 0
 
     private struct ProcessInfo {
         let binary: String
@@ -18,62 +19,88 @@ private enum TTYCommandRunnerActiveProcessRegistry {
     @discardableResult
     static func register(pid: pid_t, binary: String) -> Bool {
         guard pid > 0 else { return false }
-        self.lock.lock()
-        defer { self.lock.unlock() }
+        self.condition.lock()
+        defer { self.condition.unlock() }
         guard !self.isShuttingDown else { return false }
         self.processes[pid] = ProcessInfo(binary: binary, processGroup: nil)
         return true
     }
 
+    static func beginLaunch() -> Bool {
+        self.condition.lock()
+        defer { self.condition.unlock() }
+        guard !self.isShuttingDown else { return false }
+        self.launchesInProgress += 1
+        return true
+    }
+
+    static func endLaunch() {
+        self.condition.lock()
+        self.launchesInProgress = max(0, self.launchesInProgress - 1)
+        if self.launchesInProgress == 0 {
+            self.condition.broadcast()
+        }
+        self.condition.unlock()
+    }
+
     static func updateProcessGroup(pid: pid_t, processGroup: pid_t?) {
         guard pid > 0 else { return }
-        self.lock.lock()
+        self.condition.lock()
         guard var existing = self.processes[pid] else {
-            self.lock.unlock()
+            self.condition.unlock()
             return
         }
         existing.processGroup = processGroup
         self.processes[pid] = existing
-        self.lock.unlock()
+        self.condition.unlock()
     }
 
     static func unregister(pid: pid_t) {
         guard pid > 0 else { return }
-        self.lock.lock()
+        self.condition.lock()
         self.processes.removeValue(forKey: pid)
-        self.lock.unlock()
+        self.condition.unlock()
     }
 
-    static func drainForShutdown() -> [(pid: pid_t, binary: String, processGroup: pid_t?)] {
-        self.lock.lock()
+    static func drainForShutdown(
+        onFenceSet: (() -> Void)? = nil)
+        -> [(pid: pid_t, binary: String, processGroup: pid_t?)]
+    {
+        self.condition.lock()
         self.isShuttingDown = true
+        onFenceSet?()
+        while self.launchesInProgress > 0 {
+            self.condition.wait()
+        }
         let drained = self.processes.map {
             (pid: $0.key, binary: $0.value.binary, processGroup: $0.value.processGroup)
         }
         self.processes.removeAll()
-        self.lock.unlock()
+        self.condition.unlock()
         return drained
     }
 
     static func reset() {
-        self.lock.lock()
+        self.condition.lock()
         self.processes.removeAll()
         self.isShuttingDown = false
-        self.lock.unlock()
+        self.launchesInProgress = 0
+        self.condition.broadcast()
+        self.condition.unlock()
     }
 
     static func count() -> Int {
-        self.lock.lock()
+        self.condition.lock()
         let count = self.processes.count
-        self.lock.unlock()
+        self.condition.unlock()
         return count
     }
 
     static func testTrackProcess(pid: pid_t, binary: String, processGroup: pid_t?) {
         guard pid > 0 else { return }
-        self.lock.lock()
+        self.condition.lock()
         self.processes[pid] = ProcessInfo(binary: binary, processGroup: processGroup)
-        self.lock.unlock()
+        self.condition.unlock()
     }
 }
 
@@ -240,6 +267,14 @@ public struct TTYCommandRunner {
     @discardableResult
     static func registerActiveProcessForAppShutdown(pid: pid_t, binary: String) -> Bool {
         TTYCommandRunnerActiveProcessRegistry.register(pid: pid, binary: binary)
+    }
+
+    static func beginActiveProcessLaunchForAppShutdown() -> Bool {
+        TTYCommandRunnerActiveProcessRegistry.beginLaunch()
+    }
+
+    static func endActiveProcessLaunchForAppShutdown() {
+        TTYCommandRunnerActiveProcessRegistry.endLaunch()
     }
 
     static func updateActiveProcessGroupForAppShutdown(pid: pid_t, processGroup: pid_t?) {
@@ -562,6 +597,17 @@ public struct TTYCommandRunner {
             }
         }
 
+        guard TTYCommandRunnerActiveProcessRegistry.beginLaunch() else {
+            cleanup()
+            throw Error.launchFailed("App shutdown in progress")
+        }
+        var launchReservationHeld = true
+        defer {
+            if launchReservationHeld {
+                TTYCommandRunnerActiveProcessRegistry.endLaunch()
+            }
+        }
+
         // Ensure the PTY process is always torn down, even when we throw early (e.g. login prompt).
         defer { cleanup() }
 
@@ -589,6 +635,8 @@ public struct TTYCommandRunner {
         if let processGroup {
             TTYCommandRunnerActiveProcessRegistry.updateProcessGroup(pid: pid, processGroup: processGroup)
         }
+        TTYCommandRunnerActiveProcessRegistry.endLaunch()
+        launchReservationHeld = false
         Self.log.debug("PTY launched", metadata: ["binary": binaryName])
 
         func send(_ text: String) throws {
@@ -1057,8 +1105,19 @@ extension TTYCommandRunner {
         TTYCommandRunnerActiveProcessRegistry.count()
     }
 
-    static func _test_drainTrackedProcessesForShutdown() -> [(pid: pid_t, binary: String, processGroup: pid_t?)] {
-        TTYCommandRunnerActiveProcessRegistry.drainForShutdown()
+    static func _test_beginTrackedProcessLaunch() -> Bool {
+        TTYCommandRunnerActiveProcessRegistry.beginLaunch()
+    }
+
+    static func _test_endTrackedProcessLaunch() {
+        TTYCommandRunnerActiveProcessRegistry.endLaunch()
+    }
+
+    static func _test_drainTrackedProcessesForShutdown(
+        onFenceSet: (() -> Void)? = nil)
+        -> [(pid: pid_t, binary: String, processGroup: pid_t?)]
+    {
+        TTYCommandRunnerActiveProcessRegistry.drainForShutdown(onFenceSet: onFenceSet)
     }
 
     static func _test_resolveShutdownTargets(

--- a/Sources/CodexBarCore/PathEnvironment.swift
+++ b/Sources/CodexBarCore/PathEnvironment.swift
@@ -77,6 +77,31 @@ public enum BinaryLocator {
         ]
     }
 
+    public static func resolveAntigravityBinary(
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        loginPATH: [String]? = LoginShellPathCache.shared.current,
+        commandV: (String, String?, TimeInterval, FileManager) -> String? = ShellCommandLocator.commandV,
+        aliasResolver: (String, String?, TimeInterval, FileManager, String) -> String? = ShellCommandLocator
+            .resolveAlias,
+        fileManager: FileManager = .default,
+        home: String = NSHomeDirectory()) -> String?
+    {
+        self.resolveBinary(
+            name: "agy",
+            overrideKey: "ANTIGRAVITY_CLI_PATH",
+            env: env,
+            loginPATH: loginPATH,
+            commandV: commandV,
+            aliasResolver: aliasResolver,
+            wellKnownPaths: [
+                "\(home)/.local/bin/agy",
+                "/opt/homebrew/bin/agy",
+                "/usr/local/bin/agy",
+            ],
+            fileManager: fileManager,
+            home: home)
+    }
+
     public static func resolveCodexBinary(
         env: [String: String] = ProcessInfo.processInfo.environment,
         loginPATH: [String]? = LoginShellPathCache.shared.current,

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
@@ -1,0 +1,876 @@
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+import Foundation
+
+// MARK: - Antigravity CLI Process Abstractions
+
+protocol AntigravityCLIProcessHandle: AnyObject, Sendable {
+    var pid: pid_t { get }
+    var isRunning: Bool { get }
+    var processGroup: pid_t? { get }
+
+    func assignProcessGroup() -> pid_t?
+    func sendExit() throws
+    func closePTY()
+    func terminateRoot()
+    func killRoot()
+    func descendantPIDs() -> [pid_t]
+    func terminateTree(signal: Int32, knownDescendants: [pid_t])
+    func killDescendants(_ descendants: [pid_t])
+    func drainOutput()
+}
+
+protocol AntigravityCLIProcessLaunching: Sendable {
+    func launch(binary: String) throws -> any AntigravityCLIProcessHandle
+}
+
+struct AntigravityCLIProcessIdentity: Equatable, Sendable {
+    let executablePath: String
+    let startEpoch: TimeInterval
+}
+
+protocol AntigravityCLIProcessIdentityProviding: Sendable {
+    func identity(for pid: pid_t) -> AntigravityCLIProcessIdentity?
+}
+
+struct AntigravityCLISessionRecord: Codable, Equatable, Sendable {
+    let pid: pid_t
+    let requestedBinaryPath: String
+    let executablePath: String
+    let startEpoch: TimeInterval
+    let processGroup: pid_t?
+    let ownerPID: pid_t?
+    let ownerExecutablePath: String?
+    let ownerStartEpoch: TimeInterval?
+
+    init(
+        pid: pid_t,
+        requestedBinaryPath: String,
+        executablePath: String,
+        startEpoch: TimeInterval,
+        processGroup: pid_t?,
+        ownerPID: pid_t? = nil,
+        ownerExecutablePath: String? = nil,
+        ownerStartEpoch: TimeInterval? = nil)
+    {
+        self.pid = pid
+        self.requestedBinaryPath = requestedBinaryPath
+        self.executablePath = executablePath
+        self.startEpoch = startEpoch
+        self.processGroup = processGroup
+        self.ownerPID = ownerPID
+        self.ownerExecutablePath = ownerExecutablePath
+        self.ownerStartEpoch = ownerStartEpoch
+    }
+}
+
+protocol AntigravityCLISessionRecordStoring: Sendable {
+    func load() throws -> AntigravityCLISessionRecord?
+    func save(_ record: AntigravityCLISessionRecord) throws
+    func remove() throws
+}
+
+// MARK: - AntigravityCLISession
+
+/// Manages a bounded background ``agy`` process whose embedded localhost server
+/// provides the same ``GetUserStatus`` endpoint as the desktop Antigravity app's
+/// ``language_server``. The CLI is kept alive in a PTY so its daemon stays bound
+/// to a local port — this lets CodexBar read Claude + Gemini quotas even when
+/// the desktop Antigravity app is closed.
+///
+/// The session intentionally does not scrape TUI output. It only launches and
+/// keeps the process reachable for HTTPS probing, drains discarded PTY output so
+/// the CLI cannot block on a full terminal buffer, and bounds the warm lifetime
+/// with an idle timer so CodexBar does not run an IDE backend forever.
+actor AntigravityCLISession {
+    static let shared = AntigravityCLISession()
+    private static let log = CodexBarLog.logger(LogCategories.antigravity)
+
+    struct Dependencies: Sendable {
+        var launcher: any AntigravityCLIProcessLaunching
+        var identityProvider: any AntigravityCLIProcessIdentityProviding
+        var recordStore: any AntigravityCLISessionRecordStoring
+        var registerForAppShutdown: @Sendable (pid_t, String) -> Bool
+        var updateAppShutdownProcessGroup: @Sendable (pid_t, pid_t?) -> Void
+        var unregisterForAppShutdown: @Sendable (pid_t) -> Void
+        var descendantPIDs: @Sendable (pid_t) -> [pid_t]
+        var terminateProcessTree: @Sendable (pid_t, pid_t?, Int32, [pid_t]) -> Void
+        var currentProcessID: @Sendable () -> pid_t
+        var now: @Sendable () -> Date
+        var sleep: @Sendable (UInt64) async throws -> Void
+        var idleWindow: TimeInterval
+        var failureRelaunchThreshold: Int
+        var terminationGracePeriod: TimeInterval
+
+        static func live() -> Self {
+            Self(
+                launcher: AntigravityPTYProcessLauncher(),
+                identityProvider: AntigravityDarwinProcessIdentityProvider(),
+                recordStore: AntigravityFileCLISessionRecordStore(),
+                registerForAppShutdown: { pid, binary in
+                    TTYCommandRunner.registerActiveProcessForAppShutdown(pid: pid, binary: binary)
+                },
+                updateAppShutdownProcessGroup: { pid, group in
+                    TTYCommandRunner.updateActiveProcessGroupForAppShutdown(pid: pid, processGroup: group)
+                },
+                unregisterForAppShutdown: { pid in
+                    TTYCommandRunner.unregisterActiveProcessForAppShutdown(pid: pid)
+                },
+                descendantPIDs: { pid in
+                    TTYProcessTreeTerminator.descendantPIDs(of: pid)
+                },
+                terminateProcessTree: { pid, group, signal, knownDescendants in
+                    TTYProcessTreeTerminator.terminateProcessTree(
+                        rootPID: pid,
+                        processGroup: group,
+                        signal: signal,
+                        knownDescendants: knownDescendants)
+                },
+                currentProcessID: getpid,
+                now: Date.init,
+                sleep: { nanoseconds in
+                    try await Task.sleep(nanoseconds: nanoseconds)
+                },
+                idleWindow: 180,
+                failureRelaunchThreshold: 2,
+                terminationGracePeriod: 1)
+        }
+    }
+
+    // MARK: State
+
+    private let dependencies: Dependencies
+    private var process: (any AntigravityCLIProcessHandle)?
+    private var binaryPath: String?
+    private var activeProbeCount = 0
+    private var activeSessionProbeCount = 0
+    private var resetRequestedWhenIdle = false
+    private var idleTask: Task<Void, Never>?
+    private var sessionGeneration: UInt64 = 0
+    private var consecutiveProbeFailures = 0
+    private var persistedProcessIdentity: AntigravityCLIProcessIdentity?
+    private var lifecycleOperationInProgress = false
+    private var lifecycleWaiters: [CheckedContinuation<Void, Never>] = []
+    private var exclusiveProbeWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init(dependencies: Dependencies = .live()) {
+        self.dependencies = dependencies
+    }
+
+    /// The pid of the running ``agy`` process, exposed so callers can discover
+    /// its listening ports via `lsof`.
+    var pid: pid_t? {
+        guard let proc = self.process, proc.isRunning else { return nil }
+        return proc.pid
+    }
+
+    /// Whether the managed process is alive and matches ``binaryPath``.
+    var isRunning: Bool {
+        guard let proc = self.process, proc.isRunning, self.binaryPath != nil else { return false }
+        return true
+    }
+
+    var failureCountForTesting: Int {
+        self.consecutiveProbeFailures
+    }
+
+    // MARK: Lifecycle
+
+    /// Mark a probe as active and ensure a warm ``agy`` is running on the given binary path.
+    ///
+    /// Callers must balance this with ``finishProbe(success:resetAfterFetch:)`` so
+    /// idle/reset cleanup cannot kill the process while its ports are being probed.
+    /// If previous probes repeatedly failed while the process stayed alive, this
+    /// force-relaunches instead of reusing a wedged HTTPS server forever.
+    func beginProbe(binary: String) async throws -> pid_t {
+        self.activeProbeCount += 1
+        self.cancelIdleTimer()
+        do {
+            return try await self.withLifecycleOperation {
+                let pid = try await self.ensureStartedLocked(binary: binary)
+                self.activeSessionProbeCount += 1
+                return pid
+            }
+        } catch {
+            self.activeProbeCount = max(0, self.activeProbeCount - 1)
+            self.notifyExclusiveProbeWaitersIfNeeded()
+            if self.activeProbeCount == 0, self.resetRequestedWhenIdle {
+                await self.withLifecycleOperation {
+                    guard self.activeProbeCount == 0 else {
+                        self.resetRequestedWhenIdle = true
+                        return
+                    }
+                    await self.stopCurrentSessionLocked(reason: "deferred reset after failed begin", clearRecord: true)
+                }
+            }
+            throw error
+        }
+    }
+
+    /// Record probe completion and either keep the session warm for the bounded
+    /// idle window or tear it down immediately for one-shot CLI invocations.
+    func finishProbe(success: Bool, resetAfterFetch: Bool) async {
+        if success {
+            self.consecutiveProbeFailures = 0
+        } else {
+            self.consecutiveProbeFailures += 1
+        }
+
+        self.activeProbeCount = max(0, self.activeProbeCount - 1)
+        self.activeSessionProbeCount = max(0, self.activeSessionProbeCount - 1)
+        self.notifyExclusiveProbeWaitersIfNeeded()
+        let shouldForceStopUnhealthy = !success &&
+            self.consecutiveProbeFailures >= max(1, self.dependencies.failureRelaunchThreshold)
+        let shouldReset = resetAfterFetch || self.resetRequestedWhenIdle || shouldForceStopUnhealthy
+
+        guard self.activeProbeCount == 0 else {
+            if shouldReset {
+                self.resetRequestedWhenIdle = true
+            }
+            return
+        }
+
+        if shouldReset {
+            let reason =
+                if resetAfterFetch {
+                    "one-shot CLI fetch"
+                } else if shouldForceStopUnhealthy {
+                    "unhealthy CLI HTTPS session"
+                } else {
+                    "deferred reset"
+                }
+            await self.withLifecycleOperation {
+                guard self.activeProbeCount == 0 else {
+                    self.resetRequestedWhenIdle = true
+                    return
+                }
+                self.resetRequestedWhenIdle = false
+                await self.stopCurrentSessionLocked(reason: reason, clearRecord: true)
+            }
+        } else {
+            self.armIdleTimer()
+        }
+    }
+
+    /// Ensure a warm ``agy`` is running on the given binary path.
+    ///
+    /// - If the process is already alive with the same binary, this returns immediately.
+    /// - If the process died, the binary changed, or repeated probes failed, it tears down the old one first.
+    /// - Returns the process identifier for port discovery.
+    func ensureStarted(binary: String) async throws -> pid_t {
+        try await self.withLifecycleOperation {
+            try await self.ensureStartedLocked(binary: binary)
+        }
+    }
+
+    /// Request teardown. If a probe is in flight, cleanup is deferred until the
+    /// matching ``finishProbe(success:resetAfterFetch:)`` call.
+    func reset() async {
+        self.cancelIdleTimer()
+        guard self.activeProbeCount == 0 else {
+            self.resetRequestedWhenIdle = true
+            return
+        }
+        await self.withLifecycleOperation {
+            guard self.activeProbeCount == 0 else {
+                self.resetRequestedWhenIdle = true
+                return
+            }
+            self.resetRequestedWhenIdle = false
+            await self.stopCurrentSessionLocked(reason: "manual reset", clearRecord: true)
+        }
+    }
+
+    /// Drain PTY output so the write side doesn't block.
+    func drainOutput() {
+        self.process?.drainOutput()
+    }
+
+    // MARK: Errors
+
+    enum SessionError: LocalizedError {
+        case launchFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .launchFailed(msg): "Failed to launch Antigravity CLI session: \(msg)"
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private func withLifecycleOperation<T>(_ operation: () async throws -> T) async throws -> T {
+        await self.acquireLifecycleOperation()
+        defer { self.releaseLifecycleOperation() }
+        return try await operation()
+    }
+
+    private func withLifecycleOperation(_ operation: () async -> Void) async {
+        await self.acquireLifecycleOperation()
+        defer { self.releaseLifecycleOperation() }
+        await operation()
+    }
+
+    private func acquireLifecycleOperation() async {
+        guard self.lifecycleOperationInProgress else {
+            self.lifecycleOperationInProgress = true
+            return
+        }
+        await withCheckedContinuation { continuation in
+            self.lifecycleWaiters.append(continuation)
+        }
+    }
+
+    private func releaseLifecycleOperation() {
+        guard !self.lifecycleWaiters.isEmpty else {
+            self.lifecycleOperationInProgress = false
+            return
+        }
+        let next = self.lifecycleWaiters.removeFirst()
+        next.resume()
+    }
+
+    private func waitForExclusiveProbeIfNeeded() async {
+        while self.activeSessionProbeCount > 0 {
+            await withCheckedContinuation { continuation in
+                self.exclusiveProbeWaiters.append(continuation)
+            }
+        }
+    }
+
+    private func notifyExclusiveProbeWaitersIfNeeded() {
+        guard self.activeSessionProbeCount == 0, !self.exclusiveProbeWaiters.isEmpty else { return }
+        let waiters = self.exclusiveProbeWaiters
+        self.exclusiveProbeWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func ensureStartedLocked(binary: String) async throws -> pid_t {
+        while true {
+            let canPersistRecord = if self.process == nil {
+                self.reapRecordedSessionIfNeeded()
+            } else {
+                true
+            }
+
+            if let proc = self.process,
+               proc.isRunning,
+               self.binaryPath == binary,
+               self.consecutiveProbeFailures < max(1, self.dependencies.failureRelaunchThreshold)
+            {
+                Self.log.debug("Antigravity CLI session reused", metadata: ["pid": "\(proc.pid)"])
+                return proc.pid
+            }
+
+            if self.process != nil {
+                if self.activeSessionProbeCount > 0 {
+                    await self.waitForExclusiveProbeIfNeeded()
+                    continue
+                }
+
+                let reason = self.consecutiveProbeFailures >= max(1, self.dependencies.failureRelaunchThreshold)
+                    ? "relaunching unhealthy session"
+                    : "replacing stale session"
+                await self.stopCurrentSessionLocked(reason: reason, clearRecord: true)
+            }
+
+            let launched = try self.dependencies.launcher.launch(binary: binary)
+            let launchedPID = launched.pid
+            let binaryName = URL(fileURLWithPath: binary).lastPathComponent
+            guard self.dependencies.registerForAppShutdown(launchedPID, binaryName) else {
+                await self.terminateLaunchedProcess(launched)
+                throw SessionError.launchFailed("App shutdown in progress")
+            }
+
+            let processGroup = launched.processGroup ?? launched.assignProcessGroup()
+            self.dependencies.updateAppShutdownProcessGroup(launchedPID, processGroup)
+
+            self.process = launched
+            self.binaryPath = binary
+            self.consecutiveProbeFailures = 0
+            self.sessionGeneration &+= 1
+            if canPersistRecord {
+                self.persistRecord(pid: launchedPID, binary: binary, processGroup: processGroup)
+            } else {
+                self.persistedProcessIdentity = nil
+            }
+
+            Self.log.debug(
+                "Antigravity CLI session started",
+                metadata: [
+                    "binary": binaryName,
+                    "pid": "\(launchedPID)",
+                ])
+            return launchedPID
+        }
+    }
+
+    private func cancelIdleTimer() {
+        self.idleTask?.cancel()
+        self.idleTask = nil
+    }
+
+    private func armIdleTimer() {
+        guard self.process != nil, self.dependencies.idleWindow > 0 else { return }
+        self.cancelIdleTimer()
+        let generation = self.sessionGeneration
+        let nanoseconds = Self.nanoseconds(from: self.dependencies.idleWindow)
+        let sleep = self.dependencies.sleep
+        self.idleTask = Task { [weak self] in
+            do {
+                try await sleep(nanoseconds)
+                await self?.stopIfIdle(generation: generation)
+            } catch {
+                // Cancellation is the normal path when a refresh reuses the warm session.
+            }
+        }
+    }
+
+    private func stopIfIdle(generation: UInt64) async {
+        await self.withLifecycleOperation {
+            guard generation == self.sessionGeneration else { return }
+            guard self.activeProbeCount == 0 else {
+                self.armIdleTimer()
+                return
+            }
+            await self.stopCurrentSessionLocked(reason: "idle timeout", clearRecord: true)
+        }
+    }
+
+    private func stopCurrentSessionLocked(reason: String, clearRecord: Bool) async {
+        self.cancelIdleTimer()
+        guard let proc = self.process else {
+            if clearRecord {
+                _ = self.reapRecordedSessionIfNeeded()
+            }
+            return
+        }
+
+        let pid = proc.pid
+        let identity = self.persistedProcessIdentity
+        Self.log.debug("Antigravity CLI session stopping", metadata: ["pid": "\(pid)", "reason": "\(reason)"])
+
+        self.process = nil
+        self.binaryPath = nil
+        self.persistedProcessIdentity = nil
+        self.sessionGeneration &+= 1
+
+        await self.terminateLaunchedProcess(proc)
+        self.dependencies.unregisterForAppShutdown(pid)
+        if clearRecord {
+            self.removeRecordIfMatches(pid: pid, identity: identity)
+        }
+    }
+
+    private func terminateLaunchedProcess(_ proc: any AntigravityCLIProcessHandle) async {
+        try? proc.sendExit()
+        proc.closePTY()
+
+        let descendants = proc.descendantPIDs()
+        if proc.isRunning {
+            proc.terminateRoot()
+        }
+        proc.terminateTree(signal: SIGTERM, knownDescendants: descendants)
+
+        let gracePeriod = self.dependencies.terminationGracePeriod
+        if gracePeriod > 0 {
+            let deadline = self.dependencies.now().addingTimeInterval(gracePeriod)
+            while proc.isRunning, self.dependencies.now() < deadline {
+                try? await self.dependencies.sleep(100_000_000)
+            }
+        }
+
+        if proc.isRunning {
+            proc.terminateTree(signal: SIGKILL, knownDescendants: descendants)
+            await self.waitUntilProcessExits(proc, timeout: 1)
+        } else {
+            proc.killDescendants(descendants)
+        }
+    }
+
+    private func waitUntilProcessExits(_ proc: any AntigravityCLIProcessHandle, timeout: TimeInterval) async {
+        let deadline = self.dependencies.now().addingTimeInterval(timeout)
+        while proc.isRunning, self.dependencies.now() < deadline {
+            try? await self.dependencies.sleep(50_000_000)
+        }
+        _ = proc.isRunning
+    }
+
+    private func persistRecord(pid: pid_t, binary: String, processGroup: pid_t?) {
+        guard let identity = self.dependencies.identityProvider.identity(for: pid) else {
+            self.persistedProcessIdentity = nil
+            return
+        }
+        let ownerPID = self.dependencies.currentProcessID()
+        let ownerIdentity = self.dependencies.identityProvider.identity(for: ownerPID)
+        let record = AntigravityCLISessionRecord(
+            pid: pid,
+            requestedBinaryPath: binary,
+            executablePath: identity.executablePath,
+            startEpoch: identity.startEpoch,
+            processGroup: processGroup,
+            ownerPID: ownerPID,
+            ownerExecutablePath: ownerIdentity?.executablePath,
+            ownerStartEpoch: ownerIdentity?.startEpoch)
+        do {
+            try self.dependencies.recordStore.save(record)
+            self.persistedProcessIdentity = identity
+        } catch {
+            self.persistedProcessIdentity = nil
+        }
+    }
+
+    @discardableResult
+    private func reapRecordedSessionIfNeeded() -> Bool {
+        guard let record = try? self.dependencies.recordStore.load() else { return true }
+        guard let liveIdentity = self.dependencies.identityProvider.identity(for: record.pid) else {
+            try? self.dependencies.recordStore.remove()
+            return true
+        }
+        guard liveIdentity.executablePath == record.executablePath,
+              abs(liveIdentity.startEpoch - record.startEpoch) < 0.001
+        else {
+            try? self.dependencies.recordStore.remove()
+            return true
+        }
+        if let ownerPID = record.ownerPID,
+           ownerPID != self.dependencies.currentProcessID(),
+           let ownerExecutablePath = record.ownerExecutablePath,
+           let ownerStartEpoch = record.ownerStartEpoch,
+           let liveOwnerIdentity = self.dependencies.identityProvider.identity(for: ownerPID),
+           liveOwnerIdentity.executablePath == ownerExecutablePath,
+           abs(liveOwnerIdentity.startEpoch - ownerStartEpoch) < 0.001
+        {
+            Self.log.debug("Antigravity CLI session still owned by live process", metadata: [
+                "pid": "\(record.pid)",
+                "ownerPID": "\(ownerPID)",
+            ])
+            self.persistedProcessIdentity = nil
+            return false
+        }
+
+        let knownDescendants = self.dependencies.descendantPIDs(record.pid)
+        Self.log.debug("Reaping stale Antigravity CLI session", metadata: ["pid": "\(record.pid)"])
+        self.dependencies.terminateProcessTree(record.pid, record.processGroup, SIGTERM, knownDescendants)
+        self.dependencies.terminateProcessTree(record.pid, record.processGroup, SIGKILL, knownDescendants)
+        try? self.dependencies.recordStore.remove()
+        return true
+    }
+
+    private func removeRecordIfMatches(pid: pid_t, identity: AntigravityCLIProcessIdentity?) {
+        guard let identity,
+              let record = try? self.dependencies.recordStore.load(),
+              record.pid == pid,
+              record.executablePath == identity.executablePath,
+              abs(record.startEpoch - identity.startEpoch) < 0.001
+        else { return }
+        try? self.dependencies.recordStore.remove()
+    }
+
+    private static func nanoseconds(from interval: TimeInterval) -> UInt64 {
+        guard interval > 0 else { return 0 }
+        let capped = min(interval, TimeInterval(UInt64.max) / 1_000_000_000)
+        return UInt64(capped * 1_000_000_000)
+    }
+}
+
+// MARK: - Production Process Implementation
+
+struct AntigravityPTYProcessLauncher: AntigravityCLIProcessLaunching {
+    func launch(binary: String) throws -> any AntigravityCLIProcessHandle {
+        var primaryFD: Int32 = -1
+        var secondaryFD: Int32 = -1
+        var win = winsize(ws_row: 50, ws_col: 160, ws_xpixel: 0, ws_ypixel: 0)
+        guard openpty(&primaryFD, &secondaryFD, nil, nil, &win) == 0 else {
+            throw AntigravityCLISession.SessionError.launchFailed("openpty failed")
+        }
+        _ = fcntl(primaryFD, F_SETFL, O_NONBLOCK)
+
+        let primaryHandle = FileHandle(fileDescriptor: primaryFD, closeOnDealloc: true)
+        let secondaryHandle = FileHandle(fileDescriptor: secondaryFD, closeOnDealloc: true)
+
+        #if canImport(Darwin)
+        var fileActions: posix_spawn_file_actions_t?
+        #else
+        var fileActions = posix_spawn_file_actions_t()
+        #endif
+        guard posix_spawn_file_actions_init(&fileActions) == 0 else {
+            try? primaryHandle.close()
+            try? secondaryHandle.close()
+            throw AntigravityCLISession.SessionError.launchFailed("posix_spawn_file_actions_init failed")
+        }
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+
+        posix_spawn_file_actions_adddup2(&fileActions, secondaryFD, 0)
+        posix_spawn_file_actions_adddup2(&fileActions, secondaryFD, 1)
+        posix_spawn_file_actions_adddup2(&fileActions, secondaryFD, 2)
+        posix_spawn_file_actions_addclose(&fileActions, primaryFD)
+        posix_spawn_file_actions_addclose(&fileActions, secondaryFD)
+
+        #if canImport(Darwin)
+        let homeDirectory = NSHomeDirectory()
+        _ = homeDirectory.withCString { path in
+            posix_spawn_file_actions_addchdir_np(&fileActions, path)
+        }
+        #endif
+
+        #if canImport(Darwin)
+        var attr: posix_spawnattr_t?
+        #else
+        var attr = posix_spawnattr_t()
+        #endif
+        guard posix_spawnattr_init(&attr) == 0 else {
+            try? primaryHandle.close()
+            try? secondaryHandle.close()
+            throw AntigravityCLISession.SessionError.launchFailed("posix_spawnattr_init failed")
+        }
+        defer { posix_spawnattr_destroy(&attr) }
+        posix_spawnattr_setflags(&attr, Int16(POSIX_SPAWN_SETPGROUP))
+        posix_spawnattr_setpgroup(&attr, 0)
+
+        var env = TTYCommandRunner.enrichedEnvironment()
+        env["PWD"] = NSHomeDirectory()
+        env["TERM"] = "xterm-256color"
+
+        let cArgs: [UnsafeMutablePointer<CChar>?] = [strdup(binary), nil]
+        defer {
+            for arg in cArgs {
+                if let arg {
+                    free(arg)
+                }
+            }
+        }
+
+        var cEnv: [UnsafeMutablePointer<CChar>?] = env.map { key, value in
+            strdup("\(key)=\(value)")
+        }
+        cEnv.append(nil)
+        defer {
+            for entry in cEnv {
+                if let entry {
+                    free(entry)
+                }
+            }
+        }
+
+        var pid: pid_t = 0
+        let spawnResult = binary.withCString { execPath in
+            posix_spawn(&pid, execPath, &fileActions, &attr, cArgs, cEnv)
+        }
+        guard spawnResult == 0 else {
+            try? primaryHandle.close()
+            try? secondaryHandle.close()
+            throw AntigravityCLISession.SessionError.launchFailed(String(cString: strerror(spawnResult)))
+        }
+
+        return AntigravitySpawnedPTYProcessHandle(
+            pid: pid,
+            processGroup: pid,
+            primaryFD: primaryFD,
+            primaryHandle: primaryHandle,
+            secondaryHandle: secondaryHandle)
+    }
+}
+
+final class AntigravitySpawnedPTYProcessHandle: AntigravityCLIProcessHandle, @unchecked Sendable {
+    private let lock = NSLock()
+    private let processPID: pid_t
+    private let processGroupID: pid_t
+    private let primaryFD: Int32
+    private let primaryHandle: FileHandle
+    private let secondaryHandle: FileHandle
+    private var reaped = false
+
+    init(
+        pid: pid_t,
+        processGroup: pid_t,
+        primaryFD: Int32,
+        primaryHandle: FileHandle,
+        secondaryHandle: FileHandle)
+    {
+        self.processPID = pid
+        self.processGroupID = processGroup
+        self.primaryFD = primaryFD
+        self.primaryHandle = primaryHandle
+        self.secondaryHandle = secondaryHandle
+    }
+
+    var pid: pid_t {
+        self.processPID
+    }
+
+    var isRunning: Bool {
+        self.lock.lock()
+        if self.reaped {
+            self.lock.unlock()
+            return false
+        }
+        self.lock.unlock()
+
+        var status: Int32 = 0
+        let result = waitpid(self.processPID, &status, WNOHANG)
+
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        switch result {
+        case 0:
+            return true
+        case self.processPID:
+            self.reaped = true
+            return false
+        case -1 where errno == ECHILD:
+            self.reaped = true
+            return false
+        default:
+            return kill(self.processPID, 0) == 0 || errno == EPERM
+        }
+    }
+
+    var processGroup: pid_t? {
+        self.processGroupID
+    }
+
+    func assignProcessGroup() -> pid_t? {
+        self.processGroupID
+    }
+
+    func sendExit() throws {
+        try self.writeAllToPrimary(Data("/exit\r".utf8))
+    }
+
+    func closePTY() {
+        try? self.primaryHandle.close()
+        try? self.secondaryHandle.close()
+    }
+
+    func terminateRoot() {
+        kill(self.processPID, SIGTERM)
+    }
+
+    func killRoot() {
+        kill(self.processPID, SIGKILL)
+    }
+
+    func descendantPIDs() -> [pid_t] {
+        TTYProcessTreeTerminator.descendantPIDs(of: self.processPID)
+    }
+
+    func terminateTree(signal: Int32, knownDescendants: [pid_t]) {
+        TTYProcessTreeTerminator.terminateProcessTree(
+            rootPID: self.processPID,
+            processGroup: self.processGroupID,
+            signal: signal,
+            knownDescendants: knownDescendants)
+    }
+
+    func killDescendants(_ descendants: [pid_t]) {
+        for pid in descendants where pid > 0 {
+            kill(pid, SIGKILL)
+        }
+    }
+
+    func drainOutput() {
+        var tmp = [UInt8](repeating: 0, count: 8192)
+        for _ in 0..<64 {
+            let n = read(self.primaryFD, &tmp, tmp.count)
+            if n > 0 { continue }
+            break
+        }
+    }
+
+    private func writeAllToPrimary(_ data: Data) throws {
+        data.withUnsafeBytes { rawBytes in
+            guard let baseAddress = rawBytes.baseAddress else { return }
+            var offset = 0
+            var retries = 0
+            while offset < rawBytes.count {
+                let written = write(self.primaryFD, baseAddress.advanced(by: offset), rawBytes.count - offset)
+                if written > 0 {
+                    offset += written
+                    retries = 0
+                    continue
+                }
+                if written == 0 { break }
+
+                let err = errno
+                if err == EINTR || err == EAGAIN || err == EWOULDBLOCK {
+                    retries += 1
+                    if retries > 200 { return }
+                    usleep(5000)
+                    continue
+                }
+                return
+            }
+        }
+    }
+}
+
+// MARK: - Production Stale Session Identity + Storage
+
+struct AntigravityDarwinProcessIdentityProvider: AntigravityCLIProcessIdentityProviding {
+    func identity(for pid: pid_t) -> AntigravityCLIProcessIdentity? {
+        #if canImport(Darwin)
+        var pathBuffer = [CChar](repeating: 0, count: 4096)
+        let pathLength = proc_pidpath(pid, &pathBuffer, UInt32(pathBuffer.count))
+        guard pathLength > 0 else { return nil }
+        let executablePath = pathBuffer.withUnsafeBufferPointer { buffer -> String? in
+            let rawBytes = UnsafeRawBufferPointer(start: buffer.baseAddress, count: Int(pathLength))
+            return String(bytes: rawBytes.prefix { $0 != 0 }, encoding: .utf8)
+        }
+        guard let executablePath, !executablePath.isEmpty else { return nil }
+
+        var info = proc_bsdinfo()
+        let size = proc_pidinfo(
+            pid,
+            PROC_PIDTBSDINFO,
+            0,
+            &info,
+            Int32(MemoryLayout<proc_bsdinfo>.stride))
+        guard size == Int32(MemoryLayout<proc_bsdinfo>.stride) else { return nil }
+        let startEpoch = TimeInterval(info.pbi_start_tvsec) + (TimeInterval(info.pbi_start_tvusec) / 1_000_000)
+        return AntigravityCLIProcessIdentity(executablePath: executablePath, startEpoch: startEpoch)
+        #else
+        return nil
+        #endif
+    }
+}
+
+final class AntigravityFileCLISessionRecordStore: AntigravityCLISessionRecordStoring, @unchecked Sendable {
+    private let fileURL: URL
+    private let fileManager: FileManager
+
+    init(
+        fileURL: URL = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent(".codexbar", isDirectory: true)
+            .appendingPathComponent("antigravity", isDirectory: true)
+            .appendingPathComponent("agy-session.json"),
+        fileManager: FileManager = .default)
+    {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    func load() throws -> AntigravityCLISessionRecord? {
+        guard self.fileManager.fileExists(atPath: self.fileURL.path) else { return nil }
+        let data = try Data(contentsOf: self.fileURL)
+        return try JSONDecoder().decode(AntigravityCLISessionRecord.self, from: data)
+    }
+
+    func save(_ record: AntigravityCLISessionRecord) throws {
+        let directory = self.fileURL.deletingLastPathComponent()
+        try self.fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(record)
+        try data.write(to: self.fileURL, options: [.atomic])
+    }
+
+    func remove() throws {
+        guard self.fileManager.fileExists(atPath: self.fileURL.path) else { return }
+        try self.fileManager.removeItem(at: self.fileURL)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
@@ -27,7 +27,7 @@ protocol AntigravityCLIProcessLaunching: Sendable {
     func launch(binary: String) throws -> any AntigravityCLIProcessHandle
 }
 
-struct AntigravityCLIProcessIdentity: Equatable, Sendable {
+struct AntigravityCLIProcessIdentity: Equatable {
     let executablePath: String
     let startEpoch: TimeInterval
 }
@@ -36,7 +36,7 @@ protocol AntigravityCLIProcessIdentityProviding: Sendable {
     func identity(for pid: pid_t) -> AntigravityCLIProcessIdentity?
 }
 
-struct AntigravityCLISessionRecord: Codable, Equatable, Sendable {
+struct AntigravityCLISessionRecord: Codable, Equatable {
     let pid: pid_t
     let requestedBinaryPath: String
     let executablePath: String
@@ -68,9 +68,13 @@ struct AntigravityCLISessionRecord: Codable, Equatable, Sendable {
 }
 
 protocol AntigravityCLISessionRecordStoring: Sendable {
-    func load() throws -> AntigravityCLISessionRecord?
+    func load() throws -> [AntigravityCLISessionRecord]
     func save(_ record: AntigravityCLISessionRecord) throws
-    func remove() throws
+    func remove(_ record: AntigravityCLISessionRecord) throws
+}
+
+protocol AntigravityCLISessionLaunchLocking: Sendable {
+    func withLock<T>(_ operation: () throws -> T) throws -> T
 }
 
 // MARK: - AntigravityCLISession
@@ -89,10 +93,17 @@ actor AntigravityCLISession {
     static let shared = AntigravityCLISession()
     private static let log = CodexBarLog.logger(LogCategories.antigravity)
 
-    struct Dependencies: Sendable {
+    private struct LaunchOutcome: Sendable {
+        let pid: pid_t
+        let rejectedProcess: (any AntigravityCLIProcessHandle)?
+        let rejectionMessage: String?
+    }
+
+    struct Dependencies {
         var launcher: any AntigravityCLIProcessLaunching
         var identityProvider: any AntigravityCLIProcessIdentityProviding
         var recordStore: any AntigravityCLISessionRecordStoring
+        var launchLock: any AntigravityCLISessionLaunchLocking
         var registerForAppShutdown: @Sendable (pid_t, String) -> Bool
         var updateAppShutdownProcessGroup: @Sendable (pid_t, pid_t?) -> Void
         var unregisterForAppShutdown: @Sendable (pid_t) -> Void
@@ -108,8 +119,9 @@ actor AntigravityCLISession {
         static func live() -> Self {
             Self(
                 launcher: AntigravityPTYProcessLauncher(),
-                identityProvider: AntigravityDarwinProcessIdentityProvider(),
+                identityProvider: AntigravityProcessIdentityProvider(),
                 recordStore: AntigravityFileCLISessionRecordStore(),
+                launchLock: AntigravityFileCLISessionLaunchLock(),
                 registerForAppShutdown: { pid, binary in
                     TTYCommandRunner.registerActiveProcessForAppShutdown(pid: pid, binary: binary)
                 },
@@ -145,6 +157,7 @@ actor AntigravityCLISession {
     private let dependencies: Dependencies
     private var process: (any AntigravityCLIProcessHandle)?
     private var binaryPath: String?
+    private var sessionIdleWindow: TimeInterval
     private var activeProbeCount = 0
     private var activeSessionProbeCount = 0
     private var resetRequestedWhenIdle = false
@@ -158,6 +171,7 @@ actor AntigravityCLISession {
 
     init(dependencies: Dependencies = .live()) {
         self.dependencies = dependencies
+        self.sessionIdleWindow = dependencies.idleWindow
     }
 
     /// The pid of the running ``agy`` process, exposed so callers can discover
@@ -177,6 +191,10 @@ actor AntigravityCLISession {
         self.consecutiveProbeFailures
     }
 
+    var idleWindowForTesting: TimeInterval {
+        self.sessionIdleWindow
+    }
+
     // MARK: Lifecycle
 
     /// Mark a probe as active and ensure a warm ``agy`` is running on the given binary path.
@@ -185,8 +203,11 @@ actor AntigravityCLISession {
     /// idle/reset cleanup cannot kill the process while its ports are being probed.
     /// If previous probes repeatedly failed while the process stayed alive, this
     /// force-relaunches instead of reusing a wedged HTTPS server forever.
-    func beginProbe(binary: String) async throws -> pid_t {
+    func beginProbe(binary: String, idleWindow: TimeInterval? = nil) async throws -> pid_t {
         self.activeProbeCount += 1
+        if let idleWindow, idleWindow > 0 {
+            self.sessionIdleWindow = max(self.dependencies.idleWindow, idleWindow)
+        }
         self.cancelIdleTimer()
         do {
             return try await self.withLifecycleOperation {
@@ -353,14 +374,15 @@ actor AntigravityCLISession {
 
     private func ensureStartedLocked(binary: String) async throws -> pid_t {
         while true {
-            let canPersistRecord = self.canPersistRecordForLaunch()
-
             if let proc = self.process,
                proc.isRunning,
                self.binaryPath == binary,
                self.consecutiveProbeFailures < max(1, self.dependencies.failureRelaunchThreshold)
             {
-                self.persistCurrentRecordIfNeeded(proc, binary: binary, canPersistRecord: canPersistRecord)
+                try? self.dependencies.launchLock.withLock {
+                    self.reapRecordedSessionsIfNeeded()
+                }
+                self.persistCurrentRecordIfNeeded(proc, binary: binary)
                 Self.log.debug("Antigravity CLI session reused", metadata: ["pid": "\(proc.pid)"])
                 return proc.pid
             }
@@ -377,49 +399,82 @@ actor AntigravityCLISession {
                 await self.stopCurrentSessionLocked(reason: reason, clearRecord: true)
             }
 
-            let launched = try self.dependencies.launcher.launch(binary: binary)
-            let launchedPID = launched.pid
             let binaryName = URL(fileURLWithPath: binary).lastPathComponent
-            guard self.dependencies.registerForAppShutdown(launchedPID, binaryName) else {
-                await self.terminateLaunchedProcess(launched)
-                throw SessionError.launchFailed("App shutdown in progress")
+            let launch: (Bool) throws -> LaunchOutcome = { canPersistRecord in
+                if canPersistRecord {
+                    self.prepareRecordStoreForLaunch()
+                }
+                let launched = try self.dependencies.launcher.launch(binary: binary)
+                let launchedPID = launched.pid
+                guard self.dependencies.registerForAppShutdown(launchedPID, binaryName) else {
+                    return LaunchOutcome(
+                        pid: launchedPID,
+                        rejectedProcess: launched,
+                        rejectionMessage: "App shutdown in progress")
+                }
+
+                let processGroup = launched.processGroup ?? launched.assignProcessGroup()
+                self.dependencies.updateAppShutdownProcessGroup(launchedPID, processGroup)
+
+                self.process = launched
+                self.binaryPath = binary
+                self.consecutiveProbeFailures = 0
+                self.sessionGeneration &+= 1
+                if canPersistRecord {
+                    _ = self.persistRecord(pid: launchedPID, binary: binary, processGroup: processGroup)
+                } else {
+                    self.persistedProcessIdentity = nil
+                }
+                return LaunchOutcome(pid: launchedPID, rejectedProcess: nil, rejectionMessage: nil)
             }
 
-            let processGroup = launched.processGroup ?? launched.assignProcessGroup()
-            self.dependencies.updateAppShutdownProcessGroup(launchedPID, processGroup)
+            var lockedLaunch: Result<LaunchOutcome, Error>?
+            var lockFailure: Error?
+            do {
+                try self.dependencies.launchLock.withLock {
+                    lockedLaunch = Result { try launch(true) }
+                }
+            } catch {
+                lockFailure = error
+            }
 
-            self.process = launched
-            self.binaryPath = binary
-            self.consecutiveProbeFailures = 0
-            self.sessionGeneration &+= 1
-            if canPersistRecord {
-                self.persistRecord(pid: launchedPID, binary: binary, processGroup: processGroup)
+            let outcome: LaunchOutcome
+            if let lockFailure {
+                Self.log.warning(
+                    "Antigravity CLI session coordination unavailable",
+                    metadata: ["error": lockFailure.localizedDescription])
+                outcome = try launch(false)
+            } else if let lockedLaunch {
+                outcome = try lockedLaunch.get()
             } else {
-                self.persistedProcessIdentity = nil
+                throw SessionError.launchFailed("CLI session launch did not complete")
+            }
+            if let rejectedProcess = outcome.rejectedProcess {
+                await self.terminateLaunchedProcess(rejectedProcess)
+                throw SessionError.launchFailed(outcome.rejectionMessage ?? "App shutdown in progress")
             }
 
             Self.log.debug(
                 "Antigravity CLI session started",
                 metadata: [
                     "binary": binaryName,
-                    "pid": "\(launchedPID)",
+                    "pid": "\(outcome.pid)",
                 ])
-            return launchedPID
+            return outcome.pid
         }
     }
 
-    private func canPersistRecordForLaunch() -> Bool {
-        guard self.process == nil || self.persistedProcessIdentity == nil else { return true }
-        return self.reapRecordedSessionIfNeeded()
+    private func prepareRecordStoreForLaunch() {
+        guard self.process == nil || self.persistedProcessIdentity == nil else { return }
+        self.reapRecordedSessionsIfNeeded()
     }
 
-    private func persistCurrentRecordIfNeeded(
-        _ proc: any AntigravityCLIProcessHandle,
-        binary: String,
-        canPersistRecord: Bool)
-    {
-        guard canPersistRecord, self.persistedProcessIdentity == nil else { return }
-        self.persistRecord(pid: proc.pid, binary: binary, processGroup: proc.processGroup)
+    private func persistCurrentRecordIfNeeded(_ proc: any AntigravityCLIProcessHandle, binary: String) {
+        guard self.persistedProcessIdentity == nil else { return }
+        try? self.dependencies.launchLock.withLock {
+            self.prepareRecordStoreForLaunch()
+            _ = self.persistRecord(pid: proc.pid, binary: binary, processGroup: proc.processGroup)
+        }
     }
 
     private func cancelIdleTimer() {
@@ -428,10 +483,10 @@ actor AntigravityCLISession {
     }
 
     private func armIdleTimer() {
-        guard self.process != nil, self.dependencies.idleWindow > 0 else { return }
+        guard self.process != nil, self.sessionIdleWindow > 0 else { return }
         self.cancelIdleTimer()
         let generation = self.sessionGeneration
-        let nanoseconds = Self.nanoseconds(from: self.dependencies.idleWindow)
+        let nanoseconds = Self.nanoseconds(from: self.sessionIdleWindow)
         let sleep = self.dependencies.sleep
         self.idleTask = Task { [weak self] in
             do {
@@ -458,8 +513,11 @@ actor AntigravityCLISession {
         self.cancelIdleTimer()
         guard let proc = self.process else {
             if clearRecord {
-                _ = self.reapRecordedSessionIfNeeded()
+                try? self.dependencies.launchLock.withLock {
+                    self.reapRecordedSessionsIfNeeded()
+                }
             }
+            self.sessionIdleWindow = self.dependencies.idleWindow
             return
         }
 
@@ -470,6 +528,7 @@ actor AntigravityCLISession {
         self.process = nil
         self.binaryPath = nil
         self.persistedProcessIdentity = nil
+        self.sessionIdleWindow = self.dependencies.idleWindow
         self.sessionGeneration &+= 1
 
         await self.terminateLaunchedProcess(proc)
@@ -513,10 +572,11 @@ actor AntigravityCLISession {
         _ = proc.isRunning
     }
 
-    private func persistRecord(pid: pid_t, binary: String, processGroup: pid_t?) {
+    @discardableResult
+    private func persistRecord(pid: pid_t, binary: String, processGroup: pid_t?) -> Bool {
         guard let identity = self.dependencies.identityProvider.identity(for: pid) else {
             self.persistedProcessIdentity = nil
-            return
+            return false
         }
         let ownerPID = self.dependencies.currentProcessID()
         let ownerIdentity = self.dependencies.identityProvider.identity(for: ownerPID)
@@ -532,68 +592,79 @@ actor AntigravityCLISession {
         do {
             try self.dependencies.recordStore.save(record)
             self.persistedProcessIdentity = identity
+            return true
         } catch {
-            self.persistedProcessIdentity = nil
-        }
-    }
-
-    @discardableResult
-    private func reapRecordedSessionIfNeeded() -> Bool {
-        guard let record = try? self.dependencies.recordStore.load() else { return true }
-        guard let liveIdentity = self.dependencies.identityProvider.identity(for: record.pid) else {
-            try? self.dependencies.recordStore.remove()
-            return true
-        }
-        guard liveIdentity.executablePath == record.executablePath,
-              abs(liveIdentity.startEpoch - record.startEpoch) < 0.001
-        else {
-            try? self.dependencies.recordStore.remove()
-            return true
-        }
-        if let ownerPID = record.ownerPID,
-           ownerPID != self.dependencies.currentProcessID(),
-           let ownerExecutablePath = record.ownerExecutablePath,
-           let ownerStartEpoch = record.ownerStartEpoch,
-           let liveOwnerIdentity = self.dependencies.identityProvider.identity(for: ownerPID),
-           liveOwnerIdentity.executablePath == ownerExecutablePath,
-           abs(liveOwnerIdentity.startEpoch - ownerStartEpoch) < 0.001
-        {
-            Self.log.debug("Antigravity CLI session still owned by live process", metadata: [
-                "pid": "\(record.pid)",
-                "ownerPID": "\(ownerPID)",
-            ])
             self.persistedProcessIdentity = nil
             return false
         }
+    }
 
-        let knownDescendants = self.dependencies.descendantPIDs(record.pid)
-        Self.log.debug("Reaping stale Antigravity CLI session", metadata: ["pid": "\(record.pid)"])
-        self.dependencies.terminateProcessTree(record.pid, record.processGroup, SIGTERM, knownDescendants)
-        self.dependencies.terminateProcessTree(record.pid, record.processGroup, SIGKILL, knownDescendants)
-        try? self.dependencies.recordStore.remove()
-        return true
+    private func reapRecordedSessionsIfNeeded() {
+        guard let records = try? self.dependencies.recordStore.load() else { return }
+        for record in records {
+            guard let liveIdentity = self.dependencies.identityProvider.identity(for: record.pid),
+                  liveIdentity.executablePath == record.executablePath,
+                  abs(liveIdentity.startEpoch - record.startEpoch) < 0.001
+            else {
+                try? self.dependencies.recordStore.remove(record)
+                continue
+            }
+            if let proc = self.process, proc.pid == record.pid {
+                self.persistedProcessIdentity = liveIdentity
+                continue
+            }
+            if let ownerPID = record.ownerPID,
+               ownerPID != self.dependencies.currentProcessID(),
+               let ownerExecutablePath = record.ownerExecutablePath,
+               let ownerStartEpoch = record.ownerStartEpoch,
+               let liveOwnerIdentity = self.dependencies.identityProvider.identity(for: ownerPID),
+               liveOwnerIdentity.executablePath == ownerExecutablePath,
+               abs(liveOwnerIdentity.startEpoch - ownerStartEpoch) < 0.001
+            {
+                continue
+            }
+
+            let knownDescendants = self.dependencies.descendantPIDs(record.pid)
+            Self.log.debug("Reaping stale Antigravity CLI session", metadata: ["pid": "\(record.pid)"])
+            self.dependencies.terminateProcessTree(record.pid, record.processGroup, SIGTERM, knownDescendants)
+            self.dependencies.terminateProcessTree(record.pid, record.processGroup, SIGKILL, knownDescendants)
+            try? self.dependencies.recordStore.remove(record)
+        }
     }
 
     private func removeRecordIfMatches(pid: pid_t, identity: AntigravityCLIProcessIdentity?) {
-        guard let identity,
-              let record = try? self.dependencies.recordStore.load(),
-              record.pid == pid,
-              record.executablePath == identity.executablePath,
-              abs(record.startEpoch - identity.startEpoch) < 0.001
-        else { return }
-        try? self.dependencies.recordStore.remove()
+        try? self.dependencies.launchLock.withLock {
+            guard let identity, let records = try? self.dependencies.recordStore.load() else { return }
+            for record in records
+                where record.pid == pid &&
+                record.executablePath == identity.executablePath &&
+                abs(record.startEpoch - identity.startEpoch) < 0.001
+            {
+                try? self.dependencies.recordStore.remove(record)
+            }
+        }
     }
 
     private static func nanoseconds(from interval: TimeInterval) -> UInt64 {
         guard interval > 0 else { return 0 }
-        let capped = min(interval, TimeInterval(UInt64.max) / 1_000_000_000)
-        return UInt64(capped * 1_000_000_000)
+        guard interval.isFinite else { return UInt64.max }
+        let nanoseconds = interval * 1_000_000_000
+        guard nanoseconds < TimeInterval(UInt64.max) else { return UInt64.max }
+        return UInt64(nanoseconds)
     }
 }
 
 // MARK: - Production Process Implementation
 
 struct AntigravityPTYProcessLauncher: AntigravityCLIProcessLaunching {
+    static func defaultSignalsForSpawn() -> sigset_t {
+        var signals = sigset_t()
+        sigemptyset(&signals)
+        sigaddset(&signals, SIGINT)
+        sigaddset(&signals, SIGTERM)
+        return signals
+    }
+
     func launch(binary: String) throws -> any AntigravityCLIProcessHandle {
         var primaryFD: Int32 = -1
         var secondaryFD: Int32 = -1
@@ -642,7 +713,9 @@ struct AntigravityPTYProcessLauncher: AntigravityCLIProcessLaunching {
             throw AntigravityCLISession.SessionError.launchFailed("posix_spawnattr_init failed")
         }
         defer { posix_spawnattr_destroy(&attr) }
-        posix_spawnattr_setflags(&attr, Int16(POSIX_SPAWN_SETPGROUP))
+        var defaultSignals = Self.defaultSignalsForSpawn()
+        posix_spawnattr_setsigdefault(&attr, &defaultSignals)
+        posix_spawnattr_setflags(&attr, Int16(POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGDEF))
         posix_spawnattr_setpgroup(&attr, 0)
 
         var env = TTYCommandRunner.enrichedEnvironment()
@@ -824,7 +897,7 @@ final class AntigravitySpawnedPTYProcessHandle: AntigravityCLIProcessHandle, @un
 
 // MARK: - Production Stale Session Identity + Storage
 
-struct AntigravityDarwinProcessIdentityProvider: AntigravityCLIProcessIdentityProviding {
+struct AntigravityProcessIdentityProvider: AntigravityCLIProcessIdentityProviding {
     func identity(for pid: pid_t) -> AntigravityCLIProcessIdentity? {
         #if canImport(Darwin)
         var pathBuffer = [CChar](repeating: 0, count: 4096)
@@ -847,7 +920,33 @@ struct AntigravityDarwinProcessIdentityProvider: AntigravityCLIProcessIdentityPr
         let startEpoch = TimeInterval(info.pbi_start_tvsec) + (TimeInterval(info.pbi_start_tvusec) / 1_000_000)
         return AntigravityCLIProcessIdentity(executablePath: executablePath, startEpoch: startEpoch)
         #else
-        return nil
+        let procDirectory = "/proc/\(pid)"
+        guard let executablePath = try? FileManager.default.destinationOfSymbolicLink(
+            atPath: "\(procDirectory)/exe"),
+            let stat = try? String(contentsOfFile: "\(procDirectory)/stat", encoding: .utf8),
+            let closeParen = stat.lastIndex(of: ")")
+        else {
+            return nil
+        }
+        let fields = stat[stat.index(after: closeParen)...].split(whereSeparator: \.isWhitespace)
+        let clockTicksPerSecond = sysconf(Int32(_SC_CLK_TCK))
+        let systemStat = try? String(contentsOfFile: "/proc/stat", encoding: .utf8)
+        let bootEpoch = systemStat?
+            .split(separator: "\n")
+            .first { $0.hasPrefix("btime ") }?
+            .split(whereSeparator: \.isWhitespace)
+            .dropFirst()
+            .first
+            .flatMap { TimeInterval($0) }
+        guard fields.count > 19,
+              let startTicks = TimeInterval(fields[19]),
+              clockTicksPerSecond > 0,
+              let bootEpoch
+        else {
+            return nil
+        }
+        let startEpoch = bootEpoch + (startTicks / TimeInterval(clockTicksPerSecond))
+        return AntigravityCLIProcessIdentity(executablePath: executablePath, startEpoch: startEpoch)
         #endif
     }
 }
@@ -867,21 +966,98 @@ final class AntigravityFileCLISessionRecordStore: AntigravityCLISessionRecordSto
         self.fileManager = fileManager
     }
 
-    func load() throws -> AntigravityCLISessionRecord? {
-        guard self.fileManager.fileExists(atPath: self.fileURL.path) else { return nil }
+    func load() throws -> [AntigravityCLISessionRecord] {
+        guard self.fileManager.fileExists(atPath: self.fileURL.path) else { return [] }
         let data = try Data(contentsOf: self.fileURL)
-        return try JSONDecoder().decode(AntigravityCLISessionRecord.self, from: data)
+        let decoder = JSONDecoder()
+        if let records = try? decoder.decode([AntigravityCLISessionRecord].self, from: data) {
+            return records
+        }
+        return try [decoder.decode(AntigravityCLISessionRecord.self, from: data)]
     }
 
     func save(_ record: AntigravityCLISessionRecord) throws {
+        var records = (try? self.load()) ?? []
+        records.removeAll { Self.sameOwner($0, record) }
+        records.append(record)
+        try self.write(records)
+    }
+
+    func remove(_ record: AntigravityCLISessionRecord) throws {
+        var records = try self.load()
+        records.removeAll {
+            $0.pid == record.pid &&
+                $0.executablePath == record.executablePath &&
+                abs($0.startEpoch - record.startEpoch) < 0.001
+        }
+        if records.isEmpty {
+            guard self.fileManager.fileExists(atPath: self.fileURL.path) else { return }
+            try self.fileManager.removeItem(at: self.fileURL)
+        } else {
+            try self.write(records)
+        }
+    }
+
+    private func write(_ records: [AntigravityCLISessionRecord]) throws {
         let directory = self.fileURL.deletingLastPathComponent()
         try self.fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
-        let data = try JSONEncoder().encode(record)
+        let data = try JSONEncoder().encode(records)
         try data.write(to: self.fileURL, options: [.atomic])
     }
 
-    func remove() throws {
-        guard self.fileManager.fileExists(atPath: self.fileURL.path) else { return }
-        try self.fileManager.removeItem(at: self.fileURL)
+    private static func sameOwner(
+        _ lhs: AntigravityCLISessionRecord,
+        _ rhs: AntigravityCLISessionRecord) -> Bool
+    {
+        if let lhsOwnerPID = lhs.ownerPID,
+           let rhsOwnerPID = rhs.ownerPID,
+           let lhsOwnerPath = lhs.ownerExecutablePath,
+           let rhsOwnerPath = rhs.ownerExecutablePath,
+           let lhsOwnerStart = lhs.ownerStartEpoch,
+           let rhsOwnerStart = rhs.ownerStartEpoch
+        {
+            return lhsOwnerPID == rhsOwnerPID &&
+                lhsOwnerPath == rhsOwnerPath &&
+                abs(lhsOwnerStart - rhsOwnerStart) < 0.001
+        }
+        return lhs.pid == rhs.pid &&
+            lhs.executablePath == rhs.executablePath &&
+            abs(lhs.startEpoch - rhs.startEpoch) < 0.001
+    }
+}
+
+final class AntigravityFileCLISessionLaunchLock: AntigravityCLISessionLaunchLocking, @unchecked Sendable {
+    private let fileURL: URL
+    private let fileManager: FileManager
+
+    init(
+        fileURL: URL = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent(".codexbar", isDirectory: true)
+            .appendingPathComponent("antigravity", isDirectory: true)
+            .appendingPathComponent("agy-session.lock"),
+        fileManager: FileManager = .default)
+    {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    func withLock<T>(_ operation: () throws -> T) throws -> T {
+        let directory = self.fileURL.deletingLastPathComponent()
+        try self.fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let fd = open(self.fileURL.path, O_CREAT | O_RDWR | O_CLOEXEC, S_IRUSR | S_IWUSR)
+        guard fd >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer {
+            _ = flock(fd, LOCK_UN)
+            close(fd)
+        }
+
+        while flock(fd, LOCK_EX) != 0 {
+            guard errno == EINTR else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        }
+        return try operation()
     }
 }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
@@ -93,7 +93,7 @@ actor AntigravityCLISession {
     static let shared = AntigravityCLISession()
     private static let log = CodexBarLog.logger(LogCategories.antigravity)
 
-    private struct LaunchOutcome: Sendable {
+    private struct LaunchOutcome {
         let pid: pid_t
         let rejectedProcess: (any AntigravityCLIProcessHandle)?
         let rejectionMessage: String?
@@ -695,11 +695,12 @@ struct AntigravityPTYProcessLauncher: AntigravityCLIProcessLaunching {
         posix_spawn_file_actions_addclose(&fileActions, primaryFD)
         posix_spawn_file_actions_addclose(&fileActions, secondaryFD)
 
-        #if canImport(Darwin)
         let homeDirectory = NSHomeDirectory()
         _ = homeDirectory.withCString { path in
             posix_spawn_file_actions_addchdir_np(&fileActions, path)
         }
+        #if !canImport(Darwin)
+        posix_spawn_file_actions_addclosefrom_np(&fileActions, 3)
         #endif
 
         #if canImport(Darwin)
@@ -715,7 +716,12 @@ struct AntigravityPTYProcessLauncher: AntigravityCLIProcessLaunching {
         defer { posix_spawnattr_destroy(&attr) }
         var defaultSignals = Self.defaultSignalsForSpawn()
         posix_spawnattr_setsigdefault(&attr, &defaultSignals)
-        posix_spawnattr_setflags(&attr, Int16(POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGDEF))
+        #if canImport(Darwin)
+        let spawnFlags = POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGDEF | POSIX_SPAWN_CLOEXEC_DEFAULT
+        #else
+        let spawnFlags = POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSIGDEF
+        #endif
+        posix_spawnattr_setflags(&attr, Int16(spawnFlags))
         posix_spawnattr_setpgroup(&attr, 0)
 
         var env = TTYCommandRunner.enrichedEnvironment()

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
@@ -104,6 +104,22 @@ actor AntigravityCLISession {
     static let shared = AntigravityCLISession()
     private static let log = CodexBarLog.logger(LogCategories.antigravity)
 
+    enum ResetCause: Int {
+        case deferred
+        case oneShotCLI
+        case unhealthy
+        case authentication
+
+        var message: String {
+            switch self {
+            case .deferred: "deferred reset"
+            case .oneShotCLI: "one-shot CLI fetch"
+            case .unhealthy: "unhealthy CLI HTTPS session"
+            case .authentication: "authentication required"
+            }
+        }
+    }
+
     private struct LaunchOutcome {
         let pid: pid_t
         let rejectedProcess: (any AntigravityCLIProcessHandle)?
@@ -173,12 +189,14 @@ actor AntigravityCLISession {
     private var activeSessionProbeCount = 0
     private var resetRequestedWhenIdle = false
     private var hardResetRequestedWhenIdle = false
+    private var pendingResetCause: ResetCause?
     private var idleTask: Task<Void, Never>?
     private var sessionGeneration: UInt64 = 0
     private var consecutiveProbeFailures = 0
     private var persistedProcessIdentity: AntigravityCLIProcessIdentity?
     private var recentOutput = Data()
     private var authenticationPromptObserved = false
+    private var lastStopReason: String?
     private var lifecycleOperationInProgress = false
     private var lifecycleWaiters: [CheckedContinuation<Void, Never>] = []
     private var exclusiveProbeWaiters: [CheckedContinuation<Void, Never>] = []
@@ -211,6 +229,10 @@ actor AntigravityCLISession {
 
     var activeProbeCountForTesting: Int {
         self.activeProbeCount
+    }
+
+    var lastStopReasonForTesting: String? {
+        self.lastStopReason
     }
 
     // MARK: Lifecycle
@@ -270,10 +292,15 @@ actor AntigravityCLISession {
         let shouldForceStopUnhealthy = !success &&
             self.consecutiveProbeFailures >= max(1, self.dependencies.failureRelaunchThreshold)
         let shouldReset = forceTerminate || resetAfterFetch || self.resetRequestedWhenIdle || shouldForceStopUnhealthy
+        let currentResetCause = Self.resetCause(
+            authenticationRequired: forceTerminate,
+            resetAfterFetch: resetAfterFetch,
+            shouldForceStopUnhealthy: shouldForceStopUnhealthy)
 
         guard self.activeProbeCount == 0 else {
             if shouldReset {
                 self.resetRequestedWhenIdle = true
+                self.pendingResetCause = Self.strongestResetCause(self.pendingResetCause, currentResetCause)
             }
             if shouldReset, !success || forceTerminate {
                 self.hardResetRequestedWhenIdle = true
@@ -283,19 +310,11 @@ actor AntigravityCLISession {
 
         if shouldReset {
             let shouldForceTerminate = !success || forceTerminate || self.hardResetRequestedWhenIdle
-            let reason =
-                if shouldForceTerminate {
-                    "authentication required"
-                } else if resetAfterFetch {
-                    "one-shot CLI fetch"
-                } else if shouldForceStopUnhealthy {
-                    "unhealthy CLI HTTPS session"
-                } else {
-                    "deferred reset"
-                }
+            let resetCause = Self.strongestResetCause(self.pendingResetCause, currentResetCause)
             await self.withLifecycleOperation {
                 guard self.activeProbeCount == 0 else {
                     self.resetRequestedWhenIdle = true
+                    self.pendingResetCause = Self.strongestResetCause(self.pendingResetCause, resetCause)
                     if shouldForceTerminate {
                         self.hardResetRequestedWhenIdle = true
                     }
@@ -303,14 +322,36 @@ actor AntigravityCLISession {
                 }
                 self.resetRequestedWhenIdle = false
                 self.hardResetRequestedWhenIdle = false
+                self.pendingResetCause = nil
                 await self.stopCurrentSessionLocked(
-                    reason: reason,
+                    reason: resetCause.message,
                     clearRecord: true,
                     graceful: !shouldForceTerminate)
             }
         } else {
             self.armIdleTimer()
         }
+    }
+
+    static func resetCause(
+        authenticationRequired: Bool,
+        resetAfterFetch: Bool,
+        shouldForceStopUnhealthy: Bool) -> ResetCause
+    {
+        if authenticationRequired {
+            .authentication
+        } else if shouldForceStopUnhealthy {
+            .unhealthy
+        } else if resetAfterFetch {
+            .oneShotCLI
+        } else {
+            .deferred
+        }
+    }
+
+    static func strongestResetCause(_ existing: ResetCause?, _ incoming: ResetCause) -> ResetCause {
+        guard let existing else { return incoming }
+        return existing.rawValue >= incoming.rawValue ? existing : incoming
     }
 
     /// Ensure a warm ``agy`` is running on the given binary path.
@@ -585,6 +626,9 @@ actor AntigravityCLISession {
 
     private func stopCurrentSessionLocked(reason: String, clearRecord: Bool, graceful: Bool = true) async {
         self.cancelIdleTimer()
+        let effectiveReason = self.pendingResetCause?.message ?? reason
+        self.pendingResetCause = nil
+        self.lastStopReason = effectiveReason
         guard let proc = self.process else {
             if clearRecord {
                 try? self.dependencies.launchLock.withLock {
@@ -599,7 +643,7 @@ actor AntigravityCLISession {
 
         let pid = proc.pid
         let identity = self.persistedProcessIdentity
-        Self.log.debug("Antigravity CLI session stopping", metadata: ["pid": "\(pid)", "reason": "\(reason)"])
+        Self.log.debug("Antigravity CLI session stopping", metadata: ["pid": "\(pid)", "reason": "\(effectiveReason)"])
 
         self.process = nil
         self.binaryPath = nil

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
@@ -20,11 +20,22 @@ protocol AntigravityCLIProcessHandle: AnyObject, Sendable {
     func descendantPIDs() -> [pid_t]
     func terminateTree(signal: Int32, knownDescendants: [pid_t])
     func killDescendants(_ descendants: [pid_t])
-    func drainOutput()
+    func drainOutput() -> Data
 }
 
 protocol AntigravityCLIProcessLaunching: Sendable {
     func launch(binary: String) throws -> any AntigravityCLIProcessHandle
+}
+
+enum AntigravityCLIAuthenticationPrompt {
+    static let evidence = Data("You are currently not signed in".utf8)
+
+    static func contains(_ output: Data) -> Bool {
+        [
+            self.evidence,
+            Data("Select login method:".utf8),
+        ].contains { output.range(of: $0) != nil }
+    }
 }
 
 struct AntigravityCLIProcessIdentity: Equatable {
@@ -161,10 +172,13 @@ actor AntigravityCLISession {
     private var activeProbeCount = 0
     private var activeSessionProbeCount = 0
     private var resetRequestedWhenIdle = false
+    private var hardResetRequestedWhenIdle = false
     private var idleTask: Task<Void, Never>?
     private var sessionGeneration: UInt64 = 0
     private var consecutiveProbeFailures = 0
     private var persistedProcessIdentity: AntigravityCLIProcessIdentity?
+    private var recentOutput = Data()
+    private var authenticationPromptObserved = false
     private var lifecycleOperationInProgress = false
     private var lifecycleWaiters: [CheckedContinuation<Void, Never>] = []
     private var exclusiveProbeWaiters: [CheckedContinuation<Void, Never>] = []
@@ -193,6 +207,10 @@ actor AntigravityCLISession {
 
     var idleWindowForTesting: TimeInterval {
         self.sessionIdleWindow
+    }
+
+    var activeProbeCountForTesting: Int {
+        self.activeProbeCount
     }
 
     // MARK: Lifecycle
@@ -224,7 +242,13 @@ actor AntigravityCLISession {
                         self.resetRequestedWhenIdle = true
                         return
                     }
-                    await self.stopCurrentSessionLocked(reason: "deferred reset after failed begin", clearRecord: true)
+                    let forceTerminate = self.hardResetRequestedWhenIdle || self.consecutiveProbeFailures > 0
+                    self.resetRequestedWhenIdle = false
+                    self.hardResetRequestedWhenIdle = false
+                    await self.stopCurrentSessionLocked(
+                        reason: "deferred reset after failed begin",
+                        clearRecord: true,
+                        graceful: !forceTerminate)
                 }
             }
             throw error
@@ -233,7 +257,7 @@ actor AntigravityCLISession {
 
     /// Record probe completion and either keep the session warm for the bounded
     /// idle window or tear it down immediately for one-shot CLI invocations.
-    func finishProbe(success: Bool, resetAfterFetch: Bool) async {
+    func finishProbe(success: Bool, resetAfterFetch: Bool, forceTerminate: Bool = false) async {
         if success {
             self.consecutiveProbeFailures = 0
         } else {
@@ -245,18 +269,24 @@ actor AntigravityCLISession {
         self.notifyExclusiveProbeWaitersIfNeeded()
         let shouldForceStopUnhealthy = !success &&
             self.consecutiveProbeFailures >= max(1, self.dependencies.failureRelaunchThreshold)
-        let shouldReset = resetAfterFetch || self.resetRequestedWhenIdle || shouldForceStopUnhealthy
+        let shouldReset = forceTerminate || resetAfterFetch || self.resetRequestedWhenIdle || shouldForceStopUnhealthy
 
         guard self.activeProbeCount == 0 else {
             if shouldReset {
                 self.resetRequestedWhenIdle = true
             }
+            if shouldReset, !success || forceTerminate {
+                self.hardResetRequestedWhenIdle = true
+            }
             return
         }
 
         if shouldReset {
+            let shouldForceTerminate = !success || forceTerminate || self.hardResetRequestedWhenIdle
             let reason =
-                if resetAfterFetch {
+                if shouldForceTerminate {
+                    "authentication required"
+                } else if resetAfterFetch {
                     "one-shot CLI fetch"
                 } else if shouldForceStopUnhealthy {
                     "unhealthy CLI HTTPS session"
@@ -266,10 +296,17 @@ actor AntigravityCLISession {
             await self.withLifecycleOperation {
                 guard self.activeProbeCount == 0 else {
                     self.resetRequestedWhenIdle = true
+                    if shouldForceTerminate {
+                        self.hardResetRequestedWhenIdle = true
+                    }
                     return
                 }
                 self.resetRequestedWhenIdle = false
-                await self.stopCurrentSessionLocked(reason: reason, clearRecord: true)
+                self.hardResetRequestedWhenIdle = false
+                await self.stopCurrentSessionLocked(
+                    reason: reason,
+                    clearRecord: true,
+                    graceful: !shouldForceTerminate)
             }
         } else {
             self.armIdleTimer()
@@ -301,13 +338,34 @@ actor AntigravityCLISession {
                 return
             }
             self.resetRequestedWhenIdle = false
-            await self.stopCurrentSessionLocked(reason: "manual reset", clearRecord: true)
+            let forceTerminate = self.hardResetRequestedWhenIdle || self.consecutiveProbeFailures > 0
+            self.hardResetRequestedWhenIdle = false
+            await self.stopCurrentSessionLocked(
+                reason: "manual reset",
+                clearRecord: true,
+                graceful: !forceTerminate)
         }
     }
 
-    /// Drain PTY output so the write side doesn't block.
-    func drainOutput() {
-        self.process?.drainOutput()
+    /// Drain PTY output into one rolling buffer shared by concurrent probes.
+    func drainOutput() -> Data {
+        var searchableOutput = self.recentOutput
+        if let output = self.process?.drainOutput(), !output.isEmpty {
+            searchableOutput.append(output)
+            self.recentOutput = Data(searchableOutput.suffix(4096))
+        }
+
+        if !self.authenticationPromptObserved,
+           AntigravityCLIAuthenticationPrompt.contains(searchableOutput)
+        {
+            self.authenticationPromptObserved = true
+        }
+        if self.authenticationPromptObserved,
+           !AntigravityCLIAuthenticationPrompt.contains(searchableOutput)
+        {
+            searchableOutput.append(AntigravityCLIAuthenticationPrompt.evidence)
+        }
+        return searchableOutput
     }
 
     // MARK: Errors
@@ -377,6 +435,8 @@ actor AntigravityCLISession {
             if let proc = self.process,
                proc.isRunning,
                self.binaryPath == binary,
+               !self.resetRequestedWhenIdle,
+               !self.hardResetRequestedWhenIdle,
                self.consecutiveProbeFailures < max(1, self.dependencies.failureRelaunchThreshold)
             {
                 try? self.dependencies.launchLock.withLock {
@@ -396,7 +456,13 @@ actor AntigravityCLISession {
                 let reason = self.consecutiveProbeFailures >= max(1, self.dependencies.failureRelaunchThreshold)
                     ? "relaunching unhealthy session"
                     : "replacing stale session"
-                await self.stopCurrentSessionLocked(reason: reason, clearRecord: true)
+                let forceTerminate = self.hardResetRequestedWhenIdle || self.consecutiveProbeFailures > 0
+                self.resetRequestedWhenIdle = false
+                self.hardResetRequestedWhenIdle = false
+                await self.stopCurrentSessionLocked(
+                    reason: reason,
+                    clearRecord: true,
+                    graceful: !forceTerminate)
             }
 
             let binaryName = URL(fileURLWithPath: binary).lastPathComponent
@@ -418,6 +484,8 @@ actor AntigravityCLISession {
 
                 self.process = launched
                 self.binaryPath = binary
+                self.recentOutput.removeAll(keepingCapacity: true)
+                self.authenticationPromptObserved = false
                 self.consecutiveProbeFailures = 0
                 self.sessionGeneration &+= 1
                 if canPersistRecord {
@@ -450,7 +518,7 @@ actor AntigravityCLISession {
                 throw SessionError.launchFailed("CLI session launch did not complete")
             }
             if let rejectedProcess = outcome.rejectedProcess {
-                await self.terminateLaunchedProcess(rejectedProcess)
+                await self.terminateLaunchedProcess(rejectedProcess, graceful: false)
                 throw SessionError.launchFailed(outcome.rejectionMessage ?? "App shutdown in progress")
             }
 
@@ -505,11 +573,17 @@ actor AntigravityCLISession {
                 self.armIdleTimer()
                 return
             }
-            await self.stopCurrentSessionLocked(reason: "idle timeout", clearRecord: true)
+            let forceTerminate = self.hardResetRequestedWhenIdle || self.consecutiveProbeFailures > 0
+            self.resetRequestedWhenIdle = false
+            self.hardResetRequestedWhenIdle = false
+            await self.stopCurrentSessionLocked(
+                reason: "idle timeout",
+                clearRecord: true,
+                graceful: !forceTerminate)
         }
     }
 
-    private func stopCurrentSessionLocked(reason: String, clearRecord: Bool) async {
+    private func stopCurrentSessionLocked(reason: String, clearRecord: Bool, graceful: Bool = true) async {
         self.cancelIdleTimer()
         guard let proc = self.process else {
             if clearRecord {
@@ -518,6 +592,8 @@ actor AntigravityCLISession {
                 }
             }
             self.sessionIdleWindow = self.dependencies.idleWindow
+            self.recentOutput.removeAll(keepingCapacity: true)
+            self.authenticationPromptObserved = false
             return
         }
 
@@ -529,17 +605,24 @@ actor AntigravityCLISession {
         self.binaryPath = nil
         self.persistedProcessIdentity = nil
         self.sessionIdleWindow = self.dependencies.idleWindow
+        self.recentOutput.removeAll(keepingCapacity: true)
+        self.authenticationPromptObserved = false
         self.sessionGeneration &+= 1
 
-        await self.terminateLaunchedProcess(proc)
+        await self.terminateLaunchedProcess(proc, graceful: graceful)
         self.dependencies.unregisterForAppShutdown(pid)
         if clearRecord {
             self.removeRecordIfMatches(pid: pid, identity: identity)
         }
     }
 
-    private func terminateLaunchedProcess(_ proc: any AntigravityCLIProcessHandle) async {
-        try? proc.sendExit()
+    private func terminateLaunchedProcess(
+        _ proc: any AntigravityCLIProcessHandle,
+        graceful: Bool = true) async
+    {
+        if graceful {
+            try? proc.sendExit()
+        }
         proc.closePTY()
 
         let descendants = proc.descendantPIDs()
@@ -865,13 +948,18 @@ final class AntigravitySpawnedPTYProcessHandle: AntigravityCLIProcessHandle, @un
         }
     }
 
-    func drainOutput() {
+    func drainOutput() -> Data {
         var tmp = [UInt8](repeating: 0, count: 8192)
+        var output: [UInt8] = []
         for _ in 0..<64 {
             let n = read(self.primaryFD, &tmp, tmp.count)
-            if n > 0 { continue }
+            if n > 0 {
+                output.append(contentsOf: tmp.prefix(n))
+                continue
+            }
             break
         }
+        return Data(output)
     }
 
     private func writeAllToPrimary(_ data: Data) throws {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
@@ -353,17 +353,14 @@ actor AntigravityCLISession {
 
     private func ensureStartedLocked(binary: String) async throws -> pid_t {
         while true {
-            let canPersistRecord = if self.process == nil {
-                self.reapRecordedSessionIfNeeded()
-            } else {
-                true
-            }
+            let canPersistRecord = self.canPersistRecordForLaunch()
 
             if let proc = self.process,
                proc.isRunning,
                self.binaryPath == binary,
                self.consecutiveProbeFailures < max(1, self.dependencies.failureRelaunchThreshold)
             {
+                self.persistCurrentRecordIfNeeded(proc, binary: binary, canPersistRecord: canPersistRecord)
                 Self.log.debug("Antigravity CLI session reused", metadata: ["pid": "\(proc.pid)"])
                 return proc.pid
             }
@@ -409,6 +406,20 @@ actor AntigravityCLISession {
                 ])
             return launchedPID
         }
+    }
+
+    private func canPersistRecordForLaunch() -> Bool {
+        guard self.process == nil || self.persistedProcessIdentity == nil else { return true }
+        return self.reapRecordedSessionIfNeeded()
+    }
+
+    private func persistCurrentRecordIfNeeded(
+        _ proc: any AntigravityCLIProcessHandle,
+        binary: String,
+        canPersistRecord: Bool)
+    {
+        guard canPersistRecord, self.persistedProcessIdentity == nil else { return }
+        self.persistRecord(pid: proc.pid, binary: binary, processGroup: proc.processGroup)
     }
 
     private func cancelIdleTimer() {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
@@ -124,6 +124,7 @@ actor AntigravityCLISession {
         let pid: pid_t
         let rejectedProcess: (any AntigravityCLIProcessHandle)?
         let rejectionMessage: String?
+        let holdsLaunchReservation: Bool
     }
 
     struct Dependencies {
@@ -131,6 +132,8 @@ actor AntigravityCLISession {
         var identityProvider: any AntigravityCLIProcessIdentityProviding
         var recordStore: any AntigravityCLISessionRecordStoring
         var launchLock: any AntigravityCLISessionLaunchLocking
+        var beginAppShutdownTrackedLaunch: @Sendable () -> Bool
+        var endAppShutdownTrackedLaunch: @Sendable () -> Void
         var registerForAppShutdown: @Sendable (pid_t, String) -> Bool
         var updateAppShutdownProcessGroup: @Sendable (pid_t, pid_t?) -> Void
         var unregisterForAppShutdown: @Sendable (pid_t) -> Void
@@ -149,6 +152,12 @@ actor AntigravityCLISession {
                 identityProvider: AntigravityProcessIdentityProvider(),
                 recordStore: AntigravityFileCLISessionRecordStore(),
                 launchLock: AntigravityFileCLISessionLaunchLock(),
+                beginAppShutdownTrackedLaunch: {
+                    TTYCommandRunner.beginActiveProcessLaunchForAppShutdown()
+                },
+                endAppShutdownTrackedLaunch: {
+                    TTYCommandRunner.endActiveProcessLaunchForAppShutdown()
+                },
                 registerForAppShutdown: { pid, binary in
                     TTYCommandRunner.registerActiveProcessForAppShutdown(pid: pid, binary: binary)
                 },
@@ -511,13 +520,23 @@ actor AntigravityCLISession {
                 if canPersistRecord {
                     self.prepareRecordStoreForLaunch()
                 }
-                let launched = try self.dependencies.launcher.launch(binary: binary)
+                guard self.dependencies.beginAppShutdownTrackedLaunch() else {
+                    throw SessionError.launchFailed("App shutdown in progress")
+                }
+                let launched: any AntigravityCLIProcessHandle
+                do {
+                    launched = try self.dependencies.launcher.launch(binary: binary)
+                } catch {
+                    self.dependencies.endAppShutdownTrackedLaunch()
+                    throw error
+                }
                 let launchedPID = launched.pid
                 guard self.dependencies.registerForAppShutdown(launchedPID, binaryName) else {
                     return LaunchOutcome(
                         pid: launchedPID,
                         rejectedProcess: launched,
-                        rejectionMessage: "App shutdown in progress")
+                        rejectionMessage: "App shutdown in progress",
+                        holdsLaunchReservation: true)
                 }
 
                 let processGroup = launched.processGroup ?? launched.assignProcessGroup()
@@ -534,7 +553,12 @@ actor AntigravityCLISession {
                 } else {
                     self.persistedProcessIdentity = nil
                 }
-                return LaunchOutcome(pid: launchedPID, rejectedProcess: nil, rejectionMessage: nil)
+                self.dependencies.endAppShutdownTrackedLaunch()
+                return LaunchOutcome(
+                    pid: launchedPID,
+                    rejectedProcess: nil,
+                    rejectionMessage: nil,
+                    holdsLaunchReservation: false)
             }
 
             var lockedLaunch: Result<LaunchOutcome, Error>?
@@ -560,6 +584,9 @@ actor AntigravityCLISession {
             }
             if let rejectedProcess = outcome.rejectedProcess {
                 await self.terminateLaunchedProcess(rejectedProcess, graceful: false)
+                if outcome.holdsLaunchReservation {
+                    self.dependencies.endAppShutdownTrackedLaunch()
+                }
                 throw SessionError.launchFailed(outcome.rejectionMessage ?? "App shutdown in progress")
             }
 
@@ -789,6 +816,7 @@ struct AntigravityPTYProcessLauncher: AntigravityCLIProcessLaunching {
         sigemptyset(&signals)
         sigaddset(&signals, SIGINT)
         sigaddset(&signals, SIGTERM)
+        sigaddset(&signals, SIGHUP)
         return signals
     }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
@@ -35,6 +35,33 @@ public struct AntigravityOAuthCredentials: Codable, Sendable, Equatable {
         return Date(timeIntervalSince1970: expiryDateMilliseconds / 1000)
     }
 
+    /// Email of the Google account these credentials authenticate, preferring the
+    /// signed `id_token` claim (what the remote OAuth fetcher reports) and falling
+    /// back to the stored `email` field. Used to verify that an ambient local/CLI
+    /// Antigravity snapshot belongs to the account the user explicitly selected.
+    public var resolvedAccountEmail: String? {
+        Self.email(fromIDToken: self.idToken) ?? self.email?.trimmedNonEmptyEmail
+    }
+
+    static func email(fromIDToken idToken: String?) -> String? {
+        guard let idToken else { return nil }
+        let parts = idToken.components(separatedBy: ".")
+        guard parts.count >= 2 else { return nil }
+        var payload = parts[1]
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = payload.count % 4
+        if remainder > 0 {
+            payload += String(repeating: "=", count: 4 - remainder)
+        }
+        guard let data = Data(base64Encoded: payload, options: .ignoreUnknownCharacters),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+        return (json["email"] as? String)?.trimmedNonEmptyEmail
+    }
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.accessToken =
@@ -456,5 +483,10 @@ extension JSONEncoder {
 extension String {
     fileprivate var nilIfEmpty: String? {
         self.isEmpty ? nil : self
+    }
+
+    fileprivate var trimmedNonEmptyEmail: String? {
+        let trimmed = self.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -65,7 +65,12 @@ struct AntigravityStatusFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        let probe = AntigravityStatusProbe()
+        // IDE-only: `agy` is owned by AntigravityCLIHTTPSFetchStrategy, which
+        // waits for real API readiness. Probing a half-warmed `agy` here would
+        // burn the timeout on a process that is not yet answering, so the
+        // local probe only handles the running-desktop case and otherwise
+        // fails over to the CLI strategy.
+        let probe = AntigravityStatusProbe(processScope: .ideOnly)
         let snap = try await probe.fetch()
         let usage = try snap.toUsageSnapshot()
         try AntigravitySelectedAccountGuard.validate(usage, context: context)
@@ -148,7 +153,9 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     }
 
     static func shouldResetSessionAfterFetch(_ context: ProviderFetchContext) -> Bool {
-        context.runtime == .cli
+        // Long-lived hosts (the app, `codexbar serve`) keep the warm `agy`
+        // session between fetches; only one-shot CLI invocations reset it.
+        context.runtime == .cli && !context.persistsCLISessions
     }
 
     /// Waits for real API readiness, not just socket readiness. Fresh ``agy``

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -98,7 +98,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     struct SnapshotWaitDependencies {
         let pollIntervalNanoseconds: UInt64
         let listeningPorts: @Sendable (Int, TimeInterval) async throws -> [Int]
-        let drainOutput: @Sendable () async -> Void
+        let drainOutput: @Sendable () async -> Data
         let fetchSnapshot: @Sendable ([Int]) async throws -> AntigravityStatusSnapshot
     }
 
@@ -148,7 +148,11 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
             usage = try snap.toUsageSnapshot()
             await session.finishProbe(success: true, resetAfterFetch: resetAfterFetch)
         } catch {
-            await session.finishProbe(success: false, resetAfterFetch: resetAfterFetch)
+            let authenticationRequired = (error as? AntigravityStatusProbeError) == .authenticationRequired
+            await session.finishProbe(
+                success: false,
+                resetAfterFetch: resetAfterFetch || authenticationRequired,
+                forceTerminate: authenticationRequired)
             throw error
         }
 
@@ -173,7 +177,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     {
         var lastFetchError: Error?
         while Date() < deadline {
-            await dependencies.drainOutput()
+            try await Self.checkAuthenticationPrompt(dependencies)
             let remaining = deadline.timeIntervalSinceNow
             let portProbeTimeout = min(2.0, max(0.2, remaining))
             let ports: [Int]
@@ -181,22 +185,29 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
                 ports = try await dependencies.listeningPorts(Int(pid), portProbeTimeout)
             } catch {
                 guard Self.isNoListeningPortsError(error) else {
+                    try await Self.checkAuthenticationPrompt(dependencies)
                     throw error
                 }
                 ports = []
             }
             if !ports.isEmpty {
+                var readySnapshot: AntigravityStatusSnapshot?
                 do {
                     let snapshot = try await dependencies.fetchSnapshot(ports)
                     _ = try snapshot.toUsageSnapshot()
-                    return snapshot
+                    readySnapshot = snapshot
                 } catch {
+                    try await Self.checkAuthenticationPrompt(dependencies)
                     lastFetchError = error
                     Self.log.debug("Antigravity CLI HTTPS endpoint not ready", metadata: [
                         "pid": "\(pid)",
                         "ports": ports.map(String.init).joined(separator: ","),
                         "error": error.localizedDescription,
                     ])
+                }
+                if let readySnapshot {
+                    try await Self.checkAuthenticationPrompt(dependencies)
+                    return readySnapshot
                 }
             }
 
@@ -205,12 +216,24 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
             try await Task.sleep(nanoseconds: min(dependencies.pollIntervalNanoseconds, remainingNanoseconds))
         }
 
+        try await Self.checkAuthenticationPrompt(dependencies)
         if let lastFetchError {
             throw lastFetchError
         }
         Self.log.warning("Antigravity CLI HTTPS: no ports found for pid \(pid)")
         throw AntigravityStatusProbeError.portDetectionFailed(
             "Antigravity CLI started but no listening ports found")
+    }
+
+    static func containsAuthenticationPrompt(_ output: Data) -> Bool {
+        AntigravityCLIAuthenticationPrompt.contains(output)
+    }
+
+    private static func checkAuthenticationPrompt(_ dependencies: SnapshotWaitDependencies) async throws {
+        let terminalOutput = await dependencies.drainOutput()
+        if Self.containsAuthenticationPrompt(terminalOutput) {
+            throw AntigravityStatusProbeError.authenticationRequired
+        }
     }
 
     private static func isNoListeningPortsError(_ error: Error) -> Bool {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -44,9 +44,6 @@ public enum AntigravityProviderDescriptor {
         let local = AntigravityStatusFetchStrategy()
         let cli = AntigravityCLIHTTPSFetchStrategy()
         let oauth = AntigravityOAuthFetchStrategy()
-        if context.selectedTokenAccountID != nil {
-            return [oauth]
-        }
         switch context.sourceMode {
         case .cli:
             return [local, cli]

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -95,7 +95,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     let kind: ProviderFetchKind = .cli
     private static let log = CodexBarLog.logger(LogCategories.antigravity)
 
-    struct SnapshotWaitDependencies: Sendable {
+    struct SnapshotWaitDependencies {
         let pollIntervalNanoseconds: UInt64
         let listeningPorts: @Sendable (Int, TimeInterval) async throws -> [Int]
         let drainOutput: @Sendable () async -> Void
@@ -112,14 +112,19 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         }
         let result = try await self.fetchUsingWarmSession(
             binary: binary,
+            idleWindow: context.persistentCLISessionIdleWindow,
             resetAfterFetch: Self.shouldResetSessionAfterFetch(context))
         try AntigravitySelectedAccountGuard.validate(result.usage, context: context)
         return result
     }
 
-    private func fetchUsingWarmSession(binary: String, resetAfterFetch: Bool) async throws -> ProviderFetchResult {
+    private func fetchUsingWarmSession(
+        binary: String,
+        idleWindow: TimeInterval?,
+        resetAfterFetch: Bool) async throws -> ProviderFetchResult
+    {
         let session = AntigravityCLISession.shared
-        let pid = try await session.beginProbe(binary: binary)
+        let pid = try await session.beginProbe(binary: binary, idleWindow: idleWindow)
         let deadline = Date().addingTimeInterval(5.0)
         let snap: AntigravityStatusSnapshot
         let usage: UsageSnapshot

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -103,10 +103,14 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     }
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        BinaryLocator.resolveAntigravityBinary(env: context.env) != nil
+        guard Self.supportsLocalhostServerTrust else { return false }
+        return BinaryLocator.resolveAntigravityBinary(env: context.env) != nil
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        guard Self.supportsLocalhostServerTrust else {
+            throw AntigravityStatusProbeError.notRunning
+        }
         guard let binary = BinaryLocator.resolveAntigravityBinary(env: context.env) else {
             throw AntigravityStatusProbeError.notRunning
         }
@@ -116,6 +120,14 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
             resetAfterFetch: Self.shouldResetSessionAfterFetch(context))
         try AntigravitySelectedAccountGuard.validate(result.usage, context: context)
         return result
+    }
+
+    private static var supportsLocalhostServerTrust: Bool {
+        #if os(Linux)
+        false
+        #else
+        true
+        #endif
     }
 
     private func fetchUsingWarmSession(

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -42,15 +42,18 @@ public enum AntigravityProviderDescriptor {
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {
         let local = AntigravityStatusFetchStrategy()
+        let cli = AntigravityCLIHTTPSFetchStrategy()
         let oauth = AntigravityOAuthFetchStrategy()
-
+        if context.selectedTokenAccountID != nil {
+            return [oauth]
+        }
         switch context.sourceMode {
         case .cli:
-            return [local]
+            return [local, cli]
         case .oauth:
             return [oauth]
         case .auto:
-            return [local, oauth]
+            return [local, cli, oauth]
         case .web, .api:
             return []
         }
@@ -60,7 +63,6 @@ public enum AntigravityProviderDescriptor {
 struct AntigravityStatusFetchStrategy: ProviderFetchStrategy {
     let id: String = "antigravity.local"
     let kind: ProviderFetchKind = .localProbe
-
     func isAvailable(_: ProviderFetchContext) async -> Bool {
         true
     }
@@ -72,6 +74,141 @@ struct AntigravityStatusFetchStrategy: ProviderFetchStrategy {
         return self.makeResult(
             usage: usage,
             sourceLabel: "local")
+    }
+
+    func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {
+        context.sourceMode == .auto || context.sourceMode == .cli
+    }
+}
+
+/// When the desktop Antigravity app is closed (no ``language_server`` running),
+/// this strategy spawns or reuses ``agy`` and talks to the HTTPS localhost
+/// server embedded in that CLI process. ``agy`` is an interactive REPL, not a
+/// query command, so CodexBar never scrapes TUI output here; it only keeps the
+/// process alive long enough for the server to answer ``GetUserStatus``.
+struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
+    static let sourceLabel = "cli"
+    let id: String = "antigravity.cli-https"
+    let kind: ProviderFetchKind = .cli
+    private static let log = CodexBarLog.logger(LogCategories.antigravity)
+
+    struct SnapshotWaitDependencies: Sendable {
+        let pollIntervalNanoseconds: UInt64
+        let listeningPorts: @Sendable (Int, TimeInterval) async throws -> [Int]
+        let drainOutput: @Sendable () async -> Void
+        let fetchSnapshot: @Sendable ([Int]) async throws -> AntigravityStatusSnapshot
+    }
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        BinaryLocator.resolveAntigravityBinary(env: context.env) != nil
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        guard let binary = BinaryLocator.resolveAntigravityBinary(env: context.env) else {
+            throw AntigravityStatusProbeError.notRunning
+        }
+        return try await self.fetchUsingWarmSession(
+            binary: binary,
+            resetAfterFetch: Self.shouldResetSessionAfterFetch(context))
+    }
+
+    private func fetchUsingWarmSession(binary: String, resetAfterFetch: Bool) async throws -> ProviderFetchResult {
+        let session = AntigravityCLISession.shared
+        let pid = try await session.beginProbe(binary: binary)
+        let deadline = Date().addingTimeInterval(5.0)
+        let snap: AntigravityStatusSnapshot
+        let usage: UsageSnapshot
+        do {
+            snap = try await Self.waitForSnapshot(
+                pid: pid,
+                deadline: deadline,
+                dependencies: SnapshotWaitDependencies(
+                    pollIntervalNanoseconds: 200_000_000,
+                    listeningPorts: { pid, timeout in
+                        try await AntigravityStatusProbe.listeningPorts(pid: pid, timeout: timeout)
+                    },
+                    drainOutput: {
+                        await session.drainOutput()
+                    },
+                    fetchSnapshot: { ports in
+                        let timeout = min(2.0, max(0.2, deadline.timeIntervalSinceNow))
+                        return try await AntigravityStatusProbe(timeout: timeout)
+                            .fetchFromPorts(ports, deadline: deadline)
+                    }))
+            usage = try snap.toUsageSnapshot()
+            await session.finishProbe(success: true, resetAfterFetch: resetAfterFetch)
+        } catch {
+            await session.finishProbe(success: false, resetAfterFetch: resetAfterFetch)
+            throw error
+        }
+
+        return self.makeResult(
+            usage: usage,
+            sourceLabel: Self.sourceLabel)
+    }
+
+    static func shouldResetSessionAfterFetch(_ context: ProviderFetchContext) -> Bool {
+        context.runtime == .cli
+    }
+
+    /// Waits for real API readiness, not just socket readiness. Fresh ``agy``
+    /// processes bind ports quickly, but ``GetUserStatus`` can return transient
+    /// initialization failures for a few seconds after the port appears.
+    static func waitForSnapshot(
+        pid: pid_t,
+        deadline: Date,
+        dependencies: SnapshotWaitDependencies) async throws -> AntigravityStatusSnapshot
+    {
+        var lastFetchError: Error?
+        while Date() < deadline {
+            await dependencies.drainOutput()
+            let remaining = deadline.timeIntervalSinceNow
+            let portProbeTimeout = min(2.0, max(0.2, remaining))
+            let ports: [Int]
+            do {
+                ports = try await dependencies.listeningPorts(Int(pid), portProbeTimeout)
+            } catch {
+                guard Self.isNoListeningPortsError(error) else {
+                    throw error
+                }
+                ports = []
+            }
+            if !ports.isEmpty {
+                do {
+                    let snapshot = try await dependencies.fetchSnapshot(ports)
+                    _ = try snapshot.toUsageSnapshot()
+                    return snapshot
+                } catch {
+                    lastFetchError = error
+                    Self.log.debug("Antigravity CLI HTTPS endpoint not ready", metadata: [
+                        "pid": "\(pid)",
+                        "ports": ports.map(String.init).joined(separator: ","),
+                        "error": error.localizedDescription,
+                    ])
+                }
+            }
+
+            let remainingNanoseconds = UInt64(max(0, deadline.timeIntervalSinceNow) * 1_000_000_000)
+            guard remainingNanoseconds > 0 else { break }
+            try await Task.sleep(nanoseconds: min(dependencies.pollIntervalNanoseconds, remainingNanoseconds))
+        }
+
+        if let lastFetchError {
+            throw lastFetchError
+        }
+        Self.log.warning("Antigravity CLI HTTPS: no ports found for pid \(pid)")
+        throw AntigravityStatusProbeError.portDetectionFailed(
+            "Antigravity CLI started but no listening ports found")
+    }
+
+    private static func isNoListeningPortsError(_ error: Error) -> Bool {
+        if case let AntigravityStatusProbeError.portDetectionFailed(message) = error {
+            return message == "no listening ports found"
+        }
+        if case let SubprocessRunnerError.nonZeroExit(code, stderr) = error {
+            return code == 1 && stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        return false
     }
 
     func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -64,10 +64,11 @@ struct AntigravityStatusFetchStrategy: ProviderFetchStrategy {
         true
     }
 
-    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
         let probe = AntigravityStatusProbe()
         let snap = try await probe.fetch()
         let usage = try snap.toUsageSnapshot()
+        try AntigravitySelectedAccountGuard.validate(usage, context: context)
         return self.makeResult(
             usage: usage,
             sourceLabel: "local")
@@ -104,9 +105,11 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         guard let binary = BinaryLocator.resolveAntigravityBinary(env: context.env) else {
             throw AntigravityStatusProbeError.notRunning
         }
-        return try await self.fetchUsingWarmSession(
+        let result = try await self.fetchUsingWarmSession(
             binary: binary,
             resetAfterFetch: Self.shouldResetSessionAfterFetch(context))
+        try AntigravitySelectedAccountGuard.validate(result.usage, context: context)
+        return result
     }
 
     private func fetchUsingWarmSession(binary: String, resetAfterFetch: Bool) async throws -> ProviderFetchResult {
@@ -255,5 +258,44 @@ struct AntigravityOAuthFetchStrategy: ProviderFetchStrategy {
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
         false
+    }
+}
+
+/// Guards ambient Antigravity snapshots against the explicitly selected account.
+///
+/// The local desktop probe and the ``agy`` CLI HTTPS server report whichever
+/// Antigravity account is signed into the local session. When the user has
+/// selected a specific saved Google account, an ambient probe can return a
+/// *different* account's quota. Only the OAuth strategy is account-scoped (it
+/// fetches with the selected account's injected credentials), so in ``auto``
+/// mode we reject a snapshot whose identity does not match the selected account
+/// and let the pipeline fall through to OAuth. Explicit ``cli``/``oauth`` source
+/// modes stay authoritative and are never second-guessed here.
+enum AntigravitySelectedAccountGuard {
+    static func validate(_ usage: UsageSnapshot, context: ProviderFetchContext) throws {
+        guard context.sourceMode == .auto, context.selectedTokenAccountID != nil else { return }
+        let expected = self.selectedAccountEmail(context: context)
+        let found = self.normalizedEmail(usage.identity?.accountEmail)
+        guard let expected, let found, found.caseInsensitiveCompare(expected) == .orderedSame else {
+            throw AntigravityStatusProbeError.accountMismatch(expected: expected, found: found)
+        }
+    }
+
+    /// Email of the selected token account, read from the same injected
+    /// credentials the OAuth strategy would use (`ANTIGRAVITY_OAUTH_CREDENTIALS_JSON`).
+    static func selectedAccountEmail(context: ProviderFetchContext) -> String? {
+        guard let value = context.env[AntigravityOAuthCredentialsStore.environmentCredentialsKey],
+              let credentials = AntigravityOAuthCredentialsStore.credentials(fromTokenAccountValue: value)
+        else {
+            return nil
+        }
+        return credentials.resolvedAccountEmail
+    }
+
+    private static func normalizedEmail(_ email: String?) -> String? {
+        guard let trimmed = email?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
     }
 }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -357,6 +357,7 @@ public enum AntigravityStatusProbeError: LocalizedError, Sendable, Equatable {
     case apiError(String)
     case parseFailed(String)
     case timedOut
+    case authenticationRequired
     case accountMismatch(expected: String?, found: String?)
 
     public var errorDescription: String? {
@@ -373,6 +374,8 @@ public enum AntigravityStatusProbeError: LocalizedError, Sendable, Equatable {
             "Could not parse Antigravity quota: \(message)"
         case .timedOut:
             "Antigravity quota request timed out."
+        case .authenticationRequired:
+            "Antigravity CLI is signed out. Run agy in a terminal to sign in, then retry."
         case let .accountMismatch(expected, found):
             Self.accountMismatchDescription(expected: expected, found: found)
         }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -124,7 +124,11 @@ public struct AntigravityStatusSnapshot: Sendable {
         let extraWindows = shownModels
             .sorted(by: Self.modelOrderPrecedes)
             .map { m in
-                NamedRateWindow(id: m.quota.modelId, title: m.quota.label, window: Self.rateWindow(for: m.quota))
+                NamedRateWindow(
+                    id: m.quota.modelId,
+                    title: m.quota.label,
+                    window: Self.rateWindow(for: m.quota),
+                    usageKnown: m.quota.remainingFraction != nil)
             }
 
         let identity = ProviderIdentitySnapshot(

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -408,7 +408,20 @@ public enum AntigravityStatusProbeError: LocalizedError, Sendable, Equatable {
 }
 
 public struct AntigravityStatusProbe: Sendable {
+    /// Which local Antigravity processes the probe may attach to.
+    public enum ProcessScope: Sendable {
+        /// Match the IDE language server and the `agy` CLI language server.
+        case ideAndCLI
+        /// Match only the IDE language server. The local fetch strategy
+        /// uses this so it never attaches to a stale or half-warmed `agy`
+        /// process: those accept connections but return transient errors
+        /// on `GetUserStatus`, burning the probe timeout. `agy` is owned
+        /// by `AntigravityCLIHTTPSFetchStrategy`, which has a readiness loop.
+        case ideOnly
+    }
+
     public var timeout: TimeInterval = 8.0
+    public var processScope: ProcessScope = .ideAndCLI
 
     private static let getUserStatusPath = "/exa.language_server_pb.LanguageServerService/GetUserStatus"
     private static let commandModelConfigPath =
@@ -416,12 +429,13 @@ public struct AntigravityStatusProbe: Sendable {
     private static let unleashPath = "/exa.language_server_pb.LanguageServerService/GetUnleashData"
     private static let log = CodexBarLog.logger(LogCategories.antigravity)
 
-    public init(timeout: TimeInterval = 8.0) {
+    public init(timeout: TimeInterval = 8.0, processScope: ProcessScope = .ideAndCLI) {
         self.timeout = timeout
+        self.processScope = processScope
     }
 
     public func fetch() async throws -> AntigravityStatusSnapshot {
-        let processInfo = try await Self.detectProcessInfo(timeout: self.timeout)
+        let processInfo = try await Self.detectProcessInfo(timeout: self.timeout, scope: self.processScope)
         let ports = try await Self.listeningPorts(pid: processInfo.pid, timeout: self.timeout)
         let endpoint = try await Self.resolveWorkingEndpoint(
             candidateEndpoints: Self.connectionCandidates(
@@ -617,7 +631,10 @@ public struct AntigravityStatusProbe: Sendable {
         }
     }
 
-    private static func detectProcessInfo(timeout: TimeInterval) async throws -> ProcessInfoResult {
+    private static func detectProcessInfo(
+        timeout: TimeInterval,
+        scope: ProcessScope = .ideAndCLI) async throws -> ProcessInfoResult
+    {
         let env = ProcessInfo.processInfo.environment
         let result = try await SubprocessRunner.run(
             binary: "/bin/ps",
@@ -626,16 +643,20 @@ public struct AntigravityStatusProbe: Sendable {
             timeout: timeout,
             label: "antigravity-ps")
 
-        return try Self.processInfo(fromProcessListOutput: result.stdout)
+        return try Self.processInfo(fromProcessListOutput: result.stdout, scope: scope)
     }
 
-    static func processInfo(fromProcessListOutput output: String) throws -> ProcessInfoResult {
+    static func processInfo(
+        fromProcessListOutput output: String,
+        scope: ProcessScope = .ideAndCLI) throws -> ProcessInfoResult
+    {
         let lines = output.split(separator: "\n")
         var sawTokenlessIDE = false
         for line in lines {
             let text = String(line)
             guard let match = Self.matchProcessLine(text) else { continue }
             guard let kind = Self.antigravityProcessKind(match.command) else { continue }
+            if scope == .ideOnly, kind == .cli { continue }
             // The IDE language server authenticates local requests with a
             // `--csrf_token` and must keep requiring it: skip a tokenless IDE
             // match so a later valid IDE server can still be found (and surface

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -426,21 +426,7 @@ public struct AntigravityStatusProbe: Sendable {
                 extensionServerCSRFToken: processInfo.extensionServerCSRFToken),
             timeout: self.timeout)
 
-        do {
-            return try await Self.makeParsedRequest(
-                payload: RequestPayload(
-                    path: Self.getUserStatusPath,
-                    body: Self.defaultRequestBody()),
-                context: context,
-                parse: Self.parseUserStatusResponse)
-        } catch {
-            return try await Self.makeParsedRequest(
-                payload: RequestPayload(
-                    path: Self.commandModelConfigPath,
-                    body: Self.defaultRequestBody()),
-                context: context,
-                parse: Self.parseCommandModelResponse)
-        }
+        return try await Self.fetchSnapshot(context: context)
     }
 
     public func fetchPlanInfoSummary() async throws -> AntigravityPlanInfoSummary? {
@@ -475,6 +461,30 @@ public struct AntigravityStatusProbe: Sendable {
     public static func detectVersion(timeout: TimeInterval = 4.0) async -> String? {
         let running = await Self.isRunning(timeout: timeout)
         return running ? "running" : nil
+    }
+
+    // MARK: - CLI HTTPS Fetch
+
+    /// Fetch usage data from a known set of local ports (discovered via
+    /// ``AntigravityCLISession``'s ``pid``), without requiring a running
+    /// ``language_server`` process or CSRF token.
+    ///
+    /// The ``agy`` CLI exposes the same ``GetUserStatus`` gRPC-web endpoint on
+    /// its HTTPS port as the desktop ``language_server``. Unlike the desktop
+    /// endpoint, it does not require a CSRF token header.
+    public func fetchFromPorts(_ ports: [Int], deadline: Date? = nil) async throws -> AntigravityStatusSnapshot {
+        guard !ports.isEmpty else {
+            throw AntigravityStatusProbeError.portDetectionFailed("no listening ports found")
+        }
+        let endpoints = ports.map {
+            AntigravityConnectionEndpoint(
+                scheme: "https",
+                port: $0,
+                csrfToken: "",
+                source: .cliHTTPS)
+        }
+        let context = RequestContext(endpoints: endpoints, timeout: self.timeout, deadline: deadline)
+        return try await Self.fetchSnapshot(context: context)
     }
 
     // MARK: - Parsing
@@ -572,12 +582,22 @@ public struct AntigravityStatusProbe: Sendable {
         enum Source: String {
             case languageServer = "language-server"
             case extensionServer = "extension-server"
+            case cliHTTPS = "cli-https"
         }
 
         let scheme: String
         let port: Int
         let csrfToken: String
         let source: Source
+        /// Whether this endpoint needs a CSRF token header.
+        /// The CLI HTTPS endpoint (``Source/cliHTTPS``) speaks the same HTTP API
+        /// but does not require a CSRF token.
+        var requiresCSRFToken: Bool {
+            switch self.source {
+            case .languageServer, .extensionServer: true
+            case .cliHTTPS: false
+            }
+        }
 
         func matchesRequestTarget(_ other: Self) -> Bool {
             self.scheme == other.scheme && self.port == other.port && self.csrfToken == other.csrfToken
@@ -718,7 +738,7 @@ public struct AntigravityStatusProbe: Sendable {
         return Int(raw)
     }
 
-    private static func listeningPorts(pid: Int, timeout: TimeInterval) async throws -> [Int] {
+    static func listeningPorts(pid: Int, timeout: TimeInterval) async throws -> [Int] {
         let lsof = ["/usr/sbin/lsof", "/usr/bin/lsof"].first(where: {
             FileManager.default.isExecutableFile(atPath: $0)
         })
@@ -728,13 +748,19 @@ public struct AntigravityStatusProbe: Sendable {
         }
 
         let env = ProcessInfo.processInfo.environment
-        let result = try await SubprocessRunner.run(
-            binary: lsof,
-            arguments: ["-nP", "-iTCP", "-sTCP:LISTEN", "-a", "-p", String(pid)],
-            environment: env,
-            timeout: timeout,
-            label: "antigravity-lsof")
-
+        let result: SubprocessResult
+        do {
+            result = try await SubprocessRunner.run(
+                binary: lsof,
+                arguments: ["-nP", "-iTCP", "-sTCP:LISTEN", "-a", "-p", String(pid)],
+                environment: env,
+                timeout: timeout,
+                label: "antigravity-lsof")
+        } catch let SubprocessRunnerError.nonZeroExit(code, stderr)
+            where code == 1 && stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            throw AntigravityStatusProbeError.portDetectionFailed("no listening ports found")
+        }
         let ports = Self.parseListeningPorts(result.stdout)
         if ports.isEmpty {
             throw AntigravityStatusProbeError.portDetectionFailed("no listening ports found")
@@ -953,6 +979,20 @@ public struct AntigravityStatusProbe: Sendable {
     struct RequestContext {
         let endpoints: [AntigravityConnectionEndpoint]
         let timeout: TimeInterval
+        let deadline: Date?
+
+        init(endpoints: [AntigravityConnectionEndpoint], timeout: TimeInterval, deadline: Date? = nil) {
+            self.endpoints = endpoints
+            self.timeout = timeout
+            self.deadline = deadline
+        }
+
+        func timeoutForNextAttempt() -> TimeInterval? {
+            guard let deadline else { return self.timeout }
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else { return nil }
+            return min(self.timeout, remaining)
+        }
     }
 
     private static func defaultRequestBody() -> [String: Any] {
@@ -984,6 +1024,30 @@ public struct AntigravityStatusProbe: Sendable {
         ]
     }
 
+    static func fetchSnapshot(
+        context: RequestContext,
+        send: @escaping @Sendable (RequestPayload, AntigravityConnectionEndpoint, TimeInterval) async throws -> Data =
+            sendRequest) async throws -> AntigravityStatusSnapshot
+    {
+        do {
+            return try await self.makeParsedRequest(
+                payload: RequestPayload(
+                    path: self.getUserStatusPath,
+                    body: self.defaultRequestBody()),
+                context: context,
+                send: send,
+                parse: self.parseUserStatusResponse)
+        } catch {
+            return try await self.makeParsedRequest(
+                payload: RequestPayload(
+                    path: self.commandModelConfigPath,
+                    body: self.defaultRequestBody()),
+                context: context,
+                send: send,
+                parse: self.parseCommandModelResponse)
+        }
+    }
+
     private static func makeRequest(
         payload: RequestPayload,
         context: RequestContext) async throws -> Data
@@ -1001,8 +1065,12 @@ public struct AntigravityStatusProbe: Sendable {
         var lastError: Error?
 
         for endpoint in context.endpoints {
+            guard let timeout = context.timeoutForNextAttempt() else {
+                lastError = lastError ?? AntigravityStatusProbeError.timedOut
+                break
+            }
             do {
-                let data = try await send(payload, endpoint, context.timeout)
+                let data = try await send(payload, endpoint, timeout)
                 return try parse(data)
             } catch {
                 lastError = error
@@ -1026,8 +1094,12 @@ public struct AntigravityStatusProbe: Sendable {
         var lastError: Error?
 
         for endpoint in context.endpoints {
+            guard let timeout = context.timeoutForNextAttempt() else {
+                lastError = lastError ?? AntigravityStatusProbeError.timedOut
+                break
+            }
             do {
-                return try await Self.sendRequest(payload: payload, endpoint: endpoint, timeout: context.timeout)
+                return try await Self.sendRequest(payload: payload, endpoint: endpoint, timeout: timeout)
             } catch {
                 lastError = error
                 Self.log.debug("Antigravity request attempt failed", metadata: [
@@ -1060,7 +1132,9 @@ public struct AntigravityStatusProbe: Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(String(body.count), forHTTPHeaderField: "Content-Length")
         request.setValue("1", forHTTPHeaderField: "Connect-Protocol-Version")
-        request.setValue(endpoint.csrfToken, forHTTPHeaderField: "X-Codeium-Csrf-Token")
+        if endpoint.requiresCSRFToken {
+            request.setValue(endpoint.csrfToken, forHTTPHeaderField: "X-Codeium-Csrf-Token")
+        }
 
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = timeout

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -357,6 +357,7 @@ public enum AntigravityStatusProbeError: LocalizedError, Sendable, Equatable {
     case apiError(String)
     case parseFailed(String)
     case timedOut
+    case accountMismatch(expected: String?, found: String?)
 
     public var errorDescription: String? {
         switch self {
@@ -372,7 +373,19 @@ public enum AntigravityStatusProbeError: LocalizedError, Sendable, Equatable {
             "Could not parse Antigravity quota: \(message)"
         case .timedOut:
             "Antigravity quota request timed out."
+        case let .accountMismatch(expected, found):
+            Self.accountMismatchDescription(expected: expected, found: found)
         }
+    }
+
+    private static func accountMismatchDescription(expected: String?, found: String?) -> String {
+        let selected = expected ?? "the selected account"
+        if let found {
+            return "Antigravity local session is signed in as \(found), not \(selected); "
+                + "using the selected account's OAuth data instead."
+        }
+        return "Antigravity local session did not report an account matching \(selected); "
+            + "using the selected account's OAuth data instead."
     }
 
     private static func portDetectionDescription(_ message: String) -> String {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityUsageDataSource.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityUsageDataSource.swift
@@ -13,7 +13,7 @@ public enum AntigravityUsageDataSource: String, CaseIterable, Identifiable, Send
         switch self {
         case .auto: "Auto"
         case .oauth: "Google OAuth"
-        case .cli: "Local IDE API"
+        case .cli: "Local API / agy CLI"
         }
     }
 

--- a/Sources/CodexBarCore/Providers/CLIProbeSessionResetter.swift
+++ b/Sources/CodexBarCore/Providers/CLIProbeSessionResetter.swift
@@ -4,5 +4,6 @@ public enum CLIProbeSessionResetter {
     public static func resetAll() async {
         await ClaudeCLISession.shared.reset()
         await CodexCLISession.shared.reset()
+        await AntigravityCLISession.shared.reset()
     }
 }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeCLISession.swift
@@ -304,6 +304,13 @@ actor ClaudeCLISession {
         env["PWD"] = workingDirectory.path
         proc.environment = env
 
+        guard TTYCommandRunner.beginActiveProcessLaunchForAppShutdown() else {
+            try? primaryHandle.close()
+            try? secondaryHandle.close()
+            throw SessionError.launchFailed("App shutdown in progress")
+        }
+        defer { TTYCommandRunner.endActiveProcessLaunchForAppShutdown() }
+
         do {
             try proc.run()
             Self.log.debug(

--- a/Sources/CodexBarCore/Providers/Codex/CodexCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexCLISession.swift
@@ -300,6 +300,13 @@ actor CodexCLISession {
             home: options.environment["HOME"] ?? NSHomeDirectory())
         proc.environment = env
 
+        guard TTYCommandRunner.beginActiveProcessLaunchForAppShutdown() else {
+            try? primaryHandle.close()
+            try? secondaryHandle.close()
+            throw SessionError.launchFailed("App shutdown in progress")
+        }
+        defer { TTYCommandRunner.endActiveProcessLaunchForAppShutdown() }
+
         do {
             try proc.run()
         } catch {

--- a/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
@@ -102,7 +102,10 @@ public struct ProviderDiagnosticUsageSummary: Codable, Sendable {
             windows.append(ProviderDiagnosticRateWindow(label: "tertiary", window: tertiary))
         }
         for extra in snapshot.extraRateWindows ?? [] {
-            windows.append(ProviderDiagnosticRateWindow(label: extra.title, window: extra.window))
+            windows.append(ProviderDiagnosticRateWindow(
+                label: extra.title,
+                window: extra.window,
+                usageKnown: extra.usageKnown))
         }
 
         var providerSpecificData: [String] = []
@@ -132,14 +135,50 @@ public struct ProviderDiagnosticRateWindow: Codable, Sendable {
     public let resetsAt: Date?
     public let hasResetDescription: Bool
     public let nextRegenPercent: Double?
+    public let usageKnown: Bool
 
-    public init(label: String, window: RateWindow) {
+    private enum CodingKeys: String, CodingKey {
+        case label
+        case usedPercent
+        case windowMinutes
+        case resetsAt
+        case hasResetDescription
+        case nextRegenPercent
+        case usageKnown
+    }
+
+    public init(label: String, window: RateWindow, usageKnown: Bool = true) {
         self.label = label
         self.usedPercent = window.usedPercent
         self.windowMinutes = window.windowMinutes
         self.resetsAt = window.resetsAt
         self.hasResetDescription = window.resetDescription?.isEmpty == false
         self.nextRegenPercent = window.nextRegenPercent
+        self.usageKnown = usageKnown
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.label = try container.decode(String.self, forKey: .label)
+        self.usedPercent = try container.decode(Double.self, forKey: .usedPercent)
+        self.windowMinutes = try container.decodeIfPresent(Int.self, forKey: .windowMinutes)
+        self.resetsAt = try container.decodeIfPresent(Date.self, forKey: .resetsAt)
+        self.hasResetDescription = try container.decode(Bool.self, forKey: .hasResetDescription)
+        self.nextRegenPercent = try container.decodeIfPresent(Double.self, forKey: .nextRegenPercent)
+        self.usageKnown = try container.decodeIfPresent(Bool.self, forKey: .usageKnown) ?? true
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.label, forKey: .label)
+        try container.encode(self.usedPercent, forKey: .usedPercent)
+        try container.encodeIfPresent(self.windowMinutes, forKey: .windowMinutes)
+        try container.encodeIfPresent(self.resetsAt, forKey: .resetsAt)
+        try container.encode(self.hasResetDescription, forKey: .hasResetDescription)
+        try container.encodeIfPresent(self.nextRegenPercent, forKey: .nextRegenPercent)
+        if !self.usageKnown {
+            try container.encode(false, forKey: .usageKnown)
+        }
     }
 }
 

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -37,6 +37,11 @@ public struct ProviderFetchContext: Sendable {
     public let tokenAccountTokenUpdater: TokenAccountTokenUpdater?
     public let providerManualTokenUpdater: ProviderManualTokenUpdater?
     public let costUsageHistoryDays: Int
+    /// Whether warm CLI helper sessions (such as the managed Antigravity `agy`
+    /// process) may outlive a single fetch. True for long-lived hosts (the app,
+    /// `codexbar serve`); false for one-shot CLI invocations that should reset
+    /// the session after each fetch.
+    public let persistsCLISessions: Bool
 
     public init(
         runtime: ProviderRuntime,
@@ -54,7 +59,8 @@ public struct ProviderFetchContext: Sendable {
         selectedTokenAccountID: UUID? = nil,
         tokenAccountTokenUpdater: TokenAccountTokenUpdater? = nil,
         providerManualTokenUpdater: ProviderManualTokenUpdater? = nil,
-        costUsageHistoryDays: Int = 30)
+        costUsageHistoryDays: Int = 30,
+        persistsCLISessions: Bool = false)
     {
         self.runtime = runtime
         self.sourceMode = sourceMode
@@ -72,6 +78,7 @@ public struct ProviderFetchContext: Sendable {
         self.tokenAccountTokenUpdater = tokenAccountTokenUpdater
         self.providerManualTokenUpdater = providerManualTokenUpdater
         self.costUsageHistoryDays = max(1, min(365, costUsageHistoryDays))
+        self.persistsCLISessions = persistsCLISessions
     }
 }
 

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -42,6 +42,10 @@ public struct ProviderFetchContext: Sendable {
     /// `codexbar serve`); false for one-shot CLI invocations that should reset
     /// the session after each fetch.
     public let persistsCLISessions: Bool
+    /// Minimum idle lifetime for persistent CLI helper sessions. Long-lived
+    /// hosts set this beyond their refresh cadence so a slow cold start can
+    /// recover on the next refresh.
+    public let persistentCLISessionIdleWindow: TimeInterval?
 
     public init(
         runtime: ProviderRuntime,
@@ -60,7 +64,8 @@ public struct ProviderFetchContext: Sendable {
         tokenAccountTokenUpdater: TokenAccountTokenUpdater? = nil,
         providerManualTokenUpdater: ProviderManualTokenUpdater? = nil,
         costUsageHistoryDays: Int = 30,
-        persistsCLISessions: Bool = false)
+        persistsCLISessions: Bool = false,
+        persistentCLISessionIdleWindow: TimeInterval? = nil)
     {
         self.runtime = runtime
         self.sourceMode = sourceMode
@@ -79,6 +84,13 @@ public struct ProviderFetchContext: Sendable {
         self.providerManualTokenUpdater = providerManualTokenUpdater
         self.costUsageHistoryDays = max(1, min(365, costUsageHistoryDays))
         self.persistsCLISessions = persistsCLISessions
+        self.persistentCLISessionIdleWindow = persistentCLISessionIdleWindow
+    }
+}
+
+public enum ProviderCLISessionLifecycle {
+    public static func shutdownPersistentSessions() async {
+        await AntigravityCLISession.shared.reset()
     }
 }
 

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -48,11 +48,44 @@ public struct NamedRateWindow: Codable, Equatable, Sendable {
     public let id: String
     public let title: String
     public let window: RateWindow
+    /// Whether `window.usedPercent` reflects known quota usage.
+    ///
+    /// Some providers expose reset metadata for a named quota window before
+    /// they expose remaining usage. Keep those windows visible for reset/debug
+    /// context, but mark them so clients do not render `usedPercent` as a real
+    /// exhausted quota. Missing values decode as `true` for older cached payloads.
+    public let usageKnown: Bool
 
-    public init(id: String, title: String, window: RateWindow) {
+    public init(id: String, title: String, window: RateWindow, usageKnown: Bool = true) {
         self.id = id
         self.title = title
         self.window = window
+        self.usageKnown = usageKnown
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case window
+        case usageKnown
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.window = try container.decode(RateWindow.self, forKey: .window)
+        self.usageKnown = try container.decodeIfPresent(Bool.self, forKey: .usageKnown) ?? true
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.id, forKey: .id)
+        try container.encode(self.title, forKey: .title)
+        try container.encode(self.window, forKey: .window)
+        if !self.usageKnown {
+            try container.encode(false, forKey: .usageKnown)
+        }
     }
 }
 

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -105,7 +105,7 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
     }
 
     @Test
-    func `strategy pipeline uses OAuth only for selected token account`() async {
+    func `strategy pipeline keeps source mode authoritative with selected token account`() async {
         let descriptor = ProviderDescriptorRegistry.descriptor(for: .antigravity)
 
         let accountID = UUID()
@@ -113,9 +113,12 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
             self.makeFetchContext(sourceMode: .auto, selectedTokenAccountID: accountID))
         let cliStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
             self.makeFetchContext(sourceMode: .cli, selectedTokenAccountID: accountID))
+        let oauthStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeFetchContext(sourceMode: .oauth, selectedTokenAccountID: accountID))
 
-        #expect(autoStrategies.map(\.id) == ["antigravity.oauth"])
-        #expect(cliStrategies.map(\.id) == ["antigravity.oauth"])
+        #expect(autoStrategies.map(\.id) == ["antigravity.local", "antigravity.cli-https", "antigravity.oauth"])
+        #expect(cliStrategies.map(\.id) == ["antigravity.local", "antigravity.cli-https"])
+        #expect(oauthStrategies.map(\.id) == ["antigravity.oauth"])
     }
 
     @Test

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -1,0 +1,506 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+private final class AntigravityCLICounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    @discardableResult
+    func increment() -> Int {
+        self.lock.lock()
+        self.count += 1
+        let value = self.count
+        self.lock.unlock()
+        return value
+    }
+
+    var value: Int {
+        self.lock.lock()
+        let value = self.count
+        self.lock.unlock()
+        return value
+    }
+}
+
+private final class AntigravityCLIPortRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var ports: [[Int]] = []
+
+    func append(_ value: [Int]) {
+        self.lock.lock()
+        self.ports.append(value)
+        self.lock.unlock()
+    }
+
+    func snapshot() -> [[Int]] {
+        self.lock.lock()
+        let value = self.ports
+        self.lock.unlock()
+        return value
+    }
+}
+
+private final class AntigravityCLITimeoutRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var timeouts: [TimeInterval] = []
+
+    func append(_ value: TimeInterval) {
+        self.lock.lock()
+        self.timeouts.append(value)
+        self.lock.unlock()
+    }
+
+    func snapshot() -> [TimeInterval] {
+        self.lock.lock()
+        let value = self.timeouts
+        self.lock.unlock()
+        return value
+    }
+}
+
+struct AntigravityCLIHTTPSFetchStrategyTests {
+    @Test
+    func `local strategy falls back to cli HTTPS in cli source mode`() {
+        let strategy = AntigravityStatusFetchStrategy()
+        let context = self.makeFetchContext(sourceMode: .cli)
+
+        #expect(strategy.shouldFallback(on: AntigravityStatusProbeError.notRunning, context: context))
+    }
+
+    @Test
+    func `local strategy falls back to cli HTTPS in auto source mode`() {
+        let strategy = AntigravityStatusFetchStrategy()
+        let context = self.makeFetchContext(sourceMode: .auto)
+
+        #expect(strategy.shouldFallback(on: AntigravityStatusProbeError.notRunning, context: context))
+    }
+
+    @Test
+    func `local strategy does not fallback for unrelated source modes`() {
+        let strategy = AntigravityStatusFetchStrategy()
+
+        #expect(!strategy.shouldFallback(
+            on: AntigravityStatusProbeError.notRunning,
+            context: self.makeFetchContext(sourceMode: .oauth)))
+        #expect(!strategy.shouldFallback(
+            on: AntigravityStatusProbeError.notRunning,
+            context: self.makeFetchContext(sourceMode: .web)))
+        #expect(!strategy.shouldFallback(
+            on: AntigravityStatusProbeError.notRunning,
+            context: self.makeFetchContext(sourceMode: .api)))
+    }
+
+    @Test
+    func `strategy pipeline includes cli HTTPS fallback in cli and auto modes`() async {
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: .antigravity)
+
+        let cliStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeFetchContext(sourceMode: .cli))
+        #expect(cliStrategies.map(\.id) == ["antigravity.local", "antigravity.cli-https"])
+
+        let autoStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeFetchContext(sourceMode: .auto))
+        #expect(autoStrategies.map(\.id) == ["antigravity.local", "antigravity.cli-https", "antigravity.oauth"])
+    }
+
+    @Test
+    func `strategy pipeline uses OAuth only for selected token account`() async {
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: .antigravity)
+
+        let accountID = UUID()
+        let autoStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeFetchContext(sourceMode: .auto, selectedTokenAccountID: accountID))
+        let cliStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeFetchContext(sourceMode: .cli, selectedTokenAccountID: accountID))
+
+        #expect(autoStrategies.map(\.id) == ["antigravity.oauth"])
+        #expect(cliStrategies.map(\.id) == ["antigravity.oauth"])
+    }
+
+    @Test
+    func `cli HTTPS resets session only for short lived CLI runtime`() {
+        #expect(AntigravityCLIHTTPSFetchStrategy.shouldResetSessionAfterFetch(self.makeFetchContext(runtime: .cli)))
+        #expect(!AntigravityCLIHTTPSFetchStrategy.shouldResetSessionAfterFetch(self.makeFetchContext(runtime: .app)))
+    }
+
+    @Test
+    func `cli HTTPS reports public source as cli`() {
+        #expect(AntigravityCLIHTTPSFetchStrategy.sourceLabel == "cli")
+    }
+
+    @Test
+    func `cli HTTPS falls back to command model configs when user status fails`() async throws {
+        let endpoints = [
+            AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                scheme: "https",
+                port: 50080,
+                csrfToken: "",
+                source: .cliHTTPS),
+        ]
+        let attempts = AntigravityCLICounter()
+
+        let snapshot = try await AntigravityStatusProbe.fetchSnapshot(
+            context: AntigravityStatusProbe.RequestContext(
+                endpoints: endpoints,
+                timeout: 1,
+                deadline: Date().addingTimeInterval(2)),
+            send: { payload, _, _ in
+                let attempt = attempts.increment()
+                if attempt == 1 {
+                    #expect(payload.path == "/exa.language_server_pb.LanguageServerService/GetUserStatus")
+                    throw AntigravityStatusProbeError.apiError("user status unavailable")
+                }
+                #expect(payload.path == "/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs")
+                return Data("""
+                {
+                  "clientModelConfigs": [
+                    {
+                      "label": "Claude Sonnet",
+                      "modelOrAlias": { "model": "claude-sonnet" },
+                      "quotaInfo": { "remainingFraction": 0.5 }
+                    }
+                  ]
+                }
+                """.utf8)
+            })
+
+        #expect(snapshot.modelQuotas.first?.label == "Claude Sonnet")
+        #expect(attempts.value == 2)
+    }
+
+    @Test
+    func `cli HTTPS waits for user status after ports appear`() async throws {
+        let fetchAttempts = AntigravityCLICounter()
+        let drainAttempts = AntigravityCLICounter()
+        let fetchedPorts = AntigravityCLIPortRecorder()
+        let snapshot = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+            pid: 123,
+            deadline: Date().addingTimeInterval(5),
+            dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                pollIntervalNanoseconds: 0,
+                listeningPorts: { _, _ in [50080, 50081] },
+                drainOutput: {
+                    drainAttempts.increment()
+                },
+                fetchSnapshot: { ports in
+                    fetchedPorts.append(ports)
+                    if fetchAttempts.increment() == 1 {
+                        throw AntigravityStatusProbeError.apiError("HTTP 500: GetCascadeModelConfigData() is nil")
+                    }
+                    return AntigravityStatusSnapshot(
+                        modelQuotas: [
+                            AntigravityModelQuota(
+                                label: "Claude Opus 4.6 (Thinking)",
+                                modelId: "claude-opus-4.6-thinking",
+                                remainingFraction: 1,
+                                resetTime: nil,
+                                resetDescription: nil),
+                        ],
+                        accountEmail: "user@example.com",
+                        accountPlan: "Pro",
+                        source: .local)
+                }))
+
+        #expect(snapshot.accountEmail == "user@example.com")
+        #expect(fetchAttempts.value == 2)
+        #expect(fetchedPorts.snapshot() == [[50080, 50081], [50080, 50081]])
+        #expect(drainAttempts.value == 2)
+    }
+
+    @Test
+    func `cli HTTPS retries empty quota snapshots until usage is parseable`() async throws {
+        let fetchAttempts = AntigravityCLICounter()
+
+        let snapshot = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+            pid: 123,
+            deadline: Date().addingTimeInterval(5),
+            dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                pollIntervalNanoseconds: 0,
+                listeningPorts: { _, _ in [50080] },
+                drainOutput: {},
+                fetchSnapshot: { _ in
+                    if fetchAttempts.increment() == 1 {
+                        return AntigravityStatusSnapshot(
+                            modelQuotas: [],
+                            accountEmail: nil,
+                            accountPlan: nil,
+                            source: .local)
+                    }
+                    return AntigravityStatusSnapshot(
+                        modelQuotas: [
+                            AntigravityModelQuota(
+                                label: "Claude Sonnet",
+                                modelId: "claude-sonnet",
+                                remainingFraction: 0.5,
+                                resetTime: nil,
+                                resetDescription: nil),
+                        ],
+                        accountEmail: "user@example.com",
+                        accountPlan: "Pro",
+                        source: .local)
+                }))
+
+        #expect(fetchAttempts.value == 2)
+        #expect(snapshot.modelQuotas.first?.modelId == "claude-sonnet")
+    }
+
+    @Test
+    func `cli HTTPS drains output before ports appear`() async throws {
+        let portPolls = AntigravityCLICounter()
+        let drainAttempts = AntigravityCLICounter()
+        let snapshot = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+            pid: 123,
+            deadline: Date().addingTimeInterval(5),
+            dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                pollIntervalNanoseconds: 0,
+                listeningPorts: { _, _ in
+                    portPolls.increment() == 1 ? [] : [50080]
+                },
+                drainOutput: {
+                    drainAttempts.increment()
+                },
+                fetchSnapshot: { _ in
+                    AntigravityStatusSnapshot(
+                        modelQuotas: [
+                            AntigravityModelQuota(
+                                label: "Claude Sonnet",
+                                modelId: "claude-sonnet",
+                                remainingFraction: 1,
+                                resetTime: nil,
+                                resetDescription: nil),
+                        ],
+                        accountEmail: "user@example.com",
+                        accountPlan: "Pro",
+                        source: .local)
+                }))
+
+        #expect(snapshot.accountEmail == "user@example.com")
+        #expect(portPolls.value == 2)
+        #expect(drainAttempts.value == 2)
+    }
+
+    @Test
+    func `cli HTTPS treats empty lsof exit as ports not ready`() async throws {
+        let portPolls = AntigravityCLICounter()
+        let snapshot = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+            pid: 123,
+            deadline: Date().addingTimeInterval(5),
+            dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                pollIntervalNanoseconds: 0,
+                listeningPorts: { _, _ in
+                    if portPolls.increment() == 1 {
+                        throw SubprocessRunnerError.nonZeroExit(code: 1, stderr: "")
+                    }
+                    return [50080]
+                },
+                drainOutput: {},
+                fetchSnapshot: { _ in
+                    AntigravityStatusSnapshot(
+                        modelQuotas: [
+                            AntigravityModelQuota(
+                                label: "Claude Sonnet",
+                                modelId: "claude-sonnet",
+                                remainingFraction: 0.5,
+                                resetTime: nil,
+                                resetDescription: nil),
+                        ],
+                        accountEmail: "user@example.com",
+                        accountPlan: "Pro",
+                        source: .local)
+                }))
+
+        #expect(snapshot.accountEmail == "user@example.com")
+        #expect(portPolls.value == 2)
+    }
+
+    @Test
+    func `parsed requests recompute timeout from shared deadline between endpoints`() async throws {
+        let timeoutRecorder = AntigravityCLITimeoutRecorder()
+        let attempts = AntigravityCLICounter()
+        let endpoints = [
+            AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                scheme: "https",
+                port: 50080,
+                csrfToken: "",
+                source: .cliHTTPS),
+            AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                scheme: "https",
+                port: 50081,
+                csrfToken: "",
+                source: .cliHTTPS),
+        ]
+
+        let result = try await AntigravityStatusProbe.makeParsedRequest(
+            payload: AntigravityStatusProbe.RequestPayload(path: "/status", body: [:]),
+            context: AntigravityStatusProbe.RequestContext(
+                endpoints: endpoints,
+                timeout: 10,
+                deadline: Date().addingTimeInterval(2)),
+            send: { _, _, timeout in
+                timeoutRecorder.append(timeout)
+                if attempts.increment() == 1 {
+                    try await Task.sleep(nanoseconds: 100_000_000)
+                    throw AntigravityStatusProbeError.apiError("first endpoint failed")
+                }
+                return Data("ok".utf8)
+            },
+            parse: { data in
+                guard let value = String(bytes: data, encoding: .utf8) else {
+                    throw AntigravityStatusProbeError.apiError("invalid test data")
+                }
+                return value
+            })
+
+        let timeouts = timeoutRecorder.snapshot()
+        #expect(result == "ok")
+        #expect(timeouts.count == 2)
+        #expect(timeouts.allSatisfy { $0 < 10 })
+        #expect((timeouts.last ?? 10) < (timeouts.first ?? 0))
+    }
+
+    @Test
+    func `parsed request reports timeout when shared deadline is already expired`() async {
+        do {
+            _ = try await AntigravityStatusProbe.makeParsedRequest(
+                payload: AntigravityStatusProbe.RequestPayload(path: "/status", body: [:]),
+                context: AntigravityStatusProbe.RequestContext(
+                    endpoints: [
+                        AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                            scheme: "https",
+                            port: 50080,
+                            csrfToken: "",
+                            source: .cliHTTPS),
+                    ],
+                    timeout: 10,
+                    deadline: Date().addingTimeInterval(-1)),
+                send: { _, _, _ in
+                    Issue.record("Expired deadline should not send a request")
+                    return Data()
+                },
+                parse: { _ in "ok" })
+            Issue.record("Expected timeout")
+        } catch AntigravityStatusProbeError.timedOut {
+        } catch {
+            Issue.record("Expected timedOut, got \(error)")
+        }
+    }
+
+    @Test
+    func `cli HTTPS reports last readiness error when ports never become usable`() async {
+        let fetchAttempts = AntigravityCLICounter()
+
+        do {
+            _ = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+                pid: 123,
+                deadline: Date().addingTimeInterval(2),
+                dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                    pollIntervalNanoseconds: 10_000_000,
+                    listeningPorts: { _, _ in [50080] },
+                    drainOutput: {},
+                    fetchSnapshot: { _ in
+                        let attempt = fetchAttempts.increment()
+                        throw AntigravityStatusProbeError.apiError("HTTP 500: warming attempt \(attempt)")
+                    }))
+            Issue.record("Expected readiness polling to throw")
+        } catch let AntigravityStatusProbeError.apiError(message) {
+            #expect(fetchAttempts.value > 1)
+            #expect(message == "HTTP 500: warming attempt \(fetchAttempts.value)")
+        } catch {
+            Issue.record("Expected apiError, got \(error)")
+        }
+    }
+
+    @Test
+    func `cli HTTPS preserves non transient port detection errors`() async {
+        do {
+            _ = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+                pid: 123,
+                deadline: Date().addingTimeInterval(2),
+                dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                    pollIntervalNanoseconds: 0,
+                    listeningPorts: { _, _ in
+                        throw AntigravityStatusProbeError.portDetectionFailed("lsof not available")
+                    },
+                    drainOutput: {},
+                    fetchSnapshot: { _ in
+                        Issue.record("Port detection failure should not fetch a snapshot")
+                        return AntigravityStatusSnapshot(
+                            modelQuotas: [],
+                            accountEmail: nil,
+                            accountPlan: nil,
+                            source: .local)
+                    }))
+            Issue.record("Expected port detection failure")
+        } catch let AntigravityStatusProbeError.portDetectionFailed(message) {
+            #expect(message == "lsof not available")
+        } catch {
+            Issue.record("Expected portDetectionFailed, got \(error)")
+        }
+    }
+
+    @Test
+    func `cli HTTPS endpoint does not require CSRF token`() {
+        let endpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "https",
+            port: 55624,
+            csrfToken: "ignored-by-cli",
+            source: .cliHTTPS)
+        #expect(!endpoint.requiresCSRFToken)
+    }
+
+    @Test
+    func `languageServer endpoint requires CSRF token`() {
+        let endpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "https",
+            port: 64440,
+            csrfToken: "",
+            source: .languageServer)
+        #expect(endpoint.requiresCSRFToken)
+    }
+
+    @Test
+    func `extensionServer endpoint requires CSRF token`() {
+        let endpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "http",
+            port: 64432,
+            csrfToken: "",
+            source: .extensionServer)
+        #expect(endpoint.requiresCSRFToken)
+    }
+
+    private func makeFetchContext(
+        runtime: ProviderRuntime = .app,
+        sourceMode: ProviderSourceMode = .auto,
+        selectedTokenAccountID: UUID? = nil) -> ProviderFetchContext
+    {
+        let env: [String: String] = [:]
+        return ProviderFetchContext(
+            runtime: runtime,
+            sourceMode: sourceMode,
+            includeCredits: false,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: env,
+            settings: nil,
+            fetcher: UsageFetcher(environment: env),
+            claudeFetcher: StubClaudeFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            selectedTokenAccountID: selectedTokenAccountID)
+    }
+
+    private struct StubClaudeFetcher: ClaudeUsageFetching {
+        func loadLatestUsage(model _: String) async throws -> ClaudeUsageSnapshot {
+            throw ClaudeUsageError.parseFailed("stub")
+        }
+
+        func debugRawProbe(model _: String) async -> String {
+            "stub"
+        }
+
+        func detectVersion() -> String? {
+            nil
+        }
+    }
+}

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -257,6 +257,23 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
     }
 
     @Test
+    func `cli HTTPS availability requires supported localhost trust`() async throws {
+        let binaryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-antigravity-\(UUID().uuidString)")
+        try Data("#!/bin/sh\n".utf8).write(to: binaryURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: binaryURL.path)
+        defer { try? FileManager.default.removeItem(at: binaryURL) }
+
+        let strategy = AntigravityCLIHTTPSFetchStrategy()
+        let context = self.makeFetchContext(env: ["ANTIGRAVITY_CLI_PATH": binaryURL.path])
+        let isAvailable = await strategy.isAvailable(context)
+
+        #expect(isAvailable)
+    }
+
+    @Test
     func `cli HTTPS falls back to command model configs when user status fails`() async throws {
         let endpoints = [
             AntigravityStatusProbe.AntigravityConnectionEndpoint(

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -121,6 +121,109 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
         #expect(oauthStrategies.map(\.id) == ["antigravity.oauth"])
     }
 
+    // MARK: - Selected-account guard
+
+    @Test
+    func `account guard ignores fetches without a selected account`() throws {
+        let usage = self.makeUsage(accountEmail: "ambient@example.com")
+        let context = self.makeFetchContext(
+            sourceMode: .auto,
+            env: self.accountEnv(email: "selected@example.com"))
+
+        try AntigravitySelectedAccountGuard.validate(usage, context: context)
+    }
+
+    @Test
+    func `account guard accepts matching ambient snapshot in auto mode`() throws {
+        let usage = self.makeUsage(accountEmail: "Selected@Example.com")
+        let context = self.makeFetchContext(
+            sourceMode: .auto,
+            selectedTokenAccountID: UUID(),
+            env: self.accountEnv(email: "selected@example.com"))
+
+        try AntigravitySelectedAccountGuard.validate(usage, context: context)
+    }
+
+    @Test
+    func `account guard rejects mismatched ambient snapshot in auto mode`() {
+        let usage = self.makeUsage(accountEmail: "ambient@example.com")
+        let context = self.makeFetchContext(
+            sourceMode: .auto,
+            selectedTokenAccountID: UUID(),
+            env: self.accountEnv(email: "selected@example.com"))
+
+        #expect(throws: AntigravityStatusProbeError.accountMismatch(
+            expected: "selected@example.com",
+            found: "ambient@example.com"))
+        {
+            try AntigravitySelectedAccountGuard.validate(usage, context: context)
+        }
+    }
+
+    @Test
+    func `account guard rejects snapshot without an identity email`() {
+        let usage = self.makeUsage(accountEmail: nil)
+        let context = self.makeFetchContext(
+            sourceMode: .auto,
+            selectedTokenAccountID: UUID(),
+            env: self.accountEnv(email: "selected@example.com"))
+
+        #expect(throws: AntigravityStatusProbeError.accountMismatch(
+            expected: "selected@example.com",
+            found: nil))
+        {
+            try AntigravitySelectedAccountGuard.validate(usage, context: context)
+        }
+    }
+
+    @Test
+    func `account guard rejects when selected account email cannot be resolved`() {
+        let usage = self.makeUsage(accountEmail: "ambient@example.com")
+        let context = self.makeFetchContext(
+            sourceMode: .auto,
+            selectedTokenAccountID: UUID())
+
+        #expect(throws: AntigravityStatusProbeError.accountMismatch(
+            expected: nil,
+            found: "ambient@example.com"))
+        {
+            try AntigravitySelectedAccountGuard.validate(usage, context: context)
+        }
+    }
+
+    @Test
+    func `account guard leaves explicit cli source mode authoritative`() throws {
+        let usage = self.makeUsage(accountEmail: "ambient@example.com")
+        let context = self.makeFetchContext(
+            sourceMode: .cli,
+            selectedTokenAccountID: UUID(),
+            env: self.accountEnv(email: "selected@example.com"))
+
+        try AntigravitySelectedAccountGuard.validate(usage, context: context)
+    }
+
+    @Test
+    func `selected account email resolves from id_token when email field missing`() {
+        let idToken = Self.makeIDToken(email: "jwt@example.com")
+        let context = self.makeFetchContext(
+            sourceMode: .auto,
+            selectedTokenAccountID: UUID(),
+            env: self.accountEnv(email: nil, idToken: idToken))
+
+        #expect(AntigravitySelectedAccountGuard.selectedAccountEmail(context: context) == "jwt@example.com")
+    }
+
+    @Test
+    func `selected account email prefers id_token over stored email field`() {
+        let idToken = Self.makeIDToken(email: "jwt@example.com")
+        let context = self.makeFetchContext(
+            sourceMode: .auto,
+            selectedTokenAccountID: UUID(),
+            env: self.accountEnv(email: "stored@example.com", idToken: idToken))
+
+        #expect(AntigravitySelectedAccountGuard.selectedAccountEmail(context: context) == "jwt@example.com")
+    }
+
     @Test
     func `cli HTTPS resets session only for short lived CLI runtime`() {
         #expect(AntigravityCLIHTTPSFetchStrategy.shouldResetSessionAfterFetch(self.makeFetchContext(runtime: .cli)))
@@ -475,10 +578,10 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
     private func makeFetchContext(
         runtime: ProviderRuntime = .app,
         sourceMode: ProviderSourceMode = .auto,
-        selectedTokenAccountID: UUID? = nil) -> ProviderFetchContext
+        selectedTokenAccountID: UUID? = nil,
+        env: [String: String] = [:]) -> ProviderFetchContext
     {
-        let env: [String: String] = [:]
-        return ProviderFetchContext(
+        ProviderFetchContext(
             runtime: runtime,
             sourceMode: sourceMode,
             includeCredits: false,
@@ -491,6 +594,40 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
             claudeFetcher: StubClaudeFetcher(),
             browserDetection: BrowserDetection(cacheTTL: 0),
             selectedTokenAccountID: selectedTokenAccountID)
+    }
+
+    private func makeUsage(accountEmail: String?) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .antigravity,
+                accountEmail: accountEmail,
+                accountOrganization: nil,
+                loginMethod: nil))
+    }
+
+    private func accountEnv(email: String?, idToken: String? = nil) -> [String: String] {
+        let credentials = AntigravityOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            expiryDate: Date().addingTimeInterval(3600),
+            idToken: idToken,
+            email: email)
+        guard let value = try? AntigravityOAuthCredentialsStore.tokenAccountValue(for: credentials) else {
+            return [:]
+        }
+        return [AntigravityOAuthCredentialsStore.environmentCredentialsKey: value]
+    }
+
+    private static func makeIDToken(email: String) -> String {
+        let payload = Data("{\"email\":\"\(email)\"}".utf8)
+        let encodedPayload = payload.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return "header.\(encodedPayload).signature"
     }
 
     private struct StubClaudeFetcher: ClaudeUsageFetching {

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -225,9 +225,14 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
     }
 
     @Test
-    func `cli HTTPS resets session only for short lived CLI runtime`() {
+    func `cli HTTPS resets session only for one-shot CLI runtime`() {
+        // One-shot CLI invocation: reset after fetch.
         #expect(AntigravityCLIHTTPSFetchStrategy.shouldResetSessionAfterFetch(self.makeFetchContext(runtime: .cli)))
+        // App runtime keeps the warm session.
         #expect(!AntigravityCLIHTTPSFetchStrategy.shouldResetSessionAfterFetch(self.makeFetchContext(runtime: .app)))
+        // Long-lived CLI host (codexbar serve) keeps the warm session even at .cli runtime.
+        #expect(!AntigravityCLIHTTPSFetchStrategy.shouldResetSessionAfterFetch(
+            self.makeFetchContext(runtime: .cli, persistsCLISessions: true)))
     }
 
     @Test
@@ -579,6 +584,7 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
         runtime: ProviderRuntime = .app,
         sourceMode: ProviderSourceMode = .auto,
         selectedTokenAccountID: UUID? = nil,
+        persistsCLISessions: Bool = false,
         env: [String: String] = [:]) -> ProviderFetchContext
     {
         ProviderFetchContext(
@@ -593,7 +599,8 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
             fetcher: UsageFetcher(environment: env),
             claudeFetcher: StubClaudeFetcher(),
             browserDetection: BrowserDetection(cacheTTL: 0),
-            selectedTokenAccountID: selectedTokenAccountID)
+            selectedTokenAccountID: selectedTokenAccountID,
+            persistsCLISessions: persistsCLISessions)
     }
 
     private func makeUsage(accountEmail: String?) -> UsageSnapshot {

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -59,6 +59,22 @@ private final class AntigravityCLITimeoutRecorder: @unchecked Sendable {
     }
 }
 
+private final class AntigravityCLIOutputSequence: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [Data]
+
+    init(_ values: [Data]) {
+        self.values = values
+    }
+
+    func next() -> Data {
+        self.lock.lock()
+        let value = self.values.isEmpty ? Data() : self.values.removeFirst()
+        self.lock.unlock()
+        return value
+    }
+}
+
 struct AntigravityCLIHTTPSFetchStrategyTests {
     @Test
     func `local strategy falls back to cli HTTPS in cli source mode`() {
@@ -293,6 +309,7 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
                 listeningPorts: { _, _ in [50080, 50081] },
                 drainOutput: {
                     drainAttempts.increment()
+                    return Data()
                 },
                 fetchSnapshot: { ports in
                     fetchedPorts.append(ports)
@@ -316,7 +333,7 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
         #expect(snapshot.accountEmail == "user@example.com")
         #expect(fetchAttempts.value == 2)
         #expect(fetchedPorts.snapshot() == [[50080, 50081], [50080, 50081]])
-        #expect(drainAttempts.value == 2)
+        #expect(drainAttempts.value == 4)
     }
 
     @Test
@@ -329,7 +346,7 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
             dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
                 pollIntervalNanoseconds: 0,
                 listeningPorts: { _, _ in [50080] },
-                drainOutput: {},
+                drainOutput: { Data() },
                 fetchSnapshot: { _ in
                     if fetchAttempts.increment() == 1 {
                         return AntigravityStatusSnapshot(
@@ -370,6 +387,7 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
                 },
                 drainOutput: {
                     drainAttempts.increment()
+                    return Data()
                 },
                 fetchSnapshot: { _ in
                     AntigravityStatusSnapshot(
@@ -388,7 +406,83 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
 
         #expect(snapshot.accountEmail == "user@example.com")
         #expect(portPolls.value == 2)
-        #expect(drainAttempts.value == 2)
+        #expect(drainAttempts.value == 3)
+    }
+
+    @Test
+    func `cli HTTPS stops before probing when signed out prompt spans output chunks`() async {
+        let output = AntigravityCLIOutputSequence([
+            Data("Welcome. You are currently ".utf8),
+            Data("Welcome. You are currently not signed in.\nSelect login method:".utf8),
+        ])
+        let portPolls = AntigravityCLICounter()
+
+        do {
+            _ = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+                pid: 123,
+                deadline: Date().addingTimeInterval(2),
+                dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                    pollIntervalNanoseconds: 0,
+                    listeningPorts: { _, _ in
+                        portPolls.increment()
+                        return []
+                    },
+                    drainOutput: {
+                        output.next()
+                    },
+                    fetchSnapshot: { _ in
+                        Issue.record("Signed-out helper should not fetch a snapshot")
+                        return AntigravityStatusSnapshot(
+                            modelQuotas: [],
+                            accountEmail: nil,
+                            accountPlan: nil,
+                            source: .local)
+                    }))
+            Issue.record("Expected authentication failure")
+        } catch AntigravityStatusProbeError.authenticationRequired {
+            #expect(portPolls.value == 1)
+        } catch {
+            Issue.record("Expected authenticationRequired, got \(error)")
+        }
+    }
+
+    @Test
+    func `cli HTTPS rechecks signed out prompt after snapshot readiness`() async {
+        let output = AntigravityCLIOutputSequence([
+            Data(),
+            Data("You are currently not signed in.\nSelect login method:".utf8),
+        ])
+
+        do {
+            _ = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+                pid: 123,
+                deadline: Date().addingTimeInterval(2),
+                dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                    pollIntervalNanoseconds: 0,
+                    listeningPorts: { _, _ in [50080] },
+                    drainOutput: {
+                        output.next()
+                    },
+                    fetchSnapshot: { _ in
+                        AntigravityStatusSnapshot(
+                            modelQuotas: [
+                                AntigravityModelQuota(
+                                    label: "Claude Sonnet",
+                                    modelId: "claude-sonnet",
+                                    remainingFraction: 1,
+                                    resetTime: nil,
+                                    resetDescription: nil),
+                            ],
+                            accountEmail: "user@example.com",
+                            accountPlan: "Pro",
+                            source: .local)
+                    }))
+            Issue.record("Expected authentication failure")
+        } catch AntigravityStatusProbeError.authenticationRequired {
+            // Expected: the late prompt wins over the apparently ready API.
+        } catch {
+            Issue.record("Expected authenticationRequired, got \(error)")
+        }
     }
 
     @Test
@@ -405,7 +499,7 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
                     }
                     return [50080]
                 },
-                drainOutput: {},
+                drainOutput: { Data() },
                 fetchSnapshot: { _ in
                     AntigravityStatusSnapshot(
                         modelQuotas: [
@@ -508,7 +602,7 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
                 dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
                     pollIntervalNanoseconds: 10_000_000,
                     listeningPorts: { _, _ in [50080] },
-                    drainOutput: {},
+                    drainOutput: { Data() },
                     fetchSnapshot: { _ in
                         let attempt = fetchAttempts.increment()
                         throw AntigravityStatusProbeError.apiError("HTTP 500: warming attempt \(attempt)")
@@ -533,7 +627,7 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
                     listeningPorts: { _, _ in
                         throw AntigravityStatusProbeError.portDetectionFailed("lsof not available")
                     },
-                    drainOutput: {},
+                    drainOutput: { Data() },
                     fetchSnapshot: { _ in
                         Issue.record("Port detection failure should not fetch a snapshot")
                         return AntigravityStatusSnapshot(

--- a/Tests/CodexBarTests/AntigravityCLISessionTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLISessionTests.swift
@@ -1,0 +1,932 @@
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+private final class FakeAntigravityProcessHandle: AntigravityCLIProcessHandle, @unchecked Sendable {
+    private let lock = NSLock()
+    let pid: pid_t
+    var descendants: [pid_t]
+    private var running: Bool
+    private let terminateRootStopsProcess: Bool
+    private var assignedProcessGroup: pid_t?
+    private var events: [String] = []
+
+    init(pid: pid_t, running: Bool = true, descendants: [pid_t] = [], terminateRootStopsProcess: Bool = true) {
+        self.pid = pid
+        self.running = running
+        self.descendants = descendants
+        self.terminateRootStopsProcess = terminateRootStopsProcess
+    }
+
+    var isRunning: Bool {
+        self.lock.lock()
+        let value = self.running
+        self.events.append("isRunning:\(value)")
+        self.lock.unlock()
+        return value
+    }
+
+    var processGroup: pid_t? {
+        self.lock.lock()
+        let value = self.assignedProcessGroup
+        self.lock.unlock()
+        return value
+    }
+
+    func assignProcessGroup() -> pid_t? {
+        self.lock.lock()
+        self.assignedProcessGroup = self.pid
+        self.events.append("assignProcessGroup")
+        self.lock.unlock()
+        return self.pid
+    }
+
+    func sendExit() throws {
+        self.append("sendExit")
+    }
+
+    func closePTY() {
+        self.append("closePTY")
+    }
+
+    func terminateRoot() {
+        self.lock.lock()
+        if self.terminateRootStopsProcess {
+            self.running = false
+        }
+        self.events.append("terminateRoot")
+        self.lock.unlock()
+    }
+
+    func killRoot() {
+        self.lock.lock()
+        self.running = false
+        self.events.append("killRoot")
+        self.lock.unlock()
+    }
+
+    func descendantPIDs() -> [pid_t] {
+        self.lock.lock()
+        let value = self.descendants
+        self.events.append("descendantPIDs")
+        self.lock.unlock()
+        return value
+    }
+
+    func terminateTree(signal: Int32, knownDescendants _: [pid_t]) {
+        self.lock.lock()
+        if signal == SIGKILL {
+            self.running = false
+        }
+        self.events.append("terminateTree:\(signal)")
+        self.lock.unlock()
+    }
+
+    func killDescendants(_ descendants: [pid_t]) {
+        self.append("killDescendants:\(descendants.map(String.init).joined(separator: ","))")
+    }
+
+    func drainOutput() {
+        self.append("drainOutput")
+    }
+
+    func snapshotEvents() -> [String] {
+        self.lock.lock()
+        let value = self.events
+        self.lock.unlock()
+        return value
+    }
+
+    private func append(_ event: String) {
+        self.lock.lock()
+        self.events.append(event)
+        self.lock.unlock()
+    }
+}
+
+private final class FakeAntigravityProcessLauncher: AntigravityCLIProcessLaunching, @unchecked Sendable {
+    private let lock = NSLock()
+    private var nextPID: pid_t
+    private var launchError: Error?
+    private var launchedBinaries: [String] = []
+    private var terminateRootStopsProcess = true
+    private var handles: [FakeAntigravityProcessHandle] = []
+
+    init(nextPID: pid_t = 1) {
+        self.nextPID = nextPID
+    }
+
+    func launch(binary: String) throws -> any AntigravityCLIProcessHandle {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        if let launchError {
+            throw launchError
+        }
+        let handle = FakeAntigravityProcessHandle(
+            pid: self.nextPID,
+            descendants: [self.nextPID + 100],
+            terminateRootStopsProcess: self.terminateRootStopsProcess)
+        self.nextPID += 1
+        self.launchedBinaries.append(binary)
+        self.handles.append(handle)
+        return handle
+    }
+
+    func setLaunchError(_ error: Error?) {
+        self.lock.lock()
+        self.launchError = error
+        self.lock.unlock()
+    }
+
+    func setTerminateRootStopsProcess(_ value: Bool) {
+        self.lock.lock()
+        self.terminateRootStopsProcess = value
+        self.lock.unlock()
+    }
+
+    func launchedBinarySnapshot() -> [String] {
+        self.lock.lock()
+        let value = self.launchedBinaries
+        self.lock.unlock()
+        return value
+    }
+
+    func handleSnapshot() -> [FakeAntigravityProcessHandle] {
+        self.lock.lock()
+        let value = self.handles
+        self.lock.unlock()
+        return value
+    }
+}
+
+private final class FakeAntigravityIdentityProvider: AntigravityCLIProcessIdentityProviding, @unchecked Sendable {
+    private let lock = NSLock()
+    private var identities: [pid_t: AntigravityCLIProcessIdentity] = [:]
+
+    func setIdentity(pid: pid_t, executablePath: String, startEpoch: TimeInterval) {
+        self.lock.lock()
+        self.identities[pid] = AntigravityCLIProcessIdentity(executablePath: executablePath, startEpoch: startEpoch)
+        self.lock.unlock()
+    }
+
+    func removeIdentity(pid: pid_t) {
+        self.lock.lock()
+        self.identities[pid] = nil
+        self.lock.unlock()
+    }
+
+    func identity(for pid: pid_t) -> AntigravityCLIProcessIdentity? {
+        self.lock.lock()
+        let value = self.identities[pid]
+        self.lock.unlock()
+        return value
+    }
+}
+
+private final class MemoryAntigravitySessionRecordStore: AntigravityCLISessionRecordStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var record: AntigravityCLISessionRecord?
+    private var saves = 0
+    private var removes = 0
+
+    init(record: AntigravityCLISessionRecord? = nil) {
+        self.record = record
+    }
+
+    func load() throws -> AntigravityCLISessionRecord? {
+        self.lock.lock()
+        let value = self.record
+        self.lock.unlock()
+        return value
+    }
+
+    func save(_ record: AntigravityCLISessionRecord) throws {
+        self.lock.lock()
+        self.record = record
+        self.saves += 1
+        self.lock.unlock()
+    }
+
+    func remove() throws {
+        self.lock.lock()
+        self.record = nil
+        self.removes += 1
+        self.lock.unlock()
+    }
+
+    func snapshot() -> AntigravityCLISessionRecord? {
+        self.lock.lock()
+        let value = self.record
+        self.lock.unlock()
+        return value
+    }
+
+    var saveCount: Int {
+        self.lock.lock()
+        let value = self.saves
+        self.lock.unlock()
+        return value
+    }
+
+    var removeCount: Int {
+        self.lock.lock()
+        let value = self.removes
+        self.lock.unlock()
+        return value
+    }
+}
+
+private final class AntigravitySessionTerminationRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [(pid: pid_t, group: pid_t?, signal: Int32, descendants: [pid_t])] = []
+
+    func append(pid: pid_t, group: pid_t?, signal: Int32, descendants: [pid_t]) {
+        self.lock.lock()
+        self.events.append((pid: pid, group: group, signal: signal, descendants: descendants))
+        self.lock.unlock()
+    }
+
+    func snapshot() -> [(pid: pid_t, group: pid_t?, signal: Int32, descendants: [pid_t])] {
+        self.lock.lock()
+        let value = self.events
+        self.lock.unlock()
+        return value
+    }
+}
+
+private final class AntigravityRegistryRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var shouldRegister = true
+    private var registered: [pid_t] = []
+    private var unregistered: [pid_t] = []
+    private var groups: [pid_t: pid_t?] = [:]
+
+    func setShouldRegister(_ value: Bool) {
+        self.lock.lock()
+        self.shouldRegister = value
+        self.lock.unlock()
+    }
+
+    func register(pid: pid_t, _: String) -> Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        guard self.shouldRegister else { return false }
+        self.registered.append(pid)
+        return true
+    }
+
+    func update(pid: pid_t, group: pid_t?) {
+        self.lock.lock()
+        self.groups[pid] = group
+        self.lock.unlock()
+    }
+
+    func unregister(pid: pid_t) {
+        self.lock.lock()
+        self.unregistered.append(pid)
+        self.lock.unlock()
+    }
+
+    func registeredSnapshot() -> [pid_t] {
+        self.lock.lock()
+        let value = self.registered
+        self.lock.unlock()
+        return value
+    }
+
+    func unregisteredSnapshot() -> [pid_t] {
+        self.lock.lock()
+        let value = self.unregistered
+        self.lock.unlock()
+        return value
+    }
+}
+
+private final class AntigravityManualSleeper: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuations: [CheckedContinuation<Void, Error>] = []
+
+    func sleep(_: UInt64) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            self.lock.lock()
+            self.continuations.append(continuation)
+            self.lock.unlock()
+        }
+    }
+
+    func resumeAll() {
+        self.lock.lock()
+        let continuations = self.continuations
+        self.continuations.removeAll()
+        self.lock.unlock()
+
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
+
+    func waitForSleeps(_ expectedCount: Int) async {
+        for _ in 0..<200 {
+            if self.pendingSleepCount >= expectedCount { return }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        Issue.record("Timed out waiting for \(expectedCount) sleep continuation(s)")
+    }
+
+    private var pendingSleepCount: Int {
+        self.lock.lock()
+        let count = self.continuations.count
+        self.lock.unlock()
+        return count
+    }
+}
+
+struct AntigravityCLISessionTests {
+    @Test
+    func `reuses alive process for same binary`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        let firstPID = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        let secondPID = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(firstPID == 10)
+        #expect(secondPID == 10)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy"])
+    }
+
+    @Test
+    func `relaunches when binary changes`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 11, executablePath: "/new/agy", startEpoch: 101)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        let secondPID = try await fixture.session.beginProbe(binary: "/new/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(secondPID == 11)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy", "/new/agy"])
+        #expect(fixture.registry.unregisteredSnapshot() == [10])
+    }
+
+    @Test
+    func `replacement launch waits for in progress teardown`() async throws {
+        let fixture = self.makeFixture(
+            manualSleep: true,
+            terminationGracePeriod: 1,
+            terminateRootStopsProcess: false)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/old/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 11, executablePath: "/new/agy", startEpoch: 101)
+
+        _ = try await fixture.session.beginProbe(binary: "/old/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        let firstReplacement = Task {
+            try await fixture.session.beginProbe(binary: "/new/agy")
+        }
+        await fixture.sleeper?.waitForSleeps(1)
+
+        let secondReplacement = Task {
+            try await fixture.session.beginProbe(binary: "/new/agy")
+        }
+        await Task.yield()
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/old/agy"])
+
+        fixture.launcher.handleSnapshot().first?.killRoot()
+        fixture.sleeper?.resumeAll()
+        let firstPID = try await firstReplacement.value
+        let secondPID = try await secondReplacement.value
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(firstPID == 11)
+        #expect(secondPID == 11)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/old/agy", "/new/agy"])
+    }
+
+    @Test
+    func `replacement waits for active probe before relaunching`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/old/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 11, executablePath: "/new/agy", startEpoch: 101)
+
+        let firstPID = try await fixture.session.beginProbe(binary: "/old/agy")
+        let replacement = Task {
+            try await fixture.session.beginProbe(binary: "/new/agy")
+        }
+        await Task.yield()
+        await Task.yield()
+
+        #expect(firstPID == 10)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/old/agy"])
+        #expect(fixture.registry.unregisteredSnapshot().isEmpty)
+
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        let secondPID = try await replacement.value
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(secondPID == 11)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/old/agy", "/new/agy"])
+        #expect(fixture.registry.unregisteredSnapshot() == [10])
+    }
+
+    @Test
+    func `replacement ignores queued starters while waiting for active probe`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/old/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 11, executablePath: "/new/agy", startEpoch: 101)
+
+        _ = try await fixture.session.beginProbe(binary: "/old/agy")
+        let firstReplacement = Task {
+            try await fixture.session.beginProbe(binary: "/new/agy")
+        }
+        let secondReplacement = Task {
+            try await fixture.session.beginProbe(binary: "/new/agy")
+        }
+        await Task.yield()
+        await Task.yield()
+
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/old/agy"])
+
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        let didLaunchReplacement = await self.waitForLaunches(fixture.launcher, count: 2)
+        #expect(didLaunchReplacement)
+        if !didLaunchReplacement {
+            await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        }
+
+        let firstPID = try await firstReplacement.value
+        let secondPID = try await secondReplacement.value
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(firstPID == 11)
+        #expect(secondPID == 11)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/old/agy", "/new/agy"])
+    }
+
+    @Test
+    func `relaunches when existing process is dead`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 11, executablePath: "/bin/agy", startEpoch: 101)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        fixture.launcher.handleSnapshot().first?.terminateRoot()
+        let secondPID = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(secondPID == 11)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy", "/bin/agy"])
+    }
+
+    @Test
+    func `pty launcher creates dedicated process group before returning`() throws {
+        let launcher = AntigravityPTYProcessLauncher()
+        let handle = try launcher.launch(binary: "/bin/cat")
+        defer {
+            handle.killRoot()
+            handle.terminateTree(signal: SIGKILL, knownDescendants: [])
+            handle.closePTY()
+        }
+
+        #expect(handle.processGroup == handle.pid)
+        #expect(getpgid(handle.pid) == handle.pid)
+    }
+
+    @Test
+    func `spawned PTY drain is bounded per call`() throws {
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("antigravity-drain-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: temp) }
+        try Data(repeating: 1, count: 8192 * 65).write(to: temp)
+        let primaryFD = open(temp.path, O_RDONLY)
+        guard primaryFD >= 0 else {
+            Issue.record("Failed to open temporary drain input")
+            return
+        }
+        let secondaryFD = open("/dev/null", O_RDONLY)
+        guard secondaryFD >= 0 else {
+            close(primaryFD)
+            Issue.record("Failed to open /dev/null")
+            return
+        }
+        let handle = AntigravitySpawnedPTYProcessHandle(
+            pid: getpid(),
+            processGroup: getpgrp(),
+            primaryFD: primaryFD,
+            primaryHandle: FileHandle(fileDescriptor: primaryFD, closeOnDealloc: true),
+            secondaryHandle: FileHandle(fileDescriptor: secondaryFD, closeOnDealloc: true))
+        defer { handle.closePTY() }
+
+        handle.drainOutput()
+
+        #expect(lseek(primaryFD, 0, SEEK_CUR) == off_t(8192 * 64))
+    }
+
+    @Test
+    func `registration failure tears down launched process`() async {
+        let fixture = self.makeFixture()
+        fixture.registry.setShouldRegister(false)
+
+        await #expect(throws: AntigravityCLISession.SessionError.self) {
+            _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        }
+
+        let handle = fixture.launcher.handleSnapshot().first
+        #expect(handle?.isRunning == false)
+        #expect(handle?.snapshotEvents().contains("closePTY") == true)
+        #expect(fixture.registry.registeredSnapshot().isEmpty)
+    }
+
+    @Test
+    func `idle window tears down warm process`() async throws {
+        let fixture = self.makeFixture(idleWindow: 0.05, manualSleep: true)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        await fixture.sleeper?.waitForSleeps(1)
+        fixture.sleeper?.resumeAll()
+        await self.waitUntilStopped(fixture.session)
+
+        #expect(await fixture.session.isRunning == false)
+        #expect(fixture.registry.unregisteredSnapshot() == [10])
+        #expect(fixture.store.snapshot() == nil)
+    }
+
+    @Test
+    func `active probe prevents idle teardown until finish`() async throws {
+        let fixture = self.makeFixture(idleWindow: 0.05, manualSleep: true)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.sleeper?.waitForSleeps(1)
+        fixture.sleeper?.resumeAll()
+        await Task.yield()
+
+        #expect(await fixture.session.isRunning)
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        await fixture.sleeper?.waitForSleeps(1)
+        fixture.sleeper?.resumeAll()
+        await self.waitUntilStopped(fixture.session)
+        #expect(await fixture.session.isRunning == false)
+    }
+
+    @Test
+    func `manual reset waits for active probe to finish`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.reset()
+        #expect(await fixture.session.isRunning)
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(await fixture.session.isRunning == false)
+        #expect(fixture.registry.unregisteredSnapshot() == [10])
+    }
+
+    @Test
+    func `reset reaps persisted stale session when no in memory process exists`() async {
+        let store = MemoryAntigravitySessionRecordStore(record: AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777))
+        let fixture = self.makeFixture(store: store)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
+
+        await fixture.session.reset()
+
+        let terminations = fixture.terminations.snapshot()
+        #expect(terminations.map(\.signal) == [SIGTERM, SIGKILL])
+        #expect(terminations.allSatisfy { $0.pid == 777 && $0.group == 777 })
+        #expect(fixture.store.snapshot() == nil)
+    }
+
+    @Test
+    func `reset preserves persisted session owned by another live process`() async {
+        let store = MemoryAntigravitySessionRecordStore(record: AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777,
+            ownerPID: 900,
+            ownerExecutablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            ownerStartEpoch: 10))
+        let fixture = self.makeFixture(store: store, currentProcessID: 901)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
+        fixture.identity.setIdentity(
+            pid: 900,
+            executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            startEpoch: 10)
+
+        await fixture.session.reset()
+
+        #expect(fixture.terminations.snapshot().isEmpty)
+        #expect(fixture.store.snapshot() != nil)
+    }
+
+    @Test
+    func `launch preserves persisted session owned by another live process`() async throws {
+        let protectedRecord = AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777,
+            ownerPID: 900,
+            ownerExecutablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            ownerStartEpoch: 10)
+        let store = MemoryAntigravitySessionRecordStore(record: protectedRecord)
+        let fixture = self.makeFixture(store: store, currentProcessID: 901)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
+        fixture.identity.setIdentity(
+            pid: 900,
+            executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            startEpoch: 10)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        let pid = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+
+        #expect(pid == 10)
+        #expect(fixture.terminations.snapshot().isEmpty)
+        #expect(fixture.store.saveCount == 0)
+        #expect(fixture.store.snapshot() == protectedRecord)
+    }
+
+    @Test
+    func `reset rechecks protected persisted session after owner exits`() async {
+        let store = MemoryAntigravitySessionRecordStore(record: AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777,
+            ownerPID: 900,
+            ownerExecutablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            ownerStartEpoch: 10))
+        let fixture = self.makeFixture(store: store, currentProcessID: 901)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
+        fixture.identity.setIdentity(
+            pid: 900,
+            executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            startEpoch: 10)
+
+        await fixture.session.reset()
+        fixture.identity.removeIdentity(pid: 900)
+        await fixture.session.reset()
+
+        let terminations = fixture.terminations.snapshot()
+        #expect(terminations.map(\.signal) == [SIGTERM, SIGKILL])
+        #expect(terminations.allSatisfy { $0.pid == 777 && $0.group == 777 })
+        #expect(fixture.store.snapshot() == nil)
+    }
+
+    @Test
+    func `teardown preserves record written by another live session`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        let otherRecord = AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/other/agy",
+            executablePath: "/other/agy",
+            startEpoch: 42,
+            processGroup: 777)
+        try fixture.store.save(otherRecord)
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+
+        #expect(fixture.store.snapshot() == otherRecord)
+    }
+
+    @Test
+    func `force killed process is polled again so the child can be reaped`() async throws {
+        let fixture = self.makeFixture(terminateRootStopsProcess: false)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 900, executablePath: "/app/CodexBar", startEpoch: 1)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+
+        let events = fixture.launcher.handleSnapshot().first?.snapshotEvents() ?? []
+        guard let killIndex = events.firstIndex(of: "terminateTree:\(SIGKILL)") else {
+            Issue.record("Expected SIGKILL during teardown")
+            return
+        }
+        #expect(events.dropFirst(killIndex + 1).contains("isRunning:false"))
+    }
+
+    @Test
+    func `one shot CLI reset tears down after fetch`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+
+        #expect(await fixture.session.isRunning == false)
+        #expect(fixture.registry.unregisteredSnapshot() == [10])
+    }
+
+    @Test
+    func `one shot CLI reset is deferred until all active probes finish`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+        #expect(await fixture.session.isRunning)
+
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(await fixture.session.isRunning == false)
+        #expect(fixture.registry.unregisteredSnapshot() == [10])
+    }
+
+    @Test
+    func `repeated probe failures relaunch session`() async throws {
+        let fixture = self.makeFixture(failureRelaunchThreshold: 2)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 11, executablePath: "/bin/agy", startEpoch: 101)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: false, resetAfterFetch: false)
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: false, resetAfterFetch: false)
+        let relaunchedPID = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(relaunchedPID == 11)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy", "/bin/agy"])
+        #expect(await fixture.session.failureCountForTesting == 0)
+    }
+
+    @Test
+    func `success resets failure counter`() async throws {
+        let fixture = self.makeFixture(failureRelaunchThreshold: 2)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: false, resetAfterFetch: false)
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: false, resetAfterFetch: false)
+
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy"])
+        #expect(await fixture.session.failureCountForTesting == 1)
+    }
+
+    @Test
+    func `matching persisted stale process is reaped when resolved binary changed`() async throws {
+        let store = MemoryAntigravitySessionRecordStore(record: AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/old/agy",
+            executablePath: "/old/agy",
+            startEpoch: 42,
+            processGroup: 777))
+        let fixture = self.makeFixture(store: store)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/old/agy", startEpoch: 42)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/new/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/new/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        let terminations = fixture.terminations.snapshot()
+        #expect(terminations.map(\.signal) == [SIGTERM, SIGKILL])
+        #expect(terminations.allSatisfy { $0.pid == 777 && $0.group == 777 })
+    }
+
+    @Test
+    func `matching persisted stale process is reaped before launch`() async throws {
+        let store = MemoryAntigravitySessionRecordStore(record: AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777))
+        let fixture = self.makeFixture(store: store)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        let terminations = fixture.terminations.snapshot()
+        #expect(terminations.map(\.signal) == [SIGTERM, SIGKILL])
+        #expect(terminations.allSatisfy { $0.pid == 777 && $0.group == 777 })
+    }
+
+    @Test
+    func `non matching persisted process is not reaped`() async throws {
+        let store = MemoryAntigravitySessionRecordStore(record: AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777))
+        let fixture = self.makeFixture(store: store)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/usr/bin/other", startEpoch: 42)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(fixture.terminations.snapshot().isEmpty)
+    }
+
+    private func waitForLaunches(_ launcher: FakeAntigravityProcessLauncher, count: Int) async -> Bool {
+        for _ in 0..<200 {
+            if launcher.launchedBinarySnapshot().count >= count { return true }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return false
+    }
+
+    private func waitUntilStopped(_ session: AntigravityCLISession) async {
+        for _ in 0..<200 {
+            let running = await session.isRunning
+            if !running { return }
+            await Task.yield()
+        }
+        Issue.record("Timed out waiting for Antigravity CLI session to stop")
+    }
+
+    private struct Fixture {
+        let session: AntigravityCLISession
+        let launcher: FakeAntigravityProcessLauncher
+        let identity: FakeAntigravityIdentityProvider
+        let store: MemoryAntigravitySessionRecordStore
+        let terminations: AntigravitySessionTerminationRecorder
+        let registry: AntigravityRegistryRecorder
+        let sleeper: AntigravityManualSleeper?
+    }
+
+    private func makeFixture(
+        store: MemoryAntigravitySessionRecordStore = MemoryAntigravitySessionRecordStore(),
+        idleWindow: TimeInterval = 3600,
+        failureRelaunchThreshold: Int = 2,
+        manualSleep: Bool = false,
+        terminationGracePeriod: TimeInterval = 0,
+        terminateRootStopsProcess: Bool = true,
+        currentProcessID: pid_t = 900) -> Fixture
+    {
+        let launcher = FakeAntigravityProcessLauncher(nextPID: 10)
+        launcher.setTerminateRootStopsProcess(terminateRootStopsProcess)
+        let identity = FakeAntigravityIdentityProvider()
+        let terminations = AntigravitySessionTerminationRecorder()
+        let registry = AntigravityRegistryRecorder()
+        let sleeper = manualSleep ? AntigravityManualSleeper() : nil
+        let session = AntigravityCLISession(dependencies: AntigravityCLISession.Dependencies(
+            launcher: launcher,
+            identityProvider: identity,
+            recordStore: store,
+            registerForAppShutdown: { pid, binary in registry.register(pid: pid, binary) },
+            updateAppShutdownProcessGroup: { pid, group in registry.update(pid: pid, group: group) },
+            unregisterForAppShutdown: { pid in registry.unregister(pid: pid) },
+            descendantPIDs: { pid in [pid + 1, pid + 2] },
+            terminateProcessTree: { pid, group, signal, descendants in
+                terminations.append(pid: pid, group: group, signal: signal, descendants: descendants)
+            },
+            currentProcessID: { currentProcessID },
+            now: Date.init,
+            sleep: { nanoseconds in
+                if let sleeper {
+                    try await sleeper.sleep(nanoseconds)
+                } else {
+                    try await Task.sleep(nanoseconds: nanoseconds)
+                }
+            },
+            idleWindow: idleWindow,
+            failureRelaunchThreshold: failureRelaunchThreshold,
+            terminationGracePeriod: terminationGracePeriod))
+        return Fixture(
+            session: session,
+            launcher: launcher,
+            identity: identity,
+            store: store,
+            terminations: terminations,
+            registry: registry,
+            sleeper: sleeper)
+    }
+}

--- a/Tests/CodexBarTests/AntigravityCLISessionTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLISessionTests.swift
@@ -367,6 +367,32 @@ private final class AntigravityRegistryRecorder: @unchecked Sendable {
     }
 }
 
+private final class AntigravityLaunchReservationRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var beginCount = 0
+    private var endCount = 0
+
+    func begin() -> Bool {
+        self.lock.lock()
+        self.beginCount += 1
+        self.lock.unlock()
+        return true
+    }
+
+    func end() {
+        self.lock.lock()
+        self.endCount += 1
+        self.lock.unlock()
+    }
+
+    func counts() -> (begin: Int, end: Int) {
+        self.lock.lock()
+        let counts = (begin: self.beginCount, end: self.endCount)
+        self.lock.unlock()
+        return counts
+    }
+}
+
 private final class AntigravityManualSleeper: @unchecked Sendable {
     private let lock = NSLock()
     private var continuations: [CheckedContinuation<Void, Error>] = []
@@ -420,6 +446,8 @@ struct AntigravityCLISessionTests {
         #expect(firstPID == 10)
         #expect(secondPID == 10)
         #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy"])
+        #expect(fixture.launchReservations.counts().begin == 1)
+        #expect(fixture.launchReservations.counts().end == 1)
     }
 
     @Test
@@ -596,6 +624,7 @@ struct AntigravityCLISessionTests {
 
         #expect(sigismember(&signals, SIGINT) == 1)
         #expect(sigismember(&signals, SIGTERM) == 1)
+        #expect(sigismember(&signals, SIGHUP) == 1)
     }
 
     @Test
@@ -1411,6 +1440,7 @@ extension AntigravityCLISessionTests {
         let store: MemoryAntigravitySessionRecordStore
         let terminations: AntigravitySessionTerminationRecorder
         let registry: AntigravityRegistryRecorder
+        let launchReservations: AntigravityLaunchReservationRecorder
         let sleeper: AntigravityManualSleeper?
     }
 
@@ -1431,12 +1461,15 @@ extension AntigravityCLISessionTests {
         let identity = suppliedIdentity ?? FakeAntigravityIdentityProvider()
         let terminations = AntigravitySessionTerminationRecorder()
         let registry = AntigravityRegistryRecorder()
+        let launchReservations = AntigravityLaunchReservationRecorder()
         let sleeper = manualSleep ? AntigravityManualSleeper() : nil
         let session = AntigravityCLISession(dependencies: AntigravityCLISession.Dependencies(
             launcher: launcher,
             identityProvider: identity,
             recordStore: store,
             launchLock: launchLock,
+            beginAppShutdownTrackedLaunch: { launchReservations.begin() },
+            endAppShutdownTrackedLaunch: { launchReservations.end() },
             registerForAppShutdown: { pid, binary in registry.register(pid: pid, binary) },
             updateAppShutdownProcessGroup: { pid, group in registry.update(pid: pid, group: group) },
             unregisterForAppShutdown: { pid in registry.unregister(pid: pid) },
@@ -1463,6 +1496,7 @@ extension AntigravityCLISessionTests {
             store: store,
             terminations: terminations,
             registry: registry,
+            launchReservations: launchReservations,
             sleeper: sleeper)
     }
 }

--- a/Tests/CodexBarTests/AntigravityCLISessionTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLISessionTests.swift
@@ -190,38 +190,71 @@ private final class FakeAntigravityIdentityProvider: AntigravityCLIProcessIdenti
 
 private final class MemoryAntigravitySessionRecordStore: AntigravityCLISessionRecordStoring, @unchecked Sendable {
     private let lock = NSLock()
-    private var record: AntigravityCLISessionRecord?
+    private var records: [AntigravityCLISessionRecord]
+    private let failSaves: Bool
     private var saves = 0
     private var removes = 0
 
-    init(record: AntigravityCLISessionRecord? = nil) {
-        self.record = record
+    init(record: AntigravityCLISessionRecord? = nil, failSaves: Bool = false) {
+        self.records = record.map { [$0] } ?? []
+        self.failSaves = failSaves
     }
 
-    func load() throws -> AntigravityCLISessionRecord? {
+    func load() throws -> [AntigravityCLISessionRecord] {
         self.lock.lock()
-        let value = self.record
+        let value = self.records
         self.lock.unlock()
         return value
     }
 
     func save(_ record: AntigravityCLISessionRecord) throws {
         self.lock.lock()
-        self.record = record
+        guard !self.failSaves else {
+            self.lock.unlock()
+            throw CocoaError(.fileWriteNoPermission)
+        }
+        self.records.removeAll { existing in
+            if let existingOwnerPID = existing.ownerPID,
+               let recordOwnerPID = record.ownerPID,
+               let existingOwnerPath = existing.ownerExecutablePath,
+               let recordOwnerPath = record.ownerExecutablePath,
+               let existingOwnerStart = existing.ownerStartEpoch,
+               let recordOwnerStart = record.ownerStartEpoch
+            {
+                return existingOwnerPID == recordOwnerPID &&
+                    existingOwnerPath == recordOwnerPath &&
+                    abs(existingOwnerStart - recordOwnerStart) < 0.001
+            }
+            return existing.pid == record.pid &&
+                existing.executablePath == record.executablePath &&
+                abs(existing.startEpoch - record.startEpoch) < 0.001
+        }
+        self.records.append(record)
         self.saves += 1
         self.lock.unlock()
     }
 
-    func remove() throws {
+    func remove(_ record: AntigravityCLISessionRecord) throws {
         self.lock.lock()
-        self.record = nil
+        self.records.removeAll {
+            $0.pid == record.pid &&
+                $0.executablePath == record.executablePath &&
+                abs($0.startEpoch - record.startEpoch) < 0.001
+        }
         self.removes += 1
         self.lock.unlock()
     }
 
     func snapshot() -> AntigravityCLISessionRecord? {
         self.lock.lock()
-        let value = self.record
+        let value = self.records.first
+        self.lock.unlock()
+        return value
+    }
+
+    func snapshots() -> [AntigravityCLISessionRecord] {
+        self.lock.lock()
+        let value = self.records
         self.lock.unlock()
         return value
     }
@@ -238,6 +271,22 @@ private final class MemoryAntigravitySessionRecordStore: AntigravityCLISessionRe
         let value = self.removes
         self.lock.unlock()
         return value
+    }
+}
+
+private final class MemoryAntigravitySessionLaunchLock: AntigravityCLISessionLaunchLocking, @unchecked Sendable {
+    private let lock = NSLock()
+
+    func withLock<T>(_ operation: () throws -> T) throws -> T {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return try operation()
+    }
+}
+
+private struct FailingAntigravitySessionLaunchLock: AntigravityCLISessionLaunchLocking {
+    func withLock<T>(_: () throws -> T) throws -> T {
+        throw CocoaError(.fileWriteNoPermission)
     }
 }
 
@@ -505,6 +554,14 @@ struct AntigravityCLISessionTests {
     }
 
     @Test
+    func `pty launcher resets termination signals for child process`() {
+        var signals = AntigravityPTYProcessLauncher.defaultSignalsForSpawn()
+
+        #expect(sigismember(&signals, SIGINT) == 1)
+        #expect(sigismember(&signals, SIGTERM) == 1)
+    }
+
+    @Test
     func `spawned PTY drain is bounded per call`() throws {
         let temp = FileManager.default.temporaryDirectory
             .appendingPathComponent("antigravity-drain-\(UUID().uuidString)")
@@ -550,6 +607,31 @@ struct AntigravityCLISessionTests {
     }
 
     @Test
+    func `launch remains usable when coordination lock is unavailable`() async throws {
+        let fixture = self.makeFixture(launchLock: FailingAntigravitySessionLaunchLock())
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        let pid = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+
+        #expect(pid == 10)
+        #expect(fixture.store.snapshot() == nil)
+    }
+
+    @Test
+    func `launch remains usable when ownership record cannot be saved`() async throws {
+        let store = MemoryAntigravitySessionRecordStore(failSaves: true)
+        let fixture = self.makeFixture(store: store)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        let pid = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+
+        #expect(pid == 10)
+        #expect(store.snapshot() == nil)
+    }
+
+    @Test
     func `idle window tears down warm process`() async throws {
         let fixture = self.makeFixture(idleWindow: 0.05, manualSleep: true)
         fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
@@ -563,6 +645,17 @@ struct AntigravityCLISessionTests {
         #expect(await fixture.session.isRunning == false)
         #expect(fixture.registry.unregisteredSnapshot() == [10])
         #expect(fixture.store.snapshot() == nil)
+    }
+
+    @Test
+    func `host idle window extends the default session lifetime`() async throws {
+        let fixture = self.makeFixture(idleWindow: 180)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy", idleWindow: 360)
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(await fixture.session.idleWindowForTesting == 360)
     }
 
     @Test
@@ -643,7 +736,7 @@ struct AntigravityCLISessionTests {
     }
 
     @Test
-    func `launch preserves persisted session owned by another live process`() async throws {
+    func `launch tracks an independent session while another process is live`() async throws {
         let protectedRecord = AntigravityCLISessionRecord(
             pid: 777,
             requestedBinaryPath: "/bin/agy",
@@ -661,49 +754,167 @@ struct AntigravityCLISessionTests {
             executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
             startEpoch: 10)
         fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
-
-        let pid = try await fixture.session.beginProbe(binary: "/bin/agy")
-        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
-
-        #expect(pid == 10)
-        #expect(fixture.terminations.snapshot().isEmpty)
-        #expect(fixture.store.saveCount == 0)
-        #expect(fixture.store.snapshot() == protectedRecord)
-    }
-
-    @Test
-    func `binary-change relaunch preserves persisted session owned by another live process`() async throws {
-        let protectedRecord = AntigravityCLISessionRecord(
-            pid: 777,
-            requestedBinaryPath: "/bin/agy",
-            executablePath: "/bin/agy",
-            startEpoch: 42,
-            processGroup: 777,
-            ownerPID: 900,
-            ownerExecutablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
-            ownerStartEpoch: 10)
-        let store = MemoryAntigravitySessionRecordStore(record: protectedRecord)
-        let fixture = self.makeFixture(store: store, currentProcessID: 901)
-        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
-        fixture.identity.setIdentity(
-            pid: 900,
-            executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
-            startEpoch: 10)
-        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
-        fixture.identity.setIdentity(pid: 11, executablePath: "/new/agy", startEpoch: 101)
+        fixture.identity.setIdentity(pid: 901, executablePath: "/app/codexbar", startEpoch: 20)
 
         _ = try await fixture.session.beginProbe(binary: "/bin/agy")
-        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
-        let relaunchedPID = try await fixture.session.beginProbe(binary: "/new/agy")
-        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
 
-        #expect(relaunchedPID == 11)
-        #expect(fixture.store.saveCount == 0)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy"])
+        #expect(fixture.terminations.snapshot().isEmpty)
+        #expect(fixture.store.saveCount == 1)
+        #expect(Set(fixture.store.snapshots().map(\.pid)) == [10, 777])
+
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
         #expect(fixture.store.snapshot() == protectedRecord)
     }
 
     @Test
-    func `reused unrecorded session is persisted after protected owner exits`() async throws {
+    func `different binary tracks an independent session while another process is live`() async throws {
+        let protectedRecord = AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777,
+            ownerPID: 900,
+            ownerExecutablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            ownerStartEpoch: 10)
+        let store = MemoryAntigravitySessionRecordStore(record: protectedRecord)
+        let fixture = self.makeFixture(store: store, currentProcessID: 901)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
+        fixture.identity.setIdentity(
+            pid: 900,
+            executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            startEpoch: 10)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/new/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 901, executablePath: "/app/codexbar", startEpoch: 20)
+
+        _ = try await fixture.session.beginProbe(binary: "/new/agy")
+
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/new/agy"])
+        #expect(fixture.store.saveCount == 1)
+        #expect(Set(fixture.store.snapshots().map(\.pid)) == [10, 777])
+
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+        #expect(fixture.store.snapshot() == protectedRecord)
+    }
+
+    @Test
+    func `concurrent hosts atomically track independent sessions`() async {
+        let store = MemoryAntigravitySessionRecordStore()
+        let launchLock = MemoryAntigravitySessionLaunchLock()
+        let identity = FakeAntigravityIdentityProvider()
+        let firstLauncher = FakeAntigravityProcessLauncher(nextPID: 10)
+        let secondLauncher = FakeAntigravityProcessLauncher(nextPID: 20)
+        identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+        identity.setIdentity(pid: 20, executablePath: "/bin/agy", startEpoch: 200)
+        identity.setIdentity(pid: 900, executablePath: "/app/CodexBar", startEpoch: 1)
+        identity.setIdentity(pid: 901, executablePath: "/app/codexbar", startEpoch: 2)
+        let first = self.makeFixture(
+            launcher: firstLauncher,
+            identity: identity,
+            store: store,
+            launchLock: launchLock,
+            currentProcessID: 900)
+        let second = self.makeFixture(
+            launcher: secondLauncher,
+            identity: identity,
+            store: store,
+            launchLock: launchLock,
+            currentProcessID: 901)
+
+        async let firstStarted = Self.beginPersistentSession(first.session)
+        async let secondStarted = Self.beginPersistentSession(second.session)
+        let results = await [firstStarted, secondStarted]
+
+        #expect(!results.contains(false))
+        #expect(firstLauncher.launchedBinarySnapshot().count + secondLauncher.launchedBinarySnapshot().count == 2)
+        #expect(Set(store.snapshots().map(\.pid)) == [10, 20])
+
+        await first.session.reset()
+        await second.session.reset()
+        #expect(store.snapshots().isEmpty)
+    }
+
+    @Test
+    func `warm reuse reaps a crashed peer session`() async throws {
+        let store = MemoryAntigravitySessionRecordStore()
+        let launchLock = MemoryAntigravitySessionLaunchLock()
+        let identity = FakeAntigravityIdentityProvider()
+        let firstLauncher = FakeAntigravityProcessLauncher(nextPID: 10)
+        let secondLauncher = FakeAntigravityProcessLauncher(nextPID: 20)
+        identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+        identity.setIdentity(pid: 20, executablePath: "/bin/agy", startEpoch: 200)
+        identity.setIdentity(pid: 900, executablePath: "/app/CodexBar", startEpoch: 1)
+        identity.setIdentity(pid: 901, executablePath: "/app/codexbar", startEpoch: 2)
+        let first = self.makeFixture(
+            launcher: firstLauncher,
+            identity: identity,
+            store: store,
+            launchLock: launchLock,
+            currentProcessID: 900)
+        let second = self.makeFixture(
+            launcher: secondLauncher,
+            identity: identity,
+            store: store,
+            launchLock: launchLock,
+            currentProcessID: 901)
+        #expect(await Self.beginPersistentSession(first.session))
+        #expect(await Self.beginPersistentSession(second.session))
+
+        identity.removeIdentity(pid: 901)
+        _ = try await first.session.beginProbe(binary: "/bin/agy")
+        await first.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(first.terminations.snapshot().map(\.pid) == [20, 20])
+        #expect(store.snapshots().map(\.pid) == [10])
+
+        await first.session.reset()
+        await second.session.reset()
+    }
+
+    @Test
+    func `file store migrates legacy record and preserves independent owners`() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBarAntigravitySessionTests-\(UUID().uuidString)", isDirectory: true)
+        let fileURL = directory.appendingPathComponent("agy-session.json")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let legacy = AntigravityCLISessionRecord(
+            pid: 10,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 100,
+            processGroup: 10,
+            ownerPID: 900,
+            ownerExecutablePath: "/app/CodexBar",
+            ownerStartEpoch: 1)
+        try JSONEncoder().encode(legacy).write(to: fileURL)
+        let store = AntigravityFileCLISessionRecordStore(fileURL: fileURL)
+        #expect(try store.load() == [legacy])
+
+        let second = AntigravityCLISessionRecord(
+            pid: 20,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 200,
+            processGroup: 20,
+            ownerPID: 901,
+            ownerExecutablePath: "/app/codexbar",
+            ownerStartEpoch: 2)
+        try store.save(second)
+        #expect(try Set(store.load().map(\.pid)) == [10, 20])
+
+        try store.remove(legacy)
+        #expect(try store.load() == [second])
+
+        try Data("{".utf8).write(to: fileURL)
+        try store.save(legacy)
+        #expect(try store.load() == [legacy])
+    }
+
+    @Test
+    func `session reaps stale owner before launch`() async throws {
         let protectedRecord = AntigravityCLISessionRecord(
             pid: 777,
             requestedBinaryPath: "/bin/agy",
@@ -726,13 +937,10 @@ struct AntigravityCLISessionTests {
             startEpoch: 20)
         fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
 
-        let firstPID = try await fixture.session.beginProbe(binary: "/bin/agy")
-        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
         fixture.identity.removeIdentity(pid: 900)
         let secondPID = try await fixture.session.beginProbe(binary: "/bin/agy")
         let record = fixture.store.snapshot()
         await fixture.session.finishProbe(success: true, resetAfterFetch: true)
-        #expect(firstPID == 10)
         #expect(secondPID == 10)
         #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy"])
         #expect(fixture.terminations.snapshot().map(\.pid) == [777, 777])
@@ -942,6 +1150,16 @@ struct AntigravityCLISessionTests {
         Issue.record("Timed out waiting for Antigravity CLI session to stop")
     }
 
+    private static func beginPersistentSession(_ session: AntigravityCLISession) async -> Bool {
+        do {
+            _ = try await session.beginProbe(binary: "/bin/agy")
+            await session.finishProbe(success: true, resetAfterFetch: false)
+            return true
+        } catch {
+            return false
+        }
+    }
+
     private struct Fixture {
         let session: AntigravityCLISession
         let launcher: FakeAntigravityProcessLauncher
@@ -953,7 +1171,10 @@ struct AntigravityCLISessionTests {
     }
 
     private func makeFixture(
+        launcher suppliedLauncher: FakeAntigravityProcessLauncher? = nil,
+        identity suppliedIdentity: FakeAntigravityIdentityProvider? = nil,
         store: MemoryAntigravitySessionRecordStore = MemoryAntigravitySessionRecordStore(),
+        launchLock: any AntigravityCLISessionLaunchLocking = MemoryAntigravitySessionLaunchLock(),
         idleWindow: TimeInterval = 3600,
         failureRelaunchThreshold: Int = 2,
         manualSleep: Bool = false,
@@ -961,9 +1182,9 @@ struct AntigravityCLISessionTests {
         terminateRootStopsProcess: Bool = true,
         currentProcessID: pid_t = 900) -> Fixture
     {
-        let launcher = FakeAntigravityProcessLauncher(nextPID: 10)
+        let launcher = suppliedLauncher ?? FakeAntigravityProcessLauncher(nextPID: 10)
         launcher.setTerminateRootStopsProcess(terminateRootStopsProcess)
-        let identity = FakeAntigravityIdentityProvider()
+        let identity = suppliedIdentity ?? FakeAntigravityIdentityProvider()
         let terminations = AntigravitySessionTerminationRecorder()
         let registry = AntigravityRegistryRecorder()
         let sleeper = manualSleep ? AntigravityManualSleeper() : nil
@@ -971,6 +1192,7 @@ struct AntigravityCLISessionTests {
             launcher: launcher,
             identityProvider: identity,
             recordStore: store,
+            launchLock: launchLock,
             registerForAppShutdown: { pid, binary in registry.register(pid: pid, binary) },
             updateAppShutdownProcessGroup: { pid, group in registry.update(pid: pid, group: group) },
             unregisterForAppShutdown: { pid in registry.unregister(pid: pid) },

--- a/Tests/CodexBarTests/AntigravityCLISessionTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLISessionTests.swift
@@ -672,6 +672,76 @@ struct AntigravityCLISessionTests {
     }
 
     @Test
+    func `binary-change relaunch preserves persisted session owned by another live process`() async throws {
+        let protectedRecord = AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777,
+            ownerPID: 900,
+            ownerExecutablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            ownerStartEpoch: 10)
+        let store = MemoryAntigravitySessionRecordStore(record: protectedRecord)
+        let fixture = self.makeFixture(store: store, currentProcessID: 901)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
+        fixture.identity.setIdentity(
+            pid: 900,
+            executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            startEpoch: 10)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 11, executablePath: "/new/agy", startEpoch: 101)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        let relaunchedPID = try await fixture.session.beginProbe(binary: "/new/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+
+        #expect(relaunchedPID == 11)
+        #expect(fixture.store.saveCount == 0)
+        #expect(fixture.store.snapshot() == protectedRecord)
+    }
+
+    @Test
+    func `reused unrecorded session is persisted after protected owner exits`() async throws {
+        let protectedRecord = AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777,
+            ownerPID: 900,
+            ownerExecutablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            ownerStartEpoch: 10)
+        let store = MemoryAntigravitySessionRecordStore(record: protectedRecord)
+        let fixture = self.makeFixture(store: store, currentProcessID: 901)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
+        fixture.identity.setIdentity(
+            pid: 900,
+            executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            startEpoch: 10)
+        fixture.identity.setIdentity(
+            pid: 901,
+            executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            startEpoch: 20)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        let firstPID = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        fixture.identity.removeIdentity(pid: 900)
+        let secondPID = try await fixture.session.beginProbe(binary: "/bin/agy")
+        let record = fixture.store.snapshot()
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+        #expect(firstPID == 10)
+        #expect(secondPID == 10)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy"])
+        #expect(fixture.terminations.snapshot().map(\.pid) == [777, 777])
+        #expect(fixture.store.saveCount == 1)
+        #expect(record?.pid == 10)
+        #expect(record?.ownerPID == 901)
+    }
+
+    @Test
     func `reset rechecks protected persisted session after owner exits`() async {
         let store = MemoryAntigravitySessionRecordStore(record: AntigravityCLISessionRecord(
             pid: 777,

--- a/Tests/CodexBarTests/AntigravityCLISessionTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLISessionTests.swift
@@ -562,6 +562,56 @@ struct AntigravityCLISessionTests {
     }
 
     @Test
+    func `pty launcher uses home and closes unrelated descriptors`() throws {
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("antigravity-spawn-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let inheritedSourceFD = open("/dev/null", O_RDONLY)
+        guard inheritedSourceFD >= 0 else {
+            Issue.record("Failed to open descriptor fixture")
+            return
+        }
+        defer { close(inheritedSourceFD) }
+        let inheritedFD = fcntl(inheritedSourceFD, F_DUPFD, 200)
+        guard inheritedFD >= 200 else {
+            Issue.record("Failed to duplicate descriptor fixture")
+            return
+        }
+        defer { close(inheritedFD) }
+
+        let outputURL = tempDirectory.appendingPathComponent("result.txt")
+        let scriptURL = tempDirectory.appendingPathComponent("probe.sh")
+        let script = """
+        #!/bin/sh
+        pwd > \(outputURL.path)
+        if [ -e /dev/fd/\(inheritedFD) ] || [ -e /proc/self/fd/\(inheritedFD) ]; then
+          echo inherited >> \(outputURL.path)
+        else
+          echo closed >> \(outputURL.path)
+        fi
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        #expect(chmod(scriptURL.path, 0o700) == 0)
+
+        let handle = try AntigravityPTYProcessLauncher().launch(binary: scriptURL.path)
+        defer {
+            handle.killRoot()
+            handle.terminateTree(signal: SIGKILL, knownDescendants: [])
+            handle.closePTY()
+        }
+
+        for _ in 0..<200 where !FileManager.default.fileExists(atPath: outputURL.path) {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        let lines = try String(contentsOf: outputURL, encoding: .utf8)
+            .split(separator: "\n")
+            .map(String.init)
+        #expect(lines == [NSHomeDirectory(), "closed"])
+    }
+
+    @Test
     func `spawned PTY drain is bounded per call`() throws {
         let temp = FileManager.default.temporaryDirectory
             .appendingPathComponent("antigravity-drain-\(UUID().uuidString)")

--- a/Tests/CodexBarTests/AntigravityCLISessionTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLISessionTests.swift
@@ -15,6 +15,7 @@ private final class FakeAntigravityProcessHandle: AntigravityCLIProcessHandle, @
     private let terminateRootStopsProcess: Bool
     private var assignedProcessGroup: pid_t?
     private var events: [String] = []
+    private var drainOutputChunks: [Data] = []
 
     init(pid: pid_t, running: Bool = true, descendants: [pid_t] = [], terminateRootStopsProcess: Bool = true) {
         self.pid = pid
@@ -91,8 +92,18 @@ private final class FakeAntigravityProcessHandle: AntigravityCLIProcessHandle, @
         self.append("killDescendants:\(descendants.map(String.init).joined(separator: ","))")
     }
 
-    func drainOutput() {
-        self.append("drainOutput")
+    func drainOutput() -> Data {
+        self.lock.lock()
+        self.events.append("drainOutput")
+        let output = self.drainOutputChunks.isEmpty ? Data() : self.drainOutputChunks.removeFirst()
+        self.lock.unlock()
+        return output
+    }
+
+    func enqueueDrainOutput(_ output: Data) {
+        self.lock.lock()
+        self.drainOutputChunks.append(output)
+        self.lock.unlock()
     }
 
     func snapshotEvents() -> [String] {
@@ -489,6 +500,31 @@ struct AntigravityCLISessionTests {
     }
 
     @Test
+    func `queued replacement hard stops a signed out process`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/old/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 11, executablePath: "/new/agy", startEpoch: 101)
+
+        _ = try await fixture.session.beginProbe(binary: "/old/agy")
+        let replacement = Task {
+            try await fixture.session.beginProbe(binary: "/new/agy")
+        }
+        for _ in 0..<100 where await fixture.session.activeProbeCountForTesting < 2 {
+            await Task.yield()
+        }
+        #expect(await fixture.session.activeProbeCountForTesting == 2)
+
+        await fixture.session.finishProbe(success: false, resetAfterFetch: true, forceTerminate: true)
+        let replacementPID = try await replacement.value
+        let oldEvents = try #require(fixture.launcher.handleSnapshot().first).snapshotEvents()
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+
+        #expect(replacementPID == 11)
+        #expect(!oldEvents.contains("sendExit"))
+        #expect(oldEvents.contains("terminateRoot"))
+    }
+
+    @Test
     func `replacement ignores queued starters while waiting for active probe`() async throws {
         let fixture = self.makeFixture()
         fixture.identity.setIdentity(pid: 10, executablePath: "/old/agy", startEpoch: 100)
@@ -636,9 +672,53 @@ struct AntigravityCLISessionTests {
             secondaryHandle: FileHandle(fileDescriptor: secondaryFD, closeOnDealloc: true))
         defer { handle.closePTY() }
 
-        handle.drainOutput()
+        let output = handle.drainOutput()
 
         #expect(lseek(primaryFD, 0, SEEK_CUR) == off_t(8192 * 64))
+        #expect(output.count == 8192 * 64)
+    }
+
+    @Test
+    func `session keeps one rolling PTY buffer across concurrent probes`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        let handle = try #require(fixture.launcher.handleSnapshot().first)
+        handle.enqueueDrainOutput(Data([0xE2, 0x96]))
+        let first = await fixture.session.drainOutput()
+        handle.enqueueDrainOutput(Data([0x84]) + Data("You are currently not signed in".utf8))
+        let second = await fixture.session.drainOutput()
+        let third = await fixture.session.drainOutput()
+
+        #expect(first == Data([0xE2, 0x96]))
+        #expect(AntigravityCLIHTTPSFetchStrategy.containsAuthenticationPrompt(second))
+        #expect(third == second)
+
+        await fixture.session.finishProbe(success: false, resetAfterFetch: true, forceTerminate: true)
+        await fixture.session.finishProbe(success: false, resetAfterFetch: false)
+    }
+
+    @Test
+    func `session returns complete new output before retaining only its tail`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        let handle = try #require(fixture.launcher.handleSnapshot().first)
+        let prompt = Data("You are currently not signed in".utf8)
+        let oversizedRedraw = prompt + Data(repeating: 0x20, count: 8192)
+        handle.enqueueDrainOutput(oversizedRedraw)
+
+        let searchableOutput = await fixture.session.drainOutput()
+        let retainedTail = await fixture.session.drainOutput()
+
+        #expect(searchableOutput == oversizedRedraw)
+        #expect(AntigravityCLIHTTPSFetchStrategy.containsAuthenticationPrompt(searchableOutput))
+        #expect(AntigravityCLIHTTPSFetchStrategy.containsAuthenticationPrompt(retainedTail))
+
+        await fixture.session.finishProbe(success: false, resetAfterFetch: true, forceTerminate: true)
     }
 
     @Test
@@ -652,7 +732,9 @@ struct AntigravityCLISessionTests {
 
         let handle = fixture.launcher.handleSnapshot().first
         #expect(handle?.isRunning == false)
+        #expect(handle?.snapshotEvents().contains("sendExit") == false)
         #expect(handle?.snapshotEvents().contains("closePTY") == true)
+        #expect(handle?.snapshotEvents().contains("terminateRoot") == true)
         #expect(fixture.registry.registeredSnapshot().isEmpty)
     }
 
@@ -884,7 +966,9 @@ struct AntigravityCLISessionTests {
         await second.session.reset()
         #expect(store.snapshots().isEmpty)
     }
+}
 
+extension AntigravityCLISessionTests {
     @Test
     func `warm reuse reaps a crashed peer session`() async throws {
         let store = MemoryAntigravitySessionRecordStore()
@@ -1089,6 +1173,69 @@ struct AntigravityCLISessionTests {
 
         #expect(await fixture.session.isRunning == false)
         #expect(fixture.registry.unregisteredSnapshot() == [10])
+    }
+
+    @Test
+    func `authentication reset never writes interactive exit input`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: false, resetAfterFetch: true, forceTerminate: true)
+
+        let events = try #require(fixture.launcher.handleSnapshot().first).snapshotEvents()
+        #expect(!events.contains("sendExit"))
+        #expect(events.contains("closePTY"))
+        #expect(events.contains("terminateRoot"))
+        #expect(await fixture.session.isRunning == false)
+    }
+
+    @Test
+    func `failed reset never writes interactive exit input`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: false, resetAfterFetch: true)
+
+        let events = try #require(fixture.launcher.handleSnapshot().first).snapshotEvents()
+        #expect(!events.contains("sendExit"))
+        #expect(events.contains("terminateRoot"))
+        #expect(await fixture.session.isRunning == false)
+    }
+
+    @Test
+    func `concurrent success preserves a failed probes deferred hard reset`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: false, resetAfterFetch: true)
+        #expect(await fixture.session.isRunning)
+
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        let events = try #require(fixture.launcher.handleSnapshot().first).snapshotEvents()
+        #expect(!events.contains("sendExit"))
+        #expect(events.contains("terminateRoot"))
+        #expect(await fixture.session.isRunning == false)
+    }
+
+    @Test
+    func `idle timeout hard stops a previously failed process`() async throws {
+        let fixture = self.makeFixture(idleWindow: 0.05, manualSleep: true)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: false, resetAfterFetch: false)
+        await fixture.sleeper?.waitForSleeps(1)
+        fixture.sleeper?.resumeAll()
+        await self.waitUntilStopped(fixture.session)
+
+        let events = try #require(fixture.launcher.handleSnapshot().first).snapshotEvents()
+        #expect(!events.contains("sendExit"))
+        #expect(events.contains("terminateRoot"))
     }
 
     @Test

--- a/Tests/CodexBarTests/AntigravityCLISessionTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLISessionTests.swift
@@ -517,6 +517,7 @@ struct AntigravityCLISessionTests {
         await fixture.session.finishProbe(success: false, resetAfterFetch: true, forceTerminate: true)
         let replacementPID = try await replacement.value
         let oldEvents = try #require(fixture.launcher.handleSnapshot().first).snapshotEvents()
+        #expect(await fixture.session.lastStopReasonForTesting == "authentication required")
         await fixture.session.finishProbe(success: true, resetAfterFetch: true)
 
         #expect(replacementPID == 11)
@@ -1254,6 +1255,52 @@ extension AntigravityCLISessionTests {
         #expect(relaunchedPID == 11)
         #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy", "/bin/agy"])
         #expect(await fixture.session.failureCountForTesting == 0)
+    }
+
+    @Test
+    func `session reset reasons distinguish authentication from unhealthy probes`() {
+        #expect(AntigravityCLISession.resetCause(
+            authenticationRequired: true,
+            resetAfterFetch: true,
+            shouldForceStopUnhealthy: true).message == "authentication required")
+        #expect(AntigravityCLISession.resetCause(
+            authenticationRequired: false,
+            resetAfterFetch: true,
+            shouldForceStopUnhealthy: true).message == "unhealthy CLI HTTPS session")
+        #expect(AntigravityCLISession.resetCause(
+            authenticationRequired: false,
+            resetAfterFetch: true,
+            shouldForceStopUnhealthy: false).message == "one-shot CLI fetch")
+        #expect(AntigravityCLISession.resetCause(
+            authenticationRequired: false,
+            resetAfterFetch: false,
+            shouldForceStopUnhealthy: false).message == "deferred reset")
+    }
+
+    @Test
+    func `deferred unhealthy reset preserves its cause after a concurrent success`() async throws {
+        let fixture = self.makeFixture(failureRelaunchThreshold: 1)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: false, resetAfterFetch: false)
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(await fixture.session.lastStopReasonForTesting == "unhealthy CLI HTTPS session")
+    }
+
+    @Test
+    func `deferred authentication reset preserves its cause after a concurrent success`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: false, resetAfterFetch: true, forceTerminate: true)
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(await fixture.session.lastStopReasonForTesting == "authentication required")
     }
 
     @Test

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -1026,6 +1026,32 @@ extension AntigravityStatusProbeTests {
             $0.id == "MODEL_PLACEHOLDER_M36"
         })
         #expect(modelWindow.window.resetsAt == resetTime)
+        #expect(modelWindow.usageKnown == false)
+        let knownModelWindow = try #require(usage.extraRateWindows?.first {
+            $0.id == "MODEL_PLACEHOLDER_M47"
+        })
+        #expect(knownModelWindow.usageKnown)
+    }
+
+    @Test
+    func `named rate windows default legacy payloads to known usage`() throws {
+        let json = """
+        {
+          "id": "legacy-window",
+          "title": "Legacy Window",
+          "window": {
+            "usedPercent": 42,
+            "windowMinutes": null,
+            "resetsAt": null,
+            "resetDescription": null,
+            "nextRegenPercent": null
+          }
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(NamedRateWindow.self, from: Data(json.utf8))
+
+        #expect(decoded.usageKnown)
     }
 
     @Test

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -177,6 +177,28 @@ struct AntigravityStatusProbeTests {
         #expect(result.csrfToken.isEmpty)
         #expect(result.commandLine == "/Users/test/.local/bin/agy -p hello")
     }
+
+    @Test
+    func `ideOnly scope skips cli processes and reports not running`() {
+        let output = "  200 /Users/test/.local/bin/agy -p hello"
+
+        #expect(throws: AntigravityStatusProbeError.notRunning) {
+            try AntigravityStatusProbe.processInfo(fromProcessListOutput: output, scope: .ideOnly)
+        }
+    }
+
+    @Test
+    func `ideOnly scope still matches ide server listed after cli process`() throws {
+        let cli = "  200 /Users/test/.local/bin/agy -p hello"
+        let ide = "  101 /Applications/Antigravity.app/Contents/Resources/bin/language_server " +
+            "--csrf_token ide-token --app_data_dir antigravity"
+        let output = cli + "\n" + ide
+
+        let result = try AntigravityStatusProbe.processInfo(fromProcessListOutput: output, scope: .ideOnly)
+
+        #expect(result.pid == 101)
+        #expect(result.csrfToken == "ide-token")
+    }
 }
 
 extension AntigravityStatusProbeTests {

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -162,6 +162,29 @@ final class CLIEntryTests: XCTestCase {
         XCTAssertEqual(CodexBarCLI.mapError(UsageError.noRateLimitsFound), ExitCode(3))
     }
 
+    func test_antigravityPlanDebugKeepsOneShotHelperAliveUntilDebugFetch() {
+        XCTAssertTrue(CodexBarCLI.holdsAntigravityCLISessionForPlanDebug(
+            provider: .antigravity,
+            planDebugEnabled: true,
+            jsonOnly: false,
+            persistsCLISessions: false))
+        XCTAssertFalse(CodexBarCLI.holdsAntigravityCLISessionForPlanDebug(
+            provider: .codex,
+            planDebugEnabled: true,
+            jsonOnly: false,
+            persistsCLISessions: false))
+        XCTAssertFalse(CodexBarCLI.holdsAntigravityCLISessionForPlanDebug(
+            provider: .antigravity,
+            planDebugEnabled: true,
+            jsonOnly: true,
+            persistsCLISessions: false))
+        XCTAssertFalse(CodexBarCLI.holdsAntigravityCLISessionForPlanDebug(
+            provider: .antigravity,
+            planDebugEnabled: true,
+            jsonOnly: false,
+            persistsCLISessions: true))
+    }
+
     func test_missingCodexBinaryErrorPayloadUsesInstallGuidance() {
         let payload = CodexBarCLI.makeErrorPayload(CodexStatusProbeError.codexNotInstalled, kind: .provider)
 

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -1,9 +1,12 @@
+import CodexBarCore
 import Commander
 import Foundation
 import Testing
 @testable import CodexBarCLI
 @testable import CodexBarCore
 
+// Cache state-machine coverage is intentionally kept together for sequence readability.
+// swiftlint:disable:next type_body_length
 struct CLIServeRouterTests {
     @Test
     func `local http parser accepts only loopback host headers`() throws {
@@ -192,6 +195,85 @@ struct CLIServeRouterTests {
     }
 
     @Test
+    func `serve cache uses stable Codex account identities`() {
+        let storedID = UUID()
+        let firstProjection = Self.codexVisibleAccount(
+            id: "email-shaped-id",
+            workspaceAccountID: "workspace-1",
+            authFingerprint: "auth-1",
+            storedAccountID: storedID)
+        let reshapedProjection = Self.codexVisibleAccount(
+            id: "managed:\(storedID.uuidString)",
+            workspaceAccountID: "workspace-1",
+            authFingerprint: "auth-1",
+            storedAccountID: storedID)
+        let replacement = Self.codexVisibleAccount(
+            id: "email-shaped-id",
+            workspaceAccountID: "workspace-2",
+            authFingerprint: "auth-2",
+            storedAccountID: UUID())
+        let workspacePeer = Self.codexVisibleAccount(
+            id: "workspace-peer",
+            email: "other@example.com",
+            workspaceAccountID: "workspace-1",
+            authFingerprint: "auth-3",
+            storedAccountID: UUID())
+        let ambiguous = Self.codexVisibleAccount(
+            id: "email-only",
+            workspaceAccountID: nil,
+            authFingerprint: nil,
+            storedAccountID: nil)
+        let storedBeforeRefresh = Self.codexVisibleAccount(
+            id: "stored-before",
+            workspaceAccountID: nil,
+            authFingerprint: "old-auth",
+            storedAccountID: storedID)
+        let storedAfterRefresh = Self.codexVisibleAccount(
+            id: "stored-after",
+            workspaceAccountID: nil,
+            authFingerprint: "new-auth",
+            storedAccountID: storedID)
+
+        let firstKey = CodexBarCLI.usageCacheAccountKey(
+            provider: .codex,
+            account: nil,
+            codexVisibleAccount: firstProjection)
+        let reshapedKey = CodexBarCLI.usageCacheAccountKey(
+            provider: .codex,
+            account: nil,
+            codexVisibleAccount: reshapedProjection)
+        let replacementKey = CodexBarCLI.usageCacheAccountKey(
+            provider: .codex,
+            account: nil,
+            codexVisibleAccount: replacement)
+        let workspacePeerKey = CodexBarCLI.usageCacheAccountKey(
+            provider: .codex,
+            account: nil,
+            codexVisibleAccount: workspacePeer)
+        let storedBeforeKey = CodexBarCLI.usageCacheAccountKey(
+            provider: .codex,
+            account: nil,
+            codexVisibleAccount: storedBeforeRefresh)
+        let storedAfterKey = CodexBarCLI.usageCacheAccountKey(
+            provider: .codex,
+            account: nil,
+            codexVisibleAccount: storedAfterRefresh)
+
+        #expect(firstKey == reshapedKey)
+        #expect(firstKey != replacementKey)
+        #expect(firstKey != workspacePeerKey)
+        #expect(storedBeforeKey == storedAfterKey)
+        #expect(CodexBarCLI.usageCacheAccountKey(
+            provider: .codex,
+            account: nil,
+            codexVisibleAccount: ambiguous) == nil)
+        #expect(CodexBarCLI.usageCacheAccountKey(
+            provider: .antigravity,
+            account: nil,
+            codexVisibleAccount: nil) == "default:antigravity")
+    }
+
+    @Test
     func `serve cache coalesces concurrent cache misses`() async {
         let cache = CLIServeResponseCache()
         let counter = ServeTestCounter()
@@ -363,7 +445,8 @@ struct CLIServeRouterTests {
 
         // Transient failure is masked by the last good payload.
         #expect(failed.status == .ok)
-        #expect(Self.bodyString(failed) == Self.bodyString(first))
+        let failedRows = try? Self.jsonRows(failed)
+        #expect(failedRows?.first?["call"] as? Int == 1)
         #expect(await counter.current() == 2)
 
         try? await Task.sleep(nanoseconds: 100_000_000)
@@ -380,6 +463,585 @@ struct CLIServeRouterTests {
 
         #expect(recovered.status == .ok)
         #expect(Self.bodyString(recovered).contains("\"call\":3"))
+    }
+
+    @Test
+    func `serve cache replaces only failed provider account rows`() async throws {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {"provider":"codex","account":"personal","call":1},
+              {"provider":"antigravity","account":"work","call":1},
+              {"provider":"antigravity","account":"personal","call":1}
+            ]
+            """)
+        }
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let refreshed = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {"provider":"codex","account":"personal","call":2},
+              {"provider":"antigravity","account":"work","error":{"message":"transient"}},
+              {"provider":"antigravity","account":"personal","call":2}
+            ]
+            """)
+        }
+        let rows = try Self.jsonRows(refreshed)
+
+        #expect(Self.row(rows, provider: "codex", account: "personal")?["call"] as? Int == 2)
+        #expect(Self.row(rows, provider: "antigravity", account: "work")?["call"] as? Int == 1)
+        #expect(Self.row(rows, provider: "antigravity", account: "personal")?["call"] as? Int == 2)
+        #expect(rows.allSatisfy { $0["error"] == nil })
+    }
+
+    @Test
+    func `serve cache retains newer per-row success across all-error refresh`() async throws {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {"provider":"codex","call":1},
+              {"provider":"antigravity","call":1}
+            ]
+            """)
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {"provider":"codex","call":2},
+              {"provider":"antigravity","error":{"message":"transient"}}
+            ]
+            """)
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let failed = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {"provider":"codex","error":{"message":"transient"}},
+              {"provider":"antigravity","error":{"message":"transient"}}
+            ]
+            """)
+        }
+        let rows = try Self.jsonRows(failed)
+
+        #expect(Self.row(rows, provider: "codex")?["call"] as? Int == 2)
+        #expect(Self.row(rows, provider: "antigravity")?["call"] as? Int == 1)
+    }
+
+    @Test
+    func `serve cache retains merged rows across a later timeout`() async throws {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {"provider":"codex","call":1},
+              {"provider":"antigravity","call":1}
+            ]
+            """)
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {"provider":"codex","call":2},
+              {"provider":"antigravity","error":{"message":"transient"}}
+            ]
+            """)
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let timedOut = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 0.01)
+        {
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            return Self.response("[]")
+        }
+        let rows = try Self.jsonRows(timedOut)
+
+        #expect(Self.row(rows, provider: "codex")?["call"] as? Int == 2)
+        #expect(Self.row(rows, provider: "antigravity")?["call"] as? Int == 1)
+    }
+
+    @Test
+    func `serve cache retains partial fresh rows across a later timeout`() async throws {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response(#"[{"provider":"codex","call":1}]"#)
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {"provider":"codex","call":2},
+              {"provider":"antigravity","error":{"message":"transient"}}
+            ]
+            """)
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let timedOut = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 0.01)
+        {
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            return Self.response("[]")
+        }
+        let rows = try Self.jsonRows(timedOut)
+
+        #expect(Self.row(rows, provider: "codex")?["call"] as? Int == 2)
+        #expect(Self.row(rows, provider: "antigravity")?["error"] != nil)
+    }
+
+    @Test
+    func `serve cache keeps newer rows after an older merged row expires`() async throws {
+        let cache = CLIServeResponseCache()
+        let policy = CLIServeResponseCache.CachePolicy(ttl: 0, staleTTL: 10)
+        let startedAt = Date(timeIntervalSince1970: 1000)
+
+        _ = await cache.responseOrStartFetch(for: "usage:", now: startedAt)
+        _ = await cache.completeFetch(
+            Self.response(
+                """
+                [
+                  {"provider":"codex","call":1},
+                  {"provider":"antigravity","call":1}
+                ]
+                """),
+            for: "usage:",
+            policy: policy,
+            now: startedAt,
+            shouldCache: true)
+
+        let partialAt = startedAt.addingTimeInterval(9)
+        _ = await cache.responseOrStartFetch(for: "usage:", now: partialAt)
+        _ = await cache.completeFetch(
+            Self.response("""
+            [
+              {"provider":"codex","call":2},
+              {"provider":"antigravity","error":{"message":"transient"}}
+            ]
+            """),
+            for: "usage:",
+            policy: policy,
+            now: partialAt,
+            shouldCache: false)
+
+        let timeoutAt = startedAt.addingTimeInterval(11)
+        _ = await cache.responseOrStartFetch(for: "usage:", now: timeoutAt)
+        let timedOut = await cache.completeFetch(
+            Self.response(#"{"error":"request timed out"}"#, status: .gatewayTimeout),
+            for: "usage:",
+            policy: policy,
+            now: timeoutAt,
+            shouldCache: false)
+        let rows = try Self.jsonRows(timedOut)
+
+        #expect(rows.count == 1)
+        #expect(Self.row(rows, provider: "codex")?["call"] as? Int == 2)
+    }
+
+    @Test
+    func `serve cache preserves newer row when another failed row has no fallback`() async throws {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response(#"[{"provider":"codex","call":1}]"#)
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {"provider":"codex","call":2},
+              {"provider":"antigravity","error":{"message":"transient"}}
+            ]
+            """)
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let failed = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {"provider":"codex","error":{"message":"transient"}},
+              {"provider":"antigravity","error":{"message":"transient"}}
+            ]
+            """)
+        }
+        let rows = try Self.jsonRows(failed)
+
+        #expect(Self.row(rows, provider: "codex")?["call"] as? Int == 2)
+        #expect(Self.row(rows, provider: "antigravity")?["error"] != nil)
+    }
+
+    @Test
+    func `serve cache keeps fresh rows when a failed row has no stale match`() async throws {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response(#"[{"provider":"codex","account":"personal","call":1}]"#)
+        }
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let refreshed = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {"provider":"codex","account":"personal","call":2},
+              {"provider":"antigravity","account":"work","error":{"message":"transient"}}
+            ]
+            """)
+        }
+        let rows = try Self.jsonRows(refreshed)
+
+        #expect(Self.row(rows, provider: "codex", account: "personal")?["call"] as? Int == 2)
+        #expect(Self.row(rows, provider: "antigravity", account: "work")?["error"] != nil)
+    }
+
+    @Test
+    func `serve cache does not merge duplicate provider account labels`() async throws {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {"provider":"codex","account":"shared","slot":"first","call":1},
+              {"provider":"codex","account":"shared","slot":"second","call":1}
+            ]
+            """)
+        }
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let refreshed = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {
+                "provider":"codex",
+                "account":"shared",
+                "slot":"first",
+                "error":{"message":"transient"}
+              },
+              {"provider":"codex","account":"shared","slot":"second","call":2}
+            ]
+            """)
+        }
+        let rows = try Self.jsonRows(refreshed)
+        let first = rows.first { $0["slot"] as? String == "first" }
+        let second = rows.first { $0["slot"] as? String == "second" }
+
+        #expect(first?["error"] != nil)
+        #expect(second?["call"] as? Int == 2)
+    }
+
+    @Test
+    func `serve cache follows stable account identity across label changes`() async throws {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response(
+                #"[{"provider":"codex","account":"old label","call":1}]"#,
+                usageCacheKeys: ["account-1"])
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let failed = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response(
+                #"[{"provider":"codex","account":"new label","error":{"message":"transient"}}]"#,
+                usageCacheKeys: ["account-1"])
+        }
+        let row = try #require(Self.jsonRows(failed).first)
+
+        #expect(row["account"] as? String == "old label")
+        #expect(row["call"] as? Int == 1)
+    }
+
+    @Test
+    func `serve cache does not reuse a label for a different account identity`() async throws {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response(
+                #"[{"provider":"codex","account":"shared","call":1}]"#,
+                usageCacheKeys: ["account-1"])
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let refreshed = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response(
+                """
+                [
+                  {"provider":"codex","account":"shared","error":{"message":"transient"}},
+                  {"provider":"antigravity","account":"work","call":2}
+                ]
+                """,
+                usageCacheKeys: ["account-2", "account-3"])
+        }
+        let rows = try Self.jsonRows(refreshed)
+
+        #expect(Self.row(rows, provider: "codex", account: "shared")?["error"] != nil)
+        #expect(Self.row(rows, provider: "antigravity", account: "work")?["call"] as? Int == 2)
+    }
+
+    @Test
+    func `serve cache does not use whole fallback after an account switch`() async throws {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response(
+                #"[{"provider":"codex","account":"shared","call":1}]"#,
+                usageCacheKeys: ["account-1"])
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let failed = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response(
+                #"[{"provider":"codex","account":"shared","error":{"message":"transient"}}]"#,
+                usageCacheKeys: ["account-2"])
+        }
+        let row = try #require(Self.jsonRows(failed).first)
+
+        #expect(row["call"] == nil)
+        #expect(row["error"] != nil)
+
+        let timedOut = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 0.01)
+        {
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            return Self.response(
+                #"[{"provider":"codex","account":"shared","call":3}]"#,
+                usageCacheKeys: ["account-2"])
+        }
+
+        #expect(timedOut.status == .gatewayTimeout)
+        #expect(!Self.bodyString(timedOut).contains("\"call\":1"))
+    }
+
+    @Test
+    func `serve cache prunes accounts absent from a successful snapshot`() async throws {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response(#"[{"provider":"codex","account":"shared","call":1}]"#)
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response(#"[{"provider":"antigravity","account":"work","call":2}]"#)
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let refreshed = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response("""
+            [
+              {"provider":"codex","account":"shared","error":{"message":"transient"}},
+              {"provider":"antigravity","account":"work","call":3}
+            ]
+            """)
+        }
+        let rows = try Self.jsonRows(refreshed)
+
+        #expect(Self.row(rows, provider: "codex", account: "shared")?["error"] != nil)
+        #expect(Self.row(rows, provider: "antigravity", account: "work")?["call"] as? Int == 3)
+    }
+
+    @Test
+    func `serve cache fails closed when all-error rows have ambiguous identities`() async throws {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response(
+                """
+                [
+                  {"provider":"codex","account":"shared","slot":"first","call":1},
+                  {"provider":"codex","account":"shared","slot":"second","call":1},
+                  {"provider":"antigravity","account":"work","call":1}
+                ]
+                """,
+                usageCacheKeys: [nil, nil, nil])
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let failed = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response(
+                """
+                [
+                  {
+                    "provider":"codex",
+                    "account":"shared",
+                    "slot":"first",
+                    "error":{"message":"transient"}
+                  },
+                  {
+                    "provider":"codex",
+                    "account":"shared",
+                    "slot":"second",
+                    "error":{"message":"transient"}
+                  },
+                  {"provider":"antigravity","account":"work","error":{"message":"transient"}}
+                ]
+                """,
+                usageCacheKeys: [nil, nil, nil])
+        }
+        let rows = try Self.jsonRows(failed)
+
+        #expect(rows.count == 3)
+        #expect(rows.allSatisfy { $0["call"] == nil })
+        #expect(rows.allSatisfy { $0["error"] != nil })
     }
 
     @Test
@@ -448,12 +1110,68 @@ struct CLIServeRouterTests {
         }
     }
 
-    private static func response(_ body: String, status: CLIHTTPStatus = .ok) -> CLILocalHTTPResponse {
-        CLILocalHTTPResponse(status: status, body: Data(body.utf8))
+    private static func response(
+        _ body: String,
+        status: CLIHTTPStatus = .ok,
+        usageCacheKeys: [String?]? = nil) -> CLILocalHTTPResponse
+    {
+        let data = Data(body.utf8)
+        return CLILocalHTTPResponse(
+            status: status,
+            body: data,
+            usageCacheKeys: usageCacheKeys ?? Self.syntheticUsageCacheKeys(data))
     }
 
     private static func bodyString(_ response: CLILocalHTTPResponse) -> String {
         String(data: response.body, encoding: .utf8) ?? ""
+    }
+
+    private static func jsonRows(_ response: CLILocalHTTPResponse) throws -> [[String: Any]] {
+        try #require(JSONSerialization.jsonObject(with: response.body) as? [[String: Any]])
+    }
+
+    private static func row(
+        _ rows: [[String: Any]],
+        provider: String,
+        account: String) -> [String: Any]?
+    {
+        rows.first {
+            $0["provider"] as? String == provider
+                && $0["account"] as? String == account
+        }
+    }
+
+    private static func row(_ rows: [[String: Any]], provider: String) -> [String: Any]? {
+        rows.first { $0["provider"] as? String == provider }
+    }
+
+    private static func syntheticUsageCacheKeys(_ data: Data) -> [String?]? {
+        guard let rows = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else { return nil }
+        return rows.map { row in
+            guard let provider = row["provider"] as? String else { return nil }
+            let account = row["account"] as? String ?? "default"
+            return "test:\(provider):\(account)"
+        }
+    }
+
+    private static func codexVisibleAccount(
+        id: String,
+        email: String = "user@example.com",
+        workspaceAccountID: String?,
+        authFingerprint: String?,
+        storedAccountID: UUID?) -> CodexVisibleAccount
+    {
+        CodexVisibleAccount(
+            id: id,
+            email: email,
+            workspaceAccountID: workspaceAccountID,
+            authFingerprint: authFingerprint,
+            storedAccountID: storedAccountID,
+            selectionSource: .liveSystem,
+            isActive: true,
+            isLive: true,
+            canReauthenticate: true,
+            canRemove: false)
     }
 }
 

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -104,6 +104,18 @@ struct CLIServeRouterTests {
             flags: [])) == nil)
         #expect(CodexBarCLI.decodeServeRefreshInterval(from: ParsedValues(
             positional: [],
+            options: ["refreshInterval": ["inf"]],
+            flags: [])) == nil)
+        #expect(CodexBarCLI.decodeServeRefreshInterval(from: ParsedValues(
+            positional: [],
+            options: ["refreshInterval": ["86401"]],
+            flags: [])) == 86401)
+        #expect(CodexBarCLI.decodeServeRefreshInterval(from: ParsedValues(
+            positional: [],
+            options: ["refreshInterval": ["86400"]],
+            flags: [])) == 86400)
+        #expect(CodexBarCLI.decodeServeRefreshInterval(from: ParsedValues(
+            positional: [],
             options: [:],
             flags: [])) == 60)
 
@@ -378,6 +390,30 @@ struct CLIServeRouterTests {
     }
 
     @Test
+    func `serve helper idle window outlives the refresh cadence`() {
+        #expect(CodexBarCLI.serveCLISessionIdleWindow(refreshInterval: 0) == 180)
+        #expect(CodexBarCLI.serveCLISessionIdleWindow(refreshInterval: 60) == 180)
+        #expect(CodexBarCLI.serveCLISessionIdleWindow(refreshInterval: 300) == 360)
+    }
+
+    @Test
+    func `local HTTP server stops its accept loop`() async throws {
+        let listening = ServeListeningSignal()
+        let server = CLILocalHTTPServer(host: "127.0.0.1", port: 0) { _ in
+            Self.response(#"{"status":"ok"}"#)
+        }
+        let task = Task {
+            try await server.run {
+                listening.signal()
+            }
+        }
+
+        await listening.wait()
+        server.stop()
+        try await task.value
+    }
+
+    @Test
     func `serve request timeout zero disables the deadline`() async {
         let cache = CLIServeResponseCache()
 
@@ -428,5 +464,33 @@ private actor ServeTestCounter {
 
     func current() -> Int {
         self.value
+    }
+}
+
+private final class ServeListeningSignal: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isSignaled = false
+
+    func signal() {
+        let continuation = self.lock.withLock {
+            self.isSignaled = true
+            defer { self.continuation = nil }
+            return self.continuation
+        }
+        continuation?.resume()
+    }
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            let shouldResume = self.lock.withLock {
+                guard !self.isSignaled else { return true }
+                self.continuation = continuation
+                return false
+            }
+            if shouldResume {
+                continuation.resume()
+            }
+        }
     }
 }

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -270,7 +270,7 @@ struct CLIServeRouterTests {
         #expect(CodexBarCLI.usageCacheAccountKey(
             provider: .antigravity,
             account: nil,
-            codexVisibleAccount: nil) == "default:antigravity")
+            codexVisibleAccount: nil) == nil)
     }
 
     @Test
@@ -562,7 +562,7 @@ struct CLIServeRouterTests {
     }
 
     @Test
-    func `serve cache retains merged rows across a later timeout`() async throws {
+    func `serve cache fails closed on timeout after merged rows`() async {
         let cache = CLIServeResponseCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
@@ -604,14 +604,13 @@ struct CLIServeRouterTests {
             try? await Task.sleep(nanoseconds: 200_000_000)
             return Self.response("[]")
         }
-        let rows = try Self.jsonRows(timedOut)
-
-        #expect(Self.row(rows, provider: "codex")?["call"] as? Int == 2)
-        #expect(Self.row(rows, provider: "antigravity")?["call"] as? Int == 1)
+        #expect(timedOut.status == .gatewayTimeout)
+        #expect(!Self.bodyString(timedOut).contains("\"call\":1"))
+        #expect(!Self.bodyString(timedOut).contains("\"call\":2"))
     }
 
     @Test
-    func `serve cache retains partial fresh rows across a later timeout`() async throws {
+    func `serve cache fails closed on timeout after a partial refresh`() async {
         let cache = CLIServeResponseCache()
 
         _ = await CodexBarCLI.cachedServeResponse(
@@ -648,14 +647,13 @@ struct CLIServeRouterTests {
             try? await Task.sleep(nanoseconds: 200_000_000)
             return Self.response("[]")
         }
-        let rows = try Self.jsonRows(timedOut)
-
-        #expect(Self.row(rows, provider: "codex")?["call"] as? Int == 2)
-        #expect(Self.row(rows, provider: "antigravity")?["error"] != nil)
+        #expect(timedOut.status == .gatewayTimeout)
+        #expect(!Self.bodyString(timedOut).contains("\"call\":2"))
+        #expect(!Self.bodyString(timedOut).contains("antigravity"))
     }
 
     @Test
-    func `serve cache keeps newer rows after an older merged row expires`() async throws {
+    func `serve cache does not reconstruct usage rows after timeout`() async {
         let cache = CLIServeResponseCache()
         let policy = CLIServeResponseCache.CachePolicy(ttl: 0, staleTTL: 10)
         let startedAt = Date(timeIntervalSince1970: 1000)
@@ -696,10 +694,9 @@ struct CLIServeRouterTests {
             policy: policy,
             now: timeoutAt,
             shouldCache: false)
-        let rows = try Self.jsonRows(timedOut)
-
-        #expect(rows.count == 1)
-        #expect(Self.row(rows, provider: "codex")?["call"] as? Int == 2)
+        #expect(timedOut.status == .gatewayTimeout)
+        #expect(Self.bodyString(timedOut).contains("request timed out"))
+        #expect(!Self.bodyString(timedOut).contains("\"call\":2"))
     }
 
     @Test
@@ -1042,6 +1039,74 @@ struct CLIServeRouterTests {
         #expect(rows.count == 3)
         #expect(rows.allSatisfy { $0["call"] == nil })
         #expect(rows.allSatisfy { $0["error"] != nil })
+    }
+
+    @Test
+    func `serve cache does not whole-fallback ambiguous usage after timeout`() async {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response(
+                #"[{"provider":"antigravity","account":"first@example.com","call":1}]"#,
+                usageCacheKeys: [nil])
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let timedOut = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 0.01)
+        {
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            return Self.response(
+                #"[{"provider":"antigravity","account":"second@example.com","call":2}]"#,
+                usageCacheKeys: [nil])
+        }
+
+        #expect(timedOut.status == .gatewayTimeout)
+        #expect(!Self.bodyString(timedOut).contains("first@example.com"))
+        #expect(!Self.bodyString(timedOut).contains("\"call\":1"))
+    }
+
+    @Test
+    func `serve cache mixed identities do not enable timeout fallback`() async {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            Self.response(
+                """
+                [
+                  {"provider":"codex","account":"stable@example.com","call":1},
+                  {"provider":"antigravity","account":"ambient@example.com","call":1}
+                ]
+                """,
+                usageCacheKeys: ["account-1", nil])
+        }
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let timedOut = await CodexBarCLI.cachedServeResponse(
+            key: "usage:",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 0.01)
+        {
+            try? await Task.sleep(nanoseconds: 200_000_000)
+            return Self.response("[]", usageCacheKeys: [])
+        }
+        #expect(timedOut.status == .gatewayTimeout)
+        #expect(!Self.bodyString(timedOut).contains("stable@example.com"))
+        #expect(!Self.bodyString(timedOut).contains("ambient@example.com"))
     }
 
     @Test

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -387,6 +387,9 @@ struct CLIServeRouterTests {
         #expect(CodexBarCLI.serveStaleTTL(refreshInterval: 0) == 0)
         #expect(CodexBarCLI.serveStaleTTL(refreshInterval: 1) == 300)
         #expect(CodexBarCLI.serveStaleTTL(refreshInterval: 60) == 600)
+        #expect(CodexBarCLI.serveStaleTTL(refreshInterval: 1800) == 3600)
+        #expect(CodexBarCLI.serveStaleTTL(refreshInterval: 86401) == 3600)
+        #expect(CodexBarCLI.serveStaleTTL(refreshInterval: .infinity) == 3600)
     }
 
     @Test

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -320,6 +320,64 @@ struct CLIServeRouterTests {
     }
 
     @Test
+    func `serve cache serves last good payload when refresh fails`() async {
+        let cache = CLIServeResponseCache()
+        let counter = ServeTestCounter()
+
+        let first = await CodexBarCLI.cachedServeResponse(
+            key: "usage:antigravity",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            let call = await counter.increment()
+            return Self.response("[{\"provider\":\"antigravity\",\"call\":\(call)}]")
+        }
+        #expect(first.status == .ok)
+
+        // Let the fresh cache entry expire so the next request re-fetches.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let failed = await CodexBarCLI.cachedServeResponse(
+            key: "usage:antigravity",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            _ = await counter.increment()
+            return Self.response(
+                "[{\"provider\":\"antigravity\",\"error\":{\"message\":\"transient\"}}]")
+        }
+
+        // Transient failure is masked by the last good payload.
+        #expect(failed.status == .ok)
+        #expect(Self.bodyString(failed) == Self.bodyString(first))
+        #expect(await counter.current() == 2)
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let recovered = await CodexBarCLI.cachedServeResponse(
+            key: "usage:antigravity",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            let call = await counter.increment()
+            return Self.response("[{\"provider\":\"antigravity\",\"call\":\(call)}]")
+        }
+
+        #expect(recovered.status == .ok)
+        #expect(Self.bodyString(recovered).contains("\"call\":3"))
+    }
+
+    @Test
+    func `serve stale ttl is bounded and disabled without caching`() {
+        #expect(CodexBarCLI.serveStaleTTL(refreshInterval: 0) == 0)
+        #expect(CodexBarCLI.serveStaleTTL(refreshInterval: 1) == 300)
+        #expect(CodexBarCLI.serveStaleTTL(refreshInterval: 60) == 600)
+    }
+
+    @Test
     func `serve request timeout zero disables the deadline`() async {
         let cache = CLIServeResponseCache()
 

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -1,12 +1,22 @@
 import Commander
 import Foundation
 import Testing
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
 @testable import CodexBarCLI
 @testable import CodexBarCore
 
 // Cache state-machine coverage is intentionally kept together for sequence readability.
 // swiftlint:disable:next type_body_length
 struct CLIServeRouterTests {
+    @Test
+    func `termination monitor handles interactive and hangup signals`() {
+        #expect(CLITerminationSignalMonitor.signalNumbers == [SIGINT, SIGTERM, SIGHUP])
+    }
+
     @Test
     func `local http parser accepts only loopback host headers`() throws {
         let allowedHosts = [

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -1,4 +1,3 @@
-import CodexBarCore
 import Commander
 import Foundation
 import Testing
@@ -1117,6 +1116,44 @@ struct CLIServeRouterTests {
         #expect(CodexBarCLI.serveStaleTTL(refreshInterval: 1800) == 3600)
         #expect(CodexBarCLI.serveStaleTTL(refreshInterval: 86401) == 3600)
         #expect(CodexBarCLI.serveStaleTTL(refreshInterval: .infinity) == 3600)
+    }
+
+    @Test
+    func `serve cache prunes stale variants from old configurations`() async {
+        let cache = CLIServeResponseCache()
+        let startedAt = Date(timeIntervalSince1970: 1000)
+        let policy = CLIServeResponseCache.CachePolicy(
+            ttl: 0,
+            staleTTL: CLIServeResponseCache.maximumStaleTTL)
+
+        _ = await cache.responseOrStartFetch(for: "config:old", now: startedAt)
+        _ = await cache.completeFetch(
+            Self.response(#"{"status":"ok"}"#),
+            for: "config:old",
+            policy: policy,
+            now: startedAt,
+            shouldCache: true)
+
+        _ = await cache.responseOrStartFetch(for: "usage:old", now: startedAt)
+        _ = await cache.completeFetch(
+            Self.response(
+                #"[{"provider":"codex","call":1}]"#,
+                usageCacheKeys: ["account-1"]),
+            for: "usage:old",
+            policy: policy,
+            now: startedAt,
+            shouldCache: true)
+        #expect(await cache.cachedStaleVariantCount() == 2)
+
+        let expiredAt = startedAt.addingTimeInterval(CLIServeResponseCache.maximumStaleTTL + 1)
+        _ = await cache.responseOrStartFetch(for: "config:new", now: expiredAt)
+        #expect(await cache.cachedStaleVariantCount() == 0)
+        _ = await cache.completeFetch(
+            Self.response(#"{"status":"ok"}"#),
+            for: "config:new",
+            policy: policy,
+            now: expiredAt,
+            shouldCache: false)
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuCardAntigravityTests.swift
+++ b/Tests/CodexBarTests/MenuCardAntigravityTests.swift
@@ -109,6 +109,9 @@ struct MenuCardAntigravityTests {
         #expect(model.metrics[1].percent == 0)
         #expect(model.metrics[1].percentLabel == "0% left")
         #expect(model.metrics[1].resetText == nil)
+        let unknownMetric = try #require(model.metrics.first { $0.title == "Gemini 3.1 Pro (Low)" })
+        #expect(unknownMetric.statusText == "Unavailable - Resets in 1h")
+        #expect(unknownMetric.resetText == nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
+++ b/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
@@ -46,6 +46,50 @@ struct ProviderDiagnosticExportTests {
     }
 
     @Test
+    func `diagnostic export marks named windows with unknown usage`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let summary = ProviderDiagnosticUsageSummary(from: UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "nebula-window",
+                    title: "Nebula Window",
+                    window: RateWindow(
+                        usedPercent: 100,
+                        windowMinutes: nil,
+                        resetsAt: now.addingTimeInterval(3600),
+                        resetDescription: nil),
+                    usageKnown: false),
+            ],
+            updatedAt: now))
+
+        let json = try self.json(summary)
+        let object = try #require(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any])
+        let windows = try #require(object["windows"] as? [[String: Any]])
+
+        #expect(windows.first?["usageKnown"] as? Bool == false)
+    }
+
+    @Test
+    func `diagnostic rate window defaults legacy payloads to known usage`() throws {
+        let json = """
+        {
+          "label": "Legacy Window",
+          "usedPercent": 42,
+          "hasResetDescription": false
+        }
+        """
+
+        let window = try JSONDecoder().decode(
+            ProviderDiagnosticRateWindow.self,
+            from: Data(json.utf8))
+
+        #expect(window.usageKnown)
+    }
+
+    @Test
     func `raw error text never appears in encoded JSON`() throws {
         let export = ProviderDiagnosticExport(
             timestamp: Date(timeIntervalSince1970: 1_700_000_000),

--- a/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
+++ b/Tests/CodexBarTests/ProvidersPaneCoverageTests.swift
@@ -309,6 +309,41 @@ struct ProvidersPaneCoverageTests {
     }
 
     @Test
+    func `provider detail renders metric status without progress`() {
+        let metric = UsageMenuCardView.Model.Metric(
+            id: "fixture",
+            title: "Example quota",
+            percent: 0,
+            percentStyle: .left,
+            statusText: "Unavailable",
+            resetText: nil,
+            detailText: nil,
+            detailLeftText: nil,
+            detailRightText: nil,
+            pacePercent: nil,
+            paceOnTop: false)
+
+        #expect(ProviderDetailView<EmptyView>.metricInlinePresentation(metric) == .status("Unavailable"))
+    }
+
+    @Test
+    func `provider detail renders ordinary metric progress`() {
+        let metric = UsageMenuCardView.Model.Metric(
+            id: "fixture",
+            title: "Example quota",
+            percent: 50,
+            percentStyle: .left,
+            resetText: nil,
+            detailText: nil,
+            detailLeftText: nil,
+            detailRightText: nil,
+            pacePercent: nil,
+            paceOnTop: false)
+
+        #expect(ProviderDetailView<EmptyView>.metricInlinePresentation(metric) == .progress)
+    }
+
+    @Test
     func `opencode manual cookie source hides cached browser trailing text`() {
         let settings = Self.makeSettingsStore(suite: "ProvidersPaneCoverageTests-opencode-manual")
         let store = Self.makeUsageStore(settings: settings)

--- a/Tests/CodexBarTests/TTYCommandRunnerTests.swift
+++ b/Tests/CodexBarTests/TTYCommandRunnerTests.swift
@@ -73,6 +73,28 @@ struct TTYCommandRunnerEnvTests {
     }
 
     @Test
+    func `shutdown waits for launch cleanup before draining`() {
+        TTYCommandRunner._test_resetTrackedProcesses()
+        defer { TTYCommandRunner._test_resetTrackedProcesses() }
+
+        #expect(TTYCommandRunner._test_beginTrackedProcessLaunch())
+        let fenceSet = DispatchSemaphore(value: 0)
+        let completed = DispatchSemaphore(value: 0)
+        DispatchQueue.global().async {
+            _ = TTYCommandRunner._test_drainTrackedProcessesForShutdown {
+                fenceSet.signal()
+            }
+            completed.signal()
+        }
+
+        #expect(fenceSet.wait(timeout: .now() + 1) == .success)
+        #expect(completed.wait(timeout: .now() + 0.05) == .timedOut)
+        #expect(!TTYCommandRunner._test_registerTrackedProcess(pid: 2002, binary: "codex"))
+        TTYCommandRunner._test_endTrackedProcessLaunch()
+        #expect(completed.wait(timeout: .now() + 1) == .success)
+    }
+
+    @Test
     func `shutdown resolver skips host process group fallback`() {
         let hostGroup: pid_t = 4242
         let targets: [(pid: pid_t, binary: String, processGroup: pid_t?)] = [

--- a/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
@@ -196,6 +196,89 @@ struct UsageStoreHighestUsageTests {
     }
 
     @Test
+    func `automatic metric excludes antigravity only when every lane is exhausted`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-all-100"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.setMenuBarMetricPreference(.automatic, for: .antigravity)
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let antigravityMeta = registry.metadata[.antigravity] {
+            settings.setProviderEnabled(provider: .antigravity, metadata: antigravityMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+
+        let codexSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 80, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        let antigravitySnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 100, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 100, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            tertiary: RateWindow(usedPercent: 100, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(codexSnapshot, provider: .codex)
+        store._setSnapshotForTesting(antigravitySnapshot, provider: .antigravity)
+
+        let highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 80)
+    }
+
+    @Test
+    func `automatic metric skips antigravity with no quota lanes`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-empty"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.setMenuBarMetricPreference(.automatic, for: .antigravity)
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let antigravityMeta = registry.metadata[.antigravity] {
+            settings.setProviderEnabled(provider: .antigravity, metadata: antigravityMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+
+        let codexSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 80, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        let antigravitySnapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .antigravity,
+                accountEmail: "user@example.com",
+                accountOrganization: nil,
+                loginMethod: "Pro"))
+
+        store._setSnapshotForTesting(codexSnapshot, provider: .codex)
+        store._setSnapshotForTesting(antigravitySnapshot, provider: .antigravity)
+
+        let highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 80)
+    }
+
+    @Test
     func `automatic metric uses zai 5-hour token lane when ranking highest usage`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-zai-automatic-tertiary"),

--- a/TestsLinux/AntigravityCLIStrategyLinuxTests.swift
+++ b/TestsLinux/AntigravityCLIStrategyLinuxTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+#if os(Linux)
+struct AntigravityCLIStrategyLinuxTests {
+    @Test
+    func `cli HTTPS is unavailable without Linux localhost trust`() async throws {
+        let binaryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-antigravity-\(UUID().uuidString)")
+        try Data("#!/bin/sh\n".utf8).write(to: binaryURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: binaryURL.path)
+        defer { try? FileManager.default.removeItem(at: binaryURL) }
+
+        let context = ProviderFetchContext(
+            runtime: .cli,
+            sourceMode: .cli,
+            includeCredits: false,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: ["ANTIGRAVITY_CLI_PATH": binaryURL.path],
+            settings: nil,
+            fetcher: UsageFetcher(environment: [:]),
+            claudeFetcher: StubClaudeFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0))
+        let isAvailable = await AntigravityCLIHTTPSFetchStrategy().isAvailable(context)
+
+        #expect(!isAvailable)
+    }
+
+    private struct StubClaudeFetcher: ClaudeUsageFetching {
+        func loadLatestUsage(model _: String) async throws -> ClaudeUsageSnapshot {
+            throw ClaudeUsageError.parseFailed("stub")
+        }
+
+        func debugRawProbe(model _: String) async -> String {
+            "stub"
+        }
+
+        func detectVersion() -> String? {
+            nil
+        }
+    }
+}
+#endif

--- a/TestsLinux/AntigravityProcessLauncherLinuxTests.swift
+++ b/TestsLinux/AntigravityProcessLauncherLinuxTests.swift
@@ -1,0 +1,58 @@
+#if canImport(Glibc)
+import Foundation
+import Glibc
+import Testing
+@testable import CodexBarCore
+
+struct AntigravityProcessLauncherLinuxTests {
+    @Test
+    func `pty launcher uses home and closes unrelated descriptors`() throws {
+        let tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("antigravity-spawn-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+        let inheritedSourceFD = open("/dev/null", O_RDONLY)
+        guard inheritedSourceFD >= 0 else {
+            Issue.record("Failed to open descriptor fixture")
+            return
+        }
+        defer { close(inheritedSourceFD) }
+        let inheritedFD = fcntl(inheritedSourceFD, F_DUPFD, 200)
+        guard inheritedFD >= 200 else {
+            Issue.record("Failed to duplicate descriptor fixture")
+            return
+        }
+        defer { close(inheritedFD) }
+
+        let outputURL = tempDirectory.appendingPathComponent("result.txt")
+        let scriptURL = tempDirectory.appendingPathComponent("probe.sh")
+        let script = """
+        #!/bin/sh
+        pwd > \(outputURL.path)
+        if [ -e /proc/self/fd/\(inheritedFD) ]; then
+          echo inherited >> \(outputURL.path)
+        else
+          echo closed >> \(outputURL.path)
+        fi
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        #expect(chmod(scriptURL.path, 0o700) == 0)
+
+        let handle = try AntigravityPTYProcessLauncher().launch(binary: scriptURL.path)
+        defer {
+            handle.killRoot()
+            handle.terminateTree(signal: SIGKILL, knownDescendants: [])
+            handle.closePTY()
+        }
+
+        for _ in 0..<200 where !FileManager.default.fileExists(atPath: outputURL.path) {
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        let lines = try String(contentsOf: outputURL, encoding: .utf8)
+            .split(separator: "\n")
+            .map(String.init)
+        #expect(lines == [NSHomeDirectory(), "closed"])
+    }
+}
+#endif

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -9,7 +9,14 @@ read_when:
 
 # Antigravity provider
 
-Antigravity supports local probing of either the IDE or the CLI (`agy` / `antigravity-cli`) language server, plus Google OAuth-backed remote usage. The OAuth path can store multiple Google accounts through the shared token-account switcher.
+Antigravity supports three usage data sources:
+
+1. The desktop app's local `language_server` (preferred when the IDE/desktop app is open).
+2. The `agy` CLI's embedded HTTPS localhost server (used when the desktop app is closed).
+3. Google OAuth-backed remote usage (final fallback, and the source used for multi-account switching). The OAuth path can store multiple Google accounts through the shared token-account switcher.
+
+The local and CLI paths both prefer Antigravity's internal `GetUserStatus` quota payload and may fall back to
+`GetCommandModelConfigs`; CodexBar never scrapes the desktop UI or the `agy` TUI.
 
 ## OAuth account switching
 
@@ -26,11 +33,13 @@ Antigravity supports local probing of either the IDE or the CLI (`agy` / `antigr
 - `POST https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels`
 - `POST https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota`
 
-## Local data sources + fallback order
-
 ## Data sources + fallback order
 
-1) **Process detection**
+### 1) Desktop local probe
+
+When the Antigravity desktop app is running:
+
+1. **Process detection**
    - Command: `ps -ax -o pid=,command=`.
    - Match either:
      - the **IDE** language server: process name `language_server_macos` plus Antigravity
@@ -45,24 +54,61 @@ Antigravity supports local probing of either the IDE or the CLI (`agy` / `antigr
        - **CLI** matches accept an empty token, because the CLI's language server
          exposes no `--csrf_token` flag and requires none.
      - `--extension_server_port <port>` (HTTP fallback; IDE only).
+     - `--extension_server_csrf_token <token>` (preferred HTTP fallback token when present).
 
-2) **Port discovery**
-   - Command: `lsof -nP -iTCP -sTCP:LISTEN -p <pid>`.
+2. **Port discovery**
+   - Command: `lsof -nP -iTCP -sTCP:LISTEN -a -p <pid>`.
    - All listening ports are probed.
 
-3) **Connect port probe (HTTPS)**
+3. **Connect port probe (HTTPS)**
    - `POST https://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/GetUnleashData`
    - Headers:
      - `X-Codeium-Csrf-Token: <token>`
      - `Connect-Protocol-Version: 1`
    - First 200 OK response selects the connect port.
 
-4) **Quota fetch**
+4. **Quota fetch**
    - Primary:
      - `POST https://127.0.0.1:<connectPort>/exa.language_server_pb.LanguageServerService/GetUserStatus`
    - Fallback:
      - `POST https://127.0.0.1:<connectPort>/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs`
    - If HTTPS fails, retry over HTTP on `extension_server_port`.
+
+### 2) `agy` CLI HTTPS source
+
+When source mode is `auto` or `cli` and the desktop local probe fails, CodexBar resolves `agy` via:
+
+- `ANTIGRAVITY_CLI_PATH`
+- `PATH` / login-shell path lookup
+- Well-known paths:
+  - `~/.local/bin/agy`
+  - `/opt/homebrew/bin/agy`
+  - `/usr/local/bin/agy`
+
+CodexBar launches `agy` in a PTY because the CLI exposes its quota server only while the interactive process is alive.
+The implementation still does **not** scrape terminal output; it only keeps the process alive, drains discarded PTY
+rendering, discovers listening ports with `lsof`, and probes the local HTTPS server:
+
+- First: `POST https://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/GetUserStatus`
+- Fallback: `POST https://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs`
+
+The fallback can return quota without the account email or plan fields from `GetUserStatus`.
+
+Differences from the desktop local probe:
+
+- The CLI HTTPS endpoint does **not** require `X-Codeium-Csrf-Token`.
+- Readiness is endpoint-based: CodexBar retries until one of the quota endpoints parses, because fresh `agy`
+  processes can bind a port before the quota service is initialized.
+- App runtime uses a bounded warm session: `agy` is kept alive briefly after a refresh, then stopped on idle. CLI runtime
+  tears it down immediately after the one-shot fetch.
+- Repeated endpoint failures force a relaunch instead of reusing a wedged process forever.
+- CodexBar records the launched pid + executable identity and conservatively reaps only its own matching stale `agy`
+  process on the next launch. It never blind-kills a user-launched `agy`.
+
+### 3) OAuth remote fallback
+
+When source mode is `auto`, OAuth is used after both local paths fail. If a specific saved Google account is selected,
+CodexBar uses OAuth directly for that account. When source mode is `oauth`, only OAuth is used.
 
 ## Request body (summary)
 - Minimal metadata payload:
@@ -76,9 +122,9 @@ Antigravity supports local probing of either the IDE or the CLI (`agy` / `antigr
   - `userStatus.cascadeModelConfigData.clientModelConfigs[].quotaInfo.remainingFraction`
   - `userStatus.cascadeModelConfigData.clientModelConfigs[].quotaInfo.resetTime`
 - Mapping priority:
-  1) Claude (label contains `claude` but not `thinking`)
-  2) Gemini Pro Low (label contains `pro` + `low`)
-  3) Gemini Flash (label contains `gemini` + `flash`)
+  1) Claude family (thinking variants participate in the normal Claude representative selection)
+  2) Gemini Pro Low
+  3) Gemini Flash
   4) Fallback: lowest remaining percent
 - `resetTime` parsing:
   - ISO-8601 preferred; numeric epoch seconds as fallback.
@@ -90,12 +136,18 @@ Antigravity supports local probing of either the IDE or the CLI (`agy` / `antigr
   - Display: `Antigravity`
   - Labels: `Claude` (primary), `Gemini Pro` (secondary), `Gemini Flash` (tertiary)
 - Status badge: Google Workspace incidents for the Gemini product.
+- Antigravity has independent Claude, Gemini Pro, Gemini Flash, and additional model-specific quota windows such as
+  GPT-OSS. In automatic menu-bar/highest-usage selection, CodexBar treats the provider as exhausted only when the
+  displayed Claude/Gemini summary lanes are exhausted; additional model windows remain visible in detailed usage
+  breakdowns.
 
 ## Constraints
 - Internal protocol; fields may change.
-- Requires `lsof` for port detection.
-- Local HTTPS uses a self-signed cert; the probe allows insecure TLS.
+- Requires `lsof` for local/CLI port detection.
+- Local HTTPS uses a self-signed cert; the probe allows insecure TLS only for loopback hosts.
 
 ## Key files
+- `Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift`
+- `Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift`
 - `Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift`
 - `Sources/CodexBar/Providers/Antigravity/AntigravityProviderImplementation.swift`

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -24,7 +24,8 @@ The local and CLI paths both prefer Antigravity's internal `GetUserStatus` quota
 - A successful login writes the latest shared credentials to `~/.codexbar/antigravity/oauth_creds.json` and upserts a token-account entry for the Google account.
 - Each token-account entry stores serialized `AntigravityOAuthCredentials` and is injected into remote fetches through `ANTIGRAVITY_OAUTH_CREDENTIALS_JSON`.
 - When a token account is selected, the OAuth fetcher uses that account before falling back to the shared credentials file.
-- The menu action is labeled `Add Account...`; switching between saved accounts uses the existing segmented/stacked token-account menu UI.
+  Local desktop and `agy` CLI probes remain source-mode driven and are not scoped to saved OAuth accounts.
+- The menu action is labeled `Add Account...`; switching between saved accounts scopes Google OAuth fetches.
 
 ## Remote OAuth data sources
 
@@ -107,8 +108,8 @@ Differences from the desktop local probe:
 
 ### 3) OAuth remote fallback
 
-When source mode is `auto`, OAuth is used after both local paths fail. If a specific saved Google account is selected,
-CodexBar uses OAuth directly for that account. When source mode is `oauth`, only OAuth is used.
+When source mode is `auto`, OAuth is used after both local paths fail. A selected saved Google account scopes the OAuth
+fallback, but it does not bypass the desktop local or `agy` CLI probes. When source mode is `oauth`, only OAuth is used.
 
 ## Request body (summary)
 - Minimal metadata payload:

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -151,6 +151,9 @@ When source mode is `oauth`, only OAuth is used.
   GPT-OSS. In automatic menu-bar/highest-usage selection, CodexBar treats the provider as exhausted only when the
   displayed Claude/Gemini summary lanes are exhausted; additional model windows remain visible in detailed usage
   breakdowns.
+- Some Antigravity local/CLI model config entries include reset metadata but omit `remainingFraction`. Those windows stay
+  in `extraRateWindows` for reset context and are marked with `usageKnown: false`; clients should not render their
+  `usedPercent` as a real exhausted quota.
 
 ## Constraints
 - Internal protocol; fields may change.

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -44,7 +44,13 @@ When the Antigravity desktop app is running:
 
 1. **Process detection**
    - Command: `ps -ax -o pid=,command=`.
-   - Match either:
+   - The desktop local strategy scopes detection to **IDE** language servers only
+     (`AntigravityStatusProbe(processScope: .ideOnly)`). It deliberately does **not**
+     attach to an `agy` CLI process: a stale or still-initializing `agy` accepts the
+     connection but returns transient `GetUserStatus` errors, which would burn the
+     probe timeout. `agy` is owned exclusively by the CLI HTTPS source below, which
+     waits for real API readiness. The probe still classifies both kinds
+     (`processInfo(scope: .ideAndCLI)` is used by `isRunning()` for status reporting):
      - the **IDE** language server: process name `language_server_macos` plus Antigravity
        markers (`--app_data_dir antigravity` OR path contains `/antigravity/`); or
      - the **CLI**: an `antigravity-cli` / `antigravity_cli` path segment, or the

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -24,7 +24,9 @@ The local and CLI paths both prefer Antigravity's internal `GetUserStatus` quota
 - A successful login writes the latest shared credentials to `~/.codexbar/antigravity/oauth_creds.json` and upserts a token-account entry for the Google account.
 - Each token-account entry stores serialized `AntigravityOAuthCredentials` and is injected into remote fetches through `ANTIGRAVITY_OAUTH_CREDENTIALS_JSON`.
 - When a token account is selected, the OAuth fetcher uses that account before falling back to the shared credentials file.
-  Local desktop and `agy` CLI probes remain source-mode driven and are not scoped to saved OAuth accounts.
+  In `auto` mode the ambient local desktop and `agy` CLI probes still run first, but a snapshot whose account does not
+  match the selected account is rejected so the pipeline falls through to the account-scoped OAuth fetch (see
+  `AntigravitySelectedAccountGuard`). Explicit `cli`/`oauth` source modes stay authoritative and are not re-checked.
 - The menu action is labeled `Add Account...`; switching between saved accounts scopes Google OAuth fetches.
 
 ## Remote OAuth data sources
@@ -109,7 +111,9 @@ Differences from the desktop local probe:
 ### 3) OAuth remote fallback
 
 When source mode is `auto`, OAuth is used after both local paths fail. A selected saved Google account scopes the OAuth
-fallback, but it does not bypass the desktop local or `agy` CLI probes. When source mode is `oauth`, only OAuth is used.
+fallback. The local and `agy` CLI probes still run first, but in `auto` mode their snapshots are accepted only when the
+reported account matches the selected account; otherwise the pipeline falls through to this account-scoped OAuth fetch.
+When source mode is `oauth`, only OAuth is used.
 
 ## Request body (summary)
 - Minimal metadata payload:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -49,6 +49,7 @@ See `docs/configuration.md` for the schema.
   - `--refresh-interval <seconds>` defaults to `60` and controls the in-memory response cache TTL.
   - `--request-timeout <seconds>` defaults to `30` and bounds each request before returning `504 Gateway Timeout`; use `0` to keep waiting indefinitely.
   - Provider config is reloaded for each usage/cost request; cache entries are keyed by the loaded config so provider toggles and source changes do not require restarting `serve`.
+  - Transient refresh failures fall back to the last good response for up to ten refresh intervals (minimum five minutes) so polling clients do not flicker between data and errors; disabled when `--refresh-interval 0`.
   - v1 binds to `127.0.0.1` only and rejects non-loopback `Host` headers. It does not expose remote bind, auth, CORS, TLS, or daemon mode.
   - Endpoints: `GET /health`, `GET /usage`, `GET /usage?provider=<id|both|all>`, `GET /cost`, `GET /cost?provider=<id|both|all>`.
   - Codex usage responses include every visible Codex account, matching the menu bar switcher.


### PR DESCRIPTION
## Summary
- add an Antigravity `agy` CLI HTTPS fallback when the desktop app is closed
- harden warm-session ownership so live CodexBar owners keep their persisted CLI records
- add focused coverage for CLI session lifecycle, fetch strategy fallback, and menu metric selection
- make Antigravity usage source mode authoritative even when Google OAuth accounts are configured
- leave `CHANGELOG.md` untouched for the release flow

## Rationale
Antigravity desktop exposes a local `GetUserStatus` API while the desktop app is running. `agy` exposes the same local HTTPS status API without launching the full desktop app, so CodexBar can use it as the closed-desktop local fallback.

In observed live Antigravity OAuth responses, CodexBar received Gemini-oriented account/quota data and did not receive the Claude model quota lanes returned by the local Antigravity/`agy` `GetUserStatus` endpoint. The remote OAuth parser can still parse Claude quotas if Google returns them, so this PR does not assume OAuth can never provide Claude models. The practical reason for the fallback is that the `agy` local path returned the full tested quota shape: Claude + Gemini per-model lanes, used percentages, and reset timestamps while the desktop app was closed.

## Verification
- `swift test --filter AntigravityCLISessionTests`
- `swift test --filter AntigravityCLIHTTPSFetchStrategyTests`
- `make check`
- `swift test`
- bundled local app was updated/relaunched; bundled `CodexBarCLI usage --provider antigravity --source auto` now returns `source: "cli"` with the normal Google account config present

## Runtime proof: closed-desktop `agy` fallback

Local bundle built and launched from this branch with `./Scripts/compile_and_run.sh`.

Desktop Antigravity/language server was not running:

```text
$ pgrep -fl "/Applications/Antigravity|Google Antigravity|language_server"
# no output
```

Auto mode with a normal config that includes an Antigravity Google OAuth account now still follows the source-mode pipeline and falls through to `agy` before OAuth:

```text
$ ./CodexBar.app/Contents/Helpers/CodexBarCLI usage --provider antigravity --source auto --format json --pretty --log-level debug
2026-06-05T23:38:55+0800 debug ... [CodexBarCore] Antigravity CLI session started binary=agy pid=<redacted>
2026-06-05T23:38:58+0800 debug ... [CodexBarCore] Antigravity CLI session stopping pid=<redacted> reason=one-shot CLI fetch
[
  {
    "account" : "<redacted>",
    "provider" : "antigravity",
    "source" : "cli",
    "usage" : {
      "accountEmail" : "<redacted>",
      "identity" : {
        "accountEmail" : "<redacted>",
        "loginMethod" : "Google AI Pro",
        "providerID" : "antigravity"
      },
      "primary" : { "usedPercent" : 100, "resetsAt" : "<redacted>" },
      "secondary" : { "usedPercent" : 100, "resetsAt" : "<redacted>" },
      "tertiary" : { "usedPercent" : 100, "resetsAt" : "<redacted>" },
      "extraRateWindows" : [
        { "title" : "Claude Opus 4.6 (Thinking)", "window" : { "usedPercent" : 100, "resetsAt" : "<redacted>" } },
        { "title" : "Claude Sonnet 4.6 (Thinking)", "window" : { "usedPercent" : 100, "resetsAt" : "<redacted>" } },
        { "title" : "Gemini 3.1 Pro (High)", "window" : { "usedPercent" : 100, "resetsAt" : "<redacted>" } }
      ],
      "updatedAt" : "<redacted>"
    }
  }
]
```

This reproduces the intended user-visible fix: OAuth had reported `source: "oauth"`, `primary: null`, and Gemini lanes at 100% left for the same account/config; the `agy` local path reports the depleted Claude and Gemini quota lanes.