### PR TITLE
Fix Antigravity CLI usage tracking via Keychain fallback

### DIFF
--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(Security)
+import Security
+#endif
 
 public struct AntigravityOAuthCredentials: Codable, Sendable, Equatable {
     public var accessToken: String?
@@ -391,10 +394,65 @@ public struct AntigravityOAuthCredentialsStore: @unchecked Sendable {
     }
 
     public func load() throws -> AntigravityOAuthCredentials? {
+#if canImport(Security)
+        if let keychainCreds = self.loadFromKeychain() {
+            return keychainCreds
+        }
+#endif
         guard self.fileManager.fileExists(atPath: self.fileURL.path) else { return nil }
         let data = try Data(contentsOf: self.fileURL)
         return try JSONDecoder().decode(AntigravityOAuthCredentials.self, from: data)
     }
+
+#if canImport(Security)
+    private func loadFromKeychain() -> AntigravityOAuthCredentials? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "gemini",
+            kSecAttrAccount as String: "antigravity",
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data,
+              let stringValue = String(data: data, encoding: .utf8),
+              stringValue.hasPrefix("go-keyring-base64:") else {
+            return nil
+        }
+        
+        let base64String = String(stringValue.dropFirst("go-keyring-base64:".count))
+        guard let jsonData = Data(base64Encoded: base64String) else { return nil }
+        
+        struct KeychainPayload: Decodable {
+            struct TokenInfo: Decodable {
+                let access_token: String
+                let refresh_token: String
+                let expiry: String
+            }
+            let token: TokenInfo
+        }
+        
+        guard let payload = try? JSONDecoder().decode(KeychainPayload.self, from: jsonData) else {
+            return nil
+        }
+        
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let expiryDate = formatter.date(from: payload.token.expiry) ?? Date()
+        
+        return AntigravityOAuthCredentials(
+            accessToken: payload.token.access_token,
+            refreshToken: payload.token.refresh_token,
+            expiryDate: expiryDate,
+            idToken: nil,
+            email: "antigravity-cli",
+            projectID: nil,
+            clientID: nil,
+            clientSecret: nil
+        )
+    }
+#endif
 
     public func save(_ credentials: AntigravityOAuthCredentials) throws {
         let data = try JSONEncoder.antigravityCredentials.encode(credentials)

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -635,11 +635,12 @@ public struct AntigravityStatusProbe: Sendable {
     }
 
     private static func isLanguageServerCommandLine(_ lowerCommand: String) -> Bool {
-        let pattern = #"(^|[/\\])language_server(_macos|\.exe)?(\s|$)"#
+        let pattern = #"(^|[/\\])(language_server|antigravity-cli|antigravity_cli)(_macos|\.exe)?(\s|/|$)"#
         return lowerCommand.range(of: pattern, options: .regularExpression) != nil
     }
 
     private static func isAntigravityCommandLine(_ command: String) -> Bool {
+        if command.contains("antigravity-cli") || command.contains("antigravity_cli") { return true }
         if command.contains("--app_data_dir") && command.contains("antigravity") { return true }
         if command.contains("/antigravity/") || command.contains("\\antigravity\\") { return true }
         return false

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -635,12 +635,12 @@ public struct AntigravityStatusProbe: Sendable {
     }
 
     private static func isLanguageServerCommandLine(_ lowerCommand: String) -> Bool {
-        let pattern = #"(^|[/\\])(language_server|antigravity-cli|antigravity_cli)(_macos|\.exe)?(\s|/|$)"#
+        let pattern = #"(^|[/\\])(language_server|antigravity-cli|antigravity_cli|agy)(_macos|\.exe)?(\s|/|$)"#
         return lowerCommand.range(of: pattern, options: .regularExpression) != nil
     }
 
     private static func isAntigravityCommandLine(_ command: String) -> Bool {
-        if command.contains("antigravity-cli") || command.contains("antigravity_cli") { return true }
+        if command.contains("antigravity-cli") || command.contains("antigravity_cli") || command.contains("agy") { return true }
         if command.contains("--app_data_dir") && command.contains("antigravity") { return true }
         if command.contains("/antigravity/") || command.contains("\\antigravity\\") { return true }
         return false

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -63,6 +63,29 @@ struct AntigravityStatusProbeTests {
     }
 
     @Test
+    func `process detection accepts antigravity cli variations and agy`() {
+        let commandDash = """
+        node /path/to/node_modules/antigravity-cli/build/mcp-server.cjs --app_data_dir /Users/test/.gemini/antigravity
+        """
+        #expect(AntigravityStatusProbe.isAntigravityLanguageServerCommandLine(commandDash))
+
+        let commandUnderscore = """
+        node /path/to/node_modules/antigravity_cli/build/mcp-server.cjs --app_data_dir /Users/test/.gemini/antigravity
+        """
+        #expect(AntigravityStatusProbe.isAntigravityLanguageServerCommandLine(commandUnderscore))
+
+        let commandAgy = """
+        /usr/local/bin/agy --app_data_dir /Users/test/.gemini/antigravity
+        """
+        #expect(AntigravityStatusProbe.isAntigravityLanguageServerCommandLine(commandAgy))
+
+        let commandAgyNode = """
+        node /path/to/node_modules/agy/build/mcp-server.cjs --app_data_dir /Users/test/.gemini/antigravity
+        """
+        #expect(AntigravityStatusProbe.isAntigravityLanguageServerCommandLine(commandAgyNode))
+    }
+
+    @Test
     func `localhost trust policy only accepts local server trust challenges`() {
         #expect(
             LocalhostTrustPolicy.shouldAcceptServerTrust(


### PR DESCRIPTION
Since the main entry point for Antigravity is now `antigravity-cli` which stores credentials in the OS Keychain instead of `~/.codexbar/antigravity/oauth_creds.json`, usage tracking broke. This PR adds a fallback to `AntigravityOAuthCredentialsStore` to load credentials from the keychain using the `gemini` service and `antigravity` account, allowing CodexBar to successfully fetch CLI quota.