### PR TITLE
fix: integrate provider switcher quota bars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Cost usage: accept normal models.dev catalog churn while retaining prior model prices as fallbacks, so newly priced models appear without requiring a manual cache reset (#1438). Thanks @tom-rigelblu!
 - Menu bar: detect Tahoe Control Center proxy windows parked in the blocked offscreen slot during startup recovery, so hidden icons show the existing guidance without weakening menu-bar-manager safeguards (#1440).
 - AWS Bedrock: treat Cost Explorer's temporary data-unavailable response as zero usage instead of an HTTP 400 error (#1324). Thanks @enesteve0!
-- Provider switcher: place quota bars in a dedicated footer below normal-height segments and vertically center icons and labels, avoiding stretched pills and top-heavy buttons.
+- Provider switcher: inset quota bars inside fixed-height segments so icons, labels, and selected pills remain vertically centered.
 - Doubao: show an unavailable quota state when Ark omits trustworthy request-limit data instead of reporting 100% left.
 - Menu bar: anchor merged provider dropdowns to the status item's trailing edge without marking preserved in-flight refresh content fresh, preventing horizontal drift while keeping deferred updates visible (#1288). Thanks @Yuxin-Qiao!
 - Antigravity: fall back to the CLI usage server when the desktop app is closed, keep helper sessions owned and bounded without hidden sign-in flows, and show model rows with missing usage as unavailable instead of exhausted (#1313). Thanks @enieuwy!

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -43,12 +43,8 @@ final class ProviderSwitcherView: NSView {
     private var selectedSegmentIndex: Int?
     private let lightModeOverlayLayer = CALayer()
     private static let quotaIndicatorHeight: CGFloat = 2
-    private static let quotaIndicatorBottomInset: CGFloat = 1
+    private static let quotaIndicatorBottomInset: CGFloat = 2
     private static let quotaIndicatorHorizontalInset: CGFloat = 8
-    private static let quotaIndicatorContentGap: CGFloat = 2
-    private static var quotaIndicatorGutterHeight: CGFloat {
-        self.quotaIndicatorContentGap + self.quotaIndicatorHeight + self.quotaIndicatorBottomInset
-    }
 
     init(
         providers: [UsageProvider],
@@ -104,7 +100,6 @@ final class ProviderSwitcherView: NSView {
             stackedIcons: self.stackedIcons)
         self.rowSpacing = self.stackedIcons ? 4 : 2
         self.rowHeight = Self.switcherButtonHeight(stackedIcons: self.stackedIcons, rowCount: self.rowCount)
-            + Self.quotaIndicatorGutterHeight
         let height: CGFloat = self.rowHeight * CGFloat(self.rowCount)
             + self.rowSpacing * CGFloat(max(0, self.rowCount - 1))
         self.preferredWidth = width
@@ -177,8 +172,7 @@ final class ProviderSwitcherView: NSView {
             button.state = (selected == segment.selection) ? .on : .off
             button.toolTip = nil
             button.translatesAutoresizingMaskIntoConstraints = false
-            button.heightAnchor.constraint(
-                equalToConstant: self.rowHeight - Self.quotaIndicatorGutterHeight).isActive = true
+            button.heightAnchor.constraint(equalToConstant: self.rowHeight).isActive = true
             self.buttons.append(button)
             return button
         }
@@ -383,13 +377,9 @@ final class ProviderSwitcherView: NSView {
             gap.priority = .defaultHigh
             NSLayoutConstraint.activate([
                 left.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: outerPadding),
-                left.centerYAnchor.constraint(
-                    equalTo: self.centerYAnchor,
-                    constant: -Self.quotaIndicatorGutterHeight / 2),
+                left.centerYAnchor.constraint(equalTo: self.centerYAnchor),
                 right.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -outerPadding),
-                right.centerYAnchor.constraint(
-                    equalTo: self.centerYAnchor,
-                    constant: -Self.quotaIndicatorGutterHeight / 2),
+                right.centerYAnchor.constraint(equalTo: self.centerYAnchor),
                 gap,
             ])
             return
@@ -409,17 +399,11 @@ final class ProviderSwitcherView: NSView {
 
             NSLayoutConstraint.activate([
                 left.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: outerPadding),
-                left.centerYAnchor.constraint(
-                    equalTo: self.centerYAnchor,
-                    constant: -Self.quotaIndicatorGutterHeight / 2),
+                left.centerYAnchor.constraint(equalTo: self.centerYAnchor),
                 mid.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-                mid.centerYAnchor.constraint(
-                    equalTo: self.centerYAnchor,
-                    constant: -Self.quotaIndicatorGutterHeight / 2),
+                mid.centerYAnchor.constraint(equalTo: self.centerYAnchor),
                 right.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -outerPadding),
-                right.centerYAnchor.constraint(
-                    equalTo: self.centerYAnchor,
-                    constant: -Self.quotaIndicatorGutterHeight / 2),
+                right.centerYAnchor.constraint(equalTo: self.centerYAnchor),
                 leftGap,
                 rightGap,
             ])
@@ -458,9 +442,7 @@ final class ProviderSwitcherView: NSView {
                 } else {
                     NSLayoutConstraint.activate([
                         button.leadingAnchor.constraint(equalTo: rowContainer.leadingAnchor, constant: xOffset),
-                        button.centerYAnchor.constraint(
-                            equalTo: rowContainer.centerYAnchor,
-                            constant: -Self.quotaIndicatorGutterHeight / 2),
+                        button.centerYAnchor.constraint(equalTo: rowContainer.centerYAnchor),
                     ])
                 }
                 xOffset += width + computedGap
@@ -471,9 +453,7 @@ final class ProviderSwitcherView: NSView {
         if let first = self.buttons.first {
             NSLayoutConstraint.activate([
                 first.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-                first.centerYAnchor.constraint(
-                    equalTo: self.centerYAnchor,
-                    constant: -Self.quotaIndicatorGutterHeight / 2),
+                first.centerYAnchor.constraint(equalTo: self.centerYAnchor),
             ])
         }
     }
@@ -537,9 +517,7 @@ final class ProviderSwitcherView: NSView {
                 let xOffset = CGFloat(columnIndex) * (uniformWidth + computedGap)
                 NSLayoutConstraint.activate([
                     button.leadingAnchor.constraint(equalTo: gridContainer.leadingAnchor, constant: xOffset),
-                    button.centerYAnchor.constraint(
-                        equalTo: rowView.centerYAnchor,
-                        constant: -Self.quotaIndicatorGutterHeight / 2),
+                    button.centerYAnchor.constraint(equalTo: rowView.centerYAnchor),
                 ])
             }
         }
@@ -917,12 +895,7 @@ final class ProviderSwitcherView: NSView {
 
 extension ProviderSwitcherView {
     fileprivate func button(at location: NSPoint) -> NSButton? {
-        self.buttons.first { button in
-            var hitFrame = button.frame
-            hitFrame.origin.y -= Self.quotaIndicatorGutterHeight
-            hitFrame.size.height += Self.quotaIndicatorGutterHeight
-            return hitFrame.contains(location)
-        }
+        self.buttons.first { $0.frame.contains(location) }
     }
 }
 
@@ -1068,7 +1041,7 @@ extension ProviderSwitcherView {
         track.layer?.cornerRadius = Self.quotaIndicatorHeight / 2
         track.layer?.masksToBounds = true
         track.translatesAutoresizingMaskIntoConstraints = false
-        self.addSubview(track)
+        view.addSubview(track)
 
         let fill = NSView()
         fill.wantsLayer = true
@@ -1090,9 +1063,9 @@ extension ProviderSwitcherView {
             track.trailingAnchor.constraint(
                 equalTo: view.trailingAnchor,
                 constant: -Self.quotaIndicatorHorizontalInset),
-            track.topAnchor.constraint(
+            track.bottomAnchor.constraint(
                 equalTo: view.bottomAnchor,
-                constant: Self.quotaIndicatorContentGap),
+                constant: -Self.quotaIndicatorBottomInset),
             track.heightAnchor.constraint(equalToConstant: Self.quotaIndicatorHeight),
             fill.leadingAnchor.constraint(equalTo: track.leadingAnchor),
             fill.topAnchor.constraint(equalTo: track.topAnchor),

--- a/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherClickTests.swift
@@ -904,11 +904,12 @@ struct StatusMenuSwitcherClickTests {
             #expect(abs((contentFrame?.midY ?? -1) - frame.height / 2) <= 0.5)
         }
         for (buttonFrame, trackFrame) in zip(buttonFrames.dropFirst(), trackFrames) {
-            #expect(trackFrame.maxY < buttonFrame.minY)
+            #expect(trackFrame.minY >= buttonFrame.minY)
+            #expect(trackFrame.maxY <= buttonFrame.maxY)
         }
 
         #expect(view._test_rowCount() == 4)
-        #expect(view._test_rowHeight() == 44)
-        #expect(view.bounds.height == 188)
+        #expect(view._test_rowHeight() == 39)
+        #expect(view.bounds.height == 168)
     }
 }

--- a/Tests/CodexBarTests/StatusMenuSwitcherLayoutTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherLayoutTests.swift
@@ -29,7 +29,7 @@ struct StatusMenuSwitcherLayoutTests {
             #expect(frame.maxY == overviewFrame.maxY)
         }
 
-        #expect(view._test_rowHeight() == 41)
+        #expect(view._test_rowHeight() == 36)
     }
 
     @Test
@@ -54,7 +54,7 @@ struct StatusMenuSwitcherLayoutTests {
         #expect(buttonFrames.count == 3)
         #expect(contentFrames.count == 3)
         #expect(trackFrames.count == 1)
-        #expect(view._test_rowHeight() == 35)
+        #expect(view._test_rowHeight() == 30)
 
         let overviewFrame = try #require(buttonFrames.first)
         for (buttonFrame, contentFrame) in zip(buttonFrames, contentFrames) {
@@ -67,11 +67,12 @@ struct StatusMenuSwitcherLayoutTests {
         let devinButtonFrame = try #require(buttonFrames.last)
         let devinTrackFrame = try #require(trackFrames.first)
         #expect(devinButtonFrame.height == 30)
-        #expect(devinTrackFrame.maxY < devinButtonFrame.minY)
+        #expect(devinTrackFrame.minY >= devinButtonFrame.minY)
+        #expect(devinTrackFrame.maxY <= devinButtonFrame.maxY)
     }
 
     @Test
-    func `quota indicator footer selects its provider`() {
+    func `integrated quota indicator selects its provider`() {
         let view = ProviderSwitcherView(
             providers: [.codex, .devin],
             selected: .provider(.codex),


### PR DESCRIPTION
## Summary
- Keep provider switcher segments at their original fixed height instead of adding a quota footer gutter.
- Inset the quota indicator inside the owning tab's bottom edge, preserving centered icons, labels, and selected pills.
- Simplify hit testing now that the indicator stays inside the button bounds.
- Update layout and click regressions for inline and multi-row switchers.

## Proof
- `swift test --filter 'StatusMenuSwitcherLayoutTests|StatusMenuSwitcherClickTests' --skip-update`: 22 tests passed.
- `make check`: SwiftFormat clean; SwiftLint strict clean.
- Autoreview: clean, no accepted/actionable findings; confidence 0.82.
- `./Scripts/compile_and_run.sh`: release bundle built, signed, relaunched, and stayed running.
- Peekaboo live QA: switched Overview -> Devin -> Codex on the freshly built app; tab bounds and vertical centers remained stable, and the Devin quota line stayed inside the unselected tab.

## Context
Follow-up to #1453. The dedicated footer fixed stretched buttons but made the whole switcher read top-heavy. This keeps the quota signal without changing tab geometry.
