### PR TITLE
Open data-stale dropdowns in two phases (populateMenu off the click path)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Antigravity: exclude model quotas without a remaining fraction from family summaries so they no longer mask tracked usage in the automatic menu-bar metric (#1369). Thanks @Martin-Hausleitner!
+- Menu bar: open data-stale dropdowns in two phases — attach the existing content immediately on click and rebuild from current data right after display — so merged-menu opens no longer pay the full SwiftUI card rebuild before the menu appears (#1274, #1325).
 
 ## 0.32.5 — 2026-06-09
 

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -125,12 +125,39 @@ extension StatusItemController {
             self.deferMenuInteractionRefreshIfNeeded()
             return
         }
+        if self.canDeferStaleMenuRebuildUntilAfterDisplay(menu) {
+            #if DEBUG
+            self.menuLogger.debug(
+                "menu open deferred stale rebuild until after display",
+                metadata: [
+                    "items": "\(menu.items.count)",
+                    "provider": provider?.rawValue ?? "nil",
+                ])
+            #endif
+            self.scheduleOpenMenuRebuildIfStillVisible(menu, provider: provider)
+            return
+        }
         self.populateMenu(menu, provider: provider)
         self.markMenuFresh(menu)
     }
 
     private func canPreserveStaleMenuContentDuringRefresh(_ menu: NSMenu) -> Bool {
         guard self.isMenuDataRefreshInFlight, !menu.items.isEmpty else { return false }
+        let key = ObjectIdentifier(menu)
+        guard let menuVersion = self.menuVersions[key] else { return false }
+        return menuVersion >= self.latestRequiredMenuRebuildVersion
+    }
+
+    /// Two-phase open: when the only pending invalidations are data-refresh ticks, the dropdown can
+    /// attach its existing content immediately and rebuild from current store data right after the
+    /// menu is on screen, instead of paying the full `populateMenu` (incl. SwiftUI hosting-view
+    /// layout) synchronously inside `menuWillOpen` on the click path (#1274, #1325). Structural,
+    /// privacy, or localization invalidations bump `latestRequiredMenuRebuildVersion` and still
+    /// rebuild synchronously before display.
+    private func canDeferStaleMenuRebuildUntilAfterDisplay(_ menu: NSMenu) -> Bool {
+        // Without open-menu tracking the post-display rebuild would never run, leaving stale content.
+        guard self.isMenuRefreshEnabled else { return false }
+        guard !menu.items.isEmpty else { return false }
         let key = ObjectIdentifier(menu)
         guard let menuVersion = self.menuVersions[key] else { return false }
         return menuVersion >= self.latestRequiredMenuRebuildVersion

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -270,6 +270,12 @@ extension StatusMenuTests {
         controller.menuWillOpen(menu)
         defer { controller.menuDidClose(menu) }
 
+        // Two-phase open: the stale content stays attached for immediate display, and the rebuild
+        // from current data runs right after display while the menu is open.
+        #expect(controller.menuVersions[key] == openedVersion)
+        for _ in 0..<40 where controller.menuVersions[key] != controller.menuContentVersion {
+            await Task.yield()
+        }
         #expect(controller.menuVersions[key] == controller.menuContentVersion)
     }
 

--- a/Tests/CodexBarTests/StatusMenuTwoPhaseOpenTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTwoPhaseOpenTests.swift
@@ -1,0 +1,158 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+extension StatusMenuTests {
+    @Test
+    func `data stale merged menu open keeps stale content and rebuilds after display`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            if let metadata = registry.metadata[provider] {
+                settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
+            }
+        }
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.mergedMenu = menu
+        controller.statusItem.menu = menu
+        let key = ObjectIdentifier(menu)
+
+        controller.menuWillOpen(menu)
+        controller.menuDidClose(menu)
+        let openedVersion = controller.menuVersions[key]
+        #expect(openedVersion == controller.menuContentVersion)
+        #expect(!menu.items.isEmpty)
+
+        // A data-refresh tick while the merged menu is closed leaves it stale and deferred until next open.
+        controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
+        #expect(controller.menuContentVersion != openedVersion)
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        // Two-phase open: the stale content stays attached so display is immediate, and the
+        // synchronous rebuild is skipped on the click path.
+        #expect(controller.menuVersions[key] == openedVersion)
+        #expect(!menu.items.isEmpty)
+
+        // The rebuild then runs right after display while the menu is open.
+        for _ in 0..<40 where controller.menuVersions[key] != controller.menuContentVersion {
+            await Task.yield()
+        }
+        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+    }
+
+    @Test
+    func `required invalidation still rebuilds merged menu synchronously on open`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            if let metadata = registry.metadata[provider] {
+                settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
+            }
+        }
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.mergedMenu = menu
+        controller.statusItem.menu = menu
+        let key = ObjectIdentifier(menu)
+
+        controller.menuWillOpen(menu)
+        controller.menuDidClose(menu)
+        let openedVersion = controller.menuVersions[key]
+        #expect(openedVersion == controller.menuContentVersion)
+
+        // A structural/privacy invalidation requires fresh content before display.
+        controller.invalidateMenus()
+        #expect(controller.latestRequiredMenuRebuildVersion == controller.menuContentVersion)
+        #expect(controller.menuVersions[key] == openedVersion)
+
+        controller.menuWillOpen(menu)
+        defer { controller.menuDidClose(menu) }
+
+        #expect(controller.menuVersions[key] == controller.menuContentVersion)
+    }
+
+    @Test
+    func `menu close before deferred open rebuild cancels the rebuild`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            if let metadata = registry.metadata[provider] {
+                settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: provider == .codex)
+            }
+        }
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.menuRefreshEnabledOverrideForTesting = true
+        let menu = controller.makeMenu()
+        controller.mergedMenu = menu
+        controller.statusItem.menu = menu
+        let key = ObjectIdentifier(menu)
+
+        controller.menuWillOpen(menu)
+        controller.menuDidClose(menu)
+        let openedVersion = controller.menuVersions[key]
+
+        controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
+        controller.menuWillOpen(menu)
+        #expect(controller.openMenuRebuildTasks[key] != nil)
+
+        // Closing immediately (before the deferred rebuild runs) cancels the open-menu rebuild and
+        // re-defers the stale merged menu until its next open.
+        controller.menuDidClose(menu)
+        #expect(controller.openMenuRebuildTasks[key] == nil)
+        for _ in 0..<40 {
+            await Task.yield()
+        }
+        #expect(controller.menuVersions[key] == openedVersion)
+        #expect(controller.closedMenusDeferredUntilNextOpen.contains(key))
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuTwoPhaseOpenTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTwoPhaseOpenTests.swift
@@ -62,7 +62,7 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `required invalidation still rebuilds merged menu synchronously on open`() async {
+    func `required invalidation still rebuilds merged menu synchronously on open`() {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false


### PR DESCRIPTION
Refs #1374, #1274, #1325.

## Summary
- open data-stale dropdowns in two phases: when the only pending invalidations are data-refresh ticks, `menuWillOpen` attaches the menu's existing content immediately and schedules the rebuild through the existing `scheduleOpenMenuRebuildIfStillVisible` machinery, so it runs right after the menu is on screen instead of synchronously on the click path
- structural / privacy / localization invalidations (anything that bumps `latestRequiredMenuRebuildVersion`) still rebuild synchronously before display, so stale structure is never shown
- the in-flight-refresh stale-preserve path keeps precedence (#1351 semantics); refresh completion still drives the rebuild in that case
- closing before the deferred rebuild runs cancels it via the existing `forgetClosedMenu` cleanup, and the merged menu re-defers until next open
- tests-only mode (`isMenuRefreshEnabled == false`) keeps the synchronous rebuild, since the post-display rebuild would never run without open-menu tracking

## Why
#1314 deferred the closed merged menu until next open and explicitly scoped out the consequence: *"This still does not remove the first `populateMenu` or reuse hosting views; it eliminates the redundant **closed** rebuild only."*

Since every background data tick while the menu is closed leaves it deferred-stale, the next click pays the full `populateMenu` (MenuDescriptor build + `NSHostingView` creation + SwiftUI layout) synchronously inside `menuWillOpen` before the dropdown can appear — with `refreshFrequency = oneMinute` and Merge Icons on, effectively every open after ≥1 idle minute. Root-cause walkthrough in #1374; #1325's sample caught `populateMenu` / `addMenuCards` as the hot frames on that path, and the post-#1297 retest in #1274 measured it at `~306 menuWillOpen → ~153 refreshMenuForOpenIfNeeded` inclusive main-thread samples.

## Scope / honesty
- This does not reduce total rebuild work; it moves the rebuild off the click-blocking path, the same way #1286 moved it off the dismiss path. The post-display rebuild runs once while the menu is visible, through the smart-update path that preserves the provider switcher (the path open-menu invalidations already use).
- The content shown during the brief post-display window is the same content the menu showed when it last closed; only data-refresh invalidations can take this path, so it is data-staleness by definition, never stale structure.
- First-ever open (menu has no items yet) and required invalidations are unchanged: synchronous rebuild before display.

## Validation
- three focused regression tests in `StatusMenuTwoPhaseOpenTests.swift`: data-stale open keeps existing items and rebuilds after display; required invalidation still rebuilds synchronously before display; closing before the deferred rebuild cancels it and re-defers the merged menu
- one updated expectation in `StatusMenuOpenRefreshTests.swift`: the non-merged stale open now asserts the two-phase deferral instead of the synchronous rebuild (the mechanism is shared, and the deferral is the same win there)
- `swift test` (full suite) + SwiftFormat/SwiftLint were green on the fork mirror of this branch at the pre-rebase head (`abe46ca3`); the rebase onto `6f6cb097` only resolved a CHANGELOG collision with #1369, no code changes

## Behavior proof status
Packaged before/after proof on macOS 26.5 (peekaboo open-click timing + `sample` stack identity: `populateMenu` under `menuWillOpen` vs under the deferred-task thunk, #1314-style) is being collected and will be posted as a follow-up comment on this PR. A retest from the #1274/#1314 measurement setup would be very welcome — asked in #1374.
