### PR TITLE
Add Claude web session recovery action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Antigravity: exclude model quotas without a remaining fraction from family summaries so they no longer mask tracked usage in the automatic menu-bar metric (#1369). Thanks @Martin-Hausleitner!
 - Claude: add bundled Fable 5 pricing, account for native 1-hour cache-write usage, and refresh Sonnet 4.6 full-context rates (#1368). Thanks @MoollaMore!
+- Claude: show a direct claude.ai re-login action when a configured web session expires or becomes invalid (#1377). Thanks @LeoLin990405!
 - Menu bar: defer data-refresh rebuilds until the tracked menu closes, avoiding multi-second WindowServer stalls with slower providers such as Grok (#1376). Thanks @jangisaac-dev!
 - Xiaomi MiMo: import automatic session cookies from Safari, Chrome variants, Firefox, and Edge instead of limiting discovery to Chrome (#1304). Thanks @Yuxin-Qiao!
 

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -228,8 +228,35 @@ struct ClaudeProviderImplementation: ProviderImplementation {
     func loginMenuAction(context: ProviderMenuLoginContext)
         -> (label: String, action: MenuDescriptor.MenuAction)?
     {
+        if self.shouldOpenBrowserForWebSessionError(context: context) {
+            return ("Re-login at claude.ai", .loginToProvider(url: "https://claude.ai/"))
+        }
         guard self.shouldOpenTerminalForOAuthError(store: context.store) else { return nil }
         return ("Open Terminal", .openTerminal(command: "claude"))
+    }
+
+    @MainActor
+    private func shouldOpenBrowserForWebSessionError(context: ProviderMenuLoginContext) -> Bool {
+        let settings = context.settings.claudeSettingsSnapshot(tokenOverride: nil)
+        let source = settings.usageDataSource
+        guard source == .auto || source == .web,
+              settings.cookieSource == .auto,
+              let error = context.store.error(for: .claude)
+        else { return false }
+
+        let sessionErrors = [
+            ClaudeWebAPIFetcher.FetchError.unauthorized.localizedDescription,
+            ClaudeWebAPIFetcher.FetchError.noSessionKeyFound.localizedDescription,
+            ClaudeWebAPIFetcher.FetchError.invalidSessionKey.localizedDescription,
+        ]
+        if sessionErrors.contains(error) {
+            return true
+        }
+
+        guard error == ProviderFetchError.noAvailableStrategy(.claude).localizedDescription else { return false }
+        return context.store.fetchAttempts(for: .claude).contains {
+            $0.strategyID == "claude.web" && !$0.wasAvailable
+        }
     }
 
     @MainActor

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -865,6 +865,7 @@
 "Personal account" = "Compte personal";
 "Project ID" = "ID de projecte";
 "Re-auth" = "Reautentica";
+"Re-login at claude.ai" = "Torna a iniciar sessió a claude.ai";
 "Re-authenticating…" = "S'està reautenticant…";
 "Refresh Session" = "Actualitza la sessió";
 "Refresh organizations" = "Actualitza organitzacions";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1008,6 +1008,7 @@
 "Personal account" = "Personal account";
 "Project ID" = "Project ID";
 "Re-auth" = "Re-auth";
+"Re-login at claude.ai" = "Re-login at claude.ai";
 "Re-authenticating…" = "Re-authenticating…";
 "Refresh Session" = "Refresh Session";
 "Refresh organizations" = "Refresh organizations";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -865,6 +865,7 @@
 "Personal account" = "Cuenta personal";
 "Project ID" = "ID de proyecto";
 "Re-auth" = "Reautenticar";
+"Re-login at claude.ai" = "Volver a iniciar sesión en claude.ai";
 "Re-authenticating…" = "Reautenticando…";
 "Refresh Session" = "Actualizar sesión";
 "Refresh organizations" = "Actualizar organizaciones";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -1009,6 +1009,7 @@
 "Personal account" = "Compte personnel";
 "Project ID" = "ID du projet";
 "Re-auth" = "Se reconnecter";
+"Re-login at claude.ai" = "Se reconnecter à claude.ai";
 "Re-authenticating…" = "Réauthentification…";
 "Refresh Session" = "Session de rafraîchissement";
 "Refresh organizations" = "Actualiser les organisations";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -1009,6 +1009,7 @@
 "Personal account" = "Persoonlijk account";
 "Project ID" = "Project-ID";
 "Re-auth" = "Opnieuw verifiëren";
+"Re-login at claude.ai" = "Opnieuw aanmelden bij claude.ai";
 "Re-authenticating…" = "Opnieuw authenticeren…";
 "Refresh Session" = "Sessie vernieuwen";
 "Refresh organizations" = "Vernieuw organisaties";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -1008,6 +1008,7 @@
 "Personal account" = "Conta pessoal";
 "Project ID" = "ID do projeto";
 "Re-auth" = "Reautenticar";
+"Re-login at claude.ai" = "Entrar novamente no claude.ai";
 "Re-authenticating…" = "Reautenticando…";
 "Refresh Session" = "Atualizar sessão";
 "Refresh organizations" = "Atualizar organizações";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -1004,6 +1004,7 @@
 "Credits used" = "Använda krediter";
 "CodexBar will ask macOS Keychain for your OpenAI cookie header so it can fetch Codex dashboard extras. Click OK to continue." = "CodexBar kommer att be macOS Nyckelring om din OpenAI-cookie-header så att extra Codex-översiktsdata kan hämtas. Klicka på OK för att fortsätta.";
 "Re-auth" = "Autentisera igen";
+"Re-login at claude.ai" = "Logga in igen på claude.ai";
 "cache-miss input" = "cachemiss-indata";
 "Day" = "Dag";
 "Optional. Applies to the configured Admin API key; selected token accounts do not inherit OPENAI_PROJECT_ID." = "Valfritt. Gäller den konfigurerade Admin API-nyckeln. Valda tokenkonton ärver inte OPENAI_PROJECT_ID.";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -1009,6 +1009,7 @@
 "Personal account" = "Особистий рахунок";
 "Project ID" = "ID проекту";
 "Re-auth" = "Повторна авторизація";
+"Re-login at claude.ai" = "Повторно увійти на claude.ai";
 "Re-authenticating…" = "Повторна автентифікація…";
 "Refresh Session" = "Оновити сеанс";
 "Refresh organizations" = "Оновити організації";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -1008,6 +1008,7 @@
 "Personal account" = "Tài khoản cá nhân";
 "Project ID" = "ID dự án";
 "Re-auth" = "Xác thực lại";
+"Re-login at claude.ai" = "Đăng nhập lại vào claude.ai";
 "Re-authenticating…" = "Xác thực lại…";
 "Refresh Session" = "Làm mới phiên";
 "Refresh organizations" = "Làm mới tổ chức";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -982,6 +982,7 @@
 "Personal account" = "个人账号";
 "Project ID" = "项目 ID";
 "Re-auth" = "重新认证";
+"Re-login at claude.ai" = "重新登录 claude.ai";
 "Re-authenticating…" = "正在重新认证…";
 "Refresh Session" = "刷新会话";
 "Refresh organizations" = "刷新组织";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -878,6 +878,7 @@
 "Personal account" = "個人帳號";
 "Project ID" = "專案 ID";
 "Re-auth" = "重新認證";
+"Re-login at claude.ai" = "重新登入 claude.ai";
 "Re-authenticating…" = "正在重新認證…";
 "Refresh Session" = "重新整理工作階段";
 "Refresh organizations" = "重新整理組織";

--- a/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
@@ -1,0 +1,157 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct ClaudeWebRecoveryMenuTests {
+    private func makeSettings() -> SettingsStore {
+        let suite = "ClaudeWebRecoveryMenuTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+    }
+
+    private func actions(
+        error: String,
+        source: ClaudeUsageDataSource,
+        cookieSource: ProviderCookieSource = .auto,
+        selectedSessionKey: Bool = false,
+        attempts: [ProviderFetchAttempt] = []) -> [(String, MenuDescriptor.MenuAction)]
+    {
+        let settings = self.makeSettings()
+        settings.claudeUsageDataSource = source
+        if selectedSessionKey {
+            settings.addTokenAccount(provider: .claude, label: "Session", token: "sk-ant-session-token")
+        }
+        settings.claudeCookieSource = cookieSource
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        store.errors[.claude] = error
+        store.lastFetchAttempts[.claude] = attempts
+
+        return MenuDescriptor.build(
+            provider: .claude,
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updateReady: false)
+            .sections
+            .flatMap(\.entries)
+            .compactMap { entry in
+                guard case let .action(label, action) = entry else { return nil }
+                return (label, action)
+            }
+    }
+
+    @Test
+    func `web session errors show claude relogin action`() {
+        let errors = [
+            ClaudeWebAPIFetcher.FetchError.unauthorized.localizedDescription,
+            ClaudeWebAPIFetcher.FetchError.noSessionKeyFound.localizedDescription,
+            ClaudeWebAPIFetcher.FetchError.invalidSessionKey.localizedDescription,
+        ]
+
+        for error in errors {
+            let actions = self.actions(error: error, source: .web)
+            #expect(actions.contains {
+                $0.0 == "Re-login at claude.ai" &&
+                    $0.1 == .loginToProvider(url: "https://claude.ai/")
+            })
+        }
+    }
+
+    @Test
+    func `auto source shows relogin action for terminal web session error`() {
+        let actions = self.actions(
+            error: ClaudeWebAPIFetcher.FetchError.unauthorized.localizedDescription,
+            source: .auto)
+
+        #expect(actions.contains {
+            $0.0 == "Re-login at claude.ai" &&
+                $0.1 == .loginToProvider(url: "https://claude.ai/")
+        })
+    }
+
+    @Test
+    func `non-web source does not replace account action`() {
+        let actions = self.actions(
+            error: ClaudeWebAPIFetcher.FetchError.unauthorized.localizedDescription,
+            source: .oauth)
+
+        #expect(!actions.contains { $0.0 == "Re-login at claude.ai" })
+    }
+
+    @Test
+    func `manual cookies do not show browser relogin action`() {
+        let actions = self.actions(
+            error: ClaudeWebAPIFetcher.FetchError.unauthorized.localizedDescription,
+            source: .web,
+            cookieSource: .manual)
+
+        #expect(!actions.contains { $0.0 == "Re-login at claude.ai" })
+    }
+
+    @Test
+    func `selected session account does not show browser relogin action`() {
+        let actions = self.actions(
+            error: ClaudeWebAPIFetcher.FetchError.unauthorized.localizedDescription,
+            source: .web,
+            cookieSource: .auto,
+            selectedSessionKey: true)
+
+        #expect(!actions.contains { $0.0 == "Re-login at claude.ai" })
+    }
+
+    @Test
+    func `unavailable web strategy shows relogin action`() {
+        let actions = self.actions(
+            error: ProviderFetchError.noAvailableStrategy(.claude).localizedDescription,
+            source: .web,
+            attempts: [
+                ProviderFetchAttempt(
+                    strategyID: "claude.web",
+                    kind: .web,
+                    wasAvailable: false,
+                    errorDescription: nil),
+            ])
+
+        #expect(actions.contains {
+            $0.0 == "Re-login at claude.ai" &&
+                $0.1 == .loginToProvider(url: "https://claude.ai/")
+        })
+    }
+
+    @Test
+    func `generic unavailable error without web attempt keeps account action`() {
+        let actions = self.actions(
+            error: ProviderFetchError.noAvailableStrategy(.claude).localizedDescription,
+            source: .auto,
+            attempts: [
+                ProviderFetchAttempt(
+                    strategyID: "claude.cli",
+                    kind: .cli,
+                    wasAvailable: false,
+                    errorDescription: nil),
+            ])
+
+        #expect(!actions.contains { $0.0 == "Re-login at claude.ai" })
+    }
+
+    @Test
+    func `unrelated web error does not replace account action`() {
+        let actions = self.actions(
+            error: ClaudeWebAPIFetcher.FetchError.serverError(statusCode: 500).localizedDescription,
+            source: .web)
+
+        #expect(!actions.contains { $0.0 == "Re-login at claude.ai" })
+    }
+}


### PR DESCRIPTION
## Summary
- show a localized `Re-login at claude.ai` contextual action for expired or missing automatically imported Claude web sessions
- reuse the existing provider login-action/menu infrastructure instead of introducing parallel recovery state
- respect effective credential routing so manual cookies, selected session accounts, OAuth, CLI, and API modes keep their existing actions
- cover direct session errors and unavailable `claude.web` planner attempts

Closes #1377.

## Validation
- `swift test --filter ClaudeWebRecoveryMenuTests`
- `swift test --filter UserFacingLocalizationCoverageTests`
- `make check`
- `swift test` — 3,427 tests in 393 suites
- structured Codex autoreview — clean after addressing auto-mode, manual-cookie, selected-account, and unavailable-web findings

No live provider auth, browser-cookie import, or Keychain probe was run.
