### PR TITLE
fix: show Cursor billing-cycle pace details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Localization: add Ukrainian as a selectable app language (#1250). Thanks @Yuxin-Qiao!
 
 ### Fixed
+- Cursor: show deficit and run-out pace details for 30-day Total, Auto, and API billing-cycle usage rows (#1336). Thanks @dhruv-anand-aintech!
 - Codex Spark: show the same deficit and run-out pace details as the core Codex quota lanes for 5-hour and weekly model limits (#1335). Thanks @dhruv-anand-aintech!
 - Antigravity: make the automatic menu-bar summary choose the most constrained family quota so an exhausted Gemini lane is no longer hidden by a full Claude lane (#1334). Thanks @dhruv-anand-aintech!
 - Performance: memoize models.dev cost catalog load outcomes so large Codex history scans no longer re-read and decode the same cache file per row (#1322, refs #1311). Thanks @turbothad!

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -133,6 +133,25 @@ extension UsageMenuCardView.Model {
             paceOnTop: paceOnTop)
     }
 
+    static func cursorBillingCyclePaceDetail(
+        window: RateWindow,
+        input: Input,
+        pace: UsagePace? = nil) -> PaceDetail?
+    {
+        guard input.provider == .cursor,
+              window.windowMinutes != nil
+        else { return nil }
+        let resolved = pace ?? UsagePace.weekly(window: window, now: input.now, defaultWindowMinutes: 10080)
+        guard let resolved,
+              resolved.expectedUsedPercent >= 3
+        else { return nil }
+        return Self.weeklyPaceDetail(
+            window: window,
+            now: input.now,
+            pace: resolved,
+            showUsed: input.usageBarsShowUsed)
+    }
+
     static func antigravityMetrics(input: Input, snapshot: UsageSnapshot) -> [Metric] {
         let percentStyle: PercentStyle = input.usageBarsShowUsed ? .used : .left
         var metrics = [

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1156,6 +1156,7 @@ extension UsageMenuCardView.Model {
             let opusResetText: String? = input.provider == .perplexity
                 ? opus.resetDescription?.trimmingCharacters(in: .whitespacesAndNewlines)
                 : Self.resetText(for: opus, style: input.resetTimeDisplayStyle, now: input.now)
+            let tertiaryPaceDetail = Self.cursorBillingCyclePaceDetail(window: opus, input: input)
             metrics.append(Metric(
                 id: "tertiary",
                 title: labels.tertiary,
@@ -1163,10 +1164,10 @@ extension UsageMenuCardView.Model {
                 percentStyle: percentStyle,
                 resetText: opusResetText,
                 detailText: tertiaryDetailText,
-                detailLeftText: nil,
-                detailRightText: nil,
-                pacePercent: nil,
-                paceOnTop: true,
+                detailLeftText: tertiaryPaceDetail?.leftLabel,
+                detailRightText: tertiaryPaceDetail?.rightLabel,
+                pacePercent: tertiaryPaceDetail?.pacePercent,
+                paceOnTop: tertiaryPaceDetail?.paceOnTop ?? true,
                 warningMarkerPercents: Self.warningMarkerPercents(
                     thresholds: input.quotaWarningThresholds[.weekly],
                     showUsed: input.usageBarsShowUsed)))
@@ -1319,6 +1320,12 @@ extension UsageMenuCardView.Model {
                 }
             }
         }
+        if let paceDetail = Self.cursorBillingCyclePaceDetail(window: primary, input: input) {
+            primaryDetailLeft = paceDetail.leftLabel
+            primaryDetailRight = paceDetail.rightLabel
+            primaryPacePercent = paceDetail.pacePercent
+            primaryPaceOnTop = paceDetail.paceOnTop
+        }
         if input.provider == .synthetic,
            let regen = Self.syntheticRollingRegenDetail(
                window: primary,
@@ -1419,6 +1426,13 @@ extension UsageMenuCardView.Model {
            !detail.isEmpty
         {
             paceDetail = PaceDetail(leftLabel: detail, rightLabel: nil, pacePercent: nil, paceOnTop: true)
+        }
+        if let cursorPaceDetail = Self.cursorBillingCyclePaceDetail(
+            window: weekly,
+            input: input,
+            pace: input.weeklyPace)
+        {
+            paceDetail = cursorPaceDetail
         }
         // Perplexity bonus credits don't reset; show balance without "Resets" prefix.
         if input.provider == .perplexity,

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -356,6 +356,8 @@ public struct CursorStatusSnapshot: Sendable {
     public let teamOnDemandUsedUSD: Double?
     /// Team on-demand limit in USD
     public let teamOnDemandLimitUSD: Double?
+    /// Billing cycle start date
+    public let billingCycleStart: Date?
     /// Billing cycle reset date
     public let billingCycleEnd: Date?
     /// Membership type (e.g., "enterprise", "pro", "hobby")
@@ -389,6 +391,7 @@ public struct CursorStatusSnapshot: Sendable {
         onDemandLimitUSD: Double?,
         teamOnDemandUsedUSD: Double?,
         teamOnDemandLimitUSD: Double?,
+        billingCycleStart: Date? = nil,
         billingCycleEnd: Date?,
         membershipType: String?,
         accountEmail: String?,
@@ -406,6 +409,7 @@ public struct CursorStatusSnapshot: Sendable {
         self.onDemandLimitUSD = onDemandLimitUSD
         self.teamOnDemandUsedUSD = teamOnDemandUsedUSD
         self.teamOnDemandLimitUSD = teamOnDemandLimitUSD
+        self.billingCycleStart = billingCycleStart
         self.billingCycleEnd = billingCycleEnd
         self.membershipType = membershipType
         self.accountEmail = accountEmail
@@ -428,9 +432,13 @@ public struct CursorStatusSnapshot: Sendable {
             self.planPercentUsed
         }
 
+        let billingCycleWindowMinutes = Self.billingCycleWindowMinutes(
+            start: self.billingCycleStart,
+            end: self.billingCycleEnd)
+
         let primary = RateWindow(
             usedPercent: primaryUsedPercent,
-            windowMinutes: nil,
+            windowMinutes: billingCycleWindowMinutes,
             resetsAt: self.billingCycleEnd,
             resetDescription: self.billingCycleEnd.map { Self.formatResetDate($0) })
 
@@ -438,7 +446,7 @@ public struct CursorStatusSnapshot: Sendable {
         let secondary: RateWindow? = self.autoPercentUsed.map { pct in
             RateWindow(
                 usedPercent: pct,
-                windowMinutes: nil,
+                windowMinutes: billingCycleWindowMinutes,
                 resetsAt: self.billingCycleEnd,
                 resetDescription: self.billingCycleEnd.map { Self.formatResetDate($0) })
         }
@@ -447,7 +455,7 @@ public struct CursorStatusSnapshot: Sendable {
         let tertiary: RateWindow? = self.apiPercentUsed.map { pct in
             RateWindow(
                 usedPercent: pct,
-                windowMinutes: nil,
+                windowMinutes: billingCycleWindowMinutes,
                 resetsAt: self.billingCycleEnd,
                 resetDescription: self.billingCycleEnd.map { Self.formatResetDate($0) })
         }
@@ -500,6 +508,14 @@ public struct CursorStatusSnapshot: Sendable {
         formatter.dateFormat = "MMM d 'at' h:mma"
         formatter.locale = Locale(identifier: "en_US_POSIX")
         return "Resets " + formatter.string(from: date)
+    }
+
+    private static func billingCycleWindowMinutes(start: Date?, end: Date?) -> Int? {
+        guard let start,
+              let end
+        else { return nil }
+        let minutes = Int((end.timeIntervalSince(start) / 60).rounded())
+        return minutes > 0 ? minutes : nil
     }
 
     private static func formatMembershipType(_ type: String) -> String {
@@ -1018,12 +1034,14 @@ public struct CursorStatusProbe: Sendable {
         rawJSON: String?,
         requestUsage: CursorUsageResponse? = nil) -> CursorStatusSnapshot
     {
-        // Parse billing cycle end date
-        let billingCycleEnd: Date? = summary.billingCycleEnd.flatMap { dateString in
+        func parseBillingCycleDate(_ dateString: String?) -> Date? {
+            guard let dateString else { return nil }
             let formatter = ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
             return formatter.date(from: dateString) ?? ISO8601DateFormatter().date(from: dateString)
         }
+        let billingCycleStart = parseBillingCycleDate(summary.billingCycleStart)
+        let billingCycleEnd = parseBillingCycleDate(summary.billingCycleEnd)
 
         // Convert cents to USD (plan percent derives from raw values to avoid percent unit mismatches).
         // Use plan.limit directly - breakdown.total represents total *used* credits, not the limit.
@@ -1119,6 +1137,7 @@ public struct CursorStatusProbe: Sendable {
             onDemandLimitUSD: onDemandLimit,
             teamOnDemandUsedUSD: teamOnDemandUsed,
             teamOnDemandLimitUSD: teamOnDemandLimit,
+            billingCycleStart: billingCycleStart,
             billingCycleEnd: billingCycleEnd,
             membershipType: summary.membershipType,
             accountEmail: userInfo?.email,

--- a/Tests/CodexBarTests/CursorMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/CursorMenuCardModelTests.swift
@@ -1,0 +1,49 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct CursorMenuCardModelTests {
+    @Test
+    func `cursor billing cycle metrics show deficit and run out details`() throws {
+        let now = Date(timeIntervalSince1970: 0)
+        let reset = now.addingTimeInterval(6 * 24 * 3600)
+        let cycleMinutes = 30 * 24 * 60
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 90, windowMinutes: cycleMinutes, resetsAt: reset, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 90, windowMinutes: cycleMinutes, resetsAt: reset, resetDescription: nil),
+            tertiary: RateWindow(usedPercent: 90, windowMinutes: cycleMinutes, resetsAt: reset, resetDescription: nil),
+            updatedAt: now,
+            identity: nil)
+        let metadata = try #require(ProviderDefaults.metadata[.cursor])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .cursor,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.metrics.map(\.title) == ["Total", "Auto", "API"])
+        for metric in model.metrics {
+            #expect(metric.percentLabel == "10% left")
+            #expect(metric.detailLeftText == "10% in deficit")
+            #expect(metric.detailRightText == "Runs out in 2d 16h")
+            #expect(metric.pacePercent == 20)
+            #expect(metric.paceOnTop == false)
+        }
+    }
+}

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -314,7 +314,12 @@ struct CursorStatusProbeTests {
         #expect(snapshot.planPercentUsed == 0.441025641025641)
         #expect(snapshot.autoPercentUsed == 0.36)
         #expect(snapshot.apiPercentUsed == 0.7111111111111111)
-        #expect(snapshot.toUsageSnapshot().primary?.remainingPercent == 99.55897435897436)
+        #expect(snapshot.billingCycleStart != nil)
+        let usageSnapshot = snapshot.toUsageSnapshot()
+        #expect(usageSnapshot.primary?.remainingPercent == 99.55897435897436)
+        #expect(usageSnapshot.primary?.windowMinutes == 44640)
+        #expect(usageSnapshot.secondary?.windowMinutes == 44640)
+        #expect(usageSnapshot.tertiary?.windowMinutes == 44640)
     }
 
     @Test
@@ -329,6 +334,7 @@ struct CursorStatusProbeTests {
             onDemandLimitUSD: 100.0,
             teamOnDemandUsedUSD: 25.0,
             teamOnDemandLimitUSD: 500.0,
+            billingCycleStart: Date(timeIntervalSince1970: 1_735_689_600), // Jan 1, 2025
             billingCycleEnd: Date(timeIntervalSince1970: 1_738_368_000), // Feb 1, 2025
             membershipType: "pro",
             accountEmail: "user@example.com",
@@ -342,6 +348,8 @@ struct CursorStatusProbeTests {
         #expect(usageSnapshot.loginMethod(for: .cursor) == "Cursor Pro")
         #expect(usageSnapshot.secondary != nil)
         #expect(usageSnapshot.secondary?.usedPercent == 5.0)
+        #expect(usageSnapshot.primary?.windowMinutes == 44640)
+        #expect(usageSnapshot.secondary?.windowMinutes == 44640)
         #expect(usageSnapshot.providerCost?.used == 5.0)
         #expect(usageSnapshot.providerCost?.limit == 100.0)
         #expect(usageSnapshot.providerCost?.currencyCode == "USD")


### PR DESCRIPTION
## Summary
- preserve Cursor billing-cycle start/end as a concrete window duration
- show deficit and run-out pace details on Cursor Total, Auto, and API menu rows
- add Cursor parser/model regression tests and changelog entry

Fixes #1336.

## Testing
- `swift test --filter CursorStatusProbeTests`
- `swift test --filter CursorMenuCardModelTests`
- `swift test --filter UsagePaceTextTests`
- `git diff --check`
- `make check`
- `autoreview --mode local`

## Verification images
Not applicable; source-level provider/model fix covered by deterministic parser and menu-card model tests.
