### PR TITLE
Reduce merged menu tab rebuilds

### DIFF
--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -150,6 +150,7 @@ extension StatusItemController {
         }
 
         self.cancelClosedMenuRebuild(menu)
+        self.clearMergedSwitcherContentCache(for: menu)
         self.openMenus.removeValue(forKey: key)
         self.menuRefreshTasks.removeValue(forKey: key)?.cancel()
         self.openMenuRebuildTasks.removeValue(forKey: key)?.cancel()
@@ -394,12 +395,33 @@ extension StatusItemController {
                 switcherView.updateSelection(context.switcherSelection)
                 switcherView.updateQuotaIndicators()
             }
+            if let outgoingSelection = self.lastMergedMenuContentSelection,
+               outgoingSelection != context.switcherSelection
+            {
+                self.cacheVisibleMergedSwitcherContent(
+                    in: menu,
+                    selection: outgoingSelection,
+                    contentStartIndex: contentStartIndex,
+                    menuWidth: context.menuWidth)
+            }
             while menu.items.count > contentStartIndex {
                 menu.removeItem(at: contentStartIndex)
             }
 
             let enabledProviders = self.store.enabledProvidersForDisplay()
             self.rememberMergedSwitcherState(enabledProviders, context.switcherSelection)
+            if let cachedItems = self.cachedMergedSwitcherContent(
+                for: context.switcherSelection,
+                in: menu,
+                context: context)
+            {
+                self.lastCodexAccountMenuDisplay = context.codexAccountDisplay
+                self.lastTokenAccountMenuDisplay = context.tokenAccountDisplay
+                for item in cachedItems {
+                    menu.addItem(item)
+                }
+                return
+            }
             self.addCodexAccountSwitcherIfNeeded(
                 to: menu,
                 display: context.codexAccountDisplay,
@@ -423,11 +445,64 @@ extension StatusItemController {
         }
     }
 
+    func clearMergedSwitcherContentCaches() {
+        self.mergedSwitcherContentCaches.removeAll(keepingCapacity: true)
+    }
+
+    func clearMergedSwitcherContentCache(for menu: NSMenu) {
+        self.mergedSwitcherContentCaches.removeValue(forKey: ObjectIdentifier(menu))
+    }
+
+    private func cacheVisibleMergedSwitcherContent(
+        in menu: NSMenu,
+        selection: ProviderSwitcherSelection,
+        contentStartIndex: Int,
+        menuWidth: CGFloat)
+    {
+        guard self.shouldMergeIcons else { return }
+        guard contentStartIndex < menu.items.count else { return }
+        let items = Array(menu.items[contentStartIndex...])
+        guard !items.isEmpty else { return }
+
+        let menuKey = ObjectIdentifier(menu)
+        let entry = CachedMergedSwitcherMenuContent(
+            menuContentVersion: self.menuVersions[menuKey] ?? self.menuContentVersion,
+            menuWidth: menuWidth,
+            codexAccountDisplay: self.lastCodexAccountMenuDisplay,
+            tokenAccountDisplay: self.lastTokenAccountMenuDisplay,
+            localizationSignature: self.lastMenuLocalizationSignature,
+            items: items)
+        self.mergedSwitcherContentCaches[menuKey, default: [:]][selection] = entry
+    }
+
+    private func cachedMergedSwitcherContent(
+        for selection: ProviderSwitcherSelection,
+        in menu: NSMenu,
+        context: MenuUpdateContext)
+        -> [NSMenuItem]?
+    {
+        let menuKey = ObjectIdentifier(menu)
+        guard let entry = self.mergedSwitcherContentCaches[menuKey]?[selection] else { return nil }
+        guard entry.matches(
+            menuContentVersion: self.menuContentVersion,
+            menuWidth: context.menuWidth,
+            codexAccountDisplay: context.codexAccountDisplay,
+            tokenAccountDisplay: context.tokenAccountDisplay,
+            localizationSignature: self.menuLocalizationSignature())
+        else {
+            self.mergedSwitcherContentCaches[menuKey]?.removeValue(forKey: selection)
+            return nil
+        }
+        return entry.items
+    }
+
     private func rebuildMenuContent(
         _ menu: NSMenu,
         context: MenuRebuildContext)
     {
         self.performMenuMutationWithoutAnimation {
+            self.clearMergedSwitcherContentCache(for: menu)
+            self.lastMergedMenuContentSelection = nil
             menu.removeAllItems()
             self.addProviderSwitcherIfNeeded(
                 to: menu,
@@ -1572,8 +1647,10 @@ extension StatusItemController {
         if !self.settings.mergedMenuLastSelectedWasOverview, self.selectedMenuProvider == provider { return }
         self.settings.mergedMenuLastSelectedWasOverview = false
         self.lastMergedSwitcherSelection = nil
+        self.lastMergedMenuContentSelection = nil
         self.selectedMenuProvider = provider
         self.lastMenuProvider = provider
+        self.clearMergedSwitcherContentCache(for: menu)
         self.populateMenu(menu, provider: provider)
         self.markMenuFresh(menu)
         self.applyIcon(phase: nil)

--- a/Sources/CodexBar/StatusItemController+MenuContexts.swift
+++ b/Sources/CodexBar/StatusItemController+MenuContexts.swift
@@ -1,6 +1,30 @@
 import AppKit
 import CodexBarCore
 
+struct CachedMergedSwitcherMenuContent {
+    let menuContentVersion: Int
+    let menuWidth: CGFloat
+    let codexAccountDisplay: CodexAccountMenuDisplay?
+    let tokenAccountDisplay: TokenAccountMenuDisplay?
+    let localizationSignature: String
+    let items: [NSMenuItem]
+
+    func matches(
+        menuContentVersion: Int,
+        menuWidth: CGFloat,
+        codexAccountDisplay: CodexAccountMenuDisplay?,
+        tokenAccountDisplay: TokenAccountMenuDisplay?,
+        localizationSignature: String)
+        -> Bool
+    {
+        self.menuContentVersion == menuContentVersion &&
+            abs(self.menuWidth - menuWidth) <= 0.5 &&
+            self.codexAccountDisplay == codexAccountDisplay &&
+            self.tokenAccountDisplay == tokenAccountDisplay &&
+            self.localizationSignature == localizationSignature
+    }
+}
+
 extension StatusItemController {
     struct OpenAIWebContext {
         let hasUsageBreakdown: Bool

--- a/Sources/CodexBar/StatusItemController+MenuLocalization.swift
+++ b/Sources/CodexBar/StatusItemController+MenuLocalization.swift
@@ -25,6 +25,7 @@ extension StatusItemController {
         self.lastSwitcherProviders = providers
         self.lastSwitcherUsageBarsShowUsed = self.settings.usageBarsShowUsed
         self.lastMergedSwitcherSelection = selection
+        self.lastMergedMenuContentSelection = selection
         self.lastSwitcherIncludesOverview = includesOverview
         self.lastMenuLocalizationSignature = self.menuLocalizationSignature()
     }

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -32,6 +32,7 @@ extension StatusItemController {
         guard !self.isReleasedForTesting else { return }
         #endif
         self.menuContentVersion &+= 1
+        self.clearMergedSwitcherContentCaches()
         self.pruneVersionScopedMenuCardHeightCache()
         if !allowStaleContentDuringDataRefresh {
             self.latestRequiredMenuRebuildVersion = self.menuContentVersion

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -2,7 +2,7 @@ import AppKit
 import CodexBarCore
 import QuartzCore
 
-enum ProviderSwitcherSelection: Equatable {
+enum ProviderSwitcherSelection: Hashable {
     case overview
     case provider(UsageProvider)
 }
@@ -319,6 +319,7 @@ final class ProviderSwitcherView: NSView {
 
     private func applySelection(at index: Int) {
         let selection = self.segments[index].selection
+        guard self.selectedSelection != selection else { return }
         self.updateSelection(selection)
         self.onSelect(selection)
     }
@@ -585,6 +586,14 @@ final class ProviderSwitcherView: NSView {
 
     override var intrinsicContentSize: NSSize {
         NSSize(width: self.preferredWidth, height: self.frame.size.height)
+    }
+
+    var selectedSelection: ProviderSwitcherSelection? {
+        for (index, button) in self.buttons.enumerated() where button.state == .on {
+            guard self.segments.indices.contains(index) else { continue }
+            return self.segments[index].selection
+        }
+        return nil
     }
 
     func updateSelection(_ selection: ProviderSwitcherSelection) {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -206,10 +206,15 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var lastSwitcherProviders: [UsageProvider] = []
     /// Tracks which switcher tab state was used for the current merged-menu switcher instance.
     var lastMergedSwitcherSelection: ProviderSwitcherSelection?
+    /// Tracks which provider/overview content is currently attached below the merged-menu switcher.
+    var lastMergedMenuContentSelection: ProviderSwitcherSelection?
     /// Tracks the visible Codex account switcher contents for merged-menu smart updates.
     var lastCodexAccountMenuDisplay: CodexAccountMenuDisplay?
     /// Tracks the visible token account switcher contents for merged-menu smart updates.
     var lastTokenAccountMenuDisplay: TokenAccountMenuDisplay?
+    /// Keeps recently detached merged-menu content segments reusable while the same menu stays open.
+    var mergedSwitcherContentCaches: [ObjectIdentifier: [ProviderSwitcherSelection: CachedMergedSwitcherMenuContent]]
+        = [:]
     /// Monotonic token used to ignore stale deferred provider-switcher menu rebuilds.
     var providerSwitcherUpdateToken = 0
     var lastAppliedMergedIconRenderSignature: String?

--- a/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
@@ -74,6 +74,115 @@ struct StatusMenuSwitcherRefreshTests {
     }
 
     @Test
+    func `selected provider tab click does not rebuild open menu`() async throws {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = false
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
+        defer {
+            StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering
+            StatusItemController.resetMenuRefreshEnabledForTesting()
+        }
+
+        let settings = Self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        Self.enableCodexAndClaude(settings)
+        Self.disableOverview(settings)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        let switcher = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        let selectedButton = try #require(Self.switcherButtons(in: menu).first { $0.state == .on })
+
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { _ in
+            rebuildCount += 1
+        }
+        defer { controller._test_openMenuRebuildObserver = nil }
+
+        #expect(switcher._test_simulateRuntimeClick(buttonTag: selectedButton.tag) == true)
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+
+        #expect(rebuildCount == 0)
+        #expect(Self.switcherButtons(in: menu).first { $0.tag == selectedButton.tag }?.state == .on)
+    }
+
+    @Test
+    func `merged provider switch restores cached tab content`() async throws {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = false
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
+        defer {
+            StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering
+            StatusItemController.resetMenuRefreshEnabledForTesting()
+        }
+
+        let settings = Self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        Self.enableCodexAndClaude(settings)
+        Self.disableOverview(settings)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        let contentStartIndex = controller.providerSwitcherContentStartIndex(in: menu)
+        #expect(menu.items.count > contentStartIndex)
+        let originalSelectedContentID = ObjectIdentifier(menu.items[contentStartIndex])
+        let selectedButton = try #require(Self.switcherButtons(in: menu).first { $0.state == .on })
+        let alternateButton = try #require(Self.switcherButtons(in: menu).first { $0.state == .off })
+
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { _ in
+            rebuildCount += 1
+        }
+        defer { controller._test_openMenuRebuildObserver = nil }
+
+        let initialSwitcher = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        #expect(initialSwitcher._test_simulateRuntimeClick(buttonTag: alternateButton.tag) == true)
+        await Self.waitForRebuildCount(1, rebuildCount: { rebuildCount })
+        let alternateContentID = ObjectIdentifier(menu.items[contentStartIndex])
+        #expect(alternateContentID != originalSelectedContentID)
+
+        let alternateSwitcher = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        #expect(alternateSwitcher._test_simulateRuntimeClick(buttonTag: selectedButton.tag) == true)
+        await Self.waitForRebuildCount(2, rebuildCount: { rebuildCount })
+        #expect(ObjectIdentifier(menu.items[contentStartIndex]) == originalSelectedContentID)
+
+        let restoredSwitcher = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        #expect(restoredSwitcher._test_simulateRuntimeClick(buttonTag: alternateButton.tag) == true)
+        await Self.waitForRebuildCount(3, rebuildCount: { rebuildCount })
+        #expect(ObjectIdentifier(menu.items[contentStartIndex]) == alternateContentID)
+    }
+
+    @Test
     func `tab switch does not replace quota indicator constraints`() {
         let switcher = ProviderSwitcherView(
             providers: [.codex, .claude],
@@ -135,6 +244,28 @@ struct StatusMenuSwitcherRefreshTests {
             guard let metadata = registry.metadata[provider] else { continue }
             let shouldEnable = provider == .codex || provider == .claude
             settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
+        }
+    }
+
+    private static func disableOverview(_ settings: SettingsStore) {
+        let activeProviders: [UsageProvider] = [.codex, .claude]
+        _ = settings.setMergedOverviewProviderSelection(
+            provider: .codex,
+            isSelected: false,
+            activeProviders: activeProviders)
+        _ = settings.setMergedOverviewProviderSelection(
+            provider: .claude,
+            isSelected: false,
+            activeProviders: activeProviders)
+    }
+
+    private static func waitForRebuildCount(
+        _ expectedCount: Int,
+        rebuildCount: () -> Int) async
+    {
+        for _ in 0..<100 where rebuildCount() < expectedCount {
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(10))
         }
     }
 


### PR DESCRIPTION
## Summary
- cache already-built merged menu provider-tab content while the menu stays open, guarded by menu version, layout width, account switcher state, and localization
- skip open-menu rebuild scheduling when the active provider tab is selected again
- cover active-tab reselects and cached back-switches in the switcher refresh tests

Fixes #1325

## Validation
- `./Scripts/lint.sh format`
- `git diff --check`
- `swift test --filter StatusMenuSwitcherRefreshTests` (blocked locally: Command Line Tools lacks SwiftUI/Swift Testing modules; no full Xcode install is available)
- `make check` (blocked locally: SwiftLint cannot load sourcekitd from the Command Line Tools install)
