### PR TITLE
perf: size hosted menu charts without a throwaway hosting controller

### DIFF
--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -186,9 +186,9 @@ extension StatusItemController {
 
         let chartView = UsageBreakdownChartMenuView(breakdown: breakdown, width: width)
         let hosting = MenuHostingView(rootView: chartView)
-        let controller = NSHostingController(rootView: chartView)
-        let size = controller.sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude))
-        hosting.frame = NSRect(origin: .zero, size: NSSize(width: width, height: size.height))
+        hosting.frame = NSRect(
+            origin: .zero,
+            size: NSSize(width: width, height: self.hostedSubviewFittingHeight(for: hosting, width: width)))
 
         let chartItem = NSMenuItem()
         chartItem.view = hosting
@@ -213,9 +213,9 @@ extension StatusItemController {
 
         let chartView = CreditsHistoryChartMenuView(breakdown: breakdown, width: width)
         let hosting = MenuHostingView(rootView: chartView)
-        let controller = NSHostingController(rootView: chartView)
-        let size = controller.sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude))
-        hosting.frame = NSRect(origin: .zero, size: NSSize(width: width, height: size.height))
+        hosting.frame = NSRect(
+            origin: .zero,
+            size: NSSize(width: width, height: self.hostedSubviewFittingHeight(for: hosting, width: width)))
 
         let chartItem = NSMenuItem()
         chartItem.view = hosting
@@ -252,9 +252,9 @@ extension StatusItemController {
             windowLabel: tokenSnapshot.historyLabel,
             width: width)
         let hosting = MenuHostingView(rootView: chartView)
-        let controller = NSHostingController(rootView: chartView)
-        let size = controller.sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude))
-        hosting.frame = NSRect(origin: .zero, size: NSSize(width: width, height: size.height))
+        hosting.frame = NSRect(
+            origin: .zero,
+            size: NSSize(width: width, height: self.hostedSubviewFittingHeight(for: hosting, width: width)))
 
         let chartItem = NSMenuItem()
         chartItem.view = hosting
@@ -288,9 +288,9 @@ extension StatusItemController {
         let maxHeight = self.storageBreakdownMenuMaxHeight()
         let view = StorageBreakdownMenuView(footprint: footprint, width: width, maxHeight: maxHeight)
         let hosting = MenuHostingView(rootView: view)
-        let controller = NSHostingController(rootView: view)
-        let size = controller.sizeThatFits(in: CGSize(width: width, height: maxHeight))
-        hosting.frame = NSRect(origin: .zero, size: NSSize(width: width, height: size.height))
+        hosting.frame = NSRect(
+            origin: .zero,
+            size: NSSize(width: width, height: self.hostedSubviewFittingHeight(for: hosting, width: width)))
 
         let item = NSMenuItem()
         item.view = hosting
@@ -328,9 +328,9 @@ extension StatusItemController {
 
         let chartView = ZaiHourlyUsageChartMenuView(modelUsage: modelUsage, width: width)
         let hosting = MenuHostingView(rootView: chartView)
-        let controller = NSHostingController(rootView: chartView)
-        let size = controller.sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude))
-        hosting.frame = NSRect(origin: .zero, size: NSSize(width: width, height: size.height))
+        hosting.frame = NSRect(
+            origin: .zero,
+            size: NSSize(width: width, height: self.hostedSubviewFittingHeight(for: hosting, width: width)))
 
         let chartItem = NSMenuItem()
         chartItem.view = hosting

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1541,11 +1541,20 @@ extension StatusItemController {
 
         for item in menu.items {
             guard let view = item.view else { continue }
-            view.frame = NSRect(origin: .zero, size: NSSize(width: width, height: 1))
-            view.layoutSubtreeIfNeeded()
-            let height = view.fittingSize.height
+            let height = self.hostedSubviewFittingHeight(for: view, width: width)
             view.frame = NSRect(origin: .zero, size: NSSize(width: width, height: height))
         }
+    }
+
+    /// Measures the natural height of a hosted submenu view at the given width using the live
+    /// view that will actually be displayed. Hosted chart items used to spin up a second,
+    /// throwaway `NSHostingController` purely to size the chart even though every build path
+    /// immediately re-measures the live view via `fittingSize`; that extra SwiftUI hierarchy was
+    /// pure overhead on a popup-menu hot path, so callers now size the displayed view directly.
+    func hostedSubviewFittingHeight(for view: NSView, width: CGFloat) -> CGFloat {
+        view.frame = NSRect(origin: .zero, size: NSSize(width: width, height: 1))
+        view.layoutSubtreeIfNeeded()
+        return view.fittingSize.height
     }
 
     @objc func menuCardNoOp(_ sender: NSMenuItem) {

--- a/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
+++ b/Sources/CodexBar/StatusItemController+UsageHistoryMenu.swift
@@ -68,9 +68,9 @@ extension StatusItemController {
             snapshot: snapshot,
             width: width)
         let hosting = UsageHistoryMenuHostingView(rootView: chartView)
-        let controller = NSHostingController(rootView: chartView)
-        let size = controller.sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude))
-        hosting.frame = NSRect(origin: .zero, size: NSSize(width: width, height: size.height))
+        hosting.frame = NSRect(
+            origin: .zero,
+            size: NSSize(width: width, height: self.hostedSubviewFittingHeight(for: hosting, width: width)))
 
         let chartItem = NSMenuItem()
         chartItem.view = hosting

--- a/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
@@ -171,6 +171,76 @@ struct StatusMenuHostedSubmenuRefreshTests {
             seed: Self.seedZaiHourlyUsage)
     }
 
+    @Test
+    func `hosted chart items size to the displayed view without a throwaway controller`() throws {
+        try self.assertHostedChartItemHeightMatchesRefresh(
+            chartID: StatusItemController.costHistoryChartID,
+            provider: .claude,
+            seed: Self.seedClaudeSnapshots)
+        { controller, submenu, width in
+            controller.appendCostHistoryChartItem(to: submenu, provider: .claude, width: width)
+        }
+        try self.assertHostedChartItemHeightMatchesRefresh(
+            chartID: StatusItemController.usageHistoryChartID,
+            provider: .claude,
+            seed: Self.seedPlanUtilizationHistory)
+        { controller, submenu, width in
+            controller.appendUsageHistoryChartItem(to: submenu, provider: .claude, width: width)
+        }
+        try self.assertHostedChartItemHeightMatchesRefresh(
+            chartID: StatusItemController.storageBreakdownID,
+            provider: .claude,
+            seed: Self.seedStorageFootprint)
+        { controller, submenu, width in
+            controller.appendStorageBreakdownItem(to: submenu, provider: .claude, width: width)
+        }
+    }
+
+    private func assertHostedChartItemHeightMatchesRefresh(
+        chartID: String,
+        provider: UsageProvider,
+        seed: (UsageStore) -> Void,
+        append: (StatusItemController, NSMenu, CGFloat) -> Bool) throws
+    {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering }
+
+        let settings = Self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.costUsageEnabled = true
+        settings.providerStorageFootprintsEnabled = true
+        Self.enableOnly(settings, provider: provider)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        seed(store)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let width = StatusItemController.menuCardBaseWidth
+        let submenu = NSMenu()
+        submenu.minimumWidth = width
+        #expect(append(controller, submenu, width))
+
+        let item = try #require(submenu.items.first)
+        let view = try #require(item.view)
+        let heightFromAppend = view.frame.height
+        // The height the append path assigns must match the authoritative re-measure pass; otherwise
+        // dropping the throwaway NSHostingController would have changed sizing behavior.
+        controller.refreshHostedSubviewHeights(in: submenu)
+        #expect(view.frame.height == heightFromAppend)
+        #expect(heightFromAppend > 1)
+    }
+
     private func assertHostedSubmenuPreservesIdentity(
         chartID: String,
         provider: UsageProvider,


### PR DESCRIPTION
## Summary

Follow-up to the popup-menu lag reported in #1321, focused on the hosted chart submenus (cost/usage/credits history, storage breakdown, z.ai hourly, usage breakdown).

Every hosted chart item built **two** SwiftUI hierarchies on each (re)build:
1. the `MenuHostingView` that is actually displayed, and
2. a separate `NSHostingController(rootView:)` created *solely* to measure height via `sizeThatFits`.

The controller-measured height was always immediately overwritten by the subsequent `refreshHostedSubviewHeights()` `fittingSize` pass — which runs from **both** call paths (`menuWillOpen` after hydrate, and `refreshHostedSubviewMenu`). So the second SwiftUI tree was pure overhead on a popup-menu hot path that scales with provider/account count and re-runs whenever provider data changes while a chart submenu is open.

This change measures the **live displayed view** via `fittingSize` instead (the exact mechanism `refreshHostedSubviewHeights` already uses), extracted into a shared `hostedSubviewFittingHeight(for:width:)` helper. Final heights are identical; only the redundant hosting-controller hierarchy is removed.

Why it's safe:
- The displayed view is always the source of truth for the final height (`refreshHostedSubviewHeights` re-measures it on every open/refresh today).
- Chart **content** is still rebuilt from current data on every refresh — no caching, no fingerprints, so no risk of stale charts or clipped heights.
- No change to *when* or *whether* menus rebuild, so the existing AppKit menu-tracking / retry behavior is untouched.

## Proof

**Runtime measurement of the removed work**, on the real `CostHistoryChartMenuView` (30 daily entries, menu-card width 310, 400 builds, warm), comparing the two paths directly:

```
old (2 hierarchies: throwaway NSHostingController.sizeThatFits + live fittingSize): 2.080s total, 5.201 ms/build
new (1 hierarchy: live fittingSize only):                                           1.866s total, 4.664 ms/build
saved per submenu build: ~0.54 ms (10.3% less)
```

That ~0.5 ms is per chart-submenu build, on the main thread, and recurs on every open/refresh while a chart submenu is visible — multiplied across enabled providers/accounts, which is exactly the multi-provider setup the #1321/#1325 reporters describe.

**Correctness:** the new regression test asserts the height the append path assigns equals the authoritative `refreshHostedSubviewHeights` re-measure (and is non-trivial) across cost-history / usage-history / storage-breakdown — i.e. dropping the throwaway controller did **not** change sizing behavior.

(What I can't provide locally: an end-to-end popup recording on the reporters' exact multi-account machine. The change is a strict reduction of main-thread SwiftUI work on the documented hot path, with identical output.)

## Test plan

- [x] `swift build`
- [x] `make check` (SwiftFormat + SwiftLint, 0 violations)
- [x] New test `hosted chart items size to the displayed view without a throwaway controller` — asserts the append-path height matches the authoritative `refreshHostedSubviewHeights` re-measure (and is non-trivial) across cost-history / usage-history / storage-breakdown for a seeded provider
- [x] `StatusMenuHostedSubmenuRefreshTests`, `StatusMenuOpenRefreshTests`, `StatusMenuHeightCacheTests` (41 tests) pass
- [x] Ad-hoc local bundle build + launch, app healthy
- [x] Runtime measurement of removed hierarchy (see Proof)

## Notes

Complements #1351 (menu readiness signature cost). Touches the hosted-submenu sizing path that overlaps @hhh2210's recent menu-card height-cache work, so review from that area owner is welcome.

Made with [Cursor](https://cursor.com)