### PR TITLE
fix: trust SwiftPM package product paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Menu bar: keep cached provider content visible while switching merged tabs so the open menu no longer flickers through an empty state.
 - Menu bar: handle the global open-menu shortcut synchronously so repeated presses close the tracked menu instead of queueing a delayed reopen (#1470). Thanks @Zihao-Qi!
 - Settings: memoize cookie cache lookups behind the "Cached: …" picker labels so opening Settings and switching panes no longer pays a synchronous Keychain read per SwiftUI body evaluation, which froze the Providers pane for seconds (#1471). Thanks @ProspectOre!
-- Build: resolve packaged binaries from the bin path SwiftPM reports instead of assuming the legacy `.build/<arch>-apple-macosx/<conf>/` layout, so a stale directory left behind by the older build system no longer silently shadows fresh swiftbuild products in `package_app.sh`. Thanks @ProspectOre!
+- Build: trust SwiftPM-reported product paths for packaged binaries, frameworks, resources, and dSYMs, failing instead of falling back to stale legacy outputs (#1473). Thanks @ProspectOre!
 - Menu bar: stop the provider-switcher shortcut monitor from killing the menu's event tracking session. Its event-queue peek re-entered the run loop in tracking mode, which could leave a zombie menu on screen that ignored clicks for tens of seconds (beach ball) — most often right after opening the menu or after rapid Cmd-number provider switching, with Settings… the usual victim. Peeks now run in a barren private run-loop mode, start only once the tracking session is pumping, and no longer touch mouse events. Thanks @ProspectOre!
 
 ## 0.34.0 — 2026-06-12

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -15,11 +15,16 @@ check_codex_parser_hash() {
   "${ROOT_DIR}/Scripts/regenerate-codex-parser-hash.sh" --check
 }
 
+check_package_product_paths() {
+  "${ROOT_DIR}/Scripts/test_package_product_paths.sh"
+}
+
 cmd="${1:-lint}"
 
 case "$cmd" in
   lint)
     check_codex_parser_hash
+    check_package_product_paths
     ensure_tools
     "${BIN_DIR}/swiftformat" Sources Tests --lint
     "${BIN_DIR}/swiftlint" --strict

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -16,6 +16,7 @@ esac
 
 # Load version info
 source "$ROOT/version.env"
+source "$ROOT/Scripts/package_product_paths.sh"
 
 # Clean build only when explicitly requested (slower).
 if [[ "${CODEXBAR_FORCE_CLEAN:-0}" == "1" ]]; then
@@ -112,15 +113,6 @@ if [[ ! -f "$KEYBOARD_SHORTCUTS_UTIL" ]]; then
 fi
 patch_keyboard_shortcuts
 
-build_product_path() {
-  local name="$1"
-  local arch="$2"
-  case "$arch" in
-    arm64|x86_64) echo ".build/${arch}-apple-macosx/$CONF/$name" ;;
-    *) echo ".build/$CONF/$name" ;;
-  esac
-}
-
 # Resolve SwiftPM's current output path without relying on a fixed build-system layout.
 # The output variable keeps the per-arch cache in this shell instead of losing it to
 # command substitution.
@@ -130,7 +122,9 @@ swiftpm_bin_path() {
   local cache_var="SWIFTPM_BIN_PATH_${arch//[^A-Za-z0-9]/_}"
   if [[ -z "${!cache_var+set}" ]]; then
     local resolved
-    resolved=$(swift build --show-bin-path -c "$CONF" --arch "$arch" 2>/dev/null || true)
+    if ! resolved=$(codexbar_swiftpm_bin_path "$CONF" "$arch"); then
+      return 1
+    fi
     printf -v "$cache_var" '%s' "$resolved"
   fi
   printf -v "$output_var" '%s' "${!cache_var}"
@@ -147,24 +141,31 @@ binary_has_arch() {
 PRODUCT_STAGE_ROOT="$ROOT/.build/package-products/$LOWER_CONF"
 rm -rf "$PRODUCT_STAGE_ROOT"
 
-stage_binary_products() {
+stage_build_products() {
   local arch="$1"
-  local bin_dir stage_dir name
+  local bin_dir stage_dir name product
   swiftpm_bin_path "$arch" bin_dir
-  [[ -n "$bin_dir" ]] || return 0
 
   stage_dir="$PRODUCT_STAGE_ROOT/$arch"
   mkdir -p "$stage_dir"
   for name in CodexBar CodexBarCLI CodexBarClaudeWatchdog; do
-    if binary_has_arch "$bin_dir/$name" "$arch"; then
-      cp "$bin_dir/$name" "$stage_dir/$name"
+    if ! product=$(codexbar_require_product_file "$bin_dir" "$name" "$arch"); then
+      return 1
     fi
+    if ! binary_has_arch "$product" "$arch"; then
+      echo "ERROR: ${product} does not contain required architecture: ${arch}" >&2
+      return 1
+    fi
+    cp "$product" "$stage_dir/$name"
   done
+  if [[ -d "$bin_dir/CodexBar.dSYM" ]]; then
+    cp -R "$bin_dir/CodexBar.dSYM" "$stage_dir/"
+  fi
 }
 
 for ARCH in "${ARCH_LIST[@]}"; do
   swift build -c "$CONF" --arch "$ARCH"
-  stage_binary_products "$ARCH"
+  stage_build_products "$ARCH"
 done
 
 APP_FINAL="$ROOT/CodexBar.app"
@@ -263,30 +264,21 @@ cat > "$APP/Contents/Info.plist" <<PLIST
 </plist>
 PLIST
 
-# Resolve path to a built binary. Prefer the per-arch snapshot, then SwiftPM's
-# reported directory, then legacy layouts for older toolchains.
+# Resolve a built binary from the fresh per-arch snapshot or SwiftPM's reported directory.
 resolve_binary_path() {
   local name="$1"
   local arch="$2"
   local bin_dir candidate
-  candidate="$PRODUCT_STAGE_ROOT/$arch/$name"
-  if binary_has_arch "$candidate" "$arch"; then
-    echo "$candidate"
-    return
-  fi
   swiftpm_bin_path "$arch" bin_dir
-  if [[ -n "$bin_dir" ]] && binary_has_arch "$bin_dir/$name" "$arch"; then
-    echo "$bin_dir/$name"
-    return
+  if ! candidate=$(codexbar_resolve_staged_or_reported_file \
+    "$PRODUCT_STAGE_ROOT" "$bin_dir" "$name" "$arch"); then
+    return 1
   fi
-  candidate=$(build_product_path "$name" "$arch")
-  if binary_has_arch "$candidate" "$arch"; then
-    echo "$candidate"
-    return
+  if ! binary_has_arch "$candidate" "$arch"; then
+    echo "ERROR: ${candidate} does not contain required architecture: ${arch}" >&2
+    return 1
   fi
-  if [[ "$arch" == "arm64" || "$arch" == "x86_64" ]] && binary_has_arch ".build/$CONF/$name" "$arch"; then
-    echo ".build/$CONF/$name"
-  fi
+  echo "$candidate"
 }
 
 verify_binary_arches() {
@@ -314,11 +306,8 @@ install_binary() {
   local dest="$2"
   local binaries=()
   for arch in "${ARCH_LIST[@]}"; do
-    local src bin_dir
-    src=$(resolve_binary_path "$name" "$arch")
-    if [[ -z "$src" || ! -f "$src" ]]; then
-      swiftpm_bin_path "$arch" bin_dir
-      echo "ERROR: Missing ${name} build for ${arch} (looked in: $PRODUCT_STAGE_ROOT/$arch, $bin_dir, $(build_product_path "$name" "$arch"), .build/$CONF)" >&2
+    local src
+    if ! src=$(resolve_binary_path "$name" "$arch"); then
       exit 1
     fi
     binaries+=("$src")
@@ -420,21 +409,20 @@ install_widget_extension() {
 
 install_binary "CodexBar" "$APP/Contents/MacOS/CodexBar"
 # Ship CodexBarCLI alongside the app for easy symlinking.
-if [[ -n "$(resolve_binary_path "CodexBarCLI" "${ARCH_LIST[0]}")" ]]; then
-  install_binary "CodexBarCLI" "$APP/Contents/Helpers/CodexBarCLI"
-fi
+install_binary "CodexBarCLI" "$APP/Contents/Helpers/CodexBarCLI"
 # Watchdog helper: ensures `claude` probes die when CodexBar crashes/gets killed.
-if [[ -n "$(resolve_binary_path "CodexBarClaudeWatchdog" "${ARCH_LIST[0]}")" ]]; then
-  install_binary "CodexBarClaudeWatchdog" "$APP/Contents/Helpers/CodexBarClaudeWatchdog"
-fi
+install_binary "CodexBarClaudeWatchdog" "$APP/Contents/Helpers/CodexBarClaudeWatchdog"
 install_widget_extension
+
+swiftpm_bin_path "${ARCH_LIST[0]}" PREFERRED_BUILD_DIR
+
 # Embed Sparkle.framework
-if [[ -d ".build/$CONF/Sparkle.framework" ]]; then
-  cp -R ".build/$CONF/Sparkle.framework" "$APP/Contents/Frameworks/"
-  chmod -R a+rX "$APP/Contents/Frameworks/Sparkle.framework"
-  install_name_tool -add_rpath "@executable_path/../Frameworks" "$APP/Contents/MacOS/CodexBar"
-  # Re-sign Sparkle and all nested components with Developer ID + timestamp
-  SPARKLE="$APP/Contents/Frameworks/Sparkle.framework"
+SPARKLE_SOURCE=$(codexbar_require_product_directory "$PREFERRED_BUILD_DIR" Sparkle.framework packaging)
+cp -R "$SPARKLE_SOURCE" "$APP/Contents/Frameworks/"
+chmod -R a+rX "$APP/Contents/Frameworks/Sparkle.framework"
+install_name_tool -add_rpath "@executable_path/../Frameworks" "$APP/Contents/MacOS/CodexBar"
+# Re-sign Sparkle and all nested components with Developer ID + timestamp
+SPARKLE="$APP/Contents/Frameworks/Sparkle.framework"
 if [[ "$SIGNING_MODE" == "adhoc" ]]; then
   CODESIGN_ID="-"
   CODESIGN_ARGS=(--force --sign "$CODESIGN_ID")
@@ -446,19 +434,18 @@ else
   CODESIGN_ARGS=(--force --timestamp --options runtime --sign "$CODESIGN_ID")
 fi
 function resign() { codesign "${CODESIGN_ARGS[@]}" "$1"; }
-  # Sign innermost binaries first, then the framework root to seal resources
-  resign "$SPARKLE"
-  resign "$SPARKLE/Versions/B/Sparkle"
-  resign "$SPARKLE/Versions/B/Autoupdate"
-  resign "$SPARKLE/Versions/B/Updater.app"
-  resign "$SPARKLE/Versions/B/Updater.app/Contents/MacOS/Updater"
-  resign "$SPARKLE/Versions/B/XPCServices/Downloader.xpc"
-  resign "$SPARKLE/Versions/B/XPCServices/Downloader.xpc/Contents/MacOS/Downloader"
-  resign "$SPARKLE/Versions/B/XPCServices/Installer.xpc"
-  resign "$SPARKLE/Versions/B/XPCServices/Installer.xpc/Contents/MacOS/Installer"
-  resign "$SPARKLE/Versions/B"
-  resign "$SPARKLE"
-fi
+# Sign innermost binaries first, then the framework root to seal resources
+resign "$SPARKLE"
+resign "$SPARKLE/Versions/B/Sparkle"
+resign "$SPARKLE/Versions/B/Autoupdate"
+resign "$SPARKLE/Versions/B/Updater.app"
+resign "$SPARKLE/Versions/B/Updater.app/Contents/MacOS/Updater"
+resign "$SPARKLE/Versions/B/XPCServices/Downloader.xpc"
+resign "$SPARKLE/Versions/B/XPCServices/Downloader.xpc/Contents/MacOS/Downloader"
+resign "$SPARKLE/Versions/B/XPCServices/Installer.xpc"
+resign "$SPARKLE/Versions/B/XPCServices/Installer.xpc/Contents/MacOS/Installer"
+resign "$SPARKLE/Versions/B"
+resign "$SPARKLE"
 
 if [[ -f "$ICON_TARGET" ]]; then
   cp "$ICON_TARGET" "$APP/Contents/Resources/Icon.icns"
@@ -475,11 +462,6 @@ if [[ ! -f "$APP/Contents/Resources/Icon-classic.icns" ]]; then
 fi
 
 # SwiftPM resource bundles (e.g. KeyboardShortcuts) are emitted next to the built binary.
-swiftpm_bin_path "${ARCH_LIST[0]}" PREFERRED_BUILD_DIR
-if [[ -z "$PREFERRED_BUILD_DIR" ]]; then
-  CODEXBAR_BINARY="$(resolve_binary_path "CodexBar" "${ARCH_LIST[0]}")"
-  PREFERRED_BUILD_DIR="$(dirname "${CODEXBAR_BINARY:-$(build_product_path "CodexBar" "${ARCH_LIST[0]}")}")"
-fi
 shopt -s nullglob
 SWIFTPM_BUNDLES=("${PREFERRED_BUILD_DIR}/"*.bundle)
 shopt -u nullglob

--- a/Scripts/package_product_paths.sh
+++ b/Scripts/package_product_paths.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+codexbar_swiftpm_bin_path() {
+  local conf="$1"
+  shift
+  local command=(swift build --show-bin-path -c "$conf")
+  local arch
+  for arch in "$@"; do
+    command+=(--arch "$arch")
+  done
+
+  local path
+  if ! path=$("${command[@]}"); then
+    echo "ERROR: SwiftPM failed to report the ${conf} product directory for: $*" >&2
+    return 1
+  fi
+  if [[ -z "$path" ]]; then
+    echo "ERROR: SwiftPM reported an empty ${conf} product directory for: $*" >&2
+    return 1
+  fi
+  printf '%s\n' "$path"
+}
+
+codexbar_require_product_file() {
+  local bin_dir="$1"
+  local name="$2"
+  local arch_label="$3"
+  local product="$bin_dir/$name"
+  if [[ ! -f "$product" ]]; then
+    echo "ERROR: Missing ${name} for ${arch_label} at SwiftPM-reported path: ${product}" >&2
+    return 1
+  fi
+  printf '%s\n' "$product"
+}
+
+codexbar_require_product_directory() {
+  local bin_dir="$1"
+  local name="$2"
+  local context="$3"
+  local product="$bin_dir/$name"
+  if [[ ! -d "$product" ]]; then
+    echo "ERROR: Missing ${name} for ${context} at SwiftPM-reported path: ${product}" >&2
+    return 1
+  fi
+  printf '%s\n' "$product"
+}
+
+codexbar_resolve_staged_or_reported_file() {
+  local stage_root="$1"
+  local bin_dir="$2"
+  local name="$3"
+  local arch="$4"
+  local staged="$stage_root/$arch/$name"
+  if [[ -f "$staged" ]]; then
+    printf '%s\n' "$staged"
+    return
+  fi
+  codexbar_require_product_file "$bin_dir" "$name" "$arch"
+}
+
+codexbar_resolve_dsym_path() {
+  local stage_root="$1"
+  local bin_dir="$2"
+  local app_name="$3"
+  local arch="$4"
+  local staged="$stage_root/$arch/${app_name}.dSYM"
+  if [[ -d "$staged" ]]; then
+    printf '%s\n' "$staged"
+    return
+  fi
+  codexbar_require_product_directory "$bin_dir" "${app_name}.dSYM" "$arch"
+}

--- a/Scripts/sign-and-notarize.sh
+++ b/Scripts/sign-and-notarize.sh
@@ -7,6 +7,7 @@ APP_BUNDLE="CodexBar.app"
 ROOT=$(cd "$(dirname "$0")/.." && pwd)
 source "$ROOT/version.env"
 source "$ROOT/Scripts/release_artifacts.sh"
+source "$ROOT/Scripts/package_product_paths.sh"
 
 # Allow building a universal binary if ARCHES is provided; default to universal (arm64 + x86_64).
 ARCHES_VALUE=${ARCHES:-"arm64 x86_64"}
@@ -84,31 +85,46 @@ spctl -a -t exec -vv "$APP_BUNDLE"
 stapler validate "$APP_BUNDLE"
 
 echo "Packaging dSYM"
-FIRST_ARCH="${ARCH_LIST[0]}"
-PREFERRED_ARCH_DIR=".build/${FIRST_ARCH}-apple-macosx/release"
-DSYM_PATH="${PREFERRED_ARCH_DIR}/${APP_NAME}.dSYM"
-if [[ ! -d "$DSYM_PATH" ]]; then
-  echo "Missing dSYM at $DSYM_PATH" >&2
-  exit 1
-fi
+DSYM_STAGE_ROOT="$ROOT/.build/package-products/release"
+DSYM_PATHS=()
+for ARCH in "${ARCH_LIST[@]}"; do
+  STAGED_DSYM="$DSYM_STAGE_ROOT/$ARCH/${APP_NAME}.dSYM"
+  if [[ -d "$STAGED_DSYM" ]]; then
+    DSYM_PATHS+=("$STAGED_DSYM")
+    continue
+  fi
+  BIN_DIR=$(codexbar_swiftpm_bin_path release "$ARCH")
+  DSYM_PATHS+=("$(codexbar_resolve_dsym_path "$DSYM_STAGE_ROOT" "$BIN_DIR" "$APP_NAME" "$ARCH")")
+done
+
+DSYM_PATH="${DSYM_PATHS[0]}"
 if [[ ${#ARCH_LIST[@]} -gt 1 ]]; then
-  MERGED_DSYM_ROOT="${PREFERRED_ARCH_DIR}/${APP_NAME}.dSYM-universal"
+  MERGED_DSYM_ROOT="${DSYM_STAGE_ROOT}/${APP_NAME}.dSYM-universal"
   MERGED_DSYM="${MERGED_DSYM_ROOT}/${APP_NAME}.dSYM"
   rm -rf "$MERGED_DSYM_ROOT"
   mkdir -p "$MERGED_DSYM_ROOT"
   cp -R "$DSYM_PATH" "$MERGED_DSYM"
   DWARF_PATH="${MERGED_DSYM}/Contents/Resources/DWARF/${APP_NAME}"
   BINARIES=()
-  for ARCH in "${ARCH_LIST[@]}"; do
-    ARCH_DSYM=".build/${ARCH}-apple-macosx/release/${APP_NAME}.dSYM/Contents/Resources/DWARF/${APP_NAME}"
+  for ((index = 0; index < ${#ARCH_LIST[@]}; index++)); do
+    ARCH="${ARCH_LIST[$index]}"
+    ARCH_DSYM="${DSYM_PATHS[$index]}/Contents/Resources/DWARF/${APP_NAME}"
     if [[ ! -f "$ARCH_DSYM" ]]; then
-      echo "Missing dSYM for ${ARCH} at $ARCH_DSYM" >&2
+      echo "Missing fresh dSYM for ${ARCH} at: $ARCH_DSYM" >&2
+      exit 1
+    fi
+    if ! lipo -archs "$ARCH_DSYM" | tr ' ' '\n' | grep -qx "$ARCH"; then
+      echo "dSYM at ${ARCH_DSYM} does not contain required architecture: ${ARCH}" >&2
       exit 1
     fi
     BINARIES+=("$ARCH_DSYM")
   done
   lipo -create "${BINARIES[@]}" -output "$DWARF_PATH"
   DSYM_PATH="$MERGED_DSYM"
+fi
+if [[ ! -d "$DSYM_PATH" ]]; then
+  echo "Missing dSYM at SwiftPM-reported path: $DSYM_PATH" >&2
+  exit 1
 fi
 "$DITTO_BIN" --norsrc -c -k --keepParent "$DSYM_PATH" "$DSYM_ZIP"
 

--- a/Scripts/test_package_product_paths.sh
+++ b/Scripts/test_package_product_paths.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+source "$ROOT/Scripts/package_product_paths.sh"
+
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/codexbar-package-paths.XXXXXX")
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+NATIVE_DIR="$TEMP_DIR/.build/arm64-apple-macosx/release"
+SWIFTBUILD_DIR="$TEMP_DIR/.build/out/Products/Release"
+STAGE_ROOT="$TEMP_DIR/.build/package-products/release"
+mkdir -p "$NATIVE_DIR/CodexBar.dSYM" "$SWIFTBUILD_DIR/Sparkle.framework" "$SWIFTBUILD_DIR/CodexBar.dSYM"
+touch "$NATIVE_DIR/CodexBar" "$SWIFTBUILD_DIR/CodexBar"
+
+native=$(codexbar_require_product_file "$NATIVE_DIR" CodexBar arm64)
+[[ "$native" == "$NATIVE_DIR/CodexBar" ]]
+
+swiftbuild=$(codexbar_require_product_file "$SWIFTBUILD_DIR" CodexBar arm64)
+[[ "$swiftbuild" == "$SWIFTBUILD_DIR/CodexBar" ]]
+
+framework=$(codexbar_require_product_directory "$SWIFTBUILD_DIR" Sparkle.framework packaging)
+[[ "$framework" == "$SWIFTBUILD_DIR/Sparkle.framework" ]]
+
+dsym=$(codexbar_require_product_directory "$SWIFTBUILD_DIR" CodexBar.dSYM release)
+[[ "$dsym" == "$SWIFTBUILD_DIR/CodexBar.dSYM" ]]
+
+resolved=$(codexbar_resolve_staged_or_reported_file "$STAGE_ROOT" "$SWIFTBUILD_DIR" CodexBar arm64)
+[[ "$resolved" == "$SWIFTBUILD_DIR/CodexBar" ]]
+
+resolved_dsym=$(codexbar_resolve_dsym_path "$STAGE_ROOT" "$SWIFTBUILD_DIR" CodexBar arm64)
+[[ "$resolved_dsym" == "$SWIFTBUILD_DIR/CodexBar.dSYM" ]]
+
+mkdir -p "$STAGE_ROOT/arm64/CodexBar.dSYM"
+touch "$STAGE_ROOT/arm64/CodexBar"
+staged=$(codexbar_resolve_staged_or_reported_file "$STAGE_ROOT" "$SWIFTBUILD_DIR" CodexBar arm64)
+[[ "$staged" == "$STAGE_ROOT/arm64/CodexBar" ]]
+staged_dsym=$(codexbar_resolve_dsym_path "$STAGE_ROOT" "$SWIFTBUILD_DIR" CodexBar arm64)
+[[ "$staged_dsym" == "$STAGE_ROOT/arm64/CodexBar.dSYM" ]]
+
+rm -rf "$STAGE_ROOT"
+rm "$SWIFTBUILD_DIR/CodexBar"
+if codexbar_resolve_staged_or_reported_file "$STAGE_ROOT" "$SWIFTBUILD_DIR" CodexBar arm64 \
+  2>"$TEMP_DIR/missing-file.log"; then
+  echo "ERROR: Missing reported product unexpectedly fell back to legacy output." >&2
+  exit 1
+fi
+grep -Fq "$SWIFTBUILD_DIR/CodexBar" "$TEMP_DIR/missing-file.log"
+
+rm -rf "$SWIFTBUILD_DIR/Sparkle.framework"
+if codexbar_require_product_directory "$SWIFTBUILD_DIR" Sparkle.framework packaging \
+  2>"$TEMP_DIR/missing-directory.log"; then
+  echo "ERROR: Missing reported framework was accepted." >&2
+  exit 1
+fi
+grep -Fq "$SWIFTBUILD_DIR/Sparkle.framework" "$TEMP_DIR/missing-directory.log"
+
+rm -rf "$SWIFTBUILD_DIR/CodexBar.dSYM"
+if codexbar_resolve_dsym_path "$STAGE_ROOT" "$SWIFTBUILD_DIR" CodexBar arm64 \
+  2>"$TEMP_DIR/missing-dsym.log"; then
+  echo "ERROR: Missing reported dSYM unexpectedly fell back to legacy output." >&2
+  exit 1
+fi
+grep -Fq "$SWIFTBUILD_DIR/CodexBar.dSYM" "$TEMP_DIR/missing-dsym.log"
+
+swift() {
+  [[ "$*" == "build --show-bin-path -c release --arch arm64" ]]
+  printf '%s\n' "$SWIFTBUILD_DIR"
+}
+reported=$(codexbar_swiftpm_bin_path release arm64)
+[[ "$reported" == "$SWIFTBUILD_DIR" ]]
+
+swift() {
+  return 23
+}
+if codexbar_swiftpm_bin_path release arm64 2>"$TEMP_DIR/query.log"; then
+  echo "ERROR: SwiftPM bin-path query failure was ignored." >&2
+  exit 1
+fi
+grep -Fq "SwiftPM failed to report" "$TEMP_DIR/query.log"
+
+swift() {
+  return 0
+}
+if codexbar_swiftpm_bin_path release arm64 2>"$TEMP_DIR/empty.log"; then
+  echo "ERROR: Empty SwiftPM bin path was accepted." >&2
+  exit 1
+fi
+grep -Fq "SwiftPM reported an empty" "$TEMP_DIR/empty.log"
+
+echo "Package product path tests passed."


### PR DESCRIPTION
## Summary

- Treat SwiftPM's reported product directory as authoritative for app binaries, helpers, resources, and Sparkle.
- Stage each architecture's fresh products and dSYM before SwiftBuild can replace its shared output directory.
- Fail closed when a required reported product is missing instead of packaging a stale legacy-layout artifact.
- Add focused shell regression coverage to the standard lint gate.

## Context

Follow-up to #1473. The landed fix correctly introduced SwiftPM path discovery, but successful discovery could still fall back to stale legacy products, while Sparkle and release dSYM lookup remained tied to the legacy layout. Thanks @ProspectOre for identifying the original stale build-product selection.

## Proof

Exact candidate: `cc7c00edde1b8e29c454a23e6d3671418a574d96`

- Reproduced on landed `main`: removing the reported executable while retaining a stale legacy executable still produced a package; fresh app and legacy dSYM UUIDs differed; removing the legacy release symlink broke Sparkle lookup despite Sparkle existing under the reported path.
- Focused shell regression: pass, including reported native/SwiftBuild paths, staged precedence, query failure, and refusal of stale legacy binaries/frameworks/dSYMs.
- `make check`: pass, SwiftFormat and SwiftLint clean.
- Full isolated suite run: 429/429 suites passed.
- Native release package: reported arm64 path used; app, CLI, and widget arm64; Sparkle/resources present; app and staged dSYM UUID match; deep signing passed; isolated installed app remained alive for 8 seconds with zero launch-log bytes.
- Forced SwiftBuild universal package with the legacy release symlink absent: reported `out/Products/Release` path used; app, CLI, watchdog, and widget contain arm64 and x86_64; Sparkle/resources present; staged dSYMs contain the correct thin slices; merged dSYM UUIDs match both app slices; deep signing passed; isolated installed app remained alive for 8 seconds with zero launch-log bytes.
- Autoreview: clean, no accepted/actionable findings.
- Public Model Identifier Gate: PASS. Diff, test output, proof notes, and this PR body contain no non-public model identifiers or private payloads.

## Tradeoff

Missing required products now stop packaging. Older Swift toolchains that cannot report the product path will fail rather than silently selecting an unknown stale product; the repository's supported Swift toolchain provides the required query.
