### PR TITLE
Add debug-build main thread hang watchdog with activity breadcrumbs

### DIFF
--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -40,6 +40,9 @@ struct CodexBarApp: App {
 
         KeychainAccessGate.isDisabled = UserDefaults.standard.bool(forKey: "debugDisableKeychainAccess")
         KeychainPromptCoordinator.install()
+        #if DEBUG
+        MainThreadHangWatchdog.shared.start()
+        #endif
 
         let preferencesSelection = PreferencesSelection()
         let settings = SettingsStore()

--- a/Sources/CodexBar/MainThreadHangWatchdog.swift
+++ b/Sources/CodexBar/MainThreadHangWatchdog.swift
@@ -1,0 +1,203 @@
+import AppKit
+import CodexBarCore
+import Foundation
+
+#if DEBUG
+/// Tracks what the main thread is currently doing so hang reports can name the
+/// operation even when the stall happens in uninstrumented code.
+enum MainThreadActivityBreadcrumb {
+    private final class State: @unchecked Sendable {
+        let lock = NSLock()
+        var stack: [String] = []
+    }
+
+    private static let state = State()
+
+    static var current: String? {
+        self.state.lock.lock()
+        defer { self.state.lock.unlock() }
+        return self.state.stack.last
+    }
+
+    static func push(_ label: String) {
+        self.state.lock.lock()
+        defer { self.state.lock.unlock() }
+        self.state.stack.append(label)
+    }
+
+    static func pop() {
+        self.state.lock.lock()
+        defer { self.state.lock.unlock() }
+        _ = self.state.stack.popLast()
+    }
+}
+
+/// Detects main-thread stalls regardless of where they originate. A utility thread
+/// pings the main queue and measures how long each ping waits; stalls above the
+/// threshold are logged with the active breadcrumb, and long hangs additionally
+/// capture a `/usr/bin/sample` of the process so the guilty stack lands in
+/// ~/Library/Logs/CodexBar without anyone having to reproduce under a profiler.
+/// Only started in DEBUG builds; release builds never spawn the watchdog thread.
+final class MainThreadHangWatchdog: @unchecked Sendable {
+    static let shared = MainThreadHangWatchdog()
+
+    private let logger = CodexBarLog.logger(LogCategories.app)
+    private let pingInterval: TimeInterval
+    private let hangThreshold: TimeInterval
+    private let sampleThreshold: TimeInterval
+    private let sampleCooldown: TimeInterval
+    private let lock = NSLock()
+    private var isRunning = false
+    private var lastSampleAt: Date?
+    var onHangForTesting: ((TimeInterval, [String]) -> Void)?
+    var onBeforePingForTesting: (() -> Void)?
+    var onPingScheduledForTesting: (() -> Void)?
+
+    init(
+        pingInterval: TimeInterval = 0.5,
+        hangThreshold: TimeInterval = 0.15,
+        sampleThreshold: TimeInterval = 2.0,
+        sampleCooldown: TimeInterval = 300)
+    {
+        self.pingInterval = pingInterval
+        self.hangThreshold = hangThreshold
+        self.sampleThreshold = sampleThreshold
+        self.sampleCooldown = sampleCooldown
+    }
+
+    func start() {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        guard !self.isRunning else { return }
+        self.isRunning = true
+        let thread = Thread { [weak self] in self?.run() }
+        thread.name = "CodexBar.MainThreadHangWatchdog"
+        thread.qualityOfService = .utility
+        thread.start()
+    }
+
+    func stop() {
+        self.lock.lock()
+        self.isRunning = false
+        self.lock.unlock()
+    }
+
+    private var shouldRun: Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.isRunning
+    }
+
+    private final class PingBox: @unchecked Sendable {
+        private let lock = NSLock()
+        private var responded = false
+
+        func markResponded() {
+            self.lock.lock()
+            self.responded = true
+            self.lock.unlock()
+        }
+
+        var hasResponded: Bool {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            return self.responded
+        }
+    }
+
+    private func run() {
+        while self.shouldRun {
+            self.onBeforePingForTesting?()
+            let box = PingBox()
+            let pingSentAt = DispatchTime.now()
+            DispatchQueue.main.async { box.markResponded() }
+            self.onPingScheduledForTesting?()
+            Thread.sleep(forTimeInterval: self.hangThreshold)
+            guard self.shouldRun else { return }
+            if !box.hasResponded {
+                self.traceHang(box: box, pingSentAt: pingSentAt)
+            }
+            Thread.sleep(forTimeInterval: self.pingInterval)
+        }
+    }
+
+    private func traceHang(box: PingBox, pingSentAt: DispatchTime) {
+        // A single stall can span several pieces of main-thread work (runloop sources and
+        // timers interleave ahead of the queued ping), so sample the breadcrumb throughout
+        // the hang and report every distinct activity observed.
+        var activities: [String] = []
+        func recordActivity() {
+            guard activities.count < 8,
+                  let activity = MainThreadActivityBreadcrumb.current,
+                  !activities.contains(activity)
+            else { return }
+            activities.append(activity)
+        }
+
+        recordActivity()
+        var sampleFile: String?
+        while !box.hasResponded, self.shouldRun {
+            recordActivity()
+            if sampleFile == nil, self.elapsedSeconds(since: pingSentAt) >= self.sampleThreshold {
+                sampleFile = self.captureSampleIfAllowed()
+            }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        guard box.hasResponded else { return }
+        let duration = self.elapsedSeconds(since: pingSentAt)
+        var metadata: [String: String] = [
+            "durationMs": String(format: "%.0f", duration * 1000),
+            "activity": activities.isEmpty ? "unknown" : activities.joined(separator: ","),
+        ]
+        if let sampleFile {
+            metadata["sample"] = sampleFile
+        }
+        self.logger.warning("main thread hang", metadata: metadata)
+        self.onHangForTesting?(duration, activities)
+    }
+
+    private func elapsedSeconds(since start: DispatchTime) -> TimeInterval {
+        TimeInterval(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000
+    }
+
+    private func captureSampleIfAllowed() -> String? {
+        self.lock.lock()
+        if let last = self.lastSampleAt, Date().timeIntervalSince(last) < self.sampleCooldown {
+            self.lock.unlock()
+            return nil
+        }
+        self.lastSampleAt = Date()
+        self.lock.unlock()
+
+        let directory = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/CodexBar", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withFullDate, .withTime]
+        let stamp = formatter.string(from: Date()).replacingOccurrences(of: ":", with: "-")
+        let file = directory.appendingPathComponent("hang-sample-\(stamp).txt")
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/sample")
+        process.arguments = ["\(ProcessInfo.processInfo.processIdentifier)", "3", "-file", file.path]
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            self.logger.warning(
+                "main thread hang sample failed",
+                metadata: ["error": "\(error)"])
+            return nil
+        }
+        guard process.terminationStatus == 0,
+              FileManager.default.fileExists(atPath: file.path)
+        else {
+            self.logger.warning(
+                "main thread hang sample failed",
+                metadata: ["status": "\(process.terminationStatus)"])
+            return nil
+        }
+        return file.path
+    }
+}
+#endif

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -62,6 +62,10 @@ extension StatusItemController {
         menu.removeAllItems()
 
         let t0 = CACurrentMediaTime()
+        #if DEBUG
+        MainThreadActivityBreadcrumb.push("hydrateChart:\(chartID)")
+        defer { MainThreadActivityBreadcrumb.pop() }
+        #endif
         let didHydrate: Bool = switch chartID {
         case Self.usageBreakdownChartID:
             self.appendUsageBreakdownChartItem(to: menu, width: width)
@@ -103,6 +107,7 @@ extension StatusItemController {
             false
         }
         self.logChartRenderDurationIfSlow("hydrateHostedSubview:\(chartID)", startedAt: t0)
+        self.logHostedSubviewDisplaySettle("hydrateHostedSubview:\(chartID)", startedAt: t0)
 
         if !didHydrate {
             self.appendHostedSubviewUnavailableItem(
@@ -130,6 +135,10 @@ extension StatusItemController {
 
         menu.removeAllItems()
         let t0 = CACurrentMediaTime()
+        #if DEBUG
+        MainThreadActivityBreadcrumb.push("refreshChart:\(identity.chartID)")
+        defer { MainThreadActivityBreadcrumb.pop() }
+        #endif
         let didHydrate: Bool = switch identity.chartID {
         case Self.usageBreakdownChartID:
             self.appendUsageBreakdownChartItem(to: menu, width: width)
@@ -163,6 +172,7 @@ extension StatusItemController {
             false
         }
         self.logChartRenderDurationIfSlow("refreshHostedSubview:\(identity.chartID)", startedAt: t0)
+        self.logHostedSubviewDisplaySettle("refreshHostedSubview:\(identity.chartID)", startedAt: t0)
 
         if !didHydrate {
             self.appendHostedSubviewUnavailableItem(

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -57,14 +57,8 @@ extension StatusItemController {
     }
 
     func menuWillOpen(_ menu: NSMenu) {
-        let menuOpenStartedAt = CACurrentMediaTime()
-        defer {
-            self.logMenuOperationDurationIfSlow(
-                "menuWillOpen",
-                startedAt: menuOpenStartedAt,
-                menu: menu,
-                provider: self.menuProvider(for: menu))
-        }
+        let trace = self.beginMenuOperationTrace("menuWillOpen", breadcrumb: "menuWillOpen")
+        defer { self.endMenuOperationTrace(trace, menu: menu, provider: self.menuProvider(for: menu)) }
 
         self.cancelDeferredMenuInteractionRefreshTask()
         self.cancelClosedMenuRebuild(menu)
@@ -202,14 +196,10 @@ extension StatusItemController {
     }
 
     func populateMenu(_ menu: NSMenu, provider: UsageProvider?) {
-        let populateStartedAt = CACurrentMediaTime()
-        defer {
-            self.logMenuOperationDurationIfSlow(
-                "populateMenu",
-                startedAt: populateStartedAt,
-                menu: menu,
-                provider: provider)
-        }
+        let trace = self.beginMenuOperationTrace(
+            "populateMenu",
+            breadcrumb: "populateMenu:\(provider?.rawValue ?? "merged")")
+        defer { self.endMenuOperationTrace(trace, menu: menu, provider: provider) }
         defer { self.refreshMenuCardHeights(in: menu) }
 
         let enabledProviders = self.store.enabledProvidersForDisplay()

--- a/Sources/CodexBar/StatusItemController+MenuInteractionRefresh.swift
+++ b/Sources/CodexBar/StatusItemController+MenuInteractionRefresh.swift
@@ -27,6 +27,34 @@ extension StatusItemController {
         #endif
     }
 
+    struct MenuOperationTrace {
+        let operation: String
+        let startedAt: CFTimeInterval
+    }
+
+    /// Pairs the slow-operation timing log with a watchdog breadcrumb so a hang during
+    /// the operation is attributed to it even when the operation never finishes logging.
+    func beginMenuOperationTrace(
+        _ operation: String,
+        breadcrumb: @autoclosure () -> String) -> MenuOperationTrace
+    {
+        #if DEBUG
+        MainThreadActivityBreadcrumb.push(breadcrumb())
+        #endif
+        return MenuOperationTrace(operation: operation, startedAt: CACurrentMediaTime())
+    }
+
+    func endMenuOperationTrace(_ trace: MenuOperationTrace, menu: NSMenu, provider: UsageProvider?) {
+        #if DEBUG
+        MainThreadActivityBreadcrumb.pop()
+        #endif
+        self.logMenuOperationDurationIfSlow(
+            trace.operation,
+            startedAt: trace.startedAt,
+            menu: menu,
+            provider: provider)
+    }
+
     func logMenuOperationDurationIfSlow(
         _ operation: String,
         startedAt: CFTimeInterval,
@@ -56,6 +84,25 @@ extension StatusItemController {
                 "section": label,
                 "durationMs": String(format: "%.1f", elapsed * 1000),
             ])
+    }
+
+    private static let slowHostedSubviewDisplaySettleThreshold: TimeInterval = 0.1
+
+    /// Chart construction returns before SwiftUI's first draw of the hosted view, so a
+    /// fast hydrate can still display with a visible hitch. Measure to the next main
+    /// runloop turn, which includes the Core Animation commit and first render pass.
+    func logHostedSubviewDisplaySettle(_ label: String, startedAt: CFTimeInterval) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            let elapsed = CACurrentMediaTime() - startedAt
+            guard elapsed >= Self.slowHostedSubviewDisplaySettleThreshold else { return }
+            self.menuLogger.warning(
+                "slow hosted subview display",
+                metadata: [
+                    "section": label,
+                    "durationMs": String(format: "%.1f", elapsed * 1000),
+                ])
+        }
     }
 
     func deferMenuInteractionRefreshIfNeeded(providers: [UsageProvider]) {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -660,11 +660,17 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     func updateIcons() {
         #if DEBUG
         guard !self.isReleasedForTesting else { return }
+        MainThreadActivityBreadcrumb.push("updateIcons")
         #endif
         self.scheduleMenuBarCountdownRefreshIfNeeded()
         self.lastObservedStoreIconWorkSignature = self.storeIconObservationSignature()
         self.beginIconPerfUpdatePass()
-        defer { self.endIconPerfUpdatePass() }
+        defer {
+            self.endIconPerfUpdatePass()
+            #if DEBUG
+            MainThreadActivityBreadcrumb.pop()
+            #endif
+        }
         // Avoid flicker: when an animation driver is active, store updates can call `updateIcons()` and
         // briefly overwrite the animated frame with the static (phase=nil) icon.
         let phase: Double? = self.needsMenuBarIconAnimation() ? self.animationPhase : nil

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -33,6 +33,23 @@ extension UsageStore {
         return self.providerSpecs[provider]
     }
 
+    /// The menu card shows its "Refreshing…" indicator for the whole provider refresh,
+    /// so a slow fetch reads as lag even when the UI stays responsive. Persist a warning
+    /// whenever a single provider keeps the spinner up this long.
+    private static let slowProviderRefreshThreshold: TimeInterval = 5
+
+    private func logProviderRefreshDurationIfSlow(_ provider: UsageProvider, startedAt: DispatchTime) {
+        let elapsed = TimeInterval(DispatchTime.now().uptimeNanoseconds - startedAt.uptimeNanoseconds)
+            / 1_000_000_000
+        guard elapsed >= Self.slowProviderRefreshThreshold else { return }
+        self.providerLogger.warning(
+            "slow provider refresh",
+            metadata: [
+                "provider": provider.rawValue,
+                "durationMs": String(format: "%.0f", elapsed * 1000),
+            ])
+    }
+
     func refreshProvider(
         _ provider: UsageProvider,
         allowDisabled: Bool = false,
@@ -144,7 +161,9 @@ extension UsageStore {
     {
         self.providerRefreshCounts[provider, default: 0] += 1
         self.refreshingProviders.insert(provider)
+        let refreshStartedAt = DispatchTime.now()
         defer {
+            self.logProviderRefreshDurationIfSlow(provider, startedAt: refreshStartedAt)
             let remaining = max(0, self.providerRefreshCounts[provider, default: 1] - 1)
             if remaining == 0 {
                 self.providerRefreshCounts.removeValue(forKey: provider)

--- a/Tests/CodexBarTests/MainThreadHangWatchdogTests.swift
+++ b/Tests/CodexBarTests/MainThreadHangWatchdogTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct MainThreadHangWatchdogTests {
+    @MainActor
+    @Test
+    func `breadcrumb tracks nested activity`() {
+        #expect(MainThreadActivityBreadcrumb.current == nil)
+        MainThreadActivityBreadcrumb.push("outer")
+        MainThreadActivityBreadcrumb.push("inner")
+        #expect(MainThreadActivityBreadcrumb.current == "inner")
+        MainThreadActivityBreadcrumb.pop()
+        #expect(MainThreadActivityBreadcrumb.current == "outer")
+        MainThreadActivityBreadcrumb.pop()
+        #expect(MainThreadActivityBreadcrumb.current == nil)
+    }
+
+    @Test
+    func `watchdog reports a blocked main thread with the active breadcrumb`() async throws {
+        let watchdog = MainThreadHangWatchdog(
+            pingInterval: 0.02,
+            hangThreshold: 0.05,
+            sampleThreshold: 60,
+            sampleCooldown: 3600)
+
+        let reported = OSAllocatedBox<[(TimeInterval, [String])]>([])
+        watchdog.onHangForTesting = { duration, activities in
+            reported.append((duration, activities))
+        }
+
+        let ready = OSAllocatedBox(false)
+        let gateOnce = OSAllocatedBox(true)
+        let beginPing = DispatchSemaphore(value: 0)
+        let pingScheduled = DispatchSemaphore(value: 0)
+        watchdog.onBeforePingForTesting = {
+            guard gateOnce.takeTrue() else { return }
+            ready.set(true)
+            beginPing.wait()
+        }
+        watchdog.onPingScheduledForTesting = {
+            pingScheduled.signal()
+        }
+        watchdog.start()
+        defer {
+            beginPing.signal()
+            pingScheduled.signal()
+            watchdog.stop()
+        }
+
+        for _ in 0..<200 where !ready.get() {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        try #require(ready.get())
+
+        let didSchedulePing = await MainActor.run {
+            beginPing.signal()
+            guard pingScheduled.wait(timeout: .now() + 2) == .success else { return false }
+            MainThreadActivityBreadcrumb.push("testStall")
+            Thread.sleep(forTimeInterval: 0.4)
+            MainThreadActivityBreadcrumb.pop()
+            return true
+        }
+        try #require(didSchedulePing)
+
+        // Concurrent test suites stall the main thread too: a single hang report can span
+        // several of them and is only delivered once the whole stall ends, so poll for our
+        // synthetic stall instead of sleeping a fixed interval.
+        var stallReport: (TimeInterval, [String])?
+        for _ in 0..<200 {
+            if let report = reported.get().first(where: { $0.1.contains("testStall") }) {
+                stallReport = report
+                break
+            }
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        let report = try #require(stallReport)
+        #expect(report.0 >= 0.05)
+    }
+}
+
+private final class OSAllocatedBox<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: T
+
+    init(_ value: T) {
+        self.value = value
+    }
+
+    func set(_ newValue: T) {
+        self.lock.lock()
+        self.value = newValue
+        self.lock.unlock()
+    }
+
+    func get() -> T {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.value
+    }
+}
+
+extension OSAllocatedBox {
+    func append<Element>(_ element: Element) where T == [Element] {
+        self.lock.lock()
+        self.value.append(element)
+        self.lock.unlock()
+    }
+
+    func takeTrue() -> Bool where T == Bool {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        guard self.value else { return false }
+        self.value = false
+        return true
+    }
+}

--- a/Tests/CodexBarTests/MainThreadHangWatchdogTests.swift
+++ b/Tests/CodexBarTests/MainThreadHangWatchdogTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 @testable import CodexBar
 
+#if DEBUG
 struct MainThreadHangWatchdogTests {
     @MainActor
     @Test
@@ -115,3 +116,4 @@ extension OSAllocatedBox {
         return true
     }
 }
+#endif


### PR DESCRIPTION
## Summary

While chasing menu lag I kept hitting stalls that the existing slow-operation logs couldn't attribute — the hang happened in uninstrumented code, or spanned several pieces of main-thread work. This adds a main-thread hang watchdog that detects stalls wherever they originate and names what the main thread was doing at the time.

**Debug builds only**: the watchdog is started behind `#if DEBUG`, so release builds never spawn the watchdog thread or the sampling subprocess.

### How it works
- A utility thread pings the main queue; if a ping isn't answered within the hang threshold (150ms), the stall is traced until the main thread responds, then logged with its duration.
- `MainThreadActivityBreadcrumb` is a lightweight push/pop stack that instrumented operations (menu populate, hosted submenu display, provider refresh) maintain, so hang reports name the active operation even when the stall is in uninstrumented code. Breadcrumbs are sampled throughout the hang, so one report can attribute a stall that spans several operations.
- Hangs over 2s additionally capture a `/usr/bin/sample` of the process into `~/Library/Logs/CodexBar/hang-sample-*.txt` (5-minute cooldown), so the guilty stack is available without reproducing under a profiler.
- Also adds a slow-refresh log to `UsageStore` and a hosted-subview display settle probe — chart construction returns before SwiftUI's first draw, so a fast hydrate can still display with a visible hitch; the probe measures to the next runloop turn.

### Tests
- `MainThreadHangWatchdogTests`: breadcrumb stack nesting, and an end-to-end synthetic stall asserting the watchdog reports the hang with the active breadcrumb.

## Test plan

- [x] `swift test --filter MainThreadHangWatchdogTests` — 2/2 pass
- [x] `./Scripts/lint.sh lint` — 0 violations
- [x] `swift build -c release` — compiles with the watchdog gated out
- [x] Manual verification — ran a local debug build, induced menu stalls, confirmed hang logs name the breadcrumb and a sample file lands in ~/Library/Logs/CodexBar

## Maintainer validation

Rebased onto `ee911544`; exact head `77510e977d75427533275004cd78e8cff80e5c01`.

- `swift test --filter MainThreadHangWatchdogTests`: 2 tests passed, including the synthetic main-thread stall
- `swift build -c release`: passed, confirming the watchdog remains excluded from release production builds
- `make check`: SwiftFormat and SwiftLint clean
- structured autoreview: clean, no actionable findings (confidence 0.74)
- new test suite now shares the implementation's `#if DEBUG` boundary

`swift test -c release` is not a supported repository proof path today because many pre-existing test-only hooks are debug-gated; it fails across unrelated suites before test execution.
