### PR TITLE
feat: show in-flight feedback on manual refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - Settings: slightly increase the window height so standard panes fit without clipping their final controls or helper text.
+- Menu bar: show immediate in-place feedback for manual refreshes, keep tracked-menu geometry stable, and coalesce repeated clicks until the active refresh succeeds or fails (#1458). Thanks @hhh2210!
 - Grok: recover web billing from status-7 credential failures by combining current browser sessions with non-expired CLI auth, accept raw protobuf responses, and render current zero-use periods (#1452). Thanks @bcharleson!
 - Antigravity: detect current hyphenated IDE language-server processes inside Antigravity app bundles so local quota refreshes no longer report the IDE as unavailable (#1405). Thanks @lfmundim!
 - Menu bar: avoid republishing unchanged provider storage footprints so background scans no longer trigger unnecessary menu observation work (#1416). Thanks @soohanpark!

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1,25 +1,35 @@
 import AppKit
 import CodexBarCore
+import Observation
 import SwiftUI
 
-/// Narrowly-scoped observable bridge that lets a menu card subtitle re-render in place
-/// whenever the store's refreshing state changes, without rebuilding the NSMenu.
-///
-/// `UsageStore` is `@Observable`; a SwiftUI view that reads
-/// `isRefreshingIndicatorVisible(for:)` only establishes observation on the refreshing
-/// flags + per-provider error presence consulted inside
-/// `shouldShowRefreshingMenuCardIndicator(for:)`, so unrelated store mutations do not
-/// trigger card re-renders.
-@MainActor
-final class MenuCardRefreshMonitor {
-    private let store: UsageStore
+struct MenuCardLiveSubtitle {
+    let text: String
+    let style: UsageMenuCardView.Model.SubtitleStyle
+}
 
-    init(store: UsageStore) {
-        self.store = store
+/// Narrow observable bridge for updating an already-hosted card subtitle without rebuilding
+/// the tracked NSMenu.
+@MainActor
+@Observable
+final class MenuCardRefreshMonitor {
+    typealias SubtitleResolver = @MainActor (UsageProvider) -> MenuCardLiveSubtitle?
+
+    private let resolveSubtitle: SubtitleResolver
+    var isManualRefreshInFlight = false
+
+    init(resolveSubtitle: @escaping SubtitleResolver) {
+        self.resolveSubtitle = resolveSubtitle
     }
 
-    func isRefreshingIndicatorVisible(for provider: UsageProvider) -> Bool {
-        self.store.shouldShowRefreshingMenuCardIndicator(for: provider)
+    func subtitle(
+        for provider: UsageProvider,
+        fallback: MenuCardLiveSubtitle) -> MenuCardLiveSubtitle
+    {
+        if self.isManualRefreshInFlight {
+            return MenuCardLiveSubtitle(text: "\(L("Refreshing"))…", style: .loading)
+        }
+        return self.resolveSubtitle(provider) ?? fallback
     }
 }
 
@@ -130,6 +140,7 @@ struct UsageMenuCardView: View {
         let email: String
         let subtitleText: String
         let subtitleStyle: SubtitleStyle
+        var usesLiveSubtitle: Bool = false
         let planText: String?
         let metrics: [Metric]
         let usageNotes: [String]
@@ -289,20 +300,46 @@ private struct UsageMenuCardHeaderView: View {
                     .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
                     .lineLimit(1).truncationMode(.middle)
             }
-            let subtitleStyle = self.liveSubtitleStyle
-            let subtitleAlignment: VerticalAlignment = subtitleStyle == .error ? .top : .firstTextBaseline
+            let liveSubtitle = self.liveSubtitle
+            // Keep the geometry AppKit measured for this hosted row. A new error stays one line
+            // until the next rebuild; a recovered error keeps its reserved height until then.
+            let usesErrorLayout = self.model.subtitleStyle == .error
+            let subtitleAlignment: VerticalAlignment = usesErrorLayout ? .top : .firstTextBaseline
             HStack(alignment: subtitleAlignment, spacing: UsageMenuCardLayout.headerColumnSpacing) {
-                Text(self.liveSubtitleText)
-                    .font(.footnote)
-                    .foregroundStyle(self.subtitleColor(for: subtitleStyle))
-                    .lineLimit(subtitleStyle == .error ? 4 : 1)
-                    .multilineTextAlignment(.leading)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .layoutPriority(1)
-                    .padding(.bottom, subtitleStyle == .error ? 4 : 0)
+                if usesErrorLayout {
+                    Text(self.model.subtitleText)
+                        .font(.footnote)
+                        .lineLimit(4)
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.bottom, 4)
+                        .hidden()
+                        .overlay(alignment: .topLeading) {
+                            Text(liveSubtitle.text)
+                                .font(.footnote)
+                                .foregroundStyle(self.subtitleColor(for: liveSubtitle.style))
+                                .lineLimit(4)
+                                .multilineTextAlignment(.leading)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        .clipped()
+                        .layoutPriority(1)
+                } else {
+                    Text(liveSubtitle.text)
+                        .font(.footnote)
+                        .foregroundStyle(self.subtitleColor(for: liveSubtitle.style))
+                        .lineLimit(1)
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .layoutPriority(1)
+                }
                 Spacer()
-                if subtitleStyle == .error, !self.model.subtitleText.isEmpty {
-                    CopyIconButton(copyText: self.model.subtitleText, isHighlighted: self.isHighlighted)
+                if usesErrorLayout {
+                    let showsCopyButton = liveSubtitle.style == .error && !liveSubtitle.text.isEmpty
+                    CopyIconButton(copyText: liveSubtitle.text, isHighlighted: self.isHighlighted)
+                        .opacity(showsCopyButton ? 1 : 0)
+                        .allowsHitTesting(showsCopyButton)
+                        .accessibilityHidden(!showsCopyButton)
                 }
                 if let plan = self.model.planText {
                     Text(plan)
@@ -314,19 +351,10 @@ private struct UsageMenuCardHeaderView: View {
         }
     }
 
-    /// True while the live monitor reports an in-flight refresh for this provider. The
-    /// monitor gate already requires `error == nil`, so the live override never swaps the
-    /// multi-line `.error` layout — keeping the single-line subtitle height stable.
-    private var isLiveRefreshing: Bool {
-        self.refreshMonitor?.isRefreshingIndicatorVisible(for: self.model.provider) ?? false
-    }
-
-    private var liveSubtitleText: String {
-        self.isLiveRefreshing ? "\(L("Refreshing"))…" : self.model.subtitleText
-    }
-
-    private var liveSubtitleStyle: UsageMenuCardView.Model.SubtitleStyle {
-        self.isLiveRefreshing ? .loading : self.model.subtitleStyle
+    private var liveSubtitle: MenuCardLiveSubtitle {
+        let fallback = MenuCardLiveSubtitle(text: self.model.subtitleText, style: self.model.subtitleStyle)
+        guard self.model.usesLiveSubtitle else { return fallback }
+        return self.refreshMonitor?.subtitle(for: self.model.provider, fallback: fallback) ?? fallback
     }
 
     private func subtitleColor(for style: UsageMenuCardView.Model.SubtitleStyle) -> Color {
@@ -760,6 +788,7 @@ extension UsageMenuCardView.Model {
         let weeklyPace: UsagePace?
         let quotaWarningThresholds: [QuotaWarningWindow: [Int]]
         let workDaysPerWeek: Int?
+        let usesLiveSubtitle: Bool
         let now: Date
 
         init(
@@ -786,6 +815,7 @@ extension UsageMenuCardView.Model {
             weeklyPace: UsagePace? = nil,
             quotaWarningThresholds: [QuotaWarningWindow: [Int]] = [:],
             workDaysPerWeek: Int? = nil,
+            usesLiveSubtitle: Bool = false,
             now: Date)
         {
             self.provider = provider
@@ -811,6 +841,7 @@ extension UsageMenuCardView.Model {
             self.weeklyPace = weeklyPace
             self.quotaWarningThresholds = quotaWarningThresholds
             self.workDaysPerWeek = workDaysPerWeek
+            self.usesLiveSubtitle = usesLiveSubtitle
             self.now = now
         }
     }
@@ -865,6 +896,7 @@ extension UsageMenuCardView.Model {
             email: redacted.email,
             subtitleText: redacted.subtitleText,
             subtitleStyle: subtitle.style,
+            usesLiveSubtitle: input.usesLiveSubtitle,
             planText: planText,
             metrics: metrics,
             usageNotes: usageNotes,

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -2,6 +2,27 @@ import AppKit
 import CodexBarCore
 import SwiftUI
 
+/// Narrowly-scoped observable bridge that lets a menu card subtitle re-render in place
+/// whenever the store's refreshing state changes, without rebuilding the NSMenu.
+///
+/// `UsageStore` is `@Observable`; a SwiftUI view that reads
+/// `isRefreshingIndicatorVisible(for:)` only establishes observation on the refreshing
+/// flags + per-provider error presence consulted inside
+/// `shouldShowRefreshingMenuCardIndicator(for:)`, so unrelated store mutations do not
+/// trigger card re-renders.
+@MainActor
+final class MenuCardRefreshMonitor {
+    private let store: UsageStore
+
+    init(store: UsageStore) {
+        self.store = store
+    }
+
+    func isRefreshingIndicatorVisible(for provider: UsageProvider) -> Bool {
+        self.store.shouldShowRefreshingMenuCardIndicator(for: provider)
+    }
+}
+
 enum UsageMenuCardLayout {
     static let horizontalPadding: CGFloat = 20
     static let headerOnlyVerticalPadding: CGFloat = 7
@@ -255,6 +276,7 @@ struct UsageMenuCardView: View {
 private struct UsageMenuCardHeaderView: View {
     let model: UsageMenuCardView.Model
     @Environment(\.menuItemHighlighted) private var isHighlighted
+    @Environment(\.menuCardRefreshMonitor) private var refreshMonitor
 
     var body: some View {
         VStack(alignment: .leading, spacing: UsageMenuCardLayout.headerLineSpacing) {
@@ -267,18 +289,19 @@ private struct UsageMenuCardHeaderView: View {
                     .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
                     .lineLimit(1).truncationMode(.middle)
             }
-            let subtitleAlignment: VerticalAlignment = self.model.subtitleStyle == .error ? .top : .firstTextBaseline
+            let subtitleStyle = self.liveSubtitleStyle
+            let subtitleAlignment: VerticalAlignment = subtitleStyle == .error ? .top : .firstTextBaseline
             HStack(alignment: subtitleAlignment, spacing: UsageMenuCardLayout.headerColumnSpacing) {
-                Text(self.model.subtitleText)
+                Text(self.liveSubtitleText)
                     .font(.footnote)
-                    .foregroundStyle(self.subtitleColor)
-                    .lineLimit(self.model.subtitleStyle == .error ? 4 : 1)
+                    .foregroundStyle(self.subtitleColor(for: subtitleStyle))
+                    .lineLimit(subtitleStyle == .error ? 4 : 1)
                     .multilineTextAlignment(.leading)
                     .fixedSize(horizontal: false, vertical: true)
                     .layoutPriority(1)
-                    .padding(.bottom, self.model.subtitleStyle == .error ? 4 : 0)
+                    .padding(.bottom, subtitleStyle == .error ? 4 : 0)
                 Spacer()
-                if self.model.subtitleStyle == .error, !self.model.subtitleText.isEmpty {
+                if subtitleStyle == .error, !self.model.subtitleText.isEmpty {
                     CopyIconButton(copyText: self.model.subtitleText, isHighlighted: self.isHighlighted)
                 }
                 if let plan = self.model.planText {
@@ -291,8 +314,23 @@ private struct UsageMenuCardHeaderView: View {
         }
     }
 
-    private var subtitleColor: Color {
-        switch self.model.subtitleStyle {
+    /// True while the live monitor reports an in-flight refresh for this provider. The
+    /// monitor gate already requires `error == nil`, so the live override never swaps the
+    /// multi-line `.error` layout — keeping the single-line subtitle height stable.
+    private var isLiveRefreshing: Bool {
+        self.refreshMonitor?.isRefreshingIndicatorVisible(for: self.model.provider) ?? false
+    }
+
+    private var liveSubtitleText: String {
+        self.isLiveRefreshing ? "\(L("Refreshing"))…" : self.model.subtitleText
+    }
+
+    private var liveSubtitleStyle: UsageMenuCardView.Model.SubtitleStyle {
+        self.isLiveRefreshing ? .loading : self.model.subtitleStyle
+    }
+
+    private func subtitleColor(for style: UsageMenuCardView.Model.SubtitleStyle) -> Color {
+        switch style {
         case .info: MenuHighlightStyle.secondary(self.isHighlighted)
         case .loading: MenuHighlightStyle.secondary(self.isHighlighted)
         case .error: MenuHighlightStyle.error(self.isHighlighted)

--- a/Sources/CodexBar/MenuHighlightStyle.swift
+++ b/Sources/CodexBar/MenuHighlightStyle.swift
@@ -2,6 +2,10 @@ import SwiftUI
 
 extension EnvironmentValues {
     @Entry var menuItemHighlighted: Bool = false
+    /// Optional live-refresh monitor injected into menu card views so the provider card
+    /// subtitle can reflect the in-flight "Refreshing…" state in place while the NSMenu
+    /// stays open, without rebuilding the menu during AppKit tracking.
+    @Entry var menuCardRefreshMonitor: MenuCardRefreshMonitor?
 }
 
 enum MenuHighlightStyle {

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -32,6 +32,7 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     {
         await ProviderInteractionContext.$current.withValue(interaction) {
             await self.store.refresh(forceTokenUsage: forceTokenUsage)
+            guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
             self.store.scheduleStorageFootprintRefreshForOverview(force: true)
             if refreshOpenMenusWhenComplete {
                 self.refreshOpenMenusAfterExplicitStoreAction()
@@ -48,11 +49,34 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     @objc func refreshNow() {
-        // Show the persistent Refresh row spinner immediately: `refreshStore` only flips
-        // `store.isRefreshing` asynchronously, so force the spinner on here for instant click
-        // feedback. The store observation reverts it once the refresh completes (or fails).
-        self.beginPersistentRefreshRowsInProgress()
-        self.refreshStore(forceTokenUsage: true)
+        guard !self.hasPreparedForAppShutdown,
+              self.manualRefreshTask == nil,
+              !self.store.isRefreshing
+        else { return }
+
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.manualRefreshTask = nil
+                self.menuCardRefreshMonitor.isManualRefreshInFlight = false
+                self.updatePersistentRefreshRowsInProgress()
+            }
+            guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
+            #if DEBUG
+            if let operation = self._test_manualRefreshOperation {
+                await operation()
+                guard !Task.isCancelled, !self.hasPreparedForAppShutdown else { return }
+                return
+            }
+            #endif
+            await self.performStoreRefresh(
+                forceTokenUsage: true,
+                refreshOpenMenusWhenComplete: true,
+                interaction: .userInitiated)
+        }
+        self.manualRefreshTask = task
+        self.menuCardRefreshMonitor.isManualRefreshInFlight = true
+        self.updatePersistentRefreshRowsInProgress()
     }
 
     nonisolated func performPersistentRefreshAction() {

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -48,6 +48,10 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
     }
 
     @objc func refreshNow() {
+        // Show the persistent Refresh row spinner immediately: `refreshStore` only flips
+        // `store.isRefreshing` asynchronously, so force the spinner on here for instant click
+        // feedback. The store observation reverts it once the refresh completes (or fails).
+        self.beginPersistentRefreshRowsInProgress()
         self.refreshStore(forceTokenUsage: true)
     }
 

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -866,7 +866,7 @@ extension StatusItemController {
             })
 
         if action == .refresh {
-            row.setInProgress(self.store.isRefreshing)
+            row.setInProgress(self.manualRefreshTask != nil || self.store.isRefreshing)
             self.persistentRefreshRows.add(row)
         }
 

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -865,6 +865,11 @@ extension StatusItemController {
                 self?.performPersistentMenuAction(action, in: menu)
             })
 
+        if action == .refresh {
+            row.setInProgress(self.store.isRefreshing)
+            self.persistentRefreshRows.add(row)
+        }
+
         let item = NSMenuItem(title: title, action: nil, keyEquivalent: shortcut?.key ?? "")
         item.keyEquivalentModifierMask = shortcut?.modifiers ?? NSEvent.ModifierFlags()
         item.isEnabled = true

--- a/Sources/CodexBar/StatusItemController+MenuCardItems.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardItems.swift
@@ -50,7 +50,8 @@ extension StatusItemController {
                 highlightState: recycled.highlightState,
                 showsSubmenuIndicator: submenu != nil,
                 submenuIndicatorAlignment: submenuIndicatorAlignment,
-                submenuIndicatorTopPadding: submenuIndicatorTopPadding)
+                submenuIndicatorTopPadding: submenuIndicatorTopPadding,
+                refreshMonitor: self.menuCardRefreshMonitor)
             {
                 view
             }
@@ -62,7 +63,8 @@ extension StatusItemController {
                 highlightState: highlightState,
                 showsSubmenuIndicator: submenu != nil,
                 submenuIndicatorAlignment: submenuIndicatorAlignment,
-                submenuIndicatorTopPadding: submenuIndicatorTopPadding)
+                submenuIndicatorTopPadding: submenuIndicatorTopPadding,
+                refreshMonitor: self.menuCardRefreshMonitor)
             {
                 view
             }

--- a/Sources/CodexBar/StatusItemController+MenuCardModel.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardModel.swift
@@ -118,6 +118,7 @@ extension StatusItemController {
                 .weekly: self.quotaWarningMarkerThresholds(provider: target, window: .weekly),
             ],
             workDaysPerWeek: self.settings.weeklyProgressWorkDays,
+            usesLiveSubtitle: surface == .liveCard,
             now: now)
         return UsageMenuCardView.Model.make(input)
     }

--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -249,6 +249,7 @@ final class PersistentMenuActionItemView: NSView, MenuCardHighlighting {
         self.titleField.textColor = primaryColor
         self.shortcutField.textColor = secondaryColor
         self.imageView.contentTintColor = primaryColor
+        self.progressIndicator.appearance = highlighted ? NSAppearance(named: .darkAqua) : nil
     }
 
     /// Gives the persistent Refresh row immediate, in-place feedback while a manual refresh

--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -161,11 +161,13 @@ struct MenuCardSectionContainerView<Content: View>: View {
     let showsSubmenuIndicator: Bool
     let submenuIndicatorAlignment: Alignment
     let submenuIndicatorTopPadding: CGFloat
+    var refreshMonitor: MenuCardRefreshMonitor?
     @ViewBuilder let content: () -> Content
 
     var body: some View {
         self.content()
             .environment(\.menuItemHighlighted, self.highlightState.isHighlighted)
+            .environment(\.menuCardRefreshMonitor, self.refreshMonitor)
             .foregroundStyle(MenuHighlightStyle.primary(self.highlightState.isHighlighted))
             .background(alignment: .topLeading) {
                 if self.highlightState.isHighlighted {
@@ -193,9 +195,11 @@ final class PersistentMenuActionItemView: NSView, MenuCardHighlighting {
 
     private let backgroundView = NSView()
     private let imageView = NSImageView()
+    private let progressIndicator = NSProgressIndicator()
     private let titleField: NSTextField
     private let shortcutField: NSTextField
     private let onClick: () -> Void
+    private var isInProgress = false
 
     override var intrinsicContentSize: NSSize {
         NSSize(width: self.frame.width > 0 ? self.frame.width : NSView.noIntrinsicMetric, height: Self.rowHeight)
@@ -247,6 +251,29 @@ final class PersistentMenuActionItemView: NSView, MenuCardHighlighting {
         self.imageView.contentTintColor = primaryColor
     }
 
+    /// Gives the persistent Refresh row immediate, in-place feedback while a manual refresh
+    /// is in flight: the leading `arrow.clockwise` icon is swapped for a spinner occupying the
+    /// same fixed 18×18 slot, so the row height and layout never change (no menu rebuild).
+    func setInProgress(_ inProgress: Bool) {
+        guard self.isInProgress != inProgress else { return }
+        self.isInProgress = inProgress
+        // Fade the icon rather than `isHidden`: a hidden NSStackView arranged subview collapses
+        // its slot and shifts the title, whereas `alphaValue` keeps the fixed 18pt slot in place.
+        self.imageView.alphaValue = inProgress ? 0 : 1
+        self.progressIndicator.isHidden = !inProgress
+        if inProgress {
+            self.progressIndicator.startAnimation(nil)
+        } else {
+            self.progressIndicator.stopAnimation(nil)
+        }
+    }
+
+    #if DEBUG
+    var isInProgressForTesting: Bool {
+        self.isInProgress
+    }
+    #endif
+
     private func setupView(systemImageName: String?) {
         self.backgroundView.wantsLayer = true
         self.backgroundView.layer?.cornerRadius = 6
@@ -262,6 +289,13 @@ final class PersistentMenuActionItemView: NSView, MenuCardHighlighting {
             self.imageView.image = image
         }
         self.imageView.translatesAutoresizingMaskIntoConstraints = false
+
+        self.progressIndicator.style = .spinning
+        self.progressIndicator.controlSize = .small
+        self.progressIndicator.isIndeterminate = true
+        self.progressIndicator.isDisplayedWhenStopped = false
+        self.progressIndicator.isHidden = true
+        self.progressIndicator.translatesAutoresizingMaskIntoConstraints = false
 
         self.titleField.font = NSFont.menuFont(ofSize: NSFont.systemFontSize)
         self.titleField.lineBreakMode = .byTruncatingTail
@@ -289,6 +323,8 @@ final class PersistentMenuActionItemView: NSView, MenuCardHighlighting {
         stack.addArrangedSubview(spacer)
         stack.addArrangedSubview(self.shortcutField)
         self.addSubview(stack)
+        // The spinner overlaps the icon's fixed slot so toggling it never changes row metrics.
+        self.addSubview(self.progressIndicator)
 
         NSLayoutConstraint.activate([
             self.backgroundView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 6),
@@ -299,6 +335,11 @@ final class PersistentMenuActionItemView: NSView, MenuCardHighlighting {
             self.imageView.widthAnchor.constraint(equalToConstant: 18),
             self.imageView.heightAnchor.constraint(equalToConstant: 18),
             self.shortcutField.widthAnchor.constraint(equalToConstant: 38),
+
+            self.progressIndicator.centerXAnchor.constraint(equalTo: self.imageView.centerXAnchor),
+            self.progressIndicator.centerYAnchor.constraint(equalTo: self.imageView.centerYAnchor),
+            self.progressIndicator.widthAnchor.constraint(equalToConstant: 16),
+            self.progressIndicator.heightAnchor.constraint(equalToConstant: 16),
 
             stack.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 12),
             stack.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -12),

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -4,6 +4,15 @@ import CodexBarCore
 extension StatusItemController {
     private static let defaultClosedMenuPreparationDelay: Duration = .milliseconds(350)
 
+    var isMenuRefreshEnabled: Bool {
+        #if DEBUG
+        if let menuRefreshEnabledOverrideForTesting {
+            return menuRefreshEnabledOverrideForTesting
+        }
+        #endif
+        return Self.menuRefreshEnabled
+    }
+
     #if DEBUG
     private static var closedMenuPreparationDelayForTesting: Duration = defaultClosedMenuPreparationDelay
     static func setClosedMenuPreparationDelayForTesting(_ delay: Duration) {

--- a/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
+++ b/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
@@ -48,20 +48,11 @@ extension StatusItemController {
         }
     }
 
-    /// Forces every live persistent Refresh row's spinner on immediately for instant click
-    /// feedback, before the async refresh flips `store.isRefreshing`.
-    func beginPersistentRefreshRowsInProgress() {
-        for row in self.persistentRefreshRows.allObjects {
-            row.setInProgress(true)
-        }
-    }
-
-    /// Syncs every live persistent Refresh row's spinner to the store's refresh state. This is
+    /// Syncs every live persistent Refresh row's spinner to the refresh lifecycle. This is
     /// an in-place AppKit mutation on the existing row views — it never rebuilds the menu, so it
-    /// is safe to call during NSMenu tracking. Called from the store observation so the spinner
-    /// reverts once the refresh completes (including the failure path that sets the error).
+    /// is safe to call during NSMenu tracking.
     func updatePersistentRefreshRowsInProgress() {
-        let inProgress = self.store.isRefreshing
+        let inProgress = self.manualRefreshTask != nil || self.store.isRefreshing
         for row in self.persistentRefreshRows.allObjects {
             row.setInProgress(inProgress)
         }

--- a/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
+++ b/Sources/CodexBar/StatusItemController+PersistentMenuActions.swift
@@ -48,6 +48,25 @@ extension StatusItemController {
         }
     }
 
+    /// Forces every live persistent Refresh row's spinner on immediately for instant click
+    /// feedback, before the async refresh flips `store.isRefreshing`.
+    func beginPersistentRefreshRowsInProgress() {
+        for row in self.persistentRefreshRows.allObjects {
+            row.setInProgress(true)
+        }
+    }
+
+    /// Syncs every live persistent Refresh row's spinner to the store's refresh state. This is
+    /// an in-place AppKit mutation on the existing row views — it never rebuilds the menu, so it
+    /// is safe to call during NSMenu tracking. Called from the store observation so the spinner
+    /// reverts once the refresh completes (including the failure path that sets the error).
+    func updatePersistentRefreshRowsInProgress() {
+        let inProgress = self.store.isRefreshing
+        for row in self.persistentRefreshRows.allObjects {
+            row.setInProgress(inProgress)
+        }
+    }
+
     private func closeMenuForPersistentAction(_ menu: NSMenu?) {
         guard let menu else { return }
         menu.cancelTrackingWithoutAnimation()

--- a/Sources/CodexBar/StatusItemController+Shutdown.swift
+++ b/Sources/CodexBar/StatusItemController+Shutdown.swift
@@ -28,6 +28,9 @@ extension StatusItemController {
         self.menuBarCountdownRefreshTask = nil
         self.loginTask?.cancel()
         self.loginTask = nil
+        self.manualRefreshTask?.cancel()
+        self.manualRefreshTask = nil
+        self.menuCardRefreshMonitor.isManualRefreshInFlight = false
         self.screenChangeVisibilityTask?.cancel()
         self.screenChangeVisibilityTask = nil
         self.pendingScreenChangePreviousCount = nil

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -59,15 +59,6 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var menuRefreshEnabledOverrideForTesting: Bool?
     #endif
 
-    var isMenuRefreshEnabled: Bool {
-        #if DEBUG
-        if let menuRefreshEnabledOverrideForTesting {
-            return menuRefreshEnabledOverrideForTesting
-        }
-        #endif
-        return Self.menuRefreshEnabled
-    }
-
     typealias Factory =
         @MainActor (
             UsageStore,

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -105,9 +105,11 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
 
     let store: UsageStore
     let settings: SettingsStore
-    /// Injected into menu card views so the provider card subtitle reflects the in-flight
-    /// "Refreshing…" state in place while the menu stays open (no NSMenu rebuild).
-    lazy var menuCardRefreshMonitor = MenuCardRefreshMonitor(store: self.store)
+    lazy var menuCardRefreshMonitor = MenuCardRefreshMonitor { [weak self] provider in
+        guard let model = self?.menuCardModel(for: provider) else { return nil }
+        return MenuCardLiveSubtitle(text: model.subtitleText, style: model.subtitleStyle)
+    }
+
     let account: AccountInfo
     let updater: UpdaterProviding
     let managedCodexAccountCoordinator: ManagedCodexAccountCoordinator
@@ -137,6 +139,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var fallbackMenu: NSMenu?
     var openMenus: [ObjectIdentifier: NSMenu] = [:]
     var menuRefreshTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
+    var manualRefreshTask: Task<Void, Never>?
     var closedMenuRebuildTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
     var closedMenuRebuildTokens: [ObjectIdentifier: Int] = [:]
     var closedMenuRebuildTokenCounter = 0
@@ -187,6 +190,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var _test_providerSwitcherMenuRebuildDebounceNanoseconds: UInt64?
     var _test_codexAmbientLoginRunnerOverride:
         (@MainActor (TimeInterval) async -> CodexLoginRunner.Result)?
+    var _test_manualRefreshOperation: (@MainActor () async -> Void)?
     #endif
     var blinkTask: Task<Void, Never>?
     var menuBarCountdownRefreshTask: Task<Void, Never>?

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -105,6 +105,9 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
 
     let store: UsageStore
     let settings: SettingsStore
+    /// Injected into menu card views so the provider card subtitle reflects the in-flight
+    /// "Refreshing…" state in place while the menu stays open (no NSMenu rebuild).
+    lazy var menuCardRefreshMonitor = MenuCardRefreshMonitor(store: self.store)
     let account: AccountInfo
     let updater: UpdaterProviding
     let managedCodexAccountCoordinator: ManagedCodexAccountCoordinator
@@ -121,6 +124,9 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var menuVersions: [ObjectIdentifier: Int] = [:]
     var menuReadinessSignatures: [ObjectIdentifier: String] = [:]
     let hostedSubviewRenderSignatures = NSMapTable<NSMenu, NSString>.weakToStrongObjects()
+    /// Live persistent Refresh rows, tracked weakly so they can be given in-place in-flight
+    /// feedback (spinner) while the menu stays open, without rebuilding the menu.
+    let persistentRefreshRows = NSHashTable<PersistentMenuActionItemView>.weakObjects()
     var menuCardHeightCache: [MenuCardHeightCacheKey: CGFloat] = [:]
     var measuredStandardMenuWidthCache: [String: CGFloat] = [:]
     var lastMenuAdjunctReadinessSignature = ""
@@ -495,6 +501,9 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
 
     func handleObservedStoreMenuChange() {
         self.observeStoreChanges()
+        // In-place spinner sync for the persistent Refresh rows. Safe during menu tracking:
+        // it mutates existing row views only and never rebuilds the menu.
+        self.updatePersistentRefreshRowsInProgress()
         let rootOpenHandledReadiness = self.consumeRootOpenHandledMenuObservationIfNeeded()
         // `refreshOpenMenus` is only consulted when a menu is currently open.
         // Computing the readiness signature serializes every enabled provider's

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CodexBarCore
+import SwiftUI
 import Testing
 @testable import CodexBar
 
@@ -36,6 +37,31 @@ private final class UpdateReadyUpdater: UpdaterProviding {
 
     func checkForUpdates(_: Any?) {}
     func installUpdate() {}
+}
+
+@MainActor
+private final class ManualRefreshGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isOpen = false
+
+    func wait() async {
+        if self.isOpen {
+            self.isOpen = false
+            return
+        }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func resume() {
+        if let continuation = self.continuation {
+            continuation.resume()
+            self.continuation = nil
+        } else {
+            self.isOpen = true
+        }
+    }
 }
 
 @MainActor
@@ -203,11 +229,11 @@ struct StatusMenuPersistentRefreshTests {
         #expect(row != nil)
         #expect(controller.persistentRefreshRows.allObjects.contains { $0 === row })
 
-        // Immediate click feedback flips the spinner on before the async refresh begins.
-        controller.beginPersistentRefreshRowsInProgress()
+        controller.manualRefreshTask = Task {}
+        controller.updatePersistentRefreshRowsInProgress()
         #expect(row?.isInProgressForTesting == true)
 
-        // Once the store reports no refresh in flight, the observation sync reverts it.
+        controller.manualRefreshTask = nil
         controller.store.isRefreshing = false
         controller.updatePersistentRefreshRowsInProgress()
         #expect(row?.isInProgressForTesting == false)
@@ -219,18 +245,190 @@ struct StatusMenuPersistentRefreshTests {
     }
 
     @Test
-    func `refresh monitor mirrors the store refreshing indicator gate`() {
+    func `refresh monitor follows refresh success and failure`() {
         let settings = self.makeSettings()
         let controller = self.makeController(settings: settings)
-        let monitor = MenuCardRefreshMonitor(store: controller.store)
+        let monitor = controller.menuCardRefreshMonitor
+        let fallback = MenuCardLiveSubtitle(text: "Fallback", style: .info)
 
-        #expect(monitor.isRefreshingIndicatorVisible(for: .codex) == false)
+        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .info)
 
         controller.store.isRefreshing = true
-        #expect(monitor.isRefreshingIndicatorVisible(for: .codex) == true)
+        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .loading)
 
         controller.store.isRefreshing = false
-        #expect(monitor.isRefreshingIndicatorVisible(for: .codex) == false)
+        monitor.isManualRefreshInFlight = true
+        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .loading)
+        monitor.isManualRefreshInFlight = false
+
+        controller.store.isRefreshing = false
+        let now = Date()
+        controller.store.snapshots[.codex] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 10,
+                windowMinutes: nil,
+                resetsAt: now.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now)
+        let success = monitor.subtitle(for: .codex, fallback: fallback)
+        #expect(success.style == .info)
+        #expect(success.text == UsageFormatter.updatedString(from: now, now: Date()))
+
+        controller.store.errors[.codex] = "Refresh failed"
+        let failure = monitor.subtitle(for: .codex, fallback: fallback)
+        #expect(failure.style == .error)
+        #expect(failure.text == "Refresh failed")
+
+        monitor.isManualRefreshInFlight = true
+        #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .loading)
+    }
+
+    @Test
+    func `live subtitle preserves canonical model error filtering`() throws {
+        let settings = self.makeSettings()
+        let controller = self.makeController(settings: settings)
+        controller.store.errors[.codex] = UsageError.noRateLimitsFound.errorDescription
+        let model = try #require(controller.menuCardModel(for: .codex))
+        let fallback = MenuCardLiveSubtitle(text: "Fallback", style: .error)
+
+        let liveSubtitle = controller.menuCardRefreshMonitor.subtitle(for: .codex, fallback: fallback)
+
+        #expect(liveSubtitle.text == model.subtitleText)
+        #expect(liveSubtitle.style == model.subtitleStyle)
+        #expect(model.placeholder == "Limits not available")
+    }
+
+    @Test
+    func `override cards keep their own subtitle`() throws {
+        let settings = self.makeSettings()
+        let controller = self.makeController(settings: settings)
+        let liveModel = try #require(controller.menuCardModel(for: .codex))
+        let overrideModel = try #require(controller.menuCardModel(
+            for: .codex,
+            errorOverride: "Account unavailable",
+            forceOverrideCard: true))
+
+        #expect(liveModel.usesLiveSubtitle)
+        #expect(!overrideModel.usesLiveSubtitle)
+        #expect(overrideModel.subtitleText == "Account unavailable")
+    }
+
+    @Test
+    func `live failure keeps the measured card height`() throws {
+        let settings = self.makeSettings()
+        let controller = self.makeController(settings: settings)
+
+        func fittingHeight(for model: UsageMenuCardView.Model) -> CGFloat {
+            NSHostingView(rootView: UsageMenuCardView(model: model, width: 320)
+                .environment(\.menuCardRefreshMonitor, controller.menuCardRefreshMonitor))
+                .fittingSize.height
+        }
+
+        let idleModel = try #require(controller.menuCardModel(for: .codex))
+        let idleHeight = fittingHeight(for: idleModel)
+        controller.store.errors[.codex] = "Short error"
+        let failureHeight = fittingHeight(for: idleModel)
+
+        #expect(failureHeight == idleHeight)
+
+        let errorModel = try #require(controller.menuCardModel(for: .codex))
+        let errorHeight = fittingHeight(for: errorModel)
+        controller.store.errors[.codex] =
+            "Refresh failed with a much longer replacement message that must not resize the tracked menu"
+        let replacementErrorHeight = fittingHeight(for: errorModel)
+        controller.menuCardRefreshMonitor.isManualRefreshInFlight = true
+        let retryHeight = fittingHeight(for: errorModel)
+
+        #expect(replacementErrorHeight == errorHeight)
+        let fallback = MenuCardLiveSubtitle(text: errorModel.subtitleText, style: errorModel.subtitleStyle)
+        #expect(controller.menuCardRefreshMonitor.subtitle(for: .codex, fallback: fallback).style == .loading)
+        #expect(retryHeight == errorHeight)
+    }
+
+    @Test
+    func `manual refresh is suppressed after shutdown preparation`() {
+        let settings = self.makeSettings()
+        let controller = self.makeController(settings: settings)
+        var requestCount = 0
+        controller._test_manualRefreshOperation = {
+            requestCount += 1
+        }
+
+        controller.prepareForAppShutdown()
+        controller.refreshNow()
+
+        #expect(requestCount == 0)
+        #expect(controller.manualRefreshTask == nil)
+        #expect(!controller.menuCardRefreshMonitor.isManualRefreshInFlight)
+    }
+
+    @Test
+    func `repeated manual refresh clicks share one lifecycle`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        let refreshItem = try #require(menu.items.first { $0.title == "Refresh" })
+        let row = try #require(refreshItem.view as? PersistentMenuActionItemView)
+
+        let gate = ManualRefreshGate()
+        var requestCount = 0
+        controller._test_manualRefreshOperation = {
+            requestCount += 1
+            await gate.wait()
+        }
+
+        controller.refreshNow()
+        let task = try #require(controller.manualRefreshTask)
+        controller.refreshNow()
+        controller.refreshNow()
+        await Task.yield()
+
+        #expect(requestCount == 1)
+        #expect(row.isInProgressForTesting)
+        #expect(controller.menuCardRefreshMonitor.isManualRefreshInFlight)
+
+        gate.resume()
+        await task.value
+
+        #expect(controller.manualRefreshTask == nil)
+        #expect(!row.isInProgressForTesting)
+        #expect(!controller.menuCardRefreshMonitor.isManualRefreshInFlight)
+    }
+
+    @Test
+    func `failed manual refresh returns row to idle and surfaces error`() async throws {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+        let refreshItem = try #require(menu.items.first { $0.title == "Refresh" })
+        let row = try #require(refreshItem.view as? PersistentMenuActionItemView)
+        let gate = ManualRefreshGate()
+
+        controller._test_manualRefreshOperation = {
+            await gate.wait()
+            controller.store.errors[.codex] = "Refresh failed"
+        }
+
+        controller.refreshNow()
+        let task = try #require(controller.manualRefreshTask)
+        #expect(row.isInProgressForTesting)
+
+        gate.resume()
+        await task.value
+
+        #expect(controller.manualRefreshTask == nil)
+        #expect(!row.isInProgressForTesting)
+        let fallback = MenuCardLiveSubtitle(text: "Fallback", style: .info)
+        #expect(controller.menuCardRefreshMonitor.subtitle(for: .codex, fallback: fallback).style == .error)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -166,6 +166,74 @@ struct StatusMenuPersistentRefreshTests {
     }
 
     @Test
+    func `refresh row in-progress spinner keeps fixed metrics`() {
+        let view = PersistentMenuActionItemView(
+            title: "Refresh",
+            systemImageName: "arrow.clockwise",
+            shortcutText: "⌘R",
+            width: 320,
+            onClick: {})
+
+        view.setInProgress(true)
+        #expect(view.frame.height == PersistentMenuActionItemView.rowHeight)
+        #expect(view.intrinsicContentSize.height == PersistentMenuActionItemView.rowHeight)
+        #expect(view.fittingSize.height == PersistentMenuActionItemView.rowHeight)
+
+        view.setHighlighted(true)
+        #expect(view.frame.height == PersistentMenuActionItemView.rowHeight)
+
+        view.setInProgress(false)
+        #expect(view.frame.height == PersistentMenuActionItemView.rowHeight)
+        #expect(view.intrinsicContentSize.height == PersistentMenuActionItemView.rowHeight)
+        #expect(view.fittingSize.height == PersistentMenuActionItemView.rowHeight)
+    }
+
+    @Test
+    func `persistent refresh rows reflect store refresh state in place`() {
+        let settings = self.makeSettings()
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let controller = self.makeController(settings: settings)
+        let menu = controller.makeMenu(for: .codex)
+        controller.menuWillOpen(menu)
+
+        let refreshItem = menu.items.first { $0.title == "Refresh" }
+        let row = refreshItem?.view as? PersistentMenuActionItemView
+        #expect(row != nil)
+        #expect(controller.persistentRefreshRows.allObjects.contains { $0 === row })
+
+        // Immediate click feedback flips the spinner on before the async refresh begins.
+        controller.beginPersistentRefreshRowsInProgress()
+        #expect(row?.isInProgressForTesting == true)
+
+        // Once the store reports no refresh in flight, the observation sync reverts it.
+        controller.store.isRefreshing = false
+        controller.updatePersistentRefreshRowsInProgress()
+        #expect(row?.isInProgressForTesting == false)
+
+        // And a live refresh flag is mirrored onto the row.
+        controller.store.isRefreshing = true
+        controller.updatePersistentRefreshRowsInProgress()
+        #expect(row?.isInProgressForTesting == true)
+    }
+
+    @Test
+    func `refresh monitor mirrors the store refreshing indicator gate`() {
+        let settings = self.makeSettings()
+        let controller = self.makeController(settings: settings)
+        let monitor = MenuCardRefreshMonitor(store: controller.store)
+
+        #expect(monitor.isRefreshingIndicatorVisible(for: .codex) == false)
+
+        controller.store.isRefreshing = true
+        #expect(monitor.isRefreshingIndicatorVisible(for: .codex) == true)
+
+        controller.store.isRefreshing = false
+        #expect(monitor.isRefreshingIndicatorVisible(for: .codex) == false)
+    }
+
+    @Test
     func `status item menu intercepts persistent shortcuts without native item selection`() throws {
         let menu = StatusItemMenu()
         let recorder = RefreshShortcutRecorder()

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -28,6 +28,8 @@ read_when:
 ## Menu card
 - Provider-specific rows with resets (countdown by default; optional absolute clock display). Primary, secondary,
   tertiary, and extra windows render when the provider snapshot has data for them.
+- Manual refresh updates the open card subtitle and persistent Refresh-row spinner in place. Repeated clicks share the
+  active request, and the existing row geometry remains fixed through success or failure.
 - Codex credits can add a separate “Buy Credits…” menu action.
 - Codex OpenAI web extras: code review remaining and usage breakdown render when dashboard data is attached.
 - Token accounts: optional account switcher bar or stacked account cards (up to 6) when multiple manual tokens exist.


### PR DESCRIPTION
## Problem

Clicking **Refresh** while the menu is open gives no immediate feedback. The visible provider cards keep their old subtitles and the persistent **Refresh** row looks idle until the network round-trip completes. Because tracked root menus intentionally defer rebuilds, the existing refreshing state was not reaching already-hosted views.

That ambiguity also encourages repeated clicks, which could start overlapping manual refresh work.

## Fix

Surface one explicit manual-refresh lifecycle in place, without rebuilding the tracked menu:

- inject a narrow observable `MenuCardRefreshMonitor` into hosted provider cards
- update eligible card subtitles to `Refreshing…`, then surface fresh success or failure subtitles when the request finishes
- preserve measured error-card geometry and copy affordance while the menu remains open
- let provider override cards retain their own subtitle behavior
- swap the persistent Refresh icon for a spinner in the same fixed slot, including high-contrast highlighted appearance
- coalesce repeated clicks behind one owned task
- cancel and drain UI state during controller shutdown

The updates mutate existing SwiftUI/AppKit views only; tracked `NSMenu` geometry remains stable.

## Tests

`StatusMenuPersistentRefreshTests` now covers 13 cases, including:

- fixed row metrics while the spinner toggles
- in-place store refresh-state propagation
- success and failure subtitle transitions
- canonical error filtering and stable error-card height
- override-card isolation
- repeated-click coalescing
- shutdown suppression and failed-refresh cleanup

## Verification

- `swift test --filter StatusMenuPersistentRefreshTests` (13/13)
- `make check`
- `./Scripts/compile_and_run.sh`
- live Peekaboo exercise: open menu, trigger and repeat Refresh; cards show `Refreshing…`, one fixed-slot spinner remains, geometry stays stable
- Codex autoreview: clean (0.86 confidence)

## Proof

<img width="310" height="818" alt="Manual refresh feedback" src="https://github.com/user-attachments/assets/da18b073-c29e-4b6d-abac-45541592fdec" />
