### PR TITLE
Fix Antigravity CLI usage detection via its local language server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Claude: remove transient ClaudeProbe session artifacts after CLI usage polls so background refreshes no longer fill Claude Code project history with CodexBar `/usage` sessions (#1301). Thanks @LPFchan and @matthewod11-stack!
 - Menu bar: keep z.ai overview rows with detail submenus in Overview so hovering quota details no longer recurses into a nested provider menu (#1279, fixes #1246). Thanks @RajvardhanPatil07!
 - Codex: backfill visible-account reset timestamps and missing 5-hour/weekly window metadata from same-workspace plan history so segmented multi-account JSON keeps machine-readable reset data (#1283). Thanks @callmepopo!
+- Antigravity: detect CLI local language-server processes and allow empty CSRF tokens only for explicit CLI matches so Antigravity CLI quota usage renders without weakening IDE CSRF detection (#1341). Thanks @oyaah!
 - Cursor: show deficit and run-out pace details for 30-day Total, Auto, and API billing-cycle usage rows (#1336). Thanks @dhruv-anand-aintech!
 - Codex: time out stalled managed `codex login` processes so account switches no longer stay stuck in progress after OAuth completes (#1330). Thanks @dhruv-anand-aintech!
 - Codex Spark: show the same deficit and run-out pace details as the core Codex quota lanes for 5-hour and weekly model limits (#1335). Thanks @dhruv-anand-aintech!

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -593,14 +593,20 @@ public struct AntigravityStatusProbe: Sendable {
             label: "antigravity-ps")
 
         let lines = result.stdout.split(separator: "\n")
+        var sawTokenlessIDE = false
         for line in lines {
             let text = String(line)
             guard let match = Self.matchProcessLine(text) else { continue }
-            guard Self.isAntigravityLanguageServerCommandLine(match.command) else { continue }
+            guard let kind = Self.antigravityProcessKind(match.command) else { continue }
             // The IDE language server authenticates local requests with a
-            // `--csrf_token`; the CLI's language server requires none, so treat
-            // the token as optional and fall back to an empty value.
-            let token = Self.extractFlag("--csrf_token", from: match.command) ?? ""
+            // `--csrf_token` and must keep requiring it: skip a tokenless IDE
+            // match so a later valid IDE server can still be found (and surface
+            // `missingCSRFToken` if none is). The CLI's language server exposes
+            // no token flag and needs none, so an empty token is allowed there.
+            guard let token = Self.resolvedCSRFToken(forKind: kind, command: match.command) else {
+                sawTokenlessIDE = true
+                continue
+            }
             let port = Self.extractPort("--extension_server_port", from: match.command)
             let extensionServerCSRFToken = Self.extractFlag("--extension_server_csrf_token", from: match.command)
             return ProcessInfoResult(
@@ -611,6 +617,9 @@ public struct AntigravityStatusProbe: Sendable {
                 commandLine: match.command)
         }
 
+        if sawTokenlessIDE {
+            throw AntigravityStatusProbeError.missingCSRFToken
+        }
         throw AntigravityStatusProbeError.notRunning
     }
 
@@ -627,12 +636,43 @@ public struct AntigravityStatusProbe: Sendable {
         return ProcessLineMatch(pid: pid, command: String(parts[1]))
     }
 
+    enum AntigravityProcessKind: Equatable {
+        /// IDE language server (`language_server*`). Requires a `--csrf_token`.
+        case ide
+        /// CLI language server (`agy` / `antigravity-cli`). Needs no CSRF token.
+        case cli
+    }
+
     static func isAntigravityLanguageServerCommandLine(_ command: String) -> Bool {
+        self.antigravityProcessKind(command) != nil
+    }
+
+    /// Classify a process command line as the Antigravity IDE language server,
+    /// the Antigravity CLI language server, or neither. The IDE match takes
+    /// precedence so its CSRF-token requirement is preserved.
+    static func antigravityProcessKind(_ command: String) -> AntigravityProcessKind? {
         let lower = command.lowercased()
         if Self.isLanguageServerCommandLine(lower), Self.isAntigravityCommandLine(lower) {
-            return true
+            return .ide
         }
-        return Self.isAntigravityCLICommandLine(lower)
+        if Self.isAntigravityCLICommandLine(lower) {
+            return .cli
+        }
+        return nil
+    }
+
+    /// Resolve the CSRF token to use for a matched process, or `nil` when the
+    /// match must be skipped. IDE matches keep requiring `--csrf_token`
+    /// (tokenless IDE matches are skipped). CLI matches accept an empty token
+    /// because the CLI's language server requires none.
+    static func resolvedCSRFToken(forKind kind: AntigravityProcessKind, command: String) -> String? {
+        if let token = extractFlag("--csrf_token", from: command) {
+            return token
+        }
+        switch kind {
+        case .ide: return nil
+        case .cli: return ""
+        }
     }
 
     private static func isLanguageServerCommandLine(_ lowerCommand: String) -> Bool {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -593,13 +593,14 @@ public struct AntigravityStatusProbe: Sendable {
             label: "antigravity-ps")
 
         let lines = result.stdout.split(separator: "\n")
-        var sawAntigravity = false
         for line in lines {
             let text = String(line)
             guard let match = Self.matchProcessLine(text) else { continue }
             guard Self.isAntigravityLanguageServerCommandLine(match.command) else { continue }
-            sawAntigravity = true
-            guard let token = Self.extractFlag("--csrf_token", from: match.command) else { continue }
+            // The IDE language server authenticates local requests with a
+            // `--csrf_token`; the CLI's language server requires none, so treat
+            // the token as optional and fall back to an empty value.
+            let token = Self.extractFlag("--csrf_token", from: match.command) ?? ""
             let port = Self.extractPort("--extension_server_port", from: match.command)
             let extensionServerCSRFToken = Self.extractFlag("--extension_server_csrf_token", from: match.command)
             return ProcessInfoResult(
@@ -610,9 +611,6 @@ public struct AntigravityStatusProbe: Sendable {
                 commandLine: match.command)
         }
 
-        if sawAntigravity {
-            throw AntigravityStatusProbeError.missingCSRFToken
-        }
         throw AntigravityStatusProbeError.notRunning
     }
 
@@ -631,12 +629,27 @@ public struct AntigravityStatusProbe: Sendable {
 
     static func isAntigravityLanguageServerCommandLine(_ command: String) -> Bool {
         let lower = command.lowercased()
-        return Self.isLanguageServerCommandLine(lower) && Self.isAntigravityCommandLine(lower)
+        if Self.isLanguageServerCommandLine(lower), Self.isAntigravityCommandLine(lower) {
+            return true
+        }
+        return Self.isAntigravityCLICommandLine(lower)
     }
 
     private static func isLanguageServerCommandLine(_ lowerCommand: String) -> Bool {
         let pattern = #"(^|[/\\])language_server(_macos|\.exe)?(\s|$)"#
         return lowerCommand.range(of: pattern, options: .regularExpression) != nil
+    }
+
+    /// The Antigravity CLI (`agy` / `antigravity-cli`) hosts the same language
+    /// server locally as the IDE, but launches it without a `--csrf_token` flag
+    /// and under a different process name. Match it so usage can be probed when
+    /// only the CLI is running.
+    private static func isAntigravityCLICommandLine(_ lowerCommand: String) -> Bool {
+        if lowerCommand.contains("antigravity-cli") || lowerCommand.contains("antigravity_cli") {
+            return true
+        }
+        let agyPattern = #"(^|[/\\])agy(\s|$)"#
+        return lowerCommand.range(of: agyPattern, options: .regularExpression) != nil
     }
 
     private static func isAntigravityCommandLine(_ command: String) -> Bool {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -559,7 +559,7 @@ public struct AntigravityStatusProbe: Sendable {
 
     // MARK: - Port detection
 
-    private struct ProcessInfoResult {
+    struct ProcessInfoResult {
         let pid: Int
         let extensionPort: Int?
         let extensionServerCSRFToken: String?
@@ -592,7 +592,11 @@ public struct AntigravityStatusProbe: Sendable {
             timeout: timeout,
             label: "antigravity-ps")
 
-        let lines = result.stdout.split(separator: "\n")
+        return try Self.processInfo(fromProcessListOutput: result.stdout)
+    }
+
+    static func processInfo(fromProcessListOutput output: String) throws -> ProcessInfoResult {
+        let lines = output.split(separator: "\n")
         var sawTokenlessIDE = false
         for line in lines {
             let text = String(line)
@@ -685,7 +689,8 @@ public struct AntigravityStatusProbe: Sendable {
     /// and under a different process name. Match it so usage can be probed when
     /// only the CLI is running.
     private static func isAntigravityCLICommandLine(_ lowerCommand: String) -> Bool {
-        if lowerCommand.contains("antigravity-cli") || lowerCommand.contains("antigravity_cli") {
+        let cliPathPattern = #"(^|[/\\])(antigravity-cli|antigravity_cli)([\s/\\]|$)"#
+        if lowerCommand.range(of: cliPathPattern, options: .regularExpression) != nil {
             return true
         }
         let agyPattern = #"(^|[/\\])agy(\s|$)"#

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -63,6 +63,29 @@ struct AntigravityStatusProbeTests {
     }
 
     @Test
+    func `process detection accepts antigravity cli without csrf token`() {
+        // The CLI launches its language server without a `--csrf_token` flag.
+        let node = """
+        node /Users/test/.gemini/antigravity-cli/build/mcp-server.cjs \
+        --app_data_dir /Users/test/.gemini/antigravity
+        """
+        #expect(AntigravityStatusProbe.isAntigravityLanguageServerCommandLine(node))
+
+        let agy = "/Users/test/.local/bin/agy -p hello"
+        #expect(AntigravityStatusProbe.isAntigravityLanguageServerCommandLine(agy))
+
+        let agyUnderscore = "/usr/local/bin/agy --app_data_dir /Users/test/.gemini/antigravity_cli"
+        #expect(AntigravityStatusProbe.isAntigravityLanguageServerCommandLine(agyUnderscore))
+    }
+
+    @Test
+    func `process detection ignores unrelated binaries containing agy substring`() {
+        // "agy" must be path-anchored so unrelated commands do not match.
+        #expect(!AntigravityStatusProbe.isAntigravityLanguageServerCommandLine("/usr/bin/legacy --run"))
+        #expect(!AntigravityStatusProbe.isAntigravityLanguageServerCommandLine("/opt/imagymagic/bin/tool"))
+    }
+
+    @Test
     func `localhost trust policy only accepts local server trust challenges`() {
         #expect(
             LocalhostTrustPolicy.shouldAcceptServerTrust(

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -86,6 +86,16 @@ struct AntigravityStatusProbeTests {
     }
 
     @Test
+    func `process detection ignores cli names outside explicit cli path segments`() {
+        #expect(
+            !AntigravityStatusProbe.isAntigravityLanguageServerCommandLine(
+                "/usr/bin/node /tmp/not-antigravity-cli/build/server.js"))
+        #expect(
+            !AntigravityStatusProbe.isAntigravityLanguageServerCommandLine(
+                "/usr/bin/helper --workspace antigravity-cli"))
+    }
+
+    @Test
     func `process kind distinguishes ide language server from cli`() {
         let ide = """
         /Applications/Antigravity.app/Contents/Resources/bin/language_server \
@@ -119,7 +129,7 @@ struct AntigravityStatusProbeTests {
         // CLI without a token resolves to an empty token (its server needs none).
         #expect(
             AntigravityStatusProbe.resolvedCSRFToken(
-                forKind: .cli, command: "/Users/test/.local/bin/agy -p hi") == "")
+                forKind: .cli, command: "/Users/test/.local/bin/agy -p hi")?.isEmpty == true)
 
         // A CLI that does carry a token still uses it.
         #expect(
@@ -127,6 +137,49 @@ struct AntigravityStatusProbeTests {
                 forKind: .cli, command: "/Users/test/.local/bin/agy --csrf_token cli-token") == "cli-token")
     }
 
+    @Test
+    func `process scan skips tokenless ide before later valid ide`() throws {
+        let tokenlessIDE =
+            "  100 /Applications/Antigravity.app/Contents/Resources/bin/language_server --app_data_dir antigravity"
+        let validIDE = "  101 /Applications/Antigravity.app/Contents/Resources/bin/language_server " +
+            "--csrf_token ide-token --app_data_dir antigravity " +
+            "--extension_server_port 64432 --extension_server_csrf_token extension-token"
+        let output = [tokenlessIDE, validIDE].joined(separator: "\n")
+
+        let result = try AntigravityStatusProbe.processInfo(fromProcessListOutput: output)
+
+        #expect(result.pid == 101)
+        #expect(result.csrfToken == "ide-token")
+        #expect(result.extensionPort == 64432)
+        #expect(result.extensionServerCSRFToken == "extension-token")
+    }
+
+    @Test
+    func `process scan reports missing csrf when only tokenless ide matches`() {
+        let output = """
+          100 /Applications/Antigravity.app/Contents/Resources/bin/language_server --app_data_dir antigravity
+        """
+
+        #expect(throws: AntigravityStatusProbeError.missingCSRFToken) {
+            try AntigravityStatusProbe.processInfo(fromProcessListOutput: output)
+        }
+    }
+
+    @Test
+    func `process scan allows empty csrf only for explicit cli match`() throws {
+        let output = """
+          200 /Users/test/.local/bin/agy -p hello
+        """
+
+        let result = try AntigravityStatusProbe.processInfo(fromProcessListOutput: output)
+
+        #expect(result.pid == 200)
+        #expect(result.csrfToken.isEmpty)
+        #expect(result.commandLine == "/Users/test/.local/bin/agy -p hello")
+    }
+}
+
+extension AntigravityStatusProbeTests {
     @Test
     func `localhost trust policy only accepts local server trust challenges`() {
         #expect(

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -86,6 +86,48 @@ struct AntigravityStatusProbeTests {
     }
 
     @Test
+    func `process kind distinguishes ide language server from cli`() {
+        let ide = """
+        /Applications/Antigravity.app/Contents/Resources/bin/language_server \
+        --csrf_token token --app_data_dir antigravity
+        """
+        #expect(AntigravityStatusProbe.antigravityProcessKind(ide) == .ide)
+        #expect(AntigravityStatusProbe.antigravityProcessKind("/Users/test/.local/bin/agy -p hi") == .cli)
+        #expect(
+            AntigravityStatusProbe.antigravityProcessKind(
+                "node /x/.gemini/antigravity-cli/build/mcp-server.cjs --app_data_dir /x/.gemini/antigravity") == .cli)
+        #expect(AntigravityStatusProbe.antigravityProcessKind("/usr/bin/legacy --run") == nil)
+    }
+
+    @Test
+    func `csrf token stays required for ide but optional for cli`() {
+        // IDE with a token returns it.
+        let ideWithToken = """
+        /Applications/Antigravity.app/Contents/Resources/bin/language_server \
+        --csrf_token ide-token --app_data_dir antigravity
+        """
+        #expect(AntigravityStatusProbe.resolvedCSRFToken(forKind: .ide, command: ideWithToken) == "ide-token")
+
+        // Tokenless IDE is skipped (nil) so detection keeps scanning for a valid
+        // server and preserves the missing-token diagnostic — no empty-token probe.
+        let ideNoToken = """
+        /Applications/Antigravity.app/Contents/Resources/bin/language_server \
+        --app_data_dir antigravity
+        """
+        #expect(AntigravityStatusProbe.resolvedCSRFToken(forKind: .ide, command: ideNoToken) == nil)
+
+        // CLI without a token resolves to an empty token (its server needs none).
+        #expect(
+            AntigravityStatusProbe.resolvedCSRFToken(
+                forKind: .cli, command: "/Users/test/.local/bin/agy -p hi") == "")
+
+        // A CLI that does carry a token still uses it.
+        #expect(
+            AntigravityStatusProbe.resolvedCSRFToken(
+                forKind: .cli, command: "/Users/test/.local/bin/agy --csrf_token cli-token") == "cli-token")
+    }
+
+    @Test
     func `localhost trust policy only accepts local server trust challenges`() {
         #expect(
             LocalhostTrustPolicy.shouldAcceptServerTrust(

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -9,7 +9,7 @@ read_when:
 
 # Antigravity provider
 
-Antigravity supports local IDE probing and Google OAuth-backed remote usage. The OAuth path can store multiple Google accounts through the shared token-account switcher.
+Antigravity supports local probing of either the IDE or the CLI (`agy` / `antigravity-cli`) language server, plus Google OAuth-backed remote usage. The OAuth path can store multiple Google accounts through the shared token-account switcher.
 
 ## OAuth account switching
 
@@ -32,11 +32,16 @@ Antigravity supports local IDE probing and Google OAuth-backed remote usage. The
 
 1) **Process detection**
    - Command: `ps -ax -o pid=,command=`.
-   - Match process name: `language_server_macos` plus Antigravity markers:
-     - `--app_data_dir antigravity` OR path contains `/antigravity/`.
+   - Match either:
+     - the **IDE** language server: process name `language_server_macos` plus Antigravity
+       markers (`--app_data_dir antigravity` OR path contains `/antigravity/`); or
+     - the **CLI**: `antigravity-cli` / `antigravity_cli`, or the `agy` binary
+       (path-anchored so unrelated binaries do not match).
    - Extract CLI flags:
-     - `--csrf_token <token>` (required).
-     - `--extension_server_port <port>` (HTTP fallback).
+     - `--csrf_token <token>` (optional). The IDE language server supplies one and
+       requires it; the CLI's language server exposes no `--csrf_token` flag and
+       requires none, so an empty token is used when the flag is absent.
+     - `--extension_server_port <port>` (HTTP fallback; IDE only).
 
 2) **Port discovery**
    - Command: `lsof -nP -iTCP -sTCP:LISTEN -p <pid>`.

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -35,8 +35,8 @@ Antigravity supports local probing of either the IDE or the CLI (`agy` / `antigr
    - Match either:
      - the **IDE** language server: process name `language_server_macos` plus Antigravity
        markers (`--app_data_dir antigravity` OR path contains `/antigravity/`); or
-     - the **CLI**: `antigravity-cli` / `antigravity_cli`, or the `agy` binary
-       (path-anchored so unrelated binaries do not match).
+     - the **CLI**: an `antigravity-cli` / `antigravity_cli` path segment, or the
+       `agy` binary (path-anchored so unrelated arguments/binaries do not match).
    - Extract CLI flags:
      - `--csrf_token <token>`. Requirement depends on the match kind:
        - **IDE** matches still require it — a tokenless IDE `language_server` match is

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -38,9 +38,12 @@ Antigravity supports local probing of either the IDE or the CLI (`agy` / `antigr
      - the **CLI**: `antigravity-cli` / `antigravity_cli`, or the `agy` binary
        (path-anchored so unrelated binaries do not match).
    - Extract CLI flags:
-     - `--csrf_token <token>` (optional). The IDE language server supplies one and
-       requires it; the CLI's language server exposes no `--csrf_token` flag and
-       requires none, so an empty token is used when the flag is absent.
+     - `--csrf_token <token>`. Requirement depends on the match kind:
+       - **IDE** matches still require it — a tokenless IDE `language_server` match is
+         skipped so a later valid IDE server can be found, otherwise `missingCSRFToken`
+         is reported (unchanged behavior).
+       - **CLI** matches accept an empty token, because the CLI's language server
+         exposes no `--csrf_token` flag and requires none.
      - `--extension_server_port <port>` (HTTP fallback; IDE only).
 
 2) **Port discovery**


### PR DESCRIPTION
Closes #1178. Supersedes the abandoned #1328 (which only widened the matcher strings; ClawSweeper correctly blocked it for lacking a real after-fix probe-path proof — that proof is included below).

### Summary

Antigravity shipped as an **IDE** whose `language_server` process exposed a local Connect API guarded by a `--csrf_token` flag. `AntigravityStatusProbe` matched that process name and treated the CSRF token as **mandatory**.

The new Antigravity **CLI** (`agy` / `antigravity-cli`) hosts the *same* `exa.language_server_pb.LanguageServerService` on `127.0.0.1`, but:
- launches it under a different process name (`agy`, or `node …/antigravity-cli/…`), and
- launches it **without** a `--csrf_token` flag — the CLI's local server requires **no CSRF token at all**.

So on current `main` the probe fails at process detection (basename ≠ `language_server`) and `--source cli` returns *"Antigravity language server not detected"*. Usage tracking then falls back to the remote `cloudcode-pa` API, which is `PERMISSION_DENIED` for CLI accounts — so nothing renders. The remote detour is unnecessary: the CLI already serves the full quota locally.

### The fix

Two small changes to `AntigravityStatusProbe`, no new dependencies / permissions / credential handling:

1. **Detect the CLI process** in `isAntigravityLanguageServerCommandLine` — `antigravity-cli`, `antigravity_cli`, and `agy` (the latter path-anchored as `(^|[/\\])agy(\s|$)` so `legacy`, `imagymagic`, … don't false-match).
2. **Make `--csrf_token` optional** — fall back to an empty token when the flag is absent (the CLI case), instead of throwing `missingCSRFToken`.

Everything downstream is unchanged: `lsof` port detection, the localhost Connect request, and `GetUserStatus` parsing already work — the CLI's language server returns the full `cascadeModelConfigData` model quotas over HTTPS on its listening port, accepting an empty CSRF header.

**IDE behavior is preserved** (addresses the earlier ClawSweeper compatibility finding): each match is classified as `.ide` or `.cli` (`antigravityProcessKind`) and the token is resolved per kind (`resolvedCSRFToken`). IDE `language_server` matches still **require** `--csrf_token` — a tokenless IDE match is skipped so a later valid IDE server can still be found, and `missingCSRFToken` is still reported when only tokenless IDE matches exist. The empty-token fallback applies **only** to CLI matches. No IDE user's request path changes.

### Proof of fix validation (real after-fix probe path, redacted)

Run end-to-end through CodexBar's own code (`CodexBarCLI`, `--source cli`) against a **live** `agy` session — i.e. the actual `AntigravityStatusProbe`, not a string check. Same running CLI process for both runs.

**Detected CLI process** (the command line that current `main` cannot match):
```
/Users/<user>/.local/bin/agy -p … --print-timeout 150s
```

**BEFORE (current `main`)** — `agy` running, CSRF-less:
```
$ codexbar usage --provider antigravity --source cli
Error (antigravity - <redacted-email>): Antigravity language server not detected. Launch Antigravity and retry.
```

**AFTER (this branch)** — same `agy` process:
```
$ codexbar usage --provider antigravity --source cli
== Antigravity (local) ==
Claude: 100% left [============]
Resets in 5h
Gemini Pro: 80% left [=========---]
Resets in 3h 33m
Gemini Flash: 80% left [=========---]
Resets in 3h 33m
Account: <redacted-email>
Plan: Google Ai Pro
```

Probe subprocess diagnostics (`--log-level debug`) confirm the full path — process match → `lsof` port detection → local probe:
```
debug …subprocess: binary=ps   label=antigravity-ps   status=0  Subprocess exit
debug …subprocess: binary=lsof label=antigravity-lsof status=0  Subprocess exit
== Antigravity (local) ==
```

Structured output (`--json --pretty`, truncated) — `source: local`, real per-model quotas parsed from the CLI's `GetUserStatus`:
```json
[
  {
    "provider": "antigravity",
    "source": "local",
    "usage": {
      "accountEmail": "<redacted-email>",
      "extraRateWindows": [
        { "id": "MODEL_PLACEHOLDER_M26", "title": "Claude Opus 4.6 (Thinking)", "window": { "usedPercent": 0,  "resetsAt": "…Z" } },
        { "id": "MODEL_PLACEHOLDER_M16", "title": "Gemini 3.1 Pro (High)",      "window": { "usedPercent": 20, "resetsAt": "…Z" } },
        { "id": "MODEL_PLACEHOLDER_M132","title": "Gemini 3.5 Flash (High)",    "window": { "usedPercent": 20, "resetsAt": "…Z" } }
      ]
    }
  }
]
```

For contrast, the remote `cloudcode-pa` / `daily-cloudcode-pa` `fetchAvailableModels` and `retrieveUserQuota` endpoints both return `403 PERMISSION_DENIED` for the same CLI account — confirming the local probe is the correct source.

### Tests

Added `AntigravityStatusProbeTests` cases for: CLI detection (`agy`, `antigravity-cli`, `antigravity_cli`); false-positive guards (`legacy`, `imagymagic`); IDE-vs-CLI kind classification; and CSRF-token resolution per kind — IDE-with-token returns the token, **tokenless IDE returns `nil` (skipped)**, CLI without a token returns `""`, CLI with a token uses it. Existing IDE / helper detection cases unchanged.

### Commands run

- `swift build --target CodexBarCore` — ✅ compiles.
- `swift build --product CodexBarCLI` — ✅ compiles; used for the live proof above.
- `swift test --filter AntigravityStatusProbeTests` — ✅ **47/47 pass** (CLI detection, IDE-vs-CLI kind, per-kind CSRF resolution, plus all existing probe tests), through the real swift-testing runner against the compiled `CodexBarCore`.
- `swiftformat` (repo `.swiftformat`) — ✅ clean.

> Environment note: the *full* `Tests/CodexBarTests` bundle additionally links the GUI targets (`CodexBar`, `CodexBarWidget`), whose SwiftUI `#Preview` macro plugin ships only inside Xcode (this machine had Command Line Tools only). This PR touches `CodexBarCore` exclusively and the entire `AntigravityStatusProbeTests` suite passes locally as shown; the macOS CI job (Xcode 26.1.1) runs the complete bundle.

*(No UI changes.)*
