### PR TITLE
fix: scope Ollama web guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Menu bar: move the highlighted Overview provider with trackpad or mouse-wheel scrolling while preserving native submenu and keyboard behavior (#1436). Thanks @joshuavial!
 
 ### Fixed
+- CLI: keep Ollama API credentials scoped to Ollama when deciding whether another provider requires macOS web support (#1466). Thanks @WadydX!
 - Provider switcher: keep localized tab titles visible by tightening outer insets only when equal-width segments would otherwise truncate.
 - OpenAI API: follow Admin usage pagination for costs and completions so multi-page organization usage totals are not undercounted (#1465). Thanks @rohitjavvadi!
 - Settings: slightly increase the window height so standard panes fit without clipping their final controls or helper text.

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -548,12 +548,13 @@ extension CodexBarCLI {
         guard provider != .grok, provider != .amp else {
             return false
         }
-        if provider == .ollama,
-           sourceMode == .auto,
-           settings?.ollama?.cookieSource == .off
-           || environment.map({ ProviderTokenResolver.ollamaToken(environment: $0) != nil }) == true
-        {
-            return false
+        if provider == .ollama, sourceMode == .auto {
+            let hasEnvironmentToken = environment.map {
+                ProviderTokenResolver.ollamaToken(environment: $0) != nil
+            } == true
+            if settings?.ollama?.cookieSource == .off || hasEnvironmentToken {
+                return false
+            }
         }
         return switch sourceMode {
         case .web:

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -316,5 +316,9 @@ final class CLIEntryTests: XCTestCase {
             provider: .ollama,
             settings: ProviderSettingsSnapshot.make(
                 ollama: .init(cookieSource: .off, manualCookieHeader: nil))))
+        XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .codex,
+            environment: ["OLLAMA_API_KEY": "ollama-test"]))
     }
 }


### PR DESCRIPTION
## Summary

- scope the Ollama auto-mode exemption to the Ollama provider
- preserve API-key and cookie-off behavior for Ollama itself
- add a regression proving `OLLAMA_API_KEY` cannot disable another provider's web-support guard

Fixes #1466.

## Verification

- `swift test --filter CLIEntryTests/test_sourceModeRequiresWebSupportIsProviderAware`
- `make check`
- autoreview: clean, no actionable findings
