### PR TITLE
Fix Cost row widening merged menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Localization: add Japanese as a selectable app language (#1385). Thanks @naoterumaker!
 
 ### Fixed
+- Menu bar: keep large dynamic Cost totals inside the fixed-width hosted row so switching providers no longer widens the menu or misaligns submenu arrows.
 - Cost history: keep all per-day model breakdown rows available in a bounded scrolling detail area instead of hiding models after the first four (#1370). Thanks @MoollaMore!
 - Cost usage: run local session-corpus scans and cache decoding on a dedicated serial queue instead of the Swift cooperative thread pool, so multi-minute scans of large archives no longer starve the app's async work or freeze menus (#1387, #1392). Thanks @ProspectOre!
 - Copilot: keep explicitly unlimited chat quotas visible instead of dropping their zero-entitlement payload as unavailable (#1320). Thanks @soumikbhatta!

--- a/Sources/CodexBar/StatusItemController+CostMenuCard.swift
+++ b/Sources/CodexBar/StatusItemController+CostMenuCard.swift
@@ -1,13 +1,73 @@
 import AppKit
+import SwiftUI
+
+private struct CostMenuCardRowView: View {
+    let title: String
+    let detailLines: [String]
+    let width: CGFloat
+    @Environment(\.menuItemHighlighted) private var isHighlighted
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(self.title)
+                .font(.system(size: NSFont.menuFont(ofSize: 0).pointSize))
+                .lineLimit(1)
+            ForEach(self.detailLines.indices, id: \.self) { index in
+                Text(self.detailLines[index])
+                    .font(.system(size: NSFont.smallSystemFontSize))
+                    .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+        .padding(.leading, 14)
+        .padding(.trailing, 28)
+        .padding(.vertical, 6)
+        .frame(width: self.width, alignment: .leading)
+    }
+}
 
 extension StatusItemController {
     static var costMenuTitle: String {
         L("Cost")
     }
 
-    func makeCostMenuCardItem(model: UsageMenuCardView.Model, submenu: NSMenu?) -> NSMenuItem {
+    func makeCostMenuCardItem(
+        model: UsageMenuCardView.Model,
+        submenu: NSMenu?,
+        width: CGFloat) -> NSMenuItem
+    {
         let tooltipLines = Self.costMenuTooltipLines(tokenUsage: model.tokenUsage)
         let visibleDetailLines = Self.costMenuVisibleDetailLines(tokenUsage: model.tokenUsage)
+        guard Self.menuCardRenderingEnabled else {
+            return Self.makeNativeCostMenuCardItem(
+                visibleDetailLines: visibleDetailLines,
+                tooltipLines: tooltipLines,
+                submenu: submenu)
+        }
+
+        let item = self.makeMenuCardItem(
+            CostMenuCardRowView(
+                title: Self.costMenuTitle,
+                detailLines: visibleDetailLines,
+                width: width),
+            id: "menuCardCost",
+            width: width,
+            heightCacheScope: model.provider.rawValue,
+            heightCacheFingerprint: "costMenuRow:\(visibleDetailLines.count)",
+            submenu: submenu,
+            submenuIndicatorAlignment: .trailing,
+            submenuIndicatorTopPadding: 0)
+        item.title = Self.costMenuTitle
+        item.toolTip = tooltipLines.joined(separator: "\n")
+        return item
+    }
+
+    private static func makeNativeCostMenuCardItem(
+        visibleDetailLines: [String],
+        tooltipLines: [String],
+        submenu: NSMenu?) -> NSMenuItem
+    {
         let item = NSMenuItem(title: Self.costMenuTitle, action: nil, keyEquivalent: "")
         item.isEnabled = true
         item.representedObject = "menuCardCost"

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1326,7 +1326,10 @@ extension StatusItemController {
             }
             let costSubmenu = webItems.hasCostHistory ? self
                 .makeCostHistorySubmenu(provider: provider, width: width) : nil
-            menu.addItem(self.makeCostMenuCardItem(model: model, submenu: costSubmenu))
+            menu.addItem(self.makeCostMenuCardItem(
+                model: model,
+                submenu: costSubmenu,
+                width: width))
         }
     }
 

--- a/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
+++ b/Tests/CodexBarTests/StatusMenuCostMenuCardTests.swift
@@ -1,3 +1,6 @@
+import AppKit
+import CodexBarCore
+import SwiftUI
 import Testing
 @testable import CodexBar
 
@@ -42,5 +45,86 @@ struct StatusMenuCostMenuCardTests {
             "Costs are estimated from local usage.",
             "Cost refresh failed.",
         ])
+    }
+
+    @Test
+    func `rendered cost menu keeps long dynamic details inside fixed row width`() throws {
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
+        let settings = self.makeSettings()
+        let fetcher = UsageFetcher()
+        let store = UsageStore(
+            fetcher: fetcher,
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let width = StatusItemController.menuCardBaseWidth
+        let tokenUsage = UsageMenuCardView.Model.TokenUsageSection(
+            sessionLine: "Today: $227.42 - 267M tokens - " + String(repeating: "wide ", count: 20),
+            monthLine: "Last 30 days: $52,431.09 - 77B tokens - " + String(repeating: "wide ", count: 20),
+            hintLine: "Costs are estimated from local usage.",
+            errorLine: nil,
+            errorCopyText: nil)
+        let model = self.makeModel(tokenUsage: tokenUsage)
+        let submenu = NSMenu()
+
+        let item = controller.makeCostMenuCardItem(
+            model: model,
+            submenu: submenu,
+            width: width)
+        let view = try #require(item.view)
+
+        #expect(view is any MenuCardMeasuring)
+        #expect(abs(view.frame.width - width) <= 0.5)
+        #expect(item.title == "Cost")
+        #expect(item.toolTip?.contains("$52,431.09") == true)
+        #expect(item.submenu === submenu)
+        #expect(item.target === controller)
+        #expect(item.action.map(NSStringFromSelector) == "menuCardNoOp:")
+    }
+
+    private func makeSettings() -> SettingsStore {
+        let suite = "StatusMenuCostMenuCardTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+    }
+
+    private func makeModel(
+        tokenUsage: UsageMenuCardView.Model.TokenUsageSection) -> UsageMenuCardView.Model
+    {
+        UsageMenuCardView.Model(
+            provider: .codex,
+            providerName: "Codex",
+            email: "user@example.com",
+            subtitleText: "Updated now",
+            subtitleStyle: .info,
+            planText: "Pro",
+            metrics: [],
+            usageNotes: [],
+            openAIAPIUsage: nil,
+            inlineUsageDashboard: nil,
+            creditsText: nil,
+            creditsRemaining: nil,
+            creditsHintText: nil,
+            creditsHintCopyText: nil,
+            providerCost: nil,
+            tokenUsage: tokenUsage,
+            placeholder: nil,
+            progressColor: .blue)
     }
 }

--- a/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHostedSubmenuRefreshTests.swift
@@ -43,11 +43,11 @@ struct StatusMenuHostedSubmenuRefreshTests {
         controller.menuVersions[parentKey] = controller.menuContentVersion
 
         let costItem = try #require(menu.items.first { ($0.representedObject as? String) == "menuCardCost" })
-        #expect(costItem.view == nil)
+        #expect(costItem.view is any MenuCardMeasuring)
         let submenu = try #require(costItem.submenu)
         let submenuAction = try #require(costItem.action)
-        #expect(NSStringFromSelector(submenuAction) == "submenuAction:")
-        #expect((costItem.target as? NSMenu) === submenu)
+        #expect(NSStringFromSelector(submenuAction) == "menuCardNoOp:")
+        #expect(costItem.target === controller)
         #expect(submenu.items.first?.representedObject as? String == StatusItemController.costHistoryChartID)
         #expect(submenu.minimumWidth >= StatusItemController.menuCardBaseWidth)
         #expect(submenu.items.first?.view == nil)


### PR DESCRIPTION
## Summary
- render the Cost detail item as a fixed-width hosted row instead of a native subtitle item
- keep long dynamic totals truncated inside the row while preserving full details in the tooltip
- align the Cost submenu chevron with other hosted submenu rows
- retain the native item path for headless tests and localization refresh coverage

## Root cause
The Cost row was the only provider detail row using `NSMenuItem.subtitle`. Large dynamic totals participated in AppKit's natural menu sizing, widening the tracked menu window. Hosted rows such as Subscription Utilization stayed at the configured width, so their custom chevrons became inset and the widened window persisted during provider switching.

## Validation
- `swift test --filter 'StatusMenu(CostMenuCard|HostedSubmenuRefresh)Tests'`
- `swift test --filter 'StatusMenu(LocalizationRefresh|OpenRefresh|Tests)'` (131 tests)
- `make check`
- `git diff --check`
- structured autoreview: no accepted/actionable findings

## Runtime proof
- Fresh packaged app built and launched from exact head `9d7967ea` with `./Scripts/compile_and_run.sh`.
- Peekaboo exercised eight Codex/Claude/Overview switches. Every tracked menu window remained exactly 310 points wide; provider-specific heights changed as expected.
- Hovering Cost produced the normal highlighted state and opened its 310-point submenu. Cost and Subscription Utilization chevrons share the same trailing edge.
- Chrome Safe Storage access was denied; validation used existing cached/local usage data.

<img width="615" height="845" alt="Redacted CodexBar Cost row width, hover, aligned arrows, and open submenu proof" src="https://github.com/user-attachments/assets/7ea9faab-6faa-4569-8f1d-92ad02fda1a1" />

## Review disposition
- Keep `CHANGELOG.md`: repository policy requires maintainer/AI-authored changelog entries for user-facing fixes.
