### PR TITLE
Memoize cookie cache lookups behind settings picker labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.34.1 — Unreleased
 
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.
-- Settings: memoize cookie cache lookups behind the "Cached: …" picker labels so opening Settings and switching panes no longer pays a synchronous Keychain read per SwiftUI body evaluation, which froze the window for seconds on the Providers pane.
+- Settings: memoize cookie cache lookups behind the "Cached: …" picker labels so opening Settings and switching panes no longer pays a synchronous Keychain read per SwiftUI body evaluation, which froze the Providers pane for seconds (#1471). Thanks @ProspectOre!
 
 ## 0.34.0 — 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.34.1 — Unreleased
 
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.
+- Settings: memoize cookie cache lookups behind the "Cached: …" picker labels so opening Settings and switching panes no longer pays a synchronous Keychain read per SwiftUI body evaluation, which froze the window for seconds on the Providers pane.
 
 ## 0.34.0 — 2026-06-12
 

--- a/Sources/CodexBar/PreferencesDebugPane.swift
+++ b/Sources/CodexBar/PreferencesDebugPane.swift
@@ -524,9 +524,13 @@ struct DebugPane: View {
     }
 
     private func clearCookieCache() {
-        let cleared = CookieHeaderCache.clearAll()
-        if cleared > 0 {
-            self.cookieCacheStatus = "Cleared \(cleared) provider\(cleared == 1 ? "" : "s")."
+        let summary = CookieHeaderCache.clearAllDetailed()
+        if summary.failedCount > 0 {
+            self.cookieCacheStatus = "Cookie cache cleanup failed for \(summary.failedCount) "
+                + "operation\(summary.failedCount == 1 ? "" : "s")."
+        } else if summary.clearedCount > 0 {
+            self.cookieCacheStatus = "Cleared \(summary.clearedCount) "
+                + "provider\(summary.clearedCount == 1 ? "" : "s")."
         } else {
             self.cookieCacheStatus = "No cached cookies found."
         }

--- a/Sources/CodexBar/Providers/Abacus/AbacusProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Abacus/AbacusProviderImplementation.swift
@@ -64,7 +64,7 @@ struct AbacusProviderImplementation: ProviderImplementation {
                 isVisible: nil,
                 onChange: nil,
                 trailingText: {
-                    guard let entry = CookieHeaderCache.load(provider: .abacus) else { return nil }
+                    guard let entry = CookieHeaderCache.loadForDisplay(provider: .abacus) else { return nil }
                     let when = entry.storedAt.relativeDescription()
                     return "Cached: \(entry.sourceLabel) • \(when)"
                 }),

--- a/Sources/CodexBar/Providers/Alibaba/AlibabaCodingPlanProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Alibaba/AlibabaCodingPlanProviderImplementation.swift
@@ -69,7 +69,7 @@ struct AlibabaCodingPlanProviderImplementation: ProviderImplementation {
                 isVisible: nil,
                 onChange: nil,
                 trailingText: {
-                    guard let entry = CookieHeaderCache.load(provider: .alibaba) else { return nil }
+                    guard let entry = CookieHeaderCache.loadForDisplay(provider: .alibaba) else { return nil }
                     let when = entry.storedAt.relativeDescription()
                     return "Cached: \(entry.sourceLabel) • \(when)"
                 }),

--- a/Sources/CodexBar/Providers/Alibaba/AlibabaTokenPlanProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Alibaba/AlibabaTokenPlanProviderImplementation.swift
@@ -57,7 +57,7 @@ struct AlibabaTokenPlanProviderImplementation: ProviderImplementation {
                 isVisible: nil,
                 onChange: nil,
                 trailingText: {
-                    guard let entry = CookieHeaderCache.load(provider: .alibabatokenplan) else { return nil }
+                    guard let entry = CookieHeaderCache.loadForDisplay(provider: .alibabatokenplan) else { return nil }
                     let when = entry.storedAt.relativeDescription()
                     return "Cached: \(entry.sourceLabel) • \(when)"
                 }),

--- a/Sources/CodexBar/Providers/Augment/AugmentProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Augment/AugmentProviderImplementation.swift
@@ -68,7 +68,7 @@ struct AugmentProviderImplementation: ProviderImplementation {
                 isVisible: nil,
                 onChange: nil,
                 trailingText: {
-                    guard let entry = CookieHeaderCache.load(provider: .augment) else { return nil }
+                    guard let entry = CookieHeaderCache.loadForDisplay(provider: .augment) else { return nil }
                     let when = entry.storedAt.relativeDescription()
                     return "Cached: \(entry.sourceLabel) • \(when)"
                 }),

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -180,7 +180,7 @@ struct ClaudeProviderImplementation: ProviderImplementation {
                 isVisible: nil,
                 onChange: nil,
                 trailingText: {
-                    guard let entry = CookieHeaderCache.load(provider: .claude) else { return nil }
+                    guard let entry = CookieHeaderCache.loadForDisplay(provider: .claude) else { return nil }
                     let when = entry.storedAt.relativeDescription()
                     return "Cached: \(entry.sourceLabel) • \(when)"
                 }),

--- a/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
@@ -169,7 +169,7 @@ struct CodexProviderImplementation: ProviderImplementation {
                 isVisible: { context.settings.openAIWebAccessEnabled },
                 onChange: nil,
                 trailingText: {
-                    guard let entry = CookieHeaderCache.load(provider: .codex) else { return nil }
+                    guard let entry = CookieHeaderCache.loadForDisplay(provider: .codex) else { return nil }
                     let when = entry.storedAt.relativeDescription()
                     return "Cached: \(entry.sourceLabel) • \(when)"
                 }),

--- a/Sources/CodexBar/Providers/Copilot/CopilotProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Copilot/CopilotProviderImplementation.swift
@@ -149,7 +149,7 @@ struct CopilotProviderImplementation: ProviderImplementation {
                 },
                 trailingText: {
                     guard context.settings.copilotBudgetCookieSource != .manual else { return nil }
-                    guard let entry = CookieHeaderCache.load(provider: .copilot) else { return nil }
+                    guard let entry = CookieHeaderCache.loadForDisplay(provider: .copilot) else { return nil }
                     let when = entry.storedAt.relativeDescription()
                     return "Cached: \(entry.sourceLabel) • \(when)"
                 }),

--- a/Sources/CodexBar/Providers/Cursor/CursorProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Cursor/CursorProviderImplementation.swift
@@ -69,7 +69,7 @@ struct CursorProviderImplementation: ProviderImplementation {
                 isVisible: nil,
                 onChange: nil,
                 trailingText: {
-                    guard let entry = CookieHeaderCache.load(provider: .cursor) else { return nil }
+                    guard let entry = CookieHeaderCache.loadForDisplay(provider: .cursor) else { return nil }
                     let when = entry.storedAt.relativeDescription()
                     return "Cached: \(entry.sourceLabel) • \(when)"
                 }),

--- a/Sources/CodexBar/Providers/Factory/FactoryProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Factory/FactoryProviderImplementation.swift
@@ -64,7 +64,7 @@ struct FactoryProviderImplementation: ProviderImplementation {
                 isVisible: nil,
                 onChange: nil,
                 trailingText: {
-                    guard let entry = CookieHeaderCache.load(provider: .factory) else { return nil }
+                    guard let entry = CookieHeaderCache.loadForDisplay(provider: .factory) else { return nil }
                     let when = entry.storedAt.relativeDescription()
                     return "Cached: \(entry.sourceLabel) • \(when)"
                 }),

--- a/Sources/CodexBar/Providers/MiMo/MiMoProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/MiMo/MiMoProviderImplementation.swift
@@ -55,7 +55,7 @@ struct MiMoProviderImplementation: ProviderImplementation {
                 isVisible: nil,
                 onChange: nil,
                 trailingText: {
-                    guard let entry = CookieHeaderCache.load(provider: .mimo) else { return nil }
+                    guard let entry = CookieHeaderCache.loadForDisplay(provider: .mimo) else { return nil }
                     let when = entry.storedAt.relativeDescription()
                     return "Cached: \(entry.sourceLabel) • \(when)"
                 }),

--- a/Sources/CodexBar/Providers/MiniMax/MiniMaxProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/MiniMax/MiniMaxProviderImplementation.swift
@@ -89,7 +89,7 @@ struct MiniMaxProviderImplementation: ProviderImplementation {
                 isVisible: { authMode().allowsCookies },
                 onChange: nil,
                 trailingText: {
-                    guard let entry = CookieHeaderCache.load(provider: .minimax) else { return nil }
+                    guard let entry = CookieHeaderCache.loadForDisplay(provider: .minimax) else { return nil }
                     let when = entry.storedAt.relativeDescription()
                     return "Cached: \(entry.sourceLabel) • \(when)"
                 }),

--- a/Sources/CodexBar/Providers/Mistral/MistralProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Mistral/MistralProviderImplementation.swift
@@ -69,7 +69,7 @@ struct MistralProviderImplementation: ProviderImplementation {
                 isVisible: nil,
                 onChange: nil,
                 trailingText: {
-                    guard let entry = CookieHeaderCache.load(provider: .mistral) else { return nil }
+                    guard let entry = CookieHeaderCache.loadForDisplay(provider: .mistral) else { return nil }
                     let when = entry.storedAt.relativeDescription()
                     return "Cached: \(entry.sourceLabel) • \(when)"
                 }),

--- a/Sources/CodexBar/Providers/OpenCode/OpenCodeProviderUI.swift
+++ b/Sources/CodexBar/Providers/OpenCode/OpenCodeProviderUI.swift
@@ -5,7 +5,7 @@ enum OpenCodeProviderUI {
     @MainActor
     static func cachedCookieTrailingText(provider: UsageProvider, cookieSource: ProviderCookieSource) -> String? {
         guard cookieSource != .manual else { return nil }
-        guard let entry = CookieHeaderCache.load(provider: provider) else { return nil }
+        guard let entry = CookieHeaderCache.loadForDisplay(provider: provider) else { return nil }
         let when = entry.storedAt.relativeDescription()
         return "Cached: \(entry.sourceLabel) • \(when)"
     }

--- a/Sources/CodexBar/Providers/StepFun/StepFunProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/StepFun/StepFunProviderImplementation.swift
@@ -96,7 +96,7 @@ struct StepFunProviderImplementation: ProviderImplementation {
                 isVisible: nil,
                 onChange: nil,
                 trailingText: {
-                    guard let entry = CookieHeaderCache.load(provider: .stepfun) else { return nil }
+                    guard let entry = CookieHeaderCache.loadForDisplay(provider: .stepfun) else { return nil }
                     let when = entry.storedAt.relativeDescription()
                     return "Cached: \(entry.sourceLabel) • \(when)"
                 }),

--- a/Sources/CodexBarCLI/CLICacheCommand.swift
+++ b/Sources/CodexBarCLI/CLICacheCommand.swift
@@ -29,11 +29,12 @@ extension CodexBarCLI {
         if clearCookies {
             if let rawProvider {
                 if let provider = ProviderDescriptorRegistry.cliNameMap[rawProvider.lowercased()] {
-                    let cleared = CookieHeaderCache.clearAllScopes(provider: provider)
+                    let summary = CookieHeaderCache.clearAllScopesDetailed(provider: provider)
                     results.append(CacheClearResult(
                         cache: "cookies",
                         provider: provider.rawValue,
-                        cleared: cleared))
+                        cleared: summary.clearedCount,
+                        error: Self.cookieClearError(failedCount: summary.failedCount)))
                 } else {
                     Self.exit(
                         code: .failure,
@@ -42,8 +43,12 @@ extension CodexBarCLI {
                         kind: .args)
                 }
             } else {
-                let cleared = CookieHeaderCache.clearAll()
-                results.append(CacheClearResult(cache: "cookies", provider: nil, cleared: cleared))
+                let summary = CookieHeaderCache.clearAllDetailed()
+                results.append(CacheClearResult(
+                    cache: "cookies",
+                    provider: nil,
+                    cleared: summary.clearedCount,
+                    error: Self.cookieClearError(failedCount: summary.failedCount)))
             }
         }
 
@@ -86,6 +91,11 @@ extension CodexBarCLI {
     static func cacheClearProviderScopeError(rawProvider: String?, clearCost: Bool) -> String? {
         guard rawProvider != nil, clearCost else { return nil }
         return "--provider only scopes cookie caches. Use --cookies --provider <name>, or omit --provider."
+    }
+
+    private static func cookieClearError(failedCount: Int) -> String? {
+        guard failedCount > 0 else { return nil }
+        return "Cookie cache cleanup failed for \(failedCount) operation\(failedCount == 1 ? "" : "s")"
     }
 }
 

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 public enum CookieHeaderCache {
     public enum Scope: Sendable, Equatable {
@@ -46,14 +51,16 @@ public enum CookieHeaderCache {
     }
 
     private enum LoadOutcome {
-        case authoritative(Entry?)
+        case authoritative(Entry?, loadedFromLegacy: Bool)
         case temporarilyUnavailable
     }
 
+    private static let legacyMutationLock = NSLock()
     private static let displayCacheLock = NSLock()
     private nonisolated(unsafe) static var displayCache: [KeychainCacheStore.Key: DisplaySnapshot] = [:]
     private nonisolated(unsafe) static var displayGenerations: [KeychainCacheStore.Key: UInt64] = [:]
     private nonisolated(unsafe) static var displayRevalidationsInFlight: Set<KeychainCacheStore.Key> = []
+    private nonisolated(unsafe) static var legacyMigrationsInFlight: Set<UsageProvider> = []
     private nonisolated(unsafe) static var displayStalenessIntervalOverride: TimeInterval?
     private nonisolated(unsafe) static var displayUnavailableRetryIntervalOverride: TimeInterval?
     private static let displayStalenessInterval: TimeInterval = 30
@@ -78,9 +85,13 @@ public enum CookieHeaderCache {
         let key = self.key(for: provider, scope: scope)
         let (cached, generation) = self.beginDisplayRead(key: key)
         guard let cached else {
-            switch self.loadOutcome(provider: provider, scope: scope) {
-            case let .authoritative(entry):
-                return self.commitDisplaySnapshotIfCurrent(key: key, entry: entry, generation: generation)
+            switch self.loadOutcome(provider: provider, scope: scope, migrateLegacy: false) {
+            case let .authoritative(entry, loadedFromLegacy):
+                let committed = self.commitDisplaySnapshotIfCurrent(key: key, entry: entry, generation: generation)
+                if loadedFromLegacy {
+                    self.scheduleLegacyMigration(provider: provider)
+                }
+                return committed
             case .temporarilyUnavailable:
                 return self.commitTemporaryDisplaySnapshotIfCurrent(key: key, generation: generation)
             }
@@ -122,15 +133,31 @@ public enum CookieHeaderCache {
         key: KeychainCacheStore.Key,
         generation: UInt64)
     {
-        switch self.loadOutcome(provider: provider, scope: scope) {
-        case let .authoritative(entry):
+        switch self.loadOutcome(provider: provider, scope: scope, migrateLegacy: false) {
+        case let .authoritative(entry, loadedFromLegacy):
             _ = self.commitDisplaySnapshotIfCurrent(key: key, entry: entry, generation: generation)
+            if loadedFromLegacy {
+                self.scheduleLegacyMigration(provider: provider)
+            }
         case .temporarilyUnavailable:
             self.deferDisplayRetryIfCurrent(key: key, generation: generation)
         }
         self.displayCacheLock.lock()
         self.displayRevalidationsInFlight.remove(key)
         self.displayCacheLock.unlock()
+    }
+
+    private static func scheduleLegacyMigration(provider: UsageProvider) {
+        self.displayCacheLock.lock()
+        let inserted = self.legacyMigrationsInFlight.insert(provider).inserted
+        self.displayCacheLock.unlock()
+        guard inserted else { return }
+        Task(priority: .utility) {
+            _ = self.migrateLegacyEntryIfNeeded(provider: provider)
+            _ = self.displayCacheLock.withLock {
+                self.legacyMigrationsInFlight.remove(provider)
+            }
+        }
     }
 
     /// Keychain reads for the display cache happen outside the lock, so a concurrent `store` or
@@ -227,6 +254,7 @@ public enum CookieHeaderCache {
         self.displayCache.removeAll()
         self.displayGenerations.removeAll()
         self.displayRevalidationsInFlight.removeAll()
+        self.legacyMigrationsInFlight.removeAll()
         self.displayCacheLock.unlock()
     }
 
@@ -260,20 +288,24 @@ public enum CookieHeaderCache {
     }
 
     public static func load(provider: UsageProvider, scope: Scope? = nil) -> Entry? {
-        switch self.loadOutcome(provider: provider, scope: scope) {
-        case let .authoritative(entry):
+        switch self.loadOutcome(provider: provider, scope: scope, migrateLegacy: true) {
+        case let .authoritative(entry, _):
             entry
         case .temporarilyUnavailable:
             nil
         }
     }
 
-    private static func loadOutcome(provider: UsageProvider, scope: Scope?) -> LoadOutcome {
+    private static func loadOutcome(
+        provider: UsageProvider,
+        scope: Scope?,
+        migrateLegacy: Bool) -> LoadOutcome
+    {
         let key = self.key(for: provider, scope: scope)
         switch KeychainCacheStore.load(key: key, as: Entry.self) {
         case let .found(entry):
             self.log.debug("Cookie cache hit", metadata: ["provider": provider.rawValue])
-            return .authoritative(entry)
+            return .authoritative(entry, loadedFromLegacy: false)
         case .temporarilyUnavailable:
             self.log.debug("Cookie cache temporarily unavailable", metadata: ["provider": provider.rawValue])
             return .temporarilyUnavailable
@@ -284,14 +316,49 @@ public enum CookieHeaderCache {
             self.log.debug("Cookie cache miss", metadata: ["provider": provider.rawValue])
         }
 
-        guard scope == nil else { return .authoritative(nil) }
-        guard let legacy = self.loadLegacyEntry(for: provider) else { return .authoritative(nil) }
-        if KeychainCacheStore.storeResult(key: key, entry: legacy) {
-            if self.removeLegacyEntry(for: provider) == .removed {
-                self.log.debug("Cookie cache migrated from legacy store", metadata: ["provider": provider.rawValue])
-            }
+        guard scope == nil else { return .authoritative(nil, loadedFromLegacy: false) }
+        if migrateLegacy {
+            return .authoritative(
+                self.migrateLegacyEntryIfNeeded(provider: provider),
+                loadedFromLegacy: false)
         }
-        return .authoritative(legacy)
+        guard let legacy = self.loadLegacyEntry(for: provider) else {
+            return .authoritative(nil, loadedFromLegacy: false)
+        }
+        return .authoritative(legacy, loadedFromLegacy: true)
+    }
+
+    /// Re-reads both stores while serialized with global cookie mutations. A display-triggered
+    /// migration may be queued before a clear, so using the captured legacy entry here would
+    /// otherwise allow the delayed task to restore credentials the user just removed.
+    private static func migrateLegacyEntryIfNeeded(provider: UsageProvider) -> Entry? {
+        do {
+            return try self.withLegacyMutationLock {
+                let key = self.key(for: provider, scope: nil)
+                switch KeychainCacheStore.load(key: key, as: Entry.self) {
+                case let .found(entry):
+                    _ = self.removeLegacyEntry(for: provider)
+                    return entry
+                case .temporarilyUnavailable:
+                    return nil
+                case .invalid:
+                    KeychainCacheStore.clear(key: key)
+                case .missing:
+                    break
+                }
+
+                guard let legacy = self.loadLegacyEntry(for: provider) else { return nil }
+                if KeychainCacheStore.storeResult(key: key, entry: legacy),
+                   self.removeLegacyEntry(for: provider) == .removed
+                {
+                    self.log.debug("Cookie cache migrated from legacy store", metadata: ["provider": provider.rawValue])
+                }
+                return legacy
+            }
+        } catch {
+            self.log.error("Cookie cache migration lock failed: \(error)")
+            return nil
+        }
     }
 
     public static func store(
@@ -307,6 +374,25 @@ public enum CookieHeaderCache {
             return
         }
         let entry = Entry(cookieHeader: normalized, storedAt: now, sourceLabel: sourceLabel)
+        if scope == nil {
+            do {
+                try self.withLegacyMutationLock {
+                    self.store(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
+                }
+            } catch {
+                self.log.error("Cookie cache store lock failed: \(error)")
+            }
+        } else {
+            self.store(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
+        }
+    }
+
+    private static func store(
+        entry: Entry,
+        provider: UsageProvider,
+        scope: Scope?,
+        sourceLabel: String)
+    {
         let key = self.key(for: provider, scope: scope)
         guard KeychainCacheStore.storeResult(key: key, entry: entry) else { return }
         self.updateDisplaySnapshot(key: key, entry: entry)
@@ -322,6 +408,20 @@ public enum CookieHeaderCache {
     }
 
     public static func clearDetailed(provider: UsageProvider, scope: Scope? = nil) -> ClearSummary {
+        if scope == nil {
+            do {
+                return try self.withLegacyMutationLock {
+                    self.clearDetailedLocked(provider: provider, scope: scope)
+                }
+            } catch {
+                self.log.error("Cookie cache clear lock failed: \(error)")
+                return ClearSummary(clearedCount: 0, failedCount: 1)
+            }
+        }
+        return self.clearDetailedLocked(provider: provider, scope: scope)
+    }
+
+    private static func clearDetailedLocked(provider: UsageProvider, scope: Scope?) -> ClearSummary {
         let key = self.key(for: provider, scope: scope)
         let result = KeychainCacheStore.clearResult(key: key)
         var cleared = result == .removed ? 1 : 0
@@ -354,6 +454,17 @@ public enum CookieHeaderCache {
     }
 
     public static func clearAllScopesDetailed(provider: UsageProvider) -> ClearSummary {
+        do {
+            return try self.withLegacyMutationLock {
+                self.clearAllScopesDetailedLocked(provider: provider)
+            }
+        } catch {
+            self.log.error("Cookie cache clearAllScopes lock failed: \(error)")
+            return ClearSummary(clearedCount: 0, failedCount: 1)
+        }
+    }
+
+    private static func clearAllScopesDetailedLocked(provider: UsageProvider) -> ClearSummary {
         let (keys, enumerationFailed) = self.cookieKeysResult(for: provider)
         var cleared = 0
         var failedKeys = Set<KeychainCacheStore.Key>()
@@ -392,6 +503,17 @@ public enum CookieHeaderCache {
     }
 
     public static func clearAllDetailed() -> ClearSummary {
+        do {
+            return try self.withLegacyMutationLock {
+                self.clearAllDetailedLocked()
+            }
+        } catch {
+            self.log.error("Cookie cache clearAll lock failed: \(error)")
+            return ClearSummary(clearedCount: 0, failedCount: 1)
+        }
+    }
+
+    private static func clearAllDetailedLocked() -> ClearSummary {
         self.displayCacheLock.lock()
         let knownDisplayKeys = Set(self.displayCache.keys).union(self.displayGenerations.keys)
         self.displayCacheLock.unlock()
@@ -514,6 +636,39 @@ public enum CookieHeaderCache {
 
     static func hasKeychainEntryForTesting(provider: UsageProvider, scope: Scope? = nil) -> Bool {
         self.hasKeychainEntry(provider: provider, scope: scope)
+    }
+
+    static func migrateLegacyEntryIfNeededForTesting(provider: UsageProvider) -> Entry? {
+        self.migrateLegacyEntryIfNeeded(provider: provider)
+    }
+
+    private static func withLegacyMutationLock<T>(_ operation: () throws -> T) throws -> T {
+        try self.legacyMutationLock.withLock {
+            let lockURL = self.legacyMutationLockURL
+            try FileManager.default.createDirectory(
+                at: lockURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true)
+            let fd = open(lockURL.path, O_CREAT | O_RDWR | O_CLOEXEC, S_IRUSR | S_IWUSR)
+            guard fd >= 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+            defer {
+                _ = flock(fd, LOCK_UN)
+                close(fd)
+            }
+            while flock(fd, LOCK_EX) != 0 {
+                guard errno == EINTR else {
+                    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                }
+            }
+            return try operation()
+        }
+    }
+
+    private static var legacyMutationLockURL: URL {
+        let base = self.legacyBaseURLOverride
+            ?? self.legacyURL(for: .codex).deletingLastPathComponent()
+        return base.appendingPathComponent("cookie-cache.lock")
     }
 
     private static func removeLegacyEntry(for provider: UsageProvider) -> LegacyRemovalResult {

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -50,10 +50,7 @@ public enum CookieHeaderCache {
     /// first lookup per key pays the keychain read.
     public static func loadForDisplay(provider: UsageProvider, scope: Scope? = nil) -> Entry? {
         let key = self.key(for: provider, scope: scope)
-        self.displayCacheLock.lock()
-        let cached = self.displayCache[key]
-        let generation = self.displayGenerations[key, default: 0]
-        self.displayCacheLock.unlock()
+        let (cached, generation) = self.beginDisplayRead(key: key)
         guard let cached else {
             let entry = self.load(provider: provider, scope: scope)
             return self.commitDisplaySnapshotIfCurrent(key: key, entry: entry, generation: generation)
@@ -62,6 +59,16 @@ public enum CookieHeaderCache {
             self.scheduleDisplayRevalidation(provider: provider, scope: scope, key: key, generation: generation)
         }
         return cached.entry
+    }
+
+    /// Registers the key before the Keychain read starts so `clearAll` can invalidate an
+    /// in-flight first population even when no display snapshot exists yet.
+    private static func beginDisplayRead(key: KeychainCacheStore.Key) -> (DisplaySnapshot?, UInt64) {
+        self.displayCacheLock.lock()
+        defer { self.displayCacheLock.unlock() }
+        let generation = self.displayGenerations[key] ?? 0
+        self.displayGenerations[key] = generation
+        return (self.displayCache[key], generation)
     }
 
     private static func scheduleDisplayRevalidation(
@@ -133,11 +140,8 @@ public enum CookieHeaderCache {
         self.displayCacheLock.unlock()
     }
 
-    static func displayGenerationForTesting(provider: UsageProvider, scope: Scope? = nil) -> UInt64 {
-        let key = self.key(for: provider, scope: scope)
-        self.displayCacheLock.lock()
-        defer { self.displayCacheLock.unlock() }
-        return self.displayGenerations[key, default: 0]
+    static func beginDisplayReadGenerationForTesting(provider: UsageProvider, scope: Scope? = nil) -> UInt64 {
+        self.beginDisplayRead(key: self.key(for: provider, scope: scope)).1
     }
 
     @discardableResult

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -30,6 +30,86 @@ public enum CookieHeaderCache {
     private static let log = CodexBarLog.logger(LogCategories.cookieCache)
     private nonisolated(unsafe) static var legacyBaseURLOverride: URL?
 
+    private struct DisplaySnapshot {
+        let entry: Entry?
+        let loadedAt: Date
+    }
+
+    private static let displayCacheLock = NSLock()
+    private nonisolated(unsafe) static var displayCache: [KeychainCacheStore.Key: DisplaySnapshot] = [:]
+    private nonisolated(unsafe) static var displayRevalidationsInFlight: Set<KeychainCacheStore.Key> = []
+    private nonisolated(unsafe) static var displayStalenessIntervalOverride: TimeInterval?
+    private static let displayStalenessInterval: TimeInterval = 30
+
+    /// Settings rows render the "Cached: …" cookie label inside SwiftUI body evaluations, which
+    /// run repeatedly within a single AppKit layout pass. Each `load` pays a synchronous
+    /// securityd round-trip and decrypt, so display paths use this memoized variant instead: it
+    /// returns the last known entry immediately and revalidates a stale snapshot off the calling
+    /// path. In-process `store` and `clear` calls update the snapshot synchronously; only the
+    /// first lookup per key pays the keychain read.
+    public static func loadForDisplay(provider: UsageProvider, scope: Scope? = nil) -> Entry? {
+        let key = self.key(for: provider, scope: scope)
+        self.displayCacheLock.lock()
+        let cached = self.displayCache[key]
+        self.displayCacheLock.unlock()
+        guard let cached else {
+            let entry = self.load(provider: provider, scope: scope)
+            self.updateDisplaySnapshot(key: key, entry: entry)
+            return entry
+        }
+        if Date().timeIntervalSince(cached.loadedAt) >= self.currentDisplayStalenessInterval {
+            self.scheduleDisplayRevalidation(provider: provider, scope: scope, key: key)
+        }
+        return cached.entry
+    }
+
+    private static func scheduleDisplayRevalidation(
+        provider: UsageProvider,
+        scope: Scope?,
+        key: KeychainCacheStore.Key)
+    {
+        self.displayCacheLock.lock()
+        let inserted = self.displayRevalidationsInFlight.insert(key).inserted
+        self.displayCacheLock.unlock()
+        guard inserted else { return }
+        Task(priority: .utility) {
+            self.revalidateDisplaySnapshot(provider: provider, scope: scope, key: key)
+        }
+    }
+
+    private static func revalidateDisplaySnapshot(
+        provider: UsageProvider,
+        scope: Scope?,
+        key: KeychainCacheStore.Key)
+    {
+        let entry = self.load(provider: provider, scope: scope)
+        self.displayCacheLock.lock()
+        self.displayCache[key] = DisplaySnapshot(entry: entry, loadedAt: Date())
+        self.displayRevalidationsInFlight.remove(key)
+        self.displayCacheLock.unlock()
+    }
+
+    private static func updateDisplaySnapshot(key: KeychainCacheStore.Key, entry: Entry?) {
+        self.displayCacheLock.lock()
+        self.displayCache[key] = DisplaySnapshot(entry: entry, loadedAt: Date())
+        self.displayCacheLock.unlock()
+    }
+
+    private static var currentDisplayStalenessInterval: TimeInterval {
+        self.displayStalenessIntervalOverride ?? self.displayStalenessInterval
+    }
+
+    static func setDisplayStalenessIntervalOverrideForTesting(_ interval: TimeInterval?) {
+        self.displayStalenessIntervalOverride = interval
+    }
+
+    static func resetDisplayCacheForTesting() {
+        self.displayCacheLock.lock()
+        self.displayCache.removeAll()
+        self.displayRevalidationsInFlight.removeAll()
+        self.displayCacheLock.unlock()
+    }
+
     public static func load(provider: UsageProvider, scope: Scope? = nil) -> Entry? {
         let key = self.key(for: provider, scope: scope)
         switch KeychainCacheStore.load(key: key, as: Entry.self) {
@@ -69,6 +149,7 @@ public enum CookieHeaderCache {
         let entry = Entry(cookieHeader: normalized, storedAt: now, sourceLabel: sourceLabel)
         let key = self.key(for: provider, scope: scope)
         KeychainCacheStore.store(key: key, entry: entry)
+        self.updateDisplaySnapshot(key: key, entry: entry)
         if scope == nil {
             self.removeLegacyEntry(for: provider)
         }
@@ -79,6 +160,7 @@ public enum CookieHeaderCache {
     public static func clear(provider: UsageProvider, scope: Scope? = nil) -> Int {
         let key = self.key(for: provider, scope: scope)
         var cleared = KeychainCacheStore.clear(key: key) ? 1 : 0
+        self.updateDisplaySnapshot(key: key, entry: nil)
         if scope == nil, self.removeLegacyEntry(for: provider) {
             cleared += 1
         }
@@ -92,8 +174,11 @@ public enum CookieHeaderCache {
     public static func clearAllScopes(provider: UsageProvider) -> Int {
         let keys = self.cookieKeys(for: provider)
         var cleared = 0
-        for key in keys where KeychainCacheStore.clear(key: key) {
-            cleared += 1
+        for key in keys {
+            if KeychainCacheStore.clear(key: key) {
+                cleared += 1
+            }
+            self.updateDisplaySnapshot(key: key, entry: nil)
         }
         if self.removeLegacyEntry(for: provider) {
             cleared += 1
@@ -116,6 +201,9 @@ public enum CookieHeaderCache {
         for provider in UsageProvider.allCases where self.removeLegacyEntry(for: provider) {
             cleared += 1
         }
+        self.displayCacheLock.lock()
+        self.displayCache.removeAll()
+        self.displayCacheLock.unlock()
         self.log.debug("Cookie cache clearAll completed", metadata: ["cleared": "\(cleared)"])
         return cleared
     }

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -37,6 +37,7 @@ public enum CookieHeaderCache {
 
     private static let displayCacheLock = NSLock()
     private nonisolated(unsafe) static var displayCache: [KeychainCacheStore.Key: DisplaySnapshot] = [:]
+    private nonisolated(unsafe) static var displayGenerations: [KeychainCacheStore.Key: UInt64] = [:]
     private nonisolated(unsafe) static var displayRevalidationsInFlight: Set<KeychainCacheStore.Key> = []
     private nonisolated(unsafe) static var displayStalenessIntervalOverride: TimeInterval?
     private static let displayStalenessInterval: TimeInterval = 30
@@ -51,14 +52,14 @@ public enum CookieHeaderCache {
         let key = self.key(for: provider, scope: scope)
         self.displayCacheLock.lock()
         let cached = self.displayCache[key]
+        let generation = self.displayGenerations[key, default: 0]
         self.displayCacheLock.unlock()
         guard let cached else {
             let entry = self.load(provider: provider, scope: scope)
-            self.updateDisplaySnapshot(key: key, entry: entry)
-            return entry
+            return self.commitDisplaySnapshotIfCurrent(key: key, entry: entry, generation: generation)
         }
         if Date().timeIntervalSince(cached.loadedAt) >= self.currentDisplayStalenessInterval {
-            self.scheduleDisplayRevalidation(provider: provider, scope: scope, key: key)
+            self.scheduleDisplayRevalidation(provider: provider, scope: scope, key: key, generation: generation)
         }
         return cached.entry
     }
@@ -66,32 +67,53 @@ public enum CookieHeaderCache {
     private static func scheduleDisplayRevalidation(
         provider: UsageProvider,
         scope: Scope?,
-        key: KeychainCacheStore.Key)
+        key: KeychainCacheStore.Key,
+        generation: UInt64)
     {
         self.displayCacheLock.lock()
         let inserted = self.displayRevalidationsInFlight.insert(key).inserted
         self.displayCacheLock.unlock()
         guard inserted else { return }
         Task(priority: .utility) {
-            self.revalidateDisplaySnapshot(provider: provider, scope: scope, key: key)
+            self.revalidateDisplaySnapshot(provider: provider, scope: scope, key: key, generation: generation)
         }
     }
 
     private static func revalidateDisplaySnapshot(
         provider: UsageProvider,
         scope: Scope?,
-        key: KeychainCacheStore.Key)
+        key: KeychainCacheStore.Key,
+        generation: UInt64)
     {
         let entry = self.load(provider: provider, scope: scope)
+        _ = self.commitDisplaySnapshotIfCurrent(key: key, entry: entry, generation: generation)
         self.displayCacheLock.lock()
-        self.displayCache[key] = DisplaySnapshot(entry: entry, loadedAt: Date())
         self.displayRevalidationsInFlight.remove(key)
         self.displayCacheLock.unlock()
+    }
+
+    /// Keychain reads for the display cache happen outside the lock, so a concurrent `store` or
+    /// `clear` can publish newer state before the read commits. Each mutation bumps the per-key
+    /// generation; a read only commits if the generation it started from is still current, and
+    /// otherwise returns whatever newer snapshot won the race.
+    private static func commitDisplaySnapshotIfCurrent(
+        key: KeychainCacheStore.Key,
+        entry: Entry?,
+        generation: UInt64) -> Entry?
+    {
+        self.displayCacheLock.lock()
+        defer { self.displayCacheLock.unlock() }
+        guard self.displayGenerations[key, default: 0] == generation else {
+            return self.displayCache[key]?.entry
+        }
+        self.displayCache[key] = DisplaySnapshot(entry: entry, loadedAt: Date())
+        return entry
     }
 
     private static func updateDisplaySnapshot(key: KeychainCacheStore.Key, entry: Entry?) {
         self.displayCacheLock.lock()
         self.displayCache[key] = DisplaySnapshot(entry: entry, loadedAt: Date())
+        self.displayGenerations[key, default: 0] += 1
         self.displayCacheLock.unlock()
     }
 
@@ -106,8 +128,29 @@ public enum CookieHeaderCache {
     static func resetDisplayCacheForTesting() {
         self.displayCacheLock.lock()
         self.displayCache.removeAll()
+        self.displayGenerations.removeAll()
         self.displayRevalidationsInFlight.removeAll()
         self.displayCacheLock.unlock()
+    }
+
+    static func displayGenerationForTesting(provider: UsageProvider, scope: Scope? = nil) -> UInt64 {
+        let key = self.key(for: provider, scope: scope)
+        self.displayCacheLock.lock()
+        defer { self.displayCacheLock.unlock() }
+        return self.displayGenerations[key, default: 0]
+    }
+
+    @discardableResult
+    static func commitDisplaySnapshotIfCurrentForTesting(
+        provider: UsageProvider,
+        scope: Scope? = nil,
+        entry: Entry?,
+        generation: UInt64) -> Entry?
+    {
+        self.commitDisplaySnapshotIfCurrent(
+            key: self.key(for: provider, scope: scope),
+            entry: entry,
+            generation: generation)
     }
 
     public static func load(provider: UsageProvider, scope: Scope? = nil) -> Entry? {
@@ -202,6 +245,9 @@ public enum CookieHeaderCache {
             cleared += 1
         }
         self.displayCacheLock.lock()
+        for key in Set(self.displayCache.keys).union(self.displayGenerations.keys) {
+            self.displayGenerations[key, default: 0] += 1
+        }
         self.displayCache.removeAll()
         self.displayCacheLock.unlock()
         self.log.debug("Cookie cache clearAll completed", metadata: ["cleared": "\(cleared)"])

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -27,12 +27,27 @@ public enum CookieHeaderCache {
         }
     }
 
+    public struct ClearSummary: Equatable, Sendable {
+        public let clearedCount: Int
+        public let failedCount: Int
+
+        public init(clearedCount: Int, failedCount: Int) {
+            self.clearedCount = clearedCount
+            self.failedCount = failedCount
+        }
+    }
+
     private static let log = CodexBarLog.logger(LogCategories.cookieCache)
     private nonisolated(unsafe) static var legacyBaseURLOverride: URL?
 
     private struct DisplaySnapshot {
         let entry: Entry?
-        let loadedAt: Date
+        let refreshAfter: Date
+    }
+
+    private enum LoadOutcome {
+        case authoritative(Entry?)
+        case temporarilyUnavailable
     }
 
     private static let displayCacheLock = NSLock()
@@ -40,7 +55,18 @@ public enum CookieHeaderCache {
     private nonisolated(unsafe) static var displayGenerations: [KeychainCacheStore.Key: UInt64] = [:]
     private nonisolated(unsafe) static var displayRevalidationsInFlight: Set<KeychainCacheStore.Key> = []
     private nonisolated(unsafe) static var displayStalenessIntervalOverride: TimeInterval?
+    private nonisolated(unsafe) static var displayUnavailableRetryIntervalOverride: TimeInterval?
     private static let displayStalenessInterval: TimeInterval = 30
+    private static let displayUnavailableRetryInterval: TimeInterval = 1
+    #if DEBUG
+    @TaskLocal private static var legacyRemovalFailureOverride = false
+    #endif
+
+    private enum LegacyRemovalResult: Equatable {
+        case removed
+        case missing
+        case failed
+    }
 
     /// Settings rows render the "Cached: …" cookie label inside SwiftUI body evaluations, which
     /// run repeatedly within a single AppKit layout pass. Each `load` pays a synchronous
@@ -52,10 +78,14 @@ public enum CookieHeaderCache {
         let key = self.key(for: provider, scope: scope)
         let (cached, generation) = self.beginDisplayRead(key: key)
         guard let cached else {
-            let entry = self.load(provider: provider, scope: scope)
-            return self.commitDisplaySnapshotIfCurrent(key: key, entry: entry, generation: generation)
+            switch self.loadOutcome(provider: provider, scope: scope) {
+            case let .authoritative(entry):
+                return self.commitDisplaySnapshotIfCurrent(key: key, entry: entry, generation: generation)
+            case .temporarilyUnavailable:
+                return self.commitTemporaryDisplaySnapshotIfCurrent(key: key, generation: generation)
+            }
         }
-        if Date().timeIntervalSince(cached.loadedAt) >= self.currentDisplayStalenessInterval {
+        if Date() >= cached.refreshAfter {
             self.scheduleDisplayRevalidation(provider: provider, scope: scope, key: key, generation: generation)
         }
         return cached.entry
@@ -92,8 +122,12 @@ public enum CookieHeaderCache {
         key: KeychainCacheStore.Key,
         generation: UInt64)
     {
-        let entry = self.load(provider: provider, scope: scope)
-        _ = self.commitDisplaySnapshotIfCurrent(key: key, entry: entry, generation: generation)
+        switch self.loadOutcome(provider: provider, scope: scope) {
+        case let .authoritative(entry):
+            _ = self.commitDisplaySnapshotIfCurrent(key: key, entry: entry, generation: generation)
+        case .temporarilyUnavailable:
+            self.deferDisplayRetryIfCurrent(key: key, generation: generation)
+        }
         self.displayCacheLock.lock()
         self.displayRevalidationsInFlight.remove(key)
         self.displayCacheLock.unlock()
@@ -113,23 +147,79 @@ public enum CookieHeaderCache {
         guard self.displayGenerations[key, default: 0] == generation else {
             return self.displayCache[key]?.entry
         }
-        self.displayCache[key] = DisplaySnapshot(entry: entry, loadedAt: Date())
+        self.displayCache[key] = self.authoritativeDisplaySnapshot(entry: entry)
         return entry
+    }
+
+    private static func commitTemporaryDisplaySnapshotIfCurrent(
+        key: KeychainCacheStore.Key,
+        generation: UInt64) -> Entry?
+    {
+        self.displayCacheLock.lock()
+        defer { self.displayCacheLock.unlock() }
+        guard self.displayGenerations[key, default: 0] == generation else {
+            return self.displayCache[key]?.entry
+        }
+        if let current = self.displayCache[key] {
+            return current.entry
+        }
+        self.displayCache[key] = self.temporaryDisplaySnapshot(entry: nil)
+        return nil
+    }
+
+    private static func deferDisplayRetryIfCurrent(key: KeychainCacheStore.Key, generation: UInt64) {
+        self.displayCacheLock.lock()
+        defer { self.displayCacheLock.unlock() }
+        guard self.displayGenerations[key, default: 0] == generation,
+              let current = self.displayCache[key]
+        else { return }
+        self.displayCache[key] = self.temporaryDisplaySnapshot(entry: current.entry)
     }
 
     private static func updateDisplaySnapshot(key: KeychainCacheStore.Key, entry: Entry?) {
         self.displayCacheLock.lock()
-        self.displayCache[key] = DisplaySnapshot(entry: entry, loadedAt: Date())
+        self.displayCache[key] = self.authoritativeDisplaySnapshot(entry: entry)
         self.displayGenerations[key, default: 0] += 1
         self.displayCacheLock.unlock()
+    }
+
+    private static func invalidateDisplaySnapshot(key: KeychainCacheStore.Key) {
+        self.displayCacheLock.lock()
+        self.displayCache.removeValue(forKey: key)
+        self.displayGenerations[key, default: 0] += 1
+        self.displayCacheLock.unlock()
+    }
+
+    private static func currentDisplayEntry(key: KeychainCacheStore.Key) -> Entry? {
+        self.displayCacheLock.lock()
+        defer { self.displayCacheLock.unlock() }
+        return self.displayCache[key]?.entry
+    }
+
+    private static func authoritativeDisplaySnapshot(entry: Entry?) -> DisplaySnapshot {
+        DisplaySnapshot(entry: entry, refreshAfter: Date().addingTimeInterval(self.currentDisplayStalenessInterval))
+    }
+
+    private static func temporaryDisplaySnapshot(entry: Entry?) -> DisplaySnapshot {
+        DisplaySnapshot(
+            entry: entry,
+            refreshAfter: Date().addingTimeInterval(self.currentDisplayUnavailableRetryInterval))
     }
 
     private static var currentDisplayStalenessInterval: TimeInterval {
         self.displayStalenessIntervalOverride ?? self.displayStalenessInterval
     }
 
+    private static var currentDisplayUnavailableRetryInterval: TimeInterval {
+        self.displayUnavailableRetryIntervalOverride ?? self.displayUnavailableRetryInterval
+    }
+
     static func setDisplayStalenessIntervalOverrideForTesting(_ interval: TimeInterval?) {
         self.displayStalenessIntervalOverride = interval
+    }
+
+    static func setDisplayUnavailableRetryIntervalOverrideForTesting(_ interval: TimeInterval?) {
+        self.displayUnavailableRetryIntervalOverride = interval
     }
 
     static func resetDisplayCacheForTesting() {
@@ -143,6 +233,18 @@ public enum CookieHeaderCache {
     static func beginDisplayReadGenerationForTesting(provider: UsageProvider, scope: Scope? = nil) -> UInt64 {
         self.beginDisplayRead(key: self.key(for: provider, scope: scope)).1
     }
+
+    static func currentDisplayEntryForTesting(provider: UsageProvider, scope: Scope? = nil) -> Entry? {
+        self.currentDisplayEntry(key: self.key(for: provider, scope: scope))
+    }
+
+    #if DEBUG
+    static func withLegacyRemovalFailureForTesting<T>(_ operation: () throws -> T) rethrows -> T {
+        try self.$legacyRemovalFailureOverride.withValue(true) {
+            try operation()
+        }
+    }
+    #endif
 
     @discardableResult
     static func commitDisplaySnapshotIfCurrentForTesting(
@@ -158,14 +260,23 @@ public enum CookieHeaderCache {
     }
 
     public static func load(provider: UsageProvider, scope: Scope? = nil) -> Entry? {
+        switch self.loadOutcome(provider: provider, scope: scope) {
+        case let .authoritative(entry):
+            entry
+        case .temporarilyUnavailable:
+            nil
+        }
+    }
+
+    private static func loadOutcome(provider: UsageProvider, scope: Scope?) -> LoadOutcome {
         let key = self.key(for: provider, scope: scope)
         switch KeychainCacheStore.load(key: key, as: Entry.self) {
         case let .found(entry):
             self.log.debug("Cookie cache hit", metadata: ["provider": provider.rawValue])
-            return entry
+            return .authoritative(entry)
         case .temporarilyUnavailable:
             self.log.debug("Cookie cache temporarily unavailable", metadata: ["provider": provider.rawValue])
-            return nil
+            return .temporarilyUnavailable
         case .invalid:
             self.log.warning("Cookie cache invalid; clearing", metadata: ["provider": provider.rawValue])
             KeychainCacheStore.clear(key: key)
@@ -173,12 +284,14 @@ public enum CookieHeaderCache {
             self.log.debug("Cookie cache miss", metadata: ["provider": provider.rawValue])
         }
 
-        guard scope == nil else { return nil }
-        guard let legacy = self.loadLegacyEntry(for: provider) else { return nil }
-        KeychainCacheStore.store(key: key, entry: legacy)
-        self.removeLegacyEntry(for: provider)
-        self.log.debug("Cookie cache migrated from legacy store", metadata: ["provider": provider.rawValue])
-        return legacy
+        guard scope == nil else { return .authoritative(nil) }
+        guard let legacy = self.loadLegacyEntry(for: provider) else { return .authoritative(nil) }
+        if KeychainCacheStore.storeResult(key: key, entry: legacy) {
+            if self.removeLegacyEntry(for: provider) == .removed {
+                self.log.debug("Cookie cache migrated from legacy store", metadata: ["provider": provider.rawValue])
+            }
+        }
+        return .authoritative(legacy)
     }
 
     public static func store(
@@ -195,75 +308,154 @@ public enum CookieHeaderCache {
         }
         let entry = Entry(cookieHeader: normalized, storedAt: now, sourceLabel: sourceLabel)
         let key = self.key(for: provider, scope: scope)
-        KeychainCacheStore.store(key: key, entry: entry)
+        guard KeychainCacheStore.storeResult(key: key, entry: entry) else { return }
         self.updateDisplaySnapshot(key: key, entry: entry)
         if scope == nil {
-            self.removeLegacyEntry(for: provider)
+            _ = self.removeLegacyEntry(for: provider)
         }
         self.log.debug("Cookie cache stored", metadata: ["provider": provider.rawValue, "source": sourceLabel])
     }
 
     @discardableResult
     public static func clear(provider: UsageProvider, scope: Scope? = nil) -> Int {
+        self.clearDetailed(provider: provider, scope: scope).clearedCount
+    }
+
+    public static func clearDetailed(provider: UsageProvider, scope: Scope? = nil) -> ClearSummary {
         let key = self.key(for: provider, scope: scope)
-        var cleared = KeychainCacheStore.clear(key: key) ? 1 : 0
-        self.updateDisplaySnapshot(key: key, entry: nil)
-        if scope == nil, self.removeLegacyEntry(for: provider) {
+        let result = KeychainCacheStore.clearResult(key: key)
+        var cleared = result == .removed ? 1 : 0
+        var failed = result == .failed ? 1 : 0
+        if result != .failed {
+            self.updateDisplaySnapshot(key: key, entry: nil)
+        }
+        let legacyResult: LegacyRemovalResult = if scope == nil {
+            self.removeLegacyEntry(for: provider)
+        } else {
+            .missing
+        }
+        if legacyResult == .removed {
             cleared += 1
+            if result == .failed {
+                self.invalidateDisplaySnapshot(key: key)
+            }
+        } else if legacyResult == .failed {
+            failed += 1
         }
         self.log.debug("Cookie cache cleared", metadata: ["provider": provider.rawValue])
-        return cleared
+        return ClearSummary(clearedCount: cleared, failedCount: failed)
     }
 
     /// Clears all cookie cache scopes for one provider, including managed Codex account scopes.
-    /// Returns the number of keychain or legacy-file entries removed.
+    /// Returns keychain/legacy removal and failure counts.
     @discardableResult
     public static func clearAllScopes(provider: UsageProvider) -> Int {
-        let keys = self.cookieKeys(for: provider)
+        self.clearAllScopesDetailed(provider: provider).clearedCount
+    }
+
+    public static func clearAllScopesDetailed(provider: UsageProvider) -> ClearSummary {
+        let (keys, enumerationFailed) = self.cookieKeysResult(for: provider)
         var cleared = 0
+        var failedKeys = Set<KeychainCacheStore.Key>()
         for key in keys {
-            if KeychainCacheStore.clear(key: key) {
+            let result = KeychainCacheStore.clearResult(key: key)
+            if result == .removed {
                 cleared += 1
             }
-            self.updateDisplaySnapshot(key: key, entry: nil)
+            if result != .failed {
+                self.updateDisplaySnapshot(key: key, entry: nil)
+            } else {
+                failedKeys.insert(key)
+            }
         }
-        if self.removeLegacyEntry(for: provider) {
+        let legacyResult = self.removeLegacyEntry(for: provider)
+        if legacyResult == .removed {
             cleared += 1
+            let globalKey = self.key(for: provider, scope: nil)
+            if failedKeys.contains(globalKey) {
+                self.invalidateDisplaySnapshot(key: globalKey)
+            }
         }
+        let failedCount = failedKeys.count + (enumerationFailed ? 1 : 0) + (legacyResult == .failed ? 1 : 0)
         self.log.debug("Cookie cache clearAllScopes completed", metadata: [
             "provider": provider.rawValue,
             "cleared": "\(cleared)",
         ])
-        return cleared
+        return ClearSummary(clearedCount: cleared, failedCount: failedCount)
     }
 
     /// Clears cookie caches for all providers, including corrupt/invalid entries.
-    /// Returns the number of keychain or legacy-file entries removed.
+    /// Returns keychain/legacy removal and failure counts.
     @discardableResult
     public static func clearAll() -> Int {
-        var cleared = 0
-        for key in KeychainCacheStore.keys(category: "cookie") where KeychainCacheStore.clear(key: key) {
-            cleared += 1
-        }
-        for provider in UsageProvider.allCases where self.removeLegacyEntry(for: provider) {
-            cleared += 1
-        }
-        self.displayCacheLock.lock()
-        for key in Set(self.displayCache.keys).union(self.displayGenerations.keys) {
-            self.displayGenerations[key, default: 0] += 1
-        }
-        self.displayCache.removeAll()
-        self.displayCacheLock.unlock()
-        self.log.debug("Cookie cache clearAll completed", metadata: ["cleared": "\(cleared)"])
-        return cleared
+        self.clearAllDetailed().clearedCount
     }
 
-    private static func cookieKeys(for provider: UsageProvider) -> [KeychainCacheStore.Key] {
+    public static func clearAllDetailed() -> ClearSummary {
+        self.displayCacheLock.lock()
+        let knownDisplayKeys = Set(self.displayCache.keys).union(self.displayGenerations.keys)
+        self.displayCacheLock.unlock()
+        let enumeratedKeys: [KeychainCacheStore.Key]
+        let enumerationFailed: Bool
+        switch KeychainCacheStore.keysResult(category: "cookie") {
+        case let .found(keys):
+            enumeratedKeys = keys
+            enumerationFailed = false
+        case .temporarilyUnavailable, .failed:
+            enumeratedKeys = []
+            enumerationFailed = true
+        }
+        let keys = Set(enumeratedKeys).union(knownDisplayKeys)
+        var cleared = 0
+        var failedKeys = Set<KeychainCacheStore.Key>()
+        for key in keys {
+            let result = KeychainCacheStore.clearResult(key: key)
+            if result == .removed {
+                cleared += 1
+            }
+            if result != .failed {
+                self.updateDisplaySnapshot(key: key, entry: nil)
+            } else {
+                failedKeys.insert(key)
+            }
+        }
+        var legacyFailures = 0
+        for provider in UsageProvider.allCases {
+            switch self.removeLegacyEntry(for: provider) {
+            case .removed:
+                cleared += 1
+                let globalKey = self.key(for: provider, scope: nil)
+                if failedKeys.contains(globalKey) {
+                    self.invalidateDisplaySnapshot(key: globalKey)
+                }
+            case .failed:
+                legacyFailures += 1
+            case .missing:
+                break
+            }
+        }
+        self.log.debug("Cookie cache clearAll completed", metadata: ["cleared": "\(cleared)"])
+        return ClearSummary(
+            clearedCount: cleared,
+            failedCount: failedKeys.count + (enumerationFailed ? 1 : 0) + legacyFailures)
+    }
+
+    private static func cookieKeysResult(for provider: UsageProvider) -> ([KeychainCacheStore.Key], Bool) {
         let exactIdentifier = provider.rawValue
         let scopedPrefix = "\(provider.rawValue)."
         var seen = Set<KeychainCacheStore.Key>()
         var keys: [KeychainCacheStore.Key] = []
-        for key in KeychainCacheStore.keys(category: "cookie") {
+        let enumeratedKeys: [KeychainCacheStore.Key]
+        let enumerationFailed: Bool
+        switch KeychainCacheStore.keysResult(category: "cookie") {
+        case let .found(keys):
+            enumeratedKeys = keys
+            enumerationFailed = false
+        case .temporarilyUnavailable, .failed:
+            enumeratedKeys = []
+            enumerationFailed = true
+        }
+        for key in enumeratedKeys {
             guard key.identifier == exactIdentifier || key.identifier.hasPrefix(scopedPrefix) else {
                 continue
             }
@@ -275,7 +467,7 @@ public enum CookieHeaderCache {
         if seen.insert(global).inserted {
             keys.append(global)
         }
-        return keys
+        return (keys, enumerationFailed)
     }
 
     static func load(from url: URL) -> Entry? {
@@ -324,18 +516,23 @@ public enum CookieHeaderCache {
         self.hasKeychainEntry(provider: provider, scope: scope)
     }
 
-    @discardableResult
-    private static func removeLegacyEntry(for provider: UsageProvider) -> Bool {
+    private static func removeLegacyEntry(for provider: UsageProvider) -> LegacyRemovalResult {
         let url = self.legacyURL(for: provider)
+        #if DEBUG
+        if self.legacyRemovalFailureOverride {
+            return .failed
+        }
+        #endif
         let existed = FileManager.default.fileExists(atPath: url.path)
         do {
             try FileManager.default.removeItem(at: url)
-            return existed
+            return existed ? .removed : .missing
         } catch {
             if (error as NSError).code != NSFileNoSuchFileError {
                 Self.log.error("Failed to remove cookie cache (\(provider.rawValue)): \(error)")
+                return .failed
             }
-            return false
+            return .missing
         }
     }
 

--- a/Sources/CodexBarCore/KeychainCacheStore.swift
+++ b/Sources/CodexBarCore/KeychainCacheStore.swift
@@ -26,6 +26,18 @@ public enum KeychainCacheStore {
         case invalid
     }
 
+    public enum ClearResult: Equatable, Sendable {
+        case removed
+        case missing
+        case failed
+    }
+
+    public enum KeysResult: Equatable, Sendable {
+        case found([Key])
+        case temporarilyUnavailable
+        case failed
+    }
+
     private static let log = CodexBarLog.logger(LogCategories.keychainCache)
     private static let cacheService = "com.steipete.codexbar.cache"
     private static let cacheLabel = "CodexBar Cache"
@@ -33,6 +45,9 @@ public enum KeychainCacheStore {
     @TaskLocal private static var serviceOverride: String?
     #if DEBUG && os(macOS)
     @TaskLocal private static var loadFailureStatusOverride: OSStatus?
+    @TaskLocal private static var storeFailureStatusOverride: OSStatus?
+    @TaskLocal private static var clearFailureStatusOverride: OSStatus?
+    @TaskLocal private static var keysFailureStatusOverride: OSStatus?
     #endif
     private static let testStoreLock = NSLock()
     private struct TestStoreKey: Hashable {
@@ -90,15 +105,26 @@ public enum KeychainCacheStore {
     }
 
     public static func store(key: Key, entry: some Codable) {
-        if self.storeInTestStore(key: key, entry: entry) {
-            return
+        _ = self.storeResult(key: key, entry: entry)
+    }
+
+    @discardableResult
+    public static func storeResult(key: Key, entry: some Codable) -> Bool {
+        #if DEBUG && os(macOS)
+        if let status = self.storeFailureStatusOverride {
+            self.log.error("Keychain cache store failed (\(key.account)): \(status)")
+            return false
         }
-        guard self.canUseRealKeychain else { return }
+        #endif
+        if let stored = self.storeInTestStore(key: key, entry: entry) {
+            return stored
+        }
+        guard self.canUseRealKeychain else { return false }
         #if os(macOS)
         let encoder = Self.makeEncoder()
         guard let data = try? encoder.encode(entry) else {
             self.log.error("Failed to encode keychain cache (\(key.account))")
-            return
+            return false
         }
 
         var query: [String: Any] = [
@@ -112,11 +138,11 @@ public enum KeychainCacheStore {
             query as CFDictionary,
             [kSecValueData as String: data] as CFDictionary)
         if updateStatus == errSecSuccess {
-            return
+            return true
         }
         if updateStatus != errSecItemNotFound {
             self.log.error("Keychain cache update failed (\(key.account)): \(updateStatus)")
-            return
+            return false
         }
 
         var addQuery = query
@@ -131,15 +157,27 @@ public enum KeychainCacheStore {
         if addStatus != errSecSuccess {
             self.log.error("Keychain cache add failed (\(key.account)): \(addStatus)")
         }
+        return addStatus == errSecSuccess
+        #else
+        return false
         #endif
     }
 
     @discardableResult
     public static func clear(key: Key) -> Bool {
-        if let removed = self.clearTestStore(key: key) {
-            return removed
+        self.clearResult(key: key) == .removed
+    }
+
+    public static func clearResult(key: Key) -> ClearResult {
+        #if DEBUG && os(macOS)
+        if let status = self.clearFailureStatusOverride {
+            return self.clearResultForKeychainDeleteStatus(status, key: key)
         }
-        guard self.canUseRealKeychain else { return false }
+        #endif
+        if let removed = self.clearTestStore(key: key) {
+            return removed ? .removed : .missing
+        }
+        guard self.canUseRealKeychain else { return .failed }
         #if os(macOS)
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -149,15 +187,29 @@ public enum KeychainCacheStore {
         KeychainNoUIQuery.apply(to: &query)
         return self.clearResultForKeychainDeleteStatus(SecItemDelete(query as CFDictionary), key: key)
         #else
-        return false
+        return .failed
         #endif
     }
 
     public static func keys(category: String) -> [Key] {
-        if let keys = self.keysFromTestStore(category: category) {
-            return keys
+        switch self.keysResult(category: category) {
+        case let .found(keys):
+            keys
+        case .temporarilyUnavailable, .failed:
+            []
         }
-        guard self.canUseRealKeychain else { return [] }
+    }
+
+    public static func keysResult(category: String) -> KeysResult {
+        #if DEBUG && os(macOS)
+        if let status = self.keysFailureStatusOverride {
+            return self.keysResultForKeychainStatus(status, category: category, result: nil)
+        }
+        #endif
+        if let keys = self.keysFromTestStore(category: category) {
+            return .found(keys)
+        }
+        guard self.canUseRealKeychain else { return .failed }
         #if os(macOS)
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -169,24 +221,9 @@ public enum KeychainCacheStore {
 
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
-        switch status {
-        case errSecSuccess:
-            guard let rows = result as? [[String: Any]] else { return [] }
-            return rows.compactMap { row in
-                guard let account = row[kSecAttrAccount as String] as? String else { return nil }
-                return self.key(fromAccount: account, category: category)
-            }
-        case errSecItemNotFound:
-            return []
-        case errSecInteractionNotAllowed:
-            self.log.info("Keychain cache keys temporarily unavailable (\(category))")
-            return []
-        default:
-            self.log.error("Keychain cache key listing failed (\(category)): \(status)")
-            return []
-        }
+        return self.keysResultForKeychainStatus(status, category: category, result: result)
         #else
-        return []
+        return .failed
         #endif
     }
 
@@ -239,6 +276,33 @@ public enum KeychainCacheStore {
         operation: () throws -> T) rethrows -> T
     {
         try self.$loadFailureStatusOverride.withValue(status) {
+            try operation()
+        }
+    }
+
+    public static func withStoreFailureStatusOverrideForTesting<T>(
+        _ status: OSStatus?,
+        operation: () throws -> T) rethrows -> T
+    {
+        try self.$storeFailureStatusOverride.withValue(status) {
+            try operation()
+        }
+    }
+
+    public static func withClearFailureStatusOverrideForTesting<T>(
+        _ status: OSStatus?,
+        operation: () throws -> T) rethrows -> T
+    {
+        try self.$clearFailureStatusOverride.withValue(status) {
+            try operation()
+        }
+    }
+
+    public static func withKeysFailureStatusOverrideForTesting<T>(
+        _ status: OSStatus?,
+        operation: () throws -> T) rethrows -> T
+    {
+        try self.$keysFailureStatusOverride.withValue(status) {
             try operation()
         }
     }
@@ -315,18 +379,42 @@ public enum KeychainCacheStore {
         }
     }
 
-    static func clearResultForKeychainDeleteStatus(_ status: OSStatus, key: Key) -> Bool {
+    static func clearResultForKeychainDeleteStatus(_ status: OSStatus, key: Key) -> ClearResult {
         switch status {
         case errSecSuccess:
-            return true
+            return .removed
         case errSecItemNotFound:
-            return false
+            return .missing
         case errSecInteractionNotAllowed:
             self.log.info("Keychain cache delete temporarily unavailable (\(key.account))")
-            return false
+            return .failed
         default:
             self.log.error("Keychain cache delete failed (\(key.account)): \(status)")
-            return false
+            return .failed
+        }
+    }
+
+    private static func keysResultForKeychainStatus(
+        _ status: OSStatus,
+        category: String,
+        result: AnyObject?) -> KeysResult
+    {
+        switch status {
+        case errSecSuccess:
+            guard let rows = result as? [[String: Any]] else { return .failed }
+            let keys: [Key] = rows.compactMap { row in
+                guard let account = row[kSecAttrAccount as String] as? String else { return nil }
+                return self.key(fromAccount: account, category: category)
+            }
+            return .found(keys)
+        case errSecItemNotFound:
+            return .found([])
+        case errSecInteractionNotAllowed:
+            self.log.info("Keychain cache keys temporarily unavailable (\(category))")
+            return .temporarilyUnavailable
+        default:
+            self.log.error("Keychain cache key listing failed (\(category)): \(status)")
+            return .failed
         }
     }
 
@@ -447,11 +535,11 @@ public enum KeychainCacheStore {
         return .found(decoded)
     }
 
-    private static func storeInTestStore(key: Key, entry: some Codable) -> Bool {
+    private static func storeInTestStore(key: Key, entry: some Codable) -> Bool? {
         self.testStoreLock.lock()
         defer { self.testStoreLock.unlock() }
         let encoder = Self.makeEncoder()
-        guard let data = try? encoder.encode(entry) else { return true }
+        guard let data = try? encoder.encode(entry) else { return false }
         let testKey = TestStoreKey(service: self.serviceName, account: key.account)
         if var store = self.testStore {
             store[testKey] = data
@@ -462,7 +550,7 @@ public enum KeychainCacheStore {
             self.implicitTestStore[testKey] = data
             return true
         }
-        return false
+        return nil
     }
 
     private static func clearTestStore(key: Key) -> Bool? {

--- a/Tests/CodexBarTests/CookieHeaderCacheTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheTests.swift
@@ -243,7 +243,68 @@ struct CookieHeaderCacheTests {
                 cookieHeader: "auth=behind-the-back",
                 storedAt: Date(timeIntervalSince1970: 0),
                 sourceLabel: "Chrome"))
+        defer { KeychainCacheStore.clear(key: .cookie(provider: provider)) }
         #expect(CookieHeaderCache.loadForDisplay(provider: provider) == nil)
+    }
+
+    @Test
+    func `loadForDisplay migrates legacy cache asynchronously`() async throws {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+
+        let legacyBase = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        CookieHeaderCache.setLegacyBaseURLOverrideForTesting(legacyBase)
+        defer { CookieHeaderCache.setLegacyBaseURLOverrideForTesting(nil) }
+
+        let provider: UsageProvider = .codex
+        CookieHeaderCache.store(
+            CookieHeaderCache.Entry(
+                cookieHeader: "auth=legacy-display",
+                storedAt: Date(timeIntervalSince1970: 0),
+                sourceLabel: "Legacy"),
+            to: CookieHeaderCache.legacyURLForTesting(provider: provider))
+
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=legacy-display")
+        for _ in 0..<100 {
+            if !CookieHeaderCache.hasLegacyEntryForTesting(provider: provider),
+               CookieHeaderCache.hasKeychainEntryForTesting(provider: provider)
+            {
+                break
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(!CookieHeaderCache.hasLegacyEntryForTesting(provider: provider))
+        #expect(CookieHeaderCache.hasKeychainEntryForTesting(provider: provider))
+        CookieHeaderCache.clear(provider: provider)
+    }
+
+    @Test
+    func `delayed legacy migration cannot restore a cleared cache`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+
+        let legacyBase = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        CookieHeaderCache.setLegacyBaseURLOverrideForTesting(legacyBase)
+        defer { CookieHeaderCache.setLegacyBaseURLOverrideForTesting(nil) }
+
+        let provider: UsageProvider = .codex
+        CookieHeaderCache.store(
+            CookieHeaderCache.Entry(
+                cookieHeader: "auth=legacy-display",
+                storedAt: Date(timeIntervalSince1970: 0),
+                sourceLabel: "Legacy"),
+            to: CookieHeaderCache.legacyURLForTesting(provider: provider))
+
+        CookieHeaderCache.clear(provider: provider)
+        #expect(CookieHeaderCache.migrateLegacyEntryIfNeededForTesting(provider: provider) == nil)
+        #expect(!CookieHeaderCache.hasLegacyEntryForTesting(provider: provider))
+        #expect(!CookieHeaderCache.hasKeychainEntryForTesting(provider: provider))
     }
 
     #if os(macOS)

--- a/Tests/CodexBarTests/CookieHeaderCacheTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheTests.swift
@@ -276,7 +276,7 @@ struct CookieHeaderCacheTests {
         #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=old")
 
         // A refresh scheduled now races with a store that lands before it commits.
-        let staleGeneration = CookieHeaderCache.displayGenerationForTesting(provider: provider)
+        let staleGeneration = CookieHeaderCache.beginDisplayReadGenerationForTesting(provider: provider)
         let staleEntry = CookieHeaderCache.load(provider: provider)
         CookieHeaderCache.store(provider: provider, cookieHeader: "auth=new", sourceLabel: "Safari")
 
@@ -300,7 +300,7 @@ struct CookieHeaderCacheTests {
         CookieHeaderCache.store(provider: provider, cookieHeader: "auth=secret", sourceLabel: "Chrome")
         #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=secret")
 
-        let staleGeneration = CookieHeaderCache.displayGenerationForTesting(provider: provider)
+        let staleGeneration = CookieHeaderCache.beginDisplayReadGenerationForTesting(provider: provider)
         let staleEntry = CookieHeaderCache.load(provider: provider)
         CookieHeaderCache.clear(provider: provider)
 
@@ -324,7 +324,7 @@ struct CookieHeaderCacheTests {
         CookieHeaderCache.store(provider: provider, cookieHeader: "auth=secret", sourceLabel: "Chrome")
         #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=secret")
 
-        let staleGeneration = CookieHeaderCache.displayGenerationForTesting(provider: provider)
+        let staleGeneration = CookieHeaderCache.beginDisplayReadGenerationForTesting(provider: provider)
         let staleEntry = CookieHeaderCache.load(provider: provider)
         CookieHeaderCache.clearAll()
 
@@ -333,6 +333,35 @@ struct CookieHeaderCacheTests {
             entry: staleEntry,
             generation: staleGeneration)
 
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider) == nil)
+    }
+
+    @Test
+    func `clear all invalidates an in flight first display population`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+
+        let provider: UsageProvider = .codex
+        KeychainCacheStore.store(
+            key: .cookie(provider: provider),
+            entry: CookieHeaderCache.Entry(
+                cookieHeader: "auth=secret",
+                storedAt: Date(timeIntervalSince1970: 0),
+                sourceLabel: "Chrome"))
+
+        // A first display load registers its key, then reads the Keychain outside the lock.
+        let staleGeneration = CookieHeaderCache.beginDisplayReadGenerationForTesting(provider: provider)
+        let staleEntry = CookieHeaderCache.load(provider: provider)
+        CookieHeaderCache.clearAll()
+
+        let committed = CookieHeaderCache.commitDisplaySnapshotIfCurrentForTesting(
+            provider: provider,
+            entry: staleEntry,
+            generation: staleGeneration)
+
+        #expect(committed == nil)
         #expect(CookieHeaderCache.loadForDisplay(provider: provider) == nil)
     }
 

--- a/Tests/CodexBarTests/CookieHeaderCacheTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheTests.swift
@@ -265,6 +265,78 @@ struct CookieHeaderCacheTests {
     }
 
     @Test
+    func `stale refresh cannot overwrite a newer store`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+
+        let provider: UsageProvider = .codex
+        CookieHeaderCache.store(provider: provider, cookieHeader: "auth=old", sourceLabel: "Chrome")
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=old")
+
+        // A refresh scheduled now races with a store that lands before it commits.
+        let staleGeneration = CookieHeaderCache.displayGenerationForTesting(provider: provider)
+        let staleEntry = CookieHeaderCache.load(provider: provider)
+        CookieHeaderCache.store(provider: provider, cookieHeader: "auth=new", sourceLabel: "Safari")
+
+        let committed = CookieHeaderCache.commitDisplaySnapshotIfCurrentForTesting(
+            provider: provider,
+            entry: staleEntry,
+            generation: staleGeneration)
+
+        #expect(committed?.cookieHeader == "auth=new")
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=new")
+    }
+
+    @Test
+    func `stale refresh cannot resurrect a cleared snapshot`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+
+        let provider: UsageProvider = .codex
+        CookieHeaderCache.store(provider: provider, cookieHeader: "auth=secret", sourceLabel: "Chrome")
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=secret")
+
+        let staleGeneration = CookieHeaderCache.displayGenerationForTesting(provider: provider)
+        let staleEntry = CookieHeaderCache.load(provider: provider)
+        CookieHeaderCache.clear(provider: provider)
+
+        let committed = CookieHeaderCache.commitDisplaySnapshotIfCurrentForTesting(
+            provider: provider,
+            entry: staleEntry,
+            generation: staleGeneration)
+
+        #expect(committed == nil)
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider) == nil)
+    }
+
+    @Test
+    func `stale refresh cannot survive clear all`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+
+        let provider: UsageProvider = .codex
+        CookieHeaderCache.store(provider: provider, cookieHeader: "auth=secret", sourceLabel: "Chrome")
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=secret")
+
+        let staleGeneration = CookieHeaderCache.displayGenerationForTesting(provider: provider)
+        let staleEntry = CookieHeaderCache.load(provider: provider)
+        CookieHeaderCache.clearAll()
+
+        CookieHeaderCache.commitDisplaySnapshotIfCurrentForTesting(
+            provider: provider,
+            entry: staleEntry,
+            generation: staleGeneration)
+
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider) == nil)
+    }
+
+    @Test
     func `stale display snapshot revalidates off the calling path`() async throws {
         KeychainCacheStore.setTestStoreForTesting(true)
         defer { KeychainCacheStore.setTestStoreForTesting(false) }

--- a/Tests/CodexBarTests/CookieHeaderCacheTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheTests.swift
@@ -209,6 +209,100 @@ struct CookieHeaderCacheTests {
     }
 
     @Test
+    func `loadForDisplay memoizes keychain lookups`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+
+        let provider: UsageProvider = .codex
+        CookieHeaderCache.store(provider: provider, cookieHeader: "auth=abc", sourceLabel: "Chrome")
+
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=abc")
+
+        // Remove the backing entry without going through CookieHeaderCache: the strict load
+        // sees the change, the display path keeps serving the memoized snapshot.
+        KeychainCacheStore.clear(key: .cookie(provider: provider))
+        #expect(CookieHeaderCache.load(provider: provider) == nil)
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=abc")
+    }
+
+    @Test
+    func `loadForDisplay memoizes missing entries`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+
+        let provider: UsageProvider = .codex
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider) == nil)
+
+        KeychainCacheStore.store(
+            key: .cookie(provider: provider),
+            entry: CookieHeaderCache.Entry(
+                cookieHeader: "auth=behind-the-back",
+                storedAt: Date(timeIntervalSince1970: 0),
+                sourceLabel: "Chrome"))
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider) == nil)
+    }
+
+    @Test
+    func `store and clear update the display snapshot immediately`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+
+        let provider: UsageProvider = .codex
+        CookieHeaderCache.store(provider: provider, cookieHeader: "auth=first", sourceLabel: "Chrome")
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=first")
+
+        CookieHeaderCache.store(provider: provider, cookieHeader: "auth=second", sourceLabel: "Safari")
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=second")
+
+        CookieHeaderCache.clear(provider: provider)
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider) == nil)
+    }
+
+    @Test
+    func `stale display snapshot revalidates off the calling path`() async throws {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+        CookieHeaderCache.setDisplayStalenessIntervalOverrideForTesting(0)
+        defer { CookieHeaderCache.setDisplayStalenessIntervalOverrideForTesting(nil) }
+
+        let provider: UsageProvider = .codex
+        KeychainCacheStore.store(
+            key: .cookie(provider: provider),
+            entry: CookieHeaderCache.Entry(
+                cookieHeader: "auth=old",
+                storedAt: Date(timeIntervalSince1970: 0),
+                sourceLabel: "Chrome"))
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=old")
+
+        KeychainCacheStore.store(
+            key: .cookie(provider: provider),
+            entry: CookieHeaderCache.Entry(
+                cookieHeader: "auth=new",
+                storedAt: Date(timeIntervalSince1970: 1),
+                sourceLabel: "Chrome"))
+
+        // The stale lookup returns the old snapshot and schedules a revalidation.
+        _ = CookieHeaderCache.loadForDisplay(provider: provider)
+        var refreshed = false
+        for _ in 0..<200 {
+            if CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=new" {
+                refreshed = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        #expect(refreshed)
+    }
+
+    @Test
     func `clear all removes every provider cookie key without decoding entries`() {
         KeychainCacheStore.setTestStoreForTesting(true)
         defer { KeychainCacheStore.setTestStoreForTesting(false) }

--- a/Tests/CodexBarTests/CookieHeaderCacheTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheTests.swift
@@ -199,9 +199,9 @@ struct CookieHeaderCacheTests {
                 sourceLabel: "Legacy"),
             to: CookieHeaderCache.legacyURLForTesting(provider: provider))
 
-        let cleared = CookieHeaderCache.clearAllScopes(provider: provider)
+        let cleared = CookieHeaderCache.clearAllScopesDetailed(provider: provider)
 
-        #expect(cleared == 4)
+        #expect(cleared == CookieHeaderCache.ClearSummary(clearedCount: 4, failedCount: 0))
         #expect(!CookieHeaderCache.hasKeychainEntryForTesting(provider: provider))
         #expect(!CookieHeaderCache.hasKeychainEntryForTesting(provider: provider, scope: .managedAccount(accountID)))
         #expect(!CookieHeaderCache.hasKeychainEntryForTesting(provider: provider, scope: .managedStoreUnreadable))
@@ -245,6 +245,155 @@ struct CookieHeaderCacheTests {
                 sourceLabel: "Chrome"))
         #expect(CookieHeaderCache.loadForDisplay(provider: provider) == nil)
     }
+
+    #if os(macOS)
+    @Test
+    func `loadForDisplay throttles temporary keychain unavailability then retries`() async throws {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+        CookieHeaderCache.setDisplayUnavailableRetryIntervalOverrideForTesting(0.05)
+        defer { CookieHeaderCache.setDisplayUnavailableRetryIntervalOverrideForTesting(nil) }
+
+        let provider: UsageProvider = .codex
+        KeychainCacheStore.store(
+            key: .cookie(provider: provider),
+            entry: CookieHeaderCache.Entry(
+                cookieHeader: "auth=available-after-retry",
+                storedAt: Date(timeIntervalSince1970: 0),
+                sourceLabel: "Chrome"))
+
+        let unavailable = KeychainCacheStore.withLoadFailureStatusOverrideForTesting(errSecInteractionNotAllowed) {
+            CookieHeaderCache.loadForDisplay(provider: provider)
+        }
+
+        #expect(unavailable == nil)
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider) == nil)
+
+        try await Task.sleep(for: .milliseconds(60))
+        var retried: CookieHeaderCache.Entry?
+        for _ in 0..<100 {
+            retried = CookieHeaderCache.loadForDisplay(provider: provider)
+            if retried != nil { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(retried?.cookieHeader == "auth=available-after-retry")
+    }
+
+    @Test
+    func `temporary first display read returns a concurrent store`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+
+        let provider: UsageProvider = .codex
+        _ = CookieHeaderCache.beginDisplayReadGenerationForTesting(provider: provider)
+        CookieHeaderCache.store(provider: provider, cookieHeader: "auth=concurrent", sourceLabel: "Chrome")
+
+        #expect(CookieHeaderCache.currentDisplayEntryForTesting(provider: provider)?
+            .cookieHeader == "auth=concurrent")
+    }
+
+    @Test
+    func `failed keychain mutations preserve the display snapshot`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+
+        let provider: UsageProvider = .codex
+        CookieHeaderCache.store(provider: provider, cookieHeader: "auth=old", sourceLabel: "Chrome")
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=old")
+
+        KeychainCacheStore.withStoreFailureStatusOverrideForTesting(errSecInteractionNotAllowed) {
+            CookieHeaderCache.store(provider: provider, cookieHeader: "auth=new", sourceLabel: "Safari")
+        }
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=old")
+
+        let cleared = KeychainCacheStore.withClearFailureStatusOverrideForTesting(errSecInteractionNotAllowed) {
+            CookieHeaderCache.clearDetailed(provider: provider)
+        }
+        #expect(cleared == CookieHeaderCache.ClearSummary(clearedCount: 0, failedCount: 1))
+        #expect(CookieHeaderCache.loadForDisplay(provider: provider)?.cookieHeader == "auth=old")
+        #expect(CookieHeaderCache.load(provider: provider)?.cookieHeader == "auth=old")
+    }
+
+    @Test
+    func `legacy removal invalidates a snapshot after failed keychain clear`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+        CookieHeaderCache.resetDisplayCacheForTesting()
+        defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+
+        KeychainCacheStore.withServiceOverrideForTesting("legacy-clear-\(UUID().uuidString)") {
+            let legacyBase = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            CookieHeaderCache.setLegacyBaseURLOverrideForTesting(legacyBase)
+            defer { CookieHeaderCache.setLegacyBaseURLOverrideForTesting(nil) }
+
+            let provider: UsageProvider = .codex
+            CookieHeaderCache.store(
+                CookieHeaderCache.Entry(
+                    cookieHeader: "auth=legacy",
+                    storedAt: Date(timeIntervalSince1970: 0),
+                    sourceLabel: "Legacy"),
+                to: CookieHeaderCache.legacyURLForTesting(provider: provider))
+
+            let displayed = KeychainCacheStore.withStoreFailureStatusOverrideForTesting(errSecInteractionNotAllowed) {
+                CookieHeaderCache.loadForDisplay(provider: provider)
+            }
+            #expect(displayed?.cookieHeader == "auth=legacy")
+
+            let cleared = KeychainCacheStore.withClearFailureStatusOverrideForTesting(errSecInteractionNotAllowed) {
+                CookieHeaderCache.clearDetailed(provider: provider)
+            }
+
+            #expect(cleared == CookieHeaderCache.ClearSummary(clearedCount: 1, failedCount: 1))
+            #expect(!CookieHeaderCache.hasLegacyEntryForTesting(provider: provider))
+            #expect(CookieHeaderCache.loadForDisplay(provider: provider) == nil)
+        }
+    }
+
+    @Test
+    func `clear all reports keychain enumeration failure`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+        let summary = KeychainCacheStore.withKeysFailureStatusOverrideForTesting(errSecInteractionNotAllowed) {
+            CookieHeaderCache.clearAllDetailed()
+        }
+
+        #expect(summary.failedCount >= 1)
+    }
+
+    @Test
+    func `clear reports legacy file deletion failure`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+        let legacyBase = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        CookieHeaderCache.setLegacyBaseURLOverrideForTesting(legacyBase)
+        defer { CookieHeaderCache.setLegacyBaseURLOverrideForTesting(nil) }
+
+        let provider: UsageProvider = .codex
+        CookieHeaderCache.store(
+            CookieHeaderCache.Entry(
+                cookieHeader: "auth=legacy",
+                storedAt: Date(timeIntervalSince1970: 0),
+                sourceLabel: "Legacy"),
+            to: CookieHeaderCache.legacyURLForTesting(provider: provider))
+
+        let summary = CookieHeaderCache.withLegacyRemovalFailureForTesting {
+            CookieHeaderCache.clearDetailed(provider: provider)
+        }
+
+        #expect(summary.failedCount == 1)
+        #expect(CookieHeaderCache.hasLegacyEntryForTesting(provider: provider))
+    }
+    #endif
 
     @Test
     func `store and clear update the display snapshot immediately`() {
@@ -419,9 +568,10 @@ struct CookieHeaderCacheTests {
                 key: .cookie(provider: .cursor),
                 entry: WrongEntry(value: "invalid"))
 
-            let cleared = CookieHeaderCache.clearAll()
+            let cleared = CookieHeaderCache.clearAllDetailed()
 
-            #expect(cleared >= 3)
+            #expect(cleared.clearedCount >= 3)
+            #expect(cleared.failedCount == 0)
             #expect(KeychainCacheStore.keys(category: "cookie").isEmpty)
         }
     }

--- a/Tests/CodexBarTests/KeychainCacheStoreTests.swift
+++ b/Tests/CodexBarTests/KeychainCacheStoreTests.swift
@@ -159,7 +159,9 @@ struct KeychainCacheStoreTests {
     @Test
     func `delete interaction not allowed is non fatal`() {
         let key = KeychainCacheStore.Key(category: "test", identifier: UUID().uuidString)
-        #expect(KeychainCacheStore.clearResultForKeychainDeleteStatus(errSecInteractionNotAllowed, key: key) == false)
+        #expect(KeychainCacheStore.clearResultForKeychainDeleteStatus(
+            errSecInteractionNotAllowed,
+            key: key) == .failed)
     }
 
     @Test


### PR DESCRIPTION
## Problem

Opening Settings and switching to the Providers pane could freeze the app for ~10 seconds (beach ball).

`ProviderSettingsPickerRowView` evaluates each picker's `trailingText` closure inside `body`, and the cookie-source pickers resolve their "Cached: …" label through `CookieHeaderCache.load`, which pays a synchronous `SecItemCopyMatching` round-trip through securityd plus a CSSM decrypt per call. SwiftUI re-runs those bodies repeatedly within a single AppKit layout pass, so the layout pass degenerates into hundreds of redundant Keychain reads on the main thread — worst right after launch, while cost scans and probes are also contending for securityd.

A 17s `sample` of one Providers-pane click on 0.34.0 showed ~10s of a single layout pass bottoming out in Keychain reads:

```
10012 NSHostingView.layout() → … → ProviderSettingsPickerRowView.body.getter
 9834   static CookieHeaderCache.load(provider:scope:)
 9819     KeychainCacheStore.load<A>(key:as:)
 9816       SecItemCopyMatching → securityd → CSSM_DecryptDataFinal
```

## Fix

Display paths now use `CookieHeaderCache.loadForDisplay`, which serves a memoized snapshot and revalidates a stale one (30s) off the calling path, following the same stale-tolerant-cache approach as the menu-build `auth.json` fix. In-process `store`/`clear` update the snapshot synchronously, so only the first lookup per key pays the Keychain read. Strict `load` semantics are unchanged for probes and fetchers.
## Verification

Before: 17s `sample` of one Providers-pane click on the unpatched build shows ~10s of a single layout pass bottoming out in Keychain reads (9,834 `SecItemCopyMatching` samples / 9,835 `ProviderSettingsPickerRowView.body` samples on the main thread).

After: live human-driven session on the patched build — Settings opened from the menu bar, Providers pane opened and switched repeatedly, panes bounced — recorded as 28 consecutive 10s `sample` windows. Zero `SecItemCopyMatching` samples on the main thread in every window; worst window had ~0.8s of main-thread work (menu rebuild), all pane switches instant.

Includes unit tests for memoization, immediate store/clear snapshot updates, async revalidation, and (after review) deterministic race coverage for store/clear/clearAll versus an in-flight stale refresh. Full `swift test` passes (two pre-existing timing-flaky suites pass in isolation).