### PR TITLE
Fix Antigravity CLI detection

### DIFF
--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -635,11 +635,12 @@ public struct AntigravityStatusProbe: Sendable {
     }
 
     private static func isLanguageServerCommandLine(_ lowerCommand: String) -> Bool {
-        let pattern = #"(^|[/\\])language_server(_macos|\.exe)?(\s|$)"#
+        let pattern = #"(^|[/\\])(language_server|antigravity-cli|antigravity_cli)(_macos|\.exe)?(\s|/|$)"#
         return lowerCommand.range(of: pattern, options: .regularExpression) != nil
     }
 
     private static func isAntigravityCommandLine(_ command: String) -> Bool {
+        if command.contains("antigravity-cli") || command.contains("antigravity_cli") { return true }
         if command.contains("--app_data_dir") && command.contains("antigravity") { return true }
         if command.contains("/antigravity/") || command.contains("\\antigravity\\") { return true }
         return false

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -635,12 +635,12 @@ public struct AntigravityStatusProbe: Sendable {
     }
 
     private static func isLanguageServerCommandLine(_ lowerCommand: String) -> Bool {
-        let pattern = #"(^|[/\\])(language_server|antigravity-cli|antigravity_cli)(_macos|\.exe)?(\s|/|$)"#
+        let pattern = #"(^|[/\\])(language_server|antigravity-cli|antigravity_cli|agy)(_macos|\.exe)?(\s|/|$)"#
         return lowerCommand.range(of: pattern, options: .regularExpression) != nil
     }
 
     private static func isAntigravityCommandLine(_ command: String) -> Bool {
-        if command.contains("antigravity-cli") || command.contains("antigravity_cli") { return true }
+        if command.contains("antigravity-cli") || command.contains("antigravity_cli") || command.contains("agy") { return true }
         if command.contains("--app_data_dir") && command.contains("antigravity") { return true }
         if command.contains("/antigravity/") || command.contains("\\antigravity\\") { return true }
         return false

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -63,6 +63,29 @@ struct AntigravityStatusProbeTests {
     }
 
     @Test
+    func `process detection accepts antigravity cli variations and agy`() {
+        let commandDash = """
+        node /path/to/node_modules/antigravity-cli/build/mcp-server.cjs --app_data_dir /Users/test/.gemini/antigravity
+        """
+        #expect(AntigravityStatusProbe.isAntigravityLanguageServerCommandLine(commandDash))
+
+        let commandUnderscore = """
+        node /path/to/node_modules/antigravity_cli/build/mcp-server.cjs --app_data_dir /Users/test/.gemini/antigravity
+        """
+        #expect(AntigravityStatusProbe.isAntigravityLanguageServerCommandLine(commandUnderscore))
+
+        let commandAgy = """
+        /usr/local/bin/agy --app_data_dir /Users/test/.gemini/antigravity
+        """
+        #expect(AntigravityStatusProbe.isAntigravityLanguageServerCommandLine(commandAgy))
+
+        let commandAgyNode = """
+        node /path/to/node_modules/agy/build/mcp-server.cjs --app_data_dir /Users/test/.gemini/antigravity
+        """
+        #expect(AntigravityStatusProbe.isAntigravityLanguageServerCommandLine(commandAgyNode))
+    }
+
+    @Test
     func `localhost trust policy only accepts local server trust challenges`() {
         #expect(
             LocalhostTrustPolicy.shouldAcceptServerTrust(


### PR DESCRIPTION
### Summary
Since the main entry point for Antigravity is now `antigravity-cli` (rather than the IDE `language_server` process), usage tracking failed to probe local status endpoints. This updates `isLanguageServerCommandLine` and `isAntigravityCommandLine` to correctly match the new `antigravity-cli` process name (as well as `agy` which is the shorter installed binary) so local probing and usage tracking can succeed.

### Commands Run
- `make check`: SwiftFormat passed (0 files require formatting).
- `swift test`: Passed locally, including new tests for `antigravity-cli`, `antigravity_cli`, and `agy`.

### Proof of Fix Validation
```
Running Probe Diagnostic Proof...
Checking antigravity-cli node process:
Command: node /path/to/node_modules/antigravity-cli/build/mcp-server.cjs --app_data_dir /Users/test/.gemini/antigravity
Detected by pattern: true
---
Checking agy process:
Command: /usr/local/bin/agy --app_data_dir /Users/test/.gemini/antigravity
Detected by pattern: true
✅ Probe validation successful.
```

*(No UI changes)*

@clawsweeper re-review
