### PR TITLE
Keep Codex cost visible without quota data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - Copilot: keep explicitly unlimited chat quotas visible instead of dropping their zero-entitlement payload as unavailable (#1320). Thanks @soumikbhatta!
 - Security: block credentialed provider redirects that leave the original HTTPS origin while preserving same-origin redirects (#1237). Thanks @Hinotoi-agent!
+- Codex: keep local token and cost history visible when remote quota data is unavailable (#1390). Thanks @vaibhavarora14!
 - Doubao: confirm zero-remaining HTTP 200 request limits before falling back, preserving genuine exhaustion and avoiding false 100% usage (#1383). Thanks @LeoLin990405 and @foobra!
 - Menu bar: defer pasteboard writes and copy feedback outside the `NSMenu` tracking callback so in-menu copy buttons no longer beachball on macOS 26 (#1388). Thanks @LeoLin990405!
 - Menu bar: defer Overview-row provider transitions out of AppKit's click callback so opening provider detail no longer performs a full synchronous menu rebuild (#1325).

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -29,6 +29,13 @@ extension UsageMenuCardView.Model {
             self.placeholder != nil
     }
 
+    var usesStackedDetailLayout: Bool {
+        !self.metrics.isEmpty ||
+            self.creditsText != nil ||
+            self.providerCost != nil ||
+            self.tokenUsage != nil
+    }
+
     static func progressColor(for provider: UsageProvider) -> Color {
         if provider == .elevenlabs {
             return Color(nsColor: .labelColor)
@@ -52,7 +59,7 @@ extension UsageMenuCardView.Model {
         }
 
         if input.snapshot == nil, !input.isRefreshing, input.lastError == nil {
-            return L("No usage yet")
+            return self.hasLocalCodexTokenUsage(input) ? nil : L("No usage yet")
         }
 
         return nil
@@ -68,6 +75,12 @@ extension UsageMenuCardView.Model {
             return nil
         }
         return lastError
+    }
+
+    private static func hasLocalCodexTokenUsage(_ input: Input) -> Bool {
+        input.provider == .codex &&
+            input.tokenCostUsageEnabled &&
+            self.tokenUsageSnapshot(input: input) != nil
     }
 
     private static func shouldShowRateLimitsUnavailablePlaceholder(input: Input, lastError: String? = nil) -> Bool {

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -143,7 +143,7 @@ struct UsageMenuCardView: View {
                 Divider()
             }
 
-            if self.model.metrics.isEmpty {
+            if !self.model.usesStackedDetailLayout {
                 if let dashboard = self.model.inlineUsageDashboard {
                     InlineUsageDashboardContent(model: dashboard)
                 } else if !self.model.usageNotes.isEmpty {
@@ -172,6 +172,10 @@ struct UsageMenuCardView: View {
                                 InlineUsageDashboardContent(model: dashboard)
                             } else if !self.model.usageNotes.isEmpty {
                                 UsageNotesContent(notes: self.model.usageNotes)
+                            } else if let placeholder = self.model.placeholder {
+                                Text(placeholder)
+                                    .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                                    .font(.subheadline)
                             }
                         }
                     }
@@ -244,9 +248,7 @@ struct UsageMenuCardView: View {
     }
 
     private var hasDetails: Bool {
-        self.model.hasUsageContent ||
-            self.model.tokenUsage != nil ||
-            self.model.providerCost != nil
+        self.model.hasUsageContent || self.model.usesStackedDetailLayout
     }
 }
 

--- a/Tests/CodexBarTests/MenuCardModelCodexDegradedQuotaTests.swift
+++ b/Tests/CodexBarTests/MenuCardModelCodexDegradedQuotaTests.swift
@@ -1,0 +1,245 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct MenuCardModelCodexDegradedQuotaTests {
+    @Test
+    func `codex local token usage keeps remote quota unavailable error visible`() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let metadata = try #require(ProviderDefaults.metadata[.codex])
+        let tokenSnapshot = CostUsageTokenSnapshot(
+            sessionTokens: 721_966,
+            sessionCostUSD: 1.081155,
+            last30DaysTokens: 824_405_060,
+            last30DaysCostUSD: 583.1287345,
+            daily: [
+                .init(
+                    date: "2026-06-05",
+                    inputTokens: 710_217,
+                    outputTokens: 11749,
+                    totalTokens: 721_966,
+                    costUSD: 1.081155,
+                    modelsUsed: ["gpt-5.5"],
+                    modelBreakdowns: nil),
+            ],
+            updatedAt: now)
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .codex,
+            metadata: metadata,
+            snapshot: nil,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: tokenSnapshot,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: "Codex usage is temporarily unavailable. Try refreshing.",
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: true,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.placeholder == nil)
+        #expect(model.subtitleStyle == .error)
+        #expect(model.subtitleText == "Codex usage is temporarily unavailable. Try refreshing.")
+        #expect(model.usesStackedDetailLayout)
+        #expect(model.tokenUsage?.sessionLine.contains("$1.08") == true)
+        #expect(model.tokenUsage?.sessionLine.contains("tokens") == true)
+        #expect(model.tokenUsage?.monthLine.contains("$583.13") == true)
+        #expect(model.tokenUsage?.monthLine.contains("tokens") == true)
+    }
+
+    @Test
+    func `codex remote quota unavailable error stays visible when token usage is hidden`() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let metadata = try #require(ProviderDefaults.metadata[.codex])
+        let tokenSnapshot = CostUsageTokenSnapshot(
+            sessionTokens: 721_966,
+            sessionCostUSD: 1.081155,
+            last30DaysTokens: 824_405_060,
+            last30DaysCostUSD: 583.1287345,
+            daily: [],
+            updatedAt: now)
+        let error = "Codex usage is temporarily unavailable. Try refreshing."
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .codex,
+            metadata: metadata,
+            snapshot: nil,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: tokenSnapshot,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: error,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.placeholder == nil)
+        #expect(model.subtitleStyle == .error)
+        #expect(model.subtitleText == error)
+        #expect(model.tokenUsage == nil)
+    }
+
+    @Test
+    func `codex local token usage preserves limits unavailable placeholder`() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let metadata = try #require(ProviderDefaults.metadata[.codex])
+        let tokenSnapshot = CostUsageTokenSnapshot(
+            sessionTokens: 721_966,
+            sessionCostUSD: 1.081155,
+            last30DaysTokens: 824_405_060,
+            last30DaysCostUSD: 583.1287345,
+            daily: [],
+            updatedAt: now)
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .codex,
+            metadata: metadata,
+            snapshot: nil,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: tokenSnapshot,
+            tokenError: nil,
+            account: AccountInfo(email: "user@example.com", plan: "Pro"),
+            isRefreshing: false,
+            lastError: UsageError.noRateLimitsFound.errorDescription,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: true,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.placeholder == "Limits not available")
+        #expect(model.subtitleStyle == .info)
+        #expect(model.tokenUsage != nil)
+        #expect(model.usesStackedDetailLayout)
+    }
+
+    @Test
+    func `codex local token usage preserves sign-in guidance`() throws {
+        let model = try self.makeModel(
+            tokenCostUsageEnabled: true,
+            lastError: "Codex CLI is not signed in. Run `codex login --device-auth`, then refresh.")
+
+        #expect(model.subtitleStyle == .error)
+        #expect(model.subtitleText.contains("codex login"))
+        #expect(model.tokenUsage != nil)
+        #expect(model.usesStackedDetailLayout)
+    }
+
+    @Test
+    func `codex local token usage preserves mapped transport error`() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let metadata = try #require(ProviderDefaults.metadata[.codex])
+        let tokenSnapshot = CostUsageTokenSnapshot(
+            sessionTokens: 721_966,
+            sessionCostUSD: 1.081155,
+            last30DaysTokens: 824_405_060,
+            last30DaysCostUSD: 583.1287345,
+            daily: [],
+            updatedAt: now)
+        let error = try #require(CodexUIErrorMapper.userFacingMessage("Codex connection failed: timed out."))
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .codex,
+            metadata: metadata,
+            snapshot: nil,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: tokenSnapshot,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: error,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: true,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.placeholder == nil)
+        #expect(model.subtitleStyle == .error)
+        #expect(model.subtitleText == "Codex usage is temporarily unavailable. Try refreshing.")
+        #expect(model.tokenUsage?.sessionLine.contains("$1.08") == true)
+    }
+
+    @Test
+    func `credits select stacked detail layout without quota metrics`() {
+        let model = UsageMenuCardView.Model(
+            provider: .codex,
+            providerName: "Codex",
+            email: "user@example.com",
+            subtitleText: "Not fetched yet",
+            subtitleStyle: .info,
+            planText: nil,
+            metrics: [],
+            usageNotes: [],
+            openAIAPIUsage: nil,
+            inlineUsageDashboard: nil,
+            creditsText: "$12.34 remaining",
+            creditsRemaining: 12.34,
+            creditsHintText: nil,
+            creditsHintCopyText: nil,
+            providerCost: nil,
+            tokenUsage: nil,
+            placeholder: "No usage yet",
+            progressColor: .blue)
+
+        #expect(model.usesStackedDetailLayout)
+    }
+
+    private func makeModel(
+        tokenCostUsageEnabled: Bool,
+        lastError: String?) throws -> UsageMenuCardView.Model
+    {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let metadata = try #require(ProviderDefaults.metadata[.codex])
+        let tokenSnapshot = CostUsageTokenSnapshot(
+            sessionTokens: 721_966,
+            sessionCostUSD: 1.081155,
+            last30DaysTokens: 824_405_060,
+            last30DaysCostUSD: 583.1287345,
+            daily: [],
+            updatedAt: now)
+
+        return UsageMenuCardView.Model.make(.init(
+            provider: .codex,
+            metadata: metadata,
+            snapshot: nil,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: tokenSnapshot,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: lastError,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: tokenCostUsageEnabled,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+    }
+}


### PR DESCRIPTION
## Summary
- Keep local Codex token and cost history visible when remote quota metrics are unavailable.
- Preserve mapped remote-refresh errors, sign-in guidance, and generic connection failures alongside useful local history.
- Preserve the limits-unavailable placeholder when rate-limit rows are absent.
- Render token, provider-cost, or credits sections even when no quota metric rows exist.

## Scope
This PR is intentionally Codex-only. The earlier Claude app-auto source-order change was removed because it is a separate provider policy decision and needs independent review.

## Proof
- `swift test`
  - 3,482 tests passed across 401 suites
- `swift test --filter 'MenuCardModelCodexDegradedQuotaTests|CodexUserFacingErrorTests|MenuCardModelCodexProjectionTests'`
  - 35 tests passed
- `make check`
  - SwiftFormat clean
  - SwiftLint: 0 violations
- Structured autoreview against `origin/main`: clean
- Fresh packaged-app proof uses an isolated Codex-only config, synthetic local history, and a failing fake CLI. No live credentials, browser cookies, or Keychain reads.

The rendering branch is covered through a pure model predicate rather than adding more headless AppKit sizing tests.

Related #1321
Related #1287
Related #1380
