### PR TITLE
Add opt-in NSPopover menu with a persistent SwiftUI hierarchy

### DIFF
--- a/Sources/CodexBar/Popover/HoverChartPopover.swift
+++ b/Sources/CodexBar/Popover/HoverChartPopover.swift
@@ -1,0 +1,89 @@
+import CodexBarCore
+import SwiftUI
+
+// MARK: - HoverChartPopover
+
+/// hover 驱动的二级图表 popover：进入延迟打开、离开宽限关闭（复刻 NSMenu 子菜单 hover 级联）。
+/// 同时保留外部通过 isPresented binding 的点击立即打开。
+///
+/// 行为细节：
+/// - 鼠标悬停触发区 ~0.18s 后自动打开（短延迟防扫过误触）。
+/// - 鼠标离开触发区后 0.35s 宽限——期间进入 popover 内容则保持打开。
+/// - 触发区与内容都不 hover 且宽限到期 → 关闭。
+/// - 点击 → 立即打开（isPresented = true，binding 外部持有）。
+/// - chart 为 nil 时 modifier 不挂任何东西，原样透传。
+struct HoverChartPopover: ViewModifier {
+    let chart: PopoverChartKind?
+    let makeChartView: (PopoverChartKind, CGFloat) -> AnyView?
+    /// 触发视图的点击仍直接置 true；hover 逻辑也通过此 binding 驱动开关。
+    @Binding var isPresented: Bool
+
+    @State private var rowHovered = false
+    @State private var contentHovered = false
+    @State private var openTask: Task<Void, Never>?
+    @State private var closeTask: Task<Void, Never>?
+
+    private static let openDelay: Duration = .milliseconds(180)
+    private static let closeGrace: Duration = .milliseconds(350)
+
+    func body(content: Content) -> some View {
+        if let chart {
+            content
+                .onHover { hovering in
+                    self.rowHovered = hovering
+                    if hovering {
+                        self.closeTask?.cancel()
+                        self.scheduleOpen()
+                    } else {
+                        self.openTask?.cancel()
+                        self.scheduleCloseIfIdle()
+                    }
+                }
+                .popover(isPresented: self.$isPresented, arrowEdge: .trailing) {
+                    Group {
+                        if let view = self.makeChartView(chart, 360) {
+                            view
+                        } else {
+                            Text("No data available")
+                                .foregroundStyle(.secondary)
+                                .padding()
+                        }
+                    }
+                    .frame(minWidth: 320)
+                    .onHover { hovering in
+                        self.contentHovered = hovering
+                        if hovering {
+                            self.closeTask?.cancel()
+                        } else {
+                            self.scheduleCloseIfIdle()
+                        }
+                    }
+                }
+        } else {
+            content
+        }
+    }
+
+    // MARK: - 私有调度方法
+
+    private func scheduleOpen() {
+        guard !self.isPresented else { return }
+        self.openTask?.cancel()
+        self.openTask = Task { @MainActor in
+            try? await Task.sleep(for: Self.openDelay)
+            guard !Task.isCancelled, self.rowHovered else { return }
+            self.isPresented = true
+        }
+    }
+
+    private func scheduleCloseIfIdle() {
+        self.closeTask?.cancel()
+        self.closeTask = Task { @MainActor in
+            try? await Task.sleep(for: Self.closeGrace)
+            guard !Task.isCancelled else { return }
+            if !self.rowHovered, !self.contentHovered {
+                self.isPresented = false
+            }
+        }
+    }
+}

--- a/Sources/CodexBar/Popover/MenuViewModel.swift
+++ b/Sources/CodexBar/Popover/MenuViewModel.swift
@@ -10,6 +10,8 @@ final class MenuViewModel {
     var selection: ProviderSwitcherSelection = .overview
     /// 当前可显示的 provider 列表（合并模式切换器用）。
     var providers: [UsageProvider] = []
+    /// 切换器是否含 Overview tab（由 controller 在 attach/打开时刷新）。
+    var includesOverview: Bool = false
     /// 内容版本号，选择/数据变化时自增，供 SwiftUI 视图 diff 参考（替代 menuContentVersion）。
     private(set) var contentVersion: Int = 0
     /// popover 是否可见（替代 openMenus 字典；后续图标动画据此冻结）。
@@ -35,9 +37,10 @@ final class MenuViewModel {
 
     // MARK: - 导航助手（Task 1.4）
 
-    /// 循环切换的停靠点：Overview + 各 provider（与 MP-16「←→ 循环含 Overview」一致）。
+    /// 循环切换的停靠点：includesOverview 为 true 时含 Overview，否则仅 providers。
     private var navigationStops: [ProviderSwitcherSelection] {
-        [.overview] + self.providers.map { .provider($0) }
+        let providerStops = self.providers.map { ProviderSwitcherSelection.provider($0) }
+        return self.includesOverview ? [.overview] + providerStops : providerStops
     }
 
     func selectNext() {

--- a/Sources/CodexBar/Popover/MenuViewModel.swift
+++ b/Sources/CodexBar/Popover/MenuViewModel.swift
@@ -28,4 +28,27 @@ final class MenuViewModel {
     func bumpContentVersion() { self.contentVersion &+= 1 }
 
     func setVisible(_ visible: Bool) { self.isVisible = visible }
+
+    // MARK: - 导航助手（Task 1.4）
+
+    /// 循环切换的停靠点：Overview + 各 provider（与 MP-16「←→ 循环含 Overview」一致）。
+    private var navigationStops: [ProviderSwitcherSelection] {
+        [.overview] + self.providers.map { .provider($0) }
+    }
+
+    func selectNext() { self.cycleSelection(by: 1) }
+    func selectPrevious() { self.cycleSelection(by: -1) }
+
+    private func cycleSelection(by delta: Int) {
+        let stops = self.navigationStops
+        guard !stops.isEmpty else { return }
+        let currentIndex = stops.firstIndex(of: self.selection) ?? 0
+        let nextIndex = ((currentIndex + delta) % stops.count + stops.count) % stops.count
+        self.select(stops[nextIndex])
+    }
+
+    func selectProvider(atIndex index: Int) {
+        guard self.providers.indices.contains(index) else { return }
+        self.select(.provider(self.providers[index]))
+    }
 }

--- a/Sources/CodexBar/Popover/MenuViewModel.swift
+++ b/Sources/CodexBar/Popover/MenuViewModel.swift
@@ -1,0 +1,31 @@
+import Observation
+import CodexBarCore
+
+/// 面板内容的单一可观察状态源。替代旧架构中以 ObjectIdentifier(NSMenu) 为 key 的
+/// openMenus / menuVersions / highlightedMenuItems 等字典追踪。
+@MainActor
+@Observable
+final class MenuViewModel {
+    /// 切换器选择：Overview 或具体 provider。复用既有 ProviderSwitcherSelection 语义。
+    var selection: ProviderSwitcherSelection = .overview
+    /// 当前可显示的 provider 列表（合并模式切换器用）。
+    var providers: [UsageProvider] = []
+    /// 内容版本号，选择/数据变化时自增，供 SwiftUI 视图 diff 参考（替代 menuContentVersion）。
+    private(set) var contentVersion: Int = 0
+    /// popover 是否可见（替代 openMenus 字典；后续图标动画据此冻结）。
+    private(set) var isVisible: Bool = false
+    /// 当前高亮项 id（集中式高亮，替代 highlightedMenuItems 字典）。
+    var highlightedItemID: String?
+
+    init() {}
+
+    func select(_ newSelection: ProviderSwitcherSelection) {
+        guard newSelection != self.selection else { return }
+        self.selection = newSelection
+        self.contentVersion &+= 1
+    }
+
+    func bumpContentVersion() { self.contentVersion &+= 1 }
+
+    func setVisible(_ visible: Bool) { self.isVisible = visible }
+}

--- a/Sources/CodexBar/Popover/MenuViewModel.swift
+++ b/Sources/CodexBar/Popover/MenuViewModel.swift
@@ -23,6 +23,17 @@ final class MenuViewModel {
 
     init() {}
 
+    /// 单 provider 模式便利工厂：providers=[provider]、includesOverview=false、selection=.provider(provider)、不设 onSelectionChanged。
+    /// 供非合并模式 per-provider popover 和测试使用。
+    static func singleProvider(_ provider: UsageProvider) -> MenuViewModel {
+        let vm = MenuViewModel()
+        vm.providers = [provider]
+        vm.includesOverview = false
+        // 直接赋值而非调用 select()，避免触发 onSelectionChanged（此时尚未注册，且单 provider 不需持久化）
+        vm.selection = .provider(provider)
+        return vm
+    }
+
     func select(_ newSelection: ProviderSwitcherSelection) {
         guard newSelection != self.selection else { return }
         self.selection = newSelection

--- a/Sources/CodexBar/Popover/MenuViewModel.swift
+++ b/Sources/CodexBar/Popover/MenuViewModel.swift
@@ -86,8 +86,9 @@ final class MenuViewModel {
         self.select(stops[nextIndex])
     }
 
-    func selectProvider(atIndex index: Int) {
-        guard self.providers.indices.contains(index) else { return }
-        self.select(.provider(self.providers[index]))
+    func selectNavigationStop(atIndex index: Int) {
+        let stops = self.navigationStops
+        guard stops.indices.contains(index) else { return }
+        self.select(stops[index])
     }
 }

--- a/Sources/CodexBar/Popover/MenuViewModel.swift
+++ b/Sources/CodexBar/Popover/MenuViewModel.swift
@@ -18,6 +18,8 @@ final class MenuViewModel {
     private(set) var isVisible: Bool = false
     /// 当前高亮项 id（集中式高亮，替代 highlightedMenuItems 字典）。
     var highlightedItemID: String?
+    /// selection 变化时回调（controller 注入以持久化）。同值不触发。
+    var onSelectionChanged: ((ProviderSwitcherSelection) -> Void)?
 
     init() {}
 
@@ -25,6 +27,7 @@ final class MenuViewModel {
         guard newSelection != self.selection else { return }
         self.selection = newSelection
         self.contentVersion &+= 1
+        self.onSelectionChanged?(newSelection)
     }
 
     func bumpContentVersion() {

--- a/Sources/CodexBar/Popover/MenuViewModel.swift
+++ b/Sources/CodexBar/Popover/MenuViewModel.swift
@@ -11,6 +11,8 @@ final class MenuViewModel {
     var selection: ProviderSwitcherSelection = .overview
     /// 当前可显示的 provider 列表（合并模式切换器用）。
     var providers: [UsageProvider] = []
+    /// Split-mode placeholder shown when no provider is available.
+    var isFallback = false
     /// Popover height cap derived from the status item's current screen.
     var maximumPopoverHeight: CGFloat = 720
     /// 切换器是否含 Overview tab（由 controller 在 attach/打开时刷新）。
@@ -35,6 +37,13 @@ final class MenuViewModel {
         vm.includesOverview = false
         // 直接赋值而非调用 select()，避免触发 onSelectionChanged（此时尚未注册，且单 provider 不需持久化）
         vm.selection = .provider(provider)
+        return vm
+    }
+
+    static func fallback(statusItemProvider: UsageProvider) -> MenuViewModel {
+        let vm = MenuViewModel()
+        vm.isFallback = true
+        vm.selection = .provider(statusItemProvider)
         return vm
     }
 

--- a/Sources/CodexBar/Popover/MenuViewModel.swift
+++ b/Sources/CodexBar/Popover/MenuViewModel.swift
@@ -1,4 +1,5 @@
 import CodexBarCore
+import CoreGraphics
 import Observation
 
 /// 面板内容的单一可观察状态源。替代旧架构中以 ObjectIdentifier(NSMenu) 为 key 的
@@ -10,6 +11,8 @@ final class MenuViewModel {
     var selection: ProviderSwitcherSelection = .overview
     /// 当前可显示的 provider 列表（合并模式切换器用）。
     var providers: [UsageProvider] = []
+    /// Popover height cap derived from the status item's current screen.
+    var maximumPopoverHeight: CGFloat = 720
     /// 切换器是否含 Overview tab（由 controller 在 attach/打开时刷新）。
     var includesOverview: Bool = false
     /// 内容版本号，选择/数据变化时自增，供 SwiftUI 视图 diff 参考（替代 menuContentVersion）。

--- a/Sources/CodexBar/Popover/MenuViewModel.swift
+++ b/Sources/CodexBar/Popover/MenuViewModel.swift
@@ -23,7 +23,8 @@ final class MenuViewModel {
 
     init() {}
 
-    /// 单 provider 模式便利工厂：providers=[provider]、includesOverview=false、selection=.provider(provider)、不设 onSelectionChanged。
+    /// 单 provider 模式便利工厂：providers=[provider]、includesOverview=false、selection=.provider(provider)、不设
+    /// onSelectionChanged。
     /// 供非合并模式 per-provider popover 和测试使用。
     static func singleProvider(_ provider: UsageProvider) -> MenuViewModel {
         let vm = MenuViewModel()

--- a/Sources/CodexBar/Popover/MenuViewModel.swift
+++ b/Sources/CodexBar/Popover/MenuViewModel.swift
@@ -1,5 +1,5 @@
-import Observation
 import CodexBarCore
+import Observation
 
 /// 面板内容的单一可观察状态源。替代旧架构中以 ObjectIdentifier(NSMenu) 为 key 的
 /// openMenus / menuVersions / highlightedMenuItems 等字典追踪。
@@ -25,9 +25,13 @@ final class MenuViewModel {
         self.contentVersion &+= 1
     }
 
-    func bumpContentVersion() { self.contentVersion &+= 1 }
+    func bumpContentVersion() {
+        self.contentVersion &+= 1
+    }
 
-    func setVisible(_ visible: Bool) { self.isVisible = visible }
+    func setVisible(_ visible: Bool) {
+        self.isVisible = visible
+    }
 
     // MARK: - 导航助手（Task 1.4）
 
@@ -36,8 +40,13 @@ final class MenuViewModel {
         [.overview] + self.providers.map { .provider($0) }
     }
 
-    func selectNext() { self.cycleSelection(by: 1) }
-    func selectPrevious() { self.cycleSelection(by: -1) }
+    func selectNext() {
+        self.cycleSelection(by: 1)
+    }
+
+    func selectPrevious() {
+        self.cycleSelection(by: -1)
+    }
 
     private func cycleSelection(by delta: Int) {
         let stops = self.navigationStops

--- a/Sources/CodexBar/Popover/PopoverAccountSwitcherView.swift
+++ b/Sources/CodexBar/Popover/PopoverAccountSwitcherView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+/// popover 内的账户 segmented 切换器（Codex/Token 通用，纯渲染）。
+/// 视觉与 PopoverRootView 的 provider 切换器对齐：plain Button、选中 accentColor.opacity(0.18)
+/// 背景圆角 5、caption 字体、选中 semibold。accounts > 3 时用 LazyVGrid 自适应换行。
+struct PopoverAccountSwitcherView: View {
+    struct Segment: Identifiable, Equatable {
+        let id: String
+        let title: String
+        let isSelected: Bool
+
+        /// 纯函数：从 ids/titles/selectedID 构造 segments，供测试和生产共用。
+        static func make(
+            ids: [String],
+            titles: [String],
+            selectedID: String?) -> [Segment]
+        {
+            zip(ids, titles).map { id, title in
+                Segment(id: id, title: title, isSelected: id == selectedID)
+            }
+        }
+    }
+
+    let segments: [Segment]
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        if self.segments.count > 3 {
+            self.gridLayout
+        } else {
+            self.rowLayout
+        }
+    }
+
+    // MARK: - 布局变体
+
+    /// <= 3 个账户：单行 HStack，与 provider 切换器样式完全一致。
+    private var rowLayout: some View {
+        HStack(spacing: 4) {
+            ForEach(self.segments) { segment in
+                self.button(for: segment)
+            }
+        }
+        .padding(8)
+    }
+
+    /// > 3 个账户：自适应 LazyVGrid 多列布局，每列最小宽度 90pt。
+    private var gridLayout: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 90))],
+            alignment: .leading,
+            spacing: 4)
+        {
+            ForEach(self.segments) { segment in
+                self.button(for: segment)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(8)
+    }
+
+    // MARK: - 单个按钮
+
+    private func button(for segment: Segment) -> some View {
+        Button {
+            self.onSelect(segment.id)
+        } label: {
+            Text(segment.title)
+                .font(.caption)
+                .fontWeight(segment.isSelected ? .semibold : .regular)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(segment.isSelected ? Color.accentColor.opacity(0.18) : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+    }
+}

--- a/Sources/CodexBar/Popover/PopoverAccountSwitcherView.swift
+++ b/Sources/CodexBar/Popover/PopoverAccountSwitcherView.swift
@@ -76,5 +76,8 @@ struct PopoverAccountSwitcherView: View {
         .padding(.vertical, 3)
         .background(segment.isSelected ? Color.accentColor.opacity(0.18) : Color.clear)
         .clipShape(RoundedRectangle(cornerRadius: 5))
+        // 无障碍：账户名作为标签，选中态加 isSelected trait
+        .accessibilityLabel(segment.title)
+        .accessibilityAddTraits(segment.isSelected ? .isSelected : [])
     }
 }

--- a/Sources/CodexBar/Popover/PopoverActionSectionsView.swift
+++ b/Sources/CodexBar/Popover/PopoverActionSectionsView.swift
@@ -1,5 +1,30 @@
 import SwiftUI
 
+// MARK: - 悬停高亮 ViewModifier
+
+/// 菜单行悬停高亮：复刻 NSMenu 行高亮观感（accent 背景 + 反白文字）。
+/// 应用到所有可点击菜单行（action、图表入口、Overview 行等）。
+struct MenuRowHoverHighlight: ViewModifier {
+    @State private var isHovered = false
+
+    func body(content: Content) -> some View {
+        content
+            .background(self.isHovered ? Color.accentColor : Color.clear)
+            .foregroundStyle(self.isHovered ? Color.white : Color.primary)
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+            .onHover { self.isHovered = $0 }
+    }
+}
+
+extension View {
+    /// 应用 NSMenu 风格行悬停高亮（accent 背景 + 反白文字）。
+    func menuRowHoverHighlight() -> some View {
+        modifier(MenuRowHoverHighlight())
+    }
+}
+
+// MARK: - PopoverActionSectionsView
+
 /// popover 底部动作区：把 MenuDescriptor.Section 列表渲染为 SwiftUI 视图。
 /// sections 来自 MenuDescriptor.build(...)，与 NSMenu 路径共用同一数据源。
 struct PopoverActionSectionsView: View {
@@ -74,31 +99,25 @@ struct PopoverActionSectionsView: View {
     @ViewBuilder
     private func actionButton(title: String, action: MenuDescriptor.MenuAction) -> some View {
         let subtitle = self.actionSubtitle?(action)
-        Button {
-            self.onAction(action)
-        } label: {
-            HStack {
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(title)
-                    if let subtitle {
-                        Text(subtitle)
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                Spacer()
-                if let label = Self.shortcutLabel(for: action) {
-                    Text(label)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 3)
-            .contentShape(Rectangle())
+        let isDisabled = subtitle != nil
+        ActionRowButton(
+            title: title,
+            action: action,
+            subtitle: subtitle,
+            isDisabled: isDisabled,
+            onAction: self.onAction)
+    }
+
+    // MARK: - 快捷键 a11y hint 映射
+
+    /// 返回动作对应的无障碍 hint（供 VoiceOver 朗读快捷键）；nil 表示无快捷键。
+    static func shortcutHint(for action: MenuDescriptor.MenuAction) -> String? {
+        switch action {
+        case .refresh: "Command R"
+        case .settings: "Command Comma"
+        case .quit: "Command Q"
+        default: nil
         }
-        .buttonStyle(.plain)
-        .disabled(subtitle != nil)
     }
 
     // MARK: - Submenu
@@ -164,5 +183,62 @@ struct PopoverActionSectionsView: View {
         case .quit: "⌘Q"
         default: nil
         }
+    }
+}
+
+// MARK: - ActionRowButton（独立视图，持有 isHovered @State）
+
+/// 单个动作行，持有自己的 hover 状态。
+/// 抽出为独立 View 以便在 @ViewBuilder 外持有 @State private var isHovered。
+private struct ActionRowButton: View {
+    let title: String
+    let action: MenuDescriptor.MenuAction
+    let subtitle: String?
+    let isDisabled: Bool
+    let onAction: (MenuDescriptor.MenuAction) -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button {
+            self.onAction(self.action)
+        } label: {
+            HStack {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(self.title)
+                    if let subtitle = self.subtitle {
+                        Text(subtitle)
+                            .font(.caption2)
+                            .foregroundStyle(
+                                self.isHovered ? Color.white.opacity(0.75) : Color.secondary)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                if let label = PopoverActionSectionsView.shortcutLabel(for: self.action) {
+                    Text(label)
+                        .font(.caption)
+                        .foregroundStyle(
+                            self.isHovered ? Color.white.opacity(0.75) : Color.secondary)
+                }
+            }
+            .padding(.horizontal, 17)
+            .padding(.vertical, 3)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(self.isDisabled)
+        // hover 高亮仅在可用时生效
+        .background(
+            (self.isHovered && !self.isDisabled) ? Color.accentColor : Color.clear)
+        .foregroundStyle(
+            (self.isHovered && !self.isDisabled) ? Color.white : Color.primary)
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .padding(.horizontal, 5)
+        .onHover { hovering in
+            if !self.isDisabled { self.isHovered = hovering }
+        }
+        // 无障碍：Button 自带 button trait；为有快捷键的动作加 hint
+        .accessibilityHint(
+            PopoverActionSectionsView.shortcutHint(for: self.action) ?? "")
     }
 }

--- a/Sources/CodexBar/Popover/PopoverActionSectionsView.swift
+++ b/Sources/CodexBar/Popover/PopoverActionSectionsView.swift
@@ -5,6 +5,9 @@ import SwiftUI
 struct PopoverActionSectionsView: View {
     let sections: [MenuDescriptor.Section]
     let onAction: (MenuDescriptor.MenuAction) -> Void
+    /// 返回 action 对应的禁用 subtitle（nil = 可用；非 nil = 禁用并显示 subtitle 小字）。
+    /// 对齐 NSMenu addActionableSections switchAccount/addCodexAccount disabled 逻辑。
+    var actionSubtitle: ((MenuDescriptor.MenuAction) -> String?)?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
@@ -68,12 +71,21 @@ struct PopoverActionSectionsView: View {
 
     // MARK: - Action Button
 
+    @ViewBuilder
     private func actionButton(title: String, action: MenuDescriptor.MenuAction) -> some View {
+        let subtitle = self.actionSubtitle?(action)
         Button {
             self.onAction(action)
         } label: {
             HStack {
-                Text(title)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title)
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
                 Spacer()
                 if let label = Self.shortcutLabel(for: action) {
                     Text(label)
@@ -86,6 +98,7 @@ struct PopoverActionSectionsView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .disabled(subtitle != nil)
     }
 
     // MARK: - Submenu

--- a/Sources/CodexBar/Popover/PopoverActionSectionsView.swift
+++ b/Sources/CodexBar/Popover/PopoverActionSectionsView.swift
@@ -36,8 +36,16 @@ struct PopoverActionSectionsView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
-            let nonEmpty = self.sections.filter { !$0.entries.isEmpty }
-            ForEach(Array(nonEmpty.enumerated()), id: \.offset) { idx, section in
+            // 与 NSMenu addActionableSections 过滤逻辑完全对齐：
+            // 只保留含 action 或 submenu 的 section，纯文本 section（usage/account 信息行）不渲染。
+            let actionable = self.sections.filter { section in
+                section.entries.contains { entry in
+                    if case .action = entry { return true }
+                    if case .submenu = entry { return true }
+                    return false
+                }
+            }
+            ForEach(Array(actionable.enumerated()), id: \.offset) { idx, section in
                 if idx > 0 {
                     Divider()
                 }
@@ -237,6 +245,8 @@ private struct ActionRowButton: View {
         .onHover { hovering in
             if !self.isDisabled { self.isHovered = hovering }
         }
+        // 禁用 popover 内的键盘 focus 框（macOS 14+）
+        .focusEffectDisabled()
         // 无障碍：Button 自带 button trait；为有快捷键的动作加 hint
         .accessibilityHint(
             PopoverActionSectionsView.shortcutHint(for: self.action) ?? "")

--- a/Sources/CodexBar/Popover/PopoverActionSectionsView.swift
+++ b/Sources/CodexBar/Popover/PopoverActionSectionsView.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+
+/// popover 底部动作区：把 MenuDescriptor.Section 列表渲染为 SwiftUI 视图。
+/// sections 来自 MenuDescriptor.build(...)，与 NSMenu 路径共用同一数据源。
+struct PopoverActionSectionsView: View {
+    let sections: [MenuDescriptor.Section]
+    let onAction: (MenuDescriptor.MenuAction) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            let nonEmpty = self.sections.filter { !$0.entries.isEmpty }
+            ForEach(Array(nonEmpty.enumerated()), id: \.offset) { idx, section in
+                if idx > 0 {
+                    Divider()
+                }
+                self.sectionView(section)
+            }
+        }
+    }
+
+    // MARK: - Section
+
+    private func sectionView(_ section: MenuDescriptor.Section) -> some View {
+        ForEach(Array(section.entries.enumerated()), id: \.offset) { _, entry in
+            self.entryView(entry)
+        }
+    }
+
+    // MARK: - Entry
+
+    @ViewBuilder
+    private func entryView(_ entry: MenuDescriptor.Entry) -> some View {
+        switch entry {
+        case let .text(text, style):
+            self.textView(text, style: style)
+        case let .action(title, action):
+            self.actionButton(title: title, action: action)
+        case let .submenu(title, systemImage, items):
+            self.submenuView(title: title, systemImage: systemImage, items: items)
+        case .divider:
+            Divider()
+        }
+    }
+
+    // MARK: - Text
+
+    @ViewBuilder
+    private func textView(_ text: String, style: MenuDescriptor.TextStyle) -> some View {
+        switch style {
+        case .headline:
+            Text(text)
+                .font(.callout.weight(.semibold))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 3)
+        case .primary:
+            Text(text)
+                .font(.callout)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 3)
+        case .secondary:
+            Text(text)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 3)
+        }
+    }
+
+    // MARK: - Action Button
+
+    private func actionButton(title: String, action: MenuDescriptor.MenuAction) -> some View {
+        Button {
+            self.onAction(action)
+        } label: {
+            HStack {
+                Text(title)
+                Spacer()
+                if let label = Self.shortcutLabel(for: action) {
+                    Text(label)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 3)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Submenu
+
+    @ViewBuilder
+    private func submenuView(
+        title: String,
+        systemImage: String?,
+        items: [MenuDescriptor.SubmenuItem]) -> some View
+    {
+        let menuContent = {
+            ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                if let action = item.action {
+                    Button {
+                        self.onAction(action)
+                    } label: {
+                        Text(item.isChecked ? "✓ \(item.title)" : item.title)
+                    }
+                    .disabled(!item.isEnabled)
+                } else {
+                    Text(item.title)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+
+        if let systemImage {
+            Menu {
+                menuContent()
+            } label: {
+                Label(title, systemImage: systemImage)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 3)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 3)
+        } else {
+            Menu {
+                menuContent()
+            } label: {
+                Text(title)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 3)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 3)
+        }
+    }
+
+    // MARK: - 快捷键标签（静态，可测试）
+
+    /// 返回动作对应的快捷键显示字符串；nil 表示无快捷键。
+    static func shortcutLabel(for action: MenuDescriptor.MenuAction) -> String? {
+        switch action {
+        case .refresh: "⌘R"
+        case .settings: "⌘,"
+        case .quit: "⌘Q"
+        default: nil
+        }
+    }
+}

--- a/Sources/CodexBar/Popover/PopoverCardPlan.swift
+++ b/Sources/CodexBar/Popover/PopoverCardPlan.swift
@@ -1,0 +1,16 @@
+import CodexBarCore
+
+/// popover 内容区的卡片渲染计划：由 StatusItemController 构造（复用 NSMenu 同源数据/分流逻辑），
+/// PopoverRootView 纯渲染消费。
+struct PopoverCardPlan {
+    struct Card: Identifiable {
+        let id: String // 稳定 id：账户 id / scope id / "single"
+        let model: UsageMenuCardView.Model
+        let workspaceHeader: String? // Codex workspace 分组 header（组内首卡携带）
+    }
+
+    var cards: [Card] = []
+    var storageText: String?
+    var showBuyCredits = false
+    var emptyText: String? // 无任何卡片时的占位文案
+}

--- a/Sources/CodexBar/Popover/PopoverCardPlan.swift
+++ b/Sources/CodexBar/Popover/PopoverCardPlan.swift
@@ -35,6 +35,7 @@ struct PopoverCardPlan {
 
     var cards: [Card] = []
     var storageText: String?
+    var storageChart: PopoverChartKind?
     var showBuyCredits = false
     var emptyText: String? // 无任何卡片时的占位文案
 }

--- a/Sources/CodexBar/Popover/PopoverCardPlan.swift
+++ b/Sources/CodexBar/Popover/PopoverCardPlan.swift
@@ -9,6 +9,30 @@ struct PopoverCardPlan {
         let workspaceHeader: String? // Codex workspace 分组 header（组内首卡携带）
     }
 
+    /// 拆段渲染计划（对齐 NSMenu addMenuCardSections；仅 OpenAI web/API usage 场景）。
+    /// 非 nil 时 PopoverRootView 优先走拆段路径，不渲染整卡（cards 字段此时通常含 1 张卡用于占位，
+    /// 实际不直接渲染）。
+    struct SectionedCard {
+        let model: UsageMenuCardView.Model
+        // ── 段存在性标志 ──
+        let hasUsageBlock: Bool // model.hasUsageContent
+        let hasCredits: Bool // model.creditsText != nil
+        let hasExtraUsage: Bool // model.providerCost != nil
+        let hasCost: Bool // model.tokenUsage != nil
+        let hasStorage: Bool // storageFootprintText(for:) != nil
+        let storageText: String? // 同上，nil 时不渲染 storage 段
+        // ── 段 chevron 图表（对齐 NSMenu 各段 submenu 条件）──
+        let usageChart: PopoverChartKind? // hasUsageBreakdown→.usageBreakdown / openai→.costHistory / zai→.zaiDetails
+        let storageChart: PopoverChartKind? // storage components 非空→.storageBreakdown(provider)
+        let creditsChart: PopoverChartKind? // hasCreditsHistory→.creditsHistory
+        let showBuyCredits: Bool // webItems.canShowBuyCredits（Credits 段后跟 Buy Credits 行）
+        let extraUsageChart: PopoverChartKind? // OpenAI API usage submenu → .costHistory(provider)
+        let costChart: PopoverChartKind? // hasCostHistory→.costHistory(provider)
+    }
+
+    /// 非 nil 时优先于 cards 路径走拆段渲染（PopoverRootView.card(for:) 中判定）。
+    var sectioned: SectionedCard?
+
     var cards: [Card] = []
     var storageText: String?
     var showBuyCredits = false

--- a/Sources/CodexBar/Popover/PopoverChartKind.swift
+++ b/Sources/CodexBar/Popover/PopoverChartKind.swift
@@ -1,0 +1,63 @@
+import CodexBarCore
+import Foundation
+
+/// popover 二级图表的种类（NSMenu 六类 hosted 子菜单的等价物）。
+enum PopoverChartKind: Identifiable, Equatable {
+    case usageBreakdown
+    case creditsHistory
+    case costHistory(UsageProvider)
+    case usageHistory(UsageProvider)
+    case storageBreakdown(UsageProvider)
+    case zaiHourly(UsageProvider)
+
+    /// 稳定的 Identifiable id 字符串（无 provider 关联时用种类名，有 provider 时拼接 rawValue）。
+    var id: String {
+        switch self {
+        case .usageBreakdown:
+            "usageBreakdown"
+        case .creditsHistory:
+            "creditsHistory"
+        case let .costHistory(provider):
+            "costHistory-\(provider.rawValue)"
+        case let .usageHistory(provider):
+            "usageHistory-\(provider.rawValue)"
+        case let .storageBreakdown(provider):
+            "storageBreakdown-\(provider.rawValue)"
+        case let .zaiHourly(provider):
+            "zaiHourly-\(provider.rawValue)"
+        }
+    }
+
+    /// 入口行标题（对齐 NSMenu 对应行标题，经 L() 本地化）。
+    var title: String {
+        switch self {
+        case .usageBreakdown:
+            L("Usage breakdown")
+        case .creditsHistory:
+            L("Credits history")
+        case .costHistory:
+            // 与 addCostHistorySubmenu 的 title 完全对齐：依赖 settings.costUsageHistoryDays，
+            // 但枚举本身不引用 settings；调用方在构造时已基于条件选择此 kind，
+            // title 此处用通用"历史"文案（NSMenu 是动态计算天数后用 L("Usage history (%d days)")，
+            // popover 列表 title 暂用不含天数的静态串 L("Usage history (30 days)")，
+            // 实际渲染 title 应由调用方使用 costHistoryTitle(settings:) 替换，此为安全默认值）。
+            L("Usage history (30 days)")
+        case .usageHistory:
+            L("Subscription Utilization")
+        case .storageBreakdown:
+            L("Storage")
+        case .zaiHourly:
+            L("Hourly Usage")
+        }
+    }
+
+    /// cost history 的动态 title（取决于 settings.costUsageHistoryDays）。
+    /// popover 入口行渲染时调用此方法获取带天数的准确标题。
+    func costHistoryTitle(historyDays: Int) -> String {
+        guard case .costHistory = self else { return self.title }
+        if historyDays == 1 {
+            return L("Usage history (today)")
+        }
+        return String(format: L("Usage history (%d days)"), historyDays)
+    }
+}

--- a/Sources/CodexBar/Popover/PopoverChartKind.swift
+++ b/Sources/CodexBar/Popover/PopoverChartKind.swift
@@ -9,6 +9,8 @@ enum PopoverChartKind: Identifiable, Equatable {
     case usageHistory(UsageProvider)
     case storageBreakdown(UsageProvider)
     case zaiHourly(UsageProvider)
+    /// Zai MCP 用量明细（纯只读列表，等价于 NSMenu makeZaiUsageDetailsSubmenu 内容）。
+    case zaiDetails(UsageProvider)
 
     /// 稳定的 Identifiable id 字符串（无 provider 关联时用种类名，有 provider 时拼接 rawValue）。
     var id: String {
@@ -25,6 +27,8 @@ enum PopoverChartKind: Identifiable, Equatable {
             "storageBreakdown-\(provider.rawValue)"
         case let .zaiHourly(provider):
             "zaiHourly-\(provider.rawValue)"
+        case let .zaiDetails(provider):
+            "zaiDetails-\(provider.rawValue)"
         }
     }
 
@@ -48,6 +52,8 @@ enum PopoverChartKind: Identifiable, Equatable {
             L("Storage")
         case .zaiHourly:
             L("Hourly Usage")
+        case .zaiDetails:
+            L("MCP details")
         }
     }
 
@@ -59,5 +65,11 @@ enum PopoverChartKind: Identifiable, Equatable {
             return L("Usage history (today)")
         }
         return String(format: L("Usage history (%d days)"), historyDays)
+    }
+
+    /// Zai details 入口可用的判定：provider == .zai 且 timeLimit 非空且 usageDetails 非空。
+    static func isZaiDetailsAvailable(snapshot: UsageSnapshot?) -> Bool {
+        guard let timeLimit = snapshot?.zaiUsage?.timeLimit else { return false }
+        return !timeLimit.usageDetails.isEmpty
     }
 }

--- a/Sources/CodexBar/Popover/PopoverMenuController.swift
+++ b/Sources/CodexBar/Popover/PopoverMenuController.swift
@@ -43,9 +43,12 @@ final class PopoverMenuController<Content: View> {
         self.closeDelegate = delegate
         popover.delegate = delegate
         // 在 init 完成后，通过闭包把 handleDidClose 回调注入桥接对象
-        // （此处 self 已完全初始化，可安全捕获）
+        // （此处 self 已完全初始化，可安全捕获）。
+        // NSPopoverDelegate 回调由 AppKit 在主线程同步触发，必须用 assumeIsolated
+        // 同步执行 handleDidClose——若用 Task 延迟，suppressNextToggleOpen 会在
+        // 紧随其后的 button.action(toggle) 之后才置位，导致防双触发失效、面板点不掉。
         delegate.onDidClose = { [weak self] in
-            Task { @MainActor [weak self] in
+            MainActor.assumeIsolated {
                 self?.handleDidClose()
             }
         }

--- a/Sources/CodexBar/Popover/PopoverMenuController.swift
+++ b/Sources/CodexBar/Popover/PopoverMenuController.swift
@@ -68,8 +68,7 @@ final class PopoverMenuController<Content: View> {
     func show(relativeTo button: NSStatusBarButton) {
         guard !self.popover.isShown else { return }
         let visibleHeight = button.window?.screen?.visibleFrame.height ?? NSScreen.main?.visibleFrame.height ?? 900
-        self.viewModel.maximumPopoverHeight = min(720, max(320, floor(visibleHeight * 0.82)))
-        self.viewModel.setVisible(true)
+        self.prepareForShow(visibleHeight: visibleHeight)
         self.popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         self.popover.contentViewController?.view.window?.makeKey()
         self.installKeyMonitor()
@@ -88,8 +87,17 @@ final class PopoverMenuController<Content: View> {
             return
         }
         // 刚因 transient 点击关闭时吞掉这次重开，避免闪烁
-        if self.suppressNextToggleOpen { return }
+        guard self.canOpenFromToggle() else { return }
         self.show(relativeTo: button)
+    }
+
+    private func prepareForShow(visibleHeight: CGFloat) {
+        self.viewModel.maximumPopoverHeight = min(720, max(320, floor(visibleHeight * 0.82)))
+        self.viewModel.setVisible(true)
+    }
+
+    private func canOpenFromToggle() -> Bool {
+        !self.suppressNextToggleOpen
     }
 
     // MARK: - 关闭统一清理（delegate 回调 + close() 共用）
@@ -107,6 +115,14 @@ final class PopoverMenuController<Content: View> {
     /// 测试接缝：模拟 transient 外部点击关闭（驱动 handleDidClose），绕过真实 NSPopover。
     func simulatePopoverDidCloseForTesting() {
         self.handleDidClose()
+    }
+
+    func prepareForShowForTesting(visibleHeight: CGFloat) {
+        self.prepareForShow(visibleHeight: visibleHeight)
+    }
+
+    func canOpenFromToggleForTesting() -> Bool {
+        self.canOpenFromToggle()
     }
 
     // MARK: - 键盘 monitor

--- a/Sources/CodexBar/Popover/PopoverMenuController.swift
+++ b/Sources/CodexBar/Popover/PopoverMenuController.swift
@@ -10,9 +10,9 @@ final class PopoverMenuController<Content: View> {
     private let viewModel: MenuViewModel
     private let popover: NSPopover
     private let hostingController: NSHostingController<Content>
-    // nonisolated(unsafe) 允许在 deinit（非 MainActor）中直接读写，
-    // 实际写入只发生在 @MainActor 方法中，线程安全由调用方保证。
-    nonisolated(unsafe) private var keyMonitor: Any?
+    /// nonisolated(unsafe) 允许在 deinit（非 MainActor）中直接读写，
+    /// 实际写入只发生在 @MainActor 方法中，线程安全由调用方保证。
+    private nonisolated(unsafe) var keyMonitor: Any?
 
     /// 防止 transient 自动关闭后 button.action 立即重开的标志。
     /// handleDidClose() 置 true，下一 runloop tick 异步清除。
@@ -61,7 +61,9 @@ final class PopoverMenuController<Content: View> {
         }
     }
 
-    var isShown: Bool { self.popover.isShown }
+    var isShown: Bool {
+        self.popover.isShown
+    }
 
     func show(relativeTo button: NSStatusBarButton) {
         guard !self.popover.isShown else { return }
@@ -114,8 +116,8 @@ final class PopoverMenuController<Content: View> {
             if self.handle(
                 characters: event.charactersIgnoringModifiers,
                 keyCode: event.keyCode,
-                modifiers: event.modifierFlags
-            ) {
+                modifiers: event.modifierFlags)
+            {
                 return nil // 吞掉已处理事件
             }
             return event
@@ -154,7 +156,7 @@ final class PopoverMenuController<Content: View> {
         }
         // 非修饰键（按 keyCode）
         switch keyCode {
-        case 53:  // Esc
+        case 53: // Esc
             self.close()
             return true
         case 123: // ←
@@ -191,6 +193,6 @@ final class PopoverCloseDelegate: NSObject, NSPopoverDelegate {
     var onDidClose: (() -> Void)?
 
     func popoverDidClose(_ notification: Notification) {
-        onDidClose?()
+        self.onDidClose?()
     }
 }

--- a/Sources/CodexBar/Popover/PopoverMenuController.swift
+++ b/Sources/CodexBar/Popover/PopoverMenuController.swift
@@ -3,6 +3,8 @@ import SwiftUI
 
 /// 用 NSPopover(.transient) 承载持久 SwiftUI 根视图，替代 statusItem.menu。
 /// 阶段 1.3：加入本地键盘 monitor，Esc 关闭面板；阶段 1.4 接入更多快捷键。
+/// 阶段 review：通过 PopoverCloseDelegate 桥接 NSPopoverDelegate，
+/// 处理 transient 自动关闭的状态同步与双触发防抖。
 @MainActor
 final class PopoverMenuController<Content: View> {
     private let viewModel: MenuViewModel
@@ -11,6 +13,13 @@ final class PopoverMenuController<Content: View> {
     // nonisolated(unsafe) 允许在 deinit（非 MainActor）中直接读写，
     // 实际写入只发生在 @MainActor 方法中，线程安全由调用方保证。
     nonisolated(unsafe) private var keyMonitor: Any?
+
+    /// 防止 transient 自动关闭后 button.action 立即重开的标志。
+    /// handleDidClose() 置 true，下一 runloop tick 异步清除。
+    private var suppressNextToggleOpen = false
+
+    /// NSPopoverDelegate 桥接对象（泛型类不能直接遵从 @objc 协议）。
+    private let closeDelegate: PopoverCloseDelegate
 
     // MARK: - 注入回调（Task 1.4）
 
@@ -29,6 +38,17 @@ final class PopoverMenuController<Content: View> {
         popover.animates = false
         popover.contentViewController = hosting
         self.popover = popover
+        // 桥接 delegate：接管关闭事件，同步 isVisible、移除 keyMonitor、防双触发
+        let delegate = PopoverCloseDelegate()
+        self.closeDelegate = delegate
+        popover.delegate = delegate
+        // 在 init 完成后，通过闭包把 handleDidClose 回调注入桥接对象
+        // （此处 self 已完全初始化，可安全捕获）
+        delegate.onDidClose = { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.handleDidClose()
+            }
+        }
     }
 
     deinit {
@@ -48,14 +68,38 @@ final class PopoverMenuController<Content: View> {
         self.installKeyMonitor()
     }
 
+    /// 显式关闭：立即同步状态，再委托 performClose 触发 delegate（幂等安全）。
     func close() {
         self.removeKeyMonitor()
-        self.popover.performClose(nil)
         self.viewModel.setVisible(false)
+        self.popover.performClose(nil)
     }
 
     func toggle(relativeTo button: NSStatusBarButton) {
-        if self.popover.isShown { self.close() } else { self.show(relativeTo: button) }
+        if self.popover.isShown {
+            self.close()
+            return
+        }
+        // 刚因 transient 点击关闭时吞掉这次重开，避免闪烁
+        if self.suppressNextToggleOpen { return }
+        self.show(relativeTo: button)
+    }
+
+    // MARK: - 关闭统一清理（delegate 回调 + close() 共用）
+
+    /// 统一清理：同步 isVisible、移除 monitor、设置防双触发标志（一个 runloop tick 后清除）。
+    private func handleDidClose() {
+        self.removeKeyMonitor()
+        self.viewModel.setVisible(false)
+        self.suppressNextToggleOpen = true
+        DispatchQueue.main.async { [weak self] in
+            self?.suppressNextToggleOpen = false
+        }
+    }
+
+    /// 测试接缝：模拟 transient 外部点击关闭（驱动 handleDidClose），绕过真实 NSPopover。
+    func simulatePopoverDidCloseForTesting() {
+        self.handleDidClose()
     }
 
     // MARK: - 键盘 monitor
@@ -132,5 +176,18 @@ final class PopoverMenuController<Content: View> {
     @discardableResult
     func handleForTesting(characters: String?, modifiers: NSEvent.ModifierFlags) -> Bool {
         self.handle(characters: characters, keyCode: 0, modifiers: modifiers)
+    }
+}
+
+// MARK: - NSPopoverDelegate 桥接
+
+/// 非泛型 NSObject 子类，作为 NSPopoverDelegate 桥接对象。
+/// 泛型类（PopoverMenuController）无法直接遵从 @objc 协议，故独立出来。
+final class PopoverCloseDelegate: NSObject, NSPopoverDelegate {
+    /// 关闭时回调，由 PopoverMenuController 在 init 后注入。
+    var onDidClose: (() -> Void)?
+
+    func popoverDidClose(_ notification: Notification) {
+        onDidClose?()
     }
 }

--- a/Sources/CodexBar/Popover/PopoverMenuController.swift
+++ b/Sources/CodexBar/Popover/PopoverMenuController.swift
@@ -12,6 +12,14 @@ final class PopoverMenuController<Content: View> {
     // 实际写入只发生在 @MainActor 方法中，线程安全由调用方保证。
     nonisolated(unsafe) private var keyMonitor: Any?
 
+    // MARK: - 注入回调（Task 1.4）
+
+    var onRefresh: (() -> Void)?
+    var onSettings: (() -> Void)?
+    var onQuit: (() -> Void)?
+    var onNavigate: ((StatusItemMenuProviderNavigationDirection) -> Void)?
+    var onSelectIndex: ((Int) -> Void)?
+
     init(viewModel: MenuViewModel, contentView: () -> Content) {
         self.viewModel = viewModel
         let hosting = NSHostingController(rootView: contentView())
@@ -56,7 +64,11 @@ final class PopoverMenuController<Content: View> {
         guard self.keyMonitor == nil else { return }
         self.keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self else { return event }
-            if self.handleKeyDown(keyCode: event.keyCode, modifiers: event.modifierFlags) {
+            if self.handle(
+                characters: event.charactersIgnoringModifiers,
+                keyCode: event.keyCode,
+                modifiers: event.modifierFlags
+            ) {
                 return nil // 吞掉已处理事件
             }
             return event
@@ -70,20 +82,55 @@ final class PopoverMenuController<Content: View> {
         }
     }
 
-    /// 处理面板可见期间的按键。返回 true 表示已处理（事件被吞）。
-    /// 阶段 1.3 仅处理 Esc；阶段 1.4 接入 Cmd+R/,/Q、←→、Cmd+1..9。
+    /// 统一按键处理。characters 用 charactersIgnoringModifiers。返回 true 表示已处理（吞掉事件）。
     @discardableResult
-    private func handleKeyDown(keyCode: UInt16, modifiers: NSEvent.ModifierFlags) -> Bool {
-        if keyCode == 53 { // Esc
+    private func handle(characters: String?, keyCode: UInt16, modifiers: NSEvent.ModifierFlags) -> Bool {
+        let command = modifiers.intersection([.command, .option, .control, .shift]) == .command
+        // Cmd 组合（字符级，兼容键盘布局）
+        if command, let ch = characters?.lowercased() {
+            switch ch {
+            case "r":
+                self.onRefresh?()
+                return true
+            case ",":
+                self.onSettings?()
+                return true
+            case "q":
+                self.onQuit?()
+                return true
+            default:
+                if let n = Int(ch), (1...9).contains(n) {
+                    self.onSelectIndex?(n - 1)
+                    return true
+                }
+            }
+        }
+        // 非修饰键（按 keyCode）
+        switch keyCode {
+        case 53:  // Esc
             self.close()
             return true
+        case 123: // ←
+            self.onNavigate?(.previous)
+            return true
+        case 124: // →
+            self.onNavigate?(.next)
+            return true
+        default:
+            return false
         }
-        return false
     }
 
-    /// 测试接缝：直接驱动按键处理，绕过真实 NSEvent monitor。
+    /// 测试接缝（keyCode 级）：直接驱动按键处理，绕过真实 NSEvent monitor。
+    /// 保持阶段 1.3 的 Esc/箭头测试可用。
     @discardableResult
     func handleKeyDownForTesting(keyCode: UInt16, modifiers: NSEvent.ModifierFlags = []) -> Bool {
-        self.handleKeyDown(keyCode: keyCode, modifiers: modifiers)
+        self.handle(characters: nil, keyCode: keyCode, modifiers: modifiers)
+    }
+
+    /// 测试接缝（字符级）：直接驱动字符快捷键处理，绕过真实 NSEvent monitor。
+    @discardableResult
+    func handleForTesting(characters: String?, modifiers: NSEvent.ModifierFlags) -> Bool {
+        self.handle(characters: characters, keyCode: 0, modifiers: modifiers)
     }
 }

--- a/Sources/CodexBar/Popover/PopoverMenuController.swift
+++ b/Sources/CodexBar/Popover/PopoverMenuController.swift
@@ -67,6 +67,8 @@ final class PopoverMenuController<Content: View> {
 
     func show(relativeTo button: NSStatusBarButton) {
         guard !self.popover.isShown else { return }
+        let visibleHeight = button.window?.screen?.visibleFrame.height ?? NSScreen.main?.visibleFrame.height ?? 900
+        self.viewModel.maximumPopoverHeight = min(720, max(320, floor(visibleHeight * 0.82)))
         self.viewModel.setVisible(true)
         self.popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         self.popover.contentViewController?.view.window?.makeKey()

--- a/Sources/CodexBar/Popover/PopoverMenuController.swift
+++ b/Sources/CodexBar/Popover/PopoverMenuController.swift
@@ -1,0 +1,40 @@
+import AppKit
+import SwiftUI
+
+/// 用 NSPopover(.transient) 承载持久 SwiftUI 根视图，替代 statusItem.menu。
+/// 阶段 0 仅实现显隐 + view model 可见性同步；键盘/dismiss 监听在后续任务加入。
+@MainActor
+final class PopoverMenuController<Content: View> {
+    private let viewModel: MenuViewModel
+    private let popover: NSPopover
+    private let hostingController: NSHostingController<Content>
+
+    init(viewModel: MenuViewModel, contentView: () -> Content) {
+        self.viewModel = viewModel
+        let hosting = NSHostingController(rootView: contentView())
+        self.hostingController = hosting
+        let popover = NSPopover()
+        popover.behavior = .transient
+        popover.animates = false
+        popover.contentViewController = hosting
+        self.popover = popover
+    }
+
+    var isShown: Bool { self.popover.isShown }
+
+    func show(relativeTo button: NSStatusBarButton) {
+        guard !self.popover.isShown else { return }
+        self.viewModel.setVisible(true)
+        self.popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        self.popover.contentViewController?.view.window?.makeKey()
+    }
+
+    func close() {
+        self.popover.performClose(nil)
+        self.viewModel.setVisible(false)
+    }
+
+    func toggle(relativeTo button: NSStatusBarButton) {
+        if self.popover.isShown { self.close() } else { self.show(relativeTo: button) }
+    }
+}

--- a/Sources/CodexBar/Popover/PopoverMenuController.swift
+++ b/Sources/CodexBar/Popover/PopoverMenuController.swift
@@ -2,12 +2,15 @@ import AppKit
 import SwiftUI
 
 /// 用 NSPopover(.transient) 承载持久 SwiftUI 根视图，替代 statusItem.menu。
-/// 阶段 0 仅实现显隐 + view model 可见性同步；键盘/dismiss 监听在后续任务加入。
+/// 阶段 1.3：加入本地键盘 monitor，Esc 关闭面板；阶段 1.4 接入更多快捷键。
 @MainActor
 final class PopoverMenuController<Content: View> {
     private let viewModel: MenuViewModel
     private let popover: NSPopover
     private let hostingController: NSHostingController<Content>
+    // nonisolated(unsafe) 允许在 deinit（非 MainActor）中直接读写，
+    // 实际写入只发生在 @MainActor 方法中，线程安全由调用方保证。
+    nonisolated(unsafe) private var keyMonitor: Any?
 
     init(viewModel: MenuViewModel, contentView: () -> Content) {
         self.viewModel = viewModel
@@ -20,6 +23,13 @@ final class PopoverMenuController<Content: View> {
         self.popover = popover
     }
 
+    deinit {
+        // deinit 不在 MainActor，直接操作 monitor 避免跨隔离调用
+        if let monitor = keyMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+    }
+
     var isShown: Bool { self.popover.isShown }
 
     func show(relativeTo button: NSStatusBarButton) {
@@ -27,14 +37,53 @@ final class PopoverMenuController<Content: View> {
         self.viewModel.setVisible(true)
         self.popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         self.popover.contentViewController?.view.window?.makeKey()
+        self.installKeyMonitor()
     }
 
     func close() {
+        self.removeKeyMonitor()
         self.popover.performClose(nil)
         self.viewModel.setVisible(false)
     }
 
     func toggle(relativeTo button: NSStatusBarButton) {
         if self.popover.isShown { self.close() } else { self.show(relativeTo: button) }
+    }
+
+    // MARK: - 键盘 monitor
+
+    private func installKeyMonitor() {
+        guard self.keyMonitor == nil else { return }
+        self.keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+            if self.handleKeyDown(keyCode: event.keyCode, modifiers: event.modifierFlags) {
+                return nil // 吞掉已处理事件
+            }
+            return event
+        }
+    }
+
+    private func removeKeyMonitor() {
+        if let monitor = self.keyMonitor {
+            NSEvent.removeMonitor(monitor)
+            self.keyMonitor = nil
+        }
+    }
+
+    /// 处理面板可见期间的按键。返回 true 表示已处理（事件被吞）。
+    /// 阶段 1.3 仅处理 Esc；阶段 1.4 接入 Cmd+R/,/Q、←→、Cmd+1..9。
+    @discardableResult
+    private func handleKeyDown(keyCode: UInt16, modifiers: NSEvent.ModifierFlags) -> Bool {
+        if keyCode == 53 { // Esc
+            self.close()
+            return true
+        }
+        return false
+    }
+
+    /// 测试接缝：直接驱动按键处理，绕过真实 NSEvent monitor。
+    @discardableResult
+    func handleKeyDownForTesting(keyCode: UInt16, modifiers: NSEvent.ModifierFlags = []) -> Bool {
+        self.handleKeyDown(keyCode: keyCode, modifiers: modifiers)
     }
 }

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -149,20 +149,24 @@ struct PopoverRootView: View {
     private static let menuWidth: CGFloat = 310
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            if self.viewModel.providers.count > 1 || self.viewModel.includesOverview {
-                self.switcher
+        ScrollView(.vertical) {
+            VStack(alignment: .leading, spacing: 0) {
+                if self.viewModel.providers.count > 1 || self.viewModel.includesOverview {
+                    self.switcher
+                    Divider()
+                }
+                self.content
                 Divider()
+                PopoverActionSectionsView(
+                    sections: self.makeSections(),
+                    onAction: self.onAction,
+                    actionSubtitle: self.actionSubtitle)
+                    .padding(.bottom, 6)
             }
-            self.content
-            Divider()
-            PopoverActionSectionsView(
-                sections: self.makeSections(),
-                onAction: self.onAction,
-                actionSubtitle: self.actionSubtitle)
-                .padding(.bottom, 6)
         }
+        .scrollBounceBehavior(.basedOnSize)
         .frame(width: Self.menuWidth, alignment: .leading)
+        .frame(maxHeight: self.viewModel.maximumPopoverHeight, alignment: .top)
         .fixedSize(horizontal: false, vertical: true)
         // 无障碍：整个菜单根容器
         .accessibilityElement(children: .contain)
@@ -447,7 +451,10 @@ struct PopoverRootView: View {
         if !entries.isEmpty {
             Divider()
             ForEach(entries) { kind in
-                ChartEntryRowView(kind: kind, makeChartView: self.makeChartView)
+                ChartEntryRowView(
+                    kind: kind,
+                    title: kind.costHistoryTitle(historyDays: self.store.settings.costUsageHistoryDays),
+                    makeChartView: self.makeChartView)
             }
         }
     }
@@ -527,6 +534,7 @@ private struct OverviewRowView: View {
 /// makeChartView 由 PopoverRootView 透传，懒构造图表内容视图。
 private struct ChartEntryRowView: View {
     let kind: PopoverChartKind
+    let title: String
     let makeChartView: (PopoverChartKind, CGFloat) -> AnyView?
 
     @State private var isHovered = false
@@ -537,7 +545,7 @@ private struct ChartEntryRowView: View {
             self.isPresentingChart = true
         } label: {
             HStack {
-                Text(self.kind.title).font(.callout)
+                Text(self.title).font(.callout)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 Image(systemName: "chevron.right")
                     .font(.caption2)

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -591,6 +591,9 @@ private struct ChartSectionContainer<Content: View>: View {
             } label: {
                 ZStack(alignment: .topTrailing) {
                     self.content()
+                        // 与 NSMenu 同机制：hover 时注入 menuItemHighlighted，
+                        // 段视图（MenuCardView 各 SectionView）自动切换高亮配色（文字变白等）。
+                            .environment(\.menuItemHighlighted, self.isHovered)
                     // 行尾 chevron（topTrailing，对齐 NSMenu MenuCardSectionContainerView 指示器）
                     Image(systemName: "chevron.right")
                         .font(.caption2)

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -25,6 +25,10 @@ struct PopoverRootView: View {
     /// 返回底部动作区所需的 sections（与 NSMenu 路径共用 MenuDescriptor.build 数据源）。
     /// 在 body 中调用以建立 @Observable 观察链，store/settings 变化时自动重算。
     let makeSections: () -> [MenuDescriptor.Section]
+    /// Overview 行数据构造闭包（Task 2.4）：与 NSMenu addOverviewRows 同源。
+    let makeOverviewRows: () -> [StatusItemController.PopoverOverviewRow]
+    /// Overview 空态文案：nil 表示有内容行；否则返回本地化文案。
+    let overviewEmptyText: () -> String?
     /// 动作分发回调，由 StatusItemController.performMenuAction(_:) 实现。
     let onAction: (MenuDescriptor.MenuAction) -> Void
     /// Buy Credits 动作回调；仅当 plan.showBuyCredits 为 true 时渲染对应按钮。
@@ -76,10 +80,38 @@ struct PopoverRootView: View {
     @ViewBuilder private var content: some View {
         switch self.viewModel.selection {
         case .overview:
-            // Phase 1 最小：overview 展示首个 provider 卡片；完整 Overview 留 Phase 2
-            self.providerContent(for: self.viewModel.providers.first ?? .codex)
+            self.overviewContent
         case let .provider(p):
             self.providerContent(for: p)
+        }
+    }
+
+    /// Overview 内容区（Task 2.4）：多 provider 概览行，与 NSMenu addOverviewRows 等价。
+    @ViewBuilder private var overviewContent: some View {
+        let rows = self.makeOverviewRows()
+        if rows.isEmpty {
+            let emptyText = self.overviewEmptyText() ?? L("No overview data available.")
+            Text(emptyText)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .padding()
+        } else {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(rows) { row in
+                    Button {
+                        self.viewModel.select(.provider(row.provider))
+                    } label: {
+                        OverviewMenuCardRowView(
+                            model: row.model,
+                            storageText: row.storageText,
+                            width: Self.menuWidth)
+                    }
+                    .buttonStyle(.plain)
+                    if row.id != rows.last?.id {
+                        Divider()
+                    }
+                }
+            }
         }
     }
 

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -59,19 +59,38 @@ struct PopoverRootView: View {
 
     // MARK: - 切换器（Phase 2：Overview tab + provider 图标）
 
+    /// tab 多时（>4，与 NSView 版"均宽不足即换行"语义对齐）切换为自适应网格自动分行；
+    /// 少量 tab 保持紧凑单行 HStack。
     private var switcher: some View {
-        HStack(spacing: 4) {
-            if self.viewModel.includesOverview {
-                self.overviewTab
-            }
-            ForEach(self.viewModel.providers, id: \.self) { provider in
-                self.providerTab(provider)
+        let tabCount = self.viewModel.providers.count + (self.viewModel.includesOverview ? 1 : 0)
+        return Group {
+            if tabCount > 4 {
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 64), spacing: 4)],
+                    alignment: .leading,
+                    spacing: 4)
+                {
+                    self.switcherTabs(fillWidth: true)
+                }
+            } else {
+                HStack(spacing: 4) {
+                    self.switcherTabs(fillWidth: false)
+                }
             }
         }
         .padding(8)
     }
 
-    private var overviewTab: some View {
+    @ViewBuilder private func switcherTabs(fillWidth: Bool) -> some View {
+        if self.viewModel.includesOverview {
+            self.overviewTab(fillWidth: fillWidth)
+        }
+        ForEach(self.viewModel.providers, id: \.self) { provider in
+            self.providerTab(provider, fillWidth: fillWidth)
+        }
+    }
+
+    private func overviewTab(fillWidth: Bool) -> some View {
         let selected = self.viewModel.selection == .overview
         return Button {
             self.viewModel.select(.overview)
@@ -79,6 +98,7 @@ struct PopoverRootView: View {
             Image(systemName: "square.grid.2x2")
                 .font(.caption)
                 .fontWeight(selected ? .semibold : .regular)
+                .frame(maxWidth: fillWidth ? .infinity : nil)
         }
         .buttonStyle(.plain)
         .padding(.horizontal, 6)
@@ -87,25 +107,24 @@ struct PopoverRootView: View {
         .clipShape(RoundedRectangle(cornerRadius: 5))
     }
 
-    private func providerTab(_ provider: UsageProvider) -> some View {
+    private func providerTab(_ provider: UsageProvider, fillWidth: Bool) -> some View {
         let selected = self.isSelected(provider)
         return Button {
             self.viewModel.select(.provider(provider))
         } label: {
-            if let icon = self.switcherIcon(provider) {
-                HStack(spacing: 3) {
+            HStack(spacing: 3) {
+                if let icon = self.switcherIcon(provider) {
                     Image(nsImage: icon)
                         .resizable()
                         .frame(width: 14, height: 14)
-                    Text(provider.rawValue)
-                        .font(.caption)
-                        .fontWeight(selected ? .semibold : .regular)
                 }
-            } else {
                 Text(provider.rawValue)
                     .font(.caption)
                     .fontWeight(selected ? .semibold : .regular)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
             }
+            .frame(maxWidth: fillWidth ? .infinity : nil)
         }
         .buttonStyle(.plain)
         .padding(.horizontal, 6)

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+/// 持久面板根视图。阶段 0 占位；阶段 1 接入切换器 + 单卡片。
+struct PopoverRootView: View {
+    @Bindable var viewModel: MenuViewModel
+    var body: some View {
+        Color.clear.frame(width: 310, height: 1)
+    }
+}

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -146,9 +146,6 @@ struct PopoverRootView: View {
     /// 懒构造图表视图；数据缺失返回 nil。
     let makeChartView: (PopoverChartKind, CGFloat) -> AnyView?
 
-    /// 当前呈现的二级图表；非 nil 时触发 .popover(item:) 弹出侧边浮层。
-    @State private var presentedChart: PopoverChartKind?
-
     private static let menuWidth: CGFloat = 310
 
     var body: some View {
@@ -170,29 +167,6 @@ struct PopoverRootView: View {
         // 无障碍：整个菜单根容器
         .accessibilityElement(children: .contain)
         .accessibilityLabel("CodexBar menu")
-        // 二级图表 popover：锚点用整体 bounds（实现最简单稳定，macOS 侧边弹出效果符合预期）
-        .popover(
-            item: self.$presentedChart,
-            attachmentAnchor: .rect(.bounds),
-            arrowEdge: .trailing)
-        { kind in
-            Group {
-                if let chart = self.makeChartView(kind, 360) {
-                    chart
-                } else {
-                    Text("No data available")
-                        .foregroundStyle(.secondary)
-                        .padding()
-                }
-            }
-            .frame(minWidth: 320)
-        }
-        // 切 provider 时关闭子 popover
-        .onChange(of: self.viewModel.selection) { _, _ in self.presentedChart = nil }
-        // popover 隐藏时关闭子 popover
-        .onChange(of: self.viewModel.isVisible) { _, isVisible in
-            if !isVisible { self.presentedChart = nil }
-        }
     }
 
     // MARK: - 切换器（垂直布局，对齐 NSView ProviderSwitcherView stackedIcons 模式）
@@ -273,8 +247,8 @@ struct PopoverRootView: View {
 
     /// Overview 内容区（Task 2.4）：多 provider 概览行，与 NSMenu addOverviewRows 等价。
     /// Task 3.2：当 makeOverviewChart(row) 非 nil 时，在行尾添加 chevron 按钮触发二级图表 popover。
-    /// 布局：HStack { 行主体 Button（切 provider）; chevronButton（呈现子 popover）}
-    /// 两个 Button 互不干扰：行主体点击执行 viewModel.select；chevron 点击设置 presentedChart。
+    /// 布局：HStack { 行主体 Button（切 provider）; chevronButton（呈现局部 popover）}
+    /// 两个 Button 互不干扰：行主体点击执行 viewModel.select；chevron 点击触发行级 isPresentingChart。
     @ViewBuilder private var overviewContent: some View {
         let rows = self.makeOverviewRows()
         if rows.isEmpty {
@@ -292,8 +266,8 @@ struct PopoverRootView: View {
                         chart: chart,
                         menuWidth: Self.menuWidth,
                         overviewChevronWidth: Self.overviewChevronWidth,
-                        onSelectProvider: { self.viewModel.select(.provider(row.provider)) },
-                        onPresentChart: { self.presentedChart = chart })
+                        makeChartView: self.makeChartView,
+                        onSelectProvider: { self.viewModel.select(.provider(row.provider)) })
                     if row.id != rows.last?.id {
                         Divider()
                     }
@@ -370,7 +344,7 @@ struct PopoverRootView: View {
             if s.hasUsageBlock {
                 ChartSectionContainer(
                     chart: s.usageChart,
-                    onPresentChart: { self.presentedChart = $0 },
+                    makeChartView: self.makeChartView,
                     content: {
                         UsageMenuCardHeaderAndUsageSectionView(
                             model: s.model,
@@ -394,7 +368,7 @@ struct PopoverRootView: View {
             if let storageText = s.storageText {
                 ChartSectionContainer(
                     chart: s.storageChart,
-                    onPresentChart: { self.presentedChart = $0 },
+                    makeChartView: self.makeChartView,
                     content: {
                         StorageMenuCardSectionView(
                             storageText: storageText,
@@ -414,7 +388,7 @@ struct PopoverRootView: View {
                 // 此处无需重复。
                 ChartSectionContainer(
                     chart: s.creditsChart,
-                    onPresentChart: { self.presentedChart = $0 },
+                    makeChartView: self.makeChartView,
                     content: {
                         UsageMenuCardCreditsSectionView(
                             model: s.model,
@@ -436,7 +410,7 @@ struct PopoverRootView: View {
             if s.hasExtraUsage {
                 ChartSectionContainer(
                     chart: s.extraUsageChart,
-                    onPresentChart: { self.presentedChart = $0 },
+                    makeChartView: self.makeChartView,
                     content: {
                         UsageMenuCardExtraUsageSectionView(
                             model: s.model,
@@ -454,7 +428,7 @@ struct PopoverRootView: View {
             if s.hasCost {
                 ChartSectionContainer(
                     chart: s.costChart,
-                    onPresentChart: { self.presentedChart = $0 },
+                    makeChartView: self.makeChartView,
                     content: { PopoverCostCompactRow(model: s.model) })
             }
         }
@@ -468,9 +442,7 @@ struct PopoverRootView: View {
         if !entries.isEmpty {
             Divider()
             ForEach(entries) { kind in
-                ChartEntryRowView(kind: kind) {
-                    self.presentedChart = kind
-                }
+                ChartEntryRowView(kind: kind, makeChartView: self.makeChartView)
             }
         }
     }
@@ -486,16 +458,18 @@ struct PopoverRootView: View {
 // MARK: - OverviewRowView（独立视图，持有 isHovered @State）
 
 /// Overview 单行：行主体 Button（切 provider）+ 可选 chevron Button（呈现图表）。
-/// 抽出为独立 View 以便持有 @State private var isHovered。
+/// 抽出为独立 View 以便持有 @State private var isHovered 和 isPresentingChart。
+/// makeChartView 由 PopoverRootView 透传，懒构造图表内容视图。
 private struct OverviewRowView: View {
     let row: StatusItemController.PopoverOverviewRow
     let chart: PopoverChartKind?
     let menuWidth: CGFloat
     let overviewChevronWidth: CGFloat
+    let makeChartView: (PopoverChartKind, CGFloat) -> AnyView?
     let onSelectProvider: () -> Void
-    let onPresentChart: () -> Void
 
     @State private var isHovered = false
+    @State private var isPresentingChart = false
 
     var body: some View {
         HStack(spacing: 0) {
@@ -516,7 +490,7 @@ private struct OverviewRowView: View {
             .accessibilityHint("Show \(self.row.provider.rawValue) details")
             if let chart = self.chart {
                 Button {
-                    self.onPresentChart()
+                    self.isPresentingChart = true
                 } label: {
                     Image(systemName: "chevron.right")
                         .font(.caption2)
@@ -528,6 +502,18 @@ private struct OverviewRowView: View {
                 .focusEffectDisabled()
                 // 无障碍
                 .accessibilityLabel(chart.title)
+                .popover(isPresented: self.$isPresentingChart, arrowEdge: .trailing) {
+                    Group {
+                        if let chartView = self.makeChartView(chart, 360) {
+                            chartView
+                        } else {
+                            Text("No data available")
+                                .foregroundStyle(.secondary)
+                                .padding()
+                        }
+                    }
+                    .frame(minWidth: 320)
+                }
             }
         }
         .background(self.isHovered ? Color.accentColor : Color.clear)
@@ -539,16 +525,18 @@ private struct OverviewRowView: View {
 
 // MARK: - ChartEntryRowView（独立视图，持有 isHovered @State）
 
-/// 图表下钻入口行，持有自己的 hover 状态。
+/// 图表下钻入口行，持有自己的 hover 状态与局部 popover 状态。
+/// makeChartView 由 PopoverRootView 透传，懒构造图表内容视图。
 private struct ChartEntryRowView: View {
     let kind: PopoverChartKind
-    let onTap: () -> Void
+    let makeChartView: (PopoverChartKind, CGFloat) -> AnyView?
 
     @State private var isHovered = false
+    @State private var isPresentingChart = false
 
     var body: some View {
         Button {
-            self.onTap()
+            self.isPresentingChart = true
         } label: {
             HStack {
                 Text(self.kind.title).font(.callout)
@@ -570,6 +558,18 @@ private struct ChartEntryRowView: View {
         .focusEffectDisabled()
         // 无障碍：Button 标题即 label，hint 说明用途
         .accessibilityHint("Show chart")
+        .popover(isPresented: self.$isPresentingChart, arrowEdge: .trailing) {
+            Group {
+                if let chartView = self.makeChartView(self.kind, 360) {
+                    chartView
+                } else {
+                    Text("No data available")
+                        .foregroundStyle(.secondary)
+                        .padding()
+                }
+            }
+            .frame(minWidth: 320)
+        }
     }
 }
 
@@ -577,17 +577,19 @@ private struct ChartEntryRowView: View {
 
 /// 可复用段容器：wrap 任意段内容，chart 非 nil 时显示行尾 chevron + hover 高亮 + 点击触发图表 popover。
 /// chart 为 nil 时纯展示，无任何交互修饰。
+/// makeChartView 由 PopoverRootView 透传，懒构造图表内容视图。
 private struct ChartSectionContainer<Content: View>: View {
     let chart: PopoverChartKind?
-    let onPresentChart: (PopoverChartKind) -> Void
+    let makeChartView: (PopoverChartKind, CGFloat) -> AnyView?
     @ViewBuilder let content: () -> Content
 
     @State private var isHovered = false
+    @State private var isPresentingChart = false
 
     var body: some View {
         if let chart {
             Button {
-                self.onPresentChart(chart)
+                self.isPresentingChart = true
             } label: {
                 ZStack(alignment: .topTrailing) {
                     self.content()
@@ -612,6 +614,18 @@ private struct ChartSectionContainer<Content: View>: View {
             .focusEffectDisabled()
             .accessibilityLabel(chart.title)
             .accessibilityHint("Show chart")
+            .popover(isPresented: self.$isPresentingChart, arrowEdge: .trailing) {
+                Group {
+                    if let chartView = self.makeChartView(chart, 360) {
+                        chartView
+                    } else {
+                        Text("No data available")
+                            .foregroundStyle(.secondary)
+                            .padding()
+                    }
+                }
+                .frame(minWidth: 320)
+            }
         } else {
             self.content()
         }

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CodexBarCore
 import SwiftUI
 
@@ -33,12 +34,15 @@ struct PopoverRootView: View {
     let onAction: (MenuDescriptor.MenuAction) -> Void
     /// Buy Credits 动作回调；仅当 plan.showBuyCredits 为 true 时渲染对应按钮。
     let onBuyCredits: () -> Void
+    /// provider 图标注入闭包：由 controller 按 switcherShowsIcons 设置返回 NSImage? 或 nil。
+    /// nil 表示不显示图标（纯文字降级）。视图不读 settings，由闭包内部决定。
+    let switcherIcon: (UsageProvider) -> NSImage?
 
     private static let menuWidth: CGFloat = 310
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if self.viewModel.providers.count > 1 {
+            if self.viewModel.providers.count > 1 || self.viewModel.includesOverview {
                 self.switcher
                 Divider()
             }
@@ -53,26 +57,61 @@ struct PopoverRootView: View {
         .fixedSize(horizontal: false, vertical: true)
     }
 
-    // MARK: - 最小 SwiftUI 切换器（Phase 1：纯文字按钮；图标/配额指示留 Phase 2）
+    // MARK: - 切换器（Phase 2：Overview tab + provider 图标）
 
     private var switcher: some View {
         HStack(spacing: 4) {
+            if self.viewModel.includesOverview {
+                self.overviewTab
+            }
             ForEach(self.viewModel.providers, id: \.self) { provider in
-                Button {
-                    self.viewModel.select(.provider(provider))
-                } label: {
-                    Text(provider.rawValue)
-                        .font(.caption)
-                        .fontWeight(self.isSelected(provider) ? .semibold : .regular)
-                }
-                .buttonStyle(.plain)
-                .padding(.horizontal, 6)
-                .padding(.vertical, 3)
-                .background(self.isSelected(provider) ? Color.accentColor.opacity(0.18) : Color.clear)
-                .clipShape(RoundedRectangle(cornerRadius: 5))
+                self.providerTab(provider)
             }
         }
         .padding(8)
+    }
+
+    private var overviewTab: some View {
+        let selected = self.viewModel.selection == .overview
+        return Button {
+            self.viewModel.select(.overview)
+        } label: {
+            Image(systemName: "square.grid.2x2")
+                .font(.caption)
+                .fontWeight(selected ? .semibold : .regular)
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(selected ? Color.accentColor.opacity(0.18) : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: 5))
+    }
+
+    private func providerTab(_ provider: UsageProvider) -> some View {
+        let selected = self.isSelected(provider)
+        return Button {
+            self.viewModel.select(.provider(provider))
+        } label: {
+            if let icon = self.switcherIcon(provider) {
+                HStack(spacing: 3) {
+                    Image(nsImage: icon)
+                        .resizable()
+                        .frame(width: 14, height: 14)
+                    Text(provider.rawValue)
+                        .font(.caption)
+                        .fontWeight(selected ? .semibold : .regular)
+                }
+            } else {
+                Text(provider.rawValue)
+                    .font(.caption)
+                    .fontWeight(selected ? .semibold : .regular)
+            }
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(selected ? Color.accentColor.opacity(0.18) : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: 5))
     }
 
     // MARK: - 内容区

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -1,9 +1,83 @@
 import SwiftUI
+import CodexBarCore
 
-/// 持久面板根视图。阶段 0 占位；阶段 1 接入切换器 + 单卡片。
+/// 持久面板根视图。阶段 1：provider 切换器 + 当前 provider 用量卡片。
+/// 整个 popover 生命周期只构造一次；切 provider 通过 viewModel.select(_:) 增量更新，不重建视图。
 struct PopoverRootView: View {
     @Bindable var viewModel: MenuViewModel
+    /// 注入 UsageStore 引用，用于在 body 中建立 @Observable 观察链：
+    /// store 数据变化时 SwiftUI 自动重渲而无需外部 bump。
+    let store: UsageStore
+    /// 由 StatusItemController 注入的卡片 model 构造闭包（self.menuCardModel(for:)）。
+    /// 持有 weak self 引用，避免强引用环。
+    let makeCardModel: (UsageProvider) -> UsageMenuCardView.Model?
+
+    private static let menuWidth: CGFloat = 310
+
     var body: some View {
-        Color.clear.frame(width: 310, height: 1)
+        VStack(alignment: .leading, spacing: 0) {
+            if viewModel.providers.count > 1 {
+                switcher
+                Divider()
+            }
+            content
+        }
+        .frame(width: Self.menuWidth, alignment: .leading)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    // MARK: - 最小 SwiftUI 切换器（Phase 1：纯文字按钮；图标/配额指示留 Phase 2）
+
+    private var switcher: some View {
+        HStack(spacing: 4) {
+            ForEach(viewModel.providers, id: \.self) { provider in
+                Button {
+                    viewModel.select(.provider(provider))
+                } label: {
+                    Text(provider.rawValue)
+                        .font(.caption)
+                        .fontWeight(isSelected(provider) ? .semibold : .regular)
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+                .background(isSelected(provider) ? Color.accentColor.opacity(0.18) : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: 5))
+            }
+        }
+        .padding(8)
+    }
+
+    // MARK: - 内容区
+
+    @ViewBuilder private var content: some View {
+        switch viewModel.selection {
+        case .overview:
+            // Phase 1 最小：overview 展示首个 provider 卡片；完整 Overview 留 Phase 2
+            card(for: viewModel.providers.first ?? .codex)
+        case let .provider(p):
+            card(for: p)
+        }
+    }
+
+    /// 关键：在 body 中同步读取 store（makeCardModel 内部读 store.* 属性），
+    /// 以建立 @Observable 观察链——store 数据变化时 SwiftUI 自动重渲。
+    @ViewBuilder private func card(for provider: UsageProvider) -> some View {
+        if let model = makeCardModel(provider) {
+            UsageMenuCardView(model: model, width: Self.menuWidth)
+        } else {
+            // store.snapshot 读取触发 @Observable 追踪，数据到达时自动更新
+            let _ = store.snapshot(for: provider)
+            Text("Loading…")
+                .foregroundStyle(.secondary)
+                .padding()
+        }
+    }
+
+    // MARK: - 辅助
+
+    private func isSelected(_ provider: UsageProvider) -> Bool {
+        if case let .provider(p) = viewModel.selection { return p == provider }
+        return false
     }
 }

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -69,6 +69,9 @@ struct PopoverRootView: View {
         }
         .frame(width: Self.menuWidth, alignment: .leading)
         .fixedSize(horizontal: false, vertical: true)
+        // 无障碍：整个菜单根容器
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("CodexBar menu")
         // 二级图表 popover：锚点用整体 bounds（实现最简单稳定，macOS 侧边弹出效果符合预期）
         .popover(
             item: self.$presentedChart,
@@ -116,6 +119,8 @@ struct PopoverRootView: View {
             }
         }
         .padding(8)
+        // 无障碍：切换器容器
+        .accessibilityElement(children: .contain)
     }
 
     @ViewBuilder private func switcherTabs(fillWidth: Bool) -> some View {
@@ -142,6 +147,8 @@ struct PopoverRootView: View {
         .padding(.vertical, 3)
         .background(selected ? Color.accentColor.opacity(0.18) : Color.clear)
         .clipShape(RoundedRectangle(cornerRadius: 5))
+        // 无障碍
+        .accessibilityLabel("Overview")
     }
 
     private func providerTab(_ provider: UsageProvider, fillWidth: Bool) -> some View {
@@ -168,6 +175,8 @@ struct PopoverRootView: View {
         .padding(.vertical, 3)
         .background(selected ? Color.accentColor.opacity(0.18) : Color.clear)
         .clipShape(RoundedRectangle(cornerRadius: 5))
+        // 无障碍
+        .accessibilityLabel(provider.rawValue)
     }
 
     // MARK: - 内容区
@@ -197,31 +206,13 @@ struct PopoverRootView: View {
             VStack(alignment: .leading, spacing: 0) {
                 ForEach(rows) { row in
                     let chart = self.makeOverviewChart(row)
-                    HStack(spacing: 0) {
-                        Button {
-                            self.viewModel.select(.provider(row.provider))
-                        } label: {
-                            OverviewMenuCardRowView(
-                                model: row.model,
-                                storageText: row.storageText,
-                                width: chart != nil
-                                    ? Self.menuWidth - Self.overviewChevronWidth
-                                    : Self.menuWidth)
-                        }
-                        .buttonStyle(.plain)
-                        if let chart {
-                            Button {
-                                self.presentedChart = chart
-                            } label: {
-                                Image(systemName: "chevron.right")
-                                    .font(.caption2)
-                                    .foregroundStyle(.secondary)
-                                    .frame(width: Self.overviewChevronWidth, alignment: .center)
-                                    .contentShape(Rectangle())
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
+                    OverviewRowView(
+                        row: row,
+                        chart: chart,
+                        menuWidth: Self.menuWidth,
+                        overviewChevronWidth: Self.overviewChevronWidth,
+                        onSelectProvider: { self.viewModel.select(.provider(row.provider)) },
+                        onPresentChart: { self.presentedChart = chart })
                     if row.id != rows.last?.id {
                         Divider()
                     }
@@ -277,15 +268,7 @@ struct PopoverRootView: View {
                 }
                 if plan.showBuyCredits {
                     Divider()
-                    Button {
-                        self.onBuyCredits()
-                    } label: {
-                        Label(L("Buy Credits..."), systemImage: "plus.circle")
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .buttonStyle(.plain)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
+                    BuyCreditsRowView(onBuyCredits: self.onBuyCredits)
                 }
             }
         }
@@ -299,21 +282,9 @@ struct PopoverRootView: View {
         if !entries.isEmpty {
             Divider()
             ForEach(entries) { kind in
-                Button {
+                ChartEntryRowView(kind: kind) {
                     self.presentedChart = kind
-                } label: {
-                    HStack {
-                        Text(kind.title).font(.callout)
-                        Spacer()
-                        Image(systemName: "chevron.right")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                    }
-                    .contentShape(Rectangle())
                 }
-                .buttonStyle(.plain)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 5)
             }
         }
     }
@@ -323,5 +294,119 @@ struct PopoverRootView: View {
     private func isSelected(_ provider: UsageProvider) -> Bool {
         if case let .provider(p) = viewModel.selection { return p == provider }
         return false
+    }
+}
+
+// MARK: - OverviewRowView（独立视图，持有 isHovered @State）
+
+/// Overview 单行：行主体 Button（切 provider）+ 可选 chevron Button（呈现图表）。
+/// 抽出为独立 View 以便持有 @State private var isHovered。
+private struct OverviewRowView: View {
+    let row: StatusItemController.PopoverOverviewRow
+    let chart: PopoverChartKind?
+    let menuWidth: CGFloat
+    let overviewChevronWidth: CGFloat
+    let onSelectProvider: () -> Void
+    let onPresentChart: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Button {
+                self.onSelectProvider()
+            } label: {
+                OverviewMenuCardRowView(
+                    model: self.row.model,
+                    storageText: self.row.storageText,
+                    width: self.chart != nil
+                        ? self.menuWidth - self.overviewChevronWidth
+                        : self.menuWidth)
+            }
+            .buttonStyle(.plain)
+            // 无障碍
+            .accessibilityLabel("\(self.row.provider.rawValue) overview")
+            .accessibilityHint("Show \(self.row.provider.rawValue) details")
+            if let chart = self.chart {
+                Button {
+                    self.onPresentChart()
+                } label: {
+                    Image(systemName: "chevron.right")
+                        .font(.caption2)
+                        .foregroundStyle(self.isHovered ? Color.white.opacity(0.75) : Color.secondary)
+                        .frame(width: self.overviewChevronWidth, alignment: .center)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                // 无障碍
+                .accessibilityLabel(chart.title)
+            }
+        }
+        .background(self.isHovered ? Color.accentColor : Color.clear)
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .padding(.horizontal, 5)
+        .onHover { self.isHovered = $0 }
+    }
+}
+
+// MARK: - ChartEntryRowView（独立视图，持有 isHovered @State）
+
+/// 图表下钻入口行，持有自己的 hover 状态。
+private struct ChartEntryRowView: View {
+    let kind: PopoverChartKind
+    let onTap: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button {
+            self.onTap()
+        } label: {
+            HStack {
+                Text(self.kind.title).font(.callout)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundStyle(self.isHovered ? Color.white.opacity(0.75) : Color.secondary)
+            }
+            .padding(.horizontal, 17)
+            .padding(.vertical, 5)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(self.isHovered ? Color.accentColor : Color.clear)
+        .foregroundStyle(self.isHovered ? Color.white : Color.primary)
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .padding(.horizontal, 5)
+        .onHover { self.isHovered = $0 }
+        // 无障碍：Button 标题即 label，hint 说明用途
+        .accessibilityHint("Show chart")
+    }
+}
+
+// MARK: - BuyCreditsRowView（独立视图，持有 isHovered @State）
+
+/// Buy Credits 行，持有自己的 hover 状态。
+private struct BuyCreditsRowView: View {
+    let onBuyCredits: () -> Void
+
+    @State private var isHovered = false
+
+    var body: some View {
+        Button {
+            self.onBuyCredits()
+        } label: {
+            Label(L("Buy Credits..."), systemImage: "plus.circle")
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 17)
+                .padding(.vertical, 6)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(self.isHovered ? Color.accentColor : Color.clear)
+        .foregroundStyle(self.isHovered ? Color.white : Color.primary)
+        .clipShape(RoundedRectangle(cornerRadius: 4))
+        .padding(.horizontal, 5)
+        .onHover { self.isHovered = $0 }
     }
 }

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -2,21 +2,23 @@ import CodexBarCore
 import SwiftUI
 
 /// 持久面板根视图。阶段 1：provider 切换器 + 当前 provider 用量卡片。
-/// 阶段 2：底部动作区（PopoverActionSectionsView）。
+/// 阶段 2：底部动作区（PopoverActionSectionsView）；完整卡片分流渲染（PopoverCardPlan）。
 /// 整个 popover 生命周期只构造一次；切 provider 通过 viewModel.select(_:) 增量更新，不重建视图。
 struct PopoverRootView: View {
     @Bindable var viewModel: MenuViewModel
     /// 注入 UsageStore 引用，用于在 body 中建立 @Observable 观察链：
     /// store 数据变化时 SwiftUI 自动重渲而无需外部 bump。
     let store: UsageStore
-    /// 由 StatusItemController 注入的卡片 model 构造闭包（self.menuCardModel(for:)）。
+    /// 由 StatusItemController 注入的卡片计划构造闭包（self.popoverCardPlan(for:)）。
     /// 持有 weak self 引用，避免强引用环。
-    let makeCardModel: (UsageProvider) -> UsageMenuCardView.Model?
+    let makeCardPlan: (UsageProvider) -> PopoverCardPlan
     /// 返回底部动作区所需的 sections（与 NSMenu 路径共用 MenuDescriptor.build 数据源）。
     /// 在 body 中调用以建立 @Observable 观察链，store/settings 变化时自动重算。
     let makeSections: () -> [MenuDescriptor.Section]
     /// 动作分发回调，由 StatusItemController.performMenuAction(_:) 实现。
     let onAction: (MenuDescriptor.MenuAction) -> Void
+    /// Buy Credits 动作回调；仅当 plan.showBuyCredits 为 true 时渲染对应按钮。
+    let onBuyCredits: () -> Void
 
     private static let menuWidth: CGFloat = 310
 
@@ -71,16 +73,51 @@ struct PopoverRootView: View {
         }
     }
 
-    /// makeCardModel 内部读取 store 属性，在 body 同步求值以建立 @Observable 观察链；
+    /// makeCardPlan 内部读取 store 属性，在 body 同步求值以建立 @Observable 观察链；
     /// store 数据变化时 SwiftUI 自动重渲而无需外部 bump。
     @ViewBuilder private func card(for provider: UsageProvider) -> some View {
-        if let model = makeCardModel(provider) {
-            UsageMenuCardView(model: model, width: Self.menuWidth)
-        } else {
-            // 防御性占位：makeCardModel 当前不返回 nil，保留以防签名变更
-            Text("Loading…")
+        let plan = self.makeCardPlan(provider)
+        if plan.cards.isEmpty {
+            Text(plan.emptyText ?? "Loading…")
                 .foregroundStyle(.secondary)
                 .padding()
+        } else {
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(plan.cards) { card in
+                    if let header = card.workspaceHeader {
+                        Text(header)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(.horizontal, 12)
+                            .padding(.top, 6)
+                            .padding(.bottom, 2)
+                    }
+                    UsageMenuCardView(model: card.model, width: Self.menuWidth)
+                    if card.id != plan.cards.last?.id {
+                        Divider()
+                    }
+                }
+                if let storageText = plan.storageText {
+                    Divider()
+                    StorageMenuCardSectionView(
+                        storageText: storageText,
+                        topPadding: 6,
+                        bottomPadding: 6,
+                        width: Self.menuWidth)
+                }
+                if plan.showBuyCredits {
+                    Divider()
+                    Button {
+                        self.onBuyCredits()
+                    } label: {
+                        Label(L("Buy Credits..."), systemImage: "plus.circle")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                }
+            }
         }
     }
 

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -319,11 +319,16 @@ struct PopoverRootView: View {
                 }
                 if let storageText = plan.storageText {
                     Divider()
-                    StorageMenuCardSectionView(
-                        storageText: storageText,
-                        topPadding: 6,
-                        bottomPadding: 6,
-                        width: Self.menuWidth)
+                    ChartSectionContainer(
+                        chart: plan.storageChart,
+                        makeChartView: self.makeChartView,
+                        content: {
+                            StorageMenuCardSectionView(
+                                storageText: storageText,
+                                topPadding: 6,
+                                bottomPadding: 6,
+                                width: Self.menuWidth)
+                        })
                 }
                 if plan.showBuyCredits {
                     Divider()

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -502,24 +502,17 @@ private struct OverviewRowView: View {
                 .focusEffectDisabled()
                 // 无障碍
                 .accessibilityLabel(chart.title)
-                .popover(isPresented: self.$isPresentingChart, arrowEdge: .trailing) {
-                    Group {
-                        if let chartView = self.makeChartView(chart, 360) {
-                            chartView
-                        } else {
-                            Text("No data available")
-                                .foregroundStyle(.secondary)
-                                .padding()
-                        }
-                    }
-                    .frame(minWidth: 320)
-                }
             }
         }
         .background(self.isHovered ? Color.accentColor : Color.clear)
         .clipShape(RoundedRectangle(cornerRadius: 4))
         .padding(.horizontal, 5)
         .onHover { self.isHovered = $0 }
+        // hover 触发整行；点击 chevron 仍直接置 true
+        .modifier(HoverChartPopover(
+            chart: self.chart,
+            makeChartView: self.makeChartView,
+            isPresented: self.$isPresentingChart))
     }
 }
 
@@ -558,18 +551,10 @@ private struct ChartEntryRowView: View {
         .focusEffectDisabled()
         // 无障碍：Button 标题即 label，hint 说明用途
         .accessibilityHint("Show chart")
-        .popover(isPresented: self.$isPresentingChart, arrowEdge: .trailing) {
-            Group {
-                if let chartView = self.makeChartView(self.kind, 360) {
-                    chartView
-                } else {
-                    Text("No data available")
-                        .foregroundStyle(.secondary)
-                        .padding()
-                }
-            }
-            .frame(minWidth: 320)
-        }
+        .modifier(HoverChartPopover(
+            chart: self.kind,
+            makeChartView: self.makeChartView,
+            isPresented: self.$isPresentingChart))
     }
 }
 
@@ -587,7 +572,7 @@ private struct ChartSectionContainer<Content: View>: View {
     @State private var isPresentingChart = false
 
     var body: some View {
-        if let chart {
+        if self.chart != nil {
             Button {
                 self.isPresentingChart = true
             } label: {
@@ -612,20 +597,12 @@ private struct ChartSectionContainer<Content: View>: View {
             .padding(.horizontal, 5)
             .onHover { self.isHovered = $0 }
             .focusEffectDisabled()
-            .accessibilityLabel(chart.title)
+            .accessibilityLabel(self.chart?.title ?? "")
             .accessibilityHint("Show chart")
-            .popover(isPresented: self.$isPresentingChart, arrowEdge: .trailing) {
-                Group {
-                    if let chartView = self.makeChartView(chart, 360) {
-                        chartView
-                    } else {
-                        Text("No data available")
-                            .foregroundStyle(.secondary)
-                            .padding()
-                    }
-                }
-                .frame(minWidth: 320)
-            }
+            .modifier(HoverChartPopover(
+                chart: self.chart,
+                makeChartView: self.makeChartView,
+                isPresented: self.$isPresentingChart))
         } else {
             self.content()
         }

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -33,6 +33,9 @@ struct PopoverRootView: View {
     let overviewEmptyText: () -> String?
     /// 动作分发回调，由 StatusItemController.performMenuAction(_:) 实现。
     let onAction: (MenuDescriptor.MenuAction) -> Void
+    /// 返回 action 对应的禁用 subtitle（nil = 可用；非 nil = 禁用并显示 subtitle 小字）。
+    /// 对齐 NSMenu addActionableSections switchAccount/addCodexAccount disabled 逻辑。
+    var actionSubtitle: ((MenuDescriptor.MenuAction) -> String?)?
     /// Buy Credits 动作回调；仅当 plan.showBuyCredits 为 true 时渲染对应按钮。
     let onBuyCredits: () -> Void
     /// provider 图标注入闭包：由 controller 按 switcherShowsIcons 设置返回 NSImage? 或 nil。
@@ -60,7 +63,8 @@ struct PopoverRootView: View {
             Divider()
             PopoverActionSectionsView(
                 sections: self.makeSections(),
-                onAction: self.onAction)
+                onAction: self.onAction,
+                actionSubtitle: self.actionSubtitle)
                 .padding(.bottom, 6)
         }
         .frame(width: Self.menuWidth, alignment: .leading)

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -319,11 +319,15 @@ struct PopoverRootView: View {
     /// store 数据变化时 SwiftUI 自动重渲而无需外部 bump。
     @ViewBuilder private func card(for provider: UsageProvider) -> some View {
         let plan = self.makeCardPlan(provider)
-        if plan.cards.isEmpty {
+        if let sectioned = plan.sectioned {
+            // 拆段模式（对齐 NSMenu addMenuCardSections）
+            self.sectionedCard(sectioned)
+        } else if plan.cards.isEmpty {
             Text(plan.emptyText ?? "Loading…")
                 .foregroundStyle(.secondary)
                 .padding()
         } else {
+            // 整卡模式（stacked / 无 webItems provider）
             VStack(alignment: .leading, spacing: 0) {
                 ForEach(plan.cards) { card in
                     if let header = card.workspaceHeader {
@@ -355,9 +359,110 @@ struct PopoverRootView: View {
         }
     }
 
+    /// 拆段渲染（对齐 NSMenu addMenuCardSections 顺序与 Divider 规律）。
+    @ViewBuilder private func sectionedCard(_ s: PopoverCardPlan.SectionedCard) -> some View {
+        let bottomPadding = CGFloat(s.hasCredits ? 4 : 6)
+        let sectionSpacing = CGFloat(6)
+        let width = Self.menuWidth
+
+        VStack(alignment: .leading, spacing: 0) {
+            // ── 1. Header + Usage 段 ──
+            if s.hasUsageBlock {
+                ChartSectionContainer(
+                    chart: s.usageChart,
+                    onPresentChart: { self.presentedChart = $0 },
+                    content: {
+                        UsageMenuCardHeaderAndUsageSectionView(
+                            model: s.model,
+                            bottomPadding: bottomPadding,
+                            width: width)
+                    })
+            } else {
+                // 无 usage 内容：仅 Header（无 chevron）
+                UsageMenuCardHeaderSectionView(
+                    model: s.model,
+                    showDivider: false,
+                    width: width)
+            }
+
+            // ── Divider 规律（对齐 1283-1291）──
+            if s.hasStorage || s.hasCredits || s.hasExtraUsage || s.hasCost {
+                Divider()
+            }
+
+            // ── 2. Storage 段 ──
+            if let storageText = s.storageText {
+                ChartSectionContainer(
+                    chart: s.storageChart,
+                    onPresentChart: { self.presentedChart = $0 },
+                    content: {
+                        StorageMenuCardSectionView(
+                            storageText: storageText,
+                            topPadding: 6,
+                            bottomPadding: 6,
+                            width: width)
+                    })
+                // storage 后若还有 credits/extraUsage/cost，加 Divider（对齐 1287-1291）
+                if s.hasCredits || s.hasExtraUsage || s.hasCost {
+                    Divider()
+                }
+            }
+
+            // ── 3. Credits 段 ──
+            if s.hasCredits {
+                // credits 在 storage 之后；storage 已在上方加了 Divider，
+                // 此处无需重复。
+                ChartSectionContainer(
+                    chart: s.creditsChart,
+                    onPresentChart: { self.presentedChart = $0 },
+                    content: {
+                        UsageMenuCardCreditsSectionView(
+                            model: s.model,
+                            showBottomDivider: false,
+                            topPadding: sectionSpacing,
+                            bottomPadding: bottomPadding,
+                            width: width)
+                    })
+                if s.showBuyCredits {
+                    BuyCreditsRowView(onBuyCredits: self.onBuyCredits)
+                }
+                // credits → extraUsage / cost 间的 separator（对齐 1316: if hasCredits）
+                if s.hasExtraUsage || s.hasCost {
+                    Divider()
+                }
+            }
+
+            // ── 4. Extra Usage 段 ──
+            if s.hasExtraUsage {
+                ChartSectionContainer(
+                    chart: s.extraUsageChart,
+                    onPresentChart: { self.presentedChart = $0 },
+                    content: {
+                        UsageMenuCardExtraUsageSectionView(
+                            model: s.model,
+                            topPadding: sectionSpacing,
+                            bottomPadding: bottomPadding,
+                            width: width)
+                    })
+                // extraUsage → cost 间的 separator（对齐 1334: if hasCredits || hasExtraUsage）
+                if s.hasCost {
+                    Divider()
+                }
+            }
+
+            // ── 5. Cost 紧凑行 ──
+            if s.hasCost {
+                ChartSectionContainer(
+                    chart: s.costChart,
+                    onPresentChart: { self.presentedChart = $0 },
+                    content: { PopoverCostCompactRow(model: s.model) })
+            }
+        }
+    }
+
     /// 单 provider 图表下钻入口行（Task 3.2）。
-    /// 出现在卡片区（含 storage/buyCredits）之后、动作区 Divider 之前。
-    /// entries 为空时不渲染（EmptyView）。
+    /// 拆段模式下只显示 usageHistory 与 zaiHourly（原版仅有的两个独立行）；
+    /// 整卡模式下同样只显示这两个入口（对齐原版整卡 provider 没有别的入口的语义）。
     @ViewBuilder private func chartEntries(for provider: UsageProvider) -> some View {
         let entries = self.makeChartEntries(provider)
         if !entries.isEmpty {
@@ -465,6 +570,71 @@ private struct ChartEntryRowView: View {
         .focusEffectDisabled()
         // 无障碍：Button 标题即 label，hint 说明用途
         .accessibilityHint("Show chart")
+    }
+}
+
+// MARK: - ChartSectionContainer（段容器：可选 chevron + hover 高亮 + 点击呈现图表）
+
+/// 可复用段容器：wrap 任意段内容，chart 非 nil 时显示行尾 chevron + hover 高亮 + 点击触发图表 popover。
+/// chart 为 nil 时纯展示，无任何交互修饰。
+private struct ChartSectionContainer<Content: View>: View {
+    let chart: PopoverChartKind?
+    let onPresentChart: (PopoverChartKind) -> Void
+    @ViewBuilder let content: () -> Content
+
+    @State private var isHovered = false
+
+    var body: some View {
+        if let chart {
+            Button {
+                self.onPresentChart(chart)
+            } label: {
+                ZStack(alignment: .topTrailing) {
+                    self.content()
+                    // 行尾 chevron（topTrailing，对齐 NSMenu MenuCardSectionContainerView 指示器）
+                    Image(systemName: "chevron.right")
+                        .font(.caption2)
+                        .foregroundStyle(self.isHovered ? Color.white.opacity(0.75) : Color.secondary)
+                        .padding(.top, 8)
+                        .padding(.trailing, 8)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .background(self.isHovered ? Color.accentColor : Color.clear)
+            .foregroundStyle(self.isHovered ? Color.white : Color.primary)
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+            .padding(.horizontal, 5)
+            .onHover { self.isHovered = $0 }
+            .focusEffectDisabled()
+            .accessibilityLabel(chart.title)
+            .accessibilityHint("Show chart")
+        } else {
+            self.content()
+        }
+    }
+}
+
+// MARK: - PopoverCostCompactRow（Cost 紧凑行，对齐 NSMenuItem title+subtitle 观感）
+
+/// Cost 紧凑行：标题 "Cost" + subtitle 详情行（对齐 NSMenu makeCostMenuCardItem）。
+private struct PopoverCostCompactRow: View {
+    let model: UsageMenuCardView.Model
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(StatusItemController.costMenuTitle)
+                .font(.callout)
+            let lines = StatusItemController.costMenuVisibleDetailLines(tokenUsage: self.model.tokenUsage)
+            ForEach(lines, id: \.self) { line in
+                Text(line)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.horizontal, UsageMenuCardLayout.horizontalPadding)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -2,9 +2,16 @@ import CodexBarCore
 import SwiftUI
 
 /// 持久面板根视图。阶段 1：provider 切换器 + 当前 provider 用量卡片。
-/// 阶段 2：底部动作区（PopoverActionSectionsView）；完整卡片分流渲染（PopoverCardPlan）。
+/// 阶段 2：底部动作区（PopoverActionSectionsView）；完整卡片分流渲染（PopoverCardPlan）；
+///         账户切换器（PopoverAccountSwitcherView）。
 /// 整个 popover 生命周期只构造一次；切 provider 通过 viewModel.select(_:) 增量更新，不重建视图。
 struct PopoverRootView: View {
+    /// 账户切换器绑定：segments 数据 + onSelect 回调。由 makeAccountSwitcher 构造闭包返回。
+    struct AccountSwitcherBinding {
+        let segments: [PopoverAccountSwitcherView.Segment]
+        let onSelect: (String) -> Void
+    }
+
     @Bindable var viewModel: MenuViewModel
     /// 注入 UsageStore 引用，用于在 body 中建立 @Observable 观察链：
     /// store 数据变化时 SwiftUI 自动重渲而无需外部 bump。
@@ -12,6 +19,9 @@ struct PopoverRootView: View {
     /// 由 StatusItemController 注入的卡片计划构造闭包（self.popoverCardPlan(for:)）。
     /// 持有 weak self 引用，避免强引用环。
     let makeCardPlan: (UsageProvider) -> PopoverCardPlan
+    /// 账户切换器构造闭包：由 StatusItemController 注入，返回非 nil 时显示切换器。
+    /// 仅在单 provider 视图（非 overview）且 display.showSwitcher 时有值。
+    let makeAccountSwitcher: (UsageProvider) -> AccountSwitcherBinding?
     /// 返回底部动作区所需的 sections（与 NSMenu 路径共用 MenuDescriptor.build 数据源）。
     /// 在 body 中调用以建立 @Observable 观察链，store/settings 变化时自动重算。
     let makeSections: () -> [MenuDescriptor.Section]
@@ -67,10 +77,19 @@ struct PopoverRootView: View {
         switch self.viewModel.selection {
         case .overview:
             // Phase 1 最小：overview 展示首个 provider 卡片；完整 Overview 留 Phase 2
-            self.card(for: self.viewModel.providers.first ?? .codex)
+            self.providerContent(for: self.viewModel.providers.first ?? .codex)
         case let .provider(p):
-            self.card(for: p)
+            self.providerContent(for: p)
         }
+    }
+
+    /// 单 provider 视图：账户切换器（有时）+ 卡片内容。
+    @ViewBuilder private func providerContent(for provider: UsageProvider) -> some View {
+        if let switcher = self.makeAccountSwitcher(provider) {
+            PopoverAccountSwitcherView(segments: switcher.segments, onSelect: switcher.onSelect)
+            Divider()
+        }
+        self.card(for: provider)
     }
 
     /// makeCardPlan 内部读取 store 属性，在 body 同步求值以建立 @Observable 观察链；

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -241,11 +241,18 @@ struct PopoverRootView: View {
     // MARK: - 内容区
 
     @ViewBuilder private var content: some View {
-        switch self.viewModel.selection {
-        case .overview:
-            self.overviewContent
-        case let .provider(p):
-            self.providerContent(for: p)
+        if self.viewModel.isFallback {
+            Text(L("No usage configured."))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding()
+        } else {
+            switch self.viewModel.selection {
+            case .overview:
+                self.overviewContent
+            case let .provider(p):
+                self.providerContent(for: p)
+            }
         }
     }
 

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// 持久面板根视图。阶段 1：provider 切换器 + 当前 provider 用量卡片。
 /// 阶段 2：底部动作区（PopoverActionSectionsView）；完整卡片分流渲染（PopoverCardPlan）；
 ///         账户切换器（PopoverAccountSwitcherView）。
+/// 阶段 3：图表二级 popover 下钻入口（PopoverChartKind）。
 /// 整个 popover 生命周期只构造一次；切 provider 通过 viewModel.select(_:) 增量更新，不重建视图。
 struct PopoverRootView: View {
     /// 账户切换器绑定：segments 数据 + onSelect 回调。由 makeAccountSwitcher 构造闭包返回。
@@ -37,6 +38,15 @@ struct PopoverRootView: View {
     /// provider 图标注入闭包：由 controller 按 switcherShowsIcons 设置返回 NSImage? 或 nil。
     /// nil 表示不显示图标（纯文字降级）。视图不读 settings，由闭包内部决定。
     let switcherIcon: (UsageProvider) -> NSImage?
+    /// 返回指定 provider 的下钻图表入口列表（Task 3.1）。
+    let makeChartEntries: (UsageProvider) -> [PopoverChartKind]
+    /// 返回 Overview 行对应的下钻图表（nil 表示该行无下钻）。
+    let makeOverviewChart: (StatusItemController.PopoverOverviewRow) -> PopoverChartKind?
+    /// 懒构造图表视图；数据缺失返回 nil。
+    let makeChartView: (PopoverChartKind, CGFloat) -> AnyView?
+
+    /// 当前呈现的二级图表；非 nil 时触发 .popover(item:) 弹出侧边浮层。
+    @State private var presentedChart: PopoverChartKind?
 
     private static let menuWidth: CGFloat = 310
 
@@ -55,6 +65,29 @@ struct PopoverRootView: View {
         }
         .frame(width: Self.menuWidth, alignment: .leading)
         .fixedSize(horizontal: false, vertical: true)
+        // 二级图表 popover：锚点用整体 bounds（实现最简单稳定，macOS 侧边弹出效果符合预期）
+        .popover(
+            item: self.$presentedChart,
+            attachmentAnchor: .rect(.bounds),
+            arrowEdge: .trailing)
+        { kind in
+            Group {
+                if let chart = self.makeChartView(kind, 360) {
+                    chart
+                } else {
+                    Text("No data available")
+                        .foregroundStyle(.secondary)
+                        .padding()
+                }
+            }
+            .frame(minWidth: 320)
+        }
+        // 切 provider 时关闭子 popover
+        .onChange(of: self.viewModel.selection) { _, _ in self.presentedChart = nil }
+        // popover 隐藏时关闭子 popover
+        .onChange(of: self.viewModel.isVisible) { _, isVisible in
+            if !isVisible { self.presentedChart = nil }
+        }
     }
 
     // MARK: - 切换器（Phase 2：Overview tab + provider 图标）
@@ -145,6 +178,9 @@ struct PopoverRootView: View {
     }
 
     /// Overview 内容区（Task 2.4）：多 provider 概览行，与 NSMenu addOverviewRows 等价。
+    /// Task 3.2：当 makeOverviewChart(row) 非 nil 时，在行尾添加 chevron 按钮触发二级图表 popover。
+    /// 布局：HStack { 行主体 Button（切 provider）; chevronButton（呈现子 popover）}
+    /// 两个 Button 互不干扰：行主体点击执行 viewModel.select；chevron 点击设置 presentedChart。
     @ViewBuilder private var overviewContent: some View {
         let rows = self.makeOverviewRows()
         if rows.isEmpty {
@@ -156,15 +192,32 @@ struct PopoverRootView: View {
         } else {
             VStack(alignment: .leading, spacing: 0) {
                 ForEach(rows) { row in
-                    Button {
-                        self.viewModel.select(.provider(row.provider))
-                    } label: {
-                        OverviewMenuCardRowView(
-                            model: row.model,
-                            storageText: row.storageText,
-                            width: Self.menuWidth)
+                    let chart = self.makeOverviewChart(row)
+                    HStack(spacing: 0) {
+                        Button {
+                            self.viewModel.select(.provider(row.provider))
+                        } label: {
+                            OverviewMenuCardRowView(
+                                model: row.model,
+                                storageText: row.storageText,
+                                width: chart != nil
+                                    ? Self.menuWidth - Self.overviewChevronWidth
+                                    : Self.menuWidth)
+                        }
+                        .buttonStyle(.plain)
+                        if let chart {
+                            Button {
+                                self.presentedChart = chart
+                            } label: {
+                                Image(systemName: "chevron.right")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                    .frame(width: Self.overviewChevronWidth, alignment: .center)
+                                    .contentShape(Rectangle())
+                            }
+                            .buttonStyle(.plain)
+                        }
                     }
-                    .buttonStyle(.plain)
                     if row.id != rows.last?.id {
                         Divider()
                     }
@@ -173,13 +226,17 @@ struct PopoverRootView: View {
         }
     }
 
-    /// 单 provider 视图：账户切换器（有时）+ 卡片内容。
+    /// Overview 行尾 chevron 占位宽（不影响 OverviewMenuCardRowView 布局计算）。
+    private static let overviewChevronWidth: CGFloat = 28
+
+    /// 单 provider 视图：账户切换器（有时）+ 卡片内容 + 图表下钻入口（有时）。
     @ViewBuilder private func providerContent(for provider: UsageProvider) -> some View {
         if let switcher = self.makeAccountSwitcher(provider) {
             PopoverAccountSwitcherView(segments: switcher.segments, onSelect: switcher.onSelect)
             Divider()
         }
         self.card(for: provider)
+        self.chartEntries(for: provider)
     }
 
     /// makeCardPlan 内部读取 store 属性，在 body 同步求值以建立 @Observable 观察链；
@@ -226,6 +283,33 @@ struct PopoverRootView: View {
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
                 }
+            }
+        }
+    }
+
+    /// 单 provider 图表下钻入口行（Task 3.2）。
+    /// 出现在卡片区（含 storage/buyCredits）之后、动作区 Divider 之前。
+    /// entries 为空时不渲染（EmptyView）。
+    @ViewBuilder private func chartEntries(for provider: UsageProvider) -> some View {
+        let entries = self.makeChartEntries(provider)
+        if !entries.isEmpty {
+            Divider()
+            ForEach(entries) { kind in
+                Button {
+                    self.presentedChart = kind
+                } label: {
+                    HStack {
+                        Text(kind.title).font(.callout)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 5)
             }
         }
     }

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import CodexBarCore
+import SwiftUI
 
 /// 持久面板根视图。阶段 1：provider 切换器 + 当前 provider 用量卡片。
 /// 整个 popover 生命周期只构造一次；切 provider 通过 viewModel.select(_:) 增量更新，不重建视图。
@@ -16,11 +16,11 @@ struct PopoverRootView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if viewModel.providers.count > 1 {
-                switcher
+            if self.viewModel.providers.count > 1 {
+                self.switcher
                 Divider()
             }
-            content
+            self.content
         }
         .frame(width: Self.menuWidth, alignment: .leading)
         .fixedSize(horizontal: false, vertical: true)
@@ -30,18 +30,18 @@ struct PopoverRootView: View {
 
     private var switcher: some View {
         HStack(spacing: 4) {
-            ForEach(viewModel.providers, id: \.self) { provider in
+            ForEach(self.viewModel.providers, id: \.self) { provider in
                 Button {
-                    viewModel.select(.provider(provider))
+                    self.viewModel.select(.provider(provider))
                 } label: {
                     Text(provider.rawValue)
                         .font(.caption)
-                        .fontWeight(isSelected(provider) ? .semibold : .regular)
+                        .fontWeight(self.isSelected(provider) ? .semibold : .regular)
                 }
                 .buttonStyle(.plain)
                 .padding(.horizontal, 6)
                 .padding(.vertical, 3)
-                .background(isSelected(provider) ? Color.accentColor.opacity(0.18) : Color.clear)
+                .background(self.isSelected(provider) ? Color.accentColor.opacity(0.18) : Color.clear)
                 .clipShape(RoundedRectangle(cornerRadius: 5))
             }
         }
@@ -51,12 +51,12 @@ struct PopoverRootView: View {
     // MARK: - 内容区
 
     @ViewBuilder private var content: some View {
-        switch viewModel.selection {
+        switch self.viewModel.selection {
         case .overview:
             // Phase 1 最小：overview 展示首个 provider 卡片；完整 Overview 留 Phase 2
-            card(for: viewModel.providers.first ?? .codex)
+            self.card(for: self.viewModel.providers.first ?? .codex)
         case let .provider(p):
-            card(for: p)
+            self.card(for: p)
         }
     }
 

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -2,6 +2,101 @@ import AppKit
 import CodexBarCore
 import SwiftUI
 
+// MARK: - ProviderSwitcherTabView（独立 view，持有 isHovered @State）
+
+/// 单个切换器 tab——垂直布局（图标在上、标题在下），与 NSView 版 StackedToggleButton 外观对齐。
+/// - 选中态：实心 accentColor 圆角胶囊 + 白色图标/文字（NSView 版 controlAccentColor 背景）
+/// - 未选中态：透明底 + secondary 文字
+/// - 底部用量条：高 3pt 圆角小条，背景灰 track + provider 品牌色 fill（仅未选中时显示）
+private struct ProviderSwitcherTabView: View {
+    let icon: NSImage?
+    let title: String
+    /// 用量指示条数据：(fraction 0-1, color)；nil 表示无数据不显示条。
+    let indicator: (fraction: Double, color: NSColor)?
+    let selected: Bool
+    let onTap: () -> Void
+
+    @State private var isHovered = false
+
+    // 对齐 NSView 版常量
+    private static let indicatorHeight: CGFloat = 3
+    private static let indicatorBottomInset: CGFloat = 2
+    private static let indicatorHorizontalInset: CGFloat = 8
+
+    var body: some View {
+        Button(action: self.onTap) {
+            VStack(spacing: 3) {
+                // 图标（约 18pt），与 NSView StackedToggleButton 图标区域对齐
+                Group {
+                    if let nsImage = self.icon {
+                        Image(nsImage: nsImage)
+                            .resizable()
+                            .scaledToFit()
+                    } else {
+                        Image(systemName: "square.fill")
+                            .resizable()
+                            .scaledToFit()
+                    }
+                }
+                .frame(width: 18, height: 18)
+                // 标题（.caption2 大小，lineLimit 1 + 截断）
+                Text(self.title)
+                    .font(.caption2)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                // 用量指示条（仅在未选中时可见，选中时隐藏，与 NSView 版行为一致）
+                if let indicator = self.indicator {
+                    self.indicatorBar(fraction: indicator.fraction, color: indicator.color)
+                        .opacity(self.selected ? 0 : 1)
+                } else {
+                    // 无数据时保留等高占位，避免 tab 高度抖动
+                    Color.clear
+                        .frame(height: Self.indicatorHeight + Self.indicatorBottomInset)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(self.selected ? Color.accentColor : (self.isHovered ? self.hoverColor : Color.clear))
+        .foregroundStyle(self.selected ? Color.white : Color.secondary)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .focusEffectDisabled()
+        .onHover { self.isHovered = $0 }
+        // 无障碍
+        .accessibilityLabel(self.title)
+        .accessibilityAddTraits(self.selected ? [.isSelected] : [])
+    }
+
+    private func indicatorBar(fraction: Double, color: NSColor) -> some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                // 灰色 track
+                RoundedRectangle(cornerRadius: Self.indicatorHeight / 2)
+                    .fill(Color(nsColor: .tertiaryLabelColor).opacity(0.22))
+                    .frame(height: Self.indicatorHeight)
+                // 品牌色 fill
+                if fraction > 0 {
+                    RoundedRectangle(cornerRadius: Self.indicatorHeight / 2)
+                        .fill(Color(nsColor: color))
+                        .frame(
+                            width: max(0, (geo.size.width - Self.indicatorHorizontalInset * 2) * CGFloat(fraction)),
+                            height: Self.indicatorHeight)
+                        .offset(x: Self.indicatorHorizontalInset)
+                }
+            }
+        }
+        .frame(height: Self.indicatorHeight + Self.indicatorBottomInset)
+        .padding(.horizontal, Self.indicatorHorizontalInset)
+    }
+
+    private var hoverColor: Color {
+        // 对齐 NSView 版 hoverPlateColor（不区分深浅模式，让 Color 自适应）
+        Color.primary.opacity(0.07)
+    }
+}
+
 /// 持久面板根视图。阶段 1：provider 切换器 + 当前 provider 用量卡片。
 /// 阶段 2：底部动作区（PopoverActionSectionsView）；完整卡片分流渲染（PopoverCardPlan）；
 ///         账户切换器（PopoverAccountSwitcherView）。
@@ -41,6 +136,9 @@ struct PopoverRootView: View {
     /// provider 图标注入闭包：由 controller 按 switcherShowsIcons 设置返回 NSImage? 或 nil。
     /// nil 表示不显示图标（纯文字降级）。视图不读 settings，由闭包内部决定。
     let switcherIcon: (UsageProvider) -> NSImage?
+    /// 用量指示条数据：返回 (fraction 0-1, color)；nil 表示该 provider 无数据不显示条。
+    /// 由 StatusItemController 注入，调用 switcherWeeklyRemaining + branding.color 计算。
+    let switcherIndicator: (UsageProvider) -> (fraction: Double, color: NSColor)?
     /// 返回指定 provider 的下钻图表入口列表（Task 3.1）。
     let makeChartEntries: (UsageProvider) -> [PopoverChartKind]
     /// 返回 Overview 行对应的下钻图表（nil 表示该行无下钻）。
@@ -97,24 +195,24 @@ struct PopoverRootView: View {
         }
     }
 
-    // MARK: - 切换器（Phase 2：Overview tab + provider 图标）
+    // MARK: - 切换器（垂直布局，对齐 NSView ProviderSwitcherView stackedIcons 模式）
 
-    /// tab 多时（>4，与 NSView 版"均宽不足即换行"语义对齐）切换为自适应网格自动分行；
-    /// 少量 tab 保持紧凑单行 HStack。
+    /// 固定 3 列网格布局，与 NSView 版 stackedIcons 行为对齐。
+    /// tab ≤ 3 时 HStack 等分；> 3 时 3 列网格自动换行。
     private var switcher: some View {
         let tabCount = self.viewModel.providers.count + (self.viewModel.includesOverview ? 1 : 0)
         return Group {
-            if tabCount > 4 {
+            if tabCount > 3 {
                 LazyVGrid(
-                    columns: [GridItem(.adaptive(minimum: 64), spacing: 4)],
+                    columns: Array(repeating: GridItem(.flexible(), spacing: 4), count: 3),
                     alignment: .leading,
                     spacing: 4)
                 {
-                    self.switcherTabs(fillWidth: true)
+                    self.switcherTabs
                 }
             } else {
                 HStack(spacing: 4) {
-                    self.switcherTabs(fillWidth: false)
+                    self.switcherTabs
                 }
             }
         }
@@ -123,61 +221,44 @@ struct PopoverRootView: View {
         .accessibilityElement(children: .contain)
     }
 
-    @ViewBuilder private func switcherTabs(fillWidth: Bool) -> some View {
+    @ViewBuilder private var switcherTabs: some View {
         if self.viewModel.includesOverview {
-            self.overviewTab(fillWidth: fillWidth)
+            self.overviewTab
         }
         ForEach(self.viewModel.providers, id: \.self) { provider in
-            self.providerTab(provider, fillWidth: fillWidth)
+            self.providerTab(provider)
         }
     }
 
-    private func overviewTab(fillWidth: Bool) -> some View {
+    private var overviewTab: some View {
         let selected = self.viewModel.selection == .overview
-        return Button {
-            self.viewModel.select(.overview)
-        } label: {
-            Image(systemName: "square.grid.2x2")
-                .font(.caption)
-                .fontWeight(selected ? .semibold : .regular)
-                .frame(maxWidth: fillWidth ? .infinity : nil)
-        }
-        .buttonStyle(.plain)
-        .padding(.horizontal, 6)
-        .padding(.vertical, 3)
-        .background(selected ? Color.accentColor.opacity(0.18) : Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: 5))
-        // 无障碍
-        .accessibilityLabel("Overview")
+        return ProviderSwitcherTabView(
+            icon: Self.overviewNSImage,
+            title: L("Overview"),
+            indicator: nil,
+            selected: selected,
+            onTap: { self.viewModel.select(.overview) })
     }
 
-    private func providerTab(_ provider: UsageProvider, fillWidth: Bool) -> some View {
+    private func providerTab(_ provider: UsageProvider) -> some View {
         let selected = self.isSelected(provider)
-        return Button {
-            self.viewModel.select(.provider(provider))
-        } label: {
-            HStack(spacing: 3) {
-                if let icon = self.switcherIcon(provider) {
-                    Image(nsImage: icon)
-                        .resizable()
-                        .frame(width: 14, height: 14)
-                }
-                Text(provider.rawValue)
-                    .font(.caption)
-                    .fontWeight(selected ? .semibold : .regular)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-            }
-            .frame(maxWidth: fillWidth ? .infinity : nil)
-        }
-        .buttonStyle(.plain)
-        .padding(.horizontal, 6)
-        .padding(.vertical, 3)
-        .background(selected ? Color.accentColor.opacity(0.18) : Color.clear)
-        .clipShape(RoundedRectangle(cornerRadius: 5))
-        // 无障碍
-        .accessibilityLabel(provider.rawValue)
+        let title = ProviderDescriptorRegistry.descriptor(for: provider).metadata.displayName
+        let icon = self.switcherIcon(provider)
+        let indicator = self.switcherIndicator(provider)
+        return ProviderSwitcherTabView(
+            icon: icon,
+            title: title,
+            indicator: indicator,
+            selected: selected,
+            onTap: { self.viewModel.select(.provider(provider)) })
     }
+
+    /// Overview tab 图标（对齐 NSView 版 overviewIcon()）。
+    private static let overviewNSImage: NSImage? = {
+        let img = NSImage(systemSymbolName: "square.grid.2x2", accessibilityDescription: nil)
+        img?.isTemplate = true
+        return img
+    }()
 
     // MARK: - 内容区
 
@@ -324,6 +405,7 @@ private struct OverviewRowView: View {
                         : self.menuWidth)
             }
             .buttonStyle(.plain)
+            .focusEffectDisabled()
             // 无障碍
             .accessibilityLabel("\(self.row.provider.rawValue) overview")
             .accessibilityHint("Show \(self.row.provider.rawValue) details")
@@ -338,6 +420,7 @@ private struct OverviewRowView: View {
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .focusEffectDisabled()
                 // 无障碍
                 .accessibilityLabel(chart.title)
             }
@@ -379,6 +462,7 @@ private struct ChartEntryRowView: View {
         .clipShape(RoundedRectangle(cornerRadius: 4))
         .padding(.horizontal, 5)
         .onHover { self.isHovered = $0 }
+        .focusEffectDisabled()
         // 无障碍：Button 标题即 label，hint 说明用途
         .accessibilityHint("Show chart")
     }
@@ -408,5 +492,6 @@ private struct BuyCreditsRowView: View {
         .clipShape(RoundedRectangle(cornerRadius: 4))
         .padding(.horizontal, 5)
         .onHover { self.isHovered = $0 }
+        .focusEffectDisabled()
     }
 }

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -27,18 +27,12 @@ private struct ProviderSwitcherTabView: View {
         Button(action: self.onTap) {
             VStack(spacing: 3) {
                 // 图标（约 18pt），与 NSView StackedToggleButton 图标区域对齐
-                Group {
-                    if let nsImage = self.icon {
-                        Image(nsImage: nsImage)
-                            .resizable()
-                            .scaledToFit()
-                    } else {
-                        Image(systemName: "square.fill")
-                            .resizable()
-                            .scaledToFit()
-                    }
+                if let nsImage = self.icon {
+                    Image(nsImage: nsImage)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 18, height: 18)
                 }
-                .frame(width: 18, height: 18)
                 // 标题（.caption2 大小，lineLimit 1 + 截断）
                 Text(self.title)
                     .font(.caption2)

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -2,6 +2,7 @@ import CodexBarCore
 import SwiftUI
 
 /// 持久面板根视图。阶段 1：provider 切换器 + 当前 provider 用量卡片。
+/// 阶段 2：底部动作区（PopoverActionSectionsView）。
 /// 整个 popover 生命周期只构造一次；切 provider 通过 viewModel.select(_:) 增量更新，不重建视图。
 struct PopoverRootView: View {
     @Bindable var viewModel: MenuViewModel
@@ -11,6 +12,11 @@ struct PopoverRootView: View {
     /// 由 StatusItemController 注入的卡片 model 构造闭包（self.menuCardModel(for:)）。
     /// 持有 weak self 引用，避免强引用环。
     let makeCardModel: (UsageProvider) -> UsageMenuCardView.Model?
+    /// 返回底部动作区所需的 sections（与 NSMenu 路径共用 MenuDescriptor.build 数据源）。
+    /// 在 body 中调用以建立 @Observable 观察链，store/settings 变化时自动重算。
+    let makeSections: () -> [MenuDescriptor.Section]
+    /// 动作分发回调，由 StatusItemController.performMenuAction(_:) 实现。
+    let onAction: (MenuDescriptor.MenuAction) -> Void
 
     private static let menuWidth: CGFloat = 310
 
@@ -21,6 +27,11 @@ struct PopoverRootView: View {
                 Divider()
             }
             self.content
+            Divider()
+            PopoverActionSectionsView(
+                sections: self.makeSections(),
+                onAction: self.onAction)
+                .padding(.bottom, 6)
         }
         .frame(width: Self.menuWidth, alignment: .leading)
         .fixedSize(horizontal: false, vertical: true)

--- a/Sources/CodexBar/Popover/PopoverRootView.swift
+++ b/Sources/CodexBar/Popover/PopoverRootView.swift
@@ -60,14 +60,13 @@ struct PopoverRootView: View {
         }
     }
 
-    /// 关键：在 body 中同步读取 store（makeCardModel 内部读 store.* 属性），
-    /// 以建立 @Observable 观察链——store 数据变化时 SwiftUI 自动重渲。
+    /// makeCardModel 内部读取 store 属性，在 body 同步求值以建立 @Observable 观察链；
+    /// store 数据变化时 SwiftUI 自动重渲而无需外部 bump。
     @ViewBuilder private func card(for provider: UsageProvider) -> some View {
         if let model = makeCardModel(provider) {
             UsageMenuCardView(model: model, width: Self.menuWidth)
         } else {
-            // store.snapshot 读取触发 @Observable 追踪，数据到达时自动更新
-            let _ = store.snapshot(for: provider)
+            // 防御性占位：makeCardModel 当前不返回 nil，保留以防签名变更
             Text("Loading…")
                 .foregroundStyle(.secondary)
                 .padding()

--- a/Sources/CodexBar/Popover/ZaiMCPDetailsView.swift
+++ b/Sources/CodexBar/Popover/ZaiMCPDetailsView.swift
@@ -1,0 +1,60 @@
+import CodexBarCore
+import SwiftUI
+
+/// Zai MCP 用量明细视图：等价于 NSMenu makeZaiUsageDetailsSubmenu 的只读列表渲染。
+/// 在 popoverChartView(.zaiDetails) 中使用，作为二级 popover 内容。
+struct ZaiMCPDetailsView: View {
+    let timeLimit: ZaiLimitEntry
+    let resetTimeDisplayStyle: ResetTimeDisplayStyle
+    let width: CGFloat
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // 标题行
+            Text(L("MCP details"))
+                .font(.callout.weight(.semibold))
+                .padding(.horizontal, 12)
+                .padding(.top, 10)
+                .padding(.bottom, 4)
+
+            // window 行
+            if let window = self.timeLimit.windowLabel {
+                Text(String(format: L("mcp_window"), window))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 2)
+            }
+
+            // 重置时间行
+            if let resetTime = self.timeLimit.nextResetTime {
+                let reset = self.resetTimeDisplayStyle == .absolute
+                    ? UsageFormatter.resetDescription(from: resetTime)
+                    : UsageFormatter.resetCountdownDescription(from: resetTime)
+                Text(String(format: L("mcp_resets"), reset))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 2)
+            }
+
+            Divider()
+                .padding(.vertical, 4)
+
+            // 模型用量明细
+            let sortedDetails = self.timeLimit.usageDetails.sorted {
+                $0.modelCode.localizedCaseInsensitiveCompare($1.modelCode) == .orderedAscending
+            }
+            ForEach(sortedDetails, id: \.modelCode) { detail in
+                let usage = UsageFormatter.tokenCountString(detail.usage)
+                Text(String(format: L("mcp_model_usage"), detail.modelCode, usage))
+                    .font(.caption)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 2)
+            }
+
+            Spacer(minLength: 8)
+        }
+        .frame(width: self.width, alignment: .leading)
+    }
+}

--- a/Sources/CodexBar/SettingsStore+Defaults.swift
+++ b/Sources/CodexBar/SettingsStore+Defaults.swift
@@ -201,6 +201,14 @@ extension SettingsStore {
         }
     }
 
+    var usePopoverMenu: Bool {
+        get { self.defaultsState.usePopoverMenu }
+        set {
+            self.defaultsState.usePopoverMenu = newValue
+            self.userDefaults.set(newValue, forKey: "usePopoverMenu")
+        }
+    }
+
     var resetTimesShowAbsolute: Bool {
         get { self.defaultsState.resetTimesShowAbsolute }
         set {

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -349,6 +349,7 @@ extension SettingsStore {
         }
         let weeklyProgressWorkDays = userDefaults.object(forKey: "weeklyProgressWorkDays") as? Int
         let usageBarsShowUsed = userDefaults.object(forKey: "usageBarsShowUsed") as? Bool ?? false
+        let usePopoverMenu = userDefaults.object(forKey: "usePopoverMenu") as? Bool ?? false
         let resetTimesShowAbsolute = userDefaults.object(forKey: "resetTimesShowAbsolute") as? Bool ?? false
         let providerChangelogLinksEnabled = userDefaults.object(
             forKey: "providerChangelogLinksEnabled") as? Bool ?? false
@@ -425,6 +426,7 @@ extension SettingsStore {
             quotaWarningMarkersVisible: quotaWarningMarkersVisible,
             weeklyProgressWorkDays: weeklyProgressWorkDays,
             usageBarsShowUsed: usageBarsShowUsed,
+            usePopoverMenu: usePopoverMenu,
             resetTimesShowAbsolute: resetTimesShowAbsolute,
             providerChangelogLinksEnabled: providerChangelogLinksEnabled,
             menuBarShowsBrandIconWithPercent: menuBarShowsBrandIconWithPercent,

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -318,6 +318,7 @@ extension SettingsStore {
         return hadExistingConfig
     }
 
+    // swiftlint:disable:next function_body_length
     private static func loadDefaultsState(userDefaults: UserDefaults) -> SettingsDefaultsState {
         let refreshDefault = userDefaults.string(forKey: "refreshFrequency")
             .flatMap(RefreshFrequency.init(rawValue:))

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -318,7 +318,6 @@ extension SettingsStore {
         return hadExistingConfig
     }
 
-    // swiftlint:disable:next function_body_length
     private static func loadDefaultsState(userDefaults: UserDefaults) -> SettingsDefaultsState {
         let refreshDefault = userDefaults.string(forKey: "refreshFrequency")
             .flatMap(RefreshFrequency.init(rawValue:))

--- a/Sources/CodexBar/SettingsStoreState.swift
+++ b/Sources/CodexBar/SettingsStoreState.swift
@@ -21,6 +21,7 @@ struct SettingsDefaultsState {
     var quotaWarningMarkersVisible: Bool
     var weeklyProgressWorkDays: Int?
     var usageBarsShowUsed: Bool
+    var usePopoverMenu: Bool
     var resetTimesShowAbsolute: Bool
     var providerChangelogLinksEnabled: Bool
     var menuBarShowsBrandIconWithPercent: Bool

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -316,6 +316,15 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             return
         }
 
+        if self.usePopoverMenu,
+           self.providerPopoverControllers.values.contains(where: \.isShown)
+        {
+            // A per-provider popover is already visible (e.g. mouse-opened). The shortcut should
+            // dismiss it (toggle-off), not resolve a possibly-stale `lastMenuProvider` and toggle a
+            // different provider — that would close the visible panel and open the wrong one.
+            self.closeAllProviderPopovers()
+            return
+        }
         let provider = self.resolvedShortcutProvider()
         // Use the lazy accessor to ensure the item exists
         let item = self.lazyStatusItem(for: provider)

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -307,6 +307,9 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             if self.usePopoverMenu, let button = self.statusItem.button {
                 self.refreshPopoverViewModelInputs()
                 self.popoverMenuController?.toggle(relativeTo: button)
+                if self.popoverMenuController?.isShown == true {
+                    self.schedulePopoverOpenRefresh(providers: self.menuViewModel.providers)
+                }
             } else {
                 self.statusItem.button?.performClick(nil)
             }
@@ -321,6 +324,9 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             self.ensureProviderPopover(for: provider)
             self.closeAllProviderPopovers(except: provider)
             self.providerPopoverControllers[provider]?.toggle(relativeTo: button)
+            if self.providerPopoverControllers[provider]?.isShown == true {
+                self.schedulePopoverOpenRefresh(providers: [provider])
+            }
         } else {
             item.button?.performClick(nil)
         }
@@ -330,6 +336,9 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         guard self.usePopoverMenu, let button = self.statusItem.button else { return }
         self.refreshPopoverViewModelInputs()
         self.popoverMenuController?.toggle(relativeTo: button)
+        if self.popoverMenuController?.isShown == true {
+            self.schedulePopoverOpenRefresh(providers: self.menuViewModel.providers)
+        }
     }
 
     /// 非合并模式 per-provider statusItem 按钮点击处理（popover 路径）。
@@ -339,6 +348,9 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         guard let provider = self.statusItems.first(where: { $0.value.button === button })?.key else { return }
         self.closeAllProviderPopovers(except: provider)
         self.providerPopoverControllers[provider]?.toggle(relativeTo: button)
+        if self.providerPopoverControllers[provider]?.isShown == true {
+            self.schedulePopoverOpenRefresh(providers: [provider])
+        }
     }
 
     @discardableResult

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -305,7 +305,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
 
         if self.shouldMergeIcons {
             if self.usePopoverMenu, let button = self.statusItem.button {
-                self.menuViewModel.providers = self.store.enabledProvidersForDisplay()
+                self.refreshPopoverViewModelInputs()
                 self.popoverMenuController?.toggle(relativeTo: button)
             } else {
                 self.statusItem.button?.performClick(nil)
@@ -321,7 +321,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
 
     @objc func handleStatusItemClick(_ sender: Any?) {
         guard self.usePopoverMenu, let button = self.statusItem.button else { return }
-        self.menuViewModel.providers = self.store.enabledProvidersForDisplay()
+        self.refreshPopoverViewModelInputs()
         self.popoverMenuController?.toggle(relativeTo: button)
     }
 

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -316,13 +316,29 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         let provider = self.resolvedShortcutProvider()
         // Use the lazy accessor to ensure the item exists
         let item = self.lazyStatusItem(for: provider)
-        item.button?.performClick(nil)
+        if self.usePopoverMenu, let button = item.button {
+            // 确保 popover controller 已创建（快捷键可能先于 attachProviderPopovers 触发）
+            self.ensureProviderPopover(for: provider)
+            self.closeAllProviderPopovers(except: provider)
+            self.providerPopoverControllers[provider]?.toggle(relativeTo: button)
+        } else {
+            item.button?.performClick(nil)
+        }
     }
 
     @objc func handleStatusItemClick(_ sender: Any?) {
         guard self.usePopoverMenu, let button = self.statusItem.button else { return }
         self.refreshPopoverViewModelInputs()
         self.popoverMenuController?.toggle(relativeTo: button)
+    }
+
+    /// 非合并模式 per-provider statusItem 按钮点击处理（popover 路径）。
+    /// sender 即 NSStatusBarButton；通过恒等比较反查 provider。
+    @objc func handleProviderStatusItemClick(_ sender: Any?) {
+        guard self.usePopoverMenu, let button = sender as? NSStatusBarButton else { return }
+        guard let provider = self.statusItems.first(where: { $0.value.button === button })?.key else { return }
+        self.closeAllProviderPopovers(except: provider)
+        self.providerPopoverControllers[provider]?.toggle(relativeTo: button)
     }
 
     @discardableResult

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -306,7 +306,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         if self.shouldMergeIcons {
             if self.usePopoverMenu, let button = self.statusItem.button {
                 self.menuViewModel.providers = self.store.enabledProvidersForDisplay()
-                self.popoverMenuController?.show(relativeTo: button)
+                self.popoverMenuController?.toggle(relativeTo: button)
             } else {
                 self.statusItem.button?.performClick(nil)
             }

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -320,12 +320,11 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         // Use the lazy accessor to ensure the item exists
         let item = self.lazyStatusItem(for: provider)
         if self.usePopoverMenu, let button = item.button {
-            // 确保 popover controller 已创建（快捷键可能先于 attachProviderPopovers 触发）
-            self.ensureProviderPopover(for: provider)
+            let viewModel = self.prepareProviderPopoverForShortcut(for: provider)
             self.closeAllProviderPopovers(except: provider)
             self.providerPopoverControllers[provider]?.toggle(relativeTo: button)
             if self.providerPopoverControllers[provider]?.isShown == true {
-                self.schedulePopoverOpenRefresh(providers: [provider])
+                self.schedulePopoverOpenRefresh(providers: viewModel.providers)
             }
         } else {
             item.button?.performClick(nil)

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -304,7 +304,12 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         }
 
         if self.shouldMergeIcons {
-            self.statusItem.button?.performClick(nil)
+            if self.usePopoverMenu, let button = self.statusItem.button {
+                self.menuViewModel.providers = self.store.enabledProvidersForDisplay()
+                self.popoverMenuController?.show(relativeTo: button)
+            } else {
+                self.statusItem.button?.performClick(nil)
+            }
             return
         }
 
@@ -312,6 +317,12 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         // Use the lazy accessor to ensure the item exists
         let item = self.lazyStatusItem(for: provider)
         item.button?.performClick(nil)
+    }
+
+    @objc func handleStatusItemClick(_ sender: Any?) {
+        guard self.usePopoverMenu, let button = self.statusItem.button else { return }
+        self.menuViewModel.providers = self.store.enabledProvidersForDisplay()
+        self.popoverMenuController?.toggle(relativeTo: button)
     }
 
     @discardableResult

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -80,6 +80,16 @@ extension StatusItemController {
                     })
             }
             self.wirePopoverShortcutCallbacks()
+            vm.onSelectionChanged = { [weak self] selection in
+                guard let self else { return }
+                switch selection {
+                case .overview:
+                    self.settings.mergedMenuLastSelectedWasOverview = true
+                case let .provider(p):
+                    self.settings.selectedMenuProvider = p
+                    self.settings.mergedMenuLastSelectedWasOverview = false
+                }
+            }
         }
         self.statusItem.button?.target = self
         self.statusItem.button?.action = #selector(self.handleStatusItemClick(_:))
@@ -89,7 +99,7 @@ extension StatusItemController {
 
     // MARK: - ViewModel 输入刷新
 
-    /// 刷新 menuViewModel 的 providers 与 includesOverview，并在 overview 非法时纠正 selection。
+    /// 刷新 menuViewModel 的 providers 与 includesOverview，并从 settings 恢复上次 selection。
     /// 在 attach、click、shortcut 打开 popover 时统一调用，避免三处重复。
     func refreshPopoverViewModelInputs() {
         let enabledProviders = self.store.enabledProvidersForDisplay()
@@ -98,9 +108,28 @@ extension StatusItemController {
             activeProviders: enabledProviders,
             maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit)
         self.menuViewModel.includesOverview = !overviewProviders.isEmpty
-        // 若 overview tab 已移除且当前选中 overview，纠正到第一个 provider
-        if !self.menuViewModel.includesOverview, self.menuViewModel.selection == .overview {
-            self.menuViewModel.select(.provider(enabledProviders.first ?? .codex))
+
+        // 从 settings 恢复上次选中项（等价于 NSMenu 的 resolvedSwitcherSelection 逻辑）：
+        //   includesOverview && mergedMenuLastSelectedWasOverview → .overview
+        //   否则 → .provider(selectedMenuProvider if enabled, else first available, else .codex)
+        // 此逻辑同时覆盖"overview tab 已移除但仍选中 overview"的纠正。
+        // 恢复时触发 onSelectionChanged 写回 settings 是幂等的，无需特殊处理。
+        let restoredProvider: UsageProvider = {
+            if let selected = self.settings.selectedMenuProvider,
+               enabledProviders.contains(selected)
+            {
+                return selected
+            }
+            return enabledProviders.first(where: { self.store.isProviderAvailable($0) })
+                ?? enabledProviders.first
+                ?? .codex
+        }()
+        let restored: ProviderSwitcherSelection =
+            (self.menuViewModel.includesOverview && self.settings.mergedMenuLastSelectedWasOverview)
+            ? .overview
+            : .provider(restoredProvider)
+        if self.menuViewModel.selection != restored {
+            self.menuViewModel.select(restored)
         }
     }
 

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -684,7 +684,6 @@ extension StatusItemController {
             if PopoverChartKind.isZaiDetailsAvailable(snapshot: snapshot) {
                 return .zaiDetails(provider)
             }
-            return nil
         }
         // tokenUsage 不为 nil → costHistory
         if model.tokenUsage != nil,

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -218,6 +218,14 @@ extension StatusItemController {
                     self?.popoverOverviewEmptyText()
                 },
                 onAction: { [weak self] action in self?.performMenuAction(action) },
+                actionSubtitle: { [weak self] action in
+                    guard let self else { return nil }
+                    switch action {
+                    case let .switchAccount(provider): return self.switchAccountSubtitle(for: provider)
+                    case .addCodexAccount: return self.codexAddAccountSubtitle()
+                    default: return nil
+                    }
+                },
                 onBuyCredits: { [weak self] in
                     self?.openCreditsPurchase()
                     // 全关（含合并与全部 per-provider popover）：此闭包被两种模式复用
@@ -534,14 +542,18 @@ extension StatusItemController {
         let hasStorageBreakdown = self.store.storageFootprint(for: provider)?.components.isEmpty == false
         let hasZaiHourly = provider == .zai &&
             self.store.snapshot(for: provider)?.zaiUsage?.modelUsage != nil
+        let hasZaiDetails = PopoverChartKind.isZaiDetailsAvailable(snapshot: self.store.snapshot(for: provider))
 
         var entries: [PopoverChartKind] = []
 
         // ── usage ──
         // 与 makeUsageSubmenu 对齐：hasUsageBreakdown → .usageBreakdown；
+        //   zai + hasZaiDetails → .zaiDetails；
         //   否则 openai + hasOpenAIAPIUsageSubmenu → .costHistory(openai)（即 "API Usage" submenu）。
         if hasUsageBreakdown {
             entries.append(.usageBreakdown)
+        } else if provider == .zai, hasZaiDetails {
+            entries.append(.zaiDetails(provider))
         } else if provider == .openai,
                   self.tokenSnapshotForCostHistorySubmenu(provider: provider)?.daily.isEmpty == false
         {
@@ -578,7 +590,7 @@ extension StatusItemController {
     }
 
     /// Overview 行的下钻图表（无则 nil），对齐 makeOverviewRowSubmenu 逻辑：
-    ///   openai+hasAPIUsage → .costHistory；zai → nil（详情菜单阶段跳过）；
+    ///   openai+hasAPIUsage → .costHistory；zai+hasZaiDetails → .zaiDetails；
     ///   tokenUsage != nil → .costHistory；usageHistory 可用 → .usageHistory；
     ///   storage 非空 → .storageBreakdown；否则 nil。
     func popoverOverviewChart(for provider: UsageProvider, model: UsageMenuCardView.Model) -> PopoverChartKind? {
@@ -588,8 +600,12 @@ extension StatusItemController {
         {
             return .costHistory(provider)
         }
-        // zai：详情菜单本阶段跳过
+        // zai：有 usageDetails 时展示 MCP 明细；否则回退后续逻辑
         if provider == .zai {
+            let snapshot = self.store.snapshot(for: provider)
+            if PopoverChartKind.isZaiDetailsAvailable(snapshot: snapshot) {
+                return .zaiDetails(provider)
+            }
             return nil
         }
         // tokenUsage 不为 nil → costHistory
@@ -660,6 +676,53 @@ extension StatusItemController {
                   let snapshot = self.store.snapshot(for: provider),
                   let modelUsage = snapshot.zaiUsage?.modelUsage else { return nil }
             return AnyView(ZaiHourlyUsageChartMenuView(modelUsage: modelUsage, width: width))
+
+        case let .zaiDetails(provider):
+            guard provider == .zai,
+                  let snapshot = self.store.snapshot(for: provider),
+                  let timeLimit = snapshot.zaiUsage?.timeLimit,
+                  !timeLimit.usageDetails.isEmpty else { return nil }
+            return AnyView(ZaiMCPDetailsView(
+                timeLimit: timeLimit,
+                resetTimeDisplayStyle: self.settings.resetTimeDisplayStyle,
+                width: width))
+        }
+    }
+
+    // MARK: - 面板可见性（子任务 A，MP-23）
+
+    /// popover-aware 版本：popover 路径下通过 MenuViewModel.isVisible 判断；
+    /// NSMenu 路径下沿用旧 openMenus 字典。
+    /// 两处 guard !self.isMergedMenuOpen（updateIcons 686、refreshMenusForLoginStateChange 787）自动获益。
+    var isMergedMenuOpen: Bool {
+        if self.usePopoverMenu {
+            if self.menuViewModel.isVisible { return true }
+            return self.providerMenuViewModels.values.contains { $0.isVisible }
+        }
+        guard let mergedMenu else { return false }
+        return self.openMenus[ObjectIdentifier(mergedMenu)] != nil
+    }
+
+    // MARK: - 打开时刷新调度（子任务 B，MP-03/29）
+
+    /// popover 打开时的刷新调度：storage footprints + stale/missing provider 的后台刷新。
+    /// NSMenu 因模态须 defer 到关闭后；popover 非模态可在打开期间直接刷新（SwiftUI 自动更新 UI）。
+    func schedulePopoverOpenRefresh(providers: [UsageProvider]) {
+        if self.settings.providerStorageFootprintsEnabled {
+            self.store.refreshStorageFootprintsForOverview()
+        }
+        let stale = providers.filter { self.store.isStale(provider: $0) || self.store.snapshot(for: $0) == nil }
+        guard !stale.isEmpty, !self.store.isRefreshing else { return }
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(1.2)) // 与 NSMenu menuOpenRefreshDelay 一致，避免打开瞬间抢资源
+            guard let self else { return }
+            guard self.isMergedMenuOpen else { return } // 已关则不刷（沿用 NSMenu"还开着才刷"语义）
+            guard !self.store.isRefreshing else { return }
+            for provider in stale
+                where self.store.isStale(provider: provider) || self.store.snapshot(for: provider) == nil
+            {
+                await self.store.refreshProvider(provider)
+            }
         }
     }
 

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -387,12 +387,99 @@ extension StatusItemController {
         // ── 4. 单卡片 ──
         if let model = self.menuCardModel(for: provider) {
             plan.cards = [PopoverCardPlan.Card(id: "single", model: model, workspaceHeader: nil)]
+            plan.sectioned = self.buildSectionedCard(model: model, provider: provider)
+            // 拆段模式下顶层 showBuyCredits 由 sectioned.showBuyCredits 接管，避免重复渲染
+            if plan.sectioned != nil {
+                plan.showBuyCredits = false
+            } else {
+                plan.showBuyCredits = self.popoverCanShowBuyCredits(for: provider)
+            }
         } else {
             plan.emptyText = "Loading…"
         }
         plan.storageText = self.store.storageFootprintText(for: provider)
-        plan.showBuyCredits = self.popoverCanShowBuyCredits(for: provider)
         return plan
+    }
+
+    /// 构造拆段渲染计划（对齐 NSMenu addMenuCardSections 的判定与各段 chevron 条件）。
+    /// 仅当 openAIWebContext.hasOpenAIWebMenuItems 或 hasOpenAIAPIUsageSubmenu 为 true 时返回非 nil。
+    private func buildSectionedCard(
+        model: UsageMenuCardView.Model,
+        provider: UsageProvider)
+        -> PopoverCardPlan.SectionedCard?
+    {
+        // ── 与 NSMenu addMenuCards:677-693 一致的拆段触发判定 ──
+        // openAIWebContext 中 showAllAccounts=false（单卡路径无 stacked）
+        let codexProjection = self.store.codexConsumerProjectionIfNeeded(
+            for: provider,
+            surface: .liveCard)
+        let hasUsageBreakdown = codexProjection?.hasUsageBreakdown == true
+        let hasCreditsHistory = codexProjection?.hasCreditsHistory == true
+        let hasCostHistory = self.settings.isCostUsageEffectivelyEnabled(for: provider) &&
+            (self.store.tokenSnapshot(for: provider)?.daily.isEmpty == false)
+        let hasOpenAIWebMenuItems = hasCreditsHistory || hasUsageBreakdown || hasCostHistory
+        // hasOpenAIAPIUsageSubmenu：provider == .openai && costHistory daily 非空（见 Menu.swift:1573-1575）
+        let hasOpenAIAPIUsageSubmenu = provider == .openai &&
+            self.tokenSnapshotForCostHistorySubmenu(provider: provider)?.daily.isEmpty == false
+
+        guard hasOpenAIWebMenuItems || hasOpenAIAPIUsageSubmenu else { return nil }
+
+        // ── 段存在性 ──
+        let hasUsageBlock = model.hasUsageContent
+        let hasCredits = model.creditsText != nil
+        let hasExtraUsage = model.providerCost != nil
+        let hasCost = model.tokenUsage != nil
+        let storageText = self.store.storageFootprintText(for: provider)
+        let hasStorage = storageText != nil
+        let canShowBuyCredits = self.settings.showOptionalCreditsAndExtraUsage &&
+            codexProjection?.canShowBuyCredits == true
+
+        // ── usageChart：对齐 makeUsageSubmenu（Menu.swift:1471-1487）──
+        let usageChart: PopoverChartKind?
+        if hasUsageBreakdown {
+            usageChart = .usageBreakdown
+        } else if provider == .openai {
+            // openai → API Usage submenu（= costHistory）
+            usageChart = hasOpenAIAPIUsageSubmenu ? .costHistory(provider) : nil
+        } else if provider == .zai {
+            let snapshot = self.store.snapshot(for: provider)
+            usageChart = PopoverChartKind.isZaiDetailsAvailable(snapshot: snapshot)
+                ? .zaiDetails(provider)
+                : nil
+        } else {
+            usageChart = nil
+        }
+
+        // ── storageChart ──
+        let storageChart: PopoverChartKind? =
+            self.store.storageFootprint(for: provider)?.components.isEmpty == false
+                ? .storageBreakdown(provider)
+                : nil
+
+        // ── creditsChart ──
+        let creditsChart: PopoverChartKind? = hasCreditsHistory ? .creditsHistory : nil
+
+        // ── extraUsageChart（Extra Usage 段用 OpenAI API usage submenu）──
+        let extraUsageChart: PopoverChartKind? =
+            provider == .openai && hasOpenAIAPIUsageSubmenu ? .costHistory(provider) : nil
+
+        // ── costChart ──
+        let costChart: PopoverChartKind? = hasCostHistory ? .costHistory(provider) : nil
+
+        return PopoverCardPlan.SectionedCard(
+            model: model,
+            hasUsageBlock: hasUsageBlock,
+            hasCredits: hasCredits,
+            hasExtraUsage: hasExtraUsage,
+            hasCost: hasCost,
+            hasStorage: hasStorage,
+            storageText: storageText,
+            usageChart: usageChart,
+            storageChart: storageChart,
+            creditsChart: creditsChart,
+            showBuyCredits: canShowBuyCredits,
+            extraUsageChart: extraUsageChart,
+            costChart: costChart)
     }
 
     /// stacked 路径空 cards 时的 fallback：尝试构造单卡片，否则显示"Loading…"。
@@ -542,63 +629,24 @@ extension StatusItemController {
 
     // MARK: - 图表下钻入口（Task 3.1）
 
-    /// 该 provider 卡片下方应显示的图表下钻入口，顺序对齐 NSMenu：
-    ///   usage(breakdown/openAIAPI) → credits → cost → usageHistory → storage → zaiHourly。
+    /// 该 provider 卡片下方应显示的图表下钻入口。
+    /// 对齐原版 NSMenu：单 provider 卡片下方独立入口行**只有** usageHistory 与 zaiHourly。
+    /// 其余图表（usageBreakdown/creditsHistory/costHistory/storageBreakdown/zaiDetails）
+    /// 经由拆段模式的段 chevron 进入，不作为独立入口行重复显示。
+    /// 整卡模式（非拆段 provider）同样只显示这两个入口，对齐原版整卡 provider 语义。
     func popoverChartEntries(for provider: UsageProvider) -> [PopoverChartKind] {
-        let codexProjection = self.store.codexConsumerProjectionIfNeeded(
-            for: provider,
-            surface: .liveCard)
-        let hasUsageBreakdown = codexProjection?.hasUsageBreakdown == true
-        let hasCreditsHistory = codexProjection?.hasCreditsHistory == true
-        // cost：tokenSnapshotForCostHistorySubmenu 与 appendCostHistoryChartItem 完全对齐
-        let tokenSnap = self.tokenSnapshotForCostHistorySubmenu(provider: provider)
-        let hasCostHistory = self.settings.isCostUsageEffectivelyEnabled(for: provider) &&
-            tokenSnap?.daily.isEmpty == false
-        let hasUsageHistory = self.store.supportsPlanUtilizationHistory(for: provider) &&
-            !self.store.shouldHidePlanUtilizationMenuItem(for: provider)
-        let hasStorageBreakdown = self.store.storageFootprint(for: provider)?.components.isEmpty == false
-        let hasZaiHourly = provider == .zai &&
-            self.store.snapshot(for: provider)?.zaiUsage?.modelUsage != nil
-        let hasZaiDetails = PopoverChartKind.isZaiDetailsAvailable(snapshot: self.store.snapshot(for: provider))
-
         var entries: [PopoverChartKind] = []
 
-        // ── usage ──
-        // 与 makeUsageSubmenu 对齐：hasUsageBreakdown → .usageBreakdown；
-        //   zai + hasZaiDetails → .zaiDetails；
-        //   否则 openai + hasOpenAIAPIUsageSubmenu → .costHistory(openai)（即 "API Usage" submenu）。
-        if hasUsageBreakdown {
-            entries.append(.usageBreakdown)
-        } else if provider == .zai, hasZaiDetails {
-            entries.append(.zaiDetails(provider))
-        } else if provider == .openai,
-                  self.tokenSnapshotForCostHistorySubmenu(provider: provider)?.daily.isEmpty == false
-        {
-            // openAI "API Usage" 子菜单等价于 costHistory；在此插入，后面 cost 入口去重跳过
-            entries.append(.costHistory(provider))
-        }
-
-        // ── credits ──
-        if hasCreditsHistory {
-            entries.append(.creditsHistory)
-        }
-
-        // ── cost（去重：usage 入口若已插入 costHistory(provider) 则跳过）──
-        if hasCostHistory, !entries.contains(.costHistory(provider)) {
-            entries.append(.costHistory(provider))
-        }
-
-        // ── usageHistory ──
+        // ── usageHistory（Subscription Utilization）──
+        let hasUsageHistory = self.store.supportsPlanUtilizationHistory(for: provider) &&
+            !self.store.shouldHidePlanUtilizationMenuItem(for: provider)
         if hasUsageHistory {
             entries.append(.usageHistory(provider))
         }
 
-        // ── storage ──
-        if hasStorageBreakdown {
-            entries.append(.storageBreakdown(provider))
-        }
-
-        // ── zaiHourly ──
+        // ── zaiHourly（Hourly Usage，仅 zai）──
+        let hasZaiHourly = provider == .zai &&
+            self.store.snapshot(for: provider)?.zaiUsage?.modelUsage != nil
         if hasZaiHourly {
             entries.append(.zaiHourly(provider))
         }

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -241,6 +241,18 @@ extension StatusItemController {
                         ? self?.popoverSwitcherIcon(for: provider)
                         : nil
                 },
+                switcherIndicator: { [weak self] provider in
+                    guard let self else { return nil }
+                    guard let remainingPercent = self.switcherWeeklyRemaining(for: provider) else { return nil }
+                    let fraction = max(0, min(1, remainingPercent / 100))
+                    let brandColor = ProviderDescriptorRegistry.descriptor(for: provider).branding.color
+                    let nsColor = NSColor(
+                        deviceRed: brandColor.red,
+                        green: brandColor.green,
+                        blue: brandColor.blue,
+                        alpha: 1)
+                    return (fraction: fraction, color: nsColor)
+                },
                 makeChartEntries: { [weak self] provider in
                     self?.popoverChartEntries(for: provider) ?? []
                 },

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -20,7 +20,7 @@ extension StatusItemController {
     func attachMergedPopover() {
         self.statusItem.menu = nil
         if self.popoverMenuController == nil {
-            self.menuViewModel.providers = self.store.enabledProvidersForDisplay()
+            self.refreshPopoverViewModelInputs()
             let vm = self.menuViewModel
             let store = self.store
             self.popoverMenuController = PopoverMenuController(viewModel: vm) { [weak self] in
@@ -72,6 +72,11 @@ extension StatusItemController {
                     onBuyCredits: { [weak self] in
                         self?.openCreditsPurchase()
                         self?.popoverMenuController?.close()
+                    },
+                    switcherIcon: { [weak self] provider in
+                        (self?.settings.switcherShowsIcons == true)
+                            ? self?.popoverSwitcherIcon(for: provider)
+                            : nil
                     })
             }
             self.wirePopoverShortcutCallbacks()
@@ -80,6 +85,29 @@ extension StatusItemController {
         self.statusItem.button?.action = #selector(self.handleStatusItemClick(_:))
         // 右键也触发 action，使右键可弹出 popover
         self.statusItem.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
+    }
+
+    // MARK: - ViewModel 输入刷新
+
+    /// 刷新 menuViewModel 的 providers 与 includesOverview，并在 overview 非法时纠正 selection。
+    /// 在 attach、click、shortcut 打开 popover 时统一调用，避免三处重复。
+    func refreshPopoverViewModelInputs() {
+        let enabledProviders = self.store.enabledProvidersForDisplay()
+        self.menuViewModel.providers = enabledProviders
+        let overviewProviders = self.settings.resolvedMergedOverviewProviders(
+            activeProviders: enabledProviders,
+            maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit)
+        self.menuViewModel.includesOverview = !overviewProviders.isEmpty
+        // 若 overview tab 已移除且当前选中 overview，纠正到第一个 provider
+        if !self.menuViewModel.includesOverview, self.menuViewModel.selection == .overview {
+            self.menuViewModel.select(.provider(enabledProviders.first ?? .codex))
+        }
+    }
+
+    /// 取 provider 品牌图标，供 switcherIcon 注入闭包使用。
+    /// 直接复用 ProviderBrandIcon（internal），不依赖 private switcherIcon(for:)。
+    func popoverSwitcherIcon(for provider: UsageProvider) -> NSImage? {
+        ProviderBrandIcon.image(for: provider)
     }
 
     // MARK: - popover 动作分发

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -26,7 +26,9 @@ extension StatusItemController {
                 PopoverRootView(
                     viewModel: vm,
                     store: store,
-                    makeCardModel: { [weak self] provider in self?.menuCardModel(for: provider) },
+                    makeCardPlan: { [weak self] provider in
+                        self?.popoverCardPlan(for: provider) ?? PopoverCardPlan()
+                    },
                     makeSections: { [weak self] in
                         guard let self else { return [] }
                         let provider: UsageProvider? = {
@@ -43,7 +45,11 @@ extension StatusItemController {
                             updateReady: self.updater.updateStatus.isUpdateReady,
                             includeContextualActions: true).sections
                     },
-                    onAction: { [weak self] action in self?.performMenuAction(action) })
+                    onAction: { [weak self] action in self?.performMenuAction(action) },
+                    onBuyCredits: { [weak self] in
+                        self?.openCreditsPurchase()
+                        self?.popoverMenuController?.close()
+                    })
             }
             self.wirePopoverShortcutCallbacks()
         }
@@ -78,6 +84,119 @@ extension StatusItemController {
         } else {
             _ = self.perform(sel)
         }
+    }
+
+    // MARK: - 卡片计划（复刻 addMenuCards 分流逻辑，纯数据）
+
+    /// 构造当前 provider 的卡片渲染计划，供 PopoverRootView 纯渲染消费。
+    /// 分流次序与 addMenuCards 保持一致：
+    ///   1. Codex 多账户 stacked → 按 workspace section 展开 cards
+    ///   2. Token 多账户 stacked → snapshot compactMap
+    ///   3. Kilo 多 scope → kiloScopeSnapshots compactMap
+    ///   4. 单卡片 / 占位
+    ///   + storageText / showBuyCredits
+    func popoverCardPlan(for provider: UsageProvider) -> PopoverCardPlan {
+        var plan = PopoverCardPlan()
+
+        // ── 1. Codex stacked ──
+        if let codexDisplay = self.codexAccountMenuDisplay(for: provider), codexDisplay.showAll {
+            let snapshotsByAccountID = Dictionary(
+                uniqueKeysWithValues: codexDisplay.snapshots.map { ($0.account.id, $0) })
+            let sections = codexDisplay.showsWorkspaceGroups
+                ? codexDisplay.workspaceSections
+                : [CodexAccountWorkspaceSection(title: "", accounts: codexDisplay.accounts)]
+
+            for section in sections {
+                var isFirstInSection = true
+                for account in section.accounts {
+                    let accountSnapshot = snapshotsByAccountID[account.id]
+                    let health = CodexAccountHealth.status(for: account, error: accountSnapshot?.error)
+                    guard let model = self.menuCardModel(
+                        for: .codex,
+                        snapshotOverride: accountSnapshot?.snapshot,
+                        errorOverride: health.label,
+                        forceOverrideCard: accountSnapshot == nil,
+                        accountOverride: self.accountInfo(for: account))
+                    else { continue }
+                    let header: String? = (codexDisplay.showsWorkspaceGroups && isFirstInSection)
+                        ? section.title
+                        : nil
+                    plan.cards.append(PopoverCardPlan.Card(
+                        id: account.id,
+                        model: model,
+                        workspaceHeader: header))
+                    isFirstInSection = false
+                }
+            }
+            plan.storageText = self.store.storageFootprintText(for: provider)
+            plan.showBuyCredits = self.popoverCanShowBuyCredits(for: provider)
+            return plan
+        }
+
+        // ── 2. Token stacked ──
+        if let tokenDisplay = self.tokenAccountMenuDisplay(for: provider), tokenDisplay.showAll {
+            let cards = tokenDisplay.snapshots.compactMap { accountSnapshot in
+                self.menuCardModel(
+                    for: provider,
+                    snapshotOverride: accountSnapshot.snapshot,
+                    errorOverride: accountSnapshot.error)
+                    .map { model in
+                        PopoverCardPlan.Card(
+                            id: accountSnapshot.account.id.uuidString,
+                            model: model,
+                            workspaceHeader: nil)
+                    }
+            }
+            plan.cards = cards
+            if plan.cards.isEmpty {
+                plan.emptyText = "Loading…"
+            }
+            plan.storageText = self.store.storageFootprintText(for: provider)
+            plan.showBuyCredits = self.popoverCanShowBuyCredits(for: provider)
+            return plan
+        }
+
+        // ── 3. Kilo multi-scope ──
+        if provider == .kilo, self.store.kiloScopeSnapshots.count > 1 {
+            let cards = self.store.kiloScopeSnapshots.compactMap { scope in
+                self.menuCardModel(
+                    for: .kilo,
+                    snapshotOverride: scope.snapshot,
+                    errorOverride: scope.errorMessage,
+                    forceOverrideCard: scope.snapshot == nil)
+                    .map { model in
+                        PopoverCardPlan.Card(id: scope.id, model: model, workspaceHeader: nil)
+                    }
+            }
+            plan.cards = cards
+            if plan.cards.isEmpty {
+                plan.emptyText = "Loading…"
+            }
+            plan.storageText = self.store.storageFootprintText(for: provider)
+            plan.showBuyCredits = self.popoverCanShowBuyCredits(for: provider)
+            return plan
+        }
+
+        // ── 4. 单卡片 ──
+        if let model = self.menuCardModel(for: provider) {
+            plan.cards = [PopoverCardPlan.Card(id: "single", model: model, workspaceHeader: nil)]
+        } else {
+            plan.emptyText = "Loading…"
+        }
+        plan.storageText = self.store.storageFootprintText(for: provider)
+        plan.showBuyCredits = self.popoverCanShowBuyCredits(for: provider)
+        return plan
+    }
+
+    /// 计算 Buy Credits 是否可显示。
+    /// 复刻 openAIWebContext 中的 canShowBuyCredits 逻辑（showAllAccounts 时不显示 Buy Credits
+    /// 对 popover 单账户路径无影响；多账户 stacked 时与 NSMenu 行为一致：不显示）。
+    private func popoverCanShowBuyCredits(for provider: UsageProvider) -> Bool {
+        guard self.settings.showOptionalCreditsAndExtraUsage else { return false }
+        let codexProjection = self.store.codexConsumerProjectionIfNeeded(
+            for: provider,
+            surface: .liveCard)
+        return codexProjection?.canShowBuyCredits == true
     }
 
     /// 接线 popover 的键盘快捷键回调（只在控制器首次创建时设一次，弱引用防环）。

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -11,8 +11,13 @@ import SwiftUI
 
 extension StatusItemController {
     /// 特性开关：是否启用 NSPopover 菜单（替代 NSMenu）。
+    /// dev 辅助：环境变量 CODEXBAR_FORCE_POPOVER=0/1 可覆盖设置值，
+    /// 用于同机双实例并排对比新旧菜单（两实例共享 UserDefaults 域，只能靠 env 区分）。
     var usePopoverMenu: Bool {
-        self.settings.usePopoverMenu
+        if let forced = ProcessInfo.processInfo.environment["CODEXBAR_FORCE_POPOVER"] {
+            return forced == "1"
+        }
+        return self.settings.usePopoverMenu
     }
 
     /// 合并模式下安装 popover：清掉 statusItem.menu，懒创建 PopoverMenuController 并接线快捷键回调，

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -132,9 +132,16 @@ extension StatusItemController {
     }
 
     /// 懒创建指定 provider 的 MenuViewModel + PopoverMenuController（首次调用后缓存）。
-    func ensureProviderPopover(for provider: UsageProvider) {
-        if self.providerPopoverControllers[provider] != nil { return }
-        let vm = MenuViewModel.singleProvider(provider)
+    func ensureProviderPopover(for provider: UsageProvider, isFallback: Bool = false) {
+        if self.providerMenuViewModels[provider]?.isFallback == isFallback,
+           self.providerPopoverControllers[provider] != nil
+        {
+            return
+        }
+        self.providerPopoverControllers[provider]?.close()
+        let vm = isFallback
+            ? MenuViewModel.fallback(statusItemProvider: provider)
+            : MenuViewModel.singleProvider(provider)
         self.providerMenuViewModels[provider] = vm
         let ctrl = self.makePopoverController(
             viewModel: vm,
@@ -163,7 +170,9 @@ extension StatusItemController {
             if shouldHaveItem {
                 let item = self.lazyStatusItem(for: provider)
                 item.menu = nil // 清掉残留 NSMenu
-                self.ensureProviderPopover(for: provider)
+                self.ensureProviderPopover(
+                    for: provider,
+                    isFallback: !self.isEnabled(provider) && fallback == provider)
                 item.button?.target = self
                 item.button?.action = #selector(self.handleProviderStatusItemClick(_:))
                 item.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
@@ -206,7 +215,7 @@ extension StatusItemController {
                 makeSections: { [weak self] in
                     guard let self else { return [] }
                     let isOverview = vm.selection == .overview
-                    let provider = self.popoverActionProvider(for: vm)
+                    let provider = vm.isFallback ? nil : self.popoverActionProvider(for: vm)
                     return MenuDescriptor.build(
                         provider: provider,
                         store: store,

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -265,13 +265,14 @@ extension StatusItemController {
 
     // MARK: - popover 动作分发
 
-    /// popover 动作分发：通过 selector(for:) 复用 NSMenu 路径的全部逻辑，
-    /// 解析当前面板动作应使用的 provider 上下文（与 NSMenu menuWillOpen 写入 lastMenuProvider
-    /// 的语义对齐）：选中具体 provider 时取之；Overview 时取第一个可用 provider；兜底 .codex。
-    /// makeSections 与动作分发共用，保证菜单内容与动作目标一致。
+    /// Resolve the provider context used by popover actions.
+    /// Provider tabs target themselves; Overview preserves the saved provider before falling back.
     func popoverActionProvider(for vm: MenuViewModel) -> UsageProvider {
-        if case let .provider(p) = vm.selection { return p }
+        if case let .provider(provider) = vm.selection { return provider }
         let enabled = vm.providers
+        if let selected = self.selectedMenuProvider, enabled.contains(selected) {
+            return selected
+        }
         return enabled.first(where: { self.store.isProviderAvailable($0) })
             ?? enabled.first
             ?? .codex

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -21,72 +21,12 @@ extension StatusItemController {
         self.statusItem.menu = nil
         if self.popoverMenuController == nil {
             let vm = self.menuViewModel
-            let store = self.store
-            self.popoverMenuController = PopoverMenuController(viewModel: vm) { [weak self] in
-                PopoverRootView(
-                    viewModel: vm,
-                    store: store,
-                    makeCardPlan: { [weak self] provider in
-                        self?.popoverCardPlan(for: provider) ?? PopoverCardPlan()
-                    },
-                    makeAccountSwitcher: { [weak self] provider in
-                        self?.popoverAccountSwitcherModel(for: provider).map { model in
-                            PopoverRootView.AccountSwitcherBinding(
-                                segments: model.segments,
-                                onSelect: model.onSelect)
-                        }
-                    },
-                    makeSections: { [weak self] in
-                        guard let self else { return [] }
-                        let isOverview = vm.selection == .overview
-                        // overview 时取 resolvedMenuProvider 等价逻辑（与 populateMenu:224-228 对齐）：
-                        // 优先选已启用且可用的 provider，不传切换器选择，等价于 NSMenu overview 路径。
-                        let provider: UsageProvider? = {
-                            if isOverview {
-                                let enabled = vm.providers
-                                if enabled.isEmpty { return UsageProvider.codex }
-                                return enabled.first(where: { self.store.isProviderAvailable($0) })
-                                    ?? enabled.first
-                            }
-                            if case let .provider(p) = vm.selection { return p }
-                            return vm.providers.first
-                        }()
-                        return MenuDescriptor.build(
-                            provider: provider,
-                            store: store,
-                            settings: self.settings,
-                            account: self.account,
-                            managedCodexAccountCoordinator: self.managedCodexAccountCoordinator,
-                            codexAccountPromotionCoordinator: self.codexAccountPromotionCoordinator,
-                            updateReady: self.updater.updateStatus.isUpdateReady,
-                            includeContextualActions: !isOverview).sections
-                    },
-                    makeOverviewRows: { [weak self] in
-                        self?.popoverOverviewRows() ?? []
-                    },
-                    overviewEmptyText: { [weak self] in
-                        self?.popoverOverviewEmptyText()
-                    },
-                    onAction: { [weak self] action in self?.performMenuAction(action) },
-                    onBuyCredits: { [weak self] in
-                        self?.openCreditsPurchase()
-                        self?.popoverMenuController?.close()
-                    },
-                    switcherIcon: { [weak self] provider in
-                        (self?.settings.switcherShowsIcons == true)
-                            ? self?.popoverSwitcherIcon(for: provider)
-                            : nil
-                    },
-                    makeChartEntries: { [weak self] provider in
-                        self?.popoverChartEntries(for: provider) ?? []
-                    },
-                    makeOverviewChart: { [weak self] row in
-                        self?.popoverOverviewChart(for: row.provider, model: row.model)
-                    },
-                    makeChartView: { [weak self] kind, width in
-                        self?.popoverChartView(for: kind, width: width)
-                    })
-            }
+            self.popoverMenuController = self.makePopoverController(
+                viewModel: vm,
+                makeOverviewRows: { [weak self] in self?.popoverOverviewRows() ?? [] },
+                makeOverviewChart: { [weak self] row in
+                    self?.popoverOverviewChart(for: row.provider, model: row.model)
+                })
             self.wirePopoverShortcutCallbacks()
             // onSelectionChanged 必须在 refreshPopoverViewModelInputs() 之前注册，
             // 确保首次 restore（select(restored)）触发时回调已就位，不会静默丢失写回 settings 的副作用。
@@ -151,6 +91,151 @@ extension StatusItemController {
     /// 直接复用 ProviderBrandIcon（internal），不依赖 private switcherIcon(for:)。
     func popoverSwitcherIcon(for provider: UsageProvider) -> NSImage? {
         ProviderBrandIcon.image(for: provider)
+    }
+
+    /// NSMenu 路径兜底：从 popover 模式切回时清掉合并与 per-provider statusItem 按钮上的残留 target/action。
+    /// 在两个 attachMenus 的 NSMenu 分支开头调用。
+    func clearPopoverButtonActions() {
+        self.statusItem.button?.target = nil
+        self.statusItem.button?.action = nil
+        for item in self.statusItems.values {
+            item.button?.target = nil
+            item.button?.action = nil
+        }
+    }
+
+    // MARK: - Per-provider popover（非合并模式）
+
+    /// 关闭除指定 provider 外的所有 per-provider popover（及合并 popover）。
+    /// NSPopover(.transient) 大多自动关，但点击另一 statusItem 不一定触发 transient 关闭，
+    /// 显式关闭保证互斥。
+    func closeAllProviderPopovers(except provider: UsageProvider? = nil) {
+        for (p, ctrl) in self.providerPopoverControllers where p != provider {
+            ctrl.close()
+        }
+        // 合并 popover 也一并关闭（模式切换时兜底）
+        self.popoverMenuController?.close()
+    }
+
+    /// 懒创建指定 provider 的 MenuViewModel + PopoverMenuController（首次调用后缓存）。
+    func ensureProviderPopover(for provider: UsageProvider) {
+        if self.providerPopoverControllers[provider] != nil { return }
+        let vm = MenuViewModel.singleProvider(provider)
+        self.providerMenuViewModels[provider] = vm
+        let ctrl = self.makePopoverController(
+            viewModel: vm,
+            makeOverviewRows: { [] },
+            makeOverviewChart: { _ in nil })
+        // per-provider 快捷键回调：onRefresh/onSettings/onQuit 照旧；
+        // onNavigate/onSelectIndex 单 provider 下 no-op（不设）。
+        ctrl.onRefresh = { [weak self] in
+            self?.refreshNow()
+            self?.providerPopoverControllers[provider]?.close()
+        }
+        ctrl.onSettings = { [weak self] in
+            self?.showSettingsGeneral()
+            self?.providerPopoverControllers[provider]?.close()
+        }
+        ctrl.onQuit = { [weak self] in
+            self?.quit()
+        }
+        // onNavigate/onSelectIndex 留为 nil（单 provider 无切换器，不处理方向键/数字键）
+        self.providerPopoverControllers[provider] = ctrl
+    }
+
+    /// 非合并模式下为每个 enabled/fallback provider 安装 per-provider popover，复刻 attachMenus(fallback:) 遍历结构。
+    func attachProviderPopovers(fallback: UsageProvider?) {
+        for provider in UsageProvider.allCases {
+            let shouldHaveItem = self.isEnabled(provider) || fallback == provider
+            if shouldHaveItem {
+                let item = self.lazyStatusItem(for: provider)
+                item.menu = nil // 清掉残留 NSMenu
+                self.ensureProviderPopover(for: provider)
+                item.button?.target = self
+                item.button?.action = #selector(self.handleProviderStatusItemClick(_:))
+                item.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
+            } else if let item = self.statusItems[provider] {
+                item.menu = nil
+                item.button?.target = nil
+                item.button?.action = nil
+            }
+        }
+    }
+
+    // MARK: - Popover controller 工厂（合并模式和 per-provider 复用）
+
+    /// 构造一个 PopoverMenuController，注入所有 make* 闭包。
+    /// vm 参数化：不同 controller 的闭包各自捕获自己的 vm，selection 语义自动正确。
+    /// - makeOverviewRows：合并模式传 { self.popoverOverviewRows() }；per-provider 传 { [] }。
+    /// - makeOverviewChart：合并模式传真实实现；per-provider 传 { _ in nil }
+    ///   （PopoverRootView 要求 non-optional 闭包，单 provider 无 overview chart）。
+    private func makePopoverController(
+        viewModel vm: MenuViewModel,
+        makeOverviewRows: @escaping () -> [PopoverOverviewRow],
+        makeOverviewChart: @escaping (PopoverOverviewRow) -> PopoverChartKind?)
+        -> PopoverMenuController<PopoverRootView>
+    {
+        let store = self.store
+        return PopoverMenuController(viewModel: vm) { [weak self] in
+            PopoverRootView(
+                viewModel: vm,
+                store: store,
+                makeCardPlan: { [weak self] provider in
+                    self?.popoverCardPlan(for: provider) ?? PopoverCardPlan()
+                },
+                makeAccountSwitcher: { [weak self] provider in
+                    self?.popoverAccountSwitcherModel(for: provider).map { model in
+                        PopoverRootView.AccountSwitcherBinding(
+                            segments: model.segments,
+                            onSelect: model.onSelect)
+                    }
+                },
+                makeSections: { [weak self] in
+                    guard let self else { return [] }
+                    let isOverview = vm.selection == .overview
+                    let provider: UsageProvider? = {
+                        if isOverview {
+                            let enabled = vm.providers
+                            if enabled.isEmpty { return UsageProvider.codex }
+                            return enabled.first(where: { self.store.isProviderAvailable($0) })
+                                ?? enabled.first
+                        }
+                        if case let .provider(p) = vm.selection { return p }
+                        return vm.providers.first
+                    }()
+                    return MenuDescriptor.build(
+                        provider: provider,
+                        store: store,
+                        settings: self.settings,
+                        account: self.account,
+                        managedCodexAccountCoordinator: self.managedCodexAccountCoordinator,
+                        codexAccountPromotionCoordinator: self.codexAccountPromotionCoordinator,
+                        updateReady: self.updater.updateStatus.isUpdateReady,
+                        includeContextualActions: !isOverview).sections
+                },
+                makeOverviewRows: makeOverviewRows,
+                overviewEmptyText: { [weak self] in
+                    self?.popoverOverviewEmptyText()
+                },
+                onAction: { [weak self] action in self?.performMenuAction(action) },
+                onBuyCredits: { [weak self] in
+                    self?.openCreditsPurchase()
+                    // 全关（含合并与全部 per-provider popover）：此闭包被两种模式复用
+                    self?.closeAllProviderPopovers()
+                },
+                switcherIcon: { [weak self] provider in
+                    (self?.settings.switcherShowsIcons == true)
+                        ? self?.popoverSwitcherIcon(for: provider)
+                        : nil
+                },
+                makeChartEntries: { [weak self] provider in
+                    self?.popoverChartEntries(for: provider) ?? []
+                },
+                makeOverviewChart: makeOverviewChart,
+                makeChartView: { [weak self] kind, width in
+                    self?.popoverChartView(for: kind, width: width)
+                })
+        }
     }
 
     // MARK: - popover 动作分发

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CodexBarCore
+import SwiftUI
 
 // MARK: - Popover 菜单接入（合并模式）
 
@@ -28,6 +29,13 @@ extension StatusItemController {
                     store: store,
                     makeCardPlan: { [weak self] provider in
                         self?.popoverCardPlan(for: provider) ?? PopoverCardPlan()
+                    },
+                    makeAccountSwitcher: { [weak self] provider in
+                        self?.popoverAccountSwitcherModel(for: provider).map { model in
+                            PopoverRootView.AccountSwitcherBinding(
+                                segments: model.segments,
+                                onSelect: model.onSelect)
+                        }
                     },
                     makeSections: { [weak self] in
                         guard let self else { return [] }
@@ -197,6 +205,85 @@ extension StatusItemController {
             for: provider,
             surface: .liveCard)
         return codexProjection?.canShowBuyCredits == true
+    }
+
+    // MARK: - 账户切换器模型
+
+    /// popover 账户切换器的数据模型：segments + onSelect 闭包。
+    struct PopoverAccountSwitcherModel {
+        let segments: [PopoverAccountSwitcherView.Segment]
+        let onSelect: (String) -> Void
+    }
+
+    /// 构造指定 provider 的 PopoverAccountSwitcherModel。
+    /// - .codex：codexAccountMenuDisplay 且 showSwitcher → Codex 路径。
+    /// - 其他：tokenAccountMenuDisplay 且 showSwitcher → Token 路径。
+    /// - 不满足或 display == nil → nil。
+    func popoverAccountSwitcherModel(for provider: UsageProvider) -> PopoverAccountSwitcherModel? {
+        if provider == .codex {
+            return self.codexAccountSwitcherModel()
+        }
+        return self.tokenAccountSwitcherModel(for: provider)
+    }
+
+    private func codexAccountSwitcherModel() -> PopoverAccountSwitcherModel? {
+        guard let display = self.codexAccountMenuDisplay(for: .codex),
+              display.showSwitcher
+        else { return nil }
+        let segments = PopoverAccountSwitcherView.Segment.make(
+            ids: display.accounts.map(\.id),
+            titles: display.accounts.map(\.menuDisplayName),
+            selectedID: display.activeVisibleAccountID)
+        return PopoverAccountSwitcherModel(
+            segments: segments,
+            onSelect: { [weak self] id in
+                guard let self else { return }
+                guard let account = display.accounts.first(where: { $0.id == id }) else { return }
+                self.handleCodexVisibleAccountSelectionFromPopover(account)
+            })
+    }
+
+    private func tokenAccountSwitcherModel(for provider: UsageProvider) -> PopoverAccountSwitcherModel? {
+        guard let display = self.tokenAccountMenuDisplay(for: provider),
+              display.showSwitcher
+        else { return nil }
+        let segments = PopoverAccountSwitcherView.Segment.make(
+            ids: display.accounts.indices.map { "\($0)" },
+            titles: display.accounts.map(\.displayName),
+            selectedID: "\(display.activeIndex)")
+        return PopoverAccountSwitcherModel(
+            segments: segments,
+            onSelect: { [weak self] idString in
+                guard let self, let index = Int(idString) else { return }
+                self.handleTokenAccountSelectionFromPopover(index: index, provider: provider)
+            })
+    }
+
+    /// Codex 账户选择处理：复刻 handleCodexVisibleAccountSelection 的逻辑，但不传 NSMenu。
+    private func handleCodexVisibleAccountSelectionFromPopover(_ account: CodexVisibleAccount) {
+        self.settings.selectDisplayedCodexVisibleAccount(account)
+        _ = self.store.prepareCodexAccountScopedRefreshIfNeeded()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                await self.store.refreshCodexAccountScopedState(
+                    allowDisabled: true,
+                    phaseDidChange: nil)
+            }
+        }
+    }
+
+    /// Token 账户选择处理：复刻 makeTokenAccountSwitcherItem 中 onSelect 闭包的逻辑，但不传 NSMenu。
+    @discardableResult
+    private func handleTokenAccountSelectionFromPopover(index: Int, provider: UsageProvider) -> Task<Void, Never> {
+        self.settings.setActiveTokenAccountIndex(index, for: provider)
+        self.applyIcon(phase: nil)
+        return Task { @MainActor [weak self] in
+            guard let self else { return }
+            await ProviderInteractionContext.$current.withValue(.userInitiated) {
+                await self.store.refreshProvider(provider)
+            }
+        }
     }
 
     /// 接线 popover 的键盘快捷键回调（只在控制器首次创建时设一次，弱引用防环）。

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -131,6 +131,11 @@ extension StatusItemController {
         self.popoverMenuController?.close()
     }
 
+    func removeProviderPopover(for provider: UsageProvider) {
+        self.providerPopoverControllers.removeValue(forKey: provider)?.close()
+        self.providerMenuViewModels.removeValue(forKey: provider)
+    }
+
     /// 懒创建指定 provider 的 MenuViewModel + PopoverMenuController（首次调用后缓存）。
     func ensureProviderPopover(for provider: UsageProvider, isFallback: Bool = false) {
         if self.providerMenuViewModels[provider]?.isFallback == isFallback,
@@ -180,6 +185,9 @@ extension StatusItemController {
                 item.menu = nil
                 item.button?.target = nil
                 item.button?.action = nil
+                self.removeProviderPopover(for: provider)
+            } else {
+                self.removeProviderPopover(for: provider)
             }
         }
     }

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -76,6 +76,15 @@ extension StatusItemController {
                         (self?.settings.switcherShowsIcons == true)
                             ? self?.popoverSwitcherIcon(for: provider)
                             : nil
+                    },
+                    makeChartEntries: { [weak self] provider in
+                        self?.popoverChartEntries(for: provider) ?? []
+                    },
+                    makeOverviewChart: { [weak self] row in
+                        self?.popoverOverviewChart(for: row.provider, model: row.model)
+                    },
+                    makeChartView: { [weak self] kind, width in
+                        self?.popoverChartView(for: kind, width: width)
                     })
             }
             self.wirePopoverShortcutCallbacks()

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -1,0 +1,61 @@
+import AppKit
+
+// MARK: - Popover 菜单接入（合并模式）
+
+//
+// 把 popover 相关的接入逻辑从 StatusItemController 主体抽出，集中于此扩展，
+// 既保持主类体在 swiftlint type_body_length 限制内，也便于后续阶段在此扩展。
+// 仅当 `usePopoverMenu` 开关开启时这些路径才生效；关闭时主类走原有 NSMenu 逻辑。
+
+extension StatusItemController {
+    /// 特性开关：是否启用 NSPopover 菜单（替代 NSMenu）。
+    var usePopoverMenu: Bool {
+        self.settings.usePopoverMenu
+    }
+
+    /// 合并模式下安装 popover：清掉 statusItem.menu，懒创建 PopoverMenuController 并接线快捷键回调，
+    /// 再把状态项按钮点击（含右键）路由到 handleStatusItemClick。仅在 usePopoverMenu 开启时调用。
+    func attachMergedPopover() {
+        self.statusItem.menu = nil
+        if self.popoverMenuController == nil {
+            self.menuViewModel.providers = self.store.enabledProvidersForDisplay()
+            let vm = self.menuViewModel
+            let store = self.store
+            self.popoverMenuController = PopoverMenuController(viewModel: vm) { [weak self] in
+                PopoverRootView(
+                    viewModel: vm,
+                    store: store,
+                    makeCardModel: { [weak self] provider in self?.menuCardModel(for: provider) })
+            }
+            self.wirePopoverShortcutCallbacks()
+        }
+        self.statusItem.button?.target = self
+        self.statusItem.button?.action = #selector(self.handleStatusItemClick(_:))
+        // 右键也触发 action，使右键可弹出 popover
+        self.statusItem.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
+    }
+
+    /// 接线 popover 的键盘快捷键回调（只在控制器首次创建时设一次，弱引用防环）。
+    private func wirePopoverShortcutCallbacks() {
+        self.popoverMenuController?.onRefresh = { [weak self] in
+            self?.refreshNow()
+            self?.popoverMenuController?.close()
+        }
+        self.popoverMenuController?.onSettings = { [weak self] in
+            self?.showSettingsGeneral()
+            self?.popoverMenuController?.close()
+        }
+        self.popoverMenuController?.onQuit = { [weak self] in
+            self?.quit()
+        }
+        self.popoverMenuController?.onNavigate = { [weak self] direction in
+            switch direction {
+            case .next: self?.menuViewModel.selectNext()
+            case .previous: self?.menuViewModel.selectPrevious()
+            }
+        }
+        self.popoverMenuController?.onSelectIndex = { [weak self] index in
+            self?.menuViewModel.selectProvider(atIndex: index)
+        }
+    }
+}

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -421,6 +421,154 @@ extension StatusItemController {
         return rows.isEmpty ? L("No overview data available.") : nil
     }
 
+    // MARK: - 图表下钻入口（Task 3.1）
+
+    /// 该 provider 卡片下方应显示的图表下钻入口，顺序对齐 NSMenu：
+    ///   usage(breakdown/openAIAPI) → credits → cost → usageHistory → storage → zaiHourly。
+    func popoverChartEntries(for provider: UsageProvider) -> [PopoverChartKind] {
+        let codexProjection = self.store.codexConsumerProjectionIfNeeded(
+            for: provider,
+            surface: .liveCard)
+        let hasUsageBreakdown = codexProjection?.hasUsageBreakdown == true
+        let hasCreditsHistory = codexProjection?.hasCreditsHistory == true
+        // cost：tokenSnapshotForCostHistorySubmenu 与 appendCostHistoryChartItem 完全对齐
+        let tokenSnap = self.tokenSnapshotForCostHistorySubmenu(provider: provider)
+        let hasCostHistory = self.settings.isCostUsageEffectivelyEnabled(for: provider) &&
+            tokenSnap?.daily.isEmpty == false
+        let hasUsageHistory = self.store.supportsPlanUtilizationHistory(for: provider) &&
+            !self.store.shouldHidePlanUtilizationMenuItem(for: provider)
+        let hasStorageBreakdown = self.store.storageFootprint(for: provider)?.components.isEmpty == false
+        let hasZaiHourly = provider == .zai &&
+            self.store.snapshot(for: provider)?.zaiUsage?.modelUsage != nil
+
+        var entries: [PopoverChartKind] = []
+
+        // ── usage ──
+        // 与 makeUsageSubmenu 对齐：hasUsageBreakdown → .usageBreakdown；
+        //   否则 openai + hasOpenAIAPIUsageSubmenu → .costHistory(openai)（即 "API Usage" submenu）。
+        if hasUsageBreakdown {
+            entries.append(.usageBreakdown)
+        } else if provider == .openai,
+                  self.tokenSnapshotForCostHistorySubmenu(provider: provider)?.daily.isEmpty == false
+        {
+            // openAI "API Usage" 子菜单等价于 costHistory；在此插入，后面 cost 入口去重跳过
+            entries.append(.costHistory(provider))
+        }
+
+        // ── credits ──
+        if hasCreditsHistory {
+            entries.append(.creditsHistory)
+        }
+
+        // ── cost（去重：usage 入口若已插入 costHistory(provider) 则跳过）──
+        if hasCostHistory, !entries.contains(.costHistory(provider)) {
+            entries.append(.costHistory(provider))
+        }
+
+        // ── usageHistory ──
+        if hasUsageHistory {
+            entries.append(.usageHistory(provider))
+        }
+
+        // ── storage ──
+        if hasStorageBreakdown {
+            entries.append(.storageBreakdown(provider))
+        }
+
+        // ── zaiHourly ──
+        if hasZaiHourly {
+            entries.append(.zaiHourly(provider))
+        }
+
+        return entries
+    }
+
+    /// Overview 行的下钻图表（无则 nil），对齐 makeOverviewRowSubmenu 逻辑：
+    ///   openai+hasAPIUsage → .costHistory；zai → nil（详情菜单阶段跳过）；
+    ///   tokenUsage != nil → .costHistory；usageHistory 可用 → .usageHistory；
+    ///   storage 非空 → .storageBreakdown；否则 nil。
+    func popoverOverviewChart(for provider: UsageProvider, model: UsageMenuCardView.Model) -> PopoverChartKind? {
+        // openai：API Usage submenu（=costHistory）
+        if provider == .openai,
+           self.tokenSnapshotForCostHistorySubmenu(provider: provider)?.daily.isEmpty == false
+        {
+            return .costHistory(provider)
+        }
+        // zai：详情菜单本阶段跳过
+        if provider == .zai {
+            return nil
+        }
+        // tokenUsage 不为 nil → costHistory
+        if model.tokenUsage != nil,
+           self.tokenSnapshotForCostHistorySubmenu(provider: provider)?.daily.isEmpty == false
+        {
+            return .costHistory(provider)
+        }
+        // usageHistory
+        if self.store.supportsPlanUtilizationHistory(for: provider),
+           !self.store.shouldHidePlanUtilizationMenuItem(for: provider)
+        {
+            return .usageHistory(provider)
+        }
+        // storageBreakdown
+        if self.store.storageFootprint(for: provider)?.components.isEmpty == false {
+            return .storageBreakdown(provider)
+        }
+        return nil
+    }
+
+    /// 懒构造图表视图；数据缺失返回 nil。width 为图表渲染宽度。
+    /// 数据获取与 +HostedSubmenus.swift 对应 append* 方法完全一致。
+    @MainActor
+    func popoverChartView(for kind: PopoverChartKind, width: CGFloat) -> AnyView? {
+        switch kind {
+        case .usageBreakdown:
+            let breakdown = OpenAIDashboardDailyBreakdown.removingSkillUsageServices(
+                from: self.store.openAIDashboard?.usageBreakdown ?? [])
+            guard !breakdown.isEmpty else { return nil }
+            return AnyView(UsageBreakdownChartMenuView(breakdown: breakdown, width: width))
+
+        case .creditsHistory:
+            let breakdown = self.store.openAIDashboard?.dailyBreakdown ?? []
+            guard !breakdown.isEmpty else { return nil }
+            return AnyView(CreditsHistoryChartMenuView(breakdown: breakdown, width: width))
+
+        case let .costHistory(provider):
+            guard let tokenSnapshot = self.tokenSnapshotForCostHistorySubmenu(provider: provider) else { return nil }
+            guard !tokenSnapshot.daily.isEmpty else { return nil }
+            return AnyView(CostHistoryChartMenuView(
+                provider: provider,
+                daily: tokenSnapshot.daily,
+                totalCostUSD: tokenSnapshot.last30DaysCostUSD,
+                currencyCode: tokenSnapshot.currencyCode,
+                historyDays: tokenSnapshot.historyDays,
+                windowLabel: tokenSnapshot.historyLabel,
+                width: width))
+
+        case let .usageHistory(provider):
+            let histories = self.store.planUtilizationHistory(for: provider)
+            let snapshot = self.store.snapshot(for: provider)
+            return AnyView(PlanUtilizationHistoryChartMenuView(
+                provider: provider,
+                histories: histories,
+                snapshot: snapshot,
+                width: width))
+
+        case let .storageBreakdown(provider):
+            guard let footprint = self.store.storageFootprint(for: provider),
+                  !footprint.components.isEmpty else { return nil }
+            let visibleHeight = NSScreen.main?.visibleFrame.height ?? 900
+            let maxHeight = min(620, max(360, floor(visibleHeight * 0.72)))
+            return AnyView(StorageBreakdownMenuView(footprint: footprint, width: width, maxHeight: maxHeight))
+
+        case let .zaiHourly(provider):
+            guard provider == .zai,
+                  let snapshot = self.store.snapshot(for: provider),
+                  let modelUsage = snapshot.zaiUsage?.modelUsage else { return nil }
+            return AnyView(ZaiHourlyUsageChartMenuView(modelUsage: modelUsage, width: width))
+        }
+    }
+
     /// 接线 popover 的键盘快捷键回调（只在控制器首次创建时设一次，弱引用防环）。
     private func wirePopoverShortcutCallbacks() {
         self.popoverMenuController?.onRefresh = { [weak self] in

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -39,7 +39,16 @@ extension StatusItemController {
                     },
                     makeSections: { [weak self] in
                         guard let self else { return [] }
+                        let isOverview = vm.selection == .overview
+                        // overview 时取 resolvedMenuProvider 等价逻辑（与 populateMenu:224-228 对齐）：
+                        // 优先选已启用且可用的 provider，不传切换器选择，等价于 NSMenu overview 路径。
                         let provider: UsageProvider? = {
+                            if isOverview {
+                                let enabled = vm.providers
+                                if enabled.isEmpty { return UsageProvider.codex }
+                                return enabled.first(where: { self.store.isProviderAvailable($0) })
+                                    ?? enabled.first
+                            }
                             if case let .provider(p) = vm.selection { return p }
                             return vm.providers.first
                         }()
@@ -51,7 +60,13 @@ extension StatusItemController {
                             managedCodexAccountCoordinator: self.managedCodexAccountCoordinator,
                             codexAccountPromotionCoordinator: self.codexAccountPromotionCoordinator,
                             updateReady: self.updater.updateStatus.isUpdateReady,
-                            includeContextualActions: true).sections
+                            includeContextualActions: !isOverview).sections
+                    },
+                    makeOverviewRows: { [weak self] in
+                        self?.popoverOverviewRows() ?? []
+                    },
+                    overviewEmptyText: { [weak self] in
+                        self?.popoverOverviewEmptyText()
                     },
                     onAction: { [weak self] action in self?.performMenuAction(action) },
                     onBuyCredits: { [weak self] in
@@ -284,6 +299,50 @@ extension StatusItemController {
                 await self.store.refreshProvider(provider)
             }
         }
+    }
+
+    // MARK: - Overview 行数据（Task 2.4）
+
+    /// Overview 模式下单行数据：与 NSMenu addOverviewRows 同源构造。
+    struct PopoverOverviewRow: Identifiable {
+        let provider: UsageProvider
+        let model: UsageMenuCardView.Model
+        let storageText: String?
+        var id: String {
+            self.provider.rawValue
+        }
+    }
+
+    /// 构造 overview 行数据列表，与 addOverviewRows 同源逻辑：
+    ///   1. reconcileMergedOverviewSelectedProviders 解析已选 providers；
+    ///   2. compactMap menuCardModel，跳过 nil 与 isOverviewErrorOnly；
+    ///   3. 每行附带 storageFootprintText。
+    func popoverOverviewRows() -> [PopoverOverviewRow] {
+        let enabledProviders = self.store.enabledProvidersForDisplay()
+        let overviewProviders = self.settings.reconcileMergedOverviewSelectedProviders(
+            activeProviders: enabledProviders)
+        return overviewProviders.compactMap { provider in
+            guard let model = self.menuCardModel(for: provider) else { return nil }
+            guard !model.isOverviewErrorOnly else { return nil }
+            let storageText = self.store.storageFootprintText(for: provider)
+            return PopoverOverviewRow(provider: provider, model: model, storageText: storageText)
+        }
+    }
+
+    /// Overview 空态文案：nil 表示有内容（rows 非空），否则返回与 NSMenu 一致的本地化文案。
+    ///   - resolvedProviders 为空 → "No providers selected for Overview."
+    ///   - resolvedProviders 非空但行数据为空 → "No overview data available."
+    func popoverOverviewEmptyText() -> String? {
+        let enabledProviders = self.store.enabledProvidersForDisplay()
+        let resolvedProviders = self.settings.resolvedMergedOverviewProviders(
+            activeProviders: enabledProviders,
+            maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit)
+        if resolvedProviders.isEmpty {
+            return L("No providers selected for Overview.")
+        }
+        // rows 非空时返回 nil（有内容，不需要空态）
+        let rows = self.popoverOverviewRows()
+        return rows.isEmpty ? L("No overview data available.") : nil
     }
 
     /// 接线 popover 的键盘快捷键回调（只在控制器首次创建时设一次，弱引用防环）。

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -36,14 +36,7 @@ extension StatusItemController {
             // onSelectionChanged 必须在 refreshPopoverViewModelInputs() 之前注册，
             // 确保首次 restore（select(restored)）触发时回调已就位，不会静默丢失写回 settings 的副作用。
             vm.onSelectionChanged = { [weak self] selection in
-                guard let self else { return }
-                switch selection {
-                case .overview:
-                    self.settings.mergedMenuLastSelectedWasOverview = true
-                case let .provider(p):
-                    self.settings.selectedMenuProvider = p
-                    self.settings.mergedMenuLastSelectedWasOverview = false
-                }
+                self?.applyPopoverSelection(selection)
             }
             // 在控制器创建与回调注册完成后再 refresh，保证首次 selection restore 的写回不丢失。
             self.refreshPopoverViewModelInputs()
@@ -52,6 +45,22 @@ extension StatusItemController {
         self.statusItem.button?.action = #selector(self.handleStatusItemClick(_:))
         // 右键也触发 action，使右键可弹出 popover
         self.statusItem.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
+    }
+
+    func applyPopoverSelection(_ selection: ProviderSwitcherSelection) {
+        self.preservingMergedSwitcherContentCachesDuringInvalidation {
+            switch selection {
+            case .overview:
+                self.settings.mergedMenuLastSelectedWasOverview = true
+                self.lastMenuProvider = self.popoverActionProvider(for: self.menuViewModel)
+            case let .provider(provider):
+                self.settings.selectedMenuProvider = provider
+                self.settings.mergedMenuLastSelectedWasOverview = false
+                self.lastMenuProvider = provider
+            }
+            self.lastMergedSwitcherSelection = selection
+            self.refreshProviderSelectionDependentUI(deferRendering: true)
+        }
     }
 
     // MARK: - ViewModel 输入刷新

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CodexBarCore
 
 // MARK: - Popover 菜单接入（合并模式）
 
@@ -25,7 +26,24 @@ extension StatusItemController {
                 PopoverRootView(
                     viewModel: vm,
                     store: store,
-                    makeCardModel: { [weak self] provider in self?.menuCardModel(for: provider) })
+                    makeCardModel: { [weak self] provider in self?.menuCardModel(for: provider) },
+                    makeSections: { [weak self] in
+                        guard let self else { return [] }
+                        let provider: UsageProvider? = {
+                            if case let .provider(p) = vm.selection { return p }
+                            return vm.providers.first
+                        }()
+                        return MenuDescriptor.build(
+                            provider: provider,
+                            store: store,
+                            settings: self.settings,
+                            account: self.account,
+                            managedCodexAccountCoordinator: self.managedCodexAccountCoordinator,
+                            codexAccountPromotionCoordinator: self.codexAccountPromotionCoordinator,
+                            updateReady: self.updater.updateStatus.isUpdateReady,
+                            includeContextualActions: true).sections
+                    },
+                    onAction: { [weak self] action in self?.performMenuAction(action) })
             }
             self.wirePopoverShortcutCallbacks()
         }
@@ -33,6 +51,33 @@ extension StatusItemController {
         self.statusItem.button?.action = #selector(self.handleStatusItemClick(_:))
         // 右键也触发 action，使右键可弹出 popover
         self.statusItem.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
+    }
+
+    // MARK: - popover 动作分发
+
+    /// popover 动作分发：通过 selector(for:) 复用 NSMenu 路径的全部逻辑，
+    /// 统一构造一个临时 NSMenuItem 传递 representedObject，再对无参/带参 selector 分别分发。
+    /// quit 不关闭 popover（应用即将退出）；其余动作执行后关闭。
+    func performMenuAction(_ action: MenuDescriptor.MenuAction) {
+        self.performLegacyMenuAction(action)
+        if action != .quit {
+            self.popoverMenuController?.close()
+        }
+    }
+
+    /// 通过已有的 selector(for:) 映射分发动作，复用 NSMenu 路径全部逻辑。
+    /// - 有 payload（带参 selector）：构造临时 NSMenuItem 传递 representedObject，
+    ///   调用 perform(_:with:)——AppKit 约定 with: 参数传给 @objc 方法的 sender 参数。
+    /// - 无 payload（无参 selector）：调用 perform(_:)，避免向无参方法传入多余参数。
+    private func performLegacyMenuAction(_ action: MenuDescriptor.MenuAction) {
+        let (sel, payload) = self.selector(for: action)
+        if let payload {
+            let item = NSMenuItem()
+            item.representedObject = payload
+            _ = self.perform(sel, with: item)
+        } else {
+            _ = self.perform(sel)
+        }
     }
 
     /// 接线 popover 的键盘快捷键回调（只在控制器首次创建时设一次，弱引用防环）。

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -866,7 +866,7 @@ extension StatusItemController {
             }
         }
         self.popoverMenuController?.onSelectIndex = { [weak self] index in
-            self?.menuViewModel.selectProvider(atIndex: index)
+            self?.menuViewModel.selectNavigationStop(atIndex: index)
         }
     }
 }

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -144,7 +144,6 @@ extension StatusItemController {
         // onNavigate/onSelectIndex 单 provider 下 no-op（不设）。
         ctrl.onRefresh = { [weak self] in
             self?.refreshNow()
-            self?.providerPopoverControllers[provider]?.close()
         }
         ctrl.onSettings = { [weak self] in
             self?.showSettingsGeneral()
@@ -826,7 +825,6 @@ extension StatusItemController {
     private func wirePopoverShortcutCallbacks() {
         self.popoverMenuController?.onRefresh = { [weak self] in
             self?.refreshNow()
-            self?.popoverMenuController?.close()
         }
         self.popoverMenuController?.onSettings = { [weak self] in
             self?.showSettingsGeneral()

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -137,11 +137,13 @@ extension StatusItemController {
     }
 
     /// 懒创建指定 provider 的 MenuViewModel + PopoverMenuController（首次调用后缓存）。
-    func ensureProviderPopover(for provider: UsageProvider, isFallback: Bool = false) {
-        if self.providerMenuViewModels[provider]?.isFallback == isFallback,
+    @discardableResult
+    func ensureProviderPopover(for provider: UsageProvider, isFallback: Bool = false) -> MenuViewModel {
+        if let viewModel = self.providerMenuViewModels[provider],
+           viewModel.isFallback == isFallback,
            self.providerPopoverControllers[provider] != nil
         {
-            return
+            return viewModel
         }
         self.providerPopoverControllers[provider]?.close()
         let vm = isFallback
@@ -166,6 +168,13 @@ extension StatusItemController {
         }
         // onNavigate/onSelectIndex 留为 nil（单 provider 无切换器，不处理方向键/数字键）
         self.providerPopoverControllers[provider] = ctrl
+        return vm
+    }
+
+    func prepareProviderPopoverForShortcut(for provider: UsageProvider) -> MenuViewModel {
+        self.ensureProviderPopover(
+            for: provider,
+            isFallback: self.fallbackProvider == provider)
     }
 
     /// 非合并模式下为每个 enabled/fallback provider 安装 per-provider popover，复刻 attachMenus(fallback:) 遍历结构。

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -198,16 +198,7 @@ extension StatusItemController {
                 makeSections: { [weak self] in
                     guard let self else { return [] }
                     let isOverview = vm.selection == .overview
-                    let provider: UsageProvider? = {
-                        if isOverview {
-                            let enabled = vm.providers
-                            if enabled.isEmpty { return UsageProvider.codex }
-                            return enabled.first(where: { self.store.isProviderAvailable($0) })
-                                ?? enabled.first
-                        }
-                        if case let .provider(p) = vm.selection { return p }
-                        return vm.providers.first
-                    }()
+                    let provider = self.popoverActionProvider(for: vm)
                     return MenuDescriptor.build(
                         provider: provider,
                         store: store,
@@ -222,7 +213,14 @@ extension StatusItemController {
                 overviewEmptyText: { [weak self] in
                     self?.popoverOverviewEmptyText()
                 },
-                onAction: { [weak self] action in self?.performMenuAction(action) },
+                onAction: { [weak self] action in
+                    guard let self else { return }
+                    // dashboard/statusPage/changelog 等动作不携带 provider payload，
+                    // 其 selector 经 lastMenuProvider 解析目标——与 NSMenu menuWillOpen
+                    // 写入该字段的语义对齐，分发前先写入当前面板的 provider 上下文。
+                    self.lastMenuProvider = self.popoverActionProvider(for: vm)
+                    self.performMenuAction(action)
+                },
                 actionSubtitle: { [weak self] action in
                     guard let self else { return nil }
                     switch action {
@@ -232,9 +230,11 @@ extension StatusItemController {
                     }
                 },
                 onBuyCredits: { [weak self] in
-                    self?.openCreditsPurchase()
+                    guard let self else { return }
+                    self.lastMenuProvider = self.popoverActionProvider(for: vm)
+                    self.openCreditsPurchase()
                     // 全关（含合并与全部 per-provider popover）：此闭包被两种模式复用
-                    self?.closeAllProviderPopovers()
+                    self.closeAllProviderPopovers()
                 },
                 switcherIcon: { [weak self] provider in
                     (self?.settings.switcherShowsIcons == true)
@@ -266,12 +266,25 @@ extension StatusItemController {
     // MARK: - popover 动作分发
 
     /// popover 动作分发：通过 selector(for:) 复用 NSMenu 路径的全部逻辑，
+    /// 解析当前面板动作应使用的 provider 上下文（与 NSMenu menuWillOpen 写入 lastMenuProvider
+    /// 的语义对齐）：选中具体 provider 时取之；Overview 时取第一个可用 provider；兜底 .codex。
+    /// makeSections 与动作分发共用，保证菜单内容与动作目标一致。
+    func popoverActionProvider(for vm: MenuViewModel) -> UsageProvider {
+        if case let .provider(p) = vm.selection { return p }
+        let enabled = vm.providers
+        return enabled.first(where: { self.store.isProviderAvailable($0) })
+            ?? enabled.first
+            ?? .codex
+    }
+
     /// 统一构造一个临时 NSMenuItem 传递 representedObject，再对无参/带参 selector 分别分发。
     /// quit 不关闭 popover（应用即将退出）；其余动作执行后关闭。
     func performMenuAction(_ action: MenuDescriptor.MenuAction) {
         self.performLegacyMenuAction(action)
         if action != .quit {
-            self.popoverMenuController?.close()
+            // 与 NSMenu 选中动作后菜单关闭对齐：合并与全部 per-provider popover 一并关闭，
+            // 避免 split 模式下动作执行后面板滞留。
+            self.closeAllProviderPopovers()
         }
     }
 

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -20,7 +20,6 @@ extension StatusItemController {
     func attachMergedPopover() {
         self.statusItem.menu = nil
         if self.popoverMenuController == nil {
-            self.refreshPopoverViewModelInputs()
             let vm = self.menuViewModel
             let store = self.store
             self.popoverMenuController = PopoverMenuController(viewModel: vm) { [weak self] in
@@ -80,6 +79,8 @@ extension StatusItemController {
                     })
             }
             self.wirePopoverShortcutCallbacks()
+            // onSelectionChanged 必须在 refreshPopoverViewModelInputs() 之前注册，
+            // 确保首次 restore（select(restored)）触发时回调已就位，不会静默丢失写回 settings 的副作用。
             vm.onSelectionChanged = { [weak self] selection in
                 guard let self else { return }
                 switch selection {
@@ -90,6 +91,8 @@ extension StatusItemController {
                     self.settings.mergedMenuLastSelectedWasOverview = false
                 }
             }
+            // 在控制器创建与回调注册完成后再 refresh，保证首次 selection restore 的写回不丢失。
+            self.refreshPopoverViewModelInputs()
         }
         self.statusItem.button?.target = self
         self.statusItem.button?.action = #selector(self.handleStatusItemClick(_:))
@@ -107,7 +110,9 @@ extension StatusItemController {
         let overviewProviders = self.settings.resolvedMergedOverviewProviders(
             activeProviders: enabledProviders,
             maxVisibleProviders: SettingsStore.mergedOverviewProviderLimit)
-        self.menuViewModel.includesOverview = !overviewProviders.isEmpty
+        // 与 NSMenu 对齐：只有多个 provider 时才显示切换器（含 overview tab）；
+        // 单 provider 时即使 overviewProviders 非空也不展示，避免多余的切换器。
+        self.menuViewModel.includesOverview = !overviewProviders.isEmpty && enabledProviders.count > 1
 
         // 从 settings 恢复上次选中项（等价于 NSMenu 的 resolvedSwitcherSelection 逻辑）：
         //   includesOverview && mergedMenuLastSelectedWasOverview → .overview
@@ -152,18 +157,15 @@ extension StatusItemController {
     }
 
     /// 通过已有的 selector(for:) 映射分发动作，复用 NSMenu 路径全部逻辑。
-    /// - 有 payload（带参 selector）：构造临时 NSMenuItem 传递 representedObject，
-    ///   调用 perform(_:with:)——AppKit 约定 with: 参数传给 @objc 方法的 sender 参数。
-    /// - 无 payload（无参 selector）：调用 perform(_:)，避免向无参方法传入多余参数。
+    /// 始终构造临时 NSMenuItem 并调用 perform(_:with:)：
+    ///   - 带 payload 的方法：representedObject 设为 payload，方法正常读取。
+    ///   - 无 payload（无参签名）的方法：representedObject 为 nil，ObjC 消息派发下多余实参被忽略，安全。
+    /// 消除了两路分支与 addCodexAccount（payload=nil 但方法带 NSMenuItem 参数）的 ABI 歧义。
     private func performLegacyMenuAction(_ action: MenuDescriptor.MenuAction) {
         let (sel, payload) = self.selector(for: action)
-        if let payload {
-            let item = NSMenuItem()
-            item.representedObject = payload
-            _ = self.perform(sel, with: item)
-        } else {
-            _ = self.perform(sel)
-        }
+        let item = NSMenuItem()
+        item.representedObject = payload
+        _ = self.perform(sel, with: item)
     }
 
     // MARK: - 卡片计划（复刻 addMenuCards 分流逻辑，纯数据）
@@ -174,7 +176,10 @@ extension StatusItemController {
     ///   2. Token 多账户 stacked → snapshot compactMap
     ///   3. Kilo 多 scope → kiloScopeSnapshots compactMap
     ///   4. 单卡片 / 占位
-    ///   + storageText / showBuyCredits
+    ///   + storageText
+    ///   stacked 路径强制 showBuyCredits = false（与 NSMenu addStackedMenuCards 一致，
+    ///   NSMenu stacked 分支 return false 早退，不经过单卡片 canShowBuyCredits 路径）；
+    ///   仅单卡片路径（分支 4）保留 popoverCanShowBuyCredits 计算。
     func popoverCardPlan(for provider: UsageProvider) -> PopoverCardPlan {
         var plan = PopoverCardPlan()
 
@@ -208,8 +213,11 @@ extension StatusItemController {
                     isFirstInSection = false
                 }
             }
+            // stacked 路径：cards 为空时 fallback 到单卡片，与 NSMenu addStackedCodexMenuCards:49-56 对齐
+            self.applyStackedFallback(to: &plan, provider: provider)
             plan.storageText = self.store.storageFootprintText(for: provider)
-            plan.showBuyCredits = self.popoverCanShowBuyCredits(for: provider)
+            // stacked 路径不显示 Buy Credits，与 NSMenu stacked 路径 return false 早退一致
+            plan.showBuyCredits = false
             return plan
         }
 
@@ -228,11 +236,11 @@ extension StatusItemController {
                     }
             }
             plan.cards = cards
-            if plan.cards.isEmpty {
-                plan.emptyText = "Loading…"
-            }
+            // stacked 路径：cards 为空时 fallback 到单卡片，与 NSMenu addStackedMenuCards:716-722 对齐
+            self.applyStackedFallback(to: &plan, provider: provider)
             plan.storageText = self.store.storageFootprintText(for: provider)
-            plan.showBuyCredits = self.popoverCanShowBuyCredits(for: provider)
+            // stacked 路径不显示 Buy Credits，与 NSMenu stacked 路径 return false 早退一致
+            plan.showBuyCredits = false
             return plan
         }
 
@@ -249,11 +257,11 @@ extension StatusItemController {
                     }
             }
             plan.cards = cards
-            if plan.cards.isEmpty {
-                plan.emptyText = "Loading…"
-            }
+            // stacked 路径：cards 为空时 fallback 到单卡片，与 NSMenu addStackedMenuCards:716-722 对齐
+            self.applyStackedFallback(to: &plan, provider: provider)
             plan.storageText = self.store.storageFootprintText(for: provider)
-            plan.showBuyCredits = self.popoverCanShowBuyCredits(for: provider)
+            // stacked 路径不显示 Buy Credits，与 NSMenu stacked 路径 return false 早退一致
+            plan.showBuyCredits = false
             return plan
         }
 
@@ -266,6 +274,17 @@ extension StatusItemController {
         plan.storageText = self.store.storageFootprintText(for: provider)
         plan.showBuyCredits = self.popoverCanShowBuyCredits(for: provider)
         return plan
+    }
+
+    /// stacked 路径空 cards 时的 fallback：尝试构造单卡片，否则显示"Loading…"。
+    /// 与 NSMenu addStackedCodexMenuCards:49-56 / addStackedMenuCards:716-722 语义对齐。
+    private func applyStackedFallback(to plan: inout PopoverCardPlan, provider: UsageProvider) {
+        guard plan.cards.isEmpty else { return }
+        if let model = self.menuCardModel(for: provider) {
+            plan.cards = [PopoverCardPlan.Card(id: "single", model: model, workspaceHeader: nil)]
+        } else {
+            plan.emptyText = "Loading…"
+        }
     }
 
     /// 计算 Buy Credits 是否可显示。

--- a/Sources/CodexBar/StatusItemController+Popover.swift
+++ b/Sources/CodexBar/StatusItemController+Popover.swift
@@ -288,13 +288,22 @@ extension StatusItemController {
     }
 
     /// 统一构造一个临时 NSMenuItem 传递 representedObject，再对无参/带参 selector 分别分发。
-    /// quit 不关闭 popover（应用即将退出）；其余动作执行后关闭。
+    /// Refresh stays open so updated data can render in place; quit exits the app.
     func performMenuAction(_ action: MenuDescriptor.MenuAction) {
         self.performLegacyMenuAction(action)
-        if action != .quit {
+        if Self.shouldClosePopover(after: action) {
             // 与 NSMenu 选中动作后菜单关闭对齐：合并与全部 per-provider popover 一并关闭，
             // 避免 split 模式下动作执行后面板滞留。
             self.closeAllProviderPopovers()
+        }
+    }
+
+    static func shouldClosePopover(after action: MenuDescriptor.MenuAction) -> Bool {
+        switch action {
+        case .refresh, .quit:
+            false
+        default:
+            true
         }
     }
 
@@ -324,6 +333,10 @@ extension StatusItemController {
     ///   仅单卡片路径（分支 4）保留 popoverCanShowBuyCredits 计算。
     func popoverCardPlan(for provider: UsageProvider) -> PopoverCardPlan {
         var plan = PopoverCardPlan()
+        plan.storageText = self.store.storageFootprintText(for: provider)
+        if self.store.storageFootprint(for: provider)?.components.isEmpty == false {
+            plan.storageChart = .storageBreakdown(provider)
+        }
 
         // ── 1. Codex stacked ──
         if let codexDisplay = self.codexAccountMenuDisplay(for: provider), codexDisplay.showAll {
@@ -357,7 +370,6 @@ extension StatusItemController {
             }
             // stacked 路径：cards 为空时 fallback 到单卡片，与 NSMenu addStackedCodexMenuCards:49-56 对齐
             self.applyStackedFallback(to: &plan, provider: provider)
-            plan.storageText = self.store.storageFootprintText(for: provider)
             // stacked 路径不显示 Buy Credits，与 NSMenu stacked 路径 return false 早退一致
             plan.showBuyCredits = false
             return plan
@@ -380,7 +392,6 @@ extension StatusItemController {
             plan.cards = cards
             // stacked 路径：cards 为空时 fallback 到单卡片，与 NSMenu addStackedMenuCards:716-722 对齐
             self.applyStackedFallback(to: &plan, provider: provider)
-            plan.storageText = self.store.storageFootprintText(for: provider)
             // stacked 路径不显示 Buy Credits，与 NSMenu stacked 路径 return false 早退一致
             plan.showBuyCredits = false
             return plan
@@ -401,7 +412,6 @@ extension StatusItemController {
             plan.cards = cards
             // stacked 路径：cards 为空时 fallback 到单卡片，与 NSMenu addStackedMenuCards:716-722 对齐
             self.applyStackedFallback(to: &plan, provider: provider)
-            plan.storageText = self.store.storageFootprintText(for: provider)
             // stacked 路径不显示 Buy Credits，与 NSMenu stacked 路径 return false 早退一致
             plan.showBuyCredits = false
             return plan
@@ -420,7 +430,6 @@ extension StatusItemController {
         } else {
             plan.emptyText = "Loading…"
         }
-        plan.storageText = self.store.storageFootprintText(for: provider)
         return plan
     }
 

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -150,6 +150,12 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var deferredOpenAIDashboardRefreshReason: String?
     var deferredMenuInteractionRefreshTask: Task<Void, Never>?
     var highlightedMenuItems: [ObjectIdentifier: NSMenuItem] = [:]
+    // MARK: - Popover menu (gated by settings.usePopoverMenu; inactive until wired in Task 1.1)
+    let menuViewModel = MenuViewModel()
+    var popoverMenuController: PopoverMenuController<PopoverRootView>?
+
+    var usePopoverMenu: Bool { self.settings.usePopoverMenu }
+
     var providerSwitcherShortcutEventMonitor: ProviderSwitcherShortcutEventMonitor?
     var providerSwitcherShortcutMenuID: ObjectIdentifier?
     var providerSwitcherPointerInteractionMenuID: ObjectIdentifier?

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -835,9 +835,14 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             }
             self.statusItem.button?.target = self
             self.statusItem.button?.action = #selector(self.handleStatusItemClick(_:))
+            // 右键也触发 action，使右键可弹出 popover
+            self.statusItem.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
             return
         }
         // ↓ original logic unchanged
+        // 从 popover 模式切回时清掉残留的 button target/action
+        self.statusItem.button?.target = nil
+        self.statusItem.button?.action = nil
         if self.mergedMenu == nil {
             self.mergedMenu = self.makeMenu()
         }

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -867,6 +867,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     }
 
     private func removeProviderStatusItem(for provider: UsageProvider) {
+        self.removeProviderPopover(for: provider)
         if let menu = self.providerMenus.removeValue(forKey: provider) {
             let menuID = ObjectIdentifier(menu)
             self.menuProviders.removeValue(forKey: menuID)

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -799,6 +799,19 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     }
 
     private func attachMenus() {
+        if self.usePopoverMenu {
+            self.statusItem.menu = nil
+            if self.popoverMenuController == nil {
+                self.menuViewModel.providers = self.store.enabledProvidersForDisplay()
+                self.popoverMenuController = PopoverMenuController(viewModel: self.menuViewModel) {
+                    PopoverRootView(viewModel: self.menuViewModel)
+                }
+            }
+            self.statusItem.button?.target = self
+            self.statusItem.button?.action = #selector(self.handleStatusItemClick(_:))
+            return
+        }
+        // ↓ original logic unchanged
         if self.mergedMenu == nil {
             self.mergedMenu = self.makeMenu()
         }

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -707,11 +707,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         self.updateBlinkingState()
     }
 
-    var isMergedMenuOpen: Bool {
-        guard let mergedMenu else { return false }
-        return self.openMenus[ObjectIdentifier(mergedMenu)] != nil
-    }
-
     /// Lazily retrieves or creates a status item for the given provider
     func lazyStatusItem(for provider: UsageProvider) -> NSStatusItem {
         if let existing = self.statusItems[provider] {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -150,11 +150,11 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var deferredOpenAIDashboardRefreshReason: String?
     var deferredMenuInteractionRefreshTask: Task<Void, Never>?
     var highlightedMenuItems: [ObjectIdentifier: NSMenuItem] = [:]
-    // MARK: - Popover menu (gated by settings.usePopoverMenu; inactive until wired in Task 1.1)
+
+    // MARK: - Popover menu (gated by settings.usePopoverMenu; see StatusItemController+Popover)
+
     let menuViewModel = MenuViewModel()
     var popoverMenuController: PopoverMenuController<PopoverRootView>?
-
-    var usePopoverMenu: Bool { self.settings.usePopoverMenu }
 
     var providerSwitcherShortcutEventMonitor: ProviderSwitcherShortcutEventMonitor?
     var providerSwitcherShortcutMenuID: ObjectIdentifier?
@@ -800,43 +800,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
 
     private func attachMenus() {
         if self.usePopoverMenu {
-            self.statusItem.menu = nil
-            if self.popoverMenuController == nil {
-                self.menuViewModel.providers = self.store.enabledProvidersForDisplay()
-                let vm = self.menuViewModel
-                let store = self.store
-                self.popoverMenuController = PopoverMenuController(viewModel: vm) { [weak self] in
-                    PopoverRootView(
-                        viewModel: vm,
-                        store: store,
-                        makeCardModel: { [weak self] provider in self?.menuCardModel(for: provider) })
-                }
-                // Task 1.4：接线快捷键回调（只在首次创建时设一次，弱引用防环）
-                self.popoverMenuController?.onRefresh = { [weak self] in
-                    self?.refreshNow()
-                    self?.popoverMenuController?.close()
-                }
-                self.popoverMenuController?.onSettings = { [weak self] in
-                    self?.showSettingsGeneral()
-                    self?.popoverMenuController?.close()
-                }
-                self.popoverMenuController?.onQuit = { [weak self] in
-                    self?.quit()
-                }
-                self.popoverMenuController?.onNavigate = { [weak self] direction in
-                    switch direction {
-                    case .next: self?.menuViewModel.selectNext()
-                    case .previous: self?.menuViewModel.selectPrevious()
-                    }
-                }
-                self.popoverMenuController?.onSelectIndex = { [weak self] index in
-                    self?.menuViewModel.selectProvider(atIndex: index)
-                }
-            }
-            self.statusItem.button?.target = self
-            self.statusItem.button?.action = #selector(self.handleStatusItemClick(_:))
-            // 右键也触发 action，使右键可弹出 popover
-            self.statusItem.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
+            self.attachMergedPopover()
             return
         }
         // ↓ original logic unchanged

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -155,6 +155,9 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
 
     let menuViewModel = MenuViewModel()
     var popoverMenuController: PopoverMenuController<PopoverRootView>?
+    // per-provider popover（非合并模式；keyed by UsageProvider）
+    var providerPopoverControllers: [UsageProvider: PopoverMenuController<PopoverRootView>] = [:]
+    var providerMenuViewModels: [UsageProvider: MenuViewModel] = [:]
 
     var providerSwitcherShortcutEventMonitor: ProviderSwitcherShortcutEventMonitor?
     var providerSwitcherShortcutMenuID: ObjectIdentifier?
@@ -804,9 +807,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             return
         }
         // ↓ original logic unchanged
-        // 从 popover 模式切回时清掉残留的 button target/action
-        self.statusItem.button?.target = nil
-        self.statusItem.button?.action = nil
+        self.clearPopoverButtonActions()
         if self.mergedMenu == nil {
             self.mergedMenu = self.makeMenu()
         }
@@ -817,6 +818,11 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     }
 
     private func attachMenus(fallback: UsageProvider? = nil) {
+        if self.usePopoverMenu {
+            self.attachProviderPopovers(fallback: fallback)
+            return
+        }
+        self.clearPopoverButtonActions()
         for provider in UsageProvider.allCases {
             // Only access/create the status item if it's actually needed
             let shouldHaveItem = self.isEnabled(provider) || fallback == provider

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -803,8 +803,13 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             self.statusItem.menu = nil
             if self.popoverMenuController == nil {
                 self.menuViewModel.providers = self.store.enabledProvidersForDisplay()
-                self.popoverMenuController = PopoverMenuController(viewModel: self.menuViewModel) {
-                    PopoverRootView(viewModel: self.menuViewModel)
+                let vm = self.menuViewModel
+                let store = self.store
+                self.popoverMenuController = PopoverMenuController(viewModel: vm) { [weak self] in
+                    PopoverRootView(
+                        viewModel: vm,
+                        store: store,
+                        makeCardModel: { [weak self] provider in self?.menuCardModel(for: provider) })
                 }
             }
             self.statusItem.button?.target = self

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -811,6 +811,27 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
                         store: store,
                         makeCardModel: { [weak self] provider in self?.menuCardModel(for: provider) })
                 }
+                // Task 1.4：接线快捷键回调（只在首次创建时设一次，弱引用防环）
+                self.popoverMenuController?.onRefresh = { [weak self] in
+                    self?.refreshNow()
+                    self?.popoverMenuController?.close()
+                }
+                self.popoverMenuController?.onSettings = { [weak self] in
+                    self?.showSettingsGeneral()
+                    self?.popoverMenuController?.close()
+                }
+                self.popoverMenuController?.onQuit = { [weak self] in
+                    self?.quit()
+                }
+                self.popoverMenuController?.onNavigate = { [weak self] direction in
+                    switch direction {
+                    case .next: self?.menuViewModel.selectNext()
+                    case .previous: self?.menuViewModel.selectPrevious()
+                    }
+                }
+                self.popoverMenuController?.onSelectIndex = { [weak self] index in
+                    self?.menuViewModel.selectProvider(atIndex: index)
+                }
             }
             self.statusItem.button?.target = self
             self.statusItem.button?.action = #selector(self.handleStatusItemClick(_:))

--- a/Sources/CodexBar/StatusItemMenu.swift
+++ b/Sources/CodexBar/StatusItemMenu.swift
@@ -1,6 +1,6 @@
 import AppKit
 
-enum StatusItemMenuProviderNavigationDirection {
+enum StatusItemMenuProviderNavigationDirection: Equatable {
     case previous
     case next
 }

--- a/Tests/CodexBarTests/MenuViewModelTests.swift
+++ b/Tests/CodexBarTests/MenuViewModelTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import CodexBar
+
+@MainActor @Suite struct MenuViewModelTests {
+    @Test func defaultsToFirstProviderNotVisible() {
+        let vm = MenuViewModel()
+        #expect(vm.isVisible == false)
+        #expect(vm.selection == .overview)
+    }
+
+    @Test func selectingProviderBumpsContentVersionOnce() {
+        let vm = MenuViewModel()
+        vm.providers = [.codex, .claude]
+        let v0 = vm.contentVersion
+        vm.select(.provider(.claude))
+        #expect(vm.selection == .provider(.claude))
+        #expect(vm.contentVersion == v0 + 1)
+    }
+
+    @Test func selectingSameValueDoesNotBump() {
+        let vm = MenuViewModel()
+        vm.select(.overview)            // already .overview
+        #expect(vm.contentVersion == 0) // no change → no bump
+    }
+
+    @Test func markVisibleTogglesState() {
+        let vm = MenuViewModel()
+        vm.setVisible(true)
+        #expect(vm.isVisible == true)
+        vm.setVisible(false)
+        #expect(vm.isVisible == false)
+    }
+}

--- a/Tests/CodexBarTests/MenuViewModelTests.swift
+++ b/Tests/CodexBarTests/MenuViewModelTests.swift
@@ -59,6 +59,46 @@ import Testing
         #expect(vm.selection == .provider(.claude))
     }
 
+    // MARK: - Task 2.6 onSelectionChanged 回调
+
+    @Test func onSelectionChangedFiresOnActualChange() {
+        let vm = MenuViewModel()
+        vm.providers = [.codex, .claude]
+        var received: [ProviderSwitcherSelection] = []
+        vm.onSelectionChanged = { received.append($0) }
+
+        vm.select(.provider(.codex)) // 变更：overview → .provider(.codex)
+        vm.select(.provider(.codex)) // 同值：不触发
+        vm.select(.provider(.claude)) // 变更：.provider(.codex) → .provider(.claude)
+
+        #expect(received.count == 2)
+        #expect(received[0] == .provider(.codex))
+        #expect(received[1] == .provider(.claude))
+    }
+
+    @Test func onSelectionChangedValueMatchesSelection() {
+        let vm = MenuViewModel()
+        vm.providers = [.codex, .claude]
+        vm.includesOverview = true
+        var callbackValue: ProviderSwitcherSelection?
+        vm.onSelectionChanged = { callbackValue = $0 }
+
+        vm.select(.provider(.codex))
+        #expect(callbackValue == vm.selection)
+
+        vm.select(.overview)
+        #expect(callbackValue == vm.selection)
+    }
+
+    @Test func onSelectionChangedNotFiredForSameValue() {
+        let vm = MenuViewModel()
+        // 初始值 .overview，再次 select .overview 不应触发
+        var callCount = 0
+        vm.onSelectionChanged = { _ in callCount += 1 }
+        vm.select(.overview)
+        #expect(callCount == 0)
+    }
+
     // MARK: - Task 2.5 includesOverview
 
     @Test func includesOverviewFalseSkipsOverviewInNavigation() {

--- a/Tests/CodexBarTests/MenuViewModelTests.swift
+++ b/Tests/CodexBarTests/MenuViewModelTests.swift
@@ -19,7 +19,7 @@ import Testing
 
     @Test func selectingSameValueDoesNotBump() {
         let vm = MenuViewModel()
-        vm.select(.overview)            // already .overview
+        vm.select(.overview) // already .overview
         #expect(vm.contentVersion == 0) // no change → no bump
     }
 

--- a/Tests/CodexBarTests/MenuViewModelTests.swift
+++ b/Tests/CodexBarTests/MenuViewModelTests.swift
@@ -1,14 +1,14 @@
 import Testing
 @testable import CodexBar
 
-@MainActor @Suite struct MenuViewModelTests {
-    @Test func defaultsToFirstProviderNotVisible() {
+@MainActor struct MenuViewModelTests {
+    @Test func `defaults to first provider not visible`() {
         let vm = MenuViewModel()
         #expect(vm.isVisible == false)
         #expect(vm.selection == .overview)
     }
 
-    @Test func selectingProviderBumpsContentVersionOnce() {
+    @Test func `selecting provider bumps content version once`() {
         let vm = MenuViewModel()
         vm.providers = [.codex, .claude]
         let v0 = vm.contentVersion
@@ -17,13 +17,13 @@ import Testing
         #expect(vm.contentVersion == v0 + 1)
     }
 
-    @Test func selectingSameValueDoesNotBump() {
+    @Test func `selecting same value does not bump`() {
         let vm = MenuViewModel()
         vm.select(.overview) // already .overview
         #expect(vm.contentVersion == 0) // no change → no bump
     }
 
-    @Test func markVisibleTogglesState() {
+    @Test func `mark visible toggles state`() {
         let vm = MenuViewModel()
         vm.setVisible(true)
         #expect(vm.isVisible == true)
@@ -33,7 +33,7 @@ import Testing
 
     // MARK: - Task 1.4 导航助手
 
-    @Test func selectNextCyclesThroughOverviewAndProviders() {
+    @Test func `select next cycles through overview and providers`() {
         let vm = MenuViewModel()
         vm.providers = [.codex, .claude]
         vm.includesOverview = true
@@ -44,24 +44,37 @@ import Testing
         vm.selectNext(); #expect(vm.selection == .overview)
     }
 
-    @Test func selectPreviousWrapsBackward() {
+    @Test func `select previous wraps backward`() {
         let vm = MenuViewModel()
         vm.providers = [.codex, .claude]
         vm.includesOverview = true
         vm.selectPrevious(); #expect(vm.selection == .provider(.claude)) // overview ← 回绕到末尾
     }
 
-    @Test func selectProviderAtIndexBounds() {
+    @Test func `select navigation stop at index includes overview in visible order`() {
         let vm = MenuViewModel()
         vm.providers = [.codex, .claude]
-        vm.selectProvider(atIndex: 1); #expect(vm.selection == .provider(.claude))
-        vm.selectProvider(atIndex: 9) // 越界：无变化
+        vm.includesOverview = true
+        vm.select(.provider(.claude))
+
+        vm.selectNavigationStop(atIndex: 0); #expect(vm.selection == .overview)
+        vm.selectNavigationStop(atIndex: 2); #expect(vm.selection == .provider(.claude))
+        vm.selectNavigationStop(atIndex: 9) // 越界：无变化
         #expect(vm.selection == .provider(.claude))
+    }
+
+    @Test func `select navigation stop at index starts with provider without overview`() {
+        let vm = MenuViewModel()
+        vm.providers = [.codex, .claude]
+
+        vm.selectNavigationStop(atIndex: 0)
+
+        #expect(vm.selection == .provider(.codex))
     }
 
     // MARK: - Task 2.6 onSelectionChanged 回调
 
-    @Test func onSelectionChangedFiresOnActualChange() {
+    @Test func `on selection changed fires on actual change`() {
         let vm = MenuViewModel()
         vm.providers = [.codex, .claude]
         var received: [ProviderSwitcherSelection] = []
@@ -76,7 +89,7 @@ import Testing
         #expect(received[1] == .provider(.claude))
     }
 
-    @Test func onSelectionChangedValueMatchesSelection() {
+    @Test func `on selection changed value matches selection`() {
         let vm = MenuViewModel()
         vm.providers = [.codex, .claude]
         vm.includesOverview = true
@@ -90,7 +103,7 @@ import Testing
         #expect(callbackValue == vm.selection)
     }
 
-    @Test func onSelectionChangedNotFiredForSameValue() {
+    @Test func `on selection changed not fired for same value`() {
         let vm = MenuViewModel()
         // 初始值 .overview，再次 select .overview 不应触发
         var callCount = 0
@@ -101,7 +114,7 @@ import Testing
 
     // MARK: - Task 2.5 includesOverview
 
-    @Test func includesOverviewFalseSkipsOverviewInNavigation() {
+    @Test func `includes overview false skips overview in navigation`() {
         let vm = MenuViewModel()
         vm.providers = [.codex, .claude]
         vm.includesOverview = false
@@ -115,7 +128,7 @@ import Testing
         vm.selectNext(); #expect(vm.selection == .provider(.claude))
     }
 
-    @Test func includesOverviewTrueAddsOverviewToNavigationStops() {
+    @Test func `includes overview true adds overview to navigation stops`() {
         let vm = MenuViewModel()
         vm.providers = [.codex]
         vm.includesOverview = true

--- a/Tests/CodexBarTests/MenuViewModelTests.swift
+++ b/Tests/CodexBarTests/MenuViewModelTests.swift
@@ -36,6 +36,7 @@ import Testing
     @Test func selectNextCyclesThroughOverviewAndProviders() {
         let vm = MenuViewModel()
         vm.providers = [.codex, .claude]
+        vm.includesOverview = true
         // 起点 .overview → next → .provider(codex) → next → .provider(claude) → next → 回 .overview
         #expect(vm.selection == .overview)
         vm.selectNext(); #expect(vm.selection == .provider(.codex))
@@ -46,6 +47,7 @@ import Testing
     @Test func selectPreviousWrapsBackward() {
         let vm = MenuViewModel()
         vm.providers = [.codex, .claude]
+        vm.includesOverview = true
         vm.selectPrevious(); #expect(vm.selection == .provider(.claude)) // overview ← 回绕到末尾
     }
 
@@ -55,5 +57,32 @@ import Testing
         vm.selectProvider(atIndex: 1); #expect(vm.selection == .provider(.claude))
         vm.selectProvider(atIndex: 9) // 越界：无变化
         #expect(vm.selection == .provider(.claude))
+    }
+
+    // MARK: - Task 2.5 includesOverview
+
+    @Test func includesOverviewFalseSkipsOverviewInNavigation() {
+        let vm = MenuViewModel()
+        vm.providers = [.codex, .claude]
+        vm.includesOverview = false
+        // stops = [.provider(.codex), .provider(.claude)]
+        // 起点 .overview 不在 stops 中，firstIndex 返回 nil，降级 index 0。
+        // selectNext: delta=+1 → index 1 → .provider(.claude)
+        vm.selectNext(); #expect(vm.selection == .provider(.claude))
+        // 已在 stops 中：.provider(.claude) → index 1，delta=+1 → index 0 → .provider(.codex)
+        vm.selectNext(); #expect(vm.selection == .provider(.codex))
+        // .provider(.codex) → index 0，delta=+1 → index 1 → .provider(.claude)；永不经过 overview
+        vm.selectNext(); #expect(vm.selection == .provider(.claude))
+    }
+
+    @Test func includesOverviewTrueAddsOverviewToNavigationStops() {
+        let vm = MenuViewModel()
+        vm.providers = [.codex]
+        vm.includesOverview = true
+        // stops = [.overview, .provider(.codex)]
+        // 起点 .overview → next → .provider(.codex) → next → 回 .overview
+        #expect(vm.selection == .overview)
+        vm.selectNext(); #expect(vm.selection == .provider(.codex))
+        vm.selectNext(); #expect(vm.selection == .overview)
     }
 }

--- a/Tests/CodexBarTests/MenuViewModelTests.swift
+++ b/Tests/CodexBarTests/MenuViewModelTests.swift
@@ -30,4 +30,30 @@ import Testing
         vm.setVisible(false)
         #expect(vm.isVisible == false)
     }
+
+    // MARK: - Task 1.4 导航助手
+
+    @Test func selectNextCyclesThroughOverviewAndProviders() {
+        let vm = MenuViewModel()
+        vm.providers = [.codex, .claude]
+        // 起点 .overview → next → .provider(codex) → next → .provider(claude) → next → 回 .overview
+        #expect(vm.selection == .overview)
+        vm.selectNext(); #expect(vm.selection == .provider(.codex))
+        vm.selectNext(); #expect(vm.selection == .provider(.claude))
+        vm.selectNext(); #expect(vm.selection == .overview)
+    }
+
+    @Test func selectPreviousWrapsBackward() {
+        let vm = MenuViewModel()
+        vm.providers = [.codex, .claude]
+        vm.selectPrevious(); #expect(vm.selection == .provider(.claude)) // overview ← 回绕到末尾
+    }
+
+    @Test func selectProviderAtIndexBounds() {
+        let vm = MenuViewModel()
+        vm.providers = [.codex, .claude]
+        vm.selectProvider(atIndex: 1); #expect(vm.selection == .provider(.claude))
+        vm.selectProvider(atIndex: 9) // 越界：无变化
+        #expect(vm.selection == .provider(.claude))
+    }
 }

--- a/Tests/CodexBarTests/PopoverAccountSwitcherTests.swift
+++ b/Tests/CodexBarTests/PopoverAccountSwitcherTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+// MARK: - PopoverAccountSwitcherView.Segment 基本测试
+
+struct PopoverAccountSwitcherTests {
+    // MARK: - Identifiable
+
+    @Test
+    func `Segment id is used as Identifiable id`() {
+        let seg = PopoverAccountSwitcherView.Segment(id: "abc", title: "Alice", isSelected: false)
+        #expect(seg.id == "abc")
+    }
+
+    // MARK: - Equatable
+
+    @Test
+    func `Segment Equatable: same values are equal`() {
+        let a = PopoverAccountSwitcherView.Segment(id: "x", title: "X", isSelected: true)
+        let b = PopoverAccountSwitcherView.Segment(id: "x", title: "X", isSelected: true)
+        #expect(a == b)
+    }
+
+    @Test
+    func `Segment Equatable: different id not equal`() {
+        let a = PopoverAccountSwitcherView.Segment(id: "x", title: "X", isSelected: false)
+        let b = PopoverAccountSwitcherView.Segment(id: "y", title: "X", isSelected: false)
+        #expect(a != b)
+    }
+
+    @Test
+    func `Segment Equatable: different isSelected not equal`() {
+        let a = PopoverAccountSwitcherView.Segment(id: "x", title: "X", isSelected: false)
+        let b = PopoverAccountSwitcherView.Segment(id: "x", title: "X", isSelected: true)
+        #expect(a != b)
+    }
+
+    // MARK: - make(ids:titles:selectedID:) isSelected 映射逻辑
+
+    @Test
+    func `make: correct isSelected when selectedID matches one id`() {
+        let segs = PopoverAccountSwitcherView.Segment.make(
+            ids: ["a", "b", "c"],
+            titles: ["A", "B", "C"],
+            selectedID: "b")
+        #expect(segs.count == 3)
+        #expect(segs[0].isSelected == false)
+        #expect(segs[1].isSelected == true)
+        #expect(segs[2].isSelected == false)
+    }
+
+    @Test
+    func `make: all unselected when selectedID is nil`() {
+        let segs = PopoverAccountSwitcherView.Segment.make(
+            ids: ["a", "b"],
+            titles: ["A", "B"],
+            selectedID: nil)
+        #expect(segs.allSatisfy { !$0.isSelected })
+    }
+
+    @Test
+    func `make: all unselected when selectedID does not match any id`() {
+        let segs = PopoverAccountSwitcherView.Segment.make(
+            ids: ["a", "b"],
+            titles: ["A", "B"],
+            selectedID: "z")
+        #expect(segs.allSatisfy { !$0.isSelected })
+    }
+
+    @Test
+    func `make: titles are preserved in order`() {
+        let segs = PopoverAccountSwitcherView.Segment.make(
+            ids: ["1", "2", "3"],
+            titles: ["One", "Two", "Three"],
+            selectedID: "1")
+        #expect(segs.map(\.title) == ["One", "Two", "Three"])
+    }
+
+    @Test
+    func `make: ids are preserved in order`() {
+        let segs = PopoverAccountSwitcherView.Segment.make(
+            ids: ["id1", "id2"],
+            titles: ["T1", "T2"],
+            selectedID: "id1")
+        #expect(segs.map(\.id) == ["id1", "id2"])
+    }
+
+    @Test
+    func `make: empty input produces empty output`() {
+        let segs = PopoverAccountSwitcherView.Segment.make(
+            ids: [],
+            titles: [],
+            selectedID: nil)
+        #expect(segs.isEmpty)
+    }
+
+    @Test
+    func `make: first selected when selectedID equals first id`() {
+        let segs = PopoverAccountSwitcherView.Segment.make(
+            ids: ["0", "1", "2"],
+            titles: ["Zero", "One", "Two"],
+            selectedID: "0")
+        #expect(segs[0].isSelected == true)
+        #expect(segs[1].isSelected == false)
+        #expect(segs[2].isSelected == false)
+    }
+
+    @Test
+    func `make: last selected when selectedID equals last id`() {
+        let segs = PopoverAccountSwitcherView.Segment.make(
+            ids: ["0", "1", "2"],
+            titles: ["Zero", "One", "Two"],
+            selectedID: "2")
+        #expect(segs[0].isSelected == false)
+        #expect(segs[1].isSelected == false)
+        #expect(segs[2].isSelected == true)
+    }
+
+    /// Token 路径：index 字符串 id
+    @Test
+    func `make: token-style index ids - selectedID maps correctly`() {
+        let segs = PopoverAccountSwitcherView.Segment.make(
+            ids: ["0", "1", "2"],
+            titles: ["Account A", "Account B", "Account C"],
+            selectedID: "1")
+        #expect(segs[0].isSelected == false)
+        #expect(segs[1].isSelected == true)
+        #expect(segs[2].isSelected == false)
+    }
+}
+
+// MARK: - display 依赖重的构造路径说明
+
+//
+// popoverAccountSwitcherModel(for:) 内部依赖 StatusItemController（需要完整的
+// UsageStore + SettingsStore + 运行时账户状态），构造成本高且非 headless 可用，
+// 因此不在单测中覆盖。全量回归（swift test）+ 人工验证（打开 popover、切换账户
+// 确认 UI 响应）作为兜底。

--- a/Tests/CodexBarTests/PopoverActionDispatchTests.swift
+++ b/Tests/CodexBarTests/PopoverActionDispatchTests.swift
@@ -1,0 +1,115 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+// MARK: - PopoverActionSectionsView shortcutLabel 映射测试
+
+struct PopoverActionSectionsViewTests {
+    @Test
+    func `shortcutLabel returns command-R for refresh`() {
+        #expect(PopoverActionSectionsView.shortcutLabel(for: .refresh) == "⌘R")
+    }
+
+    @Test
+    func `shortcutLabel returns command-comma for settings`() {
+        #expect(PopoverActionSectionsView.shortcutLabel(for: .settings) == "⌘,")
+    }
+
+    @Test
+    func `shortcutLabel returns command-Q for quit`() {
+        #expect(PopoverActionSectionsView.shortcutLabel(for: .quit) == "⌘Q")
+    }
+
+    @Test
+    func `shortcutLabel returns nil for dashboard`() {
+        #expect(PopoverActionSectionsView.shortcutLabel(for: .dashboard) == nil)
+    }
+
+    @Test
+    func `shortcutLabel returns nil for about`() {
+        #expect(PopoverActionSectionsView.shortcutLabel(for: .about) == nil)
+    }
+
+    @Test
+    func `shortcutLabel returns nil for installUpdate`() {
+        #expect(PopoverActionSectionsView.shortcutLabel(for: .installUpdate) == nil)
+    }
+}
+
+// MARK: - MenuDescriptor.build 底部 metaSection 契约测试
+
+@MainActor
+struct PopoverActionSectionsDescriptorTests {
+    /// metaSection 必须包含 refresh/settings/quit 动作，popover 才能正确渲染底部动作区。
+    @Test
+    func `metaSection contains refresh settings and quit actions`() throws {
+        let suite = "PopoverActionDispatchTests-meta"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+
+        let descriptor = MenuDescriptor.build(
+            provider: .codex,
+            store: store,
+            settings: settings,
+            account: AccountInfo(email: nil, plan: nil),
+            updateReady: false,
+            includeContextualActions: false)
+
+        let allActions = descriptor.sections.flatMap(\.entries).compactMap { entry -> MenuDescriptor.MenuAction? in
+            guard case let .action(_, action) = entry else { return nil }
+            return action
+        }
+
+        #expect(allActions.contains(.refresh), "metaSection should include .refresh action")
+        #expect(allActions.contains(.settings), "metaSection should include .settings action")
+        #expect(allActions.contains(.quit), "metaSection should include .quit action")
+    }
+
+    /// updateReady=true 时 metaSection 包含 installUpdate 动作。
+    @Test
+    func `metaSection contains installUpdate when update is ready`() throws {
+        let suite = "PopoverActionDispatchTests-update"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+
+        let descriptor = MenuDescriptor.build(
+            provider: .codex,
+            store: store,
+            settings: settings,
+            account: AccountInfo(email: nil, plan: nil),
+            updateReady: true,
+            includeContextualActions: false)
+
+        let allActions = descriptor.sections.flatMap(\.entries).compactMap { entry -> MenuDescriptor.MenuAction? in
+            guard case let .action(_, action) = entry else { return nil }
+            return action
+        }
+
+        #expect(allActions.contains(.installUpdate), "metaSection should include .installUpdate when updateReady=true")
+    }
+}

--- a/Tests/CodexBarTests/PopoverActionDispatchTests.swift
+++ b/Tests/CodexBarTests/PopoverActionDispatchTests.swift
@@ -35,6 +35,18 @@ struct PopoverActionSectionsViewTests {
     func `shortcutLabel returns nil for installUpdate`() {
         #expect(PopoverActionSectionsView.shortcutLabel(for: .installUpdate) == nil)
     }
+
+    @MainActor
+    @Test
+    func refreshKeepsPopoverOpen() {
+        #expect(StatusItemController.shouldClosePopover(after: .refresh) == false)
+    }
+
+    @MainActor
+    @Test
+    func navigationActionClosesPopover() {
+        #expect(StatusItemController.shouldClosePopover(after: .settings) == true)
+    }
 }
 
 // MARK: - MenuDescriptor.build 底部 metaSection 契约测试

--- a/Tests/CodexBarTests/PopoverCardPlanTests.swift
+++ b/Tests/CodexBarTests/PopoverCardPlanTests.swift
@@ -15,6 +15,7 @@ struct PopoverCardPlanTests {
         let plan = PopoverCardPlan()
         #expect(plan.cards.isEmpty)
         #expect(plan.storageText == nil)
+        #expect(plan.storageChart == nil)
         #expect(plan.showBuyCredits == false)
         #expect(plan.emptyText == nil)
     }
@@ -39,6 +40,27 @@ struct PopoverCardPlanTests {
         var plan = PopoverCardPlan()
         plan.storageText = "1.2 GB"
         #expect(plan.storageText == "1.2 GB")
+    }
+
+    @MainActor
+    @Test
+    func wholeCardStorageIncludesBreakdownChart() throws {
+        let (controller, settings) = try makeMinimalController()
+        defer { controller.releaseStatusItemsForTesting() }
+        settings.providerStorageFootprintsEnabled = true
+        controller.store.providerStorageFootprints[.claude] = ProviderStorageFootprint(
+            provider: .claude,
+            totalBytes: 1024,
+            paths: ["/tmp/claude"],
+            missingPaths: [],
+            unreadablePaths: [],
+            components: [.init(path: "/tmp/claude/cache", totalBytes: 1024)],
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000))
+
+        let plan = controller.popoverCardPlan(for: .claude)
+
+        #expect(plan.storageText != nil)
+        #expect(plan.storageChart == .storageBreakdown(.claude))
     }
 
     // MARK: 2. Card Identifiable id 稳定性

--- a/Tests/CodexBarTests/PopoverCardPlanTests.swift
+++ b/Tests/CodexBarTests/PopoverCardPlanTests.swift
@@ -1,0 +1,143 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+// MARK: - PopoverCardPlan 基础值/空态测试
+
+@Suite
+struct PopoverCardPlanTests {
+    // MARK: 1. 默认值/空态
+
+    @Test
+    func `默认 PopoverCardPlan 为空态`() {
+        let plan = PopoverCardPlan()
+        #expect(plan.cards.isEmpty)
+        #expect(plan.storageText == nil)
+        #expect(plan.showBuyCredits == false)
+        #expect(plan.emptyText == nil)
+    }
+
+    @Test
+    func `emptyText 可单独设置`() {
+        var plan = PopoverCardPlan()
+        plan.emptyText = "Loading…"
+        #expect(plan.cards.isEmpty)
+        #expect(plan.emptyText == "Loading…")
+    }
+
+    @Test
+    func `showBuyCredits 可设置为 true`() {
+        var plan = PopoverCardPlan()
+        plan.showBuyCredits = true
+        #expect(plan.showBuyCredits)
+    }
+
+    @Test
+    func `storageText 可设置`() {
+        var plan = PopoverCardPlan()
+        plan.storageText = "1.2 GB"
+        #expect(plan.storageText == "1.2 GB")
+    }
+
+    // MARK: 2. Card Identifiable id 稳定性
+
+    @MainActor
+    @Test
+    func `两张不同 id 的卡片 id 不相等`() throws {
+        // 通过 StatusItemController 获取真实 model，验证 Card 结构体 id 唯一性
+        let (controller, _) = try makeMinimalController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let plan = controller.popoverCardPlan(for: .codex)
+
+        // 构造两张不同 id 的 Card，断言 id 不同
+        if plan.cards.count >= 2 {
+            let ids = plan.cards.map(\.id)
+            let uniqueIDs = Set(ids)
+            #expect(uniqueIDs.count == ids.count, "卡片 id 应唯一，无重复")
+        } else {
+            // 单卡或空：验证 id 格式
+            if let card = plan.cards.first {
+                #expect(!card.id.isEmpty)
+            }
+        }
+    }
+
+    @Test
+    func `单卡片使用 id single`() {
+        // PopoverCardPlan 中单卡路径使用 id="single"，通过手动构造 plan 验证
+        var plan = PopoverCardPlan()
+        // 模拟单卡路径：cards 中只含一张 id 为 "single" 的 Card
+        // 无需真实 model，只验证 id 约定
+        #expect(plan.cards.isEmpty)
+        plan.emptyText = "Loading…"
+        #expect(plan.emptyText == "Loading…")
+        // 若 cards 非空，single 卡的 id 应为 "single"
+        // 此处通过 integration test（下方 popoverCardPlan 测试）验证
+    }
+
+    @Test
+    func `workspace header 仅首卡携带约定`() {
+        // 验证 PopoverCardPlan.Card 的 workspaceHeader 语义：
+        // 分组首卡有 header，其余为 nil
+        // 这里只测类型结构，真实 header 值由集成测试覆盖
+        var plan = PopoverCardPlan()
+        // 空 plan 无 cards，不存在 header 问题
+        #expect(plan.cards.allSatisfy { $0.workspaceHeader == nil })
+        plan.emptyText = nil
+        #expect(plan.emptyText == nil)
+    }
+
+    // MARK: 3. popoverCardPlan 集成：默认无数据 provider → 返回合理计划
+
+    @MainActor
+    @Test
+    func `无数据 codex provider 返回单卡或占位`() throws {
+        let (controller, _) = try makeMinimalController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let plan = controller.popoverCardPlan(for: .codex)
+
+        // 约束：cards 与 emptyText 不能同时非空（语义互斥）
+        if !plan.cards.isEmpty {
+            #expect(plan.emptyText == nil, "有卡片时 emptyText 应为 nil")
+        }
+        // 无数据时：单张卡片（id="single"）或 emptyText="Loading…"
+        if plan.cards.count == 1 {
+            #expect(plan.cards[0].id == "single")
+        }
+    }
+}
+
+// MARK: - 测试辅助
+
+@MainActor
+private func makeMinimalController() throws -> (StatusItemController, SettingsStore) {
+    let suite = "PopoverCardPlanTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suite)!
+    defaults.removePersistentDomain(forName: suite)
+    let configStore = testConfigStore(suiteName: suite)
+    let settings = SettingsStore(
+        userDefaults: defaults,
+        configStore: configStore,
+        zaiTokenStore: NoopZaiTokenStore(),
+        syntheticTokenStore: NoopSyntheticTokenStore())
+    settings.statusChecksEnabled = false
+    settings.refreshFrequency = .manual
+
+    let fetcher = UsageFetcher()
+    let store = UsageStore(
+        fetcher: fetcher,
+        browserDetection: BrowserDetection(cacheTTL: 0),
+        settings: settings)
+    let controller = StatusItemController(
+        store: store,
+        settings: settings,
+        account: fetcher.loadAccountInfo(),
+        updater: DisabledUpdaterController(),
+        preferencesSelection: PreferencesSelection(),
+        statusBar: .system)
+    return (controller, settings)
+}

--- a/Tests/CodexBarTests/PopoverCardPlanTests.swift
+++ b/Tests/CodexBarTests/PopoverCardPlanTests.swift
@@ -111,6 +111,69 @@ struct PopoverCardPlanTests {
     }
 }
 
+// MARK: - PopoverCardPlan.SectionedCard 纯逻辑测试
+
+@Suite
+struct PopoverCardPlanSectionedTests {
+    // MARK: 1. SectionedCard 字段默认值语义验证
+
+    @Test
+    func `PopoverCardPlan 默认 sectioned 为 nil`() {
+        let plan = PopoverCardPlan()
+        #expect(plan.sectioned == nil)
+    }
+
+    // MARK: 2. popoverCardPlan 集成：空 store 下 sectioned 为 nil（无 openAI web/API usage 数据）
+
+    @MainActor
+    @Test
+    func `空 store 无 web items 时 sectioned 为 nil`() throws {
+        let (controller, _) = try makeMinimalController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        // 空 store 下 codex/claude 不满足拆段条件，sectioned 应为 nil
+        for provider in [UsageProvider.codex, .claude] {
+            let plan = controller.popoverCardPlan(for: provider)
+            #expect(plan.sectioned == nil, "provider \(provider.rawValue) 空 store 下不应拆段")
+        }
+    }
+
+    // MARK: 3. 拆段模式下 plan.showBuyCredits 被置为 false（避免重复渲染）
+
+    @MainActor
+    @Test
+    func `拆段时顶层 showBuyCredits 为 false`() throws {
+        let (controller, settings) = try makeMinimalController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        // 即使 showOptionalCreditsAndExtraUsage 开启，若 sectioned 非 nil 则顶层 showBuyCredits=false
+        settings.showOptionalCreditsAndExtraUsage = true
+        let plan = controller.popoverCardPlan(for: .openai)
+        if plan.sectioned != nil {
+            #expect(plan.showBuyCredits == false, "拆段时顶层 showBuyCredits 应为 false，由 sectioned.showBuyCredits 接管")
+        }
+    }
+
+    // MARK: 4. stacked 路径不产生 sectioned
+
+    @MainActor
+    @Test
+    func `stacked 路径返回时 sectioned 为 nil`() throws {
+        let (controller, _) = try makeMinimalController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        // codex stacked/token stacked 路径直接 return plan（不经过单卡片 buildSectionedCard）
+        // 空 store 下 codexAccountMenuDisplay 返回 nil，走单卡路径，sectioned 可能 nil（无数据）
+        // 此测试验证：若走了 stacked 路径（early return），sectioned 必为 nil
+        // 此处通过检查 cards 路径来间接验证（stacked 有多卡时 sectioned 应为 nil）
+        let plan = controller.popoverCardPlan(for: .codex)
+        if plan.cards.count > 1 {
+            // 多卡是 stacked 路径，不应有 sectioned
+            #expect(plan.sectioned == nil, "stacked 多卡路径 sectioned 应为 nil")
+        }
+    }
+}
+
 // MARK: - 测试辅助
 
 @MainActor

--- a/Tests/CodexBarTests/PopoverChartTests.swift
+++ b/Tests/CodexBarTests/PopoverChartTests.swift
@@ -1,0 +1,247 @@
+import AppKit
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+// MARK: - PopoverChartKind 静态属性测试
+
+// 测试 PopoverChartKind 枚举的 id 稳定性、唯一性与 title 非空。
+// 说明：
+//   - popoverChartEntries / popoverOverviewChart / popoverChartView 依赖 store 数据，
+//     需要真实数据才有意义，此处只覆盖纯静态属性（id、title），不强测数据条件分支。
+//   - 数据条件分支和工厂方法的集成验证由全量回归 + 阶段验收人工兜底。
+
+@Suite
+struct PopoverChartKindTests {
+    // MARK: 1. id 稳定性：相同 case 产出相同 id
+
+    @Test
+    func `usageBreakdown id 稳定`() {
+        #expect(PopoverChartKind.usageBreakdown.id == "usageBreakdown")
+        #expect(PopoverChartKind.usageBreakdown.id == PopoverChartKind.usageBreakdown.id)
+    }
+
+    @Test
+    func `creditsHistory id 稳定`() {
+        #expect(PopoverChartKind.creditsHistory.id == "creditsHistory")
+    }
+
+    @Test
+    func `costHistory id 含 provider rawValue`() {
+        #expect(PopoverChartKind.costHistory(.codex).id == "costHistory-codex")
+        #expect(PopoverChartKind.costHistory(.openai).id == "costHistory-openai")
+    }
+
+    @Test
+    func `usageHistory id 含 provider rawValue`() {
+        #expect(PopoverChartKind.usageHistory(.claude).id == "usageHistory-claude")
+        #expect(PopoverChartKind.usageHistory(.codex).id == "usageHistory-codex")
+    }
+
+    @Test
+    func `storageBreakdown id 含 provider rawValue`() {
+        #expect(PopoverChartKind.storageBreakdown(.codex).id == "storageBreakdown-codex")
+        #expect(PopoverChartKind.storageBreakdown(.kilo).id == "storageBreakdown-kilo")
+    }
+
+    @Test
+    func `zaiHourly id 含 provider rawValue`() {
+        #expect(PopoverChartKind.zaiHourly(.zai).id == "zaiHourly-zai")
+    }
+
+    // MARK: 2. id 唯一性：六类 + 多 provider 参数时互不相同
+
+    @Test
+    func `不同 kind 的 id 互不相同`() {
+        let kinds: [PopoverChartKind] = [
+            .usageBreakdown,
+            .creditsHistory,
+            .costHistory(.codex),
+            .costHistory(.openai),
+            .costHistory(.claude),
+            .usageHistory(.codex),
+            .usageHistory(.claude),
+            .storageBreakdown(.codex),
+            .storageBreakdown(.kilo),
+            .zaiHourly(.zai),
+        ]
+        let ids = kinds.map(\.id)
+        let unique = Set(ids)
+        #expect(unique.count == ids.count, "所有 kind id 应唯一，无重复")
+    }
+
+    @Test
+    func `相同 provider 不同 kind 的 id 不相同`() {
+        let costID = PopoverChartKind.costHistory(.codex).id
+        let usageHistoryID = PopoverChartKind.usageHistory(.codex).id
+        let storageID = PopoverChartKind.storageBreakdown(.codex).id
+        #expect(costID != usageHistoryID)
+        #expect(costID != storageID)
+        #expect(usageHistoryID != storageID)
+    }
+
+    @Test
+    func `不同 provider 的同 kind id 不相同`() {
+        let a = PopoverChartKind.costHistory(.codex).id
+        let b = PopoverChartKind.costHistory(.openai).id
+        #expect(a != b)
+    }
+
+    // MARK: 3. title 非空
+
+    @Test
+    func `所有 kind title 非空`() {
+        let kinds: [PopoverChartKind] = [
+            .usageBreakdown,
+            .creditsHistory,
+            .costHistory(.codex),
+            .usageHistory(.codex),
+            .storageBreakdown(.codex),
+            .zaiHourly(.zai),
+        ]
+        for kind in kinds {
+            #expect(!kind.title.isEmpty, "title 不应为空：\(kind.id)")
+        }
+    }
+
+    // MARK: 4. costHistoryTitle 动态标题
+
+    @Test
+    func `costHistoryTitle days=1 返回 today 文案`() {
+        let kind = PopoverChartKind.costHistory(.codex)
+        let title = kind.costHistoryTitle(historyDays: 1)
+        #expect(!title.isEmpty)
+        // 不依赖具体本地化文案，只验证与 days>1 时不同
+        let title30 = kind.costHistoryTitle(historyDays: 30)
+        #expect(title != title30)
+    }
+
+    @Test
+    func `非 costHistory kind 调用 costHistoryTitle 返回 self title`() {
+        let kind = PopoverChartKind.usageBreakdown
+        #expect(kind.costHistoryTitle(historyDays: 30) == kind.title)
+    }
+
+    // MARK: 5. Equatable
+
+    @Test
+    func `相同 kind 相等`() {
+        #expect(PopoverChartKind.usageBreakdown == .usageBreakdown)
+        #expect(PopoverChartKind.costHistory(.codex) == .costHistory(.codex))
+    }
+
+    @Test
+    func `不同 provider 的同 kind 不相等`() {
+        #expect(PopoverChartKind.costHistory(.codex) != .costHistory(.openai))
+    }
+
+    @Test
+    func `不同 kind 不相等`() {
+        #expect(PopoverChartKind.usageBreakdown != .creditsHistory)
+        #expect(PopoverChartKind.usageHistory(.codex) != .storageBreakdown(.codex))
+    }
+}
+
+// MARK: - popoverChartEntries 基础结构测试
+
+@Suite
+struct PopoverChartEntriesTests {
+    // 说明：popoverChartEntries 依赖 store/settings 运行时数据，
+    // 空 store 下大部分条件不满足，验证返回空数组不崩溃即可。
+    // 完整条件路径由全量回归 + 人工验收覆盖。
+
+    @MainActor
+    @Test
+    func `空 store 下 popoverChartEntries 不崩溃且返回数组`() throws {
+        let (controller, _) = try makeChartTestController()
+        defer { controller.releaseStatusItemsForTesting() }
+        let entries = controller.popoverChartEntries(for: .codex)
+        // 空 store 无数据，期望空或非空均可，不崩溃即通过
+        _ = entries
+    }
+
+    @MainActor
+    @Test
+    func `返回的 entries id 无重复`() throws {
+        let (controller, _) = try makeChartTestController()
+        defer { controller.releaseStatusItemsForTesting() }
+        for provider in [UsageProvider.codex, .openai, .claude, .zai] {
+            let entries = controller.popoverChartEntries(for: provider)
+            let ids = entries.map(\.id)
+            let unique = Set(ids)
+            #expect(unique.count == ids.count, "provider \(provider.rawValue) 下 entries id 应唯一")
+        }
+    }
+
+    @MainActor
+    @Test
+    func `popoverOverviewChart 不崩溃`() throws {
+        let (controller, _) = try makeChartTestController()
+        defer { controller.releaseStatusItemsForTesting() }
+        // 通过 popoverOverviewRows 获取真实 model；若 rows 为空则跳过 overview 路径
+        let rows = controller.popoverOverviewRows()
+        if let row = rows.first {
+            _ = controller.popoverOverviewChart(for: row.provider, model: row.model)
+        }
+        // 无 model 可用时，通过 menuCardModel 构造（空 store 可能返回 nil，此时跳过）
+        for provider in [UsageProvider.codex, .openai, .zai] {
+            if let model = controller.menuCardModel(for: provider) {
+                _ = controller.popoverOverviewChart(for: provider, model: model)
+            }
+        }
+    }
+
+    @MainActor
+    @Test
+    func `popoverChartView 数据缺失时返回 nil 不崩溃`() throws {
+        let (controller, _) = try makeChartTestController()
+        defer { controller.releaseStatusItemsForTesting() }
+        let width: CGFloat = 320
+        // 空 store 数据缺失，期望返回 nil
+        let kinds: [PopoverChartKind] = [
+            .usageBreakdown,
+            .creditsHistory,
+            .costHistory(.codex),
+            .usageHistory(.codex),
+            .storageBreakdown(.codex),
+            .zaiHourly(.zai),
+        ]
+        for kind in kinds {
+            let view = controller.popoverChartView(for: kind, width: width)
+            // 空 store 下应为 nil；不崩溃即通过
+            _ = view
+        }
+    }
+}
+
+// MARK: - 测试辅助
+
+@MainActor
+private func makeChartTestController() throws -> (StatusItemController, SettingsStore) {
+    let suite = "PopoverChartTests-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suite)!
+    defaults.removePersistentDomain(forName: suite)
+    let configStore = testConfigStore(suiteName: suite)
+    let settings = SettingsStore(
+        userDefaults: defaults,
+        configStore: configStore,
+        zaiTokenStore: NoopZaiTokenStore(),
+        syntheticTokenStore: NoopSyntheticTokenStore())
+    settings.statusChecksEnabled = false
+    settings.refreshFrequency = .manual
+
+    let fetcher = UsageFetcher()
+    let store = UsageStore(
+        fetcher: fetcher,
+        browserDetection: BrowserDetection(cacheTTL: 0),
+        settings: settings)
+    let controller = StatusItemController(
+        store: store,
+        settings: settings,
+        account: fetcher.loadAccountInfo(),
+        updater: DisabledUpdaterController(),
+        preferencesSelection: PreferencesSelection(),
+        statusBar: .system)
+    return (controller, settings)
+}

--- a/Tests/CodexBarTests/PopoverChartTests.swift
+++ b/Tests/CodexBarTests/PopoverChartTests.swift
@@ -252,6 +252,18 @@ struct PopoverChartEntriesTests {
 
     @MainActor
     @Test
+    func overviewActionsUseSavedSelectedProvider() throws {
+        let (controller, settings) = try makeChartTestController()
+        defer { controller.releaseStatusItemsForTesting() }
+        settings.selectedMenuProvider = .claude
+        let viewModel = MenuViewModel()
+        viewModel.providers = [.codex, .claude]
+
+        #expect(controller.popoverActionProvider(for: viewModel) == .claude)
+    }
+
+    @MainActor
+    @Test
     func `popoverChartView 数据缺失时返回 nil 不崩溃`() throws {
         let (controller, _) = try makeChartTestController()
         defer { controller.releaseStatusItemsForTesting() }

--- a/Tests/CodexBarTests/PopoverChartTests.swift
+++ b/Tests/CodexBarTests/PopoverChartTests.swift
@@ -147,8 +147,9 @@ struct PopoverChartKindTests {
 
 @Suite
 struct PopoverChartEntriesTests {
-    // 说明：popoverChartEntries 依赖 store/settings 运行时数据，
-    // 空 store 下大部分条件不满足，验证返回空数组不崩溃即可。
+    // 说明：popoverChartEntries 已收缩为仅返回 usageHistory 与 zaiHourly（对齐原版 NSMenu 独立入口行语义）。
+    // 其余图表入口（usageBreakdown/creditsHistory/costHistory/storageBreakdown/zaiDetails）经由
+    // 拆段模式的段 chevron 进入，不作为独立入口行。
     // 完整条件路径由全量回归 + 人工验收覆盖。
 
     @MainActor
@@ -157,8 +158,27 @@ struct PopoverChartEntriesTests {
         let (controller, _) = try makeChartTestController()
         defer { controller.releaseStatusItemsForTesting() }
         let entries = controller.popoverChartEntries(for: .codex)
-        // 空 store 无数据，期望空或非空均可，不崩溃即通过
+        // 空 store 无数据，期望空数组（usageHistory/zaiHourly 均无数据）
         _ = entries
+    }
+
+    @MainActor
+    @Test
+    func `收缩后 entries 只含 usageHistory 和 zaiHourly 两类`() throws {
+        let (controller, _) = try makeChartTestController()
+        defer { controller.releaseStatusItemsForTesting() }
+        for provider in [UsageProvider.codex, .openai, .claude, .zai] {
+            let entries = controller.popoverChartEntries(for: provider)
+            // 收缩后每个 kind 只能是 usageHistory 或 zaiHourly
+            for kind in entries {
+                switch kind {
+                case .usageHistory, .zaiHourly:
+                    break // 合法
+                default:
+                    #expect(Bool(false), "provider \(provider.rawValue) entries 不应含 \(kind.id)（应经由段 chevron 进入）")
+                }
+            }
+        }
     }
 
     @MainActor

--- a/Tests/CodexBarTests/PopoverChartTests.swift
+++ b/Tests/CodexBarTests/PopoverChartTests.swift
@@ -264,6 +264,22 @@ struct PopoverChartEntriesTests {
 
     @MainActor
     @Test
+    func popoverSelectionRefreshesProviderDependentState() throws {
+        let (controller, settings) = try makeChartTestController()
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.menuViewModel.providers = [.codex, .claude]
+
+        controller.applyPopoverSelection(.provider(.claude))
+
+        #expect(settings.selectedMenuProvider == .claude)
+        #expect(settings.mergedMenuLastSelectedWasOverview == false)
+        #expect(controller.lastMenuProvider == .claude)
+        #expect(controller.lastMergedSwitcherSelection == .provider(.claude))
+        #expect(controller.providerSelectionUIRefreshTask != nil)
+    }
+
+    @MainActor
+    @Test
     func `popoverChartView 数据缺失时返回 nil 不崩溃`() throws {
         let (controller, _) = try makeChartTestController()
         defer { controller.releaseStatusItemsForTesting() }

--- a/Tests/CodexBarTests/PopoverChartTests.swift
+++ b/Tests/CodexBarTests/PopoverChartTests.swift
@@ -214,6 +214,44 @@ struct PopoverChartEntriesTests {
 
     @MainActor
     @Test
+    func zaiOverviewFallsBackToStorageWhenMCPDetailsAreUnavailable() throws {
+        let (controller, settings) = try makeChartTestController()
+        defer { controller.releaseStatusItemsForTesting() }
+        settings.providerStorageFootprintsEnabled = true
+        let root = "/Users/test/.zai"
+        controller.store.providerStorageFootprints[.zai] = ProviderStorageFootprint(
+            provider: .zai,
+            totalBytes: 1024,
+            paths: [root],
+            missingPaths: [],
+            unreadablePaths: [],
+            components: [.init(path: "\(root)/cache", totalBytes: 1024)],
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000))
+        let model = UsageMenuCardView.Model(
+            provider: .zai,
+            providerName: "Z.ai",
+            email: "",
+            subtitleText: "",
+            subtitleStyle: .info,
+            planText: nil,
+            metrics: [],
+            usageNotes: [],
+            openAIAPIUsage: nil,
+            inlineUsageDashboard: nil,
+            creditsText: nil,
+            creditsRemaining: nil,
+            creditsHintText: nil,
+            creditsHintCopyText: nil,
+            providerCost: nil,
+            tokenUsage: nil,
+            placeholder: nil,
+            progressColor: .blue)
+
+        #expect(controller.popoverOverviewChart(for: .zai, model: model) == .storageBreakdown(.zai))
+    }
+
+    @MainActor
+    @Test
     func `popoverChartView 数据缺失时返回 nil 不崩溃`() throws {
         let (controller, _) = try makeChartTestController()
         defer { controller.releaseStatusItemsForTesting() }

--- a/Tests/CodexBarTests/PopoverMenuControllerTests.swift
+++ b/Tests/CodexBarTests/PopoverMenuControllerTests.swift
@@ -4,30 +4,31 @@ import Testing
 @testable import CodexBar
 
 @MainActor @Suite struct PopoverMenuControllerTests {
-    @Test func showAndCloseUpdatesViewModelVisibility() throws {
+    @Test(arguments: [
+        (visibleHeight: CGFloat(300), expectedMaximumHeight: CGFloat(320)),
+        (visibleHeight: CGFloat(600), expectedMaximumHeight: CGFloat(491)),
+        (visibleHeight: CGFloat(1000), expectedMaximumHeight: CGFloat(720)),
+    ])
+    func showPreparationUpdatesViewModel(
+        visibleHeight: CGFloat,
+        expectedMaximumHeight: CGFloat)
+    {
         let vm = MenuViewModel()
-        let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        let button = try #require(statusItem.button)
         let controller = PopoverMenuController(viewModel: vm) { EmptyContentProbe() }
-        controller.show(relativeTo: button)
+        controller.prepareForShowForTesting(visibleHeight: visibleHeight)
         #expect(vm.isVisible == true)
-        #expect(vm.maximumPopoverHeight >= 320)
-        #expect(vm.maximumPopoverHeight <= 720)
+        #expect(vm.maximumPopoverHeight == expectedMaximumHeight)
         controller.close()
         #expect(vm.isVisible == false)
-        NSStatusBar.system.removeStatusItem(statusItem)
     }
 
-    @Test func escapeKeyClosesPopover() throws {
+    @Test func escapeKeyClosesPopover() {
         let vm = MenuViewModel()
-        let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        let button = try #require(statusItem.button)
         let controller = PopoverMenuController(viewModel: vm) { EmptyContentProbe() }
-        controller.show(relativeTo: button)
+        controller.prepareForShowForTesting(visibleHeight: 600)
         let handled = controller.handleKeyDownForTesting(keyCode: 53) // Esc
         #expect(handled == true)
         #expect(vm.isVisible == false)
-        NSStatusBar.system.removeStatusItem(statusItem)
     }
 
     @Test func nonEscapeKeyNotHandled() {
@@ -88,18 +89,14 @@ import Testing
 
     // MARK: - #1 transient 双触发防抖
 
-    @Test func toggleAfterCloseIsSuppressedWithinSameRunloop() throws {
+    @Test func toggleAfterCloseIsSuppressedWithinSameRunloop() {
         let vm = MenuViewModel()
-        let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        let button = try #require(statusItem.button)
         let controller = PopoverMenuController(viewModel: vm) { EmptyContentProbe() }
-        controller.show(relativeTo: button)
+        controller.prepareForShowForTesting(visibleHeight: 600)
         #expect(vm.isVisible == true)
         controller.simulatePopoverDidCloseForTesting() // 模拟 transient 外部点击关闭
         #expect(vm.isVisible == false)
-        controller.toggle(relativeTo: button) // 紧随的 button.action：应被吞掉，不重开
-        #expect(vm.isVisible == false)
-        NSStatusBar.system.removeStatusItem(statusItem)
+        #expect(controller.canOpenFromToggleForTesting() == false)
     }
 }
 

--- a/Tests/CodexBarTests/PopoverMenuControllerTests.swift
+++ b/Tests/CodexBarTests/PopoverMenuControllerTests.swift
@@ -83,6 +83,22 @@ import SwiftUI
         let controller = PopoverMenuController(viewModel: MenuViewModel()) { EmptyContentProbe() }
         #expect(controller.handleForTesting(characters: "x", modifiers: .command) == false)
     }
+
+    // MARK: - #1 transient 双触发防抖
+
+    @Test func toggleAfterCloseIsSuppressedWithinSameRunloop() {
+        let vm = MenuViewModel()
+        let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        let button = statusItem.button!
+        let controller = PopoverMenuController(viewModel: vm) { EmptyContentProbe() }
+        controller.show(relativeTo: button)
+        #expect(vm.isVisible == true)
+        controller.simulatePopoverDidCloseForTesting() // 模拟 transient 外部点击关闭
+        #expect(vm.isVisible == false)
+        controller.toggle(relativeTo: button)          // 紧随的 button.action：应被吞掉，不重开
+        #expect(vm.isVisible == false)
+        NSStatusBar.system.removeStatusItem(statusItem)
+    }
 }
 
 private struct EmptyContentProbe: View {

--- a/Tests/CodexBarTests/PopoverMenuControllerTests.swift
+++ b/Tests/CodexBarTests/PopoverMenuControllerTests.swift
@@ -1,0 +1,22 @@
+import Testing
+import AppKit
+import SwiftUI
+@testable import CodexBar
+
+@MainActor @Suite struct PopoverMenuControllerTests {
+    @Test func showAndCloseUpdatesViewModelVisibility() {
+        let vm = MenuViewModel()
+        let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        let button = statusItem.button!
+        let controller = PopoverMenuController(viewModel: vm) { EmptyContentProbe() }
+        controller.show(relativeTo: button)
+        #expect(vm.isVisible == true)
+        controller.close()
+        #expect(vm.isVisible == false)
+        NSStatusBar.system.removeStatusItem(statusItem)
+    }
+}
+
+private struct EmptyContentProbe: View {
+    var body: some View { Color.clear.frame(width: 1, height: 1) }
+}

--- a/Tests/CodexBarTests/PopoverMenuControllerTests.swift
+++ b/Tests/CodexBarTests/PopoverMenuControllerTests.swift
@@ -11,6 +11,8 @@ import Testing
         let controller = PopoverMenuController(viewModel: vm) { EmptyContentProbe() }
         controller.show(relativeTo: button)
         #expect(vm.isVisible == true)
+        #expect(vm.maximumPopoverHeight >= 320)
+        #expect(vm.maximumPopoverHeight <= 720)
         controller.close()
         #expect(vm.isVisible == false)
         NSStatusBar.system.removeStatusItem(statusItem)

--- a/Tests/CodexBarTests/PopoverMenuControllerTests.swift
+++ b/Tests/CodexBarTests/PopoverMenuControllerTests.swift
@@ -34,6 +34,55 @@ import SwiftUI
         let handled = controller.handleKeyDownForTesting(keyCode: 0) // 'a'
         #expect(handled == false)
     }
+
+    // MARK: - Task 1.4 字符级快捷键派发
+
+    @Test func commandRTriggersRefresh() {
+        var fired = false
+        let controller = PopoverMenuController(viewModel: MenuViewModel()) { EmptyContentProbe() }
+        controller.onRefresh = { fired = true }
+        #expect(controller.handleForTesting(characters: "r", modifiers: .command) == true)
+        #expect(fired)
+    }
+
+    @Test func commandCommaTriggersSettings() {
+        var fired = false
+        let controller = PopoverMenuController(viewModel: MenuViewModel()) { EmptyContentProbe() }
+        controller.onSettings = { fired = true }
+        #expect(controller.handleForTesting(characters: ",", modifiers: .command) == true)
+        #expect(fired)
+    }
+
+    @Test func commandQTriggersQuit() {
+        var fired = false
+        let controller = PopoverMenuController(viewModel: MenuViewModel()) { EmptyContentProbe() }
+        controller.onQuit = { fired = true }
+        #expect(controller.handleForTesting(characters: "q", modifiers: .command) == true)
+        #expect(fired)
+    }
+
+    @Test func commandDigitSelectsIndex() {
+        var picked: Int?
+        let controller = PopoverMenuController(viewModel: MenuViewModel()) { EmptyContentProbe() }
+        controller.onSelectIndex = { picked = $0 }
+        #expect(controller.handleForTesting(characters: "3", modifiers: .command) == true)
+        #expect(picked == 2)
+    }
+
+    @Test func arrowsNavigate() {
+        var dir: StatusItemMenuProviderNavigationDirection?
+        let controller = PopoverMenuController(viewModel: MenuViewModel()) { EmptyContentProbe() }
+        controller.onNavigate = { dir = $0 }
+        #expect(controller.handleKeyDownForTesting(keyCode: 124) == true) // →
+        #expect(dir == .next)
+        #expect(controller.handleKeyDownForTesting(keyCode: 123) == true) // ←
+        #expect(dir == .previous)
+    }
+
+    @Test func unhandledKeyReturnsFalse() {
+        let controller = PopoverMenuController(viewModel: MenuViewModel()) { EmptyContentProbe() }
+        #expect(controller.handleForTesting(characters: "x", modifiers: .command) == false)
+    }
 }
 
 private struct EmptyContentProbe: View {

--- a/Tests/CodexBarTests/PopoverMenuControllerTests.swift
+++ b/Tests/CodexBarTests/PopoverMenuControllerTests.swift
@@ -15,6 +15,25 @@ import SwiftUI
         #expect(vm.isVisible == false)
         NSStatusBar.system.removeStatusItem(statusItem)
     }
+
+    @Test func escapeKeyClosesPopover() {
+        let vm = MenuViewModel()
+        let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        let button = statusItem.button!
+        let controller = PopoverMenuController(viewModel: vm) { EmptyContentProbe() }
+        controller.show(relativeTo: button)
+        let handled = controller.handleKeyDownForTesting(keyCode: 53) // Esc
+        #expect(handled == true)
+        #expect(vm.isVisible == false)
+        NSStatusBar.system.removeStatusItem(statusItem)
+    }
+
+    @Test func nonEscapeKeyNotHandled() {
+        let vm = MenuViewModel()
+        let controller = PopoverMenuController(viewModel: vm) { EmptyContentProbe() }
+        let handled = controller.handleKeyDownForTesting(keyCode: 0) // 'a'
+        #expect(handled == false)
+    }
 }
 
 private struct EmptyContentProbe: View {

--- a/Tests/CodexBarTests/PopoverMenuControllerTests.swift
+++ b/Tests/CodexBarTests/PopoverMenuControllerTests.swift
@@ -1,13 +1,13 @@
-import Testing
 import AppKit
 import SwiftUI
+import Testing
 @testable import CodexBar
 
 @MainActor @Suite struct PopoverMenuControllerTests {
-    @Test func showAndCloseUpdatesViewModelVisibility() {
+    @Test func showAndCloseUpdatesViewModelVisibility() throws {
         let vm = MenuViewModel()
         let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        let button = statusItem.button!
+        let button = try #require(statusItem.button)
         let controller = PopoverMenuController(viewModel: vm) { EmptyContentProbe() }
         controller.show(relativeTo: button)
         #expect(vm.isVisible == true)
@@ -16,10 +16,10 @@ import SwiftUI
         NSStatusBar.system.removeStatusItem(statusItem)
     }
 
-    @Test func escapeKeyClosesPopover() {
+    @Test func escapeKeyClosesPopover() throws {
         let vm = MenuViewModel()
         let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        let button = statusItem.button!
+        let button = try #require(statusItem.button)
         let controller = PopoverMenuController(viewModel: vm) { EmptyContentProbe() }
         controller.show(relativeTo: button)
         let handled = controller.handleKeyDownForTesting(keyCode: 53) // Esc
@@ -86,21 +86,23 @@ import SwiftUI
 
     // MARK: - #1 transient 双触发防抖
 
-    @Test func toggleAfterCloseIsSuppressedWithinSameRunloop() {
+    @Test func toggleAfterCloseIsSuppressedWithinSameRunloop() throws {
         let vm = MenuViewModel()
         let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        let button = statusItem.button!
+        let button = try #require(statusItem.button)
         let controller = PopoverMenuController(viewModel: vm) { EmptyContentProbe() }
         controller.show(relativeTo: button)
         #expect(vm.isVisible == true)
         controller.simulatePopoverDidCloseForTesting() // 模拟 transient 外部点击关闭
         #expect(vm.isVisible == false)
-        controller.toggle(relativeTo: button)          // 紧随的 button.action：应被吞掉，不重开
+        controller.toggle(relativeTo: button) // 紧随的 button.action：应被吞掉，不重开
         #expect(vm.isVisible == false)
         NSStatusBar.system.removeStatusItem(statusItem)
     }
 }
 
 private struct EmptyContentProbe: View {
-    var body: some View { Color.clear.frame(width: 1, height: 1) }
+    var body: some View {
+        Color.clear.frame(width: 1, height: 1)
+    }
 }

--- a/Tests/CodexBarTests/PopoverMenuFeatureFlagTests.swift
+++ b/Tests/CodexBarTests/PopoverMenuFeatureFlagTests.swift
@@ -1,0 +1,80 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite struct PopoverMenuFeatureFlagTests {
+    @Test func usePopoverMenuDefaultsToFalse() {
+        let suite = "test.popover.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            kimiK2TokenStore: InMemoryKimiK2TokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore())
+        #expect(settings.usePopoverMenu == false)
+    }
+
+    @Test func usePopoverMenuPersists() {
+        let suite = "test.popover.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            kimiK2TokenStore: InMemoryKimiK2TokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore())
+        settings.usePopoverMenu = true
+        #expect(settings.usePopoverMenu == true)
+        #expect(defaults.bool(forKey: "usePopoverMenu") == true)
+        let reloaded = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            kimiK2TokenStore: InMemoryKimiK2TokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore())
+        #expect(reloaded.usePopoverMenu == true)
+    }
+}

--- a/Tests/CodexBarTests/PopoverMenuFeatureFlagTests.swift
+++ b/Tests/CodexBarTests/PopoverMenuFeatureFlagTests.swift
@@ -5,9 +5,9 @@ import Testing
 
 @MainActor
 @Suite struct PopoverMenuFeatureFlagTests {
-    @Test func usePopoverMenuDefaultsToFalse() {
+    @Test func usePopoverMenuDefaultsToFalse() throws {
         let suite = "test.popover.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
+        let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
         let configStore = testConfigStore(suiteName: suite)
         let settings = SettingsStore(
@@ -31,9 +31,9 @@ import Testing
         #expect(settings.usePopoverMenu == false)
     }
 
-    @Test func usePopoverMenuPersists() {
+    @Test func usePopoverMenuPersists() throws {
         let suite = "test.popover.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suite)!
+        let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
         let configStore = testConfigStore(suiteName: suite)
         let settings = SettingsStore(

--- a/Tests/CodexBarTests/PopoverOverviewTests.swift
+++ b/Tests/CodexBarTests/PopoverOverviewTests.swift
@@ -8,13 +8,37 @@ import Testing
 struct PopoverOverviewRowTests {
     // MARK: 1. id 稳定性
 
+    /// 通过实际构造 PopoverOverviewRow 验证 id 计算属性等于 provider.rawValue。
     @Test
-    func `PopoverOverviewRow id 等于 provider rawValue`() {
-        // id 应稳定地映射为 provider.rawValue，与 NSMenu overviewRowIdentifier 保持一致
+    func `PopoverOverviewRow id 等于 provider rawValue`() throws {
+        // 构造最简 UsageMenuCardView.Model（snapshot=nil、account 填占位值）
         let providers: [UsageProvider] = [.codex, .claude, .cursor]
         for provider in providers {
-            // 通过符合稳定约定来验证：rawValue 是 string 常量
-            #expect(provider.rawValue == provider.rawValue, "id 应稳定：同一 provider 两次求值相等")
+            let metadata = try #require(ProviderDefaults.metadata[provider])
+            let model = UsageMenuCardView.Model.make(.init(
+                provider: provider,
+                metadata: metadata,
+                snapshot: nil,
+                credits: nil,
+                creditsError: nil,
+                dashboard: nil,
+                dashboardError: nil,
+                tokenSnapshot: nil,
+                tokenError: nil,
+                account: AccountInfo(email: nil, plan: nil),
+                isRefreshing: false,
+                lastError: nil,
+                usageBarsShowUsed: false,
+                resetTimeDisplayStyle: .countdown,
+                tokenCostUsageEnabled: false,
+                showOptionalCreditsAndExtraUsage: false,
+                hidePersonalInfo: false,
+                now: Date()))
+            let row = StatusItemController.PopoverOverviewRow(
+                provider: provider,
+                model: model,
+                storageText: nil)
+            #expect(row.id == provider.rawValue, "id 应等于 provider.rawValue（provider: \(provider.rawValue)）")
         }
     }
 

--- a/Tests/CodexBarTests/PopoverOverviewTests.swift
+++ b/Tests/CodexBarTests/PopoverOverviewTests.swift
@@ -71,6 +71,7 @@ struct MenuViewModelOverviewSwitchTests {
     func `overview 状态下 selectNext 切到第一个 provider`() {
         let vm = MenuViewModel()
         vm.providers = [.codex, .claude]
+        vm.includesOverview = true // 导航停靠点含 overview
         #expect(vm.selection == .overview)
 
         vm.selectNext()
@@ -82,6 +83,7 @@ struct MenuViewModelOverviewSwitchTests {
     func `provider 状态 selectPrevious 可回到 overview`() {
         let vm = MenuViewModel()
         vm.providers = [.codex, .claude]
+        vm.includesOverview = true // 导航停靠点含 overview
         vm.select(.provider(.codex))
 
         vm.selectPrevious()

--- a/Tests/CodexBarTests/PopoverOverviewTests.swift
+++ b/Tests/CodexBarTests/PopoverOverviewTests.swift
@@ -1,0 +1,132 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+// MARK: - PopoverOverviewRow 结构测试
+
+struct PopoverOverviewRowTests {
+    // MARK: 1. id 稳定性
+
+    @Test
+    func `PopoverOverviewRow id 等于 provider rawValue`() {
+        // id 应稳定地映射为 provider.rawValue，与 NSMenu overviewRowIdentifier 保持一致
+        let providers: [UsageProvider] = [.codex, .claude, .cursor]
+        for provider in providers {
+            // 通过符合稳定约定来验证：rawValue 是 string 常量
+            #expect(provider.rawValue == provider.rawValue, "id 应稳定：同一 provider 两次求值相等")
+        }
+    }
+
+    @Test
+    func `不同 provider 产生不同 id`() {
+        // 验证 provider.rawValue 作为 id 的唯一性约束
+        let providers: [UsageProvider] = [.codex, .claude, .cursor, .openai]
+        let ids = providers.map(\.rawValue)
+        let uniqueIDs = Set(ids)
+        #expect(uniqueIDs.count == ids.count, "不同 provider 的 rawValue id 不得重复")
+    }
+
+    @Test
+    func `id 与 rawValue 一致`() {
+        // 对 PopoverOverviewRow 类型本身验证 id 计算属性语义
+        // 此处通过类型文档约定确认（id = provider.rawValue），无需 model 构造
+        let provider = UsageProvider.codex
+        #expect(!provider.rawValue.isEmpty, "provider rawValue 不应为空")
+    }
+}
+
+// MARK: - MenuViewModel overview→provider 切换测试
+
+@MainActor
+@Suite
+struct MenuViewModelOverviewSwitchTests {
+    // MARK: 2. overview → provider 切换
+
+    @Test
+    func `overview 切换到 provider 后 selection 正确`() {
+        let vm = MenuViewModel()
+        vm.providers = [.codex, .claude]
+        // 初始为 overview
+        #expect(vm.selection == .overview)
+
+        // 切到 codex
+        vm.select(.provider(.codex))
+        #expect(vm.selection == .provider(.codex))
+    }
+
+    @Test
+    func `overview 切换到 provider 后可再切回 overview`() {
+        let vm = MenuViewModel()
+        vm.providers = [.codex, .claude]
+
+        vm.select(.provider(.codex))
+        #expect(vm.selection == .provider(.codex))
+
+        vm.select(.overview)
+        #expect(vm.selection == .overview)
+    }
+
+    @Test
+    func `overview 状态下 selectNext 切到第一个 provider`() {
+        let vm = MenuViewModel()
+        vm.providers = [.codex, .claude]
+        #expect(vm.selection == .overview)
+
+        vm.selectNext()
+        // 导航顺序：[.overview, .provider(.codex), .provider(.claude)]
+        #expect(vm.selection == .provider(.codex))
+    }
+
+    @Test
+    func `provider 状态 selectPrevious 可回到 overview`() {
+        let vm = MenuViewModel()
+        vm.providers = [.codex, .claude]
+        vm.select(.provider(.codex))
+
+        vm.selectPrevious()
+        // 从第一个 provider 向前 → overview
+        #expect(vm.selection == .overview)
+    }
+
+    @Test
+    func `从 overview 切换到不同 provider 各自正确`() {
+        let vm = MenuViewModel()
+        let providers: [UsageProvider] = [.codex, .claude, .cursor]
+        vm.providers = providers
+
+        for provider in providers {
+            vm.select(.overview)
+            vm.select(.provider(provider))
+            #expect(vm.selection == .provider(provider), "切换到 \(provider.rawValue) 后 selection 应为该 provider")
+        }
+    }
+
+    @Test
+    func `overview→provider 切换 contentVersion 自增`() {
+        let vm = MenuViewModel()
+        vm.providers = [.codex]
+        let vBefore = vm.contentVersion
+
+        vm.select(.provider(.codex))
+        #expect(
+            vm.contentVersion > vBefore || vm.contentVersion == vBefore &+ 1,
+            "切换 selection 时 contentVersion 应自增")
+    }
+}
+
+// MARK: - popoverOverviewRows / popoverOverviewEmptyText 集成说明
+
+//
+// popoverOverviewRows() 和 popoverOverviewEmptyText() 内部依赖：
+//   - store.enabledProvidersForDisplay()（运行时账户/启用状态）
+//   - settings.reconcileMergedOverviewSelectedProviders（UserDefaults）
+//   - menuCardModel（snapshot 数据）
+//   - store.storageFootprintText（存储快照）
+//
+// 这些依赖需要完整的 StatusItemController + 真实运行时数据，在 headless 测试环境
+// 下无法稳定触发有意义的 rows（enabledProviders 通常为空）。
+// 因此：
+//   - rows/空态构造逻辑通过全量回归（swift test）+ 人工验证兜底。
+//   - 空态文案字符串正确性（L("No providers selected for Overview.") 等）
+//     在 addOverviewEmptyState NSMenu 路径已有覆盖，popover 复用同一 L() 调用。

--- a/Tests/CodexBarTests/PopoverPerProviderTests.swift
+++ b/Tests/CodexBarTests/PopoverPerProviderTests.swift
@@ -43,4 +43,44 @@ import Testing
         #expect(vm.providers.isEmpty)
         #expect(vm.selection == .provider(.codex))
     }
+
+    @Test func removingProviderPopoverClearsControllerAndVisibility() throws {
+        let controller = try makePerProviderController()
+        defer { controller.releaseStatusItemsForTesting() }
+        controller.ensureProviderPopover(for: .claude)
+        let viewModel = try #require(controller.providerMenuViewModels[.claude])
+        viewModel.setVisible(true)
+
+        controller.removeProviderPopover(for: .claude)
+
+        #expect(controller.providerPopoverControllers[.claude] == nil)
+        #expect(controller.providerMenuViewModels[.claude] == nil)
+        #expect(viewModel.isVisible == false)
+    }
+}
+
+@MainActor
+private func makePerProviderController() throws -> StatusItemController {
+    let suite = "PopoverPerProviderTests-\(UUID().uuidString)"
+    let defaults = try #require(UserDefaults(suiteName: suite))
+    defaults.removePersistentDomain(forName: suite)
+    let settings = SettingsStore(
+        userDefaults: defaults,
+        configStore: testConfigStore(suiteName: suite),
+        zaiTokenStore: NoopZaiTokenStore(),
+        syntheticTokenStore: NoopSyntheticTokenStore())
+    settings.statusChecksEnabled = false
+    settings.refreshFrequency = .manual
+    let fetcher = UsageFetcher(environment: [:])
+    let store = UsageStore(
+        fetcher: fetcher,
+        browserDetection: BrowserDetection(cacheTTL: 0),
+        settings: settings)
+    return StatusItemController(
+        store: store,
+        settings: settings,
+        account: AccountInfo(email: nil, plan: nil),
+        updater: DisabledUpdaterController(),
+        preferencesSelection: PreferencesSelection(),
+        statusBar: .system)
 }

--- a/Tests/CodexBarTests/PopoverPerProviderTests.swift
+++ b/Tests/CodexBarTests/PopoverPerProviderTests.swift
@@ -57,6 +57,24 @@ import Testing
         #expect(controller.providerMenuViewModels[.claude] == nil)
         #expect(viewModel.isVisible == false)
     }
+
+    @Test func shortcutPreservesFallbackWhenNoProviderIsEnabled() throws {
+        let controller = try makePerProviderController()
+        defer { controller.releaseStatusItemsForTesting() }
+        let registry = ProviderRegistry.shared
+        for provider in UsageProvider.allCases {
+            guard let metadata = registry.metadata[provider] else { continue }
+            controller.settings.setProviderEnabled(provider: provider, metadata: metadata, enabled: false)
+        }
+        controller.ensureProviderPopover(for: .codex)
+
+        let viewModel = controller.prepareProviderPopoverForShortcut(for: .codex)
+
+        #expect(controller.fallbackProvider == .codex)
+        #expect(viewModel.isFallback)
+        #expect(viewModel.providers.isEmpty)
+        #expect(controller.providerMenuViewModels[.codex] === viewModel)
+    }
 }
 
 @MainActor

--- a/Tests/CodexBarTests/PopoverPerProviderTests.swift
+++ b/Tests/CodexBarTests/PopoverPerProviderTests.swift
@@ -35,4 +35,12 @@ import Testing
         vm.select(newSelection)
         #expect(vm.selection == newSelection)
     }
+
+    @Test func fallbackFactoryDoesNotExposeProviderContent() {
+        let vm = MenuViewModel.fallback(statusItemProvider: .codex)
+
+        #expect(vm.isFallback)
+        #expect(vm.providers.isEmpty)
+        #expect(vm.selection == .provider(.codex))
+    }
 }

--- a/Tests/CodexBarTests/PopoverPerProviderTests.swift
+++ b/Tests/CodexBarTests/PopoverPerProviderTests.swift
@@ -1,0 +1,38 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite struct PopoverPerProviderTests {
+    // MARK: - MenuViewModel.singleProvider 工厂
+
+    @Test func singleProviderFactorySetProviders() {
+        let vm = MenuViewModel.singleProvider(.claude)
+        #expect(vm.providers == [.claude])
+    }
+
+    @Test func singleProviderFactoryNoOverview() {
+        let vm = MenuViewModel.singleProvider(.claude)
+        #expect(vm.includesOverview == false)
+    }
+
+    @Test func singleProviderFactorySelectionIsProvider() {
+        let vm = MenuViewModel.singleProvider(.codex)
+        #expect(vm.selection == .provider(.codex))
+    }
+
+    @Test func singleProviderFactoryNoSelectionChangedCallback() {
+        let vm = MenuViewModel.singleProvider(.openai)
+        // 单 provider 不接 onSelectionChanged，不应触发持久化
+        #expect(vm.onSelectionChanged == nil)
+    }
+
+    @Test func singleProviderFactorySelectDoesNotCrash() {
+        let vm = MenuViewModel.singleProvider(.claude)
+        // 调用 select 不应崩溃（onSelectionChanged 为 nil 时）
+        let newSelection = ProviderSwitcherSelection.provider(.openai)
+        vm.select(newSelection)
+        #expect(vm.selection == newSelection)
+    }
+}

--- a/docs/refactor/menu-popover-migration-contract.md
+++ b/docs/refactor/menu-popover-migration-contract.md
@@ -1,0 +1,120 @@
+# 菜单架构重构迁移契约（NSMenu → NSPopover + 持久 SwiftUI）
+
+> 目的：把"每次打开/切换都重建 NSMenuItem + 全新 NSHostingView + 同步测高"的菜单，重构为
+> "单一长期存活的 SwiftUI 视图树 + `@Observable` 增量更新"，根治交互卡顿。
+> 本文是**迁移契约**：列出迁移中必须保留的行为、需替代的 NSMenu 专有能力、新视图蓝图、测试契约与风险。
+> 由穷尽式代码盘点工作流产出（2026-06，覆盖 31 个 StatusItemController+*.swift 文件 + 菜单视图 + 现有测试）。
+
+## 0. 已确认的方向决策
+
+| 维度 | 决策 |
+|---|---|
+| 容器 | **NSPopover(.transient)**，保留 `StatusItemController` + 图标/动画体系不动，仅替换 `statusItem.menu` 赋值为手动弹出 popover |
+| 内容承载 | 单一长期存活 SwiftUI 根视图（`NSHostingController`）+ `@Observable` MenuViewModel 驱动 |
+| 图表下钻 | **二级级联 popover**，复刻当前 NSMenu 子菜单向侧边弹出的视觉/交互（不是内联展开） |
+| 键盘快捷键 | **全保留**：Cmd+R/,/Q、←→ 循环切 provider（含 Overview）、Cmd+1..9 选第 N 个 |
+| 测试节奏 | **先双跑过渡**：先在现有 NSMenu 实现上把断言下沉到 view-model 层，新旧架构复用同一批断言 |
+| 排除项 | MenuBarExtra（需重构 App 生命周期、放弃自定义动态图标/动画体系，改动过大） |
+
+App 结构：SwiftUI `App` 外壳 + `@NSApplicationDelegateAdaptor(AppDelegate)`，状态项/图标/菜单全部由 AppKit `StatusItemController` 管理；SwiftUI Scene 仅有保活窗口 + Settings。
+
+## 1. 必须保留的行为（MP-01 .. MP-29）
+
+### 状态项与生命周期
+- **MP-01/02 双模式状态项**：合并模式单 `NSStatusItem`（autosave `codexbar-merged`）；非合并模式按 provider 多个（`statusItems:[UsageProvider:NSStatusItem]`，autosave `codexbar-<provider>`）。可见性由 enabled/fallback/debugForceAnimation 控制。迁移保留 statusItem 作锚点，移除 `statusItem.menu=`。
+- **MP-03 打开初始化序列**（`menuWillOpen`→ `onAppear`/`willShow`）：标记打开、hydrate、populate、装快捷键监听、调度 1.2s 后刷新。
+- **MP-04 关闭清理序列**（`menuDidClose`→ `onDisappear`/`willHide`）：移除打开记录、取消刷新任务、清高亮、**关闭后后台预备下次内容**避免下次弹出卡顿。
+- **MP-05 登录态变化重建**：`loginTask/activeLoginProvider/loginPhase` 变化 → 失效+重渲；打开期间不中断交互。
+
+### 内容结构
+- **MP-10 内容分流**：Overview / 单 provider；单 provider 再按 Codex showAll 堆叠卡片 / Token showAll 堆叠 / Kilo 多 scope 堆叠 / 单卡片分流。
+- **MP-11 卡片分段（条件渲染 + 段间分隔符）**：Header（名/邮箱/plan/副标题）→ Usage（主/次/三级窗口 %、reset、pace）→ Storage → Credits（含 Buy Credits…）→ Extra Usage/Provider Cost（Codex 企业花费）→ Cost/Token Usage（会话/月/top model）。
+- **MP-17 底部动作区**（`MenuDescriptor.Section`）：账户/登录动作、provider 专属动作、Dashboard、Status Page、Changelog、状态行、Update ready、Refresh/Settings/About/Quit（带快捷键标签）。
+
+### 图表下钻（6 类）
+- **MP-12 懒水合 + 重测高**：usageBreakdown/creditsHistory/costHistory/usageHistory/storageBreakdown/zaiHourlyUsage；首开实例化，数据变更刷新；provider 切换关闭所有图表。图表读 store 数据 + 本地 @State 交互（选中天/系列）。
+- **MP-13 父内容防抖**：子图表开启时父内容不抖动/闪烁。
+- **MP-14 下钻入口**：Overview 行子菜单（OpenAI cost history、Zai 详情、storage）；Usage History（Plan Utilization）与 Zai Hourly 作为独立项。
+- StorageBreakdown 高度约束：`min(620, max(360, visibleHeight*0.72))` + 滚动。
+
+### 快捷键/导航/高亮/消失
+- **MP-15 持久快捷键** Cmd+R/,/Q：打开期间无需点项即响应。
+- **MP-16 provider 导航** Cmd+1..9 选第 N 个 enabled；←→（keyCode 123/124）循环切含 Overview。
+- **MP-18 悬停高亮**：仅 enabled 项；`MenuCardHighlightState`（@Observable）注入渲染选中背景/文字色。
+- **MP-19 消失语义**：点外部 / Esc / 选中项后关闭（现全靠 NSMenu 模态，迁移须显式实现）。
+
+### 图标/动画（横切，需与面板内容解耦）
+- **MP-20 加载动画** DisplayLink 30FPS，最长 30s 或数据到达即停；knightRider/cylon/unbraid 相位。
+- **MP-21 闲置 blink/wiggle/tilt** 状态机，作为不可变快照传入 `IconRenderer.makeIcon`。
+- **MP-22 图标渲染签名缓存**（命中跳过 makeIcon）+ quota 警告闪烁。**与菜单内容正交**。
+- **MP-23 面板可见冻结动画**：`guard !popoverVisible`。
+
+### 外观/无障碍/定位/版本
+- **MP-24 vibrancy + 系统色跟随 + 本地化签名**（语言切换重算重布局）；副标题 SwiftUI 化免去 macOS 14.4 版本分支。
+- **MP-25 多屏定位**：按钮屏幕坐标换算 + 跨屏最优弹出位 + 响应 screensDidChange/睡眠唤醒；保留 `MenuBarStatusItemPlacementPreflight` 越界清理。
+- **MP-26 无障碍树**（**Critical**）：现 NSMenu 免费提供，迁移须手工 `.accessibilityRole(.menu)` + 项 `.isButton` trait + label + hint（含快捷键）+ `.combine`。
+- **MP-27 宽度自适应/高度测量**：基础 310pt；SwiftUI 自适应替代 fittingSize 手测。
+- **MP-28 readiness 签名 + 版本追踪**：检测数据变更决定增量/全量；迁移改为 `@Observable` Equatable + contentVersion。
+- **MP-29 延迟交互刷新**：打开缺数据 → 关闭后 250ms `store.refreshProvider(.background)`；OpenAI dashboard 延迟刷新语义保留。
+
+## 2. 需替代的 NSMenu 专有能力（14 项，摘录高风险）
+
+- `statusItem.menu=` 自动弹出 → 手动 `NSPopover.show(relativeTo:of:preferredEdge:)`（中风险）
+- `NSMenuDelegate` 生命周期 → popover delegate / `.onAppear/.onDisappear`（高）
+- `StatusItemMenu.performKeyEquivalent` 模态拦截快捷键 → 面板可见期 `NSEvent.addLocalMonitorForEvents(.keyDown)` 或 `.onKeyPress`（**高/Critical**）
+- `ProviderSwitcherShortcutEventMonitor`（CFRunLoopObserver .eventTracking）→ popover 非菜单模态，改面板级 monitor / 原生 Button（高），可删 hitTest/handleMenuTracking workaround
+- NSMenu 自动消失 → `.transient` + 显式 Esc/选中 dismiss（高）
+- `NSMenuItem.view` 逐次新建 NSHostingView → 单一持久 SwiftUI 树 + @Observable（高）
+- NSMenu submenu 级联 → 二级级联 popover 复刻（中）
+- NSMenu 内置无障碍 → 手工无障碍树（**高/Critical**）
+- `NSMenu.allowsVibrancy` / `NSMenuItem.subtitle` → NSVisualEffectView + SwiftUI 文本（中）
+- NSStatusBar 自动定位 → popover relativeTo 大体自动，自定义面板需手工（中）
+- 大量 `ObjectIdentifier(NSMenu)` 字典 key → 合并模式单面板单版本，删除大部分字典（中）
+
+## 3. 新 SwiftUI 内容视图蓝图
+
+```
+PopoverRootView（单一持久，@Observable MenuViewModel；固定宽 ~310pt；NSVisualEffectView vibrancy；
+                 .accessibilityRole(.menu)；onAppear=打开序列，onDisappear=关闭序列）
+├─ 1. ProviderSwitcher 区（仅 merged && providers>1）：分段控件(Overview + providers)，
+│     selection 绑定 selectedMenuProvider + lastSelectedWasOverview（持久化）；←→/Cmd+1..9
+├─ Divider
+├─ 2. 账户切换器区（二选一，仅 segmented）：Codex 账户 / Token 账户
+├─ Divider
+├─ 3. 主内容区
+│   ├─ Overview 分支：ForEach(overviewProviders) → OverviewMenuCardRowView（可点击切换 + 行内下钻）
+│   └─ 单 provider 分支：按账户/scope 分流（Codex/Token showAll 堆叠、Kilo scopes、单卡片）
+│       └─ 4. 卡片分段（@ViewBuilder 条件 + Divider）：Header→Usage→Storage→Credits→ExtraUsage→Cost/Token
+├─ 5. 图表下钻（6 类，二级级联 popover，懒加载，provider 切换收起）
+├─ Divider
+└─ 7. 底部动作区：账户/登录→provider 动作→Dashboard→Status→Changelog→状态行→Update→Refresh/Settings/About/Quit
+
+横切：StatusBarIconService(@Observable) 独立于面板（DisplayLink/blink/签名缓存/quota 闪烁；面板可见冻结）
+横切：集中式 @State highlightedItemID（.onHover）；面板级事件 monitor（Cmd 系列/←→/Esc/点外部关闭）
+```
+
+## 4. 测试契约
+
+### 迁移后必须覆盖
+内容结构（读 @Observable model 而非 menu.items）、switcher 切换与持久化、账户切换同步 state+触发刷新、智能更新 vs 全量判定、图表懒加载/刷新/收起/高度约束、打开初始化序列、关闭清理+250ms 延迟刷新、关闭后预备、快捷键全集、图标层独立性（面板可见冻结/签名跳过）、登录态变化、多屏定位、**无障碍（新增）**、本地化重布局、vibrancy/系统色。
+
+### 需重写的现有测试
+所有基于 `menu.items[]` 索引/`representedObject`/视图类型断言（`StatusItemControllerMenuTests`、`StatusMenuSwitcherRefreshTests`、`StatusMenuOpenRefreshTests`、`StatusMenuHostedSubmenuRefreshTests` 等 ~50+）→ 改读 view-model；直接驱动 `populateMenu/makeMenu/menuWillOpen` 的同步调用 → 驱动 model 状态 + onAppear/onDisappear。
+
+### 新增可测试接缝
+`@Published contentVersion/updateID`（替代 `_test_openMenuRebuildObserver`+menuVersions）；可注入 `isPopoverVisible`；`highlightedItemID` 快照；可注入延迟（1.2s/350ms/250ms 经 environment/init，测试设 .zero）；`@Environment(\.disableMenuRefresh/disableCardRendering)`（替代静态 flag）；DisplayLink onTick mock；图标签名检视保留。
+
+## 5. 风险（按严重度）
+
+| 级别 | 风险 | 缓解 |
+|---|---|---|
+| **Critical** | 快捷键/事件拦截架构整体失效（依赖 NSMenu 模态 + CFRunLoopObserver） | 面板 willShow 装全局 local monitor / `.onKeyPress`，didClose 移除；先以最小面板验证快捷键链路再迁内容 |
+| **Critical** | 无障碍树退化（NSMenu 免费提供，SwiftUI 须手工） | 迁移即同步补全；纳入测试强制覆盖；Accessibility Inspector 验收 |
+| High | 面板消失语义易错（动作后忘 dismiss、monitor 冲突） | 优先 `.transient`；frame 边界判定；每动作显式 dismiss；三路径各写测试 |
+| High | 性能回归（复用不当/频繁 layout/动画未解耦） | 图标动画迁出独立服务；面板内更新防抖批量；图表懒加载；`.equatable()` 阻无谓重渲；保留签名缓存与 350ms 预备 |
+| High | 智能复用/缓存状态机迁移复杂（切 tab 闪烁/内容丢失/Overview 选中重置） | @Observable 响应式 + SwiftUI diff 替代手动缓存；先快照测试锁定判定条件再逐条对拍 |
+| High | 测试套件大面积失效 | 先双跑：现有实现上把断言下沉 view-model，新架构复用同一批 |
+| Medium | 高度测量/裁剪、多屏定位、双模式隔离、高亮重渲丢失 | SwiftUI 固有尺寸 + maxHeight/ScrollView；按钮坐标换算+screensDidChange；合并/非合并面板管理完全隔离；高亮集中态 + `.id()` |
+
+## 6. 待迁移中决策的次要问题
+非合并模式：每 provider 独立面板 vs 共享单面板按点击切换；高亮是否需键盘上下移动（NSMenu 原生）还是仅悬停；动画服务所有权（AppDelegate/单例/StatusItemController）；是否弃用 `NSFont.menuFont` 改系统字体。

--- a/docs/superpowers/plans/2026-06-09-menu-popover-refactor.md
+++ b/docs/superpowers/plans/2026-06-09-menu-popover-refactor.md
@@ -1,0 +1,689 @@
+# 菜单 NSMenu → NSPopover + 持久 SwiftUI 重构 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把"每次打开/切换都重建 NSMenuItem + 全新 NSHostingView + 同步测高"的菜单，重构为"单一长期存活的 SwiftUI 视图树 + `@Observable` 增量更新"的 NSPopover，根治打开菜单/切 provider 的卡顿。
+
+**Architecture:** 保留 AppKit `StatusItemController` 与图标/动画体系不动；用 `NSPopover(.transient)` + `NSHostingController` 承载一棵长期存活的 SwiftUI 根视图，由 `@Observable MenuViewModel` 驱动；切 provider = 改 view model 属性 → SwiftUI 增量 diff，不再拆建 NSMenuItem。全程**特性开关 `usePopoverMenu` 隔离**（默认关），逐阶段交付、每阶段可测可回退。
+
+**Tech Stack:** Swift 6 / SwiftPM、AppKit（NSStatusItem/NSPopover/NSHostingController）、SwiftUI、Observation（@Observable）、swift-testing（`@Test`/`#expect`）、macOS 14+。
+
+**配套文档:** 迁移契约见 `docs/refactor/menu-popover-migration-contract.md`（29 条必保留行为 MP-01..29、14 项需替代能力、新视图蓝图、测试契约、风险）。
+
+**构建/测试命令:** `swift build` / `swift test`；本地跑 `Scripts/compile_and_run.sh`；lint `Scripts/lint.sh lint`。采样验证卡顿：用户侧 `bash /tmp/cb_profile.sh`（见 `[[menu-perf-investigation-method]]`）。
+
+---
+
+## 阶段路线图（每阶段独立可交付、特性开关隔离）
+
+| 阶段 | 目标 | 交付物 | 本计划详度 |
+|---|---|---|---|
+| **0** | 地基：特性开关 + view-model 抽象 + 测试双跑接缝 | 开关关时**零行为变化** | ✅ 完整 TDD 步骤 |
+| **1** | popover 骨架 + 架构验证 | 开关开时：点击弹出 popover，渲染切换器+单卡片，切换走增量更新；**采样确认卡顿消失** | ✅ 详细步骤 |
+| 2 | 内容全量对齐（合并模式） | 全部卡片分段、Overview、各 provider 分流 | 🔜 独立计划 |
+| 3 | 图表二级级联 popover（复刻现子菜单观感） | 6 类图表懒加载、provider 切换收起 | 🔜 独立计划 |
+| 4 | 非合并模式（per-provider popover） | `providerPanels` 映射 | 🔜 独立计划 |
+| 5 | 动画/图标解耦 + 清理 | 面板可见冻结动画、删除旧 NSMenu 路径 | 🔜 独立计划 |
+| 6 | 无障碍 + 完整测试 + 翻转默认开关 | a11y 树、全测试契约覆盖、性能复测、默认开 | 🔜 独立计划 |
+
+> 阶段 2–6 在前一阶段落地后各自展开为 `docs/superpowers/plans/` 下的独立计划（依赖前阶段产出的真实类型，提前写死只会是占位符）。本计划完整覆盖**阶段 0 与阶段 1**。
+
+---
+
+## 文件结构（阶段 0 + 1 新增/修改）
+
+**新增：**
+- `Sources/CodexBar/Popover/PopoverMenuController.swift` — NSPopover 生命周期 + 锚定 statusItem.button + 显示/隐藏/dismiss + 键盘事件 monitor
+- `Sources/CodexBar/Popover/MenuViewModel.swift` — `@Observable`，持有 selectedProvider/providers/contentVersion/isVisible 等面板状态（替代 NSMenu 字典追踪）
+- `Sources/CodexBar/Popover/PopoverRootView.swift` — SwiftUI 持久根视图（阶段 1 仅切换器 + 单卡片）
+- `Tests/CodexBarTests/PopoverMenuFeatureFlagTests.swift`
+- `Tests/CodexBarTests/MenuViewModelTests.swift`
+- `Tests/CodexBarTests/PopoverMenuControllerTests.swift`
+
+**修改：**
+- `Sources/CodexBar/SettingsStoreState.swift` — 加 `usePopoverMenu` 字段
+- `Sources/CodexBar/SettingsStore.swift` — `loadDefaultsState` 加载该字段
+- `Sources/CodexBar/SettingsStore+Defaults.swift` — 暴露 `usePopoverMenu` 计算属性
+- `Sources/CodexBar/StatusItemController.swift` — 持有 `PopoverMenuController?`；按开关在 attach 路径分流
+- `Sources/CodexBar/StatusItemController+Actions.swift` — `openMenuFromShortcut`/点击触发分流到 popover
+
+---
+
+## 阶段 0：地基（特性开关 + view model + 测试接缝）
+
+> 不变量：`usePopoverMenu == false` 时，App 行为与当前**逐字节一致**（所有新代码处于未激活分支）。
+
+### Task 0.1：新增特性开关 `usePopoverMenu`（默认 false）
+
+**Files:**
+- Modify: `Sources/CodexBar/SettingsStoreState.swift`（加字段，照 `usageBarsShowUsed` 范例）
+- Modify: `Sources/CodexBar/SettingsStore.swift:~345`（`loadDefaultsState` 内加载）
+- Modify: `Sources/CodexBar/SettingsStore+Defaults.swift:~196`（计算属性 get/set）
+- Test: `Tests/CodexBarTests/PopoverMenuFeatureFlagTests.swift`
+
+- [ ] **Step 1: 写失败测试**
+
+```swift
+import Testing
+import Foundation
+@testable import CodexBar
+
+@Suite struct PopoverMenuFeatureFlagTests {
+    private func makeSettings() -> SettingsStore {
+        let defaults = UserDefaults(suiteName: "test.popover.\(UUID().uuidString)")!
+        return SettingsStore(userDefaults: defaults)
+    }
+
+    @Test func usePopoverMenuDefaultsToFalse() {
+        let settings = makeSettings()
+        #expect(settings.usePopoverMenu == false)
+    }
+
+    @Test func usePopoverMenuPersists() {
+        let suite = "test.popover.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        let settings = SettingsStore(userDefaults: defaults)
+        settings.usePopoverMenu = true
+        #expect(settings.usePopoverMenu == true)
+        #expect(defaults.bool(forKey: "usePopoverMenu") == true)
+        // 重新加载验证持久化
+        let reloaded = SettingsStore(userDefaults: defaults)
+        #expect(reloaded.usePopoverMenu == true)
+    }
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `swift test --filter PopoverMenuFeatureFlagTests`
+Expected: FAIL（`usePopoverMenu` 未定义，编译错误）
+
+- [ ] **Step 3: 按 `usageBarsShowUsed` 范例实现开关**
+
+精确照抄三处范例（不要发明新模式）：
+1. `SettingsStoreState.swift`：在 `SettingsDefaultsState` 加 `var usePopoverMenu: Bool`（参考其中 `usageBarsShowUsed` 字段位置），并在其 init/默认值处补 `usePopoverMenu: false`。
+2. `SettingsStore.swift` 的 `loadDefaultsState`（约 345 行，`usageBarsShowUsed` 加载旁）：
+   ```swift
+   let usePopoverMenu = userDefaults.object(forKey: "usePopoverMenu") as? Bool ?? false
+   ```
+   并在构造 `SettingsDefaultsState(...)` 处传入 `usePopoverMenu: usePopoverMenu`。
+3. `SettingsStore+Defaults.swift`（约 196 行，照 `usageBarsShowUsed`）：
+   ```swift
+   var usePopoverMenu: Bool {
+       get { self.defaultsState.usePopoverMenu }
+       set {
+           self.defaultsState.usePopoverMenu = newValue
+           self.userDefaults.set(newValue, forKey: "usePopoverMenu")
+       }
+   }
+   ```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `swift test --filter PopoverMenuFeatureFlagTests`
+Expected: PASS（2 测试）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Sources/CodexBar/SettingsStoreState.swift Sources/CodexBar/SettingsStore.swift Sources/CodexBar/SettingsStore+Defaults.swift Tests/CodexBarTests/PopoverMenuFeatureFlagTests.swift
+git commit -m "feat(menu): add usePopoverMenu feature flag (default off)"
+```
+
+### Task 0.2：新增 `MenuViewModel`（@Observable 面板状态）
+
+**Files:**
+- Create: `Sources/CodexBar/Popover/MenuViewModel.swift`
+- Test: `Tests/CodexBarTests/MenuViewModelTests.swift`
+
+- [ ] **Step 1: 写失败测试**
+
+```swift
+import Testing
+@testable import CodexBar
+
+@MainActor @Suite struct MenuViewModelTests {
+    @Test func defaultsToFirstProviderNotVisible() {
+        let vm = MenuViewModel()
+        #expect(vm.isVisible == false)
+        #expect(vm.selection == .overview || vm.providers.isEmpty)
+    }
+
+    @Test func selectingProviderBumpsContentVersionWithoutRebuildFlag() {
+        let vm = MenuViewModel()
+        vm.providers = [.codex, .claude]
+        let v0 = vm.contentVersion
+        vm.select(.provider(.claude))
+        #expect(vm.selection == .provider(.claude))
+        #expect(vm.contentVersion == v0 + 1)
+    }
+
+    @Test func markVisibleTogglesState() {
+        let vm = MenuViewModel()
+        vm.setVisible(true)
+        #expect(vm.isVisible == true)
+        vm.setVisible(false)
+        #expect(vm.isVisible == false)
+    }
+}
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `swift test --filter MenuViewModelTests`
+Expected: FAIL（`MenuViewModel` 未定义）
+
+- [ ] **Step 3: 实现 MenuViewModel**
+
+```swift
+import Observation
+import CodexBarCore
+
+/// 面板内容的单一可观察状态源。替代旧架构中以 ObjectIdentifier(NSMenu) 为 key 的
+/// openMenus/menuVersions/highlightedMenuItems 等字典追踪（迁移契约 MP-28、MP-18、MP-19）。
+@MainActor
+@Observable
+final class MenuViewModel {
+    /// 切换器选择：Overview 或具体 provider。复用既有 ProviderSwitcherSelection 语义。
+    var selection: ProviderSwitcherSelection = .overview
+    /// 当前可显示的 provider 列表（合并模式切换器用）。
+    var providers: [UsageProvider] = []
+    /// 内容版本号，数据/选择变化时自增，供 SwiftUI 视图 .id()/diff 参考（替代 menuContentVersion）。
+    private(set) var contentVersion: Int = 0
+    /// popover 是否可见（替代 openMenus 字典；图标动画据此冻结，见 MP-23）。
+    private(set) var isVisible: Bool = false
+    /// 当前高亮项 id（集中式高亮，替代 highlightedMenuItems 字典，见 MP-18）。
+    var highlightedItemID: String?
+
+    init() {}
+
+    func select(_ newSelection: ProviderSwitcherSelection) {
+        guard newSelection != self.selection else { return }
+        self.selection = newSelection
+        self.contentVersion &+= 1
+    }
+
+    func bumpContentVersion() { self.contentVersion &+= 1 }
+
+    func setVisible(_ visible: Bool) { self.isVisible = visible }
+}
+```
+
+> 注：若 `ProviderSwitcherSelection` 不是 `Equatable`，本任务内为其补 `Equatable` 一致性（它已是带 `.overview`/`.provider(UsageProvider)` 的枚举，编译器可自动合成）。验证其定义位置后再决定是否需要显式声明。
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `swift test --filter MenuViewModelTests`
+Expected: PASS（3 测试）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Sources/CodexBar/Popover/MenuViewModel.swift Tests/CodexBarTests/MenuViewModelTests.swift
+git commit -m "feat(menu): add @Observable MenuViewModel for popover state"
+```
+
+### Task 0.3：`PopoverMenuController` 骨架（开关关时 no-op）
+
+**Files:**
+- Create: `Sources/CodexBar/Popover/PopoverMenuController.swift`
+- Create: `Sources/CodexBar/Popover/PopoverRootView.swift`（阶段 0 占位最小视图，阶段 1 扩展）
+- Test: `Tests/CodexBarTests/PopoverMenuControllerTests.swift`
+
+- [ ] **Step 1: 写失败测试**（控制器构造 + 显隐切换不崩，且与 view model 同步）
+
+```swift
+import Testing
+import AppKit
+@testable import CodexBar
+
+@MainActor @Suite struct PopoverMenuControllerTests {
+    @Test func showAndCloseUpdatesViewModelVisibility() {
+        let vm = MenuViewModel()
+        let button = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength).button!
+        let controller = PopoverMenuController(viewModel: vm, contentView: { EmptyContentProbe() })
+        controller.show(relativeTo: button)
+        #expect(vm.isVisible == true)
+        controller.close()
+        #expect(vm.isVisible == false)
+    }
+}
+
+// 测试探针视图，避免依赖真实内容
+import SwiftUI
+private struct EmptyContentProbe: View { var body: some View { Color.clear.frame(width: 1, height: 1) } }
+```
+
+- [ ] **Step 2: 运行确认失败**
+
+Run: `swift test --filter PopoverMenuControllerTests`
+Expected: FAIL（`PopoverMenuController` 未定义）
+
+- [ ] **Step 3: 实现 PopoverMenuController 骨架**
+
+```swift
+import AppKit
+import SwiftUI
+
+/// 用 NSPopover(.transient) 承载持久 SwiftUI 根视图，替代 statusItem.menu。
+/// 阶段 0 仅实现显隐 + view model 可见性同步；键盘/dismiss 监听在阶段 1 加入。
+@MainActor
+final class PopoverMenuController<Content: View> {
+    private let viewModel: MenuViewModel
+    private let popover: NSPopover
+    private let hostingController: NSHostingController<Content>
+
+    init(viewModel: MenuViewModel, contentView: () -> Content) {
+        self.viewModel = viewModel
+        let hosting = NSHostingController(rootView: contentView())
+        self.hostingController = hosting
+        let popover = NSPopover()
+        popover.behavior = .transient
+        popover.animates = false
+        popover.contentViewController = hosting
+        self.popover = popover
+    }
+
+    var isShown: Bool { self.popover.isShown }
+
+    func show(relativeTo button: NSStatusBarButton) {
+        guard !self.popover.isShown else { return }
+        self.viewModel.setVisible(true)
+        self.popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        self.popover.contentViewController?.view.window?.makeKey()
+    }
+
+    func close() {
+        self.popover.performClose(nil)
+        self.viewModel.setVisible(false)
+    }
+
+    func toggle(relativeTo button: NSStatusBarButton) {
+        if self.popover.isShown { self.close() } else { self.show(relativeTo: button) }
+    }
+}
+```
+
+`PopoverRootView.swift`（阶段 0 占位）：
+
+```swift
+import SwiftUI
+
+/// 持久面板根视图。阶段 0 占位；阶段 1 接入切换器 + 单卡片。
+struct PopoverRootView: View {
+    @Bindable var viewModel: MenuViewModel
+    var body: some View {
+        Color.clear.frame(width: 310, height: 1)
+    }
+}
+```
+
+- [ ] **Step 4: 运行确认通过**
+
+Run: `swift test --filter PopoverMenuControllerTests`
+Expected: PASS
+
+> 若 swift-testing 在无 GUI 环境创建 NSPopover/NSWindow 受限，则改为断言 `controller.isShown` 状态机而非真实窗口；必要时给 controller 注入一个可 mock 的 presenter 协议（记录 show/close 调用）。优先真实路径，受限再降级。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add Sources/CodexBar/Popover/PopoverMenuController.swift Sources/CodexBar/Popover/PopoverRootView.swift Tests/CodexBarTests/PopoverMenuControllerTests.swift
+git commit -m "feat(menu): add PopoverMenuController + PopoverRootView skeleton (inactive)"
+```
+
+### Task 0.4：在 StatusItemController 持有 controller（开关关时不激活）
+
+**Files:**
+- Modify: `Sources/CodexBar/StatusItemController.swift`（加 `var popoverMenuController` 惰性属性 + `usePopoverMenu` 便捷读取）
+
+- [ ] **Step 1: 写失败测试**（开关关时 `mergedMenu` 仍被 attach、popover 不创建）
+
+```swift
+// 追加到 PopoverMenuFeatureFlagTests.swift
+@MainActor
+@Test func attachUsesNSMenuWhenFlagOff() {
+    // 复用现有测试构造 StatusItemController 的 helper（见 StatusItemControllerSplitLifecycleTests）
+    // 断言：settings.usePopoverMenu == false 时，attachMenus 后 statusItem.menu !== nil
+}
+```
+
+> 实现前先读 `StatusItemControllerSplitLifecycleTests.swift` 与 `StatusMenuTests.swift`，复用它们构造 `StatusItemController` 的既有 helper（factory/mock store），不要新发明构造方式。
+
+- [ ] **Step 2: 运行确认失败** — `swift test --filter PopoverMenuFeatureFlagTests`，Expected: FAIL
+
+- [ ] **Step 3: 加属性与开关读取**
+
+在 `StatusItemController.swift` 属性区（约 144 行附近，monitor 字段旁）加：
+
+```swift
+var popoverMenuController: PopoverMenuController<PopoverRootView>?
+let menuViewModel = MenuViewModel()
+
+var usePopoverMenu: Bool { self.settings.usePopoverMenu }
+```
+
+> 本任务**不**改 attach 逻辑（保持开关关行为不变）；仅引入持有点，证明编译与现有测试不回归。
+
+- [ ] **Step 4: 运行确认通过** — `swift test`（全量），Expected: 现有测试全 PASS（无回归）
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add -A && git commit -m "feat(menu): hold PopoverMenuController in StatusItemController (gated, inactive)"
+```
+
+### Task 0.5：阶段 0 验收
+
+- [ ] 运行 `swift build` → 成功
+- [ ] 运行 `swift test` → 全绿（无回归）
+- [ ] `Scripts/lint.sh lint` → 通过
+- [ ] 人工确认：`usePopoverMenu` 默认关，App 行为与重构前一致
+
+---
+
+## 阶段 1：popover 骨架 + 架构验证
+
+> 目标：开关开时，点击状态项弹出 **NSPopover**，渲染 **provider 切换器 + 当前 provider 的单张用量卡片**，切换 provider = 改 `MenuViewModel.select(...)`（SwiftUI 增量更新，**不重建**）。dismiss（transient/Esc）+ 键盘快捷键（Cmd+R/,/Q、←→、Cmd+1..9）。**采样确认主线程不再有重建/测高突发**。这是架构正确性的最小可验证证明。
+
+### Task 1.1：点击状态项 → 弹出 popover（开关开）
+
+**Files:**
+- Modify: `Sources/CodexBar/StatusItemController.swift`（attach 路径按开关分流：开关开时不设 `statusItem.menu`，改设 button.action → toggle popover）
+- Modify: `Sources/CodexBar/StatusItemController+Actions.swift`（`openMenuFromShortcut` 分流）
+- Test: `Tests/CodexBarTests/PopoverMenuControllerTests.swift`（追加：开关开时点击切换 popover 显隐）
+
+- [ ] **Step 1: 写失败测试**
+
+```swift
+@MainActor
+@Test func buttonClickTogglesPopoverWhenFlagOn() {
+    // 构造 settings.usePopoverMenu = true 的 controller（复用既有 helper）
+    // 模拟 statusItem.button 点击 → 期望 menuViewModel.isVisible 翻转
+    // 再次点击 → 关闭
+}
+```
+
+- [ ] **Step 2: 运行确认失败** — Expected: FAIL
+
+- [ ] **Step 3: 实现 attach 分流 + 点击 target/action**
+
+在 `attachMenus`（StatusItemController.swift:795-824）开关开分支：
+```swift
+if self.usePopoverMenu {
+    self.statusItem.menu = nil
+    if self.popoverMenuController == nil {
+        self.menuViewModel.providers = self.store.enabledProvidersForDisplay()
+        self.popoverMenuController = PopoverMenuController(viewModel: self.menuViewModel) {
+            PopoverRootView(viewModel: self.menuViewModel)
+        }
+    }
+    self.statusItem.button?.target = self
+    self.statusItem.button?.action = #selector(self.handleStatusItemClick(_:))
+    return
+}
+// ...既有 NSMenu 赋值逻辑保持不变...
+```
+
+加方法（建议放 `StatusItemController+Actions.swift`）：
+```swift
+@objc func handleStatusItemClick(_ sender: Any?) {
+    guard self.usePopoverMenu, let button = self.statusItem.button else { return }
+    self.menuViewModel.providers = self.store.enabledProvidersForDisplay()
+    self.popoverMenuController?.toggle(relativeTo: button)
+}
+```
+
+`openMenuFromShortcut`（+Actions.swift:271-285）开关开分支：直接 `popoverMenuController?.show(relativeTo: button)` 而非 `performClick`。
+
+- [ ] **Step 4: 运行确认通过** — `swift test --filter PopoverMenuControllerTests`，Expected: PASS
+
+- [ ] **Step 5: 提交** — `git commit -m "feat(menu): open NSPopover on status item click when flag on"`
+
+### Task 1.2：切换器 + 单卡片渲染（持久视图，切换走增量更新）
+
+**Files:**
+- Modify: `Sources/CodexBar/Popover/PopoverRootView.swift`（接入 ProviderSwitcher + 单 provider 用量卡片）
+- Test: `Tests/CodexBarTests/MenuViewModelTests.swift`（追加：选择切换驱动 selection，不触发任何"重建"副作用）
+
+- [ ] **Step 1: 写失败测试**（view model 选择切换的语义；视图本身用 SwiftUI 预览/快照在阶段 6 补充 a11y/渲染测试）
+
+```swift
+@MainActor
+@Test func switchingProviderUpdatesSelectionInPlace() {
+    let vm = MenuViewModel()
+    vm.providers = [.codex, .claude]
+    vm.select(.provider(.codex))
+    let v1 = vm.contentVersion
+    vm.select(.provider(.claude))
+    #expect(vm.selection == .provider(.claude))
+    #expect(vm.contentVersion == v1 + 1)   // 仅 +1，证明是单次增量而非多次重建
+}
+```
+
+- [ ] **Step 2: 运行确认失败** — Expected: FAIL（若 select 语义不符）或先 PASS（model 已就绪）→ 则本步重点在视图接线，测试作回归护栏
+
+- [ ] **Step 3: 实现 PopoverRootView 渲染**
+
+```swift
+import SwiftUI
+import CodexBarCore
+
+struct PopoverRootView: View {
+    @Bindable var viewModel: MenuViewModel
+    let store: UsageStore            // 注入既有 store，复用现成卡片视图
+    let settings: SettingsStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if viewModel.providers.count > 1 {
+                ProviderSwitcherView(/* 复用既有切换器视图，selection 绑定 viewModel.selection */)
+                Divider()
+            }
+            content
+        }
+        .frame(width: 310)
+        .fixedSize(horizontal: false, vertical: true)
+        .accessibilityElement(children: .contain)
+        .accessibilityAddTraits(.isModal)
+    }
+
+    @ViewBuilder private var content: some View {
+        switch viewModel.selection {
+        case .overview:
+            // 阶段 2 补全 Overview；阶段 1 暂展示首个 provider 卡片
+            providerCard(for: viewModel.providers.first ?? .codex)
+        case let .provider(p):
+            providerCard(for: p)
+        }
+    }
+
+    @ViewBuilder private func providerCard(for provider: UsageProvider) -> some View {
+        if let snapshot = store.snapshot(for: provider) {
+            UsageMenuCardView(/* 复用既有卡片视图 + 既有 model 构造 */)
+        } else {
+            Text("Loading…").foregroundStyle(.secondary).padding()
+        }
+    }
+}
+```
+
+> 关键：`PopoverRootView` 持有 `store`/`settings`（@Observable），SwiftUI 自动订阅其变化；切 provider 仅改 `viewModel.selection`，无 NSMenuItem 拆建、无手动测高。`UsageMenuCardView` / `ProviderSwitcherView` **复用现有视图**，不重写——它们已是 SwiftUI。构造参数照现有 `makeMenuCardItem`/`makeProviderSwitcherItem` 的调用方式（实现时读取并对齐）。
+
+`PopoverMenuController` 与 `attachMenus` 构造处补传 `store`/`settings`。
+
+- [ ] **Step 4: 运行确认通过** — `swift test`，Expected: 全绿
+
+- [ ] **Step 5: 提交** — `git commit -m "feat(menu): render switcher + provider card in persistent popover view"`
+
+### Task 1.3：dismiss（Esc / 点外部 / 选中动作后）
+
+**Files:**
+- Modify: `Sources/CodexBar/Popover/PopoverMenuController.swift`（`.transient` 已含点外部关闭；加 Esc local monitor + 暴露 dismiss 给动作回调）
+- Test: 追加 `PopoverMenuControllerTests`
+
+- [ ] **Step 1: 写失败测试**（Esc 触发 close；动作回调触发 close）
+
+```swift
+@MainActor
+@Test func escapeKeyClosesPopover() {
+    let vm = MenuViewModel()
+    let controller = PopoverMenuController(viewModel: vm) { EmptyContentProbe() }
+    let button = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength).button!
+    controller.show(relativeTo: button)
+    controller.handleKeyDownForTesting(keyCode: 53) // Esc
+    #expect(vm.isVisible == false)
+}
+```
+
+- [ ] **Step 2: 运行确认失败** — Expected: FAIL
+
+- [ ] **Step 3: 实现键盘 monitor**
+
+在 controller 中，`show` 时安装 `NSEvent.addLocalMonitorForEvents(matching: .keyDown)`，`close` 时移除；Esc(53) → close。暴露 `handleKeyDownForTesting(keyCode:)` 内部接缝供测试。
+
+```swift
+private var keyMonitor: Any?
+
+private func installKeyMonitor() {
+    self.keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+        guard let self else { return event }
+        if self.handleKeyDown(keyCode: event.keyCode, modifiers: event.modifierFlags) { return nil }
+        return event
+    }
+}
+private func removeKeyMonitor() {
+    if let m = self.keyMonitor { NSEvent.removeMonitor(m); self.keyMonitor = nil }
+}
+@discardableResult func handleKeyDownForTesting(keyCode: UInt16, modifiers: NSEvent.ModifierFlags = []) -> Bool {
+    self.handleKeyDown(keyCode: keyCode, modifiers: modifiers)
+}
+private func handleKeyDown(keyCode: UInt16, modifiers: NSEvent.ModifierFlags) -> Bool {
+    if keyCode == 53 { self.close(); return true }   // Esc
+    return false   // 其余快捷键在 Task 1.4 接入
+}
+```
+
+`show()` 末尾调 `installKeyMonitor()`；`close()` 开头调 `removeKeyMonitor()`。
+
+- [ ] **Step 4: 运行确认通过** — Expected: PASS
+- [ ] **Step 5: 提交** — `git commit -m "feat(menu): Esc + transient dismissal for popover"`
+
+### Task 1.4：键盘快捷键全保留（Cmd+R/,/Q、←→、Cmd+1..9）
+
+**Files:**
+- Modify: `Sources/CodexBar/Popover/PopoverMenuController.swift`（在 `handleKeyDown` 接入；分发到既有 action 与 provider 导航）
+- Modify: 注入 action 回调（refresh/settings/quit）与 provider 导航闭包（复用 `StatusItemController+ProviderNavigation.swift` 的 `navigateProviderSwitcher`/`providerSelectionIndex` 语义）
+- Test: 追加 `PopoverMenuControllerTests`（每个快捷键各一断言，用 `handleKeyDownForTesting`）
+
+- [ ] **Step 1: 写失败测试**
+
+```swift
+@MainActor @Test func commandRTriggersRefresh() {
+    var refreshed = false
+    let vm = MenuViewModel()
+    let controller = PopoverMenuController(viewModel: vm) { EmptyContentProbe() }
+    controller.onRefresh = { refreshed = true }
+    _ = controller.handleKeyDownForTesting(keyCode: 15, modifiers: .command) // R
+    #expect(refreshed == true)
+}
+@MainActor @Test func rightArrowNavigatesNext() {
+    var moved: ProviderNavigationDirection?
+    let vm = MenuViewModel(); vm.providers = [.codex, .claude]
+    let controller = PopoverMenuController(viewModel: vm) { EmptyContentProbe() }
+    controller.onNavigate = { moved = $0 }
+    _ = controller.handleKeyDownForTesting(keyCode: 124, modifiers: []) // →
+    #expect(moved == .next)
+}
+@MainActor @Test func commandOneSelectsFirstProvider() {
+    var picked: Int?
+    let vm = MenuViewModel(); vm.providers = [.codex, .claude]
+    let controller = PopoverMenuController(viewModel: vm) { EmptyContentProbe() }
+    controller.onSelectIndex = { picked = $0 }
+    _ = controller.handleKeyDownForTesting(keyCode: 18, modifiers: .command) // 1
+    #expect(picked == 0)
+}
+```
+
+- [ ] **Step 2: 运行确认失败** — Expected: FAIL（回调/keyCode 未接入）
+
+- [ ] **Step 3: 实现快捷键分发**
+
+在 controller 加注入回调 `var onRefresh/onSettings/onQuit: (() -> Void)?`、`var onNavigate: ((ProviderNavigationDirection) -> Void)?`、`var onSelectIndex: ((Int) -> Void)?`；在 `handleKeyDown` 内：
+```swift
+if modifiers.contains(.command) {
+    switch keyCode {
+    case 15: self.onRefresh?(); return true            // R
+    case 43: self.onSettings?(); return true           // ,
+    case 12: self.onQuit?(); return true               // Q
+    case 18...26:                                      // 1..9
+        let index = Int(keyCode) - 18
+        self.onSelectIndex?(index); return true
+    default: break
+    }
+}
+switch keyCode {
+case 53: self.close(); return true                     // Esc
+case 123: self.onNavigate?(.previous); return true     // ←
+case 124: self.onNavigate?(.next); return true         // →
+default: return false
+}
+```
+> keyCode 1..9 映射：18,19,20,21,23,22,26,28,25。实现时用映射表精确对应（上面的 `18...26` 仅示意，需替换为正确的离散映射）。`ProviderNavigationDirection` 复用既有类型（确认其定义后对齐 case 名）。
+
+在 `attachMenus` 创建 controller 处接线：
+```swift
+controller.onRefresh = { [weak self] in self?.refreshFromMenu(); self?.popoverMenuController?.close() }
+controller.onSettings = { [weak self] in self?.openSettings(); self?.popoverMenuController?.close() }
+controller.onQuit = { [weak self] in self?.quitFromMenu() }
+controller.onNavigate = { [weak self] dir in self?.navigateProviderSwitcher(dir) }   // 复用既有
+controller.onSelectIndex = { [weak self] i in self?.selectProvider(atIndex: i) }     // 复用既有语义
+```
+> 上述 `refreshFromMenu/openSettings/quitFromMenu/selectProvider(atIndex:)` 对齐既有 action 方法名（实现时从 `StatusItemController+Actions.swift`/`+PersistentMenuActions.swift`/`+ProviderNavigation.swift` 找到真实方法名复用，勿新建）。
+
+- [ ] **Step 4: 运行确认通过** — `swift test --filter PopoverMenuControllerTests`，Expected: PASS
+- [ ] **Step 5: 提交** — `git commit -m "feat(menu): keep Cmd+R/,/Q, arrows, Cmd+1..9 in popover"`
+
+### Task 1.5：架构验证 — 采样确认卡顿消失
+
+**Files:** 无（验证步骤）
+
+- [ ] **Step 1: 构建并以开关开运行**
+
+```bash
+swift build
+defaults write com.steipete.codexbar usePopoverMenu -bool true
+Scripts/compile_and_run.sh
+```
+
+- [ ] **Step 2: 采样**（用户侧执行，回放 `[[menu-perf-investigation-method]]` 的脚本）
+
+让用户运行 `bash /tmp/cb_profile.sh` 并在 15s 内反复打开 popover + 切 provider。
+
+- [ ] **Step 3: 判定**
+
+Expected:
+- 主线程**不再出现** `populateMenu`/`rebuildMenuContent`/`makeMenuCardItem`/`measuredHeight`/`hostedSubviewFittingHeight` 的工作帧（切换走 SwiftUI 增量更新）。
+- 切 provider 的主线程突发显著下降（与开关关时对比）。
+- 若仍有可观测卡顿 → 回到 systematic-debugging Phase 1，定位是否 store 频繁触发整树重渲（用 `.equatable()`/拆分 @Observable 子模型缓解）。
+
+- [ ] **Step 4: 记录对比数据到** `docs/refactor/menu-popover-migration-contract.md` 的"验证记录"小节。
+
+- [ ] **Step 5: 提交**（若有文档更新）— `git commit -m "docs(menu): record popover phase-1 perf verification"`
+
+### Task 1.6：阶段 1 验收
+
+- [ ] `swift build` 成功；`swift test` 全绿；lint 通过
+- [ ] 开关关：行为与重构前一致（NSMenu 路径未受影响）
+- [ ] 开关开：弹出 popover、切换器/单卡片可用、切换增量更新、Esc/点外部/快捷键全部工作
+- [ ] 采样证明主线程重建/测高突发消失
+- [ ] 已知缺口（留待阶段 2+）：完整卡片分段、Overview、账户切换器、图表下钻、非合并模式、悬停高亮、无障碍树、动画解耦——均在路线图中
+
+---
+
+## 自检（Self-Review）
+
+- **Spec 覆盖**：阶段 0/1 覆盖了迁移契约的 MP-01/02（状态项保留）、MP-15/16（快捷键）、MP-19（dismiss）、MP-23（可见性信号基础）、MP-28（contentVersion）、测试接缝（contentVersion/isVisible/highlightedItemID/handleKeyDownForTesting）。MP-10/11/12/14/17/18/20-22/24-27/29 明确标注留待阶段 2–6，并列入路线图，无静默遗漏。
+- **占位符扫描**：所有"实现时对齐既有方法名/类型"处均给出了**确切的参考文件与现成范例**（usageBarsShowUsed、navigateProviderSwitcher、UsageMenuCardView 等），非 TODO。keyCode 1..9 离散映射已标注需替换示意值为精确表。
+- **类型一致性**：`MenuViewModel.select(_:)`/`contentVersion`/`isVisible`/`setVisible(_:)`、`PopoverMenuController.show/close/toggle/handleKeyDownForTesting`、回调 `onRefresh/onSettings/onQuit/onNavigate/onSelectIndex` 在各 Task 间命名一致。
+- **风险对齐**：Critical「快捷键/事件拦截」在 Task 1.3/1.4 以 local monitor 优先验证；Critical「无障碍」明确排期阶段 6 并在契约中标注；High「性能回归」在 Task 1.5 设采样判定 + 缓解预案。

--- a/docs/superpowers/plans/2026-06-10-menu-popover-phase2.md
+++ b/docs/superpowers/plans/2026-06-10-menu-popover-phase2.md
@@ -1,0 +1,107 @@
+# 菜单 Popover 重构阶段 2：合并模式内容全量对齐 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 popover（`usePopoverMenu` 开时的合并模式菜单）的内容补全到与 NSMenu 等价：底部动作区、完整卡片分流（Codex/Token 堆叠、Kilo 多 scope、Storage、Buy Credits）、账户切换器、Overview 模式、切换器图标、selection 持久化。
+
+**Architecture:** 延续阶段 1：持久 `PopoverRootView` + `@Observable MenuViewModel`。**数据/决策留在 StatusItemController（复用 `MenuDescriptor.build`、`menuCardModel`、`*AccountMenuDisplay`），以闭包注入；PopoverRootView 只做纯渲染**。动作分发用新的 `performMenuAction(_:)`（switch 调既有 @objc 方法），替代 NSMenuItem selector。
+
+**Tech Stack:** 同阶段 1（SwiftUI/Observation/swift-testing；全程 `usePopoverMenu` 开关隔离）。
+
+**前置事实（已核实，file:line）：**
+- `MenuDescriptor`：`Section{entries:[Entry]}`，`Entry = text(String,TextStyle)|action(String,MenuAction)|submenu(String,String?,[SubmenuItem])|divider`；`MenuAction` 16 case（MenuDescriptor.swift:5-52）；`build(provider:store:settings:account:managedCodexAccountCoordinator:codexAccountPromotionCoordinator:updateReady:includeContextualActions:)`（74-134）。
+- selector 映射：StatusItemController+MenuActionMapping.swift:4-24（`selector(for:) -> (Selector, Any?)`）。
+- 账户 display：`TokenAccountMenuDisplay{provider,accounts,snapshots,activeIndex,layout}`、`CodexAccountMenuDisplay{accounts,snapshots,activeVisibleAccountID,layout}`，`showAll == .stacked`、`showSwitcher == .segmented`（+MenuTypes.swift:67-170）。来源 `tokenAccountMenuDisplay(for:)`/`codexAccountMenuDisplay(for:)`（+AccountMenuDisplay.swift:5-53）。
+- NSView 切换器 onSelect：Codex `(CodexVisibleAccount) -> Void`（+SwitcherViews.swift:1262），Token `(Int) -> Task<Void,Never>?`（1121）。
+- 卡片分流参考：`addMenuCards`（+Menu.swift:645-709）、`addStackedCodexMenuCards`（+CodexStackedMenu.swift:4-61，含 workspace 分组+health）、Kilo `store.kiloScopeSnapshots`（UsageStore+KiloOrgRefresh.swift:4-17）。
+- Storage：`store.storageFootprintText(for:)` 非 nil 时显示 `StorageMenuCardSectionView(storageText:topPadding:bottomPadding:width:)`（SwiftUI，StorageBreakdownMenuView.swift:5-24）。
+- Buy Credits：`context.openAIContext.canShowBuyCredits` 时显示，动作 `openCreditsPurchase`（+Menu.swift:1422-1434）。
+- Overview：`OverviewMenuCardRowView(model:storageText:width:)`（SwiftUI，+MenuTypes.swift:16-58）；行数据构造见 `addOverviewRows`（+Menu.swift:583-629）；空态文案 632-643；tab 出现条件 `includesOverviewTab`（1146-1150）；持久化 `settings.mergedMenuLastSelectedWasOverview`/`selectedMenuProvider`。
+- 切换器图标：`switcherIcon(for:)`（+Menu.swift:1362-1420，NSImage）；Overview 图标 `square.grid.2x2`；`settings.switcherShowsIcons`。
+
+---
+
+## 任务总览（顺序执行，每个 TDD + 全量回归 + 提交）
+
+| # | 任务 | 新文件 |
+|---|---|---|
+| 2.1 | 动作分发 `performMenuAction` + 底部动作区视图 | `Popover/PopoverActionSectionsView.swift`、`StatusItemController+Popover` 扩展 |
+| 2.2 | 卡片计划 `PopoverCardPlan` + 完整卡片分流渲染 | `Popover/PopoverCardPlan.swift` |
+| 2.3 | SwiftUI 账户切换器（Codex/Token segmented） | `Popover/PopoverAccountSwitcherView.swift` |
+| 2.4 | Overview 模式（行复用 + 点击切换 + 空态） | （改 PopoverRootView/+Popover） |
+| 2.5 | 切换器升级：provider 图标 + Overview tab | （改 PopoverRootView） |
+| 2.6 | selection 持久化 + 阶段验收（dev build + 人工验证） | （改 MenuViewModel 接线） |
+
+### Task 2.1 动作分发与底部动作区
+
+**Files:** Create `Sources/CodexBar/Popover/PopoverActionSectionsView.swift`；Modify `StatusItemController+Popover.swift`；Test `Tests/CodexBarTests/PopoverActionDispatchTests.swift`
+
+1. `StatusItemController+Popover.swift` 加 `func performMenuAction(_ action: MenuDescriptor.MenuAction)`：复用 `selector(for:)` 的映射语义，但直接 switch 调方法（refresh→`refreshNow()`、settings→`showSettingsGeneral()`、quit→`quit()`、dashboard→`openDashboard()`、statusPage/changelog/installUpdate/copyError/openTerminal/loginToProvider/switchAccount/addProviderAccount/addCodexAccount/requestCodexSystemPromotion 同理——带参 case 用现有 @objc 方法所需的 representedObject 语义改为直接传参调用；若个别 @objc 方法只接受 NSMenuItem sender，则在扩展里新增直调重载或构造临时 NSMenuItem 设 representedObject 后 perform，以现有方法实现为准）。执行后除 quit 外关闭 popover。
+2. `PopoverActionSectionsView(sections: [MenuDescriptor.Section], onAction: (MenuDescriptor.MenuAction) -> Void)`：ForEach sections（section 间 Divider）；entry 渲染：`.text`→按 TextStyle 的 disabled Text；`.action`→Button（label + 右对齐快捷键标签 ⌘R/⌘,/⌘Q，复用 shortcut(for:) 的映射写死三条）；`.submenu`→SwiftUI `Menu`（item disabled/checked 状态保留）；`.divider`→Divider。
+3. `PopoverRootView` 末尾接入：注入 `makeSections: () -> [MenuDescriptor.Section]`（controller 里 `MenuDescriptor.build(...)` 同 populateMenu 的参数）与 `onAction`。
+4. 测试：`performMenuAction` 关键 case 触发对应行为（用可注入回调/状态断言，避免真打开 URL——必要时只测安全 case：refresh/settings/quit 的分发 + popover close 行为）；View 层不做渲染快照测试。
+
+### Task 2.2 卡片计划与完整分流
+
+**Files:** Create `Sources/CodexBar/Popover/PopoverCardPlan.swift`；Modify `StatusItemController+Popover.swift`、`PopoverRootView.swift`；Test `Tests/CodexBarTests/PopoverCardPlanTests.swift`
+
+1. ```swift
+   struct PopoverCardPlan {
+       struct Card: Identifiable { let id: String; let model: UsageMenuCardView.Model; let workspaceHeader: String? }
+       var cards: [Card]
+       var storageText: String?
+       var showBuyCredits: Bool
+       var emptyText: String?
+   }
+   ```
+2. `StatusItemController+Popover.swift` 加 `func popoverCardPlan(for provider: UsageProvider) -> PopoverCardPlan`：复刻 `addMenuCards` 分流（+Menu.swift:645-709 与 +CodexStackedMenu.swift）：Codex showAll→按 workspaceSections 展开（header 进 `workspaceHeader`），Token showAll→snapshots compactMap，Kilo 多 scope→kiloScopeSnapshots compactMap，否则单 `menuCardModel(for:)`；storageText=`store.storageFootprintText(for:)`；showBuyCredits 按 openAIWebContext 的 canShowBuyCredits（复用 populateMenu 中 openAIContext 构造，简化为单 provider 场景）。
+3. `PopoverRootView.card(for:)` 改为消费 plan：ForEach cards（含可选 workspace header 灰字、卡片间 Divider）→ Storage 段（StorageMenuCardSectionView）→ Buy Credits Button（plus.circle 图标，onAction(.buyCredits) 或直调注入闭包）。注入签名改 `makeCardPlan: (UsageProvider) -> PopoverCardPlan`。
+4. 测试：构造假 display/snapshot 数据不易（依赖 store），改为**对 plan 结构本身**与"单卡片回退/空态"路径做窄测试；堆叠路径以现有 NSMenu 测试（同一 menuCardModel 数据源）背书 + Task 2.6 人工验证。
+
+### Task 2.3 SwiftUI 账户切换器
+
+**Files:** Create `Sources/CodexBar/Popover/PopoverAccountSwitcherView.swift`；Modify `PopoverRootView.swift`、`StatusItemController+Popover.swift`；Test `Tests/CodexBarTests/PopoverAccountSwitcherTests.swift`
+
+1. 通用 segmented 视图：
+   ```swift
+   struct PopoverAccountSwitcherView: View {
+       struct Segment: Identifiable, Equatable { let id: String; let title: String; let isSelected: Bool }
+       let segments: [Segment]
+       let onSelect: (String) -> Void   // segment id
+   }
+   ```
+   视觉对齐 Phase 1 provider 切换器（选中 accent 背景，>3 个自动换行用 LazyVGrid 或 wrap HStack）。
+2. controller 提供 `popoverAccountSwitcherSegments(for provider:) -> (segments: [Segment], onSelect: (String) -> Void)?`：Codex 用 `codexAccountMenuDisplay(for:)`（showSwitcher 时，id=account.id，选中= activeVisibleAccountID，onSelect 调用现有 Codex 选择处理——参考 addCodexAccountSwitcherIfNeeded 注入的闭包实现）；Token 用 `tokenAccountMenuDisplay(for:)`（id=index 字符串，onSelect 调现有 token 选择逻辑，注意其返回 `Task<Void,Never>?` 直接丢弃句柄）。
+3. PopoverRootView 在切换器 Divider 与内容区之间条件渲染。
+4. 测试：Segment 构造纯函数（给定 display→segments 选中态正确）+ onSelect 回调触发。
+
+### Task 2.4 Overview 模式
+
+**Files:** Modify `PopoverRootView.swift`、`StatusItemController+Popover.swift`；Test `Tests/CodexBarTests/PopoverOverviewTests.swift`
+
+1. controller 加 `popoverOverviewRows() -> [PopoverOverviewRow]`，`struct PopoverOverviewRow: Identifiable { let provider: UsageProvider; let model: UsageMenuCardView.Model; let storageText: String? }`——复刻 addOverviewRows 的数据构造（resolvedMergedOverviewProviders + menuCardModel + storageFootprintText）。
+2. PopoverRootView `.overview` 分支：rows 为空→`Text(L("No providers selected for Overview."))` 风格空态（文案与 NSMenu 一致，+Menu.swift:632-643）；否则 ForEach → `OverviewMenuCardRowView(model:storageText:width:)`（直接复用 SwiftUI 视图）包 Button/onTapGesture → `viewModel.select(.provider(row.provider))`，行间 Divider。
+3. 测试：rows 构造的空态/非空逻辑；点击行后 `viewModel.selection` 切换。
+
+### Task 2.5 切换器升级（图标 + Overview tab）
+
+**Files:** Modify `PopoverRootView.swift`、`StatusItemController+Popover.swift`；Test 复用 MenuViewModelTests
+
+1. `MenuViewModel` 加 `var includesOverview: Bool = false`（attach/click 时由 controller 用 `includesOverviewTab` 等价逻辑刷新；navigationStops 改为 includesOverview ? [.overview]+providers : providers）。
+2. 切换器渲染：includesOverview 时首位加 Overview tab（`Image(systemName: "square.grid.2x2")`）；provider tab 按 `settings.switcherShowsIcons` 显示图标（注入 `switcherIcon: (UsageProvider) -> NSImage?`，用 `Image(nsImage:)`）+ 文字；选中态样式不变。
+3. 测试：navigationStops 含/不含 overview 的循环导航。
+
+### Task 2.6 selection 持久化 + 阶段验收
+
+**Files:** Modify `StatusItemController+Popover.swift`（wire）、`Popover/MenuViewModel.swift`（onSelectionChanged 回调）；Test 更新 MenuViewModelTests
+
+1. `MenuViewModel` 加 `var onSelectionChanged: ((ProviderSwitcherSelection) -> Void)?`，`select(_:)` 末尾调用。controller wiring：`.overview`→`settings.mergedMenuLastSelectedWasOverview = true`；`.provider(p)`→`settings.selectedMenuProvider = p`（写法对齐现有 onSelect，见 +Menu.swift:1033-1055）+ `mergedMenuLastSelectedWasOverview = false`。
+2. 打开 popover（handleStatusItemClick/openMenuFromShortcut）时恢复：用 `resolvedSwitcherSelection(enabledProviders:includesOverview:)` 等价逻辑设置 `viewModel.selection` 初值。
+3. 验收：`swift build`、全量 `swift test`、`Scripts/lint.sh lint` 全过；`CODEXBAR_SKIP_WIDGET=1 bash Scripts/compile_and_run.sh` 重建 dev build → 人工验证（完整动作区/账户切换/堆叠/Overview/持久化）+ 复跑 `/tmp/cb_verify_popover.sh` 确认重建帧仍为 0。
+
+---
+
+## 自检
+- 覆盖迁移契约 MP-10/11(卡片分流/分段——分段在 UsageMenuCardView 内已有)/14 部分(Overview 行)/17(动作区)/28 部分(持久化)；图表下钻(MP-12/13)留阶段 3，明确不在本计划。
+- 所有"复刻/对齐现有逻辑"处均给出了精确参考 file:line；动作分发的带参 case 标注了两种实现策略由实现者按真实方法签名选择。
+- 类型一致：`PopoverCardPlan.Card`、`PopoverOverviewRow`、`PopoverAccountSwitcherView.Segment`、`performMenuAction(_:)`、`makeCardPlan`/`makeSections`/`onAction` 注入命名全计划统一。

--- a/docs/superpowers/plans/2026-06-10-menu-popover-phase3.md
+++ b/docs/superpowers/plans/2026-06-10-menu-popover-phase3.md
@@ -1,0 +1,51 @@
+# 菜单 Popover 重构阶段 3：图表二级级联 popover 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development。
+
+**Goal:** popover 菜单补全 6 类图表下钻（usage breakdown / credits history / cost history / plan utilization(usage history) / storage breakdown / Zai hourly），以**二级 popover 从入口侧边级联弹出**复刻 NSMenu 子菜单观感；懒加载、provider 切换自动收起。
+
+**Architecture:** 6 类图表视图全是纯 SwiftUI（直接复用）。controller 提供"图表入口清单 + 视图工厂"（数据/条件判定复用 NSMenu 同源逻辑）；PopoverRootView 用 `@State presentedChart: PopoverChartKind?` + `.popover(item:arrowEdge:.trailing)` 侧弹。入口呈现为"下钻行"（标题 + chevron，对齐 NSMenu 独立行样式）；与 NSMenu"hover 段级联"的差异（点击行弹出）在最终界面对比时确认。
+
+**前置事实（已核实）：**
+- 视图构造：`UsageBreakdownChartMenuView(breakdown:width:)`（数据 `store.openAIDashboard?.usageBreakdown`）；`CreditsHistoryChartMenuView(breakdown:width:)`（`store.openAIDashboard?.dailyBreakdown`）；`CostHistoryChartMenuView(provider:daily:totalCostUSD:currencyCode:historyDays:windowLabel:width:)`（`tokenSnapshotForCostHistorySubmenu(provider)`，构造参数取法见 +HostedSubmenus.swift:234-252）；`PlanUtilizationHistoryChartMenuView(provider:histories:snapshot:width:)`（`store.planUtilizationHistory(for:)` + `store.snapshot(for:)`）；`StorageBreakdownMenuView(footprint:width:maxHeight:)`（`store.storageFootprint(for:)`，maxHeight=`min(620,max(360,floor(visibleHeight*0.72)))` 见 +HostedSubmenus.swift:304-307）；`ZaiHourlyUsageChartMenuView(modelUsage:width:)`（`snapshot.zaiUsage?.modelUsage`）。
+- 入口条件：usage 卡片 submenu 判定 `makeUsageSubmenu`（+Menu.swift:1471-1487）：hasUsageBreakdown→breakdown；openai→API usage(=costHistory)；zai→Zai details（非图表，阶段 3 暂记待办）；credits=`hasCreditsHistory`、cost=`hasCostHistory`（openAIWebContext，+Menu.swift:528-548）；usage history=`store.supportsPlanUtilizationHistory(for:) && !store.shouldHidePlanUtilizationMenuItem(for:)`（+UsageHistoryMenu.swift:36-46）；storage=`store.storageFootprint(for:)?.components` 非空（+Menu.swift:1577-1586）；zai hourly=`.zai && modelUsage != nil`（+ZaiHourlyChartMenu.swift:8-14）。
+- Overview 行 submenu 判定（+OverviewSubmenus.swift:5-29）：openai→costHistory；zai→details；tokenUsage!=nil→costHistory；plan utilization 可用→usageHistory；否则 storage。
+- NSMenu 独立行：Usage History "Subscription Utilization"、Zai "Hourly Usage"（+Menu.swift:791-804）。
+
+## Task 3.1 图表种类 + controller 工厂
+
+**Files:** Create `Sources/CodexBar/Popover/PopoverChartKind.swift`；Modify `StatusItemController+Popover.swift`；Test `Tests/CodexBarTests/PopoverChartTests.swift`
+
+```swift
+enum PopoverChartKind: Identifiable, Equatable {
+    case usageBreakdown
+    case creditsHistory
+    case costHistory(UsageProvider)
+    case usageHistory(UsageProvider)
+    case storageBreakdown(UsageProvider)
+    case zaiHourly(UsageProvider)
+    var id: String { ... }   // 稳定字符串
+    var title: String { ... } // 入口行标题（与 NSMenu 对应 submenu 项标题一致，本地化）
+}
+```
+controller：
+- `popoverChartEntries(for provider:) -> [PopoverChartKind]`：按上面入口条件返回该 provider 卡片下方应显示的下钻入口（usage breakdown / credits / cost / usage history / storage / zai hourly，顺序对齐 NSMenu）。
+- `popoverOverviewChart(for provider:, model:) -> PopoverChartKind?`：Overview 行的下钻（按 +OverviewSubmenus.swift 判定，Zai details 暂返回 nil）。
+- `popoverChartView(for kind:, width:) -> AnyView?`：懒构造对应 SwiftUI 图表（数据取法与 +HostedSubmenus.swift 各 append* 完全一致；数据缺失返回 nil）。
+- 测试：PopoverChartKind id/title 稳定；条件判定可单测部分（依赖重则全量回归+人工兜底）。
+
+## Task 3.2 UI 接入 + 切换收起
+
+**Files:** Modify `Popover/PopoverRootView.swift`、`Popover/PopoverCardPlan.swift`（可选扩展）；Test 更新
+
+- PopoverRootView：`@State private var presentedChart: PopoverChartKind?`；注入 `makeChartEntries: (UsageProvider) -> [PopoverChartKind]`、`makeOverviewChart: (PopoverOverviewRow) -> PopoverChartKind?`、`makeChartView: (PopoverChartKind, CGFloat) -> AnyView?`。
+- 单 provider 内容：卡片之后渲染入口行（每个 entry 一行：`Button { presentedChart = kind } label: { HStack { Text(kind.title); Spacer(); Image(systemName: "chevron.right") } }`，样式对齐动作区行）。
+- Overview 行：行尾 chevron（有 chart 时），点击 `presentedChart = chart`（不触发 provider 切换；行主体点击仍切 provider）。
+- 弹出：在入口行容器上 `.popover(item: $presentedChart, attachmentAnchor: .rect(.bounds), arrowEdge: .trailing) { kind in (makeChartView(kind, 360) ?? AnyView(Text("No data").padding())) }`——宽度与 NSMenu 渲染宽度对齐（≥310）。StorageBreakdown 已内置 maxHeight 滚动。
+- 收起：`.onChange(of: viewModel.selection) { presentedChart = nil }`；popover 关闭（isVisible false）时也置 nil。
+- 测试：presentedChart 状态流转用 MenuViewModel/纯逻辑测试覆盖能测的部分；视觉靠人工。
+
+## Task 3.3 验收
+build/test/lint 全过 → `CODEXBAR_SKIP_WIDGET=1 bash Scripts/compile_and_run.sh` → 人工验证 6 类图表弹出/数据/收起 → 采样复查仍无重建帧。
+
+**已知待办（不在本阶段）：** Zai MCP details 子菜单（非图表）；I2 action disabled 态。

--- a/docs/superpowers/plans/2026-06-10-menu-popover-phase4.md
+++ b/docs/superpowers/plans/2026-06-10-menu-popover-phase4.md
@@ -1,0 +1,564 @@
+# 菜单 Popover 阶段 4：非合并模式 per-provider popover 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 非合并模式（mergeIcons=false）下，每个 enabled provider 的 NSStatusItem 使用独立 popover 替代 NSMenu，保持与合并模式 popover 行为一致，实现 per-provider `PopoverMenuController<PopoverRootView>` + `MenuViewModel`。
+
+**Architecture:** 在 `StatusItemController+Popover.swift` 中提取 `makePopoverController(viewModel:)` 私有 helper 供合并模式和 per-provider 两路复用，消除代码重复；新增 `attachProviderPopovers(fallback:)` 复刻 `attachMenus(fallback:)` 遍历逻辑；`handleProviderStatusItemClick(_:)` 通过恒等比较反查 provider；多面板互斥通过 `closeAllProviderPopovers(except:)` 实现。
+
+**Tech Stack:** Swift 5.9+，SwiftUI，AppKit，NSPopover，`@Observable`，Swift Testing
+
+---
+
+## 文件结构
+
+| 文件 | 改动 |
+|------|------|
+| `Sources/CodexBar/StatusItemController.swift` | 新增 `providerPopoverControllers` / `providerMenuViewModels` 两个字典属性（放在 Popover 属性区） |
+| `Sources/CodexBar/StatusItemController+Popover.swift` | 提取 `makePopoverController(viewModel:)`；新增 `attachProviderPopovers(fallback:)`、`ensureProviderPopover(for:)`、`closeAllProviderPopovers(except:)` |
+| `Sources/CodexBar/StatusItemController+Actions.swift` | 新增 `handleProviderStatusItemClick(_:)`；修改 `openMenuFromShortcut` 非合并分支；`attachMenus(fallback:)` 开头加 popover 分流 |
+| `Sources/CodexBar/Popover/MenuViewModel.swift` | 新增 `static func singleProvider(_ p: UsageProvider) -> MenuViewModel` 便利工厂（供测试） |
+| `Tests/CodexBarTests/PopoverPerProviderTests.swift` | 新建测试文件：singleProvider 工厂语义测试 |
+
+---
+
+## Task 1：在 MenuViewModel 添加 `singleProvider` 便利工厂
+
+**Files:**
+- Modify: `Sources/CodexBar/Popover/MenuViewModel.swift`
+- Test: `Tests/CodexBarTests/PopoverPerProviderTests.swift`（新建）
+
+### 1.1 先写测试
+
+- [ ] **新建测试文件 `Tests/CodexBarTests/PopoverPerProviderTests.swift`**
+
+```swift
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite struct PopoverPerProviderTests {
+    // MARK: - MenuViewModel.singleProvider 工厂
+
+    @Test func singleProviderFactorySetProviders() {
+        let vm = MenuViewModel.singleProvider(.claude)
+        #expect(vm.providers == [.claude])
+    }
+
+    @Test func singleProviderFactoryNoOverview() {
+        let vm = MenuViewModel.singleProvider(.claude)
+        #expect(vm.includesOverview == false)
+    }
+
+    @Test func singleProviderFactorySelectionIsProvider() {
+        let vm = MenuViewModel.singleProvider(.codex)
+        #expect(vm.selection == .provider(.codex))
+    }
+
+    @Test func singleProviderFactoryNoSelectionChangedCallback() {
+        let vm = MenuViewModel.singleProvider(.openai)
+        // 单 provider 不接 onSelectionChanged，不应触发持久化
+        #expect(vm.onSelectionChanged == nil)
+    }
+
+    @Test func singleProviderFactorySelectDoesNotCrash() {
+        let vm = MenuViewModel.singleProvider(.claude)
+        // 调用 select 不应崩溃（onSelectionChanged 为 nil 时）
+        vm.select(.provider(.openai))
+        #expect(vm.selection == .provider(.openai))
+    }
+}
+```
+
+- [ ] **运行测试验证失败**
+
+```bash
+cd /Users/jassy/Documents/glm/codexbar
+swift test --filter PopoverPerProviderTests 2>&1 | tail -20
+```
+
+期望：编译错误（`singleProvider` 尚未存在）。
+
+### 1.2 实现 `singleProvider` 工厂
+
+- [ ] **修改 `MenuViewModel.swift`，在 `init()` 后添加工厂方法**
+
+在 `MenuViewModel.swift` 的 `init() {}` 行后面插入：
+
+```swift
+    /// 单 provider 模式便利工厂：providers=[p]、includesOverview=false、selection=.provider(p)、不设 onSelectionChanged。
+    /// 供非合并模式 per-provider popover 和测试使用。
+    static func singleProvider(_ provider: UsageProvider) -> MenuViewModel {
+        let vm = MenuViewModel()
+        vm.providers = [provider]
+        vm.includesOverview = false
+        // 不调用 select()（避免触发 onSelectionChanged），直接设置 selection
+        vm.selection = .provider(provider)
+        return vm
+    }
+```
+
+- [ ] **运行测试验证通过**
+
+```bash
+swift test --filter PopoverPerProviderTests 2>&1 | tail -20
+```
+
+期望：5 个测试全部 PASS。
+
+- [ ] **提交**
+
+```bash
+git add Sources/CodexBar/Popover/MenuViewModel.swift Tests/CodexBarTests/PopoverPerProviderTests.swift
+git commit -m "feat(popover): add MenuViewModel.singleProvider factory for per-provider mode
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2：在 StatusItemController 添加 per-provider 存储属性
+
+**Files:**
+- Modify: `Sources/CodexBar/StatusItemController.swift`（属性区 Popover 段）
+
+### 2.1 添加两个字典属性
+
+- [ ] **在 `StatusItemController.swift` Popover 属性区添加存储**
+
+找到 `var popoverMenuController: PopoverMenuController<PopoverRootView>?` 那行（约第 148 行），在其后插入：
+
+```swift
+    // per-provider popover（非合并模式；keyed by UsageProvider）
+    var providerPopoverControllers: [UsageProvider: PopoverMenuController<PopoverRootView>] = [:]
+    var providerMenuViewModels: [UsageProvider: MenuViewModel] = [:]
+```
+
+- [ ] **验证编译**
+
+```bash
+swift build 2>&1 | tail -20
+```
+
+期望：build succeeded，0 errors。
+
+- [ ] **提交**
+
+```bash
+git add Sources/CodexBar/StatusItemController.swift
+git commit -m "feat(popover): add providerPopoverControllers/providerMenuViewModels storage for per-provider mode
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3：提取 `makePopoverController(viewModel:)` helper
+
+**Files:**
+- Modify: `Sources/CodexBar/StatusItemController+Popover.swift`
+
+提取目的：`attachMergedPopover()` 中构造 `PopoverMenuController` 的注入闭包有 20+ 行，per-provider 版完全同构（仅 vm 参数化），不提取会造成严重重复。
+
+### 3.1 提取 helper
+
+- [ ] **在 `StatusItemController+Popover.swift` 中，将 `attachMergedPopover()` 中 `PopoverMenuController(viewModel:)` 构造块提取为私有 helper**
+
+在 `performLegacyMenuAction` 前面（`// MARK: - popover 动作分发` 上方）插入：
+
+```swift
+    // MARK: - Popover controller 工厂（合并模式和 per-provider 复用）
+
+    /// 构造一个 PopoverMenuController，注入所有 make* 闭包。
+    /// vm 参数化：不同 controller 的闭包各自捕获自己的 vm，selection 语义自动正确。
+    /// - makeOverviewRows 注入：合并模式传 { self.popoverOverviewRows() }；
+    ///   per-provider 传 { [] }（单 provider 无 overview）。
+    /// - makeOverviewChart 注入：合并模式传真实实现；
+    ///   per-provider 传 { _ in nil }（单 provider 无 overview chart，但 PopoverRootView
+    ///   要求 non-optional 闭包，因此传返回 nil 的 no-op 闭包）。
+    private func makePopoverController(
+        viewModel vm: MenuViewModel,
+        makeOverviewRows: @escaping () -> [PopoverOverviewRow] = { [] },
+        makeOverviewChart: @escaping (PopoverOverviewRow) -> PopoverChartKind? = { _ in nil }
+    ) -> PopoverMenuController<PopoverRootView> {
+        let store = self.store
+        return PopoverMenuController(viewModel: vm) { [weak self] in
+            PopoverRootView(
+                viewModel: vm,
+                store: store,
+                makeCardPlan: { [weak self] provider in
+                    self?.popoverCardPlan(for: provider) ?? PopoverCardPlan()
+                },
+                makeAccountSwitcher: { [weak self] provider in
+                    self?.popoverAccountSwitcherModel(for: provider).map { model in
+                        PopoverRootView.AccountSwitcherBinding(
+                            segments: model.segments,
+                            onSelect: model.onSelect)
+                    }
+                },
+                makeSections: { [weak self] in
+                    guard let self else { return [] }
+                    let isOverview = vm.selection == .overview
+                    let provider: UsageProvider? = {
+                        if isOverview {
+                            let enabled = vm.providers
+                            if enabled.isEmpty { return UsageProvider.codex }
+                            return enabled.first(where: { self.store.isProviderAvailable($0) })
+                                ?? enabled.first
+                        }
+                        if case let .provider(p) = vm.selection { return p }
+                        return vm.providers.first
+                    }()
+                    return MenuDescriptor.build(
+                        provider: provider,
+                        store: store,
+                        settings: self.settings,
+                        account: self.account,
+                        managedCodexAccountCoordinator: self.managedCodexAccountCoordinator,
+                        codexAccountPromotionCoordinator: self.codexAccountPromotionCoordinator,
+                        updateReady: self.updater.updateStatus.isUpdateReady,
+                        includeContextualActions: !isOverview).sections
+                },
+                makeOverviewRows: makeOverviewRows,
+                overviewEmptyText: { [weak self] in
+                    self?.popoverOverviewEmptyText()
+                },
+                onAction: { [weak self] action in self?.performMenuAction(action) },
+                onBuyCredits: { [weak self] in
+                    self?.openCreditsPurchase()
+                    self?.popoverMenuController?.close()
+                },
+                switcherIcon: { [weak self] provider in
+                    (self?.settings.switcherShowsIcons == true)
+                        ? self?.popoverSwitcherIcon(for: provider)
+                        : nil
+                },
+                makeChartEntries: { [weak self] provider in
+                    self?.popoverChartEntries(for: provider) ?? []
+                },
+                makeOverviewChart: makeOverviewChart,
+                makeChartView: { [weak self] kind, width in
+                    self?.popoverChartView(for: kind, width: width)
+                })
+        }
+    }
+```
+
+注意：`makeOverviewChart` 的闭包签名需与 `PopoverRootView` 的对应参数一致。先查一下实际签名：
+
+- [ ] **查看 PopoverRootView 的 makeOverviewChart 参数签名**
+
+```bash
+grep -n "makeOverviewChart" /Users/jassy/Documents/glm/codexbar/Sources/CodexBar/Popover/PopoverRootView.swift | head -5
+```
+
+根据查到的签名调整上面的 `makeOverviewChart` 参数类型。
+
+### 3.2 重构 attachMergedPopover 使用 helper
+
+- [ ] **修改 `attachMergedPopover()`：将其中的 `PopoverMenuController(viewModel: vm) { ... }` 大块替换为调用 `makePopoverController`**
+
+原来 `attachMergedPopover()` 中的构造块（第 25-89 行）替换为：
+
+```swift
+            self.popoverMenuController = self.makePopoverController(
+                viewModel: vm,
+                makeOverviewRows: { [weak self] in self?.popoverOverviewRows() ?? [] },
+                makeOverviewChart: { [weak self] row in
+                    self?.popoverOverviewChart(for: row.provider, model: row.model)
+                })
+```
+
+同时删除原来 `PopoverMenuController(viewModel: vm) { ... }` 整个大闭包块（第 25 行的 `self.popoverMenuController = PopoverMenuController(viewModel: vm) { [weak self] in` 到对应的 `}` 行）。
+
+- [ ] **验证编译**
+
+```bash
+swift build 2>&1 | tail -20
+```
+
+期望：build succeeded，0 errors。
+
+- [ ] **运行全量测试确认没有回归**
+
+```bash
+swift test 2>&1 | tail -30
+```
+
+期望：所有现有测试 PASS。
+
+- [ ] **提交**
+
+```bash
+git add Sources/CodexBar/StatusItemController+Popover.swift
+git commit -m "refactor(popover): extract makePopoverController helper to eliminate merged/per-provider duplication
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4：实现 `ensureProviderPopover(for:)` 和 `attachProviderPopovers(fallback:)`
+
+**Files:**
+- Modify: `Sources/CodexBar/StatusItemController+Popover.swift`
+
+### 4.1 添加 closeAllProviderPopovers 和 ensureProviderPopover
+
+- [ ] **在 `StatusItemController+Popover.swift` 中，在 `// MARK: - popover 动作分发` 前面插入**
+
+```swift
+    // MARK: - Per-provider popover（非合并模式）
+
+    /// 关闭除指定 provider 外的所有 per-provider popover（及合并 popover）。
+    /// NSPopover(.transient) 大多自动关，但点击另一 statusItem 不一定触发 transient 关闭，
+    /// 显式关闭保证互斥。
+    func closeAllProviderPopovers(except provider: UsageProvider? = nil) {
+        for (p, ctrl) in self.providerPopoverControllers where p != provider {
+            ctrl.close()
+        }
+        // 合并 popover 也一并关闭（模式切换时兜底）
+        self.popoverMenuController?.close()
+    }
+
+    /// 懒创建指定 provider 的 MenuViewModel + PopoverMenuController（首次调用后缓存）。
+    func ensureProviderPopover(for provider: UsageProvider) {
+        if self.providerPopoverControllers[provider] != nil { return }
+        let vm = MenuViewModel.singleProvider(provider)
+        self.providerMenuViewModels[provider] = vm
+        let ctrl = self.makePopoverController(
+            viewModel: vm,
+            makeOverviewRows: { [] },
+            makeOverviewChart: { _ in nil })
+        // per-provider 快捷键回调：onRefresh/onSettings/onQuit 照旧；
+        // onNavigate/onSelectIndex 单 provider 下 no-op（不设）。
+        ctrl.onRefresh = { [weak self] in
+            self?.refreshNow()
+            self?.providerPopoverControllers[provider]?.close()
+        }
+        ctrl.onSettings = { [weak self] in
+            self?.showSettingsGeneral()
+            self?.providerPopoverControllers[provider]?.close()
+        }
+        ctrl.onQuit = { [weak self] in
+            self?.quit()
+        }
+        // onNavigate/onSelectIndex 留为 nil（单 provider 无切换器，不处理方向键/数字键）
+        self.providerPopoverControllers[provider] = ctrl
+    }
+
+    /// 非合并模式下为每个 enabled/fallback provider 安装 per-provider popover，复刻 attachMenus(fallback:) 遍历结构。
+    func attachProviderPopovers(fallback: UsageProvider?) {
+        for provider in UsageProvider.allCases {
+            let shouldHaveItem = self.isEnabled(provider) || fallback == provider
+            if shouldHaveItem {
+                let item = self.lazyStatusItem(for: provider)
+                item.menu = nil  // 清掉残留 NSMenu
+                self.ensureProviderPopover(for: provider)
+                item.button?.target = self
+                item.button?.action = #selector(self.handleProviderStatusItemClick(_:))
+                item.button?.sendAction(on: [.leftMouseUp, .rightMouseUp])
+            } else if let item = self.statusItems[provider] {
+                item.menu = nil
+                item.button?.target = nil
+                item.button?.action = nil
+            }
+        }
+    }
+```
+
+- [ ] **验证编译**
+
+```bash
+swift build 2>&1 | tail -20
+```
+
+期望：build succeeded，0 errors。（`handleProviderStatusItemClick` 还未定义，可能有编译错误——如有，暂时注释掉该 selector 引用，下一步补全。）
+
+---
+
+## Task 5：实现 `handleProviderStatusItemClick(_:)`
+
+**Files:**
+- Modify: `Sources/CodexBar/StatusItemController+Actions.swift`
+
+### 5.1 添加点击处理器
+
+- [ ] **在 `StatusItemController+Actions.swift` 中，在 `handleStatusItemClick(_:)` 方法后面插入**
+
+```swift
+    /// 非合并模式 per-provider statusItem 按钮点击处理（popover 路径）。
+    /// sender 即 NSStatusBarButton；通过恒等比较反查 provider。
+    @objc func handleProviderStatusItemClick(_ sender: Any?) {
+        guard self.usePopoverMenu, let button = sender as? NSStatusBarButton else { return }
+        guard let provider = self.statusItems.first(where: { $0.value.button === button })?.key else { return }
+        self.closeAllProviderPopovers(except: provider)
+        self.providerPopoverControllers[provider]?.toggle(relativeTo: button)
+    }
+```
+
+- [ ] **验证编译**
+
+```bash
+swift build 2>&1 | tail -20
+```
+
+期望：build succeeded，0 errors。
+
+---
+
+## Task 6：分流接线——attachMenus(fallback:) 和 openMenuFromShortcut
+
+**Files:**
+- Modify: `Sources/CodexBar/StatusItemController.swift`（`attachMenus(fallback:)` 开头）
+- Modify: `Sources/CodexBar/StatusItemController+Actions.swift`（`openMenuFromShortcut` 非合并分支）
+
+### 6.1 attachMenus(fallback:) 开头加 popover 分流
+
+- [ ] **在 `StatusItemController.swift` 的 `private func attachMenus(fallback: UsageProvider? = nil)` 方法体开头插入**
+
+在 `for provider in UsageProvider.allCases {` 前面加：
+
+```swift
+        if self.usePopoverMenu {
+            self.attachProviderPopovers(fallback: fallback)
+            return
+        }
+        // NSMenu 路径（从 popover 切回时清残留 button target/action）
+        for provider in UsageProvider.allCases {
+            if let item = self.statusItems[provider] {
+                item.button?.target = nil
+                item.button?.action = nil
+            }
+        }
+```
+
+注意：原方法中已有一个 for 循环，上面新加的清理 loop 要放在原 for loop 之前、但在 popover 分流的 `return` 之后；或者更简洁地在原 for loop 头部每次给有 item 的 provider 清掉 target/action（在 `if shouldHaveItem {` 的 else 分支中已有 `item.menu = nil` 但无 target 清理）。
+
+具体插入方式：将 `private func attachMenus(fallback: UsageProvider? = nil) {` 的方法体开头替换为：
+
+```swift
+    private func attachMenus(fallback: UsageProvider? = nil) {
+        if self.usePopoverMenu {
+            self.attachProviderPopovers(fallback: fallback)
+            return
+        }
+        // 从 popover 模式切回时清掉残留 button target/action（保证 NSMenu 路径不残留 action）
+        for provider in UsageProvider.allCases {
+            if let item = self.statusItems[provider] {
+                item.button?.target = nil
+                item.button?.action = nil
+            }
+        }
+        for provider in UsageProvider.allCases {
+            // Only access/create the status item if it's actually needed
+            let shouldHaveItem = self.isEnabled(provider) || fallback == provider
+            // ... 以下原逻辑不变 ...
+```
+
+（原 `for provider in UsageProvider.allCases {` 开头的 for 循环保持完整不删，只在方法最开头加上面的分流块 + 清理循环。）
+
+### 6.2 openMenuFromShortcut 非合并分支加 popover 分流
+
+- [ ] **修改 `StatusItemController+Actions.swift` 的 `openMenuFromShortcut()` 方法的非合并分支**
+
+找到：
+
+```swift
+        let provider = self.resolvedShortcutProvider()
+        // Use the lazy accessor to ensure the item exists
+        let item = self.lazyStatusItem(for: provider)
+        item.button?.performClick(nil)
+```
+
+替换为：
+
+```swift
+        let provider = self.resolvedShortcutProvider()
+        // Use the lazy accessor to ensure the item exists
+        let item = self.lazyStatusItem(for: provider)
+        if self.usePopoverMenu, let button = item.button {
+            // 确保 popover controller 已创建（快捷键可能先于 attachProviderPopovers 触发）
+            self.ensureProviderPopover(for: provider)
+            self.closeAllProviderPopovers(except: provider)
+            self.providerPopoverControllers[provider]?.toggle(relativeTo: button)
+        } else {
+            item.button?.performClick(nil)
+        }
+```
+
+- [ ] **验证编译**
+
+```bash
+swift build 2>&1 | tail -20
+```
+
+期望：build succeeded，0 errors。
+
+- [ ] **运行全量测试**
+
+```bash
+swift test 2>&1 | tail -30
+```
+
+期望：所有测试 PASS。
+
+- [ ] **提交**
+
+```bash
+git add Sources/CodexBar/StatusItemController.swift Sources/CodexBar/StatusItemController+Actions.swift Sources/CodexBar/StatusItemController+Popover.swift
+git commit -m "feat(menu): per-provider popovers for split (non-merged) icon mode
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7：lint 检查 + 最终提交
+
+**Files:** 无新增，仅验证
+
+### 7.1 Lint
+
+- [ ] **运行 lint format + lint check**
+
+```bash
+cd /Users/jassy/Documents/glm/codexbar
+bash Scripts/lint.sh format
+bash Scripts/lint.sh lint
+```
+
+期望：0 violations。若有 violations，根据提示修复后重新运行。
+
+### 7.2 全量测试再跑一次
+
+- [ ] **最终测试**
+
+```bash
+swift test 2>&1 | tail -30
+```
+
+期望：所有测试 PASS。
+
+### 7.3 确认 Task 25 可关闭
+
+- [ ] **确认编译 + lint + 测试全部 PASS 后，标记 Task 25 完成（最终验收：新旧界面对比）并口头报告**
+
+---
+
+## 自检 checklist
+
+实现完成后逐项确认：
+
+- [ ] `providerPopoverControllers` / `providerMenuViewModels` 已加入 StatusItemController 主类属性区
+- [ ] `makePopoverController(viewModel:makeOverviewRows:makeOverviewChart:)` helper 提取完成，`attachMergedPopover()` 已使用 helper
+- [ ] `attachProviderPopovers(fallback:)` 遍历结构与 `attachMenus(fallback:)` 一一对应
+- [ ] `ensureProviderPopover(for:)` 使用 `MenuViewModel.singleProvider()`，不接 `onSelectionChanged`
+- [ ] `handleProviderStatusItemClick(_:)` 通过恒等比较反查 provider
+- [ ] `closeAllProviderPopovers(except:)` 同时关闭合并 popover
+- [ ] `attachMenus(fallback:)` 开头有 `usePopoverMenu` 分流到 `attachProviderPopovers`
+- [ ] `openMenuFromShortcut` 非合并分支有 popover 路径
+- [ ] 从 popover 切回 NSMenu 时 button target/action 被清理（无残留）
+- [ ] `swift build` 0 errors，`swift test` 全部 PASS，lint 0 violations


### PR DESCRIPTION
## Summary

This PR adds an **opt-in** NSPopover-based menu that replaces the per-open NSMenu rebuild cycle with a single persistent SwiftUI hierarchy driven by `@Observable` state. It directly targets the architectural root cause behind the long tail of merged-menu hang reports (#1321 and the follow-up perf PRs): every menu open / provider switch currently rebuilds NSMenuItems, instantiates fresh `NSHostingView`s, and synchronously measures them on the main thread (`layoutSubtreeIfNeeded` + `fittingSize`). The existing caches (width/height/switcher-content) only memoize measurements — the SwiftUI view construction itself is re-done on every interaction.

With the popover implementation, switching providers mutates one `@Observable` property and SwiftUI diffs the persistent tree.

**Off by default.** Nothing changes unless the user opts in:

```
defaults write com.steipete.codexbar usePopoverMenu -bool true
```

The NSMenu path is untouched when the flag is off (verified by the full test suite). A follow-up branch that removes the legacy NSMenu implementation once this has soaked is ready (`popover-cleanup`, −15k lines) — happy to open it as a stacked PR if you want to go that way.

## What the popover implements (aligned with the NSMenu UI)

- Provider switcher: vertical icon+title tabs, accent-filled selection, per-provider quota indicator bars, Overview tab, multi-row wrapping, `switcherShowsIcons` honored
- Full card flows: Codex stacked accounts (incl. workspace groups + health fallback), token-account stacking, Kilo scopes, storage section, Buy Credits
- Sectioned card rendering matching `addMenuCardSections` (usage/credits/extra-usage/compact cost rows with per-section chart drill-downs)
- Chart drill-downs as cascading popovers anchored to their rows, hover-to-open with NSMenu-style grace-period dismissal (180ms open / 350ms linger), click still works
- Account switchers (Codex visible accounts / provider token accounts) as segmented SwiftUI controls wired to the existing selection handlers
- Overview mode reusing `OverviewMenuCardRowView`, row tap switches provider, chevron opens the per-provider chart
- Bottom action sections from the same `MenuDescriptor.build` data source, dispatched through the existing `selector(for:)` mapping with the active panel's provider context written to `lastMenuProvider` first; in-flight login disabling via `switchAccountSubtitle`/`codexAddAccountSubtitle`
- Keyboard shortcuts preserved while the panel is open: ⌘R / ⌘, / ⌘Q, ←/→ cycling, ⌘1–9 visible-tab selection (including Overview), Esc to close
- Selection persistence (`selectedMenuProvider` / `mergedMenuLastSelectedWasOverview`), open-time stale-provider refresh, storage-footprint refresh, icon animation freeze while the panel is visible
- Hover highlighting through the same `menuItemHighlighted` environment the section views already consume; manual accessibility tree (labels/hints incl. shortcut descriptions)
- Split (non-merged) icon mode: one popover per provider status item with mutual exclusion; menu actions dismiss every active popover

## Review follow-ups addressed

All automated-review findings were real and are fixed in the branch:

- **[P1] Provider context before legacy action dispatch** — `onAction`/`onBuyCredits` now write `lastMenuProvider` from the active panel's selection (same resolution that feeds `MenuDescriptor.build`, so menu content and action targets always agree) before invoking the legacy selectors. Dashboard/status/changelog from a Claude panel now route to Claude.
- **[P2] Split-popover dismissal** — `performMenuAction` now closes every popover (merged + per-provider) for non-quit actions, matching NSMenu's dismiss-on-action behavior.
- **[P2] No-provider shortcut fallback** — keyboard opening preserves the provider-less fallback model and schedules refreshes only for providers visible in that model.
- **[P2] Numeric shortcut order** — ⌘1–9 now indexes the same visible navigation stops as arrow keys, so ⌘1 selects Overview when Overview is present and the first provider otherwise.
- **Packaging script changes removed from this PR** — the two local-dev switches in `Scripts/package_app.sh` were dropped from the branch; `Scripts/` is now untouched (`git diff main -- Scripts/` is empty).

## Current-head verification

Current PR head: `61124b62` — one fix on top of `0beed39f`: in split-icon mode the menu shortcut now dismisses a visible per-provider popover instead of resolving a possibly-stale `lastMenuProvider` and toggling the wrong provider (the shortcut-targeting finding from the latest review).

- `swift test --filter 'Popover|MenuViewModelTests'` — 101 tests in 13 suites passed.
- `make check` — SwiftFormat clean; SwiftLint 0 violations.
- Structured autoreview against `origin/main` — clean, no accepted/actionable findings (0.78 confidence).
- CI follow-up autoreview — clean, no accepted/actionable findings (0.86 confidence).
- Headless popover-controller tests now exercise production state seams instead of creating a live `NSStatusBar` item, which aborted the Intel CI process before assertions ran.
- Exact-head GitHub CI is required before merge.

**Current-head runtime proof** (head `61124b62`, flag on, `hidePersonalInfo` enabled). Scripted run against the freshly built bundle — AppleScript opens the popover, cycles providers with →, closes with Esc, 4 rounds, while `sample` profiles the process:

```
$ defaults read CodexBar.app/Contents/Info.plist CodexGitCommit
61124b62

$ grep -cE "populateMenu|rebuildMenuContent|makeMenuCardItem|measuredHeight|hostedSubviewFittingHeight|updateMenuContentPreservingSwitcher" sample.txt
0

$ grep -oE "(PopoverRootView|NSHostingView.layout|_NSPopoverWindow)[A-Za-z.()]*" sample.txt | sort | uniq -c | sort -rn | head
  27 PopoverRootView.swift
  22 NSHostingView.layout()
  12 PopoverRootView.body.getter
   5 _NSPopoverWindow

# app still alive afterward (PID 94475)
```

Zero NSMenu rebuild/measure frames on the main thread; only lightweight SwiftUI layout runs.

**Redacted desktop screenshots** (current head, `hidePersonalInfo` on) are attached in a comment below — single-provider card (sectioned content + action section), Overview mode, provider switching (z.ai), bottom action section (⌘R/⌘,/⌘Q), and a hover-triggered chart drill-down (Hourly Tokens) cascading from its row.

The earlier-head profiling below is retained as historical architecture proof.

## Historical runtime proof (earlier head `f3f3b496`, flag on)

Scripted run against the freshly built bundle: AppleScript opens the popover, cycles providers with →, and closes with Esc, 4 rounds, while `sample` profiles the process.

```
$ defaults read com.steipete.codexbar usePopoverMenu
1

$ defaults read CodexBar.app/Contents/Info.plist CodexGitCommit   # built from PR branch
f3f3b496

# sampling PID 20371 for 14s while AppleScript opens/closes the popover and cycles providers

$ grep -cE "populateMenu|rebuildMenuContent|makeMenuCardItem|measuredHeight|hostedSubviewFittingHeight|updateMenuContentPreservingSwitcher" sample.txt
0

$ grep -oE "(PopoverRootView|PopoverMenuController|_NSPopoverWindow|NSHostingView)[A-Za-z.()]*" sample.txt | sort | uniq -c | sort -rn | head -6
  20 PopoverRootView.swift
  18 NSHostingView.layout()
   4 PopoverRootView.body.getter
   4 PopoverMenuController.swift
   4 NSHostingView.windowDidLayout()
   4 NSHostingView.updateConstraints()

# app still alive after the loop:
PID 20371
```

Zero NSMenu rebuild/measure frames on the main thread during open/switch loops; the popover code path is what's executing. I can additionally post redacted screenshots (with `hidePersonalInfo` enabled) on request.

## Before / after benchmark (same machine, same build, instrumented)

To quantify the win I temporarily lowered `slowMenuOperationThreshold` to `0` and printed every `logMenuOperationDurationIfSlow` sample, then drove the app with AppleScript and `sample` (instrumentation was on a throwaway branch, not in this PR).

| Metric | NSMenu (flag off) | Popover (flag on) |
| --- | --- | --- |
| Main-thread sync cost to **build/rebuild** menu content (`populateMenu`) | **33.1 ms** | **0** — no rebuild path exists |
| `populateMenu`/`makeMenuCardItem`/`measuredHeight`/`hostedSubviewFittingHeight` frames on the main thread during open + provider-switch loops (`sample`) | present every time content changes | **0** |
| Steady-state reopen with no content change | 0.1 ms (existing caches already make this fast) | lightweight SwiftUI |
| Resident memory | ~107 MB | ~105 MB |

**Honest framing:** the NSMenu path is *not* slow on every open — the existing caches make a steady-state reopen ~0.1 ms. The cost lands on every **content change**: first open, provider switch, post-refresh redraw all synchronously rebuild NSMenuItems, instantiate fresh `NSHostingView`s, and measure them on the main thread (≈33 ms each on an idle machine; this scales up under memory pressure or with deep content such as the Zai hourly chart, which is where the recurring "switching is laggy" reports come from). The popover removes the rebuild step entirely — the view tree is built once and switching providers mutates one `@Observable` property — so that per-change cost drops to **0**, as the profiling above shows.

## Commands run

- `swift build` / `swift test` — 3493 tests, 404 suites, all passing (flag off and on)
- `make check` (SwiftFormat + SwiftLint `--strict`) — 0 violations
- `Scripts/compile_and_run.sh` — bundle-level validation, app stays running
- Scripted `sample` profiling (output above)

## Notes for review

- Verified side-by-side against the NSMenu implementation on live data (two instances); the layouts match section-for-section.
- The commit history is intentionally granular (flag → view model → controller → content parity → charts → split mode → polish → review fixes); each commit builds and passes the suite.
- New popover code lives in `Sources/CodexBar/Popover/` plus `StatusItemController+Popover.swift`; shared card/chart/descriptor code is reused, not duplicated.
- Refs #1321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


