### PR TITLE
Fix Kiro CLI discovery after slow login PATH capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Menu bar: defer merged-menu close rebuilds and cache repeated menu-card height measurements so dismissing or rapidly switching the merged dropdown avoids rebuilding SwiftUI-backed cards on the main thread (#1274, #1286, #1314). Thanks @hhh2210!
 - Menu bar: observe a compact icon-state signature so merged status icons no longer redraw for provider snapshot changes that cannot affect the visible icon (#1297). Thanks @hhh2210!
 - Menu bar: keep provider-switcher quota bars from replacing Auto Layout constraints when the visible ratio is unchanged, making tab switches responsive with many providers enabled (#1303, #1315). Thanks @juanjoseluisgarcia!
+- Kiro: retry login-shell PATH capture when CLI discovery races a slow cold shell startup, so `kiro-cli` is no longer stuck as missing for the whole app session (#1316). Thanks @bt-justtrack!
 
 ## 0.32.4 — 2026-06-02
 

--- a/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
+++ b/Sources/CodexBarCore/Host/PTY/TTYCommandRunner.swift
@@ -981,7 +981,11 @@ public struct TTYCommandRunner {
         proc.executableURL = URL(fileURLWithPath: "/usr/bin/which")
         proc.arguments = [tool]
         var env = ProcessInfo.processInfo.environment
-        env["PATH"] = PathBuilder.effectivePATH(purposes: [.tty, .nodeTooling], env: env)
+        let loginPATH = LoginShellPathCache.shared.currentOrCapture()
+        env["PATH"] = PathBuilder.effectivePATH(
+            purposes: [.tty, .nodeTooling],
+            env: env,
+            loginPATH: loginPATH)
         proc.environment = env
         let pipe = Pipe()
         proc.standardOutput = pipe

--- a/Sources/CodexBarCore/PathEnvironment.swift
+++ b/Sources/CodexBarCore/PathEnvironment.swift
@@ -905,9 +905,11 @@ public enum PathBuilder {
 }
 
 enum LoginShellPathCapturer {
+    static let defaultTimeout: TimeInterval = 6.0
+
     static func capture(
         shell: String? = ProcessInfo.processInfo.environment["SHELL"],
-        timeout: TimeInterval = 2.0) -> [String]?
+        timeout: TimeInterval = Self.defaultTimeout) -> [String]?
     {
         let shellPath = (shell?.isEmpty == false) ? shell! : "/bin/zsh"
         let isCI = ["1", "true"].contains(ProcessInfo.processInfo.environment["CI"]?.lowercased())
@@ -957,7 +959,7 @@ public final class LoginShellPathCache: @unchecked Sendable {
 
     public func captureOnce(
         shell: String? = ProcessInfo.processInfo.environment["SHELL"],
-        timeout: TimeInterval = 2.0,
+        timeout: TimeInterval = 6.0,
         onFinish: (([String]?) -> Void)? = nil)
     {
         self.lock.lock()
@@ -992,5 +994,43 @@ public final class LoginShellPathCache: @unchecked Sendable {
 
             callbacks.forEach { $0(result) }
         }
+    }
+
+    public func currentOrCapture(
+        shell: String? = ProcessInfo.processInfo.environment["SHELL"],
+        timeout: TimeInterval = 6.0) -> [String]?
+    {
+        self.lock.lock()
+        if let captured {
+            self.lock.unlock()
+            return captured
+        }
+
+        if self.isCapturing {
+            let semaphore = DispatchSemaphore(value: 0)
+            var callbackResult: [String]?
+            self.callbacks.append { result in
+                callbackResult = result
+                semaphore.signal()
+            }
+            self.lock.unlock()
+            let deadline = DispatchTime.now() + timeout
+            _ = semaphore.wait(timeout: deadline)
+            return callbackResult ?? self.current
+        }
+
+        self.isCapturing = true
+        self.lock.unlock()
+
+        let result = LoginShellPathCapturer.capture(shell: shell, timeout: timeout)
+        self.lock.lock()
+        self.captured = result
+        self.isCapturing = false
+        let callbacks = self.callbacks
+        self.callbacks.removeAll()
+        self.lock.unlock()
+
+        callbacks.forEach { $0(result) }
+        return result
     }
 }

--- a/Tests/CodexBarTests/PathBuilderTests.swift
+++ b/Tests/CodexBarTests/PathBuilderTests.swift
@@ -45,6 +45,30 @@ struct PathBuilderTests {
     }
 
     @Test
+    func `login shell cache retries after timed out nil capture`() throws {
+        let shell = try Self.makeLoginShellPathScript(
+            delay: 0.2,
+            path: "/login/bin:/usr/bin")
+        defer { try? FileManager.default.removeItem(at: shell) }
+
+        let cache = LoginShellPathCache()
+        let semaphore = DispatchSemaphore(value: 0)
+        var firstResult: [String]?
+        cache.captureOnce(shell: shell.path, timeout: 0.01) { result in
+            firstResult = result
+            semaphore.signal()
+        }
+
+        #expect(semaphore.wait(timeout: .now() + 2.0) == .success)
+        #expect(firstResult == nil)
+        #expect(cache.current == nil)
+
+        let recovered = cache.currentOrCapture(shell: shell.path, timeout: 2.0)
+        #expect(recovered == ["/login/bin", "/usr/bin"])
+        #expect(cache.current == ["/login/bin", "/usr/bin"])
+    }
+
+    @Test
     func `shell runner drains noisy stdout and stderr`() throws {
         let script = """
         i=0
@@ -625,6 +649,19 @@ struct PathBuilderTests {
 
     private static func shellSingleQuoted(_ value: String) -> String {
         "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+
+    private static func makeLoginShellPathScript(delay: TimeInterval, path: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-login-path-\(UUID().uuidString).sh")
+        let script = """
+        #!/bin/sh
+        sleep \(delay)
+        printf '__CODEXBAR_PATH__%s__CODEXBAR_PATH__' \(self.shellSingleQuoted(path))
+        """
+        try script.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+        return url
     }
 }
 


### PR DESCRIPTION
## Summary
- Retry login-shell PATH capture from CLI discovery when the cache is still empty.
- Increase the default login-shell capture budget from 2s to 6s for slow cold shells.
- Add a regression test for recovery after an initial timed-out nil capture.

Fixes #1316.

## Verification
- swift test --filter PathBuilderTests
- swift test --filter KiroStatusProbeTests
- make check via autoreview
- autoreview clean: no accepted/actionable findings
- ./Scripts/package_app.sh
- Peekaboo: relaunched /Users/steipete/Projects/codexbar/CodexBar.app, verified menubar click on codexbar-merged; screenshot artifact /tmp/codexbar-1316-screen-open.png
