### PR TITLE
Harden main thread hang diagnostics

### DIFF
--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -40,9 +40,9 @@ struct CodexBarApp: App {
 
         KeychainAccessGate.isDisabled = UserDefaults.standard.bool(forKey: "debugDisableKeychainAccess")
         KeychainPromptCoordinator.install()
-        #if DEBUG
-        MainThreadHangWatchdog.shared.start()
-        #endif
+        if MainThreadHangWatchdog.isEnabledForCurrentProcess {
+            MainThreadHangWatchdog.shared.start()
+        }
 
         let preferencesSelection = PreferencesSelection()
         let settings = SettingsStore()

--- a/Sources/CodexBar/MainThreadHangWatchdog.swift
+++ b/Sources/CodexBar/MainThreadHangWatchdog.swift
@@ -1,8 +1,6 @@
-import AppKit
 import CodexBarCore
 import Foundation
 
-#if DEBUG
 /// Tracks what the main thread is currently doing so hang reports can name the
 /// operation even when the stall happens in uninstrumented code.
 enum MainThreadActivityBreadcrumb {
@@ -14,55 +12,69 @@ enum MainThreadActivityBreadcrumb {
     private static let state = State()
 
     static var current: String? {
-        self.state.lock.lock()
-        defer { self.state.lock.unlock() }
-        return self.state.stack.last
+        guard MainThreadHangWatchdog.isEnabledForCurrentProcess else { return nil }
+        return self.state.lock.withLock { self.state.stack.last }
     }
 
     static func push(_ label: String) {
-        self.state.lock.lock()
-        defer { self.state.lock.unlock() }
-        self.state.stack.append(label)
+        guard MainThreadHangWatchdog.isEnabledForCurrentProcess else { return }
+        self.state.lock.withLock {
+            self.state.stack.append(label)
+        }
     }
 
     static func pop() {
-        self.state.lock.lock()
-        defer { self.state.lock.unlock() }
-        _ = self.state.stack.popLast()
+        guard MainThreadHangWatchdog.isEnabledForCurrentProcess else { return }
+        self.state.lock.withLock {
+            _ = self.state.stack.popLast()
+        }
     }
 }
 
-/// Detects main-thread stalls regardless of where they originate. A utility thread
-/// pings the main queue and measures how long each ping waits; stalls above the
-/// threshold are logged with the active breadcrumb, and long hangs additionally
-/// capture a `/usr/bin/sample` of the process so the guilty stack lands in
-/// ~/Library/Logs/CodexBar without anyone having to reproduce under a profiler.
-/// Only started in DEBUG builds; release builds never spawn the watchdog thread.
+/// Detects main-queue response delays and records breadcrumbs for the work that
+/// occupied the main thread. Long hangs launch `/usr/bin/sample` asynchronously
+/// so sampling cannot delay recovery detection or inflate the reported duration.
 final class MainThreadHangWatchdog: @unchecked Sendable {
     static let shared = MainThreadHangWatchdog()
+    static let isEnabledForCurrentProcess: Bool = {
+        #if DEBUG
+        true
+        #else
+        let environment = ProcessInfo.processInfo.environment
+        return environment["CODEXBAR_MAIN_THREAD_HANG_WATCHDOG"] == "1" ||
+            UserDefaults.standard.bool(forKey: "debugMainThreadHangWatchdog")
+        #endif
+    }()
 
     private let logger = CodexBarLog.logger(LogCategories.app)
     private let pingInterval: TimeInterval
     private let hangThreshold: TimeInterval
     private let sampleThreshold: TimeInterval
     private let sampleCooldown: TimeInterval
+    private let sampleCaptureOverride: (@Sendable () -> String?)?
     private let lock = NSLock()
     private var isRunning = false
     private var lastSampleAt: Date?
+    private var activeSampleProcesses: [ObjectIdentifier: Process] = [:]
     var onHangForTesting: ((TimeInterval, [String]) -> Void)?
-    var onBeforePingForTesting: (() -> Void)?
-    var onPingScheduledForTesting: (() -> Void)?
+
+    private enum SampleCaptureResult {
+        case coolingDown
+        case attempted(String?)
+    }
 
     init(
-        pingInterval: TimeInterval = 0.5,
+        pingInterval: TimeInterval = 0.025,
         hangThreshold: TimeInterval = 0.15,
         sampleThreshold: TimeInterval = 2.0,
-        sampleCooldown: TimeInterval = 300)
+        sampleCooldown: TimeInterval = 300,
+        sampleCaptureOverride: (@Sendable () -> String?)? = nil)
     {
         self.pingInterval = pingInterval
         self.hangThreshold = hangThreshold
         self.sampleThreshold = sampleThreshold
         self.sampleCooldown = sampleCooldown
+        self.sampleCaptureOverride = sampleCaptureOverride
     }
 
     func start() {
@@ -77,54 +89,53 @@ final class MainThreadHangWatchdog: @unchecked Sendable {
     }
 
     func stop() {
-        self.lock.lock()
-        self.isRunning = false
-        self.lock.unlock()
+        self.lock.withLock {
+            self.isRunning = false
+        }
     }
 
     private var shouldRun: Bool {
-        self.lock.lock()
-        defer { self.lock.unlock() }
-        return self.isRunning
+        self.lock.withLock { self.isRunning }
     }
 
     private final class PingBox: @unchecked Sendable {
         private let lock = NSLock()
-        private var responded = false
+        private let semaphore = DispatchSemaphore(value: 0)
+        private var _respondedAt: DispatchTime?
 
         func markResponded() {
-            self.lock.lock()
-            self.responded = true
-            self.lock.unlock()
+            self.lock.withLock {
+                self._respondedAt = .now()
+            }
+            self.semaphore.signal()
         }
 
-        var hasResponded: Bool {
-            self.lock.lock()
-            defer { self.lock.unlock() }
-            return self.responded
+        var respondedAt: DispatchTime? {
+            self.lock.withLock { self._respondedAt }
+        }
+
+        func waitForResponse(timeout: TimeInterval) -> Bool {
+            self.semaphore.wait(timeout: .now() + timeout) == .success
         }
     }
 
     private func run() {
         while self.shouldRun {
-            self.onBeforePingForTesting?()
             let box = PingBox()
             let pingSentAt = DispatchTime.now()
             DispatchQueue.main.async { box.markResponded() }
-            self.onPingScheduledForTesting?()
-            Thread.sleep(forTimeInterval: self.hangThreshold)
-            guard self.shouldRun else { return }
-            if !box.hasResponded {
+            if !box.waitForResponse(timeout: self.hangThreshold) {
+                guard self.shouldRun else { return }
                 self.traceHang(box: box, pingSentAt: pingSentAt)
             }
+            guard self.shouldRun else { return }
             Thread.sleep(forTimeInterval: self.pingInterval)
         }
     }
 
     private func traceHang(box: PingBox, pingSentAt: DispatchTime) {
-        // A single stall can span several pieces of main-thread work (runloop sources and
-        // timers interleave ahead of the queued ping), so sample the breadcrumb throughout
-        // the hang and report every distinct activity observed.
+        // One delayed ping can span several main-thread operations, so retain each
+        // distinct breadcrumb observed until the queued ping finally executes.
         var activities: [String] = []
         func recordActivity() {
             guard activities.count < 8,
@@ -136,58 +147,104 @@ final class MainThreadHangWatchdog: @unchecked Sendable {
 
         recordActivity()
         var sampleFile: String?
-        while !box.hasResponded, self.shouldRun {
+        var didAttemptSample = false
+        while box.respondedAt == nil, self.shouldRun {
             recordActivity()
-            if sampleFile == nil, self.elapsedSeconds(since: pingSentAt) >= self.sampleThreshold {
-                sampleFile = self.captureSampleIfAllowed()
+            if !didAttemptSample, self.elapsedSeconds(since: pingSentAt) >= self.sampleThreshold {
+                switch self.captureSampleIfAllowed() {
+                case .coolingDown:
+                    break
+                case let .attempted(file):
+                    didAttemptSample = true
+                    sampleFile = file
+                }
             }
-            Thread.sleep(forTimeInterval: 0.05)
+            Thread.sleep(forTimeInterval: 0.025)
         }
-        guard box.hasResponded else { return }
-        let duration = self.elapsedSeconds(since: pingSentAt)
+        guard let respondedAt = box.respondedAt else { return }
+        let duration = self.elapsedSeconds(from: pingSentAt, to: respondedAt)
         var metadata: [String: String] = [
             "durationMs": String(format: "%.0f", duration * 1000),
             "activity": activities.isEmpty ? "unknown" : activities.joined(separator: ","),
         ]
         if let sampleFile {
-            metadata["sample"] = sampleFile
+            metadata["sampleRequested"] = sampleFile
         }
         self.logger.warning("main thread hang", metadata: metadata)
         self.onHangForTesting?(duration, activities)
     }
 
     private func elapsedSeconds(since start: DispatchTime) -> TimeInterval {
-        TimeInterval(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000
+        self.elapsedSeconds(from: start, to: .now())
     }
 
-    private func captureSampleIfAllowed() -> String? {
-        self.lock.lock()
-        if let last = self.lastSampleAt, Date().timeIntervalSince(last) < self.sampleCooldown {
-            self.lock.unlock()
-            return nil
-        }
-        self.lastSampleAt = Date()
-        self.lock.unlock()
+    private func elapsedSeconds(from start: DispatchTime, to end: DispatchTime) -> TimeInterval {
+        TimeInterval(end.uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000_000
+    }
 
+    private func captureSampleIfAllowed() -> SampleCaptureResult {
+        let now = Date()
+        let shouldCapture = self.lock.withLock {
+            if self.lastSampleAt.map({ now.timeIntervalSince($0) < self.sampleCooldown }) ?? false {
+                return false
+            }
+            self.lastSampleAt = now
+            return true
+        }
+        guard shouldCapture else { return .coolingDown }
+
+        let file = if let sampleCaptureOverride {
+            sampleCaptureOverride()
+        } else {
+            self.launchSample()
+        }
+        return .attempted(file)
+    }
+
+    private func launchSample() -> String? {
         let directory = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Logs/CodexBar", isDirectory: true)
-        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        } catch {
+            self.logger.warning(
+                "main thread hang sample failed",
+                metadata: ["error": "\(error)"])
+            return nil
+        }
+
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withFullDate, .withTime]
         let stamp = formatter.string(from: Date()).replacingOccurrences(of: ":", with: "-")
         let file = directory.appendingPathComponent("hang-sample-\(stamp).txt")
 
         let process = Process()
+        let processID = ObjectIdentifier(process)
         process.executableURL = URL(fileURLWithPath: "/usr/bin/sample")
         process.arguments = ["\(ProcessInfo.processInfo.processIdentifier)", "3", "-file", file.path]
+        process.terminationHandler = { [weak self] completedProcess in
+            self?.sampleDidFinish(completedProcess, processID: processID, file: file)
+        }
+        self.lock.withLock {
+            self.activeSampleProcesses[processID] = process
+        }
         do {
             try process.run()
-            process.waitUntilExit()
         } catch {
+            _ = self.lock.withLock {
+                self.activeSampleProcesses.removeValue(forKey: processID)
+            }
             self.logger.warning(
                 "main thread hang sample failed",
                 metadata: ["error": "\(error)"])
             return nil
+        }
+        return file.path
+    }
+
+    private func sampleDidFinish(_ process: Process, processID: ObjectIdentifier, file: URL) {
+        _ = self.lock.withLock {
+            self.activeSampleProcesses.removeValue(forKey: processID)
         }
         guard process.terminationStatus == 0,
               FileManager.default.fileExists(atPath: file.path)
@@ -195,9 +252,30 @@ final class MainThreadHangWatchdog: @unchecked Sendable {
             self.logger.warning(
                 "main thread hang sample failed",
                 metadata: ["status": "\(process.terminationStatus)"])
-            return nil
+            return
         }
-        return file.path
+        self.logger.info(
+            "main thread hang sample captured",
+            metadata: ["sample": file.path])
     }
+
+    #if DEBUG
+    func traceHangForTesting(responseDelay: TimeInterval) {
+        self.lock.withLock {
+            self.isRunning = true
+        }
+        defer {
+            self.lock.withLock {
+                self.isRunning = false
+            }
+        }
+
+        let box = PingBox()
+        let pingSentAt = DispatchTime.now()
+        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + responseDelay) {
+            box.markResponded()
+        }
+        self.traceHang(box: box, pingSentAt: pingSentAt)
+    }
+    #endif
 }
-#endif

--- a/Sources/CodexBar/MainThreadHangWatchdog.swift
+++ b/Sources/CodexBar/MainThreadHangWatchdog.swift
@@ -169,14 +169,6 @@ final class MainThreadHangWatchdog: @unchecked Sendable {
         }
         guard let respondedAt = box.respondedAt else { return }
         let duration = self.elapsedSeconds(from: pingSentAt, to: respondedAt)
-        // The watchdog thread can itself be descheduled until after the main thread
-        // recovers. Preserve sampling for long hangs even when the polling loop misses
-        // the threshold crossing.
-        if !didAttemptSample, duration >= self.sampleThreshold {
-            if case let .attempted(file) = self.captureSampleIfAllowed() {
-                sampleFile = file
-            }
-        }
         var metadata: [String: String] = [
             "durationMs": String(format: "%.0f", duration * 1000),
             "activity": activities.isEmpty ? "unknown" : activities.joined(separator: ","),
@@ -274,7 +266,11 @@ final class MainThreadHangWatchdog: @unchecked Sendable {
     }
 
     #if DEBUG
-    func traceHangForTesting(responseDelay: TimeInterval, waitForSampleAttempt: Bool = false) {
+    func traceHangForTesting(
+        responseDelay: TimeInterval,
+        waitForSampleAttempt: Bool = false,
+        responseBeforeTrace: Bool = false)
+    {
         self.lock.withLock {
             self.isRunning = true
         }
@@ -292,7 +288,10 @@ final class MainThreadHangWatchdog: @unchecked Sendable {
                 box.markResponded()
             }
         }
-        if waitForSampleAttempt {
+        if responseBeforeTrace {
+            Thread.sleep(forTimeInterval: responseDelay)
+            box.markResponded()
+        } else if waitForSampleAttempt {
             self.onSampleAttemptForTesting = scheduleResponse
         } else {
             scheduleResponse()

--- a/Sources/CodexBar/MainThreadHangWatchdog.swift
+++ b/Sources/CodexBar/MainThreadHangWatchdog.swift
@@ -163,6 +163,14 @@ final class MainThreadHangWatchdog: @unchecked Sendable {
         }
         guard let respondedAt = box.respondedAt else { return }
         let duration = self.elapsedSeconds(from: pingSentAt, to: respondedAt)
+        // The watchdog thread can itself be descheduled until after the main thread
+        // recovers. Preserve sampling for long hangs even when the polling loop misses
+        // the threshold crossing.
+        if !didAttemptSample, duration >= self.sampleThreshold {
+            if case let .attempted(file) = self.captureSampleIfAllowed() {
+                sampleFile = file
+            }
+        }
         var metadata: [String: String] = [
             "durationMs": String(format: "%.0f", duration * 1000),
             "activity": activities.isEmpty ? "unknown" : activities.joined(separator: ","),

--- a/Sources/CodexBar/MainThreadHangWatchdog.swift
+++ b/Sources/CodexBar/MainThreadHangWatchdog.swift
@@ -57,6 +57,9 @@ final class MainThreadHangWatchdog: @unchecked Sendable {
     private var lastSampleAt: Date?
     private var activeSampleProcesses: [ObjectIdentifier: Process] = [:]
     var onHangForTesting: ((TimeInterval, [String]) -> Void)?
+    #if DEBUG
+    private var onSampleAttemptForTesting: (() -> Void)?
+    #endif
 
     private enum SampleCaptureResult {
         case coolingDown
@@ -151,6 +154,9 @@ final class MainThreadHangWatchdog: @unchecked Sendable {
         while box.respondedAt == nil, self.shouldRun {
             recordActivity()
             if !didAttemptSample, self.elapsedSeconds(since: pingSentAt) >= self.sampleThreshold {
+                #if DEBUG
+                self.onSampleAttemptForTesting?()
+                #endif
                 switch self.captureSampleIfAllowed() {
                 case .coolingDown:
                     break
@@ -268,7 +274,7 @@ final class MainThreadHangWatchdog: @unchecked Sendable {
     }
 
     #if DEBUG
-    func traceHangForTesting(responseDelay: TimeInterval) {
+    func traceHangForTesting(responseDelay: TimeInterval, waitForSampleAttempt: Bool = false) {
         self.lock.withLock {
             self.isRunning = true
         }
@@ -276,12 +282,20 @@ final class MainThreadHangWatchdog: @unchecked Sendable {
             self.lock.withLock {
                 self.isRunning = false
             }
+            self.onSampleAttemptForTesting = nil
         }
 
         let box = PingBox()
         let pingSentAt = DispatchTime.now()
-        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + responseDelay) {
-            box.markResponded()
+        let scheduleResponse = {
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + responseDelay) {
+                box.markResponded()
+            }
+        }
+        if waitForSampleAttempt {
+            self.onSampleAttemptForTesting = scheduleResponse
+        } else {
+            scheduleResponse()
         }
         self.traceHang(box: box, pingSentAt: pingSentAt)
     }

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -62,10 +62,8 @@ extension StatusItemController {
         menu.removeAllItems()
 
         let t0 = CACurrentMediaTime()
-        #if DEBUG
         MainThreadActivityBreadcrumb.push("hydrateChart:\(chartID)")
         defer { MainThreadActivityBreadcrumb.pop() }
-        #endif
         let didHydrate: Bool = switch chartID {
         case Self.usageBreakdownChartID:
             self.appendUsageBreakdownChartItem(to: menu, width: width)
@@ -107,7 +105,6 @@ extension StatusItemController {
             false
         }
         self.logChartRenderDurationIfSlow("hydrateHostedSubview:\(chartID)", startedAt: t0)
-        self.logHostedSubviewDisplaySettle("hydrateHostedSubview:\(chartID)", startedAt: t0)
 
         if !didHydrate {
             self.appendHostedSubviewUnavailableItem(
@@ -135,10 +132,8 @@ extension StatusItemController {
 
         menu.removeAllItems()
         let t0 = CACurrentMediaTime()
-        #if DEBUG
         MainThreadActivityBreadcrumb.push("refreshChart:\(identity.chartID)")
         defer { MainThreadActivityBreadcrumb.pop() }
-        #endif
         let didHydrate: Bool = switch identity.chartID {
         case Self.usageBreakdownChartID:
             self.appendUsageBreakdownChartItem(to: menu, width: width)
@@ -172,7 +167,6 @@ extension StatusItemController {
             false
         }
         self.logChartRenderDurationIfSlow("refreshHostedSubview:\(identity.chartID)", startedAt: t0)
-        self.logHostedSubviewDisplaySettle("refreshHostedSubview:\(identity.chartID)", startedAt: t0)
 
         if !didHydrate {
             self.appendHostedSubviewUnavailableItem(

--- a/Sources/CodexBar/StatusItemController+MenuInteractionRefresh.swift
+++ b/Sources/CodexBar/StatusItemController+MenuInteractionRefresh.swift
@@ -38,16 +38,12 @@ extension StatusItemController {
         _ operation: String,
         breadcrumb: @autoclosure () -> String) -> MenuOperationTrace
     {
-        #if DEBUG
         MainThreadActivityBreadcrumb.push(breadcrumb())
-        #endif
         return MenuOperationTrace(operation: operation, startedAt: CACurrentMediaTime())
     }
 
     func endMenuOperationTrace(_ trace: MenuOperationTrace, menu: NSMenu, provider: UsageProvider?) {
-        #if DEBUG
         MainThreadActivityBreadcrumb.pop()
-        #endif
         self.logMenuOperationDurationIfSlow(
             trace.operation,
             startedAt: trace.startedAt,
@@ -84,25 +80,6 @@ extension StatusItemController {
                 "section": label,
                 "durationMs": String(format: "%.1f", elapsed * 1000),
             ])
-    }
-
-    private static let slowHostedSubviewDisplaySettleThreshold: TimeInterval = 0.1
-
-    /// Chart construction returns before SwiftUI's first draw of the hosted view, so a
-    /// fast hydrate can still display with a visible hitch. Measure to the next main
-    /// runloop turn, which includes the Core Animation commit and first render pass.
-    func logHostedSubviewDisplaySettle(_ label: String, startedAt: CFTimeInterval) {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            let elapsed = CACurrentMediaTime() - startedAt
-            guard elapsed >= Self.slowHostedSubviewDisplaySettleThreshold else { return }
-            self.menuLogger.warning(
-                "slow hosted subview display",
-                metadata: [
-                    "section": label,
-                    "durationMs": String(format: "%.1f", elapsed * 1000),
-                ])
-        }
     }
 
     func deferMenuInteractionRefreshIfNeeded(providers: [UsageProvider]) {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -660,16 +660,14 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     func updateIcons() {
         #if DEBUG
         guard !self.isReleasedForTesting else { return }
-        MainThreadActivityBreadcrumb.push("updateIcons")
         #endif
+        MainThreadActivityBreadcrumb.push("updateIcons")
         self.scheduleMenuBarCountdownRefreshIfNeeded()
         self.lastObservedStoreIconWorkSignature = self.storeIconObservationSignature()
         self.beginIconPerfUpdatePass()
         defer {
             self.endIconPerfUpdatePass()
-            #if DEBUG
             MainThreadActivityBreadcrumb.pop()
-            #endif
         }
         // Avoid flicker: when an animation driver is active, store updates can call `updateIcons()` and
         // briefly overwrite the animated frame with the static (phase=nil) icon.

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -33,23 +33,6 @@ extension UsageStore {
         return self.providerSpecs[provider]
     }
 
-    /// The menu card shows its "Refreshing…" indicator for the whole provider refresh,
-    /// so a slow fetch reads as lag even when the UI stays responsive. Persist a warning
-    /// whenever a single provider keeps the spinner up this long.
-    private static let slowProviderRefreshThreshold: TimeInterval = 5
-
-    private func logProviderRefreshDurationIfSlow(_ provider: UsageProvider, startedAt: DispatchTime) {
-        let elapsed = TimeInterval(DispatchTime.now().uptimeNanoseconds - startedAt.uptimeNanoseconds)
-            / 1_000_000_000
-        guard elapsed >= Self.slowProviderRefreshThreshold else { return }
-        self.providerLogger.warning(
-            "slow provider refresh",
-            metadata: [
-                "provider": provider.rawValue,
-                "durationMs": String(format: "%.0f", elapsed * 1000),
-            ])
-    }
-
     func refreshProvider(
         _ provider: UsageProvider,
         allowDisabled: Bool = false,
@@ -161,9 +144,7 @@ extension UsageStore {
     {
         self.providerRefreshCounts[provider, default: 0] += 1
         self.refreshingProviders.insert(provider)
-        let refreshStartedAt = DispatchTime.now()
         defer {
-            self.logProviderRefreshDurationIfSlow(provider, startedAt: refreshStartedAt)
             let remaining = max(0, self.providerRefreshCounts[provider, default: 1] - 1)
             if remaining == 0 {
                 self.providerRefreshCounts.removeValue(forKey: provider)

--- a/Tests/CodexBarTests/MainThreadHangWatchdogTests.swift
+++ b/Tests/CodexBarTests/MainThreadHangWatchdogTests.swift
@@ -3,6 +3,7 @@ import Testing
 @testable import CodexBar
 
 #if DEBUG
+@Suite(.serialized)
 struct MainThreadHangWatchdogTests {
     @MainActor
     @Test
@@ -18,9 +19,9 @@ struct MainThreadHangWatchdogTests {
     }
 
     @Test
-    func `watchdog reports a blocked main thread with the active breadcrumb`() async throws {
+    func `watchdog reports an unsynchronized main thread stall`() async throws {
         let watchdog = MainThreadHangWatchdog(
-            pingInterval: 0.02,
+            pingInterval: 0.01,
             hangThreshold: 0.05,
             sampleThreshold: 60,
             sampleCooldown: 3600)
@@ -30,39 +31,15 @@ struct MainThreadHangWatchdogTests {
             reported.append((duration, activities))
         }
 
-        let ready = OSAllocatedBox(false)
-        let gateOnce = OSAllocatedBox(true)
-        let beginPing = DispatchSemaphore(value: 0)
-        let pingScheduled = DispatchSemaphore(value: 0)
-        watchdog.onBeforePingForTesting = {
-            guard gateOnce.takeTrue() else { return }
-            ready.set(true)
-            beginPing.wait()
-        }
-        watchdog.onPingScheduledForTesting = {
-            pingScheduled.signal()
-        }
         watchdog.start()
-        defer {
-            beginPing.signal()
-            pingScheduled.signal()
-            watchdog.stop()
-        }
+        defer { watchdog.stop() }
 
-        for _ in 0..<200 where !ready.get() {
-            try await Task.sleep(for: .milliseconds(10))
-        }
-        try #require(ready.get())
-
-        let didSchedulePing = await MainActor.run {
-            beginPing.signal()
-            guard pingScheduled.wait(timeout: .now() + 2) == .success else { return false }
+        try await Task.sleep(for: .milliseconds(75))
+        await MainActor.run {
             MainThreadActivityBreadcrumb.push("testStall")
-            Thread.sleep(forTimeInterval: 0.4)
+            Thread.sleep(forTimeInterval: 0.25)
             MainThreadActivityBreadcrumb.pop()
-            return true
         }
-        try #require(didSchedulePing)
 
         // Concurrent test suites stall the main thread too: a single hang report can span
         // several of them and is only delivered once the whole stall ends, so poll for our
@@ -78,7 +55,75 @@ struct MainThreadHangWatchdogTests {
         let report = try #require(stallReport)
         #expect(report.0 >= 0.05)
     }
+
+    @Test
+    func `sample capture cannot inflate reported hang duration`() throws {
+        let sampleRequested = OSAllocatedBox(false)
+        let watchdog = MainThreadHangWatchdog(
+            pingInterval: 0.01,
+            hangThreshold: 0.03,
+            sampleThreshold: 0.05,
+            sampleCooldown: 3600,
+            sampleCaptureOverride: {
+                sampleRequested.set(true)
+                Thread.sleep(forTimeInterval: 0.3)
+                return "/tmp/codexbar-watchdog-test-sample.txt"
+            })
+
+        let reported = OSAllocatedBox<[(TimeInterval, [String])]>([])
+        watchdog.onHangForTesting = { duration, activities in
+            reported.append((duration, activities))
+        }
+
+        MainThreadActivityBreadcrumb.push("sampledStall")
+        watchdog.traceHangForTesting(responseDelay: 0.12)
+        MainThreadActivityBreadcrumb.pop()
+
+        let report = try #require(reported.get().first)
+        #expect(sampleRequested.get())
+        #expect(report.1.contains("sampledStall"))
+        #expect(report.0 >= 0.03)
+        #expect(report.0 < 0.2)
+    }
+
+    @Test
+    func `failed sample capture is attempted once per hang`() {
+        let attempts = OSAllocatedBox(0)
+        let watchdog = MainThreadHangWatchdog(
+            pingInterval: 0.01,
+            hangThreshold: 0.01,
+            sampleThreshold: 0.02,
+            sampleCooldown: 3600,
+            sampleCaptureOverride: {
+                attempts.withValue { $0 += 1 }
+                return nil
+            })
+
+        watchdog.traceHangForTesting(responseDelay: 0.12)
+
+        #expect(attempts.get() == 1)
+    }
+
+    @Test
+    func `cooldown blocked hang samples when cooldown expires`() {
+        let attempts = OSAllocatedBox(0)
+        let watchdog = MainThreadHangWatchdog(
+            pingInterval: 0.01,
+            hangThreshold: 0.01,
+            sampleThreshold: 0.01,
+            sampleCooldown: 0.2,
+            sampleCaptureOverride: {
+                attempts.withValue { $0 += 1 }
+                return nil
+            })
+
+        watchdog.traceHangForTesting(responseDelay: 0.05)
+        watchdog.traceHangForTesting(responseDelay: 0.3)
+
+        #expect(attempts.get() == 2)
+    }
 }
+#endif
 
 private final class OSAllocatedBox<T>: @unchecked Sendable {
     private let lock = NSLock()
@@ -108,12 +153,9 @@ extension OSAllocatedBox {
         self.lock.unlock()
     }
 
-    func takeTrue() -> Bool where T == Bool {
+    func withValue(_ body: (inout T) -> Void) {
         self.lock.lock()
-        defer { self.lock.unlock() }
-        guard self.value else { return false }
-        self.value = false
-        return true
+        body(&self.value)
+        self.lock.unlock()
     }
 }
-#endif

--- a/Tests/CodexBarTests/MainThreadHangWatchdogTests.swift
+++ b/Tests/CodexBarTests/MainThreadHangWatchdogTests.swift
@@ -105,6 +105,26 @@ struct MainThreadHangWatchdogTests {
     }
 
     @Test
+    func `missed sample window does not consume cooldown`() {
+        let attempts = OSAllocatedBox(0)
+        let watchdog = MainThreadHangWatchdog(
+            pingInterval: 0.01,
+            hangThreshold: 0.01,
+            sampleThreshold: 0.02,
+            sampleCooldown: 3600,
+            sampleCaptureOverride: {
+                attempts.withValue { $0 += 1 }
+                return nil
+            })
+
+        watchdog.traceHangForTesting(responseDelay: 0.05, responseBeforeTrace: true)
+        #expect(attempts.get() == 0)
+
+        watchdog.traceHangForTesting(responseDelay: 0.05, waitForSampleAttempt: true)
+        #expect(attempts.get() == 1)
+    }
+
+    @Test
     func `cooldown blocked hang samples when cooldown expires`() {
         let attempts = OSAllocatedBox(0)
         let watchdog = MainThreadHangWatchdog(

--- a/Tests/CodexBarTests/MainThreadHangWatchdogTests.swift
+++ b/Tests/CodexBarTests/MainThreadHangWatchdogTests.swift
@@ -66,7 +66,7 @@ struct MainThreadHangWatchdogTests {
             sampleCooldown: 3600,
             sampleCaptureOverride: {
                 sampleRequested.set(true)
-                Thread.sleep(forTimeInterval: 0.3)
+                Thread.sleep(forTimeInterval: 1)
                 return "/tmp/codexbar-watchdog-test-sample.txt"
             })
 
@@ -76,14 +76,14 @@ struct MainThreadHangWatchdogTests {
         }
 
         MainThreadActivityBreadcrumb.push("sampledStall")
-        watchdog.traceHangForTesting(responseDelay: 0.12)
+        watchdog.traceHangForTesting(responseDelay: 0.05, waitForSampleAttempt: true)
         MainThreadActivityBreadcrumb.pop()
 
         let report = try #require(reported.get().first)
         #expect(sampleRequested.get())
         #expect(report.1.contains("sampledStall"))
         #expect(report.0 >= 0.03)
-        #expect(report.0 < 0.2)
+        #expect(report.0 < 0.75)
     }
 
     @Test
@@ -92,14 +92,14 @@ struct MainThreadHangWatchdogTests {
         let watchdog = MainThreadHangWatchdog(
             pingInterval: 0.01,
             hangThreshold: 0.01,
-            sampleThreshold: 0.02,
+            sampleThreshold: 0,
             sampleCooldown: 3600,
             sampleCaptureOverride: {
                 attempts.withValue { $0 += 1 }
                 return nil
             })
 
-        watchdog.traceHangForTesting(responseDelay: 0.12)
+        watchdog.traceHangForTesting(responseDelay: 0.05, waitForSampleAttempt: true)
 
         #expect(attempts.get() == 1)
     }
@@ -110,15 +110,15 @@ struct MainThreadHangWatchdogTests {
         let watchdog = MainThreadHangWatchdog(
             pingInterval: 0.01,
             hangThreshold: 0.01,
-            sampleThreshold: 0.01,
+            sampleThreshold: 0,
             sampleCooldown: 0.2,
             sampleCaptureOverride: {
                 attempts.withValue { $0 += 1 }
                 return nil
             })
 
-        watchdog.traceHangForTesting(responseDelay: 0.05)
-        watchdog.traceHangForTesting(responseDelay: 0.3)
+        watchdog.traceHangForTesting(responseDelay: 0.05, waitForSampleAttempt: true)
+        watchdog.traceHangForTesting(responseDelay: 1)
 
         #expect(attempts.get() == 2)
     }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -166,6 +166,22 @@ log show --predicate 'category == "keychain-migration"' --last 5m
 3. Check Preferences → Providers → Augment → Cookie source is "Automatic"
 4. Enable debug logging and check Console.app
 
+### Main-Thread Hangs
+
+Debug builds start the hang watchdog automatically. To diagnose a release build,
+enable it explicitly and restart CodexBar:
+
+```bash
+defaults write com.steipete.codexbar debugMainThreadHangWatchdog -bool true
+```
+
+Hangs are written to the app log. Hangs over two seconds also request a process
+sample under `~/Library/Logs/CodexBar/`. Disable the release opt-in with:
+
+```bash
+defaults delete com.steipete.codexbar debugMainThreadHangWatchdog
+```
+
 ## Architecture Notes
 
 ### Menu Bar App Pattern


### PR DESCRIPTION
## Summary

Follow-up hardening for #1437 after the original PR merged while review was still in progress.

- detect stalls continuously instead of leaving a 500 ms blind interval
- measure recovery at the exact main-queue response time
- launch `/usr/bin/sample` asynchronously and retain it through termination
- limit failed sampling to one attempt per hang while allowing cooldown-blocked hangs to retry once eligible
- support explicit release-build diagnostics through an environment variable or defaults key
- remove unrelated provider-refresh logging and misleading render-settle breadcrumbs
- document release-build opt-in and sample locations

## Verification

- `swift test --filter MainThreadHangWatchdogTests`
- `make check`
- `git diff --check`
- autoreview: no actionable findings

The full local suite reached unrelated existing parallel-test flakes on two runs; all watchdog tests passed in both runs. A release-configured build compiled and linked the app target, then the repository's existing release test target failed on unrelated debug-only test seams.
