### PR TITLE
Fix merged menu width after provider switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Doubao: confirm zero-remaining HTTP 200 request limits before falling back, preserving genuine exhaustion and avoiding false 100% usage (#1383). Thanks @LeoLin990405 and @foobra!
 - Menu bar: defer pasteboard writes and copy feedback outside the `NSMenu` tracking callback so in-menu copy buttons no longer beachball on macOS 26 (#1388). Thanks @LeoLin990405!
 - Menu bar: defer merged status-icon redraws until the tracked menu closes while preserving animation lifecycle and quota-warning timing, reducing WindowServer churn during long menu sessions (#1409, fixes #1399). Thanks @kiranmagic7!
+- Menu bar: keep one stable width across merged provider tabs and resize every hosted card row to AppKit's final menu width so provider switching no longer leaves a widened menu with inset submenu arrows (#1410).
 - Menu bar: defer Overview-row provider transitions out of AppKit's click callback so opening provider detail no longer performs a full synchronous menu rebuild (#1325).
 - Menu bar: open cached menus immediately after data-only invalidations, then refresh missing or stale provider data asynchronously without queuing redundant work on close (#1398). Thanks @joshuavial!
 - Menu bar: recycle SwiftUI card hosting views across data refreshes and provider switches, and reconcile matching menu rows in place instead of removing and reinserting every row, cutting open-click, switch, and idle rebuild cost (#1394). Thanks @bcssewl!

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -49,15 +49,6 @@ extension StatusItemController {
         }
     }
 
-    private func menuCardWidth(
-        for providers: [UsageProvider],
-        sections: [MenuDescriptor.Section]) -> CGFloat
-    {
-        _ = providers
-        let baselineWidth = Self.menuCardBaseWidth
-        return max(baselineWidth, self.measuredStandardMenuWidth(for: sections, baseWidth: baselineWidth))
-    }
-
     func makeMenu() -> NSMenu {
         guard self.shouldMergeIcons else {
             return self.makeMenu(for: nil)
@@ -217,6 +208,7 @@ extension StatusItemController {
                 menu: menu,
                 provider: provider)
         }
+        defer { self.refreshMenuCardHeights(in: menu) }
 
         let enabledProviders = self.store.enabledProvidersForDisplay()
         let includesOverview = self.includesOverviewTab(enabledProviders: enabledProviders)
@@ -244,16 +236,13 @@ extension StatusItemController {
         let openAIContext = self.openAIWebContext(
             currentProvider: currentProvider,
             showAllAccounts: showAllAccounts)
-        let descriptor = MenuDescriptor.build(
+        let descriptor = self.makeMenuDescriptor(
             provider: selectedProvider,
-            store: self.store,
-            settings: self.settings,
-            account: self.account,
-            managedCodexAccountCoordinator: self.managedCodexAccountCoordinator,
-            codexAccountPromotionCoordinator: self.codexAccountPromotionCoordinator,
-            updateReady: self.updater.updateStatus.isUpdateReady,
             includeContextualActions: !isOverviewSelected)
-        let menuWidth = self.menuCardWidth(for: enabledProviders, sections: descriptor.sections)
+        let menuWidth = self.menuCardWidth(
+            for: enabledProviders,
+            selectedProvider: selectedProvider,
+            descriptor: descriptor)
 
         let hasTokenSwitcher = menu.items.contains { $0.view is TokenAccountSwitcherView }
         let hasCodexSwitcher = menu.items.contains { $0.view is CodexAccountSwitcherView }

--- a/Sources/CodexBar/StatusItemController+MenuCardItems.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardItems.swift
@@ -3,12 +3,10 @@ import SwiftUI
 
 extension StatusItemController {
     func refreshMenuCardHeights(in menu: NSMenu) {
-        let cardItems = menu.items.filter { item in
-            (item.representedObject as? String)?.hasPrefix("menuCard") == true
-        }
-        for item in cardItems {
-            guard let view = item.view else { continue }
-            let width = self.renderedMenuWidth(for: menu)
+        let width = self.renderedMenuWidth(for: menu)
+        for item in menu.items {
+            guard let view = item.view, view is any MenuCardMeasuring else { continue }
+            guard abs(view.frame.width - width) > 0.5 else { continue }
             let id = item.representedObject as? String ?? "menuCard"
             let scope = self.menuProvider(for: menu)?.rawValue ?? id
             let height = self.cachedMenuCardHeight(for: id, scope: scope, width: width) {

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -199,8 +199,29 @@ extension StatusItemController {
     }
 
     func renderedMenuWidth(for menu: NSMenu) -> CGFloat {
-        let measuredWidth = ceil(menu.size.width)
-        return max(measuredWidth, Self.menuCardBaseWidth)
+        let menuKey = ObjectIdentifier(menu)
+        let trackedWindowWidth: CGFloat? = if self.openMenus[menuKey] != nil {
+            menu.items.lazy.compactMap { item -> CGFloat? in
+                guard let window = item.view?.window else { return nil }
+                let contentWidth = window.contentLayoutRect.width
+                return contentWidth > 0 ? contentWidth : window.frame.width
+            }.first
+        } else {
+            nil
+        }
+        return Self.resolvedRenderedMenuWidth(
+            menuWidth: menu.size.width,
+            trackedWindowWidth: trackedWindowWidth)
+    }
+
+    static func resolvedRenderedMenuWidth(
+        menuWidth: CGFloat,
+        trackedWindowWidth: CGFloat?) -> CGFloat
+    {
+        max(
+            ceil(menuWidth),
+            ceil(trackedWindowWidth ?? 0),
+            menuCardBaseWidth)
     }
 
     func rebuildClosedMenuIfNeeded(_ menu: NSMenu) {

--- a/Sources/CodexBar/StatusItemController+MenuWidthCache.swift
+++ b/Sources/CodexBar/StatusItemController+MenuWidthCache.swift
@@ -1,7 +1,50 @@
 import AppKit
+import CodexBarCore
 
 extension StatusItemController {
     private static let measuredStandardMenuWidthCacheLimit = 96
+
+    func menuCardWidth(
+        for providers: [UsageProvider],
+        selectedProvider: UsageProvider?,
+        descriptor: MenuDescriptor) -> CGFloat
+    {
+        let sectionSets: [[MenuDescriptor.Section]] = if self.shouldMergeIcons, providers.count > 1 {
+            providers.map { provider in
+                if provider == selectedProvider {
+                    return descriptor.sections
+                }
+                return self.makeMenuDescriptor(
+                    provider: provider,
+                    includeContextualActions: true).sections
+            }
+        } else {
+            [descriptor.sections]
+        }
+        return self.measuredMenuCardWidth(for: sectionSets)
+    }
+
+    func measuredMenuCardWidth(for sectionSets: [[MenuDescriptor.Section]]) -> CGFloat {
+        let baselineWidth = Self.menuCardBaseWidth
+        return sectionSets.reduce(baselineWidth) { width, sections in
+            max(width, self.measuredStandardMenuWidth(for: sections, baseWidth: baselineWidth))
+        }
+    }
+
+    func makeMenuDescriptor(
+        provider: UsageProvider?,
+        includeContextualActions: Bool) -> MenuDescriptor
+    {
+        MenuDescriptor.build(
+            provider: provider,
+            store: self.store,
+            settings: self.settings,
+            account: self.account,
+            managedCodexAccountCoordinator: self.managedCodexAccountCoordinator,
+            codexAccountPromotionCoordinator: self.codexAccountPromotionCoordinator,
+            updateReady: self.updater.updateStatus.isUpdateReady,
+            includeContextualActions: includeContextualActions)
+    }
 
     func measuredStandardMenuWidth(for sections: [MenuDescriptor.Section], baseWidth: CGFloat) -> CGFloat {
         let cacheKey = self.measuredStandardMenuWidthCacheKey(for: sections, baseWidth: baseWidth)

--- a/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
+++ b/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
@@ -36,6 +36,74 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `merged menu width uses widest provider action set`() {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        let controller = self.makeRecyclingController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let narrow = [
+            MenuDescriptor.Section(entries: [
+                .action("Usage Dashboard", .dashboard),
+            ]),
+        ]
+        let wide = [
+            MenuDescriptor.Section(entries: [
+                .action(String(repeating: "W", count: 60), .dashboard),
+            ]),
+        ]
+
+        let narrowWidth = controller.measuredMenuCardWidth(for: [narrow])
+        let stableWidth = controller.measuredMenuCardWidth(for: [narrow, wide])
+
+        #expect(narrowWidth == StatusItemController.menuCardBaseWidth)
+        #expect(stableWidth > narrowWidth)
+        #expect(controller.measuredMenuCardWidth(for: [wide, narrow]) == stableWidth)
+    }
+
+    @Test
+    func `menu width normalization includes usage history submenu row`() {
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        let controller = self.makeRecyclingController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = NSMenu()
+        let usageHistoryItem = controller.makeMenuCardItem(
+            Text("Subscription Utilization"),
+            id: "usageHistorySubmenu",
+            width: StatusItemController.menuCardBaseWidth)
+        menu.addItem(usageHistoryItem)
+        menu.addItem(NSMenuItem(
+            title: String(repeating: "W", count: 60),
+            action: nil,
+            keyEquivalent: ""))
+
+        let expectedWidth = controller.renderedMenuWidth(for: menu)
+        #expect(expectedWidth > StatusItemController.menuCardBaseWidth)
+
+        controller.refreshMenuCardHeights(in: menu)
+
+        #expect(abs((usageHistoryItem.view?.frame.width ?? 0) - expectedWidth) <= 0.5)
+    }
+
+    @Test
+    func `rendered menu width keeps tracked window width after AppKit shrink`() {
+        let width = StatusItemController.resolvedRenderedMenuWidth(
+            menuWidth: 310,
+            trackedWindowWidth: 356)
+
+        #expect(width == 356)
+        #expect(StatusItemController.resolvedRenderedMenuWidth(
+            menuWidth: 310,
+            trackedWindowWidth: nil) == 310)
+    }
+
+    @Test
     func `data only repopulate reuses menu card hosting views`() {
         StatusItemController.setMenuRefreshEnabledForTesting(false)
         let previousRendering = StatusItemController.menuCardRenderingEnabled


### PR DESCRIPTION
Fixes #1410

## Summary
- keep one stable width across enabled merged-provider tabs
- use the live tracked menu window width when AppKit retains a wider window
- resize every hosted card row, including Subscription Utilization

## Proof
- `make check`
- `swift test --filter MenuCardViewRecyclingTests`
- `swift test --filter StatusMenuSwitcherRefreshTests`
- full `swift test`: 3,531 tests; one unrelated RPC timeout test flaked and passed its exact rerun
- Peekaboo: 30 tracked switches, width 310 pt every time, 72-119 ms (81 ms average)
- xtrace Time Profiler, 25 seconds: zero potential-hang events
- autoreview clean
