### PR TITLE
fix: preserve menu bar text when pace is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.1 — Unreleased
 
+- Menu bar: keep the selected quota percentage visible in Pace mode when pace is temporarily unavailable instead of collapsing to an icon-only status item (fixes #1462).
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.
 - Menu bar: keep cached provider content visible while switching merged tabs so the open menu no longer flickers through an empty state.
 - Menu bar: handle the global open-menu shortcut synchronously so repeated presses close the tracked menu instead of queueing a delayed reopen (#1470). Thanks @Zihao-Qi!

--- a/Sources/CodexBar/MenuBarDisplayText.swift
+++ b/Sources/CodexBar/MenuBarDisplayText.swift
@@ -28,7 +28,10 @@ enum MenuBarDisplayText {
         case .percent:
             return self.percentText(window: percentWindow, showUsed: showUsed)
         case .pace:
+            // Pace can be temporarily unavailable near a reset or when a provider omits window metadata.
+            // Keep the selected quota visible instead of collapsing the status item to an icon-only state.
             return self.paceText(pace: pace)
+                ?? self.percentText(window: percentWindow, showUsed: showUsed)
         case .both:
             guard let percent = percentText(window: percentWindow, showUsed: showUsed) else { return nil }
             // Fall back to percent-only when pace is unavailable (e.g. Copilot)

--- a/Tests/CodexBarTests/StatusItemAnimationTests.swift
+++ b/Tests/CodexBarTests/StatusItemAnimationTests.swift
@@ -907,8 +907,7 @@ struct StatusItemAnimationTests {
             percentWindow: percentWindow,
             showUsed: true)
 
-        #expect(pace == nil)
-        // "Both" mode falls back to percent-only when pace is unavailable
+        #expect(pace == "40%")
         #expect(both == "40%")
     }
 
@@ -927,8 +926,7 @@ struct StatusItemAnimationTests {
             pace: nil,
             showUsed: true)
 
-        #expect(pace == nil)
-        // "Both" mode falls back to percent-only when pace is unavailable
+        #expect(pace == "40%")
         #expect(both == "40%")
     }
 


### PR DESCRIPTION
## Summary
- fall back to the selected quota percentage when Pace mode cannot compute pace
- keep the status item from collapsing to icon-only near resets or with incomplete window metadata
- add focused regression coverage

Fixes #1462.

## Proof
- `swift test --filter StatusItemAnimationTests`
- `swift test --filter 'menu bar display text falls back to percent when pace'`
- `make check`
- autoreview: clean