### PR TITLE
Fix current Antigravity IDE detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Menu bar: move the highlighted Overview provider with trackpad or mouse-wheel scrolling while preserving native submenu and keyboard behavior (#1436). Thanks @joshuavial!
 
 ### Fixed
+- Antigravity: detect current hyphenated IDE language-server processes inside Antigravity app bundles so local quota refreshes no longer report the IDE as unavailable (#1405). Thanks @lfmundim!
 - Menu bar: avoid republishing unchanged provider storage footprints so background scans no longer trigger unnecessary menu observation work (#1416). Thanks @soohanpark!
 - Claude: explain that an unauthorized Web session requires signing in at claude.ai or refreshing imported cookies (#1287). Thanks @LeoLin990405!
 - CLI server: reload provider config for every usage and cost request, invalidate config-dependent cache entries, and prune expired config variants without restarting `codexbar serve`. Thanks @enieuwy!

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -703,7 +703,7 @@ public struct AntigravityStatusProbe: Sendable {
     }
 
     enum AntigravityProcessKind: Equatable {
-        /// IDE language server (`language_server*`). Requires a `--csrf_token`.
+        /// IDE language server (`language_server*` or `language-server`). Requires a `--csrf_token`.
         case ide
         /// CLI language server (`agy` / `antigravity-cli`). Needs no CSRF token.
         case cli
@@ -742,7 +742,7 @@ public struct AntigravityStatusProbe: Sendable {
     }
 
     private static func isLanguageServerCommandLine(_ lowerCommand: String) -> Bool {
-        let pattern = #"(^|[/\\])language_server(_macos|\.exe)?(\s|$)"#
+        let pattern = #"(^|[/\\])language(?:_|-)server(_macos|\.exe)?(\s|$)"#
         return lowerCommand.range(of: pattern, options: .regularExpression) != nil
     }
 
@@ -761,6 +761,7 @@ public struct AntigravityStatusProbe: Sendable {
 
     private static func isAntigravityCommandLine(_ command: String) -> Bool {
         if command.contains("--app_data_dir") && command.contains("antigravity") { return true }
+        if command.contains("antigravity.app/") || command.contains("antigravity.app\\") { return true }
         if command.contains("/antigravity/") || command.contains("\\antigravity\\") { return true }
         return false
     }

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -43,6 +43,21 @@ struct AntigravityStatusProbeTests {
     }
 
     @Test
+    func `process detection accepts hyphenated language server from app bundle`() throws {
+        let command = """
+        /Applications/Google Antigravity.app/Contents/Resources/bin/language-server --standalone \
+        --csrf_token token --extension_server_port 64123
+        """
+
+        #expect(AntigravityStatusProbe.isAntigravityLanguageServerCommandLine(command))
+
+        let result = try AntigravityStatusProbe.processInfo(fromProcessListOutput: "  321 \(command)")
+        #expect(result.pid == 321)
+        #expect(result.csrfToken == "token")
+        #expect(result.extensionPort == 64123)
+    }
+
+    @Test
     func `process detection keeps ignoring non language server antigravity helpers`() {
         let helper = """
         /Applications/Antigravity.app/Contents/Frameworks/Antigravity Helper.app/Contents/MacOS/Antigravity Helper \

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -51,13 +51,14 @@ When the Antigravity desktop app is running:
      probe timeout. `agy` is owned exclusively by the CLI HTTPS source below, which
      waits for real API readiness. The probe still classifies both kinds
      (`processInfo(scope: .ideAndCLI)` is used by `isRunning()` for status reporting):
-     - the **IDE** language server: process name `language_server_macos` plus Antigravity
-       markers (`--app_data_dir antigravity` OR path contains `/antigravity/`); or
+     - the **IDE** language server: process name `language_server*` or `language-server` plus
+       Antigravity markers (`--app_data_dir antigravity`, an Antigravity app bundle path,
+       or a path containing `/antigravity/`); or
      - the **CLI**: an `antigravity-cli` / `antigravity_cli` path segment, or the
        `agy` binary (path-anchored so unrelated arguments/binaries do not match).
    - Extract CLI flags:
      - `--csrf_token <token>`. Requirement depends on the match kind:
-       - **IDE** matches still require it — a tokenless IDE `language_server` match is
+       - **IDE** matches still require it — a tokenless IDE language-server match is
          skipped so a later valid IDE server can be found, otherwise `missingCSRFToken`
          is reported (unchanged behavior).
        - **CLI** matches accept an empty token, because the CLI's language server


### PR DESCRIPTION
## Summary

- recognize current Antigravity IDE processes whose executable is named `language-server`;
- accept Antigravity `.app` bundle paths as an IDE ownership marker;
- preserve the existing non-empty CSRF requirement for IDE processes and the explicit tokenless CLI exception;
- document the updated process shapes and add the changelog entry.

Addresses the local IDE-detection failure in #1405. The separate OAuth quota-shape mismatch remains outside this patch.

## Cause

The process classifier only accepted underscore executable names such as `language_server` and narrow `/antigravity/` path segments. Current Antigravity process shapes accepted by the working `antigravity-usage` local detector can use `language-server` inside `Antigravity.app`, so CodexBar discarded the running IDE before port discovery.

Reference implementation checked: https://github.com/skainguyen1412/antigravity-usage/blob/1b6dc0bc862e0a8e099ad8344ab7c744108e7252/src/local/process-detector.ts

## Proof

- `swift test --filter AntigravityStatusProbeTests` — 52 tests passed
- `make check` — clean
- autoreview — clean, confidence 0.86
- issue screenshot shows the reference local tool succeeding while CodexBar reports the language server unavailable

No live account, Keychain, or provider request was needed for this process-classification fix.
