### PR TITLE
fix: show unavailable Doubao quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Menu bar: detect Tahoe Control Center proxy windows parked in the blocked offscreen slot during startup recovery, so hidden icons show the existing guidance without weakening menu-bar-manager safeguards (#1440).
 - AWS Bedrock: treat Cost Explorer's temporary data-unavailable response as zero usage instead of an HTTP 400 error (#1324). Thanks @enesteve0!
 - Provider switcher: place quota bars in a dedicated footer below normal-height segments and vertically center icons and labels, avoiding stretched pills and top-heavy buttons.
+- Doubao: show an unavailable quota state when Ark omits trustworthy request-limit data instead of reporting 100% left.
 - Menu bar: anchor merged provider dropdowns to the status item's trailing edge without marking preserved in-flight refresh content fresh, preventing horizontal drift while keeping deferred updates visible (#1288). Thanks @Yuxin-Qiao!
 - Antigravity: fall back to the CLI usage server when the desktop app is closed, keep helper sessions owned and bounded without hidden sign-in flows, and show model rows with missing usage as unavailable instead of exhausted (#1313). Thanks @enieuwy!
 - Cost usage: replace repeated Foundation metadata/root checks with one portable file-stat pass so expired Codex history refreshes stay responsive on very large session archives (#1392). Thanks @TheAngryPit and @ProspectOre!

--- a/Sources/CodexBarCore/Providers/Doubao/DoubaoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Doubao/DoubaoUsageFetcher.swift
@@ -30,26 +30,25 @@ public struct DoubaoUsageSnapshot: Sendable {
     }
 
     public func toUsageSnapshot() -> UsageSnapshot {
-        let usedPercent: Double
-        let resetDescription: String
-
+        let primary: RateWindow?
         if self.limitRequests > 0, self.requestLimitsReliable {
             let used = max(0, self.limitRequests - self.remainingRequests)
-            usedPercent = min(100, max(0, Double(used) / Double(self.limitRequests) * 100))
-            resetDescription = "\(used)/\(self.limitRequests) requests"
+            primary = RateWindow(
+                usedPercent: min(100, max(0, Double(used) / Double(self.limitRequests) * 100)),
+                windowMinutes: nil,
+                resetsAt: self.resetTime,
+                resetDescription: "\(used)/\(self.limitRequests) requests")
         } else if self.apiKeyValid {
-            usedPercent = 0
-            resetDescription = "Active - check dashboard for details"
+            // Ark can return successful requests without a trustworthy request-limit window.
+            // Omitting the window prevents the UI from presenting unknown usage as 100% left.
+            primary = nil
         } else {
-            usedPercent = 0
-            resetDescription = "No usage data"
+            primary = RateWindow(
+                usedPercent: 0,
+                windowMinutes: nil,
+                resetsAt: self.resetTime,
+                resetDescription: "No usage data")
         }
-
-        let primary = RateWindow(
-            usedPercent: usedPercent,
-            windowMinutes: nil,
-            resetsAt: self.resetTime,
-            resetDescription: resetDescription)
 
         let identity = ProviderIdentitySnapshot(
             providerID: .doubao,

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -483,6 +483,15 @@ public enum UsageLimitsAvailability: Equatable, Sendable {
         account: AccountInfo? = nil,
         lastErrorDescription: String? = nil) -> Self
     {
+        if provider == .doubao {
+            guard let snapshot,
+                  snapshot.identity(for: provider) != nil
+            else {
+                return .available
+            }
+            return snapshot.hasRateLimitWindows ? .available : .unavailable
+        }
+
         guard provider == .codex else { return .available }
 
         if let snapshot {

--- a/Tests/CodexBarTests/DoubaoMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/DoubaoMenuCardModelTests.swift
@@ -1,0 +1,44 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct DoubaoMenuCardModelTests {
+    @Test
+    func `unknown request limit renders unavailable instead of full quota`() throws {
+        let now = Date(timeIntervalSince1970: 1_742_771_200)
+        let metadata = try #require(ProviderDefaults.metadata[.doubao])
+        let snapshot = DoubaoUsageSnapshot(
+            remainingRequests: 0,
+            limitRequests: 1000,
+            resetTime: nil,
+            updatedAt: now,
+            apiKeyValid: true,
+            requestLimitsReliable: false)
+            .toUsageSnapshot()
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .doubao,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.metrics.isEmpty)
+        #expect(model.placeholder == "Limits not available")
+        #expect(model.subtitleStyle == .info)
+    }
+}

--- a/Tests/CodexBarTests/DoubaoProviderTests.swift
+++ b/Tests/CodexBarTests/DoubaoProviderTests.swift
@@ -22,7 +22,7 @@ struct DoubaoProviderTests {
     }
 
     @Test
-    func `usage snapshot shows active key when headers are absent`() {
+    func `usage snapshot omits unknown request limit when headers are absent`() {
         let now = Date(timeIntervalSince1970: 1_742_771_200)
         let snapshot = DoubaoUsageSnapshot(
             remainingRequests: 0,
@@ -33,7 +33,7 @@ struct DoubaoProviderTests {
 
         let usage = snapshot.toUsageSnapshot()
 
-        #expect(usage.primary?.usedPercent == 0)
-        #expect(usage.primary?.resetDescription == "Active - check dashboard for details")
+        #expect(usage.primary == nil)
+        #expect(usage.rateLimitsUnavailable(for: .doubao))
     }
 }

--- a/Tests/CodexBarTests/DoubaoUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/DoubaoUsageFetcherTests.swift
@@ -30,7 +30,7 @@ struct DoubaoUsageSnapshotTests {
     }
 
     @Test
-    func `unreliable headers limit positive remaining zero falls back to Active hint`() {
+    func `unreliable headers omit the request limit window`() {
         let snapshot = DoubaoUsageSnapshot(
             remainingRequests: 0,
             limitRequests: 1000,
@@ -39,8 +39,8 @@ struct DoubaoUsageSnapshotTests {
             apiKeyValid: true,
             requestLimitsReliable: false)
         let usage = snapshot.toUsageSnapshot()
-        #expect(usage.primary?.usedPercent == 0)
-        #expect(usage.primary?.resetDescription == "Active - check dashboard for details")
+        #expect(usage.primary == nil)
+        #expect(usage.rateLimitsUnavailable(for: .doubao))
     }
 
     @Test
@@ -57,7 +57,7 @@ struct DoubaoUsageSnapshotTests {
     }
 
     @Test
-    func `both headers missing but key valid falls back to Active hint`() {
+    func `both headers missing but key valid omit the request limit window`() {
         let snapshot = DoubaoUsageSnapshot(
             remainingRequests: 0,
             limitRequests: 0,
@@ -65,8 +65,8 @@ struct DoubaoUsageSnapshotTests {
             updatedAt: Date(),
             apiKeyValid: true)
         let usage = snapshot.toUsageSnapshot()
-        #expect(usage.primary?.usedPercent == 0)
-        #expect(usage.primary?.resetDescription == "Active - check dashboard for details")
+        #expect(usage.primary == nil)
+        #expect(usage.rateLimitsUnavailable(for: .doubao))
     }
 
     @Test
@@ -98,7 +98,7 @@ struct DoubaoUsageSnapshotTests {
 
 struct DoubaoUsageFetcherTests {
     @Test
-    func `repeated successful zero remaining responses use active fallback`() async throws {
+    func `repeated successful zero remaining responses omit unknown request limit`() async throws {
         let transport = DoubaoScriptedTransport(results: [
             .response(statusCode: 200, limit: 1000, remaining: 0),
             .response(statusCode: 200, limit: 1000, remaining: 0),
@@ -107,8 +107,8 @@ struct DoubaoUsageFetcherTests {
         let snapshot = try await DoubaoUsageFetcher.fetchUsage(apiKey: "test-key", session: transport)
         let usage = snapshot.toUsageSnapshot()
 
-        #expect(usage.primary?.usedPercent == 0)
-        #expect(usage.primary?.resetDescription == "Active - check dashboard for details")
+        #expect(usage.primary == nil)
+        #expect(usage.rateLimitsUnavailable(for: .doubao))
         #expect(await transport.requestCount() == 2)
     }
 
@@ -157,7 +157,7 @@ struct DoubaoUsageFetcherTests {
     }
 
     @Test
-    func `bare rate limit uses active fallback`() async throws {
+    func `bare rate limit omits unknown request limit`() async throws {
         let transport = DoubaoScriptedTransport(results: [
             .response(statusCode: 429, limit: nil, remaining: nil),
         ])
@@ -165,8 +165,8 @@ struct DoubaoUsageFetcherTests {
         let snapshot = try await DoubaoUsageFetcher.fetchUsage(apiKey: "test-key", session: transport)
         let usage = snapshot.toUsageSnapshot()
 
-        #expect(usage.primary?.usedPercent == 0)
-        #expect(usage.primary?.resetDescription == "Active - check dashboard for details")
+        #expect(usage.primary == nil)
+        #expect(usage.rateLimitsUnavailable(for: .doubao))
         #expect(await transport.requestCount() == 1)
     }
 


### PR DESCRIPTION
## Summary
- stop converting missing or unreliable Doubao Ark request-limit headers into a zero-used quota window
- reuse the existing unavailable-limits presentation for identified Doubao snapshots without a trustworthy window
- preserve normal percentage rendering when headers are reliable and existing invalid-key fallback behavior

Fixes #1454.

## Proof
- `swift test --filter 'DoubaoProviderTests|DoubaoUsageSnapshotTests|DoubaoUsageFetcherTests|DoubaoMenuCardModelTests' --skip-update` (18 tests)
- `swift test --filter 'CodexCLIWindowNormalizationTests|OverviewMenuCardVisibilityTests' --skip-update` (17 tests)
- `make check` (SwiftFormat clean; SwiftLint 0 violations)
- autoreview clean, confidence 0.86
