### PR TITLE
Fix Claude menu bar session pace

### DIFF
--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -670,6 +670,10 @@ extension StatusItemController {
         }
 
         let percentWindow = self.menuBarPercentWindow(for: provider, snapshot: snapshot)
+        let weeklyFallbackWindow =
+            snapshot?.secondary
+                // Abacus has no secondary window; pace is computed on primary monthly credits.
+                ?? (provider == .abacus ? snapshot?.primary : nil)
         let mode = self.settings.menuBarDisplayMode
         let now = Date()
         let codexProjection = self.store.codexConsumerProjectionIfNeeded(
@@ -677,19 +681,16 @@ extension StatusItemController {
             surface: .menuBar,
             snapshotOverride: snapshot,
             now: now)
-        let pace: UsagePace?
-        switch mode {
+        let pace: UsagePace? = switch mode {
         case .percent:
-            pace = nil
+            nil
         case .pace, .both:
-            let weeklyWindow =
-                codexProjection?.rateWindow(for: .weekly)
-                ?? snapshot?.secondary
-                // Abacus has no secondary window; pace is computed on primary monthly credits
-                ?? (provider == .abacus ? snapshot?.primary : nil)
-            pace = weeklyWindow.flatMap { window in
-                self.store.weeklyPace(provider: provider, window: window, now: now)
-            }
+            self.menuBarPace(
+                for: provider,
+                percentWindow: percentWindow,
+                weeklyFallbackWindow: weeklyFallbackWindow,
+                codexProjection: codexProjection,
+                now: now)
         }
         let displayText = MenuBarDisplayText.displayText(
             mode: mode,
@@ -710,6 +711,26 @@ extension StatusItemController {
         }
 
         return displayText
+    }
+
+    private func menuBarPace(
+        for provider: UsageProvider,
+        percentWindow: RateWindow?,
+        weeklyFallbackWindow: RateWindow?,
+        codexProjection: CodexConsumerProjection?,
+        now: Date)
+        -> UsagePace?
+    {
+        if let codexWeekly = codexProjection?.rateWindow(for: .weekly) {
+            return self.store.weeklyPace(provider: provider, window: codexWeekly, now: now)
+        }
+        if let percentWindow,
+           let sessionPace = UsagePaceText.sessionPace(provider: provider, window: percentWindow, now: now)
+        {
+            return sessionPace
+        }
+        guard let weeklyFallbackWindow else { return nil }
+        return self.store.weeklyPace(provider: provider, window: weeklyFallbackWindow, now: now)
     }
 
     nonisolated static func deepSeekBalanceDisplayText(snapshot: UsageSnapshot?) -> String? {

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -1025,6 +1025,110 @@ struct StatusItemAnimationTests {
     }
 
     @Test
+    func `menu bar display text pairs claude primary percent with session pace`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-claude-primary-session-pace"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.menuBarDisplayMode = .both
+        settings.usageBarsShowUsed = false
+        settings.setMenuBarMetricPreference(.primary, for: .claude)
+
+        let registry = ProviderRegistry.shared
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let now = Date()
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 17,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(107 * 60),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 3,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(9172 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        let displayText = controller.menuBarDisplayText(for: .claude, snapshot: snapshot)
+
+        #expect(displayText == "83% · -47%")
+    }
+
+    @Test
+    func `menu bar display text preserves weekly fallback when selected metric lacks session timing`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "StatusItemAnimationTests-claude-primary-weekly-fallback"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .claude
+        settings.menuBarDisplayMode = .both
+        settings.usageBarsShowUsed = false
+        settings.setMenuBarMetricPreference(.primary, for: .claude)
+
+        let registry = ProviderRegistry.shared
+        if let claudeMeta = registry.metadata[.claude] {
+            settings.setProviderEnabled(provider: .claude, metadata: claudeMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let now = Date()
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 17,
+                windowMinutes: nil,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 3,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(9172 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+
+        store._setSnapshotForTesting(snapshot, provider: .claude)
+        store._setErrorForTesting(nil, provider: .claude)
+
+        let displayText = controller.menuBarDisplayText(for: .claude, snapshot: snapshot)
+
+        #expect(displayText == "83% · -6%")
+    }
+
+    @Test
     func `menu bar display text shows zero percent for kilo zero total edge`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "StatusItemAnimationTests-kilo-zero-edge"),


### PR DESCRIPTION
## Summary
- Pair Claude Primary (Session) menu-bar percent with the same session pace instead of the weekly reserve.
- Preserve the prior weekly fallback when the selected metric cannot produce session pace.
- Keep Codex projection/credits fallback precedence unchanged.

Fixes #1302

## Tests
- `make check`
- `swift test --filter StatusItemAnimationTests`
- `swift test --filter MenuBarMetricWindowResolverTests`
- `swift test` *(fails on unrelated existing/local-environment cases: MiniMax date localization expects English but locale output is Chinese; PathBuilder login shell cache timeout)*

## Review
- Spawned independent reviewer Fermat: found the initial weekly-fallback regression.
- Fixed that issue and added a fallback regression test.
- Spawned independent reviewer Ramanujan: no findings after the fix.