### PR TITLE
Reduce merged menu tab rebuilds

### DIFF
--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -413,7 +413,9 @@ extension StatusItemController {
             if let cachedItems = self.cachedMergedSwitcherContent(
                 for: context.switcherSelection,
                 in: menu,
-                context: context)
+                menuWidth: context.menuWidth,
+                codexAccountDisplay: context.codexAccountDisplay,
+                tokenAccountDisplay: context.tokenAccountDisplay)
             {
                 self.lastCodexAccountMenuDisplay = context.codexAccountDisplay
                 self.lastTokenAccountMenuDisplay = context.tokenAccountDisplay
@@ -443,57 +445,6 @@ extension StatusItemController {
             self.addPrimaryMenuContent(to: menu, context: menuContext, switcherSelection: context.switcherSelection)
             self.addActionableSections(context.descriptor.sections, to: menu, width: context.menuWidth)
         }
-    }
-
-    func clearMergedSwitcherContentCaches() {
-        self.mergedSwitcherContentCaches.removeAll(keepingCapacity: true)
-    }
-
-    func clearMergedSwitcherContentCache(for menu: NSMenu) {
-        self.mergedSwitcherContentCaches.removeValue(forKey: ObjectIdentifier(menu))
-    }
-
-    private func cacheVisibleMergedSwitcherContent(
-        in menu: NSMenu,
-        selection: ProviderSwitcherSelection,
-        contentStartIndex: Int,
-        menuWidth: CGFloat)
-    {
-        guard self.shouldMergeIcons else { return }
-        guard contentStartIndex < menu.items.count else { return }
-        let items = Array(menu.items[contentStartIndex...])
-        guard !items.isEmpty else { return }
-
-        let menuKey = ObjectIdentifier(menu)
-        let entry = CachedMergedSwitcherMenuContent(
-            menuContentVersion: self.menuVersions[menuKey] ?? self.menuContentVersion,
-            menuWidth: menuWidth,
-            codexAccountDisplay: self.lastCodexAccountMenuDisplay,
-            tokenAccountDisplay: self.lastTokenAccountMenuDisplay,
-            localizationSignature: self.lastMenuLocalizationSignature,
-            items: items)
-        self.mergedSwitcherContentCaches[menuKey, default: [:]][selection] = entry
-    }
-
-    private func cachedMergedSwitcherContent(
-        for selection: ProviderSwitcherSelection,
-        in menu: NSMenu,
-        context: MenuUpdateContext)
-        -> [NSMenuItem]?
-    {
-        let menuKey = ObjectIdentifier(menu)
-        guard let entry = self.mergedSwitcherContentCaches[menuKey]?[selection] else { return nil }
-        guard entry.matches(
-            menuContentVersion: self.menuContentVersion,
-            menuWidth: context.menuWidth,
-            codexAccountDisplay: context.codexAccountDisplay,
-            tokenAccountDisplay: context.tokenAccountDisplay,
-            localizationSignature: self.menuLocalizationSignature())
-        else {
-            self.mergedSwitcherContentCaches[menuKey]?.removeValue(forKey: selection)
-            return nil
-        }
-        return entry.items
     }
 
     private func rebuildMenuContent(

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1011,15 +1011,17 @@ extension StatusItemController {
             },
             onSelect: { [weak self, weak menu] selection in
                 guard let self, let menu else { return }
-                let provider: UsageProvider?
-                switch selection {
-                case .overview:
-                    self.settings.mergedMenuLastSelectedWasOverview = true
-                    provider = self.resolvedMenuProvider()
-                case let .provider(selectedProvider):
-                    self.settings.mergedMenuLastSelectedWasOverview = false
-                    self.selectedMenuProvider = selectedProvider
-                    provider = selectedProvider
+                var provider: UsageProvider?
+                self.preservingMergedSwitcherContentCachesDuringInvalidation {
+                    switch selection {
+                    case .overview:
+                        self.settings.mergedMenuLastSelectedWasOverview = true
+                        provider = self.resolvedMenuProvider()
+                    case let .provider(selectedProvider):
+                        self.settings.mergedMenuLastSelectedWasOverview = false
+                        self.selectedMenuProvider = selectedProvider
+                        provider = selectedProvider
+                    }
                 }
                 switch selection {
                 case .overview:

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -444,6 +444,11 @@ extension StatusItemController {
                 openAIContext: context.openAIContext)
             self.addPrimaryMenuContent(to: menu, context: menuContext, switcherSelection: context.switcherSelection)
             self.addActionableSections(context.descriptor.sections, to: menu, width: context.menuWidth)
+            self.cacheVisibleMergedSwitcherContent(
+                in: menu,
+                selection: context.switcherSelection,
+                contentStartIndex: contentStartIndex,
+                menuWidth: context.menuWidth)
         }
     }
 
@@ -490,6 +495,11 @@ extension StatusItemController {
                 context: menuContext,
                 switcherSelection: context.switcherSelection ?? .provider(context.currentProvider))
             self.addActionableSections(context.descriptor.sections, to: menu, width: context.menuWidth)
+            self.cacheVisibleMergedSwitcherContent(
+                in: menu,
+                selection: context.switcherSelection ?? .provider(context.currentProvider),
+                contentStartIndex: self.providerSwitcherContentStartIndex(in: menu),
+                menuWidth: context.menuWidth)
         }
     }
 

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -150,6 +150,7 @@ extension StatusItemController {
         }
 
         self.cancelClosedMenuRebuild(menu)
+        self.clearMergedSwitcherContentCache(for: menu)
         self.openMenus.removeValue(forKey: key)
         self.menuRefreshTasks.removeValue(forKey: key)?.cancel()
         self.openMenuRebuildTasks.removeValue(forKey: key)?.cancel()
@@ -394,12 +395,33 @@ extension StatusItemController {
                 switcherView.updateSelection(context.switcherSelection)
                 switcherView.updateQuotaIndicators()
             }
+            if let outgoingSelection = self.lastMergedMenuContentSelection,
+               outgoingSelection != context.switcherSelection
+            {
+                self.cacheVisibleMergedSwitcherContent(
+                    in: menu,
+                    selection: outgoingSelection,
+                    contentStartIndex: contentStartIndex,
+                    menuWidth: context.menuWidth)
+            }
             while menu.items.count > contentStartIndex {
                 menu.removeItem(at: contentStartIndex)
             }
 
             let enabledProviders = self.store.enabledProvidersForDisplay()
             self.rememberMergedSwitcherState(enabledProviders, context.switcherSelection)
+            if let cachedItems = self.cachedMergedSwitcherContent(
+                for: context.switcherSelection,
+                in: menu,
+                context: context)
+            {
+                self.lastCodexAccountMenuDisplay = context.codexAccountDisplay
+                self.lastTokenAccountMenuDisplay = context.tokenAccountDisplay
+                for item in cachedItems {
+                    menu.addItem(item)
+                }
+                return
+            }
             self.addCodexAccountSwitcherIfNeeded(
                 to: menu,
                 display: context.codexAccountDisplay,
@@ -423,11 +445,64 @@ extension StatusItemController {
         }
     }
 
+    func clearMergedSwitcherContentCaches() {
+        self.mergedSwitcherContentCaches.removeAll(keepingCapacity: true)
+    }
+
+    func clearMergedSwitcherContentCache(for menu: NSMenu) {
+        self.mergedSwitcherContentCaches.removeValue(forKey: ObjectIdentifier(menu))
+    }
+
+    private func cacheVisibleMergedSwitcherContent(
+        in menu: NSMenu,
+        selection: ProviderSwitcherSelection,
+        contentStartIndex: Int,
+        menuWidth: CGFloat)
+    {
+        guard self.shouldMergeIcons else { return }
+        guard contentStartIndex < menu.items.count else { return }
+        let items = Array(menu.items[contentStartIndex...])
+        guard !items.isEmpty else { return }
+
+        let menuKey = ObjectIdentifier(menu)
+        let entry = CachedMergedSwitcherMenuContent(
+            menuContentVersion: self.menuVersions[menuKey] ?? self.menuContentVersion,
+            menuWidth: menuWidth,
+            codexAccountDisplay: self.lastCodexAccountMenuDisplay,
+            tokenAccountDisplay: self.lastTokenAccountMenuDisplay,
+            localizationSignature: self.lastMenuLocalizationSignature,
+            items: items)
+        self.mergedSwitcherContentCaches[menuKey, default: [:]][selection] = entry
+    }
+
+    private func cachedMergedSwitcherContent(
+        for selection: ProviderSwitcherSelection,
+        in menu: NSMenu,
+        context: MenuUpdateContext)
+        -> [NSMenuItem]?
+    {
+        let menuKey = ObjectIdentifier(menu)
+        guard let entry = self.mergedSwitcherContentCaches[menuKey]?[selection] else { return nil }
+        guard entry.matches(
+            menuContentVersion: self.menuContentVersion,
+            menuWidth: context.menuWidth,
+            codexAccountDisplay: context.codexAccountDisplay,
+            tokenAccountDisplay: context.tokenAccountDisplay,
+            localizationSignature: self.menuLocalizationSignature())
+        else {
+            self.mergedSwitcherContentCaches[menuKey]?.removeValue(forKey: selection)
+            return nil
+        }
+        return entry.items
+    }
+
     private func rebuildMenuContent(
         _ menu: NSMenu,
         context: MenuRebuildContext)
     {
         self.performMenuMutationWithoutAnimation {
+            self.clearMergedSwitcherContentCache(for: menu)
+            self.lastMergedMenuContentSelection = nil
             menu.removeAllItems()
             self.addProviderSwitcherIfNeeded(
                 to: menu,
@@ -1572,8 +1647,10 @@ extension StatusItemController {
         if !self.settings.mergedMenuLastSelectedWasOverview, self.selectedMenuProvider == provider { return }
         self.settings.mergedMenuLastSelectedWasOverview = false
         self.lastMergedSwitcherSelection = nil
+        self.lastMergedMenuContentSelection = nil
         self.selectedMenuProvider = provider
         self.lastMenuProvider = provider
+        self.clearMergedSwitcherContentCache(for: menu)
         self.populateMenu(menu, provider: provider)
         self.markMenuFresh(menu)
         self.applyIcon(phase: nil)

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -410,18 +410,13 @@ extension StatusItemController {
 
             let enabledProviders = self.store.enabledProvidersForDisplay()
             self.rememberMergedSwitcherState(enabledProviders, context.switcherSelection)
-            if let cachedItems = self.cachedMergedSwitcherContent(
+            if self.addCachedMergedSwitcherContent(
                 for: context.switcherSelection,
-                in: menu,
+                to: menu,
                 menuWidth: context.menuWidth,
                 codexAccountDisplay: context.codexAccountDisplay,
                 tokenAccountDisplay: context.tokenAccountDisplay)
             {
-                self.lastCodexAccountMenuDisplay = context.codexAccountDisplay
-                self.lastTokenAccountMenuDisplay = context.tokenAccountDisplay
-                for item in cachedItems {
-                    menu.addItem(item)
-                }
                 return
             }
             self.addCodexAccountSwitcherIfNeeded(
@@ -475,18 +470,13 @@ extension StatusItemController {
             }
             if self.shouldMergeIcons,
                context.enabledProviders.count > 1,
-               let cachedItems = self.cachedMergedSwitcherContent(
+               self.addCachedMergedSwitcherContent(
                    for: contentSelection,
-                   in: menu,
+                   to: menu,
                    menuWidth: context.menuWidth,
                    codexAccountDisplay: context.codexAccountDisplay,
                    tokenAccountDisplay: context.tokenAccountDisplay)
             {
-                self.lastCodexAccountMenuDisplay = context.codexAccountDisplay
-                self.lastTokenAccountMenuDisplay = context.tokenAccountDisplay
-                for item in cachedItems {
-                    menu.addItem(item)
-                }
                 return
             }
             self.addCodexAccountSwitcherIfNeeded(

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -457,9 +457,9 @@ extension StatusItemController {
         context: MenuRebuildContext)
     {
         self.performMenuMutationWithoutAnimation {
-            self.clearMergedSwitcherContentCache(for: menu)
             self.lastMergedMenuContentSelection = nil
             menu.removeAllItems()
+            let contentSelection = context.switcherSelection ?? .provider(context.currentProvider)
             self.addProviderSwitcherIfNeeded(
                 to: menu,
                 enabledProviders: context.enabledProviders,
@@ -472,6 +472,22 @@ extension StatusItemController {
                     context.enabledProviders,
                     context.switcherSelection,
                     context.includesOverview)
+            }
+            if self.shouldMergeIcons,
+               context.enabledProviders.count > 1,
+               let cachedItems = self.cachedMergedSwitcherContent(
+                   for: contentSelection,
+                   in: menu,
+                   menuWidth: context.menuWidth,
+                   codexAccountDisplay: context.codexAccountDisplay,
+                   tokenAccountDisplay: context.tokenAccountDisplay)
+            {
+                self.lastCodexAccountMenuDisplay = context.codexAccountDisplay
+                self.lastTokenAccountMenuDisplay = context.tokenAccountDisplay
+                for item in cachedItems {
+                    menu.addItem(item)
+                }
+                return
             }
             self.addCodexAccountSwitcherIfNeeded(
                 to: menu,
@@ -493,11 +509,11 @@ extension StatusItemController {
             self.addPrimaryMenuContent(
                 to: menu,
                 context: menuContext,
-                switcherSelection: context.switcherSelection ?? .provider(context.currentProvider))
+                switcherSelection: contentSelection)
             self.addActionableSections(context.descriptor.sections, to: menu, width: context.menuWidth)
             self.cacheVisibleMergedSwitcherContent(
                 in: menu,
-                selection: context.switcherSelection ?? .provider(context.currentProvider),
+                selection: contentSelection,
                 contentStartIndex: self.providerSwitcherContentStartIndex(in: menu),
                 menuWidth: context.menuWidth)
         }

--- a/Sources/CodexBar/StatusItemController+MenuContexts.swift
+++ b/Sources/CodexBar/StatusItemController+MenuContexts.swift
@@ -1,30 +1,6 @@
 import AppKit
 import CodexBarCore
 
-struct CachedMergedSwitcherMenuContent {
-    let menuContentVersion: Int
-    let menuWidth: CGFloat
-    let codexAccountDisplay: CodexAccountMenuDisplay?
-    let tokenAccountDisplay: TokenAccountMenuDisplay?
-    let localizationSignature: String
-    let items: [NSMenuItem]
-
-    func matches(
-        menuContentVersion: Int,
-        menuWidth: CGFloat,
-        codexAccountDisplay: CodexAccountMenuDisplay?,
-        tokenAccountDisplay: TokenAccountMenuDisplay?,
-        localizationSignature: String)
-        -> Bool
-    {
-        self.menuContentVersion == menuContentVersion &&
-            abs(self.menuWidth - menuWidth) <= 0.5 &&
-            self.codexAccountDisplay == codexAccountDisplay &&
-            self.tokenAccountDisplay == tokenAccountDisplay &&
-            self.localizationSignature == localizationSignature
-    }
-}
-
 extension StatusItemController {
     struct OpenAIWebContext {
         let hasUsageBreakdown: Bool

--- a/Sources/CodexBar/StatusItemController+MenuContexts.swift
+++ b/Sources/CodexBar/StatusItemController+MenuContexts.swift
@@ -1,6 +1,30 @@
 import AppKit
 import CodexBarCore
 
+struct CachedMergedSwitcherMenuContent {
+    let menuContentVersion: Int
+    let menuWidth: CGFloat
+    let codexAccountDisplay: CodexAccountMenuDisplay?
+    let tokenAccountDisplay: TokenAccountMenuDisplay?
+    let localizationSignature: String
+    let items: [NSMenuItem]
+
+    func matches(
+        menuContentVersion: Int,
+        menuWidth: CGFloat,
+        codexAccountDisplay: CodexAccountMenuDisplay?,
+        tokenAccountDisplay: TokenAccountMenuDisplay?,
+        localizationSignature: String)
+        -> Bool
+    {
+        self.menuContentVersion == menuContentVersion &&
+            abs(self.menuWidth - menuWidth) <= 0.5 &&
+            self.codexAccountDisplay == codexAccountDisplay &&
+            self.tokenAccountDisplay == tokenAccountDisplay &&
+            self.localizationSignature == localizationSignature
+    }
+}
+
 extension StatusItemController {
     struct OpenAIWebContext {
         let hasUsageBreakdown: Bool

--- a/Sources/CodexBar/StatusItemController+MenuLocalization.swift
+++ b/Sources/CodexBar/StatusItemController+MenuLocalization.swift
@@ -25,6 +25,7 @@ extension StatusItemController {
         self.lastSwitcherProviders = providers
         self.lastSwitcherUsageBarsShowUsed = self.settings.usageBarsShowUsed
         self.lastMergedSwitcherSelection = selection
+        self.lastMergedMenuContentSelection = selection
         self.lastSwitcherIncludesOverview = includesOverview
         self.lastMenuLocalizationSignature = self.menuLocalizationSignature()
     }

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -32,13 +32,14 @@ extension StatusItemController {
         guard !self.isReleasedForTesting else { return }
         #endif
         self.menuContentVersion &+= 1
-        if !self.preservesMergedSwitcherContentCachesDuringInvalidation,
+        let preservesMergedSwitcherContentCaches = self.preservesMergedSwitcherContentCachesDuringInvalidation
+        if !preservesMergedSwitcherContentCaches,
            !allowStaleContentDuringDataRefresh || refreshOpenMenus
         {
             self.clearMergedSwitcherContentCaches()
         }
         self.pruneVersionScopedMenuCardHeightCache()
-        if !allowStaleContentDuringDataRefresh {
+        if !allowStaleContentDuringDataRefresh, !preservesMergedSwitcherContentCaches {
             self.latestRequiredMenuRebuildVersion = self.menuContentVersion
         }
         guard self.isMenuRefreshEnabled else { return }

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -32,7 +32,9 @@ extension StatusItemController {
         guard !self.isReleasedForTesting else { return }
         #endif
         self.menuContentVersion &+= 1
-        if !allowStaleContentDuringDataRefresh || refreshOpenMenus {
+        if !self.preservesMergedSwitcherContentCachesDuringInvalidation,
+           !allowStaleContentDuringDataRefresh || refreshOpenMenus
+        {
             self.clearMergedSwitcherContentCaches()
         }
         self.pruneVersionScopedMenuCardHeightCache()

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -32,7 +32,9 @@ extension StatusItemController {
         guard !self.isReleasedForTesting else { return }
         #endif
         self.menuContentVersion &+= 1
-        self.clearMergedSwitcherContentCaches()
+        if !allowStaleContentDuringDataRefresh || refreshOpenMenus {
+            self.clearMergedSwitcherContentCaches()
+        }
         self.pruneVersionScopedMenuCardHeightCache()
         if !allowStaleContentDuringDataRefresh {
             self.latestRequiredMenuRebuildVersion = self.menuContentVersion

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -32,6 +32,7 @@ extension StatusItemController {
         guard !self.isReleasedForTesting else { return }
         #endif
         self.menuContentVersion &+= 1
+        self.clearMergedSwitcherContentCaches()
         self.pruneVersionScopedMenuCardHeightCache()
         if !allowStaleContentDuringDataRefresh {
             self.latestRequiredMenuRebuildVersion = self.menuContentVersion

--- a/Sources/CodexBar/StatusItemController+MergedSwitcherContentCache.swift
+++ b/Sources/CodexBar/StatusItemController+MergedSwitcherContentCache.swift
@@ -1,0 +1,80 @@
+import AppKit
+
+struct CachedMergedSwitcherMenuContent {
+    let menuContentVersion: Int
+    let menuWidth: CGFloat
+    let codexAccountDisplay: CodexAccountMenuDisplay?
+    let tokenAccountDisplay: TokenAccountMenuDisplay?
+    let localizationSignature: String
+    let items: [NSMenuItem]
+
+    func matches(
+        menuContentVersion: Int,
+        menuWidth: CGFloat,
+        codexAccountDisplay: CodexAccountMenuDisplay?,
+        tokenAccountDisplay: TokenAccountMenuDisplay?,
+        localizationSignature: String)
+        -> Bool
+    {
+        self.menuContentVersion == menuContentVersion &&
+            abs(self.menuWidth - menuWidth) <= 0.5 &&
+            self.codexAccountDisplay == codexAccountDisplay &&
+            self.tokenAccountDisplay == tokenAccountDisplay &&
+            self.localizationSignature == localizationSignature
+    }
+}
+
+extension StatusItemController {
+    func clearMergedSwitcherContentCaches() {
+        self.mergedSwitcherContentCaches.removeAll(keepingCapacity: true)
+    }
+
+    func clearMergedSwitcherContentCache(for menu: NSMenu) {
+        self.mergedSwitcherContentCaches.removeValue(forKey: ObjectIdentifier(menu))
+    }
+
+    func cacheVisibleMergedSwitcherContent(
+        in menu: NSMenu,
+        selection: ProviderSwitcherSelection,
+        contentStartIndex: Int,
+        menuWidth: CGFloat)
+    {
+        guard self.shouldMergeIcons else { return }
+        guard contentStartIndex < menu.items.count else { return }
+        let items = Array(menu.items[contentStartIndex...])
+        guard !items.isEmpty else { return }
+
+        let menuKey = ObjectIdentifier(menu)
+        let entry = CachedMergedSwitcherMenuContent(
+            menuContentVersion: self.menuVersions[menuKey] ?? self.menuContentVersion,
+            menuWidth: menuWidth,
+            codexAccountDisplay: self.lastCodexAccountMenuDisplay,
+            tokenAccountDisplay: self.lastTokenAccountMenuDisplay,
+            localizationSignature: self.lastMenuLocalizationSignature,
+            items: items)
+        self.mergedSwitcherContentCaches[menuKey, default: [:]][selection] = entry
+    }
+
+    func cachedMergedSwitcherContent(
+        for selection: ProviderSwitcherSelection,
+        in menu: NSMenu,
+        menuWidth: CGFloat,
+        codexAccountDisplay: CodexAccountMenuDisplay?,
+        tokenAccountDisplay: TokenAccountMenuDisplay?)
+        -> [NSMenuItem]?
+    {
+        let menuKey = ObjectIdentifier(menu)
+        guard let entry = self.mergedSwitcherContentCaches[menuKey]?[selection] else { return nil }
+        guard entry.matches(
+            menuContentVersion: self.menuContentVersion,
+            menuWidth: menuWidth,
+            codexAccountDisplay: codexAccountDisplay,
+            tokenAccountDisplay: tokenAccountDisplay,
+            localizationSignature: self.menuLocalizationSignature())
+        else {
+            self.mergedSwitcherContentCaches[menuKey]?.removeValue(forKey: selection)
+            return nil
+        }
+        return entry.items
+    }
+}

--- a/Sources/CodexBar/StatusItemController+MergedSwitcherContentCache.swift
+++ b/Sources/CodexBar/StatusItemController+MergedSwitcherContentCache.swift
@@ -25,6 +25,13 @@ struct CachedMergedSwitcherMenuContent {
 }
 
 extension StatusItemController {
+    func preservingMergedSwitcherContentCachesDuringInvalidation(_ body: () -> Void) {
+        let previous = self.preservesMergedSwitcherContentCachesDuringInvalidation
+        self.preservesMergedSwitcherContentCachesDuringInvalidation = true
+        defer { self.preservesMergedSwitcherContentCachesDuringInvalidation = previous }
+        body()
+    }
+
     func clearMergedSwitcherContentCaches() {
         self.mergedSwitcherContentCaches.removeAll(keepingCapacity: true)
     }

--- a/Sources/CodexBar/StatusItemController+MergedSwitcherContentCache.swift
+++ b/Sources/CodexBar/StatusItemController+MergedSwitcherContentCache.swift
@@ -9,14 +9,14 @@ struct CachedMergedSwitcherMenuContent {
     let items: [NSMenuItem]
 
     func matches(
-        menuContentVersion: Int,
+        minimumMenuContentVersion: Int,
         menuWidth: CGFloat,
         codexAccountDisplay: CodexAccountMenuDisplay?,
         tokenAccountDisplay: TokenAccountMenuDisplay?,
         localizationSignature: String)
         -> Bool
     {
-        self.menuContentVersion == menuContentVersion &&
+        self.menuContentVersion >= minimumMenuContentVersion &&
             abs(self.menuWidth - menuWidth) <= 0.5 &&
             self.codexAccountDisplay == codexAccountDisplay &&
             self.tokenAccountDisplay == tokenAccountDisplay &&
@@ -79,7 +79,7 @@ extension StatusItemController {
             return nil
         }
         guard entry.matches(
-            menuContentVersion: visibleMenuVersion,
+            minimumMenuContentVersion: self.latestRequiredMenuRebuildVersion,
             menuWidth: menuWidth,
             codexAccountDisplay: codexAccountDisplay,
             tokenAccountDisplay: tokenAccountDisplay,

--- a/Sources/CodexBar/StatusItemController+MergedSwitcherContentCache.swift
+++ b/Sources/CodexBar/StatusItemController+MergedSwitcherContentCache.swift
@@ -65,8 +65,13 @@ extension StatusItemController {
     {
         let menuKey = ObjectIdentifier(menu)
         guard let entry = self.mergedSwitcherContentCaches[menuKey]?[selection] else { return nil }
+        let visibleMenuVersion = self.menuVersions[menuKey] ?? self.menuContentVersion
+        guard visibleMenuVersion >= self.latestRequiredMenuRebuildVersion else {
+            self.mergedSwitcherContentCaches[menuKey]?.removeValue(forKey: selection)
+            return nil
+        }
         guard entry.matches(
-            menuContentVersion: self.menuContentVersion,
+            menuContentVersion: visibleMenuVersion,
             menuWidth: menuWidth,
             codexAccountDisplay: codexAccountDisplay,
             tokenAccountDisplay: tokenAccountDisplay,

--- a/Sources/CodexBar/StatusItemController+MergedSwitcherContentCache.swift
+++ b/Sources/CodexBar/StatusItemController+MergedSwitcherContentCache.swift
@@ -40,13 +40,14 @@ extension StatusItemController {
         menuWidth: CGFloat)
     {
         guard self.shouldMergeIcons else { return }
+        guard menu.items.first?.view is ProviderSwitcherView else { return }
         guard contentStartIndex < menu.items.count else { return }
         let items = Array(menu.items[contentStartIndex...])
         guard !items.isEmpty else { return }
 
         let menuKey = ObjectIdentifier(menu)
         let entry = CachedMergedSwitcherMenuContent(
-            menuContentVersion: self.menuVersions[menuKey] ?? self.menuContentVersion,
+            menuContentVersion: self.menuContentVersion,
             menuWidth: menuWidth,
             codexAccountDisplay: self.lastCodexAccountMenuDisplay,
             tokenAccountDisplay: self.lastTokenAccountMenuDisplay,

--- a/Sources/CodexBar/StatusItemController+MergedSwitcherContentCache.swift
+++ b/Sources/CodexBar/StatusItemController+MergedSwitcherContentCache.swift
@@ -90,4 +90,28 @@ extension StatusItemController {
         }
         return entry.items
     }
+
+    func addCachedMergedSwitcherContent(
+        for selection: ProviderSwitcherSelection,
+        to menu: NSMenu,
+        menuWidth: CGFloat,
+        codexAccountDisplay: CodexAccountMenuDisplay?,
+        tokenAccountDisplay: TokenAccountMenuDisplay?)
+        -> Bool
+    {
+        guard let cachedItems = self.cachedMergedSwitcherContent(
+            for: selection,
+            in: menu,
+            menuWidth: menuWidth,
+            codexAccountDisplay: codexAccountDisplay,
+            tokenAccountDisplay: tokenAccountDisplay)
+        else { return false }
+
+        self.lastCodexAccountMenuDisplay = codexAccountDisplay
+        self.lastTokenAccountMenuDisplay = tokenAccountDisplay
+        for item in cachedItems {
+            menu.addItem(item)
+        }
+        return true
+    }
 }

--- a/Sources/CodexBar/StatusItemController+ProviderNavigation.swift
+++ b/Sources/CodexBar/StatusItemController+ProviderNavigation.swift
@@ -26,17 +26,19 @@ extension StatusItemController {
         let delta = direction == .next ? 1 : -1
         let nextIndex = (currentIndex + delta + selections.count) % selections.count
         let selection = selections[nextIndex]
-        switch selection {
-        case .overview:
-            self.settings.mergedMenuLastSelectedWasOverview = true
-            self.lastMenuProvider = self.navigationResolvedProvider(enabledProviders: enabledProviders) ?? .codex
-        case let .provider(provider):
-            self.settings.mergedMenuLastSelectedWasOverview = false
-            self.selectedMenuProvider = provider
-            self.lastMenuProvider = provider
+        self.preservingMergedSwitcherContentCachesDuringInvalidation {
+            switch selection {
+            case .overview:
+                self.settings.mergedMenuLastSelectedWasOverview = true
+                self.lastMenuProvider = self.navigationResolvedProvider(enabledProviders: enabledProviders) ?? .codex
+            case let .provider(provider):
+                self.settings.mergedMenuLastSelectedWasOverview = false
+                self.selectedMenuProvider = provider
+                self.lastMenuProvider = provider
+            }
+            self.lastMergedSwitcherSelection = selection
+            self.invalidateMenus(refreshOpenMenus: true)
         }
-        self.lastMergedSwitcherSelection = selection
-        self.invalidateMenus(refreshOpenMenus: true)
         self.applyIcon(phase: nil)
     }
 

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -2,7 +2,7 @@ import AppKit
 import CodexBarCore
 import QuartzCore
 
-enum ProviderSwitcherSelection: Equatable {
+enum ProviderSwitcherSelection: Hashable {
     case overview
     case provider(UsageProvider)
 }
@@ -319,6 +319,7 @@ final class ProviderSwitcherView: NSView {
 
     private func applySelection(at index: Int) {
         let selection = self.segments[index].selection
+        guard self.selectedSelection != selection else { return }
         self.updateSelection(selection)
         self.onSelect(selection)
     }
@@ -585,6 +586,14 @@ final class ProviderSwitcherView: NSView {
 
     override var intrinsicContentSize: NSSize {
         NSSize(width: self.preferredWidth, height: self.frame.size.height)
+    }
+
+    var selectedSelection: ProviderSwitcherSelection? {
+        for (index, button) in self.buttons.enumerated() where button.state == .on {
+            guard self.segments.indices.contains(index) else { continue }
+            return self.segments[index].selection
+        }
+        return nil
     }
 
     func updateSelection(_ selection: ProviderSwitcherSelection) {

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -602,14 +602,6 @@ final class ProviderSwitcherView: NSView {
         NSSize(width: self.preferredWidth, height: self.frame.size.height)
     }
 
-    var selectedSelection: ProviderSwitcherSelection? {
-        for (index, button) in self.buttons.enumerated() where button.state == .on {
-            guard self.segments.indices.contains(index) else { continue }
-            return self.segments[index].selection
-        }
-        return nil
-    }
-
     func updateSelection(_ selection: ProviderSwitcherSelection) {
         var selectedIndex: Int?
         for (index, button) in self.buttons.enumerated() {

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -40,6 +40,7 @@ final class ProviderSwitcherView: NSView {
     private var preferredWidth: CGFloat = 0
     private var hoveredButtonTag: Int?
     private var pressedButtonTag: Int?
+    private var selectedSegmentIndex: Int?
     private let lightModeOverlayLayer = CALayer()
     private static let quotaIndicatorHeight: CGFloat = 3
     private static let quotaIndicatorBottomInset: CGFloat = 2
@@ -190,6 +191,9 @@ final class ProviderSwitcherView: NSView {
             let button = makeButton(index: index, segment: segment)
             self.addSubview(button)
         }
+        self.selectedSegmentIndex = selected.flatMap { selected in
+            self.segments.firstIndex { $0.selection == selected }
+        }
 
         let uniformWidth: CGFloat
         if self.rowCount > 1 || !self.stackedIcons {
@@ -319,7 +323,7 @@ final class ProviderSwitcherView: NSView {
 
     private func applySelection(at index: Int) {
         let selection = self.segments[index].selection
-        guard self.selectedSelection != selection else { return }
+        guard self.selectedSegmentIndex != index else { return }
         self.updateSelection(selection)
         self.onSelect(selection)
     }
@@ -332,6 +336,16 @@ final class ProviderSwitcherView: NSView {
     func _test_simulateRuntimeClick(buttonTag: Int) -> Bool {
         guard self.segments.indices.contains(buttonTag) else { return false }
         self.applySelection(at: buttonTag)
+        return true
+    }
+
+    @discardableResult
+    func _test_simulateNativeAction(buttonTag: Int, preToggleState: Bool = true) -> Bool {
+        guard let button = self.buttons.first(where: { $0.tag == buttonTag }) else { return false }
+        if preToggleState {
+            button.state = .on
+        }
+        self.handleSelection(button)
         return true
     }
     #endif
@@ -597,10 +611,15 @@ final class ProviderSwitcherView: NSView {
     }
 
     func updateSelection(_ selection: ProviderSwitcherSelection) {
+        var selectedIndex: Int?
         for (index, button) in self.buttons.enumerated() {
             let isSelected = self.segments.indices.contains(index) && self.segments[index].selection == selection
+            if isSelected {
+                selectedIndex = index
+            }
             button.state = isSelected ? .on : .off
         }
+        self.selectedSegmentIndex = selectedIndex
         self.updateButtonStyles()
     }
 

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -215,6 +215,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     /// Keeps recently detached merged-menu content segments reusable while the same menu stays open.
     var mergedSwitcherContentCaches: [ObjectIdentifier: [ProviderSwitcherSelection: CachedMergedSwitcherMenuContent]]
         = [:]
+    var preservesMergedSwitcherContentCachesDuringInvalidation = false
     /// Monotonic token used to ignore stale deferred provider-switcher menu rebuilds.
     var providerSwitcherUpdateToken = 0
     var lastAppliedMergedIconRenderSignature: String?

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -206,10 +206,15 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var lastSwitcherProviders: [UsageProvider] = []
     /// Tracks which switcher tab state was used for the current merged-menu switcher instance.
     var lastMergedSwitcherSelection: ProviderSwitcherSelection?
+    /// Tracks which provider/overview content is currently attached below the merged-menu switcher.
+    var lastMergedMenuContentSelection: ProviderSwitcherSelection?
     /// Tracks the visible Codex account switcher contents for merged-menu smart updates.
     var lastCodexAccountMenuDisplay: CodexAccountMenuDisplay?
     /// Tracks the visible token account switcher contents for merged-menu smart updates.
     var lastTokenAccountMenuDisplay: TokenAccountMenuDisplay?
+    /// Keeps recently detached merged-menu content segments reusable while the same menu stays open.
+    var mergedSwitcherContentCaches: [ObjectIdentifier: [ProviderSwitcherSelection: CachedMergedSwitcherMenuContent]]
+        = [:]
     /// Monotonic token used to ignore stale deferred provider-switcher menu rebuilds.
     var providerSwitcherUpdateToken = 0
     var lastAppliedMergedIconRenderSignature: String?

--- a/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
@@ -67,6 +67,42 @@ struct StatusMenuSwitcherClickTests {
     }
 
     @Test
+    func `native switcher action preserves off tab switches after button state toggles`() {
+        var selections: [ProviderSwitcherSelection] = []
+        let switcher = ProviderSwitcherView(
+            providers: [.codex, .claude],
+            selected: .provider(.codex),
+            includesOverview: false,
+            width: 310,
+            showsIcons: false,
+            iconProvider: { _ in NSImage() },
+            weeklyRemainingProvider: { _ in nil },
+            onSelect: { selections.append($0) })
+
+        #expect(switcher._test_simulateNativeAction(buttonTag: 1) == true)
+        #expect(selections == [.provider(.claude)])
+        #expect(switcher.selectedSelection == .provider(.claude))
+    }
+
+    @Test
+    func `native switcher action ignores active tab reselect`() {
+        var selections: [ProviderSwitcherSelection] = []
+        let switcher = ProviderSwitcherView(
+            providers: [.codex, .claude],
+            selected: .provider(.codex),
+            includesOverview: false,
+            width: 310,
+            showsIcons: false,
+            iconProvider: { _ in NSImage() },
+            weeklyRemainingProvider: { _ in nil },
+            onSelect: { selections.append($0) })
+
+        #expect(switcher._test_simulateNativeAction(buttonTag: 0) == true)
+        #expect(selections.isEmpty)
+        #expect(switcher.selectedSelection == .provider(.codex))
+    }
+
+    @Test
     func `merged switcher routes runtime clicks after overview round-trip`() throws {
         // Regression test for #867: after Provider → Overview, subsequent runtime clicks on a
         // sub-provider tab dropped through NSButton's tracking and never updated state.

--- a/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
@@ -81,7 +81,6 @@ struct StatusMenuSwitcherClickTests {
 
         #expect(switcher._test_simulateNativeAction(buttonTag: 1) == true)
         #expect(selections == [.provider(.claude)])
-        #expect(switcher.selectedSelection == .provider(.claude))
     }
 
     @Test
@@ -99,7 +98,6 @@ struct StatusMenuSwitcherClickTests {
 
         #expect(switcher._test_simulateNativeAction(buttonTag: 0) == true)
         #expect(selections.isEmpty)
-        #expect(switcher.selectedSelection == .provider(.codex))
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
@@ -74,6 +74,115 @@ struct StatusMenuSwitcherRefreshTests {
     }
 
     @Test
+    func `selected provider tab click does not rebuild open menu`() async throws {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = false
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
+        defer {
+            StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering
+            StatusItemController.resetMenuRefreshEnabledForTesting()
+        }
+
+        let settings = Self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        Self.enableCodexAndClaude(settings)
+        Self.disableOverview(settings)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        let switcher = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        let selectedButton = try #require(Self.switcherButtons(in: menu).first { $0.state == .on })
+
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { _ in
+            rebuildCount += 1
+        }
+        defer { controller._test_openMenuRebuildObserver = nil }
+
+        #expect(switcher._test_simulateRuntimeClick(buttonTag: selectedButton.tag) == true)
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+
+        #expect(rebuildCount == 0)
+        #expect(Self.switcherButtons(in: menu).first { $0.tag == selectedButton.tag }?.state == .on)
+    }
+
+    @Test
+    func `merged provider switch restores cached tab content`() async throws {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = false
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
+        defer {
+            StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering
+            StatusItemController.resetMenuRefreshEnabledForTesting()
+        }
+
+        let settings = Self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        Self.enableCodexAndClaude(settings)
+        Self.disableOverview(settings)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        let contentStartIndex = controller.providerSwitcherContentStartIndex(in: menu)
+        #expect(menu.items.count > contentStartIndex)
+        let originalSelectedContentID = ObjectIdentifier(menu.items[contentStartIndex])
+        let selectedButton = try #require(Self.switcherButtons(in: menu).first { $0.state == .on })
+        let alternateButton = try #require(Self.switcherButtons(in: menu).first { $0.state == .off })
+
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { _ in
+            rebuildCount += 1
+        }
+        defer { controller._test_openMenuRebuildObserver = nil }
+
+        let initialSwitcher = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        #expect(initialSwitcher._test_simulateRuntimeClick(buttonTag: alternateButton.tag) == true)
+        await Self.waitForRebuildCount(1, rebuildCount: { rebuildCount })
+        let alternateContentID = ObjectIdentifier(menu.items[contentStartIndex])
+        #expect(alternateContentID != originalSelectedContentID)
+
+        let alternateSwitcher = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        #expect(alternateSwitcher._test_simulateRuntimeClick(buttonTag: selectedButton.tag) == true)
+        await Self.waitForRebuildCount(2, rebuildCount: { rebuildCount })
+        #expect(ObjectIdentifier(menu.items[contentStartIndex]) == originalSelectedContentID)
+
+        let restoredSwitcher = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        #expect(restoredSwitcher._test_simulateRuntimeClick(buttonTag: alternateButton.tag) == true)
+        await Self.waitForRebuildCount(3, rebuildCount: { rebuildCount })
+        #expect(ObjectIdentifier(menu.items[contentStartIndex]) == alternateContentID)
+    }
+
+    @Test
     func `tab switch does not replace quota indicator constraints`() {
         let switcher = ProviderSwitcherView(
             providers: [.codex, .claude],
@@ -135,6 +244,28 @@ struct StatusMenuSwitcherRefreshTests {
             guard let metadata = registry.metadata[provider] else { continue }
             let shouldEnable = provider == .codex || provider == .claude
             settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: shouldEnable)
+        }
+    }
+
+    private static func disableOverview(_ settings: SettingsStore) {
+        let activeProviders: [UsageProvider] = [.codex, .claude]
+        _ = settings.setMergedOverviewProviderSelection(
+            provider: .codex,
+            isSelected: false,
+            activeProviders: activeProviders)
+        _ = settings.setMergedOverviewProviderSelection(
+            provider: .claude,
+            isSelected: false,
+            activeProviders: activeProviders)
+    }
+
+    private static func waitForRebuildCount(
+        _ expectedCount: Int,
+        rebuildCount: () -> Int) async
+    {
+        for _ in 0..<100 where rebuildCount() < expectedCount {
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(10))
         }
     }
 


### PR DESCRIPTION
## Summary
- cache already-built merged menu provider-tab content while the menu stays open, guarded by menu version, layout width, account switcher state, and localization
- skip open-menu rebuild scheduling when the active provider tab is selected again
- cover active-tab reselects and cached back-switches in the switcher refresh tests

Fixes #1325

## Validation
- `./Scripts/lint.sh format`
- `git diff --check`
- `swift test --filter StatusMenuSwitcherRefreshTests` (blocked locally: Command Line Tools lacks SwiftUI/Swift Testing modules; no full Xcode install is available)
- `make check` (blocked locally: SwiftLint cannot load sourcekitd from the Command Line Tools install)
