### PR TITLE
Fix OpenAI Admin usage pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 - Provider switcher: keep localized tab titles visible by tightening outer insets only when equal-width segments would otherwise truncate.
+- OpenAI API: follow Admin usage pagination for costs and completions so multi-page organization usage totals are not undercounted (#1465). Thanks @rohitjavvadi!
 - Settings: slightly increase the window height so standard panes fit without clipping their final controls or helper text.
 - Menu bar: show immediate in-place feedback for manual refreshes, keep tracked-menu geometry stable, and coalesce repeated clicks until the active refresh succeeds or fails (#1458). Thanks @hhh2210!
 - Grok: recover web billing from status-7 credential failures by combining current browser sessions with non-expired CLI auth, accept raw protobuf responses, and render current zero-use periods (#1452). Thanks @bcharleson!

--- a/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIUsageFetcher.swift
@@ -38,6 +38,7 @@ public enum OpenAIAPIUsageFetcher {
         URL(string: "https://api.openai.com/v1/organization/usage/completions")!
 
     private static let maxDailyBucketLimit = 31
+    private static let maxPaginationPages = 100
     private static let timeoutSeconds: TimeInterval = 20
 
     private struct EndpointRequestContext {
@@ -51,7 +52,13 @@ public enum OpenAIAPIUsageFetcher {
         let name: String
         let baseURL: URL
         let queryItems: [URLQueryItem]
-        let decodeBuckets: (Data) throws -> [Bucket]
+        let decodePage: (Data) throws -> UsagePage<Bucket>
+    }
+
+    private struct UsagePage<Bucket> {
+        let data: [Bucket]
+        let hasMore: Bool
+        let nextPage: String?
     }
 
     private typealias SnapshotMetadata = (now: Date, calendar: Calendar, historyDays: Int, projectID: String?)
@@ -122,7 +129,13 @@ public enum OpenAIAPIUsageFetcher {
             name: "costs",
             baseURL: baseURL,
             queryItems: [URLQueryItem(name: "group_by", value: "line_item")],
-            decodeBuckets: { try self.decodeCosts($0).data })
+            decodePage: {
+                let response = try self.decodeCosts($0)
+                return UsagePage(
+                    data: response.data,
+                    hasMore: response.hasMore,
+                    nextPage: response.nextPage)
+            })
     }
 
     private static func completionsEndpoint(
@@ -132,7 +145,13 @@ public enum OpenAIAPIUsageFetcher {
             name: "completions",
             baseURL: baseURL,
             queryItems: [URLQueryItem(name: "group_by", value: "model")],
-            decodeBuckets: { try self.decodeCompletions($0).data })
+            decodePage: {
+                let response = try self.decodeCompletions($0)
+                return UsagePage(
+                    data: response.data,
+                    hasMore: response.hasMore,
+                    nextPage: response.nextPage)
+            })
     }
 
     private static func fetchBuckets<Bucket>(
@@ -142,17 +161,48 @@ public enum OpenAIAPIUsageFetcher {
     {
         var buckets: [Bucket] = []
         for range in ranges {
-            let url = Self.url(
-                baseURL: endpoint.baseURL,
-                range: range,
-                queryItems: endpoint.queryItems + Self.projectQueryItems(projectID: context.projectID))
-            let data = try await Self.fetchData(
-                url: url,
-                apiKey: context.apiKey,
-                endpoint: endpoint.name,
-                transport: context.transport,
-                retryPolicy: context.retryPolicy)
-            try buckets.append(contentsOf: endpoint.decodeBuckets(data))
+            var nextPage: String?
+            var seenPages: Set<String> = []
+            var pageCount = 0
+
+            repeat {
+                pageCount += 1
+                guard pageCount <= Self.maxPaginationPages else {
+                    throw OpenAIAPIUsageError.parseFailed(
+                        endpoint: endpoint.name,
+                        message: "Pagination exceeded \(Self.maxPaginationPages) pages.")
+                }
+
+                let url = Self.url(
+                    baseURL: endpoint.baseURL,
+                    range: range,
+                    queryItems: endpoint.queryItems + Self.projectQueryItems(projectID: context.projectID),
+                    page: nextPage)
+                let data = try await Self.fetchData(
+                    url: url,
+                    apiKey: context.apiKey,
+                    endpoint: endpoint.name,
+                    transport: context.transport,
+                    retryPolicy: context.retryPolicy)
+                let page = try endpoint.decodePage(data)
+                buckets.append(contentsOf: page.data)
+
+                guard page.hasMore else {
+                    nextPage = nil
+                    continue
+                }
+                guard let cursor = Self.cleanedPageCursor(page.nextPage) else {
+                    throw OpenAIAPIUsageError.parseFailed(
+                        endpoint: endpoint.name,
+                        message: "Pagination cursor missing.")
+                }
+                guard seenPages.insert(cursor).inserted else {
+                    throw OpenAIAPIUsageError.parseFailed(
+                        endpoint: endpoint.name,
+                        message: "Pagination cursor repeated.")
+                }
+                nextPage = cursor
+            } while nextPage != nil
         }
         return buckets
     }
@@ -270,14 +320,30 @@ public enum OpenAIAPIUsageFetcher {
         return trimmed
     }
 
-    private static func url(baseURL: URL, range: DateRange, queryItems extraItems: [URLQueryItem]) -> URL {
+    private static func cleanedPageCursor(_ raw: String?) -> String? {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func url(
+        baseURL: URL,
+        range: DateRange,
+        queryItems extraItems: [URLQueryItem],
+        page: String? = nil) -> URL
+    {
         var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!
-        components.queryItems = [
+        var queryItems = [
             URLQueryItem(name: "start_time", value: String(range.startTime)),
             URLQueryItem(name: "end_time", value: String(range.endTime)),
             URLQueryItem(name: "bucket_width", value: "1d"),
             URLQueryItem(name: "limit", value: String(range.limit)),
         ] + extraItems
+        if let page {
+            queryItems.append(URLQueryItem(name: "page", value: page))
+        }
+        components.queryItems = queryItems
         return components.url!
     }
 

--- a/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIUsageResponses.swift
+++ b/Sources/CodexBarCore/Providers/OpenAI/OpenAIAPIUsageResponses.swift
@@ -2,6 +2,21 @@ import Foundation
 
 struct CostsResponse: Decodable {
     let data: [OpenAICostBucket]
+    let hasMore: Bool
+    let nextPage: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case data
+        case hasMore = "has_more"
+        case nextPage = "next_page"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.data = try container.decode([OpenAICostBucket].self, forKey: .data)
+        self.hasMore = try container.decode(Bool.self, forKey: .hasMore)
+        self.nextPage = try container.decodeIfPresent(String.self, forKey: .nextPage)
+    }
 }
 
 struct OpenAICostBucket: Decodable {
@@ -44,6 +59,21 @@ struct OpenAICostResult: Decodable {
 
 struct CompletionsUsageResponse: Decodable {
     let data: [OpenAICompletionsUsageBucket]
+    let hasMore: Bool
+    let nextPage: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case data
+        case hasMore = "has_more"
+        case nextPage = "next_page"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.data = try container.decode([OpenAICompletionsUsageBucket].self, forKey: .data)
+        self.hasMore = try container.decode(Bool.self, forKey: .hasMore)
+        self.nextPage = try container.decodeIfPresent(String.self, forKey: .nextPage)
+    }
 }
 
 struct OpenAICompletionsUsageBucket: Decodable {

--- a/Tests/CodexBarTests/OpenAIAPIUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/OpenAIAPIUsageFetcherTests.swift
@@ -191,6 +191,127 @@ struct OpenAIAPIUsageFetcherTests {
     }
 
     @Test
+    func `admin usage follows costs and completions pagination cursors`() async throws {
+        let now = Date(timeIntervalSince1970: 1_700_179_200)
+        let transport = OpenAIAdminUsagePaginationScript()
+
+        let snapshot = try await OpenAIAPIUsageFetcher.fetchUsage(
+            apiKey: "sk-test",
+            projectID: "proj_abc",
+            costsURL: #require(URL(string: "https://api.openai.test/v1/organization/costs")),
+            completionsURL: #require(URL(string: "https://api.openai.test/v1/organization/usage/completions")),
+            session: transport,
+            now: now,
+            historyDays: 1)
+
+        let requests = await transport.requests()
+        let costsRequests = requests.filter { $0.url?.path.contains("/organization/costs") == true }
+        let completionRequests = requests.filter { $0.url?.path.contains("/usage/completions") == true }
+
+        #expect(snapshot.daily.count == 1)
+        #expect(snapshot.latestDay.costUSD == 4.0)
+        #expect(snapshot.latestDay.requests == 3)
+        #expect(snapshot.latestDay.totalTokens == 45)
+        #expect(costsRequests.count == 2)
+        #expect(completionRequests.count == 2)
+        #expect(Self.queryValue("page", in: costsRequests[0]) == nil)
+        #expect(Self.queryValue("page", in: costsRequests[1]) == "costs_page_2")
+        #expect(Self.queryValue("page", in: completionRequests[0]) == nil)
+        #expect(Self.queryValue("page", in: completionRequests[1]) == "completions_page_2")
+        #expect(requests.allSatisfy { Self.queryValue("project_ids", in: $0) == "proj_abc" })
+    }
+
+    @Test
+    func `admin usage rejects repeated pagination cursor`() async throws {
+        let transport = OpenAIAdminUsageRepeatingCursorScript()
+
+        await #expect(throws: OpenAIAPIUsageError.parseFailed(
+            endpoint: "costs",
+            message: "Pagination cursor repeated."))
+        {
+            try await OpenAIAPIUsageFetcher.fetchUsage(
+                apiKey: "sk-test",
+                costsURL: #require(URL(string: "https://api.openai.test/v1/organization/costs")),
+                completionsURL: #require(URL(string: "https://api.openai.test/v1/organization/usage/completions")),
+                session: transport,
+                now: Date(timeIntervalSince1970: 1_700_179_200),
+                historyDays: 1)
+        }
+    }
+
+    @Test
+    func `admin usage rejects missing pagination cursor`() async throws {
+        let transport = OpenAIAdminUsageMissingCursorScript()
+
+        await #expect(throws: OpenAIAPIUsageError.parseFailed(
+            endpoint: "costs",
+            message: "Pagination cursor missing."))
+        {
+            try await OpenAIAPIUsageFetcher.fetchUsage(
+                apiKey: "sk-test",
+                costsURL: #require(URL(string: "https://api.openai.test/v1/organization/costs")),
+                completionsURL: #require(URL(string: "https://api.openai.test/v1/organization/usage/completions")),
+                session: transport,
+                now: Date(timeIntervalSince1970: 1_700_179_200),
+                historyDays: 1)
+        }
+    }
+
+    @Test
+    func `admin usage rejects page without costs data`() async throws {
+        let transport = OpenAIAdminUsageMalformedPageScript(
+            costs: #"{"object":"page","has_more":false,"next_page":null}"#,
+            completions: #"{"object":"page","data":[],"has_more":false,"next_page":null}"#)
+
+        do {
+            _ = try await OpenAIAPIUsageFetcher.fetchUsage(
+                apiKey: "sk-test",
+                costsURL: #require(URL(string: "https://api.openai.test/v1/organization/costs")),
+                completionsURL: #require(URL(string: "https://api.openai.test/v1/organization/usage/completions")),
+                session: transport,
+                now: Date(timeIntervalSince1970: 1_700_179_200),
+                historyDays: 1)
+            Issue.record("Expected costs parse failure.")
+        } catch let error as OpenAIAPIUsageError {
+            guard case let .parseFailed(endpoint, message) = error else {
+                Issue.record("Expected parse failure, got \(error).")
+                return
+            }
+            #expect(endpoint == "costs")
+            #expect(message.contains("data"))
+        } catch {
+            Issue.record("Expected OpenAIAPIUsageError, got \(error).")
+        }
+    }
+
+    @Test
+    func `admin usage rejects page without completions pagination state`() async throws {
+        let transport = OpenAIAdminUsageMalformedPageScript(
+            costs: #"{"object":"page","data":[],"has_more":false,"next_page":null}"#,
+            completions: #"{"object":"page","data":[],"next_page":null}"#)
+
+        do {
+            _ = try await OpenAIAPIUsageFetcher.fetchUsage(
+                apiKey: "sk-test",
+                costsURL: #require(URL(string: "https://api.openai.test/v1/organization/costs")),
+                completionsURL: #require(URL(string: "https://api.openai.test/v1/organization/usage/completions")),
+                session: transport,
+                now: Date(timeIntervalSince1970: 1_700_179_200),
+                historyDays: 1)
+            Issue.record("Expected completions parse failure.")
+        } catch let error as OpenAIAPIUsageError {
+            guard case let .parseFailed(endpoint, message) = error else {
+                Issue.record("Expected parse failure, got \(error).")
+                return
+            }
+            #expect(endpoint == "completions")
+            #expect(message.contains("missing"))
+        } catch {
+            Issue.record("Expected OpenAIAPIUsageError, got \(error).")
+        }
+    }
+
+    @Test
     func `admin usage retries transient completions failure once`() async throws {
         let now = Date(timeIntervalSince1970: 1_700_179_200)
         let emptyPage = Data(#"{"object":"page","data":[],"has_more":false,"next_page":null}"#.utf8)
@@ -332,6 +453,196 @@ struct OpenAIAPIUsageFetcherTests {
         #expect(snapshot.daily[1].requestCount == 42)
         #expect(snapshot.daily[1].modelBreakdowns?.first?.requestCount == 42)
         #expect(snapshot.daily[1].modelBreakdowns?.first?.modelName == "gpt-5.2-codex")
+    }
+
+    private static func queryValue(_ name: String, in request: URLRequest) -> String? {
+        guard let url = request.url,
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else { return nil }
+        return components.queryItems?.first(where: { $0.name == name })?.value
+    }
+}
+
+private actor OpenAIAdminUsagePaginationScript: ProviderHTTPTransport {
+    private var recordedRequests: [URLRequest] = []
+
+    func requests() -> [URLRequest] {
+        self.recordedRequests
+    }
+
+    func data(for request: URLRequest) throws -> (Data, URLResponse) {
+        self.recordedRequests.append(request)
+        let url = request.url ?? URL(string: "https://api.openai.test")!
+        let page = Self.queryValue("page", in: url)
+        let body: String = if url.path.contains("/organization/costs") {
+            page == "costs_page_2" ? Self.costsPage2 : Self.costsPage1
+        } else if url.path.contains("/usage/completions") {
+            page == "completions_page_2" ? Self.completionsPage2 : Self.completionsPage1
+        } else {
+            #"{"object":"page","data":[],"has_more":false,"next_page":null}"#
+        }
+        return (Data(body.utf8), HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil)!)
+    }
+
+    private static func queryValue(_ name: String, in url: URL) -> String? {
+        URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .first(where: { $0.name == name })?
+            .value
+    }
+
+    private static let costsPage1 = """
+    {
+      "object": "page",
+      "data": [
+        {
+          "object": "bucket",
+          "start_time": 1700000000,
+          "end_time": 1700086400,
+          "results": [
+            {
+              "object": "organization.costs.result",
+              "amount": { "value": 1.25, "currency": "usd" },
+              "line_item": "Text tokens"
+            }
+          ]
+        }
+      ],
+      "has_more": true,
+      "next_page": "costs_page_2"
+    }
+    """
+
+    private static let costsPage2 = """
+    {
+      "object": "page",
+      "data": [
+        {
+          "object": "bucket",
+          "start_time": 1700000000,
+          "end_time": 1700086400,
+          "results": [
+            {
+              "object": "organization.costs.result",
+              "amount": { "value": 2.75, "currency": "usd" },
+              "line_item": "Web search tool calls"
+            }
+          ]
+        }
+      ],
+      "has_more": false,
+      "next_page": null
+    }
+    """
+
+    private static let completionsPage1 = """
+    {
+      "object": "page",
+      "data": [
+        {
+          "object": "bucket",
+          "start_time": 1700000000,
+          "end_time": 1700086400,
+          "results": [
+            {
+              "object": "organization.usage.completions.result",
+              "input_tokens": 10,
+              "output_tokens": 5,
+              "num_model_requests": 1,
+              "model": "gpt-5.2"
+            }
+          ]
+        }
+      ],
+      "has_more": true,
+      "next_page": "completions_page_2"
+    }
+    """
+
+    private static let completionsPage2 = """
+    {
+      "object": "page",
+      "data": [
+        {
+          "object": "bucket",
+          "start_time": 1700000000,
+          "end_time": 1700086400,
+          "results": [
+            {
+              "object": "organization.usage.completions.result",
+              "input_tokens": 20,
+              "output_tokens": 10,
+              "num_model_requests": 2,
+              "model": "gpt-5.2"
+            }
+          ]
+        }
+      ],
+      "has_more": false,
+      "next_page": null
+    }
+    """
+}
+
+private actor OpenAIAdminUsageRepeatingCursorScript: ProviderHTTPTransport {
+    func data(for request: URLRequest) throws -> (Data, URLResponse) {
+        let url = request.url ?? URL(string: "https://api.openai.test")!
+        let body = """
+        {
+          "object": "page",
+          "data": [],
+          "has_more": true,
+          "next_page": "same_page"
+        }
+        """
+        return (Data(body.utf8), HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil)!)
+    }
+}
+
+private actor OpenAIAdminUsageMissingCursorScript: ProviderHTTPTransport {
+    func data(for request: URLRequest) throws -> (Data, URLResponse) {
+        let url = request.url ?? URL(string: "https://api.openai.test")!
+        let body = """
+        {
+          "object": "page",
+          "data": [],
+          "has_more": true,
+          "next_page": null
+        }
+        """
+        return (Data(body.utf8), HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil)!)
+    }
+}
+
+private actor OpenAIAdminUsageMalformedPageScript: ProviderHTTPTransport {
+    private let costs: String
+    private let completions: String
+
+    init(costs: String, completions: String) {
+        self.costs = costs
+        self.completions = completions
+    }
+
+    func data(for request: URLRequest) throws -> (Data, URLResponse) {
+        let url = request.url ?? URL(string: "https://api.openai.test")!
+        let body = url.path.contains("/usage/completions") ? self.completions : self.costs
+        return (Data(body.utf8), HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil)!)
     }
 }
 


### PR DESCRIPTION
## Summary

OpenAI Admin usage responses can be paginated, but CodexBar was only reading the first page for both costs and completions usage. That could undercount organization usage whenever the API returned `has_more: true`.

This updates the OpenAI API usage fetcher to follow `next_page` cursors for both endpoints, preserve the existing range/project/group query parameters on each page request, and fail closed on malformed pagination state instead of silently returning partial totals.

## What changed

- Follow `has_more` / `next_page` pagination for OpenAI Admin costs and completions usage.
- Keep `project_ids`, `group_by`, time range, bucket width, and limit query params across page requests.
- Detect repeated cursors, missing cursors when `has_more` is true, and excessive pagination.
- Require top-level `data` and `has_more` in Admin usage page responses so malformed pages do not look like empty successful usage.
- Add regression coverage for multi-page costs/completions, repeated cursors, missing cursors, and malformed page responses.

## Live behavior proof

I verified the pagination path against a real OpenAI Admin API response with keys, cursors, project/org identifiers, and model names redacted. The probe used the same Admin costs and completions endpoints with `bucket_width=1d` and `limit=1` to force cursor traversal.

```text
OpenAI Admin live pagination proof, redacted. range=2026-05-14..2026-06-12 bucket_width=1d limit=1

costs:
  pages_fetched=30 final_has_more=false all_next_page_cursors_present_until_final=true
  first_page: buckets=1 results=0 cost_usd=0.000000 requests=0 input_tokens=0 output_tokens=0
  all_pages: buckets=30 results=17 cost_usd=0.000000 requests=0 input_tokens=0 output_tokens=0

completions:
  pages_fetched=30 final_has_more=false all_next_page_cursors_present_until_final=true
  first_page: buckets=1 results=0 cost_usd=0.000000 requests=0 input_tokens=0 output_tokens=0
  all_pages: buckets=30 results=7 cost_usd=0.000000 requests=22 input_tokens=16284907 output_tokens=292570
```

That shows the old first-page-only behavior would report zero completions usage for this range, while following all pages finds the later usage buckets.

## Testing

- `swift test --filter OpenAIAPIUsageFetcherTests --filter OpenAIAPICreditBalanceTests --filter OpenAIAPIMenuCardModelTests`
- `make check`

I also tried an aggregate `swift test --disable-sandbox` run after rebasing on latest `upstream/main`; it hit a timing-sensitive `MainThreadHangWatchdogTests` failure during the full run, and that same suite passed when rerun directly with `swift test --disable-sandbox --filter MainThreadHangWatchdogTests`.
