### PR TITLE
perf: add menu chart render timing logs

### DIFF
--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CodexBarCore
+import QuartzCore
 import SwiftUI
 
 extension StatusItemController {
@@ -60,6 +61,7 @@ extension StatusItemController {
             providerRawValue: placeholder.toolTip)
         menu.removeAllItems()
 
+        let t0 = CACurrentMediaTime()
         let didHydrate: Bool = switch chartID {
         case Self.usageBreakdownChartID:
             self.appendUsageBreakdownChartItem(to: menu, width: width)
@@ -100,6 +102,7 @@ extension StatusItemController {
         default:
             false
         }
+        self.logChartRenderDurationIfSlow("hydrateHostedSubview:\(chartID)", startedAt: t0)
 
         if !didHydrate {
             self.appendHostedSubviewUnavailableItem(
@@ -126,6 +129,7 @@ extension StatusItemController {
         }
 
         menu.removeAllItems()
+        let t0 = CACurrentMediaTime()
         let didHydrate: Bool = switch identity.chartID {
         case Self.usageBreakdownChartID:
             self.appendUsageBreakdownChartItem(to: menu, width: width)
@@ -158,6 +162,7 @@ extension StatusItemController {
         default:
             false
         }
+        self.logChartRenderDurationIfSlow("refreshHostedSubview:\(identity.chartID)", startedAt: t0)
 
         if !didHydrate {
             self.appendHostedSubviewUnavailableItem(

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -597,6 +597,9 @@ extension StatusItemController {
             }
         guard !rows.isEmpty else { return false }
 
+        let t0 = CACurrentMediaTime()
+        defer { self.logChartRenderDurationIfSlow("addOverviewRows(\(rows.count))", startedAt: t0) }
+
         for (index, row) in rows.enumerated() {
             let identifier = "\(Self.overviewRowIdentifierPrefix)\(row.provider.rawValue)"
             let storageText = self.store.storageFootprintText(for: row.provider)

--- a/Sources/CodexBar/StatusItemController+MenuInteractionRefresh.swift
+++ b/Sources/CodexBar/StatusItemController+MenuInteractionRefresh.swift
@@ -5,6 +5,7 @@ import QuartzCore
 extension StatusItemController {
     private static let defaultDeferredMenuInteractionRefreshDelay: Duration = .milliseconds(250)
     private static let slowMenuOperationThreshold: TimeInterval = 0.15
+    private static let slowChartRenderThreshold: TimeInterval = 0.050
 
     #if DEBUG
     private static var deferredMenuInteractionRefreshDelayForTesting: Duration = .milliseconds(250)
@@ -43,6 +44,17 @@ extension StatusItemController {
                 "provider": provider?.rawValue ?? "nil",
                 "openMenus": "\(self.openMenus.count)",
                 "storeRefreshing": self.store.isRefreshing ? "1" : "0",
+            ])
+    }
+
+    func logChartRenderDurationIfSlow(_ label: String, startedAt: CFTimeInterval) {
+        let elapsed = CACurrentMediaTime() - startedAt
+        guard elapsed >= Self.slowChartRenderThreshold else { return }
+        self.menuLogger.warning(
+            "slow chart render",
+            metadata: [
+                "section": label,
+                "durationMs": String(format: "%.1f", elapsed * 1000),
             ])
     }
 


### PR DESCRIPTION
## Summary

Adds lightweight timing instrumentation around chart hydration and overview row rendering to help narrow down remaining menu latency/freezing issues.

## Changes

Adds timing logs with a 50ms threshold for:

- `hydrateHostedSubviewMenuIfNeeded`
- `refreshHostedSubviewMenu`
- `addOverviewRows`

Logs are only emitted when a measured section exceeds the threshold.

## How to use

Run CodexBar locally and watch logs:

```bash
log stream --predicate 'process == "CodexBar"' --style compact | grep "slow chart render"
```

## Motivation

The recent menu-merging changes appear to have improved the app's responsiveness, at least in my case, but there are still reports of freezes and slow menu interactions.

The existing menu timing logs show the outer operation. This adds some visibility into chart hydration and overview rendering paths.

## Testing

Built and ran locally using:

```bash
./Scripts/compile_and_run.sh
```

I ran a few local tests:

50ms threshold with 1 provider:
- No logs emitted and no noticeable lag.

50ms threshold with 2 providers:

```text
slow chart render (durationMs=55.2 section=hydrateHostedSubview:usageHistoryChart)
```

10ms threshold with 1 provider:

```text
slow chart render (durationMs=17.4 section=hydrateHostedSubview:usageHistoryChart)
```

10ms threshold with 2 providers:

```text
slow chart render (durationMs=29.2 section=hydrateHostedSubview:usageHistoryChart)
slow chart render (durationMs=30.4 section=hydrateHostedSubview:usageHistoryChart)
```

## Notes

- No behavior changes intended
- No third-party dependencies added
- 20 lines of code added across three files

## Maintainer validation

- Rebased onto current `main` at `71a38c29`
- `make check` passes: SwiftFormat clean, SwiftLint 0 violations
- Full `swift test` reached all 3,482 tests; one unrelated local-only WebKit idle-timing test failed under full-suite contention and passes in isolation. That AppKit timing test is intentionally skipped on CI.
- Structured branch autoreview: clean, no actionable findings
- Full GitHub Actions matrix approved for rebased head `ab952fa3`
