### PR TITLE
fix: preserve Codex reset windows across account refresh

### DIFF
--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -177,7 +177,7 @@ extension UsageStore {
     {
         let currentGuard = self.freshCodexAccountScopedRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
-        guard Self.codexGuardAuthFingerprintAllowsApply(currentGuard, expectedGuard) else { return false }
+        guard Self.codexGuardAuthFingerprintAllowsUsageApply(currentGuard, expectedGuard) else { return false }
 
         if expectedGuard.identity != .unresolved {
             return currentGuard.identity == expectedGuard.identity
@@ -199,7 +199,7 @@ extension UsageStore {
     func shouldApplyCodexScopedFailure(expectedGuard: CodexAccountScopedRefreshGuard) -> Bool {
         let currentGuard = self.freshCodexAccountScopedRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
-        guard Self.codexGuardAuthFingerprintAllowsApply(currentGuard, expectedGuard) else { return false }
+        guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
 
         if expectedGuard.identity != .unresolved {
             return currentGuard.identity == expectedGuard.identity
@@ -208,10 +208,25 @@ extension UsageStore {
         return currentGuard.identity == .unresolved
     }
 
+    func codexScopedNonUsageSuccessApplyGuard(
+        expectedGuard: CodexAccountScopedRefreshGuard) -> CodexAccountScopedRefreshGuard?
+    {
+        let currentGuard = self.freshCodexAccountScopedRefreshGuard()
+        guard currentGuard.source == expectedGuard.source else { return nil }
+        guard Self.codexGuardAuthFingerprintAllowsUsageApply(currentGuard, expectedGuard) else { return nil }
+        guard expectedGuard.identity != .unresolved else { return nil }
+        guard currentGuard.identity == expectedGuard.identity else { return nil }
+        return currentGuard
+    }
+
     func shouldApplyCodexScopedNonUsageResult(expectedGuard: CodexAccountScopedRefreshGuard) -> Bool {
+        self.codexScopedNonUsageSuccessApplyGuard(expectedGuard: expectedGuard) != nil
+    }
+
+    func shouldApplyCodexScopedNonUsageFailure(expectedGuard: CodexAccountScopedRefreshGuard) -> Bool {
         let currentGuard = self.freshCodexAccountScopedRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
-        guard Self.codexGuardAuthFingerprintAllowsApply(currentGuard, expectedGuard) else { return false }
+        guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
         guard expectedGuard.identity != .unresolved else { return false }
         return currentGuard.identity == expectedGuard.identity
     }
@@ -223,7 +238,7 @@ extension UsageStore {
         let normalizedRoutingTargetEmail = CodexIdentityResolver.normalizeEmail(routingTargetEmail)
         let currentGuard = self.freshCodexOpenAIWebRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
-        guard Self.codexGuardAuthFingerprintAllowsApply(currentGuard, expectedGuard) else { return false }
+        guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
 
         if expectedGuard.identity != .unresolved {
             return currentGuard.identity == expectedGuard.identity
@@ -324,7 +339,7 @@ extension UsageStore {
         return true
     }
 
-    private static func codexGuardAuthFingerprintAllowsApply(
+    private static func codexGuardAuthFingerprintAllowsUsageApply(
         _ lhs: CodexAccountScopedRefreshGuard,
         _ rhs: CodexAccountScopedRefreshGuard) -> Bool
     {

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -13,6 +13,19 @@ struct CodexAccountScopedRefreshGuard: Equatable {
     let source: CodexActiveSource
     let identity: CodexIdentity
     let accountKey: String?
+    let authFingerprint: String?
+
+    init(
+        source: CodexActiveSource,
+        identity: CodexIdentity,
+        accountKey: String?,
+        authFingerprint: String? = nil)
+    {
+        self.source = source
+        self.identity = identity
+        self.accountKey = accountKey
+        self.authFingerprint = CodexAuthFingerprint.normalize(authFingerprint)
+    }
 }
 
 @MainActor
@@ -106,7 +119,8 @@ extension UsageStore {
         self.lastCodexAccountScopedRefreshGuard = CodexAccountScopedRefreshGuard(
             source: resolvedSource,
             identity: resolvedIdentity,
-            accountKey: accountKey)
+            accountKey: accountKey,
+            authFingerprint: self.currentCodexAuthFingerprint(source: resolvedSource))
     }
 
     func currentCodexAccountScopedRefreshGuard(
@@ -121,7 +135,8 @@ extension UsageStore {
                 allowLastKnownLiveFallback: allowLastKnownLiveFallback),
             accountKey: self.codexAccountScopedRefreshKey(
                 preferCurrentSnapshot: preferCurrentSnapshot,
-                allowLastKnownLiveFallback: allowLastKnownLiveFallback))
+                allowLastKnownLiveFallback: allowLastKnownLiveFallback),
+            authFingerprint: self.currentCodexAuthFingerprint(source: self.settings.codexResolvedActiveSource))
     }
 
     func currentCodexOpenAIWebRefreshGuard() -> CodexAccountScopedRefreshGuard {
@@ -137,7 +152,8 @@ extension UsageStore {
         return CodexAccountScopedRefreshGuard(
             source: source,
             identity: self.currentCodexOpenAIWebIdentity(source: source),
-            accountKey: accountKey)
+            accountKey: accountKey,
+            authFingerprint: self.currentCodexAuthFingerprint(source: source))
     }
 
     func shouldApplyCodexUsageResult(
@@ -146,6 +162,7 @@ extension UsageStore {
     {
         let currentGuard = self.currentCodexAccountScopedRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
+        guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
 
         if expectedGuard.identity != .unresolved {
             return currentGuard.identity == expectedGuard.identity
@@ -167,6 +184,7 @@ extension UsageStore {
     func shouldApplyCodexScopedFailure(expectedGuard: CodexAccountScopedRefreshGuard) -> Bool {
         let currentGuard = self.currentCodexAccountScopedRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
+        guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
 
         if expectedGuard.identity != .unresolved {
             return currentGuard.identity == expectedGuard.identity
@@ -178,6 +196,7 @@ extension UsageStore {
     func shouldApplyCodexScopedNonUsageResult(expectedGuard: CodexAccountScopedRefreshGuard) -> Bool {
         let currentGuard = self.currentCodexAccountScopedRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
+        guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
         guard expectedGuard.identity != .unresolved else { return false }
         return currentGuard.identity == expectedGuard.identity
     }
@@ -189,6 +208,7 @@ extension UsageStore {
         let normalizedRoutingTargetEmail = CodexIdentityResolver.normalizeEmail(routingTargetEmail)
         let currentGuard = self.currentCodexOpenAIWebRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
+        guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
 
         if expectedGuard.identity != .unresolved {
             return currentGuard.identity == expectedGuard.identity
@@ -275,6 +295,28 @@ extension UsageStore {
         guard case .liveSystem = self.settings.codexResolvedActiveSource else { return }
         guard let normalized = Self.normalizeCodexAccountScopedEmail(email) else { return }
         self.lastKnownLiveSystemCodexEmail = normalized
+    }
+
+    static func codexGuardAuthFingerprintMatches(
+        _ lhs: CodexAccountScopedRefreshGuard,
+        _ rhs: CodexAccountScopedRefreshGuard) -> Bool
+    {
+        let lhsFingerprint = CodexAuthFingerprint.normalize(lhs.authFingerprint)
+        let rhsFingerprint = CodexAuthFingerprint.normalize(rhs.authFingerprint)
+        if lhsFingerprint != nil || rhsFingerprint != nil {
+            return lhsFingerprint == rhsFingerprint
+        }
+        return true
+    }
+
+    func currentCodexAuthFingerprint(source: CodexActiveSource) -> String? {
+        let snapshot = self.settings.codexAccountReconciliationSnapshot
+        switch source {
+        case .liveSystem:
+            return CodexAuthFingerprint.normalize(snapshot.liveSystemAccount?.authFingerprint)
+        case let .managedAccount(id):
+            return CodexAuthFingerprint.normalize(snapshot.storedAccounts.first { $0.id == id }?.authFingerprint)
+        }
     }
 
     func codexAccountScopedRefreshKey(

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -47,7 +47,7 @@ extension UsageStore {
         phaseDidChange?(.credits)
 
         if self.settings.codexCookieSource.isEnabled {
-            let expectedGuard = self.currentCodexOpenAIWebRefreshGuard()
+            let expectedGuard = self.freshCodexOpenAIWebRefreshGuard()
             await self.refreshOpenAIDashboardIfNeeded(
                 force: true,
                 expectedGuard: expectedGuard,
@@ -68,7 +68,7 @@ extension UsageStore {
 
     @discardableResult
     func prepareCodexAccountScopedRefreshIfNeeded() -> Bool {
-        let currentGuard = self.currentCodexAccountScopedRefreshGuard(
+        let currentGuard = self.freshCodexAccountScopedRefreshGuard(
             preferCurrentSnapshot: false,
             allowLastKnownLiveFallback: false)
         let previousGuard = self.lastCodexAccountScopedRefreshGuard
@@ -156,11 +156,26 @@ extension UsageStore {
             authFingerprint: self.currentCodexAuthFingerprint(source: source))
     }
 
+    func freshCodexAccountScopedRefreshGuard(
+        preferCurrentSnapshot: Bool = true,
+        allowLastKnownLiveFallback: Bool = true) -> CodexAccountScopedRefreshGuard
+    {
+        self.settings.invalidateCodexAccountReconciliationSnapshotCache()
+        return self.currentCodexAccountScopedRefreshGuard(
+            preferCurrentSnapshot: preferCurrentSnapshot,
+            allowLastKnownLiveFallback: allowLastKnownLiveFallback)
+    }
+
+    func freshCodexOpenAIWebRefreshGuard() -> CodexAccountScopedRefreshGuard {
+        self.settings.invalidateCodexAccountReconciliationSnapshotCache()
+        return self.currentCodexOpenAIWebRefreshGuard()
+    }
+
     func shouldApplyCodexUsageResult(
         expectedGuard: CodexAccountScopedRefreshGuard,
         usage: UsageSnapshot) -> Bool
     {
-        let currentGuard = self.currentCodexAccountScopedRefreshGuard()
+        let currentGuard = self.freshCodexAccountScopedRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
         guard Self.codexGuardAuthFingerprintAllowsApply(currentGuard, expectedGuard) else { return false }
 
@@ -182,7 +197,7 @@ extension UsageStore {
     }
 
     func shouldApplyCodexScopedFailure(expectedGuard: CodexAccountScopedRefreshGuard) -> Bool {
-        let currentGuard = self.currentCodexAccountScopedRefreshGuard()
+        let currentGuard = self.freshCodexAccountScopedRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
         guard Self.codexGuardAuthFingerprintAllowsApply(currentGuard, expectedGuard) else { return false }
 
@@ -194,7 +209,7 @@ extension UsageStore {
     }
 
     func shouldApplyCodexScopedNonUsageResult(expectedGuard: CodexAccountScopedRefreshGuard) -> Bool {
-        let currentGuard = self.currentCodexAccountScopedRefreshGuard()
+        let currentGuard = self.freshCodexAccountScopedRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
         guard Self.codexGuardAuthFingerprintAllowsApply(currentGuard, expectedGuard) else { return false }
         guard expectedGuard.identity != .unresolved else { return false }
@@ -206,7 +221,7 @@ extension UsageStore {
         routingTargetEmail: String?) -> Bool
     {
         let normalizedRoutingTargetEmail = CodexIdentityResolver.normalizeEmail(routingTargetEmail)
-        let currentGuard = self.currentCodexOpenAIWebRefreshGuard()
+        let currentGuard = self.freshCodexOpenAIWebRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
         guard Self.codexGuardAuthFingerprintAllowsApply(currentGuard, expectedGuard) else { return false }
 
@@ -316,8 +331,9 @@ extension UsageStore {
         if self.codexGuardAuthFingerprintMatches(lhs, rhs) {
             return true
         }
-        guard case .providerAccount = rhs.identity else { return false }
-        return lhs.identity == rhs.identity
+        guard case .providerAccount = rhs.identity, lhs.identity == rhs.identity else { return false }
+        guard case .liveSystem = lhs.source else { return true }
+        return lhs.accountKey != nil && lhs.accountKey == rhs.accountKey
     }
 
     func currentCodexAuthFingerprint(source: CodexActiveSource) -> String? {

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -384,7 +384,8 @@ extension UsageStore {
         case .liveSystem:
             return CodexAuthFingerprint.normalize(snapshot.liveSystemAccount?.authFingerprint)
         case let .managedAccount(id):
-            return CodexAuthFingerprint.normalize(snapshot.storedAccounts.first { $0.id == id }?.authFingerprint)
+            guard let account = snapshot.storedAccounts.first(where: { $0.id == id }) else { return nil }
+            return CodexAuthFingerprint.fingerprint(homePath: account.managedHomePath)
         }
     }
 

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -316,7 +316,7 @@ extension UsageStore {
         if self.codexGuardAuthFingerprintMatches(lhs, rhs) {
             return true
         }
-        guard rhs.identity != .unresolved else { return false }
+        guard case .providerAccount = rhs.identity else { return false }
         return lhs.identity == rhs.identity
     }
 

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -162,7 +162,7 @@ extension UsageStore {
     {
         let currentGuard = self.currentCodexAccountScopedRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
-        guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
+        guard Self.codexGuardAuthFingerprintAllowsApply(currentGuard, expectedGuard) else { return false }
 
         if expectedGuard.identity != .unresolved {
             return currentGuard.identity == expectedGuard.identity
@@ -184,7 +184,7 @@ extension UsageStore {
     func shouldApplyCodexScopedFailure(expectedGuard: CodexAccountScopedRefreshGuard) -> Bool {
         let currentGuard = self.currentCodexAccountScopedRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
-        guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
+        guard Self.codexGuardAuthFingerprintAllowsApply(currentGuard, expectedGuard) else { return false }
 
         if expectedGuard.identity != .unresolved {
             return currentGuard.identity == expectedGuard.identity
@@ -196,7 +196,7 @@ extension UsageStore {
     func shouldApplyCodexScopedNonUsageResult(expectedGuard: CodexAccountScopedRefreshGuard) -> Bool {
         let currentGuard = self.currentCodexAccountScopedRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
-        guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
+        guard Self.codexGuardAuthFingerprintAllowsApply(currentGuard, expectedGuard) else { return false }
         guard expectedGuard.identity != .unresolved else { return false }
         return currentGuard.identity == expectedGuard.identity
     }
@@ -208,7 +208,7 @@ extension UsageStore {
         let normalizedRoutingTargetEmail = CodexIdentityResolver.normalizeEmail(routingTargetEmail)
         let currentGuard = self.currentCodexOpenAIWebRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
-        guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
+        guard Self.codexGuardAuthFingerprintAllowsApply(currentGuard, expectedGuard) else { return false }
 
         if expectedGuard.identity != .unresolved {
             return currentGuard.identity == expectedGuard.identity
@@ -307,6 +307,17 @@ extension UsageStore {
             return lhsFingerprint == rhsFingerprint
         }
         return true
+    }
+
+    private static func codexGuardAuthFingerprintAllowsApply(
+        _ lhs: CodexAccountScopedRefreshGuard,
+        _ rhs: CodexAccountScopedRefreshGuard) -> Bool
+    {
+        if self.codexGuardAuthFingerprintMatches(lhs, rhs) {
+            return true
+        }
+        guard rhs.identity != .unresolved else { return false }
+        return lhs.identity == rhs.identity
     }
 
     func currentCodexAuthFingerprint(source: CodexActiveSource) -> String? {

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -74,7 +74,9 @@ extension UsageStore {
         let previousGuard = self.lastCodexAccountScopedRefreshGuard
         self.lastCodexAccountScopedRefreshGuard = currentGuard
 
-        guard previousGuard != nil, previousGuard != currentGuard else { return false }
+        guard let previousGuard,
+              !Self.codexScopedRefreshGuardsMatchAccount(previousGuard, currentGuard)
+        else { return false }
 
         self.snapshots.removeValue(forKey: .codex)
         self.errors[.codex] = nil
@@ -376,6 +378,21 @@ extension UsageStore {
         guard case .providerAccount = rhs.identity, lhs.identity == rhs.identity else { return false }
         guard case .liveSystem = lhs.source else { return true }
         return lhs.accountKey != nil && lhs.accountKey == rhs.accountKey
+    }
+
+    nonisolated static func codexScopedRefreshGuardsMatchAccount(
+        _ lhs: CodexAccountScopedRefreshGuard,
+        _ rhs: CodexAccountScopedRefreshGuard) -> Bool
+    {
+        guard lhs.source == rhs.source else { return false }
+        if lhs == rhs { return true }
+        guard lhs.identity != .unresolved,
+              lhs.identity == rhs.identity,
+              lhs.accountKey == rhs.accountKey
+        else {
+            return false
+        }
+        return self.codexGuardAuthFingerprintAllowsUsageApply(lhs, rhs)
     }
 
     func currentCodexAuthFingerprint(source: CodexActiveSource) -> String? {

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -238,7 +238,7 @@ extension UsageStore {
         let normalizedRoutingTargetEmail = CodexIdentityResolver.normalizeEmail(routingTargetEmail)
         let currentGuard = self.freshCodexOpenAIWebRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
-        guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
+        guard Self.codexGuardAuthFingerprintAllowsUsageApply(currentGuard, expectedGuard) else { return false }
 
         if expectedGuard.identity != .unresolved {
             return currentGuard.identity == expectedGuard.identity
@@ -256,9 +256,21 @@ extension UsageStore {
         expectedGuard: CodexAccountScopedRefreshGuard,
         routingTargetEmail: String?) -> Bool
     {
-        self.shouldApplyOpenAIDashboardRefreshGuard(
-            expectedGuard: expectedGuard,
-            routingTargetEmail: routingTargetEmail)
+        let normalizedRoutingTargetEmail = CodexIdentityResolver.normalizeEmail(routingTargetEmail)
+        let currentGuard = self.freshCodexOpenAIWebRefreshGuard()
+        guard currentGuard.source == expectedGuard.source else { return false }
+        guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
+
+        if expectedGuard.identity != .unresolved {
+            return currentGuard.identity == expectedGuard.identity
+        }
+
+        guard case .liveSystem = expectedGuard.source else { return false }
+        guard currentGuard.identity == .unresolved else { return false }
+        return CodexIdentityResolver.normalizeEmail(
+            self.currentCodexOpenAIWebTargetEmail(
+                allowCurrentSnapshotFallback: true,
+                allowLastKnownLiveFallback: false)) == normalizedRoutingTargetEmail
     }
 
     func codexDashboardKnownOwnerCandidates() -> [CodexDashboardKnownOwnerCandidate] {

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -354,7 +354,7 @@ extension UsageStore {
         self.lastKnownLiveSystemCodexEmail = normalized
     }
 
-    static func codexGuardAuthFingerprintMatches(
+    nonisolated static func codexGuardAuthFingerprintMatches(
         _ lhs: CodexAccountScopedRefreshGuard,
         _ rhs: CodexAccountScopedRefreshGuard) -> Bool
     {
@@ -366,7 +366,7 @@ extension UsageStore {
         return true
     }
 
-    private static func codexGuardAuthFingerprintAllowsUsageApply(
+    nonisolated static func codexGuardAuthFingerprintAllowsUsageApply(
         _ lhs: CodexAccountScopedRefreshGuard,
         _ rhs: CodexAccountScopedRefreshGuard) -> Bool
     {

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -187,11 +187,18 @@ extension UsageStore {
         let canProveNilToCurrentAuth = expectedAuthFingerprint == nil && currentAuthFingerprint != nil
         let resultIdentity = CodexIdentityResolver.resolve(accountId: nil, email: usage.accountEmail(for: .codex))
         let resultAccountKey = Self.normalizeCodexAccountScopedKey(usage.accountEmail(for: .codex))
+        let resultMatchesCurrentAccountKey = Self.codexUsageResultAccountKeyMatchesCurrentGuard(
+            resultAccountKey,
+            currentGuard: currentGuard)
 
         if expectedGuard.identity != .unresolved {
             guard currentGuard.identity == expectedGuard.identity else { return false }
-            if fingerprintsAllowApply { return true }
+            if fingerprintsAllowApply {
+                guard case .managedAccount = currentGuard.source else { return true }
+                return resultMatchesCurrentAccountKey
+            }
             guard canProveNilToCurrentAuth else { return false }
+            guard resultMatchesCurrentAccountKey else { return false }
             return resultIdentity == currentGuard.identity ||
                 (resultAccountKey != nil && resultAccountKey == currentGuard.accountKey)
         }
@@ -393,6 +400,14 @@ extension UsageStore {
             return false
         }
         return self.codexGuardAuthFingerprintAllowsUsageApply(lhs, rhs)
+    }
+
+    private nonisolated static func codexUsageResultAccountKeyMatchesCurrentGuard(
+        _ resultAccountKey: String?,
+        currentGuard: CodexAccountScopedRefreshGuard) -> Bool
+    {
+        guard let currentAccountKey = currentGuard.accountKey else { return true }
+        return resultAccountKey == currentAccountKey
     }
 
     func currentCodexAuthFingerprint(source: CodexActiveSource) -> String? {

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -383,6 +383,9 @@ extension UsageStore {
         if self.codexGuardAuthFingerprintMatches(lhs, rhs) {
             return true
         }
+        let lhsFingerprint = CodexAuthFingerprint.normalize(lhs.authFingerprint)
+        let rhsFingerprint = CodexAuthFingerprint.normalize(rhs.authFingerprint)
+        guard lhsFingerprint != nil, rhsFingerprint != nil else { return false }
         guard case .providerAccount = rhs.identity, lhs.identity == rhs.identity else { return false }
         guard case .liveSystem = lhs.source else { return true }
         return lhs.accountKey != nil && lhs.accountKey == rhs.accountKey
@@ -423,8 +426,7 @@ extension UsageStore {
             return CodexAuthFingerprint.normalize(snapshot.liveSystemAccount?.authFingerprint)
         case let .managedAccount(id):
             guard let account = snapshot.storedAccounts.first(where: { $0.id == id }) else { return nil }
-            return CodexAuthFingerprint.fingerprint(homePath: account.managedHomePath) ??
-                CodexAuthFingerprint.normalize(account.authFingerprint)
+            return CodexAuthFingerprint.fingerprint(homePath: account.managedHomePath)
         }
     }
 

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -298,6 +298,29 @@ extension UsageStore {
                 allowLastKnownLiveFallback: false)) == normalizedRoutingTargetEmail
     }
 
+    func shouldApplyOpenAIDashboardPolicyResult(
+        expectedGuard: CodexAccountScopedRefreshGuard,
+        routingTargetEmail: String?) -> Bool
+    {
+        let normalizedRoutingTargetEmail = CodexIdentityResolver.normalizeEmail(routingTargetEmail)
+        let currentGuard = self.freshCodexOpenAIWebRefreshGuard()
+        guard currentGuard.source == expectedGuard.source else { return false }
+
+        if expectedGuard.identity != .unresolved {
+            guard currentGuard.identity == expectedGuard.identity else { return false }
+            return Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) ||
+                Self.codexGuardAuthFingerprintAllowsSameProviderAccount(currentGuard, expectedGuard)
+        }
+
+        guard case .liveSystem = expectedGuard.source else { return false }
+        guard currentGuard.identity == .unresolved else { return false }
+        guard Self.codexGuardAuthFingerprintMatches(currentGuard, expectedGuard) else { return false }
+        return CodexIdentityResolver.normalizeEmail(
+            self.currentCodexOpenAIWebTargetEmail(
+                allowCurrentSnapshotFallback: true,
+                allowLastKnownLiveFallback: false)) == normalizedRoutingTargetEmail
+    }
+
     func codexDashboardKnownOwnerCandidates() -> [CodexDashboardKnownOwnerCandidate] {
         CodexKnownOwnerCatalog.candidates(from: self.settings.codexAccountReconciliationSnapshot)
     }
@@ -389,6 +412,17 @@ extension UsageStore {
         guard case .providerAccount = rhs.identity, lhs.identity == rhs.identity else { return false }
         guard case .liveSystem = lhs.source else { return true }
         return lhs.accountKey != nil && lhs.accountKey == rhs.accountKey
+    }
+
+    private nonisolated static func codexGuardAuthFingerprintAllowsSameProviderAccount(
+        _ lhs: CodexAccountScopedRefreshGuard,
+        _ rhs: CodexAccountScopedRefreshGuard) -> Bool
+    {
+        let lhsFingerprint = CodexAuthFingerprint.normalize(lhs.authFingerprint)
+        let rhsFingerprint = CodexAuthFingerprint.normalize(rhs.authFingerprint)
+        guard lhsFingerprint != nil, rhsFingerprint != nil else { return false }
+        guard case .providerAccount = rhs.identity else { return false }
+        return lhs.identity == rhs.identity
     }
 
     nonisolated static func codexScopedRefreshGuardsMatchAccount(

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -177,20 +177,35 @@ extension UsageStore {
     {
         let currentGuard = self.freshCodexAccountScopedRefreshGuard()
         guard currentGuard.source == expectedGuard.source else { return false }
-        guard Self.codexGuardAuthFingerprintAllowsUsageApply(currentGuard, expectedGuard) else { return false }
+        let fingerprintsAllowApply = Self.codexGuardAuthFingerprintAllowsUsageApply(
+            currentGuard,
+            expectedGuard)
+        let expectedAuthFingerprint = CodexAuthFingerprint.normalize(expectedGuard.authFingerprint)
+        let currentAuthFingerprint = CodexAuthFingerprint.normalize(currentGuard.authFingerprint)
+        let canProveNilToCurrentAuth = expectedAuthFingerprint == nil && currentAuthFingerprint != nil
+        let resultIdentity = CodexIdentityResolver.resolve(accountId: nil, email: usage.accountEmail(for: .codex))
+        let resultAccountKey = Self.normalizeCodexAccountScopedKey(usage.accountEmail(for: .codex))
 
         if expectedGuard.identity != .unresolved {
-            return currentGuard.identity == expectedGuard.identity
+            guard currentGuard.identity == expectedGuard.identity else { return false }
+            if fingerprintsAllowApply { return true }
+            guard canProveNilToCurrentAuth else { return false }
+            return resultIdentity == currentGuard.identity ||
+                (resultAccountKey != nil && resultAccountKey == currentGuard.accountKey)
         }
 
-        let resultIdentity = CodexIdentityResolver.resolve(accountId: nil, email: usage.accountEmail(for: .codex))
         if currentGuard.identity != .unresolved {
-            return resultIdentity == currentGuard.identity
+            guard resultIdentity == currentGuard.identity else { return false }
+            return fingerprintsAllowApply || canProveNilToCurrentAuth
         }
 
         switch currentGuard.source {
         case .liveSystem:
-            return resultIdentity != .unresolved
+            guard resultIdentity != .unresolved else { return false }
+            if fingerprintsAllowApply { return true }
+            guard canProveNilToCurrentAuth else { return false }
+            guard let currentAccountKey = currentGuard.accountKey else { return true }
+            return resultAccountKey == currentAccountKey
         case .managedAccount:
             return false
         }

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -189,6 +189,7 @@ extension UsageStore {
         let resultAccountKey = Self.normalizeCodexAccountScopedKey(usage.accountEmail(for: .codex))
         let resultMatchesCurrentAccountKey = Self.codexUsageResultAccountKeyMatchesCurrentGuard(
             resultAccountKey,
+            expectedGuard: expectedGuard,
             currentGuard: currentGuard)
 
         if expectedGuard.identity != .unresolved {
@@ -404,9 +405,14 @@ extension UsageStore {
 
     private nonisolated static func codexUsageResultAccountKeyMatchesCurrentGuard(
         _ resultAccountKey: String?,
+        expectedGuard: CodexAccountScopedRefreshGuard,
         currentGuard: CodexAccountScopedRefreshGuard) -> Bool
     {
         guard let currentAccountKey = currentGuard.accountKey else { return true }
+        guard let resultAccountKey else {
+            guard let expectedAccountKey = expectedGuard.accountKey else { return true }
+            return expectedAccountKey == currentAccountKey
+        }
         return resultAccountKey == currentAccountKey
     }
 
@@ -417,7 +423,8 @@ extension UsageStore {
             return CodexAuthFingerprint.normalize(snapshot.liveSystemAccount?.authFingerprint)
         case let .managedAccount(id):
             guard let account = snapshot.storedAccounts.first(where: { $0.id == id }) else { return nil }
-            return CodexAuthFingerprint.fingerprint(homePath: account.managedHomePath)
+            return CodexAuthFingerprint.fingerprint(homePath: account.managedHomePath) ??
+                CodexAuthFingerprint.normalize(account.authFingerprint)
         }
     }
 

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
@@ -92,15 +92,15 @@ extension UsageStore {
         do {
             let credits = try await self.loadLatestCodexCredits()
             guard !Task.isCancelled else { return }
-            guard self.shouldApplyCodexScopedNonUsageResult(expectedGuard: expectedGuard) else { return }
+            guard let applyGuard = self.codexScopedNonUsageSuccessApplyGuard(expectedGuard: expectedGuard) else { return }
             await MainActor.run {
                 self.credits = credits
                 self.lastCreditsError = nil
                 self.lastCreditsSnapshot = credits
-                self.lastCreditsSnapshotAccountKey = expectedGuard.accountKey
+                self.lastCreditsSnapshotAccountKey = applyGuard.accountKey
                 self.lastCreditsSource = .api
                 self.creditsFailureStreak = 0
-                self.lastCodexAccountScopedRefreshGuard = expectedGuard
+                self.lastCodexAccountScopedRefreshGuard = applyGuard
             }
             let codexSnapshot = await MainActor.run {
                 self.snapshots[.codex]
@@ -123,7 +123,7 @@ extension UsageStore {
             guard !Task.isCancelled else { return }
             let message = error.localizedDescription
             if message.localizedCaseInsensitiveContains("data not available yet") {
-                guard self.shouldApplyCodexScopedNonUsageResult(expectedGuard: expectedGuard) else { return }
+                guard self.shouldApplyCodexScopedNonUsageFailure(expectedGuard: expectedGuard) else { return }
                 await MainActor.run {
                     if let cached = self.lastCreditsSnapshot,
                        self.lastCreditsSnapshotAccountKey == expectedGuard.accountKey
@@ -140,7 +140,7 @@ extension UsageStore {
                 return
             }
 
-            guard self.shouldApplyCodexScopedNonUsageResult(expectedGuard: expectedGuard) else { return }
+            guard self.shouldApplyCodexScopedNonUsageFailure(expectedGuard: expectedGuard) else { return }
             await MainActor.run {
                 self.creditsFailureStreak += 1
                 if let cached = self.lastCreditsSnapshot,

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
@@ -15,7 +15,7 @@ extension UsageStore {
 
     func scheduleCreditsRefreshIfNeeded(minimumSnapshotUpdatedAt: Date? = nil) {
         let refreshKey = self.codexCreditsRefreshKey(
-            expectedGuard: self.currentCodexAccountScopedRefreshGuard())
+            expectedGuard: self.freshCodexAccountScopedRefreshGuard())
         if let existing = self.creditsRefreshTask,
            !existing.isCancelled,
            self.creditsRefreshTaskKey == refreshKey
@@ -76,13 +76,13 @@ extension UsageStore {
 
     func refreshCreditsIfNeeded(minimumSnapshotUpdatedAt: Date? = nil) async {
         guard self.isEnabled(.codex) else { return }
-        var expectedGuard = self.currentCodexAccountScopedRefreshGuard()
+        var expectedGuard = self.freshCodexAccountScopedRefreshGuard()
         if expectedGuard.identity == .unresolved,
            let minimumSnapshotUpdatedAt,
            case .liveSystem = expectedGuard.source
         {
             _ = await self.waitForCodexSnapshotOrRefreshCompletion(minimumUpdatedAt: minimumSnapshotUpdatedAt)
-            expectedGuard = self.currentCodexAccountScopedRefreshGuard()
+            expectedGuard = self.freshCodexAccountScopedRefreshGuard()
         }
         guard expectedGuard.identity != .unresolved,
               expectedGuard.accountKey != nil

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
@@ -71,6 +71,7 @@ extension UsageStore {
             sourceKey,
             identityKey,
             expectedGuard.accountKey ?? "account:nil",
+            "auth:\(expectedGuard.authFingerprint ?? "nil")",
         ].joined(separator: "|")
     }
 
@@ -92,7 +93,8 @@ extension UsageStore {
         do {
             let credits = try await self.loadLatestCodexCredits()
             guard !Task.isCancelled else { return }
-            guard let applyGuard = self.codexScopedNonUsageSuccessApplyGuard(expectedGuard: expectedGuard) else { return }
+            guard let applyGuard = self.codexScopedNonUsageSuccessApplyGuard(
+                expectedGuard: expectedGuard) else { return }
             await MainActor.run {
                 self.credits = credits
                 self.lastCreditsError = nil

--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -120,6 +120,7 @@ extension UsageStore {
         allowCodexUsageBackfill: Bool = true) async
     {
         guard self.shouldApplyOpenAIDashboardRefreshTask(token: refreshTaskToken) else { return }
+        self.settings.invalidateCodexAccountReconciliationSnapshotCache()
         let authority = self.evaluateCodexDashboardAuthority(
             dashboard: dash,
             sourceKind: .liveWeb,

--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -108,7 +108,7 @@ extension UsageStore {
                 "batterySaverEnabled": self.settings.openAIWebBatterySaverEnabled ? "1" : "0",
                 "interaction": ProviderInteractionContext.current == .userInitiated ? "user" : "background",
             ])
-        let expectedGuard = self.currentCodexOpenAIWebRefreshGuard()
+        let expectedGuard = self.freshCodexOpenAIWebRefreshGuard()
         Task { await self.refreshOpenAIDashboardIfNeeded(force: forceRefresh, expectedGuard: expectedGuard) }
     }
 
@@ -832,7 +832,7 @@ extension UsageStore {
             allowCurrentSnapshotFallback: true,
             allowLastKnownLiveFallback: false)
         _ = await self.importOpenAIDashboardCookiesIfNeeded(targetEmail: targetEmail, force: true)
-        let expectedGuard = self.currentCodexOpenAIWebRefreshGuard()
+        let expectedGuard = self.freshCodexOpenAIWebRefreshGuard()
         await self.refreshOpenAIDashboardIfNeeded(
             force: true,
             expectedGuard: expectedGuard,

--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -878,7 +878,8 @@ extension UsageStore {
         let source = String(describing: expectedGuard?.source ?? self.settings.codexResolvedActiveSource)
         let identityKey = Self.codexIdentityGuardKey(expectedGuard?.identity ?? .unresolved) ?? "unresolved"
         let accountKey = Self.normalizeCodexAccountScopedKey(targetEmail) ?? "unknown"
-        return "\(source)|\(identityKey)|\(accountKey)"
+        let authFingerprint = CodexAuthFingerprint.normalize(expectedGuard?.authFingerprint) ?? "nil"
+        return "\(source)|\(identityKey)|\(accountKey)|auth:\(authFingerprint)"
     }
 
     private func actionableOpenAIDashboardImportFailure(targetEmail: String?) -> String? {

--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -132,7 +132,7 @@ extension UsageStore {
                     expectedGuard: expectedGuard,
                     routingTargetEmail: targetEmail)
             case .displayOnly, .failClosed:
-                self.shouldApplyOpenAIWebNonSuccessResult(
+                self.shouldApplyOpenAIDashboardRefreshGuard(
                     expectedGuard: expectedGuard,
                     routingTargetEmail: targetEmail)
             }

--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -120,18 +120,24 @@ extension UsageStore {
         allowCodexUsageBackfill: Bool = true) async
     {
         guard self.shouldApplyOpenAIDashboardRefreshTask(token: refreshTaskToken) else { return }
-        if let expectedGuard,
-           !self.shouldApplyOpenAIDashboardRefreshGuard(
-               expectedGuard: expectedGuard,
-               routingTargetEmail: targetEmail)
-        {
-            return
-        }
-
         let authority = self.evaluateCodexDashboardAuthority(
             dashboard: dash,
             sourceKind: .liveWeb,
             routingTargetEmail: targetEmail)
+        if let expectedGuard {
+            let shouldApply = switch authority.decision.disposition {
+            case .attach:
+                self.shouldApplyOpenAIDashboardRefreshGuard(
+                    expectedGuard: expectedGuard,
+                    routingTargetEmail: targetEmail)
+            case .displayOnly, .failClosed:
+                self.shouldApplyOpenAIWebNonSuccessResult(
+                    expectedGuard: expectedGuard,
+                    routingTargetEmail: targetEmail)
+            }
+            guard shouldApply else { return }
+        }
+
         let attachedAccountEmail = self.codexDashboardAttachmentEmail(from: authority.input)
 
         await self.applyOpenAIDashboardAuthorityDecision(

--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -132,7 +132,7 @@ extension UsageStore {
                     expectedGuard: expectedGuard,
                     routingTargetEmail: targetEmail)
             case .displayOnly, .failClosed:
-                self.shouldApplyOpenAIDashboardRefreshGuard(
+                self.shouldApplyOpenAIDashboardPolicyResult(
                     expectedGuard: expectedGuard,
                     routingTargetEmail: targetEmail)
             }

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -105,7 +105,10 @@ extension UsageStore {
                 if claudeCredentialsChanged {
                     self.clearClaudeCredentialDerivedStateForCredentialSwapNow()
                 }
-                let backfilled = scoped.backfillingResetTimes(from: self.lastKnownResetSnapshots[provider])
+                let resetBackfillSource = provider == .codex
+                    ? self.codexLastKnownResetSnapshot(matching: codexExpectedGuard)
+                    : self.lastKnownResetSnapshots[provider]
+                let backfilled = scoped.backfillingResetTimes(from: resetBackfillSource)
                 self.handleQuotaWarningTransitions(provider: provider, snapshot: backfilled)
                 self.handleSessionQuotaTransition(provider: provider, snapshot: backfilled)
                 self.lastKnownResetSnapshots[provider] = backfilled

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -23,7 +23,7 @@ extension UsageStore {
     func refreshProvider(_ provider: UsageProvider, allowDisabled: Bool = false) async {
         self.prepareRefreshState(for: provider)
         guard let spec = await self.providerRefreshSpec(provider) else { return }
-        let codexExpectedGuard = provider == .codex ? self.currentCodexAccountScopedRefreshGuard() : nil
+        let codexExpectedGuard = provider == .codex ? self.freshCodexAccountScopedRefreshGuard() : nil
 
         if !spec.isEnabled(), !allowDisabled {
             await self.clearDisabledProviderRefreshState(provider)

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -122,7 +122,8 @@ extension UsageStore {
         let currentSnapshots = snapshots.compactMap { snapshot -> CodexAccountUsageSnapshot? in
             guard let currentAccount = Self.currentCodexVisibleAccount(
                 matching: snapshot.account,
-                projection: currentProjection)
+                projection: currentProjection,
+                allowProviderAccountAuthFingerprintMismatch: snapshot.error == nil)
             else {
                 return nil
             }
@@ -153,9 +154,16 @@ extension UsageStore {
             return
         }
 
+        let allowSelectedAuthFingerprintMismatch = switch selectedOutcome.result {
+        case .success:
+            true
+        case .failure:
+            false
+        }
         let currentSelectedAccount = Self.currentCodexVisibleAccount(
             matching: selectedAccount,
-            projection: currentProjection)
+            projection: currentProjection,
+            allowProviderAccountAuthFingerprintMismatch: allowSelectedAuthFingerprintMismatch)
         if let currentSelectedAccount {
             let currentSelectedSnapshot = Self.codexVisibleAccountSnapshotRelabeledForCurrentProjection(
                 selectedSnapshot,
@@ -206,15 +214,22 @@ extension UsageStore {
 
     private static func currentCodexVisibleAccount(
         matching account: CodexVisibleAccount,
-        projection: CodexVisibleAccountProjection) -> CodexVisibleAccount?
+        projection: CodexVisibleAccountProjection,
+        allowProviderAccountAuthFingerprintMismatch: Bool = true) -> CodexVisibleAccount?
     {
         if let currentAccount = projection.visibleAccounts.first(where: { $0.id == account.id }),
-           self.codexVisibleAccountMatchesCurrentProjection(account, account: currentAccount)
+           self.codexVisibleAccountMatchesCurrentProjection(
+               account,
+               account: currentAccount,
+               allowProviderAccountAuthFingerprintMismatch: allowProviderAccountAuthFingerprintMismatch)
         {
             return currentAccount
         }
         return projection.visibleAccounts.first {
-            self.codexVisibleAccountMatchesCurrentProjection(account, account: $0)
+            self.codexVisibleAccountMatchesCurrentProjection(
+                account,
+                account: $0,
+                allowProviderAccountAuthFingerprintMismatch: allowProviderAccountAuthFingerprintMismatch)
         }
     }
 
@@ -233,7 +248,8 @@ extension UsageStore {
 
     private static func codexVisibleAccountMatchesCurrentProjection(
         _ prior: CodexVisibleAccount,
-        account: CodexVisibleAccount) -> Bool
+        account: CodexVisibleAccount,
+        allowProviderAccountAuthFingerprintMismatch: Bool = true) -> Bool
     {
         guard prior.selectionSource == account.selectionSource else { return false }
 
@@ -246,6 +262,9 @@ extension UsageStore {
             .map(CodexOpenAIWorkspaceIdentity.normalizeWorkspaceAccountID)
         if priorWorkspaceID != nil || accountWorkspaceID != nil {
             guard priorWorkspaceID == accountWorkspaceID else { return false }
+            if !allowProviderAccountAuthFingerprintMismatch {
+                guard self.codexVisibleAccountAuthFingerprintMatches(prior, account: account) else { return false }
+            }
             switch account.selectionSource {
             case .managedAccount:
                 return true
@@ -261,6 +280,18 @@ extension UsageStore {
         }
 
         return priorEmail != nil && priorEmail == accountEmail
+    }
+
+    private static func codexVisibleAccountAuthFingerprintMatches(
+        _ prior: CodexVisibleAccount,
+        account: CodexVisibleAccount) -> Bool
+    {
+        let priorAuthFingerprint = CodexAuthFingerprint.normalize(prior.authFingerprint)
+        let accountAuthFingerprint = CodexAuthFingerprint.normalize(account.authFingerprint)
+        if priorAuthFingerprint != nil || accountAuthFingerprint != nil {
+            return priorAuthFingerprint == accountAuthFingerprint
+        }
+        return true
     }
 
     func shouldApplySelectedCodexVisibleAccountOutcome(

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -81,6 +81,7 @@ extension UsageStore {
             self.codexAccountSnapshots = []
             return
         }
+        let managedAccountIDsWithReadableAuthAtStart = self.codexManagedAccountIDsWithReadableAuth()
 
         let originalVisibleAccountID = projection.activeVisibleAccountID
         let originalSelectionSource = originalVisibleAccountID.flatMap {
@@ -124,7 +125,8 @@ extension UsageStore {
             }
         }
 
-        let currentProjection = self.freshCodexVisibleAccountProjectionForAccountRefresh()
+        let currentProjection = self.freshCodexVisibleAccountProjectionForAccountRefresh(
+            requireLiveManagedAuthFor: managedAccountIDsWithReadableAuthAtStart)
         let currentSnapshots = snapshots.compactMap { snapshot -> CodexAccountUsageSnapshot? in
             guard let currentAccount = Self.currentCodexVisibleAccount(
                 matching: snapshot.account,
@@ -211,19 +213,29 @@ extension UsageStore {
         return Self.codexVisibleAccountMatchesCurrentProjection(originalAccount, account: currentActiveAccount)
     }
 
-    private func freshCodexVisibleAccountProjectionForAccountRefresh() -> CodexVisibleAccountProjection {
+    private func freshCodexVisibleAccountProjectionForAccountRefresh(
+        requireLiveManagedAuthFor accountIDs: Set<UUID> = []) -> CodexVisibleAccountProjection
+    {
         // Auth files can change while account fetches are in flight, so account refreshes bypass the
         // short-lived reconciliation cache used for normal menu rendering and stale-result guards.
         self.settings.invalidateCodexAccountReconciliationSnapshotCache()
         let snapshot = self.settings.codexAccountReconciliationSnapshot
         return Self.codexVisibleAccountProjectionWithFreshManagedAuthFingerprints(
             CodexVisibleAccountProjection.make(from: snapshot),
-            snapshot: snapshot)
+            snapshot: snapshot,
+            requireLiveManagedAuthFor: accountIDs)
+    }
+
+    private func codexManagedAccountIDsWithReadableAuth() -> Set<UUID> {
+        Set(self.settings.codexAccountReconciliationSnapshot.storedAccounts.compactMap { account in
+            CodexAuthFingerprint.fingerprint(homePath: account.managedHomePath) == nil ? nil : account.id
+        })
     }
 
     private nonisolated static func codexVisibleAccountProjectionWithFreshManagedAuthFingerprints(
         _ projection: CodexVisibleAccountProjection,
-        snapshot: CodexAccountReconciliationSnapshot) -> CodexVisibleAccountProjection
+        snapshot: CodexAccountReconciliationSnapshot,
+        requireLiveManagedAuthFor accountIDs: Set<UUID> = []) -> CodexVisibleAccountProjection
     {
         let managedRuntimeStates = Dictionary(
             uniqueKeysWithValues: snapshot.storedAccounts.map { account in
@@ -234,9 +246,12 @@ extension UsageStore {
                     nil
                 }
                 let authFingerprint = CodexAuthFingerprint.fingerprint(homePath: account.managedHomePath)
+                let requiresLiveAuth = accountIDs.contains(account.id)
                 return (account.id, CodexManagedVisibleAccountRuntimeState(
-                    authFingerprint: authFingerprint ?? account.authFingerprint,
-                    workspaceAccountID: authFingerprint == nil ? account.workspaceAccountID : workspaceAccountID))
+                    authFingerprint: authFingerprint ?? (requiresLiveAuth ? nil : account.authFingerprint),
+                    workspaceAccountID: authFingerprint == nil && requiresLiveAuth
+                        ? nil
+                        : (workspaceAccountID ?? account.workspaceAccountID)))
             })
         let visibleAccounts = projection.visibleAccounts.map { account in
             guard case let .managedAccount(id) = account.selectionSource else { return account }

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -83,6 +83,7 @@ extension UsageStore {
         let priorByAccountID = Dictionary(uniqueKeysWithValues: self.codexAccountSnapshots.map { ($0.id, $0) })
         var snapshots: [CodexAccountUsageSnapshot] = []
         var selectedOutcome: ProviderFetchOutcome?
+        var selectedAccount: CodexVisibleAccount?
         var selectedSnapshot: UsageSnapshot?
         var selectedSourceLabel: String?
         var sawAnyNonCancellationOutcome = false
@@ -108,6 +109,7 @@ extension UsageStore {
             }
             if account.id == originalVisibleAccountID {
                 selectedOutcome = outcome
+                selectedAccount = account
                 selectedSnapshot = resolved.usage
                 selectedSourceLabel = resolved.sourceLabel
             }
@@ -123,9 +125,10 @@ extension UsageStore {
         let selectionStillMatches = self.codexVisibleSelectionStillMatches(
             originalVisibleAccountID: originalVisibleAccountID,
             originalSelectionSource: originalSelectionSource)
-        if let selectedOutcome, selectionStillMatches {
+        if let selectedOutcome, let selectedAccount, selectionStillMatches {
             await self.applySelectedCodexVisibleAccountOutcome(
                 selectedOutcome,
+                account: selectedAccount,
                 snapshot: selectedSnapshot,
                 sourceLabel: selectedSourceLabel)
         }
@@ -473,10 +476,20 @@ extension UsageStore {
         {
             snapshots.append(lastKnown)
         }
-        if let history = self.codexPlanHistoryResetBackfillSnapshot(for: account) {
+        if self.codexCanUseHistoricalResetBackfill(for: account),
+           let history = self.codexPlanHistoryResetBackfillSnapshot(for: account)
+        {
             snapshots.append(history)
         }
         return snapshots
+    }
+
+    private func codexCanUseHistoricalResetBackfill(for account: CodexVisibleAccount) -> Bool {
+        let authFingerprint = CodexAuthFingerprint.normalize(account.authFingerprint)
+        let workspaceAccountID = Self.normalizedCodexVisibleAccountText(account.workspaceAccountID)
+            .map(CodexOpenAIWorkspaceIdentity.normalizeWorkspaceAccountID)
+        guard authFingerprint != nil, workspaceAccountID == nil else { return true }
+        return Self.codexScopedGuard(self.lastCodexAccountScopedRefreshGuard, matches: account)
     }
 
     private func codexPlanHistoryResetBackfillSnapshot(for account: CodexVisibleAccount) -> UsageSnapshot? {
@@ -520,6 +533,15 @@ extension UsageStore {
             return nil
         }
         return snapshot
+    }
+
+    func codexLastKnownResetSnapshot(matching guardValue: CodexAccountScopedRefreshGuard?) -> UsageSnapshot? {
+        guard let guardValue,
+              self.lastCodexAccountScopedRefreshGuard == guardValue
+        else {
+            return nil
+        }
+        return self.lastKnownResetSnapshots[.codex]
     }
 
     private nonisolated static func codexVisibleAccountEmailMatches(
@@ -579,12 +601,28 @@ extension UsageStore {
         matches account: CodexVisibleAccount) -> Bool
     {
         guard let guardValue, guardValue.source == account.selectionSource else { return false }
+        let guardAuthFingerprint = CodexAuthFingerprint.normalize(guardValue.authFingerprint)
+        let accountAuthFingerprint = CodexAuthFingerprint.normalize(account.authFingerprint)
+        if guardAuthFingerprint != nil || accountAuthFingerprint != nil {
+            guard guardAuthFingerprint == accountAuthFingerprint else { return false }
+        }
         let identity = self.codexVisibleAccountIdentity(for: account)
         if identity != .unresolved {
             return guardValue.identity == identity
         }
         guard let accountKey = CodexIdentityResolver.normalizeEmail(account.email) else { return false }
         return guardValue.accountKey == accountKey
+    }
+
+    private nonisolated static func codexScopedRefreshGuard(for account: CodexVisibleAccount)
+        -> CodexAccountScopedRefreshGuard
+    {
+        let accountEmail = CodexIdentityResolver.normalizeEmail(account.email)
+        return CodexAccountScopedRefreshGuard(
+            source: account.selectionSource,
+            identity: self.codexVisibleAccountIdentity(for: account),
+            accountKey: accountEmail,
+            authFingerprint: account.authFingerprint)
     }
 
     private nonisolated static func codexVisibleAccountIdentity(for account: CodexVisibleAccount) -> CodexIdentity {
@@ -853,6 +891,7 @@ extension UsageStore {
 
     func applySelectedCodexVisibleAccountOutcome(
         _ outcome: ProviderFetchOutcome,
+        account: CodexVisibleAccount,
         snapshot: UsageSnapshot?,
         sourceLabel: String?) async
     {
@@ -862,6 +901,7 @@ extension UsageStore {
             guard let snapshot else { return }
             self.handleSessionQuotaTransition(provider: .codex, snapshot: snapshot)
             self.lastKnownResetSnapshots[.codex] = snapshot
+            self.lastCodexAccountScopedRefreshGuard = Self.codexScopedRefreshGuard(for: account)
             self.snapshots[.codex] = snapshot
             if let sourceLabel {
                 self.lastSourceLabels[.codex] = sourceLabel

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -45,6 +45,11 @@ private struct CodexAccountFetchResult {
     let outcome: ProviderFetchOutcome
 }
 
+private struct CodexManagedVisibleAccountRuntimeState {
+    let authFingerprint: String?
+    let workspaceAccountID: String?
+}
+
 extension UsageStore {
     static let tokenAccountMenuSnapshotLimit = 6
     private static let codexSessionWindowMinutes = 5 * 60
@@ -66,7 +71,7 @@ extension UsageStore {
     }
 
     func refreshCodexVisibleAccountsForMenu() async {
-        let projection = self.settings.codexVisibleAccountProjection
+        let projection = self.freshCodexVisibleAccountProjectionForAccountRefresh()
         let accounts = self.limitedCodexVisibleAccounts(
             projection.visibleAccounts,
             snapshots: self.codexAccountSnapshots,
@@ -118,7 +123,7 @@ extension UsageStore {
             }
         }
 
-        let currentProjection = self.freshCodexVisibleAccountProjectionForStaleResultGuard()
+        let currentProjection = self.freshCodexVisibleAccountProjectionForAccountRefresh()
         let currentSnapshots = snapshots.compactMap { snapshot -> CodexAccountUsageSnapshot? in
             guard let currentAccount = Self.currentCodexVisibleAccount(
                 matching: snapshot.account,
@@ -205,11 +210,58 @@ extension UsageStore {
         return Self.codexVisibleAccountMatchesCurrentProjection(originalAccount, account: currentActiveAccount)
     }
 
-    private func freshCodexVisibleAccountProjectionForStaleResultGuard() -> CodexVisibleAccountProjection {
-        // Auth files can change while account fetches are in flight, so stale-result guards must bypass the
-        // short-lived reconciliation cache used for normal menu rendering.
+    private func freshCodexVisibleAccountProjectionForAccountRefresh() -> CodexVisibleAccountProjection {
+        // Auth files can change while account fetches are in flight, so account refreshes bypass the
+        // short-lived reconciliation cache used for normal menu rendering and stale-result guards.
         self.settings.invalidateCodexAccountReconciliationSnapshotCache()
-        return self.settings.codexVisibleAccountProjection
+        let snapshot = self.settings.codexAccountReconciliationSnapshot
+        return Self.codexVisibleAccountProjectionWithFreshManagedAuthFingerprints(
+            CodexVisibleAccountProjection.make(from: snapshot),
+            snapshot: snapshot)
+    }
+
+    private nonisolated static func codexVisibleAccountProjectionWithFreshManagedAuthFingerprints(
+        _ projection: CodexVisibleAccountProjection,
+        snapshot: CodexAccountReconciliationSnapshot) -> CodexVisibleAccountProjection
+    {
+        let managedRuntimeStates = Dictionary(
+            uniqueKeysWithValues: snapshot.storedAccounts.map { account in
+                let workspaceAccountID: String? = switch snapshot.runtimeIdentity(for: account) {
+                case let .providerAccount(id):
+                    id
+                case .emailOnly, .unresolved:
+                    nil
+                }
+                return (account.id, CodexManagedVisibleAccountRuntimeState(
+                    authFingerprint: CodexAuthFingerprint.fingerprint(homePath: account.managedHomePath),
+                    workspaceAccountID: workspaceAccountID))
+            })
+        let visibleAccounts = projection.visibleAccounts.map { account in
+            guard case let .managedAccount(id) = account.selectionSource else { return account }
+            guard let runtimeState = managedRuntimeStates[id],
+                  let authFingerprint = runtimeState.authFingerprint,
+                  authFingerprint != account.authFingerprint
+            else {
+                return account
+            }
+            return CodexVisibleAccount(
+                id: account.id,
+                email: account.email,
+                workspaceLabel: account.workspaceLabel,
+                workspaceAccountID: runtimeState.workspaceAccountID,
+                authFingerprint: authFingerprint,
+                storedAccountID: account.storedAccountID,
+                selectionSource: account.selectionSource,
+                isActive: account.isActive,
+                isLive: account.isLive,
+                canReauthenticate: account.canReauthenticate,
+                canRemove: account.canRemove)
+        }
+        return CodexVisibleAccountProjection(
+            visibleAccounts: visibleAccounts,
+            activeVisibleAccountID: projection.activeVisibleAccountID,
+            liveVisibleAccountID: projection.liveVisibleAccountID,
+            hasUnreadableAddedAccountStore: projection.hasUnreadableAddedAccountStore)
     }
 
     private static func currentCodexVisibleAccount(
@@ -779,15 +831,7 @@ extension UsageStore {
         _ lastGuard: CodexAccountScopedRefreshGuard,
         matching expectedGuard: CodexAccountScopedRefreshGuard) -> Bool
     {
-        guard lastGuard.source == expectedGuard.source else { return false }
-        if lastGuard == expectedGuard { return true }
-        guard lastGuard.identity != .unresolved,
-              lastGuard.identity == expectedGuard.identity,
-              lastGuard.accountKey == expectedGuard.accountKey
-        else {
-            return false
-        }
-        return self.codexGuardAuthFingerprintAllowsUsageApply(lastGuard, expectedGuard)
+        self.codexScopedRefreshGuardsMatchAccount(lastGuard, expectedGuard)
     }
 
     private nonisolated static func codexScopedRefreshGuard(for account: CodexVisibleAccount)

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -55,6 +55,10 @@ extension UsageStore {
     private static let codexSessionWindowMinutes = 5 * 60
     private static let codexWeeklyWindowMinutes = 7 * 24 * 60
 
+    func freshCodexVisibleAccountsForSnapshotHydration() -> [CodexVisibleAccount] {
+        self.freshCodexVisibleAccountProjectionForAccountRefresh().visibleAccounts
+    }
+
     func tokenAccounts(for provider: UsageProvider) -> [ProviderTokenAccount] {
         guard TokenAccountSupportCatalog.support(for: provider) != nil else { return [] }
         return self.settings.tokenAccounts(for: provider)

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -688,7 +688,7 @@ extension UsageStore {
         {
             snapshots.append(lastKnown)
         }
-        if self.codexCanUseHistoricalResetBackfill(for: account),
+        if account.id != activeVisibleAccountID || self.codexCanUseHistoricalResetBackfill(for: account),
            let history = self.codexPlanHistoryResetBackfillSnapshot(for: account)
         {
             snapshots.append(history)

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -697,7 +697,8 @@ extension UsageStore {
 
     func codexLastKnownResetSnapshot(matching guardValue: CodexAccountScopedRefreshGuard?) -> UsageSnapshot? {
         guard let guardValue,
-              self.lastCodexAccountScopedRefreshGuard == guardValue
+              let lastGuard = self.lastCodexAccountScopedRefreshGuard,
+              Self.codexScopedRefreshGuardAllowsResetBackfill(lastGuard, matching: guardValue)
         else {
             return nil
         }
@@ -772,6 +773,21 @@ extension UsageStore {
         }
         guard let accountKey = CodexIdentityResolver.normalizeEmail(account.email) else { return false }
         return guardValue.accountKey == accountKey
+    }
+
+    private nonisolated static func codexScopedRefreshGuardAllowsResetBackfill(
+        _ lastGuard: CodexAccountScopedRefreshGuard,
+        matching expectedGuard: CodexAccountScopedRefreshGuard) -> Bool
+    {
+        guard lastGuard.source == expectedGuard.source else { return false }
+        if lastGuard == expectedGuard { return true }
+        guard lastGuard.identity != .unresolved,
+              lastGuard.identity == expectedGuard.identity,
+              lastGuard.accountKey == expectedGuard.accountKey
+        else {
+            return false
+        }
+        return self.codexGuardAuthFingerprintAllowsUsageApply(lastGuard, expectedGuard)
     }
 
     private nonisolated static func codexScopedRefreshGuard(for account: CodexVisibleAccount)

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -66,8 +66,9 @@ extension UsageStore {
     }
 
     func shouldFetchAllCodexVisibleAccounts() -> Bool {
-        self.settings.multiAccountMenuLayout == .stacked &&
-            self.settings.codexVisibleAccountProjection.visibleAccounts.count > 1
+        let projection = self.freshCodexVisibleAccountProjectionForAccountRefresh()
+        return self.settings.multiAccountMenuLayout == .stacked &&
+            projection.visibleAccounts.count > 1
     }
 
     func refreshCodexVisibleAccountsForMenu() async {

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -324,6 +324,9 @@ extension UsageStore {
             }
             switch account.selectionSource {
             case .managedAccount:
+                if !self.codexVisibleAccountAuthFingerprintMatches(prior, account: account) {
+                    return priorEmail != nil && priorEmail == accountEmail
+                }
                 return true
             case .liveSystem:
                 return priorEmail != nil && priorEmail == accountEmail

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -80,6 +80,9 @@ extension UsageStore {
         let originalSelectionSource = originalVisibleAccountID.flatMap {
             projection.source(forVisibleAccountID: $0)
         }
+        let originalVisibleAccount = originalVisibleAccountID.flatMap { id in
+            accounts.first { $0.id == id }
+        }
         let priorByAccountID = Dictionary(uniqueKeysWithValues: self.codexAccountSnapshots.map { ($0.id, $0) })
         var snapshots: [CodexAccountUsageSnapshot] = []
         var selectedOutcome: ProviderFetchOutcome?
@@ -115,35 +118,161 @@ extension UsageStore {
             }
         }
 
+        let currentProjection = self.freshCodexVisibleAccountProjectionForStaleResultGuard()
+        let currentSnapshots = snapshots.compactMap { snapshot -> CodexAccountUsageSnapshot? in
+            guard let currentAccount = Self.currentCodexVisibleAccount(
+                matching: snapshot.account,
+                projection: currentProjection)
+            else {
+                return nil
+            }
+            guard currentAccount != snapshot.account else { return snapshot }
+            return CodexAccountUsageSnapshot(
+                account: currentAccount,
+                snapshot: Self.codexVisibleAccountSnapshotRelabeledForCurrentProjection(
+                    snapshot.snapshot,
+                    account: currentAccount),
+                error: snapshot.error,
+                sourceLabel: snapshot.sourceLabel)
+        }
         let shouldPreservePriorState = !sawAnyNonCancellationOutcome &&
-            snapshots.allSatisfy { $0.snapshot == nil }
+            currentSnapshots.allSatisfy { $0.snapshot == nil }
         if !shouldPreservePriorState {
-            self.codexAccountSnapshots = snapshots
-            self.codexAccountUsageSnapshotStore?.store(snapshots)
+            self.codexAccountSnapshots = currentSnapshots
+            self.codexAccountUsageSnapshotStore?.store(currentSnapshots)
         }
 
         let selectionStillMatches = self.codexVisibleSelectionStillMatches(
             originalVisibleAccountID: originalVisibleAccountID,
-            originalSelectionSource: originalSelectionSource)
-        if let selectedOutcome, let selectedAccount, selectionStillMatches {
-            await self.applySelectedCodexVisibleAccountOutcome(
+            originalSelectionSource: originalSelectionSource,
+            originalAccount: originalVisibleAccount,
+            currentProjection: currentProjection)
+        guard let selectedOutcome, let selectedAccount else { return }
+        guard selectionStillMatches else {
+            _ = self.prepareCodexAccountScopedRefreshIfNeeded()
+            return
+        }
+
+        let currentSelectedAccount = Self.currentCodexVisibleAccount(
+            matching: selectedAccount,
+            projection: currentProjection)
+        if let currentSelectedAccount {
+            let currentSelectedSnapshot = Self.codexVisibleAccountSnapshotRelabeledForCurrentProjection(
+                selectedSnapshot,
+                account: currentSelectedAccount)
+            if self.shouldApplySelectedCodexVisibleAccountOutcome(
                 selectedOutcome,
-                account: selectedAccount,
-                snapshot: selectedSnapshot,
-                sourceLabel: selectedSourceLabel)
+                snapshot: currentSelectedSnapshot)
+            {
+                await self.applySelectedCodexVisibleAccountOutcome(
+                    selectedOutcome,
+                    account: currentSelectedAccount,
+                    snapshot: currentSelectedSnapshot,
+                    sourceLabel: selectedSourceLabel)
+            }
+        } else {
+            _ = self.prepareCodexAccountScopedRefreshIfNeeded()
         }
     }
 
     func codexVisibleSelectionStillMatches(
         originalVisibleAccountID: String?,
-        originalSelectionSource: CodexActiveSource?) -> Bool
+        originalSelectionSource: CodexActiveSource?,
+        originalAccount: CodexVisibleAccount? = nil,
+        currentProjection: CodexVisibleAccountProjection? = nil) -> Bool
     {
-        let currentProjection = self.settings.codexVisibleAccountProjection
-        let currentSelectionSource = originalVisibleAccountID.flatMap {
-            currentProjection.source(forVisibleAccountID: $0)
+        let currentProjection = currentProjection ?? self.settings.codexVisibleAccountProjection
+        let currentActiveAccount = currentProjection.activeVisibleAccountID.flatMap { id in
+            currentProjection.visibleAccounts.first { $0.id == id }
         }
-        return currentProjection.activeVisibleAccountID == originalVisibleAccountID &&
-            currentSelectionSource == originalSelectionSource
+        let currentSelectionSource = currentActiveAccount?.selectionSource
+        if currentProjection.activeVisibleAccountID == originalVisibleAccountID,
+           currentSelectionSource == originalSelectionSource
+        {
+            return true
+        }
+        guard let originalAccount, let currentActiveAccount, currentSelectionSource == originalSelectionSource else {
+            return false
+        }
+        return Self.codexVisibleAccountMatchesCurrentProjection(originalAccount, account: currentActiveAccount)
+    }
+
+    private func freshCodexVisibleAccountProjectionForStaleResultGuard() -> CodexVisibleAccountProjection {
+        // Auth files can change while account fetches are in flight, so stale-result guards must bypass the
+        // short-lived reconciliation cache used for normal menu rendering.
+        self.settings.invalidateCodexAccountReconciliationSnapshotCache()
+        return self.settings.codexVisibleAccountProjection
+    }
+
+    private static func currentCodexVisibleAccount(
+        matching account: CodexVisibleAccount,
+        projection: CodexVisibleAccountProjection) -> CodexVisibleAccount?
+    {
+        if let currentAccount = projection.visibleAccounts.first(where: { $0.id == account.id }),
+           self.codexVisibleAccountMatchesCurrentProjection(account, account: currentAccount)
+        {
+            return currentAccount
+        }
+        return projection.visibleAccounts.first {
+            self.codexVisibleAccountMatchesCurrentProjection(account, account: $0)
+        }
+    }
+
+    private static func codexVisibleAccountSnapshotRelabeledForCurrentProjection(
+        _ snapshot: UsageSnapshot?,
+        account: CodexVisibleAccount) -> UsageSnapshot?
+    {
+        guard let snapshot else { return nil }
+        let existing = snapshot.identity(for: .codex)
+        return snapshot.withIdentity(ProviderIdentitySnapshot(
+            providerID: .codex,
+            accountEmail: account.email,
+            accountOrganization: existing?.accountOrganization,
+            loginMethod: existing?.loginMethod ?? account.workspaceLabel))
+    }
+
+    private static func codexVisibleAccountMatchesCurrentProjection(
+        _ prior: CodexVisibleAccount,
+        account: CodexVisibleAccount) -> Bool
+    {
+        guard prior.selectionSource == account.selectionSource else { return false }
+
+        let priorEmail = CodexIdentityResolver.normalizeEmail(prior.email)
+        let accountEmail = CodexIdentityResolver.normalizeEmail(account.email)
+
+        let priorWorkspaceID = self.normalizedCodexVisibleAccountText(prior.workspaceAccountID)
+            .map(CodexOpenAIWorkspaceIdentity.normalizeWorkspaceAccountID)
+        let accountWorkspaceID = self.normalizedCodexVisibleAccountText(account.workspaceAccountID)
+            .map(CodexOpenAIWorkspaceIdentity.normalizeWorkspaceAccountID)
+        if priorWorkspaceID != nil || accountWorkspaceID != nil {
+            guard priorWorkspaceID == accountWorkspaceID else { return false }
+            switch account.selectionSource {
+            case .managedAccount:
+                return true
+            case .liveSystem:
+                return priorEmail != nil && priorEmail == accountEmail
+            }
+        }
+
+        let priorAuthFingerprint = CodexAuthFingerprint.normalize(prior.authFingerprint)
+        let accountAuthFingerprint = CodexAuthFingerprint.normalize(account.authFingerprint)
+        if priorAuthFingerprint != nil || accountAuthFingerprint != nil {
+            guard priorAuthFingerprint == accountAuthFingerprint else { return false }
+        }
+
+        return priorEmail != nil && priorEmail == accountEmail
+    }
+
+    func shouldApplySelectedCodexVisibleAccountOutcome(
+        _ outcome: ProviderFetchOutcome,
+        snapshot: UsageSnapshot?) -> Bool
+    {
+        switch outcome.result {
+        case .success:
+            snapshot != nil
+        case .failure:
+            true
+        }
     }
 
     func refreshTokenAccounts(provider: UsageProvider, accounts: [ProviderTokenAccount]) async {
@@ -909,7 +1038,7 @@ extension UsageStore {
             self.errors[.codex] = nil
             self.failureGates[.codex]?.recordSuccess()
             self.rememberLiveSystemCodexEmailIfNeeded(snapshot.accountEmail(for: .codex))
-            self.seedCodexAccountScopedRefreshGuard(accountEmail: snapshot.accountEmail(for: .codex))
+            self.seedCodexAccountScopedRefreshGuard(accountEmail: account.email)
             await self.recordPlanUtilizationHistorySample(provider: .codex, snapshot: snapshot)
             self.recordCodexHistoricalSampleIfNeeded(snapshot: snapshot)
         case let .failure(error):

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -232,15 +232,20 @@ extension UsageStore {
                 case .emailOnly, .unresolved:
                     nil
                 }
+                let authFingerprint = CodexAuthFingerprint.fingerprint(homePath: account.managedHomePath)
                 return (account.id, CodexManagedVisibleAccountRuntimeState(
-                    authFingerprint: CodexAuthFingerprint.fingerprint(homePath: account.managedHomePath),
-                    workspaceAccountID: workspaceAccountID))
+                    authFingerprint: authFingerprint ?? account.authFingerprint,
+                    workspaceAccountID: authFingerprint == nil ? account.workspaceAccountID : workspaceAccountID))
             })
         let visibleAccounts = projection.visibleAccounts.map { account in
             guard case let .managedAccount(id) = account.selectionSource else { return account }
+            let accountWorkspaceAccountID = account.workspaceAccountID
+                .map(CodexOpenAIWorkspaceIdentity.normalizeWorkspaceAccountID)
+            let runtimeWorkspaceAccountID = managedRuntimeStates[id]?.workspaceAccountID
+                .map(CodexOpenAIWorkspaceIdentity.normalizeWorkspaceAccountID)
             guard let runtimeState = managedRuntimeStates[id],
-                  let authFingerprint = runtimeState.authFingerprint,
-                  authFingerprint != account.authFingerprint
+                  runtimeState.authFingerprint != account.authFingerprint ||
+                  runtimeWorkspaceAccountID != accountWorkspaceAccountID
             else {
                 return account
             }
@@ -249,7 +254,7 @@ extension UsageStore {
                 email: account.email,
                 workspaceLabel: account.workspaceLabel,
                 workspaceAccountID: runtimeState.workspaceAccountID,
-                authFingerprint: authFingerprint,
+                authFingerprint: runtimeState.authFingerprint,
                 storedAccountID: account.storedAccountID,
                 selectionSource: account.selectionSource,
                 isActive: account.isActive,

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -620,7 +620,7 @@ final class UsageStore {
                     "phase": openAIWebRefreshPhase == .startup ? "startup" : "regular",
                 ])
             if shouldRefreshOpenAIWeb {
-                let codexDashboardGuard = self.currentCodexOpenAIWebRefreshGuard()
+                let codexDashboardGuard = self.freshCodexOpenAIWebRefreshGuard()
                 if forceTokenUsage {
                     await self.refreshOpenAIDashboardIfNeeded(
                         force: true,

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -313,7 +313,7 @@ final class UsageStore {
         self.weeklyLimitResetDetectorStates = Self.loadWeeklyLimitResetDetectorStates(from: settings.userDefaults)
         if let codexAccountUsageSnapshotStore = self.codexAccountUsageSnapshotStore {
             self.codexAccountSnapshots = codexAccountUsageSnapshotStore.load(
-                for: settings.codexVisibleAccountProjection.visibleAccounts)
+                for: self.freshCodexVisibleAccountsForSnapshotHydration())
         }
         self.logStartupState()
         self.bindSettings()

--- a/Sources/CodexBarCore/PathEnvironment.swift
+++ b/Sources/CodexBarCore/PathEnvironment.swift
@@ -946,9 +946,14 @@ public final class LoginShellPathCache: @unchecked Sendable {
     public static let shared = LoginShellPathCache()
 
     private let lock = NSLock()
+    private let capture: @Sendable (String?, TimeInterval) -> [String]?
     private var captured: [String]?
     private var isCapturing = false
     private var callbacks: [([String]?) -> Void] = []
+
+    init(capture: @escaping @Sendable (String?, TimeInterval) -> [String]? = LoginShellPathCapturer.capture) {
+        self.capture = capture
+    }
 
     public var current: [String]? {
         self.lock.lock()
@@ -981,8 +986,9 @@ public final class LoginShellPathCache: @unchecked Sendable {
         self.isCapturing = true
         self.lock.unlock()
 
+        let capture = self.capture
         DispatchQueue.global(qos: .utility).async { [weak self] in
-            let result = LoginShellPathCapturer.capture(shell: shell, timeout: timeout)
+            let result = capture(shell, timeout)
             guard let self else { return }
 
             self.lock.lock()
@@ -1022,7 +1028,7 @@ public final class LoginShellPathCache: @unchecked Sendable {
         self.isCapturing = true
         self.lock.unlock()
 
-        let result = LoginShellPathCapturer.capture(shell: shell, timeout: timeout)
+        let result = self.capture(shell, timeout)
         self.lock.lock()
         self.captured = result
         self.isCapturing = false

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -96,58 +96,6 @@ extension CodexAccountScopedRefreshTests {
     }
 
     @Test
-    func `stale stacked projection collapse runs single codex fetch`() async throws {
-        SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
-        let settings = self.makeSettingsStore(
-            suite: "CodexAccountScopedRefreshTests-stacked-collapse-single-fetch")
-        defer {
-            SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = nil
-            settings._test_liveSystemCodexAccount = nil
-            settings._test_managedCodexAccountStoreURL = nil
-        }
-        settings.refreshFrequency = .manual
-        settings.multiAccountMenuLayout = .stacked
-        settings.codexActiveSource = .liveSystem
-        settings._test_liveSystemCodexAccount = self.liveAccount(
-            email: "live-collapse@example.com",
-            identity: .providerAccount(id: "acct-live-collapse"))
-
-        let managedAccountID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-191919191919"))
-        let managedAccount = ManagedCodexAccount(
-            id: managedAccountID,
-            email: "managed-collapse@example.com",
-            managedHomePath: "/tmp/codex-managed-collapse",
-            createdAt: 1,
-            updatedAt: 2,
-            lastAuthenticatedAt: 2)
-        let staleStoreURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
-        let emptyStoreURL = try self.makeManagedAccountStoreURL(accounts: [])
-        defer {
-            try? FileManager.default.removeItem(at: staleStoreURL)
-            try? FileManager.default.removeItem(at: emptyStoreURL)
-        }
-        settings._test_managedCodexAccountStoreURL = staleStoreURL
-        let staleReconciliationSnapshot = settings.codexAccountReconciliationSnapshot
-        #expect(CodexVisibleAccountProjection.make(from: staleReconciliationSnapshot).visibleAccounts.count == 2)
-
-        settings._test_managedCodexAccountStoreURL = emptyStoreURL
-        settings.cachedCodexAccountReconciliationSnapshot = CachedCodexAccountReconciliationSnapshot(
-            activeSource: .liveSystem,
-            loadedAt: Date(),
-            snapshot: staleReconciliationSnapshot)
-
-        let store = self.makeUsageStore(settings: settings)
-        self.installImmediateCodexProvider(
-            on: store,
-            snapshot: self.codexSnapshot(email: "live-collapse@example.com", usedPercent: 42))
-
-        await store.refreshProvider(.codex, allowDisabled: true)
-
-        #expect(store.snapshots[.codex]?.primary?.usedPercent == 42)
-        #expect(store.codexAccountSnapshots.isEmpty)
-    }
-
-    @Test
     func `same account token refresh fingerprint change keeps scoped state during prepare`() {
         let settings = self.makeSettingsStore(
             suite: "CodexAccountScopedRefreshTests-token-refresh-prepare")

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -48,6 +48,189 @@ extension CodexAccountScopedRefreshTests {
     }
 
     @Test
+    func `same account token refresh fingerprint change discards codex usage failure`() async {
+        SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-token-refresh-fingerprint-failure")
+        defer {
+            SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = nil
+            settings._test_liveSystemCodexAccount = nil
+        }
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "old-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+        let staleReconciliationSnapshot = settings.codexAccountReconciliationSnapshot
+
+        let store = self.makeUsageStore(settings: settings)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        await blocker.waitUntilStarted()
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "new-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+        settings.cachedCodexAccountReconciliationSnapshot = CachedCodexAccountReconciliationSnapshot(
+            activeSource: .liveSystem,
+            loadedAt: Date(),
+            snapshot: staleReconciliationSnapshot)
+        await blocker.resume(with: .failure(TestRefreshError(message: "old token failure")))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.errors[.codex] == nil)
+    }
+
+    @Test
+    func `same account token refresh fingerprint change keeps codex credits success`() async {
+        SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-token-refresh-credits-success")
+        defer {
+            SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = nil
+            settings._test_liveSystemCodexAccount = nil
+        }
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "old-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+
+        let store = self.makeUsageStore(settings: settings)
+        store._test_codexCreditsLoaderOverride = {
+            settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+                email: "alpha@example.com",
+                authFingerprint: "new-token-material",
+                codexHomePath: "/Users/test/.codex",
+                observedAt: Date(),
+                identity: .providerAccount(id: "acct-alpha"))
+            return CreditsSnapshot(remaining: 42, events: [], updatedAt: Date())
+        }
+        defer { store._test_codexCreditsLoaderOverride = nil }
+
+        await store.refreshCreditsIfNeeded()
+
+        #expect(store.credits?.remaining == 42)
+        #expect(store.lastCreditsSnapshotAccountKey == "alpha@example.com")
+        #expect(store.lastCodexAccountScopedRefreshGuard?.authFingerprint == "new-token-material")
+        #expect(store.lastCreditsError == nil)
+    }
+
+    @Test
+    func `stacked visible refresh discards selected failure after managed token fingerprint rotates`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-selected-managed-token-failure")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-444444444444"))
+        let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-333333333333"))
+        let targetHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-managed-token-\(UUID().uuidString)", isDirectory: true)
+        let siblingHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-managed-token-sibling-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: targetHome, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: siblingHome, withIntermediateDirectories: true)
+        let targetAccount = ManagedCodexAccount(
+            id: targetID,
+            email: "managed-token@example.com",
+            providerAccountID: "acct-managed-token",
+            workspaceLabel: "Managed Team",
+            workspaceAccountID: "acct-managed-token",
+            authFingerprint: "old-managed-token",
+            managedHomePath: targetHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let updatedTarget = ManagedCodexAccount(
+            id: targetID,
+            email: "managed-token@example.com",
+            providerAccountID: "acct-managed-token",
+            workspaceLabel: "Managed Team",
+            workspaceAccountID: "acct-managed-token",
+            authFingerprint: "new-managed-token",
+            managedHomePath: targetHome.path,
+            createdAt: 1,
+            updatedAt: 3,
+            lastAuthenticatedAt: 3)
+        let siblingAccount = ManagedCodexAccount(
+            id: siblingID,
+            email: "managed-token-sibling@example.com",
+            providerAccountID: "acct-managed-token-sibling",
+            workspaceLabel: "Sibling Team",
+            workspaceAccountID: "acct-managed-token-sibling",
+            authFingerprint: "sibling-managed-token",
+            managedHomePath: siblingHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [targetAccount, siblingAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: targetHome)
+            try? FileManager.default.removeItem(at: siblingHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: targetID)
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        let blocker = BlockingCodexFetchStrategy()
+        let targetHomePath = targetHome.path
+        let now = Date()
+        self.installContextualCodexProvider(on: store) { context in
+            if context.env["CODEX_HOME"] == targetHomePath {
+                return try await blocker.awaitResult()
+            }
+            return UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 9,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "managed-token-sibling@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Sibling Team"))
+        }
+
+        let refreshTask = Task { await store.refreshCodexVisibleAccountsForMenu() }
+        await blocker.waitUntilStarted()
+        try FileManagedCodexAccountStore(fileURL: storeURL).storeAccounts(ManagedCodexAccountSet(
+            version: FileManagedCodexAccountStore.currentVersion,
+            accounts: [updatedTarget, siblingAccount]))
+        await blocker.resume(with: .failure(TestRefreshError(message: "old managed token failure")))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.errors[.codex] == nil)
+        #expect(!store.codexAccountSnapshots.contains {
+            $0.account.workspaceAccountID == "acct-managed-token"
+        })
+        #expect(!snapshotStore.storedSnapshots.contains {
+            $0.account.workspaceAccountID == "acct-managed-token"
+        })
+    }
+
+    @Test
     func `stale auth fingerprint cache at refresh start keeps current codex usage success`() async {
         SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
         let settings = self.makeSettingsStore(

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -460,6 +460,57 @@ extension CodexAccountScopedRefreshTests {
     }
 
     @Test
+    func `managed failure guard reads current auth file fingerprint`() throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-managed-auth-file-fingerprint")
+        settings.refreshFrequency = .manual
+        let accountID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-555555555555"))
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-managed-auth-file-\(UUID().uuidString)", isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "managed-auth@example.com",
+            plan: "Pro",
+            accountId: "acct-managed-auth")
+        let oldFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: managedHome.path))
+        let managedAccount = ManagedCodexAccount(
+            id: accountID,
+            email: "managed-auth@example.com",
+            providerAccountID: "acct-managed-auth",
+            workspaceLabel: "Managed Auth",
+            workspaceAccountID: "acct-managed-auth",
+            authFingerprint: oldFingerprint,
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: managedHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: accountID)
+
+        let store = self.makeUsageStore(settings: settings)
+        let expectedGuard = store.freshCodexAccountScopedRefreshGuard()
+        #expect(expectedGuard.authFingerprint == oldFingerprint)
+
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "managed-auth@example.com",
+            plan: "Team",
+            accountId: "acct-managed-auth")
+        let newFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: managedHome.path))
+        #expect(newFingerprint != oldFingerprint)
+
+        #expect(store.freshCodexAccountScopedRefreshGuard().authFingerprint == newFingerprint)
+        #expect(!store.shouldApplyCodexScopedFailure(expectedGuard: expectedGuard))
+        #expect(!store.shouldApplyCodexScopedNonUsageFailure(expectedGuard: expectedGuard))
+    }
+
+    @Test
     func `stale auth fingerprint cache at refresh start keeps current codex usage success`() async {
         SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
         let settings = self.makeSettingsStore(

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -7,8 +7,13 @@ import Testing
 extension CodexAccountScopedRefreshTests {
     @Test
     func `same account token refresh fingerprint change keeps codex usage success`() async {
+        SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
         let settings = self.makeSettingsStore(
             suite: "CodexAccountScopedRefreshTests-token-refresh-fingerprint-change")
+        defer {
+            SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = nil
+            settings._test_liveSystemCodexAccount = nil
+        }
         settings.refreshFrequency = .manual
         settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
             email: "alpha@example.com",
@@ -16,6 +21,7 @@ extension CodexAccountScopedRefreshTests {
             codexHomePath: "/Users/test/.codex",
             observedAt: Date(),
             identity: .providerAccount(id: "acct-alpha"))
+        let staleReconciliationSnapshot = settings.codexAccountReconciliationSnapshot
 
         let store = self.makeUsageStore(settings: settings)
         let blocker = BlockingCodexFetchStrategy()
@@ -29,6 +35,10 @@ extension CodexAccountScopedRefreshTests {
             codexHomePath: "/Users/test/.codex",
             observedAt: Date(),
             identity: .providerAccount(id: "acct-alpha"))
+        settings.cachedCodexAccountReconciliationSnapshot = CachedCodexAccountReconciliationSnapshot(
+            activeSource: .liveSystem,
+            loadedAt: Date(),
+            snapshot: staleReconciliationSnapshot)
         await blocker.resume(with: .success(self.codexSnapshot(email: "alpha@example.com", usedPercent: 25)))
         await refreshTask.value
 
@@ -38,9 +48,14 @@ extension CodexAccountScopedRefreshTests {
     }
 
     @Test
-    func `same email email-only auth fingerprint switch discards stale codex usage success`() async {
+    func `stale auth fingerprint cache at refresh start keeps current codex usage success`() async {
+        SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
         let settings = self.makeSettingsStore(
-            suite: "CodexAccountScopedRefreshTests-email-only-fingerprint-switch")
+            suite: "CodexAccountScopedRefreshTests-stale-start-cache-current-auth")
+        defer {
+            SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = nil
+            settings._test_liveSystemCodexAccount = nil
+        }
         settings.refreshFrequency = .manual
         settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
             email: "alpha@example.com",
@@ -48,6 +63,90 @@ extension CodexAccountScopedRefreshTests {
             codexHomePath: "/Users/test/.codex",
             observedAt: Date(),
             identity: .emailOnly(normalizedEmail: "alpha@example.com"))
+        let staleReconciliationSnapshot = settings.codexAccountReconciliationSnapshot
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "new-email-only-auth",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .emailOnly(normalizedEmail: "alpha@example.com"))
+        settings.cachedCodexAccountReconciliationSnapshot = CachedCodexAccountReconciliationSnapshot(
+            activeSource: .liveSystem,
+            loadedAt: Date(),
+            snapshot: staleReconciliationSnapshot)
+
+        let store = self.makeUsageStore(settings: settings)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        await blocker.waitUntilStarted()
+        await blocker.resume(with: .success(self.codexSnapshot(email: "alpha@example.com", usedPercent: 33)))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex]?.primary?.usedPercent == 33)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.authFingerprint == "new-email-only-auth")
+        #expect(store.errors[.codex] == nil)
+    }
+
+    @Test
+    func `same provider account live email change discards stale codex usage success`() async {
+        SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-provider-email-change")
+        defer {
+            SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = nil
+            settings._test_liveSystemCodexAccount = nil
+        }
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "old@example.com",
+            authFingerprint: "old-provider-auth",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-shared"))
+        let staleReconciliationSnapshot = settings.codexAccountReconciliationSnapshot
+
+        let store = self.makeUsageStore(settings: settings)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        await blocker.waitUntilStarted()
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "new@example.com",
+            authFingerprint: "new-provider-auth",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-shared"))
+        settings.cachedCodexAccountReconciliationSnapshot = CachedCodexAccountReconciliationSnapshot(
+            activeSource: .liveSystem,
+            loadedAt: Date(),
+            snapshot: staleReconciliationSnapshot)
+        await blocker.resume(with: .success(self.codexSnapshot(email: "old@example.com", usedPercent: 25)))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.errors[.codex] == nil)
+    }
+
+    @Test
+    func `same email email-only auth fingerprint switch discards stale codex usage success`() async {
+        SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-email-only-fingerprint-switch")
+        defer {
+            SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = nil
+            settings._test_liveSystemCodexAccount = nil
+        }
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "old-email-only-auth",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .emailOnly(normalizedEmail: "alpha@example.com"))
+        let staleReconciliationSnapshot = settings.codexAccountReconciliationSnapshot
 
         let store = self.makeUsageStore(settings: settings)
         let blocker = BlockingCodexFetchStrategy()
@@ -61,6 +160,10 @@ extension CodexAccountScopedRefreshTests {
             codexHomePath: "/Users/test/.codex",
             observedAt: Date(),
             identity: .emailOnly(normalizedEmail: "alpha@example.com"))
+        settings.cachedCodexAccountReconciliationSnapshot = CachedCodexAccountReconciliationSnapshot(
+            activeSource: .liveSystem,
+            loadedAt: Date(),
+            snapshot: staleReconciliationSnapshot)
         await blocker.resume(with: .success(self.codexSnapshot(email: "alpha@example.com", usedPercent: 25)))
         await refreshTask.value
 

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -48,6 +48,54 @@ extension CodexAccountScopedRefreshTests {
     }
 
     @Test
+    func `same account token refresh fingerprint change keeps reset backfill`() async {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-token-refresh-reset-backfill")
+        defer {
+            settings._test_liveSystemCodexAccount = nil
+        }
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "old-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+        let store = self.makeUsageStore(settings: settings)
+        let resetsAt = Date().addingTimeInterval(45 * 60)
+        store.lastCodexAccountScopedRefreshGuard = store.freshCodexAccountScopedRefreshGuard()
+        store.lastKnownResetSnapshots[.codex] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 10,
+                windowMinutes: 300,
+                resetsAt: resetsAt,
+                resetDescription: "resets soon"),
+            secondary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "alpha@example.com",
+                accountOrganization: nil,
+                loginMethod: "Pro"))
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "new-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: self.codexSnapshot(email: "alpha@example.com", usedPercent: 25))
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(store.snapshots[.codex]?.primary?.usedPercent == 25)
+        #expect(store.snapshots[.codex]?.primary?.resetsAt == resetsAt)
+        #expect(store.lastKnownResetSnapshots[.codex]?.primary?.resetsAt == resetsAt)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.authFingerprint == "new-token-material")
+    }
+
+    @Test
     func `usage success applies when auth fingerprint appears after refresh starts`() {
         let settings = self.makeSettingsStore(
             suite: "CodexAccountScopedRefreshTests-auth-fingerprint-appears")

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -126,6 +126,168 @@ extension CodexAccountScopedRefreshTests {
     }
 
     @Test
+    func `credits refresh key separates same account auth fingerprints`() {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-credits-key-auth-fingerprint")
+        let store = self.makeUsageStore(settings: settings)
+        let oldGuard = CodexAccountScopedRefreshGuard(
+            source: .liveSystem,
+            identity: .providerAccount(id: "acct-alpha"),
+            accountKey: "alpha@example.com",
+            authFingerprint: "old-token-material")
+        let newGuard = CodexAccountScopedRefreshGuard(
+            source: .liveSystem,
+            identity: .providerAccount(id: "acct-alpha"),
+            accountKey: "alpha@example.com",
+            authFingerprint: "new-token-material")
+
+        #expect(store.codexCreditsRefreshKey(expectedGuard: oldGuard) !=
+            store.codexCreditsRefreshKey(expectedGuard: newGuard))
+    }
+
+    @Test
+    func `same account token refresh fingerprint change keeps dashboard success`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-token-refresh-dashboard-success")
+        let codexMetadata = try #require(ProviderDescriptorRegistry.metadata[.codex])
+        settings.setProviderEnabled(provider: .codex, metadata: codexMetadata, enabled: true)
+        settings.refreshFrequency = .manual
+        settings.openAIWebAccessEnabled = true
+        settings.codexCookieSource = .auto
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "old-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+        defer {
+            settings._test_liveSystemCodexAccount = nil
+        }
+
+        let store = self.makeUsageStore(settings: settings)
+        let expectedGuard = store.freshCodexOpenAIWebRefreshGuard()
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
+            settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+                email: "alpha@example.com",
+                authFingerprint: "new-token-material",
+                codexHomePath: "/Users/test/.codex",
+                observedAt: Date(),
+                identity: .providerAccount(id: "acct-alpha"))
+            return self.dashboard(email: "alpha@example.com", creditsRemaining: 64, usedPercent: 27)
+        }
+        defer { store._test_openAIDashboardLoaderOverride = nil }
+
+        await store.refreshOpenAIDashboardIfNeeded(force: true, expectedGuard: expectedGuard)
+
+        #expect(store.openAIDashboard?.creditsRemaining == 64)
+        #expect(store.openAIDashboard?.signedInEmail == "alpha@example.com")
+        #expect(store.lastOpenAIDashboardError == nil)
+        #expect(store.openAIDashboardRequiresLogin == false)
+    }
+
+    @Test
+    func `dashboard refresh key separates same account auth fingerprints`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-dashboard-key-auth-fingerprint")
+        let codexMetadata = try #require(ProviderDescriptorRegistry.metadata[.codex])
+        settings.setProviderEnabled(provider: .codex, metadata: codexMetadata, enabled: true)
+        settings.refreshFrequency = .manual
+        settings.openAIWebAccessEnabled = true
+        settings.codexCookieSource = .auto
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "old-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+        defer {
+            settings._test_liveSystemCodexAccount = nil
+        }
+
+        let store = self.makeUsageStore(settings: settings)
+        let blocker = BlockingManagedOpenAIDashboardLoader()
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
+            try await blocker.awaitResult()
+        }
+        defer { store._test_openAIDashboardLoaderOverride = nil }
+
+        let oldGuard = store.freshCodexOpenAIWebRefreshGuard()
+        let oldRefreshTask = Task {
+            await store.refreshOpenAIDashboardIfNeeded(force: true, expectedGuard: oldGuard)
+        }
+        await blocker.waitUntilStarted(count: 1)
+
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "new-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+        let newGuard = store.freshCodexOpenAIWebRefreshGuard()
+        let newRefreshTask = Task {
+            await store.refreshOpenAIDashboardIfNeeded(force: true, expectedGuard: newGuard)
+        }
+
+        let didStartFreshRefresh = await blocker.waitUntilStartedWithin(count: 2)
+        #expect(didStartFreshRefresh)
+        guard didStartFreshRefresh else {
+            await blocker.resumeNext(with: .failure(TestRefreshError(message: "stale dashboard failure")))
+            await oldRefreshTask.value
+            await newRefreshTask.value
+            return
+        }
+        await blocker.resumeNext(with: .failure(TestRefreshError(message: "old dashboard failure")))
+        await blocker.resumeNext(with: .success(self.dashboard(
+            email: "alpha@example.com",
+            creditsRemaining: 64,
+            usedPercent: 27)))
+        await oldRefreshTask.value
+        await newRefreshTask.value
+
+        #expect(store.openAIDashboard?.creditsRemaining == 64)
+        #expect(store.lastOpenAIDashboardError == nil)
+    }
+
+    @Test
+    func `same account token refresh fingerprint change discards dashboard failure`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-token-refresh-dashboard-failure")
+        let codexMetadata = try #require(ProviderDescriptorRegistry.metadata[.codex])
+        settings.setProviderEnabled(provider: .codex, metadata: codexMetadata, enabled: true)
+        settings.refreshFrequency = .manual
+        settings.openAIWebAccessEnabled = true
+        settings.codexCookieSource = .auto
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "old-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+        defer {
+            settings._test_liveSystemCodexAccount = nil
+        }
+
+        let store = self.makeUsageStore(settings: settings)
+        let expectedGuard = store.freshCodexOpenAIWebRefreshGuard()
+        store._test_openAIDashboardLoaderOverride = { _, _, _, _ in
+            settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+                email: "alpha@example.com",
+                authFingerprint: "new-token-material",
+                codexHomePath: "/Users/test/.codex",
+                observedAt: Date(),
+                identity: .providerAccount(id: "acct-alpha"))
+            throw TestRefreshError(message: "old dashboard failure")
+        }
+        defer { store._test_openAIDashboardLoaderOverride = nil }
+
+        await store.refreshOpenAIDashboardIfNeeded(force: true, expectedGuard: expectedGuard)
+
+        #expect(store.openAIDashboard == nil)
+        #expect(store.lastOpenAIDashboardError == nil)
+        #expect(store.openAIDashboardRequiresLogin == false)
+    }
+
+    @Test
     func `stacked visible refresh discards selected failure after managed token fingerprint rotates`() async throws {
         let settings = self.makeSettingsStore(
             suite: "CodexAccountScopedRefreshTests-selected-managed-token-failure")

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -96,6 +96,55 @@ extension CodexAccountScopedRefreshTests {
     }
 
     @Test
+    func `same account token refresh fingerprint change keeps scoped state during prepare`() {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-token-refresh-prepare")
+        defer {
+            settings._test_liveSystemCodexAccount = nil
+        }
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "old-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+        let store = self.makeUsageStore(settings: settings)
+        let resetsAt = Date().addingTimeInterval(45 * 60)
+        let cached = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 10,
+                windowMinutes: 300,
+                resetsAt: resetsAt,
+                resetDescription: "resets soon"),
+            secondary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "alpha@example.com",
+                accountOrganization: nil,
+                loginMethod: "Pro"))
+        store.snapshots[.codex] = cached
+        store.lastKnownResetSnapshots[.codex] = cached
+        store.credits = self.credits(remaining: 42)
+        store.lastCodexAccountScopedRefreshGuard = store.freshCodexAccountScopedRefreshGuard()
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "new-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+
+        let invalidated = store.prepareCodexAccountScopedRefreshIfNeeded()
+
+        #expect(!invalidated)
+        #expect(store.snapshots[.codex]?.primary?.resetsAt == resetsAt)
+        #expect(store.lastKnownResetSnapshots[.codex]?.primary?.resetsAt == resetsAt)
+        #expect(store.credits?.remaining == 42)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.authFingerprint == "new-token-material")
+    }
+
+    @Test
     func `usage success applies when auth fingerprint appears after refresh starts`() {
         let settings = self.makeSettingsStore(
             suite: "CodexAccountScopedRefreshTests-auth-fingerprint-appears")
@@ -504,6 +553,326 @@ extension CodexAccountScopedRefreshTests {
         })
         #expect(!snapshotStore.storedSnapshots.contains {
             $0.account.workspaceAccountID == "acct-managed-token"
+        })
+    }
+
+    @Test
+    func `stacked visible refresh discards selected failure after managed auth file rotates`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-selected-managed-auth-file-failure")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-121212121212"))
+        let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-131313131313"))
+        let targetHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-managed-auth-file-\(UUID().uuidString)", isDirectory: true)
+        let siblingHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-managed-auth-file-sibling-\(UUID().uuidString)", isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: targetHome,
+            email: "managed-file-token@example.com",
+            plan: "Pro",
+            accountId: "acct-managed-file-token")
+        let oldFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: targetHome.path))
+        let targetAccount = ManagedCodexAccount(
+            id: targetID,
+            email: "managed-file-token@example.com",
+            providerAccountID: "acct-managed-file-token",
+            workspaceLabel: "Managed Team",
+            workspaceAccountID: "acct-managed-file-token",
+            authFingerprint: oldFingerprint,
+            managedHomePath: targetHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let siblingAccount = ManagedCodexAccount(
+            id: siblingID,
+            email: "managed-file-token-sibling@example.com",
+            providerAccountID: "acct-managed-file-token-sibling",
+            workspaceLabel: "Sibling Team",
+            workspaceAccountID: "acct-managed-file-token-sibling",
+            authFingerprint: "sibling-managed-file-token",
+            managedHomePath: siblingHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [targetAccount, siblingAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: targetHome)
+            try? FileManager.default.removeItem(at: siblingHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: targetID)
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        let blocker = BlockingCodexFetchStrategy()
+        let targetHomePath = targetHome.path
+        let now = Date()
+        self.installContextualCodexProvider(on: store) { context in
+            if context.env["CODEX_HOME"] == targetHomePath {
+                return try await blocker.awaitResult()
+            }
+            return UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 9,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "managed-file-token-sibling@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Sibling Team"))
+        }
+
+        let refreshTask = Task { await store.refreshCodexVisibleAccountsForMenu() }
+        await blocker.waitUntilStarted()
+        try Self.writeCodexAuthFile(
+            homeURL: targetHome,
+            email: "managed-file-token@example.com",
+            plan: "Team",
+            accountId: "acct-managed-file-token")
+        let newFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: targetHome.path))
+        #expect(newFingerprint != oldFingerprint)
+        await blocker.resume(with: .failure(TestRefreshError(message: "old managed auth file failure")))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.errors[.codex] == nil)
+        #expect(!store.codexAccountSnapshots.contains {
+            $0.account.workspaceAccountID == "acct-managed-file-token"
+        })
+        #expect(!snapshotStore.storedSnapshots.contains {
+            $0.account.workspaceAccountID == "acct-managed-file-token"
+        })
+    }
+
+    @Test
+    func `stacked visible refresh keeps selected failure when managed auth file rotated before start`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-selected-managed-auth-file-current-failure")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-161616161616"))
+        let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-171717171717"))
+        let targetHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-managed-current-failure-\(UUID().uuidString)", isDirectory: true)
+        let siblingHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-managed-current-sibling-\(UUID().uuidString)", isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: targetHome,
+            email: "managed-current-failure@example.com",
+            plan: "Pro",
+            accountId: "acct-managed-current-failure")
+        let oldFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: targetHome.path))
+        let targetAccount = ManagedCodexAccount(
+            id: targetID,
+            email: "managed-current-failure@example.com",
+            providerAccountID: "acct-managed-current-failure",
+            workspaceLabel: "Managed Team",
+            workspaceAccountID: "acct-managed-current-failure",
+            authFingerprint: oldFingerprint,
+            managedHomePath: targetHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let siblingAccount = ManagedCodexAccount(
+            id: siblingID,
+            email: "managed-current-sibling@example.com",
+            providerAccountID: "acct-managed-current-sibling",
+            workspaceLabel: "Sibling Team",
+            workspaceAccountID: "acct-managed-current-sibling",
+            authFingerprint: "sibling-managed-current",
+            managedHomePath: siblingHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [targetAccount, siblingAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: targetHome)
+            try? FileManager.default.removeItem(at: siblingHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: targetID)
+
+        try Self.writeCodexAuthFile(
+            homeURL: targetHome,
+            email: "managed-current-failure@example.com",
+            plan: "Team",
+            accountId: "acct-managed-current-failure")
+        let newFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: targetHome.path))
+        #expect(newFingerprint != oldFingerprint)
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        let targetHomePath = targetHome.path
+        let now = Date()
+        self.installContextualCodexProvider(on: store) { context in
+            if context.env["CODEX_HOME"] == targetHomePath {
+                throw TestRefreshError(message: "current managed auth file failure")
+            }
+            return UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 9,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "managed-current-sibling@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Sibling Team"))
+        }
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        #expect(store.errors[.codex] == "current managed auth file failure")
+        let targetSnapshot = try #require(store.codexAccountSnapshots.first {
+            $0.account.workspaceAccountID == "acct-managed-current-failure"
+        })
+        #expect(targetSnapshot.error == "current managed auth file failure")
+        #expect(targetSnapshot.account.authFingerprint == newFingerprint)
+        let persistedTargetSnapshot = try #require(snapshotStore.storedSnapshots.first {
+            $0.account.workspaceAccountID == "acct-managed-current-failure"
+        })
+        #expect(persistedTargetSnapshot.error == "current managed auth file failure")
+        #expect(persistedTargetSnapshot.account.authFingerprint == newFingerprint)
+    }
+
+    @Test
+    func `stacked visible refresh discards selected success after managed auth file switches accounts`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-selected-managed-auth-file-success")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-141414141414"))
+        let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-151515151515"))
+        let targetHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-managed-auth-success-\(UUID().uuidString)", isDirectory: true)
+        let siblingHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "codex-visible-managed-auth-success-sibling-\(UUID().uuidString)",
+                isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: targetHome,
+            email: "managed-old-success@example.com",
+            plan: "Pro",
+            accountId: "acct-managed-old-success")
+        let oldFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: targetHome.path))
+        let targetAccount = ManagedCodexAccount(
+            id: targetID,
+            email: "managed-old-success@example.com",
+            providerAccountID: "acct-managed-old-success",
+            workspaceLabel: "Managed Team",
+            workspaceAccountID: "acct-managed-old-success",
+            authFingerprint: oldFingerprint,
+            managedHomePath: targetHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let siblingAccount = ManagedCodexAccount(
+            id: siblingID,
+            email: "managed-success-sibling@example.com",
+            providerAccountID: "acct-managed-success-sibling",
+            workspaceLabel: "Sibling Team",
+            workspaceAccountID: "acct-managed-success-sibling",
+            authFingerprint: "sibling-managed-success",
+            managedHomePath: siblingHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [targetAccount, siblingAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: targetHome)
+            try? FileManager.default.removeItem(at: siblingHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: targetID)
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        let blocker = BlockingCodexFetchStrategy()
+        let targetHomePath = targetHome.path
+        let now = Date()
+        self.installContextualCodexProvider(on: store) { context in
+            if context.env["CODEX_HOME"] == targetHomePath {
+                return try await blocker.awaitResult()
+            }
+            return UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 9,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "managed-success-sibling@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Sibling Team"))
+        }
+
+        let refreshTask = Task { await store.refreshCodexVisibleAccountsForMenu() }
+        await blocker.waitUntilStarted()
+        try Self.writeCodexAuthFile(
+            homeURL: targetHome,
+            email: "managed-new-success@example.com",
+            plan: "Pro",
+            accountId: "acct-managed-new-success")
+        let newFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: targetHome.path))
+        #expect(newFingerprint != oldFingerprint)
+        await blocker.resume(with: .success(UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 64,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "managed-old-success@example.com",
+                accountOrganization: nil,
+                loginMethod: "Managed Team"))))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.errors[.codex] == nil)
+        #expect(!store.codexAccountSnapshots.contains {
+            $0.account.workspaceAccountID == "acct-managed-old-success"
+        })
+        #expect(!snapshotStore.storedSnapshots.contains {
+            $0.account.workspaceAccountID == "acct-managed-old-success"
         })
     }
 

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -1011,6 +1011,61 @@ extension CodexAccountScopedRefreshTests {
     }
 
     @Test
+    func `same provider account managed email change discards stale codex usage success`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-managed-provider-email-change")
+        settings.refreshFrequency = .manual
+
+        let accountID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-161616161616"))
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-managed-provider-email-\(UUID().uuidString)", isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "old-managed@example.com",
+            plan: "Pro",
+            accountId: "acct-managed-shared")
+        let oldFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: managedHome.path))
+        let managedAccount = ManagedCodexAccount(
+            id: accountID,
+            email: "old-managed@example.com",
+            providerAccountID: "acct-managed-shared",
+            workspaceLabel: "Managed Team",
+            workspaceAccountID: "acct-managed-shared",
+            authFingerprint: oldFingerprint,
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: managedHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: accountID)
+
+        let store = self.makeUsageStore(settings: settings)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        await blocker.waitUntilStarted()
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "new-managed@example.com",
+            plan: "Pro",
+            accountId: "acct-managed-shared")
+        let newFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: managedHome.path))
+        #expect(newFingerprint != oldFingerprint)
+        await blocker.resume(with: .success(self.codexSnapshot(email: "old-managed@example.com", usedPercent: 25)))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.errors[.codex] == nil)
+    }
+
+    @Test
     func `same email email-only auth fingerprint switch discards stale codex usage success`() async {
         SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
         let settings = self.makeSettingsStore(

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -96,6 +96,58 @@ extension CodexAccountScopedRefreshTests {
     }
 
     @Test
+    func `stale stacked projection collapse runs single codex fetch`() async throws {
+        SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-stacked-collapse-single-fetch")
+        defer {
+            SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = nil
+            settings._test_liveSystemCodexAccount = nil
+            settings._test_managedCodexAccountStoreURL = nil
+        }
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+        settings.codexActiveSource = .liveSystem
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "live-collapse@example.com",
+            identity: .providerAccount(id: "acct-live-collapse"))
+
+        let managedAccountID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-191919191919"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "managed-collapse@example.com",
+            managedHomePath: "/tmp/codex-managed-collapse",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let staleStoreURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        let emptyStoreURL = try self.makeManagedAccountStoreURL(accounts: [])
+        defer {
+            try? FileManager.default.removeItem(at: staleStoreURL)
+            try? FileManager.default.removeItem(at: emptyStoreURL)
+        }
+        settings._test_managedCodexAccountStoreURL = staleStoreURL
+        let staleReconciliationSnapshot = settings.codexAccountReconciliationSnapshot
+        #expect(CodexVisibleAccountProjection.make(from: staleReconciliationSnapshot).visibleAccounts.count == 2)
+
+        settings._test_managedCodexAccountStoreURL = emptyStoreURL
+        settings.cachedCodexAccountReconciliationSnapshot = CachedCodexAccountReconciliationSnapshot(
+            activeSource: .liveSystem,
+            loadedAt: Date(),
+            snapshot: staleReconciliationSnapshot)
+
+        let store = self.makeUsageStore(settings: settings)
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: self.codexSnapshot(email: "live-collapse@example.com", usedPercent: 42))
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(store.snapshots[.codex]?.primary?.usedPercent == 42)
+        #expect(store.codexAccountSnapshots.isEmpty)
+    }
+
+    @Test
     func `same account token refresh fingerprint change keeps scoped state during prepare`() {
         let settings = self.makeSettingsStore(
             suite: "CodexAccountScopedRefreshTests-token-refresh-prepare")

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -1,0 +1,70 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+extension CodexAccountScopedRefreshTests {
+    @Test
+    func `same account token refresh fingerprint change keeps codex usage success`() async {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-token-refresh-fingerprint-change")
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "old-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+
+        let store = self.makeUsageStore(settings: settings)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        await blocker.waitUntilStarted()
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "new-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+        await blocker.resume(with: .success(self.codexSnapshot(email: "alpha@example.com", usedPercent: 25)))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex]?.primary?.usedPercent == 25)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.authFingerprint == "new-token-material")
+        #expect(store.errors[.codex] == nil)
+    }
+
+    @Test
+    func `same email email-only auth fingerprint switch discards stale codex usage success`() async {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-email-only-fingerprint-switch")
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "old-email-only-auth",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .emailOnly(normalizedEmail: "alpha@example.com"))
+
+        let store = self.makeUsageStore(settings: settings)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        await blocker.waitUntilStarted()
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "new-email-only-auth",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .emailOnly(normalizedEmail: "alpha@example.com"))
+        await blocker.resume(with: .success(self.codexSnapshot(email: "alpha@example.com", usedPercent: 25)))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.errors[.codex] == nil)
+    }
+}

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -414,7 +414,7 @@ extension CodexAccountScopedRefreshTests {
     }
 
     @Test
-    func `same account token refresh fingerprint change discards dashboard policy failure`() async throws {
+    func `same account token refresh fingerprint change applies dashboard policy failure`() async throws {
         let settings = self.makeSettingsStore(
             suite: "CodexAccountScopedRefreshTests-token-refresh-dashboard-policy-failure")
         let codexMetadata = try #require(ProviderDescriptorRegistry.metadata[.codex])
@@ -447,8 +447,8 @@ extension CodexAccountScopedRefreshTests {
             expectedGuard: expectedGuard)
 
         #expect(store.openAIDashboard == nil)
-        #expect(store.lastOpenAIDashboardError == nil)
-        #expect(store.openAIDashboardRequiresLogin == false)
+        #expect(store.lastOpenAIDashboardError?.contains("OpenAI dashboard signed in as other@example.com") == true)
+        #expect(store.openAIDashboardRequiresLogin == true)
     }
 
     @Test
@@ -998,6 +998,128 @@ extension CodexAccountScopedRefreshTests {
         })
         #expect(persistedTarget.account.authFingerprint == newFingerprint)
         #expect(persistedTarget.snapshot?.primary?.usedPercent == 64)
+    }
+
+    @Test
+    func `stacked visible refresh discards selected success after managed auth file email changes`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-selected-managed-auth-email-success")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-191919191919"))
+        let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-202020202020"))
+        let targetHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-managed-auth-email-\(UUID().uuidString)", isDirectory: true)
+        let siblingHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "codex-visible-managed-auth-email-sibling-\(UUID().uuidString)",
+                isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: targetHome,
+            email: "managed-old-email@example.com",
+            plan: "Pro",
+            accountId: "acct-managed-email-same")
+        try Self.writeCodexAuthFile(
+            homeURL: siblingHome,
+            email: "managed-email-sibling@example.com",
+            plan: "Pro",
+            accountId: "acct-managed-email-sibling")
+        let oldFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: targetHome.path))
+        let siblingFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: siblingHome.path))
+        let targetAccount = ManagedCodexAccount(
+            id: targetID,
+            email: "managed-old-email@example.com",
+            providerAccountID: "acct-managed-email-same",
+            workspaceLabel: "Managed Team",
+            workspaceAccountID: "acct-managed-email-same",
+            authFingerprint: oldFingerprint,
+            managedHomePath: targetHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let siblingAccount = ManagedCodexAccount(
+            id: siblingID,
+            email: "managed-email-sibling@example.com",
+            providerAccountID: "acct-managed-email-sibling",
+            workspaceLabel: "Sibling Team",
+            workspaceAccountID: "acct-managed-email-sibling",
+            authFingerprint: siblingFingerprint,
+            managedHomePath: siblingHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [targetAccount, siblingAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: targetHome)
+            try? FileManager.default.removeItem(at: siblingHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: targetID)
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        let blocker = BlockingCodexFetchStrategy()
+        let targetHomePath = targetHome.path
+        let now = Date()
+        self.installContextualCodexProvider(on: store) { context in
+            if context.env["CODEX_HOME"] == targetHomePath {
+                return try await blocker.awaitResult()
+            }
+            return UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 9,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "managed-email-sibling@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Sibling Team"))
+        }
+
+        let refreshTask = Task { await store.refreshCodexVisibleAccountsForMenu() }
+        await blocker.waitUntilStarted()
+        try Self.writeCodexAuthFile(
+            homeURL: targetHome,
+            email: "managed-new-email@example.com",
+            plan: "Pro",
+            accountId: "acct-managed-email-same")
+        let newFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: targetHome.path))
+        #expect(newFingerprint != oldFingerprint)
+        await blocker.resume(with: .success(UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 64,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "managed-old-email@example.com",
+                accountOrganization: nil,
+                loginMethod: "Managed Team"))))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.errors[.codex] == nil)
+        #expect(!store.codexAccountSnapshots.contains {
+            $0.account.workspaceAccountID == "acct-managed-email-same"
+        })
+        #expect(!snapshotStore.storedSnapshots.contains {
+            $0.account.workspaceAccountID == "acct-managed-email-same"
+        })
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -48,6 +48,35 @@ extension CodexAccountScopedRefreshTests {
     }
 
     @Test
+    func `usage success applies when auth fingerprint appears after refresh starts`() {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-auth-fingerprint-appears")
+        defer {
+            settings._test_liveSystemCodexAccount = nil
+        }
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: nil,
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .emailOnly(normalizedEmail: "alpha@example.com"))
+        let store = self.makeUsageStore(settings: settings)
+        let expectedGuard = store.freshCodexAccountScopedRefreshGuard()
+
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "new-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .emailOnly(normalizedEmail: "alpha@example.com"))
+
+        #expect(store.shouldApplyCodexUsageResult(
+            expectedGuard: expectedGuard,
+            usage: self.codexSnapshot(email: "alpha@example.com", usedPercent: 25)))
+    }
+
+    @Test
     func `same account token refresh fingerprint change discards codex usage failure`() async {
         SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
         let settings = self.makeSettingsStore(
@@ -281,6 +310,44 @@ extension CodexAccountScopedRefreshTests {
         defer { store._test_openAIDashboardLoaderOverride = nil }
 
         await store.refreshOpenAIDashboardIfNeeded(force: true, expectedGuard: expectedGuard)
+
+        #expect(store.openAIDashboard == nil)
+        #expect(store.lastOpenAIDashboardError == nil)
+        #expect(store.openAIDashboardRequiresLogin == false)
+    }
+
+    @Test
+    func `same account token refresh fingerprint change discards dashboard policy failure`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-token-refresh-dashboard-policy-failure")
+        let codexMetadata = try #require(ProviderDescriptorRegistry.metadata[.codex])
+        settings.setProviderEnabled(provider: .codex, metadata: codexMetadata, enabled: true)
+        settings.refreshFrequency = .manual
+        settings.openAIWebAccessEnabled = true
+        settings.codexCookieSource = .auto
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "old-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+        defer {
+            settings._test_liveSystemCodexAccount = nil
+        }
+
+        let store = self.makeUsageStore(settings: settings)
+        let expectedGuard = store.freshCodexOpenAIWebRefreshGuard()
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "new-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+
+        await store.applyOpenAIDashboard(
+            self.dashboard(email: "other@example.com", creditsRemaining: 64, usedPercent: 27),
+            targetEmail: "alpha@example.com",
+            expectedGuard: expectedGuard)
 
         #expect(store.openAIDashboard == nil)
         #expect(store.lastOpenAIDashboardError == nil)

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -1171,6 +1171,25 @@ extension CodexAccountScopedRefreshTests {
         #expect(store.freshCodexAccountScopedRefreshGuard().authFingerprint == newFingerprint)
         #expect(!store.shouldApplyCodexScopedFailure(expectedGuard: expectedGuard))
         #expect(!store.shouldApplyCodexScopedNonUsageFailure(expectedGuard: expectedGuard))
+
+        try FileManager.default.removeItem(at: managedHome)
+        #expect(store.freshCodexAccountScopedRefreshGuard().authFingerprint == nil)
+        let staleUsage = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 41,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "managed-auth@example.com",
+                accountOrganization: nil,
+                loginMethod: "Managed Auth"))
+        #expect(!store.shouldApplyCodexUsageResult(expectedGuard: expectedGuard, usage: staleUsage))
+        #expect(!store.shouldApplyCodexScopedFailure(expectedGuard: expectedGuard))
+        #expect(!store.shouldApplyCodexScopedNonUsageFailure(expectedGuard: expectedGuard))
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
+++ b/Tests/CodexBarTests/CodexAccountAuthFingerprintApplyTests.swift
@@ -877,6 +877,130 @@ extension CodexAccountScopedRefreshTests {
     }
 
     @Test
+    func `stacked visible refresh keeps migrated managed account after token rotation`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-migrated-managed-token-rotation")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-171717171717"))
+        let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-181818181818"))
+        let targetHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-migrated-managed-\(UUID().uuidString)", isDirectory: true)
+        let siblingHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "codex-visible-migrated-managed-sibling-\(UUID().uuidString)",
+                isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: targetHome,
+            email: "migrated-managed@example.com",
+            plan: "Pro",
+            accountId: "acct-migrated-managed")
+        try Self.writeCodexAuthFile(
+            homeURL: siblingHome,
+            email: "migrated-sibling@example.com",
+            plan: "Pro",
+            accountId: "acct-migrated-sibling")
+        let oldFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: targetHome.path))
+        let siblingFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: siblingHome.path))
+        let targetAccount = ManagedCodexAccount(
+            id: targetID,
+            email: "migrated-managed@example.com",
+            providerAccountID: "acct-migrated-managed",
+            workspaceLabel: "Managed Team",
+            authFingerprint: oldFingerprint,
+            managedHomePath: targetHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let siblingAccount = ManagedCodexAccount(
+            id: siblingID,
+            email: "migrated-sibling@example.com",
+            providerAccountID: "acct-migrated-sibling",
+            workspaceLabel: "Sibling Team",
+            authFingerprint: siblingFingerprint,
+            managedHomePath: siblingHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [targetAccount, siblingAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: targetHome)
+            try? FileManager.default.removeItem(at: siblingHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: targetID)
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        let blocker = BlockingCodexFetchStrategy()
+        let targetHomePath = targetHome.path
+        let now = Date()
+        self.installContextualCodexProvider(on: store) { context in
+            if context.env["CODEX_HOME"] == targetHomePath {
+                return try await blocker.awaitResult()
+            }
+            return UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 9,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "migrated-sibling@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Sibling Team"))
+        }
+
+        let refreshTask = Task { await store.refreshCodexVisibleAccountsForMenu() }
+        await blocker.waitUntilStarted()
+        try Self.writeCodexAuthFile(
+            homeURL: targetHome,
+            email: "migrated-managed@example.com",
+            plan: "Team",
+            accountId: "acct-migrated-managed")
+        let newFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: targetHome.path))
+        #expect(newFingerprint != oldFingerprint)
+        await blocker.resume(with: .success(UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 64,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "migrated-managed@example.com",
+                accountOrganization: nil,
+                loginMethod: "Managed Team"))))
+        await refreshTask.value
+
+        let selectedSnapshot = try #require(store.snapshots[.codex])
+        #expect(selectedSnapshot.primary?.usedPercent == 64)
+        let targetRow = try #require(store.codexAccountSnapshots.first {
+            $0.account.workspaceAccountID == "acct-migrated-managed"
+        })
+        #expect(targetRow.account.authFingerprint == newFingerprint)
+        #expect(targetRow.snapshot?.primary?.usedPercent == 64)
+        let persistedTarget = try #require(snapshotStore.storedSnapshots.first {
+            $0.account.workspaceAccountID == "acct-migrated-managed"
+        })
+        #expect(persistedTarget.account.authFingerprint == newFingerprint)
+        #expect(persistedTarget.snapshot?.primary?.usedPercent == 64)
+    }
+
+    @Test
     func `managed failure guard reads current auth file fingerprint`() throws {
         let settings = self.makeSettingsStore(
             suite: "CodexAccountScopedRefreshTests-managed-auth-file-fingerprint")
@@ -1059,6 +1183,125 @@ extension CodexAccountScopedRefreshTests {
         let newFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: managedHome.path))
         #expect(newFingerprint != oldFingerprint)
         await blocker.resume(with: .success(self.codexSnapshot(email: "old-managed@example.com", usedPercent: 25)))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.errors[.codex] == nil)
+    }
+
+    @Test
+    func `managed codex usage success without email applies when auth guard matches`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-managed-usage-without-email")
+        settings.refreshFrequency = .manual
+
+        let accountID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-171717171717"))
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-managed-usage-without-email-\(UUID().uuidString)", isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "email-less-managed@example.com",
+            plan: "Pro",
+            accountId: "acct-managed-email-less")
+        let authFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: managedHome.path))
+        let managedAccount = ManagedCodexAccount(
+            id: accountID,
+            email: "email-less-managed@example.com",
+            providerAccountID: "acct-managed-email-less",
+            workspaceLabel: "Managed Team",
+            workspaceAccountID: "acct-managed-email-less",
+            authFingerprint: authFingerprint,
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: managedHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: accountID)
+
+        let store = self.makeUsageStore(settings: settings)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        await blocker.waitUntilStarted()
+        await blocker.resume(with: .success(UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 25,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex]?.primary?.usedPercent == 25)
+        #expect(store.errors[.codex] == nil)
+    }
+
+    @Test
+    func `same provider account managed email change discards stale codex usage success without email`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-managed-provider-email-change-without-email")
+        settings.refreshFrequency = .manual
+
+        let accountID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-181818181818"))
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "codex-managed-provider-email-without-email-\(UUID().uuidString)",
+                isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "old-managed-empty@example.com",
+            plan: "Pro",
+            accountId: "acct-managed-shared-empty")
+        let oldFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: managedHome.path))
+        let managedAccount = ManagedCodexAccount(
+            id: accountID,
+            email: "old-managed-empty@example.com",
+            providerAccountID: "acct-managed-shared-empty",
+            workspaceLabel: "Managed Team",
+            workspaceAccountID: "acct-managed-shared-empty",
+            authFingerprint: oldFingerprint,
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: managedHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: accountID)
+
+        let store = self.makeUsageStore(settings: settings)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        await blocker.waitUntilStarted()
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "new-managed-empty@example.com",
+            plan: "Pro",
+            accountId: "acct-managed-shared-empty")
+        let newFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: managedHome.path))
+        #expect(newFingerprint != oldFingerprint)
+        await blocker.resume(with: .success(UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 25,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())))
         await refreshTask.value
 
         #expect(store.snapshots[.codex] == nil)

--- a/Tests/CodexBarTests/CodexAccountEmailOnlyHistoryBackfillTests.swift
+++ b/Tests/CodexBarTests/CodexAccountEmailOnlyHistoryBackfillTests.swift
@@ -1,0 +1,120 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+extension CodexAccountScopedRefreshTests {
+    @Test
+    func `backfills non active email only codex row from own history`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountVisibleHistoryBackfillTests-non-active-email-history")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let activeID = try #require(UUID(uuidString: "BBBBBBBB-CCCC-DDDD-EEEE-333333333333"))
+        let siblingID = try #require(UUID(uuidString: "BBBBBBBB-CCCC-DDDD-EEEE-444444444444"))
+        let activeHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-active-email-\(UUID().uuidString)", isDirectory: true)
+        let siblingHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-sibling-email-\(UUID().uuidString)", isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: activeHome,
+            email: "active-email-history@example.com",
+            plan: "Pro")
+        try Self.writeCodexAuthFile(
+            homeURL: siblingHome,
+            email: "sibling-email-history@example.com",
+            plan: "Pro")
+        let activeFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: activeHome.path))
+        let siblingFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: siblingHome.path))
+        let activeAccount = ManagedCodexAccount(
+            id: activeID,
+            email: "active-email-history@example.com",
+            workspaceLabel: "Active Team",
+            authFingerprint: activeFingerprint,
+            managedHomePath: activeHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let siblingAccount = ManagedCodexAccount(
+            id: siblingID,
+            email: "sibling-email-history@example.com",
+            workspaceLabel: "Sibling Team",
+            authFingerprint: siblingFingerprint,
+            managedHomePath: siblingHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [activeAccount, siblingAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: activeHome)
+            try? FileManager.default.removeItem(at: siblingHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: activeID)
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        let now = Date()
+        let sessionReset = now.addingTimeInterval(2 * 60 * 60)
+        let weeklyReset = now.addingTimeInterval(4 * 24 * 60 * 60)
+        let siblingHistoryKey = CodexHistoryOwnership.canonicalEmailHashKey(for: "sibling-email-history@example.com")
+        store.planUtilizationHistory[.codex] = PlanUtilizationHistoryBuckets(accounts: [
+            siblingHistoryKey: [
+                planSeries(name: .session, windowMinutes: 300, entries: [
+                    planEntry(at: now.addingTimeInterval(-60), usedPercent: 6, resetsAt: sessionReset),
+                ]),
+                planSeries(name: .weekly, windowMinutes: 10080, entries: [
+                    planEntry(at: now.addingTimeInterval(-60), usedPercent: 36, resetsAt: weeklyReset),
+                ]),
+            ],
+        ])
+        store.lastCodexAccountScopedRefreshGuard = CodexAccountScopedRefreshGuard(
+            source: .managedAccount(id: activeID),
+            identity: .emailOnly(normalizedEmail: "active-email-history@example.com"),
+            accountKey: "active-email-history@example.com",
+            authFingerprint: activeFingerprint)
+        self.installContextualCodexProvider(on: store) { context in
+            let isActive = context.env["CODEX_HOME"] == activeHome.path
+            return UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: isActive ? 3 : 6,
+                    windowMinutes: 0,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now)
+        }
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        let activeSnapshot = try #require(store.codexAccountSnapshots.first {
+            $0.account.email == "active-email-history@example.com"
+        }?.snapshot)
+        #expect(activeSnapshot.primary?.usedPercent == 3)
+        #expect(activeSnapshot.primary?.windowMinutes == 0)
+        #expect(activeSnapshot.primary?.resetsAt == nil)
+
+        let siblingSnapshot = try #require(store.codexAccountSnapshots.first {
+            $0.account.email == "sibling-email-history@example.com"
+        }?.snapshot)
+        #expect(siblingSnapshot.primary?.usedPercent == 6)
+        #expect(siblingSnapshot.primary?.windowMinutes == 300)
+        #expect(siblingSnapshot.primary?.resetsAt == sessionReset)
+        #expect(siblingSnapshot.secondary?.usedPercent == 36)
+        #expect(siblingSnapshot.secondary?.resetsAt == weeklyReset)
+        let persistedSibling = try #require(snapshotStore.storedSnapshots.first {
+            $0.account.email == "sibling-email-history@example.com"
+        }?.snapshot)
+        #expect(persistedSibling.primary?.resetsAt == sessionReset)
+        #expect(persistedSibling.secondary?.resetsAt == weeklyReset)
+    }
+}

--- a/Tests/CodexBarTests/CodexAccountRefreshProjectionTests.swift
+++ b/Tests/CodexBarTests/CodexAccountRefreshProjectionTests.swift
@@ -1,0 +1,157 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+extension CodexAccountScopedRefreshTests {
+    @Test
+    func `stale stacked projection collapse runs single codex fetch`() async throws {
+        SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-stacked-collapse-single-fetch")
+        defer {
+            SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = nil
+            settings._test_liveSystemCodexAccount = nil
+            settings._test_managedCodexAccountStoreURL = nil
+        }
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+        settings.codexActiveSource = .liveSystem
+        settings._test_liveSystemCodexAccount = self.liveAccount(
+            email: "live-collapse@example.com",
+            identity: .providerAccount(id: "acct-live-collapse"))
+
+        let managedAccountID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-191919191919"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedAccountID,
+            email: "managed-collapse@example.com",
+            managedHomePath: "/tmp/codex-managed-collapse",
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let staleStoreURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        let emptyStoreURL = try self.makeManagedAccountStoreURL(accounts: [])
+        defer {
+            try? FileManager.default.removeItem(at: staleStoreURL)
+            try? FileManager.default.removeItem(at: emptyStoreURL)
+        }
+        settings._test_managedCodexAccountStoreURL = staleStoreURL
+        let staleReconciliationSnapshot = settings.codexAccountReconciliationSnapshot
+        #expect(CodexVisibleAccountProjection.make(from: staleReconciliationSnapshot).visibleAccounts.count == 2)
+
+        settings._test_managedCodexAccountStoreURL = emptyStoreURL
+        settings.cachedCodexAccountReconciliationSnapshot = CachedCodexAccountReconciliationSnapshot(
+            activeSource: .liveSystem,
+            loadedAt: Date(),
+            snapshot: staleReconciliationSnapshot)
+
+        let store = self.makeUsageStore(settings: settings)
+        self.installImmediateCodexProvider(
+            on: store,
+            snapshot: self.codexSnapshot(email: "live-collapse@example.com", usedPercent: 42))
+
+        await store.refreshProvider(.codex, allowDisabled: true)
+
+        #expect(store.snapshots[.codex]?.primary?.usedPercent == 42)
+        #expect(store.codexAccountSnapshots.isEmpty)
+    }
+
+    @Test
+    func `stacked visible refresh discards selected success after managed auth file is removed`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-selected-managed-auth-file-removed")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-202020202020"))
+        let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-212121212121"))
+        let targetHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-managed-auth-removed-\(UUID().uuidString)", isDirectory: true)
+        let siblingHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "codex-visible-managed-auth-removed-sibling-\(UUID().uuidString)",
+                isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: targetHome,
+            email: "managed-removed@example.com",
+            plan: "Pro",
+            accountId: "acct-managed-removed")
+        let oldFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: targetHome.path))
+        let targetAccount = ManagedCodexAccount(
+            id: targetID,
+            email: "managed-removed@example.com",
+            providerAccountID: "acct-managed-removed",
+            workspaceLabel: "Managed Team",
+            workspaceAccountID: "acct-managed-removed",
+            authFingerprint: oldFingerprint,
+            managedHomePath: targetHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let siblingAccount = ManagedCodexAccount(
+            id: siblingID,
+            email: "managed-removed-sibling@example.com",
+            providerAccountID: "acct-managed-removed-sibling",
+            workspaceLabel: "Sibling Team",
+            workspaceAccountID: "acct-managed-removed-sibling",
+            authFingerprint: "sibling-managed-removed",
+            managedHomePath: siblingHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [targetAccount, siblingAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: targetHome)
+            try? FileManager.default.removeItem(at: siblingHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: targetID)
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        let blocker = BlockingCodexFetchStrategy()
+        let targetHomePath = targetHome.path
+        let now = Date()
+        self.installContextualCodexProvider(on: store) { context in
+            if context.env["CODEX_HOME"] == targetHomePath {
+                return try await blocker.awaitResult()
+            }
+            return UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 9,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "managed-removed-sibling@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Sibling Team"))
+        }
+
+        let refreshTask = Task { await store.refreshCodexVisibleAccountsForMenu() }
+        await blocker.waitUntilStarted()
+        try FileManager.default.removeItem(at: targetHome)
+        await blocker.resume(with: .success(self.codexSnapshot(email: "managed-removed@example.com", usedPercent: 44)))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.errors[.codex] == nil)
+        #expect(!store.codexAccountSnapshots.contains {
+            $0.account.workspaceAccountID == "acct-managed-removed"
+        })
+        #expect(!snapshotStore.storedSnapshots.contains {
+            $0.account.workspaceAccountID == "acct-managed-removed"
+        })
+    }
+}

--- a/Tests/CodexBarTests/CodexAccountRefreshProjectionTests.swift
+++ b/Tests/CodexBarTests/CodexAccountRefreshProjectionTests.swift
@@ -154,4 +154,86 @@ extension CodexAccountScopedRefreshTests {
             $0.account.workspaceAccountID == "acct-managed-removed"
         })
     }
+
+    @Test
+    func `startup snapshot hydration refreshes managed auth fingerprint from disk`() throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-startup-managed-auth-hydration")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let accountID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-222222222222"))
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-managed-startup-\(UUID().uuidString)", isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "managed-startup@example.com",
+            plan: "Pro")
+        let oldFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: managedHome.path))
+        let managedAccount = ManagedCodexAccount(
+            id: accountID,
+            email: "managed-startup@example.com",
+            authFingerprint: oldFingerprint,
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        let snapshotURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-managed-startup-\(UUID().uuidString).json")
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: snapshotURL)
+            try? FileManager.default.removeItem(at: managedHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: accountID)
+
+        let staleAccount = try #require(settings.codexVisibleAccountProjection.visibleAccounts
+            .first { $0.storedAccountID == accountID })
+        #expect(staleAccount.authFingerprint == oldFingerprint)
+
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "managed-startup@example.com",
+            plan: "Team")
+        let newFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: managedHome.path))
+        #expect(newFingerprint != oldFingerprint)
+
+        let freshAccount = CodexVisibleAccount(
+            id: staleAccount.id,
+            email: staleAccount.email,
+            workspaceLabel: staleAccount.workspaceLabel,
+            workspaceAccountID: staleAccount.workspaceAccountID,
+            authFingerprint: newFingerprint,
+            storedAccountID: staleAccount.storedAccountID,
+            selectionSource: staleAccount.selectionSource,
+            isActive: staleAccount.isActive,
+            isLive: staleAccount.isLive,
+            canReauthenticate: staleAccount.canReauthenticate,
+            canRemove: staleAccount.canRemove)
+        let snapshotStore = FileCodexAccountUsageSnapshotStore(fileURL: snapshotURL)
+        snapshotStore.store([
+            CodexAccountUsageSnapshot(
+                account: freshAccount,
+                snapshot: self.codexSnapshot(email: freshAccount.email, usedPercent: 64),
+                error: nil,
+                sourceLabel: "cached"),
+        ])
+        #expect(snapshotStore.load(for: [staleAccount]).isEmpty)
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+
+        let hydrated = try #require(store.codexAccountSnapshots.first)
+        #expect(store.codexAccountSnapshots.count == 1)
+        #expect(hydrated.id == freshAccount.id)
+        #expect(hydrated.account.authFingerprint == newFingerprint)
+        #expect(hydrated.snapshot?.primary?.usedPercent == 64)
+    }
 }

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshDashboardCleanupTests.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshDashboardCleanupTests.swift
@@ -205,4 +205,69 @@ extension CodexAccountScopedRefreshTests {
         #expect(store.openAIDashboardRequiresLogin == true)
         #expect(store.lastOpenAIDashboardError?.contains("OpenAI dashboard signed in as other@example.com") == true)
     }
+
+    @Test
+    func `dashboard fail closed cleanup applies after same live account email changes during token rotation`() async {
+        OpenAIDashboardCacheStore.clear()
+        defer { OpenAIDashboardCacheStore.clear() }
+
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-dashboard-fail-closed-live-email-rotation-cleanup")
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .auto
+        settings.codexActiveSource = .liveSystem
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "old-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+        defer {
+            settings._test_liveSystemCodexAccount = nil
+        }
+
+        let store = self.makeUsageStore(settings: settings)
+        let expectedGuard = store.freshCodexOpenAIWebRefreshGuard()
+        #expect(expectedGuard.accountKey == "alpha@example.com")
+        #expect(expectedGuard.authFingerprint == "old-token-material")
+        store._setSnapshotForTesting(
+            self.codexSnapshot(email: "alpha@example.com", usedPercent: 20),
+            provider: .codex)
+        store.lastSourceLabels[.codex] = "openai-web"
+        let staleCredits = self.credits(remaining: 20)
+        store.credits = staleCredits
+        store.lastCreditsSnapshot = staleCredits
+        store.lastCreditsSnapshotAccountKey = "alpha@example.com"
+        store.lastCreditsSource = .dashboardWeb
+        store.openAIDashboard = self.dashboard(email: "alpha@example.com", creditsRemaining: 20, usedPercent: 20)
+        store.lastOpenAIDashboardSnapshot = store.openAIDashboard
+        OpenAIDashboardCacheStore.save(OpenAIDashboardCache(
+            accountEmail: "alpha@example.com",
+            snapshot: self.dashboard(email: "alpha@example.com", creditsRemaining: 20, usedPercent: 20)))
+
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "beta@example.com",
+            authFingerprint: "new-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+        let currentGuard = store.freshCodexOpenAIWebRefreshGuard()
+        #expect(currentGuard.identity == expectedGuard.identity)
+        #expect(currentGuard.accountKey == "beta@example.com")
+        #expect(currentGuard.authFingerprint == "new-token-material")
+
+        await store.applyOpenAIDashboard(
+            self.dashboard(email: "alpha@example.com", creditsRemaining: 9, usedPercent: 35),
+            targetEmail: "alpha@example.com",
+            expectedGuard: expectedGuard)
+
+        #expect(store.openAIDashboard == nil)
+        #expect(store.lastOpenAIDashboardSnapshot == nil)
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.credits == nil)
+        #expect(store.lastCreditsSource == .none)
+        #expect(OpenAIDashboardCacheStore.load() == nil)
+        #expect(store.openAIDashboardRequiresLogin == true)
+        #expect(store.lastOpenAIDashboardError?.contains("OpenAI dashboard signed in as alpha@example.com") == true)
+    }
 }

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshDashboardCleanupTests.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshDashboardCleanupTests.swift
@@ -119,4 +119,90 @@ extension CodexAccountScopedRefreshTests {
         #expect(store.openAIDashboardRequiresLogin == true)
         #expect(store.lastOpenAIDashboardError?.contains("OpenAI dashboard signed in as other@example.com") == true)
     }
+
+    @Test
+    func `dashboard fail closed cleanup applies after same account managed token rotation`() async throws {
+        OpenAIDashboardCacheStore.clear()
+        defer { OpenAIDashboardCacheStore.clear() }
+
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-dashboard-fail-closed-token-rotation-cleanup")
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: managedHome) }
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "managed@example.com",
+            plan: "pro",
+            accountId: "acct-managed")
+        let oldFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: managedHome.path))
+
+        let managedAccount = ManagedCodexAccount(
+            id: UUID(),
+            email: "managed@example.com",
+            providerAccountID: "acct-managed",
+            workspaceLabel: "Managed",
+            workspaceAccountID: "acct-managed",
+            authFingerprint: oldFingerprint,
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1)
+        let managedStoreURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_activeManagedCodexAccount = nil
+            try? FileManager.default.removeItem(at: managedStoreURL)
+        }
+
+        settings.refreshFrequency = .manual
+        settings.codexCookieSource = .auto
+        settings._test_managedCodexAccountStoreURL = managedStoreURL
+        settings._test_activeManagedCodexAccount = managedAccount
+        settings.codexActiveSource = .managedAccount(id: managedAccount.id)
+
+        let store = self.makeUsageStore(settings: settings)
+        let expectedGuard = store.freshCodexOpenAIWebRefreshGuard()
+        #expect(expectedGuard.authFingerprint == oldFingerprint)
+        store._setSnapshotForTesting(
+            self.codexSnapshot(email: "managed@example.com", usedPercent: 20),
+            provider: .codex)
+        store.lastSourceLabels[.codex] = "openai-web"
+        let staleCredits = self.credits(remaining: 20)
+        store.credits = staleCredits
+        store.lastCreditsSnapshot = staleCredits
+        store.lastCreditsSnapshotAccountKey = "managed@example.com"
+        store.lastCreditsSource = .dashboardWeb
+        store.openAIDashboard = self.dashboard(email: "managed@example.com", creditsRemaining: 20, usedPercent: 20)
+        store.lastOpenAIDashboardSnapshot = store.openAIDashboard
+        OpenAIDashboardCacheStore.save(OpenAIDashboardCache(
+            accountEmail: "managed@example.com",
+            snapshot: self.dashboard(email: "managed@example.com", creditsRemaining: 20, usedPercent: 20)))
+
+        try Self.writeCodexAuthFile(
+            homeURL: managedHome,
+            email: "managed@example.com",
+            plan: "team",
+            accountId: "acct-managed")
+        let newFingerprint = try #require(CodexAuthFingerprint.fingerprint(homePath: managedHome.path))
+        #expect(newFingerprint != oldFingerprint)
+        let currentGuard = store.freshCodexOpenAIWebRefreshGuard()
+        #expect(currentGuard.identity == expectedGuard.identity)
+        #expect(currentGuard.accountKey == expectedGuard.accountKey)
+        #expect(currentGuard.authFingerprint == newFingerprint)
+
+        await store.applyOpenAIDashboard(
+            self.dashboard(email: "other@example.com", creditsRemaining: 9, usedPercent: 35),
+            targetEmail: "managed@example.com",
+            expectedGuard: expectedGuard)
+
+        #expect(store.openAIDashboard == nil)
+        #expect(store.lastOpenAIDashboardSnapshot == nil)
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.credits == nil)
+        #expect(store.lastCreditsSource == .none)
+        #expect(OpenAIDashboardCacheStore.load() == nil)
+        #expect(store.openAIDashboardRequiresLogin == true)
+        #expect(store.lastOpenAIDashboardError?.contains("OpenAI dashboard signed in as other@example.com") == true)
+    }
 }

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
@@ -159,6 +159,37 @@ struct CodexAccountScopedRefreshTests {
     }
 
     @Test
+    func `same email email-only auth fingerprint switch discards stale codex usage success`() async {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-email-only-fingerprint-switch")
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "old-email-only-auth",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .emailOnly(normalizedEmail: "alpha@example.com"))
+
+        let store = self.makeUsageStore(settings: settings)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        await blocker.waitUntilStarted()
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "new-email-only-auth",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .emailOnly(normalizedEmail: "alpha@example.com"))
+        await blocker.resume(with: .success(self.codexSnapshot(email: "alpha@example.com", usedPercent: 25)))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.errors[.codex] == nil)
+    }
+
+    @Test
     func `stale codex usage failure does not clear newer account snapshot`() async {
         let settings = self.makeSettingsStore(suite: "CodexAccountScopedRefreshTests-stale-failure")
         settings.refreshFrequency = .manual

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
@@ -127,6 +127,38 @@ struct CodexAccountScopedRefreshTests {
     }
 
     @Test
+    func `same account token refresh fingerprint change keeps codex usage success`() async {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountScopedRefreshTests-token-refresh-fingerprint-change")
+        settings.refreshFrequency = .manual
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "old-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+
+        let store = self.makeUsageStore(settings: settings)
+        let blocker = BlockingCodexFetchStrategy()
+        self.installBlockingCodexProvider(on: store, blocker: blocker)
+
+        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
+        await blocker.waitUntilStarted()
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "alpha@example.com",
+            authFingerprint: "new-token-material",
+            codexHomePath: "/Users/test/.codex",
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-alpha"))
+        await blocker.resume(with: .success(self.codexSnapshot(email: "alpha@example.com", usedPercent: 25)))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex]?.primary?.usedPercent == 25)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.authFingerprint == "new-token-material")
+        #expect(store.errors[.codex] == nil)
+    }
+
+    @Test
     func `stale codex usage failure does not clear newer account snapshot`() async {
         let settings = self.makeSettingsStore(suite: "CodexAccountScopedRefreshTests-stale-failure")
         settings.refreshFrequency = .manual

--- a/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
+++ b/Tests/CodexBarTests/CodexAccountScopedRefreshTests.swift
@@ -127,69 +127,6 @@ struct CodexAccountScopedRefreshTests {
     }
 
     @Test
-    func `same account token refresh fingerprint change keeps codex usage success`() async {
-        let settings = self.makeSettingsStore(
-            suite: "CodexAccountScopedRefreshTests-token-refresh-fingerprint-change")
-        settings.refreshFrequency = .manual
-        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
-            email: "alpha@example.com",
-            authFingerprint: "old-token-material",
-            codexHomePath: "/Users/test/.codex",
-            observedAt: Date(),
-            identity: .providerAccount(id: "acct-alpha"))
-
-        let store = self.makeUsageStore(settings: settings)
-        let blocker = BlockingCodexFetchStrategy()
-        self.installBlockingCodexProvider(on: store, blocker: blocker)
-
-        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
-        await blocker.waitUntilStarted()
-        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
-            email: "alpha@example.com",
-            authFingerprint: "new-token-material",
-            codexHomePath: "/Users/test/.codex",
-            observedAt: Date(),
-            identity: .providerAccount(id: "acct-alpha"))
-        await blocker.resume(with: .success(self.codexSnapshot(email: "alpha@example.com", usedPercent: 25)))
-        await refreshTask.value
-
-        #expect(store.snapshots[.codex]?.primary?.usedPercent == 25)
-        #expect(store.lastCodexAccountScopedRefreshGuard?.authFingerprint == "new-token-material")
-        #expect(store.errors[.codex] == nil)
-    }
-
-    @Test
-    func `same email email-only auth fingerprint switch discards stale codex usage success`() async {
-        let settings = self.makeSettingsStore(
-            suite: "CodexAccountScopedRefreshTests-email-only-fingerprint-switch")
-        settings.refreshFrequency = .manual
-        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
-            email: "alpha@example.com",
-            authFingerprint: "old-email-only-auth",
-            codexHomePath: "/Users/test/.codex",
-            observedAt: Date(),
-            identity: .emailOnly(normalizedEmail: "alpha@example.com"))
-
-        let store = self.makeUsageStore(settings: settings)
-        let blocker = BlockingCodexFetchStrategy()
-        self.installBlockingCodexProvider(on: store, blocker: blocker)
-
-        let refreshTask = Task { await store.refreshProvider(.codex, allowDisabled: true) }
-        await blocker.waitUntilStarted()
-        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
-            email: "alpha@example.com",
-            authFingerprint: "new-email-only-auth",
-            codexHomePath: "/Users/test/.codex",
-            observedAt: Date(),
-            identity: .emailOnly(normalizedEmail: "alpha@example.com"))
-        await blocker.resume(with: .success(self.codexSnapshot(email: "alpha@example.com", usedPercent: 25)))
-        await refreshTask.value
-
-        #expect(store.snapshots[.codex] == nil)
-        #expect(store.errors[.codex] == nil)
-    }
-
-    @Test
     func `stale codex usage failure does not clear newer account snapshot`() async {
         let settings = self.makeSettingsStore(suite: "CodexAccountScopedRefreshTests-stale-failure")
         settings.refreshFrequency = .manual

--- a/Tests/CodexBarTests/CodexAccountVisibleHistoryBackfillTests.swift
+++ b/Tests/CodexBarTests/CodexAccountVisibleHistoryBackfillTests.swift
@@ -931,4 +931,106 @@ extension CodexAccountScopedRefreshTests {
         #expect(liveSnapshot.primary?.windowMinutes == 0)
         #expect(liveSnapshot.primary?.resetsAt == nil)
     }
+
+    @Test
+    func `ignores active reset cache and email history after live auth fingerprint changes`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountVisibleHistoryBackfillTests-live-active-auth-change")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let managedID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-333333333333"))
+        let liveHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-live-active-auth-\(UUID().uuidString)", isDirectory: true)
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-live-active-auth-managed-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: liveHome, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: managedHome, withIntermediateDirectories: true)
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "live-active-auth@example.com",
+            authFingerprint: "current-live-active-auth",
+            codexHomePath: liveHome.path,
+            observedAt: Date(),
+            identity: .emailOnly(normalizedEmail: "live-active-auth@example.com"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedID,
+            email: "managed-active-auth@example.com",
+            providerAccountID: "acct-managed-active-auth",
+            workspaceLabel: "Managed Team",
+            workspaceAccountID: "acct-managed-active-auth",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: liveHome)
+            try? FileManager.default.removeItem(at: managedHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .liveSystem
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        let now = Date()
+        let staleSessionReset = now.addingTimeInterval(2 * 60 * 60)
+        let staleWeeklyReset = now.addingTimeInterval(2 * 24 * 60 * 60)
+        store.lastCodexAccountScopedRefreshGuard = CodexAccountScopedRefreshGuard(
+            source: .liveSystem,
+            identity: .emailOnly(normalizedEmail: "live-active-auth@example.com"),
+            accountKey: "live-active-auth@example.com",
+            authFingerprint: "stale-live-active-auth")
+        store.lastKnownResetSnapshots[.codex] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 44,
+                windowMinutes: 300,
+                resetsAt: staleSessionReset,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now.addingTimeInterval(-60),
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "live-active-auth@example.com",
+                accountOrganization: nil,
+                loginMethod: nil))
+        let emailHistoryKey = CodexHistoryOwnership.canonicalEmailHashKey(for: "live-active-auth@example.com")
+        store.planUtilizationHistory[.codex] = PlanUtilizationHistoryBuckets(accounts: [
+            emailHistoryKey: [
+                planSeries(name: .session, windowMinutes: 300, entries: [
+                    planEntry(at: now.addingTimeInterval(-60), usedPercent: 44, resetsAt: staleSessionReset),
+                ]),
+                planSeries(name: .weekly, windowMinutes: 10080, entries: [
+                    planEntry(at: now.addingTimeInterval(-60), usedPercent: 55, resetsAt: staleWeeklyReset),
+                ]),
+            ],
+        ])
+        self.installContextualCodexProvider(on: store) { _ in
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 9,
+                    windowMinutes: 0,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now)
+        }
+
+        await store.refreshCodexVisibleAccountsForMenu()
+
+        let liveSnapshot = try #require(store.codexAccountSnapshots.first {
+            $0.account.selectionSource == .liveSystem
+        }?.snapshot)
+        #expect(liveSnapshot.primary?.usedPercent == 9)
+        #expect(liveSnapshot.primary?.windowMinutes == 0)
+        #expect(liveSnapshot.primary?.resetsAt == nil)
+        #expect(liveSnapshot.secondary == nil)
+    }
 }

--- a/Tests/CodexBarTests/CodexAccountVisibleHistoryBackfillTests.swift
+++ b/Tests/CodexBarTests/CodexAccountVisibleHistoryBackfillTests.swift
@@ -1033,4 +1033,508 @@ extension CodexAccountScopedRefreshTests {
         #expect(liveSnapshot.primary?.resetsAt == nil)
         #expect(liveSnapshot.secondary == nil)
     }
+
+    @Test
+    func `stacked visible refresh skips selected apply after live auth fingerprint changes`() async throws {
+        SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountVisibleHistoryBackfillTests-selected-auth-change")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let managedID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-444444444444"))
+        let liveHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-selected-auth-\(UUID().uuidString)", isDirectory: true)
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-selected-auth-managed-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: liveHome, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: managedHome, withIntermediateDirectories: true)
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "selected-auth@example.com",
+            authFingerprint: "old-live-selected-auth",
+            codexHomePath: liveHome.path,
+            observedAt: Date(),
+            identity: .emailOnly(normalizedEmail: "selected-auth@example.com"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedID,
+            email: "managed-selected-auth@example.com",
+            providerAccountID: "acct-managed-selected-auth",
+            workspaceLabel: "Managed Team",
+            workspaceAccountID: "acct-managed-selected-auth",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = nil
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: liveHome)
+            try? FileManager.default.removeItem(at: managedHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .liveSystem
+        let staleReconciliationSnapshot = settings.codexAccountReconciliationSnapshot
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        let now = Date()
+        let staleReset = now.addingTimeInterval(2 * 60 * 60)
+        let priorDisplayedSnapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 11,
+                windowMinutes: 300,
+                resetsAt: staleReset,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "selected-auth@example.com",
+                accountOrganization: nil,
+                loginMethod: nil))
+        store._setSnapshotForTesting(priorDisplayedSnapshot, provider: .codex)
+        store.lastKnownResetSnapshots[.codex] = priorDisplayedSnapshot
+        store.lastCodexAccountScopedRefreshGuard = store.currentCodexAccountScopedRefreshGuard(
+            preferCurrentSnapshot: false)
+        let blocker = BlockingCodexFetchStrategy()
+        let liveHomePath = liveHome.path
+        self.installContextualCodexProvider(on: store) { context in
+            if context.env["CODEX_HOME"] == liveHomePath {
+                return try await blocker.awaitResult()
+            }
+            return UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 7,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "managed-selected-auth@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Managed Team"))
+        }
+
+        let refreshTask = Task { await store.refreshCodexVisibleAccountsForMenu() }
+        await blocker.waitUntilStarted()
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "selected-auth@example.com",
+            authFingerprint: "new-live-selected-auth",
+            codexHomePath: liveHome.path,
+            observedAt: Date(),
+            identity: .emailOnly(normalizedEmail: "selected-auth@example.com"))
+        settings.cachedCodexAccountReconciliationSnapshot = CachedCodexAccountReconciliationSnapshot(
+            activeSource: .liveSystem,
+            loadedAt: Date(),
+            snapshot: staleReconciliationSnapshot)
+        await blocker.resume(with: .success(UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 77,
+                windowMinutes: 300,
+                resetsAt: staleReset,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "selected-auth@example.com",
+                accountOrganization: nil,
+                loginMethod: nil))))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+        #expect(!store.codexAccountSnapshots.contains {
+            $0.account.selectionSource == .liveSystem
+        })
+        #expect(!snapshotStore.storedSnapshots.contains {
+            $0.account.selectionSource == .liveSystem
+        })
+    }
+
+    @Test
+    func `stacked visible refresh keeps selected apply after live token fingerprint rotates`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountVisibleHistoryBackfillTests-selected-token-rotation")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let managedID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-888888888888"))
+        let liveHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-selected-token-\(UUID().uuidString)", isDirectory: true)
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-selected-token-managed-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: liveHome, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: managedHome, withIntermediateDirectories: true)
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "selected-token@example.com",
+            workspaceLabel: "Live Team",
+            workspaceAccountID: "acct-selected-token",
+            authFingerprint: "old-live-selected-token",
+            codexHomePath: liveHome.path,
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-selected-token"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedID,
+            email: "managed-selected-token@example.com",
+            providerAccountID: "acct-managed-selected-token",
+            workspaceLabel: "Managed Team",
+            workspaceAccountID: "acct-managed-selected-token",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: liveHome)
+            try? FileManager.default.removeItem(at: managedHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .liveSystem
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        let blocker = BlockingCodexFetchStrategy()
+        let liveHomePath = liveHome.path
+        let now = Date()
+        let reset = now.addingTimeInterval(2 * 60 * 60)
+        self.installContextualCodexProvider(on: store) { context in
+            if context.env["CODEX_HOME"] == liveHomePath {
+                return try await blocker.awaitResult()
+            }
+            return UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 7,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "managed-selected-token@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Managed Team"))
+        }
+
+        let refreshTask = Task { await store.refreshCodexVisibleAccountsForMenu() }
+        await blocker.waitUntilStarted()
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "selected-token@example.com",
+            workspaceLabel: "Live Team",
+            workspaceAccountID: "acct-selected-token",
+            authFingerprint: "new-live-selected-token",
+            codexHomePath: liveHome.path,
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-selected-token"))
+        await blocker.resume(with: .success(UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 77,
+                windowMinutes: 300,
+                resetsAt: reset,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "selected-token@example.com",
+                accountOrganization: nil,
+                loginMethod: "Pro"))))
+        await refreshTask.value
+
+        let selectedSnapshot = try #require(store.snapshots[.codex])
+        #expect(selectedSnapshot.primary?.usedPercent == 77)
+        #expect(selectedSnapshot.accountEmail(for: .codex) == "selected-token@example.com")
+        #expect(selectedSnapshot.loginMethod(for: .codex) == "Pro")
+        #expect(store.lastCodexAccountScopedRefreshGuard?.authFingerprint == "new-live-selected-token")
+
+        let liveRow = try #require(store.codexAccountSnapshots.first {
+            $0.account.selectionSource == .liveSystem
+        })
+        #expect(liveRow.account.authFingerprint == "new-live-selected-token")
+        #expect(liveRow.snapshot?.primary?.usedPercent == 77)
+
+        let persistedLive = try #require(snapshotStore.storedSnapshots.first {
+            $0.account.selectionSource == .liveSystem
+        })
+        #expect(persistedLive.account.authFingerprint == "new-live-selected-token")
+        #expect(persistedLive.snapshot?.primary?.usedPercent == 77)
+    }
+
+    @Test
+    func `stacked visible refresh clears selected state after live account email changes`() async throws {
+        SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountVisibleHistoryBackfillTests-selected-email-change")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let managedID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-777777777777"))
+        let liveHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-selected-email-\(UUID().uuidString)", isDirectory: true)
+        let managedHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-selected-email-managed-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: liveHome, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: managedHome, withIntermediateDirectories: true)
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "old-selected@example.com",
+            workspaceLabel: "Live Team",
+            workspaceAccountID: "acct-selected-email",
+            authFingerprint: "old-live-selected-email",
+            codexHomePath: liveHome.path,
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-selected-email"))
+        let managedAccount = ManagedCodexAccount(
+            id: managedID,
+            email: "managed-selected-email@example.com",
+            providerAccountID: "acct-managed-selected-email",
+            workspaceLabel: "Managed Team",
+            workspaceAccountID: "acct-managed-selected-email",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [managedAccount])
+        defer {
+            SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = nil
+            settings._test_managedCodexAccountStoreURL = nil
+            settings._test_liveSystemCodexAccount = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: liveHome)
+            try? FileManager.default.removeItem(at: managedHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .liveSystem
+        let staleReconciliationSnapshot = settings.codexAccountReconciliationSnapshot
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        let now = Date()
+        let staleReset = now.addingTimeInterval(2 * 60 * 60)
+        let priorDisplayedSnapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 11,
+                windowMinutes: 300,
+                resetsAt: staleReset,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "old-selected@example.com",
+                accountOrganization: nil,
+                loginMethod: nil))
+        store._setSnapshotForTesting(priorDisplayedSnapshot, provider: .codex)
+        store.lastKnownResetSnapshots[.codex] = priorDisplayedSnapshot
+        store.lastCodexAccountScopedRefreshGuard = store.currentCodexAccountScopedRefreshGuard(
+            preferCurrentSnapshot: false)
+        let blocker = BlockingCodexFetchStrategy()
+        let liveHomePath = liveHome.path
+        self.installContextualCodexProvider(on: store) { context in
+            if context.env["CODEX_HOME"] == liveHomePath {
+                return try await blocker.awaitResult()
+            }
+            return UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 7,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "managed-selected-email@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Managed Team"))
+        }
+
+        let refreshTask = Task { await store.refreshCodexVisibleAccountsForMenu() }
+        await blocker.waitUntilStarted()
+        settings._test_liveSystemCodexAccount = ObservedSystemCodexAccount(
+            email: "new-selected@example.com",
+            workspaceLabel: "Live Team",
+            workspaceAccountID: "acct-selected-email",
+            authFingerprint: "new-live-selected-email",
+            codexHomePath: liveHome.path,
+            observedAt: Date(),
+            identity: .providerAccount(id: "acct-selected-email"))
+        settings.cachedCodexAccountReconciliationSnapshot = CachedCodexAccountReconciliationSnapshot(
+            activeSource: .liveSystem,
+            loadedAt: Date(),
+            snapshot: staleReconciliationSnapshot)
+        await blocker.resume(with: .success(UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 77,
+                windowMinutes: 300,
+                resetsAt: staleReset,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "old-selected@example.com",
+                accountOrganization: nil,
+                loginMethod: nil))))
+        await refreshTask.value
+
+        #expect(store.snapshots[.codex] == nil)
+        #expect(store.lastKnownResetSnapshots[.codex] == nil)
+        #expect(store.codexAccountSnapshots.isEmpty)
+        #expect(!snapshotStore.storedSnapshots.contains {
+            $0.account.selectionSource == .liveSystem
+        })
+    }
+
+    @Test
+    func `stacked visible refresh keeps selected apply after provider account email changes`() async throws {
+        let settings = self.makeSettingsStore(
+            suite: "CodexAccountVisibleHistoryBackfillTests-selected-provider-email-change")
+        settings.refreshFrequency = .manual
+        settings.multiAccountMenuLayout = .stacked
+
+        let targetID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-555555555555"))
+        let siblingID = try #require(UUID(uuidString: "DDDDDDDD-EEEE-FFFF-AAAA-666666666666"))
+        let targetHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-provider-email-\(UUID().uuidString)", isDirectory: true)
+        let siblingHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codex-visible-provider-email-sibling-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: targetHome, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: siblingHome, withIntermediateDirectories: true)
+        let originalTarget = ManagedCodexAccount(
+            id: targetID,
+            email: "old-provider@example.com",
+            providerAccountID: "acct-provider-email",
+            workspaceLabel: "Provider Team",
+            workspaceAccountID: "acct-provider-email",
+            managedHomePath: targetHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let updatedTarget = ManagedCodexAccount(
+            id: targetID,
+            email: "new-provider@example.com",
+            providerAccountID: "acct-provider-email",
+            workspaceLabel: "Provider Team",
+            workspaceAccountID: "acct-provider-email",
+            managedHomePath: targetHome.path,
+            createdAt: 1,
+            updatedAt: 3,
+            lastAuthenticatedAt: 3)
+        let siblingAccount = ManagedCodexAccount(
+            id: siblingID,
+            email: "sibling-provider@example.com",
+            providerAccountID: "acct-provider-sibling",
+            workspaceLabel: "Sibling Team",
+            workspaceAccountID: "acct-provider-sibling",
+            managedHomePath: siblingHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2)
+        let storeURL = try self.makeManagedAccountStoreURL(accounts: [originalTarget, siblingAccount])
+        defer {
+            settings._test_managedCodexAccountStoreURL = nil
+            try? FileManager.default.removeItem(at: storeURL)
+            try? FileManager.default.removeItem(at: targetHome)
+            try? FileManager.default.removeItem(at: siblingHome)
+        }
+        settings._test_managedCodexAccountStoreURL = storeURL
+        settings.codexActiveSource = .managedAccount(id: targetID)
+
+        let snapshotStore = RecordingCodexAccountUsageSnapshotStore(initialSnapshots: [])
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            codexAccountUsageSnapshotStore: snapshotStore,
+            startupBehavior: .testing)
+        let blocker = BlockingCodexFetchStrategy()
+        let targetHomePath = targetHome.path
+        let now = Date()
+        let reset = now.addingTimeInterval(90 * 60)
+        self.installContextualCodexProvider(on: store) { context in
+            if context.env["CODEX_HOME"] == targetHomePath {
+                return try await blocker.awaitResult()
+            }
+            return UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 11,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                secondary: nil,
+                updatedAt: now,
+                identity: ProviderIdentitySnapshot(
+                    providerID: .codex,
+                    accountEmail: "sibling-provider@example.com",
+                    accountOrganization: nil,
+                    loginMethod: "Sibling Team"))
+        }
+
+        let refreshTask = Task { await store.refreshCodexVisibleAccountsForMenu() }
+        await blocker.waitUntilStarted()
+        try FileManagedCodexAccountStore(fileURL: storeURL).storeAccounts(ManagedCodexAccountSet(
+            version: FileManagedCodexAccountStore.currentVersion,
+            accounts: [updatedTarget, siblingAccount]))
+        await blocker.resume(with: .success(UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 64,
+                windowMinutes: 300,
+                resetsAt: reset,
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .codex,
+                accountEmail: "old-provider@example.com",
+                accountOrganization: nil,
+                loginMethod: "Pro"))))
+        await refreshTask.value
+
+        let selectedSnapshot = try #require(store.snapshots[.codex])
+        #expect(selectedSnapshot.primary?.usedPercent == 64)
+        #expect(selectedSnapshot.accountEmail(for: .codex) == "new-provider@example.com")
+        #expect(selectedSnapshot.loginMethod(for: .codex) == "Pro")
+        #expect(store.lastKnownResetSnapshots[.codex]?.primary?.resetsAt == reset)
+        #expect(store.lastCodexAccountScopedRefreshGuard?.accountKey == "new-provider@example.com")
+
+        let targetRow = try #require(store.codexAccountSnapshots.first {
+            $0.account.workspaceAccountID == "acct-provider-email"
+        })
+        #expect(targetRow.account.email == "new-provider@example.com")
+        #expect(targetRow.snapshot?.primary?.usedPercent == 64)
+        #expect(targetRow.snapshot?.accountEmail(for: .codex) == "new-provider@example.com")
+        #expect(targetRow.snapshot?.loginMethod(for: .codex) == "Pro")
+
+        let persistedTarget = try #require(snapshotStore.storedSnapshots.first {
+            $0.account.workspaceAccountID == "acct-provider-email"
+        })
+        #expect(persistedTarget.account.email == "new-provider@example.com")
+        #expect(persistedTarget.snapshot?.primary?.usedPercent == 64)
+        #expect(persistedTarget.snapshot?.accountEmail(for: .codex) == "new-provider@example.com")
+        #expect(persistedTarget.snapshot?.loginMethod(for: .codex) == "Pro")
+    }
 }

--- a/Tests/CodexBarTests/PathBuilderTests.swift
+++ b/Tests/CodexBarTests/PathBuilderTests.swift
@@ -45,16 +45,16 @@ struct PathBuilderTests {
     }
 
     @Test
-    func `login shell cache retries after timed out nil capture`() throws {
-        let shell = try Self.makeLoginShellPathScript(
-            delay: 0.2,
-            path: "/login/bin:/usr/bin")
-        defer { try? FileManager.default.removeItem(at: shell) }
+    func `login shell cache retries after timed out nil capture`() {
+        let capture = LoginShellPathCaptureStub([
+            nil,
+            ["/login/bin", "/usr/bin"],
+        ])
 
-        let cache = LoginShellPathCache()
+        let cache = LoginShellPathCache { _, _ in capture.next() }
         let semaphore = DispatchSemaphore(value: 0)
         var firstResult: [String]?
-        cache.captureOnce(shell: shell.path, timeout: 0.01) { result in
+        cache.captureOnce(shell: "/unused", timeout: 0.01) { result in
             firstResult = result
             semaphore.signal()
         }
@@ -63,9 +63,10 @@ struct PathBuilderTests {
         #expect(firstResult == nil)
         #expect(cache.current == nil)
 
-        let recovered = cache.currentOrCapture(shell: shell.path, timeout: 2.0)
+        let recovered = cache.currentOrCapture(shell: "/unused", timeout: 2.0)
         #expect(recovered == ["/login/bin", "/usr/bin"])
         #expect(cache.current == ["/login/bin", "/usr/bin"])
+        #expect(capture.callCount == 2)
     }
 
     @Test
@@ -650,18 +651,28 @@ struct PathBuilderTests {
     private static func shellSingleQuoted(_ value: String) -> String {
         "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
+}
 
-    private static func makeLoginShellPathScript(delay: TimeInterval, path: String) throws -> URL {
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("codexbar-login-path-\(UUID().uuidString).sh")
-        let script = """
-        #!/bin/sh
-        sleep \(delay)
-        printf '__CODEXBAR_PATH__%s__CODEXBAR_PATH__' \(self.shellSingleQuoted(path))
-        """
-        try script.write(to: url, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
-        return url
+private final class LoginShellPathCaptureStub: @unchecked Sendable {
+    private let lock = NSLock()
+    private var results: [[String]?]
+    private var callCountStorage = 0
+
+    var callCount: Int {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.callCountStorage
+    }
+
+    init(_ results: [[String]?]) {
+        self.results = results
+    }
+
+    func next() -> [String]? {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        self.callCountStorage += 1
+        return self.results.isEmpty ? nil : self.results.removeFirst()
     }
 }
 

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -80,6 +80,8 @@ struct UsageStoreCoverageTests {
 
         try Self.writeCodexAuthFile(homeURL: home, email: "first@example.com", plan: "plus")
         let env = ["CODEX_HOME": home.path]
+        settings._test_codexReconciliationEnvironment = env
+        defer { settings._test_codexReconciliationEnvironment = nil }
         let store = UsageStore(
             fetcher: UsageFetcher(environment: env),
             browserDetection: BrowserDetection(cacheTTL: 0),


### PR DESCRIPTION
## Summary
- Preserve Codex account reset-window history across managed-account auth refreshes and dashboard identity cleanup.
- Hydrate startup account snapshots from live managed auth state so cached reset windows do not disappear after `auth.json` rotates.
- Stabilize the login-shell cache retry regression test that became flaky in the full suite.

Fixes #1283.

## Proof
- `make check`
- `swift test --filter PathBuilderTests`
- `swift test`
- `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
