### PR TITLE
Fix Cursor Full Disk Access hint visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Devin: add daily and weekly quota tracking from the signed-in Chrome session or a manual Bearer token (#1264, fixes #800). Thanks @coygeek!
 
+### Fixed
+- Cursor: show the Safari Full Disk Access recovery hint before the long browser login list so permission guidance remains visible when menu errors truncate (#1419, fixes #1417). Thanks @hhh2210!
+
 ## 0.33.0 — 2026-06-11
 
 ### Added

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -542,6 +542,9 @@ public enum CursorStatusProbeError: LocalizedError, Sendable {
     case parseFailed(String)
     case noSessionCookie
 
+    static let safariFullDiskAccessHint =
+        "If you use Safari, grant CodexBar Full Disk Access in System Settings ▸ Privacy & Security."
+
     public var errorDescription: String? {
         switch self {
         case .notLoggedIn:
@@ -551,8 +554,8 @@ public enum CursorStatusProbeError: LocalizedError, Sendable {
         case let .parseFailed(msg):
             "Could not parse Cursor usage: \(msg)"
         case .noSessionCookie:
-            "No Cursor session found. Please log in to cursor.com in \(cursorCookieImportOrder.loginHint). "
-                + "If you use Safari, grant CodexBar Full Disk Access in System Settings ▸ Privacy & Security. "
+            "No Cursor session found. \(Self.safariFullDiskAccessHint) "
+                + "Please log in to cursor.com in \(cursorCookieImportOrder.loginHint). "
                 + "You can also sign in to Cursor from the CodexBar menu (Add / switch account)."
         }
     }

--- a/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
+++ b/Tests/CodexBarTests/BrowserCookieOrderLabelTests.swift
@@ -24,6 +24,16 @@ struct BrowserCookieOrderStatusStringTests {
     }
 
     @Test
+    func `cursor no session shows full disk access hint before browser list`() throws {
+        let order = ProviderDefaults.metadata[.cursor]?.browserCookieOrder ?? Browser.defaultImportOrder
+        let message = try #require(CursorStatusProbeError.noSessionCookie.errorDescription)
+        let fullDiskAccessRange = try #require(message.range(of: CursorStatusProbeError.safariFullDiskAccessHint))
+        let browserListRange = try #require(message.range(of: order.loginHint))
+
+        #expect(fullDiskAccessRange.lowerBound < browserListRange.lowerBound)
+    }
+
+    @Test
     func `factory no session includes browser login hint`() {
         let order = ProviderDefaults.metadata[.factory]?.browserCookieOrder ?? Browser.defaultImportOrder
         let message = FactoryStatusProbeError.noSessionCookie.errorDescription ?? ""


### PR DESCRIPTION
## Summary

- move the Cursor no-session Safari Full Disk Access hint before the long dynamic browser list
- add a regression test that locks the hint before the browser login hint

Fixes #1417

## Proof

Fresh CodexBar UI render from commit `bac5b8f7`, using the actual `CursorStatusProbeError.noSessionCookie` message:

![Cursor FDA hint before browser list](https://raw.githubusercontent.com/hhh2210/CodexBar/8e9592f6/proof/cursor-fda-hint-before-browser-list.png)

## Validation

- `swift test --filter BrowserCookieOrderStatusStringTests`
- `make check`

## Notes

This only changes user-facing error text ordering. It does not alter browser detection, cookie import order, credential access, or live provider behavior.