### PR TITLE
fix: time out stalled managed Codex login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Cursor: show deficit and run-out pace details for 30-day Total, Auto, and API billing-cycle usage rows (#1336). Thanks @dhruv-anand-aintech!
+- Codex: time out stalled managed `codex login` processes so account switches no longer stay stuck in progress after OAuth completes (#1330). Thanks @dhruv-anand-aintech!
 - Codex Spark: show the same deficit and run-out pace details as the core Codex quota lanes for 5-hour and weekly model limits (#1335). Thanks @dhruv-anand-aintech!
 - Antigravity: make the automatic menu-bar summary choose the most constrained family quota so an exhausted Gemini lane is no longer hidden by a full Claude lane (#1334). Thanks @dhruv-anand-aintech!
 - Performance: memoize models.dev cost catalog load outcomes so large Codex history scans no longer re-read and decode the same cache file per row (#1322, refs #1311). Thanks @turbothad!

--- a/Sources/CodexBar/CodexLoginRunner.swift
+++ b/Sources/CodexBar/CodexLoginRunner.swift
@@ -16,18 +16,23 @@ struct CodexLoginRunner {
         let output: String
     }
 
-    static func run(homePath: String? = nil, timeout: TimeInterval = 120) async -> Result {
+    static func run(
+        homePath: String? = nil,
+        timeout: TimeInterval = 120,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        loginPATH: [String]? = LoginShellPathCache.shared.current) async -> Result
+    {
         await Task(priority: .userInitiated) {
-            var env = ProcessInfo.processInfo.environment
+            var env = environment
             env["PATH"] = PathBuilder.effectivePATH(
                 purposes: [.rpc, .tty, .nodeTooling],
                 env: env,
-                loginPATH: LoginShellPathCache.shared.current)
+                loginPATH: loginPATH)
             env = CodexHomeScope.scopedEnvironment(base: env, codexHome: homePath)
 
             guard let executable = BinaryLocator.resolveCodexBinary(
                 env: env,
-                loginPATH: LoginShellPathCache.shared.current)
+                loginPATH: loginPATH)
             else {
                 return Result(outcome: .missingBinary, output: "")
             }
@@ -42,6 +47,11 @@ struct CodexLoginRunner {
             process.standardOutput = stdout
             process.standardError = stderr
 
+            let termination = ProcessTermination()
+            process.terminationHandler = { _ in
+                termination.resolve(timedOut: false)
+            }
+
             var processGroup: pid_t?
             do {
                 try process.run()
@@ -50,7 +60,7 @@ struct CodexLoginRunner {
                 return Result(outcome: .launchFailed(error.localizedDescription), output: "")
             }
 
-            let timedOut = await self.wait(for: process, timeout: timeout)
+            let timedOut = await self.wait(timeout: timeout, termination: termination)
             if timedOut {
                 self.terminate(process, processGroup: processGroup)
             }
@@ -68,21 +78,58 @@ struct CodexLoginRunner {
         }.value
     }
 
-    private static func wait(for process: Process, timeout: TimeInterval) async -> Bool {
-        await withTaskGroup(of: Bool.self) { group -> Bool in
-            group.addTask {
-                process.waitUntilExit()
-                return false
+    private final class ProcessTermination: @unchecked Sendable {
+        private let lock = NSLock()
+        private var timedOut: Bool?
+        private var continuation: CheckedContinuation<Bool, Never>?
+
+        func resolve(timedOut: Bool) {
+            let continuation: CheckedContinuation<Bool, Never>?
+            self.lock.lock()
+            guard self.timedOut == nil else {
+                self.lock.unlock()
+                return
             }
-            group.addTask {
-                let nanos = UInt64(max(0, timeout) * 1_000_000_000)
-                try? await Task.sleep(nanoseconds: nanos)
-                return true
-            }
-            let result = await group.next() ?? false
-            group.cancelAll()
-            return result
+            self.timedOut = timedOut
+            continuation = self.continuation
+            self.continuation = nil
+            self.lock.unlock()
+            continuation?.resume(returning: timedOut)
         }
+
+        func wait() async -> Bool {
+            await withCheckedContinuation { continuation in
+                let timedOut: Bool?
+                self.lock.lock()
+                timedOut = self.timedOut
+                if timedOut == nil {
+                    self.continuation = continuation
+                }
+                self.lock.unlock()
+
+                if let timedOut {
+                    continuation.resume(returning: timedOut)
+                }
+            }
+        }
+    }
+
+    private static func wait(timeout: TimeInterval, termination: ProcessTermination) async -> Bool {
+        let timeoutTask = Task.detached(priority: .userInitiated) {
+            try? await Task.sleep(nanoseconds: self.timeoutNanoseconds(timeout))
+            if Task.isCancelled == false {
+                termination.resolve(timedOut: true)
+            }
+        }
+        let timedOut = await termination.wait()
+        timeoutTask.cancel()
+        return timedOut
+    }
+
+    private static func timeoutNanoseconds(_ timeout: TimeInterval) -> UInt64 {
+        guard timeout.isFinite else { return UInt64.max }
+        let seconds = max(0, min(timeout, Double(UInt64.max) / 1_000_000_000))
+        return UInt64(seconds * 1_000_000_000)
     }
 
     private static func terminate(_ process: Process, processGroup: pid_t?) {

--- a/Tests/CodexBarTests/CodexLoginRunnerTests.swift
+++ b/Tests/CodexBarTests/CodexLoginRunnerTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct CodexLoginRunnerTests {
+    @Test
+    func `login runner returns timeout before hung codex exits`() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-login-runner-\(UUID().uuidString)", isDirectory: true)
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let homeDir = root.appendingPathComponent("home", isDirectory: true)
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: homeDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let codex = binDir.appendingPathComponent("codex")
+        let script = """
+        #!/usr/bin/python3
+        import time
+
+        print("login-started", flush=True)
+        time.sleep(5)
+        print("login-finished", flush=True)
+        """
+        try script.write(to: codex, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: codex.path)
+
+        let start = Date()
+        let result = await CodexLoginRunner.run(
+            homePath: homeDir.path,
+            timeout: 0.2,
+            environment: ["PATH": binDir.path],
+            loginPATH: nil)
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(result.outcome == .timedOut)
+        #expect(result.output.contains("login-finished") == false)
+        #expect(elapsed < 2.0, "Timeout should return promptly, took \(elapsed)s")
+    }
+}

--- a/Tests/CodexBarTests/ManagedCodexAccountCoordinatorTests.swift
+++ b/Tests/CodexBarTests/ManagedCodexAccountCoordinatorTests.swift
@@ -38,6 +38,34 @@ struct ManagedCodexAccountCoordinatorTests {
         #expect(coordinator.isAuthenticatingManagedAccount == false)
         #expect(coordinator.authenticatingManagedAccountID == nil)
     }
+
+    @Test
+    func `coordinator clears in flight state after managed login timeout`() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let loginResult = CodexLoginRunner.Result(outcome: .timedOut, output: "timed out")
+        let existingAccountID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-222222222222"))
+        let service = ManagedCodexAccountService(
+            store: InMemoryManagedCodexAccountStoreForCoordinatorTests(
+                accounts: ManagedCodexAccountSet(version: 1, accounts: [])),
+            homeFactory: CoordinatorTestManagedCodexHomeFactory(root: root),
+            loginRunner: TimedOutManagedCodexLoginRunner(result: loginResult),
+            identityReader: CoordinatorStubManagedCodexIdentityReader(email: "user@example.com"))
+        let coordinator = ManagedCodexAccountCoordinator(service: service)
+
+        do {
+            _ = try await coordinator.authenticateManagedAccount(existingAccountID: existingAccountID, timeout: 0.2)
+            Issue.record("Expected managed login timeout to throw")
+        } catch let error as ManagedCodexAccountServiceError {
+            #expect(error == .loginFailed(loginResult))
+        } catch {
+            Issue.record("Expected ManagedCodexAccountServiceError.loginFailed, got \(error)")
+        }
+
+        #expect(coordinator.isAuthenticatingManagedAccount == false)
+        #expect(coordinator.authenticatingManagedAccountID == nil)
+    }
 }
 
 private actor BlockingManagedCodexLoginRunner: ManagedCodexLoginRunning {
@@ -65,6 +93,14 @@ private actor BlockingManagedCodexLoginRunner: ManagedCodexLoginRunning {
         let result = CodexLoginRunner.Result(outcome: .success, output: "ok")
         self.waiters.forEach { $0.resume(returning: result) }
         self.waiters.removeAll()
+    }
+}
+
+private struct TimedOutManagedCodexLoginRunner: ManagedCodexLoginRunning {
+    let result: CodexLoginRunner.Result
+
+    func run(homePath _: String, timeout _: TimeInterval) async -> CodexLoginRunner.Result {
+        self.result
     }
 }
 


### PR DESCRIPTION
## Summary
- time out stalled managed `codex login` processes instead of waiting forever on `waitUntilExit`
- clear managed-account in-flight state when a login timeout fails
- add fake-binary and coordinator regression coverage for #1330

Fixes #1330.

## Tests
- `swift test --filter CodexLoginRunnerTests`
- `swift test --filter ManagedCodexAccountCoordinatorTests`
- `swift test --filter CodexAccountsSettingsSectionTests`
- `swift test --filter SubprocessRunnerTests`
- `git diff --check`
- `make check`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local`

Verification images: not applicable; process timeout/state regression covered by deterministic tests.
