### PR TITLE
Fix Bedrock Cost Explorer data-unavailable errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Menu bar: reserve quota-bar space consistently across Overview and provider switcher segments so selection no longer changes segment height (#1445). Thanks @Zihao-Qi!
 - Cost usage: accept normal models.dev catalog churn while retaining prior model prices as fallbacks, so newly priced models appear without requiring a manual cache reset (#1438). Thanks @tom-rigelblu!
 - Menu bar: detect Tahoe Control Center proxy windows parked in the blocked offscreen slot during startup recovery, so hidden icons show the existing guidance without weakening menu-bar-manager safeguards (#1440).
+- AWS Bedrock: treat Cost Explorer's temporary data-unavailable response as zero usage instead of an HTTP 400 error (#1324). Thanks @enesteve0!
 - Menu bar: anchor merged provider dropdowns to the status item's trailing edge without marking preserved in-flight refresh content fresh, preventing horizontal drift while keeping deferred updates visible (#1288). Thanks @Yuxin-Qiao!
 - Antigravity: fall back to the CLI usage server when the desktop app is closed, keep helper sessions owned and bounded without hidden sign-in flows, and show model rows with missing usage as unavailable instead of exhausted (#1313). Thanks @enieuwy!
 - Cost usage: replace repeated Foundation metadata/root checks with one portable file-stat pass so expired Codex history refreshes stay responsive on very large session archives (#1392). Thanks @TheAngryPit and @ProspectOre!

--- a/Sources/CodexBarCore/Providers/Bedrock/BedrockUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Bedrock/BedrockUsageStats.swift
@@ -248,6 +248,10 @@ enum BedrockUsageFetcher {
 
         let response = try await ProviderHTTPClient.shared.response(for: request)
         guard response.statusCode == 200 else {
+            if Self.isDataUnavailableResponse(statusCode: response.statusCode, data: response.data) {
+                Self.log.info("AWS Cost Explorer data unavailable, assuming zero usage.")
+                return Data(#"{"ResultsByTime":[]}"#.utf8)
+            }
             let summary = Self.sanitizedResponseBody(response.data)
             Self.log.error("AWS Cost Explorer returned \(response.statusCode): \(summary)")
             throw BedrockUsageError.apiError("HTTP \(response.statusCode)")
@@ -392,6 +396,25 @@ enum BedrockUsageFetcher {
         let startOfToday = calendar.startOfDay(for: now)
         let tomorrow = calendar.date(byAdding: .day, value: 1, to: startOfToday)!
         return (formatter.string(from: startOfMonth), formatter.string(from: tomorrow))
+    }
+
+    private static func isDataUnavailableResponse(statusCode: Int, data: Data) -> Bool {
+        guard statusCode == 400,
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return false
+        }
+
+        let nestedError = json["Error"] as? [String: Any]
+        let candidates = [
+            json["__type"],
+            json["code"],
+            json["Code"],
+            nestedError?["Code"],
+        ]
+        return candidates.compactMap { $0 as? String }.contains { rawCode in
+            rawCode.split(separator: "#").last == "DataUnavailableException"
+        }
     }
 
     private static func sanitizedResponseBody(_ data: Data) -> String {

--- a/Tests/CodexBarTests/BedrockUsageStatsTests.swift
+++ b/Tests/CodexBarTests/BedrockUsageStatsTests.swift
@@ -124,6 +124,71 @@ struct BedrockUsageStatsTests {
     }
 
     @Test
+    func `cost explorer data unavailable response returns zero usage`() async throws {
+        let registered = URLProtocol.registerClass(BedrockStubURLProtocol.self)
+        defer {
+            if registered {
+                URLProtocol.unregisterClass(BedrockStubURLProtocol.self)
+            }
+            BedrockStubURLProtocol.handler = nil
+        }
+
+        BedrockStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            return Self.makeResponse(
+                url: url,
+                body: #"{"__type":"com.amazonaws.ce#DataUnavailableException","message":"Data is not ready"}"#,
+                statusCode: 400)
+        }
+
+        let credentials = BedrockAWSSigner.Credentials(
+            accessKeyID: "AKIATEST",
+            secretAccessKey: "testSecret",
+            sessionToken: nil)
+
+        let usage = try await BedrockUsageFetcher.fetchUsage(
+            credentials: credentials,
+            region: "us-east-1",
+            budget: 100,
+            environment: [BedrockSettingsReader.apiURLKey: "https://bedrock.test"])
+
+        #expect(usage.monthlySpend == 0)
+        #expect(usage.monthlyBudget == 100)
+    }
+
+    @Test
+    func `cost explorer unrelated bad request remains an API error`() async throws {
+        let registered = URLProtocol.registerClass(BedrockStubURLProtocol.self)
+        defer {
+            if registered {
+                URLProtocol.unregisterClass(BedrockStubURLProtocol.self)
+            }
+            BedrockStubURLProtocol.handler = nil
+        }
+
+        BedrockStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            return Self.makeResponse(
+                url: url,
+                body: #"{"__type":"ValidationException","message":"Invalid request"}"#,
+                statusCode: 400)
+        }
+
+        let credentials = BedrockAWSSigner.Credentials(
+            accessKeyID: "AKIATEST",
+            secretAccessKey: "testSecret",
+            sessionToken: nil)
+
+        await #expect(throws: BedrockUsageError.apiError("HTTP 400")) {
+            try await BedrockUsageFetcher.fetchUsage(
+                credentials: credentials,
+                region: "us-east-1",
+                budget: nil,
+                environment: [BedrockSettingsReader.apiURLKey: "https://bedrock.test"])
+        }
+    }
+
+    @Test
     func `cost explorer pagination aggregates monthly total`() async throws {
         let registered = URLProtocol.registerClass(BedrockStubURLProtocol.self)
         defer {


### PR DESCRIPTION
## Summary
- treat AWS Cost Explorer HTTP 400 `DataUnavailableException` responses as an empty usage page
- parse the structured AWS error code, including namespaced `__type` values
- keep unrelated HTTP 400 responses as API errors
- remove the original `.removalAllowed` status-item change because it could remove CodexBar's only menu entry

## Proof
- `swift test --filter BedrockUsageStatsTests` (10 tests passed)
- `make check`
- autoreview: clean, patch correct (0.86 confidence)

## Maintainer rewrite
Rebased onto current `main`. The original Bedrock report was valid, but the unrelated status-item behavior was unsafe and is no longer part of the net diff. Added focused success and negative regression coverage. Contributor credit remains in the original commit and changelog.
