### PR TITLE
Cache menu card heights and skip closed merged-menu rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.32.5 — Unreleased
 
 ### Fixed
-- Menu bar: defer merged-menu close rebuilds and cache repeated menu-card height measurements so dismissing or rapidly switching the merged dropdown avoids rebuilding SwiftUI-backed cards on the main thread (#1274, #1286). Thanks @hhh2210!
+- Menu bar: defer merged-menu close rebuilds and cache repeated menu-card height measurements so dismissing or rapidly switching the merged dropdown avoids rebuilding SwiftUI-backed cards on the main thread (#1274, #1286, #1314). Thanks @hhh2210!
 - Menu bar: observe a compact icon-state signature so merged status icons no longer redraw for provider snapshot changes that cannot affect the visible icon (#1297). Thanks @hhh2210!
 
 ## 0.32.4 — 2026-06-02

--- a/Sources/CodexBar/Localization.swift
+++ b/Sources/CodexBar/Localization.swift
@@ -16,12 +16,16 @@ private func appLanguageDefaults() -> UserDefaults {
     return UserDefaults(suiteName: "CodexBar") ?? .standard
 }
 
-private func isRunningTestsProcess() -> Bool {
+private let isRunningTestsProcessAtStartup: Bool = {
     let env = ProcessInfo.processInfo.environment
     if env["XCTestConfigurationFilePath"] != nil { return true }
     if env["TESTING_LIBRARY_VERSION"] != nil { return true }
     if env["SWIFT_TESTING"] != nil { return true }
     return NSClassFromString("XCTestCase") != nil
+}()
+
+private func isRunningTestsProcess() -> Bool {
+    isRunningTestsProcessAtStartup
 }
 
 private let standardAppLanguageAtProcessStart = UserDefaults.standard.string(forKey: "appLanguage")

--- a/Sources/CodexBar/MenuCardHeightFingerprint.swift
+++ b/Sources/CodexBar/MenuCardHeightFingerprint.swift
@@ -1,30 +1,60 @@
+import CryptoKit
+import Foundation
+
 extension UsageMenuCardView.Model {
     func heightFingerprint(section: String, additional: [String] = []) -> String {
-        MenuCardHeightFingerprint.join([
+        let notesFingerprint = MenuCardHeightFingerprint.join(self.usageNotes.map {
+            MenuCardHeightFingerprint.field("note", $0)
+        })
+        return MenuCardHeightFingerprint.join([
             "section=\(section)",
             "provider=\(self.provider.rawValue)",
-            "name=\(self.providerName)",
-            "email=\(self.email)",
-            "subtitle=\(self.subtitleText)",
+            MenuCardHeightFingerprint.field("name", self.providerName),
+            MenuCardHeightFingerprint.field("email", self.email),
+            MenuCardHeightFingerprint.field("subtitle", self.subtitleText),
             "subtitleStyle=\(self.subtitleStyle.heightFingerprint)",
-            "plan=\(self.planText ?? "")",
-            "placeholder=\(self.placeholder ?? "")",
-            "credits=\(self.creditsText ?? "")",
-            "creditsHint=\(self.creditsHintText ?? "")",
-            "creditsCopy=\(self.creditsHintCopyText ?? "")",
+            MenuCardHeightFingerprint.field("plan", self.planText),
+            MenuCardHeightFingerprint.field("placeholder", self.placeholder),
+            MenuCardHeightFingerprint.field("credits", self.creditsText),
+            "creditsRemaining=\(self.creditsRemaining.map(String.init(describing:)) ?? "nil")",
+            MenuCardHeightFingerprint.field("creditsHint", self.creditsHintText),
+            MenuCardHeightFingerprint.field("creditsCopy", self.creditsHintCopyText),
             "metrics=\(MenuCardHeightFingerprint.join(self.metrics.map(\.heightFingerprint)))",
-            "notes=\(MenuCardHeightFingerprint.join(self.usageNotes))",
+            "notes=\(notesFingerprint)",
             "dashboard=\(self.inlineUsageDashboard?.heightFingerprint ?? "")",
             "providerCost=\(self.providerCost?.heightFingerprint ?? "")",
             "tokenUsage=\(self.tokenUsage?.heightFingerprint ?? "")",
             "openaiAPI=\(self.openAIAPIUsage == nil ? "0" : "1")",
         ] + additional)
     }
+
+    static func heightFingerprintField(_ name: String, _ value: String?) -> String {
+        MenuCardHeightFingerprint.field(name, value)
+    }
 }
 
 private enum MenuCardHeightFingerprint {
+    private static let digestSalt = UUID().uuidString
+
     static func join(_ values: [String]) -> String {
         values.map { "\($0.count):\($0)" }.joined(separator: "|")
+    }
+
+    static func field(_ name: String, _ value: String?) -> String {
+        guard let value else {
+            return "\(name)=nil"
+        }
+        return "\(name)=\(Self.stringShape(value))"
+    }
+
+    private static func stringShape(_ value: String) -> String {
+        let digestInput = "\(Self.digestSalt)\u{0}\(value)"
+        let digest = SHA256.hash(data: Data(digestInput.utf8))
+            .prefix(12)
+            .map { String(format: "%02x", $0) }
+            .joined()
+        let lineCount = value.split(separator: "\n", omittingEmptySubsequences: false).count
+        return "chars:\(value.count),utf8:\(value.utf8.count),lines:\(lineCount),sha:\(digest)"
     }
 }
 
@@ -42,13 +72,13 @@ extension UsageMenuCardView.Model.Metric {
     fileprivate var heightFingerprint: String {
         MenuCardHeightFingerprint.join([
             self.id,
-            self.title,
-            self.percentLabel,
-            self.statusText ?? "",
-            self.resetText ?? "",
-            self.detailText ?? "",
-            self.detailLeftText ?? "",
-            self.detailRightText ?? "",
+            MenuCardHeightFingerprint.field("title", self.title),
+            MenuCardHeightFingerprint.field("percent", self.percentLabel),
+            MenuCardHeightFingerprint.field("status", self.statusText),
+            MenuCardHeightFingerprint.field("reset", self.resetText),
+            MenuCardHeightFingerprint.field("detail", self.detailText),
+            MenuCardHeightFingerprint.field("detailLeft", self.detailLeftText),
+            MenuCardHeightFingerprint.field("detailRight", self.detailRightText),
             self.pacePercent == nil ? "pace=0" : "pace=1",
             self.paceOnTop ? "paceTop=1" : "paceTop=0",
             self.cardStyle ? "card=1" : "card=0",
@@ -60,9 +90,9 @@ extension UsageMenuCardView.Model.Metric {
 extension UsageMenuCardView.Model.ProviderCostSection {
     fileprivate var heightFingerprint: String {
         MenuCardHeightFingerprint.join([
-            self.title,
-            self.spendLine,
-            self.percentLine ?? "",
+            MenuCardHeightFingerprint.field("title", self.title),
+            MenuCardHeightFingerprint.field("spend", self.spendLine),
+            MenuCardHeightFingerprint.field("percentLine", self.percentLine),
             self.percentUsed == nil ? "percent=0" : "percent=1",
         ])
     }
@@ -71,11 +101,11 @@ extension UsageMenuCardView.Model.ProviderCostSection {
 extension UsageMenuCardView.Model.TokenUsageSection {
     fileprivate var heightFingerprint: String {
         MenuCardHeightFingerprint.join([
-            self.sessionLine,
-            self.monthLine,
-            self.hintLine ?? "",
-            self.errorLine ?? "",
-            self.errorCopyText ?? "",
+            MenuCardHeightFingerprint.field("session", self.sessionLine),
+            MenuCardHeightFingerprint.field("month", self.monthLine),
+            MenuCardHeightFingerprint.field("hint", self.hintLine),
+            MenuCardHeightFingerprint.field("error", self.errorLine),
+            MenuCardHeightFingerprint.field("errorCopy", self.errorCopyText),
         ])
     }
 }
@@ -83,11 +113,11 @@ extension UsageMenuCardView.Model.TokenUsageSection {
 extension InlineUsageDashboardModel {
     fileprivate var heightFingerprint: String {
         MenuCardHeightFingerprint.join([
-            self.accessibilityLabel,
+            MenuCardHeightFingerprint.field("accessibility", self.accessibilityLabel),
             self.valueStyle.heightFingerprint,
             MenuCardHeightFingerprint.join(self.kpis.map(\.heightFingerprint)),
             MenuCardHeightFingerprint.join(self.points.map(\.heightFingerprint)),
-            MenuCardHeightFingerprint.join(self.detailLines),
+            MenuCardHeightFingerprint.join(self.detailLines.map { MenuCardHeightFingerprint.field("detail", $0) }),
         ])
     }
 }
@@ -95,8 +125,8 @@ extension InlineUsageDashboardModel {
 extension InlineUsageDashboardModel.KPI {
     fileprivate var heightFingerprint: String {
         MenuCardHeightFingerprint.join([
-            self.title,
-            self.value,
+            MenuCardHeightFingerprint.field("title", self.title),
+            MenuCardHeightFingerprint.field("value", self.value),
             self.emphasis ? "1" : "0",
         ])
     }
@@ -106,8 +136,8 @@ extension InlineUsageDashboardModel.Point {
     fileprivate var heightFingerprint: String {
         MenuCardHeightFingerprint.join([
             self.id,
-            self.label,
-            self.accessibilityValue,
+            MenuCardHeightFingerprint.field("label", self.label),
+            MenuCardHeightFingerprint.field("accessibilityValue", self.accessibilityValue),
         ])
     }
 }

--- a/Sources/CodexBar/MenuCardHeightFingerprint.swift
+++ b/Sources/CodexBar/MenuCardHeightFingerprint.swift
@@ -1,0 +1,126 @@
+extension UsageMenuCardView.Model {
+    func heightFingerprint(section: String, additional: [String] = []) -> String {
+        MenuCardHeightFingerprint.join([
+            "section=\(section)",
+            "provider=\(self.provider.rawValue)",
+            "name=\(self.providerName)",
+            "email=\(self.email)",
+            "subtitle=\(self.subtitleText)",
+            "subtitleStyle=\(self.subtitleStyle.heightFingerprint)",
+            "plan=\(self.planText ?? "")",
+            "placeholder=\(self.placeholder ?? "")",
+            "credits=\(self.creditsText ?? "")",
+            "creditsHint=\(self.creditsHintText ?? "")",
+            "creditsCopy=\(self.creditsHintCopyText ?? "")",
+            "metrics=\(MenuCardHeightFingerprint.join(self.metrics.map(\.heightFingerprint)))",
+            "notes=\(MenuCardHeightFingerprint.join(self.usageNotes))",
+            "dashboard=\(self.inlineUsageDashboard?.heightFingerprint ?? "")",
+            "providerCost=\(self.providerCost?.heightFingerprint ?? "")",
+            "tokenUsage=\(self.tokenUsage?.heightFingerprint ?? "")",
+            "openaiAPI=\(self.openAIAPIUsage == nil ? "0" : "1")",
+        ] + additional)
+    }
+}
+
+private enum MenuCardHeightFingerprint {
+    static func join(_ values: [String]) -> String {
+        values.map { "\($0.count):\($0)" }.joined(separator: "|")
+    }
+}
+
+extension UsageMenuCardView.Model.SubtitleStyle {
+    fileprivate var heightFingerprint: String {
+        switch self {
+        case .info: "info"
+        case .loading: "loading"
+        case .error: "error"
+        }
+    }
+}
+
+extension UsageMenuCardView.Model.Metric {
+    fileprivate var heightFingerprint: String {
+        MenuCardHeightFingerprint.join([
+            self.id,
+            self.title,
+            self.percentLabel,
+            self.statusText ?? "",
+            self.resetText ?? "",
+            self.detailText ?? "",
+            self.detailLeftText ?? "",
+            self.detailRightText ?? "",
+            self.pacePercent == nil ? "pace=0" : "pace=1",
+            self.paceOnTop ? "paceTop=1" : "paceTop=0",
+            self.cardStyle ? "card=1" : "card=0",
+            "markers=\(self.warningMarkerPercents.count)",
+        ])
+    }
+}
+
+extension UsageMenuCardView.Model.ProviderCostSection {
+    fileprivate var heightFingerprint: String {
+        MenuCardHeightFingerprint.join([
+            self.title,
+            self.spendLine,
+            self.percentLine ?? "",
+            self.percentUsed == nil ? "percent=0" : "percent=1",
+        ])
+    }
+}
+
+extension UsageMenuCardView.Model.TokenUsageSection {
+    fileprivate var heightFingerprint: String {
+        MenuCardHeightFingerprint.join([
+            self.sessionLine,
+            self.monthLine,
+            self.hintLine ?? "",
+            self.errorLine ?? "",
+            self.errorCopyText ?? "",
+        ])
+    }
+}
+
+extension InlineUsageDashboardModel {
+    fileprivate var heightFingerprint: String {
+        MenuCardHeightFingerprint.join([
+            self.accessibilityLabel,
+            self.valueStyle.heightFingerprint,
+            MenuCardHeightFingerprint.join(self.kpis.map(\.heightFingerprint)),
+            MenuCardHeightFingerprint.join(self.points.map(\.heightFingerprint)),
+            MenuCardHeightFingerprint.join(self.detailLines),
+        ])
+    }
+}
+
+extension InlineUsageDashboardModel.KPI {
+    fileprivate var heightFingerprint: String {
+        MenuCardHeightFingerprint.join([
+            self.title,
+            self.value,
+            self.emphasis ? "1" : "0",
+        ])
+    }
+}
+
+extension InlineUsageDashboardModel.Point {
+    fileprivate var heightFingerprint: String {
+        MenuCardHeightFingerprint.join([
+            self.id,
+            self.label,
+            self.accessibilityValue,
+        ])
+    }
+}
+
+extension InlineUsageDashboardModel.ValueStyle {
+    fileprivate var heightFingerprint: String {
+        switch self {
+        case .currencyUSD:
+            "currencyUSD"
+        case let .currency(symbol):
+            "currency:\(symbol)"
+        case .tokens:
+            "tokens"
+        }
+    }
+}

--- a/Sources/CodexBar/MenuCardHeightFingerprint.swift
+++ b/Sources/CodexBar/MenuCardHeightFingerprint.swift
@@ -1,4 +1,3 @@
-import CryptoKit
 import Foundation
 
 extension UsageMenuCardView.Model {
@@ -9,6 +8,7 @@ extension UsageMenuCardView.Model {
         return MenuCardHeightFingerprint.join([
             "section=\(section)",
             "provider=\(self.provider.rawValue)",
+            "localization=\(codexBarLocalizationSignature())",
             MenuCardHeightFingerprint.field("name", self.providerName),
             MenuCardHeightFingerprint.field("email", self.email),
             MenuCardHeightFingerprint.field("subtitle", self.subtitleText),
@@ -34,7 +34,7 @@ extension UsageMenuCardView.Model {
 }
 
 private enum MenuCardHeightFingerprint {
-    private static let digestSalt = UUID().uuidString
+    private static let hashSalt = UUID()
 
     static func join(_ values: [String]) -> String {
         values.map { "\($0.count):\($0)" }.joined(separator: "|")
@@ -48,13 +48,18 @@ private enum MenuCardHeightFingerprint {
     }
 
     private static func stringShape(_ value: String) -> String {
-        let digestInput = "\(Self.digestSalt)\u{0}\(value)"
-        let digest = SHA256.hash(data: Data(digestInput.utf8))
-            .prefix(12)
-            .map { String(format: "%02x", $0) }
-            .joined()
-        let lineCount = value.split(separator: "\n", omittingEmptySubsequences: false).count
-        return "chars:\(value.count),utf8:\(value.utf8.count),lines:\(lineCount),sha:\(digest)"
+        var hasher = Hasher()
+        hasher.combine(Self.hashSalt)
+        hasher.combine(value)
+        let digest = String(UInt(bitPattern: hasher.finalize()), radix: 16)
+        return "chars:\(value.count),utf8:\(value.utf8.count),lines:\(Self.lineCount(value)),hash:\(digest)"
+    }
+
+    private static func lineCount(_ value: String) -> Int {
+        guard !value.isEmpty else { return 0 }
+        return value.utf8.reduce(1) { count, byte in
+            byte == 10 ? count + 1 : count
+        }
     }
 }
 
@@ -73,7 +78,8 @@ extension UsageMenuCardView.Model.Metric {
         MenuCardHeightFingerprint.join([
             self.id,
             MenuCardHeightFingerprint.field("title", self.title),
-            MenuCardHeightFingerprint.field("percent", self.percentLabel),
+            "percent=\(Int(self.percent.rounded()))",
+            "percentStyle=\(self.percentStyle.rawValue)",
             MenuCardHeightFingerprint.field("status", self.statusText),
             MenuCardHeightFingerprint.field("reset", self.resetText),
             MenuCardHeightFingerprint.field("detail", self.detailText),

--- a/Sources/CodexBar/StatusItemController+CodexStackedMenu.swift
+++ b/Sources/CodexBar/StatusItemController+CodexStackedMenu.swift
@@ -33,7 +33,8 @@ extension StatusItemController {
                     UsageMenuCardView(model: model, width: context.menuWidth),
                     id: "menuCard-\(cardIndex)",
                     width: context.menuWidth,
-                    heightCacheScope: account.id))
+                    heightCacheScope: account.id,
+                    heightCacheFingerprint: model.heightFingerprint(section: "card")))
                 cardIndex += 1
                 if account.id != section.accounts.last?.id {
                     menu.addItem(.separator())
@@ -50,7 +51,8 @@ extension StatusItemController {
                 UsageMenuCardView(model: model, width: context.menuWidth),
                 id: "menuCard",
                 width: context.menuWidth,
-                heightCacheScope: context.currentProvider.rawValue))
+                heightCacheScope: context.currentProvider.rawValue,
+                heightCacheFingerprint: model.heightFingerprint(section: "card")))
         }
         menu.addItem(.separator())
         if self.addStorageMenuCardSection(to: menu, provider: context.currentProvider, width: context.menuWidth) {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -552,7 +552,7 @@ extension StatusItemController {
                 heightCacheScope: row.provider.rawValue,
                 heightCacheFingerprint: row.model.heightFingerprint(
                     section: "overview",
-                    additional: ["storage=\(storageText ?? "")"]),
+                    additional: [UsageMenuCardView.Model.heightFingerprintField("storage", storageText)]),
                 submenu: submenu,
                 onClick: { [weak self, weak menu] in
                     guard let self, let menu else { return }
@@ -1292,7 +1292,7 @@ extension StatusItemController {
             id: "menuCardStorage",
             width: width,
             heightCacheScope: provider.rawValue,
-            heightCacheFingerprint: "storage=\(storageText)",
+            heightCacheFingerprint: UsageMenuCardView.Model.heightFingerprintField("storage", storageText),
             submenu: storageSubmenu))
         return true
     }

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -550,6 +550,9 @@ extension StatusItemController {
                 id: identifier,
                 width: menuWidth,
                 heightCacheScope: row.provider.rawValue,
+                heightCacheFingerprint: row.model.heightFingerprint(
+                    section: "overview",
+                    additional: ["storage=\(storageText ?? "")"]),
                 submenu: submenu,
                 onClick: { [weak self, weak menu] in
                     guard let self, let menu else { return }
@@ -633,7 +636,8 @@ extension StatusItemController {
             UsageMenuCardView(model: model, width: context.menuWidth),
             id: "menuCard",
             width: context.menuWidth,
-            heightCacheScope: context.currentProvider.rawValue))
+            heightCacheScope: context.currentProvider.rawValue,
+            heightCacheFingerprint: model.heightFingerprint(section: "card")))
         if self.addStorageMenuCardSection(to: menu, provider: context.currentProvider, width: context.menuWidth) {
             menu.addItem(.separator())
         }
@@ -654,7 +658,8 @@ extension StatusItemController {
                 UsageMenuCardView(model: model, width: context.menuWidth),
                 id: "menuCard",
                 width: context.menuWidth,
-                heightCacheScope: context.currentProvider.rawValue))
+                heightCacheScope: context.currentProvider.rawValue,
+                heightCacheFingerprint: model.heightFingerprint(section: "card")))
             menu.addItem(.separator())
         } else {
             for (index, model) in cards.enumerated() {
@@ -662,7 +667,8 @@ extension StatusItemController {
                     UsageMenuCardView(model: model, width: context.menuWidth),
                     id: "menuCard-\(index)",
                     width: context.menuWidth,
-                    heightCacheScope: "\(context.currentProvider.rawValue)-\(index)"))
+                    heightCacheScope: "\(context.currentProvider.rawValue)-\(index)",
+                    heightCacheFingerprint: model.heightFingerprint(section: "card")))
                 if index < cards.count - 1 {
                     menu.addItem(.separator())
                 }
@@ -1197,6 +1203,7 @@ extension StatusItemController {
                 id: "menuCardUsage",
                 width: width,
                 heightCacheScope: provider.rawValue,
+                heightCacheFingerprint: model.heightFingerprint(section: "usage"),
                 submenu: usageSubmenu))
         } else {
             let headerView = UsageMenuCardHeaderSectionView(
@@ -1207,7 +1214,8 @@ extension StatusItemController {
                 headerView,
                 id: "menuCardHeader",
                 width: width,
-                heightCacheScope: provider.rawValue))
+                heightCacheScope: provider.rawValue,
+                heightCacheFingerprint: model.heightFingerprint(section: "header")))
         }
 
         if hasStorage || hasCredits || hasExtraUsage || hasCost {
@@ -1236,6 +1244,7 @@ extension StatusItemController {
                 id: "menuCardCredits",
                 width: width,
                 heightCacheScope: provider.rawValue,
+                heightCacheFingerprint: model.heightFingerprint(section: "credits"),
                 submenu: creditsSubmenu))
             if webItems.canShowBuyCredits {
                 menu.addItem(self.makeBuyCreditsItem())
@@ -1256,6 +1265,7 @@ extension StatusItemController {
                 id: "menuCardExtraUsage",
                 width: width,
                 heightCacheScope: provider.rawValue,
+                heightCacheFingerprint: model.heightFingerprint(section: "extraUsage"),
                 submenu: extraUsageSubmenu))
         }
         if hasCost {
@@ -1282,6 +1292,7 @@ extension StatusItemController {
             id: "menuCardStorage",
             width: width,
             heightCacheScope: provider.rawValue,
+            heightCacheFingerprint: "storage=\(storageText)",
             submenu: storageSubmenu))
         return true
     }

--- a/Sources/CodexBar/StatusItemController+MenuCardHeightCache.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardHeightCache.swift
@@ -30,4 +30,13 @@ extension StatusItemController {
         self.menuCardHeightCache[key] = height
         return height
     }
+
+    func pruneVersionScopedMenuCardHeightCache() {
+        let currentVersionFingerprint = "version:\(self.menuContentVersion)"
+        for key in self.menuCardHeightCache.keys
+            where key.fingerprint.hasPrefix("version:") && key.fingerprint != currentVersionFingerprint
+        {
+            self.menuCardHeightCache.removeValue(forKey: key)
+        }
+    }
 }

--- a/Sources/CodexBar/StatusItemController+MenuCardHeightCache.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardHeightCache.swift
@@ -5,20 +5,21 @@ extension StatusItemController {
         let id: String
         let scope: String
         let width: Int
-        let version: Int
+        let fingerprint: String
     }
 
     func cachedMenuCardHeight(
         for id: String,
         scope: String,
         width: CGFloat,
+        fingerprint: String? = nil,
         measure: () -> CGFloat) -> CGFloat
     {
         let key = MenuCardHeightCacheKey(
             id: id,
             scope: scope,
             width: Int((width * 100).rounded()),
-            version: self.menuContentVersion)
+            fingerprint: fingerprint ?? "version:\(self.menuContentVersion)")
         if let cached = self.menuCardHeightCache[key] {
             return cached
         }

--- a/Sources/CodexBar/StatusItemController+MenuCardHeightCache.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardHeightCache.swift
@@ -5,7 +5,18 @@ extension StatusItemController {
         let id: String
         let scope: String
         let width: Int
+        let textScale: Int
         let fingerprint: String
+    }
+
+    /// Measured card height also depends on the resolved font sizes, which the menu cards
+    /// derive from semantic text styles (`.body`, `.footnote`, …). Those scale with the
+    /// macOS system text-size / Dynamic Type setting, which is neither part of the content
+    /// fingerprint nor invalidated on rebuild. Fold the current resolved scale into the key
+    /// so a runtime text-size change forces a fresh measurement instead of returning a
+    /// height measured at the old scale (clipped / over-tall cards).
+    static func menuCardHeightTextScaleToken() -> Int {
+        Int((NSFont.preferredFont(forTextStyle: .body).pointSize * 100).rounded())
     }
 
     func cachedMenuCardHeight(
@@ -19,6 +30,7 @@ extension StatusItemController {
             id: id,
             scope: scope,
             width: Int((width * 100).rounded()),
+            textScale: Self.menuCardHeightTextScaleToken(),
             fingerprint: fingerprint ?? "version:\(self.menuContentVersion)")
         if let cached = self.menuCardHeightCache[key] {
             return cached

--- a/Sources/CodexBar/StatusItemController+MenuCardItems.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardItems.swift
@@ -25,6 +25,7 @@ extension StatusItemController {
         id: String,
         width: CGFloat,
         heightCacheScope: String? = nil,
+        heightCacheFingerprint: String? = nil,
         submenu: NSMenu? = nil,
         submenuIndicatorAlignment: Alignment = .topTrailing,
         submenuIndicatorTopPadding: CGFloat = 8,
@@ -52,7 +53,12 @@ extension StatusItemController {
             view
         }
         let hosting = MenuCardItemHostingView(rootView: wrapped, highlightState: highlightState, onClick: onClick)
-        let height = self.cachedMenuCardHeight(for: id, scope: heightCacheScope ?? id, width: width) {
+        let height = self.cachedMenuCardHeight(
+            for: id,
+            scope: heightCacheScope ?? id,
+            width: width,
+            fingerprint: heightCacheFingerprint)
+        {
             self.menuCardHeight(for: hosting, width: width)
         }
         hosting.frame = NSRect(origin: .zero, size: NSSize(width: width, height: height))

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -85,6 +85,10 @@ extension StatusItemController {
                 self.store.weeklyPace(provider: target, window: window, now: now)
             }
         }
+        let fallbackAccount = accountOverride
+            ?? (metadata.usesAccountFallback
+                ? self.store.accountInfo(for: target)
+                : AccountInfo(email: nil, plan: nil))
         let input = UsageMenuCardView.Model.Input(
             provider: target,
             metadata: metadata,
@@ -96,7 +100,7 @@ extension StatusItemController {
             dashboardError: dashboardError,
             tokenSnapshot: tokenSnapshot,
             tokenError: tokenError,
-            account: accountOverride ?? self.store.accountInfo(for: target),
+            account: fallbackAccount,
             isRefreshing: self.store.shouldShowRefreshingMenuCard(for: target),
             lastError: errorOverride
                 ?? codexProjection?.userFacingErrors.usage

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -32,6 +32,7 @@ extension StatusItemController {
         guard !self.isReleasedForTesting else { return }
         #endif
         self.menuContentVersion &+= 1
+        self.pruneVersionScopedMenuCardHeightCache()
         if !allowStaleContentDuringDataRefresh {
             self.latestRequiredMenuRebuildVersion = self.menuContentVersion
         }

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -53,7 +53,16 @@ extension StatusItemController {
         guard self.openMenus.isEmpty else { return }
         guard !self.isMenuDataRefreshInFlight else { return }
         for menu in self.attachedMenusForClosedPreparation() {
-            guard !self.closedMenusDeferredUntilNextOpen.contains(ObjectIdentifier(menu)) else { continue }
+            let key = ObjectIdentifier(menu)
+            guard !self.closedMenusDeferredUntilNextOpen.contains(key) else { continue }
+            // Pre-warming the merged menu while it is closed runs a full main-thread populateMenu
+            // (incl. SwiftUI hosting-view layout) that menuWillOpen redoes synchronously on display
+            // anyway. In Merge Icons mode it is the only attached menu, so this just relocates that
+            // work into a background freeze on every store tick (#1274). Defer it until next open.
+            if menu === self.mergedMenu {
+                self.closedMenusDeferredUntilNextOpen.insert(key)
+                continue
+            }
             self.rebuildClosedMenuIfNeeded(menu)
         }
     }

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -32,7 +32,6 @@ extension StatusItemController {
         guard !self.isReleasedForTesting else { return }
         #endif
         self.menuContentVersion &+= 1
-        self.menuCardHeightCache.removeAll(keepingCapacity: true)
         if !allowStaleContentDuringDataRefresh {
             self.latestRequiredMenuRebuildVersion = self.menuContentVersion
         }

--- a/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
+++ b/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
@@ -25,6 +25,7 @@ extension StatusItemController {
             id: "usageHistorySubmenu",
             width: width,
             heightCacheScope: provider.rawValue,
+            heightCacheFingerprint: "usageHistorySubmenu:\(provider.rawValue)",
             submenu: submenu,
             submenuIndicatorAlignment: .trailing,
             submenuIndicatorTopPadding: 0)

--- a/Sources/CodexBar/StatusItemController+ZaiHourlyChartMenu.swift
+++ b/Sources/CodexBar/StatusItemController+ZaiHourlyChartMenu.swift
@@ -25,6 +25,7 @@ extension StatusItemController {
             id: "zaiHourlyUsageSubmenu",
             width: width,
             heightCacheScope: provider.rawValue,
+            heightCacheFingerprint: "zaiHourlyUsageSubmenu:\(provider.rawValue)",
             submenu: submenu,
             submenuIndicatorAlignment: .trailing,
             submenuIndicatorTopPadding: 0)

--- a/Sources/CodexBar/UsageStore+Accessors.swift
+++ b/Sources/CodexBar/UsageStore+Accessors.swift
@@ -83,15 +83,30 @@ extension UsageStore {
     }
 
     func accountInfo(for provider: UsageProvider) -> AccountInfo {
-        guard provider == .codex else {
-            return self.codexFetcher.loadAccountInfo()
+        let now = Date()
+        let configRevision = self.settings.configRevision
+        if let cached = self.accountInfoCache[provider],
+           cached.isValid(now: now, configRevision: configRevision)
+        {
+            return cached.account
         }
-        let env = ProviderRegistry.makeEnvironment(
-            base: self.environmentBase,
-            provider: .codex,
-            settings: self.settings,
-            tokenOverride: nil)
-        let fetcher = ProviderRegistry.makeFetcher(base: self.codexFetcher, provider: .codex, env: env)
-        return fetcher.loadAccountInfo()
+
+        let account: AccountInfo
+        if provider == .codex {
+            let env = ProviderRegistry.makeEnvironment(
+                base: self.environmentBase,
+                provider: .codex,
+                settings: self.settings,
+                tokenOverride: nil)
+            let fetcher = ProviderRegistry.makeFetcher(base: self.codexFetcher, provider: .codex, env: env)
+            account = fetcher.loadAccountInfo()
+        } else {
+            account = self.codexFetcher.loadAccountInfo()
+        }
+        self.accountInfoCache[provider] = AccountInfoCacheEntry(
+            account: account,
+            configRevision: configRevision,
+            expiresAt: now.addingTimeInterval(self.accountInfoCacheTTL))
+        return account
     }
 }

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -111,6 +111,16 @@ final class UsageStore {
         }
     }
 
+    struct AccountInfoCacheEntry {
+        let account: AccountInfo
+        let configRevision: Int
+        let expiresAt: Date
+
+        func isValid(now: Date, configRevision: Int) -> Bool {
+            self.configRevision == configRevision && self.expiresAt > now
+        }
+    }
+
     enum CodexCreditsSource {
         case none
         case api
@@ -214,6 +224,7 @@ final class UsageStore {
     @ObservationIgnored let providerMetadata: [UsageProvider: ProviderMetadata]
     @ObservationIgnored var providerRuntimes: [UsageProvider: any ProviderRuntime] = [:]
     @ObservationIgnored private var providerAvailabilityCache: [UsageProvider: ProviderAvailabilityCacheEntry] = [:]
+    @ObservationIgnored var accountInfoCache: [UsageProvider: AccountInfoCacheEntry] = [:]
     @ObservationIgnored private var timerTask: Task<Void, Never>?
     @ObservationIgnored private var tokenTimerTask: Task<Void, Never>?
     @ObservationIgnored private var tokenRefreshSequenceTask: Task<Void, Never>?
@@ -245,6 +256,7 @@ final class UsageStore {
     @ObservationIgnored var weeklyLimitResetDetectorStates: [String: WeeklyLimitResetDetectorState] = [:]
     @ObservationIgnored private var hasCompletedInitialRefresh: Bool = false
     @ObservationIgnored private let providerAvailabilityCacheTTL: TimeInterval = 1
+    @ObservationIgnored let accountInfoCacheTTL: TimeInterval = 30
     @ObservationIgnored private let tokenFetchTTL: TimeInterval = 60 * 60
     @ObservationIgnored private let tokenFetchTimeout: TimeInterval = 10 * 60
     @ObservationIgnored let startupBehavior: StartupBehavior

--- a/Tests/CodexBarTests/MenuCardHeightFingerprintTests.swift
+++ b/Tests/CodexBarTests/MenuCardHeightFingerprintTests.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+import Testing
+@testable import CodexBar
+
+struct MenuCardHeightFingerprintTests {
+    @Test
+    func `height fingerprint does not retain raw text fields`() {
+        let model = UsageMenuCardView.Model(
+            provider: .codex,
+            providerName: "Secret Provider Name",
+            email: "very-secret@example.com",
+            subtitleText: "Signed in as very-secret@example.com",
+            subtitleStyle: .info,
+            planText: "Secret Plan",
+            metrics: [
+                .init(
+                    id: "primary",
+                    title: "Secret Metric",
+                    percent: 42,
+                    percentStyle: .left,
+                    statusText: "Secret status",
+                    resetText: nil,
+                    detailText: nil,
+                    detailLeftText: nil,
+                    detailRightText: nil,
+                    pacePercent: nil,
+                    paceOnTop: true),
+            ],
+            usageNotes: ["Secret note"],
+            openAIAPIUsage: nil,
+            inlineUsageDashboard: nil,
+            creditsText: nil,
+            creditsRemaining: nil,
+            creditsHintText: nil,
+            creditsHintCopyText: nil,
+            providerCost: nil,
+            tokenUsage: nil,
+            placeholder: nil,
+            progressColor: .blue)
+
+        let fingerprint = model.heightFingerprint(section: "card")
+
+        #expect(!fingerprint.contains("very-secret@example.com"))
+        #expect(!fingerprint.contains("Secret Provider Name"))
+        #expect(!fingerprint.contains("Secret Metric"))
+        #expect(!fingerprint.contains("Secret note"))
+    }
+
+    @Test
+    func `height fingerprint field distinguishes nil from empty string`() {
+        let nilField = UsageMenuCardView.Model.heightFingerprintField("storage", nil)
+        let emptyField = UsageMenuCardView.Model.heightFingerprintField("storage", "")
+
+        #expect(nilField != emptyField)
+    }
+}

--- a/Tests/CodexBarTests/MenuCardHeightFingerprintTests.swift
+++ b/Tests/CodexBarTests/MenuCardHeightFingerprintTests.swift
@@ -5,7 +5,39 @@ import Testing
 struct MenuCardHeightFingerprintTests {
     @Test
     func `height fingerprint does not retain raw text fields`() {
-        let model = UsageMenuCardView.Model(
+        let model = Self.model()
+
+        let fingerprint = model.heightFingerprint(section: "card")
+
+        #expect(!fingerprint.contains("very-secret@example.com"))
+        #expect(!fingerprint.contains("Secret Provider Name"))
+        #expect(!fingerprint.contains("Secret Metric"))
+        #expect(!fingerprint.contains("Secret note"))
+    }
+
+    @Test
+    func `height fingerprint field distinguishes nil from empty string`() {
+        let nilField = UsageMenuCardView.Model.heightFingerprintField("storage", nil)
+        let emptyField = UsageMenuCardView.Model.heightFingerprintField("storage", "")
+
+        #expect(nilField != emptyField)
+    }
+
+    @Test
+    func `height fingerprint keeps cheap metric percent identity`() {
+        let left = Self.model(percent: 42, percentStyle: .left).heightFingerprint(section: "card")
+        let used = Self.model(percent: 42, percentStyle: .used).heightFingerprint(section: "card")
+        let changedPercent = Self.model(percent: 43, percentStyle: .left).heightFingerprint(section: "card")
+
+        #expect(left != used)
+        #expect(left != changedPercent)
+    }
+
+    private static func model(
+        percent: Double = 42,
+        percentStyle: UsageMenuCardView.Model.PercentStyle = .left) -> UsageMenuCardView.Model
+    {
+        UsageMenuCardView.Model(
             provider: .codex,
             providerName: "Secret Provider Name",
             email: "very-secret@example.com",
@@ -16,8 +48,8 @@ struct MenuCardHeightFingerprintTests {
                 .init(
                     id: "primary",
                     title: "Secret Metric",
-                    percent: 42,
-                    percentStyle: .left,
+                    percent: percent,
+                    percentStyle: percentStyle,
                     statusText: "Secret status",
                     resetText: nil,
                     detailText: nil,
@@ -37,20 +69,5 @@ struct MenuCardHeightFingerprintTests {
             tokenUsage: nil,
             placeholder: nil,
             progressColor: .blue)
-
-        let fingerprint = model.heightFingerprint(section: "card")
-
-        #expect(!fingerprint.contains("very-secret@example.com"))
-        #expect(!fingerprint.contains("Secret Provider Name"))
-        #expect(!fingerprint.contains("Secret Metric"))
-        #expect(!fingerprint.contains("Secret note"))
-    }
-
-    @Test
-    func `height fingerprint field distinguishes nil from empty string`() {
-        let nilField = UsageMenuCardView.Model.heightFingerprintField("storage", nil)
-        let emptyField = UsageMenuCardView.Model.heightFingerprintField("storage", "")
-
-        #expect(nilField != emptyField)
     }
 }

--- a/Tests/CodexBarTests/StatusMenuHeightCacheTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHeightCacheTests.swift
@@ -26,7 +26,7 @@ extension StatusMenuTests {
         let controller = StatusItemController(
             store: store,
             settings: settings,
-            account: UsageFetcher().loadAccountInfo(),
+            account: AccountInfo(email: nil, plan: nil),
             updater: DisabledUpdaterController(),
             preferencesSelection: PreferencesSelection(),
             statusBar: self.makeStatusBarForTesting())
@@ -140,6 +140,33 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `menu invalidation prunes old version scoped height cache entries`() {
+        let controller = self.makeHeightCacheController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        _ = controller.cachedMenuCardHeight(
+            for: "versioned",
+            scope: UsageProvider.codex.rawValue,
+            width: 320)
+        {
+            42
+        }
+        _ = controller.cachedMenuCardHeight(
+            for: "fingerprinted",
+            scope: UsageProvider.codex.rawValue,
+            width: 320,
+            fingerprint: "content:stable")
+        {
+            99
+        }
+
+        controller.invalidateMenus()
+
+        #expect(controller.menuCardHeightCache.keys.allSatisfy { !$0.fingerprint.hasPrefix("version:") })
+        #expect(controller.menuCardHeightCache.keys.contains { $0.fingerprint == "content:stable" })
+    }
+
+    @Test
     func `menu card height cache scopes same row ids by provider`() {
         let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
         StatusItemController.menuCardRenderingEnabled = true
@@ -160,7 +187,6 @@ extension StatusMenuTests {
                 enabled: provider == .codex || provider == .claude)
         }
 
-        let fetcher = UsageFetcher()
         let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
         store._setSnapshotForTesting(
             UsageSnapshot(
@@ -181,7 +207,7 @@ extension StatusMenuTests {
         let controller = StatusItemController(
             store: store,
             settings: settings,
-            account: fetcher.loadAccountInfo(),
+            account: AccountInfo(email: nil, plan: nil),
             updater: DisabledUpdaterController(),
             preferencesSelection: PreferencesSelection(),
             statusBar: self.makeStatusBarForTesting())
@@ -205,7 +231,7 @@ extension StatusMenuTests {
         return StatusItemController(
             store: store,
             settings: settings,
-            account: UsageFetcher().loadAccountInfo(),
+            account: AccountInfo(email: nil, plan: nil),
             updater: DisabledUpdaterController(),
             preferencesSelection: PreferencesSelection(),
             statusBar: self.makeStatusBarForTesting())

--- a/Tests/CodexBarTests/StatusMenuHeightCacheTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHeightCacheTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 extension StatusMenuTests {
     @Test
-    func `menu card height cache is reused within one content version`() {
+    func `menu card height cache is reused for stable card content`() {
         let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
         StatusItemController.menuCardRenderingEnabled = true
         defer {
@@ -42,7 +42,101 @@ extension StatusMenuTests {
         #expect(Set(controller.menuCardHeightCache.keys) == firstKeys)
 
         controller.invalidateMenus()
-        #expect(controller.menuCardHeightCache.isEmpty)
+        #expect(Set(controller.menuCardHeightCache.keys) == firstKeys)
+    }
+
+    @Test
+    func `fingerprinted menu card height cache survives content version invalidation`() {
+        let controller = self.makeHeightCacheController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        var measureCount = 0
+        let first = controller.cachedMenuCardHeight(
+            for: "menuCard",
+            scope: UsageProvider.codex.rawValue,
+            width: 320,
+            fingerprint: "content:stable")
+        {
+            measureCount += 1
+            return 42
+        }
+
+        controller.invalidateMenus()
+
+        let second = controller.cachedMenuCardHeight(
+            for: "menuCard",
+            scope: UsageProvider.codex.rawValue,
+            width: 320,
+            fingerprint: "content:stable")
+        {
+            measureCount += 1
+            return 99
+        }
+
+        #expect(first == 42)
+        #expect(second == 42)
+        #expect(measureCount == 1)
+    }
+
+    @Test
+    func `fingerprinted menu card height cache remeasures when content changes`() {
+        let controller = self.makeHeightCacheController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        var measureCount = 0
+        let first = controller.cachedMenuCardHeight(
+            for: "menuCard",
+            scope: UsageProvider.codex.rawValue,
+            width: 320,
+            fingerprint: "content:a")
+        {
+            measureCount += 1
+            return 42
+        }
+        let second = controller.cachedMenuCardHeight(
+            for: "menuCard",
+            scope: UsageProvider.codex.rawValue,
+            width: 320,
+            fingerprint: "content:b")
+        {
+            measureCount += 1
+            return 99
+        }
+
+        #expect(first == 42)
+        #expect(second == 99)
+        #expect(measureCount == 2)
+    }
+
+    @Test
+    func `unfingerprinted menu card height cache remains content version scoped`() {
+        let controller = self.makeHeightCacheController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        var measureCount = 0
+        let first = controller.cachedMenuCardHeight(
+            for: "menuCard",
+            scope: UsageProvider.codex.rawValue,
+            width: 320)
+        {
+            measureCount += 1
+            return 42
+        }
+
+        controller.invalidateMenus()
+
+        let second = controller.cachedMenuCardHeight(
+            for: "menuCard",
+            scope: UsageProvider.codex.rawValue,
+            width: 320)
+        {
+            measureCount += 1
+            return 99
+        }
+
+        #expect(first == 42)
+        #expect(second == 99)
+        #expect(measureCount == 2)
     }
 
     @Test
@@ -100,5 +194,20 @@ extension StatusMenuTests {
         let scopes = Set(controller.menuCardHeightCache.keys.map(\.scope))
         #expect(scopes.contains(UsageProvider.codex.rawValue))
         #expect(scopes.contains(UsageProvider.claude.rawValue))
+    }
+
+    private func makeHeightCacheController() -> StatusItemController {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        return StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
     }
 }

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -169,7 +169,7 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `closed attached menu is prepared before next open after invalidation`() async {
+    func `closed merged menu defers rebuild until next open instead of pre-warming`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -199,13 +199,29 @@ extension StatusMenuTests {
         let key = ObjectIdentifier(menu)
         let openedVersion = controller.menuVersions[key]
 
-        controller.invalidateMenus()
-        for _ in 0..<40 where controller.menuVersions[key] == openedVersion {
+        // Background data-refresh tick (stale allowed): the closed merged menu must not be pre-warmed.
+        controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
+        for _ in 0..<40 {
             await Task.yield()
         }
-
         #expect(controller.openMenus.isEmpty)
+        #expect(controller.menuContentVersion != openedVersion)
+        #expect(controller.menuVersions[key] == openedVersion)
+        #expect(controller.closedMenusDeferredUntilNextOpen.contains(key))
+
+        // A required (non-stale) invalidation must also leave the closed merged menu deferred.
+        controller.invalidateMenus()
+        for _ in 0..<40 {
+            await Task.yield()
+        }
+        #expect(controller.menuVersions[key] == openedVersion)
+        #expect(controller.closedMenusDeferredUntilNextOpen.contains(key))
+
+        // The deferred merged menu is repopulated synchronously on the next open.
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
         #expect(controller.menuVersions[key] == controller.menuContentVersion)
+        #expect(!controller.closedMenusDeferredUntilNextOpen.contains(key))
     }
 
     @Test
@@ -231,7 +247,9 @@ extension StatusMenuTests {
 
         controller.menuRefreshEnabledOverrideForTesting = true
         let menu = controller.makeMenu()
-        controller.mergedMenu = menu
+        // Use a non-merged attached menu: the merged menu is intentionally never pre-warmed while
+        // closed (#1274), so the in-flight-refresh prep machinery is exercised via the fallback menu.
+        controller.fallbackMenu = menu
         controller.statusItem.menu = menu
 
         controller.populateMenu(menu, provider: nil)
@@ -281,7 +299,9 @@ extension StatusMenuTests {
 
         controller.menuRefreshEnabledOverrideForTesting = true
         let menu = controller.makeMenu()
-        controller.mergedMenu = menu
+        // Use a non-merged attached menu: the merged menu is intentionally never pre-warmed while
+        // closed (#1274), so the in-flight-refresh prep machinery is exercised via the fallback menu.
+        controller.fallbackMenu = menu
         controller.statusItem.menu = menu
 
         controller.populateMenu(menu, provider: nil)

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -71,6 +71,34 @@ struct UsageStoreCoverageTests {
     }
 
     @Test
+    func `account info caches codex auth parsing until config revision changes`() throws {
+        let settings = Self.makeSettingsStore(suite: "UsageStoreCoverageTests-account-info-cache")
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "usage-store-account-info-\(UUID().uuidString)",
+            isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        try Self.writeCodexAuthFile(homeURL: home, email: "first@example.com", plan: "plus")
+        let env = ["CODEX_HOME": home.path]
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: env),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: env)
+
+        let first = store.accountInfo(for: .codex)
+        try Self.writeCodexAuthFile(homeURL: home, email: "second@example.com", plan: "pro")
+        let cached = store.accountInfo(for: .codex)
+        settings.configRevision &+= 1
+        let refreshed = store.accountInfo(for: .codex)
+
+        #expect(first.email == "first@example.com")
+        #expect(cached.email == "first@example.com")
+        #expect(refreshed.email == "second@example.com")
+    }
+
+    @Test
     func `source label uses configured kilo source`() {
         let settings = Self.makeSettingsStore(suite: "UsageStoreCoverageTests-kilo-source")
         settings.kiloUsageDataSource = .api
@@ -593,6 +621,38 @@ struct UsageStoreCoverageTests {
             browserDetection: BrowserDetection(cacheTTL: 0),
             settings: settings,
             environmentBase: [:])
+    }
+
+    private static func writeCodexAuthFile(homeURL: URL, email: String, plan: String) throws {
+        try FileManager.default.createDirectory(at: homeURL, withIntermediateDirectories: true)
+        let auth = try [
+            "tokens": [
+                "accessToken": "access-token",
+                "refreshToken": "refresh-token",
+                "idToken": Self.fakeCodexJWT(email: email, plan: plan),
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: auth)
+        try data.write(to: homeURL.appendingPathComponent("auth.json"), options: .atomic)
+    }
+
+    private static func fakeCodexJWT(email: String, plan: String) throws -> String {
+        let header = try JSONSerialization.data(withJSONObject: ["alg": "none"])
+        let payload = try JSONSerialization.data(withJSONObject: [
+            "email": email,
+            "chatgpt_plan_type": plan,
+            "https://api.openai.com/auth": [
+                "chatgpt_plan_type": plan,
+            ],
+        ])
+        return "\(Self.base64URL(header)).\(Self.base64URL(payload))."
+    }
+
+    private static func base64URL(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "=", with: "")
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
     }
 
     private static func enableOnly(_ enabledProvider: UsageProvider, settings: SettingsStore) throws {


### PR DESCRIPTION
Refs #1274.

## Summary
- keep menu-card height cache entries reusable across menu-content version invalidations when callers provide a width + content fingerprint
- add a `UsageMenuCardView.Model` height fingerprint and pass it through the merged, stacked, history, and chart menu-card call sites
- keep no-fingerprint callers version-scoped, with focused tests for stable content, changed content, legacy fallback, eviction, and provider scoping
- after the latest #1274 retest, trim the fingerprint/account-info hot paths so the cache key no longer gives back most of the saved measurement work

## Why
The latest #1274 samples after #1297 and #1314 split the remaining Merge Icons lag into two pieces:

1. `populateMenu -> addMenuCardSections -> MenuCardItemHostingView.measuredHeight`, where each cache miss allocates a fresh `NSHostingView` just to measure card height.
2. The follow-up cost introduced by this PR's first pass: `heightFingerprint` string formatting/hash work plus `menuCardModel -> accountInfo -> loadAuthBackedCodexAccount -> CodexOAuthCredentialsStore.parse` on repeated rebuilds.

#1286 moved close rebuild work off the synchronous dismiss path, and #1297 targets icon-observation churn. This PR remains the next separate measured-height slice, but now also addresses the obvious cost regressions called out in the #1314 retest. It still does not claim to close #1274; affected macOS 26.x / Merge Icons machines should retest the packaged build.

## Claw/Copilot Follow-up
- replaced raw text cache-key fields, including account email, with per-process salted text shapes (`chars`, `utf8`, `lines`, hash), so cache keys no longer retain raw PII or user-visible strings
- encoded optional string presence explicitly, including `storageText`, so `nil` and `""` no longer collapse into the same height identity
- pruned stale `version:` fallback keys on `invalidateMenus()` while retaining content-fingerprinted keys, avoiding old version-scoped entries accumulating until the global 256-entry flush
- made the height-cache tests use deterministic `AccountInfo(email: nil, plan: nil)` fixtures instead of `UsageFetcher().loadAccountInfo()`

## Latest #1274 Retest Follow-up
@giuseppebisemi's #1314 retest showed the measured-height leaf dropped, but part of the work moved into the new fingerprint and the broader model construction still reparsed Codex OAuth credentials. Current head `254412f0` responds to that specific critique:

- `MenuCardHeightFingerprint.stringShape` no longer uses CryptoKit digest formatting, `String(format:)`, or `withVaList`; it uses a per-process salted `Hasher` value plus cheap UTF-8 newline counting.
- `Metric.heightFingerprint` no longer calls `percentLabel`, so the fingerprint path no longer reaches `PercentStyle.labelSuffix -> L(...) -> ProcessInfo.environment` per metric.
- `Localization.isRunningTestsProcess()` now caches the startup result instead of reading `ProcessInfo.processInfo.environment` on repeated localization calls.
- `UsageStore.accountInfo(for:)` now has a short `configRevision`-scoped cache, so close/open rebuild bursts do not re-read and re-parse `auth.json` / JWT payloads each time.
- `menuCardModel` now requests fallback account info only for providers whose metadata uses account fallback; non-Codex provider cards no longer pay for Codex auth parsing they will not display.

This is intentionally not full menu-model memoization. The first `populateMenu`, SwiftUI hosting/view construction, and actual model reuse remain separate future work for #1274.

## Packaged macOS 26.5 Proof From The Measured-Height Slice
Local packaged-app run at earlier PR head `74528926`, redacted for account/path data:

```text
ProductVersion: 26.5
BuildVersion:   25F71
Bundle:         CodexBar.app packaged from PR head 74528926
Signing:        CODEXBAR_SIGNING=adhoc
Status item:    codexbar-merged (Merge Icons path)
Command:        CODEXBAR_SIGNING=adhoc Scripts/package_app.sh release
Launch proof:   Info.plist CodexGitCommit=74528926; codesign --verify --deep --strict passed
```

Repeated menu-open proof:

```text
peekaboo menubar click --index 1 --verify --json
=> verified=true, executionTime=0.172299s

sample <CodexBar pid> 12 1 -mayDie -file /tmp/codexbar-pr1314-after-repeat-open.sample.txt
for 12 rounds:
  peekaboo menubar click --index 1 --json
  peekaboo press escape --foreground --json
```

Observed result across the 12 repeated open/close rounds:

```text
open clicks: 12/12 success
open click execution time: min 0.039995s, avg 0.045455s, max 0.056921s
sample header: 10,363 main-thread samples, /usr/bin/sample, macOS 26.5 (25F71)

Stack occurrence counts in the sample:
MenuCardItemHostingView    0
measuredHeight             0
menuCardHeight             0
cachedMenuCardHeight       0
addMenuCardSections        0
populateMenu               1
NSHostingView              19
GraphHost                  3
```

Interpretation: on this macOS 26.5 packaged Merge Icons run, repeated unchanged merged-menu opens did not show the old `MenuCardItemHostingView.measuredHeight` / `addMenuCardSections` hot path in the sampled main thread. There are still ordinary SwiftUI `NSHostingView` attach/layout frames, so this proof supports the targeted measured-height cache slice rather than claiming all menu work is gone.

## Current Head Validation
Current head: `254412f0`.

- `swift test --filter UsageStoreCoverageTests` (21 tests)
- `swift test --filter MenuCardHeightFingerprintTests` (3 tests)
- `swift test --filter StatusMenuHeightCacheTests` (6 tests)
- `make check` (SwiftFormat lint + SwiftLint: 0 violations)
- `swift test` (3246 tests / 385 suites)

Earlier CI had passed for PR head `74528926` (GitGuardian, `build-linux-cli` arm64/x64, and `lint-build-test`). Current head CI is expected to rerun, but I am not treating slow CI or Claw re-review as part of this local proof.

## Remaining Scope
I would still keep #1274 open after this PR. #1314 now proves the repeated unchanged measured-height cache path on one local macOS 26.5 Merge Icons packaged run, and current head removes the most obvious fingerprint/account parse regressions from that slice. It does not remove the first `populateMenu`, does not reuse actual menu item hosting views, and does not fully memoize `UsageMenuCardView.Model` construction.


## Skip closed merged-menu rebuild (folded in, head `b6d1129e`, #1274)

`@giuseppebisemi`'s post-`254412f0` retest confirmed this slice's targeted costs collapsed (`heightFingerprint` 76→3, `CodexOAuthCredentialsStore.parse` ~50→5, `menuCardModel` 105→33, `addMenuCardSections` 83→6, and the `ProcessInfo.environment`/`percentLabel` reads gone) and isolated the remaining freeze to a single structural path:

```
388  rebuildClosedMenuIfNeeded   (deferred close task)
126    populateMenu
 56    NSHostingView.layout()
```

Root cause: `menuDidClose` only defers the merged menu when it is *already* stale at close time, but `observeStoreChanges` invalidates with `allowStaleContentDuringDataRefresh: true` and still falls through to `prepareAttachedClosedMenusIfNeeded()` — so a merged menu that closed fresh is rebuilt **while closed** on the next background tick.

Rather than ship this as a third open PR, it is folded in here (same Merge Icons menu-rebuild domain). The fix: in `prepareAttachedClosedMenusIfNeeded`, when the menu being prepared is the merged menu, defer it unconditionally (insert into `closedMenusDeferredUntilNextOpen` and skip `rebuildClosedMenuIfNeeded`). Guarding inside `prepareAttachedClosedMenusIfNeeded` itself — rather than only the stale-refresh path — also covers `allowStale=false` invalidations (config / provider-order / manual), so the eager closed rebuild is gone on every path. That takes the 388-sample subtree to 0.

Correctness: `menuWillOpen` runs `refreshMenuForOpenIfNeeded` synchronously before the menu is registered open and before AppKit displays it, so the deferred merged menu is fully repopulated before it is shown — no stale flash or width jump — and the deferred-set entry is cleared on open, so it does not leak. The only remaining merged-menu populate is the one on open, the boundary `@giuseppebisemi` and I drew.

Validation at head `b6d1129e`:
- `swift test --filter StatusMenuOpenRefreshTests` (29 tests) — includes the rewritten "closed merged menu defers rebuild until next open instead of pre-warming" assertion and the two pre-warm-deferral tests re-pointed to the non-merged fallback menu
- `make check` (SwiftFormat lint + SwiftLint: 0 violations)
- `swift test` (3246 tests / 385 suites)

This still does not remove the first `populateMenu` or reuse hosting views; it eliminates the redundant *closed* rebuild only.

