### PR TITLE
Show Codex Spark pace details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Localization: add Ukrainian as a selectable app language (#1250). Thanks @Yuxin-Qiao!
 
 ### Fixed
+- Codex Spark: show the same deficit and run-out pace details as the core Codex quota lanes for 5-hour and weekly model limits (#1335). Thanks @dhruv-anand-aintech!
 - Antigravity: make the automatic menu-bar summary choose the most constrained family quota so an exhausted Gemini lane is no longer hidden by a full Claude lane (#1334). Thanks @dhruv-anand-aintech!
 - Performance: memoize models.dev cost catalog load outcomes so large Codex history scans no longer re-read and decode the same cache file per row (#1322, refs #1311). Thanks @turbothad!
 - Menu bar: compute Claude pace/reserve from the selected menu-bar metric window so Primary (Session) no longer pairs the session percentage with the weekly reserve (#1302). Thanks @outfoxer!

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -175,7 +175,11 @@ extension UsageMenuCardView.Model {
             return []
         }
         return extraRateWindows.map { namedWindow in
-            Metric(
+            let paceDetail = Self.extraRateWindowPaceDetail(
+                provider: input.provider,
+                window: namedWindow.window,
+                input: input)
+            return Metric(
                 id: namedWindow.id,
                 title: namedWindow.title,
                 percent: Self.clamped(
@@ -188,10 +192,36 @@ extension UsageMenuCardView.Model {
                     style: input.resetTimeDisplayStyle,
                     now: input.now),
                 detailText: nil,
-                detailLeftText: nil,
-                detailRightText: nil,
-                pacePercent: nil,
-                paceOnTop: true)
+                detailLeftText: paceDetail?.leftLabel,
+                detailRightText: paceDetail?.rightLabel,
+                pacePercent: paceDetail?.pacePercent,
+                paceOnTop: paceDetail?.paceOnTop ?? true)
+        }
+    }
+
+    private static func extraRateWindowPaceDetail(
+        provider: UsageProvider,
+        window: RateWindow,
+        input: Input) -> PaceDetail?
+    {
+        guard provider == .codex else { return nil }
+        switch window.windowMinutes {
+        case 300:
+            return self.sessionPaceDetail(
+                provider: provider,
+                window: window,
+                now: input.now,
+                showUsed: input.usageBarsShowUsed)
+        case 10080:
+            let pace = UsagePace.weekly(window: window, now: input.now, defaultWindowMinutes: 10080)
+                .flatMap { $0.expectedUsedPercent >= 3 ? $0 : nil }
+            return Self.weeklyPaceDetail(
+                window: window,
+                now: input.now,
+                pace: pace,
+                showUsed: input.usageBarsShowUsed)
+        default:
+            return nil
         }
     }
 

--- a/Tests/CodexBarTests/MenuCardModelCodexProjectionTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelCodexProjectionTests.swift
@@ -632,9 +632,9 @@ struct MenuCardModelCodexProjectionTests {
                     id: "codex-spark",
                     title: "Codex Spark 5-hour",
                     window: RateWindow(
-                        usedPercent: 30,
+                        usedPercent: 80,
                         windowMinutes: 300,
-                        resetsAt: now.addingTimeInterval(60 * 60),
+                        resetsAt: now.addingTimeInterval(2 * 60 * 60),
                         resetDescription: nil)),
                 NamedRateWindow(
                     id: "codex-spark-weekly",
@@ -683,14 +683,18 @@ struct MenuCardModelCodexProjectionTests {
 
         let spark = try #require(model.metrics.first { $0.id == "codex-spark" })
         #expect(spark.title == "Codex Spark 5-hour")
-        #expect(spark.percent == 70)
-        #expect(spark.percentLabel == "70% left")
+        #expect(spark.percent == 20)
+        #expect(spark.percentLabel == "20% left")
         #expect(spark.resetText != nil)
+        #expect(spark.detailLeftText == "20% in deficit")
+        #expect(spark.detailRightText == "Projected empty in 45m")
         let sparkWeekly = try #require(model.metrics.first { $0.id == "codex-spark-weekly" })
         #expect(sparkWeekly.title == "Codex Spark Weekly")
         #expect(sparkWeekly.percent == 0)
         #expect(sparkWeekly.percentLabel == "0% left")
         #expect(sparkWeekly.resetText != nil)
+        #expect(sparkWeekly.detailLeftText == "86% in deficit")
+        #expect(sparkWeekly.detailRightText == "Runs out now")
         // Spark trails the core session/weekly lanes rather than replacing them.
         let sparkIndex = try #require(model.metrics.firstIndex { $0.id == "codex-spark" })
         let sparkWeeklyIndex = try #require(model.metrics.firstIndex { $0.id == "codex-spark-weekly" })


### PR DESCRIPTION
## Summary
- Add pace details to Codex extra rate windows when they represent known 5-hour or weekly model limits.
- Keep other providers' extra windows unchanged.
- Extend the Codex Spark model test so the 5-hour row shows deficit/projected-empty detail and the weekly row shows deficit/run-out detail.
- Add changelog entry for #1335.

Fixes #1335.

## Testing
- swift test --filter MenuCardModelCodexProjectionTests
- swift test --filter UsagePaceTextTests
- git diff --check
- make check
- autoreview --mode local

## Verification images
- Not applicable; source-level menu-card model fix covered by focused model/pace tests.
