### PR TITLE
test(menu): stabilize refresh subtitle assertion

### DIFF
--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -296,7 +296,8 @@ struct StatusMenuPersistentRefreshTests {
 
         #expect(liveSubtitle.text == model.subtitleText)
         #expect(liveSubtitle.style == model.subtitleStyle)
-        #expect(model.placeholder == "Limits not available")
+        #expect(liveSubtitle.text != UsageError.noRateLimitsFound.errorDescription)
+        #expect(liveSubtitle.style != .error)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- replace the flaky placeholder-specific assertion from #1458 with the canonical error-filtering contract
- keep coverage that live subtitles match the menu-card model and never expose the no-rate-limits sentinel as an error

## Test Plan
- `swift test --filter StatusMenuPersistentRefreshTests`
- `make check`
- autoreview: clean
