### PR TITLE
Run cost-usage corpus scans off the Swift cooperative thread pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Cost history: keep all per-day model breakdown rows available in a bounded scrolling detail area instead of hiding models after the first four (#1370). Thanks @MoollaMore!
+- Cost usage: run local session-corpus scans and cache decoding on a dedicated serial queue instead of the Swift cooperative thread pool, so multi-minute scans of large archives no longer starve the app's async work or freeze menus (#1387, #1392). Thanks @ProspectOre!
 - Copilot: keep explicitly unlimited chat quotas visible instead of dropping their zero-entitlement payload as unavailable (#1320). Thanks @soumikbhatta!
 - Security: block credentialed provider redirects that leave the original HTTPS origin while preserving same-origin redirects (#1237). Thanks @Hinotoi-agent!
 - Codex: keep local token and cost history visible when remote quota data is unavailable (#1390). Thanks @vaibhavarora14!

--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -146,53 +146,60 @@ public struct CostUsageFetcher: Sendable {
         if forceRefresh {
             options.refreshMinIntervalSeconds = 0
         }
-        let checkCancellation: CostUsageScanner.CancellationCheck = {
-            try Task.checkCancellation()
+        var resolvedPiOptions = overridePiScannerOptions ?? PiSessionCostScanner.Options()
+        if resolvedPiOptions.cacheRoot == nil {
+            resolvedPiOptions.cacheRoot = options.cacheRoot
         }
-        try Task.checkCancellation()
-        var daily = try CostUsageScanner.loadDailyReportCancellable(
-            provider: provider,
-            since: since,
-            until: until,
-            now: now,
-            options: options,
-            checkCancellation: checkCancellation)
-        try Task.checkCancellation()
+        if forceRefresh {
+            resolvedPiOptions.refreshMinIntervalSeconds = 0
+        }
+        let piOptions = resolvedPiOptions
 
-        if provider == .vertexai,
-           !allowVertexClaudeFallback,
-           options.claudeLogProviderFilter == .vertexAIOnly,
-           daily.data.isEmpty
-        {
-            var fallback = options
-            fallback.claudeLogProviderFilter = .all
-            daily = try CostUsageScanner.loadDailyReportCancellable(
+        try Task.checkCancellation()
+        // The corpus scans below are synchronous and can run for minutes on large session
+        // archives. They execute on the dedicated scan queue so they never occupy a cooperative
+        // pool thread; CostUsageScanExecutor bridges this task's cancellation into the
+        // scanner-level checks.
+        let scanOptions = options
+        let daily = try await CostUsageScanExecutor.run { checkCancellation in
+            var daily = try CostUsageScanner.loadDailyReportCancellable(
                 provider: provider,
                 since: since,
                 until: until,
                 now: now,
-                options: fallback,
+                options: scanOptions,
                 checkCancellation: checkCancellation)
-            try Task.checkCancellation()
-        }
+            try checkCancellation()
 
-        if provider == .codex || provider == .claude {
-            var piOptions = overridePiScannerOptions ?? PiSessionCostScanner.Options()
-            if piOptions.cacheRoot == nil {
-                piOptions.cacheRoot = options.cacheRoot
+            if provider == .vertexai,
+               !allowVertexClaudeFallback,
+               scanOptions.claudeLogProviderFilter == .vertexAIOnly,
+               daily.data.isEmpty
+            {
+                var fallback = scanOptions
+                fallback.claudeLogProviderFilter = .all
+                daily = try CostUsageScanner.loadDailyReportCancellable(
+                    provider: provider,
+                    since: since,
+                    until: until,
+                    now: now,
+                    options: fallback,
+                    checkCancellation: checkCancellation)
+                try checkCancellation()
             }
-            if forceRefresh {
-                piOptions.refreshMinIntervalSeconds = 0
+
+            if provider == .codex || provider == .claude {
+                let piReport = try PiSessionCostScanner.loadDailyReportCancellable(
+                    provider: provider,
+                    since: since,
+                    until: until,
+                    now: now,
+                    options: piOptions,
+                    checkCancellation: checkCancellation)
+                try checkCancellation()
+                daily = CostUsageDailyReport.merged([daily, piReport])
             }
-            let piReport = try PiSessionCostScanner.loadDailyReportCancellable(
-                provider: provider,
-                since: since,
-                until: until,
-                now: now,
-                options: piOptions,
-                checkCancellation: checkCancellation)
-            try Task.checkCancellation()
-            daily = CostUsageDailyReport.merged([daily, piReport])
+            return daily
         }
 
         return Self.tokenSnapshot(from: daily, now: now, historyDays: clampedHistoryDays)
@@ -210,7 +217,9 @@ public struct CostUsageFetcher: Sendable {
             return nil
         }
 
-        return await Task.detached(priority: .utility) {
+        // Decoding the persisted scan cache parses multi-megabyte JSON; keep it off the
+        // cooperative pool alongside the scans themselves.
+        let cachedSnapshot: CostUsageTokenSnapshot?? = try? await CostUsageScanExecutor.run { _ in
             let clampedHistoryDays = max(1, min(365, historyDays))
             let until = now
             let since = Calendar.current.date(byAdding: .day, value: -(clampedHistoryDays - 1), to: now) ?? now
@@ -247,7 +256,8 @@ public struct CostUsageFetcher: Sendable {
                 from: CostUsageDailyReport.merged(reports),
                 now: now,
                 historyDays: clampedHistoryDays)
-        }.value
+        }
+        return cachedSnapshot.flatMap(\.self)
     }
 
     private static func loadBedrockDailyReport(

--- a/Sources/CodexBarCore/CostUsageScanExecutor.swift
+++ b/Sources/CodexBarCore/CostUsageScanExecutor.swift
@@ -1,0 +1,43 @@
+import Foundation
+import os
+
+/// Cost-usage scans read and parse the full local session corpus synchronously and can run for
+/// minutes on large archives. Executing that work inline on Swift's cooperative thread pool
+/// starves every other async task in the process — menus freeze while the main thread sits idle —
+/// and overlapping provider scans multiply both the pool pressure and the disk load. This
+/// executor pins all corpus scans to a single serial utility queue off the cooperative pool, so
+/// long scans cost one dedicated thread instead of the app's async runtime.
+public enum CostUsageScanExecutor {
+    public static let queueLabel = "com.steipete.codexbar.cost-usage-scan"
+
+    private static let queue = DispatchQueue(label: queueLabel, qos: .utility)
+
+    /// Runs `work` on the serial scan queue and bridges Swift task cancellation into the
+    /// scanner's cooperative `checkCancellation` callbacks. Work that is still queued when the
+    /// awaiting task is cancelled resumes immediately with `CancellationError` instead of
+    /// waiting behind an in-flight scan.
+    public static func run<T: Sendable>(
+        _ work: @escaping @Sendable (_ checkCancellation: @escaping @Sendable () throws -> Void) throws -> T)
+        async throws -> T
+    {
+        let cancelled = OSAllocatedUnfairLock(initialState: false)
+        let checkCancellation: @Sendable () throws -> Void = {
+            if cancelled.withLock({ $0 }) {
+                throw CancellationError()
+            }
+        }
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                self.queue.async {
+                    if cancelled.withLock({ $0 }) {
+                        continuation.resume(throwing: CancellationError())
+                        return
+                    }
+                    continuation.resume(with: Result { try work(checkCancellation) })
+                }
+            }
+        } onCancel: {
+            cancelled.withLock { $0 = true }
+        }
+    }
+}

--- a/Sources/CodexBarCore/CostUsageScanExecutor.swift
+++ b/Sources/CodexBarCore/CostUsageScanExecutor.swift
@@ -1,5 +1,4 @@
 import Foundation
-import os
 
 /// Cost-usage scans read and parse the full local session corpus synchronously and can run for
 /// minutes on large archives. Executing that work inline on Swift's cooperative thread pool
@@ -12,6 +11,90 @@ public enum CostUsageScanExecutor {
 
     private static let queue = DispatchQueue(label: queueLabel, qos: .utility)
 
+    private final class RunState<Value: Sendable>: @unchecked Sendable {
+        private enum Phase {
+            case initial
+            case queued
+            case running
+            case completed
+        }
+
+        private let lock = NSLock()
+        private var phase: Phase = .initial
+        private var cancellationRequested = false
+        private var continuation: CheckedContinuation<Value, Error>?
+
+        func install(_ continuation: CheckedContinuation<Value, Error>) -> Bool {
+            let shouldEnqueue: Bool
+            let shouldResumeCancellation: Bool
+            self.lock.lock()
+            if self.cancellationRequested {
+                self.phase = .completed
+                shouldEnqueue = false
+                shouldResumeCancellation = true
+            } else {
+                self.phase = .queued
+                self.continuation = continuation
+                shouldEnqueue = true
+                shouldResumeCancellation = false
+            }
+            self.lock.unlock()
+
+            if shouldResumeCancellation {
+                continuation.resume(throwing: CancellationError())
+            }
+            return shouldEnqueue
+        }
+
+        func begin() -> Bool {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            guard self.phase == .queued else { return false }
+            self.phase = .running
+            return true
+        }
+
+        func cancel() {
+            let continuation: CheckedContinuation<Value, Error>?
+            self.lock.lock()
+            self.cancellationRequested = true
+            if self.phase == .queued {
+                self.phase = .completed
+                continuation = self.continuation
+                self.continuation = nil
+            } else {
+                continuation = nil
+            }
+            self.lock.unlock()
+            continuation?.resume(throwing: CancellationError())
+        }
+
+        func checkCancellation() throws {
+            self.lock.lock()
+            let cancellationRequested = self.cancellationRequested
+            self.lock.unlock()
+            if cancellationRequested {
+                throw CancellationError()
+            }
+        }
+
+        func complete(with result: Result<Value, Error>) {
+            let continuation: CheckedContinuation<Value, Error>?
+            let resolvedResult: Result<Value, Error>
+            self.lock.lock()
+            guard self.phase == .running else {
+                self.lock.unlock()
+                return
+            }
+            self.phase = .completed
+            continuation = self.continuation
+            self.continuation = nil
+            resolvedResult = self.cancellationRequested ? .failure(CancellationError()) : result
+            self.lock.unlock()
+            continuation?.resume(with: resolvedResult)
+        }
+    }
+
     /// Runs `work` on the serial scan queue and bridges Swift task cancellation into the
     /// scanner's cooperative `checkCancellation` callbacks. Work that is still queued when the
     /// awaiting task is cancelled resumes immediately with `CancellationError` instead of
@@ -20,24 +103,20 @@ public enum CostUsageScanExecutor {
         _ work: @escaping @Sendable (_ checkCancellation: @escaping @Sendable () throws -> Void) throws -> T)
         async throws -> T
     {
-        let cancelled = OSAllocatedUnfairLock(initialState: false)
+        let state = RunState<T>()
         let checkCancellation: @Sendable () throws -> Void = {
-            if cancelled.withLock({ $0 }) {
-                throw CancellationError()
-            }
+            try state.checkCancellation()
         }
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
+                guard state.install(continuation) else { return }
                 self.queue.async {
-                    if cancelled.withLock({ $0 }) {
-                        continuation.resume(throwing: CancellationError())
-                        return
-                    }
-                    continuation.resume(with: Result { try work(checkCancellation) })
+                    guard state.begin() else { return }
+                    state.complete(with: Result { try work(checkCancellation) })
                 }
             }
         } onCancel: {
-            cancelled.withLock { $0 = true }
+            state.cancel()
         }
     }
 }

--- a/Sources/CodexBarCore/CostUsageScanExecutor.swift
+++ b/Sources/CodexBarCore/CostUsageScanExecutor.swift
@@ -103,6 +103,14 @@ public enum CostUsageScanExecutor {
         _ work: @escaping @Sendable (_ checkCancellation: @escaping @Sendable () throws -> Void) throws -> T)
         async throws -> T
     {
+        try await self.run(on: self.queue, work)
+    }
+
+    static func run<T: Sendable>(
+        on queue: DispatchQueue,
+        _ work: @escaping @Sendable (_ checkCancellation: @escaping @Sendable () throws -> Void) throws -> T)
+        async throws -> T
+    {
         let state = RunState<T>()
         let checkCancellation: @Sendable () throws -> Void = {
             try state.checkCancellation()
@@ -110,7 +118,7 @@ public enum CostUsageScanExecutor {
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 guard state.install(continuation) else { return }
-                self.queue.async {
+                queue.async {
                     guard state.begin() else { return }
                     state.complete(with: Result { try work(checkCancellation) })
                 }

--- a/Tests/CodexBarTests/CostUsageScanExecutorTests.swift
+++ b/Tests/CodexBarTests/CostUsageScanExecutorTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import os
+import Testing
+@testable import CodexBarCore
+
+struct CostUsageScanExecutorTests {
+    @Test
+    func `runs work on the dedicated scan queue and returns its value`() async throws {
+        let label = try await CostUsageScanExecutor.run { _ in
+            String(cString: __dispatch_queue_get_label(nil))
+        }
+        #expect(label == CostUsageScanExecutor.queueLabel)
+    }
+
+    @Test
+    func `propagates thrown errors`() async {
+        struct ScanFailure: Error {}
+        await #expect(throws: ScanFailure.self) {
+            try await CostUsageScanExecutor.run { _ -> Int in
+                throw ScanFailure()
+            }
+        }
+    }
+
+    @Test
+    func `serializes overlapping scans`() async throws {
+        let state = OSAllocatedUnfairLock(initialState: (active: 0, maxActive: 0))
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for _ in 0..<4 {
+                group.addTask {
+                    try await CostUsageScanExecutor.run { _ in
+                        state.withLock {
+                            $0.active += 1
+                            $0.maxActive = max($0.maxActive, $0.active)
+                        }
+                        usleep(20000)
+                        state.withLock { $0.active -= 1 }
+                    }
+                }
+            }
+            try await group.waitForAll()
+        }
+        #expect(state.withLock { $0.maxActive } == 1)
+    }
+
+    @Test
+    func `cancellation reaches in-flight work through checkCancellation`() async {
+        let workStarted = OSAllocatedUnfairLock(initialState: false)
+        let task = Task {
+            try await CostUsageScanExecutor.run { checkCancellation in
+                workStarted.withLock { $0 = true }
+                while true {
+                    try checkCancellation()
+                    usleep(5000)
+                }
+            }
+        }
+        while !workStarted.withLock({ $0 }) {
+            usleep(1000)
+        }
+        task.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+
+    @Test
+    func `work cancelled while queued resumes with CancellationError`() async {
+        let blockerStarted = OSAllocatedUnfairLock(initialState: false)
+        let releaseBlocker = OSAllocatedUnfairLock(initialState: false)
+        let blocker = Task {
+            try await CostUsageScanExecutor.run { _ in
+                blockerStarted.withLock { $0 = true }
+                while !releaseBlocker.withLock({ $0 }) {
+                    usleep(2000)
+                }
+            }
+        }
+        while !blockerStarted.withLock({ $0 }) {
+            usleep(1000)
+        }
+
+        let queued = Task {
+            try await CostUsageScanExecutor.run { _ in
+                Issue.record("queued work should not run after cancellation")
+            }
+        }
+        queued.cancel()
+        releaseBlocker.withLock { $0 = true }
+
+        await #expect(throws: CancellationError.self) {
+            try await queued.value
+        }
+        _ = try? await blocker.value
+    }
+}

--- a/Tests/CodexBarTests/CostUsageScanExecutorTests.swift
+++ b/Tests/CodexBarTests/CostUsageScanExecutorTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import os
 import Testing
 @testable import CodexBarCore
 
@@ -24,40 +23,38 @@ struct CostUsageScanExecutorTests {
 
     @Test
     func `serializes overlapping scans`() async throws {
-        let state = OSAllocatedUnfairLock(initialState: (active: 0, maxActive: 0))
+        let state = LockedValue((active: 0, maxActive: 0))
         try await withThrowingTaskGroup(of: Void.self) { group in
             for _ in 0..<4 {
                 group.addTask {
                     try await CostUsageScanExecutor.run { _ in
-                        state.withLock {
+                        state.update {
                             $0.active += 1
                             $0.maxActive = max($0.maxActive, $0.active)
                         }
-                        usleep(20000)
-                        state.withLock { $0.active -= 1 }
+                        Thread.sleep(forTimeInterval: 0.02)
+                        state.update { $0.active -= 1 }
                     }
                 }
             }
             try await group.waitForAll()
         }
-        #expect(state.withLock { $0.maxActive } == 1)
+        #expect(state.read { $0.maxActive } == 1)
     }
 
     @Test
     func `cancellation reaches in-flight work through checkCancellation`() async {
-        let workStarted = OSAllocatedUnfairLock(initialState: false)
+        let workStarted = LockedValue(false)
         let task = Task {
             try await CostUsageScanExecutor.run { checkCancellation in
-                workStarted.withLock { $0 = true }
+                workStarted.set(true)
                 while true {
                     try checkCancellation()
-                    usleep(5000)
+                    Thread.sleep(forTimeInterval: 0.005)
                 }
             }
         }
-        while !workStarted.withLock({ $0 }) {
-            usleep(1000)
-        }
+        #expect(await self.waitUntil { workStarted.value })
         task.cancel()
         await #expect(throws: CancellationError.self) {
             try await task.value
@@ -66,31 +63,85 @@ struct CostUsageScanExecutorTests {
 
     @Test
     func `work cancelled while queued resumes with CancellationError`() async {
-        let blockerStarted = OSAllocatedUnfairLock(initialState: false)
-        let releaseBlocker = OSAllocatedUnfairLock(initialState: false)
+        let blockerStarted = LockedValue(false)
+        let releaseBlocker = LockedValue(false)
         let blocker = Task {
             try await CostUsageScanExecutor.run { _ in
-                blockerStarted.withLock { $0 = true }
-                while !releaseBlocker.withLock({ $0 }) {
-                    usleep(2000)
+                blockerStarted.set(true)
+                while !releaseBlocker.value {
+                    Thread.sleep(forTimeInterval: 0.002)
                 }
             }
         }
-        while !blockerStarted.withLock({ $0 }) {
-            usleep(1000)
-        }
+        #expect(await self.waitUntil { blockerStarted.value })
 
+        let queuedWorkStarted = LockedValue(false)
         let queued = Task {
             try await CostUsageScanExecutor.run { _ in
+                queuedWorkStarted.set(true)
                 Issue.record("queued work should not run after cancellation")
             }
         }
-        queued.cancel()
-        releaseBlocker.withLock { $0 = true }
+        try? await Task.sleep(for: .milliseconds(50))
 
-        await #expect(throws: CancellationError.self) {
-            try await queued.value
+        let cancellationObserved = LockedValue<Bool?>(nil)
+        let observer = Task {
+            do {
+                try await queued.value
+                cancellationObserved.set(false)
+            } catch is CancellationError {
+                cancellationObserved.set(true)
+            } catch {
+                cancellationObserved.set(false)
+            }
         }
+        queued.cancel()
+
+        #expect(await self.waitUntil { cancellationObserved.value != nil })
+        #expect(cancellationObserved.value == true)
+        #expect(!queuedWorkStarted.value)
+        #expect(!releaseBlocker.value)
+
+        releaseBlocker.set(true)
+        await observer.value
         _ = try? await blocker.value
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        condition: @escaping @Sendable () -> Bool) async -> Bool
+    {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if condition() { return true }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return condition()
+    }
+}
+
+private final class LockedValue<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: Value
+
+    init(_ value: Value) {
+        self.storage = value
+    }
+
+    var value: Value {
+        self.lock.withLock { self.storage }
+    }
+
+    func read<Result>(_ body: (Value) -> Result) -> Result {
+        self.lock.withLock { body(self.storage) }
+    }
+
+    func set(_ value: Value) {
+        self.lock.withLock { self.storage = value }
+    }
+
+    func update(_ body: (inout Value) -> Void) {
+        self.lock.withLock { body(&self.storage) }
     }
 }

--- a/Tests/CodexBarTests/CostUsageScanExecutorTests.swift
+++ b/Tests/CodexBarTests/CostUsageScanExecutorTests.swift
@@ -5,17 +5,19 @@ import Testing
 struct CostUsageScanExecutorTests {
     @Test
     func `runs work on the dedicated scan queue and returns its value`() async throws {
-        let label = try await CostUsageScanExecutor.run { _ in
+        let queue = self.makeQueue()
+        let label = try await CostUsageScanExecutor.run(on: queue) { _ in
             String(cString: __dispatch_queue_get_label(nil))
         }
-        #expect(label == CostUsageScanExecutor.queueLabel)
+        #expect(label == queue.label)
     }
 
     @Test
     func `propagates thrown errors`() async {
         struct ScanFailure: Error {}
+        let queue = self.makeQueue()
         await #expect(throws: ScanFailure.self) {
-            try await CostUsageScanExecutor.run { _ -> Int in
+            try await CostUsageScanExecutor.run(on: queue) { _ -> Int in
                 throw ScanFailure()
             }
         }
@@ -23,11 +25,12 @@ struct CostUsageScanExecutorTests {
 
     @Test
     func `serializes overlapping scans`() async throws {
+        let queue = self.makeQueue()
         let state = LockedValue((active: 0, maxActive: 0))
         try await withThrowingTaskGroup(of: Void.self) { group in
             for _ in 0..<4 {
                 group.addTask {
-                    try await CostUsageScanExecutor.run { _ in
+                    try await CostUsageScanExecutor.run(on: queue) { _ in
                         state.update {
                             $0.active += 1
                             $0.maxActive = max($0.maxActive, $0.active)
@@ -44,9 +47,10 @@ struct CostUsageScanExecutorTests {
 
     @Test
     func `cancellation reaches in-flight work through checkCancellation`() async {
+        let queue = self.makeQueue()
         let workStarted = LockedValue(false)
         let task = Task {
-            try await CostUsageScanExecutor.run { checkCancellation in
+            try await CostUsageScanExecutor.run(on: queue) { checkCancellation in
                 workStarted.set(true)
                 while true {
                     try checkCancellation()
@@ -63,10 +67,11 @@ struct CostUsageScanExecutorTests {
 
     @Test
     func `work cancelled while queued resumes with CancellationError`() async {
+        let queue = self.makeQueue()
         let blockerStarted = LockedValue(false)
         let releaseBlocker = LockedValue(false)
         let blocker = Task {
-            try await CostUsageScanExecutor.run { _ in
+            try await CostUsageScanExecutor.run(on: queue) { _ in
                 blockerStarted.set(true)
                 while !releaseBlocker.value {
                     Thread.sleep(forTimeInterval: 0.002)
@@ -77,7 +82,7 @@ struct CostUsageScanExecutorTests {
 
         let queuedWorkStarted = LockedValue(false)
         let queued = Task {
-            try await CostUsageScanExecutor.run { _ in
+            try await CostUsageScanExecutor.run(on: queue) { _ in
                 queuedWorkStarted.set(true)
                 Issue.record("queued work should not run after cancellation")
             }
@@ -105,6 +110,10 @@ struct CostUsageScanExecutorTests {
         releaseBlocker.set(true)
         await observer.value
         _ = try? await blocker.value
+    }
+
+    private func makeQueue() -> DispatchQueue {
+        DispatchQueue(label: "\(CostUsageScanExecutor.queueLabel).tests.\(UUID().uuidString)")
     }
 
     private func waitUntil(

--- a/TestsLinux/CostUsageScanExecutorLinuxTests.swift
+++ b/TestsLinux/CostUsageScanExecutorLinuxTests.swift
@@ -1,0 +1,29 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+@Suite
+struct CostUsageScanExecutorLinuxTests {
+    @Test
+    func returnsWorkValue() async throws {
+        let value = try await CostUsageScanExecutor.run { _ in 42 }
+        #expect(value == 42)
+    }
+
+    @Test
+    func cancelledTaskThrowsCancellationError() async {
+        let task = Task {
+            try await CostUsageScanExecutor.run { checkCancellation in
+                while true {
+                    try checkCancellation()
+                    Thread.sleep(forTimeInterval: 0.005)
+                }
+            }
+        }
+        task.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Run cost-usage corpus scans and persisted-cache decoding on a dedicated serial utility queue (`CostUsageScanExecutor`) instead of inline on Swift's cooperative thread pool, with task cancellation bridged into the scanner-level cancellation checks.

## Context
This targets the systemic freeze mechanism behind the #1387 reports (and the environment of #1392). `CostUsageScanner` / `PiSessionCostScanner` scans are synchronous and can run for minutes on large session archives. `CostUsageFetcher.loadTokenSnapshot` executed them inline inside cooperative-pool tasks, which violates the pool's forward-progress contract: while a scan runs, it owns a pool thread for minutes, and overlapping provider scans (startup force-refresh racing the hourly token timer) own several. Every other async continuation in the process — menu rebuild tasks, refresh completions — queues behind them, so the UI freezes while the main thread itself samples idle.

Two amplifiers make this a release-day event for heavy users:
- Cache schema bumps (e.g. the claude artifact moving v2 → v4 in 0.32.6-dev) invalidate the whole per-file scan cache, so the first launch after such a release rescans the full corpus.
- The reporter machine for this PR holds a 2.5 GB corpus (903 MB `~/.claude/projects`, 1.6 GB / 316 files `~/.codex/sessions`); the post-bump rescan ran 7+ minutes at full tilt.

Field sample of that storm (v0.32.6-dev pre-fix, 1 ms interval, 5 s window, redacted to frame counts): 2,437 samples in the claude scan and 1,807 in the codex scan **concurrently on two cooperative-pool threads**, sustained across every capture window for ~3 minutes, while menu opens visibly froze — with the main thread parked in `mach_msg` the whole time.

## Change
- New `CostUsageScanExecutor`: one serial `DispatchQueue` (`com.steipete.codexbar.cost-usage-scan`, utility QoS). `run` bridges Swift task cancellation into a `@Sendable` check handed to the scanners, and work cancelled while still queued resumes immediately with `CancellationError` instead of waiting behind an in-flight scan.
- `CostUsageFetcher.loadTokenSnapshot` moves the scan + vertex-fallback + pi-merge block onto the executor; `loadCachedCodexTokenSnapshot` moves its multi-megabyte cache JSON decode there too (it previously ran on the pool via `Task.detached`).
- Serialization also removes concurrent provider scans hammering the same disk.

## Validation
- `swift test --filter CostUsageScanExecutorTests` — 5 new tests: labeled-queue execution, error propagation, overlap serialization, in-flight cancellation through the bridged check, queued-work cancellation.
- `swift test --filter CostUsageScanExecutorLinuxTests` — 2 Linux-compatible executor tests pass.
- `swift test --filter CostUsage` — 183 tests in 18 suites pass.
- `make check` — 0 violations; `git diff --check` clean.
- Structured autoreview — no accepted/actionable findings.

## Runtime Proof
A/B on the same machine, same protocol per phase: quit app → delete `~/Library/Caches/CodexBar/cost-usage` → relaunch → `sample CodexBar 5 1` at T+30s during the full-corpus rescan. Thread placement of the scan frames:

```text
# BEFORE (current main scan code)
3515 Thread_1092763   DispatchQueue_12: com.apple.root.utility-qos.cooperative  (concurrent)
     ... CostUsageScanner.loadClaudeDaily / CostUsageJsonl.scan ...

# AFTER (this branch)
3191 Thread_1094843   DispatchQueue_267: com.steipete.codexbar.cost-usage-scan  (serial)
     ... CostUsageScanner.loadClaudeDaily / CostUsageJsonl.scan ...
# zero scan frames on cooperative-pool threads
```

The scan can no longer occupy cooperative-pool threads at all, so async-runtime starvation by scans is structurally impossible rather than merely less likely. The post-fix full rescan completed and rewrote the per-provider caches normally (cost data intact).

## Honesty / scope notes
- This makes the app responsive *during* scans; it does not make scans cheaper. Steady-state ticks stay incremental via the existing per-file mtime/size cache; the full-rescan-after-schema-bump cost itself is #1392's refresh-policy territory.
- Serializing providers can lengthen total storm wall-time on multi-provider setups (scans no longer overlap), and the 10-minute per-provider timeout now includes time queued behind another provider's scan. On very large corpora that could surface as a timeout that previously squeaked through; the next tick resumes against the warm per-file cache.
- The 1.6s AX click-roundtrip measured in both phases is automation overhead, not app latency; the responsiveness claim rests on the structural thread-placement proof plus the documented forward-progress contract of the cooperative pool.


<!-- proof-revision: 2026-06-10 r2 -->
