### PR TITLE
test: stabilize dashboard idle prune scheduling

### DIFF
--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
@@ -113,6 +113,9 @@ final class OpenAIDashboardWebViewCache {
     private let idleTimeout: TimeInterval
     private var idlePruneWorkItem: DispatchWorkItem?
     private var idlePruneGeneration = 0
+    #if DEBUG
+    private(set) var idlePruneDeadlineForTesting: Date?
+    #endif
     /// Reuse the validated analytics page only for the immediate next handoff.
     private let preservedPageHandoffTimeout: TimeInterval = 5
     private let blankURL = URL(string: "about:blank")!
@@ -492,12 +495,18 @@ final class OpenAIDashboardWebViewCache {
             MainActor.assumeIsolated {
                 guard let self, self.idlePruneGeneration == generation else { return }
                 self.idlePruneWorkItem = nil
+                #if DEBUG
+                self.idlePruneDeadlineForTesting = nil
+                #endif
                 let pruneTime = Date()
                 self.prune(now: pruneTime)
                 self.scheduleNextIdlePrune(now: pruneTime)
             }
         }
         self.idlePruneWorkItem = workItem
+        #if DEBUG
+        self.idlePruneDeadlineForTesting = nextExpiry
+        #endif
         let delay = max(0, nextExpiry.timeIntervalSince(now)) + 0.01
         DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
     }
@@ -506,6 +515,9 @@ final class OpenAIDashboardWebViewCache {
         self.idlePruneGeneration &+= 1
         self.idlePruneWorkItem?.cancel()
         self.idlePruneWorkItem = nil
+        #if DEBUG
+        self.idlePruneDeadlineForTesting = nil
+        #endif
     }
 
     private func prune(now: Date) {

--- a/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
@@ -237,7 +237,7 @@ struct OpenAIDashboardWebViewCacheTests {
     @Test
     func `Later release does not postpone an older idle entry`() async throws {
         if self.shouldSkipOnCI() { return }
-        let cache = OpenAIDashboardWebViewCache(idleTimeout: 0.5)
+        let cache = OpenAIDashboardWebViewCache(idleTimeout: 5)
         let firstStore = WKWebsiteDataStore.nonPersistent()
         let secondStore = WKWebsiteDataStore.nonPersistent()
         let url = try #require(URL(string: "about:blank"))
@@ -247,29 +247,22 @@ struct OpenAIDashboardWebViewCacheTests {
             usageURL: url,
             logger: nil)
         firstLease.release()
+        let firstDeadline = try #require(cache.idlePruneDeadlineForTesting)
 
-        try await Task.sleep(for: .milliseconds(250))
+        try await Task.sleep(for: .milliseconds(50))
 
         let secondLease = try await cache.acquire(
             websiteDataStore: secondStore,
             usageURL: url,
             logger: nil)
         secondLease.release()
+        let rescheduledDeadline = try #require(cache.idlePruneDeadlineForTesting)
 
-        let firstDeadline = Date().addingTimeInterval(1.5)
-        while cache.hasCachedEntry(for: firstStore), Date() < firstDeadline {
-            try await Task.sleep(for: .milliseconds(20))
-        }
-
-        #expect(!cache.hasCachedEntry(for: firstStore), "Expected the oldest idle entry to be pruned first")
+        #expect(
+            abs(rescheduledDeadline.timeIntervalSince(firstDeadline)) < 0.001,
+            "A later release should keep the prune scheduled for the oldest idle entry")
+        #expect(cache.hasCachedEntry(for: firstStore))
         #expect(cache.hasCachedEntry(for: secondStore), "A later release should keep its own idle window")
-
-        let secondDeadline = Date().addingTimeInterval(1)
-        while cache.hasCachedEntry(for: secondStore), Date() < secondDeadline {
-            try await Task.sleep(for: .milliseconds(20))
-        }
-
-        #expect(!cache.hasCachedEntry(for: secondStore), "Expected the next idle deadline to be scheduled")
         cache.clearAllForTesting()
     }
 


### PR DESCRIPTION
## Summary

- replace the real-time two-entry idle-prune assertion with a deterministic scheduled-deadline assertion
- expose the pending idle-prune deadline only in debug builds
- preserve coverage that later releases cannot postpone eviction of the oldest idle entry

## Why

The previous test observed a 250 ms window between two scheduled evictions. Under full-suite main-thread contention, both deadlines could pass before the test resumed, producing a deterministic local failure despite correct scheduling.

## Validation

- focused idle-prune test passes
- `swift test --skip-build`: 3,482 tests, 401 suites, pass
- `make check`: SwiftFormat clean, SwiftLint 0 violations
- structured branch autoreview: clean, no actionable findings
