### PR TITLE
Defer status-menu quit during shutdown

### DIFF
--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -328,7 +328,16 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     @objc func quit() {
-        NSApp.terminate(nil)
+        let openMenus = Array(self.openMenus.values)
+        for menu in openMenus {
+            menu.cancelTrackingWithoutAnimation()
+        }
+
+        self.scheduleQuitTermination { [weak self] in
+            guard let self else { return }
+            self.prepareForAppShutdown()
+            self.terminateApplicationForQuit()
+        }
     }
 
     @objc func copyError(_ sender: NSMenuItem) {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -140,6 +140,16 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var providerSwitcherShortcutEventMonitor: ProviderSwitcherShortcutEventMonitor?
     var providerSwitcherShortcutMenuID: ObjectIdentifier?
     var hasPreparedForAppShutdown = false
+    var scheduleQuitTermination: (@escaping @MainActor () -> Void) -> Void = { operation in
+        DispatchQueue.main.async {
+            Task { @MainActor in
+                operation()
+            }
+        }
+    }
+    var terminateApplicationForQuit: @MainActor () -> Void = {
+        NSApp.terminate(nil)
+    }
     var openMenuInvalidationRetryTask: Task<Void, Never>?
     #if DEBUG
     var onDelayedMenuRefreshAttemptForTesting: (() -> Void)?

--- a/Tests/CodexBarTests/StatusItemControllerShutdownTests.swift
+++ b/Tests/CodexBarTests/StatusItemControllerShutdownTests.swift
@@ -58,6 +58,64 @@ struct StatusItemControllerShutdownTests {
         #expect(controller.mergedMenu == nil)
     }
 
+    @Test
+    func `status menu quit defers shutdown until menu tracking can unwind`() {
+        let controller = self.makeController()
+        defer {
+            StatusItemController.menuCardRenderingEnabled = !SettingsStore.isRunningTests
+            StatusItemController.resetMenuRefreshEnabledForTesting()
+        }
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        let key = ObjectIdentifier(menu)
+
+        var scheduledTermination: (@MainActor () -> Void)?
+        var didTerminate = false
+        controller.scheduleQuitTermination = { operation in
+            scheduledTermination = operation
+        }
+        controller.terminateApplicationForQuit = {
+            didTerminate = true
+        }
+
+        controller.quit()
+
+        #expect(scheduledTermination != nil)
+        #expect(!controller.hasPreparedForAppShutdown)
+        #expect(!didTerminate)
+        #expect(controller.openMenus[key] === menu)
+
+        scheduledTermination?()
+
+        #expect(controller.hasPreparedForAppShutdown)
+        #expect(controller.openMenus.isEmpty)
+        #expect(controller.statusItem.menu == nil)
+        #expect(didTerminate)
+    }
+
+    private func makeController() -> StatusItemController {
+        StatusItemController.menuCardRenderingEnabled = false
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        if let codexMetadata = ProviderRegistry.shared.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMetadata, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        return StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+    }
+
     private func makeSettings() -> SettingsStore {
         let suite = "StatusItemControllerShutdownTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!


### PR DESCRIPTION
## Summary

- defer the status-menu Quit path by one main-loop turn after canceling active menu tracking
- run existing shutdown cleanup before terminating from that deferred Quit path
- add a regression test that Quit schedules cleanup/termination instead of terminating synchronously

Fixes #1353. Follow-up to #1174.

## Verification

- `swift test --filter 'AppDelegateTests|StatusItemControllerShutdownTests'`
- `git diff --check`

## Affected-machine Proof

- Installed the Dock-only PR branch `7f4bac64` over `/Applications/CodexBar.app`.
- Verified the installed binary SHA-256 matches the repo-packaged app binary: `6a9999f82f284b3b4d69fd644a6c9e141edf63b3792b12fda7c037593bb6c30b`.
- Invoked Quit via CodexBar's status-menu `Quit` item on the affected Mac.
- Confirmed CodexBar exited, Dock autohide remained enabled, Dock PID stayed unchanged, and Dock accessibility still responded after moving the pointer to the Dock edge.
- Full terminal transcript: https://github.com/steipete/CodexBar/pull/1354#issuecomment-4644211470

## Notes/Risks

- This keeps the existing `prepareForAppShutdown()` cleanup from `589b77ca`; it only adds the status-menu/AppKit ordering piece that was missing from the Quit action.
- The affected-machine proof from #1174 was: cleanup-only still reproduced, cleanup plus deferred status-menu Quit fixed Dock autohide.
- I also checked `swift test --filter StatusMenuTests`; current `main` in this checkout has an unrelated failure in `StatusMenuClosedPreparationTests.swift:48` (`controller.menuVersions[key]` is `2` instead of `nil`). The targeted shutdown tests for this patch pass.
