### PR TITLE
Add T3 Chat to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ See [CLI configuration](docs/cli-configuration.md) for the full flow.
 - [z.ai](docs/zai.md) — API token for quota + MCP windows.
 - [Manus](docs/manus.md) — Browser `session_id` auth for credit balance, monthly credits, and daily refresh tracking.
 - [MiniMax](docs/minimax.md) — API token, cookie header, or browser cookies for coding-plan usage.
+- [T3 Chat](docs/providers.md#t3-chat) — Browser cookies capture for Base and Overage usage buckets.
 - [Kimi](docs/kimi.md) — Auth token (JWT from `kimi-auth` cookie) for weekly quota + 5‑hour rate limit.
 - [Kimi K2 (unofficial)](docs/kimi-k2.md) — Legacy API key flow for credit-based usage totals.
 - [Kilo](docs/kilo.md) — API token with CLI-auth fallback for Kilo Pass usage.


### PR DESCRIPTION
- Link T3 Chat in the provider list
- Describe the Base and Overage usage buckets