### PR TITLE
fix: prevent tests from terminating user Codex processes

### DIFF
--- a/Tests/CodexBarTests/TestProcessCleanup.swift
+++ b/Tests/CodexBarTests/TestProcessCleanup.swift
@@ -7,12 +7,16 @@ import Glibc
 #endif
 
 enum TestProcessCleanup {
+    static let codexTestStubCommandRegex =
+        #"codex-(stub|fallback-stub|plan-only-stub|credits-only-stub|hung-stub)-[[:xdigit:]-]+.*app-server"#
+
     static func register() {
         atexit(_testProcessCleanupAtExit)
     }
 
-    fileprivate static func terminateLeakedCodexAppServers() {
-        let pids = Self.pids(matchingFullCommandRegex: "codex.*app-server")
+    fileprivate static func terminateLeakedCodexTestStubs() {
+        // Never target an installed Codex process. These UUID-named executables are created only by this test target.
+        let pids = Self.pids(matchingFullCommandRegex: Self.codexTestStubCommandRegex)
             .filter { $0 > 0 && $0 != getpid() }
         guard !pids.isEmpty else { return }
 
@@ -65,5 +69,5 @@ private let _registerTestProcessCleanup: Void = TestProcessCleanup.register()
 
 @_cdecl("codexbar_test_cleanup_atexit")
 private func _testProcessCleanupAtExit() {
-    TestProcessCleanup.terminateLeakedCodexAppServers()
+    TestProcessCleanup.terminateLeakedCodexTestStubs()
 }

--- a/Tests/CodexBarTests/TestProcessCleanup.swift
+++ b/Tests/CodexBarTests/TestProcessCleanup.swift
@@ -7,8 +7,11 @@ import Glibc
 #endif
 
 enum TestProcessCleanup {
-    static let codexTestStubCommandRegex =
-        #"codex-(stub|fallback-stub|plan-only-stub|credits-only-stub|hung-stub)-[[:xdigit:]-]+.*app-server"#
+    static let codexTestStubCommandRegex = [
+        #"codex-(stub|fallback-stub|plan-only-stub|credits-only-stub|hung-stub)-"#,
+        #"[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}"#,
+        #"[[:space:]]+app-server([[:space:]]|$)"#,
+    ].joined()
 
     static func register() {
         atexit(_testProcessCleanupAtExit)

--- a/Tests/CodexBarTests/TestProcessCleanupTests.swift
+++ b/Tests/CodexBarTests/TestProcessCleanupTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+
+struct TestProcessCleanupTests {
+    @Test
+    func `cleanup pattern matches only CodexBar test stub app servers`() throws {
+        let regex = try NSRegularExpression(pattern: TestProcessCleanup.codexTestStubCommandRegex)
+        let testStubCommands = [
+            "/usr/bin/python3 -S /tmp/codex-stub-01234567-89AB-CDEF-0123-456789ABCDEF app-server",
+            "/bin/sh /tmp/codex-fallback-stub-01234567-89AB-CDEF-0123-456789ABCDEF app-server",
+            "/bin/sh /tmp/codex-plan-only-stub-01234567-89AB-CDEF-0123-456789ABCDEF app-server",
+            "/bin/sh /tmp/codex-credits-only-stub-01234567-89AB-CDEF-0123-456789ABCDEF app-server",
+            "/bin/sh /tmp/codex-hung-stub-01234567-89AB-CDEF-0123-456789ABCDEF app-server",
+        ]
+        let userCommands = [
+            "/Applications/Codex.app/Contents/Resources/codex app-server --listen stdio://",
+            "/opt/homebrew/bin/codex app-server",
+            "node /Users/test/node_modules/.bin/codex app-server --listen stdio://",
+        ]
+
+        for command in testStubCommands {
+            #expect(Self.matches(regex, command))
+        }
+        for command in userCommands {
+            #expect(!Self.matches(regex, command))
+        }
+    }
+
+    private static func matches(_ regex: NSRegularExpression, _ command: String) -> Bool {
+        regex.firstMatch(
+            in: command,
+            range: NSRange(command.startIndex..., in: command)) != nil
+    }
+}

--- a/Tests/CodexBarTests/TestProcessCleanupTests.swift
+++ b/Tests/CodexBarTests/TestProcessCleanupTests.swift
@@ -16,6 +16,9 @@ struct TestProcessCleanupTests {
             "/Applications/Codex.app/Contents/Resources/codex app-server --listen stdio://",
             "/opt/homebrew/bin/codex app-server",
             "node /Users/test/node_modules/.bin/codex app-server --listen stdio://",
+            "/tmp/codex-stub-cache app-server",
+            "/tmp/codex-stub-01234567-89AB-CDEF-0123 app-server",
+            "/tmp/codex-stub-01234567-89AB-CDEF-0123-456789ABCDEF app-server-helper",
         ]
 
         for command in testStubCommands {


### PR DESCRIPTION
## Summary
- restrict Codex test teardown to exact UUID-named executables created by the test suite
- stop broad process matching from targeting installed or user-owned Codex app-server processes
- add regression coverage for valid test stubs, malformed/lookalike names, and representative real Codex commands

## Risk
Test-only cleanup behavior. No application runtime changes.

## Proof
- rebased onto `main` at `69831cad`
- `swift test --filter TestProcessCleanupTests`
- `make check`
- branch-delta autoreview: clean, confidence 0.86
- existing user Codex app-server process remained alive after the focused test exited
