### PR TITLE
Fix Launch at Login disable for pending approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Menu bar: move the highlighted Overview provider with trackpad or mouse-wheel scrolling while preserving native submenu and keyboard behavior (#1436). Thanks @joshuavial!
 
 ### Fixed
+- Launch at Login: remove pending registrations when disabled without re-registering entries awaiting user approval (#1469). Thanks @AmrMohamad!
 - CLI: keep Ollama API credentials scoped to Ollama when deciding whether another provider requires macOS web support (#1466). Thanks @WadydX!
 - Provider switcher: keep localized tab titles visible by tightening outer insets only when equal-width segments would otherwise truncate.
 - OpenAI API: follow Admin usage pagination for costs and completions so multi-page organization usage totals are not undercounted (#1465). Thanks @rohitjavvadi!

--- a/Sources/CodexBar/LaunchAtLoginManager.swift
+++ b/Sources/CodexBar/LaunchAtLoginManager.swift
@@ -2,6 +2,9 @@ import CodexBarCore
 import ServiceManagement
 
 enum LaunchAtLoginManager {
+    typealias StatusProvider = () -> SMAppService.Status
+    typealias RegistrationAction = () throws -> Void
+
     private static let isRunningTests: Bool = {
         let env = ProcessInfo.processInfo.environment
         if env["XCTestConfigurationFilePath"] != nil { return true }
@@ -13,11 +16,26 @@ enum LaunchAtLoginManager {
     static func setEnabled(_ enabled: Bool) {
         if self.isRunningTests { return }
         let service = SMAppService.mainApp
+        self.setEnabled(
+            enabled,
+            status: { service.status },
+            register: { try service.register() },
+            unregister: { try service.unregister() })
+    }
+
+    static func setEnabled(
+        _ enabled: Bool,
+        status: StatusProvider,
+        register: RegistrationAction,
+        unregister: RegistrationAction)
+    {
         do {
             if enabled {
-                try service.register()
+                guard status() != .enabled else { return }
+                try register()
             } else {
-                try service.unregister()
+                guard status() != .notRegistered else { return }
+                try unregister()
             }
         } catch {
             CodexBarLog.logger(LogCategories.launchAtLogin).error("Failed to update login item: \(error)")

--- a/Sources/CodexBar/LaunchAtLoginManager.swift
+++ b/Sources/CodexBar/LaunchAtLoginManager.swift
@@ -31,11 +31,23 @@ enum LaunchAtLoginManager {
     {
         do {
             if enabled {
-                guard status() != .enabled else { return }
-                try register()
+                switch status() {
+                case .enabled, .requiresApproval:
+                    return
+                case .notRegistered, .notFound:
+                    try register()
+                @unknown default:
+                    try register()
+                }
             } else {
-                guard status() != .notRegistered else { return }
-                try unregister()
+                switch status() {
+                case .enabled, .requiresApproval:
+                    try unregister()
+                case .notRegistered, .notFound:
+                    return
+                @unknown default:
+                    try unregister()
+                }
             }
         } catch {
             CodexBarLog.logger(LogCategories.launchAtLogin).error("Failed to update login item: \(error)")

--- a/Tests/CodexBarTests/LaunchAtLoginManagerTests.swift
+++ b/Tests/CodexBarTests/LaunchAtLoginManagerTests.swift
@@ -1,0 +1,81 @@
+import ServiceManagement
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct LaunchAtLoginManagerTests {
+    @Test
+    func `set enabled skips registration when service is already enabled`() {
+        var registerCalls = 0
+        var unregisterCalls = 0
+
+        LaunchAtLoginManager.setEnabled(
+            true,
+            status: { .enabled },
+            register: { registerCalls += 1 },
+            unregister: { unregisterCalls += 1 })
+
+        #expect(registerCalls == 0)
+        #expect(unregisterCalls == 0)
+    }
+
+    @Test
+    func `set enabled registers when service is not registered`() {
+        var registerCalls = 0
+        var unregisterCalls = 0
+
+        LaunchAtLoginManager.setEnabled(
+            true,
+            status: { .notRegistered },
+            register: { registerCalls += 1 },
+            unregister: { unregisterCalls += 1 })
+
+        #expect(registerCalls == 1)
+        #expect(unregisterCalls == 0)
+    }
+
+    @Test
+    func `set disabled unregisters when service is enabled`() {
+        var registerCalls = 0
+        var unregisterCalls = 0
+
+        LaunchAtLoginManager.setEnabled(
+            false,
+            status: { .enabled },
+            register: { registerCalls += 1 },
+            unregister: { unregisterCalls += 1 })
+
+        #expect(registerCalls == 0)
+        #expect(unregisterCalls == 1)
+    }
+
+    @Test
+    func `set disabled unregisters when service requires approval`() {
+        var registerCalls = 0
+        var unregisterCalls = 0
+
+        LaunchAtLoginManager.setEnabled(
+            false,
+            status: { .requiresApproval },
+            register: { registerCalls += 1 },
+            unregister: { unregisterCalls += 1 })
+
+        #expect(registerCalls == 0)
+        #expect(unregisterCalls == 1)
+    }
+
+    @Test
+    func `set disabled skips unregister when service is not registered`() {
+        var registerCalls = 0
+        var unregisterCalls = 0
+
+        LaunchAtLoginManager.setEnabled(
+            false,
+            status: { .notRegistered },
+            register: { registerCalls += 1 },
+            unregister: { unregisterCalls += 1 })
+
+        #expect(registerCalls == 0)
+        #expect(unregisterCalls == 0)
+    }
+}

--- a/Tests/CodexBarTests/LaunchAtLoginManagerTests.swift
+++ b/Tests/CodexBarTests/LaunchAtLoginManagerTests.swift
@@ -35,6 +35,36 @@ struct LaunchAtLoginManagerTests {
     }
 
     @Test
+    func `set enabled skips registration when service requires approval`() {
+        var registerCalls = 0
+        var unregisterCalls = 0
+
+        LaunchAtLoginManager.setEnabled(
+            true,
+            status: { .requiresApproval },
+            register: { registerCalls += 1 },
+            unregister: { unregisterCalls += 1 })
+
+        #expect(registerCalls == 0)
+        #expect(unregisterCalls == 0)
+    }
+
+    @Test
+    func `set enabled registers when service is not found`() {
+        var registerCalls = 0
+        var unregisterCalls = 0
+
+        LaunchAtLoginManager.setEnabled(
+            true,
+            status: { .notFound },
+            register: { registerCalls += 1 },
+            unregister: { unregisterCalls += 1 })
+
+        #expect(registerCalls == 1)
+        #expect(unregisterCalls == 0)
+    }
+
+    @Test
     func `set disabled unregisters when service is enabled`() {
         var registerCalls = 0
         var unregisterCalls = 0
@@ -72,6 +102,21 @@ struct LaunchAtLoginManagerTests {
         LaunchAtLoginManager.setEnabled(
             false,
             status: { .notRegistered },
+            register: { registerCalls += 1 },
+            unregister: { unregisterCalls += 1 })
+
+        #expect(registerCalls == 0)
+        #expect(unregisterCalls == 0)
+    }
+
+    @Test
+    func `set disabled skips unregister when service is not found`() {
+        var registerCalls = 0
+        var unregisterCalls = 0
+
+        LaunchAtLoginManager.setEnabled(
+            false,
+            status: { .notFound },
             register: { registerCalls += 1 },
             unregister: { unregisterCalls += 1 })
 


### PR DESCRIPTION
## Summary
- Fix disabling Launch at Login when ServiceManagement reports `.requiresApproval` by unregistering every status except `.notRegistered`.
- Add focused tests around `LaunchAtLoginManager` status handling.
- Extracted from #1234 per maintainer feedback after #1231 already handled the original UI readiness issue.

## Out of scope
- No duplicate-launch guard.
- No validation harness.
- No keychain prompt changes.
- No package or run script changes.

## Verification
- `swift test --filter LaunchAtLoginManagerTests`
- `git diff --check`
- `make check`

## Runtime proof
Packaged the PR build for local macOS validation and verified the staged app bundle:

- App bundle: `.build/package/CodexBar.app`
- Bundle identifier: `com.steipete.codexbar`
- Embedded commit: `644b4f12`
- `codesign --verify --deep --strict --verbose=2 .build/package/CodexBar.app` passed

ServiceManagement status was measured inside the running packaged app with LLDB:

- Enum mapping on this host:
  - `.notRegistered` = `SMAppServiceStatus(rawValue: 0)`
  - `.enabled` = `SMAppServiceStatus(rawValue: 1)`
  - `.requiresApproval` = `SMAppServiceStatus(rawValue: 2)`
  - `.notFound` = `SMAppServiceStatus(rawValue: 3)`
- With `launchAtLogin=true`, launching `.build/package/CodexBar.app` registered the app and reported `.enabled` / `rawValue: 1`.
- System Settings > Login Items showed `CodexBar.app` under Open at Login.
- Removing `CodexBar.app` from Open at Login through System Settings changed the live status to `.notFound` / `rawValue: 3` on this machine, not `.requiresApproval`.
- Re-launching the same packaged build with `launchAtLogin=true` registered it again and returned `.enabled` / `rawValue: 1`.
- Re-launching with `launchAtLogin=false` after UI removal did not produce a login-item error in the checked log slice.

I could not reproduce a real `.requiresApproval` state locally through the normal System Settings Open at Login flow; this host transitions through `.enabled` and `.notFound` for the available UI operations. The unit test still covers the `.requiresApproval` decision path directly, and the packaged run confirms the build/register/remove surface is wired to the real ServiceManagement API.

Notes from packaging:

- The normal release package command could not use the maintainer Developer ID identity on this machine: `Developer ID Application: Peter Steinberger (Y5PE65HELJ): no identity found`.
- Re-running with `CODEXBAR_SIGNING=adhoc` produced a signed staged bundle at `.build/package/CodexBar.app`; the final root `CodexBar.app` replacement failed because the existing root bundle has permission drift, so runtime proof used the verified staged bundle directly.
