### PR TITLE
Fix shortcut menu toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.1 — Unreleased
 
+- Menu bar: make the global open-menu shortcut toggle synchronously during menu tracking so repeated presses no longer queue delayed menu reopens. Thanks @Zihao-Qi!
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.
 - Menu bar: keep cached provider content visible while switching merged tabs so the open menu no longer flickers through an empty state.
 - Menu bar: handle the global open-menu shortcut synchronously so repeated presses close the tracked menu instead of queueing a delayed reopen (#1470). Thanks @Zihao-Qi!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 0.34.1 — Unreleased
 
-- Menu bar: make the global open-menu shortcut toggle synchronously during menu tracking so repeated presses no longer queue delayed menu reopens. Thanks @Zihao-Qi!
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.
 - Menu bar: keep cached provider content visible while switching merged tabs so the open menu no longer flickers through an empty state.
 - Menu bar: handle the global open-menu shortcut synchronously so repeated presses close the tracked menu instead of queueing a delayed reopen (#1470). Thanks @Zihao-Qi!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.
 - Menu bar: keep cached provider content visible while switching merged tabs so the open menu no longer flickers through an empty state.
+- Menu bar: handle the global open-menu shortcut synchronously so repeated presses close the tracked menu instead of queueing a delayed reopen (#1470). Thanks @Zihao-Qi!
 - Settings: memoize cookie cache lookups behind the "Cached: …" picker labels so opening Settings and switching panes no longer pays a synchronous Keychain read per SwiftUI body evaluation, which froze the Providers pane for seconds (#1471). Thanks @ProspectOre!
 - Build: resolve packaged binaries from the bin path SwiftPM reports instead of assuming the legacy `.build/<arch>-apple-macosx/<conf>/` layout, so a stale directory left behind by the older build system no longer silently shadows fresh swiftbuild products in `package_app.sh`. Thanks @ProspectOre!
 - Menu bar: stop the provider-switcher shortcut monitor from killing the menu's event tracking session. Its event-queue peek re-entered the run loop in tracking mode, which could leave a zombie menu on screen that ignored clicks for tens of seconds (beach ball) — most often right after opening the menu or after rapid Cmd-number provider switching, with Settings… the usual victim. Peeks now run in a barren private run-loop mode, start only once the tracking session is pumping, and no longer touch mouse events. Thanks @ProspectOre!

--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -382,6 +382,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         AppNotifications.shared.requestAuthorizationOnStartup()
         self.ensureStatusController()
         KeyboardShortcuts.onKeyUp(for: .openMenu) { [weak self] in
+            // KeyboardShortcuts dispatches both normal and menu-tracking hotkeys on the main event loop.
             MainActor.assumeIsolated {
                 self?.statusController?.openMenuFromShortcut()
             }

--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -382,7 +382,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         AppNotifications.shared.requestAuthorizationOnStartup()
         self.ensureStatusController()
         KeyboardShortcuts.onKeyUp(for: .openMenu) { [weak self] in
-            Task { @MainActor [weak self] in
+            MainActor.assumeIsolated {
                 self?.statusController?.openMenuFromShortcut()
             }
         }


### PR DESCRIPTION
## Summary

Fixes the global open-menu shortcut so repeated shortcut presses do not queue additional menu opens while an AppKit menu is tracking.

The shortcut callback now runs synchronously on the main actor instead of scheduling a `Task { @MainActor ... }`, avoiding delayed callbacks during `NSMenu` tracking mode.

## Tests

- `swift test --filter StatusMenuTests`
- Manual check: shortcut opens menu; repeated shortcut press while menu is open should close/toggle instead of stacking queued opens

## Maintainer validation

Validated on exact head `70beaf0e` from a freshly packaged local bundle:

- `make check` — clean (SwiftFormat + SwiftLint, 0 violations)
- `swift test --filter StatusMenuTests` — 132 tests passed
- `swift test` — 3,899 tests passed
- `./Scripts/package_app.sh` — packaged `CodexBar.app` 0.34.1 (84)
- Packaged app binary SHA-256: `b7cb7921f8ce862d296371b62e87e6b0c141218f3c19882157eb66b0753907ca`
- Branch-wide autoreview against `origin/main` — clean, no accepted/actionable findings

Live AppKit proof used the existing Cmd-Option-X global shortcut against the freshly launched bundle. Ten consecutive presses were sampled after each dispatch by counting active level-101 CodexBar menu-tracking windows:

```text
press:               1 2 3 4 5 6 7 8 9 10
tracking menu count: 1 0 1 0 1 0 1 0 1 0
```

Every odd press opened exactly one tracked menu; every even press closed it synchronously. No delayed reopen appeared, and the app remained running after the sequence.
