### PR TITLE
fix: Amp fetching logic + add workspace support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@
 ## 0.32.6 — Unreleased
 
 ### Added
+- Amp: add local `amp usage` support, including Amp Free usage, account identity, and individual and workspace credit balances.
 - Settings: choose Terminal.app or iTerm for Open Terminal actions, including Vertex AI login commands (#1225, fixes #1147). Thanks @Yuxin-Qiao!
 - Localization: add Japanese as a selectable app language (#1385). Thanks @naoterumaker!
 
 ### Fixed
+- Amp: replace the broken settings-page payload scrape with the current `userDisplayBalanceInfo` endpoint and retain the legacy HTML path as a fallback.
+- Amp: show the fetched individual credit balance in menu and settings cards.
 - Copilot: keep explicitly unlimited chat quotas visible instead of dropping their zero-entitlement payload as unavailable (#1320). Thanks @soumikbhatta!
 - Security: block credentialed provider redirects that leave the original HTTPS origin while preserving same-origin redirects (#1237). Thanks @Hinotoi-agent!
 - Codex: keep local token and cost history visible when remote quota data is unavailable (#1390). Thanks @vaibhavarora14!

--- a/Sources/CodexBar/MenuCardView+Costs.swift
+++ b/Sources/CodexBar/MenuCardView+Costs.swift
@@ -11,10 +11,17 @@ extension UsageMenuCardView.Model {
 
     static func creditsLine(
         metadata: ProviderMetadata,
+        snapshot: UsageSnapshot?,
         credits: CreditsSnapshot?,
         error: String?) -> String?
     {
         guard metadata.supportsCredits else { return nil }
+        if metadata.id == .amp,
+           let ampUsage = snapshot?.ampUsage,
+           let ampCredits = self.ampCreditsLine(ampUsage)
+        {
+            return ampCredits
+        }
         if let credits {
             return UsageFormatter.creditsString(from: credits.remaining)
         }
@@ -22,6 +29,19 @@ extension UsageMenuCardView.Model {
             return error.trimmingCharacters(in: .whitespacesAndNewlines)
         }
         return L(metadata.creditsHint)
+    }
+
+    private static func ampCreditsLine(_ usage: AmpUsageDetails) -> String? {
+        var lines: [String] = []
+        if let individualCredits = usage.individualCredits {
+            lines.append(
+                "\(L("Individual credits")): \(UsageFormatter.currencyString(individualCredits, currencyCode: "USD"))")
+        }
+        lines.append(contentsOf: usage.workspaceBalances.map { workspace in
+            "\(L("Workspace")) \(workspace.name): " +
+                UsageFormatter.currencyString(workspace.remaining, currencyCode: "USD")
+        })
+        return lines.isEmpty ? nil : lines.joined(separator: "\n")
     }
 
     static func tokenUsageSection(

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -792,7 +792,11 @@ extension UsageMenuCardView.Model {
         } else if input.codexProjection != nil, !input.showOptionalCreditsAndExtraUsage {
             nil
         } else {
-            Self.creditsLine(metadata: input.metadata, credits: input.credits, error: input.creditsError)
+            Self.creditsLine(
+                metadata: input.metadata,
+                snapshot: input.snapshot,
+                credits: input.credits,
+                error: input.creditsError)
         }
         let isClaudeAdminAPI = input.provider == .claude &&
             input.snapshot?.identity?.loginMethod == "Admin API"

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -931,6 +931,7 @@ extension UsageStore {
             tertiary: snapshot.tertiary,
             extraRateWindows: snapshot.extraRateWindows,
             kiroUsage: snapshot.kiroUsage,
+            ampUsage: snapshot.ampUsage,
             providerCost: snapshot.providerCost,
             zaiUsage: snapshot.zaiUsage,
             minimaxUsage: snapshot.minimaxUsage,

--- a/Sources/CodexBarCore/PathEnvironment.swift
+++ b/Sources/CodexBarCore/PathEnvironment.swift
@@ -154,6 +154,36 @@ public enum BinaryLocator {
             home: home)
     }
 
+    public static func resolveAmpBinary(
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        loginPATH: [String]? = LoginShellPathCache.shared.current,
+        commandV: (String, String?, TimeInterval, FileManager) -> String? = ShellCommandLocator.commandV,
+        aliasResolver: (String, String?, TimeInterval, FileManager, String) -> String? = ShellCommandLocator
+            .resolveAlias,
+        fileManager: FileManager = .default,
+        home: String = NSHomeDirectory()) -> String?
+    {
+        self.resolveBinary(
+            name: "amp",
+            overrideKey: "AMP_CLI_PATH",
+            env: env,
+            loginPATH: loginPATH,
+            commandV: commandV,
+            aliasResolver: aliasResolver,
+            wellKnownPaths: self.ampWellKnownPaths(home: home),
+            fileManager: fileManager,
+            home: home)
+    }
+
+    static func ampWellKnownPaths(home: String) -> [String] {
+        [
+            "\(home)/.local/bin/amp",
+            "\(home)/.amp/bin/amp",
+            "/opt/homebrew/bin/amp",
+            "/usr/local/bin/amp",
+        ]
+    }
+
     /// Well-known install locations for the Grok Build CLI binary.
     /// Covers the installer's default (`~/.grok/bin/grok`) and the symlinks it sometimes
     /// creates into `~/.local/bin` and `/usr/local/bin`.

--- a/Sources/CodexBarCore/Providers/Amp/AmpCLIProbe.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpCLIProbe.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public struct AmpCLIProbe: Sendable {
+    private static let commandTimeout: TimeInterval = 15
+
+    public init() {}
+
+    public func fetch(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        now: Date = Date()) async throws -> AmpUsageSnapshot
+    {
+        let loginPATH = LoginShellPathCache.shared.current
+        guard let executable = BinaryLocator.resolveAmpBinary(env: environment, loginPATH: loginPATH) else {
+            throw SubprocessRunnerError.binaryNotFound("amp")
+        }
+
+        var commandEnvironment = environment
+        commandEnvironment["NO_COLOR"] = "1"
+        commandEnvironment["PATH"] = PathBuilder.effectivePATH(
+            purposes: [.tty, .nodeTooling],
+            env: environment,
+            loginPATH: loginPATH)
+
+        let result = try await SubprocessRunner.run(
+            binary: executable,
+            arguments: ["usage"],
+            environment: commandEnvironment,
+            timeout: Self.commandTimeout,
+            standardInput: FileHandle.nullDevice,
+            label: "amp-usage")
+        let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? result.stderr
+            : result.stdout
+        guard !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AmpUsageError.parseFailed("The Amp CLI returned no usage data.")
+        }
+        return try AmpUsageParser.parse(displayText: output, now: now)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
@@ -14,15 +14,15 @@ public enum AmpProviderDescriptor {
                 weeklyLabel: "Balance",
                 opusLabel: nil,
                 supportsOpus: false,
-                supportsCredits: false,
-                creditsHint: "",
+                supportsCredits: true,
+                creditsHint: "Individual and workspace credit balances from Amp.",
                 toggleTitle: "Show Amp usage",
                 cliName: "amp",
                 defaultEnabled: false,
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
                 browserCookieOrder: ProviderBrowserCookieDefaults.defaultImportOrder,
-                dashboardURL: "https://ampcode.com/settings",
+                dashboardURL: "https://ampcode.com/settings#billing",
                 statusPageURL: nil),
             branding: ProviderBranding(
                 iconStyle: .amp,
@@ -32,11 +32,46 @@ public enum AmpProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "Amp cost summary is not supported." }),
             fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .web],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [AmpStatusFetchStrategy()] })),
+                sourceModes: [.auto, .web, .cli],
+                pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "amp",
                 versionDetector: nil))
+    }
+
+    private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {
+        switch context.sourceMode {
+        case .auto:
+            [AmpCLIFetchStrategy(), AmpStatusFetchStrategy()]
+        case .cli:
+            [AmpCLIFetchStrategy()]
+        case .web:
+            [AmpStatusFetchStrategy()]
+        case .api, .oauth:
+            []
+        }
+    }
+}
+
+struct AmpCLIFetchStrategy: ProviderFetchStrategy {
+    let id: String = "amp.cli"
+    let kind: ProviderFetchKind = .cli
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        BinaryLocator.resolveAmpBinary(
+            env: context.env,
+            loginPATH: LoginShellPathCache.shared.current) != nil
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        let snapshot = try await AmpCLIProbe().fetch(environment: context.env)
+        return self.makeResult(
+            usage: snapshot.toUsageSnapshot(now: snapshot.updatedAt),
+            sourceLabel: "cli")
+    }
+
+    func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {
+        context.sourceMode == .auto
     }
 }
 
@@ -45,6 +80,7 @@ struct AmpStatusFetchStrategy: ProviderFetchStrategy {
     let kind: ProviderFetchKind = .web
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        guard context.sourceMode.usesWeb else { return false }
         guard context.settings?.amp?.cookieSource != .off else { return false }
         return true
     }

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
@@ -95,6 +95,7 @@ public enum AmpCookieImporter {
 
 public struct AmpUsageFetcher: Sendable {
     private static let settingsURL = URL(string: "https://ampcode.com/settings")!
+    static let usageURL = URL(string: "https://ampcode.com/api/internal?userDisplayBalanceInfo")!
     @MainActor private static var recentDumps: [String] = []
 
     public let browserDetection: BrowserDetection
@@ -118,28 +119,25 @@ public struct AmpUsageFetcher: Sendable {
             }
             let diagnostics = RedirectDiagnostics(cookieHeader: cookieHeader, logger: logger)
             do {
-                let (html, responseInfo) = try await self.fetchHTMLWithDiagnostics(
+                let (snapshot, responseInfo) = try await self.fetchWithDiagnostics(
                     cookieHeader: cookieHeader,
-                    diagnostics: diagnostics)
+                    diagnostics: diagnostics,
+                    now: now)
                 self.logDiagnostics(responseInfo: responseInfo, diagnostics: diagnostics, logger: logger)
-                do {
-                    return try AmpUsageParser.parse(html: html, now: now)
-                } catch {
-                    logger("[amp] Parse failed: \(error.localizedDescription)")
-                    self.logHTMLHints(html: html, logger: logger)
-                    throw error
-                }
+                return snapshot
             } catch {
                 self.logDiagnostics(responseInfo: nil, diagnostics: diagnostics, logger: logger)
+                logger("[amp] Fetch failed: \(error.localizedDescription)")
                 throw error
             }
         }
 
         let diagnostics = RedirectDiagnostics(cookieHeader: cookieHeader, logger: nil)
-        let (html, _) = try await self.fetchHTMLWithDiagnostics(
+        let (snapshot, _) = try await self.fetchWithDiagnostics(
             cookieHeader: cookieHeader,
-            diagnostics: diagnostics)
-        return try AmpUsageParser.parse(html: html, now: now)
+            diagnostics: diagnostics,
+            now: now)
+        return snapshot
     }
 
     public func debugRawProbe(cookieHeaderOverride: String? = nil) async -> String {
@@ -178,6 +176,10 @@ public struct AmpUsageFetcher: Sendable {
             lines.append("  used=\(snapshot.freeUsed)")
             lines.append("  hourlyReplenishment=\(snapshot.hourlyReplenishment)")
             lines.append("  windowHours=\(snapshot.windowHours?.description ?? "nil")")
+            lines.append("  individualCredits=\(snapshot.individualCredits?.description ?? "nil")")
+            for workspace in snapshot.workspaceBalances {
+                lines.append("  workspace[\(workspace.name)]=\(workspace.remaining)")
+            }
 
             let output = lines.joined(separator: "\n")
             Task { @MainActor in Self.recordDump(output) }
@@ -223,14 +225,49 @@ public struct AmpUsageFetcher: Sendable {
         diagnostics: RedirectDiagnostics,
         now: Date = Date()) async throws -> (AmpUsageSnapshot, ResponseInfo)
     {
-        let (html, responseInfo) = try await self.fetchHTMLWithDiagnostics(
-            cookieHeader: cookieHeader,
-            diagnostics: diagnostics)
-        let snapshot = try AmpUsageParser.parse(html: html, now: now)
-        return (snapshot, responseInfo)
+        do {
+            return try await self.fetchUsageAPIWithDiagnostics(
+                cookieHeader: cookieHeader,
+                diagnostics: diagnostics,
+                now: now)
+        } catch {
+            if diagnostics.detectedLoginRedirect {
+                throw AmpUsageError.invalidCredentials
+            }
+            guard Self.shouldTryLegacyFallback(after: error) else { throw error }
+            let (html, responseInfo) = try await self.fetchLegacyHTMLWithDiagnostics(
+                cookieHeader: cookieHeader,
+                diagnostics: diagnostics)
+            return try (AmpUsageParser.parse(html: html, now: now), responseInfo)
+        }
     }
 
-    private func fetchHTMLWithDiagnostics(
+    private func fetchUsageAPIWithDiagnostics(
+        cookieHeader: String,
+        diagnostics: RedirectDiagnostics,
+        now: Date) async throws -> (AmpUsageSnapshot, ResponseInfo)
+    {
+        var request = URLRequest(url: Self.usageURL)
+        request.httpMethod = "POST"
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "method": "userDisplayBalanceInfo",
+            "params": [:],
+        ])
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue("application/json", forHTTPHeaderField: "accept")
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        self.applyBrowserHeaders(to: &request)
+
+        let session = URLSession(configuration: .ephemeral, delegate: diagnostics, delegateQueue: nil)
+        let httpResponse = try await session.response(for: request)
+        let responseInfo = ResponseInfo(
+            statusCode: httpResponse.statusCode,
+            url: httpResponse.response.url?.absoluteString ?? "unknown")
+        try self.validate(response: httpResponse, diagnostics: diagnostics)
+        return try (Self.parseUsageAPIResponse(httpResponse.data, now: now), responseInfo)
+    }
+
+    private func fetchLegacyHTMLWithDiagnostics(
         cookieHeader: String,
         diagnostics: RedirectDiagnostics) async throws -> (String, ResponseInfo)
     {
@@ -240,6 +277,50 @@ public struct AmpUsageFetcher: Sendable {
         request.setValue(
             "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             forHTTPHeaderField: "accept")
+        self.applyBrowserHeaders(to: &request)
+
+        let session = URLSession(configuration: .ephemeral, delegate: diagnostics, delegateQueue: nil)
+        let httpResponse = try await session.response(for: request)
+        let responseInfo = ResponseInfo(
+            statusCode: httpResponse.statusCode,
+            url: httpResponse.response.url?.absoluteString ?? "unknown")
+        try self.validate(response: httpResponse, diagnostics: diagnostics)
+
+        let html = String(data: httpResponse.data, encoding: .utf8) ?? ""
+        return (html, responseInfo)
+    }
+
+    static func parseUsageAPIResponse(_ data: Data, now: Date = Date()) throws -> AmpUsageSnapshot {
+        let response: UsageAPIResponse
+        do {
+            response = try JSONDecoder().decode(UsageAPIResponse.self, from: data)
+        } catch {
+            throw AmpUsageError.parseFailed("Invalid Amp usage API response.")
+        }
+
+        guard response.ok else {
+            if response.error?.code == "auth-required" {
+                throw AmpUsageError.invalidCredentials
+            }
+            throw AmpUsageError.networkError(response.error?.message ?? "Amp usage API returned an error.")
+        }
+        guard let displayText = response.result?.displayText, !displayText.isEmpty else {
+            throw AmpUsageError.parseFailed("Missing Amp usage display text.")
+        }
+        return try AmpUsageParser.parse(displayText: displayText, now: now)
+    }
+
+    private static func shouldTryLegacyFallback(after error: Error) -> Bool {
+        guard let ampError = error as? AmpUsageError else { return true }
+        switch ampError {
+        case .networkError, .parseFailed:
+            return true
+        case .notLoggedIn, .invalidCredentials, .noSessionCookie:
+            return false
+        }
+    }
+
+    private func applyBrowserHeaders(to request: inout URLRequest) {
         request.setValue(
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
                 "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
@@ -247,25 +328,18 @@ public struct AmpUsageFetcher: Sendable {
         request.setValue("en-US,en;q=0.9", forHTTPHeaderField: "accept-language")
         request.setValue("https://ampcode.com", forHTTPHeaderField: "origin")
         request.setValue(Self.settingsURL.absoluteString, forHTTPHeaderField: "referer")
+    }
 
-        let session = URLSession(configuration: .ephemeral, delegate: diagnostics, delegateQueue: nil)
-        let httpResponse = try await session.response(for: request)
-        let responseInfo = ResponseInfo(
-            statusCode: httpResponse.statusCode,
-            url: httpResponse.response.url?.absoluteString ?? "unknown")
-
-        guard httpResponse.statusCode == 200 else {
-            if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+    private func validate(
+        response: ProviderHTTPResponse,
+        diagnostics: RedirectDiagnostics) throws
+    {
+        guard response.statusCode == 200 else {
+            if response.statusCode == 401 || response.statusCode == 403 || diagnostics.detectedLoginRedirect {
                 throw AmpUsageError.invalidCredentials
             }
-            if diagnostics.detectedLoginRedirect {
-                throw AmpUsageError.invalidCredentials
-            }
-            throw AmpUsageError.networkError("HTTP \(httpResponse.statusCode)")
+            throw AmpUsageError.networkError("HTTP \(response.statusCode)")
         }
-
-        let html = String(data: httpResponse.data, encoding: .utf8) ?? ""
-        return (html, responseInfo)
     }
 
     @MainActor private static func recordDump(_ text: String) {
@@ -325,6 +399,21 @@ public struct AmpUsageFetcher: Sendable {
         let url: String
     }
 
+    private struct UsageAPIResponse: Decodable {
+        let ok: Bool
+        let result: Result?
+        let error: APIError?
+
+        struct Result: Decodable {
+            let displayText: String
+        }
+
+        struct APIError: Decodable {
+            let code: String?
+            let message: String?
+        }
+    }
+
     private func logDiagnostics(
         responseInfo: ResponseInfo?,
         diagnostics: RedirectDiagnostics,
@@ -339,19 +428,6 @@ public struct AmpUsageFetcher: Sendable {
                 logger("[amp]   \(entry)")
             }
         }
-    }
-
-    private func logHTMLHints(html: String, logger: (String) -> Void) {
-        let trimmed = html
-            .replacingOccurrences(of: "\n", with: " ")
-            .replacingOccurrences(of: "\t", with: " ")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmed.isEmpty {
-            let snippet = trimmed.prefix(240)
-            logger("[amp] HTML snippet: \(snippet)")
-        }
-        logger("[amp] Contains freeTierUsage: \(html.contains("freeTierUsage"))")
-        logger("[amp] Contains getFreeTierUsage: \(html.contains("getFreeTierUsage"))")
     }
 
     private func cookieNames(from header: String) -> [String] {
@@ -383,6 +459,7 @@ public struct AmpUsageFetcher: Sendable {
 
     static func isLoginRedirect(_ url: URL) -> Bool {
         guard self.isAmpHost(url) else { return false }
+        if url.host?.lowercased() == "auth.ampcode.com" { return true }
 
         let path = url.path.lowercased()
         let components = path.split(separator: "/").map(String.init)

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageParser.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageParser.swift
@@ -17,6 +17,55 @@ enum AmpUsageParser {
             updatedAt: now)
     }
 
+    static func parse(displayText: String, now: Date = Date()) throws -> AmpUsageSnapshot {
+        let text = TextParsing.stripANSICodes(displayText)
+        let identityPattern = #"(?im)^\s*Signed in as\s+([^\s(]+)(?:\s+\(([^\r\n)]+)\))?\s*$"#
+        let identity = self.captures(in: text, pattern: identityPattern)
+        if identity == nil, self.looksSignedOut(text) {
+            throw AmpUsageError.notLoggedIn
+        }
+
+        let amountPattern = #"([0-9][0-9,]*(?:\.[0-9]+)?)"#
+        let freePattern = #"(?im)^\s*Amp Free:\s*\$?"# + amountPattern +
+            #"\s*/\s*\$?"# + amountPattern +
+            #"\s+remaining(?:\s*\(replenishes\s*\+\$?"# + amountPattern + #"\s*/\s*hour\))?"#
+        guard let free = self.captures(in: text, pattern: freePattern),
+              let remaining = self.number(from: free[0]),
+              let quota = self.number(from: free[1])
+        else {
+            throw AmpUsageError.parseFailed("Missing Amp Free usage data.")
+        }
+
+        let hourlyReplenishment = self.number(from: free[2]) ?? 0
+        let windowHours = hourlyReplenishment > 0
+            ? max(1, (quota / hourlyReplenishment).rounded())
+            : nil
+        let creditsPattern = #"(?im)^\s*Individual credits:\s*\$?"# + amountPattern + #"\s+remaining"#
+        let individualCredits = self.captures(in: text, pattern: creditsPattern)?.first
+            .flatMap(self.number(from:))
+        let workspacePattern = #"(?im)^\s*Workspace\s+(.+?):\s*\$?"# + amountPattern + #"\s+remaining"#
+        let workspaceBalances: [AmpWorkspaceBalance] = self.allCaptures(
+            in: text,
+            pattern: workspacePattern).compactMap { captures -> AmpWorkspaceBalance? in
+            guard captures.count == 2,
+                  let name = self.nonEmpty(captures[0]),
+                  let remaining = self.number(from: captures[1])
+            else { return nil }
+            return AmpWorkspaceBalance(name: name, remaining: remaining)
+        }
+
+        return AmpUsageSnapshot(
+            freeQuota: quota,
+            freeUsed: max(0, quota - remaining),
+            hourlyReplenishment: hourlyReplenishment,
+            windowHours: windowHours,
+            individualCredits: individualCredits,
+            workspaceBalances: workspaceBalances,
+            accountEmail: self.nonEmpty(identity?[0]),
+            accountOrganization: self.nonEmpty(identity?[1]),
+            updatedAt: now)
+    }
+
     private struct FreeTierUsage {
         let quota: Double
         let used: Double
@@ -96,6 +145,41 @@ enum AmpUsageParser {
               let valueRange = Range(match.range(at: 1), in: text)
         else { return nil }
         return Double(text[valueRange])
+    }
+
+    private static func captures(in text: String, pattern: String) -> [String]? {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range) else { return nil }
+
+        return self.captures(in: text, match: match)
+    }
+
+    private static func allCaptures(in text: String, pattern: String) -> [[String]] {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.matches(in: text, options: [], range: range).map { match in
+            self.captures(in: text, match: match)
+        }
+    }
+
+    private static func captures(in text: String, match: NSTextCheckingResult) -> [String] {
+        (1..<match.numberOfRanges).map { index in
+            let captureRange = match.range(at: index)
+            guard captureRange.location != NSNotFound,
+                  let range = Range(captureRange, in: text)
+            else { return "" }
+            return String(text[range]).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
+    private static func number(from text: String) -> Double? {
+        Double(text.replacingOccurrences(of: ",", with: ""))
+    }
+
+    private static func nonEmpty(_ text: String?) -> String? {
+        guard let text, !text.isEmpty else { return nil }
+        return text
     }
 
     private static func looksSignedOut(_ html: String) -> Bool {

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageSnapshot.swift
@@ -1,10 +1,34 @@
 import Foundation
 
+public struct AmpWorkspaceBalance: Codable, Equatable, Sendable {
+    public let name: String
+    public let remaining: Double
+
+    public init(name: String, remaining: Double) {
+        self.name = name
+        self.remaining = remaining
+    }
+}
+
+public struct AmpUsageDetails: Codable, Equatable, Sendable {
+    public let individualCredits: Double?
+    public let workspaceBalances: [AmpWorkspaceBalance]
+
+    public init(individualCredits: Double?, workspaceBalances: [AmpWorkspaceBalance]) {
+        self.individualCredits = individualCredits
+        self.workspaceBalances = workspaceBalances
+    }
+}
+
 public struct AmpUsageSnapshot: Sendable {
     public let freeQuota: Double
     public let freeUsed: Double
     public let hourlyReplenishment: Double
     public let windowHours: Double?
+    public let individualCredits: Double?
+    public let workspaceBalances: [AmpWorkspaceBalance]
+    public let accountEmail: String?
+    public let accountOrganization: String?
     public let updatedAt: Date
 
     public init(
@@ -12,12 +36,20 @@ public struct AmpUsageSnapshot: Sendable {
         freeUsed: Double,
         hourlyReplenishment: Double,
         windowHours: Double?,
+        individualCredits: Double? = nil,
+        workspaceBalances: [AmpWorkspaceBalance] = [],
+        accountEmail: String? = nil,
+        accountOrganization: String? = nil,
         updatedAt: Date)
     {
         self.freeQuota = freeQuota
         self.freeUsed = freeUsed
         self.hourlyReplenishment = hourlyReplenishment
         self.windowHours = windowHours
+        self.individualCredits = individualCredits
+        self.workspaceBalances = workspaceBalances
+        self.accountEmail = accountEmail
+        self.accountOrganization = accountOrganization
         self.updatedAt = updatedAt
     }
 }
@@ -53,14 +85,23 @@ extension AmpUsageSnapshot {
 
         let identity = ProviderIdentitySnapshot(
             providerID: .amp,
-            accountEmail: nil,
-            accountOrganization: nil,
+            accountEmail: self.accountEmail,
+            accountOrganization: self.accountOrganization,
             loginMethod: "Amp Free")
+
+        let ampUsage: AmpUsageDetails? = if self.individualCredits != nil || !self.workspaceBalances.isEmpty {
+            AmpUsageDetails(
+                individualCredits: self.individualCredits,
+                workspaceBalances: self.workspaceBalances)
+        } else {
+            nil
+        }
 
         return UsageSnapshot(
             primary: primary,
             secondary: nil,
             tertiary: nil,
+            ampUsage: ampUsage,
             providerCost: nil,
             updatedAt: self.updatedAt,
             identity: identity)

--- a/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
@@ -107,6 +107,7 @@ public struct ProviderDiagnosticUsageSummary: Codable, Sendable {
 
         var providerSpecificData: [String] = []
         if snapshot.kiroUsage != nil { providerSpecificData.append("kiroUsage") }
+        if snapshot.ampUsage != nil { providerSpecificData.append("ampUsage") }
         if snapshot.zaiUsage != nil { providerSpecificData.append("zaiUsage") }
         if snapshot.minimaxUsage != nil { providerSpecificData.append("minimaxUsage") }
         if snapshot.deepseekUsage != nil { providerSpecificData.append("deepseekUsage") }

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -91,6 +91,7 @@ public struct UsageSnapshot: Codable, Sendable {
     public let extraRateWindows: [NamedRateWindow]?
     public let providerCost: ProviderCostSnapshot?
     public let kiroUsage: KiroUsageDetails?
+    public let ampUsage: AmpUsageDetails?
     public let zaiUsage: ZaiUsageSnapshot?
     public let minimaxUsage: MiniMaxUsageSnapshot?
     public let deepseekUsage: DeepSeekUsageSummary?
@@ -112,6 +113,7 @@ public struct UsageSnapshot: Codable, Sendable {
         case extraRateWindows
         case providerCost
         case kiroUsage
+        case ampUsage
         case openRouterUsage
         case openAIAPIUsage
         case claudeAdminAPIUsage
@@ -132,6 +134,7 @@ public struct UsageSnapshot: Codable, Sendable {
         tertiary: RateWindow? = nil,
         extraRateWindows: [NamedRateWindow]? = nil,
         kiroUsage: KiroUsageDetails? = nil,
+        ampUsage: AmpUsageDetails? = nil,
         providerCost: ProviderCostSnapshot? = nil,
         zaiUsage: ZaiUsageSnapshot? = nil,
         minimaxUsage: MiniMaxUsageSnapshot? = nil,
@@ -152,6 +155,7 @@ public struct UsageSnapshot: Codable, Sendable {
         self.tertiary = tertiary
         self.extraRateWindows = extraRateWindows
         self.kiroUsage = kiroUsage
+        self.ampUsage = ampUsage
         self.providerCost = providerCost
         self.zaiUsage = zaiUsage
         self.minimaxUsage = minimaxUsage
@@ -176,6 +180,7 @@ public struct UsageSnapshot: Codable, Sendable {
         self.extraRateWindows = try container.decodeIfPresent([NamedRateWindow].self, forKey: .extraRateWindows)
         self.providerCost = try container.decodeIfPresent(ProviderCostSnapshot.self, forKey: .providerCost)
         self.kiroUsage = try container.decodeIfPresent(KiroUsageDetails.self, forKey: .kiroUsage)
+        self.ampUsage = try container.decodeIfPresent(AmpUsageDetails.self, forKey: .ampUsage)
         self.zaiUsage = nil // Not persisted, fetched fresh each time
         self.minimaxUsage = nil // Not persisted, fetched fresh each time
         self.deepseekUsage = nil // Not persisted, fetched fresh each time
@@ -217,6 +222,7 @@ public struct UsageSnapshot: Codable, Sendable {
         try container.encodeIfPresent(self.extraRateWindows, forKey: .extraRateWindows)
         try container.encodeIfPresent(self.providerCost, forKey: .providerCost)
         try container.encodeIfPresent(self.kiroUsage, forKey: .kiroUsage)
+        try container.encodeIfPresent(self.ampUsage, forKey: .ampUsage)
         try container.encodeIfPresent(self.openRouterUsage, forKey: .openRouterUsage)
         try container.encodeIfPresent(self.openAIAPIUsage, forKey: .openAIAPIUsage)
         try container.encodeIfPresent(self.claudeAdminAPIUsage, forKey: .claudeAdminAPIUsage)
@@ -317,6 +323,7 @@ public struct UsageSnapshot: Codable, Sendable {
             tertiary: self.tertiary,
             extraRateWindows: self.extraRateWindows,
             kiroUsage: self.kiroUsage,
+            ampUsage: self.ampUsage,
             providerCost: self.providerCost,
             zaiUsage: self.zaiUsage,
             minimaxUsage: self.minimaxUsage,
@@ -355,6 +362,7 @@ public struct UsageSnapshot: Codable, Sendable {
             tertiary: tertiary,
             extraRateWindows: self.extraRateWindows,
             kiroUsage: self.kiroUsage,
+            ampUsage: self.ampUsage,
             providerCost: self.providerCost,
             zaiUsage: self.zaiUsage,
             minimaxUsage: self.minimaxUsage,

--- a/Tests/CodexBarTests/AmpUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AmpUsageFetcherTests.swift
@@ -4,6 +4,13 @@ import Testing
 
 struct AmpUsageFetcherTests {
     @Test
+    func `uses amp internal usage endpoint`() {
+        #expect(
+            AmpUsageFetcher.usageURL.absoluteString ==
+                "https://ampcode.com/api/internal?userDisplayBalanceInfo")
+    }
+
+    @Test
     func `attaches cookie for amp hosts`() {
         #expect(AmpUsageFetcher.shouldAttachCookie(to: URL(string: "https://ampcode.com/settings")))
         #expect(AmpUsageFetcher.shouldAttachCookie(to: URL(string: "https://www.ampcode.com")))
@@ -41,6 +48,10 @@ struct AmpUsageFetcherTests {
 
         let signin = try #require(URL(string: "https://www.ampcode.com/signin"))
         #expect(AmpUsageFetcher.isLoginRedirect(signin))
+
+        let hostedAuth = try #require(URL(
+            string: "https://auth.ampcode.com/?client_id=test&redirect_uri=https%3A%2F%2Fampcode.com%2Fauth%2Fcallback"))
+        #expect(AmpUsageFetcher.isLoginRedirect(hostedAuth))
     }
 
     @Test

--- a/Tests/CodexBarTests/AmpUsageParserTests.swift
+++ b/Tests/CodexBarTests/AmpUsageParserTests.swift
@@ -4,6 +4,122 @@ import Testing
 
 struct AmpUsageParserTests {
     @Test
+    func `amp cli probe runs usage and parses balances`() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-amp-cli-\(UUID().uuidString)", isDirectory: true)
+        let executable = directory.appendingPathComponent("amp")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let script = """
+        #!/bin/sh
+        [ "$1" = "usage" ] || exit 2
+        cat <<'EOF'
+        Signed in as cli@example.com (team)
+        Amp Free: $6/$10 remaining (replenishes +$0.5/hour)
+        Individual credits: $12.50 remaining
+        Workspace Test Team: $7.25 remaining
+        EOF
+        """
+        try script.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = try await AmpCLIProbe().fetch(
+            environment: ["AMP_CLI_PATH": executable.path],
+            now: now)
+
+        #expect(snapshot.freeUsed == 4)
+        #expect(snapshot.individualCredits == 12.5)
+        #expect(snapshot.workspaceBalances == [AmpWorkspaceBalance(name: "Test Team", remaining: 7.25)])
+        #expect(snapshot.accountEmail == "cli@example.com")
+        #expect(snapshot.updatedAt == now)
+    }
+
+    @Test
+    func `parses current amp usage display text`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let output = """
+        \u{1B}[2mSigned in as ampcode@3kh0.net (echo)\u{1B}[0m
+        Amp Free: $4.71/$10 remaining (replenishes +$0.42/hour) - https://ampcode.com/settings#amp-free
+        Individual credits: $25.64 remaining (set up automatic top-up to avoid running out) - https://ampcode.com/settings
+        Workspace meow: $10.22 remaining (set up automatic top-up to avoid running out) - https://ampcode.com/workspaces/meow
+        """
+
+        let snapshot = try AmpUsageParser.parse(displayText: output, now: now)
+
+        #expect(snapshot.freeQuota == 10)
+        #expect(abs(snapshot.freeUsed - 5.29) < 0.001)
+        #expect(snapshot.hourlyReplenishment == 0.42)
+        #expect(snapshot.windowHours == 24)
+        #expect(snapshot.individualCredits == 25.64)
+        #expect(snapshot.workspaceBalances == [AmpWorkspaceBalance(name: "meow", remaining: 10.22)])
+        #expect(snapshot.accountEmail == "ampcode@3kh0.net")
+        #expect(snapshot.accountOrganization == "echo")
+        #expect(snapshot.toUsageSnapshot(now: now).ampUsage == AmpUsageDetails(
+            individualCredits: 25.64,
+            workspaceBalances: [AmpWorkspaceBalance(name: "meow", remaining: 10.22)]))
+
+        let encoded = try JSONEncoder().encode(snapshot.toUsageSnapshot(now: now))
+        let decoded = try JSONDecoder().decode(UsageSnapshot.self, from: encoded)
+        #expect(decoded.ampUsage == AmpUsageDetails(
+            individualCredits: 25.64,
+            workspaceBalances: [AmpWorkspaceBalance(name: "meow", remaining: 10.22)]))
+    }
+
+    @Test
+    func `signed in identity can contain login`() throws {
+        let output = """
+        Signed in as login@example.com (login-team)
+        Amp Free: $6/$10 remaining (replenishes +$0.5/hour)
+        """
+
+        let snapshot = try AmpUsageParser.parse(displayText: output)
+
+        #expect(snapshot.accountEmail == "login@example.com")
+        #expect(snapshot.accountOrganization == "login-team")
+    }
+
+    @Test
+    func `parses current usage api response`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_005_000)
+        let displayText = """
+        Signed in as user@example.com (team)
+        Amp Free: $8/$10 remaining (replenishes +$0.5/hour)
+        Individual credits: $12.50 remaining
+        Workspace Alpha Team: $1,234.56 remaining
+        Workspace Beta: $7 remaining
+        """
+        let data = try JSONSerialization.data(withJSONObject: [
+            "ok": true,
+            "result": ["displayText": displayText],
+        ])
+
+        let snapshot = try AmpUsageFetcher.parseUsageAPIResponse(data, now: now)
+
+        #expect(snapshot.freeUsed == 2)
+        #expect(snapshot.individualCredits == 12.5)
+        #expect(snapshot.workspaceBalances == [
+            AmpWorkspaceBalance(name: "Alpha Team", remaining: 1234.56),
+            AmpWorkspaceBalance(name: "Beta", remaining: 7),
+        ])
+        #expect(snapshot.accountEmail == "user@example.com")
+        #expect(snapshot.accountOrganization == "team")
+    }
+
+    @Test
+    func `usage api auth error is invalid credentials`() {
+        let data = Data(#"{"ok":false,"error":{"code":"auth-required","message":"Sign in"}}"#.utf8)
+
+        #expect {
+            try AmpUsageFetcher.parseUsageAPIResponse(data)
+        } throws: { error in
+            guard case AmpUsageError.invalidCredentials = error else { return false }
+            return true
+        }
+    }
+
+    @Test
     func `parses free tier usage from settings HTML`() throws {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let html = """

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -89,6 +89,31 @@ struct UsageStoreCoverageTests {
     }
 
     @Test
+    func `amp balances are rendered in provider cards`() {
+        let settings = Self.makeSettingsStore(suite: "UsageStoreCoverageTests-amp-credits")
+        let store = Self.makeUsageStore(settings: settings)
+        let now = Date()
+
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 51.4,
+                    windowMinutes: 1440,
+                    resetsAt: now.addingTimeInterval(12 * 3600),
+                    resetDescription: nil),
+                secondary: nil,
+                ampUsage: AmpUsageDetails(
+                    individualCredits: 25.64,
+                    workspaceBalances: [AmpWorkspaceBalance(name: "meow", remaining: 10.22)]),
+                updatedAt: now),
+            provider: .amp)
+        let model = ProvidersPane(settings: settings, store: store)._test_menuCardModel(for: .amp)
+
+        #expect(model.creditsText == "Individual credits: $25.64\nWorkspace meow: $10.22")
+        #expect(model.creditsRemaining == nil)
+    }
+
+    @Test
     func `account info caches codex auth parsing until config revision changes`() throws {
         let settings = Self.makeSettingsStore(suite: "UsageStoreCoverageTests-account-info-cache")
         let home = FileManager.default.temporaryDirectory.appendingPathComponent(

--- a/docs/amp.md
+++ b/docs/amp.md
@@ -1,5 +1,5 @@
 ---
-summary: "Amp provider notes: settings scrape, cookie auth, and free-tier usage."
+summary: "Amp provider notes: CLI usage, web fallback, cookie auth, and credits."
 read_when:
   - Adding or modifying the Amp provider
   - Debugging Amp cookie import or settings parsing
@@ -8,19 +8,23 @@ read_when:
 
 # Amp Provider
 
-The Amp provider tracks your Amp Free usage by scraping the Amp settings page with browser cookies.
+The Amp provider tracks Amp Free usage plus individual and workspace credits. It prefers the local Amp CLI and falls back to
+Amp's web usage endpoint with browser cookies.
 
 ## Features
 
 - **Amp Free meter**: Shows how much daily free usage remains.
 - **Time-to-full reset**: “Resets in …” indicates when free usage replenishes to full.
-- **Browser cookie auth**: No API keys needed.
+- **Individual credits**: Shows the remaining paid credit balance when Amp reports one.
+- **Workspace credits**: Shows each workspace's remaining paid credit balance separately.
+- **CLI-first fetch**: Uses `amp usage` when the Amp CLI is installed and signed in.
+- **Browser cookie fallback**: No separate API key is needed when the CLI is unavailable.
 
 ## Setup
 
 1. Open **Settings → Providers**
 2. Enable **Amp**
-3. Leave **Cookie source** on **Auto** (recommended)
+3. Install and sign in to the Amp CLI, or leave **Cookie source** on **Auto** for web fallback
 
 ### Manual cookie import (optional)
 
@@ -30,8 +34,10 @@ The Amp provider tracks your Amp Free usage by scraping the Amp settings page wi
 
 ## How it works
 
-- Fetches `https://ampcode.com/settings`
-- Parses the embedded `freeTierUsage` payload
+- Runs `amp usage` first in automatic mode
+- Falls back to `POST https://ampcode.com/api/internal?userDisplayBalanceInfo`
+- Parses the same usage display format returned to the CLI
+- Retains the old settings-page payload parser for older Amp deployments
 - Computes time-to-full from the hourly replenishment rate
 
 ## Troubleshooting

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -44,7 +44,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 | Vertex AI | Google ADC OAuth (gcloud) → Cloud Monitoring quota usage (`oauth`). |
 | Augment | `auggie` CLI first, then browser-cookie web fallback (`cli`, `web`). |
 | JetBrains AI | Local XML quota file (`local`). |
-| Amp | Web settings page via browser cookies (`web`). |
+| Amp | Local `amp usage` CLI with browser-cookie web fallback (`cli`, `web`). |
 | T3 Chat | Web tRPC customer-data endpoint via browser cookies (`web`). |
 | Warp | API token (config/env) → GraphQL request limits (`api`). |
 | ElevenLabs | API key from config/env → subscription usage API (`api`). |
@@ -243,8 +243,9 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Details: `docs/augment.md`.
 
 ## Amp
-- Web settings page (`https://ampcode.com/settings`) via browser cookies.
-- Parses Amp Free usage from the settings HTML.
+- Auto mode tries the local `amp usage` command first.
+- Web fallback calls Amp's usage endpoint with browser cookies.
+- Tracks Amp Free usage, account identity, and individual and workspace credit balances.
 - Status: none yet.
 - Details: `docs/amp.md`.
 


### PR DESCRIPTION
Closes #1317

# Summary

Amp recently [overhauled its website](https://ampcode.com/news/agents-everywhere), which broke the previous fetching method that relied solely on the web. This pull request not only fixes web fetching but also adds support for using the Amp CLI `amp usage` command to retrieve current usage data. Additional tests were also added.

# Demo

<img width="806" height="1062" alt="image" src="https://github.com/user-attachments/assets/e2a0bba1-795f-444a-9b85-5c474fb480fd" />

This was tested end to end with two accounts to simulate accounts that are not in a workspace but also in a workspace to make sure they both work. All tests passed, and builds go through locally without any issues.
