### PR TITLE
Fix overview switcher segment height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - CLI server: reload provider config for every usage and cost request, invalidate config-dependent cache entries, and prune expired config variants without restarting `codexbar serve`. Thanks @enieuwy!
+- Menu bar: reserve quota-bar space consistently across Overview and provider switcher segments so selection no longer changes segment height (#1445). Thanks @Zihao-Qi!
 - Menu bar: anchor merged provider dropdowns to the status item's trailing edge without marking preserved in-flight refresh content fresh, preventing horizontal drift while keeping deferred updates visible (#1288). Thanks @Yuxin-Qiao!
 - Cost usage: replace repeated Foundation metadata/root checks with one portable file-stat pass so expired Codex history refreshes stay responsive on very large session archives (#1392). Thanks @TheAngryPit and @ProspectOre!
 - Cursor: show the Safari Full Disk Access recovery hint before the long browser login list so permission guidance remains visible when menu errors truncate (#1419, fixes #1417). Thanks @hhh2210!

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -170,6 +170,7 @@ final class ProviderSwitcherView: NSView {
             case .overview:
                 nil
             }
+            Self.applyQuotaBarContentInset(to: button)
             self.addQuotaIndicator(to: button, selection: segment.selection, remainingPercent: remaining)
             button.bezelStyle = .regularSquare
             button.isBordered = false
@@ -657,7 +658,6 @@ final class ProviderSwitcherView: NSView {
                     self.addQuotaIndicator(to: button, selection: segment.selection, remainingPercent: remaining)
                 }
             } else if let indicator = self.quotaIndicators.removeValue(forKey: key) {
-                Self.applyQuotaBarContentInset(to: button, height: 0)
                 indicator.track.removeFromSuperview()
                 continue
             }

--- a/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
@@ -747,7 +747,7 @@ struct StatusMenuSwitcherClickTests {
     }
 
     @Test
-    func `switcher quota indicator disappears when remaining becomes unavailable`() throws {
+    func `switcher keeps reserved quota space when remaining becomes unavailable`() throws {
         var grokRemaining: Double? = 50
         let noQuotaView = ProviderSwitcherView(
             providers: [.claude, .grok],
@@ -779,7 +779,7 @@ struct StatusMenuSwitcherClickTests {
         #expect(view._test_quotaIndicatorFillRatios().count == 2)
         let noQuotaHeight = try #require(noQuotaView._test_buttonFittingSizes().last?.height)
         let quotaHeight = try #require(view._test_buttonFittingSizes().last?.height)
-        #expect(quotaHeight > noQuotaHeight)
+        #expect(quotaHeight == noQuotaHeight)
 
         grokRemaining = nil
         view.updateQuotaIndicators()
@@ -790,7 +790,7 @@ struct StatusMenuSwitcherClickTests {
     }
 
     @Test
-    func `text only switcher quota bars reserve title space`() throws {
+    func `text only switcher keeps stable height with quota bars`() throws {
         let providers: [UsageProvider] = [.claude, .grok]
         let textOnlyWithoutQuota = ProviderSwitcherView(
             providers: providers,
@@ -813,7 +813,7 @@ struct StatusMenuSwitcherClickTests {
 
         let withoutQuotaHeight = try #require(textOnlyWithoutQuota._test_buttonFittingSizes().first?.height)
         let withQuotaHeight = try #require(textOnlyWithQuota._test_buttonFittingSizes().first?.height)
-        #expect(withQuotaHeight > withoutQuotaHeight)
+        #expect(withQuotaHeight == withoutQuotaHeight)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusMenuSwitcherLayoutTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherLayoutTests.swift
@@ -6,7 +6,7 @@ import Testing
 @Suite(.serialized)
 struct StatusMenuSwitcherLayoutTests {
     @Test
-    func `overview switcher segment matches provider segment height when quota bars are present`() {
+    func `overview switcher segment matches provider segment height when quota bars are present`() throws {
         let view = ProviderSwitcherView(
             providers: [.claude, .grok, .cursor],
             selected: .overview,
@@ -21,7 +21,7 @@ struct StatusMenuSwitcherLayoutTests {
 
         let frames = view._test_buttonFrames()
         #expect(frames.count == 4)
-        guard let overviewFrame = frames.first else { return }
+        let overviewFrame = try #require(frames.first)
 
         for frame in frames.dropFirst() {
             #expect(frame.height == overviewFrame.height)

--- a/Tests/CodexBarTests/StatusMenuSwitcherLayoutTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherLayoutTests.swift
@@ -1,0 +1,32 @@
+import AppKit
+import Testing
+@testable import CodexBar
+
+@MainActor
+@Suite(.serialized)
+struct StatusMenuSwitcherLayoutTests {
+    @Test
+    func `overview switcher segment matches provider segment height when quota bars are present`() {
+        let view = ProviderSwitcherView(
+            providers: [.claude, .grok, .cursor],
+            selected: .overview,
+            includesOverview: true,
+            width: 300,
+            showsIcons: true,
+            iconProvider: { _ in NSImage(size: NSSize(width: 16, height: 16)) },
+            weeklyRemainingProvider: { _ in 50 },
+            onSelect: { _ in })
+        view.updateConstraintsForSubtreeIfNeeded()
+        view.layoutSubtreeIfNeeded()
+
+        let frames = view._test_buttonFrames()
+        #expect(frames.count == 4)
+        guard let overviewFrame = frames.first else { return }
+
+        for frame in frames.dropFirst() {
+            #expect(frame.height == overviewFrame.height)
+            #expect(frame.minY == overviewFrame.minY)
+            #expect(frame.maxY == overviewFrame.maxY)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the provider switcher layout so the Overview segment reserves the same quota-bar space as provider segments. This keeps the selected Overview block the same height as the other switcher buttons when provider quota bars are present.

## Changes

- Reserve quota-bar inset for every switcher button, including Overview.
- Keep provider button height stable when quota data becomes unavailable.
- Update switcher height tests for stable quota-space behavior.
- Add a layout test covering Overview plus provider segments with quota bars.

## Testing

- `swift test --filter StatusMenuSwitcher`
- `make check`
- Manually verified the packaged local app: Overview and provider switcher buttons measured the same height.