### PR TITLE
Fix provider switch rebuilds during menu tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.1 — Unreleased
 
+- Menu bar: rebuild merged provider content inside AppKit's active tracking run loop so provider switches no longer wait for the menu to close or the default run loop to resume.
 - Diagnostics: enforce probe timeouts even when an underlying provider operation ignores Swift task cancellation.
 - Kimi: add usage fetching from the official Code API key flow, with optional compatible HTTPS proxy support (#1424). Thanks @kiranmagic7!
 - Menu bar: keep the selected quota percentage visible in Pace mode when pace is temporarily unavailable instead of collapsing to an icon-only status item (fixes #1462).

--- a/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
+++ b/Sources/CodexBar/StatusItemController+MenuRefreshScheduling.swift
@@ -5,6 +5,13 @@ import QuartzCore
 extension StatusItemController {
     private static let providerSwitcherMenuRebuildDebounceNanoseconds: UInt64 = 0
 
+    private struct ScheduledOpenMenuRebuild {
+        let provider: UsageProvider?
+        let shouldCloseHostedSubviewMenus: Bool
+        let resyncReadinessBaselineAfterRebuild: Bool
+        let beforeRebuild: (@MainActor () -> Bool)?
+    }
+
     func didMenuAdjunctReadinessChange() -> Bool {
         let signature = self.menuAdjunctReadinessSignature()
         defer { self.recordMenuAdjunctReadinessBaseline(signature) }
@@ -200,6 +207,22 @@ extension StatusItemController {
         #else
         let debounceNanoseconds = Self.providerSwitcherMenuRebuildDebounceNanoseconds
         #endif
+        #if DEBUG
+        let usesTaskSchedulerForTesting = self._test_openMenuRefreshYieldOverride != nil
+            || self._test_openMenuRebuildObserver != nil
+        #else
+        let usesTaskSchedulerForTesting = false
+        #endif
+        if debounceNanoseconds == 0, !usesTaskSchedulerForTesting {
+            self.scheduleProviderSwitcherTrackingMenuRebuildIfStillVisible(
+                menu,
+                provider: provider)
+            { [weak self] in
+                guard let self else { return false }
+                return self.providerSwitcherUpdateToken == updateToken
+            }
+            return
+        }
         self.scheduleOpenMenuRebuildIfStillVisible(
             menu,
             provider: provider,
@@ -208,6 +231,32 @@ extension StatusItemController {
         { [weak self] in
             guard let self else { return false }
             return self.providerSwitcherUpdateToken == updateToken
+        }
+    }
+
+    private func scheduleProviderSwitcherTrackingMenuRebuildIfStillVisible(
+        _ menu: NSMenu,
+        provider: UsageProvider?,
+        beforeRebuild: @escaping @MainActor () -> Bool)
+    {
+        let key = ObjectIdentifier(menu)
+        self.openMenuRebuildsClosingHostedSubviewMenus.insert(key)
+        self.openMenuRebuildTokenCounter &+= 1
+        let rebuildToken = self.openMenuRebuildTokenCounter
+        self.openMenuRebuildTokens[key] = rebuildToken
+        self.openMenuRebuildTasks.removeValue(forKey: key)?.cancel()
+
+        ProviderSwitcherTrackingRunLoopScheduler.schedule { [weak self, weak menu] in
+            guard let self, let menu else { return }
+            self.performScheduledOpenMenuRebuild(
+                menu,
+                key: key,
+                rebuildToken: rebuildToken,
+                request: ScheduledOpenMenuRebuild(
+                    provider: provider,
+                    shouldCloseHostedSubviewMenus: true,
+                    resyncReadinessBaselineAfterRebuild: false,
+                    beforeRebuild: beforeRebuild))
         }
     }
 
@@ -243,23 +292,40 @@ extension StatusItemController {
                 try? await Task.sleep(nanoseconds: debounceNanoseconds)
             }
             guard !Task.isCancelled else { return }
-            guard self.openMenuRebuildTokens[key] == rebuildToken else { return }
-            defer {
-                if self.openMenuRebuildTokens[key] == rebuildToken {
-                    self.openMenuRebuildTasks.removeValue(forKey: key)
-                    self.openMenuRebuildTokens.removeValue(forKey: key)
-                    self.openMenuRebuildsClosingHostedSubviewMenus.remove(key)
-                }
+            self.performScheduledOpenMenuRebuild(
+                menu,
+                key: key,
+                rebuildToken: rebuildToken,
+                request: ScheduledOpenMenuRebuild(
+                    provider: provider,
+                    shouldCloseHostedSubviewMenus: shouldCloseHostedSubviewMenus,
+                    resyncReadinessBaselineAfterRebuild: resyncReadinessBaselineAfterRebuild,
+                    beforeRebuild: beforeRebuild))
+        }
+    }
+
+    private func performScheduledOpenMenuRebuild(
+        _ menu: NSMenu,
+        key: ObjectIdentifier,
+        rebuildToken: Int,
+        request: ScheduledOpenMenuRebuild)
+    {
+        guard self.openMenuRebuildTokens[key] == rebuildToken else { return }
+        defer {
+            if self.openMenuRebuildTokens[key] == rebuildToken {
+                self.openMenuRebuildTasks.removeValue(forKey: key)
+                self.openMenuRebuildTokens.removeValue(forKey: key)
+                self.openMenuRebuildsClosingHostedSubviewMenus.remove(key)
             }
-            guard self.openMenus[key] != nil else { return }
-            guard beforeRebuild?() ?? true else { return }
-            if shouldCloseHostedSubviewMenus {
-                self.closeHostedSubviewMenusForParentSwitch()
-            }
-            self.rebuildOpenMenuIfStillVisible(menu, provider: provider)
-            if resyncReadinessBaselineAfterRebuild, !self.menuNeedsRefresh(menu) {
-                self.resyncMenuAdjunctReadinessBaseline()
-            }
+        }
+        guard self.openMenus[key] != nil else { return }
+        guard request.beforeRebuild?() ?? true else { return }
+        if request.shouldCloseHostedSubviewMenus {
+            self.closeHostedSubviewMenusForParentSwitch()
+        }
+        self.rebuildOpenMenuIfStillVisible(menu, provider: request.provider)
+        if request.resyncReadinessBaselineAfterRebuild, !self.menuNeedsRefresh(menu) {
+            self.resyncMenuAdjunctReadinessBaseline()
         }
     }
 

--- a/Sources/CodexBar/StatusItemController+ProviderSwitcher.swift
+++ b/Sources/CodexBar/StatusItemController+ProviderSwitcher.swift
@@ -187,6 +187,43 @@ private final class ProviderSwitcherMenuTrackingState {
     var isTrackingActive = false
 }
 
+@MainActor
+private final class ProviderSwitcherTrackingRunLoopOperation {
+    private var operation: (@MainActor () -> Void)?
+
+    init(operation: @escaping @MainActor () -> Void) {
+        self.operation = operation
+    }
+
+    func run() {
+        guard let operation = self.operation else { return }
+        self.operation = nil
+        operation()
+    }
+}
+
+@MainActor
+enum ProviderSwitcherTrackingRunLoopScheduler {
+    static func schedule(_ operation: @escaping @MainActor () -> Void) {
+        let pending = ProviderSwitcherTrackingRunLoopOperation(operation: operation)
+        let runLoop = CFRunLoopGetMain()
+        // Main-actor tasks can starve while AppKit owns the modal menu loop. Queue in both modes so the
+        // rebuild runs during tracking, with the default mode as a fallback if tracking ends first.
+        let modes = [
+            RunLoop.Mode.eventTracking.rawValue,
+            RunLoop.Mode.default.rawValue,
+        ]
+        for mode in modes {
+            CFRunLoopPerformBlock(runLoop, mode as CFString) {
+                MainActor.assumeIsolated {
+                    pending.run()
+                }
+            }
+        }
+        CFRunLoopWakeUp(runLoop)
+    }
+}
+
 extension StatusItemController {
     func installProviderSwitcherShortcutMonitorIfNeeded(for menu: NSMenu) {
         guard self.isMenuRefreshEnabled,

--- a/Tests/CodexBarTests/StatusMenuSwitcherTrackingTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherTrackingTests.swift
@@ -7,6 +7,23 @@ import Testing
 @Suite(.serialized)
 struct StatusMenuSwitcherTrackingTests {
     @Test
+    func `switcher rebuild scheduler runs during menu tracking exactly once`() {
+        var runCount = 0
+        ProviderSwitcherTrackingRunLoopScheduler.schedule {
+            runCount += 1
+        }
+
+        CFRunLoopRunInMode(
+            CFRunLoopMode(RunLoop.Mode.eventTracking.rawValue as CFString),
+            0.1,
+            true)
+        #expect(runCount == 1)
+
+        CFRunLoopRunInMode(.defaultMode, 0.1, true)
+        #expect(runCount == 1)
+    }
+
+    @Test
     func `pointer switch defers structural menu rebuild until mouse up`() async throws {
         let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
         let previousMenuRefresh = StatusItemController.menuRefreshEnabled


### PR DESCRIPTION
## Summary
- schedule zero-debounce provider-switch rebuilds directly in AppKit's active event-tracking run-loop mode
- preserve token coalescing, visibility checks, hosted-submenu cleanup, and existing task-based test seams
- add a regression proving the tracking scheduler runs exactly once across tracking/default modes

## Root cause
Provider selection updated the tab immediately, then queued the structural menu rebuild in a main-actor `Task` after `Task.yield()`. While AppKit owns the modal menu event loop, that task can be starved until tracking ends, leaving the selected provider's content stale or apparently hung.

The scheduler now submits the rebuild to both the event-tracking and default run-loop modes through a one-shot operation. It can execute while the menu is open, and still has a default-mode fallback if tracking ends first.

## Verification
- rebased onto current `main` (`69831cad`)
- `swift test --filter 'StatusMenuSwitcher(Click|Tracking|Refresh)Tests|StatusMenuOpenRefreshTests'` (60 tests passed)
- `make check`
- Codex branch-delta autoreview: clean, no accepted/actionable findings, confidence 0.86

No live provider/auth probes were run; verification uses the AppKit state/model seams and avoids Keychain prompts.

Related to #1329, but does not close it: that older report also includes memory/auth symptoms requiring separate current-release live reproduction.
