### PR TITLE
Fix Tahoe blocked status item recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - CLI server: reload provider config for every usage and cost request, invalidate config-dependent cache entries, and prune expired config variants without restarting `codexbar serve`. Thanks @enieuwy!
 - Menu bar: reserve quota-bar space consistently across Overview and provider switcher segments so selection no longer changes segment height (#1445). Thanks @Zihao-Qi!
 - Cost usage: accept normal models.dev catalog churn while retaining prior model prices as fallbacks, so newly priced models appear without requiring a manual cache reset (#1438). Thanks @tom-rigelblu!
+- Menu bar: detect Tahoe Control Center proxy windows parked in the blocked offscreen slot during startup recovery, so hidden icons show the existing guidance without weakening menu-bar-manager safeguards (#1440).
 - Menu bar: anchor merged provider dropdowns to the status item's trailing edge without marking preserved in-flight refresh content fresh, preventing horizontal drift while keeping deferred updates visible (#1288). Thanks @Yuxin-Qiao!
 - Antigravity: fall back to the CLI usage server when the desktop app is closed, keep helper sessions owned and bounded without hidden sign-in flows, and show model rows with missing usage as unavailable instead of exhausted (#1313). Thanks @enieuwy!
 - Cost usage: replace repeated Foundation metadata/root checks with one portable file-stat pass so expired Codex history refreshes stay responsive on very large session archives (#1392). Thanks @TheAngryPit and @ProspectOre!

--- a/Sources/CodexBar/MenuBarStatusItemWindowProbe.swift
+++ b/Sources/CodexBar/MenuBarStatusItemWindowProbe.swift
@@ -14,6 +14,16 @@ struct MenuBarStatusItemWindowSnapshot: Equatable, CustomStringConvertible {
         return displayBounds.contains(self.bounds)
     }
 
+    var isTahoeBlockedProxy: Bool {
+        self.ownerName == "Control Center"
+            && self.isOnscreen
+            && abs(self.bounds.minX) <= 1
+            && self.bounds.maxY <= 0
+            && self.bounds.width > 0
+            && self.bounds.height > 0
+            && !self.isWithinDisplayBounds
+    }
+
     var description: String {
         let display = self.displayBounds.map {
             "display=\(Int($0.minX)),\(Int($0.minY)) \(Int($0.width))x\(Int($0.height))"

--- a/Sources/CodexBar/MenuBarVisibilityWatcher.swift
+++ b/Sources/CodexBar/MenuBarVisibilityWatcher.swift
@@ -111,6 +111,24 @@ enum MenuBarVisibilityWatcher {
         }
     }
 
+    static func hasAnyStartupRecoveryCandidate(
+        snapshots: [StatusItemVisibilitySnapshot],
+        windowSnapshots: [MenuBarStatusItemWindowSnapshot] = [],
+        detectTahoeBlockedProxy: Bool = false)
+        -> Bool
+    {
+        if self.hasAnyBlockedVisibleSnapshot(snapshots) {
+            return true
+        }
+        guard detectTahoeBlockedProxy,
+              self.hasAnyDisplacedVisibleSnapshot(snapshots),
+              windowSnapshots.contains(where: \.isTahoeBlockedProxy)
+        else {
+            return false
+        }
+        return true
+    }
+
     @MainActor
     static func visibilitySnapshots(_ items: [NSStatusItem]) -> [StatusItemVisibilitySnapshot] {
         items.map { item in
@@ -126,11 +144,16 @@ enum MenuBarVisibilityWatcher {
     static func shouldAttemptStartupRecovery(
         appLaunchedAt: Date,
         now: Date = Date(),
-        snapshots: [StatusItemVisibilitySnapshot])
+        snapshots: [StatusItemVisibilitySnapshot],
+        windowSnapshots: [MenuBarStatusItemWindowSnapshot] = [],
+        detectTahoeBlockedProxy: Bool = false)
         -> Bool
     {
         guard now.timeIntervalSince(appLaunchedAt) <= self.startupFreshnessInterval else { return false }
-        return self.hasAnyBlockedVisibleSnapshot(snapshots)
+        return self.hasAnyStartupRecoveryCandidate(
+            snapshots: snapshots,
+            windowSnapshots: windowSnapshots,
+            detectTahoeBlockedProxy: detectTahoeBlockedProxy)
     }
 
     static func shouldRefreshScreenChangePlacement(
@@ -193,27 +216,33 @@ extension StatusItemController {
 
     private func checkStartupStatusItemVisibility(appLaunchedAt: Date, now: Date = Date()) {
         let snapshots = MenuBarVisibilityWatcher.visibilitySnapshots(self.startupVisibilityStatusItems)
+        let windowSnapshots = self.statusItemWindowSnapshots()
         guard MenuBarVisibilityWatcher.shouldAttemptStartupRecovery(
             appLaunchedAt: appLaunchedAt,
             now: now,
-            snapshots: snapshots)
+            snapshots: snapshots,
+            windowSnapshots: windowSnapshots,
+            detectTahoeBlockedProxy: self.canDetectTahoeBlockedProxy)
         else {
             return
         }
 
         self.menuLogger.error(
-            "Status item failed to materialize; recreating status items",
+            "Status item failed to materialize or remained detached; recreating status items",
             metadata: [
                 "snapshots": snapshots.map(\.description).joined(separator: " | "),
-                "windows": self.statusItemWindowDiagnosticsDescription(),
+                "windows": self.statusItemWindowDiagnosticsDescription(windowSnapshots),
             ])
         self.recreateStatusItemsForVisibilityRecovery()
 
         let recoveredSnapshots = MenuBarVisibilityWatcher.visibilitySnapshots(self.startupVisibilityStatusItems)
+        let recoveredWindowSnapshots = self.statusItemWindowSnapshots()
         guard MenuBarVisibilityWatcher.shouldAttemptStartupRecovery(
             appLaunchedAt: appLaunchedAt,
             now: now,
-            snapshots: recoveredSnapshots)
+            snapshots: recoveredSnapshots,
+            windowSnapshots: recoveredWindowSnapshots,
+            detectTahoeBlockedProxy: self.canDetectTahoeBlockedProxy)
         else {
             self.menuLogger.info(
                 "Status item materialized after recreation",
@@ -222,10 +251,10 @@ extension StatusItemController {
         }
 
         self.menuLogger.error(
-            "Status item still failed to materialize after recreation",
+            "Status item still unavailable after recreation",
             metadata: [
                 "snapshots": recoveredSnapshots.map(\.description).joined(separator: " | "),
-                "windows": self.statusItemWindowDiagnosticsDescription(),
+                "windows": self.statusItemWindowDiagnosticsDescription(recoveredWindowSnapshots),
             ])
         guard #available(macOS 26.0, *),
               MenuBarVisibilityWatcher.shouldShowGuidance(defaults: self.settings.userDefaults, now: now)
@@ -353,11 +382,25 @@ extension StatusItemController {
         [self.statusItem] + Array(self.statusItems.values)
     }
 
-    private func statusItemWindowDiagnosticsDescription() -> String {
+    private var canDetectTahoeBlockedProxy: Bool {
+        if #available(macOS 26.0, *) {
+            return true
+        }
+        return false
+    }
+
+    private func statusItemWindowSnapshots() -> [MenuBarStatusItemWindowSnapshot] {
         let names = Set(self.startupVisibilityStatusItems.compactMap { item in
             item.autosaveName.isEmpty ? nil : item.autosaveName
         })
-        let snapshots = MenuBarStatusItemWindowProbe.snapshots(matching: names)
+        return MenuBarStatusItemWindowProbe.snapshots(matching: names)
+    }
+
+    private func statusItemWindowDiagnosticsDescription(
+        _ snapshots: [MenuBarStatusItemWindowSnapshot]? = nil)
+        -> String
+    {
+        let snapshots = snapshots ?? self.statusItemWindowSnapshots()
         guard !snapshots.isEmpty else { return "none" }
         return snapshots.map(\.description).joined(separator: " | ")
     }

--- a/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
+++ b/Tests/CodexBarTests/MenuBarVisibilityWatcherTests.swift
@@ -111,6 +111,42 @@ struct MenuBarVisibilityWatcherTests {
     }
 
     @Test
+    func `window probe identifies Tahoe Control Center blocked proxy geometry`() {
+        let snapshot = MenuBarStatusItemWindowSnapshot(
+            name: "codexbar-merged",
+            ownerName: "Control Center",
+            bounds: CGRect(x: 0, y: -22, width: 76, height: 22),
+            isOnscreen: true,
+            displayBounds: nil)
+
+        #expect(snapshot.isTahoeBlockedProxy)
+    }
+
+    @Test
+    func `window probe does not classify generic offscreen manager placement as Tahoe proxy`() {
+        let snapshot = MenuBarStatusItemWindowSnapshot(
+            name: "codexbar-merged",
+            ownerName: "Control Center",
+            bounds: CGRect(x: 2023, y: 0, width: 71, height: 24),
+            isOnscreen: true,
+            displayBounds: nil)
+
+        #expect(!snapshot.isTahoeBlockedProxy)
+    }
+
+    @Test
+    func `window probe does not classify stale hidden Control Center record as Tahoe proxy`() {
+        let snapshot = MenuBarStatusItemWindowSnapshot(
+            name: "codexbar-merged",
+            ownerName: "Control Center",
+            bounds: CGRect(x: 0, y: -22, width: 76, height: 22),
+            isOnscreen: false,
+            displayBounds: nil)
+
+        #expect(!snapshot.isTahoeBlockedProxy)
+    }
+
+    @Test
     func `allows visible item attached to a detached screen`() {
         let snapshot = StatusItemVisibilitySnapshot(
             isVisible: true,
@@ -183,6 +219,67 @@ struct MenuBarVisibilityWatcherTests {
             appLaunchedAt: launchedAt,
             now: launchedAt.addingTimeInterval(2),
             snapshots: [blocked]))
+    }
+
+    @Test
+    func `startup recovery retries detached Tahoe proxy corroborated by Control Center geometry`() {
+        let launchedAt = Date(timeIntervalSince1970: 1000)
+        let detachedProxy = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: false,
+            isOnCurrentScreen: false,
+            buttonWidth: 76)
+        let blockedWindow = MenuBarStatusItemWindowSnapshot(
+            name: "codexbar-merged",
+            ownerName: "Control Center",
+            bounds: CGRect(x: 0, y: -22, width: 76, height: 22),
+            isOnscreen: true,
+            displayBounds: nil)
+
+        #expect(!MenuBarVisibilityWatcher.isBlockedSnapshot(snapshot: detachedProxy))
+        #expect(MenuBarVisibilityWatcher.shouldAttemptStartupRecovery(
+            appLaunchedAt: launchedAt,
+            now: launchedAt.addingTimeInterval(2),
+            snapshots: [detachedProxy],
+            windowSnapshots: [blockedWindow],
+            detectTahoeBlockedProxy: true))
+    }
+
+    @Test
+    func `startup recovery ignores detached live item without Tahoe proxy corroboration`() {
+        let launchedAt = Date(timeIntervalSince1970: 1000)
+        let managed = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: false,
+            isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(!MenuBarVisibilityWatcher.shouldAttemptStartupRecovery(
+            appLaunchedAt: launchedAt,
+            now: launchedAt.addingTimeInterval(2),
+            snapshots: [managed],
+            detectTahoeBlockedProxy: true))
+    }
+
+    @Test
+    func `startup recovery ignores live item attached to a stale screen`() {
+        let launchedAt = Date(timeIntervalSince1970: 1000)
+        let managed = StatusItemVisibilitySnapshot(
+            isVisible: true,
+            hasButton: true,
+            hasWindow: true,
+            hasScreen: true,
+            isOnCurrentScreen: false,
+            buttonWidth: 18)
+
+        #expect(!MenuBarVisibilityWatcher.shouldAttemptStartupRecovery(
+            appLaunchedAt: launchedAt,
+            now: launchedAt.addingTimeInterval(2),
+            snapshots: [managed]))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- recognize Tahoe Control Center status-item proxies parked in the blocked offscreen slot
- retry startup recovery only when a displaced live status item is corroborated by the exact on-screen proxy geometry
- preserve existing menu-bar-manager safeguards and guidance throttling

Fixes #1440

## Proof
- `swift test --filter 'MenuBarVisibilityWatcherTests|StatusItemControllerSplitLifecycleTests'` (53 tests passed)
- `swift test --filter CodexUsageFetcherFallbackTests` (13 tests passed; isolated rerun of one transient full-suite failure)
- `make check`
- autoreview: clean, patch correct (0.82 confidence)
- release-mode ad-hoc bundle built, relaunched, and inspected on macOS 26.5
- Peekaboo opened the live menu successfully; active Control Center windows were on-screen at normal menu-bar geometry and the process remained idle

## Review notes
Two earlier autoreview findings were accepted before the final clean pass: require exact Control Center blocked-slot geometry, then require the CGWindow record to be currently on-screen. Generic offscreen manager placement and stale hidden records remain ignored.
