### PR TITLE
Reload serve config per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Menu bar: move the highlighted Overview provider with trackpad or mouse-wheel scrolling while preserving native submenu and keyboard behavior (#1436). Thanks @joshuavial!
 
 ### Fixed
+- CLI server: reload provider config for every usage and cost request, invalidate config-dependent cache entries, and prune expired config variants without restarting `codexbar serve`. Thanks @enieuwy!
 - Menu bar: anchor merged provider dropdowns to the status item's trailing edge without marking preserved in-flight refresh content fresh, preventing horizontal drift while keeping deferred updates visible (#1288). Thanks @Yuxin-Qiao!
 - Cost usage: replace repeated Foundation metadata/root checks with one portable file-stat pass so expired Codex history refreshes stay responsive on very large session archives (#1392). Thanks @TheAngryPit and @ProspectOre!
 - Cursor: show the Safari Full Disk Access recovery hint before the long browser login list so permission guidance remains visible when menu errors truncate (#1419, fixes #1417). Thanks @hhh2210!

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -145,17 +145,18 @@ actor CLIServeResponseCache {
     private var inFlightKeys: Set<String> = []
     private var waiters: [String: [CheckedContinuation<CLIServeCacheLookup, Never>]] = [:]
 
-    private func response(for key: String, now: Date) -> CLILocalHTTPResponse? {
+    private func pruneExpiredEntries(now: Date) {
+        self.entries = self.entries.filter { $0.value.expiresAt > now }
+    }
+
+    private func response(for key: String) -> CLILocalHTTPResponse? {
         guard let entry = self.entries[key] else { return nil }
-        guard entry.expiresAt > now else {
-            self.entries[key] = nil
-            return nil
-        }
         return entry.response
     }
 
     fileprivate func responseOrStartFetch(for key: String, now: Date) async -> CLIServeCacheLookup {
-        if let cached = self.response(for: key, now: now) {
+        self.pruneExpiredEntries(now: now)
+        if let cached = self.response(for: key) {
             return .response(cached)
         }
 
@@ -189,6 +190,10 @@ actor CLIServeResponseCache {
     private func store(_ response: CLILocalHTTPResponse, for key: String, ttl: TimeInterval, now: Date) {
         guard ttl > 0, response.status == .ok else { return }
         self.entries[key] = Entry(expiresAt: now.addingTimeInterval(ttl), response: response)
+    }
+
+    func cachedEntryCount() -> Int {
+        self.entries.count
     }
 }
 

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -65,6 +65,11 @@ private struct ServeHealthPayload: Encodable {
     let status: String
 }
 
+struct CLIServeConfigSnapshot: Sendable {
+    let config: CodexBarConfig
+    let cacheToken: String
+}
+
 private final class CLIServeDeadlineState: @unchecked Sendable {
     private let lock = NSLock()
     private var continuation: CheckedContinuation<CLILocalHTTPResponse, Never>?
@@ -240,12 +245,12 @@ extension CodexBarCLI {
                 kind: .args)
         }
 
-        let config = Self.loadConfig(output: output)
+        let configStore = CodexBarConfigStore()
         let cache = CLIServeResponseCache()
         let server = CLILocalHTTPServer(host: "127.0.0.1", port: port) { request in
             await Self.handleServeRequest(
                 request,
-                config: config,
+                configStore: configStore,
                 cache: cache,
                 refreshInterval: refreshInterval,
                 requestTimeout: requestTimeout)
@@ -301,7 +306,7 @@ extension CodexBarCLI {
 
     private static func handleServeRequest(
         _ request: CLILocalHTTPRequest,
-        config: CodexBarConfig,
+        configStore: CodexBarConfigStore,
         cache: CLIServeResponseCache,
         refreshInterval: TimeInterval,
         requestTimeout: TimeInterval) async -> CLILocalHTTPResponse
@@ -322,24 +327,61 @@ extension CodexBarCLI {
         case .health:
             return Self.serveJSON(ServeHealthPayload(status: "ok"))
         case let .usage(provider):
+            let snapshot: CLIServeConfigSnapshot
+            do {
+                snapshot = try Self.loadServeConfigSnapshot(configStore: configStore)
+            } catch {
+                return Self.serveError(status: .internalServerError, message: error.localizedDescription)
+            }
             return await Self.cachedServeResponse(
-                key: "usage:\(provider ?? "")",
+                key: Self.serveCacheKey(kind: "usage", provider: provider, configToken: snapshot.cacheToken),
                 cache: cache,
                 refreshInterval: refreshInterval,
                 requestTimeout: requestTimeout)
             {
-                await Self.serveUsage(provider: provider, config: config)
+                await Self.serveUsage(provider: provider, config: snapshot.config)
             }
         case let .cost(provider):
+            let snapshot: CLIServeConfigSnapshot
+            do {
+                snapshot = try Self.loadServeConfigSnapshot(configStore: configStore)
+            } catch {
+                return Self.serveError(status: .internalServerError, message: error.localizedDescription)
+            }
             return await Self.cachedServeResponse(
-                key: "cost:\(provider ?? "")",
+                key: Self.serveCacheKey(kind: "cost", provider: provider, configToken: snapshot.cacheToken),
                 cache: cache,
                 refreshInterval: refreshInterval,
                 requestTimeout: requestTimeout)
             {
-                await Self.serveCost(provider: provider, config: config)
+                await Self.serveCost(provider: provider, config: snapshot.config)
             }
         }
+    }
+
+    static func loadServeConfigSnapshot(
+        configStore: CodexBarConfigStore = CodexBarConfigStore()) throws -> CLIServeConfigSnapshot
+    {
+        let config = try configStore.load() ?? CodexBarConfig.makeDefault()
+        return try CLIServeConfigSnapshot(
+            config: config,
+            cacheToken: Self.serveConfigCacheToken(for: config))
+    }
+
+    static func serveCacheKey(kind: String, provider: String?, configToken: String) -> String {
+        "\(kind):\(provider ?? ""):\(configToken)"
+    }
+
+    static func serveConfigCacheToken(for config: CodexBarConfig) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(config.normalized())
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for byte in data {
+            hash ^= UInt64(byte)
+            hash = hash &* 1_099_511_628_211
+        }
+        return String(hash, radix: 16)
     }
 
     static func cachedServeResponse(

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -214,6 +214,31 @@ struct CLIServeRouterTests {
     }
 
     @Test
+    func `serve cache prunes expired config token entries`() async throws {
+        let cache = CLIServeResponseCache()
+
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage::old-config",
+            cache: cache,
+            refreshInterval: 0.001)
+        {
+            Self.response(#"[{"provider":"codex","config":"old"}]"#)
+        }
+        #expect(await cache.cachedEntryCount() == 1)
+
+        try await Task.sleep(nanoseconds: 20_000_000)
+        _ = await CodexBarCLI.cachedServeResponse(
+            key: "usage::new-config",
+            cache: cache,
+            refreshInterval: 60)
+        {
+            Self.response(#"[{"provider":"codex","config":"new"}]"#)
+        }
+
+        #expect(await cache.cachedEntryCount() == 1)
+    }
+
+    @Test
     func `serve cache does not cache timeouts and recovers on next success`() async {
         let cache = CLIServeResponseCache()
         let counter = ServeTestCounter()

--- a/Tests/CodexBarTests/CLIServeRouterTests.swift
+++ b/Tests/CodexBarTests/CLIServeRouterTests.swift
@@ -2,6 +2,7 @@ import Commander
 import Foundation
 import Testing
 @testable import CodexBarCLI
+@testable import CodexBarCore
 
 struct CLIServeRouterTests {
     @Test
@@ -136,6 +137,29 @@ struct CLIServeRouterTests {
         #expect(serve.contains("--request-timeout <seconds>"))
         #expect(serve.contains("codexbar serve --port 8080 --refresh-interval 60 --request-timeout 30"))
         #expect(root.contains("--request-timeout <seconds>"))
+    }
+
+    @Test
+    func `serve config snapshot reflects provider changes`() throws {
+        let store = testConfigStore(suiteName: "CLIServeRouterTests-serve-config-freshness-\(UUID().uuidString)")
+        defer { try? store.deleteIfPresent() }
+        var firstConfig = CodexBarConfig.makeDefault()
+        firstConfig.setProviderConfig(ProviderConfig(id: .opencodego, enabled: false))
+        try store.save(firstConfig)
+
+        let firstSnapshot = try CodexBarCLI.loadServeConfigSnapshot(configStore: store)
+
+        var secondConfig = firstConfig
+        secondConfig.setProviderConfig(ProviderConfig(id: .opencodego, enabled: true))
+        try store.save(secondConfig)
+        let secondSnapshot = try CodexBarCLI.loadServeConfigSnapshot(configStore: store)
+
+        #expect(!firstSnapshot.config.enabledProviders().contains(.opencodego))
+        #expect(secondSnapshot.config.enabledProviders().contains(.opencodego))
+        #expect(firstSnapshot.cacheToken != secondSnapshot.cacheToken)
+        #expect(
+            CodexBarCLI.serveCacheKey(kind: "usage", provider: nil, configToken: firstSnapshot.cacheToken) !=
+                CodexBarCLI.serveCacheKey(kind: "usage", provider: nil, configToken: secondSnapshot.cacheToken))
     }
 
     @Test

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -48,6 +48,7 @@ See `docs/configuration.md` for the schema.
   - `--port <port>` defaults to `8080`.
   - `--refresh-interval <seconds>` defaults to `60` and controls the in-memory response cache TTL.
   - `--request-timeout <seconds>` defaults to `30` and bounds each request before returning `504 Gateway Timeout`; use `0` to keep waiting indefinitely.
+  - Provider config is reloaded for each usage/cost request; cache entries are keyed by the loaded config so provider toggles and source changes do not require restarting `serve`.
   - v1 binds to `127.0.0.1` only and rejects non-loopback `Host` headers. It does not expose remote bind, auth, CORS, TLS, or daemon mode.
   - Endpoints: `GET /health`, `GET /usage`, `GET /usage?provider=<id|both|all>`, `GET /cost`, `GET /cost?provider=<id|both|all>`.
   - Codex usage responses include every visible Codex account, matching the menu bar switcher.


### PR DESCRIPTION
## Summary
- reload CodexBar provider config for each `codexbar serve` usage/cost request instead of capturing it once at startup
- key the in-memory response cache by the loaded config token so provider toggles/source changes bypass stale cached payloads
- document the live config behavior in the CLI docs

## Verification
- `swift test --filter CLIServeRouterTests`
- `./Scripts/lint.sh format && ./Scripts/lint.sh lint`

## Maintainer proof

One running server process observed edits to an isolated all-disabled config without restart: valid config returned `[]` with HTTP 200, invalid JSON returned the config decode error with HTTP 500, and restoring the valid config returned `[]` with HTTP 200. No provider, browser, account, or Keychain access was used.

Validated on head `3fd2fa65` with `swift test --filter CLIServeRouterTests` (14 passed), `make check`, `git diff --check`, and clean autoreview (0.84 confidence).
