### PR TITLE
Fix Ollama web guard scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Menu bar: move the highlighted Overview provider with trackpad or mouse-wheel scrolling while preserving native submenu and keyboard behavior (#1436). Thanks @joshuavial!
 
 ### Fixed
+- CLI: keep Ollama API credentials scoped to Ollama when deciding whether another provider requires macOS web support (#1466). Thanks @WadydX!
 - Provider switcher: keep localized tab titles visible by tightening outer insets only when equal-width segments would otherwise truncate.
 - OpenAI API: follow Admin usage pagination for costs and completions so multi-page organization usage totals are not undercounted (#1465). Thanks @rohitjavvadi!
 - Settings: slightly increase the window height so standard panes fit without clipping their final controls or helper text.

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -549,11 +549,14 @@ extension CodexBarCLI {
             return false
         }
         if provider == .ollama,
-           sourceMode == .auto,
-           settings?.ollama?.cookieSource == .off
-           || environment.map({ ProviderTokenResolver.ollamaToken(environment: $0) != nil }) == true
+           sourceMode == .auto
         {
-            return false
+            let hasEnvironmentToken = environment.map {
+                ProviderTokenResolver.ollamaToken(environment: $0) != nil
+            } == true
+            if settings?.ollama?.cookieSource == .off || hasEnvironmentToken {
+                return false
+            }
         }
         return switch sourceMode {
         case .web:

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -311,6 +311,10 @@ final class CLIEntryTests: XCTestCase {
             .auto,
             provider: .ollama,
             environment: ["OLLAMA_API_KEY": "ollama-test"]))
+        XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .codex,
+            environment: ["OLLAMA_API_KEY": "ollama-test"]))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(
             .auto,
             provider: .ollama,


### PR DESCRIPTION
## Summary
- Scope the Ollama auto-source exemption so `OLLAMA_API_KEY` only affects the Ollama provider.
- Add a regression assertion that a non-Ollama web-capable provider still requires web support when `OLLAMA_API_KEY` is present.

Closes #1466.

## Test plan
- `git diff --check`
- `swift -e 'let providerIsOllama=false; let sourceModeAuto=true; let cookieOff=false; let hasOllamaToken=true; let result = providerIsOllama && sourceModeAuto && (cookieOff || hasOllamaToken); print(result)'`
- Attempted `swift test --filter CLIEntryTests/test_sourceModeRequiresWebSupportIsProviderAware` twice; both runs timed out after 10 minutes while SwiftPM was downloading/building the Sparkle binary artifact, before the focused test could execute.
