### PR TITLE
fix: reject malformed provider endpoint hosts

### DIFF
--- a/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
+++ b/Sources/CodexBarCore/ProviderEndpointOverrideValidator.swift
@@ -99,6 +99,8 @@ struct ProviderEndpointOverrideValidator: Sendable {
         guard let decodedHost = url.host(percentEncoded: false)?.lowercased(),
               !decodedHost.isEmpty,
               !decodedHost.contains("%"),
+              decodedHost.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
+              decodedHost.rangeOfCharacter(from: .controlCharacters) == nil,
               let encodedHost = url.host(percentEncoded: true)?.lowercased(),
               self.hostHasNoEncodedDelimiters(encodedHost, decodedHost: decodedHost, url: url)
         else { return nil }

--- a/Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift
+++ b/Tests/CodexBarTests/AlibabaCodingPlanProviderTests.swift
@@ -89,6 +89,18 @@ struct AlibabaCodingPlanSettingsReaderTests {
     }
 
     @Test
+    func `endpoint overrides reject whitespace and control characters in hosts`() {
+        for host in ["https://bad host", "https://bad%20host", "https://bad%09host"] {
+            #expect(AlibabaCodingPlanSettingsReader.hostOverride(environment: [
+                AlibabaCodingPlanSettingsReader.hostKey: host,
+            ]) == nil)
+            #expect(AlibabaCodingPlanSettingsReader.quotaURL(environment: [
+                AlibabaCodingPlanSettingsReader.quotaURLKey: "\(host)/data/api.json",
+            ]) == nil)
+        }
+    }
+
+    @Test
     func `endpoint overrides require https and no userinfo`() {
         #expect(AlibabaCodingPlanSettingsReader.hostOverride(environment: [
             AlibabaCodingPlanSettingsReader.hostKey: "http://modelstudio.console.alibabacloud.com",

--- a/Tests/CodexBarTests/MiniMaxProviderTests.swift
+++ b/Tests/CodexBarTests/MiniMaxProviderTests.swift
@@ -63,6 +63,18 @@ struct MiniMaxEndpointOverrideSettingsTests {
     }
 
     @Test
+    func `endpoint overrides reject whitespace and control characters in hosts`() {
+        for host in ["https://bad host", "https://bad%20host", "https://bad%09host"] {
+            #expect(MiniMaxSettingsReader.hostOverride(environment: [
+                MiniMaxSettingsReader.hostKey: host,
+            ]) == nil)
+            #expect(MiniMaxSettingsReader.remainsURL(environment: [
+                MiniMaxSettingsReader.remainsURLKey: "\(host)/remains",
+            ]) == nil)
+        }
+    }
+
+    @Test
     func `endpoint overrides require https and no userinfo`() {
         #expect(MiniMaxSettingsReader.hostOverride(environment: [
             MiniMaxSettingsReader.hostKey: "http://platform.minimax.io",


### PR DESCRIPTION
## Summary

- reject decoded whitespace and control characters in provider endpoint host overrides
- cover raw and percent-encoded malformed hosts for MiniMax and Alibaba Coding Plan
- complete the validation shipped in #1269

## Verification

- `swift test --filter 'AlibabaCodingPlanSettingsReaderTests|MiniMaxEndpointOverrideSettingsTests'` (28 tests)
- `make check`
- `autoreview --mode branch --base origin/main` (clean)
- unreleased model-name gate: clean
