### PR TITLE
Fix Antigravity serve flakiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Localization: add Vietnamese as a selectable app language (#1247). Thanks @Yuxin-Qiao!
 
 ### Fixed
+- Antigravity: stop the local desktop probe from attaching to `agy` CLI processes, keep the warm managed `agy` session alive across `codexbar serve` refreshes (with teardown on SIGINT/SIGTERM), and serve the last good usage payload for transient refresh failures so external bar integrations (SketchyBar/Zellij) no longer flicker between data and errors.
 - Claude: remove transient ClaudeProbe session artifacts after CLI usage polls so background refreshes no longer fill Claude Code project history with CodexBar `/usage` sessions (#1301). Thanks @LPFchan and @matthewod11-stack!
 - Menu bar: keep z.ai overview rows with detail submenus in Overview so hovering quota details no longer recurses into a nested provider menu (#1279, fixes #1246). Thanks @RajvardhanPatil07!
 - Codex: backfill visible-account reset timestamps and missing 5-hour/weekly window metadata from same-workspace plan history so segmented multi-account JSON keeps machine-readable reset data (#1283). Thanks @callmepopo!

--- a/Sources/CodexBar/Providers/Antigravity/AntigravityProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Antigravity/AntigravityProviderImplementation.swift
@@ -42,7 +42,7 @@ struct AntigravityProviderImplementation: ProviderImplementation {
             ProviderSettingsPickerDescriptor(
                 id: "antigravity-usage-source",
                 title: "Usage source",
-                subtitle: "Auto uses the local IDE API first, then Google OAuth when the IDE is closed.",
+                subtitle: "Auto uses the desktop local API first, then agy CLI, then Google OAuth.",
                 binding: usageBinding,
                 options: usageOptions,
                 isVisible: nil,

--- a/Sources/CodexBar/UsageStore+HighestUsage.swift
+++ b/Sources/CodexBar/UsageStore+HighestUsage.swift
@@ -9,8 +9,10 @@ extension UsageStore {
         var highest: (provider: UsageProvider, usedPercent: Double)?
         for provider in self.enabledProviders() {
             guard let snapshot = self.snapshots[provider] else { continue }
-            let window = self.menuBarMetricWindowForHighestUsage(provider: provider, snapshot: snapshot)
-            let percent = window?.usedPercent ?? 0
+            guard let window = self.menuBarMetricWindowForHighestUsage(provider: provider, snapshot: snapshot) else {
+                continue
+            }
+            let percent = window.usedPercent
             guard !self.shouldExcludeFromHighestUsage(
                 provider: provider,
                 snapshot: snapshot,
@@ -49,7 +51,7 @@ extension UsageStore {
             // In automatic mode Copilot can have one depleted lane while another still has quota.
             return primary.usedPercent >= 100 && secondary.usedPercent >= 100
         }
-        if provider == .cursor,
+        if provider == .cursor || provider == .antigravity,
            effectivePreference == .automatic
         {
             let percents = [
@@ -60,17 +62,7 @@ extension UsageStore {
             guard !percents.isEmpty else { return true }
             return percents.allSatisfy { $0 >= 100 }
         }
-        if provider == .antigravity,
-           effectivePreference == .automatic
-        {
-            let percents = [
-                snapshot.primary?.usedPercent,
-                snapshot.secondary?.usedPercent,
-                snapshot.tertiary?.usedPercent,
-            ].compactMap(\.self)
-            guard !percents.isEmpty else { return true }
-            return percents.allSatisfy { $0 >= 100 }
-        }
+
         return true
     }
 }

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -136,7 +136,13 @@ actor CLIServeResponseCache {
         let response: CLILocalHTTPResponse
     }
 
+    private struct LastGoodEntry {
+        let recordedAt: Date
+        let response: CLILocalHTTPResponse
+    }
+
     private var entries: [String: Entry] = [:]
+    private var lastGood: [String: LastGoodEntry] = [:]
     private var inFlightKeys: Set<String> = []
     private var waiters: [String: [CheckedContinuation<CLIServeCacheLookup, Never>]] = [:]
 
@@ -164,21 +170,52 @@ actor CLIServeResponseCache {
         return .miss
     }
 
+    /// Completes an in-flight fetch and returns the response to deliver.
+    /// Successful responses are delivered (and cached) as-is. Failed fetches
+    /// fall back to the last good response when one was recorded within
+    /// `staleTTL`, so transient provider errors do not blank out consumers
+    /// (status bars poll this endpoint and hide items on error payloads).
+    struct CachePolicy {
+        /// How long a successful response stays fresh.
+        let ttl: TimeInterval
+        /// How long a last-good response may stand in for a failed refresh.
+        let staleTTL: TimeInterval
+    }
+
     fileprivate func completeFetch(
         _ response: CLILocalHTTPResponse,
         for key: String,
-        ttl: TimeInterval,
+        policy: CachePolicy,
         now: Date,
-        shouldCache: Bool)
+        shouldCache: Bool) -> CLILocalHTTPResponse
     {
+        let delivered: CLILocalHTTPResponse
         if shouldCache {
-            self.store(response, for: key, ttl: ttl, now: now)
+            self.store(response, for: key, ttl: policy.ttl, now: now)
+            self.lastGood[key] = LastGoodEntry(recordedAt: now, response: response)
+            delivered = response
+        } else {
+            delivered = self.staleResponse(for: key, staleTTL: policy.staleTTL, now: now) ?? response
         }
         self.inFlightKeys.remove(key)
         let waiters = self.waiters.removeValue(forKey: key) ?? []
         for waiter in waiters {
-            waiter.resume(returning: .response(response))
+            waiter.resume(returning: .response(delivered))
         }
+        return delivered
+    }
+
+    private func staleResponse(
+        for key: String,
+        staleTTL: TimeInterval,
+        now: Date) -> CLILocalHTTPResponse?
+    {
+        guard staleTTL > 0, let entry = self.lastGood[key] else { return nil }
+        guard now.timeIntervalSince(entry.recordedAt) <= staleTTL else {
+            self.lastGood[key] = nil
+            return nil
+        }
+        return entry.response
     }
 
     private func store(_ response: CLILocalHTTPResponse, for key: String, ttl: TimeInterval, now: Date) {
@@ -251,12 +288,33 @@ extension CodexBarCLI {
                 requestTimeout: requestTimeout)
         }
 
+        Self.installServeShutdownSignalHandlers()
+
         do {
             try await server.run {
                 Self.writeStderr("CodexBar server listening on http://127.0.0.1:\(port)\n")
             }
         } catch {
+            TTYCommandRunner.terminateActiveProcessesForAppShutdown()
             Self.exit(code: .failure, message: error.localizedDescription, output: output, kind: .runtime)
+        }
+    }
+
+    /// Serve keeps warm provider helper sessions (such as the managed
+    /// Antigravity `agy` process) alive between fetches, so it must tear them
+    /// down on SIGINT/SIGTERM — otherwise they outlive the server as orphans.
+    private nonisolated(unsafe) static var serveSignalSources: [any DispatchSourceSignal] = []
+
+    private static func installServeShutdownSignalHandlers() {
+        for sig in [SIGINT, SIGTERM] {
+            signal(sig, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(signal: sig, queue: .main)
+            source.setEventHandler {
+                TTYCommandRunner.terminateActiveProcessesForAppShutdown()
+                Foundation.exit(sig == SIGINT ? 130 : 143)
+            }
+            source.resume()
+            self.serveSignalSources.append(source)
         }
     }
 
@@ -356,13 +414,14 @@ extension CodexBarCLI {
             let response = await Self.serveResponseWithDeadline(seconds: requestTimeout) {
                 await makeResponse()
             }
-            await cache.completeFetch(
+            return await cache.completeFetch(
                 response,
                 for: key,
-                ttl: refreshInterval,
+                policy: CLIServeResponseCache.CachePolicy(
+                    ttl: refreshInterval,
+                    staleTTL: Self.serveStaleTTL(refreshInterval: refreshInterval)),
                 now: Date(),
                 shouldCache: Self.shouldCacheServeResponse(response))
-            return response
         }
     }
 
@@ -397,6 +456,15 @@ extension CodexBarCLI {
             }
             state.setTimeoutTask(timeoutTask)
         }
+    }
+
+    /// How long a last-good response may be served in place of a failed
+    /// refresh. Bounded so consumers never see data that is hours stale:
+    /// ten refresh intervals, with a five-minute floor for short intervals.
+    /// Zero (stale fallback disabled) when response caching is disabled.
+    static func serveStaleTTL(refreshInterval: TimeInterval) -> TimeInterval {
+        guard refreshInterval > 0 else { return 0 }
+        return max(refreshInterval * 10, 300)
     }
 
     static func shouldCacheServeResponse(_ response: CLILocalHTTPResponse) -> Bool {
@@ -447,7 +515,8 @@ extension CodexBarCLI {
             includeAllCodexAccounts: true,
             fetcher: UsageFetcher(),
             claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
-            browserDetection: browserDetection)
+            browserDetection: browserDetection,
+            persistCLISessions: true)
 
         var output = UsageCommandOutput()
         for provider in selection.asList {

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -18,6 +18,10 @@ struct UsageCommandContext {
     let fetcher: UsageFetcher
     let claudeFetcher: ClaudeUsageFetcher
     let browserDetection: BrowserDetection
+    /// True when running inside a long-lived process (`codexbar serve`):
+    /// warm provider helper sessions (such as the managed Antigravity `agy`
+    /// process) are kept alive between fetches instead of torn down.
+    var persistCLISessions: Bool = false
 }
 
 struct UsageCommandOutput {
@@ -291,7 +295,8 @@ extension CodexBarCLI {
             browserDetection: command.browserDetection,
             selectedTokenAccountID: account?.id,
             tokenAccountTokenUpdater: tokenContext.tokenUpdater(for: account),
-            providerManualTokenUpdater: tokenContext.manualTokenUpdater())
+            providerManualTokenUpdater: tokenContext.manualTokenUpdater(),
+            persistsCLISessions: command.persistCLISessions ? true : nil)
         let outcome = await Self.fetchProviderUsage(
             provider: provider,
             context: fetchContext)

--- a/Sources/CodexBarCore/PathEnvironment.swift
+++ b/Sources/CodexBarCore/PathEnvironment.swift
@@ -77,6 +77,31 @@ public enum BinaryLocator {
         ]
     }
 
+    public static func resolveAntigravityBinary(
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        loginPATH: [String]? = LoginShellPathCache.shared.current,
+        commandV: (String, String?, TimeInterval, FileManager) -> String? = ShellCommandLocator.commandV,
+        aliasResolver: (String, String?, TimeInterval, FileManager, String) -> String? = ShellCommandLocator
+            .resolveAlias,
+        fileManager: FileManager = .default,
+        home: String = NSHomeDirectory()) -> String?
+    {
+        self.resolveBinary(
+            name: "agy",
+            overrideKey: "ANTIGRAVITY_CLI_PATH",
+            env: env,
+            loginPATH: loginPATH,
+            commandV: commandV,
+            aliasResolver: aliasResolver,
+            wellKnownPaths: [
+                "\(home)/.local/bin/agy",
+                "/opt/homebrew/bin/agy",
+                "/usr/local/bin/agy",
+            ],
+            fileManager: fileManager,
+            home: home)
+    }
+
     public static func resolveCodexBinary(
         env: [String: String] = ProcessInfo.processInfo.environment,
         loginPATH: [String]? = LoginShellPathCache.shared.current,

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
@@ -1,0 +1,876 @@
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+import Foundation
+
+// MARK: - Antigravity CLI Process Abstractions
+
+protocol AntigravityCLIProcessHandle: AnyObject, Sendable {
+    var pid: pid_t { get }
+    var isRunning: Bool { get }
+    var processGroup: pid_t? { get }
+
+    func assignProcessGroup() -> pid_t?
+    func sendExit() throws
+    func closePTY()
+    func terminateRoot()
+    func killRoot()
+    func descendantPIDs() -> [pid_t]
+    func terminateTree(signal: Int32, knownDescendants: [pid_t])
+    func killDescendants(_ descendants: [pid_t])
+    func drainOutput()
+}
+
+protocol AntigravityCLIProcessLaunching: Sendable {
+    func launch(binary: String) throws -> any AntigravityCLIProcessHandle
+}
+
+struct AntigravityCLIProcessIdentity: Equatable, Sendable {
+    let executablePath: String
+    let startEpoch: TimeInterval
+}
+
+protocol AntigravityCLIProcessIdentityProviding: Sendable {
+    func identity(for pid: pid_t) -> AntigravityCLIProcessIdentity?
+}
+
+struct AntigravityCLISessionRecord: Codable, Equatable, Sendable {
+    let pid: pid_t
+    let requestedBinaryPath: String
+    let executablePath: String
+    let startEpoch: TimeInterval
+    let processGroup: pid_t?
+    let ownerPID: pid_t?
+    let ownerExecutablePath: String?
+    let ownerStartEpoch: TimeInterval?
+
+    init(
+        pid: pid_t,
+        requestedBinaryPath: String,
+        executablePath: String,
+        startEpoch: TimeInterval,
+        processGroup: pid_t?,
+        ownerPID: pid_t? = nil,
+        ownerExecutablePath: String? = nil,
+        ownerStartEpoch: TimeInterval? = nil)
+    {
+        self.pid = pid
+        self.requestedBinaryPath = requestedBinaryPath
+        self.executablePath = executablePath
+        self.startEpoch = startEpoch
+        self.processGroup = processGroup
+        self.ownerPID = ownerPID
+        self.ownerExecutablePath = ownerExecutablePath
+        self.ownerStartEpoch = ownerStartEpoch
+    }
+}
+
+protocol AntigravityCLISessionRecordStoring: Sendable {
+    func load() throws -> AntigravityCLISessionRecord?
+    func save(_ record: AntigravityCLISessionRecord) throws
+    func remove() throws
+}
+
+// MARK: - AntigravityCLISession
+
+/// Manages a bounded background ``agy`` process whose embedded localhost server
+/// provides the same ``GetUserStatus`` endpoint as the desktop Antigravity app's
+/// ``language_server``. The CLI is kept alive in a PTY so its daemon stays bound
+/// to a local port — this lets CodexBar read Claude + Gemini quotas even when
+/// the desktop Antigravity app is closed.
+///
+/// The session intentionally does not scrape TUI output. It only launches and
+/// keeps the process reachable for HTTPS probing, drains discarded PTY output so
+/// the CLI cannot block on a full terminal buffer, and bounds the warm lifetime
+/// with an idle timer so CodexBar does not run an IDE backend forever.
+actor AntigravityCLISession {
+    static let shared = AntigravityCLISession()
+    private static let log = CodexBarLog.logger(LogCategories.antigravity)
+
+    struct Dependencies: Sendable {
+        var launcher: any AntigravityCLIProcessLaunching
+        var identityProvider: any AntigravityCLIProcessIdentityProviding
+        var recordStore: any AntigravityCLISessionRecordStoring
+        var registerForAppShutdown: @Sendable (pid_t, String) -> Bool
+        var updateAppShutdownProcessGroup: @Sendable (pid_t, pid_t?) -> Void
+        var unregisterForAppShutdown: @Sendable (pid_t) -> Void
+        var descendantPIDs: @Sendable (pid_t) -> [pid_t]
+        var terminateProcessTree: @Sendable (pid_t, pid_t?, Int32, [pid_t]) -> Void
+        var currentProcessID: @Sendable () -> pid_t
+        var now: @Sendable () -> Date
+        var sleep: @Sendable (UInt64) async throws -> Void
+        var idleWindow: TimeInterval
+        var failureRelaunchThreshold: Int
+        var terminationGracePeriod: TimeInterval
+
+        static func live() -> Self {
+            Self(
+                launcher: AntigravityPTYProcessLauncher(),
+                identityProvider: AntigravityDarwinProcessIdentityProvider(),
+                recordStore: AntigravityFileCLISessionRecordStore(),
+                registerForAppShutdown: { pid, binary in
+                    TTYCommandRunner.registerActiveProcessForAppShutdown(pid: pid, binary: binary)
+                },
+                updateAppShutdownProcessGroup: { pid, group in
+                    TTYCommandRunner.updateActiveProcessGroupForAppShutdown(pid: pid, processGroup: group)
+                },
+                unregisterForAppShutdown: { pid in
+                    TTYCommandRunner.unregisterActiveProcessForAppShutdown(pid: pid)
+                },
+                descendantPIDs: { pid in
+                    TTYProcessTreeTerminator.descendantPIDs(of: pid)
+                },
+                terminateProcessTree: { pid, group, signal, knownDescendants in
+                    TTYProcessTreeTerminator.terminateProcessTree(
+                        rootPID: pid,
+                        processGroup: group,
+                        signal: signal,
+                        knownDescendants: knownDescendants)
+                },
+                currentProcessID: getpid,
+                now: Date.init,
+                sleep: { nanoseconds in
+                    try await Task.sleep(nanoseconds: nanoseconds)
+                },
+                idleWindow: 180,
+                failureRelaunchThreshold: 2,
+                terminationGracePeriod: 1)
+        }
+    }
+
+    // MARK: State
+
+    private let dependencies: Dependencies
+    private var process: (any AntigravityCLIProcessHandle)?
+    private var binaryPath: String?
+    private var activeProbeCount = 0
+    private var activeSessionProbeCount = 0
+    private var resetRequestedWhenIdle = false
+    private var idleTask: Task<Void, Never>?
+    private var sessionGeneration: UInt64 = 0
+    private var consecutiveProbeFailures = 0
+    private var persistedProcessIdentity: AntigravityCLIProcessIdentity?
+    private var lifecycleOperationInProgress = false
+    private var lifecycleWaiters: [CheckedContinuation<Void, Never>] = []
+    private var exclusiveProbeWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init(dependencies: Dependencies = .live()) {
+        self.dependencies = dependencies
+    }
+
+    /// The pid of the running ``agy`` process, exposed so callers can discover
+    /// its listening ports via `lsof`.
+    var pid: pid_t? {
+        guard let proc = self.process, proc.isRunning else { return nil }
+        return proc.pid
+    }
+
+    /// Whether the managed process is alive and matches ``binaryPath``.
+    var isRunning: Bool {
+        guard let proc = self.process, proc.isRunning, self.binaryPath != nil else { return false }
+        return true
+    }
+
+    var failureCountForTesting: Int {
+        self.consecutiveProbeFailures
+    }
+
+    // MARK: Lifecycle
+
+    /// Mark a probe as active and ensure a warm ``agy`` is running on the given binary path.
+    ///
+    /// Callers must balance this with ``finishProbe(success:resetAfterFetch:)`` so
+    /// idle/reset cleanup cannot kill the process while its ports are being probed.
+    /// If previous probes repeatedly failed while the process stayed alive, this
+    /// force-relaunches instead of reusing a wedged HTTPS server forever.
+    func beginProbe(binary: String) async throws -> pid_t {
+        self.activeProbeCount += 1
+        self.cancelIdleTimer()
+        do {
+            return try await self.withLifecycleOperation {
+                let pid = try await self.ensureStartedLocked(binary: binary)
+                self.activeSessionProbeCount += 1
+                return pid
+            }
+        } catch {
+            self.activeProbeCount = max(0, self.activeProbeCount - 1)
+            self.notifyExclusiveProbeWaitersIfNeeded()
+            if self.activeProbeCount == 0, self.resetRequestedWhenIdle {
+                await self.withLifecycleOperation {
+                    guard self.activeProbeCount == 0 else {
+                        self.resetRequestedWhenIdle = true
+                        return
+                    }
+                    await self.stopCurrentSessionLocked(reason: "deferred reset after failed begin", clearRecord: true)
+                }
+            }
+            throw error
+        }
+    }
+
+    /// Record probe completion and either keep the session warm for the bounded
+    /// idle window or tear it down immediately for one-shot CLI invocations.
+    func finishProbe(success: Bool, resetAfterFetch: Bool) async {
+        if success {
+            self.consecutiveProbeFailures = 0
+        } else {
+            self.consecutiveProbeFailures += 1
+        }
+
+        self.activeProbeCount = max(0, self.activeProbeCount - 1)
+        self.activeSessionProbeCount = max(0, self.activeSessionProbeCount - 1)
+        self.notifyExclusiveProbeWaitersIfNeeded()
+        let shouldForceStopUnhealthy = !success &&
+            self.consecutiveProbeFailures >= max(1, self.dependencies.failureRelaunchThreshold)
+        let shouldReset = resetAfterFetch || self.resetRequestedWhenIdle || shouldForceStopUnhealthy
+
+        guard self.activeProbeCount == 0 else {
+            if shouldReset {
+                self.resetRequestedWhenIdle = true
+            }
+            return
+        }
+
+        if shouldReset {
+            let reason =
+                if resetAfterFetch {
+                    "one-shot CLI fetch"
+                } else if shouldForceStopUnhealthy {
+                    "unhealthy CLI HTTPS session"
+                } else {
+                    "deferred reset"
+                }
+            await self.withLifecycleOperation {
+                guard self.activeProbeCount == 0 else {
+                    self.resetRequestedWhenIdle = true
+                    return
+                }
+                self.resetRequestedWhenIdle = false
+                await self.stopCurrentSessionLocked(reason: reason, clearRecord: true)
+            }
+        } else {
+            self.armIdleTimer()
+        }
+    }
+
+    /// Ensure a warm ``agy`` is running on the given binary path.
+    ///
+    /// - If the process is already alive with the same binary, this returns immediately.
+    /// - If the process died, the binary changed, or repeated probes failed, it tears down the old one first.
+    /// - Returns the process identifier for port discovery.
+    func ensureStarted(binary: String) async throws -> pid_t {
+        try await self.withLifecycleOperation {
+            try await self.ensureStartedLocked(binary: binary)
+        }
+    }
+
+    /// Request teardown. If a probe is in flight, cleanup is deferred until the
+    /// matching ``finishProbe(success:resetAfterFetch:)`` call.
+    func reset() async {
+        self.cancelIdleTimer()
+        guard self.activeProbeCount == 0 else {
+            self.resetRequestedWhenIdle = true
+            return
+        }
+        await self.withLifecycleOperation {
+            guard self.activeProbeCount == 0 else {
+                self.resetRequestedWhenIdle = true
+                return
+            }
+            self.resetRequestedWhenIdle = false
+            await self.stopCurrentSessionLocked(reason: "manual reset", clearRecord: true)
+        }
+    }
+
+    /// Drain PTY output so the write side doesn't block.
+    func drainOutput() {
+        self.process?.drainOutput()
+    }
+
+    // MARK: Errors
+
+    enum SessionError: LocalizedError {
+        case launchFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .launchFailed(msg): "Failed to launch Antigravity CLI session: \(msg)"
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private func withLifecycleOperation<T>(_ operation: () async throws -> T) async throws -> T {
+        await self.acquireLifecycleOperation()
+        defer { self.releaseLifecycleOperation() }
+        return try await operation()
+    }
+
+    private func withLifecycleOperation(_ operation: () async -> Void) async {
+        await self.acquireLifecycleOperation()
+        defer { self.releaseLifecycleOperation() }
+        await operation()
+    }
+
+    private func acquireLifecycleOperation() async {
+        guard self.lifecycleOperationInProgress else {
+            self.lifecycleOperationInProgress = true
+            return
+        }
+        await withCheckedContinuation { continuation in
+            self.lifecycleWaiters.append(continuation)
+        }
+    }
+
+    private func releaseLifecycleOperation() {
+        guard !self.lifecycleWaiters.isEmpty else {
+            self.lifecycleOperationInProgress = false
+            return
+        }
+        let next = self.lifecycleWaiters.removeFirst()
+        next.resume()
+    }
+
+    private func waitForExclusiveProbeIfNeeded() async {
+        while self.activeSessionProbeCount > 0 {
+            await withCheckedContinuation { continuation in
+                self.exclusiveProbeWaiters.append(continuation)
+            }
+        }
+    }
+
+    private func notifyExclusiveProbeWaitersIfNeeded() {
+        guard self.activeSessionProbeCount == 0, !self.exclusiveProbeWaiters.isEmpty else { return }
+        let waiters = self.exclusiveProbeWaiters
+        self.exclusiveProbeWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func ensureStartedLocked(binary: String) async throws -> pid_t {
+        while true {
+            let canPersistRecord = if self.process == nil {
+                self.reapRecordedSessionIfNeeded()
+            } else {
+                true
+            }
+
+            if let proc = self.process,
+               proc.isRunning,
+               self.binaryPath == binary,
+               self.consecutiveProbeFailures < max(1, self.dependencies.failureRelaunchThreshold)
+            {
+                Self.log.debug("Antigravity CLI session reused", metadata: ["pid": "\(proc.pid)"])
+                return proc.pid
+            }
+
+            if self.process != nil {
+                if self.activeSessionProbeCount > 0 {
+                    await self.waitForExclusiveProbeIfNeeded()
+                    continue
+                }
+
+                let reason = self.consecutiveProbeFailures >= max(1, self.dependencies.failureRelaunchThreshold)
+                    ? "relaunching unhealthy session"
+                    : "replacing stale session"
+                await self.stopCurrentSessionLocked(reason: reason, clearRecord: true)
+            }
+
+            let launched = try self.dependencies.launcher.launch(binary: binary)
+            let launchedPID = launched.pid
+            let binaryName = URL(fileURLWithPath: binary).lastPathComponent
+            guard self.dependencies.registerForAppShutdown(launchedPID, binaryName) else {
+                await self.terminateLaunchedProcess(launched)
+                throw SessionError.launchFailed("App shutdown in progress")
+            }
+
+            let processGroup = launched.processGroup ?? launched.assignProcessGroup()
+            self.dependencies.updateAppShutdownProcessGroup(launchedPID, processGroup)
+
+            self.process = launched
+            self.binaryPath = binary
+            self.consecutiveProbeFailures = 0
+            self.sessionGeneration &+= 1
+            if canPersistRecord {
+                self.persistRecord(pid: launchedPID, binary: binary, processGroup: processGroup)
+            } else {
+                self.persistedProcessIdentity = nil
+            }
+
+            Self.log.debug(
+                "Antigravity CLI session started",
+                metadata: [
+                    "binary": binaryName,
+                    "pid": "\(launchedPID)",
+                ])
+            return launchedPID
+        }
+    }
+
+    private func cancelIdleTimer() {
+        self.idleTask?.cancel()
+        self.idleTask = nil
+    }
+
+    private func armIdleTimer() {
+        guard self.process != nil, self.dependencies.idleWindow > 0 else { return }
+        self.cancelIdleTimer()
+        let generation = self.sessionGeneration
+        let nanoseconds = Self.nanoseconds(from: self.dependencies.idleWindow)
+        let sleep = self.dependencies.sleep
+        self.idleTask = Task { [weak self] in
+            do {
+                try await sleep(nanoseconds)
+                await self?.stopIfIdle(generation: generation)
+            } catch {
+                // Cancellation is the normal path when a refresh reuses the warm session.
+            }
+        }
+    }
+
+    private func stopIfIdle(generation: UInt64) async {
+        await self.withLifecycleOperation {
+            guard generation == self.sessionGeneration else { return }
+            guard self.activeProbeCount == 0 else {
+                self.armIdleTimer()
+                return
+            }
+            await self.stopCurrentSessionLocked(reason: "idle timeout", clearRecord: true)
+        }
+    }
+
+    private func stopCurrentSessionLocked(reason: String, clearRecord: Bool) async {
+        self.cancelIdleTimer()
+        guard let proc = self.process else {
+            if clearRecord {
+                _ = self.reapRecordedSessionIfNeeded()
+            }
+            return
+        }
+
+        let pid = proc.pid
+        let identity = self.persistedProcessIdentity
+        Self.log.debug("Antigravity CLI session stopping", metadata: ["pid": "\(pid)", "reason": "\(reason)"])
+
+        self.process = nil
+        self.binaryPath = nil
+        self.persistedProcessIdentity = nil
+        self.sessionGeneration &+= 1
+
+        await self.terminateLaunchedProcess(proc)
+        self.dependencies.unregisterForAppShutdown(pid)
+        if clearRecord {
+            self.removeRecordIfMatches(pid: pid, identity: identity)
+        }
+    }
+
+    private func terminateLaunchedProcess(_ proc: any AntigravityCLIProcessHandle) async {
+        try? proc.sendExit()
+        proc.closePTY()
+
+        let descendants = proc.descendantPIDs()
+        if proc.isRunning {
+            proc.terminateRoot()
+        }
+        proc.terminateTree(signal: SIGTERM, knownDescendants: descendants)
+
+        let gracePeriod = self.dependencies.terminationGracePeriod
+        if gracePeriod > 0 {
+            let deadline = self.dependencies.now().addingTimeInterval(gracePeriod)
+            while proc.isRunning, self.dependencies.now() < deadline {
+                try? await self.dependencies.sleep(100_000_000)
+            }
+        }
+
+        if proc.isRunning {
+            proc.terminateTree(signal: SIGKILL, knownDescendants: descendants)
+            await self.waitUntilProcessExits(proc, timeout: 1)
+        } else {
+            proc.killDescendants(descendants)
+        }
+    }
+
+    private func waitUntilProcessExits(_ proc: any AntigravityCLIProcessHandle, timeout: TimeInterval) async {
+        let deadline = self.dependencies.now().addingTimeInterval(timeout)
+        while proc.isRunning, self.dependencies.now() < deadline {
+            try? await self.dependencies.sleep(50_000_000)
+        }
+        _ = proc.isRunning
+    }
+
+    private func persistRecord(pid: pid_t, binary: String, processGroup: pid_t?) {
+        guard let identity = self.dependencies.identityProvider.identity(for: pid) else {
+            self.persistedProcessIdentity = nil
+            return
+        }
+        let ownerPID = self.dependencies.currentProcessID()
+        let ownerIdentity = self.dependencies.identityProvider.identity(for: ownerPID)
+        let record = AntigravityCLISessionRecord(
+            pid: pid,
+            requestedBinaryPath: binary,
+            executablePath: identity.executablePath,
+            startEpoch: identity.startEpoch,
+            processGroup: processGroup,
+            ownerPID: ownerPID,
+            ownerExecutablePath: ownerIdentity?.executablePath,
+            ownerStartEpoch: ownerIdentity?.startEpoch)
+        do {
+            try self.dependencies.recordStore.save(record)
+            self.persistedProcessIdentity = identity
+        } catch {
+            self.persistedProcessIdentity = nil
+        }
+    }
+
+    @discardableResult
+    private func reapRecordedSessionIfNeeded() -> Bool {
+        guard let record = try? self.dependencies.recordStore.load() else { return true }
+        guard let liveIdentity = self.dependencies.identityProvider.identity(for: record.pid) else {
+            try? self.dependencies.recordStore.remove()
+            return true
+        }
+        guard liveIdentity.executablePath == record.executablePath,
+              abs(liveIdentity.startEpoch - record.startEpoch) < 0.001
+        else {
+            try? self.dependencies.recordStore.remove()
+            return true
+        }
+        if let ownerPID = record.ownerPID,
+           ownerPID != self.dependencies.currentProcessID(),
+           let ownerExecutablePath = record.ownerExecutablePath,
+           let ownerStartEpoch = record.ownerStartEpoch,
+           let liveOwnerIdentity = self.dependencies.identityProvider.identity(for: ownerPID),
+           liveOwnerIdentity.executablePath == ownerExecutablePath,
+           abs(liveOwnerIdentity.startEpoch - ownerStartEpoch) < 0.001
+        {
+            Self.log.debug("Antigravity CLI session still owned by live process", metadata: [
+                "pid": "\(record.pid)",
+                "ownerPID": "\(ownerPID)",
+            ])
+            self.persistedProcessIdentity = nil
+            return false
+        }
+
+        let knownDescendants = self.dependencies.descendantPIDs(record.pid)
+        Self.log.debug("Reaping stale Antigravity CLI session", metadata: ["pid": "\(record.pid)"])
+        self.dependencies.terminateProcessTree(record.pid, record.processGroup, SIGTERM, knownDescendants)
+        self.dependencies.terminateProcessTree(record.pid, record.processGroup, SIGKILL, knownDescendants)
+        try? self.dependencies.recordStore.remove()
+        return true
+    }
+
+    private func removeRecordIfMatches(pid: pid_t, identity: AntigravityCLIProcessIdentity?) {
+        guard let identity,
+              let record = try? self.dependencies.recordStore.load(),
+              record.pid == pid,
+              record.executablePath == identity.executablePath,
+              abs(record.startEpoch - identity.startEpoch) < 0.001
+        else { return }
+        try? self.dependencies.recordStore.remove()
+    }
+
+    private static func nanoseconds(from interval: TimeInterval) -> UInt64 {
+        guard interval > 0 else { return 0 }
+        let capped = min(interval, TimeInterval(UInt64.max) / 1_000_000_000)
+        return UInt64(capped * 1_000_000_000)
+    }
+}
+
+// MARK: - Production Process Implementation
+
+struct AntigravityPTYProcessLauncher: AntigravityCLIProcessLaunching {
+    func launch(binary: String) throws -> any AntigravityCLIProcessHandle {
+        var primaryFD: Int32 = -1
+        var secondaryFD: Int32 = -1
+        var win = winsize(ws_row: 50, ws_col: 160, ws_xpixel: 0, ws_ypixel: 0)
+        guard openpty(&primaryFD, &secondaryFD, nil, nil, &win) == 0 else {
+            throw AntigravityCLISession.SessionError.launchFailed("openpty failed")
+        }
+        _ = fcntl(primaryFD, F_SETFL, O_NONBLOCK)
+
+        let primaryHandle = FileHandle(fileDescriptor: primaryFD, closeOnDealloc: true)
+        let secondaryHandle = FileHandle(fileDescriptor: secondaryFD, closeOnDealloc: true)
+
+        #if canImport(Darwin)
+        var fileActions: posix_spawn_file_actions_t?
+        #else
+        var fileActions = posix_spawn_file_actions_t()
+        #endif
+        guard posix_spawn_file_actions_init(&fileActions) == 0 else {
+            try? primaryHandle.close()
+            try? secondaryHandle.close()
+            throw AntigravityCLISession.SessionError.launchFailed("posix_spawn_file_actions_init failed")
+        }
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+
+        posix_spawn_file_actions_adddup2(&fileActions, secondaryFD, 0)
+        posix_spawn_file_actions_adddup2(&fileActions, secondaryFD, 1)
+        posix_spawn_file_actions_adddup2(&fileActions, secondaryFD, 2)
+        posix_spawn_file_actions_addclose(&fileActions, primaryFD)
+        posix_spawn_file_actions_addclose(&fileActions, secondaryFD)
+
+        #if canImport(Darwin)
+        let homeDirectory = NSHomeDirectory()
+        _ = homeDirectory.withCString { path in
+            posix_spawn_file_actions_addchdir_np(&fileActions, path)
+        }
+        #endif
+
+        #if canImport(Darwin)
+        var attr: posix_spawnattr_t?
+        #else
+        var attr = posix_spawnattr_t()
+        #endif
+        guard posix_spawnattr_init(&attr) == 0 else {
+            try? primaryHandle.close()
+            try? secondaryHandle.close()
+            throw AntigravityCLISession.SessionError.launchFailed("posix_spawnattr_init failed")
+        }
+        defer { posix_spawnattr_destroy(&attr) }
+        posix_spawnattr_setflags(&attr, Int16(POSIX_SPAWN_SETPGROUP))
+        posix_spawnattr_setpgroup(&attr, 0)
+
+        var env = TTYCommandRunner.enrichedEnvironment()
+        env["PWD"] = NSHomeDirectory()
+        env["TERM"] = "xterm-256color"
+
+        let cArgs: [UnsafeMutablePointer<CChar>?] = [strdup(binary), nil]
+        defer {
+            for arg in cArgs {
+                if let arg {
+                    free(arg)
+                }
+            }
+        }
+
+        var cEnv: [UnsafeMutablePointer<CChar>?] = env.map { key, value in
+            strdup("\(key)=\(value)")
+        }
+        cEnv.append(nil)
+        defer {
+            for entry in cEnv {
+                if let entry {
+                    free(entry)
+                }
+            }
+        }
+
+        var pid: pid_t = 0
+        let spawnResult = binary.withCString { execPath in
+            posix_spawn(&pid, execPath, &fileActions, &attr, cArgs, cEnv)
+        }
+        guard spawnResult == 0 else {
+            try? primaryHandle.close()
+            try? secondaryHandle.close()
+            throw AntigravityCLISession.SessionError.launchFailed(String(cString: strerror(spawnResult)))
+        }
+
+        return AntigravitySpawnedPTYProcessHandle(
+            pid: pid,
+            processGroup: pid,
+            primaryFD: primaryFD,
+            primaryHandle: primaryHandle,
+            secondaryHandle: secondaryHandle)
+    }
+}
+
+final class AntigravitySpawnedPTYProcessHandle: AntigravityCLIProcessHandle, @unchecked Sendable {
+    private let lock = NSLock()
+    private let processPID: pid_t
+    private let processGroupID: pid_t
+    private let primaryFD: Int32
+    private let primaryHandle: FileHandle
+    private let secondaryHandle: FileHandle
+    private var reaped = false
+
+    init(
+        pid: pid_t,
+        processGroup: pid_t,
+        primaryFD: Int32,
+        primaryHandle: FileHandle,
+        secondaryHandle: FileHandle)
+    {
+        self.processPID = pid
+        self.processGroupID = processGroup
+        self.primaryFD = primaryFD
+        self.primaryHandle = primaryHandle
+        self.secondaryHandle = secondaryHandle
+    }
+
+    var pid: pid_t {
+        self.processPID
+    }
+
+    var isRunning: Bool {
+        self.lock.lock()
+        if self.reaped {
+            self.lock.unlock()
+            return false
+        }
+        self.lock.unlock()
+
+        var status: Int32 = 0
+        let result = waitpid(self.processPID, &status, WNOHANG)
+
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        switch result {
+        case 0:
+            return true
+        case self.processPID:
+            self.reaped = true
+            return false
+        case -1 where errno == ECHILD:
+            self.reaped = true
+            return false
+        default:
+            return kill(self.processPID, 0) == 0 || errno == EPERM
+        }
+    }
+
+    var processGroup: pid_t? {
+        self.processGroupID
+    }
+
+    func assignProcessGroup() -> pid_t? {
+        self.processGroupID
+    }
+
+    func sendExit() throws {
+        try self.writeAllToPrimary(Data("/exit\r".utf8))
+    }
+
+    func closePTY() {
+        try? self.primaryHandle.close()
+        try? self.secondaryHandle.close()
+    }
+
+    func terminateRoot() {
+        kill(self.processPID, SIGTERM)
+    }
+
+    func killRoot() {
+        kill(self.processPID, SIGKILL)
+    }
+
+    func descendantPIDs() -> [pid_t] {
+        TTYProcessTreeTerminator.descendantPIDs(of: self.processPID)
+    }
+
+    func terminateTree(signal: Int32, knownDescendants: [pid_t]) {
+        TTYProcessTreeTerminator.terminateProcessTree(
+            rootPID: self.processPID,
+            processGroup: self.processGroupID,
+            signal: signal,
+            knownDescendants: knownDescendants)
+    }
+
+    func killDescendants(_ descendants: [pid_t]) {
+        for pid in descendants where pid > 0 {
+            kill(pid, SIGKILL)
+        }
+    }
+
+    func drainOutput() {
+        var tmp = [UInt8](repeating: 0, count: 8192)
+        for _ in 0..<64 {
+            let n = read(self.primaryFD, &tmp, tmp.count)
+            if n > 0 { continue }
+            break
+        }
+    }
+
+    private func writeAllToPrimary(_ data: Data) throws {
+        data.withUnsafeBytes { rawBytes in
+            guard let baseAddress = rawBytes.baseAddress else { return }
+            var offset = 0
+            var retries = 0
+            while offset < rawBytes.count {
+                let written = write(self.primaryFD, baseAddress.advanced(by: offset), rawBytes.count - offset)
+                if written > 0 {
+                    offset += written
+                    retries = 0
+                    continue
+                }
+                if written == 0 { break }
+
+                let err = errno
+                if err == EINTR || err == EAGAIN || err == EWOULDBLOCK {
+                    retries += 1
+                    if retries > 200 { return }
+                    usleep(5000)
+                    continue
+                }
+                return
+            }
+        }
+    }
+}
+
+// MARK: - Production Stale Session Identity + Storage
+
+struct AntigravityDarwinProcessIdentityProvider: AntigravityCLIProcessIdentityProviding {
+    func identity(for pid: pid_t) -> AntigravityCLIProcessIdentity? {
+        #if canImport(Darwin)
+        var pathBuffer = [CChar](repeating: 0, count: 4096)
+        let pathLength = proc_pidpath(pid, &pathBuffer, UInt32(pathBuffer.count))
+        guard pathLength > 0 else { return nil }
+        let executablePath = pathBuffer.withUnsafeBufferPointer { buffer -> String? in
+            let rawBytes = UnsafeRawBufferPointer(start: buffer.baseAddress, count: Int(pathLength))
+            return String(bytes: rawBytes.prefix { $0 != 0 }, encoding: .utf8)
+        }
+        guard let executablePath, !executablePath.isEmpty else { return nil }
+
+        var info = proc_bsdinfo()
+        let size = proc_pidinfo(
+            pid,
+            PROC_PIDTBSDINFO,
+            0,
+            &info,
+            Int32(MemoryLayout<proc_bsdinfo>.stride))
+        guard size == Int32(MemoryLayout<proc_bsdinfo>.stride) else { return nil }
+        let startEpoch = TimeInterval(info.pbi_start_tvsec) + (TimeInterval(info.pbi_start_tvusec) / 1_000_000)
+        return AntigravityCLIProcessIdentity(executablePath: executablePath, startEpoch: startEpoch)
+        #else
+        return nil
+        #endif
+    }
+}
+
+final class AntigravityFileCLISessionRecordStore: AntigravityCLISessionRecordStoring, @unchecked Sendable {
+    private let fileURL: URL
+    private let fileManager: FileManager
+
+    init(
+        fileURL: URL = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+            .appendingPathComponent(".codexbar", isDirectory: true)
+            .appendingPathComponent("antigravity", isDirectory: true)
+            .appendingPathComponent("agy-session.json"),
+        fileManager: FileManager = .default)
+    {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    func load() throws -> AntigravityCLISessionRecord? {
+        guard self.fileManager.fileExists(atPath: self.fileURL.path) else { return nil }
+        let data = try Data(contentsOf: self.fileURL)
+        return try JSONDecoder().decode(AntigravityCLISessionRecord.self, from: data)
+    }
+
+    func save(_ record: AntigravityCLISessionRecord) throws {
+        let directory = self.fileURL.deletingLastPathComponent()
+        try self.fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(record)
+        try data.write(to: self.fileURL, options: [.atomic])
+    }
+
+    func remove() throws {
+        guard self.fileManager.fileExists(atPath: self.fileURL.path) else { return }
+        try self.fileManager.removeItem(at: self.fileURL)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
@@ -353,17 +353,14 @@ actor AntigravityCLISession {
 
     private func ensureStartedLocked(binary: String) async throws -> pid_t {
         while true {
-            let canPersistRecord = if self.process == nil {
-                self.reapRecordedSessionIfNeeded()
-            } else {
-                true
-            }
+            let canPersistRecord = self.canPersistRecordForLaunch()
 
             if let proc = self.process,
                proc.isRunning,
                self.binaryPath == binary,
                self.consecutiveProbeFailures < max(1, self.dependencies.failureRelaunchThreshold)
             {
+                self.persistCurrentRecordIfNeeded(proc, binary: binary, canPersistRecord: canPersistRecord)
                 Self.log.debug("Antigravity CLI session reused", metadata: ["pid": "\(proc.pid)"])
                 return proc.pid
             }
@@ -409,6 +406,20 @@ actor AntigravityCLISession {
                 ])
             return launchedPID
         }
+    }
+
+    private func canPersistRecordForLaunch() -> Bool {
+        guard self.process == nil || self.persistedProcessIdentity == nil else { return true }
+        return self.reapRecordedSessionIfNeeded()
+    }
+
+    private func persistCurrentRecordIfNeeded(
+        _ proc: any AntigravityCLIProcessHandle,
+        binary: String,
+        canPersistRecord: Bool)
+    {
+        guard canPersistRecord, self.persistedProcessIdentity == nil else { return }
+        self.persistRecord(pid: proc.pid, binary: binary, processGroup: proc.processGroup)
     }
 
     private func cancelIdleTimer() {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
@@ -35,6 +35,33 @@ public struct AntigravityOAuthCredentials: Codable, Sendable, Equatable {
         return Date(timeIntervalSince1970: expiryDateMilliseconds / 1000)
     }
 
+    /// Email of the Google account these credentials authenticate, preferring the
+    /// signed `id_token` claim (what the remote OAuth fetcher reports) and falling
+    /// back to the stored `email` field. Used to verify that an ambient local/CLI
+    /// Antigravity snapshot belongs to the account the user explicitly selected.
+    public var resolvedAccountEmail: String? {
+        Self.email(fromIDToken: self.idToken) ?? self.email?.trimmedNonEmptyEmail
+    }
+
+    static func email(fromIDToken idToken: String?) -> String? {
+        guard let idToken else { return nil }
+        let parts = idToken.components(separatedBy: ".")
+        guard parts.count >= 2 else { return nil }
+        var payload = parts[1]
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = payload.count % 4
+        if remainder > 0 {
+            payload += String(repeating: "=", count: 4 - remainder)
+        }
+        guard let data = Data(base64Encoded: payload, options: .ignoreUnknownCharacters),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+        return (json["email"] as? String)?.trimmedNonEmptyEmail
+    }
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.accessToken =
@@ -456,5 +483,10 @@ extension JSONEncoder {
 extension String {
     fileprivate var nilIfEmpty: String? {
         self.isEmpty ? nil : self
+    }
+
+    fileprivate var trimmedNonEmptyEmail: String? {
+        let trimmed = self.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -65,7 +65,10 @@ struct AntigravityStatusFetchStrategy: ProviderFetchStrategy {
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        let probe = AntigravityStatusProbe()
+        // IDE-only: `agy` processes belong to AntigravityCLIHTTPSFetchStrategy,
+        // which owns their lifecycle and waits for real API readiness. Probing
+        // a stale/half-warm `agy` here burns the whole timeout on dead ports.
+        let probe = AntigravityStatusProbe(processScope: .ideOnly)
         let snap = try await probe.fetch()
         let usage = try snap.toUsageSnapshot()
         try AntigravitySelectedAccountGuard.validate(usage, context: context)
@@ -115,7 +118,11 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     private func fetchUsingWarmSession(binary: String, resetAfterFetch: Bool) async throws -> ProviderFetchResult {
         let session = AntigravityCLISession.shared
         let pid = try await session.beginProbe(binary: binary)
-        let deadline = Date().addingTimeInterval(5.0)
+        // A cold `agy` needs ~8-10s before `GetUserStatus` answers. One-shot
+        // CLI invocations stay snappy at 5s; long-lived runtimes (app, serve)
+        // wait longer once so the first poll succeeds instead of flashing an
+        // error before the warm session takes over.
+        let deadline = Date().addingTimeInterval(resetAfterFetch ? 5.0 : 15.0)
         let snap: AntigravityStatusSnapshot
         let usage: UsageSnapshot
         do {
@@ -148,7 +155,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     }
 
     static func shouldResetSessionAfterFetch(_ context: ProviderFetchContext) -> Bool {
-        context.runtime == .cli
+        !context.persistsCLISessions
     }
 
     /// Waits for real API readiness, not just socket readiness. Fresh ``agy``

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -44,9 +44,6 @@ public enum AntigravityProviderDescriptor {
         let local = AntigravityStatusFetchStrategy()
         let cli = AntigravityCLIHTTPSFetchStrategy()
         let oauth = AntigravityOAuthFetchStrategy()
-        if context.selectedTokenAccountID != nil {
-            return [oauth]
-        }
         switch context.sourceMode {
         case .cli:
             return [local, cli]

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -42,15 +42,18 @@ public enum AntigravityProviderDescriptor {
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {
         let local = AntigravityStatusFetchStrategy()
+        let cli = AntigravityCLIHTTPSFetchStrategy()
         let oauth = AntigravityOAuthFetchStrategy()
-
+        if context.selectedTokenAccountID != nil {
+            return [oauth]
+        }
         switch context.sourceMode {
         case .cli:
-            return [local]
+            return [local, cli]
         case .oauth:
             return [oauth]
         case .auto:
-            return [local, oauth]
+            return [local, cli, oauth]
         case .web, .api:
             return []
         }
@@ -60,7 +63,6 @@ public enum AntigravityProviderDescriptor {
 struct AntigravityStatusFetchStrategy: ProviderFetchStrategy {
     let id: String = "antigravity.local"
     let kind: ProviderFetchKind = .localProbe
-
     func isAvailable(_: ProviderFetchContext) async -> Bool {
         true
     }
@@ -72,6 +74,141 @@ struct AntigravityStatusFetchStrategy: ProviderFetchStrategy {
         return self.makeResult(
             usage: usage,
             sourceLabel: "local")
+    }
+
+    func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {
+        context.sourceMode == .auto || context.sourceMode == .cli
+    }
+}
+
+/// When the desktop Antigravity app is closed (no ``language_server`` running),
+/// this strategy spawns or reuses ``agy`` and talks to the HTTPS localhost
+/// server embedded in that CLI process. ``agy`` is an interactive REPL, not a
+/// query command, so CodexBar never scrapes TUI output here; it only keeps the
+/// process alive long enough for the server to answer ``GetUserStatus``.
+struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
+    static let sourceLabel = "cli"
+    let id: String = "antigravity.cli-https"
+    let kind: ProviderFetchKind = .cli
+    private static let log = CodexBarLog.logger(LogCategories.antigravity)
+
+    struct SnapshotWaitDependencies: Sendable {
+        let pollIntervalNanoseconds: UInt64
+        let listeningPorts: @Sendable (Int, TimeInterval) async throws -> [Int]
+        let drainOutput: @Sendable () async -> Void
+        let fetchSnapshot: @Sendable ([Int]) async throws -> AntigravityStatusSnapshot
+    }
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        BinaryLocator.resolveAntigravityBinary(env: context.env) != nil
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        guard let binary = BinaryLocator.resolveAntigravityBinary(env: context.env) else {
+            throw AntigravityStatusProbeError.notRunning
+        }
+        return try await self.fetchUsingWarmSession(
+            binary: binary,
+            resetAfterFetch: Self.shouldResetSessionAfterFetch(context))
+    }
+
+    private func fetchUsingWarmSession(binary: String, resetAfterFetch: Bool) async throws -> ProviderFetchResult {
+        let session = AntigravityCLISession.shared
+        let pid = try await session.beginProbe(binary: binary)
+        let deadline = Date().addingTimeInterval(5.0)
+        let snap: AntigravityStatusSnapshot
+        let usage: UsageSnapshot
+        do {
+            snap = try await Self.waitForSnapshot(
+                pid: pid,
+                deadline: deadline,
+                dependencies: SnapshotWaitDependencies(
+                    pollIntervalNanoseconds: 200_000_000,
+                    listeningPorts: { pid, timeout in
+                        try await AntigravityStatusProbe.listeningPorts(pid: pid, timeout: timeout)
+                    },
+                    drainOutput: {
+                        await session.drainOutput()
+                    },
+                    fetchSnapshot: { ports in
+                        let timeout = min(2.0, max(0.2, deadline.timeIntervalSinceNow))
+                        return try await AntigravityStatusProbe(timeout: timeout)
+                            .fetchFromPorts(ports, deadline: deadline)
+                    }))
+            usage = try snap.toUsageSnapshot()
+            await session.finishProbe(success: true, resetAfterFetch: resetAfterFetch)
+        } catch {
+            await session.finishProbe(success: false, resetAfterFetch: resetAfterFetch)
+            throw error
+        }
+
+        return self.makeResult(
+            usage: usage,
+            sourceLabel: Self.sourceLabel)
+    }
+
+    static func shouldResetSessionAfterFetch(_ context: ProviderFetchContext) -> Bool {
+        context.runtime == .cli
+    }
+
+    /// Waits for real API readiness, not just socket readiness. Fresh ``agy``
+    /// processes bind ports quickly, but ``GetUserStatus`` can return transient
+    /// initialization failures for a few seconds after the port appears.
+    static func waitForSnapshot(
+        pid: pid_t,
+        deadline: Date,
+        dependencies: SnapshotWaitDependencies) async throws -> AntigravityStatusSnapshot
+    {
+        var lastFetchError: Error?
+        while Date() < deadline {
+            await dependencies.drainOutput()
+            let remaining = deadline.timeIntervalSinceNow
+            let portProbeTimeout = min(2.0, max(0.2, remaining))
+            let ports: [Int]
+            do {
+                ports = try await dependencies.listeningPorts(Int(pid), portProbeTimeout)
+            } catch {
+                guard Self.isNoListeningPortsError(error) else {
+                    throw error
+                }
+                ports = []
+            }
+            if !ports.isEmpty {
+                do {
+                    let snapshot = try await dependencies.fetchSnapshot(ports)
+                    _ = try snapshot.toUsageSnapshot()
+                    return snapshot
+                } catch {
+                    lastFetchError = error
+                    Self.log.debug("Antigravity CLI HTTPS endpoint not ready", metadata: [
+                        "pid": "\(pid)",
+                        "ports": ports.map(String.init).joined(separator: ","),
+                        "error": error.localizedDescription,
+                    ])
+                }
+            }
+
+            let remainingNanoseconds = UInt64(max(0, deadline.timeIntervalSinceNow) * 1_000_000_000)
+            guard remainingNanoseconds > 0 else { break }
+            try await Task.sleep(nanoseconds: min(dependencies.pollIntervalNanoseconds, remainingNanoseconds))
+        }
+
+        if let lastFetchError {
+            throw lastFetchError
+        }
+        Self.log.warning("Antigravity CLI HTTPS: no ports found for pid \(pid)")
+        throw AntigravityStatusProbeError.portDetectionFailed(
+            "Antigravity CLI started but no listening ports found")
+    }
+
+    private static func isNoListeningPortsError(_ error: Error) -> Bool {
+        if case let AntigravityStatusProbeError.portDetectionFailed(message) = error {
+            return message == "no listening ports found"
+        }
+        if case let SubprocessRunnerError.nonZeroExit(code, stderr) = error {
+            return code == 1 && stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        return false
     }
 
     func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -64,10 +64,11 @@ struct AntigravityStatusFetchStrategy: ProviderFetchStrategy {
         true
     }
 
-    func fetch(_: ProviderFetchContext) async throws -> ProviderFetchResult {
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
         let probe = AntigravityStatusProbe()
         let snap = try await probe.fetch()
         let usage = try snap.toUsageSnapshot()
+        try AntigravitySelectedAccountGuard.validate(usage, context: context)
         return self.makeResult(
             usage: usage,
             sourceLabel: "local")
@@ -104,9 +105,11 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
         guard let binary = BinaryLocator.resolveAntigravityBinary(env: context.env) else {
             throw AntigravityStatusProbeError.notRunning
         }
-        return try await self.fetchUsingWarmSession(
+        let result = try await self.fetchUsingWarmSession(
             binary: binary,
             resetAfterFetch: Self.shouldResetSessionAfterFetch(context))
+        try AntigravitySelectedAccountGuard.validate(result.usage, context: context)
+        return result
     }
 
     private func fetchUsingWarmSession(binary: String, resetAfterFetch: Bool) async throws -> ProviderFetchResult {
@@ -255,5 +258,44 @@ struct AntigravityOAuthFetchStrategy: ProviderFetchStrategy {
 
     func shouldFallback(on _: Error, context _: ProviderFetchContext) -> Bool {
         false
+    }
+}
+
+/// Guards ambient Antigravity snapshots against the explicitly selected account.
+///
+/// The local desktop probe and the ``agy`` CLI HTTPS server report whichever
+/// Antigravity account is signed into the local session. When the user has
+/// selected a specific saved Google account, an ambient probe can return a
+/// *different* account's quota. Only the OAuth strategy is account-scoped (it
+/// fetches with the selected account's injected credentials), so in ``auto``
+/// mode we reject a snapshot whose identity does not match the selected account
+/// and let the pipeline fall through to OAuth. Explicit ``cli``/``oauth`` source
+/// modes stay authoritative and are never second-guessed here.
+enum AntigravitySelectedAccountGuard {
+    static func validate(_ usage: UsageSnapshot, context: ProviderFetchContext) throws {
+        guard context.sourceMode == .auto, context.selectedTokenAccountID != nil else { return }
+        let expected = self.selectedAccountEmail(context: context)
+        let found = self.normalizedEmail(usage.identity?.accountEmail)
+        guard let expected, let found, found.caseInsensitiveCompare(expected) == .orderedSame else {
+            throw AntigravityStatusProbeError.accountMismatch(expected: expected, found: found)
+        }
+    }
+
+    /// Email of the selected token account, read from the same injected
+    /// credentials the OAuth strategy would use (`ANTIGRAVITY_OAUTH_CREDENTIALS_JSON`).
+    static func selectedAccountEmail(context: ProviderFetchContext) -> String? {
+        guard let value = context.env[AntigravityOAuthCredentialsStore.environmentCredentialsKey],
+              let credentials = AntigravityOAuthCredentialsStore.credentials(fromTokenAccountValue: value)
+        else {
+            return nil
+        }
+        return credentials.resolvedAccountEmail
+    }
+
+    private static func normalizedEmail(_ email: String?) -> String? {
+        guard let trimmed = email?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
     }
 }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -407,7 +407,20 @@ public enum AntigravityStatusProbeError: LocalizedError, Sendable, Equatable {
 }
 
 public struct AntigravityStatusProbe: Sendable {
+    /// Which local Antigravity processes the probe may attach to.
+    public enum ProcessScope: Sendable {
+        /// Match the IDE language server and the `agy` CLI language server.
+        case ideAndCLI
+        /// Match only the IDE language server. Used by the local fetch
+        /// strategy so it never attaches to an `agy` process: stale or
+        /// half-warmed CLI servers accept connections long before
+        /// `GetUserStatus` works, and `AntigravityCLIHTTPSFetchStrategy`
+        /// already owns `agy` with a proper readiness loop.
+        case ideOnly
+    }
+
     public var timeout: TimeInterval = 8.0
+    public var processScope: ProcessScope = .ideAndCLI
 
     private static let getUserStatusPath = "/exa.language_server_pb.LanguageServerService/GetUserStatus"
     private static let commandModelConfigPath =
@@ -415,12 +428,13 @@ public struct AntigravityStatusProbe: Sendable {
     private static let unleashPath = "/exa.language_server_pb.LanguageServerService/GetUnleashData"
     private static let log = CodexBarLog.logger(LogCategories.antigravity)
 
-    public init(timeout: TimeInterval = 8.0) {
+    public init(timeout: TimeInterval = 8.0, processScope: ProcessScope = .ideAndCLI) {
         self.timeout = timeout
+        self.processScope = processScope
     }
 
     public func fetch() async throws -> AntigravityStatusSnapshot {
-        let processInfo = try await Self.detectProcessInfo(timeout: self.timeout)
+        let processInfo = try await Self.detectProcessInfo(timeout: self.timeout, scope: self.processScope)
         let ports = try await Self.listeningPorts(pid: processInfo.pid, timeout: self.timeout)
         let endpoint = try await Self.resolveWorkingEndpoint(
             candidateEndpoints: Self.connectionCandidates(
@@ -442,7 +456,7 @@ public struct AntigravityStatusProbe: Sendable {
     }
 
     public func fetchPlanInfoSummary() async throws -> AntigravityPlanInfoSummary? {
-        let processInfo = try await Self.detectProcessInfo(timeout: self.timeout)
+        let processInfo = try await Self.detectProcessInfo(timeout: self.timeout, scope: self.processScope)
         let ports = try await Self.listeningPorts(pid: processInfo.pid, timeout: self.timeout)
         let endpoint = try await Self.resolveWorkingEndpoint(
             candidateEndpoints: Self.connectionCandidates(
@@ -616,7 +630,10 @@ public struct AntigravityStatusProbe: Sendable {
         }
     }
 
-    private static func detectProcessInfo(timeout: TimeInterval) async throws -> ProcessInfoResult {
+    private static func detectProcessInfo(
+        timeout: TimeInterval,
+        scope: ProcessScope = .ideAndCLI) async throws -> ProcessInfoResult
+    {
         let env = ProcessInfo.processInfo.environment
         let result = try await SubprocessRunner.run(
             binary: "/bin/ps",
@@ -625,16 +642,20 @@ public struct AntigravityStatusProbe: Sendable {
             timeout: timeout,
             label: "antigravity-ps")
 
-        return try Self.processInfo(fromProcessListOutput: result.stdout)
+        return try Self.processInfo(fromProcessListOutput: result.stdout, scope: scope)
     }
 
-    static func processInfo(fromProcessListOutput output: String) throws -> ProcessInfoResult {
+    static func processInfo(
+        fromProcessListOutput output: String,
+        scope: ProcessScope = .ideAndCLI) throws -> ProcessInfoResult
+    {
         let lines = output.split(separator: "\n")
         var sawTokenlessIDE = false
         for line in lines {
             let text = String(line)
             guard let match = Self.matchProcessLine(text) else { continue }
             guard let kind = Self.antigravityProcessKind(match.command) else { continue }
+            if scope == .ideOnly, kind == .cli { continue }
             // The IDE language server authenticates local requests with a
             // `--csrf_token` and must keep requiring it: skip a tokenless IDE
             // match so a later valid IDE server can still be found (and surface

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -356,6 +356,7 @@ public enum AntigravityStatusProbeError: LocalizedError, Sendable, Equatable {
     case apiError(String)
     case parseFailed(String)
     case timedOut
+    case accountMismatch(expected: String?, found: String?)
 
     public var errorDescription: String? {
         switch self {
@@ -371,7 +372,19 @@ public enum AntigravityStatusProbeError: LocalizedError, Sendable, Equatable {
             "Could not parse Antigravity quota: \(message)"
         case .timedOut:
             "Antigravity quota request timed out."
+        case let .accountMismatch(expected, found):
+            Self.accountMismatchDescription(expected: expected, found: found)
         }
+    }
+
+    private static func accountMismatchDescription(expected: String?, found: String?) -> String {
+        let selected = expected ?? "the selected account"
+        if let found {
+            return "Antigravity local session is signed in as \(found), not \(selected); "
+                + "using the selected account's OAuth data instead."
+        }
+        return "Antigravity local session did not report an account matching \(selected); "
+            + "using the selected account's OAuth data instead."
     }
 
     private static func portDetectionDescription(_ message: String) -> String {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -425,21 +425,7 @@ public struct AntigravityStatusProbe: Sendable {
                 extensionServerCSRFToken: processInfo.extensionServerCSRFToken),
             timeout: self.timeout)
 
-        do {
-            return try await Self.makeParsedRequest(
-                payload: RequestPayload(
-                    path: Self.getUserStatusPath,
-                    body: Self.defaultRequestBody()),
-                context: context,
-                parse: Self.parseUserStatusResponse)
-        } catch {
-            return try await Self.makeParsedRequest(
-                payload: RequestPayload(
-                    path: Self.commandModelConfigPath,
-                    body: Self.defaultRequestBody()),
-                context: context,
-                parse: Self.parseCommandModelResponse)
-        }
+        return try await Self.fetchSnapshot(context: context)
     }
 
     public func fetchPlanInfoSummary() async throws -> AntigravityPlanInfoSummary? {
@@ -474,6 +460,30 @@ public struct AntigravityStatusProbe: Sendable {
     public static func detectVersion(timeout: TimeInterval = 4.0) async -> String? {
         let running = await Self.isRunning(timeout: timeout)
         return running ? "running" : nil
+    }
+
+    // MARK: - CLI HTTPS Fetch
+
+    /// Fetch usage data from a known set of local ports (discovered via
+    /// ``AntigravityCLISession``'s ``pid``), without requiring a running
+    /// ``language_server`` process or CSRF token.
+    ///
+    /// The ``agy`` CLI exposes the same ``GetUserStatus`` gRPC-web endpoint on
+    /// its HTTPS port as the desktop ``language_server``. Unlike the desktop
+    /// endpoint, it does not require a CSRF token header.
+    public func fetchFromPorts(_ ports: [Int], deadline: Date? = nil) async throws -> AntigravityStatusSnapshot {
+        guard !ports.isEmpty else {
+            throw AntigravityStatusProbeError.portDetectionFailed("no listening ports found")
+        }
+        let endpoints = ports.map {
+            AntigravityConnectionEndpoint(
+                scheme: "https",
+                port: $0,
+                csrfToken: "",
+                source: .cliHTTPS)
+        }
+        let context = RequestContext(endpoints: endpoints, timeout: self.timeout, deadline: deadline)
+        return try await Self.fetchSnapshot(context: context)
     }
 
     // MARK: - Parsing
@@ -571,12 +581,22 @@ public struct AntigravityStatusProbe: Sendable {
         enum Source: String {
             case languageServer = "language-server"
             case extensionServer = "extension-server"
+            case cliHTTPS = "cli-https"
         }
 
         let scheme: String
         let port: Int
         let csrfToken: String
         let source: Source
+        /// Whether this endpoint needs a CSRF token header.
+        /// The CLI HTTPS endpoint (``Source/cliHTTPS``) speaks the same HTTP API
+        /// but does not require a CSRF token.
+        var requiresCSRFToken: Bool {
+            switch self.source {
+            case .languageServer, .extensionServer: true
+            case .cliHTTPS: false
+            }
+        }
 
         func matchesRequestTarget(_ other: Self) -> Bool {
             self.scheme == other.scheme && self.port == other.port && self.csrfToken == other.csrfToken
@@ -717,7 +737,7 @@ public struct AntigravityStatusProbe: Sendable {
         return Int(raw)
     }
 
-    private static func listeningPorts(pid: Int, timeout: TimeInterval) async throws -> [Int] {
+    static func listeningPorts(pid: Int, timeout: TimeInterval) async throws -> [Int] {
         let lsof = ["/usr/sbin/lsof", "/usr/bin/lsof"].first(where: {
             FileManager.default.isExecutableFile(atPath: $0)
         })
@@ -727,13 +747,19 @@ public struct AntigravityStatusProbe: Sendable {
         }
 
         let env = ProcessInfo.processInfo.environment
-        let result = try await SubprocessRunner.run(
-            binary: lsof,
-            arguments: ["-nP", "-iTCP", "-sTCP:LISTEN", "-a", "-p", String(pid)],
-            environment: env,
-            timeout: timeout,
-            label: "antigravity-lsof")
-
+        let result: SubprocessResult
+        do {
+            result = try await SubprocessRunner.run(
+                binary: lsof,
+                arguments: ["-nP", "-iTCP", "-sTCP:LISTEN", "-a", "-p", String(pid)],
+                environment: env,
+                timeout: timeout,
+                label: "antigravity-lsof")
+        } catch let SubprocessRunnerError.nonZeroExit(code, stderr)
+            where code == 1 && stderr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            throw AntigravityStatusProbeError.portDetectionFailed("no listening ports found")
+        }
         let ports = Self.parseListeningPorts(result.stdout)
         if ports.isEmpty {
             throw AntigravityStatusProbeError.portDetectionFailed("no listening ports found")
@@ -952,6 +978,20 @@ public struct AntigravityStatusProbe: Sendable {
     struct RequestContext {
         let endpoints: [AntigravityConnectionEndpoint]
         let timeout: TimeInterval
+        let deadline: Date?
+
+        init(endpoints: [AntigravityConnectionEndpoint], timeout: TimeInterval, deadline: Date? = nil) {
+            self.endpoints = endpoints
+            self.timeout = timeout
+            self.deadline = deadline
+        }
+
+        func timeoutForNextAttempt() -> TimeInterval? {
+            guard let deadline else { return self.timeout }
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else { return nil }
+            return min(self.timeout, remaining)
+        }
     }
 
     private static func defaultRequestBody() -> [String: Any] {
@@ -983,6 +1023,30 @@ public struct AntigravityStatusProbe: Sendable {
         ]
     }
 
+    static func fetchSnapshot(
+        context: RequestContext,
+        send: @escaping @Sendable (RequestPayload, AntigravityConnectionEndpoint, TimeInterval) async throws -> Data =
+            sendRequest) async throws -> AntigravityStatusSnapshot
+    {
+        do {
+            return try await self.makeParsedRequest(
+                payload: RequestPayload(
+                    path: self.getUserStatusPath,
+                    body: self.defaultRequestBody()),
+                context: context,
+                send: send,
+                parse: self.parseUserStatusResponse)
+        } catch {
+            return try await self.makeParsedRequest(
+                payload: RequestPayload(
+                    path: self.commandModelConfigPath,
+                    body: self.defaultRequestBody()),
+                context: context,
+                send: send,
+                parse: self.parseCommandModelResponse)
+        }
+    }
+
     private static func makeRequest(
         payload: RequestPayload,
         context: RequestContext) async throws -> Data
@@ -1000,8 +1064,12 @@ public struct AntigravityStatusProbe: Sendable {
         var lastError: Error?
 
         for endpoint in context.endpoints {
+            guard let timeout = context.timeoutForNextAttempt() else {
+                lastError = lastError ?? AntigravityStatusProbeError.timedOut
+                break
+            }
             do {
-                let data = try await send(payload, endpoint, context.timeout)
+                let data = try await send(payload, endpoint, timeout)
                 return try parse(data)
             } catch {
                 lastError = error
@@ -1025,8 +1093,12 @@ public struct AntigravityStatusProbe: Sendable {
         var lastError: Error?
 
         for endpoint in context.endpoints {
+            guard let timeout = context.timeoutForNextAttempt() else {
+                lastError = lastError ?? AntigravityStatusProbeError.timedOut
+                break
+            }
             do {
-                return try await Self.sendRequest(payload: payload, endpoint: endpoint, timeout: context.timeout)
+                return try await Self.sendRequest(payload: payload, endpoint: endpoint, timeout: timeout)
             } catch {
                 lastError = error
                 Self.log.debug("Antigravity request attempt failed", metadata: [
@@ -1059,7 +1131,9 @@ public struct AntigravityStatusProbe: Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue(String(body.count), forHTTPHeaderField: "Content-Length")
         request.setValue("1", forHTTPHeaderField: "Connect-Protocol-Version")
-        request.setValue(endpoint.csrfToken, forHTTPHeaderField: "X-Codeium-Csrf-Token")
+        if endpoint.requiresCSRFToken {
+            request.setValue(endpoint.csrfToken, forHTTPHeaderField: "X-Codeium-Csrf-Token")
+        }
 
         let config = URLSessionConfiguration.ephemeral
         config.timeoutIntervalForRequest = timeout

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityUsageDataSource.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityUsageDataSource.swift
@@ -13,7 +13,7 @@ public enum AntigravityUsageDataSource: String, CaseIterable, Identifiable, Send
         switch self {
         case .auto: "Auto"
         case .oauth: "Google OAuth"
-        case .cli: "Local IDE API"
+        case .cli: "Local API / agy CLI"
         }
     }
 

--- a/Sources/CodexBarCore/Providers/CLIProbeSessionResetter.swift
+++ b/Sources/CodexBarCore/Providers/CLIProbeSessionResetter.swift
@@ -4,5 +4,6 @@ public enum CLIProbeSessionResetter {
     public static func resetAll() async {
         await ClaudeCLISession.shared.reset()
         await CodexCLISession.shared.reset()
+        await AntigravityCLISession.shared.reset()
     }
 }

--- a/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
+++ b/Sources/CodexBarCore/Providers/ProviderFetchPlan.swift
@@ -37,6 +37,10 @@ public struct ProviderFetchContext: Sendable {
     public let tokenAccountTokenUpdater: TokenAccountTokenUpdater?
     public let providerManualTokenUpdater: ProviderManualTokenUpdater?
     public let costUsageHistoryDays: Int
+    /// Whether warm CLI helper sessions (for example the managed `agy`
+    /// process) may outlive a single fetch. True for long-lived processes
+    /// (the app, `codexbar serve`); false for one-shot CLI invocations.
+    public let persistsCLISessions: Bool
 
     public init(
         runtime: ProviderRuntime,
@@ -54,7 +58,8 @@ public struct ProviderFetchContext: Sendable {
         selectedTokenAccountID: UUID? = nil,
         tokenAccountTokenUpdater: TokenAccountTokenUpdater? = nil,
         providerManualTokenUpdater: ProviderManualTokenUpdater? = nil,
-        costUsageHistoryDays: Int = 30)
+        costUsageHistoryDays: Int = 30,
+        persistsCLISessions: Bool? = nil)
     {
         self.runtime = runtime
         self.sourceMode = sourceMode
@@ -72,6 +77,7 @@ public struct ProviderFetchContext: Sendable {
         self.tokenAccountTokenUpdater = tokenAccountTokenUpdater
         self.providerManualTokenUpdater = providerManualTokenUpdater
         self.costUsageHistoryDays = max(1, min(365, costUsageHistoryDays))
+        self.persistsCLISessions = persistsCLISessions ?? (runtime == .app)
     }
 }
 

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -105,7 +105,7 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
     }
 
     @Test
-    func `strategy pipeline uses OAuth only for selected token account`() async {
+    func `strategy pipeline keeps source mode authoritative with selected token account`() async {
         let descriptor = ProviderDescriptorRegistry.descriptor(for: .antigravity)
 
         let accountID = UUID()
@@ -113,9 +113,12 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
             self.makeFetchContext(sourceMode: .auto, selectedTokenAccountID: accountID))
         let cliStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
             self.makeFetchContext(sourceMode: .cli, selectedTokenAccountID: accountID))
+        let oauthStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeFetchContext(sourceMode: .oauth, selectedTokenAccountID: accountID))
 
-        #expect(autoStrategies.map(\.id) == ["antigravity.oauth"])
-        #expect(cliStrategies.map(\.id) == ["antigravity.oauth"])
+        #expect(autoStrategies.map(\.id) == ["antigravity.local", "antigravity.cli-https", "antigravity.oauth"])
+        #expect(cliStrategies.map(\.id) == ["antigravity.local", "antigravity.cli-https"])
+        #expect(oauthStrategies.map(\.id) == ["antigravity.oauth"])
     }
 
     @Test

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -231,6 +231,12 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
     }
 
     @Test
+    func `cli HTTPS keeps warm session when CLI runtime persists sessions`() {
+        let serveLike = self.makeFetchContext(runtime: .cli, persistsCLISessions: true)
+        #expect(!AntigravityCLIHTTPSFetchStrategy.shouldResetSessionAfterFetch(serveLike))
+    }
+
+    @Test
     func `cli HTTPS reports public source as cli`() {
         #expect(AntigravityCLIHTTPSFetchStrategy.sourceLabel == "cli")
     }
@@ -579,7 +585,8 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
         runtime: ProviderRuntime = .app,
         sourceMode: ProviderSourceMode = .auto,
         selectedTokenAccountID: UUID? = nil,
-        env: [String: String] = [:]) -> ProviderFetchContext
+        env: [String: String] = [:],
+        persistsCLISessions: Bool? = nil) -> ProviderFetchContext
     {
         ProviderFetchContext(
             runtime: runtime,
@@ -593,7 +600,8 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
             fetcher: UsageFetcher(environment: env),
             claudeFetcher: StubClaudeFetcher(),
             browserDetection: BrowserDetection(cacheTTL: 0),
-            selectedTokenAccountID: selectedTokenAccountID)
+            selectedTokenAccountID: selectedTokenAccountID,
+            persistsCLISessions: persistsCLISessions)
     }
 
     private func makeUsage(accountEmail: String?) -> UsageSnapshot {

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -1,0 +1,506 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+private final class AntigravityCLICounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    @discardableResult
+    func increment() -> Int {
+        self.lock.lock()
+        self.count += 1
+        let value = self.count
+        self.lock.unlock()
+        return value
+    }
+
+    var value: Int {
+        self.lock.lock()
+        let value = self.count
+        self.lock.unlock()
+        return value
+    }
+}
+
+private final class AntigravityCLIPortRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var ports: [[Int]] = []
+
+    func append(_ value: [Int]) {
+        self.lock.lock()
+        self.ports.append(value)
+        self.lock.unlock()
+    }
+
+    func snapshot() -> [[Int]] {
+        self.lock.lock()
+        let value = self.ports
+        self.lock.unlock()
+        return value
+    }
+}
+
+private final class AntigravityCLITimeoutRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var timeouts: [TimeInterval] = []
+
+    func append(_ value: TimeInterval) {
+        self.lock.lock()
+        self.timeouts.append(value)
+        self.lock.unlock()
+    }
+
+    func snapshot() -> [TimeInterval] {
+        self.lock.lock()
+        let value = self.timeouts
+        self.lock.unlock()
+        return value
+    }
+}
+
+struct AntigravityCLIHTTPSFetchStrategyTests {
+    @Test
+    func `local strategy falls back to cli HTTPS in cli source mode`() {
+        let strategy = AntigravityStatusFetchStrategy()
+        let context = self.makeFetchContext(sourceMode: .cli)
+
+        #expect(strategy.shouldFallback(on: AntigravityStatusProbeError.notRunning, context: context))
+    }
+
+    @Test
+    func `local strategy falls back to cli HTTPS in auto source mode`() {
+        let strategy = AntigravityStatusFetchStrategy()
+        let context = self.makeFetchContext(sourceMode: .auto)
+
+        #expect(strategy.shouldFallback(on: AntigravityStatusProbeError.notRunning, context: context))
+    }
+
+    @Test
+    func `local strategy does not fallback for unrelated source modes`() {
+        let strategy = AntigravityStatusFetchStrategy()
+
+        #expect(!strategy.shouldFallback(
+            on: AntigravityStatusProbeError.notRunning,
+            context: self.makeFetchContext(sourceMode: .oauth)))
+        #expect(!strategy.shouldFallback(
+            on: AntigravityStatusProbeError.notRunning,
+            context: self.makeFetchContext(sourceMode: .web)))
+        #expect(!strategy.shouldFallback(
+            on: AntigravityStatusProbeError.notRunning,
+            context: self.makeFetchContext(sourceMode: .api)))
+    }
+
+    @Test
+    func `strategy pipeline includes cli HTTPS fallback in cli and auto modes`() async {
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: .antigravity)
+
+        let cliStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeFetchContext(sourceMode: .cli))
+        #expect(cliStrategies.map(\.id) == ["antigravity.local", "antigravity.cli-https"])
+
+        let autoStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeFetchContext(sourceMode: .auto))
+        #expect(autoStrategies.map(\.id) == ["antigravity.local", "antigravity.cli-https", "antigravity.oauth"])
+    }
+
+    @Test
+    func `strategy pipeline uses OAuth only for selected token account`() async {
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: .antigravity)
+
+        let accountID = UUID()
+        let autoStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeFetchContext(sourceMode: .auto, selectedTokenAccountID: accountID))
+        let cliStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeFetchContext(sourceMode: .cli, selectedTokenAccountID: accountID))
+
+        #expect(autoStrategies.map(\.id) == ["antigravity.oauth"])
+        #expect(cliStrategies.map(\.id) == ["antigravity.oauth"])
+    }
+
+    @Test
+    func `cli HTTPS resets session only for short lived CLI runtime`() {
+        #expect(AntigravityCLIHTTPSFetchStrategy.shouldResetSessionAfterFetch(self.makeFetchContext(runtime: .cli)))
+        #expect(!AntigravityCLIHTTPSFetchStrategy.shouldResetSessionAfterFetch(self.makeFetchContext(runtime: .app)))
+    }
+
+    @Test
+    func `cli HTTPS reports public source as cli`() {
+        #expect(AntigravityCLIHTTPSFetchStrategy.sourceLabel == "cli")
+    }
+
+    @Test
+    func `cli HTTPS falls back to command model configs when user status fails`() async throws {
+        let endpoints = [
+            AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                scheme: "https",
+                port: 50080,
+                csrfToken: "",
+                source: .cliHTTPS),
+        ]
+        let attempts = AntigravityCLICounter()
+
+        let snapshot = try await AntigravityStatusProbe.fetchSnapshot(
+            context: AntigravityStatusProbe.RequestContext(
+                endpoints: endpoints,
+                timeout: 1,
+                deadline: Date().addingTimeInterval(2)),
+            send: { payload, _, _ in
+                let attempt = attempts.increment()
+                if attempt == 1 {
+                    #expect(payload.path == "/exa.language_server_pb.LanguageServerService/GetUserStatus")
+                    throw AntigravityStatusProbeError.apiError("user status unavailable")
+                }
+                #expect(payload.path == "/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs")
+                return Data("""
+                {
+                  "clientModelConfigs": [
+                    {
+                      "label": "Claude Sonnet",
+                      "modelOrAlias": { "model": "claude-sonnet" },
+                      "quotaInfo": { "remainingFraction": 0.5 }
+                    }
+                  ]
+                }
+                """.utf8)
+            })
+
+        #expect(snapshot.modelQuotas.first?.label == "Claude Sonnet")
+        #expect(attempts.value == 2)
+    }
+
+    @Test
+    func `cli HTTPS waits for user status after ports appear`() async throws {
+        let fetchAttempts = AntigravityCLICounter()
+        let drainAttempts = AntigravityCLICounter()
+        let fetchedPorts = AntigravityCLIPortRecorder()
+        let snapshot = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+            pid: 123,
+            deadline: Date().addingTimeInterval(5),
+            dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                pollIntervalNanoseconds: 0,
+                listeningPorts: { _, _ in [50080, 50081] },
+                drainOutput: {
+                    drainAttempts.increment()
+                },
+                fetchSnapshot: { ports in
+                    fetchedPorts.append(ports)
+                    if fetchAttempts.increment() == 1 {
+                        throw AntigravityStatusProbeError.apiError("HTTP 500: GetCascadeModelConfigData() is nil")
+                    }
+                    return AntigravityStatusSnapshot(
+                        modelQuotas: [
+                            AntigravityModelQuota(
+                                label: "Claude Opus 4.6 (Thinking)",
+                                modelId: "claude-opus-4.6-thinking",
+                                remainingFraction: 1,
+                                resetTime: nil,
+                                resetDescription: nil),
+                        ],
+                        accountEmail: "user@example.com",
+                        accountPlan: "Pro",
+                        source: .local)
+                }))
+
+        #expect(snapshot.accountEmail == "user@example.com")
+        #expect(fetchAttempts.value == 2)
+        #expect(fetchedPorts.snapshot() == [[50080, 50081], [50080, 50081]])
+        #expect(drainAttempts.value == 2)
+    }
+
+    @Test
+    func `cli HTTPS retries empty quota snapshots until usage is parseable`() async throws {
+        let fetchAttempts = AntigravityCLICounter()
+
+        let snapshot = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+            pid: 123,
+            deadline: Date().addingTimeInterval(5),
+            dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                pollIntervalNanoseconds: 0,
+                listeningPorts: { _, _ in [50080] },
+                drainOutput: {},
+                fetchSnapshot: { _ in
+                    if fetchAttempts.increment() == 1 {
+                        return AntigravityStatusSnapshot(
+                            modelQuotas: [],
+                            accountEmail: nil,
+                            accountPlan: nil,
+                            source: .local)
+                    }
+                    return AntigravityStatusSnapshot(
+                        modelQuotas: [
+                            AntigravityModelQuota(
+                                label: "Claude Sonnet",
+                                modelId: "claude-sonnet",
+                                remainingFraction: 0.5,
+                                resetTime: nil,
+                                resetDescription: nil),
+                        ],
+                        accountEmail: "user@example.com",
+                        accountPlan: "Pro",
+                        source: .local)
+                }))
+
+        #expect(fetchAttempts.value == 2)
+        #expect(snapshot.modelQuotas.first?.modelId == "claude-sonnet")
+    }
+
+    @Test
+    func `cli HTTPS drains output before ports appear`() async throws {
+        let portPolls = AntigravityCLICounter()
+        let drainAttempts = AntigravityCLICounter()
+        let snapshot = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+            pid: 123,
+            deadline: Date().addingTimeInterval(5),
+            dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                pollIntervalNanoseconds: 0,
+                listeningPorts: { _, _ in
+                    portPolls.increment() == 1 ? [] : [50080]
+                },
+                drainOutput: {
+                    drainAttempts.increment()
+                },
+                fetchSnapshot: { _ in
+                    AntigravityStatusSnapshot(
+                        modelQuotas: [
+                            AntigravityModelQuota(
+                                label: "Claude Sonnet",
+                                modelId: "claude-sonnet",
+                                remainingFraction: 1,
+                                resetTime: nil,
+                                resetDescription: nil),
+                        ],
+                        accountEmail: "user@example.com",
+                        accountPlan: "Pro",
+                        source: .local)
+                }))
+
+        #expect(snapshot.accountEmail == "user@example.com")
+        #expect(portPolls.value == 2)
+        #expect(drainAttempts.value == 2)
+    }
+
+    @Test
+    func `cli HTTPS treats empty lsof exit as ports not ready`() async throws {
+        let portPolls = AntigravityCLICounter()
+        let snapshot = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+            pid: 123,
+            deadline: Date().addingTimeInterval(5),
+            dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                pollIntervalNanoseconds: 0,
+                listeningPorts: { _, _ in
+                    if portPolls.increment() == 1 {
+                        throw SubprocessRunnerError.nonZeroExit(code: 1, stderr: "")
+                    }
+                    return [50080]
+                },
+                drainOutput: {},
+                fetchSnapshot: { _ in
+                    AntigravityStatusSnapshot(
+                        modelQuotas: [
+                            AntigravityModelQuota(
+                                label: "Claude Sonnet",
+                                modelId: "claude-sonnet",
+                                remainingFraction: 0.5,
+                                resetTime: nil,
+                                resetDescription: nil),
+                        ],
+                        accountEmail: "user@example.com",
+                        accountPlan: "Pro",
+                        source: .local)
+                }))
+
+        #expect(snapshot.accountEmail == "user@example.com")
+        #expect(portPolls.value == 2)
+    }
+
+    @Test
+    func `parsed requests recompute timeout from shared deadline between endpoints`() async throws {
+        let timeoutRecorder = AntigravityCLITimeoutRecorder()
+        let attempts = AntigravityCLICounter()
+        let endpoints = [
+            AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                scheme: "https",
+                port: 50080,
+                csrfToken: "",
+                source: .cliHTTPS),
+            AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                scheme: "https",
+                port: 50081,
+                csrfToken: "",
+                source: .cliHTTPS),
+        ]
+
+        let result = try await AntigravityStatusProbe.makeParsedRequest(
+            payload: AntigravityStatusProbe.RequestPayload(path: "/status", body: [:]),
+            context: AntigravityStatusProbe.RequestContext(
+                endpoints: endpoints,
+                timeout: 10,
+                deadline: Date().addingTimeInterval(2)),
+            send: { _, _, timeout in
+                timeoutRecorder.append(timeout)
+                if attempts.increment() == 1 {
+                    try await Task.sleep(nanoseconds: 100_000_000)
+                    throw AntigravityStatusProbeError.apiError("first endpoint failed")
+                }
+                return Data("ok".utf8)
+            },
+            parse: { data in
+                guard let value = String(bytes: data, encoding: .utf8) else {
+                    throw AntigravityStatusProbeError.apiError("invalid test data")
+                }
+                return value
+            })
+
+        let timeouts = timeoutRecorder.snapshot()
+        #expect(result == "ok")
+        #expect(timeouts.count == 2)
+        #expect(timeouts.allSatisfy { $0 < 10 })
+        #expect((timeouts.last ?? 10) < (timeouts.first ?? 0))
+    }
+
+    @Test
+    func `parsed request reports timeout when shared deadline is already expired`() async {
+        do {
+            _ = try await AntigravityStatusProbe.makeParsedRequest(
+                payload: AntigravityStatusProbe.RequestPayload(path: "/status", body: [:]),
+                context: AntigravityStatusProbe.RequestContext(
+                    endpoints: [
+                        AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                            scheme: "https",
+                            port: 50080,
+                            csrfToken: "",
+                            source: .cliHTTPS),
+                    ],
+                    timeout: 10,
+                    deadline: Date().addingTimeInterval(-1)),
+                send: { _, _, _ in
+                    Issue.record("Expired deadline should not send a request")
+                    return Data()
+                },
+                parse: { _ in "ok" })
+            Issue.record("Expected timeout")
+        } catch AntigravityStatusProbeError.timedOut {
+        } catch {
+            Issue.record("Expected timedOut, got \(error)")
+        }
+    }
+
+    @Test
+    func `cli HTTPS reports last readiness error when ports never become usable`() async {
+        let fetchAttempts = AntigravityCLICounter()
+
+        do {
+            _ = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+                pid: 123,
+                deadline: Date().addingTimeInterval(2),
+                dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                    pollIntervalNanoseconds: 10_000_000,
+                    listeningPorts: { _, _ in [50080] },
+                    drainOutput: {},
+                    fetchSnapshot: { _ in
+                        let attempt = fetchAttempts.increment()
+                        throw AntigravityStatusProbeError.apiError("HTTP 500: warming attempt \(attempt)")
+                    }))
+            Issue.record("Expected readiness polling to throw")
+        } catch let AntigravityStatusProbeError.apiError(message) {
+            #expect(fetchAttempts.value > 1)
+            #expect(message == "HTTP 500: warming attempt \(fetchAttempts.value)")
+        } catch {
+            Issue.record("Expected apiError, got \(error)")
+        }
+    }
+
+    @Test
+    func `cli HTTPS preserves non transient port detection errors`() async {
+        do {
+            _ = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+                pid: 123,
+                deadline: Date().addingTimeInterval(2),
+                dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                    pollIntervalNanoseconds: 0,
+                    listeningPorts: { _, _ in
+                        throw AntigravityStatusProbeError.portDetectionFailed("lsof not available")
+                    },
+                    drainOutput: {},
+                    fetchSnapshot: { _ in
+                        Issue.record("Port detection failure should not fetch a snapshot")
+                        return AntigravityStatusSnapshot(
+                            modelQuotas: [],
+                            accountEmail: nil,
+                            accountPlan: nil,
+                            source: .local)
+                    }))
+            Issue.record("Expected port detection failure")
+        } catch let AntigravityStatusProbeError.portDetectionFailed(message) {
+            #expect(message == "lsof not available")
+        } catch {
+            Issue.record("Expected portDetectionFailed, got \(error)")
+        }
+    }
+
+    @Test
+    func `cli HTTPS endpoint does not require CSRF token`() {
+        let endpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "https",
+            port: 55624,
+            csrfToken: "ignored-by-cli",
+            source: .cliHTTPS)
+        #expect(!endpoint.requiresCSRFToken)
+    }
+
+    @Test
+    func `languageServer endpoint requires CSRF token`() {
+        let endpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "https",
+            port: 64440,
+            csrfToken: "",
+            source: .languageServer)
+        #expect(endpoint.requiresCSRFToken)
+    }
+
+    @Test
+    func `extensionServer endpoint requires CSRF token`() {
+        let endpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "http",
+            port: 64432,
+            csrfToken: "",
+            source: .extensionServer)
+        #expect(endpoint.requiresCSRFToken)
+    }
+
+    private func makeFetchContext(
+        runtime: ProviderRuntime = .app,
+        sourceMode: ProviderSourceMode = .auto,
+        selectedTokenAccountID: UUID? = nil) -> ProviderFetchContext
+    {
+        let env: [String: String] = [:]
+        return ProviderFetchContext(
+            runtime: runtime,
+            sourceMode: sourceMode,
+            includeCredits: false,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: env,
+            settings: nil,
+            fetcher: UsageFetcher(environment: env),
+            claudeFetcher: StubClaudeFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            selectedTokenAccountID: selectedTokenAccountID)
+    }
+
+    private struct StubClaudeFetcher: ClaudeUsageFetching {
+        func loadLatestUsage(model _: String) async throws -> ClaudeUsageSnapshot {
+            throw ClaudeUsageError.parseFailed("stub")
+        }
+
+        func debugRawProbe(model _: String) async -> String {
+            "stub"
+        }
+
+        func detectVersion() -> String? {
+            nil
+        }
+    }
+}

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -121,6 +121,109 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
         #expect(oauthStrategies.map(\.id) == ["antigravity.oauth"])
     }
 
+    // MARK: - Selected-account guard
+
+    @Test
+    func `account guard ignores fetches without a selected account`() throws {
+        let usage = self.makeUsage(accountEmail: "ambient@example.com")
+        let context = self.makeFetchContext(
+            sourceMode: .auto,
+            env: self.accountEnv(email: "selected@example.com"))
+
+        try AntigravitySelectedAccountGuard.validate(usage, context: context)
+    }
+
+    @Test
+    func `account guard accepts matching ambient snapshot in auto mode`() throws {
+        let usage = self.makeUsage(accountEmail: "Selected@Example.com")
+        let context = self.makeFetchContext(
+            sourceMode: .auto,
+            selectedTokenAccountID: UUID(),
+            env: self.accountEnv(email: "selected@example.com"))
+
+        try AntigravitySelectedAccountGuard.validate(usage, context: context)
+    }
+
+    @Test
+    func `account guard rejects mismatched ambient snapshot in auto mode`() {
+        let usage = self.makeUsage(accountEmail: "ambient@example.com")
+        let context = self.makeFetchContext(
+            sourceMode: .auto,
+            selectedTokenAccountID: UUID(),
+            env: self.accountEnv(email: "selected@example.com"))
+
+        #expect(throws: AntigravityStatusProbeError.accountMismatch(
+            expected: "selected@example.com",
+            found: "ambient@example.com"))
+        {
+            try AntigravitySelectedAccountGuard.validate(usage, context: context)
+        }
+    }
+
+    @Test
+    func `account guard rejects snapshot without an identity email`() {
+        let usage = self.makeUsage(accountEmail: nil)
+        let context = self.makeFetchContext(
+            sourceMode: .auto,
+            selectedTokenAccountID: UUID(),
+            env: self.accountEnv(email: "selected@example.com"))
+
+        #expect(throws: AntigravityStatusProbeError.accountMismatch(
+            expected: "selected@example.com",
+            found: nil))
+        {
+            try AntigravitySelectedAccountGuard.validate(usage, context: context)
+        }
+    }
+
+    @Test
+    func `account guard rejects when selected account email cannot be resolved`() {
+        let usage = self.makeUsage(accountEmail: "ambient@example.com")
+        let context = self.makeFetchContext(
+            sourceMode: .auto,
+            selectedTokenAccountID: UUID())
+
+        #expect(throws: AntigravityStatusProbeError.accountMismatch(
+            expected: nil,
+            found: "ambient@example.com"))
+        {
+            try AntigravitySelectedAccountGuard.validate(usage, context: context)
+        }
+    }
+
+    @Test
+    func `account guard leaves explicit cli source mode authoritative`() throws {
+        let usage = self.makeUsage(accountEmail: "ambient@example.com")
+        let context = self.makeFetchContext(
+            sourceMode: .cli,
+            selectedTokenAccountID: UUID(),
+            env: self.accountEnv(email: "selected@example.com"))
+
+        try AntigravitySelectedAccountGuard.validate(usage, context: context)
+    }
+
+    @Test
+    func `selected account email resolves from id_token when email field missing`() {
+        let idToken = Self.makeIDToken(email: "jwt@example.com")
+        let context = self.makeFetchContext(
+            sourceMode: .auto,
+            selectedTokenAccountID: UUID(),
+            env: self.accountEnv(email: nil, idToken: idToken))
+
+        #expect(AntigravitySelectedAccountGuard.selectedAccountEmail(context: context) == "jwt@example.com")
+    }
+
+    @Test
+    func `selected account email prefers id_token over stored email field`() {
+        let idToken = Self.makeIDToken(email: "jwt@example.com")
+        let context = self.makeFetchContext(
+            sourceMode: .auto,
+            selectedTokenAccountID: UUID(),
+            env: self.accountEnv(email: "stored@example.com", idToken: idToken))
+
+        #expect(AntigravitySelectedAccountGuard.selectedAccountEmail(context: context) == "jwt@example.com")
+    }
+
     @Test
     func `cli HTTPS resets session only for short lived CLI runtime`() {
         #expect(AntigravityCLIHTTPSFetchStrategy.shouldResetSessionAfterFetch(self.makeFetchContext(runtime: .cli)))
@@ -475,10 +578,10 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
     private func makeFetchContext(
         runtime: ProviderRuntime = .app,
         sourceMode: ProviderSourceMode = .auto,
-        selectedTokenAccountID: UUID? = nil) -> ProviderFetchContext
+        selectedTokenAccountID: UUID? = nil,
+        env: [String: String] = [:]) -> ProviderFetchContext
     {
-        let env: [String: String] = [:]
-        return ProviderFetchContext(
+        ProviderFetchContext(
             runtime: runtime,
             sourceMode: sourceMode,
             includeCredits: false,
@@ -491,6 +594,40 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
             claudeFetcher: StubClaudeFetcher(),
             browserDetection: BrowserDetection(cacheTTL: 0),
             selectedTokenAccountID: selectedTokenAccountID)
+    }
+
+    private func makeUsage(accountEmail: String?) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .antigravity,
+                accountEmail: accountEmail,
+                accountOrganization: nil,
+                loginMethod: nil))
+    }
+
+    private func accountEnv(email: String?, idToken: String? = nil) -> [String: String] {
+        let credentials = AntigravityOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            expiryDate: Date().addingTimeInterval(3600),
+            idToken: idToken,
+            email: email)
+        guard let value = try? AntigravityOAuthCredentialsStore.tokenAccountValue(for: credentials) else {
+            return [:]
+        }
+        return [AntigravityOAuthCredentialsStore.environmentCredentialsKey: value]
+    }
+
+    private static func makeIDToken(email: String) -> String {
+        let payload = Data("{\"email\":\"\(email)\"}".utf8)
+        let encodedPayload = payload.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return "header.\(encodedPayload).signature"
     }
 
     private struct StubClaudeFetcher: ClaudeUsageFetching {

--- a/Tests/CodexBarTests/AntigravityCLISessionTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLISessionTests.swift
@@ -1,0 +1,932 @@
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+private final class FakeAntigravityProcessHandle: AntigravityCLIProcessHandle, @unchecked Sendable {
+    private let lock = NSLock()
+    let pid: pid_t
+    var descendants: [pid_t]
+    private var running: Bool
+    private let terminateRootStopsProcess: Bool
+    private var assignedProcessGroup: pid_t?
+    private var events: [String] = []
+
+    init(pid: pid_t, running: Bool = true, descendants: [pid_t] = [], terminateRootStopsProcess: Bool = true) {
+        self.pid = pid
+        self.running = running
+        self.descendants = descendants
+        self.terminateRootStopsProcess = terminateRootStopsProcess
+    }
+
+    var isRunning: Bool {
+        self.lock.lock()
+        let value = self.running
+        self.events.append("isRunning:\(value)")
+        self.lock.unlock()
+        return value
+    }
+
+    var processGroup: pid_t? {
+        self.lock.lock()
+        let value = self.assignedProcessGroup
+        self.lock.unlock()
+        return value
+    }
+
+    func assignProcessGroup() -> pid_t? {
+        self.lock.lock()
+        self.assignedProcessGroup = self.pid
+        self.events.append("assignProcessGroup")
+        self.lock.unlock()
+        return self.pid
+    }
+
+    func sendExit() throws {
+        self.append("sendExit")
+    }
+
+    func closePTY() {
+        self.append("closePTY")
+    }
+
+    func terminateRoot() {
+        self.lock.lock()
+        if self.terminateRootStopsProcess {
+            self.running = false
+        }
+        self.events.append("terminateRoot")
+        self.lock.unlock()
+    }
+
+    func killRoot() {
+        self.lock.lock()
+        self.running = false
+        self.events.append("killRoot")
+        self.lock.unlock()
+    }
+
+    func descendantPIDs() -> [pid_t] {
+        self.lock.lock()
+        let value = self.descendants
+        self.events.append("descendantPIDs")
+        self.lock.unlock()
+        return value
+    }
+
+    func terminateTree(signal: Int32, knownDescendants _: [pid_t]) {
+        self.lock.lock()
+        if signal == SIGKILL {
+            self.running = false
+        }
+        self.events.append("terminateTree:\(signal)")
+        self.lock.unlock()
+    }
+
+    func killDescendants(_ descendants: [pid_t]) {
+        self.append("killDescendants:\(descendants.map(String.init).joined(separator: ","))")
+    }
+
+    func drainOutput() {
+        self.append("drainOutput")
+    }
+
+    func snapshotEvents() -> [String] {
+        self.lock.lock()
+        let value = self.events
+        self.lock.unlock()
+        return value
+    }
+
+    private func append(_ event: String) {
+        self.lock.lock()
+        self.events.append(event)
+        self.lock.unlock()
+    }
+}
+
+private final class FakeAntigravityProcessLauncher: AntigravityCLIProcessLaunching, @unchecked Sendable {
+    private let lock = NSLock()
+    private var nextPID: pid_t
+    private var launchError: Error?
+    private var launchedBinaries: [String] = []
+    private var terminateRootStopsProcess = true
+    private var handles: [FakeAntigravityProcessHandle] = []
+
+    init(nextPID: pid_t = 1) {
+        self.nextPID = nextPID
+    }
+
+    func launch(binary: String) throws -> any AntigravityCLIProcessHandle {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        if let launchError {
+            throw launchError
+        }
+        let handle = FakeAntigravityProcessHandle(
+            pid: self.nextPID,
+            descendants: [self.nextPID + 100],
+            terminateRootStopsProcess: self.terminateRootStopsProcess)
+        self.nextPID += 1
+        self.launchedBinaries.append(binary)
+        self.handles.append(handle)
+        return handle
+    }
+
+    func setLaunchError(_ error: Error?) {
+        self.lock.lock()
+        self.launchError = error
+        self.lock.unlock()
+    }
+
+    func setTerminateRootStopsProcess(_ value: Bool) {
+        self.lock.lock()
+        self.terminateRootStopsProcess = value
+        self.lock.unlock()
+    }
+
+    func launchedBinarySnapshot() -> [String] {
+        self.lock.lock()
+        let value = self.launchedBinaries
+        self.lock.unlock()
+        return value
+    }
+
+    func handleSnapshot() -> [FakeAntigravityProcessHandle] {
+        self.lock.lock()
+        let value = self.handles
+        self.lock.unlock()
+        return value
+    }
+}
+
+private final class FakeAntigravityIdentityProvider: AntigravityCLIProcessIdentityProviding, @unchecked Sendable {
+    private let lock = NSLock()
+    private var identities: [pid_t: AntigravityCLIProcessIdentity] = [:]
+
+    func setIdentity(pid: pid_t, executablePath: String, startEpoch: TimeInterval) {
+        self.lock.lock()
+        self.identities[pid] = AntigravityCLIProcessIdentity(executablePath: executablePath, startEpoch: startEpoch)
+        self.lock.unlock()
+    }
+
+    func removeIdentity(pid: pid_t) {
+        self.lock.lock()
+        self.identities[pid] = nil
+        self.lock.unlock()
+    }
+
+    func identity(for pid: pid_t) -> AntigravityCLIProcessIdentity? {
+        self.lock.lock()
+        let value = self.identities[pid]
+        self.lock.unlock()
+        return value
+    }
+}
+
+private final class MemoryAntigravitySessionRecordStore: AntigravityCLISessionRecordStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var record: AntigravityCLISessionRecord?
+    private var saves = 0
+    private var removes = 0
+
+    init(record: AntigravityCLISessionRecord? = nil) {
+        self.record = record
+    }
+
+    func load() throws -> AntigravityCLISessionRecord? {
+        self.lock.lock()
+        let value = self.record
+        self.lock.unlock()
+        return value
+    }
+
+    func save(_ record: AntigravityCLISessionRecord) throws {
+        self.lock.lock()
+        self.record = record
+        self.saves += 1
+        self.lock.unlock()
+    }
+
+    func remove() throws {
+        self.lock.lock()
+        self.record = nil
+        self.removes += 1
+        self.lock.unlock()
+    }
+
+    func snapshot() -> AntigravityCLISessionRecord? {
+        self.lock.lock()
+        let value = self.record
+        self.lock.unlock()
+        return value
+    }
+
+    var saveCount: Int {
+        self.lock.lock()
+        let value = self.saves
+        self.lock.unlock()
+        return value
+    }
+
+    var removeCount: Int {
+        self.lock.lock()
+        let value = self.removes
+        self.lock.unlock()
+        return value
+    }
+}
+
+private final class AntigravitySessionTerminationRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [(pid: pid_t, group: pid_t?, signal: Int32, descendants: [pid_t])] = []
+
+    func append(pid: pid_t, group: pid_t?, signal: Int32, descendants: [pid_t]) {
+        self.lock.lock()
+        self.events.append((pid: pid, group: group, signal: signal, descendants: descendants))
+        self.lock.unlock()
+    }
+
+    func snapshot() -> [(pid: pid_t, group: pid_t?, signal: Int32, descendants: [pid_t])] {
+        self.lock.lock()
+        let value = self.events
+        self.lock.unlock()
+        return value
+    }
+}
+
+private final class AntigravityRegistryRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var shouldRegister = true
+    private var registered: [pid_t] = []
+    private var unregistered: [pid_t] = []
+    private var groups: [pid_t: pid_t?] = [:]
+
+    func setShouldRegister(_ value: Bool) {
+        self.lock.lock()
+        self.shouldRegister = value
+        self.lock.unlock()
+    }
+
+    func register(pid: pid_t, _: String) -> Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        guard self.shouldRegister else { return false }
+        self.registered.append(pid)
+        return true
+    }
+
+    func update(pid: pid_t, group: pid_t?) {
+        self.lock.lock()
+        self.groups[pid] = group
+        self.lock.unlock()
+    }
+
+    func unregister(pid: pid_t) {
+        self.lock.lock()
+        self.unregistered.append(pid)
+        self.lock.unlock()
+    }
+
+    func registeredSnapshot() -> [pid_t] {
+        self.lock.lock()
+        let value = self.registered
+        self.lock.unlock()
+        return value
+    }
+
+    func unregisteredSnapshot() -> [pid_t] {
+        self.lock.lock()
+        let value = self.unregistered
+        self.lock.unlock()
+        return value
+    }
+}
+
+private final class AntigravityManualSleeper: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuations: [CheckedContinuation<Void, Error>] = []
+
+    func sleep(_: UInt64) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            self.lock.lock()
+            self.continuations.append(continuation)
+            self.lock.unlock()
+        }
+    }
+
+    func resumeAll() {
+        self.lock.lock()
+        let continuations = self.continuations
+        self.continuations.removeAll()
+        self.lock.unlock()
+
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
+
+    func waitForSleeps(_ expectedCount: Int) async {
+        for _ in 0..<200 {
+            if self.pendingSleepCount >= expectedCount { return }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        Issue.record("Timed out waiting for \(expectedCount) sleep continuation(s)")
+    }
+
+    private var pendingSleepCount: Int {
+        self.lock.lock()
+        let count = self.continuations.count
+        self.lock.unlock()
+        return count
+    }
+}
+
+struct AntigravityCLISessionTests {
+    @Test
+    func `reuses alive process for same binary`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        let firstPID = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        let secondPID = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(firstPID == 10)
+        #expect(secondPID == 10)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy"])
+    }
+
+    @Test
+    func `relaunches when binary changes`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 11, executablePath: "/new/agy", startEpoch: 101)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        let secondPID = try await fixture.session.beginProbe(binary: "/new/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(secondPID == 11)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy", "/new/agy"])
+        #expect(fixture.registry.unregisteredSnapshot() == [10])
+    }
+
+    @Test
+    func `replacement launch waits for in progress teardown`() async throws {
+        let fixture = self.makeFixture(
+            manualSleep: true,
+            terminationGracePeriod: 1,
+            terminateRootStopsProcess: false)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/old/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 11, executablePath: "/new/agy", startEpoch: 101)
+
+        _ = try await fixture.session.beginProbe(binary: "/old/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        let firstReplacement = Task {
+            try await fixture.session.beginProbe(binary: "/new/agy")
+        }
+        await fixture.sleeper?.waitForSleeps(1)
+
+        let secondReplacement = Task {
+            try await fixture.session.beginProbe(binary: "/new/agy")
+        }
+        await Task.yield()
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/old/agy"])
+
+        fixture.launcher.handleSnapshot().first?.killRoot()
+        fixture.sleeper?.resumeAll()
+        let firstPID = try await firstReplacement.value
+        let secondPID = try await secondReplacement.value
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(firstPID == 11)
+        #expect(secondPID == 11)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/old/agy", "/new/agy"])
+    }
+
+    @Test
+    func `replacement waits for active probe before relaunching`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/old/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 11, executablePath: "/new/agy", startEpoch: 101)
+
+        let firstPID = try await fixture.session.beginProbe(binary: "/old/agy")
+        let replacement = Task {
+            try await fixture.session.beginProbe(binary: "/new/agy")
+        }
+        await Task.yield()
+        await Task.yield()
+
+        #expect(firstPID == 10)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/old/agy"])
+        #expect(fixture.registry.unregisteredSnapshot().isEmpty)
+
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        let secondPID = try await replacement.value
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(secondPID == 11)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/old/agy", "/new/agy"])
+        #expect(fixture.registry.unregisteredSnapshot() == [10])
+    }
+
+    @Test
+    func `replacement ignores queued starters while waiting for active probe`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/old/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 11, executablePath: "/new/agy", startEpoch: 101)
+
+        _ = try await fixture.session.beginProbe(binary: "/old/agy")
+        let firstReplacement = Task {
+            try await fixture.session.beginProbe(binary: "/new/agy")
+        }
+        let secondReplacement = Task {
+            try await fixture.session.beginProbe(binary: "/new/agy")
+        }
+        await Task.yield()
+        await Task.yield()
+
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/old/agy"])
+
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        let didLaunchReplacement = await self.waitForLaunches(fixture.launcher, count: 2)
+        #expect(didLaunchReplacement)
+        if !didLaunchReplacement {
+            await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        }
+
+        let firstPID = try await firstReplacement.value
+        let secondPID = try await secondReplacement.value
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(firstPID == 11)
+        #expect(secondPID == 11)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/old/agy", "/new/agy"])
+    }
+
+    @Test
+    func `relaunches when existing process is dead`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 11, executablePath: "/bin/agy", startEpoch: 101)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        fixture.launcher.handleSnapshot().first?.terminateRoot()
+        let secondPID = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(secondPID == 11)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy", "/bin/agy"])
+    }
+
+    @Test
+    func `pty launcher creates dedicated process group before returning`() throws {
+        let launcher = AntigravityPTYProcessLauncher()
+        let handle = try launcher.launch(binary: "/bin/cat")
+        defer {
+            handle.killRoot()
+            handle.terminateTree(signal: SIGKILL, knownDescendants: [])
+            handle.closePTY()
+        }
+
+        #expect(handle.processGroup == handle.pid)
+        #expect(getpgid(handle.pid) == handle.pid)
+    }
+
+    @Test
+    func `spawned PTY drain is bounded per call`() throws {
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("antigravity-drain-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: temp) }
+        try Data(repeating: 1, count: 8192 * 65).write(to: temp)
+        let primaryFD = open(temp.path, O_RDONLY)
+        guard primaryFD >= 0 else {
+            Issue.record("Failed to open temporary drain input")
+            return
+        }
+        let secondaryFD = open("/dev/null", O_RDONLY)
+        guard secondaryFD >= 0 else {
+            close(primaryFD)
+            Issue.record("Failed to open /dev/null")
+            return
+        }
+        let handle = AntigravitySpawnedPTYProcessHandle(
+            pid: getpid(),
+            processGroup: getpgrp(),
+            primaryFD: primaryFD,
+            primaryHandle: FileHandle(fileDescriptor: primaryFD, closeOnDealloc: true),
+            secondaryHandle: FileHandle(fileDescriptor: secondaryFD, closeOnDealloc: true))
+        defer { handle.closePTY() }
+
+        handle.drainOutput()
+
+        #expect(lseek(primaryFD, 0, SEEK_CUR) == off_t(8192 * 64))
+    }
+
+    @Test
+    func `registration failure tears down launched process`() async {
+        let fixture = self.makeFixture()
+        fixture.registry.setShouldRegister(false)
+
+        await #expect(throws: AntigravityCLISession.SessionError.self) {
+            _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        }
+
+        let handle = fixture.launcher.handleSnapshot().first
+        #expect(handle?.isRunning == false)
+        #expect(handle?.snapshotEvents().contains("closePTY") == true)
+        #expect(fixture.registry.registeredSnapshot().isEmpty)
+    }
+
+    @Test
+    func `idle window tears down warm process`() async throws {
+        let fixture = self.makeFixture(idleWindow: 0.05, manualSleep: true)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        await fixture.sleeper?.waitForSleeps(1)
+        fixture.sleeper?.resumeAll()
+        await self.waitUntilStopped(fixture.session)
+
+        #expect(await fixture.session.isRunning == false)
+        #expect(fixture.registry.unregisteredSnapshot() == [10])
+        #expect(fixture.store.snapshot() == nil)
+    }
+
+    @Test
+    func `active probe prevents idle teardown until finish`() async throws {
+        let fixture = self.makeFixture(idleWindow: 0.05, manualSleep: true)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.sleeper?.waitForSleeps(1)
+        fixture.sleeper?.resumeAll()
+        await Task.yield()
+
+        #expect(await fixture.session.isRunning)
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        await fixture.sleeper?.waitForSleeps(1)
+        fixture.sleeper?.resumeAll()
+        await self.waitUntilStopped(fixture.session)
+        #expect(await fixture.session.isRunning == false)
+    }
+
+    @Test
+    func `manual reset waits for active probe to finish`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.reset()
+        #expect(await fixture.session.isRunning)
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(await fixture.session.isRunning == false)
+        #expect(fixture.registry.unregisteredSnapshot() == [10])
+    }
+
+    @Test
+    func `reset reaps persisted stale session when no in memory process exists`() async {
+        let store = MemoryAntigravitySessionRecordStore(record: AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777))
+        let fixture = self.makeFixture(store: store)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
+
+        await fixture.session.reset()
+
+        let terminations = fixture.terminations.snapshot()
+        #expect(terminations.map(\.signal) == [SIGTERM, SIGKILL])
+        #expect(terminations.allSatisfy { $0.pid == 777 && $0.group == 777 })
+        #expect(fixture.store.snapshot() == nil)
+    }
+
+    @Test
+    func `reset preserves persisted session owned by another live process`() async {
+        let store = MemoryAntigravitySessionRecordStore(record: AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777,
+            ownerPID: 900,
+            ownerExecutablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            ownerStartEpoch: 10))
+        let fixture = self.makeFixture(store: store, currentProcessID: 901)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
+        fixture.identity.setIdentity(
+            pid: 900,
+            executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            startEpoch: 10)
+
+        await fixture.session.reset()
+
+        #expect(fixture.terminations.snapshot().isEmpty)
+        #expect(fixture.store.snapshot() != nil)
+    }
+
+    @Test
+    func `launch preserves persisted session owned by another live process`() async throws {
+        let protectedRecord = AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777,
+            ownerPID: 900,
+            ownerExecutablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            ownerStartEpoch: 10)
+        let store = MemoryAntigravitySessionRecordStore(record: protectedRecord)
+        let fixture = self.makeFixture(store: store, currentProcessID: 901)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
+        fixture.identity.setIdentity(
+            pid: 900,
+            executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            startEpoch: 10)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        let pid = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+
+        #expect(pid == 10)
+        #expect(fixture.terminations.snapshot().isEmpty)
+        #expect(fixture.store.saveCount == 0)
+        #expect(fixture.store.snapshot() == protectedRecord)
+    }
+
+    @Test
+    func `reset rechecks protected persisted session after owner exits`() async {
+        let store = MemoryAntigravitySessionRecordStore(record: AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777,
+            ownerPID: 900,
+            ownerExecutablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            ownerStartEpoch: 10))
+        let fixture = self.makeFixture(store: store, currentProcessID: 901)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
+        fixture.identity.setIdentity(
+            pid: 900,
+            executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            startEpoch: 10)
+
+        await fixture.session.reset()
+        fixture.identity.removeIdentity(pid: 900)
+        await fixture.session.reset()
+
+        let terminations = fixture.terminations.snapshot()
+        #expect(terminations.map(\.signal) == [SIGTERM, SIGKILL])
+        #expect(terminations.allSatisfy { $0.pid == 777 && $0.group == 777 })
+        #expect(fixture.store.snapshot() == nil)
+    }
+
+    @Test
+    func `teardown preserves record written by another live session`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        let otherRecord = AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/other/agy",
+            executablePath: "/other/agy",
+            startEpoch: 42,
+            processGroup: 777)
+        try fixture.store.save(otherRecord)
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+
+        #expect(fixture.store.snapshot() == otherRecord)
+    }
+
+    @Test
+    func `force killed process is polled again so the child can be reaped`() async throws {
+        let fixture = self.makeFixture(terminateRootStopsProcess: false)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 900, executablePath: "/app/CodexBar", startEpoch: 1)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+
+        let events = fixture.launcher.handleSnapshot().first?.snapshotEvents() ?? []
+        guard let killIndex = events.firstIndex(of: "terminateTree:\(SIGKILL)") else {
+            Issue.record("Expected SIGKILL during teardown")
+            return
+        }
+        #expect(events.dropFirst(killIndex + 1).contains("isRunning:false"))
+    }
+
+    @Test
+    func `one shot CLI reset tears down after fetch`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+
+        #expect(await fixture.session.isRunning == false)
+        #expect(fixture.registry.unregisteredSnapshot() == [10])
+    }
+
+    @Test
+    func `one shot CLI reset is deferred until all active probes finish`() async throws {
+        let fixture = self.makeFixture()
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+        #expect(await fixture.session.isRunning)
+
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(await fixture.session.isRunning == false)
+        #expect(fixture.registry.unregisteredSnapshot() == [10])
+    }
+
+    @Test
+    func `repeated probe failures relaunch session`() async throws {
+        let fixture = self.makeFixture(failureRelaunchThreshold: 2)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 11, executablePath: "/bin/agy", startEpoch: 101)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: false, resetAfterFetch: false)
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: false, resetAfterFetch: false)
+        let relaunchedPID = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(relaunchedPID == 11)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy", "/bin/agy"])
+        #expect(await fixture.session.failureCountForTesting == 0)
+    }
+
+    @Test
+    func `success resets failure counter`() async throws {
+        let fixture = self.makeFixture(failureRelaunchThreshold: 2)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: false, resetAfterFetch: false)
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: false, resetAfterFetch: false)
+
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy"])
+        #expect(await fixture.session.failureCountForTesting == 1)
+    }
+
+    @Test
+    func `matching persisted stale process is reaped when resolved binary changed`() async throws {
+        let store = MemoryAntigravitySessionRecordStore(record: AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/old/agy",
+            executablePath: "/old/agy",
+            startEpoch: 42,
+            processGroup: 777))
+        let fixture = self.makeFixture(store: store)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/old/agy", startEpoch: 42)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/new/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/new/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        let terminations = fixture.terminations.snapshot()
+        #expect(terminations.map(\.signal) == [SIGTERM, SIGKILL])
+        #expect(terminations.allSatisfy { $0.pid == 777 && $0.group == 777 })
+    }
+
+    @Test
+    func `matching persisted stale process is reaped before launch`() async throws {
+        let store = MemoryAntigravitySessionRecordStore(record: AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777))
+        let fixture = self.makeFixture(store: store)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        let terminations = fixture.terminations.snapshot()
+        #expect(terminations.map(\.signal) == [SIGTERM, SIGKILL])
+        #expect(terminations.allSatisfy { $0.pid == 777 && $0.group == 777 })
+    }
+
+    @Test
+    func `non matching persisted process is not reaped`() async throws {
+        let store = MemoryAntigravitySessionRecordStore(record: AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777))
+        let fixture = self.makeFixture(store: store)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/usr/bin/other", startEpoch: 42)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+
+        #expect(fixture.terminations.snapshot().isEmpty)
+    }
+
+    private func waitForLaunches(_ launcher: FakeAntigravityProcessLauncher, count: Int) async -> Bool {
+        for _ in 0..<200 {
+            if launcher.launchedBinarySnapshot().count >= count { return true }
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+        return false
+    }
+
+    private func waitUntilStopped(_ session: AntigravityCLISession) async {
+        for _ in 0..<200 {
+            let running = await session.isRunning
+            if !running { return }
+            await Task.yield()
+        }
+        Issue.record("Timed out waiting for Antigravity CLI session to stop")
+    }
+
+    private struct Fixture {
+        let session: AntigravityCLISession
+        let launcher: FakeAntigravityProcessLauncher
+        let identity: FakeAntigravityIdentityProvider
+        let store: MemoryAntigravitySessionRecordStore
+        let terminations: AntigravitySessionTerminationRecorder
+        let registry: AntigravityRegistryRecorder
+        let sleeper: AntigravityManualSleeper?
+    }
+
+    private func makeFixture(
+        store: MemoryAntigravitySessionRecordStore = MemoryAntigravitySessionRecordStore(),
+        idleWindow: TimeInterval = 3600,
+        failureRelaunchThreshold: Int = 2,
+        manualSleep: Bool = false,
+        terminationGracePeriod: TimeInterval = 0,
+        terminateRootStopsProcess: Bool = true,
+        currentProcessID: pid_t = 900) -> Fixture
+    {
+        let launcher = FakeAntigravityProcessLauncher(nextPID: 10)
+        launcher.setTerminateRootStopsProcess(terminateRootStopsProcess)
+        let identity = FakeAntigravityIdentityProvider()
+        let terminations = AntigravitySessionTerminationRecorder()
+        let registry = AntigravityRegistryRecorder()
+        let sleeper = manualSleep ? AntigravityManualSleeper() : nil
+        let session = AntigravityCLISession(dependencies: AntigravityCLISession.Dependencies(
+            launcher: launcher,
+            identityProvider: identity,
+            recordStore: store,
+            registerForAppShutdown: { pid, binary in registry.register(pid: pid, binary) },
+            updateAppShutdownProcessGroup: { pid, group in registry.update(pid: pid, group: group) },
+            unregisterForAppShutdown: { pid in registry.unregister(pid: pid) },
+            descendantPIDs: { pid in [pid + 1, pid + 2] },
+            terminateProcessTree: { pid, group, signal, descendants in
+                terminations.append(pid: pid, group: group, signal: signal, descendants: descendants)
+            },
+            currentProcessID: { currentProcessID },
+            now: Date.init,
+            sleep: { nanoseconds in
+                if let sleeper {
+                    try await sleeper.sleep(nanoseconds)
+                } else {
+                    try await Task.sleep(nanoseconds: nanoseconds)
+                }
+            },
+            idleWindow: idleWindow,
+            failureRelaunchThreshold: failureRelaunchThreshold,
+            terminationGracePeriod: terminationGracePeriod))
+        return Fixture(
+            session: session,
+            launcher: launcher,
+            identity: identity,
+            store: store,
+            terminations: terminations,
+            registry: registry,
+            sleeper: sleeper)
+    }
+}

--- a/Tests/CodexBarTests/AntigravityCLISessionTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLISessionTests.swift
@@ -672,6 +672,76 @@ struct AntigravityCLISessionTests {
     }
 
     @Test
+    func `binary-change relaunch preserves persisted session owned by another live process`() async throws {
+        let protectedRecord = AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777,
+            ownerPID: 900,
+            ownerExecutablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            ownerStartEpoch: 10)
+        let store = MemoryAntigravitySessionRecordStore(record: protectedRecord)
+        let fixture = self.makeFixture(store: store, currentProcessID: 901)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
+        fixture.identity.setIdentity(
+            pid: 900,
+            executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            startEpoch: 10)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+        fixture.identity.setIdentity(pid: 11, executablePath: "/new/agy", startEpoch: 101)
+
+        _ = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        let relaunchedPID = try await fixture.session.beginProbe(binary: "/new/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+
+        #expect(relaunchedPID == 11)
+        #expect(fixture.store.saveCount == 0)
+        #expect(fixture.store.snapshot() == protectedRecord)
+    }
+
+    @Test
+    func `reused unrecorded session is persisted after protected owner exits`() async throws {
+        let protectedRecord = AntigravityCLISessionRecord(
+            pid: 777,
+            requestedBinaryPath: "/bin/agy",
+            executablePath: "/bin/agy",
+            startEpoch: 42,
+            processGroup: 777,
+            ownerPID: 900,
+            ownerExecutablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            ownerStartEpoch: 10)
+        let store = MemoryAntigravitySessionRecordStore(record: protectedRecord)
+        let fixture = self.makeFixture(store: store, currentProcessID: 901)
+        fixture.identity.setIdentity(pid: 777, executablePath: "/bin/agy", startEpoch: 42)
+        fixture.identity.setIdentity(
+            pid: 900,
+            executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            startEpoch: 10)
+        fixture.identity.setIdentity(
+            pid: 901,
+            executablePath: "/Applications/CodexBar.app/Contents/MacOS/CodexBar",
+            startEpoch: 20)
+        fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
+
+        let firstPID = try await fixture.session.beginProbe(binary: "/bin/agy")
+        await fixture.session.finishProbe(success: true, resetAfterFetch: false)
+        fixture.identity.removeIdentity(pid: 900)
+        let secondPID = try await fixture.session.beginProbe(binary: "/bin/agy")
+        let record = fixture.store.snapshot()
+        await fixture.session.finishProbe(success: true, resetAfterFetch: true)
+        #expect(firstPID == 10)
+        #expect(secondPID == 10)
+        #expect(fixture.launcher.launchedBinarySnapshot() == ["/bin/agy"])
+        #expect(fixture.terminations.snapshot().map(\.pid) == [777, 777])
+        #expect(fixture.store.saveCount == 1)
+        #expect(record?.pid == 10)
+        #expect(record?.ownerPID == 901)
+    }
+
+    @Test
     func `reset rechecks protected persisted session after owner exits`() async {
         let store = MemoryAntigravitySessionRecordStore(record: AntigravityCLISessionRecord(
             pid: 777,

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -177,6 +177,28 @@ struct AntigravityStatusProbeTests {
         #expect(result.csrfToken.isEmpty)
         #expect(result.commandLine == "/Users/test/.local/bin/agy -p hello")
     }
+
+    @Test
+    func `ideOnly scope skips cli processes and reports not running`() {
+        let output = "  200 /Users/test/.local/bin/agy -p hello"
+
+        #expect(throws: AntigravityStatusProbeError.notRunning) {
+            try AntigravityStatusProbe.processInfo(fromProcessListOutput: output, scope: .ideOnly)
+        }
+    }
+
+    @Test
+    func `ideOnly scope still matches ide server listed after cli process`() throws {
+        let cli = "  200 /Users/test/.local/bin/agy -p hello"
+        let ide = "  101 /Applications/Antigravity.app/Contents/Resources/bin/language_server " +
+            "--csrf_token ide-token --app_data_dir antigravity"
+        let output = [cli, ide].joined(separator: "\n")
+
+        let result = try AntigravityStatusProbe.processInfo(fromProcessListOutput: output, scope: .ideOnly)
+
+        #expect(result.pid == 101)
+        #expect(result.csrfToken == "ide-token")
+    }
 }
 
 extension AntigravityStatusProbeTests {

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -271,6 +271,64 @@ struct CLIServeRouterTests {
     }
 
     @Test
+    func `serve cache serves last good payload when refresh fails`() async {
+        let cache = CLIServeResponseCache()
+        let counter = ServeTestCounter()
+
+        let first = await CodexBarCLI.cachedServeResponse(
+            key: "usage:antigravity",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            let call = await counter.increment()
+            return Self.response("[{\"provider\":\"antigravity\",\"call\":\(call)}]")
+        }
+        #expect(first.status == .ok)
+
+        // Let the fresh cache entry expire so the next request re-fetches.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let failed = await CodexBarCLI.cachedServeResponse(
+            key: "usage:antigravity",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            _ = await counter.increment()
+            return Self.response(
+                "[{\"provider\":\"antigravity\",\"error\":{\"message\":\"transient\"}}]")
+        }
+
+        // Transient failure is masked by the last good payload.
+        #expect(failed.status == .ok)
+        #expect(Self.bodyString(failed) == Self.bodyString(first))
+        #expect(await counter.current() == 2)
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        let recovered = await CodexBarCLI.cachedServeResponse(
+            key: "usage:antigravity",
+            cache: cache,
+            refreshInterval: 0.05,
+            requestTimeout: 1)
+        {
+            let call = await counter.increment()
+            return Self.response("[{\"provider\":\"antigravity\",\"call\":\(call)}]")
+        }
+
+        #expect(recovered.status == .ok)
+        #expect(Self.bodyString(recovered).contains("\"call\":3"))
+    }
+
+    @Test
+    func `serve stale ttl is bounded and disabled without caching`() {
+        #expect(CodexBarCLI.serveStaleTTL(refreshInterval: 0) == 0)
+        #expect(CodexBarCLI.serveStaleTTL(refreshInterval: 1) == 300)
+        #expect(CodexBarCLI.serveStaleTTL(refreshInterval: 60) == 600)
+    }
+
+    @Test
     func `serve request timeout zero disables the deadline`() async {
         let cache = CLIServeResponseCache()
 

--- a/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
@@ -196,6 +196,89 @@ struct UsageStoreHighestUsageTests {
     }
 
     @Test
+    func `automatic metric excludes antigravity only when every lane is exhausted`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-all-100"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.setMenuBarMetricPreference(.automatic, for: .antigravity)
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let antigravityMeta = registry.metadata[.antigravity] {
+            settings.setProviderEnabled(provider: .antigravity, metadata: antigravityMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+
+        let codexSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 80, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        let antigravitySnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 100, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 100, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            tertiary: RateWindow(usedPercent: 100, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(codexSnapshot, provider: .codex)
+        store._setSnapshotForTesting(antigravitySnapshot, provider: .antigravity)
+
+        let highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 80)
+    }
+
+    @Test
+    func `automatic metric skips antigravity with no quota lanes`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-empty"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.setMenuBarMetricPreference(.automatic, for: .antigravity)
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let antigravityMeta = registry.metadata[.antigravity] {
+            settings.setProviderEnabled(provider: .antigravity, metadata: antigravityMeta, enabled: true)
+        }
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+
+        let codexSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 80, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        let antigravitySnapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .antigravity,
+                accountEmail: "user@example.com",
+                accountOrganization: nil,
+                loginMethod: "Pro"))
+
+        store._setSnapshotForTesting(codexSnapshot, provider: .codex)
+        store._setSnapshotForTesting(antigravitySnapshot, provider: .antigravity)
+
+        let highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .codex)
+        #expect(highest?.usedPercent == 80)
+    }
+
+    @Test
     func `automatic metric uses zai 5-hour token lane when ranking highest usage`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-zai-automatic-tertiary"),

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -9,7 +9,14 @@ read_when:
 
 # Antigravity provider
 
-Antigravity supports local probing of either the IDE or the CLI (`agy` / `antigravity-cli`) language server, plus Google OAuth-backed remote usage. The OAuth path can store multiple Google accounts through the shared token-account switcher.
+Antigravity supports three usage data sources:
+
+1. The desktop app's local `language_server` (preferred when the IDE/desktop app is open).
+2. The `agy` CLI's embedded HTTPS localhost server (used when the desktop app is closed).
+3. Google OAuth-backed remote usage (final fallback, and the source used for multi-account switching). The OAuth path can store multiple Google accounts through the shared token-account switcher.
+
+The local and CLI paths both prefer Antigravity's internal `GetUserStatus` quota payload and may fall back to
+`GetCommandModelConfigs`; CodexBar never scrapes the desktop UI or the `agy` TUI.
 
 ## OAuth account switching
 
@@ -26,11 +33,13 @@ Antigravity supports local probing of either the IDE or the CLI (`agy` / `antigr
 - `POST https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels`
 - `POST https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota`
 
-## Local data sources + fallback order
-
 ## Data sources + fallback order
 
-1) **Process detection**
+### 1) Desktop local probe
+
+When the Antigravity desktop app is running:
+
+1. **Process detection**
    - Command: `ps -ax -o pid=,command=`.
    - Match either:
      - the **IDE** language server: process name `language_server_macos` plus Antigravity
@@ -45,24 +54,61 @@ Antigravity supports local probing of either the IDE or the CLI (`agy` / `antigr
        - **CLI** matches accept an empty token, because the CLI's language server
          exposes no `--csrf_token` flag and requires none.
      - `--extension_server_port <port>` (HTTP fallback; IDE only).
+     - `--extension_server_csrf_token <token>` (preferred HTTP fallback token when present).
 
-2) **Port discovery**
-   - Command: `lsof -nP -iTCP -sTCP:LISTEN -p <pid>`.
+2. **Port discovery**
+   - Command: `lsof -nP -iTCP -sTCP:LISTEN -a -p <pid>`.
    - All listening ports are probed.
 
-3) **Connect port probe (HTTPS)**
+3. **Connect port probe (HTTPS)**
    - `POST https://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/GetUnleashData`
    - Headers:
      - `X-Codeium-Csrf-Token: <token>`
      - `Connect-Protocol-Version: 1`
    - First 200 OK response selects the connect port.
 
-4) **Quota fetch**
+4. **Quota fetch**
    - Primary:
      - `POST https://127.0.0.1:<connectPort>/exa.language_server_pb.LanguageServerService/GetUserStatus`
    - Fallback:
      - `POST https://127.0.0.1:<connectPort>/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs`
    - If HTTPS fails, retry over HTTP on `extension_server_port`.
+
+### 2) `agy` CLI HTTPS source
+
+When source mode is `auto` or `cli` and the desktop local probe fails, CodexBar resolves `agy` via:
+
+- `ANTIGRAVITY_CLI_PATH`
+- `PATH` / login-shell path lookup
+- Well-known paths:
+  - `~/.local/bin/agy`
+  - `/opt/homebrew/bin/agy`
+  - `/usr/local/bin/agy`
+
+CodexBar launches `agy` in a PTY because the CLI exposes its quota server only while the interactive process is alive.
+The implementation still does **not** scrape terminal output; it only keeps the process alive, drains discarded PTY
+rendering, discovers listening ports with `lsof`, and probes the local HTTPS server:
+
+- First: `POST https://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/GetUserStatus`
+- Fallback: `POST https://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs`
+
+The fallback can return quota without the account email or plan fields from `GetUserStatus`.
+
+Differences from the desktop local probe:
+
+- The CLI HTTPS endpoint does **not** require `X-Codeium-Csrf-Token`.
+- Readiness is endpoint-based: CodexBar retries until one of the quota endpoints parses, because fresh `agy`
+  processes can bind a port before the quota service is initialized.
+- App runtime uses a bounded warm session: `agy` is kept alive briefly after a refresh, then stopped on idle. CLI runtime
+  tears it down immediately after the one-shot fetch.
+- Repeated endpoint failures force a relaunch instead of reusing a wedged process forever.
+- CodexBar records the launched pid + executable identity and conservatively reaps only its own matching stale `agy`
+  process on the next launch. It never blind-kills a user-launched `agy`.
+
+### 3) OAuth remote fallback
+
+When source mode is `auto`, OAuth is used after both local paths fail. If a specific saved Google account is selected,
+CodexBar uses OAuth directly for that account. When source mode is `oauth`, only OAuth is used.
 
 ## Request body (summary)
 - Minimal metadata payload:
@@ -76,9 +122,9 @@ Antigravity supports local probing of either the IDE or the CLI (`agy` / `antigr
   - `userStatus.cascadeModelConfigData.clientModelConfigs[].quotaInfo.remainingFraction`
   - `userStatus.cascadeModelConfigData.clientModelConfigs[].quotaInfo.resetTime`
 - Mapping priority:
-  1) Claude (label contains `claude` but not `thinking`)
-  2) Gemini Pro Low (label contains `pro` + `low`)
-  3) Gemini Flash (label contains `gemini` + `flash`)
+  1) Claude family (thinking variants participate in the normal Claude representative selection)
+  2) Gemini Pro Low
+  3) Gemini Flash
   4) Fallback: lowest remaining percent
 - `resetTime` parsing:
   - ISO-8601 preferred; numeric epoch seconds as fallback.
@@ -90,12 +136,18 @@ Antigravity supports local probing of either the IDE or the CLI (`agy` / `antigr
   - Display: `Antigravity`
   - Labels: `Claude` (primary), `Gemini Pro` (secondary), `Gemini Flash` (tertiary)
 - Status badge: Google Workspace incidents for the Gemini product.
+- Antigravity has independent Claude, Gemini Pro, Gemini Flash, and additional model-specific quota windows such as
+  GPT-OSS. In automatic menu-bar/highest-usage selection, CodexBar treats the provider as exhausted only when the
+  displayed Claude/Gemini summary lanes are exhausted; additional model windows remain visible in detailed usage
+  breakdowns.
 
 ## Constraints
 - Internal protocol; fields may change.
-- Requires `lsof` for port detection.
-- Local HTTPS uses a self-signed cert; the probe allows insecure TLS.
+- Requires `lsof` for local/CLI port detection.
+- Local HTTPS uses a self-signed cert; the probe allows insecure TLS only for loopback hosts.
 
 ## Key files
+- `Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift`
+- `Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift`
 - `Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift`
 - `Sources/CodexBar/Providers/Antigravity/AntigravityProviderImplementation.swift`

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -24,7 +24,8 @@ The local and CLI paths both prefer Antigravity's internal `GetUserStatus` quota
 - A successful login writes the latest shared credentials to `~/.codexbar/antigravity/oauth_creds.json` and upserts a token-account entry for the Google account.
 - Each token-account entry stores serialized `AntigravityOAuthCredentials` and is injected into remote fetches through `ANTIGRAVITY_OAUTH_CREDENTIALS_JSON`.
 - When a token account is selected, the OAuth fetcher uses that account before falling back to the shared credentials file.
-- The menu action is labeled `Add Account...`; switching between saved accounts uses the existing segmented/stacked token-account menu UI.
+  Local desktop and `agy` CLI probes remain source-mode driven and are not scoped to saved OAuth accounts.
+- The menu action is labeled `Add Account...`; switching between saved accounts scopes Google OAuth fetches.
 
 ## Remote OAuth data sources
 
@@ -107,8 +108,8 @@ Differences from the desktop local probe:
 
 ### 3) OAuth remote fallback
 
-When source mode is `auto`, OAuth is used after both local paths fail. If a specific saved Google account is selected,
-CodexBar uses OAuth directly for that account. When source mode is `oauth`, only OAuth is used.
+When source mode is `auto`, OAuth is used after both local paths fail. A selected saved Google account scopes the OAuth
+fallback, but it does not bypass the desktop local or `agy` CLI probes. When source mode is `oauth`, only OAuth is used.
 
 ## Request body (summary)
 - Minimal metadata payload:

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -24,7 +24,9 @@ The local and CLI paths both prefer Antigravity's internal `GetUserStatus` quota
 - A successful login writes the latest shared credentials to `~/.codexbar/antigravity/oauth_creds.json` and upserts a token-account entry for the Google account.
 - Each token-account entry stores serialized `AntigravityOAuthCredentials` and is injected into remote fetches through `ANTIGRAVITY_OAUTH_CREDENTIALS_JSON`.
 - When a token account is selected, the OAuth fetcher uses that account before falling back to the shared credentials file.
-  Local desktop and `agy` CLI probes remain source-mode driven and are not scoped to saved OAuth accounts.
+  In `auto` mode the ambient local desktop and `agy` CLI probes still run first, but a snapshot whose account does not
+  match the selected account is rejected so the pipeline falls through to the account-scoped OAuth fetch (see
+  `AntigravitySelectedAccountGuard`). Explicit `cli`/`oauth` source modes stay authoritative and are not re-checked.
 - The menu action is labeled `Add Account...`; switching between saved accounts scopes Google OAuth fetches.
 
 ## Remote OAuth data sources
@@ -109,7 +111,9 @@ Differences from the desktop local probe:
 ### 3) OAuth remote fallback
 
 When source mode is `auto`, OAuth is used after both local paths fail. A selected saved Google account scopes the OAuth
-fallback, but it does not bypass the desktop local or `agy` CLI probes. When source mode is `oauth`, only OAuth is used.
+fallback. The local and `agy` CLI probes still run first, but in `auto` mode their snapshots are accepted only when the
+reported account matches the selected account; otherwise the pipeline falls through to this account-scoped OAuth fetch.
+When source mode is `oauth`, only OAuth is used.
 
 ## Request body (summary)
 - Minimal metadata payload:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,6 +48,8 @@ See `docs/configuration.md` for the schema.
   - `--port <port>` defaults to `8080`.
   - `--refresh-interval <seconds>` defaults to `60` and controls the in-memory response cache TTL.
   - `--request-timeout <seconds>` defaults to `30` and bounds each request before returning `504 Gateway Timeout`; use `0` to keep waiting indefinitely.
+  - Transient refresh failures fall back to the last good response for up to ten refresh intervals (minimum five minutes) so polling bar integrations do not flicker; disabled when `--refresh-interval 0`.
+  - Warm provider helper sessions (such as the managed Antigravity `agy` process) stay alive between refreshes and are torn down on SIGINT/SIGTERM.
   - v1 binds to `127.0.0.1` only and rejects non-loopback `Host` headers. It does not expose remote bind, auth, CORS, TLS, or daemon mode.
   - Endpoints: `GET /health`, `GET /usage`, `GET /usage?provider=<id|both|all>`, `GET /cost`, `GET /cost?provider=<id|both|all>`.
   - Codex usage responses include every visible Codex account, matching the menu bar switcher.


### PR DESCRIPTION
## Summary

Fix three bugs in the Antigravity provider pipeline and `codexbar serve` that cause the `/usage?provider=antigravity` endpoint to return intermittent errors.

### Bug 1: Local probe attaches to half-warm `agy` processes

`AntigravityStatusProbe` matched all running Antigravity processes including the `agy` CLI. The probe would find a stale or still-initializing `agy`, wait the full 8s timeout, and return an error — while `AntigravityCLIHTTPSFetchStrategy` also tried to manage the same process.

**Fix:** `ProcessScope` enum (`.ideOnly` / `.ideAndCLI`) on the probe. The local fetch strategy uses `.ideOnly` so it only matches the IDE language server. `isRunning()` keeps `.ideAndCLI` for accurate status reporting.

### Bug 2: `codexbar serve` kills warm `agy` sessions every refresh

`shouldResetSessionAfterFetch` returned `true` for `.cli` runtime, which includes `serve`. Every refresh cycle tore down a warm `agy` and the next poll had to cold-start a new one (~10s). If the cold start didn't finish before the request timeout, the serve endpoint returned an error.

**Fix:** New `persistsCLISessions` flag on `ProviderFetchContext`, defaulting `true` for app/serve and `false` for one-shot CLI. Warm sessions stay alive across fetches in persistent runtimes. Serve also installs SIGINT/SIGTERM handlers to tear down managed processes cleanly (no orphaned `agy`).

### Bug 3: `codexbar serve` returns fresh errors instead of last-good data

`shouldCacheServeResponse` returned `false` for error responses. A single Antigravity timeout or 502 replaced the last good payload with a fresh error, so any client polling the serve endpoint would see an error response instead of stale-but-valid data.

**Fix:** `CLIServeResponseCache` records the last good response per key and serves it in place of a failed refresh, bounded by `CachePolicy.staleTTL` (10× refresh interval, 5-minute floor). Disabled when `--refresh-interval 0`.

### Additional improvements

- `AntigravityStatusProbe.fetch()` falls back to `GetCommandModelConfigs` when `GetUserStatus` fails, matching the CLI strategy's error resilience.
- Cold-start warmup deadline raised from 5s to 15s for persistent runtimes.

### Verification

- New tests: probe `ideOnly` scope (2), persistent-session reset (1), serve stale fallback (2), stale TTL bounds (1). 142 focused tests pass.
- `make check`: 0 violations.
- Live e2e against rebuilt serve: cold-start 6.7s, cached ~30ms, transient-failure poll returned last-good payload, SIGTERM left no orphaned `agy`.

Closes #1313 (replaces with a simpler approach — no process manager needed).