### PR TITLE
Fix Antigravity menu card: drop redundant family summary lanes and placeholder quota

### DIFF
--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -154,30 +154,39 @@ extension UsageMenuCardView.Model {
 
     static func antigravityMetrics(input: Input, snapshot: UsageSnapshot) -> [Metric] {
         let percentStyle: PercentStyle = input.usageBarsShowUsed ? .used : .left
-        var metrics = [
-            Self.antigravityMetric(
-                id: "primary",
-                title: L(input.metadata.sessionLabel),
-                window: snapshot.primary,
-                input: input,
-                percentStyle: percentStyle),
-            Self.antigravityMetric(
-                id: "secondary",
-                title: L(input.metadata.weeklyLabel),
-                window: snapshot.secondary,
-                input: input,
-                percentStyle: percentStyle),
-            Self.antigravityMetric(
-                id: "tertiary",
-                title: input.metadata.opusLabel.map(L) ?? L("Gemini Flash"),
-                window: snapshot.tertiary,
-                input: input,
-                percentStyle: percentStyle),
-        ]
-        metrics.append(contentsOf: Self.extraRateWindowMetrics(
+        let extraMetrics = Self.extraRateWindowMetrics(
             snapshot: snapshot,
             input: input,
-            percentStyle: percentStyle))
+            percentStyle: percentStyle)
+        if !extraMetrics.isEmpty {
+            return extraMetrics
+        }
+
+        var metrics: [Metric] = []
+        if let primary = snapshot.primary {
+            metrics.append(Self.antigravityMetric(
+                id: "primary",
+                title: L(input.metadata.sessionLabel),
+                window: primary,
+                input: input,
+                percentStyle: percentStyle))
+        }
+        if let secondary = snapshot.secondary {
+            metrics.append(Self.antigravityMetric(
+                id: "secondary",
+                title: L(input.metadata.weeklyLabel),
+                window: secondary,
+                input: input,
+                percentStyle: percentStyle))
+        }
+        if let tertiary = snapshot.tertiary {
+            metrics.append(Self.antigravityMetric(
+                id: "tertiary",
+                title: input.metadata.opusLabel.map(L) ?? L("Gemini Flash"),
+                window: tertiary,
+                input: input,
+                percentStyle: percentStyle))
+        }
         return metrics
     }
 
@@ -247,25 +256,10 @@ extension UsageMenuCardView.Model {
     static func antigravityMetric(
         id: String,
         title: String,
-        window: RateWindow?,
+        window: RateWindow,
         input: Input,
         percentStyle: PercentStyle) -> Metric
     {
-        guard let window else {
-            let placeholderPercent = input.usageBarsShowUsed ? 100.0 : 0.0
-            return Metric(
-                id: id,
-                title: title,
-                percent: placeholderPercent,
-                percentStyle: percentStyle,
-                statusText: nil,
-                resetText: nil,
-                detailText: nil,
-                detailLeftText: nil,
-                detailRightText: nil,
-                pacePercent: nil,
-                paceOnTop: true)
-        }
         let percent = input.usageBarsShowUsed ? window.usedPercent : window.remainingPercent
         return Metric(
             id: id,

--- a/Tests/CodexBarTests/MenuCardAntigravityTests.swift
+++ b/Tests/CodexBarTests/MenuCardAntigravityTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 struct MenuCardAntigravityTests {
     @Test
-    func `antigravity metrics show zero percent for missing families`() throws {
+    func `antigravity metrics omit missing families instead of showing zero percent`() throws {
         let now = Date()
         let identity = ProviderIdentitySnapshot(
             providerID: .antigravity,
@@ -44,20 +44,14 @@ struct MenuCardAntigravityTests {
             hidePersonalInfo: false,
             now: now))
 
-        #expect(model.metrics.count == 3)
-        #expect(model.metrics.map(\.title) == ["Claude", "Gemini Pro", "Gemini Flash"])
-        #expect(model.metrics[1].percent == 0)
-        #expect(model.metrics[1].percentLabel == "0% left")
-        #expect(model.metrics[1].statusText == nil)
-        #expect(model.metrics[1].detailText == nil)
-        #expect(model.metrics[2].percent == 0)
-        #expect(model.metrics[2].percentLabel == "0% left")
-        #expect(model.metrics[2].statusText == nil)
-        #expect(model.metrics[2].detailText == nil)
+        #expect(model.metrics.count == 1)
+        #expect(model.metrics.map(\.title) == ["Claude"])
+        #expect(model.metrics[0].percent == 95)
+        #expect(model.metrics[0].percentLabel == "95% left")
     }
 
     @Test
-    func `antigravity zero percent metric still shows reset text`() throws {
+    func `antigravity exhausted real model still shows reset text`() throws {
         let now = Date(timeIntervalSince1970: 1_735_000_000)
         let resetTime = now.addingTimeInterval(3600)
         let antigravitySnapshot = AntigravityStatusSnapshot(
@@ -71,7 +65,7 @@ struct MenuCardAntigravityTests {
                 AntigravityModelQuota(
                     label: "Gemini 3.1 Pro (Low)",
                     modelId: "MODEL_PLACEHOLDER_M36",
-                    remainingFraction: nil,
+                    remainingFraction: 0,
                     resetTime: resetTime,
                     resetDescription: nil),
                 AntigravityModelQuota(
@@ -106,9 +100,10 @@ struct MenuCardAntigravityTests {
             hidePersonalInfo: false,
             now: now))
 
-        #expect(model.metrics[1].percent == 0)
-        #expect(model.metrics[1].percentLabel == "0% left")
-        #expect(model.metrics[1].resetText != nil)
+        let exhausted = try #require(model.metrics.first { $0.title == "Gemini 3.1 Pro (Low)" })
+        #expect(exhausted.percent == 0)
+        #expect(exhausted.percentLabel == "0% left")
+        #expect(exhausted.resetText != nil)
     }
 
     @Test
@@ -169,15 +164,12 @@ struct MenuCardAntigravityTests {
             now: now))
 
         #expect(model.metrics.map(\.title) == [
-            "Claude",
-            "Gemini Pro",
-            "Gemini Flash",
             "Claude Opus 4.6 (Thinking)",
             "Gemini 3 Pro (High)",
             "Gemini 3 Pro (Low)",
             "GPT-OSS 120B (Medium)",
         ])
-        #expect(model.metrics.suffix(4).map(\.percentLabel) == [
+        #expect(model.metrics.map(\.percentLabel) == [
             "75% left",
             "100% left",
             "50% left",
@@ -237,7 +229,7 @@ struct MenuCardAntigravityTests {
     }
 
     @Test
-    func `antigravity missing families show full usage in used mode`() throws {
+    func `antigravity missing families stay omitted in used mode`() throws {
         let now = Date()
         let identity = ProviderIdentitySnapshot(
             providerID: .antigravity,
@@ -276,9 +268,9 @@ struct MenuCardAntigravityTests {
             hidePersonalInfo: false,
             now: now))
 
-        #expect(model.metrics[1].percent == 100)
-        #expect(model.metrics[1].percentLabel == "100% used")
-        #expect(model.metrics[2].percent == 100)
-        #expect(model.metrics[2].percentLabel == "100% used")
+        #expect(model.metrics.count == 1)
+        #expect(model.metrics.map(\.title) == ["Claude"])
+        #expect(model.metrics[0].percent == 5)
+        #expect(model.metrics[0].percentLabel == "5% used")
     }
 }


### PR DESCRIPTION
## Summary
The Antigravity menu card duplicated quota rows and drew placeholders for
families that have no real data:

- When per-model quota windows are available, the card prepended the three
  generic family summary lanes ("Claude", "Gemini Pro", "Gemini Flash") on top
  of the detailed per-model rows, showing the same quota twice.
- When a Claude/Gemini family lane was missing, it was rendered as a fake
  `0% left` / `100% used` placeholder instead of being omitted.

This PR renders the real per-model `extraRateWindows` when present, and
otherwise falls back to the summary lanes while skipping any missing (nil)
lane — so there are no duplicated or placeholder rows.

## Changes
- `MenuCardView+ModelHelpers.swift`: prefer per-model extra windows and render
  only those when present; otherwise render the summary lanes, skipping nil
  ones. Removes the placeholder branch that drew `0% left` / `100% used` for
  absent windows.
- `MenuCardAntigravityTests.swift`: missing families are omitted (not shown at
  zero percent), an exhausted real model still shows its reset text, and
  per-model rows render without duplicated summary lanes.

## Before / After
| Before | After |
| --- | --- |
|  <img width="634" height="1566" alt="Antigravity_Usage_Before" src="https://github.com/user-attachments/assets/48767170-550c-43b7-8461-239d64b14864" /> | <img width="630" height="1216" alt="Antigravity_Usage_After" src="https://github.com/user-attachments/assets/bbe24129-7c56-46af-a859-c6acb15f2053" /> |

## Testing
- `swift test --filter MenuCardAntigravityTests --filter AntigravityStatusProbeTests` — 56 tests / 2 suites passed
- `make check` — 0 violations / 0 serious in 1022 files

## Scope notes
- Presentation-only change. The remote display-filter rework is intentionally
  left out (keeps the #1209 behaviour), and the `nil`-fraction `remainingPercent`
  fix is deferred to #1369.
