### PR TITLE
Fix Copilot unlimited chat quota display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.32.6 — Unreleased
 
 ### Fixed
+- Copilot: keep explicitly unlimited chat quotas visible instead of dropping their zero-entitlement payload as unavailable (#1320). Thanks @soumikbhatta!
 - Doubao: confirm zero-remaining HTTP 200 request limits before falling back, preserving genuine exhaustion and avoiding false 100% usage (#1383). Thanks @LeoLin990405 and @foobra!
 - Menu bar: defer pasteboard writes and copy feedback outside the `NSMenu` tracking callback so in-menu copy buttons no longer beachball on macOS 26 (#1388). Thanks @LeoLin990405!
 - Antigravity: exclude model quotas without a remaining fraction from family summaries so they no longer mask tracked usage in the automatic menu-bar metric (#1369). Thanks @Martin-Hausleitner!

--- a/Sources/CodexBarCore/CopilotUsageModels.swift
+++ b/Sources/CodexBarCore/CopilotUsageModels.swift
@@ -22,6 +22,7 @@ public struct CopilotUsageResponse: Sendable, Decodable {
         public let percentRemaining: Double
         public let quotaId: String
         public let hasPercentRemaining: Bool
+        public let unlimited: Bool
         private let entitlementWasDecoded: Bool
         private let remainingWasDecoded: Bool
         public var usedPercent: Double {
@@ -33,6 +34,10 @@ public struct CopilotUsageResponse: Sendable, Decodable {
         }
 
         public var isPlaceholder: Bool {
+            if self.unlimited {
+                return false
+            }
+
             if self.entitlement == 0,
                self.remaining == 0,
                self.percentRemaining == 0,
@@ -55,6 +60,7 @@ public struct CopilotUsageResponse: Sendable, Decodable {
             case remaining
             case percentRemaining = "percent_remaining"
             case quotaId = "quota_id"
+            case unlimited
         }
 
         public init(
@@ -62,13 +68,15 @@ public struct CopilotUsageResponse: Sendable, Decodable {
             remaining: Double,
             percentRemaining: Double,
             quotaId: String,
-            hasPercentRemaining: Bool = true)
+            hasPercentRemaining: Bool = true,
+            unlimited: Bool = false)
         {
             self.entitlement = entitlement
             self.remaining = remaining
             self.percentRemaining = percentRemaining
             self.quotaId = quotaId
             self.hasPercentRemaining = hasPercentRemaining
+            self.unlimited = unlimited
             self.entitlementWasDecoded = true
             self.remainingWasDecoded = true
         }
@@ -81,9 +89,13 @@ public struct CopilotUsageResponse: Sendable, Decodable {
             self.remaining = decodedRemaining ?? 0
             self.entitlementWasDecoded = decodedEntitlement != nil
             self.remainingWasDecoded = decodedRemaining != nil
+            let decodedUnlimited = try container.decodeIfPresent(Bool.self, forKey: .unlimited) ?? false
             let decodedPercent = Self.decodeNumberIfPresent(container: container, key: .percentRemaining)
             if let decodedPercent {
                 self.percentRemaining = decodedPercent
+                self.hasPercentRemaining = true
+            } else if decodedUnlimited {
+                self.percentRemaining = 100
                 self.hasPercentRemaining = true
             } else if let entitlement = decodedEntitlement,
                       entitlement > 0,
@@ -98,6 +110,7 @@ public struct CopilotUsageResponse: Sendable, Decodable {
                 self.hasPercentRemaining = false
             }
             self.quotaId = try container.decodeIfPresent(String.self, forKey: .quotaId) ?? ""
+            self.unlimited = decodedUnlimited
         }
 
         private static func decodeNumberIfPresent(

--- a/Sources/CodexBarCore/CopilotUsageModels.swift
+++ b/Sources/CodexBarCore/CopilotUsageModels.swift
@@ -73,9 +73,9 @@ public struct CopilotUsageResponse: Sendable, Decodable {
         {
             self.entitlement = entitlement
             self.remaining = remaining
-            self.percentRemaining = percentRemaining
+            self.percentRemaining = unlimited ? 100 : percentRemaining
             self.quotaId = quotaId
-            self.hasPercentRemaining = hasPercentRemaining
+            self.hasPercentRemaining = unlimited || hasPercentRemaining
             self.unlimited = unlimited
             self.entitlementWasDecoded = true
             self.remainingWasDecoded = true
@@ -91,11 +91,11 @@ public struct CopilotUsageResponse: Sendable, Decodable {
             self.remainingWasDecoded = decodedRemaining != nil
             let decodedUnlimited = try container.decodeIfPresent(Bool.self, forKey: .unlimited) ?? false
             let decodedPercent = Self.decodeNumberIfPresent(container: container, key: .percentRemaining)
-            if let decodedPercent {
-                self.percentRemaining = decodedPercent
-                self.hasPercentRemaining = true
-            } else if decodedUnlimited {
+            if decodedUnlimited {
                 self.percentRemaining = 100
+                self.hasPercentRemaining = true
+            } else if let decodedPercent {
+                self.percentRemaining = decodedPercent
                 self.hasPercentRemaining = true
             } else if let entitlement = decodedEntitlement,
                       entitlement > 0,

--- a/Tests/CodexBarTests/CopilotUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CopilotUsageFetcherTests.swift
@@ -68,6 +68,40 @@ struct CopilotUsageFetcherTests {
     }
 
     @Test
+    func `fetch keeps explicitly unlimited chat quota`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "token gh-token")
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"])!
+            let data = Data(
+                """
+                {
+                  "copilot_plan": "individual",
+                  "quota_snapshots": {
+                    "chat_messages": {
+                      "entitlement": 0,
+                      "remaining": 0,
+                      "quota_id": "chat_messages",
+                      "unlimited": true
+                    }
+                  }
+                }
+                """.utf8)
+            return (data, response)
+        }
+        let fetcher = CopilotUsageFetcher(token: "gh-token", transport: transport)
+
+        let snapshot = try await fetcher.fetch()
+
+        #expect(snapshot.primary == nil)
+        #expect(snapshot.secondary?.usedPercent == 0)
+        #expect(snapshot.identity?.loginMethod == "Individual")
+    }
+
+    @Test
     func `makeRateWindow drops business token billing placeholder quota`() {
         // entitlement=0/remaining=0/percent_remaining=100 must not become a "0% used"
         // rate window for Copilot Business token-based billing accounts. (#1258)

--- a/Tests/CodexBarTests/CopilotUsageModelsTests.swift
+++ b/Tests/CodexBarTests/CopilotUsageModelsTests.swift
@@ -501,7 +501,32 @@ struct CopilotUsageModelsTests {
 
         #expect(response.quotaSnapshots.premiumInteractions?.quotaId == "premium_interactions")
         #expect(response.quotaSnapshots.chat?.quotaId == "chat_messages")
+        #expect(response.quotaSnapshots.chat?.unlimited == true)
         #expect(response.quotaSnapshots.chat?.usedPercent == 0)
+    }
+
+    @Test
+    func `unlimited quota overrides placeholder percent remaining`() throws {
+        let response = try Self.decodeFixture(
+            """
+            {
+              "copilot_plan": "individual",
+              "quota_snapshots": {
+                "chat": {
+                  "entitlement": 0,
+                  "remaining": 0,
+                  "percent_remaining": 0,
+                  "quota_id": "chat",
+                  "unlimited": true
+                }
+              }
+            }
+            """)
+
+        let chat = try #require(response.quotaSnapshots.chat)
+        #expect(chat.percentRemaining == 100)
+        #expect(chat.usedPercent == 0)
+        #expect(!chat.isPlaceholder)
     }
 
     @Test

--- a/Tests/CodexBarTests/CopilotUsageModelsTests.swift
+++ b/Tests/CodexBarTests/CopilotUsageModelsTests.swift
@@ -477,6 +477,34 @@ struct CopilotUsageModelsTests {
     }
 
     @Test
+    func `keeps unlimited chat fallback quota without percent remaining`() throws {
+        let response = try Self.decodeFixture(
+            """
+            {
+              "copilot_plan": "individual",
+              "quota_snapshots": {
+                "premium_interactions": {
+                  "entitlement": 200,
+                  "remaining": 191,
+                  "percent_remaining": 95.5,
+                  "quota_id": "premium_interactions"
+                },
+                "chat_messages": {
+                  "entitlement": 0,
+                  "remaining": 0,
+                  "quota_id": "chat_messages",
+                  "unlimited": true
+                }
+              }
+            }
+            """)
+
+        #expect(response.quotaSnapshots.premiumInteractions?.quotaId == "premium_interactions")
+        #expect(response.quotaSnapshots.chat?.quotaId == "chat_messages")
+        #expect(response.quotaSnapshots.chat?.usedPercent == 0)
+    }
+
+    @Test
     func `flags zero entitlement snapshot as placeholder`() {
         let snapshot = CopilotUsageResponse.QuotaSnapshot(
             entitlement: 0,


### PR DESCRIPTION
## Summary
- Decode Copilot quota snapshots that explicitly report `unlimited`.
- Keep unlimited zero-entitlement Copilot chat quota snapshots instead of treating them as placeholders.
- Add regression coverage for an unlimited chat-like quota without `percent_remaining`.

## Why
GitHub Copilot can report chat as an unlimited quota snapshot with `entitlement=0` and `remaining=0`. CodexBar's placeholder filter treated that shape as unusable, so the Copilot menu only showed Premium and dropped the unlimited Chat lane.

This keeps the existing placeholder behavior for ordinary zero-entitlement snapshots. The exception only applies when the payload explicitly says `unlimited: true`.

## Validation
- `swift test --filter CopilotUsageModelsTests`
- `swift test --filter CopilotUsageFetcherTests`
- `./Scripts/lint.sh lint`
- Live CLI proof against the same Copilot account: installed CodexBar `0.32.4` returns `secondary: null`; this branch returns `secondary.usedPercent: 0`.
