### PR TITLE
Fix quota indicator constraint churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Menu bar: defer merged-menu close rebuilds and cache repeated menu-card height measurements so dismissing or rapidly switching the merged dropdown avoids rebuilding SwiftUI-backed cards on the main thread (#1274, #1286). Thanks @hhh2210!
 - Menu bar: observe a compact icon-state signature so merged status icons no longer redraw for provider snapshot changes that cannot affect the visible icon (#1297). Thanks @hhh2210!
+- Menu bar: keep provider-switcher quota bars from replacing Auto Layout constraints when the visible ratio is unchanged, making tab switches responsive with many providers enabled (#1303, #1315). Thanks @juanjoseluisgarcia!
 
 ## 0.32.4 — 2026-06-02
 

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -613,11 +613,14 @@ final class ProviderSwitcherView: NSView {
             let key = ObjectIdentifier(button)
             if let remaining {
                 if var indicator = self.quotaIndicators[key] {
-                    Self.updateQuotaIndicatorFill(
-                        indicator: &indicator,
-                        remainingPercent: remaining,
-                        selection: segment.selection)
-                    self.quotaIndicators[key] = indicator
+                    let newRatio = Self.quotaIndicatorRatio(remainingPercent: remaining)
+                    if newRatio != indicator.fillRatio {
+                        Self.updateQuotaIndicatorFill(
+                            indicator: &indicator,
+                            remainingPercent: remaining,
+                            selection: segment.selection)
+                        self.quotaIndicators[key] = indicator
+                    }
                 } else {
                     self.addQuotaIndicator(to: button, selection: segment.selection, remainingPercent: remaining)
                 }
@@ -689,6 +692,12 @@ final class ProviderSwitcherView: NSView {
     func _test_quotaIndicatorFillFrames() -> [NSRect] {
         self.buttons.compactMap { button in
             self.quotaIndicators[ObjectIdentifier(button)]?.fill.frame
+        }
+    }
+
+    func _test_quotaIndicatorConstraintIdentifiers() -> [ObjectIdentifier] {
+        self.buttons.compactMap { button in
+            self.quotaIndicators[ObjectIdentifier(button)].map { ObjectIdentifier($0.fillWidthConstraint) }
         }
     }
     #endif

--- a/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
@@ -73,6 +73,50 @@ struct StatusMenuSwitcherRefreshTests {
         #expect(Self.switcherButtons(in: menu).first { $0.tag == nextProviderButton.tag }?.state == .on)
     }
 
+    @Test
+    func `tab switch does not replace quota indicator constraints`() {
+        let switcher = ProviderSwitcherView(
+            providers: [.codex, .claude],
+            selected: .provider(.codex),
+            includesOverview: false,
+            width: 310,
+            showsIcons: false,
+            iconProvider: { _ in NSImage() },
+            weeklyRemainingProvider: { _ in 75.0 },
+            onSelect: { _ in })
+
+        let initialConstraints = switcher._test_quotaIndicatorConstraintIdentifiers()
+        #expect(initialConstraints.count == 2, "both providers should have quota indicators")
+
+        switcher.updateQuotaIndicators()
+
+        let afterFirstCall = switcher._test_quotaIndicatorConstraintIdentifiers()
+        #expect(afterFirstCall == initialConstraints, "same ratio: constraints must not be replaced")
+    }
+
+    @Test
+    func `quota indicator constraints are replaced when ratio changes`() {
+        var currentRemaining = 75.0
+        let switcher = ProviderSwitcherView(
+            providers: [.codex, .claude],
+            selected: .provider(.codex),
+            includesOverview: false,
+            width: 310,
+            showsIcons: false,
+            iconProvider: { _ in NSImage() },
+            weeklyRemainingProvider: { _ in currentRemaining },
+            onSelect: { _ in })
+
+        let initialConstraints = switcher._test_quotaIndicatorConstraintIdentifiers()
+        #expect(initialConstraints.count == 2)
+
+        currentRemaining = 40.0
+        switcher.updateQuotaIndicators()
+
+        let afterDataChange = switcher._test_quotaIndicatorConstraintIdentifiers()
+        #expect(afterDataChange != initialConstraints, "changed ratio: constraints should be replaced")
+    }
+
     private static func makeSettings() -> SettingsStore {
         let suite = "StatusMenuSwitcherRefreshTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!


### PR DESCRIPTION
## Summary
- Preserve provider-switcher quota indicator constraints when the computed ratio is unchanged.
- Still replace the fill-width constraint when usage data changes the visible ratio.
- Add regression coverage for unchanged and changed quota ratios.

Fixes #1303.
Supersedes the unique quota-bar part of #1315, without carrying the already-landed #1297 overlap.

## Verification
- swift test --filter StatusMenuSwitcherRefreshTests
- make check via autoreview
- autoreview clean: no accepted/actionable findings
- ./Scripts/package_app.sh
- Peekaboo: relaunched /Users/steipete/Projects/codexbar/CodexBar.app and verified menubar click on codexbar-merged
