### PR TITLE
feat: track Cursor local storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Localization: add native Korean language support across the app and language picker (#1460). Thanks @soohanpark!
 - Devin: add daily and weekly quota tracking from the signed-in Chrome session or a manual Bearer token (#1264, fixes #800). Thanks @coygeek!
 - Menu bar: add an optional reset-time display for the selected quota metric, with percent fallback when reset metadata is unavailable (#1223, fixes #1185). Thanks @Yuxin-Qiao!
+- Cursor: include application data, extensions, settings, and caches in optional local storage tracking (fixes #1403). Thanks @dhruv-anand-aintech!
 - Menu bar: move the highlighted Overview provider with trackpad or mouse-wheel scrolling while preserving native submenu and keyboard behavior (#1436). Thanks @joshuavial!
 
 ### Fixed

--- a/Sources/CodexBarCore/ProviderStorageFootprint.swift
+++ b/Sources/CodexBarCore/ProviderStorageFootprint.swift
@@ -329,6 +329,15 @@ public enum ProviderStoragePathCatalog {
             [
                 homePath(".config/github-copilot"),
             ]
+        case .cursor:
+            [
+                homePath("Library/Application Support/Cursor"),
+                homePath(".cursor"),
+                homePath("Library/Caches/Cursor"),
+                homePath("Library/Caches/com.todesktop.230313mzl4w4u92"),
+                homePath("Library/Caches/com.todesktop.230313mzl4w4u92.ShipIt"),
+                homePath("Library/Caches/cursor-compile-cache"),
+            ]
         default:
             []
         }

--- a/Sources/CodexBarCore/ProviderStorageFootprint.swift
+++ b/Sources/CodexBarCore/ProviderStorageFootprint.swift
@@ -332,11 +332,13 @@ public enum ProviderStoragePathCatalog {
         case .cursor:
             [
                 homePath("Library/Application Support/Cursor"),
+                homePath("Library/Application Support/Caches/cursor-updater"),
                 homePath(".cursor"),
                 homePath("Library/Caches/Cursor"),
                 homePath("Library/Caches/com.todesktop.230313mzl4w4u92"),
                 homePath("Library/Caches/com.todesktop.230313mzl4w4u92.ShipIt"),
                 homePath("Library/Caches/cursor-compile-cache"),
+                homePath("Library/HTTPStorages/com.todesktop.230313mzl4w4u92"),
             ]
         default:
             []

--- a/Tests/CodexBarTests/ProviderStorageFootprintTests.swift
+++ b/Tests/CodexBarTests/ProviderStorageFootprintTests.swift
@@ -109,6 +109,21 @@ struct ProviderStorageFootprintTests {
     }
 
     @Test
+    func `cursor path catalog includes application data and caches`() {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let paths = ProviderStoragePathCatalog.candidatePaths(for: .cursor, environment: [:])
+
+        #expect(paths == [
+            home.appendingPathComponent("Library/Application Support/Cursor", isDirectory: true).path,
+            home.appendingPathComponent(".cursor", isDirectory: true).path,
+            home.appendingPathComponent("Library/Caches/Cursor", isDirectory: true).path,
+            home.appendingPathComponent("Library/Caches/com.todesktop.230313mzl4w4u92", isDirectory: true).path,
+            home.appendingPathComponent("Library/Caches/com.todesktop.230313mzl4w4u92.ShipIt", isDirectory: true).path,
+            home.appendingPathComponent("Library/Caches/cursor-compile-cache", isDirectory: true).path,
+        ])
+    }
+
+    @Test
     func `claude recommendations use documented cleanup categories`() {
         let root = "/Users/test/.claude"
         let footprint = ProviderStorageFootprint(

--- a/Tests/CodexBarTests/ProviderStorageFootprintTests.swift
+++ b/Tests/CodexBarTests/ProviderStorageFootprintTests.swift
@@ -115,11 +115,17 @@ struct ProviderStorageFootprintTests {
 
         #expect(paths == [
             home.appendingPathComponent("Library/Application Support/Cursor", isDirectory: true).path,
+            home.appendingPathComponent(
+                "Library/Application Support/Caches/cursor-updater",
+                isDirectory: true).path,
             home.appendingPathComponent(".cursor", isDirectory: true).path,
             home.appendingPathComponent("Library/Caches/Cursor", isDirectory: true).path,
             home.appendingPathComponent("Library/Caches/com.todesktop.230313mzl4w4u92", isDirectory: true).path,
             home.appendingPathComponent("Library/Caches/com.todesktop.230313mzl4w4u92.ShipIt", isDirectory: true).path,
             home.appendingPathComponent("Library/Caches/cursor-compile-cache", isDirectory: true).path,
+            home.appendingPathComponent(
+                "Library/HTTPStorages/com.todesktop.230313mzl4w4u92",
+                isDirectory: true).path,
         ])
     }
 

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -46,6 +46,17 @@ Manual option:
 - Chrome/Chromium forks: `~/Library/Application Support/Google/Chrome/*/Cookies`
 - Firefox: `~/Library/Application Support/Firefox/Profiles/*/cookies.sqlite`
 
+## Local storage footprint
+When **Settings → Advanced → Track provider local storage** is enabled, CodexBar measures:
+- `~/Library/Application Support/Cursor`
+- `~/.cursor`
+- `~/Library/Caches/Cursor`
+- `~/Library/Caches/com.todesktop.230313mzl4w4u92`
+- `~/Library/Caches/com.todesktop.230313mzl4w4u92.ShipIt`
+- `~/Library/Caches/cursor-compile-cache`
+
+The storage detail lists measured paths and their sizes. CodexBar does not delete Cursor data.
+
 ## Snapshot mapping
 - Primary: plan usage percent (included plan).
 - Secondary: Auto + Composer usage percent.

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -49,11 +49,13 @@ Manual option:
 ## Local storage footprint
 When **Settings → Advanced → Track provider local storage** is enabled, CodexBar measures:
 - `~/Library/Application Support/Cursor`
+- `~/Library/Application Support/Caches/cursor-updater`
 - `~/.cursor`
 - `~/Library/Caches/Cursor`
 - `~/Library/Caches/com.todesktop.230313mzl4w4u92`
 - `~/Library/Caches/com.todesktop.230313mzl4w4u92.ShipIt`
 - `~/Library/Caches/cursor-compile-cache`
+- `~/Library/HTTPStorages/com.todesktop.230313mzl4w4u92`
 
 The storage detail lists measured paths and their sizes. CodexBar does not delete Cursor data.
 


### PR DESCRIPTION
## Summary
- add Cursor application data, CLI/config, and cache roots to optional provider storage tracking
- include current ToDesktop bundle and updater cache locations while retaining the legacy Cursor cache path
- document the read-only storage footprint behavior and add focused path-catalog coverage

Closes #1403.

## Proof
- `swift test --filter ProviderStorageFootprintTests` — 16/16 passed
- `make check` — SwiftFormat/SwiftLint clean
- branch autoreview — clean after adding the installed Cursor bundle-ID cache paths (`gpt-5.5`, confidence 0.86)
- local installation confirms `com.todesktop.230313mzl4w4u92` and `.ShipIt` cache roots

## Risk
Low. Storage tracking is opt-in, scans on the existing detached utility-priority path, and remains read-only.
