### PR TITLE
fix(amp): restore usage fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Localization: add native Korean language support across the app and language picker (#1460). Thanks @soohanpark!
 - Devin: add daily and weekly quota tracking from the signed-in Chrome session or a manual Bearer token (#1264, fixes #800). Thanks @coygeek!
+- Amp: add local `amp usage` support, including account identity and individual and workspace credit balances (fixes #1317). Thanks @3kh0!
 - Menu bar: add an optional reset-time display for the selected quota metric, with percent fallback when reset metadata is unavailable (#1223, fixes #1185). Thanks @Yuxin-Qiao!
 - Menu bar: move the highlighted Overview provider with trackpad or mouse-wheel scrolling while preserving native submenu and keyboard behavior (#1436). Thanks @joshuavial!
 
@@ -12,6 +13,7 @@
 - Settings: slightly increase the window height so standard panes fit without clipping their final controls or helper text.
 - Menu bar: show immediate in-place feedback for manual refreshes, keep tracked-menu geometry stable, and coalesce repeated clicks until the active refresh succeeds or fails (#1458). Thanks @hhh2210!
 - Grok: recover web billing from status-7 credential failures by combining current browser sessions with non-expired CLI auth, accept raw protobuf responses, and render current zero-use periods (#1452). Thanks @bcharleson!
+- Amp: restore usage fetching against the current balance endpoint while retaining the legacy settings-page parser as a fallback. Thanks @3kh0!
 - Antigravity: detect current hyphenated IDE language-server processes inside Antigravity app bundles so local quota refreshes no longer report the IDE as unavailable (#1405). Thanks @lfmundim!
 - Menu bar: avoid republishing unchanged provider storage footprints so background scans no longer trigger unnecessary menu observation work (#1416). Thanks @soohanpark!
 - Cursor: show capped team Extra usage when no individual cap exists, and honor percent used/remaining menu bar display settings instead of always showing currency spend (#1426). Thanks @lpc-eol!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Settings: slightly increase the window height so standard panes fit without clipping their final controls or helper text.
 - Menu bar: show immediate in-place feedback for manual refreshes, keep tracked-menu geometry stable, and coalesce repeated clicks until the active refresh succeeds or fails (#1458). Thanks @hhh2210!
 - Grok: recover web billing from status-7 credential failures by combining current browser sessions with non-expired CLI auth, accept raw protobuf responses, and render current zero-use periods (#1452). Thanks @bcharleson!
-- Amp: restore usage fetching against the current balance endpoint while retaining the legacy settings-page parser as a fallback. Thanks @3kh0!
+- Amp: restore usage fetching with access-token authentication for the current balance endpoint and retain browser-cookie settings parsing as a fallback. Thanks @3kh0!
 - Antigravity: detect current hyphenated IDE language-server processes inside Antigravity app bundles so local quota refreshes no longer report the IDE as unavailable (#1405). Thanks @lfmundim!
 - Menu bar: avoid republishing unchanged provider storage footprints so background scans no longer trigger unnecessary menu observation work (#1416). Thanks @soohanpark!
 - Cursor: show capped team Extra usage when no individual cap exists, and honor percent used/remaining menu bar display settings instead of always showing currency spend (#1426). Thanks @lpc-eol!

--- a/Sources/CodexBar/MenuCardView+Costs.swift
+++ b/Sources/CodexBar/MenuCardView+Costs.swift
@@ -11,10 +11,17 @@ extension UsageMenuCardView.Model {
 
     static func creditsLine(
         metadata: ProviderMetadata,
+        snapshot: UsageSnapshot?,
         credits: CreditsSnapshot?,
         error: String?) -> String?
     {
         guard metadata.supportsCredits else { return nil }
+        if metadata.id == .amp,
+           let ampUsage = snapshot?.ampUsage,
+           let ampCredits = self.ampCreditsLine(ampUsage)
+        {
+            return ampCredits
+        }
         if let credits {
             return UsageFormatter.creditsString(from: credits.remaining)
         }
@@ -22,6 +29,19 @@ extension UsageMenuCardView.Model {
             return error.trimmingCharacters(in: .whitespacesAndNewlines)
         }
         return L(metadata.creditsHint)
+    }
+
+    private static func ampCreditsLine(_ usage: AmpUsageDetails) -> String? {
+        var lines: [String] = []
+        if let individualCredits = usage.individualCredits {
+            lines.append(
+                "\(L("Individual credits")): \(UsageFormatter.currencyString(individualCredits, currencyCode: "USD"))")
+        }
+        lines.append(contentsOf: usage.workspaceBalances.map { workspace in
+            "\(L("Workspace")) \(workspace.name): " +
+                UsageFormatter.currencyString(workspace.remaining, currencyCode: "USD")
+        })
+        return lines.isEmpty ? nil : lines.joined(separator: "\n")
     }
 
     static func tokenUsageSection(

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -856,7 +856,7 @@ extension UsageMenuCardView.Model {
         let openAIAPIUsage = input.snapshot?.openAIAPIUsage
         let inlineUsageDashboard = Self.inlineUsageDashboard(input: input)
         let usageNotes = Self.usageNotes(input: input)
-        let creditsText: String? = if input.provider == .openrouter {
+        let rawCreditsText: String? = if input.provider == .openrouter {
             nil
         } else if input.codexProjection != nil, !input.showOptionalCreditsAndExtraUsage {
             nil
@@ -867,6 +867,7 @@ extension UsageMenuCardView.Model {
                 credits: input.credits,
                 error: input.creditsError)
         }
+        let creditsText = PersonalInfoRedactor.redactEmails(in: rawCreditsText, isEnabled: input.hidePersonalInfo)
         let isClaudeAdminAPI = input.provider == .claude &&
             input.snapshot?.identity?.loginMethod == "Admin API"
         let hidesOptionalProviderCost = ((input.provider == .claude && !isClaudeAdminAPI) ||

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -861,7 +861,11 @@ extension UsageMenuCardView.Model {
         } else if input.codexProjection != nil, !input.showOptionalCreditsAndExtraUsage {
             nil
         } else {
-            Self.creditsLine(metadata: input.metadata, credits: input.credits, error: input.creditsError)
+            Self.creditsLine(
+                metadata: input.metadata,
+                snapshot: input.snapshot,
+                credits: input.credits,
+                error: input.creditsError)
         }
         let isClaudeAdminAPI = input.provider == .claude &&
             input.snapshot?.identity?.loginMethod == "Admin API"

--- a/Sources/CodexBar/Providers/Amp/AmpProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Amp/AmpProviderImplementation.swift
@@ -10,8 +10,15 @@ struct AmpProviderImplementation: ProviderImplementation {
 
     @MainActor
     func observeSettings(_ settings: SettingsStore) {
+        _ = settings.ampUsageDataSource
+        _ = settings.ampAPIToken
         _ = settings.ampCookieSource
         _ = settings.ampCookieHeader
+    }
+
+    @MainActor
+    func sourceMode(context: ProviderSourceModeContext) -> ProviderSourceMode {
+        context.settings.ampUsageDataSource
     }
 
     @MainActor
@@ -21,6 +28,17 @@ struct AmpProviderImplementation: ProviderImplementation {
 
     @MainActor
     func settingsPickers(context: ProviderSettingsContext) -> [ProviderSettingsPickerDescriptor] {
+        let sourceBinding = Binding(
+            get: { context.settings.ampUsageDataSource.rawValue },
+            set: { raw in
+                context.settings.ampUsageDataSource = ProviderSourceMode(rawValue: raw) ?? .auto
+            })
+        let sourceOptions: [ProviderSettingsPickerOption] = [
+            ProviderSettingsPickerOption(id: ProviderSourceMode.auto.rawValue, title: "Auto"),
+            ProviderSettingsPickerOption(id: ProviderSourceMode.cli.rawValue, title: "Amp CLI"),
+            ProviderSettingsPickerOption(id: ProviderSourceMode.api.rawValue, title: "Access token"),
+            ProviderSettingsPickerOption(id: ProviderSourceMode.web.rawValue, title: "Browser cookies"),
+        ]
         let cookieBinding = Binding(
             get: { context.settings.ampCookieSource.rawValue },
             set: { raw in
@@ -41,13 +59,24 @@ struct AmpProviderImplementation: ProviderImplementation {
 
         return [
             ProviderSettingsPickerDescriptor(
+                id: "amp-usage-source",
+                title: "Usage source",
+                subtitle: "Auto tries the Amp CLI, access token, then browser cookies.",
+                binding: sourceBinding,
+                options: sourceOptions,
+                isVisible: nil,
+                onChange: nil),
+            ProviderSettingsPickerDescriptor(
                 id: "amp-cookie-source",
                 title: "Cookie source",
                 subtitle: "Automatic imports browser cookies.",
                 dynamicSubtitle: cookieSubtitle,
                 binding: cookieBinding,
                 options: cookieOptions,
-                isVisible: nil,
+                isVisible: {
+                    context.settings.ampUsageDataSource == .auto ||
+                        context.settings.ampUsageDataSource == .web
+                },
                 onChange: nil),
         ]
     }
@@ -55,6 +84,30 @@ struct AmpProviderImplementation: ProviderImplementation {
     @MainActor
     func settingsFields(context: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {
         [
+            ProviderSettingsFieldDescriptor(
+                id: "amp-api-token",
+                title: "Access token",
+                subtitle: "Stored in ~/.codexbar/config.json. You can also set AMP_API_KEY.",
+                kind: .secure,
+                placeholder: "sgamp_...",
+                binding: context.stringBinding(\.ampAPIToken),
+                actions: [
+                    ProviderSettingsActionDescriptor(
+                        id: "amp-open-access-tokens",
+                        title: "Open Amp Access Tokens",
+                        style: .link,
+                        isVisible: nil,
+                        perform: {
+                            if let url = URL(string: "https://ampcode.com/settings") {
+                                NSWorkspace.shared.open(url)
+                            }
+                        }),
+                ],
+                isVisible: {
+                    context.settings.ampUsageDataSource == .auto ||
+                        context.settings.ampUsageDataSource == .api
+                },
+                onActivate: { context.settings.ensureAmpAPITokenLoaded() }),
             ProviderSettingsFieldDescriptor(
                 id: "amp-cookie",
                 title: "",
@@ -74,7 +127,11 @@ struct AmpProviderImplementation: ProviderImplementation {
                             }
                         }),
                 ],
-                isVisible: { context.settings.ampCookieSource == .manual },
+                isVisible: {
+                    (context.settings.ampUsageDataSource == .auto ||
+                        context.settings.ampUsageDataSource == .web) &&
+                        context.settings.ampCookieSource == .manual
+                },
                 onActivate: { context.settings.ensureAmpCookieLoaded() }),
         ]
     }

--- a/Sources/CodexBar/Providers/Amp/AmpSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Amp/AmpSettingsStore.swift
@@ -2,6 +2,26 @@ import CodexBarCore
 import Foundation
 
 extension SettingsStore {
+    var ampUsageDataSource: ProviderSourceMode {
+        get { self.configSnapshot.providerConfig(for: .amp)?.source ?? .auto }
+        set {
+            self.updateProviderConfig(provider: .amp) { entry in
+                entry.source = newValue == .auto ? nil : newValue
+            }
+            self.logProviderModeChange(provider: .amp, field: "source", value: newValue.rawValue)
+        }
+    }
+
+    var ampAPIToken: String {
+        get { self.configSnapshot.providerConfig(for: .amp)?.sanitizedAPIKey ?? "" }
+        set {
+            self.updateProviderConfig(provider: .amp) { entry in
+                entry.apiKey = self.normalizedConfigValue(newValue)
+            }
+            self.logSecretUpdate(provider: .amp, field: "apiKey", value: newValue)
+        }
+    }
+
     var ampCookieHeader: String {
         get { self.configSnapshot.providerConfig(for: .amp)?.sanitizedCookieHeader ?? "" }
         set {
@@ -21,6 +41,8 @@ extension SettingsStore {
             self.logProviderModeChange(provider: .amp, field: "cookieSource", value: newValue.rawValue)
         }
     }
+
+    func ensureAmpAPITokenLoaded() {}
 
     func ensureAmpCookieLoaded() {}
 }

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -98,6 +98,8 @@
 "Could not start codex login" = "No s'ha pogut iniciar codex login";
 "Could not switch system account" = "No s'ha pogut canviar el compte del sistema";
 "Credits" = "Crèdits";
+"Individual credits" = "Crèdits individuals";
+"Workspace" = "Espai de treball";
 "Credits history" = "Historial de crèdits";
 "Cursor login failed" = "L'inici de sessió de Cursor ha fallat";
 "Custom" = "Personalitzat";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -99,6 +99,8 @@
 "Could not start codex login" = "Could not start codex login";
 "Could not switch system account" = "Could not switch system account";
 "Credits" = "Credits";
+"Individual credits" = "Individual credits";
+"Workspace" = "Workspace";
 "Credits history" = "Credits history";
 "Cursor login failed" = "Cursor login failed";
 "Custom" = "Custom";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -98,6 +98,8 @@
 "Could not start codex login" = "No se pudo iniciar codex login";
 "Could not switch system account" = "No se pudo cambiar la cuenta del sistema";
 "Credits" = "Créditos";
+"Individual credits" = "Créditos individuales";
+"Workspace" = "Espacio de trabajo";
 "Credits history" = "Historial de créditos";
 "Cursor login failed" = "El inicio de sesión de Cursor falló";
 "Custom" = "Personalizado";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -99,6 +99,8 @@
 "Could not start codex login" = "Impossible de démarrer la connexion à Codex";
 "Could not switch system account" = "Impossible de changer de compte système";
 "Credits" = "Crédits";
+"Individual credits" = "Crédits individuels";
+"Workspace" = "Espace de travail";
 "Credits history" = "Historique des crédits";
 "Cursor login failed" = "La connexion au curseur a échoué";
 "Custom" = "Personnalisé";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -99,6 +99,8 @@
 "Could not start codex login" = "codex login を開始できませんでした";
 "Could not switch system account" = "システムアカウントを切り替えられませんでした";
 "Credits" = "クレジット";
+"Individual credits" = "個人クレジット";
+"Workspace" = "ワークスペース";
 "Credits history" = "クレジット履歴";
 "Cursor login failed" = "Cursor のログインに失敗しました";
 "Custom" = "カスタム";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -99,6 +99,8 @@
 "Could not start codex login" = "codex login을 시작할 수 없음";
 "Could not switch system account" = "시스템 계정을 전환할 수 없음";
 "Credits" = "크레딧";
+"Individual credits" = "개인 크레딧";
+"Workspace" = "작업 공간";
 "Credits history" = "크레딧 내역";
 "Cursor login failed" = "Cursor 로그인 실패";
 "Custom" = "사용자 설정";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -99,6 +99,8 @@
 "Could not start codex login" = "Kan codex-aanmelding niet starten";
 "Could not switch system account" = "Kan van systeemaccount niet wisselen";
 "Credits" = "Kredieten";
+"Individual credits" = "Individuele kredieten";
+"Workspace" = "Werkruimte";
 "Credits history" = "Creditgeschiedenis";
 "Cursor login failed" = "Cursoraanmelding mislukt";
 "Custom" = "Aangepast";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -99,6 +99,8 @@
 "Could not start codex login" = "Não foi possível iniciar o login do Codex";
 "Could not switch system account" = "Não foi possível trocar a conta do sistema";
 "Credits" = "Créditos";
+"Individual credits" = "Créditos individuais";
+"Workspace" = "Workspace";
 "Credits history" = "Histórico de créditos";
 "Cursor login failed" = "Falha no login do Cursor";
 "Custom" = "Personalizado";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -99,6 +99,8 @@
 "Could not start codex login" = "Kunde inte starta codex login";
 "Could not switch system account" = "Kunde inte byta systemkonto";
 "Credits" = "Krediter";
+"Individual credits" = "Individuella krediter";
+"Workspace" = "Arbetsyta";
 "Credits history" = "Kredithistorik";
 "Cursor login failed" = "Cursor-inloggning misslyckades";
 "Custom" = "Anpassat";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -99,6 +99,8 @@
 "Could not start codex login" = "Не вдалося розпочати вхід до Codex";
 "Could not switch system account" = "Не вдалося змінити обліковий запис системи";
 "Credits" = "Кредити";
+"Individual credits" = "Особисті кредити";
+"Workspace" = "Робоча область";
 "Credits history" = "Кредитна історія";
 "Cursor login failed" = "Помилка входу в систему курсору";
 "Custom" = "Користувацький";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -99,6 +99,8 @@
 "Could not start codex login" = "Không thể bắt đầu đăng nhập codex";
 "Could not switch system account" = "Không thể không chuyển đổi tài khoản hệ thống";
 "Credits" = "Tín dụng";
+"Individual credits" = "Tín dụng cá nhân";
+"Workspace" = "Không gian làm việc";
 "Credits history" = "Lịch sử tín dụng";
 "Cursor login failed" = "Đăng nhập con trỏ không thành công";
 "Custom" = "Tùy chỉnh";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -101,6 +101,8 @@
 "Could not start codex login" = "无法启动 codex login";
 "Could not switch system account" = "无法切换系统账户";
 "Credits" = "额度";
+"Individual credits" = "个人额度";
+"Workspace" = "工作区";
 "Credits history" = "额度记录";
 "Cursor login failed" = "Cursor 登录失败";
 "Custom" = "自定义";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -101,6 +101,8 @@
 "Could not start codex login" = "無法啟動 codex login";
 "Could not switch system account" = "無法切換系統帳號";
 "Credits" = "額度";
+"Individual credits" = "個人額度";
+"Workspace" = "工作區";
 "Credits history" = "額度歷史";
 "Cursor login failed" = "Cursor 登入失敗";
 "Custom" = "自訂";

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -953,6 +953,7 @@ extension UsageStore {
             tertiary: snapshot.tertiary,
             extraRateWindows: snapshot.extraRateWindows,
             kiroUsage: snapshot.kiroUsage,
+            ampUsage: snapshot.ampUsage,
             providerCost: snapshot.providerCost,
             zaiUsage: snapshot.zaiUsage,
             minimaxUsage: snapshot.minimaxUsage,

--- a/Sources/CodexBarCLI/CLIRenderer.swift
+++ b/Sources/CodexBarCLI/CLIRenderer.swift
@@ -35,6 +35,7 @@ enum CLIRenderer {
             lines: &lines)
         self.appendTertiaryLines(snapshot: snapshot, labels: labels, context: context, now: now, lines: &lines)
         self.appendDeepgramLines(snapshot: snapshot, useColor: context.useColor, lines: &lines)
+        self.appendAmpBalanceLines(snapshot: snapshot, useColor: context.useColor, lines: &lines)
         self.appendLimitsUnavailableLine(
             provider: provider,
             snapshot: snapshot,
@@ -143,6 +144,26 @@ enum CLIRenderer {
             } else {
                 lines.append(self.labelValueLine("Usage", value: line, useColor: useColor))
             }
+        }
+    }
+
+    private static func appendAmpBalanceLines(
+        snapshot: UsageSnapshot,
+        useColor: Bool,
+        lines: inout [String])
+    {
+        guard let usage = snapshot.ampUsage else { return }
+        if let individualCredits = usage.individualCredits {
+            lines.append(self.labelValueLine(
+                "Individual credits",
+                value: UsageFormatter.currencyString(individualCredits, currencyCode: "USD"),
+                useColor: useColor))
+        }
+        for workspace in usage.workspaceBalances {
+            lines.append(self.labelValueLine(
+                "Workspace \(workspace.name)",
+                value: UsageFormatter.currencyString(workspace.remaining, currencyCode: "USD"),
+                useColor: useColor))
         }
     }
 

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -545,7 +545,7 @@ extension CodexBarCLI {
         environment: [String: String]? = nil,
         settings: ProviderSettingsSnapshot? = nil) -> Bool
     {
-        guard provider != .grok else {
+        guard provider != .grok, provider != .amp else {
             return false
         }
         if provider == .ollama,

--- a/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
+++ b/Sources/CodexBarCore/Config/ProviderConfigEnvironment.swift
@@ -76,6 +76,8 @@ public enum ProviderConfigEnvironment {
 
     private static func directAPIKeyEnvironmentKey(for provider: UsageProvider) -> String? {
         switch provider {
+        case .amp:
+            AmpSettingsReader.apiTokenKey
         case .openai:
             OpenAIAPISettingsReader.adminAPIKeyEnvironmentKey
         case .azureopenai:

--- a/Sources/CodexBarCore/PathEnvironment.swift
+++ b/Sources/CodexBarCore/PathEnvironment.swift
@@ -179,6 +179,36 @@ public enum BinaryLocator {
             home: home)
     }
 
+    public static func resolveAmpBinary(
+        env: [String: String] = ProcessInfo.processInfo.environment,
+        loginPATH: [String]? = LoginShellPathCache.shared.current,
+        commandV: (String, String?, TimeInterval, FileManager) -> String? = ShellCommandLocator.commandV,
+        aliasResolver: (String, String?, TimeInterval, FileManager, String) -> String? = ShellCommandLocator
+            .resolveAlias,
+        fileManager: FileManager = .default,
+        home: String = NSHomeDirectory()) -> String?
+    {
+        self.resolveBinary(
+            name: "amp",
+            overrideKey: "AMP_CLI_PATH",
+            env: env,
+            loginPATH: loginPATH,
+            commandV: commandV,
+            aliasResolver: aliasResolver,
+            wellKnownPaths: self.ampWellKnownPaths(home: home),
+            fileManager: fileManager,
+            home: home)
+    }
+
+    static func ampWellKnownPaths(home: String) -> [String] {
+        [
+            "\(home)/.local/bin/amp",
+            "\(home)/.amp/bin/amp",
+            "/opt/homebrew/bin/amp",
+            "/usr/local/bin/amp",
+        ]
+    }
+
     /// Well-known install locations for the Grok Build CLI binary.
     /// Covers the installer's default (`~/.grok/bin/grok`) and the symlinks it sometimes
     /// creates into `~/.local/bin` and `/usr/local/bin`.

--- a/Sources/CodexBarCore/Providers/Amp/AmpCLIProbe.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpCLIProbe.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public struct AmpCLIProbe: Sendable {
+    private static let commandTimeout: TimeInterval = 15
+
+    public init() {}
+
+    public func fetch(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        now: Date = Date()) async throws -> AmpUsageSnapshot
+    {
+        let loginPATH = LoginShellPathCache.shared.current
+        guard let executable = BinaryLocator.resolveAmpBinary(env: environment, loginPATH: loginPATH) else {
+            throw SubprocessRunnerError.binaryNotFound("amp")
+        }
+
+        var commandEnvironment = environment
+        commandEnvironment["NO_COLOR"] = "1"
+        commandEnvironment["PATH"] = PathBuilder.effectivePATH(
+            purposes: [.tty, .nodeTooling],
+            env: environment,
+            loginPATH: loginPATH)
+
+        let result = try await SubprocessRunner.run(
+            binary: executable,
+            arguments: ["usage"],
+            environment: commandEnvironment,
+            timeout: Self.commandTimeout,
+            standardInput: FileHandle.nullDevice,
+            label: "amp-usage")
+        let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? result.stderr
+            : result.stdout
+        guard !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw AmpUsageError.parseFailed("The Amp CLI returned no usage data.")
+        }
+        return try AmpUsageParser.parse(displayText: output, now: now)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
@@ -70,8 +70,11 @@ struct AmpCLIFetchStrategy: ProviderFetchStrategy {
             sourceLabel: "cli")
     }
 
-    func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {
-        context.sourceMode == .auto
+    func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
+        if error is CancellationError || (error as? URLError)?.code == .cancelled {
+            return false
+        }
+        return context.sourceMode == .auto
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
@@ -14,15 +14,15 @@ public enum AmpProviderDescriptor {
                 weeklyLabel: "Balance",
                 opusLabel: nil,
                 supportsOpus: false,
-                supportsCredits: false,
-                creditsHint: "",
+                supportsCredits: true,
+                creditsHint: "Individual and workspace credit balances from Amp.",
                 toggleTitle: "Show Amp usage",
                 cliName: "amp",
                 defaultEnabled: false,
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
                 browserCookieOrder: ProviderBrowserCookieDefaults.defaultImportOrder,
-                dashboardURL: "https://ampcode.com/settings",
+                dashboardURL: "https://ampcode.com/settings#billing",
                 statusPageURL: nil),
             branding: ProviderBranding(
                 iconStyle: .amp,
@@ -32,11 +32,46 @@ public enum AmpProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "Amp cost summary is not supported." }),
             fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .web],
-                pipeline: ProviderFetchPipeline(resolveStrategies: { _ in [AmpStatusFetchStrategy()] })),
+                sourceModes: [.auto, .web, .cli],
+                pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "amp",
                 versionDetector: nil))
+    }
+
+    private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {
+        switch context.sourceMode {
+        case .auto:
+            [AmpCLIFetchStrategy(), AmpStatusFetchStrategy()]
+        case .cli:
+            [AmpCLIFetchStrategy()]
+        case .web:
+            [AmpStatusFetchStrategy()]
+        case .api, .oauth:
+            []
+        }
+    }
+}
+
+struct AmpCLIFetchStrategy: ProviderFetchStrategy {
+    let id: String = "amp.cli"
+    let kind: ProviderFetchKind = .cli
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        BinaryLocator.resolveAmpBinary(
+            env: context.env,
+            loginPATH: LoginShellPathCache.shared.current) != nil
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        let snapshot = try await AmpCLIProbe().fetch(environment: context.env)
+        return self.makeResult(
+            usage: snapshot.toUsageSnapshot(now: snapshot.updatedAt),
+            sourceLabel: "cli")
+    }
+
+    func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {
+        context.sourceMode == .auto
     }
 }
 
@@ -45,6 +80,7 @@ struct AmpStatusFetchStrategy: ProviderFetchStrategy {
     let kind: ProviderFetchKind = .web
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        guard context.sourceMode.usesWeb else { return false }
         guard context.settings?.amp?.cookieSource != .off else { return false }
         return true
     }

--- a/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
@@ -32,7 +32,7 @@ public enum AmpProviderDescriptor {
                 supportsTokenCost: false,
                 noDataMessage: { "Amp cost summary is not supported." }),
             fetchPlan: ProviderFetchPlan(
-                sourceModes: [.auto, .web, .cli],
+                sourceModes: [.auto, .api, .web, .cli],
                 pipeline: ProviderFetchPipeline(resolveStrategies: self.resolveStrategies)),
             cli: ProviderCLIConfig(
                 name: "amp",
@@ -42,12 +42,14 @@ public enum AmpProviderDescriptor {
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {
         switch context.sourceMode {
         case .auto:
-            [AmpCLIFetchStrategy(), AmpStatusFetchStrategy()]
+            [AmpCLIFetchStrategy(), AmpAPIFetchStrategy(), AmpStatusFetchStrategy()]
         case .cli:
             [AmpCLIFetchStrategy()]
+        case .api:
+            [AmpAPIFetchStrategy()]
         case .web:
             [AmpStatusFetchStrategy()]
-        case .api, .oauth:
+        case .oauth:
             []
         }
     }
@@ -75,6 +77,35 @@ struct AmpCLIFetchStrategy: ProviderFetchStrategy {
             return false
         }
         return context.sourceMode == .auto
+    }
+}
+
+struct AmpAPIFetchStrategy: ProviderFetchStrategy {
+    let id: String = "amp.api"
+    let kind: ProviderFetchKind = .apiToken
+
+    func isAvailable(_ context: ProviderFetchContext) async -> Bool {
+        _ = context
+        return true
+    }
+
+    func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
+        guard let token = ProviderTokenResolver.ampToken(environment: context.env) else {
+            throw AmpUsageError.missingAPIToken
+        }
+        let logger: ((String) -> Void)? = context.verbose
+            ? { msg in CodexBarLog.logger(LogCategories.amp).verbose(msg) }
+            : nil
+        let snapshot = try await AmpUsageFetcher(browserDetection: context.browserDetection)
+            .fetch(apiToken: token, logger: logger)
+        return self.makeResult(
+            usage: snapshot.toUsageSnapshot(now: snapshot.updatedAt),
+            sourceLabel: "api")
+    }
+
+    func shouldFallback(on error: Error, context: ProviderFetchContext) -> Bool {
+        guard context.sourceMode == .auto else { return false }
+        return !(error is CancellationError) && (error as? URLError)?.code != .cancelled
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpProviderDescriptor.swift
@@ -81,8 +81,14 @@ struct AmpStatusFetchStrategy: ProviderFetchStrategy {
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
         guard context.sourceMode.usesWeb else { return false }
-        guard context.settings?.amp?.cookieSource != .off else { return false }
-        return true
+        #if os(macOS)
+        let canImportBrowserCookies = true
+        #else
+        let canImportBrowserCookies = false
+        #endif
+        return Self.canUseWebFallback(
+            settings: context.settings?.amp,
+            canImportBrowserCookies: canImportBrowserCookies)
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
@@ -101,8 +107,30 @@ struct AmpStatusFetchStrategy: ProviderFetchStrategy {
         false
     }
 
+    static func canUseWebFallback(
+        settings: ProviderSettingsSnapshot.AmpProviderSettings?,
+        canImportBrowserCookies: Bool) -> Bool
+    {
+        guard let settings else { return canImportBrowserCookies }
+        switch settings.cookieSource {
+        case .auto:
+            return canImportBrowserCookies
+        case .manual:
+            return Self.manualCookieHeader(from: settings.manualCookieHeader) != nil
+        case .off:
+            return false
+        }
+    }
+
     private static func manualCookieHeader(from context: ProviderFetchContext) -> String? {
-        guard context.settings?.amp?.cookieSource == .manual else { return nil }
-        return CookieHeaderNormalizer.normalize(context.settings?.amp?.manualCookieHeader)
+        guard let settings = context.settings?.amp, settings.cookieSource == .manual else { return nil }
+        return Self.manualCookieHeader(from: settings.manualCookieHeader)
+    }
+
+    private static func manualCookieHeader(from rawHeader: String?) -> String? {
+        guard let header = CookieHeaderNormalizer.normalize(rawHeader),
+              CookieHeaderNormalizer.pairs(from: header).contains(where: { $0.name == "session" })
+        else { return nil }
+        return header
     }
 }

--- a/Sources/CodexBarCore/Providers/Amp/AmpSettingsReader.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpSettingsReader.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public enum AmpSettingsReader {
+    public static let apiTokenKey = "AMP_API_KEY"
+
+    public static func apiToken(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        self.cleaned(environment[self.apiTokenKey])
+    }
+
+    static func cleaned(_ raw: String?) -> String? {
+        guard var value = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        if (value.hasPrefix("\"") && value.hasSuffix("\"")) ||
+            (value.hasPrefix("'") && value.hasSuffix("'"))
+        {
+            value = String(value.dropFirst().dropLast())
+        }
+        value = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.isEmpty ? nil : value
+    }
+}

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
@@ -310,7 +310,10 @@ public struct AmpUsageFetcher: Sendable {
         return try AmpUsageParser.parse(displayText: displayText, now: now)
     }
 
-    private static func shouldTryLegacyFallback(after error: Error) -> Bool {
+    static func shouldTryLegacyFallback(after error: Error) -> Bool {
+        if error is CancellationError || (error as? URLError)?.code == .cancelled {
+            return false
+        }
         guard let ampError = error as? AmpUsageError else { return true }
         switch ampError {
         case .networkError, .parseFailed:

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
@@ -95,6 +95,7 @@ public enum AmpCookieImporter {
 
 public struct AmpUsageFetcher: Sendable {
     private static let settingsURL = URL(string: "https://ampcode.com/settings")!
+    static let usageURL = URL(string: "https://ampcode.com/api/internal?userDisplayBalanceInfo")!
     @MainActor private static var recentDumps: [String] = []
 
     public let browserDetection: BrowserDetection
@@ -118,28 +119,25 @@ public struct AmpUsageFetcher: Sendable {
             }
             let diagnostics = RedirectDiagnostics(cookieHeader: cookieHeader, logger: logger)
             do {
-                let (html, responseInfo) = try await self.fetchHTMLWithDiagnostics(
+                let (snapshot, responseInfo) = try await self.fetchWithDiagnostics(
                     cookieHeader: cookieHeader,
-                    diagnostics: diagnostics)
+                    diagnostics: diagnostics,
+                    now: now)
                 self.logDiagnostics(responseInfo: responseInfo, diagnostics: diagnostics, logger: logger)
-                do {
-                    return try AmpUsageParser.parse(html: html, now: now)
-                } catch {
-                    logger("[amp] Parse failed: \(error.localizedDescription)")
-                    self.logHTMLHints(html: html, logger: logger)
-                    throw error
-                }
+                return snapshot
             } catch {
                 self.logDiagnostics(responseInfo: nil, diagnostics: diagnostics, logger: logger)
+                logger("[amp] Fetch failed: \(error.localizedDescription)")
                 throw error
             }
         }
 
         let diagnostics = RedirectDiagnostics(cookieHeader: cookieHeader, logger: nil)
-        let (html, _) = try await self.fetchHTMLWithDiagnostics(
+        let (snapshot, _) = try await self.fetchWithDiagnostics(
             cookieHeader: cookieHeader,
-            diagnostics: diagnostics)
-        return try AmpUsageParser.parse(html: html, now: now)
+            diagnostics: diagnostics,
+            now: now)
+        return snapshot
     }
 
     public func debugRawProbe(cookieHeaderOverride: String? = nil) async -> String {
@@ -174,10 +172,14 @@ public struct AmpUsageFetcher: Sendable {
 
             lines.append("")
             lines.append("Amp Free:")
-            lines.append("  quota=\(snapshot.freeQuota)")
-            lines.append("  used=\(snapshot.freeUsed)")
-            lines.append("  hourlyReplenishment=\(snapshot.hourlyReplenishment)")
+            lines.append("  quota=\(snapshot.freeQuota?.description ?? "nil")")
+            lines.append("  used=\(snapshot.freeUsed?.description ?? "nil")")
+            lines.append("  hourlyReplenishment=\(snapshot.hourlyReplenishment?.description ?? "nil")")
             lines.append("  windowHours=\(snapshot.windowHours?.description ?? "nil")")
+            lines.append("  individualCredits=\(snapshot.individualCredits?.description ?? "nil")")
+            for workspace in snapshot.workspaceBalances {
+                lines.append("  workspace[\(workspace.name)]=\(workspace.remaining)")
+            }
 
             let output = lines.joined(separator: "\n")
             Task { @MainActor in Self.recordDump(output) }
@@ -223,14 +225,49 @@ public struct AmpUsageFetcher: Sendable {
         diagnostics: RedirectDiagnostics,
         now: Date = Date()) async throws -> (AmpUsageSnapshot, ResponseInfo)
     {
-        let (html, responseInfo) = try await self.fetchHTMLWithDiagnostics(
-            cookieHeader: cookieHeader,
-            diagnostics: diagnostics)
-        let snapshot = try AmpUsageParser.parse(html: html, now: now)
-        return (snapshot, responseInfo)
+        do {
+            return try await self.fetchUsageAPIWithDiagnostics(
+                cookieHeader: cookieHeader,
+                diagnostics: diagnostics,
+                now: now)
+        } catch {
+            if diagnostics.detectedLoginRedirect {
+                throw AmpUsageError.invalidCredentials
+            }
+            guard Self.shouldTryLegacyFallback(after: error) else { throw error }
+            let (html, responseInfo) = try await self.fetchLegacyHTMLWithDiagnostics(
+                cookieHeader: cookieHeader,
+                diagnostics: diagnostics)
+            return try (AmpUsageParser.parse(html: html, now: now), responseInfo)
+        }
     }
 
-    private func fetchHTMLWithDiagnostics(
+    private func fetchUsageAPIWithDiagnostics(
+        cookieHeader: String,
+        diagnostics: RedirectDiagnostics,
+        now: Date) async throws -> (AmpUsageSnapshot, ResponseInfo)
+    {
+        var request = URLRequest(url: Self.usageURL)
+        request.httpMethod = "POST"
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "method": "userDisplayBalanceInfo",
+            "params": [:],
+        ])
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue("application/json", forHTTPHeaderField: "accept")
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        self.applyBrowserHeaders(to: &request)
+
+        let session = URLSession(configuration: .ephemeral, delegate: diagnostics, delegateQueue: nil)
+        let httpResponse = try await session.response(for: request)
+        let responseInfo = ResponseInfo(
+            statusCode: httpResponse.statusCode,
+            url: httpResponse.response.url?.absoluteString ?? "unknown")
+        try self.validate(response: httpResponse, diagnostics: diagnostics)
+        return try (Self.parseUsageAPIResponse(httpResponse.data, now: now), responseInfo)
+    }
+
+    private func fetchLegacyHTMLWithDiagnostics(
         cookieHeader: String,
         diagnostics: RedirectDiagnostics) async throws -> (String, ResponseInfo)
     {
@@ -240,6 +277,50 @@ public struct AmpUsageFetcher: Sendable {
         request.setValue(
             "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             forHTTPHeaderField: "accept")
+        self.applyBrowserHeaders(to: &request)
+
+        let session = URLSession(configuration: .ephemeral, delegate: diagnostics, delegateQueue: nil)
+        let httpResponse = try await session.response(for: request)
+        let responseInfo = ResponseInfo(
+            statusCode: httpResponse.statusCode,
+            url: httpResponse.response.url?.absoluteString ?? "unknown")
+        try self.validate(response: httpResponse, diagnostics: diagnostics)
+
+        let html = String(data: httpResponse.data, encoding: .utf8) ?? ""
+        return (html, responseInfo)
+    }
+
+    static func parseUsageAPIResponse(_ data: Data, now: Date = Date()) throws -> AmpUsageSnapshot {
+        let response: UsageAPIResponse
+        do {
+            response = try JSONDecoder().decode(UsageAPIResponse.self, from: data)
+        } catch {
+            throw AmpUsageError.parseFailed("Invalid Amp usage API response.")
+        }
+
+        guard response.ok else {
+            if response.error?.code == "auth-required" {
+                throw AmpUsageError.invalidCredentials
+            }
+            throw AmpUsageError.networkError(response.error?.message ?? "Amp usage API returned an error.")
+        }
+        guard let displayText = response.result?.displayText, !displayText.isEmpty else {
+            throw AmpUsageError.parseFailed("Missing Amp usage display text.")
+        }
+        return try AmpUsageParser.parse(displayText: displayText, now: now)
+    }
+
+    private static func shouldTryLegacyFallback(after error: Error) -> Bool {
+        guard let ampError = error as? AmpUsageError else { return true }
+        switch ampError {
+        case .networkError, .parseFailed:
+            return true
+        case .notLoggedIn, .invalidCredentials, .noSessionCookie:
+            return false
+        }
+    }
+
+    private func applyBrowserHeaders(to request: inout URLRequest) {
         request.setValue(
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
                 "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
@@ -247,25 +328,18 @@ public struct AmpUsageFetcher: Sendable {
         request.setValue("en-US,en;q=0.9", forHTTPHeaderField: "accept-language")
         request.setValue("https://ampcode.com", forHTTPHeaderField: "origin")
         request.setValue(Self.settingsURL.absoluteString, forHTTPHeaderField: "referer")
+    }
 
-        let session = URLSession(configuration: .ephemeral, delegate: diagnostics, delegateQueue: nil)
-        let httpResponse = try await session.response(for: request)
-        let responseInfo = ResponseInfo(
-            statusCode: httpResponse.statusCode,
-            url: httpResponse.response.url?.absoluteString ?? "unknown")
-
-        guard httpResponse.statusCode == 200 else {
-            if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+    private func validate(
+        response: ProviderHTTPResponse,
+        diagnostics: RedirectDiagnostics) throws
+    {
+        guard response.statusCode == 200 else {
+            if response.statusCode == 401 || response.statusCode == 403 || diagnostics.detectedLoginRedirect {
                 throw AmpUsageError.invalidCredentials
             }
-            if diagnostics.detectedLoginRedirect {
-                throw AmpUsageError.invalidCredentials
-            }
-            throw AmpUsageError.networkError("HTTP \(httpResponse.statusCode)")
+            throw AmpUsageError.networkError("HTTP \(response.statusCode)")
         }
-
-        let html = String(data: httpResponse.data, encoding: .utf8) ?? ""
-        return (html, responseInfo)
     }
 
     @MainActor private static func recordDump(_ text: String) {
@@ -325,6 +399,21 @@ public struct AmpUsageFetcher: Sendable {
         let url: String
     }
 
+    private struct UsageAPIResponse: Decodable {
+        let ok: Bool
+        let result: Result?
+        let error: APIError?
+
+        struct Result: Decodable {
+            let displayText: String
+        }
+
+        struct APIError: Decodable {
+            let code: String?
+            let message: String?
+        }
+    }
+
     private func logDiagnostics(
         responseInfo: ResponseInfo?,
         diagnostics: RedirectDiagnostics,
@@ -339,19 +428,6 @@ public struct AmpUsageFetcher: Sendable {
                 logger("[amp]   \(entry)")
             }
         }
-    }
-
-    private func logHTMLHints(html: String, logger: (String) -> Void) {
-        let trimmed = html
-            .replacingOccurrences(of: "\n", with: " ")
-            .replacingOccurrences(of: "\t", with: " ")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmed.isEmpty {
-            let snippet = trimmed.prefix(240)
-            logger("[amp] HTML snippet: \(snippet)")
-        }
-        logger("[amp] Contains freeTierUsage: \(html.contains("freeTierUsage"))")
-        logger("[amp] Contains getFreeTierUsage: \(html.contains("getFreeTierUsage"))")
     }
 
     private func cookieNames(from header: String) -> [String] {
@@ -383,6 +459,7 @@ public struct AmpUsageFetcher: Sendable {
 
     static func isLoginRedirect(_ url: URL) -> Bool {
         guard self.isAmpHost(url) else { return false }
+        if url.host?.lowercased() == "auth.ampcode.com" { return true }
 
         let path = url.path.lowercased()
         let components = path.split(separator: "/").map(String.init)

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageFetcher.swift
@@ -10,6 +10,8 @@ import SweetCookieKit
 public enum AmpUsageError: LocalizedError, Sendable {
     case notLoggedIn
     case invalidCredentials
+    case missingAPIToken
+    case invalidAPIToken
     case parseFailed(String)
     case networkError(String)
     case noSessionCookie
@@ -20,6 +22,10 @@ public enum AmpUsageError: LocalizedError, Sendable {
             "Not logged in to Amp. Please log in via ampcode.com."
         case .invalidCredentials:
             "Amp session cookie expired. Please log in again."
+        case .missingAPIToken:
+            "Amp access token not configured. Set AMP_API_KEY or add it in Settings."
+        case .invalidAPIToken:
+            "Amp access token is invalid or expired."
         case let .parseFailed(message):
             "Could not parse Amp usage: \(message)"
         case let .networkError(message):
@@ -119,12 +125,11 @@ public struct AmpUsageFetcher: Sendable {
             }
             let diagnostics = RedirectDiagnostics(cookieHeader: cookieHeader, logger: logger)
             do {
-                let (snapshot, responseInfo) = try await self.fetchWithDiagnostics(
+                let (html, responseInfo) = try await self.fetchLegacyHTMLWithDiagnostics(
                     cookieHeader: cookieHeader,
-                    diagnostics: diagnostics,
-                    now: now)
+                    diagnostics: diagnostics)
                 self.logDiagnostics(responseInfo: responseInfo, diagnostics: diagnostics, logger: logger)
-                return snapshot
+                return try AmpUsageParser.parse(html: html, now: now)
             } catch {
                 self.logDiagnostics(responseInfo: nil, diagnostics: diagnostics, logger: logger)
                 logger("[amp] Fetch failed: \(error.localizedDescription)")
@@ -133,11 +138,28 @@ public struct AmpUsageFetcher: Sendable {
         }
 
         let diagnostics = RedirectDiagnostics(cookieHeader: cookieHeader, logger: nil)
-        let (snapshot, _) = try await self.fetchWithDiagnostics(
+        let (html, _) = try await self.fetchLegacyHTMLWithDiagnostics(
             cookieHeader: cookieHeader,
-            diagnostics: diagnostics,
-            now: now)
-        return snapshot
+            diagnostics: diagnostics)
+        return try AmpUsageParser.parse(html: html, now: now)
+    }
+
+    public func fetch(
+        apiToken: String,
+        logger: ((String) -> Void)? = nil,
+        now: Date = Date()) async throws -> AmpUsageSnapshot
+    {
+        guard let token = AmpSettingsReader.cleaned(apiToken) else {
+            throw AmpUsageError.missingAPIToken
+        }
+        let request = try Self.makeUsageAPIRequest(apiToken: token)
+        let diagnostics = APIRedirectDiagnostics(logger: logger)
+        let session = URLSession(configuration: .ephemeral, delegate: diagnostics, delegateQueue: nil)
+        let httpResponse = try await session.response(for: request)
+        logger?("[amp] API response: \(httpResponse.statusCode) " +
+            "\(httpResponse.response.url?.absoluteString ?? "unknown")")
+        try Self.validateAPIResponse(httpResponse)
+        return try Self.parseUsageAPIResponse(httpResponse.data, now: now)
     }
 
     public func debugRawProbe(cookieHeaderOverride: String? = nil) async -> String {
@@ -154,9 +176,10 @@ public struct AmpUsageFetcher: Sendable {
             let cookieNames = CookieHeaderNormalizer.pairs(from: cookieHeader).map(\.name)
             lines.append("Cookie names: \(cookieNames.joined(separator: ", "))")
 
-            let (snapshot, responseInfo) = try await self.fetchWithDiagnostics(
+            let (html, responseInfo) = try await self.fetchLegacyHTMLWithDiagnostics(
                 cookieHeader: cookieHeader,
                 diagnostics: diagnostics)
+            let snapshot = try AmpUsageParser.parse(html: html)
 
             lines.append("")
             lines.append("Fetch Success")
@@ -220,51 +243,17 @@ public struct AmpUsageFetcher: Sendable {
         #endif
     }
 
-    private func fetchWithDiagnostics(
-        cookieHeader: String,
-        diagnostics: RedirectDiagnostics,
-        now: Date = Date()) async throws -> (AmpUsageSnapshot, ResponseInfo)
-    {
-        do {
-            return try await self.fetchUsageAPIWithDiagnostics(
-                cookieHeader: cookieHeader,
-                diagnostics: diagnostics,
-                now: now)
-        } catch {
-            if diagnostics.detectedLoginRedirect {
-                throw AmpUsageError.invalidCredentials
-            }
-            guard Self.shouldTryLegacyFallback(after: error) else { throw error }
-            let (html, responseInfo) = try await self.fetchLegacyHTMLWithDiagnostics(
-                cookieHeader: cookieHeader,
-                diagnostics: diagnostics)
-            return try (AmpUsageParser.parse(html: html, now: now), responseInfo)
-        }
-    }
-
-    private func fetchUsageAPIWithDiagnostics(
-        cookieHeader: String,
-        diagnostics: RedirectDiagnostics,
-        now: Date) async throws -> (AmpUsageSnapshot, ResponseInfo)
-    {
+    static func makeUsageAPIRequest(apiToken: String) throws -> URLRequest {
         var request = URLRequest(url: Self.usageURL)
         request.httpMethod = "POST"
         request.httpBody = try JSONSerialization.data(withJSONObject: [
             "method": "userDisplayBalanceInfo",
             "params": [:],
         ])
-        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "accept")
         request.setValue("application/json", forHTTPHeaderField: "content-type")
-        self.applyBrowserHeaders(to: &request)
-
-        let session = URLSession(configuration: .ephemeral, delegate: diagnostics, delegateQueue: nil)
-        let httpResponse = try await session.response(for: request)
-        let responseInfo = ResponseInfo(
-            statusCode: httpResponse.statusCode,
-            url: httpResponse.response.url?.absoluteString ?? "unknown")
-        try self.validate(response: httpResponse, diagnostics: diagnostics)
-        return try (Self.parseUsageAPIResponse(httpResponse.data, now: now), responseInfo)
+        return request
     }
 
     private func fetchLegacyHTMLWithDiagnostics(
@@ -277,14 +266,14 @@ public struct AmpUsageFetcher: Sendable {
         request.setValue(
             "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             forHTTPHeaderField: "accept")
-        self.applyBrowserHeaders(to: &request)
+        Self.applyBrowserHeaders(to: &request)
 
         let session = URLSession(configuration: .ephemeral, delegate: diagnostics, delegateQueue: nil)
         let httpResponse = try await session.response(for: request)
         let responseInfo = ResponseInfo(
             statusCode: httpResponse.statusCode,
             url: httpResponse.response.url?.absoluteString ?? "unknown")
-        try self.validate(response: httpResponse, diagnostics: diagnostics)
+        try Self.validateBrowserResponse(response: httpResponse, diagnostics: diagnostics)
 
         let html = String(data: httpResponse.data, encoding: .utf8) ?? ""
         return (html, responseInfo)
@@ -300,7 +289,7 @@ public struct AmpUsageFetcher: Sendable {
 
         guard response.ok else {
             if response.error?.code == "auth-required" {
-                throw AmpUsageError.invalidCredentials
+                throw AmpUsageError.invalidAPIToken
             }
             throw AmpUsageError.networkError(response.error?.message ?? "Amp usage API returned an error.")
         }
@@ -310,36 +299,32 @@ public struct AmpUsageFetcher: Sendable {
         return try AmpUsageParser.parse(displayText: displayText, now: now)
     }
 
-    static func shouldTryLegacyFallback(after error: Error) -> Bool {
-        if error is CancellationError || (error as? URLError)?.code == .cancelled {
-            return false
-        }
-        guard let ampError = error as? AmpUsageError else { return true }
-        switch ampError {
-        case .networkError, .parseFailed:
-            return true
-        case .notLoggedIn, .invalidCredentials, .noSessionCookie:
-            return false
-        }
-    }
-
-    private func applyBrowserHeaders(to request: inout URLRequest) {
+    private static func applyBrowserHeaders(to request: inout URLRequest) {
         request.setValue(
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
                 "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
             forHTTPHeaderField: "user-agent")
         request.setValue("en-US,en;q=0.9", forHTTPHeaderField: "accept-language")
         request.setValue("https://ampcode.com", forHTTPHeaderField: "origin")
-        request.setValue(Self.settingsURL.absoluteString, forHTTPHeaderField: "referer")
+        request.setValue(self.settingsURL.absoluteString, forHTTPHeaderField: "referer")
     }
 
-    private func validate(
+    private static func validateBrowserResponse(
         response: ProviderHTTPResponse,
         diagnostics: RedirectDiagnostics) throws
     {
         guard response.statusCode == 200 else {
             if response.statusCode == 401 || response.statusCode == 403 || diagnostics.detectedLoginRedirect {
                 throw AmpUsageError.invalidCredentials
+            }
+            throw AmpUsageError.networkError("HTTP \(response.statusCode)")
+        }
+    }
+
+    private static func validateAPIResponse(_ response: ProviderHTTPResponse) throws {
+        guard response.statusCode == 200 else {
+            if response.statusCode == 401 || response.statusCode == 403 {
+                throw AmpUsageError.invalidAPIToken
             }
             throw AmpUsageError.networkError("HTTP \(response.statusCode)")
         }
@@ -394,6 +379,28 @@ public struct AmpUsageFetcher: Sendable {
                 logger("[amp] Redirect \(response.statusCode) \(from) -> \(to)")
             }
             completionHandler(updated)
+        }
+    }
+
+    /// Amp's balance RPC should not redirect. Refusing redirects guarantees the bearer token cannot cross hosts.
+    private final class APIRedirectDiagnostics: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+        private let logger: ((String) -> Void)?
+
+        init(logger: ((String) -> Void)?) {
+            self.logger = logger
+        }
+
+        func urlSession(
+            _: URLSession,
+            task _: URLSessionTask,
+            willPerformHTTPRedirection response: HTTPURLResponse,
+            newRequest request: URLRequest,
+            completionHandler: @escaping (URLRequest?) -> Void)
+        {
+            let from = response.url?.absoluteString ?? "unknown"
+            let to = request.url?.absoluteString ?? "unknown"
+            self.logger?("[amp] API redirect blocked: \(response.statusCode) \(from) -> \(to)")
+            completionHandler(nil)
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageParser.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageParser.swift
@@ -17,6 +17,62 @@ enum AmpUsageParser {
             updatedAt: now)
     }
 
+    static func parse(displayText: String, now: Date = Date()) throws -> AmpUsageSnapshot {
+        let text = TextParsing.stripANSICodes(displayText)
+        let identityPattern = #"(?im)^\s*Signed in as\s+([^\s(]+)(?:\s+\(([^\r\n)]+)\))?\s*$"#
+        let identity = self.captures(in: text, pattern: identityPattern)
+        if identity == nil, self.looksSignedOut(text) {
+            throw AmpUsageError.notLoggedIn
+        }
+
+        let amountPattern = #"([0-9][0-9,]*(?:\.[0-9]+)?)"#
+        let freePattern = #"(?im)^\s*Amp Free:\s*\$?"# + amountPattern +
+            #"\s*/\s*\$?"# + amountPattern +
+            #"\s+remaining(?:\s*\(replenishes\s*\+\$?"# + amountPattern + #"\s*/\s*hour\))?"#
+        let creditsPattern = #"(?im)^\s*Individual credits:\s*\$?"# + amountPattern + #"\s+remaining"#
+        let individualCredits = self.captures(in: text, pattern: creditsPattern)?.first
+            .flatMap(self.number(from:))
+        let workspacePattern = #"(?im)^\s*Workspace\s+(.+?):\s*\$?"# + amountPattern + #"\s+remaining"#
+        let workspaceBalances: [AmpWorkspaceBalance] = self.allCaptures(
+            in: text,
+            pattern: workspacePattern).compactMap { captures -> AmpWorkspaceBalance? in
+            guard captures.count == 2,
+                  let name = self.nonEmpty(captures[0]),
+                  let remaining = self.number(from: captures[1])
+            else { return nil }
+            return AmpWorkspaceBalance(name: name, remaining: remaining)
+        }
+        let freeUsage: FreeTierUsage? = {
+            guard let free = self.captures(in: text, pattern: freePattern),
+                  let remaining = self.number(from: free[0]),
+                  let quota = self.number(from: free[1])
+            else { return nil }
+            let hourlyReplenishment = self.number(from: free[2]) ?? 0
+            let windowHours = hourlyReplenishment > 0
+                ? max(1, (quota / hourlyReplenishment).rounded())
+                : nil
+            return FreeTierUsage(
+                quota: quota,
+                used: max(0, quota - remaining),
+                hourlyReplenishment: hourlyReplenishment,
+                windowHours: windowHours)
+        }()
+        guard freeUsage != nil || individualCredits != nil || !workspaceBalances.isEmpty else {
+            throw AmpUsageError.parseFailed("Missing Amp usage data.")
+        }
+
+        return AmpUsageSnapshot(
+            freeQuota: freeUsage?.quota,
+            freeUsed: freeUsage?.used,
+            hourlyReplenishment: freeUsage?.hourlyReplenishment,
+            windowHours: freeUsage?.windowHours,
+            individualCredits: individualCredits,
+            workspaceBalances: workspaceBalances,
+            accountEmail: self.nonEmpty(identity?[0]),
+            accountOrganization: self.nonEmpty(identity?[1]),
+            updatedAt: now)
+    }
+
     private struct FreeTierUsage {
         let quota: Double
         let used: Double
@@ -96,6 +152,41 @@ enum AmpUsageParser {
               let valueRange = Range(match.range(at: 1), in: text)
         else { return nil }
         return Double(text[valueRange])
+    }
+
+    private static func captures(in text: String, pattern: String) -> [String]? {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range) else { return nil }
+
+        return self.captures(in: text, match: match)
+    }
+
+    private static func allCaptures(in text: String, pattern: String) -> [[String]] {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.matches(in: text, options: [], range: range).map { match in
+            self.captures(in: text, match: match)
+        }
+    }
+
+    private static func captures(in text: String, match: NSTextCheckingResult) -> [String] {
+        (1..<match.numberOfRanges).map { index in
+            let captureRange = match.range(at: index)
+            guard captureRange.location != NSNotFound,
+                  let range = Range(captureRange, in: text)
+            else { return "" }
+            return String(text[range]).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
+    private static func number(from text: String) -> Double? {
+        Double(text.replacingOccurrences(of: ",", with: ""))
+    }
+
+    private static func nonEmpty(_ text: String?) -> String? {
+        guard let text, !text.isEmpty else { return nil }
+        return text
     }
 
     private static func looksSignedOut(_ html: String) -> Bool {

--- a/Sources/CodexBarCore/Providers/Amp/AmpUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/Amp/AmpUsageSnapshot.swift
@@ -1,66 +1,104 @@
 import Foundation
 
+public struct AmpWorkspaceBalance: Codable, Equatable, Sendable {
+    public let name: String
+    public let remaining: Double
+
+    public init(name: String, remaining: Double) {
+        self.name = name
+        self.remaining = remaining
+    }
+}
+
+public struct AmpUsageDetails: Codable, Equatable, Sendable {
+    public let individualCredits: Double?
+    public let workspaceBalances: [AmpWorkspaceBalance]
+
+    public init(individualCredits: Double?, workspaceBalances: [AmpWorkspaceBalance]) {
+        self.individualCredits = individualCredits
+        self.workspaceBalances = workspaceBalances
+    }
+}
+
 public struct AmpUsageSnapshot: Sendable {
-    public let freeQuota: Double
-    public let freeUsed: Double
-    public let hourlyReplenishment: Double
+    public let freeQuota: Double?
+    public let freeUsed: Double?
+    public let hourlyReplenishment: Double?
     public let windowHours: Double?
+    public let individualCredits: Double?
+    public let workspaceBalances: [AmpWorkspaceBalance]
+    public let accountEmail: String?
+    public let accountOrganization: String?
     public let updatedAt: Date
 
     public init(
-        freeQuota: Double,
-        freeUsed: Double,
-        hourlyReplenishment: Double,
+        freeQuota: Double?,
+        freeUsed: Double?,
+        hourlyReplenishment: Double?,
         windowHours: Double?,
+        individualCredits: Double? = nil,
+        workspaceBalances: [AmpWorkspaceBalance] = [],
+        accountEmail: String? = nil,
+        accountOrganization: String? = nil,
         updatedAt: Date)
     {
         self.freeQuota = freeQuota
         self.freeUsed = freeUsed
         self.hourlyReplenishment = hourlyReplenishment
         self.windowHours = windowHours
+        self.individualCredits = individualCredits
+        self.workspaceBalances = workspaceBalances
+        self.accountEmail = accountEmail
+        self.accountOrganization = accountOrganization
         self.updatedAt = updatedAt
     }
 }
 
 extension AmpUsageSnapshot {
     public func toUsageSnapshot(now: Date = Date()) -> UsageSnapshot {
-        let quota = max(0, self.freeQuota)
-        let used = max(0, self.freeUsed)
-        let percent: Double = if quota > 0 {
-            min(100, (used / quota) * 100)
-        } else {
-            0
-        }
-
-        let windowMinutes: Int? = if let hours = self.windowHours, hours > 0 {
-            Int((hours * 60).rounded())
+        let primary: RateWindow? = if let freeQuota, let freeUsed {
+            {
+                let quota = max(0, freeQuota)
+                let used = max(0, freeUsed)
+                let percent = quota > 0 ? min(100, (used / quota) * 100) : 0
+                let windowMinutes: Int? = if let hours = self.windowHours, hours > 0 {
+                    Int((hours * 60).rounded())
+                } else {
+                    nil
+                }
+                let resetsAt: Date? = {
+                    guard quota > 0, let hourlyReplenishment, hourlyReplenishment > 0 else { return nil }
+                    return now.addingTimeInterval(max(0, used / hourlyReplenishment * 3600))
+                }()
+                return RateWindow(
+                    usedPercent: percent,
+                    windowMinutes: windowMinutes,
+                    resetsAt: resetsAt,
+                    resetDescription: nil)
+            }()
         } else {
             nil
         }
 
-        let resetsAt: Date? = {
-            guard quota > 0, self.hourlyReplenishment > 0 else { return nil }
-            let hoursToFull = used / self.hourlyReplenishment
-            let seconds = max(0, hoursToFull * 3600)
-            return now.addingTimeInterval(seconds)
-        }()
-
-        let primary = RateWindow(
-            usedPercent: percent,
-            windowMinutes: windowMinutes,
-            resetsAt: resetsAt,
-            resetDescription: nil)
-
         let identity = ProviderIdentitySnapshot(
             providerID: .amp,
-            accountEmail: nil,
-            accountOrganization: nil,
-            loginMethod: "Amp Free")
+            accountEmail: self.accountEmail,
+            accountOrganization: self.accountOrganization,
+            loginMethod: primary == nil ? "Amp" : "Amp Free")
+
+        let ampUsage: AmpUsageDetails? = if self.individualCredits != nil || !self.workspaceBalances.isEmpty {
+            AmpUsageDetails(
+                individualCredits: self.individualCredits,
+                workspaceBalances: self.workspaceBalances)
+        } else {
+            nil
+        }
 
         return UsageSnapshot(
             primary: primary,
             secondary: nil,
             tertiary: nil,
+            ampUsage: ampUsage,
             providerCost: nil,
             updatedAt: self.updatedAt,
             identity: identity)

--- a/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
@@ -110,6 +110,7 @@ public struct ProviderDiagnosticUsageSummary: Codable, Sendable {
 
         var providerSpecificData: [String] = []
         if snapshot.kiroUsage != nil { providerSpecificData.append("kiroUsage") }
+        if snapshot.ampUsage != nil { providerSpecificData.append("ampUsage") }
         if snapshot.zaiUsage != nil { providerSpecificData.append("zaiUsage") }
         if snapshot.minimaxUsage != nil { providerSpecificData.append("minimaxUsage") }
         if snapshot.deepseekUsage != nil { providerSpecificData.append("deepseekUsage") }

--- a/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
+++ b/Sources/CodexBarCore/Providers/ProviderTokenResolver.swift
@@ -16,6 +16,10 @@ public struct ProviderTokenResolution: Sendable {
 }
 
 public enum ProviderTokenResolver {
+    public static func ampToken(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
+        self.ampResolution(environment: environment)?.token
+    }
+
     public static func zaiToken(environment: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         self.zaiResolution(environment: environment)?.token
     }
@@ -149,6 +153,12 @@ public enum ProviderTokenResolver {
         environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
     {
         self.resolveEnv(BedrockSettingsReader.accessKeyID(environment: environment))
+    }
+
+    public static func ampResolution(
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> ProviderTokenResolution?
+    {
+        self.resolveEnv(AmpSettingsReader.apiToken(environment: environment))
     }
 
     public static func deepseekResolution(

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -124,6 +124,7 @@ public struct UsageSnapshot: Codable, Sendable {
     public let extraRateWindows: [NamedRateWindow]?
     public let providerCost: ProviderCostSnapshot?
     public let kiroUsage: KiroUsageDetails?
+    public let ampUsage: AmpUsageDetails?
     public let zaiUsage: ZaiUsageSnapshot?
     public let minimaxUsage: MiniMaxUsageSnapshot?
     public let deepseekUsage: DeepSeekUsageSummary?
@@ -145,6 +146,7 @@ public struct UsageSnapshot: Codable, Sendable {
         case extraRateWindows
         case providerCost
         case kiroUsage
+        case ampUsage
         case openRouterUsage
         case openAIAPIUsage
         case claudeAdminAPIUsage
@@ -165,6 +167,7 @@ public struct UsageSnapshot: Codable, Sendable {
         tertiary: RateWindow? = nil,
         extraRateWindows: [NamedRateWindow]? = nil,
         kiroUsage: KiroUsageDetails? = nil,
+        ampUsage: AmpUsageDetails? = nil,
         providerCost: ProviderCostSnapshot? = nil,
         zaiUsage: ZaiUsageSnapshot? = nil,
         minimaxUsage: MiniMaxUsageSnapshot? = nil,
@@ -185,6 +188,7 @@ public struct UsageSnapshot: Codable, Sendable {
         self.tertiary = tertiary
         self.extraRateWindows = extraRateWindows
         self.kiroUsage = kiroUsage
+        self.ampUsage = ampUsage
         self.providerCost = providerCost
         self.zaiUsage = zaiUsage
         self.minimaxUsage = minimaxUsage
@@ -209,6 +213,7 @@ public struct UsageSnapshot: Codable, Sendable {
         self.extraRateWindows = try container.decodeIfPresent([NamedRateWindow].self, forKey: .extraRateWindows)
         self.providerCost = try container.decodeIfPresent(ProviderCostSnapshot.self, forKey: .providerCost)
         self.kiroUsage = try container.decodeIfPresent(KiroUsageDetails.self, forKey: .kiroUsage)
+        self.ampUsage = try container.decodeIfPresent(AmpUsageDetails.self, forKey: .ampUsage)
         self.zaiUsage = nil // Not persisted, fetched fresh each time
         self.minimaxUsage = nil // Not persisted, fetched fresh each time
         self.deepseekUsage = nil // Not persisted, fetched fresh each time
@@ -250,6 +255,7 @@ public struct UsageSnapshot: Codable, Sendable {
         try container.encodeIfPresent(self.extraRateWindows, forKey: .extraRateWindows)
         try container.encodeIfPresent(self.providerCost, forKey: .providerCost)
         try container.encodeIfPresent(self.kiroUsage, forKey: .kiroUsage)
+        try container.encodeIfPresent(self.ampUsage, forKey: .ampUsage)
         try container.encodeIfPresent(self.openRouterUsage, forKey: .openRouterUsage)
         try container.encodeIfPresent(self.openAIAPIUsage, forKey: .openAIAPIUsage)
         try container.encodeIfPresent(self.claudeAdminAPIUsage, forKey: .claudeAdminAPIUsage)
@@ -350,6 +356,7 @@ public struct UsageSnapshot: Codable, Sendable {
             tertiary: self.tertiary,
             extraRateWindows: self.extraRateWindows,
             kiroUsage: self.kiroUsage,
+            ampUsage: self.ampUsage,
             providerCost: self.providerCost,
             zaiUsage: self.zaiUsage,
             minimaxUsage: self.minimaxUsage,
@@ -388,6 +395,7 @@ public struct UsageSnapshot: Codable, Sendable {
             tertiary: tertiary,
             extraRateWindows: self.extraRateWindows,
             kiroUsage: self.kiroUsage,
+            ampUsage: self.ampUsage,
             providerCost: self.providerCost,
             zaiUsage: self.zaiUsage,
             minimaxUsage: self.minimaxUsage,

--- a/Tests/CodexBarTests/AmpUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AmpUsageFetcherTests.swift
@@ -4,6 +4,13 @@ import Testing
 
 struct AmpUsageFetcherTests {
     @Test
+    func `uses amp internal usage endpoint`() {
+        #expect(
+            AmpUsageFetcher.usageURL.absoluteString ==
+                "https://ampcode.com/api/internal?userDisplayBalanceInfo")
+    }
+
+    @Test
     func `attaches cookie for amp hosts`() {
         #expect(AmpUsageFetcher.shouldAttachCookie(to: URL(string: "https://ampcode.com/settings")))
         #expect(AmpUsageFetcher.shouldAttachCookie(to: URL(string: "https://www.ampcode.com")))
@@ -41,6 +48,10 @@ struct AmpUsageFetcherTests {
 
         let signin = try #require(URL(string: "https://www.ampcode.com/signin"))
         #expect(AmpUsageFetcher.isLoginRedirect(signin))
+
+        let hostedAuth = try #require(URL(
+            string: "https://auth.ampcode.com/?client_id=test&redirect_uri=https%3A%2F%2Fampcode.com%2Fauth%2Fcallback"))
+        #expect(AmpUsageFetcher.isLoginRedirect(hostedAuth))
     }
 
     @Test

--- a/Tests/CodexBarTests/AmpUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AmpUsageFetcherTests.swift
@@ -3,6 +3,22 @@ import Testing
 @testable import CodexBarCore
 
 struct AmpUsageFetcherTests {
+    private func makeContext(sourceMode: ProviderSourceMode) -> ProviderFetchContext {
+        let browserDetection = BrowserDetection(cacheTTL: 0)
+        return ProviderFetchContext(
+            runtime: .app,
+            sourceMode: sourceMode,
+            includeCredits: true,
+            webTimeout: 1,
+            webDebugDumpHTML: false,
+            verbose: false,
+            env: [:],
+            settings: nil,
+            fetcher: UsageFetcher(),
+            claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
+            browserDetection: browserDetection)
+    }
+
     @Test
     func `uses amp internal usage endpoint`() {
         #expect(
@@ -35,6 +51,28 @@ struct AmpUsageFetcherTests {
         #expect(AmpStatusFetchStrategy.canUseWebFallback(
             settings: validManual,
             canImportBrowserCookies: false))
+    }
+
+    @Test
+    func `cli cancellation does not fall back to web`() {
+        let strategy = AmpCLIFetchStrategy()
+        let context = self.makeContext(sourceMode: .auto)
+
+        #expect(!strategy.shouldFallback(on: CancellationError(), context: context))
+        #expect(!strategy.shouldFallback(on: URLError(.cancelled), context: context))
+        #expect(strategy.shouldFallback(on: AmpUsageError.parseFailed("missing"), context: context))
+        #expect(!strategy.shouldFallback(
+            on: AmpUsageError.parseFailed("missing"),
+            context: self.makeContext(sourceMode: .cli)))
+    }
+
+    @Test
+    func `api cancellation does not fall back to legacy scraper`() {
+        #expect(!AmpUsageFetcher.shouldTryLegacyFallback(after: CancellationError()))
+        #expect(!AmpUsageFetcher.shouldTryLegacyFallback(after: URLError(.cancelled)))
+        #expect(AmpUsageFetcher.shouldTryLegacyFallback(after: URLError(.timedOut)))
+        #expect(AmpUsageFetcher.shouldTryLegacyFallback(after: AmpUsageError.parseFailed("missing")))
+        #expect(!AmpUsageFetcher.shouldTryLegacyFallback(after: AmpUsageError.invalidCredentials))
     }
 
     @Test

--- a/Tests/CodexBarTests/AmpUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AmpUsageFetcherTests.swift
@@ -3,7 +3,10 @@ import Testing
 @testable import CodexBarCore
 
 struct AmpUsageFetcherTests {
-    private func makeContext(sourceMode: ProviderSourceMode) -> ProviderFetchContext {
+    private func makeContext(
+        sourceMode: ProviderSourceMode,
+        env: [String: String] = [:]) -> ProviderFetchContext
+    {
         let browserDetection = BrowserDetection(cacheTTL: 0)
         return ProviderFetchContext(
             runtime: .app,
@@ -12,7 +15,7 @@ struct AmpUsageFetcherTests {
             webTimeout: 1,
             webDebugDumpHTML: false,
             verbose: false,
-            env: [:],
+            env: env,
             settings: nil,
             fetcher: UsageFetcher(),
             claudeFetcher: ClaudeUsageFetcher(browserDetection: browserDetection),
@@ -67,12 +70,33 @@ struct AmpUsageFetcherTests {
     }
 
     @Test
-    func `api cancellation does not fall back to legacy scraper`() {
-        #expect(!AmpUsageFetcher.shouldTryLegacyFallback(after: CancellationError()))
-        #expect(!AmpUsageFetcher.shouldTryLegacyFallback(after: URLError(.cancelled)))
-        #expect(AmpUsageFetcher.shouldTryLegacyFallback(after: URLError(.timedOut)))
-        #expect(AmpUsageFetcher.shouldTryLegacyFallback(after: AmpUsageError.parseFailed("missing")))
-        #expect(!AmpUsageFetcher.shouldTryLegacyFallback(after: AmpUsageError.invalidCredentials))
+    func `api request uses bearer token without cookies`() throws {
+        let request = try AmpUsageFetcher.makeUsageAPIRequest(apiToken: "sgamp_test")
+
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sgamp_test")
+        #expect(request.value(forHTTPHeaderField: "Cookie") == nil)
+    }
+
+    @Test
+    func `api strategy falls back only from auto mode and preserves cancellation`() {
+        let strategy = AmpAPIFetchStrategy()
+        let auto = self.makeContext(sourceMode: .auto)
+
+        #expect(strategy.shouldFallback(on: AmpUsageError.missingAPIToken, context: auto))
+        #expect(strategy.shouldFallback(on: AmpUsageError.invalidAPIToken, context: auto))
+        #expect(strategy.shouldFallback(on: URLError(.timedOut), context: auto))
+        #expect(!strategy.shouldFallback(on: CancellationError(), context: auto))
+        #expect(!strategy.shouldFallback(on: URLError(.cancelled), context: auto))
+        #expect(!strategy.shouldFallback(
+            on: AmpUsageError.invalidAPIToken,
+            context: self.makeContext(sourceMode: .api)))
+    }
+
+    @Test
+    func `amp config token resolves through environment`() {
+        let env = [AmpSettingsReader.apiTokenKey: " 'sgamp_test' "]
+
+        #expect(ProviderTokenResolver.ampToken(environment: env) == "sgamp_test")
     }
 
     @Test

--- a/Tests/CodexBarTests/AmpUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AmpUsageFetcherTests.swift
@@ -11,6 +11,33 @@ struct AmpUsageFetcherTests {
     }
 
     @Test
+    func `web fallback requires browser import or a manual session cookie`() {
+        let disabled = ProviderSettingsSnapshot.AmpProviderSettings(cookieSource: .off, manualCookieHeader: nil)
+        let invalidManual = ProviderSettingsSnapshot.AmpProviderSettings(
+            cookieSource: .manual,
+            manualCookieHeader: "other=value")
+        let validManual = ProviderSettingsSnapshot.AmpProviderSettings(
+            cookieSource: .manual,
+            manualCookieHeader: "session=test")
+
+        #expect(AmpStatusFetchStrategy.canUseWebFallback(
+            settings: nil,
+            canImportBrowserCookies: false) == false)
+        #expect(AmpStatusFetchStrategy.canUseWebFallback(
+            settings: nil,
+            canImportBrowserCookies: true))
+        #expect(AmpStatusFetchStrategy.canUseWebFallback(
+            settings: disabled,
+            canImportBrowserCookies: true) == false)
+        #expect(AmpStatusFetchStrategy.canUseWebFallback(
+            settings: invalidManual,
+            canImportBrowserCookies: false) == false)
+        #expect(AmpStatusFetchStrategy.canUseWebFallback(
+            settings: validManual,
+            canImportBrowserCookies: false))
+    }
+
+    @Test
     func `attaches cookie for amp hosts`() {
         #expect(AmpUsageFetcher.shouldAttachCookie(to: URL(string: "https://ampcode.com/settings")))
         #expect(AmpUsageFetcher.shouldAttachCookie(to: URL(string: "https://www.ampcode.com")))

--- a/Tests/CodexBarTests/AmpUsageParserTests.swift
+++ b/Tests/CodexBarTests/AmpUsageParserTests.swift
@@ -4,6 +4,162 @@ import Testing
 
 struct AmpUsageParserTests {
     @Test
+    func `amp cli probe runs usage and parses balances`() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-amp-cli-\(UUID().uuidString)", isDirectory: true)
+        let executable = directory.appendingPathComponent("amp")
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let script = """
+        #!/bin/sh
+        [ "$1" = "usage" ] || exit 2
+        cat <<'EOF'
+        Signed in as cli@example.com (team)
+        Amp Free: $6/$10 remaining (replenishes +$0.5/hour)
+        Individual credits: $12.50 remaining
+        Workspace Test Team: $7.25 remaining
+        EOF
+        """
+        try script.write(to: executable, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = try await AmpCLIProbe().fetch(
+            environment: ["AMP_CLI_PATH": executable.path],
+            now: now)
+
+        #expect(snapshot.freeUsed == 4)
+        #expect(snapshot.individualCredits == 12.5)
+        #expect(snapshot.workspaceBalances == [AmpWorkspaceBalance(name: "Test Team", remaining: 7.25)])
+        #expect(snapshot.accountEmail == "cli@example.com")
+        #expect(snapshot.updatedAt == now)
+    }
+
+    @Test
+    func `parses current amp usage display text`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let output = """
+        \u{1B}[2mSigned in as ampcode@3kh0.net (echo)\u{1B}[0m
+        Amp Free: $4.71/$10 remaining (replenishes +$0.42/hour) - https://ampcode.com/settings#amp-free
+        Individual credits: $25.64 remaining (set up automatic top-up to avoid running out) - https://ampcode.com/settings
+        Workspace meow: $10.22 remaining (set up automatic top-up to avoid running out) - https://ampcode.com/workspaces/meow
+        """
+
+        let snapshot = try AmpUsageParser.parse(displayText: output, now: now)
+
+        #expect(snapshot.freeQuota == 10)
+        #expect(try abs(#require(snapshot.freeUsed) - 5.29) < 0.001)
+        #expect(snapshot.hourlyReplenishment == 0.42)
+        #expect(snapshot.windowHours == 24)
+        #expect(snapshot.individualCredits == 25.64)
+        #expect(snapshot.workspaceBalances == [AmpWorkspaceBalance(name: "meow", remaining: 10.22)])
+        #expect(snapshot.accountEmail == "ampcode@3kh0.net")
+        #expect(snapshot.accountOrganization == "echo")
+        #expect(snapshot.toUsageSnapshot(now: now).ampUsage == AmpUsageDetails(
+            individualCredits: 25.64,
+            workspaceBalances: [AmpWorkspaceBalance(name: "meow", remaining: 10.22)]))
+
+        let encoded = try JSONEncoder().encode(snapshot.toUsageSnapshot(now: now))
+        let decoded = try JSONDecoder().decode(UsageSnapshot.self, from: encoded)
+        #expect(decoded.ampUsage == AmpUsageDetails(
+            individualCredits: 25.64,
+            workspaceBalances: [AmpWorkspaceBalance(name: "meow", remaining: 10.22)]))
+    }
+
+    @Test
+    func `parses individual credits without free tier usage`() throws {
+        let output = """
+        Signed in as paid@example.com
+        Individual credits: $25.64 remaining
+        """
+
+        let snapshot = try AmpUsageParser.parse(displayText: output)
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(snapshot.freeQuota == nil)
+        #expect(snapshot.freeUsed == nil)
+        #expect(snapshot.individualCredits == 25.64)
+        #expect(usage.primary == nil)
+        #expect(usage.ampUsage == AmpUsageDetails(individualCredits: 25.64, workspaceBalances: []))
+        #expect(usage.identity?.loginMethod == "Amp")
+    }
+
+    @Test
+    func `parses workspace credits without free tier usage`() throws {
+        let output = """
+        Signed in as workspace@example.com (team)
+        Workspace Alpha Team: $1,234.56 remaining
+        Workspace Beta: $7 remaining
+        """
+
+        let snapshot = try AmpUsageParser.parse(displayText: output)
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(snapshot.freeQuota == nil)
+        #expect(snapshot.workspaceBalances == [
+            AmpWorkspaceBalance(name: "Alpha Team", remaining: 1234.56),
+            AmpWorkspaceBalance(name: "Beta", remaining: 7),
+        ])
+        #expect(usage.primary == nil)
+        #expect(usage.ampUsage == AmpUsageDetails(
+            individualCredits: nil,
+            workspaceBalances: snapshot.workspaceBalances))
+    }
+
+    @Test
+    func `signed in identity can contain login`() throws {
+        let output = """
+        Signed in as login@example.com (login-team)
+        Amp Free: $6/$10 remaining (replenishes +$0.5/hour)
+        """
+
+        let snapshot = try AmpUsageParser.parse(displayText: output)
+
+        #expect(snapshot.accountEmail == "login@example.com")
+        #expect(snapshot.accountOrganization == "login-team")
+    }
+
+    @Test
+    func `parses current usage api response`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_005_000)
+        let displayText = """
+        Signed in as user@example.com (team)
+        Amp Free: $8/$10 remaining (replenishes +$0.5/hour)
+        Individual credits: $12.50 remaining
+        Workspace Alpha Team: $1,234.56 remaining
+        Workspace Beta: $7 remaining
+        """
+        let data = try JSONSerialization.data(withJSONObject: [
+            "ok": true,
+            "result": ["displayText": displayText],
+        ])
+
+        let snapshot = try AmpUsageFetcher.parseUsageAPIResponse(data, now: now)
+
+        #expect(snapshot.freeUsed == 2)
+        #expect(snapshot.individualCredits == 12.5)
+        #expect(snapshot.workspaceBalances == [
+            AmpWorkspaceBalance(name: "Alpha Team", remaining: 1234.56),
+            AmpWorkspaceBalance(name: "Beta", remaining: 7),
+        ])
+        #expect(snapshot.accountEmail == "user@example.com")
+        #expect(snapshot.accountOrganization == "team")
+    }
+
+    @Test
+    func `usage api auth error is invalid credentials`() {
+        let data = Data(#"{"ok":false,"error":{"code":"auth-required","message":"Sign in"}}"#.utf8)
+
+        #expect {
+            try AmpUsageFetcher.parseUsageAPIResponse(data)
+        } throws: { error in
+            guard case AmpUsageError.invalidCredentials = error else { return false }
+            return true
+        }
+    }
+
+    @Test
     func `parses free tier usage from settings HTML`() throws {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let html = """

--- a/Tests/CodexBarTests/AmpUsageParserTests.swift
+++ b/Tests/CodexBarTests/AmpUsageParserTests.swift
@@ -148,13 +148,13 @@ struct AmpUsageParserTests {
     }
 
     @Test
-    func `usage api auth error is invalid credentials`() {
+    func `usage api auth error is invalid API token`() {
         let data = Data(#"{"ok":false,"error":{"code":"auth-required","message":"Sign in"}}"#.utf8)
 
         #expect {
             try AmpUsageFetcher.parseUsageAPIResponse(data)
         } throws: { error in
-            guard case AmpUsageError.invalidCredentials = error else { return false }
+            guard case AmpUsageError.invalidAPIToken = error else { return false }
             return true
         }
     }

--- a/Tests/CodexBarTests/CLIConfigCommandTests.swift
+++ b/Tests/CodexBarTests/CLIConfigCommandTests.swift
@@ -79,6 +79,7 @@ struct CLIConfigCommandTests {
         #expect(ProviderConfigEnvironment.supportsAPIKeyOverride(for: .groq))
         #expect(ProviderConfigEnvironment.supportsAPIKeyOverride(for: .llmproxy))
         #expect(ProviderConfigEnvironment.supportsAPIKeyOverride(for: .openai))
+        #expect(ProviderConfigEnvironment.supportsAPIKeyOverride(for: .amp))
         #expect(!ProviderConfigEnvironment.supportsAPIKeyOverride(for: .bedrock))
         #expect(!ProviderConfigEnvironment.supportsAPIKeyOverride(for: .deepseek))
         #expect(!ProviderConfigEnvironment.supportsAPIKeyOverride(for: .cursor))

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -305,6 +305,7 @@ final class CLIEntryTests: XCTestCase {
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .kilo))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .grok))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.web, provider: .grok))
+        XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .amp))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.api, provider: .kilo))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(
             .auto,

--- a/Tests/CodexBarTests/CLIOutputTests.swift
+++ b/Tests/CodexBarTests/CLIOutputTests.swift
@@ -64,4 +64,35 @@ struct CLIOutputTests {
         #expect(text.contains("Usage: 1.2 agent hours · 150 tokens · 1,200 TTS chars"))
         #expect(text.contains("Period: 2026-05-10 to 2026-05-17"))
     }
+
+    @Test
+    func `text renderer includes amp credits without free tier usage`() {
+        let snapshot = AmpUsageSnapshot(
+            freeQuota: nil,
+            freeUsed: nil,
+            hourlyReplenishment: nil,
+            windowHours: nil,
+            individualCredits: 25.64,
+            workspaceBalances: [
+                AmpWorkspaceBalance(name: "Alpha Team", remaining: 1234.56),
+            ],
+            accountEmail: "paid@example.com",
+            updatedAt: Date(timeIntervalSince1970: 0))
+            .toUsageSnapshot()
+
+        let text = CLIRenderer.renderText(
+            provider: .amp,
+            snapshot: snapshot,
+            credits: nil,
+            context: RenderContext(
+                header: "Amp (cli)",
+                status: nil,
+                useColor: false,
+                resetStyle: .countdown))
+
+        #expect(text.contains("Individual credits: $25.64"))
+        #expect(text.contains("Workspace Alpha Team: $1,234.56"))
+        #expect(text.contains("Account: paid@example.com"))
+        #expect(!text.contains("Amp Free:"))
+    }
 }

--- a/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
+++ b/Tests/CodexBarTests/ProviderConfigEnvironmentTests.swift
@@ -3,6 +3,18 @@ import Testing
 
 struct ProviderConfigEnvironmentTests {
     @Test
+    func `applies API key override for amp`() {
+        let config = ProviderConfig(id: .amp, apiKey: "sgamp-config")
+        let env = ProviderConfigEnvironment.applyAPIKeyOverride(
+            base: [:],
+            provider: .amp,
+            config: config)
+
+        #expect(env[AmpSettingsReader.apiTokenKey] == "sgamp-config")
+        #expect(ProviderTokenResolver.ampToken(environment: env) == "sgamp-config")
+    }
+
+    @Test
     func `applies API key override for zai`() {
         let config = ProviderConfig(id: .zai, apiKey: "z-token")
         let env = ProviderConfigEnvironment.applyAPIKeyOverride(

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -104,13 +104,17 @@ struct UsageStoreCoverageTests {
                 secondary: nil,
                 ampUsage: AmpUsageDetails(
                     individualCredits: 25.64,
-                    workspaceBalances: [AmpWorkspaceBalance(name: "meow", remaining: 10.22)]),
+                    workspaceBalances: [AmpWorkspaceBalance(name: "billing@example.test", remaining: 10.22)]),
                 updatedAt: now),
             provider: .amp)
         let model = ProvidersPane(settings: settings, store: store)._test_menuCardModel(for: .amp)
 
-        #expect(model.creditsText == "Individual credits: $25.64\nWorkspace meow: $10.22")
+        #expect(model.creditsText == "Individual credits: $25.64\nWorkspace billing@example.test: $10.22")
         #expect(model.creditsRemaining == nil)
+
+        settings.hidePersonalInfo = true
+        let redactedModel = ProvidersPane(settings: settings, store: store)._test_menuCardModel(for: .amp)
+        #expect(redactedModel.creditsText == "Individual credits: $25.64\nWorkspace Hidden: $10.22")
     }
 
     @Test

--- a/Tests/CodexBarTests/UsageStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreCoverageTests.swift
@@ -89,6 +89,31 @@ struct UsageStoreCoverageTests {
     }
 
     @Test
+    func `amp balances are rendered in provider cards`() {
+        let settings = Self.makeSettingsStore(suite: "UsageStoreCoverageTests-amp-credits")
+        let store = Self.makeUsageStore(settings: settings)
+        let now = Date()
+
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(
+                    usedPercent: 51.4,
+                    windowMinutes: 1440,
+                    resetsAt: now.addingTimeInterval(12 * 3600),
+                    resetDescription: nil),
+                secondary: nil,
+                ampUsage: AmpUsageDetails(
+                    individualCredits: 25.64,
+                    workspaceBalances: [AmpWorkspaceBalance(name: "meow", remaining: 10.22)]),
+                updatedAt: now),
+            provider: .amp)
+        let model = ProvidersPane(settings: settings, store: store)._test_menuCardModel(for: .amp)
+
+        #expect(model.creditsText == "Individual credits: $25.64\nWorkspace meow: $10.22")
+        #expect(model.creditsRemaining == nil)
+    }
+
+    @Test
     func `account info caches codex auth parsing until config revision changes`() throws {
         let settings = Self.makeSettingsStore(suite: "UsageStoreCoverageTests-account-info-cache")
         let home = FileManager.default.temporaryDirectory.appendingPathComponent(

--- a/TestsLinux/PlatformGatingTests.swift
+++ b/TestsLinux/PlatformGatingTests.swift
@@ -1,8 +1,14 @@
 import CodexBarCore
 import Testing
+@testable import CodexBarCLI
 
 @Suite
 struct PlatformGatingTests {
+    @Test
+    func ampAutoSource_doesNotRequireWebSupport() {
+        #expect(!CodexBarCLI.sourceModeRequiresWebSupport(.auto, provider: .amp))
+    }
+
     @Test
     func claudeWebFetcher_isNotSupportedOnLinux() async {
         #if os(Linux)

--- a/docs/amp.md
+++ b/docs/amp.md
@@ -1,5 +1,5 @@
 ---
-summary: "Amp provider notes: settings scrape, cookie auth, and free-tier usage."
+summary: "Amp provider notes: CLI usage, web fallback, cookie auth, and credits."
 read_when:
   - Adding or modifying the Amp provider
   - Debugging Amp cookie import or settings parsing
@@ -8,19 +8,23 @@ read_when:
 
 # Amp Provider
 
-The Amp provider tracks your Amp Free usage by scraping the Amp settings page with browser cookies.
+The Amp provider tracks Amp Free usage plus individual and workspace credits. It prefers the local Amp CLI and falls back to
+Amp's web usage endpoint with browser cookies.
 
 ## Features
 
 - **Amp Free meter**: Shows how much daily free usage remains.
 - **Time-to-full reset**: “Resets in …” indicates when free usage replenishes to full.
-- **Browser cookie auth**: No API keys needed.
+- **Individual credits**: Shows the remaining paid credit balance when Amp reports one.
+- **Workspace credits**: Shows each workspace's remaining paid credit balance separately.
+- **CLI-first fetch**: Uses `amp usage` when the Amp CLI is installed and signed in.
+- **Browser cookie fallback**: No separate API key is needed when the CLI is unavailable.
 
 ## Setup
 
 1. Open **Settings → Providers**
 2. Enable **Amp**
-3. Leave **Cookie source** on **Auto** (recommended)
+3. Install and sign in to the Amp CLI, or leave **Cookie source** on **Auto** for web fallback
 
 ### Manual cookie import (optional)
 
@@ -30,8 +34,10 @@ The Amp provider tracks your Amp Free usage by scraping the Amp settings page wi
 
 ## How it works
 
-- Fetches `https://ampcode.com/settings`
-- Parses the embedded `freeTierUsage` payload
+- Runs `amp usage` first in automatic mode
+- Falls back to `POST https://ampcode.com/api/internal?userDisplayBalanceInfo`
+- Parses the same usage display format returned to the CLI
+- Retains the old settings-page payload parser for older Amp deployments
 - Computes time-to-full from the hourly replenishment rate
 
 ## Troubleshooting

--- a/docs/amp.md
+++ b/docs/amp.md
@@ -8,8 +8,8 @@ read_when:
 
 # Amp Provider
 
-The Amp provider tracks Amp Free usage plus individual and workspace credits. It prefers the local Amp CLI and falls back to
-Amp's web usage endpoint with browser cookies.
+The Amp provider tracks Amp Free usage plus individual and workspace credits. It prefers the local Amp CLI, then an Amp
+access token, and finally browser cookies.
 
 ## Features
 
@@ -18,13 +18,18 @@ Amp's web usage endpoint with browser cookies.
 - **Individual credits**: Shows the remaining paid credit balance when Amp reports one.
 - **Workspace credits**: Shows each workspace's remaining paid credit balance separately.
 - **CLI-first fetch**: Uses `amp usage` when the Amp CLI is installed and signed in.
-- **Browser cookie fallback**: No separate API key is needed when the CLI is unavailable.
+- **Access token support**: Uses `AMP_API_KEY` or the access token saved in CodexBar settings.
+- **Browser cookie fallback**: Reads the legacy settings-page payload when the CLI and access token are unavailable.
 
 ## Setup
 
 1. Open **Settings → Providers**
 2. Enable **Amp**
-3. Install and sign in to the Amp CLI, or leave **Cookie source** on **Auto** for web fallback
+3. Install and sign in to the Amp CLI, add an Amp access token, or leave **Cookie source** on **Auto** for web fallback
+
+### Access token (optional)
+
+Create an access token in Amp settings, then paste it into **Amp → Access token** or set `AMP_API_KEY`.
 
 ### Manual cookie import (optional)
 
@@ -35,10 +40,14 @@ Amp's web usage endpoint with browser cookies.
 ## How it works
 
 - Runs `amp usage` first in automatic mode
-- Falls back to `POST https://ampcode.com/api/internal?userDisplayBalanceInfo`
+- Calls `POST https://ampcode.com/api/internal?userDisplayBalanceInfo` with an Amp access token
+- Falls back to the settings page with browser cookies
 - Parses the same usage display format returned to the CLI
-- Retains the old settings-page payload parser for older Amp deployments
 - Computes time-to-full from the hourly replenishment rate
+
+### “Amp access token is invalid or expired”
+
+Create a new access token in Amp settings, update `AMP_API_KEY` or CodexBar settings, then refresh.
 
 ## Troubleshooting
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -45,7 +45,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 | Vertex AI | Google ADC OAuth (gcloud) → Cloud Monitoring quota usage (`oauth`). |
 | Augment | `auggie` CLI first, then browser-cookie web fallback (`cli`, `web`). |
 | JetBrains AI | Local XML quota file (`local`). |
-| Amp | Local `amp usage` CLI with browser-cookie web fallback (`cli`, `web`). |
+| Amp | Local `amp usage` CLI, access-token API, then browser-cookie legacy fallback (`cli`, `api`, `web`). |
 | T3 Chat | Web tRPC customer-data endpoint via browser cookies (`web`). |
 | Warp | API token (config/env) → GraphQL request limits (`api`). |
 | ElevenLabs | API key from config/env → subscription usage API (`api`). |
@@ -252,7 +252,8 @@ headers, source selection, provider ordering, and token accounts are stored in `
 
 ## Amp
 - Auto mode tries the local `amp usage` command first.
-- Web fallback calls Amp's usage endpoint with browser cookies.
+- API mode calls Amp's balance endpoint with an access token.
+- Web fallback reads the legacy settings page with browser cookies.
 - Tracks Amp Free usage, account identity, and individual and workspace credit balances.
 - Status: none yet.
 - Details: `docs/amp.md`.

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -45,7 +45,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 | Vertex AI | Google ADC OAuth (gcloud) → Cloud Monitoring quota usage (`oauth`). |
 | Augment | `auggie` CLI first, then browser-cookie web fallback (`cli`, `web`). |
 | JetBrains AI | Local XML quota file (`local`). |
-| Amp | Web settings page via browser cookies (`web`). |
+| Amp | Local `amp usage` CLI with browser-cookie web fallback (`cli`, `web`). |
 | T3 Chat | Web tRPC customer-data endpoint via browser cookies (`web`). |
 | Warp | API token (config/env) → GraphQL request limits (`api`). |
 | ElevenLabs | API key from config/env → subscription usage API (`api`). |
@@ -251,8 +251,9 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Details: `docs/augment.md`.
 
 ## Amp
-- Web settings page (`https://ampcode.com/settings`) via browser cookies.
-- Parses Amp Free usage from the settings HTML.
+- Auto mode tries the local `amp usage` command first.
+- Web fallback calls Amp's usage endpoint with browser cookies.
+- Tracks Amp Free usage, account identity, and individual and workspace credit balances.
 - Status: none yet.
 - Details: `docs/amp.md`.
 


### PR DESCRIPTION
## Summary
- restore Amp usage fetching with the current `userDisplayBalanceInfo` endpoint
- prefer local `amp usage` in Auto mode, then an Amp access token, then browser-cookie settings parsing
- expose individual and workspace credit balances in the existing Amp card
- add `AMP_API_KEY` and Settings UI support for explicit access-token usage
- honor Hide personal information for email-like workspace labels

Closes #1317.
Supersedes #1400 because its fork does not allow maintainer edits. The implementation and contributor credit are preserved from @3kh0.

## Security
- the balance RPC uses `Authorization: Bearer` and never receives browser cookies
- API redirects are refused so the bearer token cannot cross hosts
- the browser path imports only the `session` cookie and limits redirects to HTTPS Amp hosts
- diagnostics emit cookie names, never values
- CLI stdin is closed and execution is bounded by a 15-second timeout
- credit workspace labels use the existing personal-information redactor

## Proof
- rebased onto current `main` at `3fdb549a`
- `swift test --filter Amp` (24 tests)
- `swift test --filter UsageStoreCoverageTests` (23 tests)
- `swift test --filter ProviderConfigEnvironmentTests` (30 tests)
- `swift test --filter CLIConfigCommandTests` (9 tests)
- `make check` (0 formatting changes, 0 lint violations)
- exact-head autoreview: clean, no accepted/actionable findings; correctness 0.97
- redacted live CLI proof: individual credits and workspace credits parsed successfully from a credits-only response
- redacted live API proof: explicit API source selected; individual credits, workspace credits, and account metadata parsed successfully using a real stored Amp access token
- contributor reports live end-to-end validation with personal and workspace accounts in #1400
- fresh exact-head CI pending on `46626f76d1a18da174249e03e194bef0d4b93761`

## Risk
Medium-low. CLI and access-token API paths now have redacted live proof; browser-cookie fallback is constrained to the legacy settings page and covered by focused parser/fallback tests.
