### PR TITLE
Fix Antigravity summaries for untracked quotas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.32.6 — Unreleased
 
+### Fixed
+- Antigravity: exclude model quotas without a remaining fraction from family summaries so they no longer mask tracked usage in the automatic menu-bar metric (#1369). Thanks @Martin-Hausleitner!
+
 ## 0.32.5 — 2026-06-09
 
 ### Added

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -25,7 +25,7 @@ public struct AntigravityModelQuota: Sendable {
     }
 
     public var remainingPercent: Double {
-        guard let remainingFraction else { return 100 }
+        guard let remainingFraction else { return 0 }
         return max(0, min(100, remainingFraction * 100))
     }
 }
@@ -87,12 +87,13 @@ public struct AntigravityStatusSnapshot: Sendable {
         }
 
         let normalized = Self.normalizedModels(self.modelQuotas)
-        let summaryModels: [AntigravityNormalizedModel] = switch self.source {
+        let summaryCandidates: [AntigravityNormalizedModel] = switch self.source {
         case .local:
             normalized
         case .remote:
             normalized.filter(Self.isRemoteSummaryCandidate)
         }
+        let summaryModels = summaryCandidates.filter { $0.quota.remainingFraction != nil }
         let primaryQuota = Self.representative(for: .claude, in: summaryModels)
         let secondaryQuota = Self.representative(for: .geminiPro, in: summaryModels)
         let tertiaryQuota = Self.representative(for: .geminiFlash, in: summaryModels)

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -25,7 +25,7 @@ public struct AntigravityModelQuota: Sendable {
     }
 
     public var remainingPercent: Double {
-        guard let remainingFraction else { return 0 }
+        guard let remainingFraction else { return 100 }
         return max(0, min(100, remainingFraction * 100))
     }
 }

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -977,7 +977,7 @@ extension AntigravityStatusProbeTests {
     }
 
     @Test
-    func `model without remaining fraction keeps reset time`() throws {
+    func `model without remaining fraction stays out of family summary and preserves reset metadata`() throws {
         let resetTime = Date(timeIntervalSince1970: 1_735_000_000)
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
@@ -998,9 +998,12 @@ extension AntigravityStatusProbeTests {
             accountPlan: nil)
 
         let usage = try snapshot.toUsageSnapshot()
-        #expect(usage.secondary?.remainingPercent.rounded() == 0)
-        #expect(usage.secondary?.resetsAt == resetTime)
+        #expect(usage.secondary == nil)
         #expect(usage.tertiary?.remainingPercent.rounded() == 100)
+        let modelWindow = try #require(usage.extraRateWindows?.first {
+            $0.id == "MODEL_PLACEHOLDER_M36"
+        })
+        #expect(modelWindow.window.resetsAt == resetTime)
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
+++ b/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
@@ -57,6 +57,41 @@ struct MenuBarMetricWindowResolverTests {
     }
 
     @Test
+    func `automatic metric ignores untracked antigravity family lane`() throws {
+        let untrackedReset = Date(timeIntervalSince1970: 1000)
+        let exhaustedReset = Date(timeIntervalSince1970: 2000)
+        let antigravitySnapshot = AntigravityStatusSnapshot(
+            modelQuotas: [
+                AntigravityModelQuota(
+                    label: "Claude Sonnet 4.6",
+                    modelId: "claude-sonnet-4-6",
+                    remainingFraction: nil,
+                    resetTime: untrackedReset,
+                    resetDescription: nil),
+                AntigravityModelQuota(
+                    label: "Gemini 3.1 Pro",
+                    modelId: "gemini-3-1-pro",
+                    remainingFraction: 0,
+                    resetTime: exhaustedReset,
+                    resetDescription: nil),
+            ],
+            accountEmail: nil,
+            accountPlan: nil,
+            source: .local)
+        let snapshot = try antigravitySnapshot.toUsageSnapshot()
+        #expect(snapshot.primary == nil)
+
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .automatic,
+            provider: .antigravity,
+            snapshot: snapshot,
+            supportsAverage: false)
+
+        #expect(window?.usedPercent == 100)
+        #expect(window?.resetsAt == exhaustedReset)
+    }
+
+    @Test
     func `explicit antigravity metric keeps requested family lane`() {
         let snapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 0, windowMinutes: nil, resetsAt: nil, resetDescription: "Claude"),

--- a/Tests/CodexBarTests/MenuCardAntigravityTests.swift
+++ b/Tests/CodexBarTests/MenuCardAntigravityTests.swift
@@ -57,7 +57,7 @@ struct MenuCardAntigravityTests {
     }
 
     @Test
-    func `antigravity zero percent metric still shows reset text`() throws {
+    func `antigravity untracked metric stays out of family summary`() throws {
         let now = Date(timeIntervalSince1970: 1_735_000_000)
         let resetTime = now.addingTimeInterval(3600)
         let antigravitySnapshot = AntigravityStatusSnapshot(
@@ -108,7 +108,7 @@ struct MenuCardAntigravityTests {
 
         #expect(model.metrics[1].percent == 0)
         #expect(model.metrics[1].percentLabel == "0% left")
-        #expect(model.metrics[1].resetText != nil)
+        #expect(model.metrics[1].resetText == nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Exclude Antigravity models without a reported `remainingFraction` from the three family summary lanes.
- Preserve those models in per-model quota windows, including reset metadata.
- Add regression coverage proving automatic mode selects tracked constrained usage instead of an untracked family.

## Verification
- `swift test --filter AntigravityStatusProbeTests`
- `swift test --filter MenuCardAntigravityTests`
- `swift test --filter MenuBarMetricWindowResolverTests`
- `make check`
- Structured autoreview: clean, no accepted/actionable findings

Refs #1334.
