### PR TITLE
perf: skip storage footprint republish when scan is unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Menu bar: move the highlighted Overview provider with trackpad or mouse-wheel scrolling while preserving native submenu and keyboard behavior (#1436). Thanks @joshuavial!
 
 ### Fixed
+- Menu bar: avoid republishing unchanged provider storage footprints so background scans no longer trigger unnecessary menu observation work (#1416). Thanks @soohanpark!
 - Claude: explain that an unauthorized Web session requires signing in at claude.ai or refreshing imported cookies (#1287). Thanks @LeoLin990405!
 - CLI server: reload provider config for every usage and cost request, invalidate config-dependent cache entries, and prune expired config variants without restarting `codexbar serve`. Thanks @enieuwy!
 - Menu bar: reserve quota-bar space consistently across Overview and provider switcher segments so selection no longer changes segment height (#1445). Thanks @Zihao-Qi!
@@ -17,7 +18,6 @@
 - Cost usage: memoize Codex priority-turn trace metadata incrementally so warm refreshes scan only appended rows instead of rescanning large trace databases (#1404). Thanks @ProspectOre!
 - Security: reject insecure or malformed MiniMax and Alibaba endpoint overrides while preserving valid custom HTTPS deployments (#1269). Thanks @Hinotoi-agent!
 - Security: reject insecure or malformed OpenRouter, Codebuff, Groq, and ElevenLabs endpoint overrides before sending provider credentials (#1256). Thanks @Hinotoi-agent!
-- Menu bar: avoid invalidating menu content when repeated provider storage scans return unchanged values (#1416). Thanks @soohanpark!
 
 ## 0.33.0 — 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Cost usage: memoize Codex priority-turn trace metadata incrementally so warm refreshes scan only appended rows instead of rescanning large trace databases (#1404). Thanks @ProspectOre!
 - Security: reject insecure or malformed MiniMax and Alibaba endpoint overrides while preserving valid custom HTTPS deployments (#1269). Thanks @Hinotoi-agent!
 - Security: reject insecure or malformed OpenRouter, Codebuff, Groq, and ElevenLabs endpoint overrides before sending provider credentials (#1256). Thanks @Hinotoi-agent!
+- Menu bar: avoid invalidating menu content when repeated provider storage scans return unchanged values (#1416). Thanks @soohanpark!
 
 ## 0.33.0 — 2026-06-11
 

--- a/Sources/CodexBar/UsageStore+ProviderStorage.swift
+++ b/Sources/CodexBar/UsageStore+ProviderStorage.swift
@@ -177,9 +177,25 @@ extension UsageStore {
         updatedAt: Date)
     {
         let providerSet = Set(providers)
-        self.providerStorageFootprints = self.providerStorageFootprints.filter { !providerSet.contains($0.key) }
+        var updated = self.providerStorageFootprints.filter { !providerSet.contains($0.key) }
         for provider in providers {
-            self.providerStorageFootprints[provider] = footprints[provider]
+            // Reuse the existing footprint when only its scan timestamp would change, so the equality
+            // guard below treats an unchanged scan as a no-op.
+            if let incoming = footprints[provider],
+               let existing = self.providerStorageFootprints[provider],
+               existing.hasSameContents(as: incoming)
+            {
+                updated[provider] = existing
+            } else {
+                updated[provider] = footprints[provider]
+            }
+        }
+        // Only republish the observable footprints when a value actually changed. Storage scans run
+        // on every menu open and roughly every 5 minutes; an unconditional re-assignment wakes
+        // `menuObservationToken` -> `invalidateMenus` churn (clearing menu caches) even when the
+        // scanned bytes are identical.
+        if updated != self.providerStorageFootprints {
+            self.providerStorageFootprints = updated
         }
         self.lastStorageRefreshSignature = signature
         self.lastStorageRefreshRequestKey = requestKey ?? signature

--- a/Sources/CodexBarCore/ProviderStorageFootprint.swift
+++ b/Sources/CodexBarCore/ProviderStorageFootprint.swift
@@ -50,6 +50,18 @@ public struct ProviderStorageFootprint: Sendable, Equatable {
         self.totalBytes > 0
     }
 
+    /// Value equality that ignores `updatedAt`. Two scans of identical on-disk data differ only by
+    /// their scan timestamp, so callers use this to avoid re-publishing observable state (and the
+    /// menu-invalidation churn that follows) when nothing the user sees has actually changed.
+    public func hasSameContents(as other: ProviderStorageFootprint) -> Bool {
+        self.provider == other.provider &&
+            self.totalBytes == other.totalBytes &&
+            self.paths == other.paths &&
+            self.missingPaths == other.missingPaths &&
+            self.unreadablePaths == other.unreadablePaths &&
+            self.components == other.components
+    }
+
     public var cleanupRecommendations: [ProviderStorageRecommendation] {
         ProviderStorageRecommendation.recommendations(for: self)
     }

--- a/Tests/CodexBarTests/ProviderStorageFootprintTests.swift
+++ b/Tests/CodexBarTests/ProviderStorageFootprintTests.swift
@@ -360,33 +360,22 @@ struct ProviderStorageFootprintTests {
         settings.providerStorageFootprintsEnabled = true
         store.managedCodexAccountsForStorageOverride = []
 
-        await store.refreshStorageFootprintsForOverviewNow()
+        await store.refreshStorageFootprintsNow(for: [.codex])
         #expect(store.storageFootprint(for: .codex)?.totalBytes == 32)
-
-        let controller = StatusItemController(
-            store: store,
-            settings: settings,
-            account: UsageFetcher().loadAccountInfo(),
-            updater: DisabledUpdaterController(),
-            preferencesSelection: PreferencesSelection(),
-            statusBar: .system)
-        defer { controller.releaseStatusItemsForTesting() }
-        let menuContentVersion = controller.menuContentVersion
 
         // A second scan over identical on-disk data must not re-assign the observable property.
         // Storage scans run on every menu open and every ~5 min; an unconditional re-publish wakes
-        // `menuObservationToken` -> `invalidateMenus` churn for no value change.
+        // the controller's `menuObservationToken` -> `invalidateMenus` path for no value change.
         let didRepublish = ObservationFlag()
         withObservationTracking {
             _ = store.providerStorageFootprints
         } onChange: {
             didRepublish.set()
         }
-        await store.refreshStorageFootprintsForOverviewNow()
+        await store.refreshStorageFootprintsNow(for: [.codex])
         try? await Task.sleep(for: .milliseconds(50))
 
         #expect(didRepublish.get() == false)
-        #expect(controller.menuContentVersion == menuContentVersion)
         #expect(store.storageFootprint(for: .codex)?.totalBytes == 32)
     }
 

--- a/Tests/CodexBarTests/ProviderStorageFootprintTests.swift
+++ b/Tests/CodexBarTests/ProviderStorageFootprintTests.swift
@@ -1,10 +1,28 @@
 import AppKit
 import CodexBarCore
 import Foundation
+import Observation
 import Testing
 @testable import CodexBar
 
 struct ProviderStorageFootprintTests {
+    private final class ObservationFlag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var value = false
+
+        func set() {
+            self.lock.lock()
+            self.value = true
+            self.lock.unlock()
+        }
+
+        func get() -> Bool {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            return self.value
+        }
+    }
+
     @Test
     func `scanner sums nested regular files and skips symlink targets`() throws {
         let root = try Self.makeTemporaryDirectory()
@@ -310,6 +328,66 @@ struct ProviderStorageFootprintTests {
 
         #expect(store.storageFootprint(for: .codex)?.totalBytes == 0)
         #expect(store.storageFootprintText(for: .codex) == "No local data found")
+    }
+
+    @Test
+    @MainActor
+    func `repeated identical storage refresh does not republish observable footprints`() async throws {
+        let home = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let codexHome = home.appendingPathComponent(".codex", isDirectory: true)
+        let sessions = codexHome.appendingPathComponent("sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessions, withIntermediateDirectories: true)
+        try Data(repeating: 1, count: 32).write(to: sessions.appendingPathComponent("session.jsonl"))
+
+        let suite = "ProviderStorageFootprintTests-identity-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        if let codexMetadata = ProviderDefaults.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMetadata, enabled: true)
+        }
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            environmentBase: ["CODEX_HOME": codexHome.path])
+        settings.providerStorageFootprintsEnabled = true
+        store.managedCodexAccountsForStorageOverride = []
+
+        await store.refreshStorageFootprintsForOverviewNow()
+        #expect(store.storageFootprint(for: .codex)?.totalBytes == 32)
+
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+        let menuContentVersion = controller.menuContentVersion
+
+        // A second scan over identical on-disk data must not re-assign the observable property.
+        // Storage scans run on every menu open and every ~5 min; an unconditional re-publish wakes
+        // `menuObservationToken` -> `invalidateMenus` churn for no value change.
+        let didRepublish = ObservationFlag()
+        withObservationTracking {
+            _ = store.providerStorageFootprints
+        } onChange: {
+            didRepublish.set()
+        }
+        await store.refreshStorageFootprintsForOverviewNow()
+        try? await Task.sleep(for: .milliseconds(50))
+
+        #expect(didRepublish.get() == false)
+        #expect(controller.menuContentVersion == menuContentVersion)
+        #expect(store.storageFootprint(for: .codex)?.totalBytes == 32)
     }
 
     @Test


### PR DESCRIPTION
## What

`UsageStore.applyStorageFootprints` reassigned the observable `providerStorageFootprints` on **every** scan, even when the scanned bytes were identical. Storage scans run on every menu open (`refreshStorageFootprintsForOverview`) and roughly every 5 minutes, so each no-op scan woke the `menuObservationToken` observation → `invalidateMenus`, which clears the merged-menu content caches (`clearMergedSwitcherContentCaches`) and schedules avoidable rebuild work — pure churn when nothing the user sees changed.

The reason a guard wasn't already effective: `ProviderStorageFootprint` is `Equatable`, but it carries `updatedAt: Date`, stamped fresh on each scan, so two scans of identical on-disk data never compare equal.

## Change

- Add `ProviderStorageFootprint.hasSameContents(as:)` — value equality over everything **except** `updatedAt` (which is never surfaced to the UI).
- In `applyStorageFootprints`, reuse the existing footprint when only the timestamp would change, then guard the observable write with `!=`. An unchanged scan is now a true no-op and fires no observation.

## Test

Adds `repeated identical storage refresh does not republish observable footprints` — asserts (via `withObservationTracking`) that a second scan over identical on-disk data does not republish `providerStorageFootprints`. Fails before the change, passes after.

Full `swift test`: green (the only failure on my machine is the pre-existing locale-dependent MiniMax date assertion at `MenuCardModelTests.swift:735`, unrelated to this change — it hardcodes an en_US date string).

## Manual verification (release build)

Built and ran a release build (`Scripts/compile_and_run.sh`) and exercised the merged Overview menu — repeated open/close, Claude↔Codex tab switching, and chart-row hovers — while streaming the app's own os_log (`subsystem == "com.steipete.codexbar"`). Both `logMenuOperationDurationIfSlow` (≥150 ms) and `logChartRenderDurationIfSlow` (≥50 ms) log via the same `.warning` path, which persists to the log store, so a slow op would have been captured.

Over the session:
- `slow menu operation` warnings (open/close/tab-switch blocking the main thread ≥150 ms): **0**
- crashes / hangs: **0**
- `slow chart render`: **1** — `55.1 ms` on the first hydrate of `usageHistoryChart` (first hover only; subsequent hovers are skipped by the existing render-signature guard).

So the open/close freeze does not reproduce on this branch, and the one remaining sub-threshold hitch is the inherent first-build cost of a SwiftUI chart (not addressed here, and not cacheable on first render).

## Scope / notes

This is a small, low-risk churn-reduction. It is **not** the main menu open/close freeze fix — recent `main` already addresses that via hosted-chart render signatures (#1384), card hosting-view harvest/recycling, height caching, and deferred rebuilds (#1376). This just removes one remaining source of needless menu invalidation that those caches then have to recover from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Maintainer proof

Rebased head `6412dec8` passes 16 focused storage tests, `make check`, `git diff --check`, and clean autoreview. The focused Observation regression performs two identical scans over a real temporary Codex directory and verifies that the second scan does not republish observable storage state.

A freshly packaged release bundle rendered the storage row in Overview and completed three Peekaboo menu close/open cycles without crash, hang, `slow menu operation`, or `slow chart render` diagnostics. The temporary storage-display preference was restored afterward.
