### PR TITLE
Fix package_app.sh preferring stale legacy build products over fresh swiftbuild output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.
 - Settings: memoize cookie cache lookups behind the "Cached: …" picker labels so opening Settings and switching panes no longer pays a synchronous Keychain read per SwiftUI body evaluation, which froze the Providers pane for seconds (#1471). Thanks @ProspectOre!
+- Build: resolve packaged binaries from the bin path SwiftPM reports instead of assuming the legacy `.build/<arch>-apple-macosx/<conf>/` layout, so a stale directory left behind by the older build system no longer silently shadows fresh swiftbuild products in `package_app.sh`.
 
 ## 0.34.0 — 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.
 - Settings: memoize cookie cache lookups behind the "Cached: …" picker labels so opening Settings and switching panes no longer pays a synchronous Keychain read per SwiftUI body evaluation, which froze the Providers pane for seconds (#1471). Thanks @ProspectOre!
-- Build: resolve packaged binaries from the bin path SwiftPM reports instead of assuming the legacy `.build/<arch>-apple-macosx/<conf>/` layout, so a stale directory left behind by the older build system no longer silently shadows fresh swiftbuild products in `package_app.sh`.
+- Build: resolve packaged binaries from the bin path SwiftPM reports instead of assuming the legacy `.build/<arch>-apple-macosx/<conf>/` layout, so a stale directory left behind by the older build system no longer silently shadows fresh swiftbuild products in `package_app.sh`. Thanks @ProspectOre!
 
 ## 0.34.0 — 2026-06-12
 

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -214,11 +214,33 @@ build_product_path() {
   esac
 }
 
-# Resolve path to built binary; some SwiftPM versions use .build/$CONF/ when building for host only.
+# Ask SwiftPM where it put the products for this arch (cached per arch).
+# The legacy native build system uses .build/<arch>-apple-macosx/<conf>/, but the
+# swiftbuild system emits to .build/out/Products/<Conf>; resolving from the
+# toolchain keeps a stale legacy directory from shadowing fresh builds.
+swiftpm_bin_path() {
+  local arch="$1"
+  local var="SWIFTPM_BIN_PATH_${arch//[^A-Za-z0-9]/_}"
+  if [[ -z "${!var+set}" ]]; then
+    local path
+    path=$(swift build --show-bin-path -c "$CONF" --arch "$arch" 2>/dev/null || true)
+    printf -v "$var" '%s' "$path"
+  fi
+  echo "${!var}"
+}
+
+# Resolve path to built binary; prefer the bin dir SwiftPM reports, then fall
+# back to the known legacy layouts (.build/<arch>-apple-macosx/<conf>/ and
+# .build/$CONF/ for host-only builds on some SwiftPM versions).
 resolve_binary_path() {
   local name="$1"
   local arch="$2"
-  local candidate
+  local bin_dir candidate
+  bin_dir=$(swiftpm_bin_path "$arch")
+  if [[ -n "$bin_dir" && -f "$bin_dir/$name" ]]; then
+    echo "$bin_dir/$name"
+    return
+  fi
   candidate=$(build_product_path "$name" "$arch")
   if [[ -f "$candidate" ]]; then
     echo "$candidate"
@@ -257,7 +279,7 @@ install_binary() {
     local src
     src=$(resolve_binary_path "$name" "$arch")
     if [[ -z "$src" || ! -f "$src" ]]; then
-      echo "ERROR: Missing ${name} build for ${arch} at $(build_product_path "$name" "$arch")" >&2
+      echo "ERROR: Missing ${name} build for ${arch} (looked in: $(swiftpm_bin_path "$arch"), $(build_product_path "$name" "$arch"), .build/$CONF)" >&2
       exit 1
     fi
     binaries+=("$src")

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -6,6 +6,13 @@ SIGNING_MODE=${CODEXBAR_SIGNING:-}
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 cd "$ROOT"
 LOWER_CONF=$(printf "%s" "$CONF" | tr '[:upper:]' '[:lower:]')
+case "$LOWER_CONF" in
+  debug|release) ;;
+  *)
+    echo "ERROR: Unsupported build configuration: $CONF (expected debug or release)" >&2
+    exit 1
+    ;;
+esac
 
 # Load version info
 source "$ROOT/version.env"
@@ -105,8 +112,59 @@ if [[ ! -f "$KEYBOARD_SHORTCUTS_UTIL" ]]; then
 fi
 patch_keyboard_shortcuts
 
+build_product_path() {
+  local name="$1"
+  local arch="$2"
+  case "$arch" in
+    arm64|x86_64) echo ".build/${arch}-apple-macosx/$CONF/$name" ;;
+    *) echo ".build/$CONF/$name" ;;
+  esac
+}
+
+# Resolve SwiftPM's current output path without relying on a fixed build-system layout.
+# The output variable keeps the per-arch cache in this shell instead of losing it to
+# command substitution.
+swiftpm_bin_path() {
+  local arch="$1"
+  local output_var="$2"
+  local cache_var="SWIFTPM_BIN_PATH_${arch//[^A-Za-z0-9]/_}"
+  if [[ -z "${!cache_var+set}" ]]; then
+    local resolved
+    resolved=$(swift build --show-bin-path -c "$CONF" --arch "$arch" 2>/dev/null || true)
+    printf -v "$cache_var" '%s' "$resolved"
+  fi
+  printf -v "$output_var" '%s' "${!cache_var}"
+}
+
+binary_has_arch() {
+  local binary="$1"
+  local arch="$2"
+  [[ -f "$binary" ]] && lipo -archs "$binary" 2>/dev/null | tr ' ' '\n' | grep -qx "$arch"
+}
+
+# SwiftBuild can reuse one output directory for sequential per-arch builds. Snapshot
+# each fresh slice before the next build can replace it.
+PRODUCT_STAGE_ROOT="$ROOT/.build/package-products/$LOWER_CONF"
+rm -rf "$PRODUCT_STAGE_ROOT"
+
+stage_binary_products() {
+  local arch="$1"
+  local bin_dir stage_dir name
+  swiftpm_bin_path "$arch" bin_dir
+  [[ -n "$bin_dir" ]] || return 0
+
+  stage_dir="$PRODUCT_STAGE_ROOT/$arch"
+  mkdir -p "$stage_dir"
+  for name in CodexBar CodexBarCLI CodexBarClaudeWatchdog; do
+    if binary_has_arch "$bin_dir/$name" "$arch"; then
+      cp "$bin_dir/$name" "$stage_dir/$name"
+    fi
+  done
+}
+
 for ARCH in "${ARCH_LIST[@]}"; do
   swift build -c "$CONF" --arch "$ARCH"
+  stage_binary_products "$ARCH"
 done
 
 APP_FINAL="$ROOT/CodexBar.app"
@@ -205,48 +263,28 @@ cat > "$APP/Contents/Info.plist" <<PLIST
 </plist>
 PLIST
 
-build_product_path() {
-  local name="$1"
-  local arch="$2"
-  case "$arch" in
-    arm64|x86_64) echo ".build/${arch}-apple-macosx/$CONF/$name" ;;
-    *) echo ".build/$CONF/$name" ;;
-  esac
-}
-
-# Ask SwiftPM where it put the products for this arch (cached per arch).
-# The legacy native build system uses .build/<arch>-apple-macosx/<conf>/, but the
-# swiftbuild system emits to .build/out/Products/<Conf>; resolving from the
-# toolchain keeps a stale legacy directory from shadowing fresh builds.
-swiftpm_bin_path() {
-  local arch="$1"
-  local var="SWIFTPM_BIN_PATH_${arch//[^A-Za-z0-9]/_}"
-  if [[ -z "${!var+set}" ]]; then
-    local path
-    path=$(swift build --show-bin-path -c "$CONF" --arch "$arch" 2>/dev/null || true)
-    printf -v "$var" '%s' "$path"
-  fi
-  echo "${!var}"
-}
-
-# Resolve path to built binary; prefer the bin dir SwiftPM reports, then fall
-# back to the known legacy layouts (.build/<arch>-apple-macosx/<conf>/ and
-# .build/$CONF/ for host-only builds on some SwiftPM versions).
+# Resolve path to a built binary. Prefer the per-arch snapshot, then SwiftPM's
+# reported directory, then legacy layouts for older toolchains.
 resolve_binary_path() {
   local name="$1"
   local arch="$2"
   local bin_dir candidate
-  bin_dir=$(swiftpm_bin_path "$arch")
-  if [[ -n "$bin_dir" && -f "$bin_dir/$name" ]]; then
+  candidate="$PRODUCT_STAGE_ROOT/$arch/$name"
+  if binary_has_arch "$candidate" "$arch"; then
+    echo "$candidate"
+    return
+  fi
+  swiftpm_bin_path "$arch" bin_dir
+  if [[ -n "$bin_dir" ]] && binary_has_arch "$bin_dir/$name" "$arch"; then
     echo "$bin_dir/$name"
     return
   fi
   candidate=$(build_product_path "$name" "$arch")
-  if [[ -f "$candidate" ]]; then
+  if binary_has_arch "$candidate" "$arch"; then
     echo "$candidate"
     return
   fi
-  if [[ "$arch" == "arm64" || "$arch" == "x86_64" ]] && [[ -f ".build/$CONF/$name" ]]; then
+  if [[ "$arch" == "arm64" || "$arch" == "x86_64" ]] && binary_has_arch ".build/$CONF/$name" "$arch"; then
     echo ".build/$CONF/$name"
   fi
 }
@@ -276,10 +314,11 @@ install_binary() {
   local dest="$2"
   local binaries=()
   for arch in "${ARCH_LIST[@]}"; do
-    local src
+    local src bin_dir
     src=$(resolve_binary_path "$name" "$arch")
     if [[ -z "$src" || ! -f "$src" ]]; then
-      echo "ERROR: Missing ${name} build for ${arch} (looked in: $(swiftpm_bin_path "$arch"), $(build_product_path "$name" "$arch"), .build/$CONF)" >&2
+      swiftpm_bin_path "$arch" bin_dir
+      echo "ERROR: Missing ${name} build for ${arch} (looked in: $PRODUCT_STAGE_ROOT/$arch, $bin_dir, $(build_product_path "$name" "$arch"), .build/$CONF)" >&2
       exit 1
     fi
     binaries+=("$src")
@@ -436,8 +475,11 @@ if [[ ! -f "$APP/Contents/Resources/Icon-classic.icns" ]]; then
 fi
 
 # SwiftPM resource bundles (e.g. KeyboardShortcuts) are emitted next to the built binary.
-CODEXBAR_BINARY="$(resolve_binary_path "CodexBar" "${ARCH_LIST[0]}")"
-PREFERRED_BUILD_DIR="$(dirname "${CODEXBAR_BINARY:-$(build_product_path "CodexBar" "${ARCH_LIST[0]}")}")"
+swiftpm_bin_path "${ARCH_LIST[0]}" PREFERRED_BUILD_DIR
+if [[ -z "$PREFERRED_BUILD_DIR" ]]; then
+  CODEXBAR_BINARY="$(resolve_binary_path "CodexBar" "${ARCH_LIST[0]}")"
+  PREFERRED_BUILD_DIR="$(dirname "${CODEXBAR_BINARY:-$(build_product_path "CodexBar" "${ARCH_LIST[0]}")}")"
+fi
 shopt -s nullglob
 SWIFTPM_BUNDLES=("${PREFERRED_BUILD_DIR}/"*.bundle)
 shopt -u nullglob


### PR DESCRIPTION
## Problem

`package_app.sh` resolves built binaries by checking the legacy native build system layout (`.build/<arch>-apple-macosx/<conf>/`) first, falling back to `.build/<conf>/`. Newer toolchains default to the **swiftbuild** build system, which emits products to `.build/out/Products/<Conf>` (with `.build/<conf>` as a symlink into it).

When a stale `.build/<arch>-apple-macosx/` directory is left behind from an earlier toolchain run, the script silently packages those old binaries instead of the ones `swift build` just produced. The app looks freshly built — new Info.plist, new `CodexGitCommit` — but runs days-old code. This cost me a debugging session this week: "fresh" dev builds of the menu fix were actually running Jun 10 binaries until I noticed and `rm -rf`'d the legacy directory.

## Fix

Ask the toolchain where the products actually are via `swift build --show-bin-path -c <conf> --arch <arch>` (cached per arch) and prefer that location. The legacy layouts stay as fallbacks for toolchains where `--show-bin-path` is unavailable or the product is missing from the reported path, so existing flows are unchanged:

- **Native build system** (single arch or universal): `--show-bin-path --arch <a>` reports the per-arch `.build/<arch>-apple-macosx/<conf>/` directory the script already used — identical behavior.
- **swiftbuild, host arch**: resolves to `.build/out/Products/<Conf>`, immune to stale legacy directories.
- `install_binary`'s error message now lists every location searched instead of only the legacy path.

No associative arrays or other bash 4 features — works on macOS's stock bash 3.2.

## Proof

Function-level test (bash 3.2): with a stale `.build/arm64-apple-macosx/release/CodexBar` planted next to a fresh swiftbuild product, resolution now returns `.build/out/Products/Release/CodexBar`; with `swift build --show-bin-path` stubbed to fail (old-toolchain simulation), the legacy path still wins.

End-to-end: in a clean worktree I planted a distinguishable 20.8 MB binary (a copy of CodexBarCLI) at `.build/arm64-apple-macosx/release/CodexBar` alongside the fresh 32.9 MB swiftbuild product, then ran `CODEXBAR_SIGNING=adhoc ./Scripts/package_app.sh release`. Before this change the script packages the planted stale binary; with it, the packaged `CodexBar.app/Contents/MacOS/CodexBar` is the fresh 32.7 MB arm64 product (post re-sign), and the script exits 0 with the KeyboardShortcuts resource bundle and widget appex intact.