### PR TITLE
fix(menu): defer copy-icon click work off the NSMenu tracking loop (macOS 26 beachball)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Doubao: confirm zero-remaining HTTP 200 request limits before falling back, preserving genuine exhaustion and avoiding false 100% usage (#1383). Thanks @LeoLin990405 and @foobra!
+- Menu bar: defer pasteboard writes and drop `withAnimation` in copy handlers so copy actions no longer beachball inside the `NSMenu` tracking loop on macOS 26 (#1388). Thanks @LeoLin990405!
 - Antigravity: exclude model quotas without a remaining fraction from family summaries so they no longer mask tracked usage in the automatic menu-bar metric (#1369). Thanks @Martin-Hausleitner!
 - Claude: add bundled Fable 5 pricing, account for native 1-hour cache-write usage, and refresh Sonnet 4.6 full-context rates (#1368). Thanks @MoollaMore!
 - Claude: show a direct claude.ai re-login action when a configured web session expires or becomes invalid (#1377). Thanks @LeoLin990405!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 - Doubao: confirm zero-remaining HTTP 200 request limits before falling back, preserving genuine exhaustion and avoiding false 100% usage (#1383). Thanks @LeoLin990405 and @foobra!
-- Menu bar: defer pasteboard writes and drop `withAnimation` in copy handlers so copy actions no longer beachball inside the `NSMenu` tracking loop on macOS 26 (#1388). Thanks @LeoLin990405!
+- Menu bar: defer pasteboard writes and copy feedback outside the `NSMenu` tracking callback so in-menu copy buttons no longer beachball on macOS 26 (#1388). Thanks @LeoLin990405!
 - Antigravity: exclude model quotas without a remaining fraction from family summaries so they no longer mask tracked usage in the automatic menu-bar metric (#1369). Thanks @Martin-Hausleitner!
 - Claude: add bundled Fable 5 pricing, account for native 1-hour cache-write usage, and refresh Sonnet 4.6 full-context rates (#1368). Thanks @MoollaMore!
 - Claude: show a direct claude.ai re-login action when a configured web session expires or becomes invalid (#1377). Thanks @LeoLin990405!

--- a/Sources/CodexBar/ClickToCopyOverlay.swift
+++ b/Sources/CodexBar/ClickToCopyOverlay.swift
@@ -1,6 +1,35 @@
 import AppKit
 import SwiftUI
 
+@MainActor
+enum MenuPasteboardCopy {
+    typealias DeferredAction = @MainActor @Sendable () -> Void
+    typealias Scheduler = @MainActor @Sendable (@escaping DeferredAction) -> Void
+    typealias Writer = @MainActor @Sendable (String) -> Void
+
+    static func perform(
+        _ text: String,
+        scheduler: Scheduler = Self.schedule,
+        writer: @escaping Writer = Self.write,
+        completion: @escaping DeferredAction = {})
+    {
+        scheduler {
+            writer(text)
+            completion()
+        }
+    }
+
+    private static func schedule(_ action: @escaping DeferredAction) {
+        DispatchQueue.main.async(execute: action)
+    }
+
+    private static func write(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+}
+
 struct ClickToCopyOverlay: NSViewRepresentable {
     let copyText: String
 
@@ -20,9 +49,14 @@ struct ClickToCopyOverlay: NSViewRepresentable {
 
 final class ClickToCopyView: NSView {
     var copyText: String
+    private let copyAction: (String) -> Void
 
-    init(copyText: String) {
+    init(
+        copyText: String,
+        copyAction: @escaping (String) -> Void = { MenuPasteboardCopy.perform($0) })
+    {
         self.copyText = copyText
+        self.copyAction = copyAction
         super.init(frame: .zero)
         self.wantsLayer = false
     }
@@ -38,18 +72,6 @@ final class ClickToCopyView: NSView {
 
     override func mouseDown(with event: NSEvent) {
         _ = event
-        // Defer the pasteboard write to the next main-loop tick so it does not
-        // run synchronously inside the active NSMenu tracking event loop. On
-        // macOS 26, NSPasteboard.setString triggers distributed notifications
-        // whose synchronous watchers can re-enter menu tracking and freeze the
-        // system (visible as a multi-second beachball after the click).
-        // Capturing copyText locally is intentional — the NSView may be
-        // updated by SwiftUI before the async block runs.
-        let text = self.copyText
-        DispatchQueue.main.async {
-            let pb = NSPasteboard.general
-            pb.clearContents()
-            pb.setString(text, forType: .string)
-        }
+        self.copyAction(self.copyText)
     }
 }

--- a/Sources/CodexBar/ClickToCopyOverlay.swift
+++ b/Sources/CodexBar/ClickToCopyOverlay.swift
@@ -9,6 +9,11 @@ struct ClickToCopyOverlay: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: ClickToCopyView, context: Context) {
+        // Guard against no-op writes to avoid AppKit view invalidation on every
+        // parent card SwiftUI diff (each MenuCardView body re-eval runs through
+        // .overlay { ClickToCopyOverlay(...) }, which calls updateNSView even
+        // when copyText is unchanged).
+        guard nsView.copyText != self.copyText else { return }
         nsView.copyText = self.copyText
     }
 }
@@ -33,8 +38,18 @@ final class ClickToCopyView: NSView {
 
     override func mouseDown(with event: NSEvent) {
         _ = event
-        let pb = NSPasteboard.general
-        pb.clearContents()
-        pb.setString(self.copyText, forType: .string)
+        // Defer the pasteboard write to the next main-loop tick so it does not
+        // run synchronously inside the active NSMenu tracking event loop. On
+        // macOS 26, NSPasteboard.setString triggers distributed notifications
+        // whose synchronous watchers can re-enter menu tracking and freeze the
+        // system (visible as a multi-second beachball after the click).
+        // Capturing copyText locally is intentional — the NSView may be
+        // updated by SwiftUI before the async block runs.
+        let text = self.copyText
+        DispatchQueue.main.async {
+            let pb = NSPasteboard.general
+            pb.clearContents()
+            pb.setString(text, forType: .string)
+        }
     }
 }

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -322,17 +322,7 @@ private struct CopyIconButton: View {
 
     var body: some View {
         Button {
-            self.copyToPasteboard()
-            withAnimation(.easeOut(duration: 0.12)) {
-                self.didCopy = true
-            }
-            self.resetTask?.cancel()
-            self.resetTask = Task { @MainActor in
-                try? await Task.sleep(for: .seconds(0.9))
-                withAnimation(.easeOut(duration: 0.2)) {
-                    self.didCopy = false
-                }
-            }
+            self.handleCopy()
         } label: {
             Image(systemName: self.didCopy ? "checkmark" : "doc.on.doc")
                 .font(.caption2.weight(.semibold))
@@ -343,10 +333,27 @@ private struct CopyIconButton: View {
         .accessibilityLabel(self.didCopy ? L("Copied") : L("Copy error"))
     }
 
-    private func copyToPasteboard() {
-        let pb = NSPasteboard.general
-        pb.clearContents()
-        pb.setString(self.copyText, forType: .string)
+    /// Handle the click without doing any work synchronously inside the NSMenu
+    /// tracking event loop. On macOS 26 a SwiftUI `Button` action running
+    /// `withAnimation { ... }` while the menu is tracking forces a hosted
+    /// view rebuild on the main thread mid-tracking and beachballs the system
+    /// for several seconds. Defer the pasteboard write and state mutation to
+    /// the next main-loop tick (outside the tracking dispatch), and use plain
+    /// state mutation rather than `withAnimation` so a synchronous SwiftUI
+    /// layout pass cannot re-enter the menu engine.
+    private func handleCopy() {
+        let text = self.copyText
+        self.resetTask?.cancel()
+        DispatchQueue.main.async {
+            let pb = NSPasteboard.general
+            pb.clearContents()
+            pb.setString(text, forType: .string)
+            self.didCopy = true
+            self.resetTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(0.9))
+                self.didCopy = false
+            }
+        }
     }
 }
 

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -333,27 +333,16 @@ private struct CopyIconButton: View {
         .accessibilityLabel(self.didCopy ? L("Copied") : L("Copy error"))
     }
 
-    /// Handle the click without doing any work synchronously inside the NSMenu
-    /// tracking event loop. On macOS 26 a SwiftUI `Button` action running
-    /// `withAnimation { ... }` while the menu is tracking forces a hosted
-    /// view rebuild on the main thread mid-tracking and beachballs the system
-    /// for several seconds. Defer the pasteboard write and state mutation to
-    /// the next main-loop tick (outside the tracking dispatch), and use plain
-    /// state mutation rather than `withAnimation` so a synchronous SwiftUI
-    /// layout pass cannot re-enter the menu engine.
     private func handleCopy() {
         let text = self.copyText
         self.resetTask?.cancel()
-        DispatchQueue.main.async {
-            let pb = NSPasteboard.general
-            pb.clearContents()
-            pb.setString(text, forType: .string)
+        MenuPasteboardCopy.perform(text, completion: {
             self.didCopy = true
             self.resetTask = Task { @MainActor in
                 try? await Task.sleep(for: .seconds(0.9))
                 self.didCopy = false
             }
-        }
+        })
     }
 }
 

--- a/Sources/CodexBar/StorageBreakdownMenuView.swift
+++ b/Sources/CodexBar/StorageBreakdownMenuView.swift
@@ -191,17 +191,14 @@ struct StoragePathCopyButton: View {
 
     var body: some View {
         Button {
-            Self.copyToPasteboard(self.path)
-            withAnimation(.easeOut(duration: 0.12)) {
-                self.didCopy = true
-            }
             self.resetTask?.cancel()
-            self.resetTask = Task { @MainActor in
-                try? await Task.sleep(for: .seconds(0.9))
-                withAnimation(.easeOut(duration: 0.2)) {
+            MenuPasteboardCopy.perform(self.path, completion: {
+                self.didCopy = true
+                self.resetTask = Task { @MainActor in
+                    try? await Task.sleep(for: .seconds(0.9))
                     self.didCopy = false
                 }
-            }
+            })
         } label: {
             Image(systemName: self.didCopy ? "checkmark" : "doc.on.doc")
                 .font(.caption2.weight(.semibold))
@@ -212,11 +209,5 @@ struct StoragePathCopyButton: View {
         .buttonStyle(.plain)
         .help(self.didCopy ? L("Copied") : L("Copy path"))
         .accessibilityLabel(self.didCopy ? L("Copied") : L("Copy path"))
-    }
-
-    static func copyToPasteboard(_ path: String) {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(path, forType: .string)
     }
 }

--- a/Tests/CodexBarTests/ClickToCopyOverlayTests.swift
+++ b/Tests/CodexBarTests/ClickToCopyOverlayTests.swift
@@ -1,5 +1,4 @@
 import AppKit
-import Foundation
 import Testing
 @testable import CodexBar
 
@@ -14,28 +13,33 @@ struct ClickToCopyOverlayTests {
     }
 
     @Test
-    func `mouseDown writes copyText to general pasteboard asynchronously`() async throws {
-        let pb = NSPasteboard.general
-        // Sentinel value so we can detect whether the write actually happened.
-        let sentinel = "click-to-copy-test-\(UUID().uuidString)"
-        pb.clearContents()
-        pb.setString("sentinel-not-replaced", forType: .string)
+    func `pasteboard copy waits for deferred scheduler`() {
+        var pendingAction: (() -> Void)?
+        var copiedText: String?
+        var completed = false
 
-        let view = ClickToCopyView(copyText: sentinel)
-        // NSEvent.mouseEvent requires a non-nil context for a real event; pass
-        // a synthetic event constructed from CGEvent so the override runs.
-        let cgEvent = try #require(CGEvent(
-            mouseEventSource: nil,
-            mouseType: .leftMouseDown,
-            mouseCursorPosition: .zero,
-            mouseButton: .left))
-        let nsEvent = try #require(NSEvent(cgEvent: cgEvent))
-        view.mouseDown(with: nsEvent)
+        MenuPasteboardCopy.perform(
+            "copy me",
+            scheduler: { pendingAction = $0 },
+            writer: { copiedText = $0 },
+            completion: { completed = true })
 
-        // The fix defers the pasteboard write off the current run-loop tick.
-        // Yield to the main loop so the async block has a chance to run.
-        try? await Task.sleep(nanoseconds: 50_000_000) // 50 ms
-        #expect(pb.string(forType: .string) == sentinel)
+        #expect(copiedText == nil)
+        #expect(!completed)
+        pendingAction?()
+        #expect(copiedText == "copy me")
+        #expect(completed)
+    }
+
+    @Test
+    func `mouseDown forwards the latest copyText`() {
+        var copiedText: String?
+        let view = ClickToCopyView(copyText: "original") { copiedText = $0 }
+        view.copyText = "updated"
+
+        view.mouseDown(with: NSEvent())
+
+        #expect(copiedText == "updated")
     }
 
     @Test

--- a/Tests/CodexBarTests/ClickToCopyOverlayTests.swift
+++ b/Tests/CodexBarTests/ClickToCopyOverlayTests.swift
@@ -1,0 +1,46 @@
+import AppKit
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct ClickToCopyOverlayTests {
+    @Test
+    func `view stores the latest copyText`() {
+        let view = ClickToCopyView(copyText: "original")
+        #expect(view.copyText == "original")
+        view.copyText = "updated"
+        #expect(view.copyText == "updated")
+    }
+
+    @Test
+    func `mouseDown writes copyText to general pasteboard asynchronously`() async throws {
+        let pb = NSPasteboard.general
+        // Sentinel value so we can detect whether the write actually happened.
+        let sentinel = "click-to-copy-test-\(UUID().uuidString)"
+        pb.clearContents()
+        pb.setString("sentinel-not-replaced", forType: .string)
+
+        let view = ClickToCopyView(copyText: sentinel)
+        // NSEvent.mouseEvent requires a non-nil context for a real event; pass
+        // a synthetic event constructed from CGEvent so the override runs.
+        let cgEvent = try #require(CGEvent(
+            mouseEventSource: nil,
+            mouseType: .leftMouseDown,
+            mouseCursorPosition: .zero,
+            mouseButton: .left))
+        let nsEvent = try #require(NSEvent(cgEvent: cgEvent))
+        view.mouseDown(with: nsEvent)
+
+        // The fix defers the pasteboard write off the current run-loop tick.
+        // Yield to the main loop so the async block has a chance to run.
+        try? await Task.sleep(nanoseconds: 50_000_000) // 50 ms
+        #expect(pb.string(forType: .string) == sentinel)
+    }
+
+    @Test
+    func `accepts first mouse so error text overlay is clickable on first focus`() {
+        let view = ClickToCopyView(copyText: "x")
+        #expect(view.acceptsFirstMouse(for: nil) == true)
+    }
+}

--- a/Tests/CodexBarTests/ProviderStorageFootprintTests.swift
+++ b/Tests/CodexBarTests/ProviderStorageFootprintTests.swift
@@ -274,15 +274,6 @@ struct ProviderStorageFootprintTests {
 
     @Test
     @MainActor
-    func `storage path copy button writes exact path to pasteboard`() {
-        let path = "/Users/test/.claude/projects/example"
-        StoragePathCopyButton.copyToPasteboard(path)
-
-        #expect(NSPasteboard.general.string(forType: .string) == path)
-    }
-
-    @Test
-    @MainActor
     func `manual storage refresh updates deleted provider data`() async throws {
         let home = try Self.makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: home) }


### PR DESCRIPTION
## Problem

On macOS 26, clicking an inline copy control inside a hosted `NSMenu` card can freeze the cursor for several seconds. The handlers synchronously wrote to `NSPasteboard` and changed animated SwiftUI state while the menu tracking callback was active.

Fixes #1388.

## Solution

- Route menu-card pasteboard writes through one deferred helper.
- Defer copy feedback state changes with the pasteboard write.
- Apply the same behavior to error overlays, error copy buttons, and storage-path copy buttons.
- Avoid no-op `NSViewRepresentable` updates when the copied text is unchanged.
- Test scheduling and text forwarding through injected closures without modifying the user's general clipboard.

## Proof

- `swift test --filter "ClickToCopyOverlayTests|ProviderStorageFootprintTests"`: 19 tests passed.
- `make check`: SwiftFormat clean; SwiftLint 0 violations.
- Structured autoreview: clean, no accepted/actionable findings.
- Fresh release bundle built and launched with `./Scripts/compile_and_run.sh`.
- Peekaboo: merged menu opened in 0.22s; provider-tab clicks completed in about 0.09s without a stall.

The live account state did not expose an error-copy control without changing provider configuration, so the exact copy callback is covered by the injected regression test rather than mutating auth settings.
