### PR TITLE
fix: enforce diagnostic probe timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.1 — Unreleased
 
+- Diagnostics: enforce probe timeouts even when an underlying provider operation ignores Swift task cancellation.
 - Kimi: add usage fetching from the official Code API key flow, with optional compatible HTTPS proxy support (#1424). Thanks @kiranmagic7!
 - Menu bar: keep the selected quota percentage visible in Pace mode when pace is temporarily unavailable instead of collapsing to an icon-only status item (fixes #1462).
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.

--- a/Sources/CodexBar/UsageStore+Timeout.swift
+++ b/Sources/CodexBar/UsageStore+Timeout.swift
@@ -1,19 +1,76 @@
 import Foundation
 
 extension UsageStore {
+    private final class ProbeTimeoutRace: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<String, Never>?
+        private var result: String?
+        private var tasks: [Task<Void, Never>] = []
+
+        func install(_ continuation: CheckedContinuation<String, Never>) {
+            let result: String? = self.lock.withLock {
+                if let result = self.result {
+                    return result
+                }
+                self.continuation = continuation
+                return nil
+            }
+            if let result {
+                continuation.resume(returning: result)
+            }
+        }
+
+        func install(_ task: Task<Void, Never>) {
+            let shouldCancel = self.lock.withLock {
+                guard self.result == nil else { return true }
+                self.tasks.append(task)
+                return false
+            }
+            if shouldCancel {
+                task.cancel()
+            }
+        }
+
+        func complete(with result: String) {
+            let completion = self.lock.withLock {
+                guard self.result == nil else {
+                    return (nil as CheckedContinuation<String, Never>?, [] as [Task<Void, Never>])
+                }
+                self.result = result
+                let continuation = self.continuation
+                self.continuation = nil
+                let tasks = self.tasks
+                self.tasks.removeAll()
+                return (continuation, tasks)
+            }
+            completion.1.forEach { $0.cancel() }
+            completion.0?.resume(returning: result)
+        }
+    }
+
     nonisolated static func runWithTimeout(
         seconds: Double,
         operation: @escaping @Sendable () async -> String) async -> String
     {
-        await withTaskGroup(of: String?.self) { group -> String in
-            group.addTask { await operation() }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-                return nil
+        let timeoutMessage = "Probe timed out after \(Int(seconds))s"
+        let race = ProbeTimeoutRace()
+
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                race.install(continuation)
+
+                race.install(Task {
+                    let result = await operation()
+                    race.complete(with: result)
+                })
+                race.install(Task {
+                    try? await Task.sleep(for: .seconds(max(seconds, 0)))
+                    guard !Task.isCancelled else { return }
+                    race.complete(with: timeoutMessage)
+                })
             }
-            let result = await group.next()?.flatMap(\.self)
-            group.cancelAll()
-            return result ?? "Probe timed out after \(Int(seconds))s"
+        } onCancel: {
+            race.complete(with: timeoutMessage)
         }
     }
 }

--- a/Tests/CodexBarTests/UsageStoreTimeoutTests.swift
+++ b/Tests/CodexBarTests/UsageStoreTimeoutTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct UsageStoreTimeoutTests {
+    private final class ProbeGate: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<Void, Never>?
+        private var released = false
+
+        func wait() async {
+            await withCheckedContinuation { continuation in
+                let shouldResume = self.lock.withLock {
+                    guard !self.released else { return true }
+                    self.continuation = continuation
+                    return false
+                }
+                if shouldResume {
+                    continuation.resume()
+                }
+            }
+        }
+
+        func release() {
+            let continuation = self.lock.withLock {
+                self.released = true
+                let continuation = self.continuation
+                self.continuation = nil
+                return continuation
+            }
+            continuation?.resume()
+        }
+    }
+
+    @Test
+    func `timeout does not wait for a cancellation ignoring probe`() async {
+        let gate = ProbeGate()
+        let releaseTask = Task {
+            try? await Task.sleep(for: .seconds(1))
+            gate.release()
+        }
+        defer {
+            releaseTask.cancel()
+            gate.release()
+        }
+
+        let startedAt = ContinuousClock.now
+        let result = await UsageStore.runWithTimeout(seconds: 0.03) {
+            await gate.wait()
+            return "late result"
+        }
+        let elapsed = startedAt.duration(to: .now)
+
+        #expect(result == "Probe timed out after 0s")
+        #expect(elapsed < .milliseconds(500))
+    }
+
+    @Test
+    func `completed probe wins timeout race`() async {
+        let result = await UsageStore.runWithTimeout(seconds: 1) {
+            "probe result"
+        }
+
+        #expect(result == "probe result")
+    }
+}


### PR DESCRIPTION
## Summary
- make diagnostic probe timeouts return even when a provider operation ignores Swift task cancellation
- cancel the losing probe/timeout task without keeping the caller inside a structured task-group scope
- add a regression that models a cancellation-ignoring probe

## Proof
- `swift test --filter UsageStoreTimeoutTests`
- `make check`
- autoreview clean