### PR TITLE
Show Cursor legacy request quotas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Cursor: show the Safari Full Disk Access recovery hint before the long browser login list so permission guidance remains visible when menu errors truncate (#1419, fixes #1417). Thanks @hhh2210!
+- Cursor: present legacy request-based plans as one Requests quota with the raw used/limit count instead of unrelated token-based Auto/API bars (#1420, fixes #1418). Thanks @hhh2210!
 
 ## 0.33.0 — 2026-06-11
 

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1217,9 +1217,16 @@ extension UsageMenuCardView.Model {
         if input.provider == .factory, snapshot.tertiary != nil {
             return ("5-hour", L("Weekly"), L("Monthly"), true)
         }
-        let primaryLabel = input.provider == .grok
-            ? GrokProviderDescriptor.primaryLabel(window: snapshot.primary) ?? input.metadata.sessionLabel
-            : input.metadata.sessionLabel
+        // Legacy request-based Cursor plans track a request quota, not the token-based "Total" pool —
+        // relabel the primary bar so it reads as a request count instead of a dollar percentage.
+        let primaryLabel = if input.provider == .cursor, snapshot.cursorRequests != nil {
+            "Requests"
+        } else if input.provider == .grok {
+            GrokProviderDescriptor.primaryLabel(window: snapshot.primary) ?? input.metadata
+                .sessionLabel
+        } else {
+            input.metadata.sessionLabel
+        }
         return (
             L(primaryLabel),
             L(input.metadata.weeklyLabel),
@@ -1323,6 +1330,14 @@ extension UsageMenuCardView.Model {
             primaryDetailRight = paceDetail.rightLabel
             primaryPacePercent = paceDetail.pacePercent
             primaryPaceOnTop = paceDetail.paceOnTop
+        }
+        // Legacy request-based Cursor plans: surface the raw used/limit quota on its own line,
+        // since the percentage bar and pace detail alone never spell out the request cap.
+        if input.provider == .cursor, let requests = input.snapshot?.cursorRequests {
+            primaryDetailText = String(
+                format: L("Request quota: %@ / %@"),
+                "\(requests.used)",
+                "\(requests.limit)")
         }
         if input.provider == .synthetic,
            let regen = Self.syntheticRollingRegenDetail(

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -1069,3 +1069,5 @@
 "Search providers" = "Search providers";
 
 "language_vietnamese" = "Vietnamese";
+
+"Request quota: %@ / %@" = "Request quota: %@ / %@";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -1041,3 +1041,5 @@
 "Search providers" = "搜索提供商";
 
 "language_vietnamese" = "越南语";
+
+"Request quota: %@ / %@" = "请求额度：%@ / %@";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -937,3 +937,5 @@
 "Search providers" = "搜尋提供者";
 
 "language_vietnamese" = "越南語";
+
+"Request quota: %@ / %@" = "請求額度：%@ / %@";

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -442,8 +442,10 @@ public struct CursorStatusSnapshot: Sendable {
             resetsAt: self.billingCycleEnd,
             resetDescription: self.billingCycleEnd.map { Self.formatResetDate($0) })
 
-        // Secondary: Auto + Composer usage (shown as its own bar below Total)
-        let secondary: RateWindow? = self.autoPercentUsed.map { pct in
+        // Secondary: Auto + Composer usage (shown as its own bar below Total).
+        // Legacy request-based plans don't have the token-based Auto/API breakdown — those percentages
+        // come from the new usage-based pricing and are meaningless next to a request quota, so hide them.
+        let secondary: RateWindow? = self.isLegacyRequestPlan ? nil : self.autoPercentUsed.map { pct in
             RateWindow(
                 usedPercent: pct,
                 windowMinutes: billingCycleWindowMinutes,
@@ -451,8 +453,8 @@ public struct CursorStatusSnapshot: Sendable {
                 resetDescription: self.billingCycleEnd.map { Self.formatResetDate($0) })
         }
 
-        // Tertiary: API (named model) usage
-        let tertiary: RateWindow? = self.apiPercentUsed.map { pct in
+        // Tertiary: API (named model) usage — hidden for legacy request-based plans (see above).
+        let tertiary: RateWindow? = self.isLegacyRequestPlan ? nil : self.apiPercentUsed.map { pct in
             RateWindow(
                 usedPercent: pct,
                 windowMinutes: billingCycleWindowMinutes,

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -421,16 +421,17 @@ public struct CursorStatusSnapshot: Sendable {
 
     /// Convert to UsageSnapshot for the common provider interface
     public func toUsageSnapshot() -> UsageSnapshot {
-        // Primary: For legacy request-based plans, use request usage; otherwise use plan percentage
-        let primaryUsedPercent: Double = if self.isLegacyRequestPlan,
-                                            let used = self.requestsUsed,
-                                            let limit = self.requestsLimit,
-                                            limit > 0
+        let cursorRequests: CursorRequestUsage? = if let used = self.requestsUsed,
+                                                     let limit = self.requestsLimit,
+                                                     limit > 0
         {
-            (Double(used) / Double(limit)) * 100
+            CursorRequestUsage(used: used, limit: limit)
         } else {
-            self.planPercentUsed
+            nil
         }
+
+        // Primary: For usable legacy request quotas, use request usage; otherwise preserve plan percentage.
+        let primaryUsedPercent = cursorRequests?.usedPercent ?? self.planPercentUsed
 
         let billingCycleWindowMinutes = Self.billingCycleWindowMinutes(
             start: self.billingCycleStart,
@@ -445,7 +446,7 @@ public struct CursorStatusSnapshot: Sendable {
         // Secondary: Auto + Composer usage (shown as its own bar below Total).
         // Legacy request-based plans don't have the token-based Auto/API breakdown — those percentages
         // come from the new usage-based pricing and are meaningless next to a request quota, so hide them.
-        let secondary: RateWindow? = self.isLegacyRequestPlan ? nil : self.autoPercentUsed.map { pct in
+        let secondary: RateWindow? = cursorRequests != nil ? nil : self.autoPercentUsed.map { pct in
             RateWindow(
                 usedPercent: pct,
                 windowMinutes: billingCycleWindowMinutes,
@@ -454,7 +455,7 @@ public struct CursorStatusSnapshot: Sendable {
         }
 
         // Tertiary: API (named model) usage — hidden for legacy request-based plans (see above).
-        let tertiary: RateWindow? = self.isLegacyRequestPlan ? nil : self.apiPercentUsed.map { pct in
+        let tertiary: RateWindow? = cursorRequests != nil ? nil : self.apiPercentUsed.map { pct in
             RateWindow(
                 usedPercent: pct,
                 windowMinutes: billingCycleWindowMinutes,
@@ -477,15 +478,6 @@ public struct CursorStatusSnapshot: Sendable {
                 period: "Monthly",
                 resetsAt: self.billingCycleEnd,
                 updatedAt: Date())
-        } else {
-            nil
-        }
-
-        // Legacy plan request usage (when maxRequestUsage is set)
-        let cursorRequests: CursorRequestUsage? = if let used = self.requestsUsed,
-                                                     let limit = self.requestsLimit
-        {
-            CursorRequestUsage(used: used, limit: limit)
         } else {
             nil
         }

--- a/Tests/CodexBarTests/CursorLegacyRequestProjectionTests.swift
+++ b/Tests/CodexBarTests/CursorLegacyRequestProjectionTests.swift
@@ -1,0 +1,59 @@
+import Testing
+@testable import CodexBarCore
+
+struct CursorLegacyRequestProjectionTests {
+    @Test
+    func `legacy plan hides token-based auto and api bars`() {
+        let snapshot = Self.snapshot(requestsUsed: 347, requestsLimit: 500)
+
+        let usageSnapshot = snapshot.toUsageSnapshot()
+
+        #expect(abs((usageSnapshot.primary?.usedPercent ?? 0) - 69.4) < 0.01)
+        #expect(usageSnapshot.cursorRequests?.used == 347)
+        #expect(usageSnapshot.cursorRequests?.limit == 500)
+        #expect(usageSnapshot.secondary == nil)
+        #expect(usageSnapshot.tertiary == nil)
+    }
+
+    @Test
+    func `unusable legacy request quota preserves token bars`() {
+        let requestCases: [(used: Int?, limit: Int?)] = [
+            (nil, 500),
+            (12, 0),
+        ]
+
+        for requestCase in requestCases {
+            let usageSnapshot = Self.snapshot(
+                requestsUsed: requestCase.used,
+                requestsLimit: requestCase.limit).toUsageSnapshot()
+
+            #expect(usageSnapshot.primary?.usedPercent == 7.0)
+            #expect(usageSnapshot.cursorRequests == nil)
+            #expect(usageSnapshot.secondary?.usedPercent == 11.0)
+            #expect(usageSnapshot.tertiary?.usedPercent == 22.0)
+        }
+    }
+
+    private static func snapshot(
+        requestsUsed: Int?,
+        requestsLimit: Int?) -> CursorStatusSnapshot
+    {
+        CursorStatusSnapshot(
+            planPercentUsed: 7.0,
+            autoPercentUsed: 11.0,
+            apiPercentUsed: 22.0,
+            planUsedUSD: 1.4,
+            planLimitUSD: 20.0,
+            onDemandUsedUSD: 0,
+            onDemandLimitUSD: nil,
+            teamOnDemandUsedUSD: nil,
+            teamOnDemandLimitUSD: nil,
+            billingCycleEnd: nil,
+            membershipType: "pro",
+            accountEmail: "user@example.com",
+            accountName: nil,
+            rawJSON: nil,
+            requestsUsed: requestsUsed,
+            requestsLimit: requestsLimit)
+    }
+}

--- a/Tests/CodexBarTests/CursorMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/CursorMenuCardModelTests.swift
@@ -46,4 +46,48 @@ struct CursorMenuCardModelTests {
             #expect(metric.paceOnTop == false)
         }
     }
+
+    @Test
+    func `legacy request plan shows single requests bar with count`() throws {
+        let now = Date(timeIntervalSince1970: 0)
+        let reset = now.addingTimeInterval(6 * 24 * 3600)
+        let cycleMinutes = 30 * 24 * 60
+        // A legacy snapshot, as produced by CursorStatusSnapshot.toUsageSnapshot(): only the request
+        // window survives, Auto/API are dropped, and the request count rides along.
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 69.4,
+                windowMinutes: cycleMinutes,
+                resetsAt: reset,
+                resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            cursorRequests: CursorRequestUsage(used: 347, limit: 500),
+            updatedAt: now,
+            identity: nil)
+        let metadata = try #require(ProviderDefaults.metadata[.cursor])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .cursor,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.metrics.map(\.title) == ["Requests"])
+        #expect(model.metrics.first?.detailText == "Request quota: 347 / 500")
+    }
 }

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -527,38 +527,6 @@ struct CursorStatusProbeTests {
     }
 
     @Test
-    func `legacy plan hides token-based auto and api bars`() {
-        // A migrated legacy account can still report token-based Auto/API percentages from the new
-        // usage-based pricing. Those don't map to the request quota, so the snapshot must drop them.
-        let snapshot = CursorStatusSnapshot(
-            planPercentUsed: 7.0,
-            autoPercentUsed: 0.0,
-            apiPercentUsed: 31.0,
-            planUsedUSD: 13.88,
-            planLimitUSD: 20.0,
-            onDemandUsedUSD: 0,
-            onDemandLimitUSD: nil,
-            teamOnDemandUsedUSD: nil,
-            teamOnDemandLimitUSD: nil,
-            billingCycleEnd: nil,
-            membershipType: "pro",
-            accountEmail: "user@example.com",
-            accountName: nil,
-            rawJSON: nil,
-            requestsUsed: 347,
-            requestsLimit: 500)
-
-        let usageSnapshot = snapshot.toUsageSnapshot()
-
-        // Primary stays on the request quota; Auto/API bars are suppressed for legacy plans.
-        #expect(abs((usageSnapshot.primary?.usedPercent ?? 0) - 69.4) < 0.01)
-        #expect(usageSnapshot.cursorRequests?.used == 347)
-        #expect(usageSnapshot.cursorRequests?.limit == 500)
-        #expect(usageSnapshot.secondary == nil)
-        #expect(usageSnapshot.tertiary == nil)
-    }
-
-    @Test
     func `parse usage summary prefers request total`() {
         let summary = CursorUsageSummary(
             billingCycleStart: nil,

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -527,6 +527,38 @@ struct CursorStatusProbeTests {
     }
 
     @Test
+    func `legacy plan hides token-based auto and api bars`() {
+        // A migrated legacy account can still report token-based Auto/API percentages from the new
+        // usage-based pricing. Those don't map to the request quota, so the snapshot must drop them.
+        let snapshot = CursorStatusSnapshot(
+            planPercentUsed: 7.0,
+            autoPercentUsed: 0.0,
+            apiPercentUsed: 31.0,
+            planUsedUSD: 13.88,
+            planLimitUSD: 20.0,
+            onDemandUsedUSD: 0,
+            onDemandLimitUSD: nil,
+            teamOnDemandUsedUSD: nil,
+            teamOnDemandLimitUSD: nil,
+            billingCycleEnd: nil,
+            membershipType: "pro",
+            accountEmail: "user@example.com",
+            accountName: nil,
+            rawJSON: nil,
+            requestsUsed: 347,
+            requestsLimit: 500)
+
+        let usageSnapshot = snapshot.toUsageSnapshot()
+
+        // Primary stays on the request quota; Auto/API bars are suppressed for legacy plans.
+        #expect(abs((usageSnapshot.primary?.usedPercent ?? 0) - 69.4) < 0.01)
+        #expect(usageSnapshot.cursorRequests?.used == 347)
+        #expect(usageSnapshot.cursorRequests?.limit == 500)
+        #expect(usageSnapshot.secondary == nil)
+        #expect(usageSnapshot.tertiary == nil)
+    }
+
+    @Test
     func `parse usage summary prefers request total`() {
         let summary = CursorUsageSummary(
             billingCycleStart: nil,


### PR DESCRIPTION
## Summary

- hide token-based Auto/API bars for Cursor legacy request-based plans
- label the primary Cursor legacy bar as Requests instead of Total
- show the raw request quota on the menu card detail line, for example `Request quota: 347 / 500`
- add focused Core snapshot and menu card model coverage

Fixes #1418

## Proof

Fresh CodexBar UI render from commit `6de03db3`, using the actual `UsageMenuCardView` model projection. The combined screenshot shows both states in one artifact: legacy request plans render a single Requests bar with quota detail, while modern usage-based plans still render Total / Auto / API.

![Cursor legacy and modern proof](https://raw.githubusercontent.com/hhh2210/CodexBar/94cd8684/proof/cursor-legacy-and-modern-proof.png)

## Validation

- `swift test --filter "CursorStatusProbeTests|CursorMenuCardModelTests"`
- `plutil -lint Sources/CodexBar/Resources/en.lproj/Localizable.strings Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings`
- `make check`

## Notes

This is scoped to presentation/projection for parsed Cursor legacy request usage. Non-legacy Cursor usage-based plans still show Total/Auto/API bars as before, and fetching/auth/cookie import paths are unchanged.