### PR TITLE
Increase Settings window height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Menu bar: move the highlighted Overview provider with trackpad or mouse-wheel scrolling while preserving native submenu and keyboard behavior (#1436). Thanks @joshuavial!
 
 ### Fixed
+- Settings: slightly increase the window height so standard panes fit without clipping their final controls or helper text.
 - Grok: recover web billing from status-7 credential failures by combining current browser sessions with non-expired CLI auth, accept raw protobuf responses, and render current zero-use periods (#1452). Thanks @bcharleson!
 - Antigravity: detect current hyphenated IDE language-server processes inside Antigravity app bundles so local quota refreshes no longer report the IDE as unavailable (#1405). Thanks @lfmundim!
 - Menu bar: avoid republishing unchanged provider storage footprints so background scans no longer trigger unnecessary menu observation work (#1416). Thanks @soohanpark!

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -12,7 +12,7 @@ enum PreferencesTab: String, CaseIterable, Hashable {
 
     static let defaultWidth: CGFloat = 546
     static let providersWidth: CGFloat = 792
-    static let windowHeight: CGFloat = 638
+    static let windowHeight: CGFloat = 662
 
     var title: String {
         switch self {


### PR DESCRIPTION
## Summary

- increase the shared Settings content height from 638 to 662 points
- keep the existing compact widths and animated tab resizing
- prevent standard panes from clipping their final controls or helper text

## Verification

- `swift test --filter PreferencesPaneSmokeTests`
- `make check`
- `git diff --check`
- autoreview: no actionable findings, patch correct (0.99)
- packaged and launched an ad-hoc debug app
- captured General, Providers, Display, Advanced, and About at the new height
- verified General shows the complete quota-warning helper text with bottom padding

Screenshots were captured locally at 546x750 for standard panes and 792x750 for Providers.
