### PR TITLE
ci: avoid duplicate pull request runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
 
 concurrency:


### PR DESCRIPTION
## Summary
- run push CI only for `main`
- retain full CI for every pull request
- stop launching duplicate push and pull-request matrices for the same PR head

## Proof
- `actionlint .github/workflows/ci.yml`
- `make check`
- branch autoreview: clean