### PR TITLE
Decode provider status feeds off the main actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Doubao: confirm zero-remaining HTTP 200 request limits before falling back, preserving genuine exhaustion and avoiding false 100% usage (#1383). Thanks @LeoLin990405 and @foobra!
 - Menu bar: defer pasteboard writes and copy feedback outside the `NSMenu` tracking callback so in-menu copy buttons no longer beachball on macOS 26 (#1388). Thanks @LeoLin990405!
 - Menu bar: defer merged status-icon redraws until the tracked menu closes while preserving animation lifecycle and quota-warning timing, reducing WindowServer churn during long menu sessions (#1409, fixes #1399). Thanks @kiranmagic7!
+- Provider status: decode status feeds on the concurrent executor and reuse ISO8601 formatters, removing a measured main-thread stall during refreshes (#1406). Thanks @ProspectOre!
 - Menu bar: keep one stable width across merged provider tabs and resize every hosted card row to AppKit's final menu width so provider switching no longer leaves a widened menu with inset submenu arrows (#1410).
 - Menu bar: defer Overview-row provider transitions out of AppKit's click callback so opening provider detail no longer performs a full synchronous menu rebuild (#1325).
 - Menu bar: open cached menus immediately after data-only invalidations, then refresh missing or stale provider data asynchronously without queuing redundant work on close (#1398). Thanks @joshuavial!

--- a/Sources/CodexBar/UsageStore+Status.swift
+++ b/Sources/CodexBar/UsageStore+Status.swift
@@ -44,6 +44,7 @@ extension UsageStore {
     /// Status feeds decode off the main actor: the Google Workspace incidents payload alone
     /// can be hundreds of kilobytes and cost 150-340ms to decode (#1399), and these helpers
     /// touch no store state.
+    @concurrent
     nonisolated static func fetchStatus(
         from baseURL: URL,
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared)
@@ -84,9 +85,11 @@ extension UsageStore {
             updatedAt: response.page?.updatedAt)
     }
 
+    @concurrent
     nonisolated static func fetchWorkspaceStatus(
         productID: String,
-        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared)
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
+        beforeDecoding: (@Sendable () -> Void)? = nil)
         async throws -> ProviderStatus
     {
         guard let url = URL(string: "https://www.google.com/appsstatus/dashboard/incidents.json") else {
@@ -95,6 +98,7 @@ extension UsageStore {
         var request = URLRequest(url: url)
         request.timeoutInterval = 10
         let (data, _) = try await transport.data(for: request)
+        beforeDecoding?()
         return try Self.parseGoogleWorkspaceStatus(data: data, productID: productID)
     }
 

--- a/Sources/CodexBar/UsageStore+Status.swift
+++ b/Sources/CodexBar/UsageStore+Status.swift
@@ -1,8 +1,50 @@
 import CodexBarCore
 import Foundation
 
+/// Shared, lock-guarded ISO8601 formatters for status feeds. Allocating a fresh
+/// `ISO8601DateFormatter` per decoded date field is a measurable share of decoding the
+/// Google Workspace incidents feed, which can run to hundreds of kilobytes (#1399).
+private final class StatusISO8601FormatterBox: @unchecked Sendable {
+    let lock = NSLock()
+    let withFractional: ISO8601DateFormatter = {
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fmt
+    }()
+
+    let plain: ISO8601DateFormatter = {
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime]
+        return fmt
+    }()
+}
+
+private enum StatusFeedDateParser {
+    static let box = StatusISO8601FormatterBox()
+
+    static func parse(_ text: String) -> Date? {
+        self.box.lock.lock()
+        defer { self.box.lock.unlock() }
+        return self.box.withFractional.date(from: text) ?? self.box.plain.date(from: text)
+    }
+
+    static func decodingStrategy() -> JSONDecoder.DateDecodingStrategy {
+        .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let raw = try container.decode(String.self)
+            guard let date = StatusFeedDateParser.parse(raw) else {
+                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid ISO8601 date")
+            }
+            return date
+        }
+    }
+}
+
 extension UsageStore {
-    static func fetchStatus(
+    /// Status feeds decode off the main actor: the Google Workspace incidents payload alone
+    /// can be hundreds of kilobytes and cost 150-340ms to decode (#1399), and these helpers
+    /// touch no store state.
+    nonisolated static func fetchStatus(
         from baseURL: URL,
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared)
         async throws -> ProviderStatus
@@ -32,16 +74,7 @@ extension UsageStore {
         }
 
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .custom { decoder in
-            let container = try decoder.singleValueContainer()
-            let raw = try container.decode(String.self)
-            let formatter = ISO8601DateFormatter()
-            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            if let date = formatter.date(from: raw) { return date }
-            formatter.formatOptions = [.withInternetDateTime]
-            if let date = formatter.date(from: raw) { return date }
-            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid ISO8601 date")
-        }
+        decoder.dateDecodingStrategy = StatusFeedDateParser.decodingStrategy()
 
         let response = try decoder.decode(Response.self, from: data)
         let indicator = ProviderStatusIndicator(rawValue: response.status.indicator) ?? .unknown
@@ -51,7 +84,7 @@ extension UsageStore {
             updatedAt: response.page?.updatedAt)
     }
 
-    static func fetchWorkspaceStatus(
+    nonisolated static func fetchWorkspaceStatus(
         productID: String,
         transport: any ProviderHTTPTransport = ProviderHTTPClient.shared)
         async throws -> ProviderStatus
@@ -65,19 +98,10 @@ extension UsageStore {
         return try Self.parseGoogleWorkspaceStatus(data: data, productID: productID)
     }
 
-    static func parseGoogleWorkspaceStatus(data: Data, productID: String) throws -> ProviderStatus {
+    nonisolated static func parseGoogleWorkspaceStatus(data: Data, productID: String) throws -> ProviderStatus {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        decoder.dateDecodingStrategy = .custom { decoder in
-            let container = try decoder.singleValueContainer()
-            let raw = try container.decode(String.self)
-            let formatter = ISO8601DateFormatter()
-            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            if let date = formatter.date(from: raw) { return date }
-            formatter.formatOptions = [.withInternetDateTime]
-            if let date = formatter.date(from: raw) { return date }
-            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid ISO8601 date")
-        }
+        decoder.dateDecodingStrategy = StatusFeedDateParser.decodingStrategy()
 
         let incidents = try decoder.decode([GoogleWorkspaceIncident].self, from: data)
         let active = incidents.filter { $0.isRelevant(productID: productID) && $0.isActive }
@@ -105,7 +129,7 @@ extension UsageStore {
         return ProviderStatus(indicator: best.indicator, description: description, updatedAt: updatedAt)
     }
 
-    private static func indicatorRank(_ indicator: ProviderStatusIndicator) -> Int {
+    private nonisolated static func indicatorRank(_ indicator: ProviderStatusIndicator) -> Int {
         switch indicator {
         case .none: 0
         case .maintenance: 1
@@ -116,7 +140,7 @@ extension UsageStore {
         }
     }
 
-    private static func workspaceIndicator(status: String?, severity: String?) -> ProviderStatusIndicator {
+    private nonisolated static func workspaceIndicator(status: String?, severity: String?) -> ProviderStatusIndicator {
         switch status?.uppercased() {
         case "AVAILABLE": return .none
         case "SERVICE_INFORMATION": return .minor
@@ -134,7 +158,7 @@ extension UsageStore {
         }
     }
 
-    private static func workspaceSummary(from text: String?) -> String? {
+    private nonisolated static func workspaceSummary(from text: String?) -> String? {
         guard let text else { return nil }
         let normalized = text
             .replacingOccurrences(of: "\r\n", with: "\n")

--- a/Tests/CodexBarTests/GoogleWorkspaceStatusNetworkTests.swift
+++ b/Tests/CodexBarTests/GoogleWorkspaceStatusNetworkTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import Testing
 @testable import CodexBar
 
@@ -40,5 +41,28 @@ struct GoogleWorkspaceStatusNetworkTests {
         let requests = await transport.requests()
         #expect(requests.count == 1)
         #expect(requests.first?.url?.host == "www.google.com")
+    }
+
+    @Test
+    func `fetchWorkspaceStatus stays off the main thread when called from the main actor`() async throws {
+        // The incidents feed can run to hundreds of kilobytes; decoding it on the main
+        // actor stalls the UI for 150-340ms per Google-status provider per refresh (#1399).
+        let fetchedOffMainThread = OSAllocatedUnfairLock(initialState: false)
+        let transport = ProviderHTTPTransportStub { request in
+            fetchedOffMainThread.withLock { $0 = !Thread.isMainThread }
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"])!
+            return (Data("[]".utf8), response)
+        }
+
+        let status = try await UsageStore.fetchWorkspaceStatus(
+            productID: "npdyhgECDJ6tB66MxXyo",
+            transport: transport)
+
+        #expect(status.indicator == .none)
+        #expect(fetchedOffMainThread.withLock { $0 })
     }
 }

--- a/Tests/CodexBarTests/GoogleWorkspaceStatusNetworkTests.swift
+++ b/Tests/CodexBarTests/GoogleWorkspaceStatusNetworkTests.swift
@@ -44,12 +44,11 @@ struct GoogleWorkspaceStatusNetworkTests {
     }
 
     @Test
-    func `fetchWorkspaceStatus stays off the main thread when called from the main actor`() async throws {
+    func `fetchWorkspaceStatus decodes off the main thread when called from the main actor`() async throws {
         // The incidents feed can run to hundreds of kilobytes; decoding it on the main
         // actor stalls the UI for 150-340ms per Google-status provider per refresh (#1399).
-        let fetchedOffMainThread = OSAllocatedUnfairLock(initialState: false)
+        let decodedOffMainThread = OSAllocatedUnfairLock(initialState: false)
         let transport = ProviderHTTPTransportStub { request in
-            fetchedOffMainThread.withLock { $0 = !Thread.isMainThread }
             let response = try HTTPURLResponse(
                 url: #require(request.url),
                 statusCode: 200,
@@ -60,9 +59,12 @@ struct GoogleWorkspaceStatusNetworkTests {
 
         let status = try await UsageStore.fetchWorkspaceStatus(
             productID: "npdyhgECDJ6tB66MxXyo",
-            transport: transport)
+            transport: transport,
+            beforeDecoding: {
+                decodedOffMainThread.withLock { $0 = !Thread.isMainThread }
+            })
 
         #expect(status.indicator == .none)
-        #expect(fetchedOffMainThread.withLock { $0 })
+        #expect(decodedOffMainThread.withLock { $0 })
     }
 }


### PR DESCRIPTION
## Summary
Decode provider status feeds off the main actor and reuse shared ISO8601 formatters, removing a 150–340ms main-thread stall per Google-status provider per refresh.

## Context
Credit to @kcharlan's instrumentation in #1399 (finding 4): with status checks on, `UsageStore.parseGoogleWorkspaceStatus` decodes the full `https://www.google.com/appsstatus/dashboard/incidents.json` payload (hundreds of kilobytes live) **on the MainActor**, allocating a fresh `ISO8601DateFormatter` per decoded date field. Their Instruments capture measured 150–340ms of main-thread stall per decode, once per Google-status provider (Gemini *and* Antigravity) per refresh — and refreshes fire during menu interaction. The single flagged microhang across their sessions was exactly this stack. The payload is live data, so the cost grows whenever Google has a busy incident week, on all app versions simultaneously.

The same shape applies to the statuspage path (`fetchStatus`), which is also MainActor-isolated with per-field formatter allocation; it is included for consistency.

## Change
- `fetchStatus` and `fetchWorkspaceStatus` are explicitly `@concurrent nonisolated`, so feed fetching and decoding stay on the concurrent executor even if the package later adopts caller-inherited nonisolated async behavior. The pure parse helpers remain `nonisolated`; the caller (`refreshStatus`) already hops back to the main actor to publish results.
- Per-date-field `ISO8601DateFormatter()` allocations are replaced with shared lock-guarded formatters (`StatusISO8601FormatterBox`), mirroring the existing `CostUsageISO8601FormatterBox` pattern in CodexBarCore.

## Validation
- `swift test --filter GoogleWorkspaceStatus` — 4 tests pass, including a regression guard that records the executor immediately before JSON decoding begins.
- `swift test` — 3,532 tests in 402 suites pass.
- `make check` — 0 violations; `git diff --check` clean.
- autoreview — no accepted/actionable findings.

## Runtime Proof

**Live-feed artifact** (terminal capture; decode of the real `https://www.google.com/appsstatus/dashboard/incidents.json` payload fetched June 10, 2026 — 420,521 bytes, matching the ~418 KB measured in #1399; 5 iterations per strategy, same process, this branch's packaged toolchain):

```text
LIVE_FEED_PROOF payload_bytes=420521
LIVE_FEED_PROOF before(per-field formatters) ms=[69.9, 69.1, 69.4, 68.0, 71.1]
LIVE_FEED_PROOF after(shared formatters, full parse) ms=[25.8, 22.3, 22.1, 21.7, 21.6]
LIVE_FEED_PROOF gemini_status_indicator=Optional(CodexBar.ProviderStatusIndicator.major)
```

~3.1× faster on the live payload (which happened to carry a real active Gemini incident that parsed correctly through the new path), and the entire cost now lands on a background executor instead of the main thread. The committed regression observes the exact pre-decode boundary rather than the actor-backed transport stub:

```text
Test "fetchWorkspaceStatus decodes off the main thread when called from the main actor" passed
Test run with 4 tests in 2 suites passed
```

Synthetic stress check (699 KB fixture, 300 incidents x 4 dated updates, 10 iterations): 332.6–356.4 ms → 101.2–104.3 ms per decode, same ratio. The #1399 Instruments measurement (150–340 ms live) sits between these two payload sizes, consistent with both.

## Honesty / scope notes
- This fixes #1399's *secondary* finding only. The primary mechanism reported there — WindowServer event-buffer starvation during long merged-menu tracking sessions — is untouched by this PR and still needs a design that keeps refresh churn out of active tracking sessions.
- The decode still costs ~100ms of CPU somewhere; it is now off the UI's critical path rather than free.

<details>
<summary>Timing harness (drop into Tests/CodexBarTests to reproduce)</summary>

```swift
import Foundation
import Testing
@testable import CodexBar

struct StatusDecodeTimingHarness {
    @Test
    func `workspace status decode timing harness`() throws {
        // Synthetic feed shaped like incidents.json: ~300 incidents, each with several
        // updates and date fields, sized to match the measured live payload (~420 KB).
        var incidents: [[String: Any]] = []
        for index in 0..<300 {
            var updates: [[String: Any]] = []
            for u in 0..<4 {
                updates.append([
                    "when": "2026-05-\(String(format: "%02d", (index % 27) + 1))T0\(u):15:00+00:00",
                    "status": "SERVICE_INFORMATION",
                    "text": String(repeating: "status update body text ", count: 12),
                ])
            }
            incidents.append([
                "begin": "2026-05-\(String(format: "%02d", (index % 27) + 1))T00:00:00+00:00",
                "end": index % 7 == 0 ? NSNull() : "2026-05-\(String(format: "%02d", (index % 27) + 2))T00:00:00+00:00",
                "modified": "2026-05-\(String(format: "%02d", (index % 27) + 1))T12:00:00.123+00:00",
                "external_desc": String(repeating: "incident description ", count: 10),
                "severity": "medium",
                "status_impact": "SERVICE_INFORMATION",
                "affected_products": [["title": "Gemini", "id": "npdyhgECDJ6tB66MxXyo"]],
                "most_recent_update": updates[0],
                "updates": updates,
            ])
        }
        let data = try JSONSerialization.data(withJSONObject: incidents)
        struct Incident: Decodable { let begin: Date?; let end: Date?; let modified: Date?
            let updates: [Update]?
            struct Update: Decodable { let when: Date? } }
        func measure(_ strategy: JSONDecoder.DateDecodingStrategy) -> [String] {
            let clock = ContinuousClock()
            var ms: [Double] = []
            for _ in 0..<10 {
                let d = clock.measure {
                    let decoder = JSONDecoder()
                    decoder.keyDecodingStrategy = .convertFromSnakeCase
                    decoder.dateDecodingStrategy = strategy
                    _ = try? decoder.decode([Incident].self, from: data)
                }
                ms.append(Double(d.components.attoseconds) / 1e15 + Double(d.components.seconds) * 1000)
            }
            return ms.map { String(format: "%.1f", $0) }
        }
        let previousStrategy = JSONDecoder.DateDecodingStrategy.custom { decoder in
            let container = try decoder.singleValueContainer()
            let raw = try container.decode(String.self)
            let formatter = ISO8601DateFormatter()
            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
            if let date = formatter.date(from: raw) { return date }
            formatter.formatOptions = [.withInternetDateTime]
            if let date = formatter.date(from: raw) { return date }
            throw DecodingError.dataCorruptedError(in: container, debugDescription: "bad date")
        }
        print("TIMING_RESULT payload_bytes=\(data.count)")
        print("BEFORE per-field formatters: \(measure(previousStrategy))")
        let clock = ContinuousClock()
        var ms2: [Double] = []
        for _ in 0..<10 {
            let d = clock.measure {
                _ = try? UsageStore.parseGoogleWorkspaceStatus(data: data, productID: "npdyhgECDJ6tB66MxXyo")
            }
            ms2.append(Double(d.components.attoseconds) / 1e15 + Double(d.components.seconds) * 1000)
        }
        print("AFTER shared formatters (full parse incl. filtering): \(ms2.map { String(format: "%.1f", $0) })")
    }
}
```

</details>

