### PR TITLE
Fix provider switcher quota bar alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Cost usage: accept normal models.dev catalog churn while retaining prior model prices as fallbacks, so newly priced models appear without requiring a manual cache reset (#1438). Thanks @tom-rigelblu!
 - Menu bar: detect Tahoe Control Center proxy windows parked in the blocked offscreen slot during startup recovery, so hidden icons show the existing guidance without weakening menu-bar-manager safeguards (#1440).
 - AWS Bedrock: treat Cost Explorer's temporary data-unavailable response as zero usage instead of an HTTP 400 error (#1324). Thanks @enesteve0!
+- Provider switcher: place quota bars in a dedicated footer below normal-height segments and vertically center icons and labels, avoiding stretched pills and top-heavy buttons.
 - Menu bar: anchor merged provider dropdowns to the status item's trailing edge without marking preserved in-flight refresh content fresh, preventing horizontal drift while keeping deferred updates visible (#1288). Thanks @Yuxin-Qiao!
 - Antigravity: fall back to the CLI usage server when the desktop app is closed, keep helper sessions owned and bounded without hidden sign-in flows, and show model rows with missing usage as unavailable instead of exhausted (#1313). Thanks @enieuwy!
 - Cost usage: replace repeated Foundation metadata/root checks with one portable file-stat pass so expired Codex history refreshes stay responsive on very large session archives (#1392). Thanks @TheAngryPit and @ProspectOre!

--- a/Sources/CodexBar/ProviderSwitcherButtons.swift
+++ b/Sources/CodexBar/ProviderSwitcherButtons.swift
@@ -1,8 +1,6 @@
 import AppKit
 
 final class PaddedToggleButton: NSButton {
-    private var quotaBarReservedHeight: CGFloat = 0
-
     var contentPadding = NSEdgeInsets(top: 4, left: 7, bottom: 4, right: 7) {
         didSet {
             if oldValue.top != self.contentPadding.top ||
@@ -19,22 +17,9 @@ final class PaddedToggleButton: NSButton {
         let size = super.intrinsicContentSize
         return NSSize(
             width: size.width + self.contentPadding.left + self.contentPadding.right,
-            height: size.height + self.contentPadding.top + self.contentPadding.bottom + self.quotaBarReservedHeight)
-    }
-
-    func setQuotaBarReservedHeight(_ height: CGFloat) {
-        guard self.quotaBarReservedHeight != height else { return }
-        self.quotaBarReservedHeight = height
-        self.invalidateIntrinsicContentSize()
+            height: size.height + self.contentPadding.top + self.contentPadding.bottom)
     }
 }
-
-@MainActor
-protocol ProviderSwitcherToggleButton: AnyObject {
-    func setQuotaBarReservedHeight(_ height: CGFloat)
-}
-
-extension PaddedToggleButton: ProviderSwitcherToggleButton {}
 
 final class InlineIconToggleButton: NSButton {
     private let iconView = NSImageView()
@@ -42,7 +27,6 @@ final class InlineIconToggleButton: NSButton {
     private let stack = NSStackView()
     private var paddingConstraints: [NSLayoutConstraint] = []
     private var iconSizeConstraints: [NSLayoutConstraint] = []
-    private var quotaBarReservedHeight: CGFloat = 0
     private var isConfiguring = false // Batch invalidation during setup
 
     var contentPadding = NSEdgeInsets(top: 4, left: 7, bottom: 4, right: 7) {
@@ -50,8 +34,7 @@ final class InlineIconToggleButton: NSButton {
             self.paddingConstraints.first { $0.firstAttribute == .top }?.constant = self.contentPadding.top
             self.paddingConstraints.first { $0.firstAttribute == .leading }?.constant = self.contentPadding.left
             self.paddingConstraints.first { $0.firstAttribute == .trailing }?.constant = -self.contentPadding.right
-            self.paddingConstraints.first { $0.firstAttribute == .bottom }?.constant =
-                -(self.contentPadding.bottom + self.quotaBarReservedHeight)
+            self.paddingConstraints.first { $0.firstAttribute == .bottom }?.constant = -self.contentPadding.bottom
             if !self.isConfiguring { self.invalidateIntrinsicContentSize() }
         }
     }
@@ -88,14 +71,6 @@ final class InlineIconToggleButton: NSButton {
         self.titleField.font = NSFont.systemFont(ofSize: size)
     }
 
-    func setQuotaBarReservedHeight(_ height: CGFloat) {
-        guard self.quotaBarReservedHeight != height else { return }
-        self.quotaBarReservedHeight = height
-        self.paddingConstraints.first { $0.firstAttribute == .bottom }?.constant =
-            -(self.contentPadding.bottom + height)
-        if !self.isConfiguring { self.invalidateIntrinsicContentSize() }
-    }
-
     func setAllowsTwoLineTitle(_ allow: Bool) {
         let hasWhitespace = self.titleField.stringValue.rangeOfCharacter(from: .whitespacesAndNewlines) != nil
         let shouldWrap = allow && hasWhitespace
@@ -108,7 +83,7 @@ final class InlineIconToggleButton: NSButton {
         let size = self.stack.fittingSize
         return NSSize(
             width: size.width + self.contentPadding.left + self.contentPadding.right,
-            height: size.height + self.contentPadding.top + self.contentPadding.bottom + self.quotaBarReservedHeight)
+            height: size.height + self.contentPadding.top + self.contentPadding.bottom)
     }
 
     init(title: String, image: NSImage, target: AnyObject?, action: Selector?) {
@@ -158,7 +133,7 @@ final class InlineIconToggleButton: NSButton {
         self.iconSizeConstraints = [iconWidth, iconHeight]
 
         let top = self.stack.topAnchor.constraint(
-            equalTo: self.topAnchor,
+            greaterThanOrEqualTo: self.topAnchor,
             constant: self.contentPadding.top)
         let leading = self.stack.leadingAnchor.constraint(
             greaterThanOrEqualTo: self.leadingAnchor,
@@ -168,16 +143,15 @@ final class InlineIconToggleButton: NSButton {
             constant: -self.contentPadding.right)
         let centerX = self.stack.centerXAnchor.constraint(equalTo: self.centerXAnchor)
         centerX.priority = .defaultHigh
+        let centerY = self.stack.centerYAnchor.constraint(equalTo: self.centerYAnchor)
         let bottom = self.stack.bottomAnchor.constraint(
             lessThanOrEqualTo: self.bottomAnchor,
             constant: -self.contentPadding.bottom)
-        self.paddingConstraints = [top, leading, trailing, bottom, centerX]
+        self.paddingConstraints = [top, leading, trailing, bottom, centerX, centerY]
 
         NSLayoutConstraint.activate(self.paddingConstraints + self.iconSizeConstraints)
     }
 }
-
-extension InlineIconToggleButton: ProviderSwitcherToggleButton {}
 
 final class StackedToggleButton: NSButton {
     private let iconView = NSImageView()
@@ -185,7 +159,6 @@ final class StackedToggleButton: NSButton {
     private let stack = NSStackView()
     private var paddingConstraints: [NSLayoutConstraint] = []
     private var iconSizeConstraints: [NSLayoutConstraint] = []
-    private var quotaBarReservedHeight: CGFloat = 0
     private var isConfiguring = false // Batch invalidation during setup
 
     var contentPadding = NSEdgeInsets(top: 2, left: 4, bottom: 2, right: 4) {
@@ -193,8 +166,7 @@ final class StackedToggleButton: NSButton {
             self.paddingConstraints.first { $0.firstAttribute == .top }?.constant = self.contentPadding.top
             self.paddingConstraints.first { $0.firstAttribute == .leading }?.constant = self.contentPadding.left
             self.paddingConstraints.first { $0.firstAttribute == .trailing }?.constant = -self.contentPadding.right
-            self.paddingConstraints.first { $0.firstAttribute == .bottom }?.constant =
-                -(self.contentPadding.bottom + self.quotaBarReservedHeight)
+            self.paddingConstraints.first { $0.firstAttribute == .bottom }?.constant = -self.contentPadding.bottom
             if !self.isConfiguring { self.invalidateIntrinsicContentSize() }
         }
     }
@@ -231,14 +203,6 @@ final class StackedToggleButton: NSButton {
         self.titleField.font = NSFont.systemFont(ofSize: size)
     }
 
-    func setQuotaBarReservedHeight(_ height: CGFloat) {
-        guard self.quotaBarReservedHeight != height else { return }
-        self.quotaBarReservedHeight = height
-        self.paddingConstraints.first { $0.firstAttribute == .bottom }?.constant =
-            -(self.contentPadding.bottom + height)
-        if !self.isConfiguring { self.invalidateIntrinsicContentSize() }
-    }
-
     func setAllowsTwoLineTitle(_ allow: Bool) {
         let hasWhitespace = self.titleField.stringValue.rangeOfCharacter(from: .whitespacesAndNewlines) != nil
         let shouldWrap = allow && hasWhitespace
@@ -251,7 +215,7 @@ final class StackedToggleButton: NSButton {
         let size = self.stack.fittingSize
         return NSSize(
             width: size.width + self.contentPadding.left + self.contentPadding.right,
-            height: size.height + self.contentPadding.top + self.contentPadding.bottom + self.quotaBarReservedHeight)
+            height: size.height + self.contentPadding.top + self.contentPadding.bottom)
     }
 
     init(title: String, image: NSImage, target: AnyObject?, action: Selector?) {
@@ -300,10 +264,9 @@ final class StackedToggleButton: NSButton {
         let iconHeight = self.iconView.heightAnchor.constraint(equalToConstant: 16)
         self.iconSizeConstraints = [iconWidth, iconHeight]
 
-        // Avoid subpixel centering: pin from the top so the icon sits on whole-point coordinates.
         // Force an even layout width (button width minus padding) so the icon doesn't land on 0.5pt centers.
         let top = self.stack.topAnchor.constraint(
-            equalTo: self.topAnchor,
+            greaterThanOrEqualTo: self.topAnchor,
             constant: self.contentPadding.top)
         let leading = self.stack.leadingAnchor.constraint(
             equalTo: self.leadingAnchor,
@@ -314,10 +277,9 @@ final class StackedToggleButton: NSButton {
         let bottom = self.stack.bottomAnchor.constraint(
             lessThanOrEqualTo: self.bottomAnchor,
             constant: -self.contentPadding.bottom)
-        self.paddingConstraints = [top, leading, trailing, bottom]
+        let centerY = self.stack.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+        self.paddingConstraints = [top, leading, trailing, bottom, centerY]
 
         NSLayoutConstraint.activate(self.paddingConstraints + self.iconSizeConstraints)
     }
 }
-
-extension StackedToggleButton: ProviderSwitcherToggleButton {}

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -42,12 +42,12 @@ final class ProviderSwitcherView: NSView {
     private var pressedButtonTag: Int?
     private var selectedSegmentIndex: Int?
     private let lightModeOverlayLayer = CALayer()
-    private static let quotaIndicatorHeight: CGFloat = 3
-    private static let quotaIndicatorBottomInset: CGFloat = 2
+    private static let quotaIndicatorHeight: CGFloat = 2
+    private static let quotaIndicatorBottomInset: CGFloat = 1
     private static let quotaIndicatorHorizontalInset: CGFloat = 8
-    private static let quotaIndicatorContentGap: CGFloat = 3
-    private static var quotaIndicatorReservedHeight: CGFloat {
-        quotaIndicatorContentGap + quotaIndicatorHeight + quotaIndicatorBottomInset
+    private static let quotaIndicatorContentGap: CGFloat = 2
+    private static var quotaIndicatorGutterHeight: CGFloat {
+        self.quotaIndicatorContentGap + self.quotaIndicatorHeight + self.quotaIndicatorBottomInset
     }
 
     init(
@@ -103,7 +103,8 @@ final class ProviderSwitcherView: NSView {
             maxAllowedSegmentWidth: initialMaxAllowedSegmentWidth,
             stackedIcons: self.stackedIcons)
         self.rowSpacing = self.stackedIcons ? 4 : 2
-        self.rowHeight = Self.switcherRowHeight(stackedIcons: self.stackedIcons)
+        self.rowHeight = Self.switcherButtonHeight(stackedIcons: self.stackedIcons, rowCount: self.rowCount)
+            + Self.quotaIndicatorGutterHeight
         let height: CGFloat = self.rowHeight * CGFloat(self.rowCount)
             + self.rowSpacing * CGFloat(max(0, self.rowCount - 1))
         self.preferredWidth = width
@@ -164,14 +165,6 @@ final class ProviderSwitcherView: NSView {
                 button.imagePosition = .noImage
             }
 
-            let remaining: Double? = switch segment.selection {
-            case let .provider(provider):
-                self.weeklyRemainingProvider(provider)
-            case .overview:
-                nil
-            }
-            Self.applyQuotaBarContentInset(to: button)
-            self.addQuotaIndicator(to: button, selection: segment.selection, remainingPercent: remaining)
             button.bezelStyle = .regularSquare
             button.isBordered = false
             button.controlSize = .small
@@ -184,6 +177,8 @@ final class ProviderSwitcherView: NSView {
             button.state = (selected == segment.selection) ? .on : .off
             button.toolTip = nil
             button.translatesAutoresizingMaskIntoConstraints = false
+            button.heightAnchor.constraint(
+                equalToConstant: self.rowHeight - Self.quotaIndicatorGutterHeight).isActive = true
             self.buttons.append(button)
             return button
         }
@@ -191,6 +186,10 @@ final class ProviderSwitcherView: NSView {
         for (index, segment) in self.segments.enumerated() {
             let button = makeButton(index: index, segment: segment)
             self.addSubview(button)
+            self.addQuotaIndicator(
+                to: button,
+                selection: segment.selection,
+                remainingPercent: self.remainingPercent(for: segment.selection))
         }
         self.selectedSegmentIndex = selected.flatMap { selected in
             self.segments.firstIndex { $0.selection == selected }
@@ -266,7 +265,7 @@ final class ProviderSwitcherView: NSView {
 
     override func mouseMoved(with event: NSEvent) {
         let location = self.convert(event.locationInWindow, from: nil)
-        let hoveredTag = self.buttons.first(where: { $0.frame.contains(location) })?.tag
+        let hoveredTag = self.button(at: location)?.tag
         guard hoveredTag != self.hoveredButtonTag else { return }
         self.hoveredButtonTag = hoveredTag
         self.updateButtonStyles()
@@ -310,7 +309,7 @@ final class ProviderSwitcherView: NSView {
     func handleMenuTrackingMouseDown(_ event: NSEvent) -> Bool {
         guard event.type == .leftMouseDown else { return false }
         let location = self.locationInView(for: event)
-        guard let pressedTag = self.buttons.first(where: { $0.frame.contains(location) })?.tag,
+        guard let pressedTag = self.button(at: location)?.tag,
               self.segments.indices.contains(pressedTag)
         else {
             return false
@@ -325,7 +324,7 @@ final class ProviderSwitcherView: NSView {
         defer { self.pressedButtonTag = nil }
         guard let pressedTag = self.pressedButtonTag else { return false }
         let location = self.locationInView(for: event)
-        guard let releasedTag = self.buttons.first(where: { $0.frame.contains(location) })?.tag,
+        guard let releasedTag = self.button(at: location)?.tag,
               releasedTag == pressedTag
         else {
             return true
@@ -384,9 +383,13 @@ final class ProviderSwitcherView: NSView {
             gap.priority = .defaultHigh
             NSLayoutConstraint.activate([
                 left.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: outerPadding),
-                left.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+                left.centerYAnchor.constraint(
+                    equalTo: self.centerYAnchor,
+                    constant: -Self.quotaIndicatorGutterHeight / 2),
                 right.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -outerPadding),
-                right.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+                right.centerYAnchor.constraint(
+                    equalTo: self.centerYAnchor,
+                    constant: -Self.quotaIndicatorGutterHeight / 2),
                 gap,
             ])
             return
@@ -406,11 +409,17 @@ final class ProviderSwitcherView: NSView {
 
             NSLayoutConstraint.activate([
                 left.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: outerPadding),
-                left.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+                left.centerYAnchor.constraint(
+                    equalTo: self.centerYAnchor,
+                    constant: -Self.quotaIndicatorGutterHeight / 2),
                 mid.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-                mid.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+                mid.centerYAnchor.constraint(
+                    equalTo: self.centerYAnchor,
+                    constant: -Self.quotaIndicatorGutterHeight / 2),
                 right.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -outerPadding),
-                right.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+                right.centerYAnchor.constraint(
+                    equalTo: self.centerYAnchor,
+                    constant: -Self.quotaIndicatorGutterHeight / 2),
                 leftGap,
                 rightGap,
             ])
@@ -449,7 +458,9 @@ final class ProviderSwitcherView: NSView {
                 } else {
                     NSLayoutConstraint.activate([
                         button.leadingAnchor.constraint(equalTo: rowContainer.leadingAnchor, constant: xOffset),
-                        button.centerYAnchor.constraint(equalTo: rowContainer.centerYAnchor),
+                        button.centerYAnchor.constraint(
+                            equalTo: rowContainer.centerYAnchor,
+                            constant: -Self.quotaIndicatorGutterHeight / 2),
                     ])
                 }
                 xOffset += width + computedGap
@@ -460,7 +471,9 @@ final class ProviderSwitcherView: NSView {
         if let first = self.buttons.first {
             NSLayoutConstraint.activate([
                 first.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-                first.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+                first.centerYAnchor.constraint(
+                    equalTo: self.centerYAnchor,
+                    constant: -Self.quotaIndicatorGutterHeight / 2),
             ])
         }
     }
@@ -524,7 +537,9 @@ final class ProviderSwitcherView: NSView {
                 let xOffset = CGFloat(columnIndex) * (uniformWidth + computedGap)
                 NSLayoutConstraint.activate([
                     button.leadingAnchor.constraint(equalTo: gridContainer.leadingAnchor, constant: xOffset),
-                    button.centerYAnchor.constraint(equalTo: rowView.centerYAnchor),
+                    button.centerYAnchor.constraint(
+                        equalTo: rowView.centerYAnchor,
+                        constant: -Self.quotaIndicatorGutterHeight / 2),
                 ])
             }
         }
@@ -581,9 +596,9 @@ final class ProviderSwitcherView: NSView {
         return rows
     }
 
-    private static func switcherRowHeight(stackedIcons: Bool) -> CGFloat {
-        let baseRowHeight: CGFloat = stackedIcons ? 36 : 30
-        return baseRowHeight + self.quotaIndicatorReservedHeight
+    private static func switcherButtonHeight(stackedIcons: Bool, rowCount: Int) -> CGFloat {
+        guard stackedIcons else { return 30 }
+        return rowCount >= 3 ? 39 : 36
     }
 
     private static func switcherOuterPadding(for width: CGFloat, count: Int, minimumGap: CGFloat) -> CGFloat {
@@ -636,12 +651,7 @@ final class ProviderSwitcherView: NSView {
         for (index, button) in self.buttons.enumerated() {
             guard self.segments.indices.contains(index) else { continue }
             let segment = self.segments[index]
-            let remaining: Double? = switch segment.selection {
-            case let .provider(provider):
-                self.weeklyRemainingProvider(provider)
-            case .overview:
-                nil
-            }
+            let remaining = self.remainingPercent(for: segment.selection)
 
             let key = ObjectIdentifier(button)
             if let remaining {
@@ -662,6 +672,15 @@ final class ProviderSwitcherView: NSView {
                 continue
             }
             self.updateQuotaIndicatorVisibility(for: button)
+        }
+    }
+
+    private func remainingPercent(for selection: ProviderSwitcherSelection) -> Double? {
+        switch selection {
+        case let .provider(provider):
+            self.weeklyRemainingProvider(provider)
+        case .overview:
+            nil
         }
     }
 
@@ -896,6 +915,17 @@ final class ProviderSwitcherView: NSView {
     }
 }
 
+extension ProviderSwitcherView {
+    fileprivate func button(at location: NSPoint) -> NSButton? {
+        self.buttons.first { button in
+            var hitFrame = button.frame
+            hitFrame.origin.y -= Self.quotaIndicatorGutterHeight
+            hitFrame.size.height += Self.quotaIndicatorGutterHeight
+            return hitFrame.contains(location)
+        }
+    }
+}
+
 #if DEBUG
 extension ProviderSwitcherView {
     func _test_mouseDownEvent(buttonTag: Int) -> NSEvent? {
@@ -906,12 +936,28 @@ extension ProviderSwitcherView {
         self._test_mouseEvent(buttonTag: buttonTag, type: .leftMouseUp)
     }
 
+    func _test_quotaIndicatorMouseEvent(buttonTag: Int, type: NSEvent.EventType) -> NSEvent? {
+        guard let button = self.buttons.first(where: { $0.tag == buttonTag }),
+              let track = self.quotaIndicators[ObjectIdentifier(button)]?.track
+        else {
+            return nil
+        }
+        self.updateConstraintsForSubtreeIfNeeded()
+        self.layoutSubtreeIfNeeded()
+        let point = self.convert(NSPoint(x: track.bounds.midX, y: track.bounds.midY), from: track)
+        return self._test_mouseEvent(at: point, type: type)
+    }
+
     private func _test_mouseEvent(buttonTag: Int, type: NSEvent.EventType) -> NSEvent? {
         guard let button = self.buttons.first(where: { $0.tag == buttonTag }) else { return nil }
         self.updateConstraintsForSubtreeIfNeeded()
         self.layoutSubtreeIfNeeded()
         let point = self.convert(NSPoint(x: button.bounds.midX, y: button.bounds.midY), from: button)
-        return NSEvent.mouseEvent(
+        return self._test_mouseEvent(at: point, type: type)
+    }
+
+    private func _test_mouseEvent(at point: NSPoint, type: NSEvent.EventType) -> NSEvent? {
+        NSEvent.mouseEvent(
             with: type,
             location: point,
             modifierFlags: [],
@@ -939,6 +985,18 @@ extension ProviderSwitcherView {
     }
 
     @discardableResult
+    func _test_simulateRuntimeClickOnQuotaIndicator(buttonTag: Int) -> Bool {
+        guard let mouseDown = self._test_quotaIndicatorMouseEvent(buttonTag: buttonTag, type: .leftMouseDown),
+              self.handleMenuTrackingMouseDown(mouseDown),
+              let mouseUp = self._test_quotaIndicatorMouseEvent(buttonTag: buttonTag, type: .leftMouseUp),
+              self.handleMenuTrackingMouseUp(mouseUp)
+        else {
+            return false
+        }
+        return self.selectedSegmentIndex == buttonTag
+    }
+
+    @discardableResult
     func _test_simulateNativeAction(buttonTag: Int, state: NSControl.StateValue) -> Bool {
         guard let button = self.buttons.first(where: { $0.tag == buttonTag }) else { return false }
         button.state = state
@@ -952,6 +1010,12 @@ extension ProviderSwitcherView {
 
     func _test_buttonFittingSizes() -> [NSSize] {
         self.buttons.map(\.fittingSize)
+    }
+
+    func _test_buttonContentFrames() -> [NSRect?] {
+        self.buttons.map { button in
+            button.subviews.first(where: { $0 is NSStackView })?.frame
+        }
     }
 
     func _test_rowCount() -> Int {
@@ -979,6 +1043,13 @@ extension ProviderSwitcherView {
         }
     }
 
+    func _test_quotaIndicatorTrackFrames() -> [NSRect] {
+        self.buttons.compactMap { button in
+            guard let track = self.quotaIndicators[ObjectIdentifier(button)]?.track else { return nil }
+            return self.convert(track.bounds, from: track)
+        }
+    }
+
     func _test_quotaIndicatorConstraintIdentifiers() -> [ObjectIdentifier] {
         self.buttons.compactMap { button in
             self.quotaIndicators[ObjectIdentifier(button)].map { ObjectIdentifier($0.fillWidthConstraint) }
@@ -990,7 +1061,6 @@ extension ProviderSwitcherView {
 extension ProviderSwitcherView {
     private func addQuotaIndicator(to view: NSView, selection: ProviderSwitcherSelection, remainingPercent: Double?) {
         guard let remainingPercent else { return }
-        Self.applyQuotaBarContentInset(to: view)
 
         let track = NSView()
         track.wantsLayer = true
@@ -998,7 +1068,7 @@ extension ProviderSwitcherView {
         track.layer?.cornerRadius = Self.quotaIndicatorHeight / 2
         track.layer?.masksToBounds = true
         track.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(track)
+        self.addSubview(track)
 
         let fill = NSView()
         fill.wantsLayer = true
@@ -1020,9 +1090,9 @@ extension ProviderSwitcherView {
             track.trailingAnchor.constraint(
                 equalTo: view.trailingAnchor,
                 constant: -Self.quotaIndicatorHorizontalInset),
-            track.bottomAnchor.constraint(
+            track.topAnchor.constraint(
                 equalTo: view.bottomAnchor,
-                constant: -Self.quotaIndicatorBottomInset),
+                constant: Self.quotaIndicatorContentGap),
             track.heightAnchor.constraint(equalToConstant: Self.quotaIndicatorHeight),
             fill.leadingAnchor.constraint(equalTo: track.leadingAnchor),
             fill.topAnchor.constraint(equalTo: track.topAnchor),
@@ -1036,13 +1106,6 @@ extension ProviderSwitcherView {
             fillWidthConstraint: fillWidthConstraint,
             fillRatio: ratio)
         self.updateQuotaIndicatorVisibility(for: view)
-    }
-
-    fileprivate static func applyQuotaBarContentInset(
-        to view: NSView,
-        height: CGFloat = quotaIndicatorReservedHeight)
-    {
-        (view as? ProviderSwitcherToggleButton)?.setQuotaBarReservedHeight(height)
     }
 
     private func updateQuotaIndicatorVisibility(for view: NSView) {

--- a/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
@@ -747,7 +747,7 @@ struct StatusMenuSwitcherClickTests {
     }
 
     @Test
-    func `switcher keeps reserved quota space when remaining becomes unavailable`() throws {
+    func `switcher keeps stable height when remaining becomes unavailable`() throws {
         var grokRemaining: Double? = 50
         let noQuotaView = ProviderSwitcherView(
             providers: [.claude, .grok],
@@ -895,9 +895,16 @@ struct StatusMenuSwitcherClickTests {
         view.layoutSubtreeIfNeeded()
 
         // All buttons must stay within switcher bounds (no vertical overflow).
-        for frame in view._test_buttonFrames() {
+        let buttonFrames = view._test_buttonFrames()
+        let contentFrames = view._test_buttonContentFrames()
+        let trackFrames = view._test_quotaIndicatorTrackFrames()
+        for (frame, contentFrame) in zip(buttonFrames, contentFrames) {
             #expect(frame.minY >= 0)
             #expect(frame.maxY <= view.bounds.maxY)
+            #expect(abs((contentFrame?.midY ?? -1) - frame.height / 2) <= 0.5)
+        }
+        for (buttonFrame, trackFrame) in zip(buttonFrames.dropFirst(), trackFrames) {
+            #expect(trackFrame.maxY < buttonFrame.minY)
         }
 
         #expect(view._test_rowCount() == 4)

--- a/Tests/CodexBarTests/StatusMenuSwitcherLayoutTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherLayoutTests.swift
@@ -28,5 +28,60 @@ struct StatusMenuSwitcherLayoutTests {
             #expect(frame.minY == overviewFrame.minY)
             #expect(frame.maxY == overviewFrame.maxY)
         }
+
+        #expect(view._test_rowHeight() == 41)
+    }
+
+    @Test
+    func `quota bars do not offset inline switcher content`() throws {
+        let view = ProviderSwitcherView(
+            providers: [.codex, .devin],
+            selected: .provider(.codex),
+            includesOverview: true,
+            width: 300,
+            showsIcons: true,
+            iconProvider: { _ in NSImage(size: NSSize(width: 16, height: 16)) },
+            weeklyRemainingProvider: { provider in
+                provider == .devin ? 50 : nil
+            },
+            onSelect: { _ in })
+        view.updateConstraintsForSubtreeIfNeeded()
+        view.layoutSubtreeIfNeeded()
+
+        let buttonFrames = view._test_buttonFrames()
+        let contentFrames = view._test_buttonContentFrames()
+        let trackFrames = view._test_quotaIndicatorTrackFrames()
+        #expect(buttonFrames.count == 3)
+        #expect(contentFrames.count == 3)
+        #expect(trackFrames.count == 1)
+        #expect(view._test_rowHeight() == 35)
+
+        let overviewFrame = try #require(buttonFrames.first)
+        for (buttonFrame, contentFrame) in zip(buttonFrames, contentFrames) {
+            let contentFrame = try #require(contentFrame)
+            #expect(buttonFrame.minY == overviewFrame.minY)
+            #expect(buttonFrame.maxY == overviewFrame.maxY)
+            #expect(abs(contentFrame.midY - buttonFrame.height / 2) < 0.01)
+        }
+
+        let devinButtonFrame = try #require(buttonFrames.last)
+        let devinTrackFrame = try #require(trackFrames.first)
+        #expect(devinButtonFrame.height == 30)
+        #expect(devinTrackFrame.maxY < devinButtonFrame.minY)
+    }
+
+    @Test
+    func `quota indicator footer selects its provider`() {
+        let view = ProviderSwitcherView(
+            providers: [.codex, .devin],
+            selected: .provider(.codex),
+            includesOverview: true,
+            width: 300,
+            showsIcons: true,
+            iconProvider: { _ in NSImage(size: NSSize(width: 16, height: 16)) },
+            weeklyRemainingProvider: { $0 == .devin ? 50 : nil },
+            onSelect: { _ in })
+
+        #expect(view._test_simulateRuntimeClickOnQuotaIndicator(buttonTag: 2))
     }
 }


### PR DESCRIPTION
## Summary

- keep provider switcher segments at their normal height and place quota indicators in a dedicated footer
- vertically center inline and stacked icon/title content across segments with and without quota data
- extend switcher hit testing through the quota footer so the indicator remains clickable
- add regressions for equal button frames, centered content, footer placement, and footer selection

## Verification

- `swift test --filter StatusMenuSwitcher` (33 tests passed)
- `swift test` (3,756 tests passed)
- `make check`
- autoreview: no actionable findings
- `./Scripts/compile_and_run.sh`
- live Peekaboo: Overview, Codex, and Devin kept identical tab geometry; clicking Devin's quota footer selected Devin
