### PR TITLE
Clarify Claude Web reauthentication guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Menu bar: move the highlighted Overview provider with trackpad or mouse-wheel scrolling while preserving native submenu and keyboard behavior (#1436). Thanks @joshuavial!
 
 ### Fixed
+- Claude: explain that an unauthorized Web session requires signing in at claude.ai or refreshing imported cookies (#1287). Thanks @LeoLin990405!
 - CLI server: reload provider config for every usage and cost request, invalidate config-dependent cache entries, and prune expired config variants without restarting `codexbar serve`. Thanks @enieuwy!
 - Menu bar: anchor merged provider dropdowns to the status item's trailing edge without marking preserved in-flight refresh content fresh, preventing horizontal drift while keeping deferred updates visible (#1288). Thanks @Yuxin-Qiao!
 - Cost usage: replace repeated Foundation metadata/root checks with one portable file-stat pass so expired Codex history refreshes stay responsive on very large session archives (#1392). Thanks @TheAngryPit and @ProspectOre!

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -69,7 +69,7 @@ public enum ClaudeWebAPIFetcher {
             case .invalidResponse:
                 "Invalid response from Claude API."
             case .unauthorized:
-                "Unauthorized. Your Claude session may have expired."
+                "Sign in to claude.ai (or refresh Claude cookies) to load usage data."
             case let .serverError(code):
                 "Claude API error: HTTP \(code)"
             case .noOrganization:

--- a/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebRecoveryMenuTests.swift
@@ -6,6 +6,13 @@ import Testing
 @MainActor
 @Suite(.serialized)
 struct ClaudeWebRecoveryMenuTests {
+    @Test
+    func `unauthorized error explains how to restore web usage`() {
+        #expect(
+            ClaudeWebAPIFetcher.FetchError.unauthorized.localizedDescription ==
+                "Sign in to claude.ai (or refresh Claude cookies) to load usage data.")
+    }
+
     private func makeSettings() -> SettingsStore {
         let suite = "ClaudeWebRecoveryMenuTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!


### PR DESCRIPTION
## Summary
- replace the vague Claude Web unauthorized error with direct sign-in/cookie-refresh guidance
- lock the user-facing copy with a focused regression test
- keep OAuth refresh ownership, cookie persistence, and account isolation unchanged

## Validation
- `swift test --filter 'ClaudeWebRecoveryMenuTests|ClaudeWebRefreshResilienceTests|CLIWebFallbackTests'` (21 tests)
- `make check`
- autoreview clean
- released/fictitious model-name gate clean

Fixes the narrow guidance portion of #1287. The broader auth lifecycle issue remains open.
