### PR TITLE
Cache localized bundle resolution to cut main-thread disk lookups (#1347)

### DIFF
--- a/Sources/CodexBar/Localization.swift
+++ b/Sources/CodexBar/Localization.swift
@@ -45,10 +45,73 @@ func codexBarLocalizationSignature() -> String {
     resolvedAppLanguage()
 }
 
+/// Resolving the `.lproj`/resource bundles repeats `Bundle(url:)`/`Bundle(path:)` filesystem lookups,
+/// which are surprisingly hot: every `L(…)` and `codexBarLocalizationSignature()` call runs them, and
+/// menu row bodies (`MetricRow`, `ProviderCostContent`, `UsageMenuCardView.Model`) re-evaluate them on
+/// every closed-menu rebuild tick on the main thread (#1347). The resolved bundles never change unless
+/// the language changes, so cache them. A single lock with compute-happening-outside-the-lock keeps the
+/// disk work off the critical section and avoids re-entrant deadlock when the localized-bundle compute
+/// closure calls back into the resource-bundle accessor.
+private enum LocalizationBundleCache {
+    private static let lock = NSLock()
+    private nonisolated(unsafe) static var resourceBundle: Bundle?
+    private nonisolated(unsafe) static var cachedLanguage: String?
+    private nonisolated(unsafe) static var cachedLocalizedBundle: Bundle?
+
+    static func defaultResourceBundle(_ compute: () -> Bundle) -> Bundle {
+        self.lock.lock()
+        if let resourceBundle {
+            self.lock.unlock()
+            return resourceBundle
+        }
+        self.lock.unlock()
+        let computed = compute()
+        self.lock.lock()
+        resourceBundle = computed
+        self.lock.unlock()
+        return computed
+    }
+
+    static func localizedBundle(forLanguage language: String, _ compute: () -> Bundle) -> Bundle {
+        self.lock.lock()
+        if self.cachedLanguage == language, let cachedLocalizedBundle {
+            let hit = cachedLocalizedBundle
+            self.lock.unlock()
+            return hit
+        }
+        self.lock.unlock()
+        let computed = compute()
+        self.lock.lock()
+        self.cachedLanguage = language
+        cachedLocalizedBundle = computed
+        self.lock.unlock()
+        return computed
+    }
+
+    static func reset() {
+        self.lock.lock()
+        self.resourceBundle = nil
+        self.cachedLanguage = nil
+        self.cachedLocalizedBundle = nil
+        self.lock.unlock()
+    }
+}
+
 func codexBarLocalizationResourceBundle(
     mainBundle: Bundle = .main,
     bundleName: String = "CodexBar_CodexBar") -> Bundle
 {
+    // Only the default (process `.main`) resolution is cached: it is constant for the lifetime of the
+    // process. Custom arguments (tests) keep resolving directly so they stay isolated from the cache.
+    guard mainBundle === Bundle.main, bundleName == "CodexBar_CodexBar" else {
+        return resolveLocalizationResourceBundle(mainBundle: mainBundle, bundleName: bundleName)
+    }
+    return LocalizationBundleCache.defaultResourceBundle {
+        resolveLocalizationResourceBundle(mainBundle: mainBundle, bundleName: bundleName)
+    }
+}
+
+private func resolveLocalizationResourceBundle(mainBundle: Bundle, bundleName: String) -> Bundle {
     guard mainBundle.bundleURL.pathExtension == "app" else {
         return Bundle.module
     }
@@ -69,8 +132,16 @@ func codexBarLocalizationResourceBundle(
 }
 
 private func localizedBundle() -> Bundle {
-    let resourceBundle = codexBarLocalizationResourceBundle()
+    // Keyed on the resolved language so a language switch (settings change or test override) transparently
+    // re-resolves; otherwise the cached bundle is returned without touching the filesystem.
     let language = resolvedAppLanguage()
+    return LocalizationBundleCache.localizedBundle(forLanguage: language) {
+        resolveLocalizedBundle(forLanguage: language)
+    }
+}
+
+private func resolveLocalizedBundle(forLanguage language: String) -> Bundle {
+    let resourceBundle = codexBarLocalizationResourceBundle()
     if !language.isEmpty {
         if let bundle = lprojBundle(named: language, in: resourceBundle) {
             return bundle
@@ -144,6 +215,16 @@ func codexBarLocalizedString(_ key: String, bundle: Bundle, resourceBundle: Bund
     let fallback = englishBundle.localizedString(forKey: key, value: nil, table: nil)
     return fallback.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? key : fallback
 }
+
+#if DEBUG
+func codexBarLocalizedBundleForTesting() -> Bundle {
+    localizedBundle()
+}
+
+func resetCodexBarLocalizationCacheForTesting() {
+    LocalizationBundleCache.reset()
+}
+#endif
 
 func configureUsageFormatterLocalizationProvider() {
     UsageFormatter.setLocalizationProvider { key in

--- a/Tests/CodexBarTests/LocalizationBundleCacheTests.swift
+++ b/Tests/CodexBarTests/LocalizationBundleCacheTests.swift
@@ -20,10 +20,10 @@ struct LocalizationBundleCacheTests {
         #expect(fr.bundleURL.lastPathComponent == "fr.lproj")
 
         // Switching language must re-resolve rather than return the cached French bundle.
-        let ja = CodexBarLocalizationOverride.$appLanguage.withValue("ja") {
+        let es = CodexBarLocalizationOverride.$appLanguage.withValue("es") {
             codexBarLocalizedBundleForTesting()
         }
-        #expect(ja.bundleURL.lastPathComponent == "ja.lproj")
+        #expect(es.bundleURL.lastPathComponent == "es.lproj")
 
         // Switching back must still produce the French bundle (cache key is the language).
         let frAgain = CodexBarLocalizationOverride.$appLanguage.withValue("fr") {

--- a/Tests/CodexBarTests/LocalizationBundleCacheTests.swift
+++ b/Tests/CodexBarTests/LocalizationBundleCacheTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+/// Regression coverage for the localized-bundle caching added for #1347.
+///
+/// The cache is process-global and these tests run in a parallel suite, so identity (`===`) assertions
+/// would race against any other test that resolves a different language. Instead these assert the
+/// concurrency-safe property that matters for correctness: every call resolves to the right `.lproj`
+/// regardless of what is currently cached, so a language switch (and switch-back) is always honored and
+/// the cache can never serve a stale localization.
+struct LocalizationBundleCacheTests {
+    @Test
+    func `resolves the correct lproj per language and re-resolves on switch`() {
+        resetCodexBarLocalizationCacheForTesting()
+
+        let fr = CodexBarLocalizationOverride.$appLanguage.withValue("fr") {
+            codexBarLocalizedBundleForTesting()
+        }
+        #expect(fr.bundleURL.lastPathComponent == "fr.lproj")
+
+        // Switching language must re-resolve rather than return the cached French bundle.
+        let ja = CodexBarLocalizationOverride.$appLanguage.withValue("ja") {
+            codexBarLocalizedBundleForTesting()
+        }
+        #expect(ja.bundleURL.lastPathComponent == "ja.lproj")
+
+        // Switching back must still produce the French bundle (cache key is the language).
+        let frAgain = CodexBarLocalizationOverride.$appLanguage.withValue("fr") {
+            codexBarLocalizedBundleForTesting()
+        }
+        #expect(frAgain.bundleURL.lastPathComponent == "fr.lproj")
+    }
+
+    @Test
+    func `repeated same-language calls keep resolving the same lproj`() {
+        resetCodexBarLocalizationCacheForTesting()
+
+        for _ in 0..<5 {
+            let bundle = CodexBarLocalizationOverride.$appLanguage.withValue("es") {
+                codexBarLocalizedBundleForTesting()
+            }
+            #expect(bundle.bundleURL.lastPathComponent == "es.lproj")
+        }
+    }
+
+    @Test
+    func `unknown language falls back to en lproj`() {
+        resetCodexBarLocalizationCacheForTesting()
+
+        let bundle = CodexBarLocalizationOverride.$appLanguage.withValue("zz-unknown") {
+            codexBarLocalizedBundleForTesting()
+        }
+        #expect(bundle.bundleURL.lastPathComponent == "en.lproj")
+    }
+
+    @Test
+    func `resolution survives an explicit cache reset`() {
+        let first = CodexBarLocalizationOverride.$appLanguage.withValue("uk") {
+            codexBarLocalizedBundleForTesting()
+        }
+        #expect(first.bundleURL.lastPathComponent == "uk.lproj")
+
+        resetCodexBarLocalizationCacheForTesting()
+
+        let afterReset = CodexBarLocalizationOverride.$appLanguage.withValue("uk") {
+            codexBarLocalizedBundleForTesting()
+        }
+        #expect(afterReset.bundleURL.lastPathComponent == "uk.lproj")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the localization hot path behind the long-uptime idle main-thread spin in #1347 (the part **not** covered by the `isRunningTestsProcess()` cache already on main, as confirmed by @YossiGS's `sample` landing on `rebuildClosedMenuIfNeeded → populateMenu → menu body getters → localizedBundle()`).

`localizedBundle()`, `codexBarLocalizationResourceBundle()` and `lprojBundle()` did `Bundle(url:)` / `Bundle(path:)` filesystem lookups on **every** call. A single `L("…")` resolves the resource bundle twice, reads `UserDefaults`, and does an `.lproj` disk lookup — all uncached. Menu row bodies (`MetricRow`, `ProviderCostContent`, `UsageMenuCardView.Model`) call `L()` / `codexBarLocalizationSignature()`, and they re-evaluate on every closed-menu rebuild tick on the main thread, so the per-call cost shows up as sustained idle CPU.

This PR caches:
- the resource bundle (constant for the process lifetime; only the default `.main` resolution is cached, custom-arg calls used by tests stay direct), and
- the resolved `localizedBundle()` keyed on the current language, so a settings/locale language switch transparently re-resolves.

A single `NSLock` with the compute happening **outside** the lock keeps the disk work off the critical section and avoids re-entrant deadlock (the localized-bundle compute calls back into the resource-bundle accessor).

## Proof

Micro-benchmark of `localizedBundle()` resolution, 20k iterations (temporary test, removed before commit):

```
uncached (per-call disk resolve): 3.933 us/call
cached   (lock + key compare):    0.973 us/call
saved per L()/signature call:     2.961 us (75.3% less)
```

This is a **lower bound**: in the test harness `Bundle.main` is not a `.app`, so the resource-bundle `Bundle.main.url(forResource:"CodexBar_CodexBar")` + `Bundle(url:)` path (run twice per `L()` pre-fix) isn't even exercised. In the shipped app that disk work is also eliminated, so the real-app savings are larger. Each menu rebuild calls `L()` many times across providers/rows, multiplying the saved time per closed-menu tick.

## Test plan

- [x] `swift build`
- [x] New `LocalizationBundleCacheTests` (4 cases): correct `.lproj` per language, re-resolve on switch + switch-back, unknown-language fallback to `en.lproj`, survives explicit cache reset. Assertions are concurrency-safe (they verify the resolved bundle is always correct for the requested language rather than relying on global cache identity).
- [x] `make check` (SwiftFormat + SwiftLint, 0 violations)
- [x] `swift test` — only pre-existing, environment-dependent failures remain (`PreferencesPaneSmokeTests`/`MiniMaxMenuCardModelTests`), which also fail on clean `origin/main` on a machine whose `UserDefaults.standard appLanguage` is set (verified by reverting this patch); they pass where `appLanguage` is unset (CI).

Refs #1347
