### PR TITLE
Fix: schedule idle prune so cached dashboard WebViews are evicted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Claude: show a direct claude.ai re-login action when a configured web session expires or becomes invalid (#1377). Thanks @LeoLin990405!
 - Menu: reuse unchanged hosted chart submenus and precompute utilization history models to reduce expand and hover stalls (#1379). Thanks @hhh2210!
 - Menu bar: defer data-refresh rebuilds until the tracked menu closes, avoiding multi-second WindowServer stalls with slower providers such as Grok (#1376). Thanks @jangisaac-dev!
+- OpenAI Web: evict cached dashboard WebViews after their idle timeout even when no later cache activity occurs, releasing hidden WebKit helper processes (#1386). Thanks @naoterumaker!
 - Xiaomi MiMo: import automatic session cookies from Safari, Chrome variants, Firefox, and Edge instead of limiting discovery to Chrome (#1304). Thanks @Yuxin-Qiao!
 
 ## 0.32.5 — 2026-06-09

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
@@ -110,7 +110,8 @@ final class OpenAIDashboardWebViewCache {
     private var entries: [ObjectIdentifier: Entry] = [:]
     /// Keep the WebView alive only long enough for immediate retries/menu reopens.
     /// Long-lived hidden ChatGPT tabs still consume noticeable energy on some setups.
-    private let idleTimeout: TimeInterval = 60
+    private var idleTimeout: TimeInterval = 60
+    private var idlePruneWorkItem: DispatchWorkItem?
     /// Reuse the validated analytics page only for the immediate next handoff.
     private let preservedPageHandoffTimeout: TimeInterval = 5
     private let blankURL = URL(string: "about:blank")!
@@ -162,6 +163,7 @@ final class OpenAIDashboardWebViewCache {
             host: entry.host,
             preserveLoadedPage: preserveLoadedPage)
         self.prune(now: Date())
+        self.scheduleIdlePrune()
     }
 
     private func releaseNewEntry(_ entry: Entry, webView: WKWebView, preserveLoadedPage: Bool) {
@@ -173,6 +175,7 @@ final class OpenAIDashboardWebViewCache {
             host: entry.host,
             preserveLoadedPage: preserveLoadedPage)
         self.prune(now: Date())
+        self.scheduleIdlePrune()
     }
 
     // MARK: - Testing support
@@ -196,6 +199,11 @@ final class OpenAIDashboardWebViewCache {
 
     var idleTimeoutForTesting: TimeInterval {
         self.idleTimeout
+    }
+
+    /// Shorten the idle timeout so scheduled prune behavior is observable in tests.
+    func setIdleTimeoutForTesting(_ timeout: TimeInterval) {
+        self.idleTimeout = timeout
     }
 
     var preservedPageHandoffTimeoutForTesting: TimeInterval {
@@ -462,6 +470,23 @@ final class OpenAIDashboardWebViewCache {
         webView.evaluateJavaScript(self.idlePageClearScript, completionHandler: nil)
         _ = webView.load(URLRequest(url: self.blankURL))
         host.hide()
+    }
+
+    /// Make sure an idle entry is evicted once `idleTimeout` elapses even when the cache
+    /// sees no further activity. `prune` otherwise only runs on the next acquire/release,
+    /// which can be an hour away on slow refresh cadences — leaving the hidden WebKit
+    /// helper processes (WebContent/GPU/Networking) resident the whole time.
+    private func scheduleIdlePrune() {
+        self.idlePruneWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.idlePruneWorkItem = nil
+                self.prune(now: Date())
+            }
+        }
+        self.idlePruneWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + self.idleTimeout + 1, execute: workItem)
     }
 
     private func prune(now: Date) {

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
@@ -110,8 +110,9 @@ final class OpenAIDashboardWebViewCache {
     private var entries: [ObjectIdentifier: Entry] = [:]
     /// Keep the WebView alive only long enough for immediate retries/menu reopens.
     /// Long-lived hidden ChatGPT tabs still consume noticeable energy on some setups.
-    private var idleTimeout: TimeInterval = 60
+    private let idleTimeout: TimeInterval
     private var idlePruneWorkItem: DispatchWorkItem?
+    private var idlePruneGeneration = 0
     /// Reuse the validated analytics page only for the immediate next handoff.
     private let preservedPageHandoffTimeout: TimeInterval = 5
     private let blankURL = URL(string: "about:blank")!
@@ -154,28 +155,34 @@ final class OpenAIDashboardWebViewCache {
     })();
     """
 
+    init(idleTimeout: TimeInterval = 60) {
+        self.idleTimeout = idleTimeout
+    }
+
     private func releaseCachedEntry(_ entry: Entry, preserveLoadedPage: Bool) {
         entry.isBusy = false
-        entry.lastUsedAt = Date()
+        let now = Date()
+        entry.lastUsedAt = now
         self.updatePreservedPageState(for: entry, preserveLoadedPage: preserveLoadedPage)
         self.prepareCachedWebViewForIdle(
             entry.webView,
             host: entry.host,
             preserveLoadedPage: preserveLoadedPage)
-        self.prune(now: Date())
-        self.scheduleIdlePrune()
+        self.prune(now: now)
+        self.scheduleNextIdlePrune(now: now)
     }
 
     private func releaseNewEntry(_ entry: Entry, webView: WKWebView, preserveLoadedPage: Bool) {
         entry.isBusy = false
-        entry.lastUsedAt = Date()
+        let now = Date()
+        entry.lastUsedAt = now
         self.updatePreservedPageState(for: entry, preserveLoadedPage: preserveLoadedPage)
         self.prepareCachedWebViewForIdle(
             webView,
             host: entry.host,
             preserveLoadedPage: preserveLoadedPage)
-        self.prune(now: Date())
-        self.scheduleIdlePrune()
+        self.prune(now: now)
+        self.scheduleNextIdlePrune(now: now)
     }
 
     // MARK: - Testing support
@@ -199,11 +206,6 @@ final class OpenAIDashboardWebViewCache {
 
     var idleTimeoutForTesting: TimeInterval {
         self.idleTimeout
-    }
-
-    /// Shorten the idle timeout so scheduled prune behavior is observable in tests.
-    func setIdleTimeoutForTesting(_ timeout: TimeInterval) {
-        self.idleTimeout = timeout
     }
 
     var preservedPageHandoffTimeoutForTesting: TimeInterval {
@@ -256,6 +258,7 @@ final class OpenAIDashboardWebViewCache {
 
     /// Clear all cached entries (for test isolation).
     func clearAllForTesting() {
+        self.cancelIdlePrune()
         for (_, entry) in self.entries {
             entry.clearPreservedPage()
             entry.host.close()
@@ -438,9 +441,11 @@ final class OpenAIDashboardWebViewCache {
         entry.clearPreservedPage()
         Self.log.debug("OpenAI webview evicted")
         entry.host.close()
+        self.scheduleNextIdlePrune()
     }
 
     func evictAll() {
+        self.cancelIdlePrune()
         let existing = self.entries
         self.entries.removeAll()
         for (_, entry) in existing {
@@ -472,21 +477,35 @@ final class OpenAIDashboardWebViewCache {
         host.hide()
     }
 
-    /// Make sure an idle entry is evicted once `idleTimeout` elapses even when the cache
-    /// sees no further activity. `prune` otherwise only runs on the next acquire/release,
-    /// which can be an hour away on slow refresh cadences — leaving the hidden WebKit
-    /// helper processes (WebContent/GPU/Networking) resident the whole time.
-    private func scheduleIdlePrune() {
-        self.idlePruneWorkItem?.cancel()
+    /// Schedule against the oldest idle entry so later releases cannot postpone its eviction.
+    private func scheduleNextIdlePrune(now: Date = Date()) {
+        self.cancelIdlePrune()
+
+        guard let nextExpiry = self.entries.values
+            .filter({ !$0.isBusy })
+            .map({ $0.lastUsedAt.addingTimeInterval(self.idleTimeout) })
+            .min()
+        else { return }
+
+        let generation = self.idlePruneGeneration
         let workItem = DispatchWorkItem { [weak self] in
             MainActor.assumeIsolated {
-                guard let self else { return }
+                guard let self, self.idlePruneGeneration == generation else { return }
                 self.idlePruneWorkItem = nil
-                self.prune(now: Date())
+                let pruneTime = Date()
+                self.prune(now: pruneTime)
+                self.scheduleNextIdlePrune(now: pruneTime)
             }
         }
         self.idlePruneWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + self.idleTimeout + 1, execute: workItem)
+        let delay = max(0, nextExpiry.timeIntervalSince(now)) + 0.01
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    private func cancelIdlePrune() {
+        self.idlePruneGeneration &+= 1
+        self.idlePruneWorkItem?.cancel()
+        self.idlePruneWorkItem = nil
     }
 
     private func prune(now: Date) {
@@ -500,7 +519,7 @@ final class OpenAIDashboardWebViewCache {
         }
 
         let expired = self.entries.filter { _, entry in
-            !entry.isBusy && now.timeIntervalSince(entry.lastUsedAt) > self.idleTimeout
+            !entry.isBusy && now.timeIntervalSince(entry.lastUsedAt) >= self.idleTimeout
         }
         for (key, entry) in expired {
             entry.host.close()

--- a/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
@@ -209,16 +209,16 @@ struct OpenAIDashboardWebViewCacheTests {
     @Test
     func `Idle prune is scheduled without future cache activity`() async throws {
         if self.shouldSkipOnCI() { return }
-        let cache = OpenAIDashboardWebViewCache()
-        cache.setIdleTimeoutForTesting(0.2)
+        let cache = OpenAIDashboardWebViewCache(idleTimeout: 0.2)
         let store = WKWebsiteDataStore.nonPersistent()
         let url = try #require(URL(string: "about:blank"))
 
-        let lease = try await cache.acquire(
+        var lease: OpenAIDashboardWebViewLease? = try await cache.acquire(
             websiteDataStore: store,
             usageURL: url,
             logger: nil)
-        lease.release()
+        lease?.release()
+        lease = nil
 
         #expect(cache.hasCachedEntry(for: store), "WebView should remain cached right after release")
 
@@ -231,6 +231,45 @@ struct OpenAIDashboardWebViewCacheTests {
             !cache.hasCachedEntry(for: store),
             "Expected the scheduled idle prune to evict the WebView without any further cache activity")
 
+        cache.clearAllForTesting()
+    }
+
+    @Test
+    func `Later release does not postpone an older idle entry`() async throws {
+        if self.shouldSkipOnCI() { return }
+        let cache = OpenAIDashboardWebViewCache(idleTimeout: 0.5)
+        let firstStore = WKWebsiteDataStore.nonPersistent()
+        let secondStore = WKWebsiteDataStore.nonPersistent()
+        let url = try #require(URL(string: "about:blank"))
+
+        let firstLease = try await cache.acquire(
+            websiteDataStore: firstStore,
+            usageURL: url,
+            logger: nil)
+        firstLease.release()
+
+        try await Task.sleep(for: .milliseconds(250))
+
+        let secondLease = try await cache.acquire(
+            websiteDataStore: secondStore,
+            usageURL: url,
+            logger: nil)
+        secondLease.release()
+
+        let firstDeadline = Date().addingTimeInterval(1.5)
+        while cache.hasCachedEntry(for: firstStore), Date() < firstDeadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+
+        #expect(!cache.hasCachedEntry(for: firstStore), "Expected the oldest idle entry to be pruned first")
+        #expect(cache.hasCachedEntry(for: secondStore), "A later release should keep its own idle window")
+
+        let secondDeadline = Date().addingTimeInterval(1)
+        while cache.hasCachedEntry(for: secondStore), Date() < secondDeadline {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+
+        #expect(!cache.hasCachedEntry(for: secondStore), "Expected the next idle deadline to be scheduled")
         cache.clearAllForTesting()
     }
 

--- a/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
@@ -207,6 +207,34 @@ struct OpenAIDashboardWebViewCacheTests {
     }
 
     @Test
+    func `Idle prune is scheduled without future cache activity`() async throws {
+        if self.shouldSkipOnCI() { return }
+        let cache = OpenAIDashboardWebViewCache()
+        cache.setIdleTimeoutForTesting(0.2)
+        let store = WKWebsiteDataStore.nonPersistent()
+        let url = try #require(URL(string: "about:blank"))
+
+        let lease = try await cache.acquire(
+            websiteDataStore: store,
+            usageURL: url,
+            logger: nil)
+        lease.release()
+
+        #expect(cache.hasCachedEntry(for: store), "WebView should remain cached right after release")
+
+        let deadline = Date().addingTimeInterval(5)
+        while cache.hasCachedEntry(for: store), Date() < deadline {
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+
+        #expect(
+            !cache.hasCachedEntry(for: store),
+            "Expected the scheduled idle prune to evict the WebView without any further cache activity")
+
+        cache.clearAllForTesting()
+    }
+
+    @Test
     func `Reused page reset clears one shot scraper globals`() async throws {
         if self.shouldSkipOnCI() { return }
         let cache = OpenAIDashboardWebViewCache()


### PR DESCRIPTION
## Problem

`OpenAIDashboardWebViewCache` intends to keep the offscreen dashboard WebView alive for only 60s (`idleTimeout`, with a comment noting long-lived hidden ChatGPT tabs are expensive). But `prune()` is only invoked on the next acquire/release or preserved-page expiry — there is no timer that fires after the idle window. With the default hourly refresh cadence, the WebView released after a scrape is never pruned until the *next* refresh acquires it again.

Net effect: the WebKit helper processes stay resident essentially permanently. Measured on an M-series MacBook (CodexBar 0.32.6, Codex provider with web usage source): after each refresh, a `com.apple.WebKit.WebContent` process (~500MB RSS) plus GPU and Networking helpers (~75MB) survive the full hour between refreshes, instead of 60 seconds.

## Fix

Schedule pruning for the earliest nonbusy cache entry's idle deadline. Each timer reschedules after pruning so independently released entries retain their own deadlines, and a generation guard prevents canceled/stale work items from mutating current timer state.

The idle timeout is injected through the cache initializer for focused tests. Regression coverage verifies eviction without later cache activity and verifies that a later release does not postpone an older idle entry.

## Testing

- `swift test --filter OpenAIDashboardWebViewCacheTests` - 17 tests passed.
- `make check` - SwiftFormat and strict SwiftLint clean.
- `swift test` - 3,432 tests in 394 suites passed.
- Runtime proof used an isolated nonpersistent `WKWebsiteDataStore` loading `about:blank`, without provider auth, cookies, or Keychain access. New WebContent/GPU/Networking helper PIDs appeared; WebContent exited about 2 seconds after the test idle prune, and GPU/Networking exited about 8 seconds after appearance while the harness process remained alive.
- `autoreview --mode branch --base origin/main` - clean, confidence 0.94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
