### PR TITLE
Fix truncated daily cost model details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Localization: add Japanese as a selectable app language (#1385). Thanks @naoterumaker!
 
 ### Fixed
+- Cost history: keep all per-day model breakdown rows available in a bounded scrolling detail area instead of hiding models after the first four (#1370). Thanks @MoollaMore!
 - Copilot: keep explicitly unlimited chat quotas visible instead of dropping their zero-entitlement payload as unavailable (#1320). Thanks @soumikbhatta!
 - Security: block credentialed provider redirects that leave the original HTTPS origin while preserving same-origin redirects (#1237). Thanks @Hinotoi-agent!
 - Codex: keep local token and cost history visible when remote quota data is unavailable (#1390). Thanks @vaibhavarora14!

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -131,47 +131,68 @@ struct CostHistoryChartMenuView: View {
                         .lineLimit(1)
                         .truncationMode(.tail)
                         .frame(height: Self.detailPrimaryLineHeight, alignment: .leading)
-                    ForEach(detail.rows) { row in
-                        HStack(alignment: .top, spacing: 8) {
-                            Rectangle()
-                                .fill(row.accentColor)
-                                .frame(
-                                    width: 2,
-                                    height: Self.accentHeight(for: row))
-                                .padding(.top, 1)
+                    if model.maxRenderedBreakdownRows > 0 {
+                        ScrollView(.vertical) {
+                            VStack(alignment: .leading, spacing: Self.detailSpacing) {
+                                ForEach(detail.rows) { row in
+                                    HStack(alignment: .top, spacing: 8) {
+                                        Rectangle()
+                                            .fill(row.accentColor)
+                                            .frame(
+                                                width: 2,
+                                                height: Self.accentHeight(for: row))
+                                            .padding(.top, 1)
 
-                            VStack(alignment: .leading, spacing: 1) {
-                                Text(row.title)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(1)
-                                    .truncationMode(.tail)
-                                    .frame(height: Self.detailTitleLineHeight, alignment: .leading)
-                                if let subtitle = row.subtitle {
-                                    Text(subtitle)
-                                        .font(.caption2)
-                                        .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                                        .lineLimit(1)
-                                        .truncationMode(.tail)
-                                        .frame(height: Self.detailSubtitleLineHeight, alignment: .leading)
+                                        VStack(alignment: .leading, spacing: 1) {
+                                            Text(row.title)
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                                .lineLimit(1)
+                                                .truncationMode(.tail)
+                                                .frame(height: Self.detailTitleLineHeight, alignment: .leading)
+                                            if let subtitle = row.subtitle {
+                                                Text(subtitle)
+                                                    .font(.caption2)
+                                                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                                                    .lineLimit(1)
+                                                    .truncationMode(.tail)
+                                                    .frame(
+                                                        height: Self.detailSubtitleLineHeight,
+                                                        alignment: .leading)
+                                            }
+                                            if let modeSubtitle = row.modeSubtitle {
+                                                Text(modeSubtitle)
+                                                    .font(.caption2)
+                                                    .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
+                                                    .lineLimit(1)
+                                                    .truncationMode(.tail)
+                                                    .frame(
+                                                        height: Self.detailSubtitleLineHeight,
+                                                        alignment: .leading)
+                                            }
+                                        }
+                                    }
+                                    .frame(height: Self.detailRowHeight(for: row), alignment: .leading)
                                 }
-                                if let modeSubtitle = row.modeSubtitle {
-                                    Text(modeSubtitle)
-                                        .font(.caption2)
-                                        .foregroundStyle(Color(nsColor: .tertiaryLabelColor))
-                                        .lineLimit(1)
-                                        .truncationMode(.tail)
-                                        .frame(height: Self.detailSubtitleLineHeight, alignment: .leading)
+                                ForEach(
+                                    0..<max(model.maxRenderedBreakdownRows - detail.rows.count, 0),
+                                    id: \.self)
+                                { _ in
+                                    Text(" ")
+                                        .font(.caption)
+                                        .frame(height: Self.compactDetailRowHeight, alignment: .leading)
+                                        .opacity(0)
                                 }
                             }
                         }
-                        .frame(height: Self.detailRowHeight(for: row), alignment: .leading)
-                    }
-                    ForEach(0..<max(model.maxRenderedBreakdownRows - detail.rows.count, 0), id: \.self) { _ in
-                        Text(" ")
-                            .font(.caption)
-                            .frame(height: Self.compactDetailRowHeight, alignment: .leading)
-                            .opacity(0)
+                        .scrollIndicators(
+                            Self.detailRowsNeedScrolling(itemCount: detail.rows.count) ? .visible : .hidden)
+                        .frame(
+                            height: Self.detailRowsViewportHeight(
+                                maxBreakdownRows: model.maxRenderedBreakdownRows,
+                                maxRowsHeight: model.maxDetailRowsHeight),
+                            alignment: .topLeading)
+                        .id(self.selectedDateKey)
                     }
                 }
                 .frame(
@@ -211,7 +232,7 @@ struct CostHistoryChartMenuView: View {
     }
 
     private static let selectionBandColor = Color(nsColor: .labelColor).opacity(0.1)
-    private static let maxVisibleDetailLines = 4
+    static let maxVisibleDetailLines = 4
     private static let detailPrimaryLineHeight: CGFloat = 16
     private static let detailTitleLineHeight: CGFloat = 16
     private static let detailSubtitleLineHeight: CGFloat = 13
@@ -338,8 +359,8 @@ struct CostHistoryChartMenuView: View {
     private static func renderedBreakdownRowsMetric(for entry: DailyEntry) -> (count: Int, height: CGFloat) {
         guard let breakdown = entry.modelBreakdowns, !breakdown.isEmpty else { return (0, 0) }
         let renderedRows = Array(
-            self.sortedBreakdown(breakdown)
-                .prefix(self.maxVisibleDetailLines))
+            self.orderedBreakdownItems(breakdown)
+                .prefix(self.detailViewportRowCount(itemCount: breakdown.count)))
         let height = renderedRows.reduce(CGFloat(0)) { total, item in
             total + self.detailRowHeight(hasModeSubtitle: Self.hasModeSubtitle(item))
         }
@@ -353,8 +374,18 @@ struct CostHistoryChartMenuView: View {
     private static func detailBlockHeight(maxBreakdownRows: Int, maxRowsHeight: CGFloat) -> CGFloat {
         guard maxBreakdownRows > 0 else { return self.detailPrimaryLineHeight }
         return self.detailPrimaryLineHeight +
-            maxRowsHeight +
-            (CGFloat(maxBreakdownRows) * self.detailSpacing)
+            self.detailRowsViewportHeight(
+                maxBreakdownRows: maxBreakdownRows,
+                maxRowsHeight: maxRowsHeight) +
+            self.detailSpacing
+    }
+
+    private static func detailRowsViewportHeight(
+        maxBreakdownRows: Int,
+        maxRowsHeight: CGFloat) -> CGFloat
+    {
+        guard maxBreakdownRows > 0 else { return 0 }
+        return maxRowsHeight + (CGFloat(maxBreakdownRows - 1) * self.detailSpacing)
     }
 
     private func selectionBandRect(model: Model, proxy: ChartProxy, geo: GeometryProxy) -> CGRect? {
@@ -400,10 +431,9 @@ struct CostHistoryChartMenuView: View {
         proxy: ChartProxy,
         geo: GeometryProxy)
     {
-        guard let location else {
-            if self.selectedDateKey != nil { self.selectedDateKey = nil }
-            return
-        }
+        // Keep the last hovered day selected when the pointer leaves the chart so the adjacent
+        // model-breakdown scroller remains interactive. The selection resets with the menu view.
+        guard let location else { return }
 
         guard let plotAnchor = proxy.plotFrame else { return }
         let plotFrame = geo[plotAnchor]
@@ -457,8 +487,7 @@ struct CostHistoryChartMenuView: View {
         guard let entry = model.entriesByDateKey[key] else { return [] }
         guard let breakdown = entry.modelBreakdowns, !breakdown.isEmpty else { return [] }
 
-        return Self.sortedBreakdown(breakdown)
-            .prefix(Self.maxVisibleDetailLines)
+        return Self.orderedBreakdownItems(breakdown)
             .enumerated()
             .map { index, item in
                 DetailRow(
@@ -470,7 +499,7 @@ struct CostHistoryChartMenuView: View {
             }
     }
 
-    private static func sortedBreakdown(
+    static func orderedBreakdownItems(
         _ breakdown: [CostUsageDailyReport.ModelBreakdown]) -> [CostUsageDailyReport.ModelBreakdown]
     {
         breakdown.sorted { lhs, rhs in
@@ -484,6 +513,14 @@ struct CostHistoryChartMenuView: View {
 
             return lhs.modelName > rhs.modelName
         }
+    }
+
+    static func detailViewportRowCount(itemCount: Int) -> Int {
+        min(max(itemCount, 0), self.maxVisibleDetailLines)
+    }
+
+    static func detailRowsNeedScrolling(itemCount: Int) -> Bool {
+        itemCount > self.maxVisibleDetailLines
     }
 
     private func modelBreakdownTotalSubtitle(_ item: CostUsageDailyReport.ModelBreakdown) -> String? {

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -1,5 +1,6 @@
 import Testing
 @testable import CodexBar
+@testable import CodexBarCore
 
 struct CostHistoryChartMenuViewTests {
     @Test
@@ -8,5 +9,37 @@ struct CostHistoryChartMenuViewTests {
         #expect(CostHistoryChartMenuView.windowLabel(days: 1) == "Today")
         #expect(CostHistoryChartMenuView.windowLabel(days: 7) == "Last 7 days")
         #expect(CostHistoryChartMenuView.windowLabel(days: 30) == "Last 30 days")
+    }
+
+    @Test
+    @MainActor
+    func `model breakdown keeps every item behind a bounded scrolling viewport`() {
+        let breakdown = (1...6).map { index in
+            CostUsageDailyReport.ModelBreakdown(
+                modelName: "model-\(index)",
+                costUSD: Double(index),
+                totalTokens: index * 100)
+        }
+
+        let ordered = CostHistoryChartMenuView.orderedBreakdownItems(breakdown)
+
+        #expect(ordered.map(\.modelName) == [
+            "model-6",
+            "model-5",
+            "model-4",
+            "model-3",
+            "model-2",
+            "model-1",
+        ])
+        #expect(ordered.count == 6)
+        #expect(CostHistoryChartMenuView.detailViewportRowCount(itemCount: ordered.count) == 4)
+        #expect(CostHistoryChartMenuView.detailRowsNeedScrolling(itemCount: ordered.count))
+    }
+
+    @Test
+    @MainActor
+    func `short model breakdown does not scroll or reserve extra rows`() {
+        #expect(CostHistoryChartMenuView.detailViewportRowCount(itemCount: 3) == 3)
+        #expect(CostHistoryChartMenuView.detailRowsNeedScrolling(itemCount: 3) == false)
     }
 }


### PR DESCRIPTION
## Summary
- keep every per-day model cost breakdown row available instead of truncating after four
- bound the menu detail area to a four-row viewport and enable scrolling only when needed
- retain the hovered day while moving into the detail scroller

Fixes #1370.

## Validation
- `swift test --filter CostHistoryChartMenuViewTests`
- `make check`
- `swift test --skip-build` (3,484 tests in 401 suites)
- autoreview clean
