### PR TITLE
perf: cut menu readiness signature cost on store changes

### DIFF
--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -85,6 +85,11 @@ extension StatusItemController {
         self.cancelDeferredMenuInteractionRefreshTask()
         self.cancelClosedMenuRebuild(menu)
 
+        // Track whether this is the root menu opening (no menus were open). Only the root open rebuilds
+        // all content from current data, so the readiness baseline is re-anchored only here — re-anchoring
+        // on a nested submenu open could mask a pending refresh for the already-open parent menu.
+        let menuTrackingWasIdle = self.openMenus.isEmpty
+
         if self.isHostedSubviewMenu(menu) {
             self.hydrateHostedSubviewMenuIfNeeded(menu)
             self.refreshHostedSubviewHeights(in: menu)
@@ -95,6 +100,9 @@ extension StatusItemController {
                 // Intentionally skip open-menu tracking when refresh is disabled (tests).
                 // If refresh is re-enabled while this menu stays open, it will not be backfilled until next open.
                 self.openMenus[ObjectIdentifier(menu)] = menu
+                if menuTrackingWasIdle {
+                    self.resyncMenuAdjunctReadinessBaseline()
+                }
             }
             // Removed redundant async refresh - single pass is sufficient after initial layout
             return
@@ -128,6 +136,9 @@ extension StatusItemController {
             // Intentionally skip open-menu tracking when refresh is disabled (tests).
             // If refresh is re-enabled while this menu stays open, it will not be backfilled until next open.
             self.openMenus[ObjectIdentifier(menu)] = menu
+            if menuTrackingWasIdle {
+                self.resyncMenuAdjunctReadinessBaseline()
+            }
             self.installProviderSwitcherShortcutMonitorIfNeeded(for: menu)
             // Only schedule refresh after menu is registered as open - refreshNow is called async
             self.scheduleOpenMenuRefresh(for: menu)

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -136,7 +136,10 @@ extension StatusItemController {
             // Intentionally skip open-menu tracking when refresh is disabled (tests).
             // If refresh is re-enabled while this menu stays open, it will not be backfilled until next open.
             self.openMenus[ObjectIdentifier(menu)] = menu
-            if menuTrackingWasIdle {
+            // Only re-anchor when the opened menu actually shows current data. During an in-flight provider
+            // refresh `refreshMenuForOpenIfNeeded` can preserve stale content; resyncing the baseline to
+            // live store data in that case would mask the refresh-completion update (#1351).
+            if menuTrackingWasIdle, !self.menuNeedsRefresh(menu) {
                 self.resyncMenuAdjunctReadinessBaseline()
             }
             self.installProviderSwitcherShortcutMonitorIfNeeded(for: menu)

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -131,6 +131,7 @@ extension StatusItemController {
             self.deferOpenAIDashboardRefreshUntilMenuCloses(reason: "parent menu open")
         }
 
+        let menuWasFreshBeforeOpen = !self.menuNeedsRefresh(menu)
         self.refreshMenuForOpenIfNeeded(menu, provider: provider)
         if self.isMenuRefreshEnabled {
             // Intentionally skip open-menu tracking when refresh is disabled (tests).
@@ -140,7 +141,10 @@ extension StatusItemController {
             // refresh `refreshMenuForOpenIfNeeded` can preserve stale content; resyncing the baseline to
             // live store data in that case would mask the refresh-completion update (#1351).
             if menuTrackingWasIdle, !self.menuNeedsRefresh(menu) {
-                self.resyncMenuAdjunctReadinessBaseline()
+                self.resyncMenuAdjunctReadinessBaselineForRootOpen(
+                    menu,
+                    provider: provider,
+                    menuWasFreshBeforeOpen: menuWasFreshBeforeOpen)
             }
             self.installProviderSwitcherShortcutMonitorIfNeeded(for: menu)
             // Only schedule refresh after menu is registered as open - refreshNow is called async

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -27,6 +27,10 @@ extension StatusItemController {
 
     /// Resyncs a root-menu baseline after open and handles the narrow race where a store change
     /// has updated live data but its deferred observation task has not invalidated menus yet.
+    ///
+    /// If a previously fresh menu sees new live data before the observer version tick, invalidate all
+    /// menus first, rebuild only the opened menu, then consume the matching observer. This keeps sibling
+    /// provider menus stale instead of globally acknowledging data they have not rendered.
     func resyncMenuAdjunctReadinessBaselineForRootOpen(
         _ menu: NSMenu,
         provider: UsageProvider?,
@@ -36,6 +40,7 @@ extension StatusItemController {
         guard signature != self.lastMenuAdjunctReadinessSignature else { return }
 
         if menuWasFreshBeforeOpen {
+            self.invalidateMenus()
             self.populateMenu(menu, provider: provider)
             self.markMenuFresh(menu)
             self.rememberRootOpenHandledMenuObservation(signature: signature)

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -11,6 +11,17 @@ extension StatusItemController {
         return signature != self.lastMenuAdjunctReadinessSignature
     }
 
+    /// Resyncs the readiness baseline to the data the menu was just built from.
+    ///
+    /// Because the baseline is no longer recomputed on every store change while all menus are closed,
+    /// it can drift from the live store state. When a root menu opens it is rebuilt from current data,
+    /// so the baseline must be re-anchored here; otherwise a later open-menu store change that happens
+    /// to revert to the stale baseline value would be treated as "unchanged" and skip a needed rebuild,
+    /// leaving the visible menu showing the older content.
+    func resyncMenuAdjunctReadinessBaseline() {
+        self.lastMenuAdjunctReadinessSignature = self.menuAdjunctReadinessSignature()
+    }
+
     func menuAdjunctReadinessSignature() -> String {
         let dashboard = self.store.openAIDashboard
         let dashboardUsageBreakdown = OpenAIDashboardDailyBreakdown.removingSkillUsageServices(

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -7,7 +7,7 @@ extension StatusItemController {
 
     func didMenuAdjunctReadinessChange() -> Bool {
         let signature = self.menuAdjunctReadinessSignature()
-        defer { self.lastMenuAdjunctReadinessSignature = signature }
+        defer { self.recordMenuAdjunctReadinessBaseline(signature) }
         return signature != self.lastMenuAdjunctReadinessSignature
     }
 
@@ -22,7 +22,7 @@ extension StatusItemController {
     /// content during an in-flight refresh — that would record live store data while the visible menu
     /// still shows older content and mask the refresh-completion update.
     func resyncMenuAdjunctReadinessBaseline() {
-        self.lastMenuAdjunctReadinessSignature = self.menuAdjunctReadinessSignature()
+        self.recordMenuAdjunctReadinessBaseline(self.menuAdjunctReadinessSignature())
     }
 
     /// Resyncs a root-menu baseline after open and handles the narrow race where a store change
@@ -40,13 +40,27 @@ extension StatusItemController {
         guard signature != self.lastMenuAdjunctReadinessSignature else { return }
 
         if menuWasFreshBeforeOpen {
-            guard !self.isMenuDataRefreshInFlight else { return }
+            let menuKey = ObjectIdentifier(menu)
+            let menuIsFreshForNewerVersion = self.menuVersions[menuKey] == self.menuContentVersion &&
+                self.menuContentVersion > self.lastMenuAdjunctReadinessBaselineVersion
+            if self.isMenuDataRefreshInFlight, !menuIsFreshForNewerVersion {
+                return
+            }
+            if menuIsFreshForNewerVersion {
+                self.recordMenuAdjunctReadinessBaseline(signature)
+                return
+            }
             self.invalidateMenus()
             self.populateMenu(menu, provider: provider)
             self.markMenuFresh(menu)
             self.rememberRootOpenHandledMenuObservation(signature: signature)
         }
+        self.recordMenuAdjunctReadinessBaseline(signature)
+    }
+
+    private func recordMenuAdjunctReadinessBaseline(_ signature: String) {
         self.lastMenuAdjunctReadinessSignature = signature
+        self.lastMenuAdjunctReadinessBaselineVersion = self.menuContentVersion
     }
 
     private func rememberRootOpenHandledMenuObservation(signature: String) {
@@ -67,7 +81,7 @@ extension StatusItemController {
             return false
         }
         self.rootOpenHandledMenuObservationSignature = nil
-        self.lastMenuAdjunctReadinessSignature = signature
+        self.recordMenuAdjunctReadinessBaseline(signature)
         return true
     }
 

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -40,6 +40,7 @@ extension StatusItemController {
         guard signature != self.lastMenuAdjunctReadinessSignature else { return }
 
         if menuWasFreshBeforeOpen {
+            guard !self.isMenuDataRefreshInFlight else { return }
             self.invalidateMenus()
             self.populateMenu(menu, provider: provider)
             self.markMenuFresh(menu)

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -14,10 +14,13 @@ extension StatusItemController {
     /// Resyncs the readiness baseline to the data the menu was just built from.
     ///
     /// Because the baseline is no longer recomputed on every store change while all menus are closed,
-    /// it can drift from the live store state. When a root menu opens it is rebuilt from current data,
-    /// so the baseline must be re-anchored here; otherwise a later open-menu store change that happens
-    /// to revert to the stale baseline value would be treated as "unchanged" and skip a needed rebuild,
-    /// leaving the visible menu showing the older content.
+    /// it can drift from the live store state. When a root menu opens and is actually rebuilt (or is
+    /// already fresh for the current `menuContentVersion`), the baseline must be re-anchored here;
+    /// otherwise a later open-menu store change that happens to revert to the stale baseline value would
+    /// be treated as "unchanged" and skip a needed rebuild, leaving the visible menu showing the older
+    /// content. Callers must **not** invoke this when `refreshMenuForOpenIfNeeded` preserved stale
+    /// content during an in-flight refresh — that would record live store data while the visible menu
+    /// still shows older content and mask the refresh-completion update.
     func resyncMenuAdjunctReadinessBaseline() {
         self.lastMenuAdjunctReadinessSignature = self.menuAdjunctReadinessSignature()
     }

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -37,15 +37,24 @@ extension StatusItemController {
         menuWasFreshBeforeOpen: Bool)
     {
         let signature = self.menuAdjunctReadinessSignature()
+        let menuKey = ObjectIdentifier(menu)
+        let menuRenderedCurrentSignature = self.menuVersions[menuKey] == self.menuContentVersion &&
+            self.menuReadinessSignatures[menuKey] == signature
         guard signature != self.lastMenuAdjunctReadinessSignature else {
-            self.lastMenuAdjunctReadinessBaselineVersion = self.menuContentVersion
+            guard menuWasFreshBeforeOpen, !menuRenderedCurrentSignature else {
+                self.lastMenuAdjunctReadinessBaselineVersion = self.menuContentVersion
+                return
+            }
+            guard !self.isMenuDataRefreshInFlight else { return }
+            self.invalidateMenus()
+            self.populateMenu(menu, provider: provider)
+            self.markMenuFresh(menu)
+            self.rememberRootOpenHandledMenuObservation(signature: signature)
+            self.recordMenuAdjunctReadinessBaseline(signature)
             return
         }
 
         if menuWasFreshBeforeOpen {
-            let menuKey = ObjectIdentifier(menu)
-            let menuRenderedCurrentSignature = self.menuVersions[menuKey] == self.menuContentVersion &&
-                self.menuReadinessSignatures[menuKey] == signature
             if self.isMenuDataRefreshInFlight, !menuRenderedCurrentSignature {
                 return
             }

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -29,8 +29,8 @@ extension StatusItemController {
     /// has updated live data but its deferred observation task has not invalidated menus yet.
     ///
     /// If a previously fresh menu sees new live data before the observer version tick, invalidate all
-    /// menus first, rebuild only the opened menu, then consume the matching observer. This keeps sibling
-    /// provider menus stale instead of globally acknowledging data they have not rendered.
+    /// menus first and rebuild only the opened menu. The matching observer can then skip the expensive
+    /// readiness comparison while still invalidating menu-observed state that is not in the signature.
     func resyncMenuAdjunctReadinessBaselineForRootOpen(
         _ menu: NSMenu,
         provider: UsageProvider?,

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -89,8 +89,12 @@ extension StatusItemController {
         return self.formatDoubleForSignature(value)
     }
 
+    /// The signature is only ever compared for equality against the previous signature, so it does
+    /// not need a human-readable decimal form. `String(format: "%.8f", …)` is a surprisingly hot
+    /// cost here because it runs for every daily/service value across every enabled provider on each
+    /// store mutation. The raw bit pattern is both exact (no rounding collisions) and far cheaper.
     private static func formatDoubleForSignature(_ value: Double) -> String {
-        String(format: "%.8f", value)
+        String(value.bitPattern, radix: 16)
     }
 
     func performMenuMutationWithoutAnimation(_ updates: () -> Void) {

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -37,7 +37,10 @@ extension StatusItemController {
         menuWasFreshBeforeOpen: Bool)
     {
         let signature = self.menuAdjunctReadinessSignature()
-        guard signature != self.lastMenuAdjunctReadinessSignature else { return }
+        guard signature != self.lastMenuAdjunctReadinessSignature else {
+            self.lastMenuAdjunctReadinessBaselineVersion = self.menuContentVersion
+            return
+        }
 
         if menuWasFreshBeforeOpen {
             let menuKey = ObjectIdentifier(menu)

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -25,6 +25,46 @@ extension StatusItemController {
         self.lastMenuAdjunctReadinessSignature = self.menuAdjunctReadinessSignature()
     }
 
+    /// Resyncs a root-menu baseline after open and handles the narrow race where a store change
+    /// has updated live data but its deferred observation task has not invalidated menus yet.
+    func resyncMenuAdjunctReadinessBaselineForRootOpen(
+        _ menu: NSMenu,
+        provider: UsageProvider?,
+        menuWasFreshBeforeOpen: Bool)
+    {
+        let signature = self.menuAdjunctReadinessSignature()
+        guard signature != self.lastMenuAdjunctReadinessSignature else { return }
+
+        if menuWasFreshBeforeOpen {
+            self.populateMenu(menu, provider: provider)
+            self.markMenuFresh(menu)
+            self.rememberRootOpenHandledMenuObservation(signature: signature)
+        }
+        self.lastMenuAdjunctReadinessSignature = signature
+    }
+
+    private func rememberRootOpenHandledMenuObservation(signature: String) {
+        self.rootOpenHandledMenuObservationSignature = signature
+        Task { @MainActor [weak self] in
+            await Task.yield()
+            if self?.rootOpenHandledMenuObservationSignature == signature {
+                self?.rootOpenHandledMenuObservationSignature = nil
+            }
+        }
+    }
+
+    func consumeRootOpenHandledMenuObservationIfNeeded() -> Bool {
+        guard let handledSignature = self.rootOpenHandledMenuObservationSignature else { return false }
+        let signature = self.menuAdjunctReadinessSignature()
+        guard signature == handledSignature else {
+            self.rootOpenHandledMenuObservationSignature = nil
+            return false
+        }
+        self.rootOpenHandledMenuObservationSignature = nil
+        self.lastMenuAdjunctReadinessSignature = signature
+        return true
+    }
+
     func menuAdjunctReadinessSignature() -> String {
         let dashboard = self.store.openAIDashboard
         let dashboardUsageBreakdown = OpenAIDashboardDailyBreakdown.removingSkillUsageServices(

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -44,12 +44,12 @@ extension StatusItemController {
 
         if menuWasFreshBeforeOpen {
             let menuKey = ObjectIdentifier(menu)
-            let menuIsFreshForNewerVersion = self.menuVersions[menuKey] == self.menuContentVersion &&
-                self.menuContentVersion > self.lastMenuAdjunctReadinessBaselineVersion
-            if self.isMenuDataRefreshInFlight, !menuIsFreshForNewerVersion {
+            let menuRenderedCurrentSignature = self.menuVersions[menuKey] == self.menuContentVersion &&
+                self.menuReadinessSignatures[menuKey] == signature
+            if self.isMenuDataRefreshInFlight, !menuRenderedCurrentSignature {
                 return
             }
-            if menuIsFreshForNewerVersion {
+            if menuRenderedCurrentSignature {
                 self.recordMenuAdjunctReadinessBaseline(signature)
                 return
             }

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -91,6 +91,7 @@ extension StatusItemController {
     func clearTransientMenuTrackingState(_ key: ObjectIdentifier) {
         self.menuProviders.removeValue(forKey: key)
         self.menuVersions.removeValue(forKey: key)
+        self.menuReadinessSignatures.removeValue(forKey: key)
         self.closedMenusDeferredUntilNextOpen.remove(key)
     }
 
@@ -227,6 +228,7 @@ extension StatusItemController {
     func markMenuFresh(_ menu: NSMenu) {
         let key = ObjectIdentifier(menu)
         self.menuVersions[key] = self.menuContentVersion
+        self.menuReadinessSignatures[key] = self.menuAdjunctReadinessSignature()
     }
 
     func hasOpenHostedSubviewMenu() -> Bool {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -119,6 +119,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var menuVersions: [ObjectIdentifier: Int] = [:]
     var menuCardHeightCache: [MenuCardHeightCacheKey: CGFloat] = [:]
     var lastMenuAdjunctReadinessSignature = ""
+    var lastMenuAdjunctReadinessBaselineVersion = 0
     var rootOpenHandledMenuObservationSignature: String?
     var mergedMenu: NSMenu?
     var providerMenus: [UsageProvider: NSMenu] = [:]
@@ -374,6 +375,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
                 metadata: ["keys": repairedStatusItemVisibilityKeys.joined(separator: ",")])
         }
         self.lastMenuAdjunctReadinessSignature = self.menuAdjunctReadinessSignature()
+        self.lastMenuAdjunctReadinessBaselineVersion = self.menuContentVersion
         self.wireBindings()
         self.updateVisibility()
         self.updateIcons()

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -119,6 +119,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var menuVersions: [ObjectIdentifier: Int] = [:]
     var menuCardHeightCache: [MenuCardHeightCacheKey: CGFloat] = [:]
     var lastMenuAdjunctReadinessSignature = ""
+    var rootOpenHandledMenuObservationSignature: String?
     var mergedMenu: NSMenu?
     var providerMenus: [UsageProvider: NSMenu] = [:]
     var fallbackMenu: NSMenu?
@@ -443,20 +444,27 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         } onChange: { [weak self] in
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                self.observeStoreChanges()
-                // `refreshOpenMenus` is only consulted when a menu is currently open.
-                // Computing the readiness signature serializes every enabled provider's
-                // token snapshot and 30-day daily breakdown, which is wasted main-thread
-                // work on the common path where no menu is open (background refresh ticks).
-                let refreshOpenMenus = self.openMenus.isEmpty
-                    ? false
-                    : self.didMenuAdjunctReadinessChange()
-                self.invalidateMenus(
-                    refreshOpenMenus: refreshOpenMenus,
-                    deferOpenParentMenuRebuild: true,
-                    allowStaleContentDuringDataRefresh: true)
+                self.handleObservedStoreMenuChange()
             }
         }
+    }
+
+    func handleObservedStoreMenuChange() {
+        self.observeStoreChanges()
+        if self.consumeRootOpenHandledMenuObservationIfNeeded() {
+            return
+        }
+        // `refreshOpenMenus` is only consulted when a menu is currently open.
+        // Computing the readiness signature serializes every enabled provider's
+        // token snapshot and 30-day daily breakdown, which is wasted main-thread
+        // work on the common path where no menu is open (background refresh ticks).
+        let refreshOpenMenus = self.openMenus.isEmpty
+            ? false
+            : self.didMenuAdjunctReadinessChange()
+        self.invalidateMenus(
+            refreshOpenMenus: refreshOpenMenus,
+            deferOpenParentMenuRebuild: true,
+            allowStaleContentDuringDataRefresh: true)
     }
 
     private func observeStoreIconChanges() {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -444,8 +444,15 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.observeStoreChanges()
+                // `refreshOpenMenus` is only consulted when a menu is currently open.
+                // Computing the readiness signature serializes every enabled provider's
+                // token snapshot and 30-day daily breakdown, which is wasted main-thread
+                // work on the common path where no menu is open (background refresh ticks).
+                let refreshOpenMenus = self.openMenus.isEmpty
+                    ? false
+                    : self.didMenuAdjunctReadinessChange()
                 self.invalidateMenus(
-                    refreshOpenMenus: self.didMenuAdjunctReadinessChange(),
+                    refreshOpenMenus: refreshOpenMenus,
                     deferOpenParentMenuRebuild: true,
                     allowStaleContentDuringDataRefresh: true)
             }

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -451,16 +451,14 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
 
     func handleObservedStoreMenuChange() {
         self.observeStoreChanges()
-        if self.consumeRootOpenHandledMenuObservationIfNeeded() {
-            return
-        }
+        let rootOpenHandledReadiness = self.consumeRootOpenHandledMenuObservationIfNeeded()
         // `refreshOpenMenus` is only consulted when a menu is currently open.
         // Computing the readiness signature serializes every enabled provider's
         // token snapshot and 30-day daily breakdown, which is wasted main-thread
         // work on the common path where no menu is open (background refresh ticks).
         let refreshOpenMenus = self.openMenus.isEmpty
             ? false
-            : self.didMenuAdjunctReadinessChange()
+            : rootOpenHandledReadiness || self.didMenuAdjunctReadinessChange()
         self.invalidateMenus(
             refreshOpenMenus: refreshOpenMenus,
             deferOpenParentMenuRebuild: true,

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -117,6 +117,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var menuContentVersion: Int = 0
     var latestRequiredMenuRebuildVersion: Int = 0
     var menuVersions: [ObjectIdentifier: Int] = [:]
+    var menuReadinessSignatures: [ObjectIdentifier: String] = [:]
     var menuCardHeightCache: [MenuCardHeightCacheKey: CGFloat] = [:]
     var lastMenuAdjunctReadinessSignature = ""
     var lastMenuAdjunctReadinessBaselineVersion = 0

--- a/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
+++ b/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
@@ -1,0 +1,100 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+extension StatusMenuTests {
+    @Test
+    func `reopening root menu resyncs readiness baseline so reverted store data still refreshes`() {
+        // Regression for the readiness-signature optimization (#1351): the baseline is no longer
+        // recomputed on every store change while menus are closed, so it must be re-anchored when a
+        // root menu opens. Otherwise a closed-then-reopened menu built from new data, followed by an
+        // open-menu change that reverts to the *previous* baseline value, would be treated as
+        // "unchanged" and skip the rebuild, leaving the visible menu showing stale content.
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.costUsageEnabled = true
+        self.enableOnlyCodexForReadinessBaseline(settings)
+
+        let snapshotA = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 111,
+            sessionCostUSD: 1.11,
+            last30DaysTokens: 1111,
+            last30DaysCostUSD: 11.11,
+            updatedAt: Date(timeIntervalSince1970: 100))
+        let snapshotB = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 222,
+            sessionCostUSD: 2.22,
+            last30DaysTokens: 2222,
+            last30DaysCostUSD: 22.22,
+            updatedAt: Date(timeIntervalSince1970: 200))
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._setTokenSnapshotForTesting(snapshotA, provider: .codex)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let menu = controller.makeMenu()
+
+        // Root open anchors the baseline to snapshot A. Normalize via an explicit comparison so the
+        // assertion below is independent of whatever the controller's initial baseline happened to be.
+        controller.menuWillOpen(menu)
+        _ = controller.didMenuAdjunctReadinessChange()
+        controller.menuDidClose(menu)
+
+        // Closed store change to B: the optimization intentionally skips recomputing the baseline here.
+        store._setTokenSnapshotForTesting(snapshotB, provider: .codex)
+
+        // Reopening the root menu rebuilds from B and must re-anchor the baseline to B.
+        controller.menuWillOpen(menu)
+        controller.menuDidClose(menu)
+
+        // Reverting to A (the value the *first* baseline held) must still register as a change.
+        store._setTokenSnapshotForTesting(snapshotA, provider: .codex)
+        #expect(controller.didMenuAdjunctReadinessChange())
+    }
+
+    private func enableOnlyCodexForReadinessBaseline(_ settings: SettingsStore) {
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            guard let metadata = registry.metadata[provider] else { continue }
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
+        }
+    }
+
+    private func makeReadinessBaselineTokenSnapshot(
+        sessionTokens: Int,
+        sessionCostUSD: Double,
+        last30DaysTokens: Int,
+        last30DaysCostUSD: Double,
+        updatedAt: Date) -> CostUsageTokenSnapshot
+    {
+        CostUsageTokenSnapshot(
+            sessionTokens: sessionTokens,
+            sessionCostUSD: sessionCostUSD,
+            last30DaysTokens: last30DaysTokens,
+            last30DaysCostUSD: last30DaysCostUSD,
+            daily: [
+                CostUsageDailyReport.Entry(
+                    date: "2026-05-24",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: sessionTokens,
+                    costUSD: last30DaysCostUSD,
+                    modelsUsed: nil,
+                    modelBreakdowns: nil),
+            ],
+            updatedAt: updatedAt)
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
+++ b/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
@@ -189,11 +189,78 @@ extension StatusMenuTests {
         #expect(!controller.didMenuAdjunctReadinessChange())
     }
 
+    @Test
+    func `provider root open before deferred store observation leaves sibling provider menu stale`() {
+        // The readiness signature is global across enabled providers. In split-icon mode, opening one
+        // provider's menu must not consume a pending global observation while leaving sibling menus marked
+        // fresh even though their provider data changed.
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.costUsageEnabled = true
+        self.enableProvidersForReadinessBaseline(settings, providers: [.claude, .codex])
+
+        let snapshotA = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 111,
+            sessionCostUSD: 1.11,
+            last30DaysTokens: 1111,
+            last30DaysCostUSD: 11.11,
+            updatedAt: Date(timeIntervalSince1970: 100))
+        let snapshotB = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 222,
+            sessionCostUSD: 2.22,
+            last30DaysTokens: 2222,
+            last30DaysCostUSD: 22.22,
+            updatedAt: Date(timeIntervalSince1970: 200))
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._setTokenSnapshotForTesting(snapshotA, provider: .claude)
+        store._setTokenSnapshotForTesting(snapshotA, provider: .codex)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let claudeMenu = controller.makeMenu(for: .claude)
+        controller.populateMenu(claudeMenu, provider: .claude)
+        controller.markMenuFresh(claudeMenu)
+        let codexMenu = controller.makeMenu(for: .codex)
+        controller.populateMenu(codexMenu, provider: .codex)
+        controller.markMenuFresh(codexMenu)
+        controller.resyncMenuAdjunctReadinessBaseline()
+
+        store._setTokenSnapshotForTesting(snapshotB, provider: .claude)
+        controller.menuWillOpen(codexMenu)
+        defer { controller.menuDidClose(codexMenu) }
+
+        let versionAfterOpen = controller.menuContentVersion
+        #expect(!controller.menuNeedsRefresh(codexMenu))
+        #expect(controller.menuNeedsRefresh(claudeMenu))
+
+        controller.handleObservedStoreMenuChange()
+
+        #expect(controller.menuContentVersion == versionAfterOpen)
+        #expect(!controller.menuNeedsRefresh(codexMenu))
+        #expect(controller.menuNeedsRefresh(claudeMenu))
+        #expect(!controller.didMenuAdjunctReadinessChange())
+    }
+
     private func enableOnlyCodexForReadinessBaseline(_ settings: SettingsStore) {
+        self.enableProvidersForReadinessBaseline(settings, providers: [.codex])
+    }
+
+    private func enableProvidersForReadinessBaseline(_ settings: SettingsStore, providers: Set<UsageProvider>) {
         let registry = ProviderRegistry.shared
         for provider in UsageProvider.allCases {
             guard let metadata = registry.metadata[provider] else { continue }
-            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
+            settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: providers.contains(provider))
         }
     }
 

--- a/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
+++ b/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
@@ -65,6 +65,69 @@ extension StatusMenuTests {
         #expect(controller.didMenuAdjunctReadinessChange())
     }
 
+    @Test
+    func `root open during in flight refresh preserves stale content and does not resync baseline`() {
+        // When `refreshMenuForOpenIfNeeded` keeps existing menu content during an in-flight provider
+        // refresh, the readiness baseline must not be re-anchored to live store data. Otherwise the
+        // refresh-completion store mutation would compare equal against the prematurely resynced baseline
+        // and skip the rebuild, leaving stale content visible (#1351).
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.costUsageEnabled = true
+        self.enableOnlyCodexForReadinessBaseline(settings)
+
+        let snapshotA = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 111,
+            sessionCostUSD: 1.11,
+            last30DaysTokens: 1111,
+            last30DaysCostUSD: 11.11,
+            updatedAt: Date(timeIntervalSince1970: 100))
+        let snapshotB = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 222,
+            sessionCostUSD: 2.22,
+            last30DaysTokens: 2222,
+            last30DaysCostUSD: 22.22,
+            updatedAt: Date(timeIntervalSince1970: 200))
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._setTokenSnapshotForTesting(snapshotA, provider: .codex)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let menu = controller.makeMenu()
+        controller.populateMenu(menu, provider: .codex)
+        controller.markMenuFresh(menu)
+        let key = ObjectIdentifier(menu)
+        let openedVersion = controller.menuVersions[key]
+
+        store.isRefreshing = true
+        store._setTokenSnapshotForTesting(snapshotB, provider: .codex)
+        controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
+
+        #expect(controller.menuContentVersion != openedVersion)
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        // Stale content was preserved: the menu is still behind the current content version.
+        #expect(controller.menuNeedsRefresh(menu))
+
+        store.isRefreshing = false
+        // Refresh completion must still register as a readiness change so the open menu can rebuild.
+        #expect(controller.didMenuAdjunctReadinessChange())
+    }
+
     private func enableOnlyCodexForReadinessBaseline(_ settings: SettingsStore) {
         let registry = ProviderRegistry.shared
         for provider in UsageProvider.allCases {

--- a/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
+++ b/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
@@ -190,6 +190,64 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `root open before deferred store observation during refresh leaves observer pending`() {
+        // The pre-observer root-open repair must not bypass the in-flight refresh stale-content path.
+        // While data is refreshing, the deferred observer should still invalidate the open menu and defer
+        // parent rebuild instead of marking an intermediate snapshot fresh.
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.costUsageEnabled = true
+        self.enableOnlyCodexForReadinessBaseline(settings)
+
+        let snapshotA = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 111,
+            sessionCostUSD: 1.11,
+            last30DaysTokens: 1111,
+            last30DaysCostUSD: 11.11,
+            updatedAt: Date(timeIntervalSince1970: 100))
+        let snapshotB = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 222,
+            sessionCostUSD: 2.22,
+            last30DaysTokens: 2222,
+            last30DaysCostUSD: 22.22,
+            updatedAt: Date(timeIntervalSince1970: 200))
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._setTokenSnapshotForTesting(snapshotA, provider: .codex)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let menu = controller.makeMenu()
+        controller.populateMenu(menu, provider: .codex)
+        controller.markMenuFresh(menu)
+        controller.resyncMenuAdjunctReadinessBaseline()
+
+        store.isRefreshing = true
+        store._setTokenSnapshotForTesting(snapshotB, provider: .codex)
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        let versionAfterOpen = controller.menuContentVersion
+        #expect(!controller.menuNeedsRefresh(menu))
+
+        controller.handleObservedStoreMenuChange()
+
+        #expect(controller.menuContentVersion != versionAfterOpen)
+        #expect(controller.menuNeedsRefresh(menu))
+        #expect(!controller.didMenuAdjunctReadinessChange())
+    }
+
+    @Test
     func `provider root open before deferred store observation leaves sibling provider menu stale`() {
         // The readiness signature is global across enabled providers. In split-icon mode, opening one
         // provider's menu must not consume a pending global observation while leaving sibling menus marked

--- a/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
+++ b/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
@@ -248,6 +248,61 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `fresh newer-version root open during unrelated refresh still reanchors baseline`() {
+        // An in-flight refresh elsewhere must not block re-anchoring when this menu was already rebuilt for
+        // a newer menuContentVersion. Otherwise the stale baseline can still hide a later reverted update.
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.costUsageEnabled = true
+        self.enableOnlyCodexForReadinessBaseline(settings)
+
+        let snapshotA = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 111,
+            sessionCostUSD: 1.11,
+            last30DaysTokens: 1111,
+            last30DaysCostUSD: 11.11,
+            updatedAt: Date(timeIntervalSince1970: 100))
+        let snapshotB = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 222,
+            sessionCostUSD: 2.22,
+            last30DaysTokens: 2222,
+            last30DaysCostUSD: 22.22,
+            updatedAt: Date(timeIntervalSince1970: 200))
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._setTokenSnapshotForTesting(snapshotA, provider: .codex)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let menu = controller.makeMenu()
+        controller.populateMenu(menu, provider: .codex)
+        controller.markMenuFresh(menu)
+        controller.resyncMenuAdjunctReadinessBaseline()
+
+        store._setTokenSnapshotForTesting(snapshotB, provider: .codex)
+        controller.invalidateMenus()
+        controller.populateMenu(menu, provider: .codex)
+        controller.markMenuFresh(menu)
+
+        store.isRefreshing = true
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        store._setTokenSnapshotForTesting(snapshotA, provider: .codex)
+        #expect(controller.didMenuAdjunctReadinessChange())
+    }
+
+    @Test
     func `provider root open before deferred store observation leaves sibling provider menu stale`() {
         // The readiness signature is global across enabled providers. In split-icon mode, opening one
         // provider's menu must not consume a pending global observation while leaving sibling menus marked

--- a/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
+++ b/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
@@ -429,6 +429,67 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `equal-signature root open rebuilds when rendered signature reverted before observer`() {
+        // A closed provider menu can be rebuilt from B while the readiness baseline remains A. If live data
+        // reverts to A before the deferred observer runs, root open must still repair the B-rendered menu.
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.costUsageEnabled = true
+        self.enableOnlyCodexForReadinessBaseline(settings)
+
+        let snapshotA = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 111,
+            sessionCostUSD: 1.11,
+            last30DaysTokens: 1111,
+            last30DaysCostUSD: 11.11,
+            updatedAt: Date(timeIntervalSince1970: 100))
+        let snapshotB = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 222,
+            sessionCostUSD: 2.22,
+            last30DaysTokens: 2222,
+            last30DaysCostUSD: 22.22,
+            updatedAt: Date(timeIntervalSince1970: 200))
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._setTokenSnapshotForTesting(snapshotA, provider: .codex)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let menu = controller.makeMenu(for: .codex)
+        controller.providerMenus[.codex] = menu
+        let key = ObjectIdentifier(menu)
+        controller.populateMenu(menu, provider: .codex)
+        controller.markMenuFresh(menu)
+        controller.resyncMenuAdjunctReadinessBaseline()
+
+        store._setTokenSnapshotForTesting(snapshotB, provider: .codex)
+        controller.invalidateMenus()
+        controller.populateMenu(menu, provider: .codex)
+        controller.markMenuFresh(menu)
+
+        let renderedBSignature = controller.menuReadinessSignatures[key]
+        store._setTokenSnapshotForTesting(snapshotA, provider: .codex)
+        let versionBeforeOpen = controller.menuContentVersion
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        #expect(controller.menuContentVersion != versionBeforeOpen)
+        #expect(controller.menuReadinessSignatures[key] != renderedBSignature)
+        #expect(controller.menuReadinessSignatures[key] == controller.menuAdjunctReadinessSignature())
+        #expect(!controller.didMenuAdjunctReadinessChange())
+    }
+
+    @Test
     func `provider root open before deferred store observation leaves sibling provider menu stale`() {
         // The readiness signature is global across enabled providers. In split-icon mode, opening one
         // provider's menu must not consume a pending global observation while leaving sibling menus marked

--- a/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
+++ b/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
@@ -128,6 +128,67 @@ extension StatusMenuTests {
         #expect(controller.didMenuAdjunctReadinessChange())
     }
 
+    @Test
+    func `root open before deferred store observation rebuilds and consumes matching observer`() {
+        // Store observation invalidates menus from a deferred main-actor task. If a closed menu opens after
+        // live data changes but before that task runs, it must rebuild from live data and consume the matching
+        // observer instead of letting it mark the freshly rebuilt visible menu stale.
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.costUsageEnabled = true
+        self.enableOnlyCodexForReadinessBaseline(settings)
+
+        let snapshotA = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 111,
+            sessionCostUSD: 1.11,
+            last30DaysTokens: 1111,
+            last30DaysCostUSD: 11.11,
+            updatedAt: Date(timeIntervalSince1970: 100))
+        let snapshotB = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 222,
+            sessionCostUSD: 2.22,
+            last30DaysTokens: 2222,
+            last30DaysCostUSD: 22.22,
+            updatedAt: Date(timeIntervalSince1970: 200))
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._setTokenSnapshotForTesting(snapshotA, provider: .codex)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let menu = controller.makeMenu()
+        controller.populateMenu(menu, provider: .codex)
+        controller.markMenuFresh(menu)
+        controller.resyncMenuAdjunctReadinessBaseline()
+
+        // Simulate the live store mutation being visible before the observation task has invalidated menus.
+        store._setTokenSnapshotForTesting(snapshotB, provider: .codex)
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        let key = ObjectIdentifier(menu)
+        let versionAfterOpen = controller.menuContentVersion
+        let menuVersionAfterOpen = controller.menuVersions[key]
+        #expect(!controller.menuNeedsRefresh(menu))
+
+        controller.handleObservedStoreMenuChange()
+
+        #expect(controller.menuContentVersion == versionAfterOpen)
+        #expect(controller.menuVersions[key] == menuVersionAfterOpen)
+        #expect(!controller.menuNeedsRefresh(menu))
+        #expect(!controller.didMenuAdjunctReadinessChange())
+    }
+
     private func enableOnlyCodexForReadinessBaseline(_ settings: SettingsStore) {
         let registry = ProviderRegistry.shared
         for provider in UsageProvider.allCases {

--- a/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
+++ b/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
@@ -303,6 +303,66 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `equal-signature root open advances baseline version before next pre-observer change`() {
+        // A root open whose signature still equals the baseline can nevertheless confirm that the visible
+        // menu is fresh for a newer menuContentVersion. Record that version so a later live-data change before
+        // its deferred observer does not look like already-rendered data.
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.costUsageEnabled = true
+        self.enableOnlyCodexForReadinessBaseline(settings)
+
+        let snapshotA = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 111,
+            sessionCostUSD: 1.11,
+            last30DaysTokens: 1111,
+            last30DaysCostUSD: 11.11,
+            updatedAt: Date(timeIntervalSince1970: 100))
+        let snapshotB = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 222,
+            sessionCostUSD: 2.22,
+            last30DaysTokens: 2222,
+            last30DaysCostUSD: 22.22,
+            updatedAt: Date(timeIntervalSince1970: 200))
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._setTokenSnapshotForTesting(snapshotA, provider: .codex)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let menu = controller.makeMenu(for: .codex)
+        controller.providerMenus[.codex] = menu
+        controller.populateMenu(menu, provider: .codex)
+        controller.markMenuFresh(menu)
+        controller.resyncMenuAdjunctReadinessBaseline()
+
+        controller.invalidateMenus()
+        controller.populateMenu(menu, provider: .codex)
+        controller.markMenuFresh(menu)
+        controller.menuWillOpen(menu)
+        controller.menuDidClose(menu)
+
+        let versionBeforeChange = controller.menuContentVersion
+        store._setTokenSnapshotForTesting(snapshotB, provider: .codex)
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        #expect(controller.menuContentVersion != versionBeforeChange)
+        #expect(!controller.menuNeedsRefresh(menu))
+        #expect(!controller.didMenuAdjunctReadinessChange())
+    }
+
+    @Test
     func `provider root open before deferred store observation leaves sibling provider menu stale`() {
         // The readiness signature is global across enabled providers. In split-icon mode, opening one
         // provider's menu must not consume a pending global observation while leaving sibling menus marked

--- a/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
+++ b/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
@@ -363,6 +363,72 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `newer-version root open rebuilds when rendered signature is older than live data`() {
+        // A menu can be fresh for the current menuContentVersion while still having rendered an older
+        // readiness signature than the current live store. Root open must rebuild in that pre-observer gap.
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.costUsageEnabled = true
+        self.enableOnlyCodexForReadinessBaseline(settings)
+
+        let snapshotA = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 111,
+            sessionCostUSD: 1.11,
+            last30DaysTokens: 1111,
+            last30DaysCostUSD: 11.11,
+            updatedAt: Date(timeIntervalSince1970: 100))
+        let snapshotB = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 222,
+            sessionCostUSD: 2.22,
+            last30DaysTokens: 2222,
+            last30DaysCostUSD: 22.22,
+            updatedAt: Date(timeIntervalSince1970: 200))
+        let snapshotC = self.makeReadinessBaselineTokenSnapshot(
+            sessionTokens: 333,
+            sessionCostUSD: 3.33,
+            last30DaysTokens: 3333,
+            last30DaysCostUSD: 33.33,
+            updatedAt: Date(timeIntervalSince1970: 300))
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        store._setTokenSnapshotForTesting(snapshotA, provider: .codex)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let menu = controller.makeMenu(for: .codex)
+        controller.providerMenus[.codex] = menu
+        controller.populateMenu(menu, provider: .codex)
+        controller.markMenuFresh(menu)
+        controller.resyncMenuAdjunctReadinessBaseline()
+
+        store._setTokenSnapshotForTesting(snapshotB, provider: .codex)
+        controller.invalidateMenus()
+        controller.populateMenu(menu, provider: .codex)
+        controller.markMenuFresh(menu)
+        controller.menuWillOpen(menu)
+        controller.menuDidClose(menu)
+
+        let versionBeforeChange = controller.menuContentVersion
+        store._setTokenSnapshotForTesting(snapshotC, provider: .codex)
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        #expect(controller.menuContentVersion != versionBeforeChange)
+        #expect(!controller.menuNeedsRefresh(menu))
+        #expect(!controller.didMenuAdjunctReadinessChange())
+    }
+
+    @Test
     func `provider root open before deferred store observation leaves sibling provider menu stale`() {
         // The readiness signature is global across enabled providers. In split-icon mode, opening one
         // provider's menu must not consume a pending global observation while leaving sibling menus marked

--- a/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
+++ b/Tests/CodexBarTests/StatusMenuReadinessBaselineTests.swift
@@ -129,10 +129,10 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `root open before deferred store observation rebuilds and consumes matching observer`() {
+    func `root open before deferred store observation rebuilds and refreshes matching observer`() {
         // Store observation invalidates menus from a deferred main-actor task. If a closed menu opens after
-        // live data changes but before that task runs, it must rebuild from live data and consume the matching
-        // observer instead of letting it mark the freshly rebuilt visible menu stale.
+        // live data changes but before that task runs, it must rebuild from live data and let the matching
+        // observer invalidate any coalesced non-readiness menu state without losing the readiness baseline.
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -183,9 +183,9 @@ extension StatusMenuTests {
 
         controller.handleObservedStoreMenuChange()
 
-        #expect(controller.menuContentVersion == versionAfterOpen)
+        #expect(controller.menuContentVersion != versionAfterOpen)
         #expect(controller.menuVersions[key] == menuVersionAfterOpen)
-        #expect(!controller.menuNeedsRefresh(menu))
+        #expect(controller.menuNeedsRefresh(menu))
         #expect(!controller.didMenuAdjunctReadinessChange())
     }
 
@@ -304,8 +304,8 @@ extension StatusMenuTests {
 
         controller.handleObservedStoreMenuChange()
 
-        #expect(controller.menuContentVersion == versionAfterOpen)
-        #expect(!controller.menuNeedsRefresh(codexMenu))
+        #expect(controller.menuContentVersion != versionAfterOpen)
+        #expect(controller.menuNeedsRefresh(codexMenu))
         #expect(controller.menuNeedsRefresh(claudeMenu))
         #expect(!controller.didMenuAdjunctReadinessChange())
     }


### PR DESCRIPTION
## Summary

Targets the popup-menu lag reported in #1321. Multiple users confirmed the lag appeared in the 0.32 series and that downgrading to 0.31.0 restores responsiveness, so this focuses on a 0.32-era main-thread regression that still exists on `main`.

The menu *readiness signature* (`menuAdjunctReadinessSignature()`) serializes every enabled provider's token snapshot plus its 30-day daily breakdown (and the OpenAI dashboard per-service breakdown) into a string on **every** store mutation, via `observeStoreChanges`. This runs on the main actor on each background refresh tick and scales with provider/account count.

Three changes:

- **Skip the signature entirely when no menu is open.** `observeStoreChanges` always computed `didMenuAdjunctReadinessChange()` to pass as `refreshOpenMenus`, but `invalidateMenus` only consults that argument while a menu is open. When the menu is closed (the common case during background refresh) the result was computed and discarded.
- **Re-anchor the baseline when a root menu opens and actually shows current data (correctness for the skip).** Because the baseline is no longer recomputed on every closed-menu store change, it can drift from live store data. Without re-anchoring, a menu reopened from new data followed by an open-menu change that *reverts* to the previous baseline value would compare equal and skip the rebuild, leaving stale content visible. The baseline is now resynced when a **root** menu opens **and** `!menuNeedsRefresh(menu)` after `refreshMenuForOpenIfNeeded` — i.e. the menu was rebuilt or was already fresh for the current `menuContentVersion`. If an in-flight provider refresh causes `refreshMenuForOpenIfNeeded` to preserve stale content, resync is skipped so the refresh-completion update is not masked. Nested submenu opens intentionally do **not** resync, so a pending parent refresh can't be masked. Thanks to @clawsweeper for catching both the original drift case and the in-flight stale-preservation case.
- **Make the signature cheaper.** Replace `String(format: "%.8f", …)` (a hot per-value cost run for every daily/service value of every provider) with the raw `Double` bit pattern. The signature is only ever compared for equality against the previous signature, so the bit pattern is both exact (no rounding collisions) and far cheaper. This also helps while a menu *is* open, where the signature is recomputed on each tick.

Net effect: less main-thread work both at idle (closed) and during interaction (open), which is the responsiveness path that regressed in 0.32.

## Proof

**Real app — freshly built ad-hoc bundle of this branch, 7 providers enabled** (codex, claude, cursor, gemini, antigravity, minimax, deepseek), `refreshFrequency = oneMinute`, menu **closed**. A 65 s `sample` of the running `CodexBar` process — spanning at least one background refresh tick — shows the menu signature/rebuild path never lands on the main thread:

```
$ sample CodexBar 65
# grep across ALL threads:
menuAdjunctReadinessSignature | formatDoubleForSignature | populateMenu
  | updateMenuContentPreservingSwitcher | sizeThatFits  -> 0 hits
observeStoreChanges | invalidateMenus                   -> 0 hits

main thread: 54126/54126 samples parked in App.main -> __CFRunLoopRun -> mach_msg
idle CPU: ~0.3%
```

So with a multi-provider setup and the menu closed, the readiness/rebuild work is no longer a sustained main-thread cost. (Honest caveat: `sample` is 1 ms-coarse and a single per-tick signature call is ~tens of µs, so this demonstrates the path is not a sustained closed-path cost rather than a precise per-call delta.)

**Real app — menu *open* with 7 providers enabled** (same ad-hoc bundle: codex, claude, cursor, gemini, antigravity, minimax, deepseek). Opened via `osascript` + System Events (`click menu bar item "CodexBar"`):

```
click-to-open (11 visible items): ~190 ms real
20 s sample while menu held open:
  menuAdjunctReadinessSignature | populateMenu | observeStoreChanges
    | invalidateMenus | updateMenuContentPreservingSwitcher | sizeThatFits  -> 0 hits
  main thread: 17133/17138 samples parked in mach_msg
```

So the open-menu interaction path is responsive on first open, and there is no sustained signature/rebuild churn while the menu stays open across background refresh ticks.

**Runtime cost of the work skipped when closed**, measured on the real `menuAdjunctReadinessSignature()` with a realistic multi-provider store (4 providers, each with a 30-day token daily breakdown, 5000 calls, warm):

```
menuAdjunctReadinessSignature(): 0.391s / 5000 = ~78 us/call
```

That full ~78 µs call ran on the main actor on **every** store mutation pre-fix, even with all menus closed (i.e. on each background refresh tick). It now runs only when a menu is actually open, and the cost grows with enabled providers/accounts.

**Why the per-call cost itself also dropped — signature double-formatting micro-benchmark** (`swiftc -O`, 60 doubles/iter × 200k iters):

```
old(%.8f):       10.799s
new(bitPattern):  1.166s
speedup: 9.3x
```

**Regression tests are negative-validated.**

`reopening root menu resyncs readiness baseline so reverted store data still refreshes` — fails when resync is disabled, passes with it:

```
# resync disabled:
✘ Expectation failed: controller.didMenuAdjunctReadinessChange()
# resync enabled:
✔ Test "reopening root menu resyncs readiness baseline …" passed
```

`root open during in flight refresh preserves stale content and does not resync baseline` — fails when baseline resync is unconditional on root open, passes when gated on `!menuNeedsRefresh(menu)`:

```
# unconditional resync on root open:
✘ Expectation failed: controller.didMenuAdjunctReadinessChange()
# gated resync (only when menu is fresh):
✔ Test "root open during in flight refresh …" passed
```

## Test plan

- [x] `swift build`
- [x] `make check` (SwiftFormat + SwiftLint, 0 violations, 1018 files)
- [x] `swift test --filter StatusMenuTests` — includes existing open-menu refresh coverage plus both baseline-resync regression tests (closed reopen revert + in-flight stale preservation)
- [x] Negative validation of both regression tests (each fails without its respective fix)
- [x] Runtime measurement of the skipped signature call + the formatting speedup (see Proof)
- [x] Real-app 65 s `sample`, 7 providers, menu closed — no main-thread signature/rebuild churn (see Proof)
- [x] Menu-*open* responsiveness with 7 enabled providers (real app): ~190 ms click-to-open, 11 items; 20 s open-menu `sample` shows 0 signature/rebuild hot-path hits, main thread parked (see Proof). Maintainer/reporter multi-account spot-check still welcome on merge but is not author-blocking (clawsweeper: ready for maintainer look).

## Notes / follow-ups (not in this PR)

- Chart submenus still `removeAllItems` + rebuild their `NSHostingView` when underlying data changes; gating that on a per-provider content fingerprint is a possible follow-up (overlaps active menu-card-height work).
- The multi-account "freeze on open" reports appear largely mitigated on current `main` by the recent Codex token-scan budget commits.

Made with [Cursor](https://cursor.com)

