### PR TITLE
Gate switcher event monitor pump on hardware event counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Localization: add Japanese as a selectable app language (#1385). Thanks @naoterumaker!
 
 ### Fixed
+- Menu: gate the merged provider switcher's event monitor on hardware event counters so its run-loop pump no longer fires on every menu-tracking cycle, fixing dropped clicks and system-wide beachballs during long merged-menu sessions (#1399).
 - Cost history: keep all per-day model breakdown rows available in a bounded scrolling detail area instead of hiding models after the first four (#1370). Thanks @MoollaMore!
 - Copilot: keep explicitly unlimited chat quotas visible instead of dropping their zero-entitlement payload as unavailable (#1320). Thanks @soumikbhatta!
 - Security: block credentialed provider redirects that leave the original HTTPS origin while preserving same-origin redirects (#1237). Thanks @Hinotoi-agent!

--- a/Sources/CodexBar/StatusItemController+ProviderSwitcher.swift
+++ b/Sources/CodexBar/StatusItemController+ProviderSwitcher.swift
@@ -12,15 +12,48 @@ final class ProviderSwitcherShortcutEventMonitor {
     private let observer: CFRunLoopObserver
     private var isActive = false
 
+    /// Hardware-event counters for exactly the event types the monitor handles. The run-loop
+    /// observer fires on every cycle of the menu-tracking loop, and each `nextEvent` peek
+    /// re-enters the run loop; doing that continuously while the pointer moves multiplies
+    /// WindowServer traffic enough to overflow every other application's event buffers and
+    /// freeze the desktop system-wide (#1399). Peeking only when one of these counters has
+    /// changed keeps delivery semantics identical while reducing the pump from once per
+    /// run-loop cycle to once per actual click or key press.
+    private final class EventCounterGate: @unchecked Sendable {
+        private var lastCounts: (UInt32, UInt32, UInt32)?
+        private var lastCheckUptime: TimeInterval = 0
+
+        func hasNewMatchingEvent() -> Bool {
+            // Pure-userspace time bound so the counter queries themselves cannot run more than
+            // ~125 times per second no matter how hot the tracking loop spins.
+            let now = ProcessInfo.processInfo.systemUptime
+            guard now - self.lastCheckUptime >= 0.008 else { return false }
+            self.lastCheckUptime = now
+            let counts = (
+                CGEventSource.counterForEventType(.combinedSessionState, eventType: .leftMouseDown),
+                CGEventSource.counterForEventType(.combinedSessionState, eventType: .leftMouseUp),
+                CGEventSource.counterForEventType(.combinedSessionState, eventType: .keyDown))
+            guard let last = self.lastCounts else {
+                self.lastCounts = counts
+                return true
+            }
+            guard counts != last else { return false }
+            self.lastCounts = counts
+            return true
+        }
+    }
+
     init(events: NSEvent.EventTypeMask, callback: @escaping @MainActor (NSEvent) -> Bool) {
         self.callback = callback
 
+        let counterGate = EventCounterGate()
         self.observer = CFRunLoopObserverCreateWithHandler(
             nil,
             CFRunLoopActivity.beforeSources.rawValue,
             true,
             0)
         { [events, callback] _, _ in
+            guard counterGate.hasNewMatchingEvent() else { return }
             MainActor.assumeIsolated {
                 while let event = NSApp.nextEvent(
                     matching: events,


### PR DESCRIPTION
## Summary
Gate the merged provider switcher's event-monitor pump on hardware event counters, so it runs once per actual click or key press instead of once per menu-tracking run-loop cycle. This fixes the felt input freezes / dropped clicks during long merged-menu sessions reported in #1399, isolated by controlled bisection on reproducing hardware.

## Context
`ProviderSwitcherShortcutEventMonitor` (the only working delivery mechanism for switcher clicks and Command-number/arrow shortcuts during tracking — see the #1260 closure evidence) installs a `beforeSources` run-loop observer for the tracking mode. The observer fired on **every cycle** of the menu-tracking loop, and each `NSApp.nextEvent(until: .distantPast, ...)` peek re-enters the run loop. Under continuous pointer movement this multiplies run-loop passes and starves the tracking session's own input processing: clicks drop, the desktop beachballs, and the process profiles healthy throughout — the signature in #1399, #1387, #1364.

## Isolation evidence (same machine, same ~2-minute manual interaction protocol per round, WindowServer `log stream` + 1ms `sample` captures)

| Build | Felt beachballs / dropped input | WindowServer buffer-clear events |
|---|---|---|
| Stock current main | **yes** | 5 (single burst at ~50s of tracking) |
| Experiment: all in-tracking churn suppressed | no | 0 |
| Experiment: churn suppressed, **monitor alone re-enabled** | **yes** | 1 |
| Stock + **this fix** | **no** — switcher clicks and ⌘1/⌘2/⌘3 and ←/→ all verified working | 7 (single burst; see honesty notes) |

Control: 120s holding an *Apple* menu-bar menu open with continuous cursor motion produced zero buffer-clear events, ruling out generic macOS tracking behavior. Full protocol and logs posted on #1399.

## Change
- `EventCounterGate`: before peeking, compare `CGEventSource.counterForEventType(.combinedSessionState, ...)` for exactly the three event types the monitor handles (`leftMouseDown`, `leftMouseUp`, `keyDown`). Unchanged counters → no pump. Identical delivery semantics: any matching hardware event changes a counter, so the very next observer fire pumps.
- A pure-userspace 8ms time bound caps the counter queries themselves regardless of how hot the tracking loop spins.

## Validation
- `swift test --filter 'StatusMenuSwitcherClickTests|StatusMenuPersistentRefreshTests|StatusItemControllerShutdownTests'` — 25 tests pass.
- `make check` — 0 violations; `git diff --check` clean.
- Live manual verification on reproducing hardware (table above): no beachballs, switcher clicks work, ⌘-number and arrow shortcuts work during tracking.

## Honesty / scope notes
- This fixes the **felt input starvation**. The WindowServer datagram-buffer overflow events still occur on a stock-behavior build during sustained merged-menu sessions (they track in-tracking *churn* broadly — rebuilds, icon updates — and only disappeared with all churn suppressed). That is a second, separable driver in #1399's evidence, in the direction #1394 is already pushing (less reconstruction during tracking). The two phenomena correlate in user reports but bisect apart cleanly.
- `CGEventSource.counterForEventType` calls are bounded to ≤125/s by the time check; the previous behavior was an unbounded full event-queue peek + nested run-loop pass per tracking cycle.
- Counter state is per-monitor-instance; the first observer fire after install always pumps once.
