### PR TITLE
Add Kimi Code API usage source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Localization: add Turkish as a selectable app language (#1232). Thanks @ykarateke!
 - Devin: add daily and weekly quota tracking from the signed-in Chrome session or a manual Bearer token (#1264, fixes #800). Thanks @coygeek!
 - Amp: add local `amp usage` support, including account identity and individual and workspace credit balances (fixes #1317). Thanks @3kh0!
+- Kimi: add usage fetching from the official Code API key flow, with optional compatible HTTPS proxy support (#1424). Thanks @kiranmagic7!
 - Menu bar: add an optional reset-time display for the selected quota metric, with percent fallback when reset metadata is unavailable (#1223, fixes #1185). Thanks @Yuxin-Qiao!
 - Cursor: include application data, extensions, settings, and caches in optional local storage tracking (fixes #1403). Thanks @dhruv-anand-aintech!
 - Menu bar: move the highlighted Overview provider with trackpad or mouse-wheel scrolling while preserving native submenu and keyboard behavior (#1436). Thanks @joshuavial!

--- a/Sources/CodexBar/Providers/Kimi/KimiProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Kimi/KimiProviderImplementation.swift
@@ -105,7 +105,7 @@ struct KimiProviderImplementation: ProviderImplementation {
             ProviderSettingsFieldDescriptor(
                 id: "kimi-api-key",
                 title: "API key",
-                subtitle: "Stored in ~/.codexbar/config.json. You can also provide KIMI_API_KEY.",
+                subtitle: "Stored in ~/.codexbar/config.json. You can also provide KIMI_CODE_API_KEY.",
                 kind: .secure,
                 placeholder: "Paste Kimi Code API key...",
                 binding: context.stringBinding(\.kimiAPIKey),

--- a/Sources/CodexBar/Providers/Kimi/KimiProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Kimi/KimiProviderImplementation.swift
@@ -10,7 +10,9 @@ struct KimiProviderImplementation: ProviderImplementation {
 
     @MainActor
     func presentation(context _: ProviderPresentationContext) -> ProviderPresentation {
-        ProviderPresentation { _ in "web" }
+        ProviderPresentation { context in
+            context.store.sourceLabel(for: context.provider)
+        }
     }
 
     @MainActor

--- a/Sources/CodexBar/Providers/Kimi/KimiProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Kimi/KimiProviderImplementation.swift
@@ -15,6 +15,8 @@ struct KimiProviderImplementation: ProviderImplementation {
 
     @MainActor
     func observeSettings(_ settings: SettingsStore) {
+        _ = settings.kimiUsageDataSource
+        _ = settings.kimiAPIKey
         _ = settings.kimiCookieSource
         _ = settings.kimiManualCookieHeader
     }
@@ -25,7 +27,32 @@ struct KimiProviderImplementation: ProviderImplementation {
     }
 
     @MainActor
+    func defaultSourceLabel(context: ProviderSourceLabelContext) -> String? {
+        context.settings.kimiUsageDataSource.rawValue
+    }
+
+    @MainActor
+    func sourceMode(context: ProviderSourceModeContext) -> ProviderSourceMode {
+        switch context.settings.kimiUsageDataSource {
+        case .api: .api
+        case .web: .web
+        case .auto, .cli, .oauth: .auto
+        }
+    }
+
+    @MainActor
     func settingsPickers(context: ProviderSettingsContext) -> [ProviderSettingsPickerDescriptor] {
+        let usageBinding = Binding(
+            get: { context.settings.kimiUsageDataSource.rawValue },
+            set: { raw in
+                context.settings.kimiUsageDataSource = ProviderSourceMode(rawValue: raw) ?? .auto
+            })
+        let usageOptions = [
+            ProviderSettingsPickerOption(id: ProviderSourceMode.auto.rawValue, title: "Auto"),
+            ProviderSettingsPickerOption(id: ProviderSourceMode.api.rawValue, title: "API key"),
+            ProviderSettingsPickerOption(id: ProviderSourceMode.web.rawValue, title: "Browser cookies"),
+        ]
+
         let cookieBinding = Binding(
             get: { context.settings.kimiCookieSource.rawValue },
             set: { raw in
@@ -46,6 +73,19 @@ struct KimiProviderImplementation: ProviderImplementation {
 
         return [
             ProviderSettingsPickerDescriptor(
+                id: "kimi-usage-source",
+                title: "Usage source",
+                subtitle: "Auto uses the Kimi Code API key first, then falls back to browser cookies.",
+                binding: usageBinding,
+                options: usageOptions,
+                isVisible: nil,
+                onChange: nil,
+                trailingText: {
+                    guard context.settings.kimiUsageDataSource == .auto else { return nil }
+                    let label = context.store.sourceLabel(for: .kimi)
+                    return label == "auto" ? nil : label
+                }),
+            ProviderSettingsPickerDescriptor(
                 id: "kimi-cookie-source",
                 title: "Cookie source",
                 subtitle: "Automatic imports browser cookies.",
@@ -60,6 +100,27 @@ struct KimiProviderImplementation: ProviderImplementation {
     @MainActor
     func settingsFields(context: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {
         [
+            ProviderSettingsFieldDescriptor(
+                id: "kimi-api-key",
+                title: "API key",
+                subtitle: "Stored in ~/.codexbar/config.json. You can also provide KIMI_API_KEY.",
+                kind: .secure,
+                placeholder: "Paste Kimi Code API key...",
+                binding: context.stringBinding(\.kimiAPIKey),
+                actions: [
+                    ProviderSettingsActionDescriptor(
+                        id: "kimi-open-api-docs",
+                        title: "Open API docs",
+                        style: .link,
+                        isVisible: nil,
+                        perform: {
+                            if let url = URL(string: "https://www.kimi.com/code/docs/en/") {
+                                NSWorkspace.shared.open(url)
+                            }
+                        }),
+                ],
+                isVisible: nil,
+                onActivate: nil),
             ProviderSettingsFieldDescriptor(
                 id: "kimi-cookie",
                 title: "",

--- a/Sources/CodexBar/Providers/Kimi/KimiSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Kimi/KimiSettingsStore.swift
@@ -2,6 +2,32 @@ import CodexBarCore
 import Foundation
 
 extension SettingsStore {
+    var kimiUsageDataSource: ProviderSourceMode {
+        get { self.configSnapshot.providerConfig(for: .kimi)?.source ?? .auto }
+        set {
+            let source: ProviderSourceMode? = switch newValue {
+            case .auto: .auto
+            case .api: .api
+            case .web: .web
+            case .cli, .oauth: .auto
+            }
+            self.updateProviderConfig(provider: .kimi) { entry in
+                entry.source = source
+            }
+            self.logProviderModeChange(provider: .kimi, field: "usageSource", value: newValue.rawValue)
+        }
+    }
+
+    var kimiAPIKey: String {
+        get { self.configSnapshot.providerConfig(for: .kimi)?.sanitizedAPIKey ?? "" }
+        set {
+            self.updateProviderConfig(provider: .kimi) { entry in
+                entry.apiKey = self.normalizedConfigValue(newValue)
+            }
+            self.logSecretUpdate(provider: .kimi, field: "apiKey", value: newValue)
+        }
+    }
+
     var kimiManualCookieHeader: String {
         get { self.configSnapshot.providerConfig(for: .kimi)?.sanitizedCookieHeader ?? "" }
         set {

--- a/Sources/CodexBarCLI/CLIDiagnoseCommand.swift
+++ b/Sources/CodexBarCLI/CLIDiagnoseCommand.swift
@@ -228,6 +228,8 @@ extension CodexBarCLI {
         environment: [String: String]) -> Bool
     {
         switch provider {
+        case .kimi:
+            KimiSettingsReader.apiKey(environment: environment) != nil
         case .kimik2:
             KimiK2SettingsReader.apiKey(environment: environment) != nil
         case .llmproxy:

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -558,6 +558,12 @@ extension CodexBarCLI {
                 return false
             }
         }
+        if provider == .kimi,
+           sourceMode == .auto,
+           environment.map({ ProviderTokenResolver.kimiAPIToken(environment: $0) != nil }) == true
+        {
+            return false
+        }
         return switch sourceMode {
         case .web:
             true

--- a/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfigValidation.swift
@@ -159,7 +159,8 @@ public enum CodexBarConfigValidator {
                 provider: provider,
                 field: "enterpriseHost",
                 code: "enterprise_host_unused",
-                message: "enterpriseHost is set but only azureopenai, copilot, and llmproxy support enterpriseHost."))
+                message: "enterpriseHost is set but only azureopenai, copilot, kimi, " +
+                    "and llmproxy support enterpriseHost."))
         }
 
         if let tokenAccounts = entry.tokenAccounts, !tokenAccounts.accounts.isEmpty,
@@ -207,7 +208,7 @@ public enum CodexBarConfigValidator {
 
     private static func providerSupportsEnterpriseHost(_ provider: UsageProvider) -> Bool {
         switch provider {
-        case .azureopenai, .copilot, .llmproxy:
+        case .azureopenai, .copilot, .kimi, .llmproxy:
             true
         default:
             false

--- a/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
+++ b/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
@@ -21,6 +21,9 @@ public enum ProviderConfigEnvironment {
         if provider == .azureopenai {
             return self.applyAzureOpenAIOverrides(base: base, config: config)
         }
+        if provider == .kimi {
+            return self.applyKimiOverrides(base: base, config: config)
+        }
         guard let apiKey = config?.sanitizedAPIKey, !apiKey.isEmpty else { return base }
         var env = base
         if let key = self.directAPIKeyEnvironmentKey(for: provider) {
@@ -100,6 +103,8 @@ public enum ProviderConfigEnvironment {
             ElevenLabsSettingsReader.apiKeyEnvironmentKey
         case .moonshot:
             MoonshotSettingsReader.apiKeyEnvironmentKeys.first
+        case .kimi:
+            KimiSettingsReader.apiKeyEnvironmentKeys.first
         case .ollama:
             OllamaAPISettingsReader.apiKeyEnvironmentKeys.first
         case .venice:
@@ -216,6 +221,23 @@ public enum ProviderConfigEnvironment {
         }
         if let baseURL = config?.sanitizedEnterpriseHost {
             env[LLMProxySettingsReader.baseURLEnvironmentKey] = baseURL
+        }
+        return env
+    }
+
+    private static func applyKimiOverrides(
+        base: [String: String],
+        config: ProviderConfig?) -> [String: String]
+    {
+        guard let config else { return base }
+        var env = base
+        if let apiKey = config.sanitizedAPIKey,
+           let key = KimiSettingsReader.apiKeyEnvironmentKeys.first
+        {
+            env[key] = apiKey
+        }
+        if let baseURL = config.sanitizedEnterpriseHost {
+            env[KimiSettingsReader.codeAPIBaseURLEnvironmentKey] = baseURL
         }
         return env
     }

--- a/Sources/CodexBarCore/Providers/Kimi/KimiAPIError.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiAPIError.swift
@@ -3,6 +3,8 @@ import Foundation
 public enum KimiAPIError: LocalizedError, Sendable, Equatable {
     case missingToken
     case invalidToken
+    case missingAPIKey
+    case invalidAPIKey
     case invalidRequest(String)
     case networkError(String)
     case apiError(String)
@@ -14,6 +16,10 @@ public enum KimiAPIError: LocalizedError, Sendable, Equatable {
             "Kimi auth token is missing. Please add your JWT token from the Kimi console."
         case .invalidToken:
             "Kimi auth token is invalid or expired. Please refresh your token."
+        case .missingAPIKey:
+            "Kimi Code API key is missing. Add it in Settings > Providers > Kimi or set KIMI_CODE_API_KEY."
+        case .invalidAPIKey:
+            "Kimi Code API key is invalid or expired. Please refresh your API key."
         case let .invalidRequest(message):
             "Invalid request: \(message)"
         case let .networkError(message):

--- a/Sources/CodexBarCore/Providers/Kimi/KimiModels.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiModels.swift
@@ -4,6 +4,11 @@ struct KimiUsageResponse: Codable {
     let usages: [KimiUsage]
 }
 
+struct KimiCodeAPIUsageResponse: Codable {
+    let usage: KimiUsageDetail
+    let limits: [KimiRateLimit]?
+}
+
 struct KimiUsage: Codable {
     let scope: String
     let detail: KimiUsageDetail

--- a/Sources/CodexBarCore/Providers/Kimi/KimiModels.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiModels.swift
@@ -21,11 +21,71 @@ public struct KimiUsageDetail: Codable, Sendable {
     public let remaining: String?
     public let resetTime: String?
 
+    private enum CodingKeys: String, CodingKey {
+        case limit
+        case used
+        case remaining
+        case resetTime
+        case resetAt
+        case resetTimeSnake = "reset_time"
+        case resetAtSnake = "reset_at"
+    }
+
     public init(limit: String, used: String?, remaining: String?, resetTime: String?) {
         self.limit = limit
         self.used = used
         self.remaining = remaining
         self.resetTime = resetTime
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        guard let limit = Self.stringValue(in: container, forKey: .limit) else {
+            throw DecodingError.keyNotFound(
+                CodingKeys.limit,
+                DecodingError.Context(
+                    codingPath: container.codingPath,
+                    debugDescription: "Kimi usage limit is missing"))
+        }
+
+        self.limit = limit
+        self.used = Self.stringValue(in: container, forKey: .used)
+        self.remaining = Self.stringValue(in: container, forKey: .remaining)
+        self.resetTime =
+            Self.stringValue(in: container, forKey: .resetTime) ??
+            Self.stringValue(in: container, forKey: .resetAt) ??
+            Self.stringValue(in: container, forKey: .resetTimeSnake) ??
+            Self.stringValue(in: container, forKey: .resetAtSnake)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.limit, forKey: .limit)
+        try container.encodeIfPresent(self.used, forKey: .used)
+        try container.encodeIfPresent(self.remaining, forKey: .remaining)
+        try container.encodeIfPresent(self.resetTime, forKey: .resetTime)
+    }
+
+    private static func stringValue(
+        in container: KeyedDecodingContainer<CodingKeys>,
+        forKey key: CodingKeys) -> String?
+    {
+        if let value = try? container.decode(String.self, forKey: key) {
+            return value
+        }
+        if let value = try? container.decode(Int64.self, forKey: key) {
+            return String(value)
+        }
+        if let value = try? container.decode(Double.self, forKey: key) {
+            if value.rounded(.towardZero) == value,
+               value >= Double(Int64.min),
+               value <= Double(Int64.max)
+            {
+                return String(Int64(value))
+            }
+            return String(value)
+        }
+        return nil
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -64,7 +64,7 @@ struct KimiAPIFetchStrategy: ProviderFetchStrategy {
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
         guard let apiKey = Self.resolveToken(environment: context.env) else {
-            throw KimiAPIError.missingToken
+            throw KimiAPIError.missingAPIKey
         }
         let baseURL = try KimiSettingsReader.codeAPIBaseURL(environment: context.env)
         let snapshot = try await KimiUsageFetcher.fetchCodeAPIUsage(
@@ -81,8 +81,8 @@ struct KimiAPIFetchStrategy: ProviderFetchStrategy {
         if let urlError = error as? URLError {
             return urlError.code != .cancelled
         }
-        if case KimiAPIError.missingToken = error { return true }
-        if case KimiAPIError.invalidToken = error { return true }
+        if case KimiAPIError.missingAPIKey = error { return true }
+        if case KimiAPIError.invalidAPIKey = error { return true }
         if case KimiAPIError.apiError = error { return true }
         if error is DecodingError { return true }
         return false

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -66,9 +66,10 @@ struct KimiAPIFetchStrategy: ProviderFetchStrategy {
         guard let apiKey = Self.resolveToken(environment: context.env) else {
             throw KimiAPIError.missingToken
         }
+        let baseURL = try KimiSettingsReader.codeAPIBaseURL(environment: context.env)
         let snapshot = try await KimiUsageFetcher.fetchCodeAPIUsage(
             apiKey: apiKey,
-            baseURL: KimiSettingsReader.codeAPIBaseURL(environment: context.env))
+            baseURL: baseURL)
         return self.makeResult(
             usage: snapshot.toUsageSnapshot(),
             sourceLabel: "api")
@@ -76,10 +77,14 @@ struct KimiAPIFetchStrategy: ProviderFetchStrategy {
 
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
         guard context.sourceMode == .auto else { return false }
+        if error is CancellationError { return false }
+        if let urlError = error as? URLError {
+            return urlError.code != .cancelled
+        }
         if case KimiAPIError.missingToken = error { return true }
         if case KimiAPIError.invalidToken = error { return true }
         if case KimiAPIError.apiError = error { return true }
-        if error is URLError { return true }
+        if error is DecodingError { return true }
         return false
     }
 

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -77,6 +77,7 @@ struct KimiAPIFetchStrategy: ProviderFetchStrategy {
     func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
         guard context.sourceMode == .auto else { return false }
         if case KimiAPIError.missingToken = error { return true }
+        if case KimiAPIError.invalidToken = error { return true }
         if case KimiAPIError.apiError = error { return true }
         if error is URLError { return true }
         return false

--- a/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiProviderDescriptor.swift
@@ -32,12 +32,58 @@ public enum KimiProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "Kimi cost summary is not supported." }),
             fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .web],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [KimiWebFetchStrategy()] })),
+                sourceModes: [.auto, .api, .web],
+                pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "kimi",
                 aliases: ["kimi-ai"],
                 versionDetector: nil))
+    }
+
+    private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {
+        switch context.sourceMode {
+        case .api:
+            [KimiAPIFetchStrategy()]
+        case .web:
+            [KimiWebFetchStrategy()]
+        case .auto:
+            [KimiAPIFetchStrategy(), KimiWebFetchStrategy()]
+        case .cli, .oauth:
+            []
+        }
+    }
+}
+
+struct KimiAPIFetchStrategy: ProviderFetchStrategy {
+    let id: String = "kimi.api"
+    let kind: ProviderFetchKind = .apiToken
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        context.sourceMode == .api || Self.resolveToken(environment: context.env) != nil
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        guard let apiKey = Self.resolveToken(environment: context.env) else {
+            throw KimiAPIError.missingToken
+        }
+        let snapshot = try await KimiUsageFetcher.fetchCodeAPIUsage(
+            apiKey: apiKey,
+            baseURL: KimiSettingsReader.codeAPIBaseURL(environment: context.env))
+        return self.makeResult(
+            usage: snapshot.toUsageSnapshot(),
+            sourceLabel: "api")
+    }
+
+    func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
+        guard context.sourceMode == .auto else { return false }
+        if case KimiAPIError.missingToken = error { return true }
+        if case KimiAPIError.apiError = error { return true }
+        if error is URLError { return true }
+        return false
+    }
+
+    private static func resolveToken(environment: [String: String]) -> String? {
+        ProviderTokenResolver.kimiAPIToken(environment: environment)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
@@ -2,8 +2,8 @@ import Foundation
 
 public enum KimiSettingsReader {
     public static let apiKeyEnvironmentKeys = [
-        "KIMI_API_KEY",
         "KIMI_CODE_API_KEY",
+        "KIMI_API_KEY",
     ]
     public static let codeAPIBaseURLEnvironmentKey = "KIMI_CODE_BASE_URL"
     public static let defaultCodeAPIBaseURL = URL(string: "https://api.kimi.com")!

--- a/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
@@ -24,9 +24,8 @@ public enum KimiSettingsReader {
 
     public static func codeAPIBaseURL(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL {
         guard let raw = self.cleaned(environment[self.codeAPIBaseURLEnvironmentKey]),
-              let url = URL(string: raw),
-              url.scheme != nil,
-              url.host != nil
+              URL(string: raw)?.scheme != nil,
+              let url = ProviderEndpointOverrideValidator().validatedURL(raw)
         else {
             return self.defaultCodeAPIBaseURL
         }

--- a/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
@@ -19,12 +19,17 @@ public enum KimiSettingsReader {
         return nil
     }
 
-    public static func codeAPIBaseURL(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL {
-        guard let raw = self.cleaned(environment[self.codeAPIBaseURLEnvironmentKey]),
-              URL(string: raw)?.scheme != nil,
+    public static func codeAPIBaseURL(
+        environment: [String: String] = ProcessInfo.processInfo.environment) throws -> URL
+    {
+        guard let raw = self.cleaned(environment[self.codeAPIBaseURLEnvironmentKey]) else {
+            return self.defaultCodeAPIBaseURL
+        }
+
+        guard URL(string: raw)?.scheme != nil,
               let url = ProviderEndpointOverrideValidator().validatedURL(raw)
         else {
-            return self.defaultCodeAPIBaseURL
+            throw KimiAPIError.invalidRequest("Kimi Code API base URL must use HTTPS without user info")
         }
         return url
     }

--- a/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
@@ -1,9 +1,36 @@
 import Foundation
 
 public enum KimiSettingsReader {
+    public static let apiKeyEnvironmentKeys = [
+        "KIMI_API_KEY",
+        "KIMI_CODE_API_KEY",
+    ]
+    public static let codeAPIBaseURLEnvironmentKey = "KIMI_CODE_BASE_URL"
+    public static let defaultCodeAPIBaseURL = URL(string: "https://api.kimi.com")!
+
     public static func authToken(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         let raw = environment["KIMI_AUTH_TOKEN"] ?? environment["kimi_auth_token"]
         return self.cleaned(raw)
+    }
+
+    public static func apiKey(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        for key in self.apiKeyEnvironmentKeys {
+            if let value = self.cleaned(environment[key]) {
+                return value
+            }
+        }
+        return nil
+    }
+
+    public static func codeAPIBaseURL(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL {
+        guard let raw = self.cleaned(environment[self.codeAPIBaseURLEnvironmentKey]),
+              let url = URL(string: raw),
+              url.scheme != nil,
+              url.host != nil
+        else {
+            return self.defaultCodeAPIBaseURL
+        }
+        return url
     }
 
     private static func cleaned(_ raw: String?) -> String? {

--- a/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiSettingsReader.swift
@@ -1,10 +1,7 @@
 import Foundation
 
 public enum KimiSettingsReader {
-    public static let apiKeyEnvironmentKeys = [
-        "KIMI_CODE_API_KEY",
-        "KIMI_API_KEY",
-    ]
+    public static let apiKeyEnvironmentKeys = ["KIMI_CODE_API_KEY"]
     public static let codeAPIBaseURLEnvironmentKey = "KIMI_CODE_BASE_URL"
     public static let defaultCodeAPIBaseURL = URL(string: "https://api.kimi.com")!
 

--- a/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
@@ -18,7 +18,11 @@ public struct KimiUsageFetcher: Sendable {
             throw KimiAPIError.missingToken
         }
 
-        let endpoint = self.codeAPIUsageEndpoint(baseURL: baseURL)
+        guard let validatedBaseURL = ProviderEndpointOverrideValidator().validatedURL(baseURL.absoluteString) else {
+            throw KimiAPIError.invalidRequest("Kimi Code API base URL must use HTTPS without user info")
+        }
+
+        let endpoint = self.codeAPIUsageEndpoint(baseURL: validatedBaseURL)
         var request = URLRequest(url: endpoint)
         request.httpMethod = "GET"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")

--- a/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
@@ -9,6 +9,43 @@ public struct KimiUsageFetcher: Sendable {
     private static let usageURL =
         URL(string: "https://www.kimi.com/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages")!
 
+    public static func fetchCodeAPIUsage(
+        apiKey: String,
+        baseURL: URL = KimiSettingsReader.defaultCodeAPIBaseURL,
+        now: Date = Date()) async throws -> KimiUsageSnapshot
+    {
+        guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw KimiAPIError.missingToken
+        }
+
+        let endpoint = baseURL.appendingPathComponent("coding/v1/usages")
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let response = try await ProviderHTTPClient.shared.response(for: request)
+        let data = response.data
+        guard response.statusCode == 200 else {
+            let responseBody = String(data: data, encoding: .utf8) ?? "<binary data>"
+            Self.log.error("Kimi Code API returned \(response.statusCode): \(responseBody)")
+
+            if response.statusCode == 401 || response.statusCode == 403 {
+                throw KimiAPIError.invalidToken
+            }
+            if response.statusCode == 400 {
+                throw KimiAPIError.invalidRequest("Bad request")
+            }
+            throw KimiAPIError.apiError("HTTP \(response.statusCode)")
+        }
+
+        return try self.parseCodeAPIUsage(from: data, now: now)
+    }
+
+    static func _parseCodeAPIUsageForTesting(_ data: Data, now: Date = Date()) throws -> KimiUsageSnapshot {
+        try self.parseCodeAPIUsage(from: data, now: now)
+    }
+
     public static func fetchUsage(authToken: String, now: Date = Date()) async throws -> KimiUsageSnapshot {
         // Decode JWT to get session info
         let sessionInfo = self.decodeSessionInfo(from: authToken)
@@ -72,6 +109,14 @@ public struct KimiUsageFetcher: Sendable {
         return KimiUsageSnapshot(
             weekly: codingUsage.detail,
             rateLimit: codingUsage.limits?.first?.detail,
+            updatedAt: now)
+    }
+
+    private static func parseCodeAPIUsage(from data: Data, now: Date) throws -> KimiUsageSnapshot {
+        let response = try JSONDecoder().decode(KimiCodeAPIUsageResponse.self, from: data)
+        return KimiUsageSnapshot(
+            weekly: response.usage,
+            rateLimit: response.limits?.first?.detail,
             updatedAt: now)
     }
 

--- a/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
@@ -18,7 +18,7 @@ public struct KimiUsageFetcher: Sendable {
             throw KimiAPIError.missingToken
         }
 
-        let endpoint = baseURL.appendingPathComponent("coding/v1/usages")
+        let endpoint = self.codeAPIUsageEndpoint(baseURL: baseURL)
         var request = URLRequest(url: endpoint)
         request.httpMethod = "GET"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
@@ -44,6 +44,10 @@ public struct KimiUsageFetcher: Sendable {
 
     static func _parseCodeAPIUsageForTesting(_ data: Data, now: Date = Date()) throws -> KimiUsageSnapshot {
         try self.parseCodeAPIUsage(from: data, now: now)
+    }
+
+    static func _codeAPIUsageEndpointForTesting(baseURL: URL) -> URL {
+        self.codeAPIUsageEndpoint(baseURL: baseURL)
     }
 
     public static func fetchUsage(authToken: String, now: Date = Date()) async throws -> KimiUsageSnapshot {
@@ -118,6 +122,18 @@ public struct KimiUsageFetcher: Sendable {
             weekly: response.usage,
             rateLimit: response.limits?.first?.detail,
             updatedAt: now)
+    }
+
+    private static func codeAPIUsageEndpoint(baseURL: URL) -> URL {
+        let normalizedPath = baseURL.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        if normalizedPath.hasSuffix("coding/v1") {
+            return baseURL.appendingPathComponent("usages")
+        }
+
+        return baseURL
+            .appendingPathComponent("coding")
+            .appendingPathComponent("v1")
+            .appendingPathComponent("usages")
     }
 
     private static func decodeSessionInfo(from jwt: String) -> SessionInfo? {

--- a/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
@@ -15,7 +15,7 @@ public struct KimiUsageFetcher: Sendable {
         now: Date = Date()) async throws -> KimiUsageSnapshot
     {
         guard !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw KimiAPIError.missingToken
+            throw KimiAPIError.missingAPIKey
         }
 
         guard let validatedBaseURL = ProviderEndpointOverrideValidator().validatedURL(baseURL.absoluteString) else {
@@ -33,14 +33,7 @@ public struct KimiUsageFetcher: Sendable {
         guard response.statusCode == 200 else {
             let responseBody = String(data: data, encoding: .utf8) ?? "<binary data>"
             Self.log.error("Kimi Code API returned \(response.statusCode): \(responseBody)")
-
-            if response.statusCode == 401 || response.statusCode == 403 {
-                throw KimiAPIError.invalidToken
-            }
-            if response.statusCode == 400 {
-                throw KimiAPIError.invalidRequest("Bad request")
-            }
-            throw KimiAPIError.apiError("HTTP \(response.statusCode)")
+            throw self.codeAPIError(statusCode: response.statusCode)
         }
 
         return try self.parseCodeAPIUsage(from: data, now: now)
@@ -52,6 +45,10 @@ public struct KimiUsageFetcher: Sendable {
 
     static func _codeAPIUsageEndpointForTesting(baseURL: URL) -> URL {
         self.codeAPIUsageEndpoint(baseURL: baseURL)
+    }
+
+    static func _codeAPIErrorForTesting(statusCode: Int) -> KimiAPIError {
+        self.codeAPIError(statusCode: statusCode)
     }
 
     public static func fetchUsage(authToken: String, now: Date = Date()) async throws -> KimiUsageSnapshot {
@@ -143,6 +140,19 @@ public struct KimiUsageFetcher: Sendable {
             .appendingPathComponent("coding")
             .appendingPathComponent("v1")
             .appendingPathComponent("usages")
+    }
+
+    private static func codeAPIError(statusCode: Int) -> KimiAPIError {
+        switch statusCode {
+        case 400:
+            .invalidRequest("Bad request")
+        case 401:
+            .invalidAPIKey
+        case 403:
+            .apiError("HTTP 403 (permission or quota denied)")
+        default:
+            .apiError("HTTP \(statusCode)")
+        }
     }
 
     private static func decodeSessionInfo(from jwt: String) -> SessionInfo? {

--- a/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Kimi/KimiUsageFetcher.swift
@@ -130,8 +130,13 @@ public struct KimiUsageFetcher: Sendable {
 
     private static func codeAPIUsageEndpoint(baseURL: URL) -> URL {
         let normalizedPath = baseURL.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        if normalizedPath.hasSuffix("coding/v1") {
+        if normalizedPath == "coding/v1" || normalizedPath.hasSuffix("/coding/v1") {
             return baseURL.appendingPathComponent("usages")
+        }
+        if normalizedPath == "coding" || normalizedPath.hasSuffix("/coding") {
+            return baseURL
+                .appendingPathComponent("v1")
+                .appendingPathComponent("usages")
         }
 
         return baseURL

--- a/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
+++ b/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
@@ -68,6 +68,10 @@ public enum ProviderTokenResolver {
         self.kimiAuthResolution(environment: environment)?.token
     }
 
+    public static func kimiAPIToken(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        self.kimiAPIResolution(environment: environment)?.token
+    }
+
     public static func kimiK2Token(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         self.kimiK2Resolution(environment: environment)?.token
     }
@@ -269,6 +273,12 @@ public enum ProviderTokenResolver {
         }
         #endif
         return nil
+    }
+
+    public static func kimiAPIResolution(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
+    {
+        self.resolveEnv(KimiSettingsReader.apiKey(environment: environment))
     }
 
     public static func kimiK2Resolution(

--- a/Tests/CodexBarTests/CLIConfigCommandTests.swift
+++ b/Tests/CodexBarTests/CLIConfigCommandTests.swift
@@ -80,6 +80,7 @@ struct CLIConfigCommandTests {
         #expect(ProviderConfigEnvironment.supportsAPIKeyOverride(for: .llmproxy))
         #expect(ProviderConfigEnvironment.supportsAPIKeyOverride(for: .openai))
         #expect(ProviderConfigEnvironment.supportsAPIKeyOverride(for: .amp))
+        #expect(ProviderConfigEnvironment.supportsAPIKeyOverride(for: .kimi))
         #expect(!ProviderConfigEnvironment.supportsAPIKeyOverride(for: .bedrock))
         #expect(!ProviderConfigEnvironment.supportsAPIKeyOverride(for: .deepseek))
         #expect(!ProviderConfigEnvironment.supportsAPIKeyOverride(for: .cursor))

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -323,6 +323,6 @@ final class CLIEntryTests: XCTestCase {
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(
             .auto,
             provider: .kimi,
-            environment: ["KIMI_API_KEY": "kimi-test"]))
+            environment: ["KIMI_CODE_API_KEY": "kimi-test"]))
     }
 }

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -320,5 +320,9 @@ final class CLIEntryTests: XCTestCase {
             provider: .ollama,
             settings: ProviderSettingsSnapshot.make(
                 ollama: .init(cookieSource: .off, manualCookieHeader: nil))))
+        XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .kimi,
+            environment: ["KIMI_API_KEY": "kimi-test"]))
     }
 }

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -11,6 +11,34 @@ struct KimiSettingsReaderTests {
     }
 
     @Test
+    func `reads API key from preferred environment variable`() {
+        let env = ["KIMI_API_KEY": "kimi-api-token"]
+        let token = KimiSettingsReader.apiKey(environment: env)
+        #expect(token == "kimi-api-token")
+    }
+
+    @Test
+    func `reads API key from code specific environment variable`() {
+        let env = ["KIMI_CODE_API_KEY": "'kimi-code-token'"]
+        let token = KimiSettingsReader.apiKey(environment: env)
+        #expect(token == "kimi-code-token")
+    }
+
+    @Test
+    func `uses custom code API base URL when valid`() {
+        let env = ["KIMI_CODE_BASE_URL": "https://proxy.example.com/kimi"]
+        let url = KimiSettingsReader.codeAPIBaseURL(environment: env)
+        #expect(url.absoluteString == "https://proxy.example.com/kimi")
+    }
+
+    @Test
+    func `falls back to default code API base URL when invalid`() {
+        let env = ["KIMI_CODE_BASE_URL": "not a url"]
+        let url = KimiSettingsReader.codeAPIBaseURL(environment: env)
+        #expect(url == KimiSettingsReader.defaultCodeAPIBaseURL)
+    }
+
+    @Test
     func `normalizes quoted token`() {
         let env = ["KIMI_AUTH_TOKEN": "\"test.jwt.token\""]
         let token = KimiSettingsReader.authToken(environment: env)
@@ -133,6 +161,40 @@ struct KimiUsageResponseParsingTests {
 
         let response = try JSONDecoder().decode(KimiUsageResponse.self, from: Data(json.utf8))
         #expect(response.usages.first?.limits == nil)
+    }
+
+    @Test
+    func `parses code API usage response`() throws {
+        let json = """
+        {
+          "usage": {
+            "limit": "2048",
+            "used": "375",
+            "remaining": "1673",
+            "resetTime": "2026-01-09T15:23:13.373329235Z"
+          },
+          "limits": [
+            {
+              "window": {
+                "duration": 300,
+                "timeUnit": "TIME_UNIT_MINUTE"
+              },
+              "detail": {
+                "limit": "200",
+                "used": "19",
+                "remaining": "181",
+                "resetTime": "2026-01-06T15:05:24.374187075Z"
+              }
+            }
+          ]
+        }
+        """
+
+        let snapshot = try KimiUsageFetcher._parseCodeAPIUsageForTesting(Data(json.utf8))
+        #expect(snapshot.weekly.limit == "2048")
+        #expect(snapshot.weekly.used == "375")
+        #expect(snapshot.rateLimit?.limit == "200")
+        #expect(snapshot.rateLimit?.used == "19")
     }
 
     @Test

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -65,31 +65,49 @@ struct KimiSettingsReaderTests {
     }
 
     @Test
-    func `uses custom code API base URL when valid`() {
+    func `uses default code API base URL when override is absent`() throws {
+        let url = try KimiSettingsReader.codeAPIBaseURL(environment: [:])
+        #expect(url == KimiSettingsReader.defaultCodeAPIBaseURL)
+    }
+
+    @Test
+    func `uses custom code API base URL when valid`() throws {
         let env = ["KIMI_CODE_BASE_URL": "https://proxy.example.com/kimi"]
-        let url = KimiSettingsReader.codeAPIBaseURL(environment: env)
+        let url = try KimiSettingsReader.codeAPIBaseURL(environment: env)
         #expect(url.absoluteString == "https://proxy.example.com/kimi")
     }
 
     @Test
-    func `falls back to default code API base URL when invalid`() {
+    func `rejects invalid code API base URL`() {
         let env = ["KIMI_CODE_BASE_URL": "not a url"]
-        let url = KimiSettingsReader.codeAPIBaseURL(environment: env)
-        #expect(url == KimiSettingsReader.defaultCodeAPIBaseURL)
+
+        #expect(throws: KimiAPIError.invalidRequest(
+            "Kimi Code API base URL must use HTTPS without user info"))
+        {
+            try KimiSettingsReader.codeAPIBaseURL(environment: env)
+        }
     }
 
     @Test
-    func `falls back to default code API base URL when insecure`() {
+    func `rejects insecure code API base URL`() {
         let env = ["KIMI_CODE_BASE_URL": "http://proxy.example.com/kimi"]
-        let url = KimiSettingsReader.codeAPIBaseURL(environment: env)
-        #expect(url == KimiSettingsReader.defaultCodeAPIBaseURL)
+
+        #expect(throws: KimiAPIError.invalidRequest(
+            "Kimi Code API base URL must use HTTPS without user info"))
+        {
+            try KimiSettingsReader.codeAPIBaseURL(environment: env)
+        }
     }
 
     @Test
-    func `falls back to default code API base URL when URL contains user info`() {
+    func `rejects code API base URL containing user info`() {
         let env = ["KIMI_CODE_BASE_URL": "https://api.kimi.com@proxy.example.com/kimi"]
-        let url = KimiSettingsReader.codeAPIBaseURL(environment: env)
-        #expect(url == KimiSettingsReader.defaultCodeAPIBaseURL)
+
+        #expect(throws: KimiAPIError.invalidRequest(
+            "Kimi Code API base URL must use HTTPS without user info"))
+        {
+            try KimiSettingsReader.codeAPIBaseURL(environment: env)
+        }
     }
 
     @Test
@@ -136,6 +154,35 @@ struct KimiAPIFetchStrategyTests {
         let context = makeKimiFetchContext(sourceMode: .api)
 
         #expect(strategy.shouldFallback(on: KimiAPIError.invalidToken, context: context) == false)
+    }
+
+    @Test
+    func `auto mode falls back from API response decoding failure`() {
+        let strategy = KimiAPIFetchStrategy()
+        let context = makeKimiFetchContext(sourceMode: .auto)
+        let error = DecodingError.dataCorrupted(
+            DecodingError.Context(codingPath: [], debugDescription: "Unexpected Kimi payload"))
+
+        #expect(strategy.shouldFallback(on: error, context: context))
+    }
+
+    @Test
+    func `explicit API mode surfaces response decoding failure`() {
+        let strategy = KimiAPIFetchStrategy()
+        let context = makeKimiFetchContext(sourceMode: .api)
+        let error = DecodingError.dataCorrupted(
+            DecodingError.Context(codingPath: [], debugDescription: "Unexpected Kimi payload"))
+
+        #expect(strategy.shouldFallback(on: error, context: context) == false)
+    }
+
+    @Test
+    func `auto mode does not start web fallback after cancellation`() {
+        let strategy = KimiAPIFetchStrategy()
+        let context = makeKimiFetchContext(sourceMode: .auto)
+
+        #expect(strategy.shouldFallback(on: CancellationError(), context: context) == false)
+        #expect(strategy.shouldFallback(on: URLError(.cancelled), context: context) == false)
     }
 }
 
@@ -267,6 +314,44 @@ struct KimiUsageResponseParsingTests {
         #expect(snapshot.weekly.used == "375")
         #expect(snapshot.rateLimit?.limit == "200")
         #expect(snapshot.rateLimit?.used == "19")
+    }
+
+    @Test
+    func `parses official numeric values and reset key variants`() throws {
+        let json = """
+        {
+          "usage": {
+            "limit": 1000,
+            "used": 40,
+            "remaining": 960,
+            "resetAt": "2026-01-09T15:23:13Z"
+          },
+          "limits": [
+            {
+              "window": {
+                "duration": 300,
+                "timeUnit": "TIME_UNIT_MINUTE"
+              },
+              "detail": {
+                "limit": 100,
+                "remaining": 99,
+                "reset_at": "2026-01-06T13:33:02Z"
+              }
+            }
+          ]
+        }
+        """
+
+        let snapshot = try KimiUsageFetcher._parseCodeAPIUsageForTesting(Data(json.utf8))
+
+        #expect(snapshot.weekly.limit == "1000")
+        #expect(snapshot.weekly.used == "40")
+        #expect(snapshot.weekly.remaining == "960")
+        #expect(snapshot.weekly.resetTime == "2026-01-09T15:23:13Z")
+        #expect(snapshot.rateLimit?.limit == "100")
+        #expect(snapshot.rateLimit?.used == nil)
+        #expect(snapshot.rateLimit?.remaining == "99")
+        #expect(snapshot.rateLimit?.resetTime == "2026-01-06T13:33:02Z")
     }
 
     @Test

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -292,6 +292,14 @@ struct KimiUsageResponseParsingTests {
     }
 
     @Test
+    func `does not duplicate coding path prefix`() throws {
+        let baseURL = try #require(URL(string: "https://proxy.example.com/kimi/coding/"))
+        let endpoint = KimiUsageFetcher._codeAPIUsageEndpointForTesting(baseURL: baseURL)
+
+        #expect(endpoint.absoluteString == "https://proxy.example.com/kimi/coding/v1/usages")
+    }
+
+    @Test
     func `rejects insecure code API base URL before sending bearer token`() async throws {
         let baseURL = try #require(URL(string: "http://proxy.example.com/kimi"))
 

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -2,6 +2,36 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
+private struct KimiStubClaudeFetcher: ClaudeUsageFetching {
+    func loadLatestUsage(model _: String) async throws -> ClaudeUsageSnapshot {
+        throw ClaudeUsageError.parseFailed("stub")
+    }
+
+    func debugRawProbe(model _: String) async -> String {
+        "stub"
+    }
+
+    func detectVersion() -> String? {
+        nil
+    }
+}
+
+private func makeKimiFetchContext(sourceMode: ProviderSourceMode) -> ProviderFetchContext {
+    let env: [String: String] = [:]
+    return ProviderFetchContext(
+        runtime: .app,
+        sourceMode: sourceMode,
+        includeCredits: false,
+        webTimeout: 1,
+        webDebugDumpHTML: false,
+        verbose: false,
+        env: env,
+        settings: nil,
+        fetcher: UsageFetcher(environment: env),
+        claudeFetcher: KimiStubClaudeFetcher(),
+        browserDetection: BrowserDetection(cacheTTL: 0))
+}
+
 struct KimiSettingsReaderTests {
     @Test
     func `reads token from environment variable`() {
@@ -64,6 +94,24 @@ struct KimiSettingsReaderTests {
         let env = ["kimi_auth_token": "test.jwt.token"]
         let token = KimiSettingsReader.authToken(environment: env)
         #expect(token == "test.jwt.token")
+    }
+}
+
+struct KimiAPIFetchStrategyTests {
+    @Test
+    func `auto mode falls back from invalid API key to web cookies`() {
+        let strategy = KimiAPIFetchStrategy()
+        let context = makeKimiFetchContext(sourceMode: .auto)
+
+        #expect(strategy.shouldFallback(on: KimiAPIError.invalidToken, context: context))
+    }
+
+    @Test
+    func `explicit API mode does not fall back from invalid API key`() {
+        let strategy = KimiAPIFetchStrategy()
+        let context = makeKimiFetchContext(sourceMode: .api)
+
+        #expect(strategy.shouldFallback(on: KimiAPIError.invalidToken, context: context) == false)
     }
 }
 
@@ -195,6 +243,38 @@ struct KimiUsageResponseParsingTests {
         #expect(snapshot.weekly.used == "375")
         #expect(snapshot.rateLimit?.limit == "200")
         #expect(snapshot.rateLimit?.used == "19")
+    }
+
+    @Test
+    func `builds default code API usage endpoint`() throws {
+        let baseURL = try #require(URL(string: "https://api.kimi.com"))
+        let endpoint = KimiUsageFetcher._codeAPIUsageEndpointForTesting(baseURL: baseURL)
+
+        #expect(endpoint.absoluteString == "https://api.kimi.com/coding/v1/usages")
+    }
+
+    @Test
+    func `appends code API path to custom proxy root`() throws {
+        let baseURL = try #require(URL(string: "https://proxy.example.com/kimi"))
+        let endpoint = KimiUsageFetcher._codeAPIUsageEndpointForTesting(baseURL: baseURL)
+
+        #expect(endpoint.absoluteString == "https://proxy.example.com/kimi/coding/v1/usages")
+    }
+
+    @Test
+    func `does not duplicate code API path when base URL already includes it`() throws {
+        let baseURL = try #require(URL(string: "https://api.kimi.com/coding/v1"))
+        let endpoint = KimiUsageFetcher._codeAPIUsageEndpointForTesting(baseURL: baseURL)
+
+        #expect(endpoint.absoluteString == "https://api.kimi.com/coding/v1/usages")
+    }
+
+    @Test
+    func `does not duplicate code API path with trailing slash`() throws {
+        let baseURL = try #require(URL(string: "https://proxy.example.com/kimi/coding/v1/"))
+        let endpoint = KimiUsageFetcher._codeAPIUsageEndpointForTesting(baseURL: baseURL)
+
+        #expect(endpoint.absoluteString == "https://proxy.example.com/kimi/coding/v1/usages")
     }
 
     @Test

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -48,14 +48,14 @@ struct KimiSettingsReaderTests {
     }
 
     @Test
-    func `falls back to generic API key environment variable`() {
+    func `does not consume generic Kimi K2 API key environment variable`() {
         let env = ["KIMI_API_KEY": "'kimi-api-token'"]
         let token = KimiSettingsReader.apiKey(environment: env)
-        #expect(token == "kimi-api-token")
+        #expect(token == nil)
     }
 
     @Test
-    func `prefers code specific API key over generic Kimi key`() {
+    func `uses code specific API key when generic Kimi K2 key also exists`() {
         let env = [
             "KIMI_API_KEY": "generic-kimi-token",
             "KIMI_CODE_API_KEY": "kimi-code-token",

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -42,14 +42,24 @@ struct KimiSettingsReaderTests {
 
     @Test
     func `reads API key from preferred environment variable`() {
-        let env = ["KIMI_API_KEY": "kimi-api-token"]
+        let env = ["KIMI_CODE_API_KEY": "kimi-code-token"]
+        let token = KimiSettingsReader.apiKey(environment: env)
+        #expect(token == "kimi-code-token")
+    }
+
+    @Test
+    func `falls back to generic API key environment variable`() {
+        let env = ["KIMI_API_KEY": "'kimi-api-token'"]
         let token = KimiSettingsReader.apiKey(environment: env)
         #expect(token == "kimi-api-token")
     }
 
     @Test
-    func `reads API key from code specific environment variable`() {
-        let env = ["KIMI_CODE_API_KEY": "'kimi-code-token'"]
+    func `prefers code specific API key over generic Kimi key`() {
+        let env = [
+            "KIMI_API_KEY": "generic-kimi-token",
+            "KIMI_CODE_API_KEY": "kimi-code-token",
+        ]
         let token = KimiSettingsReader.apiKey(environment: env)
         #expect(token == "kimi-code-token")
     }

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -145,7 +145,7 @@ struct KimiAPIFetchStrategyTests {
         let strategy = KimiAPIFetchStrategy()
         let context = makeKimiFetchContext(sourceMode: .auto)
 
-        #expect(strategy.shouldFallback(on: KimiAPIError.invalidToken, context: context))
+        #expect(strategy.shouldFallback(on: KimiAPIError.invalidAPIKey, context: context))
     }
 
     @Test
@@ -153,7 +153,17 @@ struct KimiAPIFetchStrategyTests {
         let strategy = KimiAPIFetchStrategy()
         let context = makeKimiFetchContext(sourceMode: .api)
 
-        #expect(strategy.shouldFallback(on: KimiAPIError.invalidToken, context: context) == false)
+        #expect(strategy.shouldFallback(on: KimiAPIError.invalidAPIKey, context: context) == false)
+    }
+
+    @Test
+    func `explicit API mode reports API key remediation when key is missing`() async {
+        let strategy = KimiAPIFetchStrategy()
+        let context = makeKimiFetchContext(sourceMode: .api)
+
+        await #expect(throws: KimiAPIError.missingAPIKey) {
+            try await strategy.fetch(context)
+        }
     }
 
     @Test
@@ -406,6 +416,14 @@ struct KimiUsageResponseParsingTests {
     }
 
     @Test
+    func `maps code API authentication and permission errors separately`() {
+        #expect(KimiUsageFetcher._codeAPIErrorForTesting(statusCode: 401) == .invalidAPIKey)
+        #expect(
+            KimiUsageFetcher._codeAPIErrorForTesting(statusCode: 403)
+                == .apiError("HTTP 403 (permission or quota denied)"))
+    }
+
+    @Test
     func `throws on invalid json`() {
         let invalidJson = "{ invalid json }"
 
@@ -573,6 +591,9 @@ struct KimiAPIErrorTests {
     func `error descriptions are helpful`() {
         #expect(KimiAPIError.missingToken.errorDescription?.contains("missing") == true)
         #expect(KimiAPIError.invalidToken.errorDescription?.contains("invalid") == true)
+        #expect(KimiAPIError.missingAPIKey.errorDescription?.contains("Settings > Providers > Kimi") == true)
+        #expect(KimiAPIError.missingAPIKey.errorDescription?.contains("KIMI_CODE_API_KEY") == true)
+        #expect(KimiAPIError.invalidAPIKey.errorDescription?.contains("API key") == true)
         #expect(KimiAPIError.invalidRequest("Bad request").errorDescription?.contains("Bad request") == true)
         #expect(KimiAPIError.networkError("Timeout").errorDescription?.contains("Timeout") == true)
         #expect(KimiAPIError.apiError("HTTP 500").errorDescription?.contains("HTTP 500") == true)

--- a/Tests/CodexBarTests/KimiProviderTests.swift
+++ b/Tests/CodexBarTests/KimiProviderTests.swift
@@ -69,6 +69,20 @@ struct KimiSettingsReaderTests {
     }
 
     @Test
+    func `falls back to default code API base URL when insecure`() {
+        let env = ["KIMI_CODE_BASE_URL": "http://proxy.example.com/kimi"]
+        let url = KimiSettingsReader.codeAPIBaseURL(environment: env)
+        #expect(url == KimiSettingsReader.defaultCodeAPIBaseURL)
+    }
+
+    @Test
+    func `falls back to default code API base URL when URL contains user info`() {
+        let env = ["KIMI_CODE_BASE_URL": "https://api.kimi.com@proxy.example.com/kimi"]
+        let url = KimiSettingsReader.codeAPIBaseURL(environment: env)
+        #expect(url == KimiSettingsReader.defaultCodeAPIBaseURL)
+    }
+
+    @Test
     func `normalizes quoted token`() {
         let env = ["KIMI_AUTH_TOKEN": "\"test.jwt.token\""]
         let token = KimiSettingsReader.authToken(environment: env)
@@ -275,6 +289,17 @@ struct KimiUsageResponseParsingTests {
         let endpoint = KimiUsageFetcher._codeAPIUsageEndpointForTesting(baseURL: baseURL)
 
         #expect(endpoint.absoluteString == "https://proxy.example.com/kimi/coding/v1/usages")
+    }
+
+    @Test
+    func `rejects insecure code API base URL before sending bearer token`() async throws {
+        let baseURL = try #require(URL(string: "http://proxy.example.com/kimi"))
+
+        await #expect(throws: KimiAPIError.invalidRequest(
+            "Kimi Code API base URL must use HTTPS without user info"))
+        {
+            _ = try await KimiUsageFetcher.fetchCodeAPIUsage(apiKey: "secret-token", baseURL: baseURL)
+        }
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
+++ b/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
@@ -78,6 +78,23 @@ struct ProviderConfigEnvironmentTests {
     }
 
     @Test
+    func `applies Kimi API key and base URL config overrides`() {
+        let config = ProviderConfig(
+            id: .kimi,
+            apiKey: "kimi-api-token",
+            enterpriseHost: "https://proxy.example.com/kimi")
+        let env = ProviderConfigEnvironment.applyProviderConfigOverrides(
+            base: [:],
+            provider: .kimi,
+            config: config)
+
+        #expect(env[KimiSettingsReader.apiKeyEnvironmentKeys[0]] == "kimi-api-token")
+        #expect(env[KimiSettingsReader.codeAPIBaseURLEnvironmentKey] == "https://proxy.example.com/kimi")
+        #expect(ProviderTokenResolver.kimiAPIToken(environment: env) == "kimi-api-token")
+        #expect(KimiSettingsReader.codeAPIBaseURL(environment: env).absoluteString == "https://proxy.example.com/kimi")
+    }
+
+    @Test
     func `applies API key override for elevenlabs`() {
         let config = ProviderConfig(id: .elevenlabs, apiKey: "xi-token")
         let env = ProviderConfigEnvironment.applyAPIKeyOverride(

--- a/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
+++ b/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
@@ -88,7 +88,8 @@ struct ProviderConfigEnvironmentTests {
             provider: .kimi,
             config: config)
 
-        #expect(env[KimiSettingsReader.apiKeyEnvironmentKeys[0]] == "kimi-api-token")
+        #expect(env["KIMI_CODE_API_KEY"] == "kimi-api-token")
+        #expect(env["KIMI_API_KEY"] == nil)
         #expect(env[KimiSettingsReader.codeAPIBaseURLEnvironmentKey] == "https://proxy.example.com/kimi")
         #expect(ProviderTokenResolver.kimiAPIToken(environment: env) == "kimi-api-token")
         #expect(KimiSettingsReader.codeAPIBaseURL(environment: env).absoluteString == "https://proxy.example.com/kimi")

--- a/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
+++ b/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
@@ -78,7 +78,7 @@ struct ProviderConfigEnvironmentTests {
     }
 
     @Test
-    func `applies Kimi API key and base URL config overrides`() {
+    func `applies Kimi API key and base URL config overrides`() throws {
         let config = ProviderConfig(
             id: .kimi,
             apiKey: "kimi-api-token",
@@ -92,7 +92,8 @@ struct ProviderConfigEnvironmentTests {
         #expect(env["KIMI_API_KEY"] == nil)
         #expect(env[KimiSettingsReader.codeAPIBaseURLEnvironmentKey] == "https://proxy.example.com/kimi")
         #expect(ProviderTokenResolver.kimiAPIToken(environment: env) == "kimi-api-token")
-        #expect(KimiSettingsReader.codeAPIBaseURL(environment: env).absoluteString == "https://proxy.example.com/kimi")
+        #expect(try KimiSettingsReader.codeAPIBaseURL(environment: env).absoluteString ==
+            "https://proxy.example.com/kimi")
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -196,6 +196,20 @@ struct ProviderSettingsDescriptorTests {
     }
 
     @Test
+    func `kimi presentation follows selected source label`() throws {
+        let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-kimi-presentation")
+        fixture.settings.kimiUsageDataSource = .api
+        let metadata = try #require(ProviderDescriptorRegistry.metadata[.kimi])
+        let context = fixture.presentationContext(provider: .kimi, metadata: metadata)
+
+        let detailLine = KimiProviderImplementation()
+            .presentation(context: context)
+            .detailLine(context)
+
+        #expect(detailLine == "api")
+    }
+
+    @Test
     func `deepgram exposes api key and project id fields`() throws {
         let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-deepgram")
         let context = fixture.settingsContext(provider: .deepgram)

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -181,6 +181,21 @@ struct ProviderSettingsDescriptorTests {
     }
 
     @Test
+    func `kimi exposes usage source picker plus api and cookie fields`() throws {
+        let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-kimi")
+        let context = fixture.settingsContext(provider: .kimi)
+
+        let implementation = KimiProviderImplementation()
+        let pickers = implementation.settingsPickers(context: context)
+        let fields = implementation.settingsFields(context: context)
+
+        #expect(pickers.contains(where: { $0.id == "kimi-usage-source" }))
+        #expect(pickers.contains(where: { $0.id == "kimi-cookie-source" }))
+        #expect(fields.contains(where: { $0.id == "kimi-api-key" }))
+        #expect(fields.contains(where: { $0.id == "kimi-cookie" }))
+    }
+
+    @Test
     func `deepgram exposes api key and project id fields`() throws {
         let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-deepgram")
         let context = fixture.settingsContext(provider: .deepgram)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -72,7 +72,7 @@ See `docs/configuration.md` for the schema.
     - `web` (macOS only): web-only where that provider exposes an explicit web source; no CLI/API fallback.
     - `cli`: CLI/local-helper source where the provider exposes one (for example Codex RPC/PTy, Claude PTY, Kilo CLI fallback, Kiro CLI, local probes).
     - `oauth`: OAuth-backed source where supported (Codex, Claude, Vertex AI).
-    - `api`: API-key/token flow when the provider supports it (OpenAI, Claude Admin API, z.ai, Gemini, Alibaba, Copilot, Kilo, Kimi K2, MiniMax, Ollama, Warp, OpenRouter, ElevenLabs, Deepgram, Synthetic, DeepSeek, Moonshot, Doubao, Codebuff, Crof, Venice, AWS Bedrock).
+    - `api`: API-key/token flow when the provider supports it (OpenAI, Claude Admin API, z.ai, Gemini, Alibaba, Copilot, Kilo, Kimi, Kimi K2, MiniMax, Ollama, Warp, OpenRouter, ElevenLabs, Deepgram, Synthetic, DeepSeek, Moonshot, Doubao, Codebuff, Crof, Venice, AWS Bedrock).
     - Output `source` reflects the strategy actually used (`openai-web`, `web`, `oauth`, `api`, `local`, `cli`, or provider CLI label).
     - Codex web: OpenAI web dashboard (usage limits, credits remaining, code review remaining, usage breakdown).
         - `--web-timeout <seconds>` (default: 60)

--- a/docs/kimi.md
+++ b/docs/kimi.md
@@ -14,14 +14,32 @@ Tracks usage for [Kimi For Coding](https://www.kimi.com/code) in CodexBar.
 
 - Displays weekly request quota (from membership tier)
 - Shows current 5-hour rate limit usage
-- Automatic and manual authentication methods
+- API-key, automatic cookie, and manual cookie authentication methods
 - Automatic refresh countdown
 
 ## Setup
 
-Choose one of two authentication methods:
+Choose one of three authentication methods:
 
-### Method 1: Automatic Browser Import (Recommended)
+### Method 1: Kimi Code API Key (Recommended)
+
+Use the API key created by the official Kimi Code flow:
+
+```bash
+kimi login
+codexbar config set-api-key --provider kimi --api-key "kimi-api-key-here"
+```
+
+Or provide it through the environment:
+
+```bash
+export KIMI_API_KEY="kimi-api-key-here"
+```
+
+CodexBar calls `GET https://api.kimi.com/coding/v1/usages` with the API key. Set
+`KIMI_CODE_BASE_URL` only when testing a compatible proxy or alternate host.
+
+### Method 2: Automatic Browser Import
 
 **No setup needed!** If you're already logged in to Kimi in Arc, Chrome, Safari, Edge, Brave, or Chromium:
 
@@ -32,7 +50,7 @@ Choose one of two authentication methods:
 
 **Note**: Requires Full Disk Access to read browser cookies (System Settings → Privacy & Security → Full Disk Access → CodexBar).
 
-### Method 2: Manual Token Entry
+### Method 3: Manual Token Entry
 
 For advanced users or when automatic import fails:
 
@@ -44,7 +62,7 @@ For advanced users or when automatic import fails:
 6. Copy the `kimi-auth` cookie value (JWT token)
 7. Paste it into the "Auth Token" field in CodexBar
 
-### Method 3: Environment Variable
+### Cookie Environment Variable
 
 Alternatively, set the `KIMI_AUTH_TOKEN` environment variable:
 
@@ -56,13 +74,43 @@ export KIMI_AUTH_TOKEN="jwt-token-here"
 
 When multiple sources are available, CodexBar uses this order:
 
-1. Manual token (from Settings UI)
-2. Environment variable (`KIMI_AUTH_TOKEN`)
-3. Browser cookies (Arc → Chrome → Safari → Edge → Brave → Chromium)
+1. API key (`KIMI_API_KEY`, or `providers[].apiKey`) in Auto mode
+2. Manual cookie/token (from Settings UI) when web fallback is used
+3. Cookie environment variable (`KIMI_AUTH_TOKEN`)
+4. Browser cookies (Arc → Chrome → Safari → Edge → Brave → Chromium)
 
 **Note**: Browser cookie import requires Full Disk Access permission.
 
 ## API Details
+
+### Kimi Code API key
+
+**Endpoint**: `GET https://api.kimi.com/coding/v1/usages`
+
+**Authentication**: Bearer token (from `KIMI_API_KEY` or `providers[].apiKey`)
+
+**Response**:
+```json
+{
+  "usage": {
+    "limit": "2048",
+    "used": "214",
+    "remaining": "1834",
+    "resetTime": "2026-01-09T15:23:13.716839300Z"
+  },
+  "limits": [{
+    "window": {"duration": 300, "timeUnit": "TIME_UNIT_MINUTE"},
+    "detail": {
+      "limit": "200",
+      "used": "139",
+      "remaining": "61",
+      "resetTime": "2026-01-06T13:33:02.717479433Z"
+    }
+  }]
+}
+```
+
+### Kimi web cookie fallback
 
 **Endpoint**: `POST https://www.kimi.com/apiv2/kimi.gateway.billing.v1.BillingService/GetUsages`
 

--- a/docs/kimi.md
+++ b/docs/kimi.md
@@ -33,7 +33,7 @@ codexbar config set-api-key --provider kimi --api-key "kimi-api-key-here"
 Or provide it through the environment:
 
 ```bash
-export KIMI_API_KEY="kimi-api-key-here"
+export KIMI_CODE_API_KEY="kimi-code-api-key-here"
 ```
 
 CodexBar calls `GET https://api.kimi.com/coding/v1/usages` with the API key. Set
@@ -74,7 +74,7 @@ export KIMI_AUTH_TOKEN="jwt-token-here"
 
 When multiple sources are available, CodexBar uses this order:
 
-1. API key (`KIMI_API_KEY`, or `providers[].apiKey`) in Auto mode
+1. API key (`providers[].apiKey`, `KIMI_CODE_API_KEY`, or fallback `KIMI_API_KEY`) in Auto mode
 2. Manual cookie/token (from Settings UI) when web fallback is used
 3. Cookie environment variable (`KIMI_AUTH_TOKEN`)
 4. Browser cookies (Arc → Chrome → Safari → Edge → Brave → Chromium)
@@ -87,7 +87,7 @@ When multiple sources are available, CodexBar uses this order:
 
 **Endpoint**: `GET https://api.kimi.com/coding/v1/usages`
 
-**Authentication**: Bearer token (from `KIMI_API_KEY` or `providers[].apiKey`)
+**Authentication**: Bearer token (from `providers[].apiKey`, `KIMI_CODE_API_KEY`, or fallback `KIMI_API_KEY`)
 
 **Response**:
 ```json

--- a/docs/kimi.md
+++ b/docs/kimi.md
@@ -23,10 +23,9 @@ Choose one of three authentication methods:
 
 ### Method 1: Kimi Code API Key (Recommended)
 
-Use the API key created by the official Kimi Code flow:
+Create an API key in the [Kimi Code Console](https://www.kimi.com/code/console), then save it in CodexBar:
 
 ```bash
-kimi login
 codexbar config set-api-key --provider kimi --api-key "kimi-api-key-here"
 ```
 

--- a/docs/kimi.md
+++ b/docs/kimi.md
@@ -37,7 +37,7 @@ export KIMI_API_KEY="kimi-api-key-here"
 ```
 
 CodexBar calls `GET https://api.kimi.com/coding/v1/usages` with the API key. Set
-`KIMI_CODE_BASE_URL` only when testing a compatible proxy or alternate host.
+`KIMI_CODE_BASE_URL` only when testing a compatible HTTPS proxy or alternate host.
 
 ### Method 2: Automatic Browser Import
 

--- a/docs/kimi.md
+++ b/docs/kimi.md
@@ -74,7 +74,7 @@ export KIMI_AUTH_TOKEN="jwt-token-here"
 
 When multiple sources are available, CodexBar uses this order:
 
-1. API key (`providers[].apiKey`, `KIMI_CODE_API_KEY`, or fallback `KIMI_API_KEY`) in Auto mode
+1. API key (`providers[].apiKey` or `KIMI_CODE_API_KEY`) in Auto mode
 2. Manual cookie/token (from Settings UI) when web fallback is used
 3. Cookie environment variable (`KIMI_AUTH_TOKEN`)
 4. Browser cookies (Arc → Chrome → Safari → Edge → Brave → Chromium)
@@ -87,7 +87,7 @@ When multiple sources are available, CodexBar uses this order:
 
 **Endpoint**: `GET https://api.kimi.com/coding/v1/usages`
 
-**Authentication**: Bearer token (from `providers[].apiKey`, `KIMI_CODE_API_KEY`, or fallback `KIMI_API_KEY`)
+**Authentication**: Bearer token (from `providers[].apiKey` or `KIMI_CODE_API_KEY`)
 
 **Response**:
 ```json

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -37,7 +37,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 | z.ai | API token from config/env → quota API (`api`). |
 | Manus | Browser `session_id` cookie (auto/manual/env) → credits API (`web`). |
 | MiniMax | Manual/browser session via Coding Plan web path (`web`), or Coding Plan API token (`api`). |
-| Kimi | Auth token from `kimi-auth` cookie/manual token/env → usage API (`web`). |
+| Kimi | Kimi Code API key (`api`), then `kimi-auth` cookie/manual token/env fallback (`web`). |
 | Kilo | API token from config/env → usage API (`api`); auto falls back to CLI session auth (`cli`). |
 | Copilot | Device-flow/env/config token → `copilot_internal` API (`api`). |
 | Kimi K2 (unofficial) | API key from config/env → legacy credit endpoint (`api`). |
@@ -129,7 +129,8 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Details: `docs/minimax.md`.
 
 ## Kimi
-- Auth token (JWT from `kimi-auth` cookie) via manual entry or `KIMI_AUTH_TOKEN` env var.
+- Kimi Code API key via `~/.codexbar/config.json`, `KIMI_API_KEY`, or `KIMI_CODE_API_KEY`.
+- Web fallback uses the JWT from `kimi-auth` cookie via manual entry or `KIMI_AUTH_TOKEN` env var.
 - Shows weekly quota and 5-hour rate limit (300 minutes).
 - Status: none yet.
 - Details: `docs/kimi.md`.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -129,7 +129,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Details: `docs/minimax.md`.
 
 ## Kimi
-- Kimi Code API key via `~/.codexbar/config.json`, `KIMI_CODE_API_KEY`, or fallback `KIMI_API_KEY`.
+- Kimi Code API key via `~/.codexbar/config.json` or `KIMI_CODE_API_KEY`.
 - Web fallback uses the JWT from `kimi-auth` cookie via manual entry or `KIMI_AUTH_TOKEN` env var.
 - Shows weekly quota and 5-hour rate limit (300 minutes).
 - Status: none yet.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -129,7 +129,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Details: `docs/minimax.md`.
 
 ## Kimi
-- Kimi Code API key via `~/.codexbar/config.json`, `KIMI_API_KEY`, or `KIMI_CODE_API_KEY`.
+- Kimi Code API key via `~/.codexbar/config.json`, `KIMI_CODE_API_KEY`, or fallback `KIMI_API_KEY`.
 - Web fallback uses the JWT from `kimi-auth` cookie via manual entry or `KIMI_AUTH_TOKEN` env var.
 - Shows weekly quota and 5-hour rate limit (300 minutes).
 - Status: none yet.


### PR DESCRIPTION
Fixes #1412

## Summary
- Add a Kimi `.api` source mode that reads `KIMI_CODE_API_KEY`, `KIMI_API_KEY`, or `providers[].apiKey` and calls `GET /coding/v1/usages`.
- Keep `.auto` user-friendly by trying the Kimi Code API key first, then falling back to the existing Kimi web cookie strategy.
- Add Settings UI source/API-key controls, config/env mapping, diagnose support, docs, and parser/config/settings regression tests.
- Restrict endpoint overrides to valid HTTPS URLs without embedded credentials and normalize compatible coding base paths.

## Current proof
- Rebased onto current `main`; exact head: `23b1c709b6aee187c508701f37e90310573cbfe9`.
- 88 focused tests passed across `KimiProviderTests`, `ProviderConfigEnvironmentTests`, `CLIConfigCommandTests`, and `ProviderSettingsDescriptorTests`.
- `make check`: SwiftFormat clean; SwiftLint strict clean.
- Autoreview: clean, no accepted/actionable findings; confidence 0.82.
- Fresh exact-head CI pending.

## Risk / landing state
No live Kimi account probe or browser/Keychain prompt was run. Coverage is parser, configuration, settings, endpoint-security, and fetch-strategy level. Prepared for product/live-account review; not queued for autonomous merge.
