### PR TITLE
fix: honor Cursor extra usage percent display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 - Antigravity: detect current hyphenated IDE language-server processes inside Antigravity app bundles so local quota refreshes no longer report the IDE as unavailable (#1405). Thanks @lfmundim!
 - Menu bar: avoid republishing unchanged provider storage footprints so background scans no longer trigger unnecessary menu observation work (#1416). Thanks @soohanpark!
+- Cursor: honor the global percent used/remaining display setting for Extra usage in the menu bar instead of always showing currency spend (#1426).
 - Claude: explain that an unauthorized Web session requires signing in at claude.ai or refreshing imported cookies (#1287). Thanks @LeoLin990405!
 - CLI server: reload provider config for every usage and cost request, invalidate config-dependent cache entries, and prune expired config variants without restarting `codexbar serve`. Thanks @enieuwy!
 - Menu bar: reserve quota-bar space consistently across Overview and provider switcher segments so selection no longer changes segment height (#1445). Thanks @Zihao-Qi!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Fixed
 - Antigravity: detect current hyphenated IDE language-server processes inside Antigravity app bundles so local quota refreshes no longer report the IDE as unavailable (#1405). Thanks @lfmundim!
 - Menu bar: avoid republishing unchanged provider storage footprints so background scans no longer trigger unnecessary menu observation work (#1416). Thanks @soohanpark!
-- Cursor: honor the global percent used/remaining display setting for Extra usage in the menu bar instead of always showing currency spend (#1426).
+- Cursor: show capped team Extra usage when no individual cap exists, and honor percent used/remaining menu bar display settings instead of always showing currency spend (#1426). Thanks @lpc-eol!
 - Claude: explain that an unauthorized Web session requires signing in at claude.ai or refreshing imported cookies (#1287). Thanks @LeoLin990405!
 - CLI server: reload provider config for every usage and cost request, invalidate config-dependent cache entries, and prune expired config variants without restarting `codexbar serve`. Thanks @enieuwy!
 - Menu bar: reserve quota-bar space consistently across Overview and provider switcher segments so selection no longer changes segment height (#1445). Thanks @Zihao-Qi!

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -726,6 +726,7 @@ extension StatusItemController {
         }
         if mode != .resetTime,
            self.settings.menuBarMetricPreference(for: provider, snapshot: snapshot) == .extraUsage,
+           provider != .cursor || mode == .pace,
            let spend = Self.extraUsageSpendDisplayText(snapshot: snapshot)
         {
             return spend

--- a/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Cursor/CursorStatusProbe.swift
@@ -463,9 +463,19 @@ public struct CursorStatusSnapshot: Sendable {
                 resetDescription: self.billingCycleEnd.map { Self.formatResetDate($0) })
         }
 
-        // On-demand: tracked via providerCost only (shown in the credits/cost section)
-        let resolvedOnDemandUsed = self.onDemandUsedUSD
-        let resolvedOnDemandLimit = self.onDemandLimitUSD
+        // Prefer a personal cap. Team accounts with no user cap expose only the shared on-demand budget.
+        let resolvedOnDemandUsed: Double
+        let resolvedOnDemandLimit: Double?
+        if (self.onDemandLimitUSD ?? 0) > 0 {
+            resolvedOnDemandUsed = self.onDemandUsedUSD
+            resolvedOnDemandLimit = self.onDemandLimitUSD
+        } else if (self.teamOnDemandLimitUSD ?? 0) > 0 {
+            resolvedOnDemandUsed = self.teamOnDemandUsedUSD ?? 0
+            resolvedOnDemandLimit = self.teamOnDemandLimitUSD
+        } else {
+            resolvedOnDemandUsed = self.onDemandUsedUSD
+            resolvedOnDemandLimit = self.onDemandLimitUSD
+        }
 
         // Provider cost snapshot for on-demand usage (include budget before first spend)
         let providerCost: ProviderCostSnapshot? = if resolvedOnDemandUsed > 0

--- a/Tests/CodexBarTests/CursorStatusProbeTests.swift
+++ b/Tests/CodexBarTests/CursorStatusProbeTests.swift
@@ -407,6 +407,31 @@ struct CursorStatusProbeTests {
     }
 
     @Test
+    func `uses team on demand budget when individual usage has no cap`() {
+        let snapshot = CursorStatusSnapshot(
+            planPercentUsed: 0,
+            autoPercentUsed: 0,
+            apiPercentUsed: 0,
+            planUsedUSD: 0,
+            planLimitUSD: 20,
+            onDemandUsedUSD: 0,
+            onDemandLimitUSD: nil,
+            teamOnDemandUsedUSD: 0,
+            teamOnDemandLimitUSD: 2349,
+            billingCycleEnd: nil,
+            membershipType: "enterprise",
+            accountEmail: nil,
+            accountName: nil,
+            rawJSON: nil)
+
+        let usageSnapshot = snapshot.toUsageSnapshot()
+
+        #expect(usageSnapshot.providerCost?.used == 0)
+        #expect(usageSnapshot.providerCost?.limit == 2349)
+        #expect(usageSnapshot.providerCost?.currencyCode == "USD")
+    }
+
+    @Test
     func `formats membership types`() {
         let testCases: [(input: String, expected: String)] = [
             ("pro", "Cursor Pro"),

--- a/Tests/CodexBarTests/StatusItemExtraUsageMetricTests.swift
+++ b/Tests/CodexBarTests/StatusItemExtraUsageMetricTests.swift
@@ -106,11 +106,35 @@ struct StatusItemExtraUsageMetricTests {
     }
 
     @Test
-    func `menu bar extra usage preference keeps currency fallback in pace mode`() {
+    func `menu bar extra usage preference keeps cursor currency fallback in pace mode`() {
+        let (store, controller) = self.makeController(
+            suiteName: "StatusItemExtraUsageMetricTests-cursor-pace-spend-text",
+            provider: .cursor)
+        controller.settings.menuBarDisplayMode = .pace
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 42, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 12.34,
+                limit: 100,
+                currencyCode: "USD",
+                updatedAt: Date()),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .cursor)
+        store._setErrorForTesting(nil, provider: .cursor)
+
+        let displayText = controller.menuBarDisplayText(for: .cursor, snapshot: snapshot)
+
+        #expect(displayText == "$12.34")
+    }
+
+    @Test
+    func `menu bar extra usage preference preserves claude currency display`() {
         let (store, controller) = self.makeController(
             suiteName: "StatusItemExtraUsageMetricTests-claude-spend-text",
             provider: .claude)
-        controller.settings.menuBarDisplayMode = .pace
         let snapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 42, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
             secondary: nil,

--- a/Tests/CodexBarTests/StatusItemExtraUsageMetricTests.swift
+++ b/Tests/CodexBarTests/StatusItemExtraUsageMetricTests.swift
@@ -131,6 +131,31 @@ struct StatusItemExtraUsageMetricTests {
     }
 
     @Test
+    func `menu bar extra usage preference uses percent in combined mode`() {
+        let (store, controller) = self.makeController(
+            suiteName: "StatusItemExtraUsageMetricTests-cursor-combined-text",
+            provider: .cursor)
+        controller.settings.menuBarDisplayMode = .both
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 56,
+                limit: 100,
+                currencyCode: "USD",
+                updatedAt: Date()),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .cursor)
+        store._setErrorForTesting(nil, provider: .cursor)
+
+        let displayText = controller.menuBarDisplayText(for: .cursor, snapshot: snapshot)
+
+        #expect(displayText == "56%")
+    }
+
+    @Test
     func `menu bar extra usage preference preserves claude currency display`() {
         let (store, controller) = self.makeController(
             suiteName: "StatusItemExtraUsageMetricTests-claude-spend-text",

--- a/Tests/CodexBarTests/StatusItemExtraUsageMetricTests.swift
+++ b/Tests/CodexBarTests/StatusItemExtraUsageMetricTests.swift
@@ -57,7 +57,7 @@ struct StatusItemExtraUsageMetricTests {
     }
 
     @Test
-    func `menu bar extra usage preference shows currency spend text for cursor when provider cost exists`() {
+    func `menu bar extra usage preference honors percent used display for cursor`() {
         let (store, controller) = self.makeController(
             suiteName: "StatusItemExtraUsageMetricTests-cursor-spend-text",
             provider: .cursor)
@@ -77,14 +77,40 @@ struct StatusItemExtraUsageMetricTests {
 
         let displayText = controller.menuBarDisplayText(for: .cursor, snapshot: snapshot)
 
-        #expect(displayText == "$12.34")
+        #expect(displayText == "12%")
     }
 
     @Test
-    func `menu bar extra usage preference shows currency spend text for claude when provider cost exists`() {
+    func `menu bar extra usage preference honors percent remaining display for cursor`() {
+        let (store, controller) = self.makeController(
+            suiteName: "StatusItemExtraUsageMetricTests-cursor-remaining-text",
+            provider: .cursor)
+        controller.settings.usageBarsShowUsed = false
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 10, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 20, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            tertiary: RateWindow(usedPercent: 72, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            providerCost: ProviderCostSnapshot(
+                used: 12.34,
+                limit: 100,
+                currencyCode: "USD",
+                updatedAt: Date()),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .cursor)
+        store._setErrorForTesting(nil, provider: .cursor)
+
+        let displayText = controller.menuBarDisplayText(for: .cursor, snapshot: snapshot)
+
+        #expect(displayText == "88%")
+    }
+
+    @Test
+    func `menu bar extra usage preference keeps currency fallback in pace mode`() {
         let (store, controller) = self.makeController(
             suiteName: "StatusItemExtraUsageMetricTests-claude-spend-text",
             provider: .claude)
+        controller.settings.menuBarDisplayMode = .pace
         let snapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 42, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
             secondary: nil,

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -48,8 +48,9 @@ Manual option:
 
 ## Snapshot mapping
 - Primary: plan usage percent (included plan).
-- Secondary: on-demand usage percent (individual usage).
-- Provider cost: on-demand usage USD (limit when known).
+- Secondary: Auto + Composer usage percent.
+- Tertiary: API (named model) usage percent.
+- Provider cost: Extra usage USD. A capped individual budget wins; team accounts without a user cap use the shared team on-demand budget.
 - Reset: billing cycle end date.
 
 ## Key files


### PR DESCRIPTION
## Summary
- honor Cursor Extra usage percent display in Percent and Both modes
- respect used vs remaining percentage while preserving Pace currency fallback
- preserve Claude Extra usage currency and reset-time behavior
- use a capped team Extra usage budget when no individual Cursor cap exists

Closes #1426

## Proof
- exact PR head `c4a2d0e3`: 45 focused tests across Cursor parsing, Extra usage display, and reset-time behavior passed
- full local suite exercised 3,778 tests / 417 suites; one aggregate-only fake app-server timeout failed, then its exact 9-test suite passed in isolation
- `make check`: SwiftFormat clean; SwiftLint 0 violations across 1,064 files
- `swift build -c release`: passed
- signed debug app: deep strict code-sign verification passed
- live Cursor Enterprise profile: Extra usage rendered `Monthly: $0.00 / $2,349.00` and `0% used`
- autoreview: no accepted/actionable findings; correctness confidence 0.82
- Public Model Identifier Gate: PASS
