### PR TITLE
Add opt-in rolling window auto-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.34.1 — Unreleased
 
 - Settings: keep the native tab toolbar in sync when macOS switches appearance while the window is open (#1484). Thanks @hhh2210!
+- Providers: add an opt-in Codex and Claude setting that starts a new five-hour rolling window with a tiny CLI prompt after the previous window expires, restricted to matching CLI-backed usage sources (#1481). Thanks @Quicksaver!
 - Menu bar: avoid starting a duplicate background provider refresh when the menu closes while its initial missing-data refresh is still in flight.
 - Menu bar: rebuild merged provider content inside AppKit's active tracking run loop so provider switches no longer wait for the menu to close or the default run loop to resume.
 - Diagnostics: enforce probe timeouts even when an underlying provider operation ignores Swift task cancellation.

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -364,8 +364,12 @@ struct ProvidersPane: View {
     private func extraSettingsToggles(for provider: UsageProvider) -> [ProviderSettingsToggleDescriptor] {
         guard let impl = ProviderCatalog.implementation(for: provider) else { return [] }
         let context = self.makeSettingsContext(provider: provider)
-        let shared = RollingWindowAutoStartSupport.toggle(context: context).map { [$0] } ?? []
-        return (shared + impl.settingsToggles(context: context))
+        var toggles: [ProviderSettingsToggleDescriptor] = []
+        if let rollingWindowToggle = RollingWindowAutoStartSupport.toggle(context: context) {
+            toggles.append(rollingWindowToggle)
+        }
+        toggles.append(contentsOf: impl.settingsToggles(context: context))
+        return toggles
             .filter { $0.isVisible?() ?? true }
     }
 

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -364,7 +364,8 @@ struct ProvidersPane: View {
     private func extraSettingsToggles(for provider: UsageProvider) -> [ProviderSettingsToggleDescriptor] {
         guard let impl = ProviderCatalog.implementation(for: provider) else { return [] }
         let context = self.makeSettingsContext(provider: provider)
-        return impl.settingsToggles(context: context)
+        let shared = RollingWindowAutoStartSupport.toggle(context: context).map { [$0] } ?? []
+        return (shared + impl.settingsToggles(context: context))
             .filter { $0.isVisible?() ?? true }
     }
 

--- a/Sources/CodexBar/RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/RollingWindowAutoStart.swift
@@ -178,7 +178,7 @@ enum RollingWindowPingStarter {
             return self.command(
                 binary: binary,
                 executable: "claude",
-                arguments: ["-p", prompt, "--model", model],
+                arguments: ["-p", "--no-session-persistence", "--model", model, prompt],
                 timeout: timeout)
         case .opencode:
             let model = self.value(environment: environment, key: self.envKey(provider: provider, suffix: "MODEL"))

--- a/Sources/CodexBar/RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/RollingWindowAutoStart.swift
@@ -1,0 +1,242 @@
+import CodexBarCore
+import Foundation
+import SwiftUI
+
+enum RollingWindowAutoStartSupport {
+    static let providers: Set<UsageProvider> = [
+        .codex,
+        .claude,
+        .opencode,
+    ]
+
+    @MainActor
+    static func toggle(context: ProviderSettingsContext) -> ProviderSettingsToggleDescriptor? {
+        guard self.providers.contains(context.provider) else { return nil }
+
+        let binding = Binding(
+            get: { context.settings.rollingWindowAutoStartEnabled(provider: context.provider) },
+            set: { enabled in
+                context.settings.setRollingWindowAutoStartEnabled(provider: context.provider, enabled: enabled)
+            })
+
+        return ProviderSettingsToggleDescriptor(
+            id: "\(context.provider.rawValue)-rolling-window-auto-start",
+            title: "Auto-start rolling window",
+            subtitle: "When a rolling window expires and provider data shows no active replacement, "
+                + "send a tiny prompt through the provider CLI.",
+            binding: binding,
+            statusText: {
+                context.store.rollingWindowAutoStartStatus[context.provider]
+            },
+            actions: [],
+            isVisible: nil,
+            onChange: nil,
+            onAppDidBecomeActive: nil,
+            onAppearWhenEnabled: nil)
+    }
+
+    static func rollingWindow(provider: UsageProvider, snapshot: UsageSnapshot) -> RateWindow? {
+        guard self.providers.contains(provider) else { return nil }
+        return snapshot.primary
+    }
+}
+
+final class RollingWindowAutoStartRuntimeState {
+    var inFlight: Set<UsageProvider> = []
+    var attemptedResetAt: [UsageProvider: Date] = [:]
+    var testRunnerOverride: (any RollingWindowPingRunning)?
+}
+
+struct RollingWindowAutoStartDecision: Equatable {
+    let resetAt: Date
+
+    static func shouldStart(
+        provider: UsageProvider,
+        previous: UsageSnapshot?,
+        currentProviderData: UsageSnapshot,
+        now: Date = Date()) -> RollingWindowAutoStartDecision?
+    {
+        guard RollingWindowAutoStartSupport.providers.contains(provider),
+              let previousWindow = previous.flatMap({ RollingWindowAutoStartSupport.rollingWindow(
+                  provider: provider,
+                  snapshot: $0) }),
+              let previousResetAt = previousWindow.resetsAt,
+              previousResetAt <= now
+        else {
+            return nil
+        }
+
+        let currentWindow = RollingWindowAutoStartSupport.rollingWindow(
+            provider: provider,
+            snapshot: currentProviderData)
+        if let currentResetAt = currentWindow?.resetsAt, currentResetAt > now {
+            return nil
+        }
+
+        return RollingWindowAutoStartDecision(resetAt: previousResetAt)
+    }
+}
+
+struct RollingWindowPingRequest: Sendable {
+    let provider: UsageProvider
+    let binary: String
+    let arguments: [String]
+    let environment: [String: String]
+    let timeout: TimeInterval
+    let label: String
+}
+
+protocol RollingWindowPingRunning: Sendable {
+    func run(_ request: RollingWindowPingRequest) async throws
+}
+
+struct SubprocessRollingWindowPingRunner: RollingWindowPingRunning {
+    func run(_ request: RollingWindowPingRequest) async throws {
+        _ = try await SubprocessRunner.run(
+            binary: request.binary,
+            arguments: request.arguments,
+            environment: request.environment,
+            timeout: request.timeout,
+            label: request.label)
+    }
+}
+
+enum RollingWindowPingStarter {
+    static let defaultPrompt = "hi"
+    static let defaultTimeout: TimeInterval = 90
+
+    static func start(
+        provider: UsageProvider,
+        environment baseEnvironment: [String: String],
+        runner: any RollingWindowPingRunning = SubprocessRollingWindowPingRunner()) async throws
+    {
+        guard let command = self.command(
+            provider: provider,
+            environment: baseEnvironment)
+        else {
+            throw RollingWindowPingError.unsupportedProvider(provider)
+        }
+
+        var environment = baseEnvironment
+        environment["PATH"] = PathBuilder.effectivePATH(purposes: [.tty, .rpc], env: environment)
+
+        try await runner.run(RollingWindowPingRequest(
+            provider: provider,
+            binary: command.binary,
+            arguments: command.arguments,
+            environment: environment,
+            timeout: command.timeout,
+            label: "rolling-window-auto-start-\(provider.rawValue)"))
+    }
+
+    static func command(provider: UsageProvider, environment: [String: String]) -> RollingWindowPingCommand? {
+        let prompt = self.value(
+            environment: environment,
+            key: self.envKey(provider: provider, suffix: "PROMPT")) ?? self.defaultPrompt
+        let timeout = self.doubleValue(
+            environment: environment,
+            key: self.envKey(provider: provider, suffix: "TIMEOUT")) ?? self.defaultTimeout
+        let binary = self.value(
+            environment: environment,
+            key: self.envKey(provider: provider, suffix: "BINARY"))
+
+        switch provider {
+        case .codex:
+            let model = self.value(environment: environment, key: self.envKey(provider: provider, suffix: "MODEL"))
+                ?? "gpt-5.4-mini"
+            let reasoning = self.value(
+                environment: environment,
+                key: self.envKey(provider: provider, suffix: "REASONING")) ?? "low"
+            return self.command(
+                binary: binary,
+                executable: "codex",
+                arguments: [
+                    "exec",
+                    "--skip-git-repo-check",
+                    "--ephemeral",
+                    "-m",
+                    model,
+                    "-c",
+                    "model_reasoning_effort=\"\(reasoning)\"",
+                    prompt,
+                ],
+                timeout: timeout)
+        case .claude:
+            let model = self.value(environment: environment, key: self.envKey(provider: provider, suffix: "MODEL"))
+                ?? "haiku"
+            return self.command(
+                binary: binary,
+                executable: "claude",
+                arguments: ["-p", prompt, "--model", model],
+                timeout: timeout)
+        case .opencode:
+            let model = self.value(environment: environment, key: self.envKey(provider: provider, suffix: "MODEL"))
+                ?? "anthropic/claude-3-5-haiku-latest"
+            return self.command(
+                binary: binary,
+                executable: "opencode",
+                arguments: ["run", "--model", model, "--variant", "minimal", prompt],
+                timeout: timeout)
+        default:
+            return nil
+        }
+    }
+
+    private static func command(
+        binary: String?,
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval) -> RollingWindowPingCommand
+    {
+        if let binary {
+            return RollingWindowPingCommand(binary: binary, arguments: arguments, timeout: timeout)
+        }
+        return RollingWindowPingCommand(binary: "/usr/bin/env", arguments: [executable] + arguments, timeout: timeout)
+    }
+
+    private static func envKey(provider: UsageProvider, suffix: String) -> String {
+        let normalized = provider.rawValue
+            .uppercased()
+            .replacingOccurrences(of: "-", with: "_")
+        return "CODEXBAR_ROLLING_WINDOW_\(normalized)_\(suffix)"
+    }
+
+    private static func value(environment: [String: String], key: String) -> String? {
+        let value = environment[key]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return value?.isEmpty == false ? value : nil
+    }
+
+    private static func doubleValue(environment: [String: String], key: String) -> Double? {
+        guard let value = self.value(environment: environment, key: key),
+              let parsed = Double(value),
+              parsed.isFinite,
+              parsed > 0
+        else {
+            return nil
+        }
+        return parsed
+    }
+}
+
+struct RollingWindowPingCommand: Equatable {
+    let binary: String
+    let arguments: [String]
+    let timeout: TimeInterval
+}
+
+enum RollingWindowPingError: LocalizedError {
+    case unsupportedProvider(UsageProvider)
+
+    var errorDescription: String? {
+        switch self {
+        case let .unsupportedProvider(provider):
+            "\(provider.displayName) does not have a configured rolling-window CLI ping command."
+        }
+    }
+}
+
+extension UsageProvider {
+    var displayName: String {
+        ProviderDescriptorRegistry.metadata[self]?.displayName ?? self.rawValue
+    }
+}

--- a/Sources/CodexBar/RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/RollingWindowAutoStart.swift
@@ -41,10 +41,13 @@ enum RollingWindowAutoStartSupport {
     }
 }
 
+@MainActor
 final class RollingWindowAutoStartRuntimeState {
     var inFlight: Set<UsageProvider> = []
     var attemptedResetAt: [UsageProvider: Date] = [:]
+    #if DEBUG
     var testRunnerOverride: (any RollingWindowPingRunning)?
+    #endif
 }
 
 struct RollingWindowAutoStartDecision: Equatable {
@@ -66,10 +69,13 @@ struct RollingWindowAutoStartDecision: Equatable {
             return nil
         }
 
-        let currentWindow = RollingWindowAutoStartSupport.rollingWindow(
+        guard let currentWindow = RollingWindowAutoStartSupport.rollingWindow(
             provider: provider,
             snapshot: currentProviderData)
-        if let currentResetAt = currentWindow?.resetsAt, currentResetAt > now {
+        else {
+            return nil
+        }
+        if let currentResetAt = currentWindow.resetsAt, currentResetAt > now {
             return nil
         }
 
@@ -105,6 +111,11 @@ enum RollingWindowPingStarter {
     static let defaultPrompt = "hi"
     static let defaultTimeout: TimeInterval = 90
 
+    /// Builds a tiny provider CLI prompt from environment overrides.
+    ///
+    /// Supported keys are `CODEXBAR_ROLLING_WINDOW_<PROVIDER>_PROMPT`,
+    /// `_TIMEOUT`, `_BINARY`, `_MODEL`, and `_REASONING`, where provider is the
+    /// uppercased provider id with hyphens replaced by underscores.
     static func start(
         provider: UsageProvider,
         environment baseEnvironment: [String: String],
@@ -157,7 +168,7 @@ enum RollingWindowPingStarter {
                     "-m",
                     model,
                     "-c",
-                    "model_reasoning_effort=\"\(reasoning)\"",
+                    "model_reasoning_effort=\(reasoning)",
                     prompt,
                 ],
                 timeout: timeout)
@@ -232,11 +243,5 @@ enum RollingWindowPingError: LocalizedError {
         case let .unsupportedProvider(provider):
             "\(provider.displayName) does not have a configured rolling-window CLI ping command."
         }
-    }
-}
-
-extension UsageProvider {
-    var displayName: String {
-        ProviderDescriptorRegistry.metadata[self]?.displayName ?? self.rawValue
     }
 }

--- a/Sources/CodexBar/RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/RollingWindowAutoStart.swift
@@ -3,6 +3,8 @@ import Foundation
 import SwiftUI
 
 enum RollingWindowAutoStartSupport {
+    static let sessionWindowMinutes = 5 * 60
+
     static let providers: Set<UsageProvider> = [
         .codex,
         .claude,
@@ -47,7 +49,7 @@ enum RollingWindowAutoStartSupport {
         case .claude:
             return [snapshot.primary, snapshot.secondary, snapshot.tertiary]
                 .compactMap(\.self)
-                .first { $0.windowMinutes == 5 * 60 }
+                .first { $0.windowMinutes == self.sessionWindowMinutes }
         default:
             return snapshot.primary
         }
@@ -71,6 +73,8 @@ enum RollingWindowAutoStartSupport {
         case .codex:
             return self.sourceSupportsAutoStart(provider: provider, sourceLabel: sourceLabel)
         case .claude:
+            // Claude web/OAuth snapshots can report the session window, but only
+            // Claude CLI credentials can be routed for auto-start prompts.
             return normalized == "claude" || normalized == "web" || normalized == "oauth"
         default:
             return false
@@ -88,7 +92,9 @@ enum RollingWindowAutoStartSupport {
         return windows
             .compactMap(\.self)
             .contains { window in
-                guard window.windowMinutes != 5 * 60 else { return false }
+                // Only exhausted non-session quotas block auto-start. Claude's
+                // model-specific tertiary window is intentionally ignored.
+                guard window.windowMinutes != Self.sessionWindowMinutes else { return false }
                 return window.usedPercent >= 100
             }
     }

--- a/Sources/CodexBar/RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/RollingWindowAutoStart.swift
@@ -79,7 +79,13 @@ enum RollingWindowAutoStartSupport {
 
     static func hasExhaustedBlockingWindow(provider: UsageProvider, snapshot: UsageSnapshot) -> Bool {
         guard self.providers.contains(provider) else { return false }
-        return [snapshot.primary, snapshot.secondary, snapshot.tertiary]
+        let windows = switch provider {
+        case .claude:
+            [snapshot.primary, snapshot.secondary]
+        default:
+            [snapshot.primary, snapshot.secondary, snapshot.tertiary]
+        }
+        return windows
             .compactMap(\.self)
             .contains { window in
                 guard window.windowMinutes != 5 * 60 else { return false }

--- a/Sources/CodexBar/RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/RollingWindowAutoStart.swift
@@ -108,7 +108,7 @@ struct SubprocessRollingWindowPingRunner: RollingWindowPingRunning {
 }
 
 enum RollingWindowPingStarter {
-    static let defaultPrompt = "hi"
+    static let defaultPrompt = "Say hi, then stop."
     static let defaultTimeout: TimeInterval = 90
 
     /// Builds a tiny provider CLI prompt from environment overrides.

--- a/Sources/CodexBar/RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/RollingWindowAutoStart.swift
@@ -55,6 +55,23 @@ enum RollingWindowAutoStartSupport {
         }
     }
 
+    static func isActiveRollingWindow(_ window: RateWindow, now: Date = Date()) -> Bool {
+        if let resetsAt = window.resetsAt, resetsAt > now {
+            return true
+        }
+        if window.usedPercent > 0 {
+            return true
+        }
+        return self.hasResetDescription(window)
+    }
+
+    static func hasResetDescription(_ window: RateWindow) -> Bool {
+        guard let resetDescription = window.resetDescription?.trimmingCharacters(in: .whitespacesAndNewlines) else {
+            return false
+        }
+        return !resetDescription.isEmpty
+    }
+
     static func sourceSupportsAutoStart(provider: UsageProvider, sourceLabel: String?) -> Bool {
         let normalized = sourceLabel?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         switch provider {
@@ -104,6 +121,7 @@ enum RollingWindowAutoStartSupport {
 final class RollingWindowAutoStartRuntimeState {
     var inFlight: Set<RollingWindowAutoStartRoute> = []
     var attemptedResetAt: [RollingWindowAutoStartRoute: Date] = [:]
+    var attemptedInactiveWithoutReset: Set<RollingWindowAutoStartRoute> = []
     #if DEBUG
     var testRunnerOverride: (any RollingWindowPingRunning)?
     #endif
@@ -125,7 +143,7 @@ enum RollingWindowAutoStartRoute: Hashable {
 }
 
 struct RollingWindowAutoStartDecision: Equatable {
-    let resetAt: Date
+    let resetAt: Date?
 
     static func shouldStart(
         provider: UsageProvider,
@@ -137,26 +155,22 @@ struct RollingWindowAutoStartDecision: Equatable {
     {
         guard RollingWindowAutoStartSupport.sourceCanReportRollingWindow(
             provider: provider,
-            sourceLabel: previousSourceLabel),
-            RollingWindowAutoStartSupport.sourceCanReportRollingWindow(
+            sourceLabel: sourceLabel),
+            let currentWindow = RollingWindowAutoStartSupport.rollingWindow(
                 provider: provider,
-                sourceLabel: sourceLabel),
-            let previousWindow = previous.flatMap({ RollingWindowAutoStartSupport.rollingWindow(
-                provider: provider,
-                snapshot: $0) }),
-            let previousResetAt = previousWindow.resetsAt,
-            previousResetAt <= now
+                snapshot: currentProviderData)
         else {
+            return nil
+        }
+        if previous != nil,
+           !RollingWindowAutoStartSupport.sourceCanReportRollingWindow(
+               provider: provider,
+               sourceLabel: previousSourceLabel)
+        {
             return nil
         }
 
-        guard let currentWindow = RollingWindowAutoStartSupport.rollingWindow(
-            provider: provider,
-            snapshot: currentProviderData)
-        else {
-            return nil
-        }
-        if let currentResetAt = currentWindow.resetsAt, currentResetAt > now {
+        if RollingWindowAutoStartSupport.isActiveRollingWindow(currentWindow, now: now) {
             return nil
         }
         guard !RollingWindowAutoStartSupport.hasExhaustedBlockingWindow(
@@ -166,7 +180,25 @@ struct RollingWindowAutoStartDecision: Equatable {
             return nil
         }
 
-        return RollingWindowAutoStartDecision(resetAt: previousResetAt)
+        if let previousWindow = previous.flatMap({ RollingWindowAutoStartSupport.rollingWindow(
+            provider: provider,
+            snapshot: $0) }),
+            let previousResetAt = previousWindow.resetsAt
+        {
+            guard previousResetAt <= now else { return nil }
+            return RollingWindowAutoStartDecision(resetAt: previousResetAt)
+        }
+
+        guard currentWindow.usedPercent <= 0,
+              !RollingWindowAutoStartSupport.hasResetDescription(currentWindow)
+        else {
+            return nil
+        }
+        if let currentResetAt = currentWindow.resetsAt {
+            guard currentResetAt <= now else { return nil }
+            return RollingWindowAutoStartDecision(resetAt: currentResetAt)
+        }
+        return RollingWindowAutoStartDecision(resetAt: nil)
     }
 }
 

--- a/Sources/CodexBar/RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/RollingWindowAutoStart.swift
@@ -68,11 +68,26 @@ enum RollingWindowAutoStartSupport {
 
 @MainActor
 final class RollingWindowAutoStartRuntimeState {
-    var inFlight: Set<UsageProvider> = []
-    var attemptedResetAt: [UsageProvider: Date] = [:]
+    var inFlight: Set<RollingWindowAutoStartRoute> = []
+    var attemptedResetAt: [RollingWindowAutoStartRoute: Date] = [:]
     #if DEBUG
     var testRunnerOverride: (any RollingWindowPingRunning)?
     #endif
+}
+
+enum RollingWindowAutoStartRoute: Hashable {
+    case provider(UsageProvider)
+    case codexLiveSystem
+    case codexManagedAccount(UUID)
+
+    var provider: UsageProvider {
+        switch self {
+        case let .provider(provider):
+            provider
+        case .codexLiveSystem, .codexManagedAccount:
+            .codex
+        }
+    }
 }
 
 struct RollingWindowAutoStartDecision: Equatable {

--- a/Sources/CodexBar/RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/RollingWindowAutoStart.swift
@@ -6,7 +6,6 @@ enum RollingWindowAutoStartSupport {
     static let providers: Set<UsageProvider> = [
         .codex,
         .claude,
-        .opencode,
     ]
 
     @MainActor
@@ -23,10 +22,17 @@ enum RollingWindowAutoStartSupport {
             id: "\(context.provider.rawValue)-rolling-window-auto-start",
             title: "Auto-start rolling window",
             subtitle: "When a rolling window expires and provider data shows no active replacement, "
-                + "send a tiny prompt through the provider CLI.",
+                + "send a tiny prompt through matching provider CLI credentials.",
             binding: binding,
             statusText: {
-                context.store.rollingWindowAutoStartStatus[context.provider]
+                if binding.wrappedValue,
+                   !self.sourceSupportsAutoStart(
+                       provider: context.provider,
+                       sourceLabel: context.store.lastSourceLabels[context.provider])
+                {
+                    return "Waiting for usage from matching CLI credentials."
+                }
+                return context.store.rollingWindowAutoStartStatus[context.provider]
             },
             actions: [],
             isVisible: nil,
@@ -37,7 +43,26 @@ enum RollingWindowAutoStartSupport {
 
     static func rollingWindow(provider: UsageProvider, snapshot: UsageSnapshot) -> RateWindow? {
         guard self.providers.contains(provider) else { return nil }
-        return snapshot.primary
+        switch provider {
+        case .claude:
+            return [snapshot.primary, snapshot.secondary, snapshot.tertiary]
+                .compactMap(\.self)
+                .first { $0.windowMinutes == 5 * 60 }
+        default:
+            return snapshot.primary
+        }
+    }
+
+    static func sourceSupportsAutoStart(provider: UsageProvider, sourceLabel: String?) -> Bool {
+        let normalized = sourceLabel?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch provider {
+        case .codex:
+            return normalized == "codex-cli" || normalized == "oauth"
+        case .claude:
+            return normalized == "claude"
+        default:
+            return false
+        }
     }
 }
 
@@ -55,16 +80,23 @@ struct RollingWindowAutoStartDecision: Equatable {
 
     static func shouldStart(
         provider: UsageProvider,
+        previousSourceLabel: String?,
+        sourceLabel: String?,
         previous: UsageSnapshot?,
         currentProviderData: UsageSnapshot,
         now: Date = Date()) -> RollingWindowAutoStartDecision?
     {
-        guard RollingWindowAutoStartSupport.providers.contains(provider),
-              let previousWindow = previous.flatMap({ RollingWindowAutoStartSupport.rollingWindow(
-                  provider: provider,
-                  snapshot: $0) }),
-              let previousResetAt = previousWindow.resetsAt,
-              previousResetAt <= now
+        guard RollingWindowAutoStartSupport.sourceSupportsAutoStart(
+            provider: provider,
+            sourceLabel: previousSourceLabel),
+            RollingWindowAutoStartSupport.sourceSupportsAutoStart(
+                provider: provider,
+                sourceLabel: sourceLabel),
+            let previousWindow = previous.flatMap({ RollingWindowAutoStartSupport.rollingWindow(
+                provider: provider,
+                snapshot: $0) }),
+            let previousResetAt = previousWindow.resetsAt,
+            previousResetAt <= now
         else {
             return nil
         }
@@ -83,7 +115,7 @@ struct RollingWindowAutoStartDecision: Equatable {
     }
 }
 
-struct RollingWindowPingRequest: Sendable {
+struct RollingWindowPingRequest {
     let provider: UsageProvider
     let binary: String
     let arguments: [String]
@@ -179,14 +211,6 @@ enum RollingWindowPingStarter {
                 binary: binary,
                 executable: "claude",
                 arguments: ["-p", "--no-session-persistence", "--model", model, prompt],
-                timeout: timeout)
-        case .opencode:
-            let model = self.value(environment: environment, key: self.envKey(provider: provider, suffix: "MODEL"))
-                ?? "anthropic/claude-3-5-haiku-latest"
-            return self.command(
-                binary: binary,
-                executable: "opencode",
-                arguments: ["run", "--model", model, "--variant", "minimal", prompt],
                 timeout: timeout)
         default:
             return nil

--- a/Sources/CodexBar/RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/RollingWindowAutoStart.swift
@@ -57,6 +57,7 @@ enum RollingWindowAutoStartSupport {
 
     static func isActiveRollingWindow(_ window: RateWindow, now: Date = Date()) -> Bool {
         if let resetsAt = window.resetsAt {
+            // A window expiring exactly at now is no longer active for auto-start gating.
             return resetsAt > now
         }
         if window.usedPercent > 0 {
@@ -98,7 +99,7 @@ enum RollingWindowAutoStartSupport {
         }
     }
 
-    static func sourceAllowsNoHistoryAutoStart(provider: UsageProvider, sourceLabel: String?) -> Bool {
+    static func sourceAllowsResetlessAutoStart(provider: UsageProvider, sourceLabel: String?) -> Bool {
         let normalized = sourceLabel?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         return provider == .codex && normalized == "openai-web"
     }
@@ -149,6 +150,7 @@ enum RollingWindowAutoStartRoute: Hashable {
 
 struct RollingWindowAutoStartDecision: Equatable {
     let resetAt: Date?
+    let resetSource: RollingWindowAutoStartResetSource
 
     static func shouldStart(
         provider: UsageProvider,
@@ -191,10 +193,10 @@ struct RollingWindowAutoStartDecision: Equatable {
             let previousResetAt = previousWindow.resetsAt
         {
             guard previousResetAt <= now else { return nil }
-            return RollingWindowAutoStartDecision(resetAt: previousResetAt)
+            return RollingWindowAutoStartDecision(resetAt: previousResetAt, resetSource: .previousExpiredReset)
         }
 
-        guard RollingWindowAutoStartSupport.sourceAllowsNoHistoryAutoStart(
+        guard RollingWindowAutoStartSupport.sourceAllowsResetlessAutoStart(
             provider: provider,
             sourceLabel: sourceLabel)
         else {
@@ -202,14 +204,37 @@ struct RollingWindowAutoStartDecision: Equatable {
         }
         if let currentResetAt = currentWindow.resetsAt {
             guard currentResetAt <= now else { return nil }
-            return RollingWindowAutoStartDecision(resetAt: currentResetAt)
+            return RollingWindowAutoStartDecision(resetAt: currentResetAt, resetSource: .currentExpiredReset)
         }
-        guard currentWindow.usedPercent <= 0,
-              !RollingWindowAutoStartSupport.hasResetDescription(currentWindow)
-        else {
-            return nil
+        return RollingWindowAutoStartDecision(resetAt: nil, resetSource: .inactiveWithoutReset)
+    }
+}
+
+enum RollingWindowAutoStartResetSource: Equatable {
+    case previousExpiredReset
+    case currentExpiredReset
+    case inactiveWithoutReset
+
+    var logValue: String {
+        switch self {
+        case .previousExpiredReset:
+            "previous-expired-reset"
+        case .currentExpiredReset:
+            "current-expired-reset"
+        case .inactiveWithoutReset:
+            "inactive-without-reset"
         }
-        return RollingWindowAutoStartDecision(resetAt: nil)
+    }
+
+    var trigger: String {
+        switch self {
+        case .previousExpiredReset:
+            "expired-previous-reset"
+        case .currentExpiredReset:
+            "expired-current-reset"
+        case .inactiveWithoutReset:
+            "inactive-without-reset"
+        }
     }
 }
 

--- a/Sources/CodexBar/RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/RollingWindowAutoStart.swift
@@ -56,8 +56,8 @@ enum RollingWindowAutoStartSupport {
     }
 
     static func isActiveRollingWindow(_ window: RateWindow, now: Date = Date()) -> Bool {
-        if let resetsAt = window.resetsAt, resetsAt > now {
-            return true
+        if let resetsAt = window.resetsAt {
+            return resetsAt > now
         }
         if window.usedPercent > 0 {
             return true
@@ -96,6 +96,11 @@ enum RollingWindowAutoStartSupport {
         default:
             return false
         }
+    }
+
+    static func sourceAllowsNoHistoryAutoStart(provider: UsageProvider, sourceLabel: String?) -> Bool {
+        let normalized = sourceLabel?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return provider == .codex && normalized == "openai-web"
     }
 
     static func hasExhaustedBlockingWindow(provider: UsageProvider, snapshot: UsageSnapshot) -> Bool {
@@ -189,14 +194,20 @@ struct RollingWindowAutoStartDecision: Equatable {
             return RollingWindowAutoStartDecision(resetAt: previousResetAt)
         }
 
-        guard currentWindow.usedPercent <= 0,
-              !RollingWindowAutoStartSupport.hasResetDescription(currentWindow)
+        guard RollingWindowAutoStartSupport.sourceAllowsNoHistoryAutoStart(
+            provider: provider,
+            sourceLabel: sourceLabel)
         else {
             return nil
         }
         if let currentResetAt = currentWindow.resetsAt {
             guard currentResetAt <= now else { return nil }
             return RollingWindowAutoStartDecision(resetAt: currentResetAt)
+        }
+        guard currentWindow.usedPercent <= 0,
+              !RollingWindowAutoStartSupport.hasResetDescription(currentWindow)
+        else {
+            return nil
         }
         return RollingWindowAutoStartDecision(resetAt: nil)
     }

--- a/Sources/CodexBar/RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/RollingWindowAutoStart.swift
@@ -57,12 +57,34 @@ enum RollingWindowAutoStartSupport {
         let normalized = sourceLabel?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         switch provider {
         case .codex:
-            return normalized == "codex-cli" || normalized == "oauth"
+            return normalized == "codex-cli" || normalized == "oauth" || normalized == "openai-web"
         case .claude:
             return normalized == "claude"
         default:
             return false
         }
+    }
+
+    static func sourceCanReportRollingWindow(provider: UsageProvider, sourceLabel: String?) -> Bool {
+        let normalized = sourceLabel?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch provider {
+        case .codex:
+            return self.sourceSupportsAutoStart(provider: provider, sourceLabel: sourceLabel)
+        case .claude:
+            return normalized == "claude" || normalized == "web" || normalized == "oauth"
+        default:
+            return false
+        }
+    }
+
+    static func hasExhaustedBlockingWindow(provider: UsageProvider, snapshot: UsageSnapshot) -> Bool {
+        guard self.providers.contains(provider) else { return false }
+        return [snapshot.primary, snapshot.secondary, snapshot.tertiary]
+            .compactMap(\.self)
+            .contains { window in
+                guard window.windowMinutes != 5 * 60 else { return false }
+                return window.usedPercent >= 100
+            }
     }
 }
 
@@ -101,10 +123,10 @@ struct RollingWindowAutoStartDecision: Equatable {
         currentProviderData: UsageSnapshot,
         now: Date = Date()) -> RollingWindowAutoStartDecision?
     {
-        guard RollingWindowAutoStartSupport.sourceSupportsAutoStart(
+        guard RollingWindowAutoStartSupport.sourceCanReportRollingWindow(
             provider: provider,
             sourceLabel: previousSourceLabel),
-            RollingWindowAutoStartSupport.sourceSupportsAutoStart(
+            RollingWindowAutoStartSupport.sourceCanReportRollingWindow(
                 provider: provider,
                 sourceLabel: sourceLabel),
             let previousWindow = previous.flatMap({ RollingWindowAutoStartSupport.rollingWindow(
@@ -123,6 +145,12 @@ struct RollingWindowAutoStartDecision: Equatable {
             return nil
         }
         if let currentResetAt = currentWindow.resetsAt, currentResetAt > now {
+            return nil
+        }
+        guard !RollingWindowAutoStartSupport.hasExhaustedBlockingWindow(
+            provider: provider,
+            snapshot: currentProviderData)
+        else {
             return nil
         }
 

--- a/Sources/CodexBar/RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/RollingWindowAutoStart.swift
@@ -211,7 +211,6 @@ enum RollingWindowPingStarter {
                 arguments: [
                     "exec",
                     "--skip-git-repo-check",
-                    "--ephemeral",
                     "-m",
                     model,
                     "-c",

--- a/Sources/CodexBar/SettingsStore+Config.swift
+++ b/Sources/CodexBar/SettingsStore+Config.swift
@@ -22,6 +22,16 @@ extension SettingsStore {
             global: self.quotaWarningWindowEnabled(window))
     }
 
+    func rollingWindowAutoStartEnabled(provider: UsageProvider) -> Bool {
+        self.configSnapshot.providerConfig(for: provider)?.rollingWindowAutoStartEnabled ?? false
+    }
+
+    func setRollingWindowAutoStartEnabled(provider: UsageProvider, enabled: Bool) {
+        self.updateProviderConfig(provider: provider) { entry in
+            entry.rollingWindowAutoStartEnabled = enabled ? true : nil
+        }
+    }
+
     func hasQuotaWarningOverride(provider: UsageProvider, window: QuotaWarningWindow) -> Bool {
         self.quotaWarningConfig(for: provider).hasOverride(for: window)
     }

--- a/Sources/CodexBar/UsageProvider+DisplayName.swift
+++ b/Sources/CodexBar/UsageProvider+DisplayName.swift
@@ -1,0 +1,7 @@
+import CodexBarCore
+
+extension UsageProvider {
+    var displayName: String {
+        ProviderDescriptorRegistry.metadata[self]?.displayName ?? self.rawValue
+    }
+}

--- a/Sources/CodexBar/UsageStore+BackgroundRefresh.swift
+++ b/Sources/CodexBar/UsageStore+BackgroundRefresh.swift
@@ -10,6 +10,9 @@ extension UsageStore {
         self.lastSourceLabels.removeValue(forKey: provider)
         self.lastFetchAttempts.removeValue(forKey: provider)
         self.accountSnapshots.removeValue(forKey: provider)
+        self.rollingWindowAutoStartStatus.removeValue(forKey: provider)
+        self.rollingWindowAutoStartRuntime.inFlight.remove(provider)
+        self.rollingWindowAutoStartRuntime.attemptedResetAt.removeValue(forKey: provider)
         self.tokenSnapshots.removeValue(forKey: provider)
         self.tokenErrors[provider] = nil
         self.providerStorageFootprints.removeValue(forKey: provider)

--- a/Sources/CodexBar/UsageStore+BackgroundRefresh.swift
+++ b/Sources/CodexBar/UsageStore+BackgroundRefresh.swift
@@ -10,9 +10,7 @@ extension UsageStore {
         self.lastSourceLabels.removeValue(forKey: provider)
         self.lastFetchAttempts.removeValue(forKey: provider)
         self.accountSnapshots.removeValue(forKey: provider)
-        self.rollingWindowAutoStartStatus.removeValue(forKey: provider)
-        self.rollingWindowAutoStartRuntime.inFlight.remove(provider)
-        self.rollingWindowAutoStartRuntime.attemptedResetAt.removeValue(forKey: provider)
+        self.resetRollingWindowAutoStartState(for: provider)
         self.tokenSnapshots.removeValue(forKey: provider)
         self.tokenErrors[provider] = nil
         self.providerStorageFootprints.removeValue(forKey: provider)

--- a/Sources/CodexBar/UsageStore+Observation.swift
+++ b/Sources/CodexBar/UsageStore+Observation.swift
@@ -1,0 +1,55 @@
+import CodexBarCore
+import Observation
+
+// MARK: - Observation helpers
+
+@MainActor
+extension UsageStore {
+    var menuObservationToken: Int {
+        _ = self.snapshots
+        _ = self.errors
+        _ = self.lastSourceLabels
+        _ = self.lastFetchAttempts
+        _ = self.accountSnapshots
+        _ = self.codexAccountSnapshots
+        _ = self.kiloScopeSnapshots
+        _ = self.tokenSnapshots
+        _ = self.tokenErrors
+        _ = self.tokenRefreshInFlight
+        _ = self.credits
+        _ = self.lastCreditsError
+        _ = self.openAIDashboard
+        _ = self.lastOpenAIDashboardError
+        _ = self.openAIDashboardRequiresLogin
+        _ = self.openAIDashboardAttachmentRevision
+        _ = self.versions
+        _ = self.isRefreshing
+        _ = self.refreshingProviders
+        _ = self.pathDebugInfo
+        _ = self.statuses
+        _ = self.probeLogs
+        _ = self.historicalPaceRevision
+        _ = self.planUtilizationHistoryRevision
+        _ = self.providerStorageFootprints
+        return 0
+    }
+
+    var iconObservationToken: Int {
+        _ = self.snapshots
+        _ = self.errors
+        _ = self.credits
+        _ = self.lastCreditsError
+        _ = self.openAIDashboard
+        _ = self.lastOpenAIDashboardError
+        _ = self.openAIDashboardRequiresLogin
+        _ = self.refreshingProviders
+        _ = self.statuses
+        _ = self.historicalPaceRevision
+        return 0
+    }
+
+    var attachedOpenAIDashboardSnapshot: OpenAIDashboardSnapshot? {
+        guard self.openAIDashboardAttachmentAuthorized else { return nil }
+        return self.openAIDashboard
+    }
+}

--- a/Sources/CodexBar/UsageStore+Observation.swift
+++ b/Sources/CodexBar/UsageStore+Observation.swift
@@ -28,6 +28,7 @@ extension UsageStore {
         _ = self.pathDebugInfo
         _ = self.statuses
         _ = self.probeLogs
+        _ = self.rollingWindowAutoStartStatus
         _ = self.historicalPaceRevision
         _ = self.planUtilizationHistoryRevision
         _ = self.providerStorageFootprints

--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -246,13 +246,24 @@ extension UsageStore {
 
             if decision.allowedEffects.contains(.usageBackfill),
                allowCodexUsageBackfill,
-               self.snapshots[.codex] == nil,
+               self.snapshots[.codex] == nil || self.lastSourceLabels[.codex] == "openai-web",
                let usage = dashboard.toUsageSnapshot(provider: .codex, accountEmail: attachedAccountEmail)
             {
-                self.snapshots[.codex] = usage
+                let previousSnapshot = self.lastKnownResetSnapshots[.codex]
+                let previousSourceLabel = previousSnapshot == nil ? nil : self.lastSourceLabels[.codex]
+                let backfilled = usage.backfillingResetTimes(from: previousSnapshot)
+                self.lastKnownResetSnapshots[.codex] = backfilled
+                self.snapshots[.codex] = backfilled
                 self.errors[.codex] = nil
                 self.failureGates[.codex]?.recordSuccess()
                 self.lastSourceLabels[.codex] = "openai-web"
+                self.scheduleRollingWindowAutoStartIfNeeded(
+                    provider: .codex,
+                    previousSourceLabel: previousSourceLabel,
+                    sourceLabel: "openai-web",
+                    previousSnapshot: previousSnapshot,
+                    currentProviderData: backfilled,
+                    codexActiveSourceOverride: self.settings.codexResolvedActiveSource)
             }
 
             if decision.allowedEffects.contains(.creditsAttachment),
@@ -329,6 +340,7 @@ extension UsageStore {
     private func clearDashboardDerivedCodexUsageIfNeeded() {
         guard self.lastSourceLabels[.codex] == "openai-web" else { return }
         self.snapshots.removeValue(forKey: .codex)
+        self.lastKnownResetSnapshots.removeValue(forKey: .codex)
         self.errors[.codex] = nil
         self.lastSourceLabels.removeValue(forKey: .codex)
         self.lastFetchAttempts.removeValue(forKey: .codex)
@@ -337,6 +349,7 @@ extension UsageStore {
         self.failureGates[.codex]?.reset()
         self.lastKnownSessionRemaining.removeValue(forKey: .codex)
         self.lastKnownSessionWindowSource.removeValue(forKey: .codex)
+        self.resetRollingWindowAutoStartState(for: .codex)
     }
 
     private func clearDashboardDerivedCreditsIfNeeded() {

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -303,11 +303,11 @@ extension UsageStore {
             await self.recordPlanUtilizationHistorySample(
                 provider: provider,
                 snapshot: backfilled)
+            guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
             self.scheduleRollingWindowAutoStartIfNeeded(
                 provider: provider,
                 previousSnapshot: refreshSnapshots.previous,
                 currentProviderData: scoped)
-            guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
             if let runtime = self.providerRuntimes[provider] {
                 let context = ProviderRuntimeContext(
                     provider: provider, settings: self.settings, store: self)
@@ -347,9 +347,7 @@ extension UsageStore {
             self.lastSourceLabels.removeValue(forKey: provider)
             self.lastFetchAttempts.removeValue(forKey: provider)
             self.accountSnapshots.removeValue(forKey: provider)
-            self.rollingWindowAutoStartStatus.removeValue(forKey: provider)
-            self.rollingWindowAutoStartRuntime.inFlight.remove(provider)
-            self.rollingWindowAutoStartRuntime.attemptedResetAt.removeValue(forKey: provider)
+            self.resetRollingWindowAutoStartState(for: provider)
             if provider == .codex {
                 self.codexAccountSnapshots = []
             }

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -263,7 +263,8 @@ extension UsageStore {
             {
                 return
             }
-            let refreshSnapshots = await MainActor.run { () -> (current: UsageSnapshot, previous: UsageSnapshot?)? in
+            let refreshSnapshots = await MainActor.run {
+                () -> (current: UsageSnapshot, previous: UsageSnapshot?, previousSourceLabel: String?)? in
                 guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else {
                     return nil
                 }
@@ -273,6 +274,7 @@ extension UsageStore {
                 let resetBackfillSource = provider == .codex
                     ? self.codexLastKnownResetSnapshot(matching: context.codexExpectedGuard)
                     : self.lastKnownResetSnapshots[provider]
+                let previousSourceLabel = resetBackfillSource == nil ? nil : self.lastSourceLabels[provider]
                 let backfilled = scoped.backfillingResetTimes(from: resetBackfillSource)
                 self.handleQuotaWarningTransitions(provider: provider, snapshot: backfilled)
                 self.handleSessionQuotaTransition(provider: provider, snapshot: backfilled)
@@ -293,7 +295,7 @@ extension UsageStore {
                     self.rememberLiveSystemCodexEmailIfNeeded(scoped.accountEmail(for: .codex))
                     self.seedCodexAccountScopedRefreshGuard(accountEmail: scoped.accountEmail(for: .codex))
                 }
-                return (backfilled, resetBackfillSource)
+                return (backfilled, resetBackfillSource, previousSourceLabel)
             }
             guard let refreshSnapshots else { return }
             let backfilled = refreshSnapshots.current
@@ -306,6 +308,8 @@ extension UsageStore {
             guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
             self.scheduleRollingWindowAutoStartIfNeeded(
                 provider: provider,
+                previousSourceLabel: refreshSnapshots.previousSourceLabel,
+                sourceLabel: result.sourceLabel,
                 previousSnapshot: refreshSnapshots.previous,
                 currentProviderData: scoped)
             if let runtime = self.providerRuntimes[provider] {

--- a/Sources/CodexBar/UsageStore+Refresh.swift
+++ b/Sources/CodexBar/UsageStore+Refresh.swift
@@ -263,7 +263,7 @@ extension UsageStore {
             {
                 return
             }
-            let backfilled = await MainActor.run { () -> UsageSnapshot? in
+            let refreshSnapshots = await MainActor.run { () -> (current: UsageSnapshot, previous: UsageSnapshot?)? in
                 guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else {
                     return nil
                 }
@@ -293,15 +293,20 @@ extension UsageStore {
                     self.rememberLiveSystemCodexEmailIfNeeded(scoped.accountEmail(for: .codex))
                     self.seedCodexAccountScopedRefreshGuard(accountEmail: scoped.accountEmail(for: .codex))
                 }
-                return backfilled
+                return (backfilled, resetBackfillSource)
             }
-            guard let backfilled else { return }
+            guard let refreshSnapshots else { return }
+            let backfilled = refreshSnapshots.current
             if context.shouldConsumeClaudeKeychainFingerprint {
                 _ = await Self.consumeClaudeKeychainFingerprintChangeWithoutPrompt()
             }
             await self.recordPlanUtilizationHistorySample(
                 provider: provider,
                 snapshot: backfilled)
+            self.scheduleRollingWindowAutoStartIfNeeded(
+                provider: provider,
+                previousSnapshot: refreshSnapshots.previous,
+                currentProviderData: scoped)
             guard self.isCurrentProviderRefreshGeneration(provider, generation: context.generation) else { return }
             if let runtime = self.providerRuntimes[provider] {
                 let context = ProviderRuntimeContext(
@@ -342,6 +347,9 @@ extension UsageStore {
             self.lastSourceLabels.removeValue(forKey: provider)
             self.lastFetchAttempts.removeValue(forKey: provider)
             self.accountSnapshots.removeValue(forKey: provider)
+            self.rollingWindowAutoStartStatus.removeValue(forKey: provider)
+            self.rollingWindowAutoStartRuntime.inFlight.remove(provider)
+            self.rollingWindowAutoStartRuntime.attemptedResetAt.removeValue(forKey: provider)
             if provider == .codex {
                 self.codexAccountSnapshots = []
             }

--- a/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
@@ -53,6 +53,15 @@ extension UsageStore {
         self.rollingWindowAutoStartRuntime.attemptedResetAt[route] = decision.resetAt
         self.rollingWindowAutoStartRuntime.inFlight.insert(route)
         self.rollingWindowAutoStartStatus[provider] = "Starting a new rolling window..."
+        let metadata = Self.rollingWindowAutoStartLogMetadata(
+            provider: provider,
+            route: route,
+            previousSourceLabel: previousSourceLabel,
+            sourceLabel: sourceLabel,
+            expiredResetAt: decision.resetAt)
+        self.providerLogger.info(
+            "CodexBar detected inactive rolling window; pinging provider to start one",
+            metadata: metadata)
 
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -78,12 +87,26 @@ extension UsageStore {
                     environment: environment,
                     runner: runner)
                 self.rollingWindowAutoStartStatus[provider] = "Ping prompt sent."
+                self.providerLogger.info(
+                    "Rolling window auto-start ping successfully processed by provider",
+                    metadata: metadata)
                 await self.refreshProvider(provider)
                 let refreshedWindow = self.snapshots[provider].flatMap {
                     RollingWindowAutoStartSupport.rollingWindow(provider: provider, snapshot: $0)
                 }
                 if let resetsAt = refreshedWindow?.resetsAt, resetsAt > Date() {
                     self.rollingWindowAutoStartStatus.removeValue(forKey: provider)
+                    self.providerLogger.info(
+                        "Rolling window auto-start verified new rolling window",
+                        metadata: metadata.merging([
+                            "verifiedResetAt": Self.rollingWindowAutoStartTimestamp(resetsAt),
+                        ], uniquingKeysWith: { _, new in new }))
+                } else {
+                    self.providerLogger.warning(
+                        "Rolling window auto-start could not verify new rolling window",
+                        metadata: metadata.merging([
+                            "verifiedResetAt": Self.rollingWindowAutoStartTimestamp(refreshedWindow?.resetsAt),
+                        ], uniquingKeysWith: { _, new in new }))
                 }
             } catch {
                 self.rollingWindowAutoStartRuntime.attemptedResetAt.removeValue(forKey: route)
@@ -121,5 +144,39 @@ extension UsageStore {
         tokenOverride: TokenAccountOverride?) -> Bool
     {
         tokenOverride == nil && self.settings.selectedTokenAccount(for: provider) == nil
+    }
+
+    private static func rollingWindowAutoStartLogMetadata(
+        provider: UsageProvider,
+        route: RollingWindowAutoStartRoute,
+        previousSourceLabel: String?,
+        sourceLabel: String?,
+        expiredResetAt: Date) -> [String: String]
+    {
+        [
+            "provider": provider.rawValue,
+            "route": self.rollingWindowAutoStartRouteLabel(route),
+            "previousSource": previousSourceLabel ?? "none",
+            "source": sourceLabel ?? "none",
+            "expiredResetAt": self.rollingWindowAutoStartTimestamp(expiredResetAt),
+        ]
+    }
+
+    private static func rollingWindowAutoStartRouteLabel(_ route: RollingWindowAutoStartRoute) -> String {
+        switch route {
+        case let .provider(provider):
+            provider.rawValue
+        case .codexLiveSystem:
+            "codex-live-system"
+        case let .codexManagedAccount(id):
+            "codex-managed-account:\(id.uuidString)"
+        }
+    }
+
+    private static func rollingWindowAutoStartTimestamp(_ date: Date?) -> String {
+        guard let date else { return "none" }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
     }
 }

--- a/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
@@ -3,6 +3,8 @@ import Foundation
 
 extension UsageStore {
     private static let rollingWindowAutoStartSameResetTolerance: TimeInterval = 1
+    private static let rollingWindowAutoStartTimestampFormat = Date.ISO8601FormatStyle(
+        includingFractionalSeconds: true)
 
     func resetRollingWindowAutoStartState(for provider: UsageProvider) {
         self.rollingWindowAutoStartStatus.removeValue(forKey: provider)
@@ -58,7 +60,7 @@ extension UsageStore {
             route: route,
             previousSourceLabel: previousSourceLabel,
             sourceLabel: sourceLabel,
-            expiredResetAt: decision.resetAt)
+            previousResetAt: decision.resetAt)
         self.providerLogger.info(
             "CodexBar detected inactive rolling window; pinging provider to start one",
             metadata: metadata)
@@ -146,37 +148,40 @@ extension UsageStore {
         tokenOverride == nil && self.settings.selectedTokenAccount(for: provider) == nil
     }
 
-    private static func rollingWindowAutoStartLogMetadata(
+    static func rollingWindowAutoStartLogMetadata(
         provider: UsageProvider,
         route: RollingWindowAutoStartRoute,
         previousSourceLabel: String?,
         sourceLabel: String?,
-        expiredResetAt: Date) -> [String: String]
+        previousResetAt: Date) -> [String: String]
     {
         [
             "provider": provider.rawValue,
             "route": self.rollingWindowAutoStartRouteLabel(route),
             "previousSource": previousSourceLabel ?? "none",
             "source": sourceLabel ?? "none",
-            "expiredResetAt": self.rollingWindowAutoStartTimestamp(expiredResetAt),
+            "previousResetAt": self.rollingWindowAutoStartTimestamp(previousResetAt),
         ]
     }
 
-    private static func rollingWindowAutoStartRouteLabel(_ route: RollingWindowAutoStartRoute) -> String {
+    static func rollingWindowAutoStartRouteLabel(_ route: RollingWindowAutoStartRoute) -> String {
         switch route {
         case let .provider(provider):
-            provider.rawValue
+            "provider:\(provider.rawValue)"
         case .codexLiveSystem:
             "codex-live-system"
         case let .codexManagedAccount(id):
-            "codex-managed-account:\(id.uuidString)"
+            "codex-managed-account:\(Self.redactedRollingWindowAutoStartAccountID(id))"
         }
     }
 
-    private static func rollingWindowAutoStartTimestamp(_ date: Date?) -> String {
+    static func rollingWindowAutoStartTimestamp(_ date: Date?) -> String {
         guard let date else { return "none" }
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return formatter.string(from: date)
+        return Self.rollingWindowAutoStartTimestampFormat.format(date)
+    }
+
+    private static func redactedRollingWindowAutoStartAccountID(_ id: UUID) -> String {
+        let value = id.uuidString
+        return "\(value.prefix(6))...\(value.suffix(6))"
     }
 }

--- a/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
@@ -2,6 +2,15 @@ import CodexBarCore
 import Foundation
 
 extension UsageStore {
+    private static let rollingWindowAutoStartSameResetTolerance: TimeInterval = 1
+
+    func resetRollingWindowAutoStartState(for provider: UsageProvider) {
+        self.rollingWindowAutoStartStatus.removeValue(forKey: provider)
+        self.rollingWindowAutoStartRuntime.inFlight.remove(provider)
+        self.rollingWindowAutoStartRuntime.attemptedResetAt.removeValue(forKey: provider)
+    }
+
+    @MainActor
     func scheduleRollingWindowAutoStartIfNeeded(
         provider: UsageProvider,
         previousSnapshot: UsageSnapshot?,
@@ -20,7 +29,8 @@ extension UsageStore {
         }
 
         if let attempted = self.rollingWindowAutoStartRuntime.attemptedResetAt[provider],
-           abs(attempted.timeIntervalSince(decision.resetAt)) < 1
+           // Reset timestamps can be rounded differently across adjacent snapshots.
+           abs(attempted.timeIntervalSince(decision.resetAt)) < Self.rollingWindowAutoStartSameResetTolerance
         {
             return
         }
@@ -36,15 +46,26 @@ extension UsageStore {
             }
 
             do {
+                #if DEBUG
                 let runner = self.rollingWindowAutoStartRuntime
                     .testRunnerOverride ?? SubprocessRollingWindowPingRunner()
+                #else
+                let runner = SubprocessRollingWindowPingRunner()
+                #endif
                 try await RollingWindowPingStarter.start(
                     provider: provider,
                     environment: self.environmentBase,
                     runner: runner)
                 self.rollingWindowAutoStartStatus[provider] = "Ping prompt sent."
                 await self.refreshProvider(provider, coalesceIfRefreshing: true)
+                let refreshedWindow = self.snapshots[provider].flatMap {
+                    RollingWindowAutoStartSupport.rollingWindow(provider: provider, snapshot: $0)
+                }
+                if let resetsAt = refreshedWindow?.resetsAt, resetsAt > Date() {
+                    self.rollingWindowAutoStartStatus.removeValue(forKey: provider)
+                }
             } catch {
+                self.rollingWindowAutoStartRuntime.attemptedResetAt.removeValue(forKey: provider)
                 self.rollingWindowAutoStartStatus[provider] = error.localizedDescription
                 self.providerLogger.warning(
                     "Rolling window auto-start failed",

--- a/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
@@ -1,0 +1,58 @@
+import CodexBarCore
+import Foundation
+
+extension UsageStore {
+    func scheduleRollingWindowAutoStartIfNeeded(
+        provider: UsageProvider,
+        previousSnapshot: UsageSnapshot?,
+        currentProviderData: UsageSnapshot,
+        now: Date = Date())
+    {
+        guard self.settings.rollingWindowAutoStartEnabled(provider: provider),
+              !self.rollingWindowAutoStartRuntime.inFlight.contains(provider),
+              let decision = RollingWindowAutoStartDecision.shouldStart(
+                  provider: provider,
+                  previous: previousSnapshot,
+                  currentProviderData: currentProviderData,
+                  now: now)
+        else {
+            return
+        }
+
+        if let attempted = self.rollingWindowAutoStartRuntime.attemptedResetAt[provider],
+           abs(attempted.timeIntervalSince(decision.resetAt)) < 1
+        {
+            return
+        }
+
+        self.rollingWindowAutoStartRuntime.attemptedResetAt[provider] = decision.resetAt
+        self.rollingWindowAutoStartRuntime.inFlight.insert(provider)
+        self.rollingWindowAutoStartStatus[provider] = "Starting a new rolling window..."
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.rollingWindowAutoStartRuntime.inFlight.remove(provider)
+            }
+
+            do {
+                let runner = self.rollingWindowAutoStartRuntime
+                    .testRunnerOverride ?? SubprocessRollingWindowPingRunner()
+                try await RollingWindowPingStarter.start(
+                    provider: provider,
+                    environment: self.environmentBase,
+                    runner: runner)
+                self.rollingWindowAutoStartStatus[provider] = "Ping prompt sent."
+                await self.refreshProvider(provider, coalesceIfRefreshing: true)
+            } catch {
+                self.rollingWindowAutoStartStatus[provider] = error.localizedDescription
+                self.providerLogger.warning(
+                    "Rolling window auto-start failed",
+                    metadata: [
+                        "provider": provider.rawValue,
+                        "error": error.localizedDescription,
+                    ])
+            }
+        }
+    }
+}

--- a/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
@@ -12,6 +12,9 @@ extension UsageStore {
             .filter { $0.provider != provider }
         self.rollingWindowAutoStartRuntime.attemptedResetAt = self.rollingWindowAutoStartRuntime.attemptedResetAt
             .filter { $0.key.provider != provider }
+        self.rollingWindowAutoStartRuntime.attemptedInactiveWithoutReset =
+            self.rollingWindowAutoStartRuntime.attemptedInactiveWithoutReset
+                .filter { $0.provider != provider }
     }
 
     @MainActor
@@ -67,14 +70,21 @@ extension UsageStore {
             return
         }
 
-        if let attempted = self.rollingWindowAutoStartRuntime.attemptedResetAt[route],
-           // Reset timestamps can be rounded differently across adjacent snapshots.
-           abs(attempted.timeIntervalSince(decision.resetAt)) < Self.rollingWindowAutoStartSameResetTolerance
-        {
-            return
+        if let resetAt = decision.resetAt {
+            if let attempted = self.rollingWindowAutoStartRuntime.attemptedResetAt[route],
+               // Reset timestamps can be rounded differently across adjacent snapshots.
+               abs(attempted.timeIntervalSince(resetAt)) < Self.rollingWindowAutoStartSameResetTolerance
+            {
+                return
+            }
+            self.rollingWindowAutoStartRuntime.attemptedResetAt[route] = resetAt
+        } else {
+            guard !self.rollingWindowAutoStartRuntime.attemptedInactiveWithoutReset.contains(route) else {
+                return
+            }
+            self.rollingWindowAutoStartRuntime.attemptedInactiveWithoutReset.insert(route)
         }
 
-        self.rollingWindowAutoStartRuntime.attemptedResetAt[route] = decision.resetAt
         self.rollingWindowAutoStartRuntime.inFlight.insert(route)
         self.rollingWindowAutoStartStatus[provider] = "Starting a new rolling window..."
         self.providerLogger.info(
@@ -112,22 +122,28 @@ extension UsageStore {
                 let refreshedWindow = self.snapshots[provider].flatMap {
                     RollingWindowAutoStartSupport.rollingWindow(provider: provider, snapshot: $0)
                 }
-                if let resetsAt = refreshedWindow?.resetsAt, resetsAt > Date() {
+                let verified = refreshedWindow.map {
+                    RollingWindowAutoStartSupport.isActiveRollingWindow($0)
+                } ?? false
+                if verified {
                     self.rollingWindowAutoStartStatus.removeValue(forKey: provider)
                     self.providerLogger.info(
                         "Rolling window auto-start verified new rolling window",
                         metadata: metadata.merging([
-                            "verifiedResetAt": Self.rollingWindowAutoStartTimestamp(resetsAt),
+                            "verifiedResetAt": Self.rollingWindowAutoStartTimestamp(refreshedWindow?.resetsAt),
+                            "verifiedResetDescription": Self.rollingWindowAutoStartResetDescription(refreshedWindow),
                         ], uniquingKeysWith: { _, new in new }))
                 } else {
                     self.providerLogger.warning(
                         "Rolling window auto-start could not verify new rolling window",
                         metadata: metadata.merging([
                             "verifiedResetAt": Self.rollingWindowAutoStartTimestamp(refreshedWindow?.resetsAt),
+                            "verifiedResetDescription": Self.rollingWindowAutoStartResetDescription(refreshedWindow),
                         ], uniquingKeysWith: { _, new in new }))
                 }
             } catch {
                 self.rollingWindowAutoStartRuntime.attemptedResetAt.removeValue(forKey: route)
+                self.rollingWindowAutoStartRuntime.attemptedInactiveWithoutReset.remove(route)
                 self.rollingWindowAutoStartStatus[provider] = error.localizedDescription
                 self.providerLogger.warning(
                     "Rolling window auto-start failed",
@@ -257,7 +273,7 @@ extension UsageStore {
         route: RollingWindowAutoStartRoute,
         previousSourceLabel: String?,
         sourceLabel: String?,
-        previousResetAt: Date) -> [String: String]
+        previousResetAt: Date?) -> [String: String]
     {
         [
             "provider": provider.rawValue,
@@ -265,6 +281,7 @@ extension UsageStore {
             "previousSource": previousSourceLabel ?? "none",
             "source": sourceLabel ?? "none",
             "previousResetAt": self.rollingWindowAutoStartTimestamp(previousResetAt),
+            "trigger": previousResetAt == nil ? "inactive-without-previous-reset" : "expired-previous-reset",
         ]
     }
 
@@ -282,6 +299,15 @@ extension UsageStore {
     static func rollingWindowAutoStartTimestamp(_ date: Date?) -> String {
         guard let date else { return "none" }
         return Self.rollingWindowAutoStartTimestampFormat.format(date)
+    }
+
+    static func rollingWindowAutoStartResetDescription(_ window: RateWindow?) -> String {
+        guard let resetDescription = window?.resetDescription?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !resetDescription.isEmpty
+        else {
+            return "none"
+        }
+        return resetDescription
     }
 
     private static func redactedRollingWindowAutoStartAccountID(_ id: UUID) -> String {

--- a/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
@@ -13,6 +13,8 @@ extension UsageStore {
     @MainActor
     func scheduleRollingWindowAutoStartIfNeeded(
         provider: UsageProvider,
+        previousSourceLabel: String?,
+        sourceLabel: String?,
         previousSnapshot: UsageSnapshot?,
         currentProviderData: UsageSnapshot,
         now: Date = Date())
@@ -21,6 +23,8 @@ extension UsageStore {
               !self.rollingWindowAutoStartRuntime.inFlight.contains(provider),
               let decision = RollingWindowAutoStartDecision.shouldStart(
                   provider: provider,
+                  previousSourceLabel: previousSourceLabel,
+                  sourceLabel: sourceLabel,
                   previous: previousSnapshot,
                   currentProviderData: currentProviderData,
                   now: now)

--- a/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
@@ -32,7 +32,6 @@ extension UsageStore {
             provider: provider,
             codexActiveSource: resolvedCodexActiveSource)
         guard self.settings.rollingWindowAutoStartEnabled(provider: provider),
-              self.canRouteRollingWindowAutoStart(provider: provider, tokenOverride: tokenOverride),
               !self.rollingWindowAutoStartRuntime.inFlight.contains(route),
               let decision = RollingWindowAutoStartDecision.shouldStart(
                   provider: provider,
@@ -42,6 +41,29 @@ extension UsageStore {
                   currentProviderData: currentProviderData,
                   now: now)
         else {
+            return
+        }
+
+        let metadata = Self.rollingWindowAutoStartLogMetadata(
+            provider: provider,
+            route: route,
+            previousSourceLabel: previousSourceLabel,
+            sourceLabel: sourceLabel,
+            previousResetAt: decision.resetAt)
+        switch self.canRouteRollingWindowAutoStart(
+            provider: provider,
+            tokenOverride: tokenOverride,
+            sourceLabel: sourceLabel,
+            currentProviderData: currentProviderData,
+            codexActiveSource: resolvedCodexActiveSource)
+        {
+        case .allowed:
+            break
+        case let .blocked(reason):
+            self.rollingWindowAutoStartStatus[provider] = reason.statusMessage
+            self.providerLogger.warning(
+                "Rolling window auto-start skipped because usage account cannot be matched to prompt CLI account",
+                metadata: metadata.merging(reason.metadata, uniquingKeysWith: { _, new in new }))
             return
         }
 
@@ -55,12 +77,6 @@ extension UsageStore {
         self.rollingWindowAutoStartRuntime.attemptedResetAt[route] = decision.resetAt
         self.rollingWindowAutoStartRuntime.inFlight.insert(route)
         self.rollingWindowAutoStartStatus[provider] = "Starting a new rolling window..."
-        let metadata = Self.rollingWindowAutoStartLogMetadata(
-            provider: provider,
-            route: route,
-            previousSourceLabel: previousSourceLabel,
-            sourceLabel: sourceLabel,
-            previousResetAt: decision.resetAt)
         self.providerLogger.info(
             "CodexBar detected inactive rolling window; pinging provider to start one",
             metadata: metadata)
@@ -143,9 +159,97 @@ extension UsageStore {
 
     private func canRouteRollingWindowAutoStart(
         provider: UsageProvider,
-        tokenOverride: TokenAccountOverride?) -> Bool
+        tokenOverride: TokenAccountOverride?,
+        sourceLabel: String?,
+        currentProviderData: UsageSnapshot,
+        codexActiveSource: CodexActiveSource?) -> RollingWindowAutoStartRouteCheck
     {
-        tokenOverride == nil && self.settings.selectedTokenAccount(for: provider) == nil
+        if tokenOverride != nil || self.settings.selectedTokenAccount(for: provider) != nil {
+            return .blocked(.selectedTokenAccount)
+        }
+        switch provider {
+        case .codex:
+            guard Self.normalizedRollingWindowAutoStartSourceLabel(sourceLabel) == "openai-web" else {
+                return .allowed
+            }
+            return self.codexOpenAIWebSnapshotMatchesRollingWindowAutoStartRoute(
+                currentProviderData,
+                activeSource: codexActiveSource)
+                ? .allowed
+                : .blocked(self.codexOpenAIWebAutoStartBlockReason(
+                    currentProviderData,
+                    activeSource: codexActiveSource))
+        case .claude:
+            guard Self.normalizedRollingWindowAutoStartSourceLabel(sourceLabel) == "claude" else {
+                return .blocked(.unverifiedPromptAccount(
+                    snapshotAccount: Self.rollingWindowAutoStartAccountState(
+                        currentProviderData.accountEmail(for: .claude)),
+                    routedAccount: "unknown",
+                    sourceKind: "non-cli"))
+            }
+            return .allowed
+        default:
+            return .allowed
+        }
+    }
+
+    private func codexOpenAIWebSnapshotMatchesRollingWindowAutoStartRoute(
+        _ snapshot: UsageSnapshot,
+        activeSource: CodexActiveSource?) -> Bool
+    {
+        guard let activeSource,
+              let snapshotEmail = CodexIdentityResolver.normalizeEmail(snapshot.accountEmail(for: .codex)),
+              let routedEmail = Self.codexRollingWindowAutoStartRoutedEmail(
+                  settings: self.settings,
+                  activeSource: activeSource)
+        else {
+            return false
+        }
+        return snapshotEmail == routedEmail
+    }
+
+    private func codexOpenAIWebAutoStartBlockReason(
+        _ snapshot: UsageSnapshot,
+        activeSource: CodexActiveSource?) -> RollingWindowAutoStartRouteBlockReason
+    {
+        let snapshotAccount = Self.rollingWindowAutoStartAccountState(snapshot.accountEmail(for: .codex))
+        let routedAccount = Self.rollingWindowAutoStartAccountState(
+            activeSource.flatMap {
+                Self.codexRollingWindowAutoStartRoutedEmail(settings: self.settings, activeSource: $0)
+            })
+        return .unverifiedPromptAccount(
+            snapshotAccount: snapshotAccount,
+            routedAccount: routedAccount,
+            sourceKind: activeSource == nil ? "missing-route" : "openai-web")
+    }
+
+    private static func codexRollingWindowAutoStartRoutedEmail(
+        settings: SettingsStore,
+        activeSource: CodexActiveSource) -> String?
+    {
+        let reconciliation = settings.codexAccountReconciliationSnapshot(activeSourceOverride: activeSource)
+        switch activeSource {
+        case .liveSystem:
+            return CodexIdentityResolver.normalizeEmail(reconciliation.liveSystemAccount?.email)
+        case let .managedAccount(id):
+            guard let account = reconciliation.storedAccounts.first(where: { $0.id == id }) else {
+                return nil
+            }
+            return CodexIdentityResolver.normalizeEmail(reconciliation.runtimeEmail(for: account))
+        }
+    }
+
+    private static func normalizedRollingWindowAutoStartSourceLabel(_ sourceLabel: String?) -> String? {
+        sourceLabel?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private static func rollingWindowAutoStartAccountState(_ account: String?) -> String {
+        if let account = account?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !account.isEmpty
+        {
+            return "present"
+        }
+        return "missing"
     }
 
     static func rollingWindowAutoStartLogMetadata(
@@ -183,5 +287,38 @@ extension UsageStore {
     private static func redactedRollingWindowAutoStartAccountID(_ id: UUID) -> String {
         let value = id.uuidString
         return "\(value.prefix(6))...\(value.suffix(6))"
+    }
+}
+
+private enum RollingWindowAutoStartRouteCheck {
+    case allowed
+    case blocked(RollingWindowAutoStartRouteBlockReason)
+}
+
+private enum RollingWindowAutoStartRouteBlockReason {
+    case selectedTokenAccount
+    case unverifiedPromptAccount(snapshotAccount: String, routedAccount: String, sourceKind: String)
+
+    var statusMessage: String {
+        switch self {
+        case .selectedTokenAccount:
+            "Skipped: selected account cannot be pinged through ambient CLI."
+        case .unverifiedPromptAccount:
+            "Skipped: usage account does not match prompt CLI account."
+        }
+    }
+
+    var metadata: [String: String] {
+        switch self {
+        case .selectedTokenAccount:
+            ["skipReason": "selected-token-account"]
+        case let .unverifiedPromptAccount(snapshotAccount, routedAccount, sourceKind):
+            [
+                "skipReason": "account-match-unverified",
+                "snapshotAccount": snapshotAccount,
+                "routedAccount": routedAccount,
+                "sourceKind": sourceKind,
+            ]
+        }
     }
 }

--- a/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
@@ -17,9 +17,12 @@ extension UsageStore {
         sourceLabel: String?,
         previousSnapshot: UsageSnapshot?,
         currentProviderData: UsageSnapshot,
+        tokenOverride: TokenAccountOverride? = nil,
+        codexActiveSourceOverride: CodexActiveSource? = nil,
         now: Date = Date())
     {
         guard self.settings.rollingWindowAutoStartEnabled(provider: provider),
+              self.canRouteRollingWindowAutoStart(provider: provider, tokenOverride: tokenOverride),
               !self.rollingWindowAutoStartRuntime.inFlight.contains(provider),
               let decision = RollingWindowAutoStartDecision.shouldStart(
                   provider: provider,
@@ -60,7 +63,8 @@ extension UsageStore {
                     base: self.environmentBase,
                     provider: provider,
                     settings: self.settings,
-                    tokenOverride: nil)
+                    tokenOverride: nil,
+                    codexActiveSourceOverride: codexActiveSourceOverride)
                 try await RollingWindowPingStarter.start(
                     provider: provider,
                     environment: environment,
@@ -84,5 +88,12 @@ extension UsageStore {
                     ])
             }
         }
+    }
+
+    private func canRouteRollingWindowAutoStart(
+        provider: UsageProvider,
+        tokenOverride: TokenAccountOverride?) -> Bool
+    {
+        tokenOverride == nil && self.settings.selectedTokenAccount(for: provider) == nil
     }
 }

--- a/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
@@ -52,9 +52,14 @@ extension UsageStore {
                 #else
                 let runner = SubprocessRollingWindowPingRunner()
                 #endif
+                let environment = ProviderRegistry.makeEnvironment(
+                    base: self.environmentBase,
+                    provider: provider,
+                    settings: self.settings,
+                    tokenOverride: nil)
                 try await RollingWindowPingStarter.start(
                     provider: provider,
-                    environment: self.environmentBase,
+                    environment: environment,
                     runner: runner)
                 self.rollingWindowAutoStartStatus[provider] = "Ping prompt sent."
                 await self.refreshProvider(provider, coalesceIfRefreshing: true)

--- a/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
@@ -52,7 +52,7 @@ extension UsageStore {
             route: route,
             previousSourceLabel: previousSourceLabel,
             sourceLabel: sourceLabel,
-            previousResetAt: decision.resetAt)
+            decision: decision)
         switch self.canRouteRollingWindowAutoStart(
             provider: provider,
             tokenOverride: tokenOverride,
@@ -78,10 +78,12 @@ extension UsageStore {
                 return
             }
             self.rollingWindowAutoStartRuntime.attemptedResetAt[route] = resetAt
+            self.rollingWindowAutoStartRuntime.attemptedInactiveWithoutReset.remove(route)
         } else {
             guard !self.rollingWindowAutoStartRuntime.attemptedInactiveWithoutReset.contains(route) else {
                 return
             }
+            self.rollingWindowAutoStartRuntime.attemptedResetAt.removeValue(forKey: route)
             self.rollingWindowAutoStartRuntime.attemptedInactiveWithoutReset.insert(route)
         }
 
@@ -123,9 +125,11 @@ extension UsageStore {
                     RollingWindowAutoStartSupport.rollingWindow(provider: provider, snapshot: $0)
                 }
                 let verified = refreshedWindow.map {
-                    RollingWindowAutoStartSupport.isActiveRollingWindow($0)
+                    RollingWindowAutoStartSupport.isActiveRollingWindow($0, now: now)
                 } ?? false
                 if verified {
+                    self.rollingWindowAutoStartRuntime.attemptedResetAt.removeValue(forKey: route)
+                    self.rollingWindowAutoStartRuntime.attemptedInactiveWithoutReset.remove(route)
                     self.rollingWindowAutoStartStatus.removeValue(forKey: provider)
                     self.providerLogger.info(
                         "Rolling window auto-start verified new rolling window",
@@ -273,15 +277,16 @@ extension UsageStore {
         route: RollingWindowAutoStartRoute,
         previousSourceLabel: String?,
         sourceLabel: String?,
-        previousResetAt: Date?) -> [String: String]
+        decision: RollingWindowAutoStartDecision) -> [String: String]
     {
         [
             "provider": provider.rawValue,
             "route": self.rollingWindowAutoStartRouteLabel(route),
             "previousSource": previousSourceLabel ?? "none",
             "source": sourceLabel ?? "none",
-            "previousResetAt": self.rollingWindowAutoStartTimestamp(previousResetAt),
-            "trigger": previousResetAt == nil ? "inactive-without-previous-reset" : "expired-previous-reset",
+            "resetAt": self.rollingWindowAutoStartTimestamp(decision.resetAt),
+            "resetSource": decision.resetSource.logValue,
+            "trigger": decision.resetSource.trigger,
         ]
     }
 

--- a/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
@@ -78,7 +78,7 @@ extension UsageStore {
                     environment: environment,
                     runner: runner)
                 self.rollingWindowAutoStartStatus[provider] = "Ping prompt sent."
-                await self.refreshProvider(provider, coalesceIfRefreshing: true)
+                await self.refreshProvider(provider)
                 let refreshedWindow = self.snapshots[provider].flatMap {
                     RollingWindowAutoStartSupport.rollingWindow(provider: provider, snapshot: $0)
                 }

--- a/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
@@ -6,8 +6,10 @@ extension UsageStore {
 
     func resetRollingWindowAutoStartState(for provider: UsageProvider) {
         self.rollingWindowAutoStartStatus.removeValue(forKey: provider)
-        self.rollingWindowAutoStartRuntime.inFlight.remove(provider)
-        self.rollingWindowAutoStartRuntime.attemptedResetAt.removeValue(forKey: provider)
+        self.rollingWindowAutoStartRuntime.inFlight = self.rollingWindowAutoStartRuntime.inFlight
+            .filter { $0.provider != provider }
+        self.rollingWindowAutoStartRuntime.attemptedResetAt = self.rollingWindowAutoStartRuntime.attemptedResetAt
+            .filter { $0.key.provider != provider }
     }
 
     @MainActor
@@ -21,9 +23,15 @@ extension UsageStore {
         codexActiveSourceOverride: CodexActiveSource? = nil,
         now: Date = Date())
     {
+        let resolvedCodexActiveSource = provider == .codex
+            ? (codexActiveSourceOverride ?? self.settings.codexResolvedActiveSource)
+            : nil
+        let route = Self.rollingWindowAutoStartRoute(
+            provider: provider,
+            codexActiveSource: resolvedCodexActiveSource)
         guard self.settings.rollingWindowAutoStartEnabled(provider: provider),
               self.canRouteRollingWindowAutoStart(provider: provider, tokenOverride: tokenOverride),
-              !self.rollingWindowAutoStartRuntime.inFlight.contains(provider),
+              !self.rollingWindowAutoStartRuntime.inFlight.contains(route),
               let decision = RollingWindowAutoStartDecision.shouldStart(
                   provider: provider,
                   previousSourceLabel: previousSourceLabel,
@@ -35,21 +43,21 @@ extension UsageStore {
             return
         }
 
-        if let attempted = self.rollingWindowAutoStartRuntime.attemptedResetAt[provider],
+        if let attempted = self.rollingWindowAutoStartRuntime.attemptedResetAt[route],
            // Reset timestamps can be rounded differently across adjacent snapshots.
            abs(attempted.timeIntervalSince(decision.resetAt)) < Self.rollingWindowAutoStartSameResetTolerance
         {
             return
         }
 
-        self.rollingWindowAutoStartRuntime.attemptedResetAt[provider] = decision.resetAt
-        self.rollingWindowAutoStartRuntime.inFlight.insert(provider)
+        self.rollingWindowAutoStartRuntime.attemptedResetAt[route] = decision.resetAt
+        self.rollingWindowAutoStartRuntime.inFlight.insert(route)
         self.rollingWindowAutoStartStatus[provider] = "Starting a new rolling window..."
 
         Task { @MainActor [weak self] in
             guard let self else { return }
             defer {
-                self.rollingWindowAutoStartRuntime.inFlight.remove(provider)
+                self.rollingWindowAutoStartRuntime.inFlight.remove(route)
             }
 
             do {
@@ -64,7 +72,7 @@ extension UsageStore {
                     provider: provider,
                     settings: self.settings,
                     tokenOverride: nil,
-                    codexActiveSourceOverride: codexActiveSourceOverride)
+                    codexActiveSourceOverride: resolvedCodexActiveSource)
                 try await RollingWindowPingStarter.start(
                     provider: provider,
                     environment: environment,
@@ -78,7 +86,7 @@ extension UsageStore {
                     self.rollingWindowAutoStartStatus.removeValue(forKey: provider)
                 }
             } catch {
-                self.rollingWindowAutoStartRuntime.attemptedResetAt.removeValue(forKey: provider)
+                self.rollingWindowAutoStartRuntime.attemptedResetAt.removeValue(forKey: route)
                 self.rollingWindowAutoStartStatus[provider] = error.localizedDescription
                 self.providerLogger.warning(
                     "Rolling window auto-start failed",
@@ -87,6 +95,24 @@ extension UsageStore {
                         "error": error.localizedDescription,
                     ])
             }
+        }
+    }
+
+    private static func rollingWindowAutoStartRoute(
+        provider: UsageProvider,
+        codexActiveSource: CodexActiveSource?) -> RollingWindowAutoStartRoute
+    {
+        guard provider == .codex else {
+            return .provider(provider)
+        }
+
+        switch codexActiveSource {
+        case .liveSystem:
+            return .codexLiveSystem
+        case let .managedAccount(id):
+            return .codexManagedAccount(id)
+        case nil:
+            preconditionFailure("Codex rolling-window auto-start requires a resolved active source")
         }
     }
 

--- a/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
@@ -124,8 +124,9 @@ extension UsageStore {
                 let refreshedWindow = self.snapshots[provider].flatMap {
                     RollingWindowAutoStartSupport.rollingWindow(provider: provider, snapshot: $0)
                 }
+                let verificationNow = Date()
                 let verified = refreshedWindow.map {
-                    RollingWindowAutoStartSupport.isActiveRollingWindow($0, now: now)
+                    RollingWindowAutoStartSupport.isActiveRollingWindow($0, now: verificationNow)
                 } ?? false
                 if verified {
                     self.rollingWindowAutoStartRuntime.attemptedResetAt.removeValue(forKey: route)
@@ -134,6 +135,7 @@ extension UsageStore {
                     self.providerLogger.info(
                         "Rolling window auto-start verified new rolling window",
                         metadata: metadata.merging([
+                            "verifiedAt": Self.rollingWindowAutoStartTimestamp(verificationNow),
                             "verifiedResetAt": Self.rollingWindowAutoStartTimestamp(refreshedWindow?.resetsAt),
                             "verifiedResetDescription": Self.rollingWindowAutoStartResetDescription(refreshedWindow),
                         ], uniquingKeysWith: { _, new in new }))
@@ -141,6 +143,7 @@ extension UsageStore {
                     self.providerLogger.warning(
                         "Rolling window auto-start could not verify new rolling window",
                         metadata: metadata.merging([
+                            "verifiedAt": Self.rollingWindowAutoStartTimestamp(verificationNow),
                             "verifiedResetAt": Self.rollingWindowAutoStartTimestamp(refreshedWindow?.resetsAt),
                             "verifiedResetDescription": Self.rollingWindowAutoStartResetDescription(refreshedWindow),
                         ], uniquingKeysWith: { _, new in new }))

--- a/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
+++ b/Sources/CodexBar/UsageStore+RollingWindowAutoStart.swift
@@ -62,7 +62,7 @@ extension UsageStore {
         case let .blocked(reason):
             self.rollingWindowAutoStartStatus[provider] = reason.statusMessage
             self.providerLogger.warning(
-                "Rolling window auto-start skipped because usage account cannot be matched to prompt CLI account",
+                "\(reason.logMessage)",
                 metadata: metadata.merging(reason.metadata, uniquingKeysWith: { _, new in new }))
             return
         }
@@ -189,7 +189,7 @@ extension UsageStore {
             }
             return .allowed
         default:
-            return .allowed
+            return .blocked(.unsupportedProvider(provider.rawValue))
         }
     }
 
@@ -298,13 +298,31 @@ private enum RollingWindowAutoStartRouteCheck {
 private enum RollingWindowAutoStartRouteBlockReason {
     case selectedTokenAccount
     case unverifiedPromptAccount(snapshotAccount: String, routedAccount: String, sourceKind: String)
+    case unsupportedProvider(String)
 
     var statusMessage: String {
         switch self {
         case .selectedTokenAccount:
             "Skipped: selected account cannot be pinged through ambient CLI."
-        case .unverifiedPromptAccount:
+        case let .unverifiedPromptAccount(_, _, sourceKind) where sourceKind == "openai-web":
             "Skipped: usage account does not match prompt CLI account."
+        case .unverifiedPromptAccount:
+            "Skipped: usage account cannot be verified against prompt CLI account."
+        case .unsupportedProvider:
+            "Skipped: provider cannot be routed through ambient CLI."
+        }
+    }
+
+    var logMessage: String {
+        switch self {
+        case .selectedTokenAccount:
+            "Rolling window auto-start skipped because selected account cannot be routed through ambient CLI"
+        case let .unverifiedPromptAccount(_, _, sourceKind) where sourceKind == "openai-web":
+            "Rolling window auto-start skipped because usage account does not match prompt CLI account"
+        case .unverifiedPromptAccount:
+            "Rolling window auto-start skipped because usage account cannot be verified against prompt CLI account"
+        case .unsupportedProvider:
+            "Rolling window auto-start skipped because provider cannot be routed through ambient CLI"
         }
     }
 
@@ -318,6 +336,11 @@ private enum RollingWindowAutoStartRouteBlockReason {
                 "snapshotAccount": snapshotAccount,
                 "routedAccount": routedAccount,
                 "sourceKind": sourceKind,
+            ]
+        case let .unsupportedProvider(provider):
+            [
+                "skipReason": "unsupported-provider",
+                "unsupportedProvider": provider,
             ]
         }
     }

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -1185,11 +1185,11 @@ extension UsageStore {
             self.rememberLiveSystemCodexEmailIfNeeded(snapshot.accountEmail(for: .codex))
             self.seedCodexAccountScopedRefreshGuard(accountEmail: account.email)
             await self.recordPlanUtilizationHistorySample(provider: .codex, snapshot: snapshot)
+            guard self.isCurrentProviderRefreshGeneration(.codex, generation: generation) else { return }
             self.scheduleRollingWindowAutoStartIfNeeded(
                 provider: .codex,
                 previousSnapshot: previousSnapshot,
                 currentProviderData: snapshot)
-            guard self.isCurrentProviderRefreshGeneration(.codex, generation: generation) else { return }
             self.recordCodexHistoricalSampleIfNeeded(snapshot: snapshot)
         case let .failure(error):
             guard let message = self.tokenAccountErrorMessage(error) else {
@@ -1249,6 +1249,7 @@ extension UsageStore {
                 provider: provider,
                 snapshot: backfilled.current,
                 account: account)
+            guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
             self.scheduleRollingWindowAutoStartIfNeeded(
                 provider: provider,
                 previousSnapshot: backfilled.previous,

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -1192,7 +1192,8 @@ extension UsageStore {
                 previousSourceLabel: previousSourceLabel,
                 sourceLabel: sourceLabel,
                 previousSnapshot: previousSnapshot,
-                currentProviderData: snapshot)
+                currentProviderData: snapshot,
+                codexActiveSourceOverride: account.selectionSource)
             self.recordCodexHistoricalSampleIfNeeded(snapshot: snapshot)
         case let .failure(error):
             guard let message = self.tokenAccountErrorMessage(error) else {
@@ -1259,7 +1260,8 @@ extension UsageStore {
                 previousSourceLabel: backfilled.previousSourceLabel,
                 sourceLabel: result.sourceLabel,
                 previousSnapshot: backfilled.previous,
-                currentProviderData: backfilled.current)
+                currentProviderData: backfilled.current,
+                tokenOverride: account.map { TokenAccountOverride(provider: provider, account: $0) })
         case let .failure(error):
             await MainActor.run {
                 guard let message = self.tokenAccountErrorMessage(error) else {

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -1172,7 +1172,8 @@ extension UsageStore {
         switch outcome.result {
         case .success:
             guard let snapshot else { return }
-            let previousSnapshot = self.lastKnownResetSnapshots[.codex]
+            let previousSnapshot = self.codexLastKnownResetSnapshot(for: account)
+            let previousSourceLabel = previousSnapshot == nil ? nil : self.lastSourceLabels[.codex]
             self.handleSessionQuotaTransition(provider: .codex, snapshot: snapshot)
             self.lastKnownResetSnapshots[.codex] = snapshot
             self.lastCodexAccountScopedRefreshGuard = Self.codexScopedRefreshGuard(for: account)
@@ -1188,6 +1189,8 @@ extension UsageStore {
             guard self.isCurrentProviderRefreshGeneration(.codex, generation: generation) else { return }
             self.scheduleRollingWindowAutoStartIfNeeded(
                 provider: .codex,
+                previousSourceLabel: previousSourceLabel,
+                sourceLabel: sourceLabel,
                 previousSnapshot: previousSnapshot,
                 currentProviderData: snapshot)
             self.recordCodexHistoricalSampleIfNeeded(snapshot: snapshot)
@@ -1231,9 +1234,10 @@ extension UsageStore {
             }
             let backfilled = await MainActor.run {
                 guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else {
-                    return nil as (current: UsageSnapshot, previous: UsageSnapshot?)?
+                    return nil as (current: UsageSnapshot, previous: UsageSnapshot?, previousSourceLabel: String?)?
                 }
                 let previousSnapshot = self.lastKnownResetSnapshots[provider]
+                let previousSourceLabel = previousSnapshot == nil ? nil : self.lastSourceLabels[provider]
                 let backfilled = labeled.backfillingResetTimes(from: self.lastKnownResetSnapshots[provider])
                 self.handleQuotaWarningTransitions(provider: provider, snapshot: backfilled)
                 self.handleSessionQuotaTransition(provider: provider, snapshot: backfilled)
@@ -1242,7 +1246,7 @@ extension UsageStore {
                 self.lastSourceLabels[provider] = result.sourceLabel
                 self.errors[provider] = nil
                 self.failureGates[provider]?.recordSuccess()
-                return (backfilled, previousSnapshot)
+                return (backfilled, previousSnapshot, previousSourceLabel)
             }
             guard let backfilled else { return }
             await self.recordPlanUtilizationHistorySample(
@@ -1252,6 +1256,8 @@ extension UsageStore {
             guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else { return }
             self.scheduleRollingWindowAutoStartIfNeeded(
                 provider: provider,
+                previousSourceLabel: backfilled.previousSourceLabel,
+                sourceLabel: result.sourceLabel,
                 previousSnapshot: backfilled.previous,
                 currentProviderData: backfilled.current)
         case let .failure(error):

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -1172,6 +1172,7 @@ extension UsageStore {
         switch outcome.result {
         case .success:
             guard let snapshot else { return }
+            let previousSnapshot = self.lastKnownResetSnapshots[.codex]
             self.handleSessionQuotaTransition(provider: .codex, snapshot: snapshot)
             self.lastKnownResetSnapshots[.codex] = snapshot
             self.lastCodexAccountScopedRefreshGuard = Self.codexScopedRefreshGuard(for: account)
@@ -1184,6 +1185,10 @@ extension UsageStore {
             self.rememberLiveSystemCodexEmailIfNeeded(snapshot.accountEmail(for: .codex))
             self.seedCodexAccountScopedRefreshGuard(accountEmail: account.email)
             await self.recordPlanUtilizationHistorySample(provider: .codex, snapshot: snapshot)
+            self.scheduleRollingWindowAutoStartIfNeeded(
+                provider: .codex,
+                previousSnapshot: previousSnapshot,
+                currentProviderData: snapshot)
             guard self.isCurrentProviderRefreshGeneration(.codex, generation: generation) else { return }
             self.recordCodexHistoricalSampleIfNeeded(snapshot: snapshot)
         case let .failure(error):
@@ -1226,8 +1231,9 @@ extension UsageStore {
             }
             let backfilled = await MainActor.run {
                 guard self.isCurrentProviderRefreshGeneration(provider, generation: generation) else {
-                    return nil as UsageSnapshot?
+                    return nil as (current: UsageSnapshot, previous: UsageSnapshot?)?
                 }
+                let previousSnapshot = self.lastKnownResetSnapshots[provider]
                 let backfilled = labeled.backfillingResetTimes(from: self.lastKnownResetSnapshots[provider])
                 self.handleQuotaWarningTransitions(provider: provider, snapshot: backfilled)
                 self.handleSessionQuotaTransition(provider: provider, snapshot: backfilled)
@@ -1236,13 +1242,17 @@ extension UsageStore {
                 self.lastSourceLabels[provider] = result.sourceLabel
                 self.errors[provider] = nil
                 self.failureGates[provider]?.recordSuccess()
-                return backfilled
+                return (backfilled, previousSnapshot)
             }
             guard let backfilled else { return }
             await self.recordPlanUtilizationHistorySample(
                 provider: provider,
-                snapshot: backfilled,
+                snapshot: backfilled.current,
                 account: account)
+            self.scheduleRollingWindowAutoStartIfNeeded(
+                provider: provider,
+                previousSnapshot: backfilled.previous,
+                currentProviderData: backfilled.current)
         case let .failure(error):
             await MainActor.run {
                 guard let message = self.tokenAccountErrorMessage(error) else {

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -4,53 +4,8 @@ import Foundation
 import Observation
 import SweetCookieKit
 
-// MARK: - Observation helpers
-
 @MainActor
 extension UsageStore {
-    var menuObservationToken: Int {
-        _ = self.snapshots
-        _ = self.errors
-        _ = self.lastSourceLabels
-        _ = self.lastFetchAttempts
-        _ = self.accountSnapshots
-        _ = self.codexAccountSnapshots
-        _ = self.kiloScopeSnapshots
-        _ = self.tokenSnapshots
-        _ = self.tokenErrors
-        _ = self.tokenRefreshInFlight
-        _ = self.credits
-        _ = self.lastCreditsError
-        _ = self.openAIDashboard
-        _ = self.lastOpenAIDashboardError
-        _ = self.openAIDashboardRequiresLogin
-        _ = self.openAIDashboardAttachmentRevision
-        _ = self.versions
-        _ = self.isRefreshing
-        _ = self.refreshingProviders
-        _ = self.pathDebugInfo
-        _ = self.statuses
-        _ = self.probeLogs
-        _ = self.historicalPaceRevision
-        _ = self.planUtilizationHistoryRevision
-        _ = self.providerStorageFootprints
-        return 0
-    }
-
-    var iconObservationToken: Int {
-        _ = self.snapshots
-        _ = self.errors
-        _ = self.credits
-        _ = self.lastCreditsError
-        _ = self.openAIDashboard
-        _ = self.lastOpenAIDashboardError
-        _ = self.openAIDashboardRequiresLogin
-        _ = self.refreshingProviders
-        _ = self.statuses
-        _ = self.historicalPaceRevision
-        return 0
-    }
-
     func observeSettingsChanges() {
         withObservationTracking {
             _ = self.backgroundWorkSettingsObservationToken
@@ -94,11 +49,6 @@ extension UsageStore {
         _ = self.settings.historicalTrackingEnabled
         _ = self.settings.providerStorageFootprintsEnabled
         return 0
-    }
-
-    var attachedOpenAIDashboardSnapshot: OpenAIDashboardSnapshot? {
-        guard self.openAIDashboardAttachmentAuthorized else { return nil }
-        return self.openAIDashboard
     }
 }
 
@@ -155,6 +105,7 @@ final class UsageStore {
     var pathDebugInfo: PathDebugSnapshot = .empty
     var statuses: [UsageProvider: ProviderStatus] = [:]
     var probeLogs: [UsageProvider: String] = [:]
+    var rollingWindowAutoStartStatus: [UsageProvider: String] = [:]
     var historicalPaceRevision: Int = 0
     var planUtilizationHistoryRevision: Int = 0
     var providerStorageFootprints: [UsageProvider: ProviderStorageFootprint] = [:]
@@ -258,6 +209,7 @@ final class UsageStore {
     @ObservationIgnored var codexHistoricalDatasetAccountKey: String?
     @ObservationIgnored var lastKnownResetSnapshots: [UsageProvider: UsageSnapshot] = [:]
     @ObservationIgnored var lastKnownSessionRemaining: [UsageProvider: Double] = [:]
+    @ObservationIgnored var rollingWindowAutoStartRuntime = RollingWindowAutoStartRuntimeState()
     @ObservationIgnored var lastKnownSessionWindowSource: [UsageProvider: SessionQuotaWindowSource] = [:]
     @ObservationIgnored var quotaWarningState: [QuotaWarningStateKey: QuotaWarningState] = [:]
     @ObservationIgnored var lastPermissionPromptNotificationAt: [UsageProvider: Date] = [:]

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -77,6 +77,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
     public var enabled: Bool?
     public var source: ProviderSourceMode?
     public var extrasEnabled: Bool?
+    public var rollingWindowAutoStartEnabled: Bool?
     public var apiKey: String?
     public var secretKey: String?
     public var cookieHeader: String?
@@ -97,6 +98,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         enabled: Bool? = nil,
         source: ProviderSourceMode? = nil,
         extrasEnabled: Bool? = nil,
+        rollingWindowAutoStartEnabled: Bool? = nil,
         apiKey: String? = nil,
         secretKey: String? = nil,
         cookieHeader: String? = nil,
@@ -116,6 +118,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         self.enabled = enabled
         self.source = source
         self.extrasEnabled = extrasEnabled
+        self.rollingWindowAutoStartEnabled = rollingWindowAutoStartEnabled
         self.apiKey = apiKey
         self.secretKey = secretKey
         self.cookieHeader = cookieHeader

--- a/Tests/CodexBarTests/RollingWindowAutoStartReviewFixTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartReviewFixTests.swift
@@ -99,6 +99,127 @@ struct RollingWindowAutoStartReviewFixTests {
     }
 
     @Test
+    func `OpenAI web dashboard attach schedules inactive window without cached reset`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartReviewFixTests-dashboard-no-reset")
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
+        settings._test_liveSystemCodexAccount = Self.liveSystemCodexAccount(email: "codex@example.com")
+        defer { settings._test_liveSystemCodexAccount = nil }
+        let store = Self.makeUsageStore(settings: settings)
+        let runner = ReviewFixRollingWindowPingRunner()
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+        var refreshCount = 0
+        store._test_providerRefreshOverride = { _ in
+            refreshCount += 1
+        }
+
+        await store.applyOpenAIDashboard(
+            Self.openAIWebDashboard(
+                email: "codex@example.com",
+                primaryLimit: RateWindow(
+                    usedPercent: 0,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                updatedAt: Date()),
+            targetEmail: "codex@example.com")
+
+        try await Self.waitForAutoStartToFinish(store: store, provider: .codex)
+        #expect(await runner.count == 1)
+        #expect(refreshCount == 1)
+        #expect(store.rollingWindowAutoStartRuntime.attemptedInactiveWithoutReset.contains(.codexLiveSystem))
+    }
+
+    @Test
+    func `decision skips active codex OpenAI web window with reset description and no reset timestamp`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let previous = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(-60),
+                resetDescription: nil),
+            provider: .codex,
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 2,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: "Resets 8:44 PM"),
+            provider: .codex,
+            updatedAt: now)
+
+        let decision = RollingWindowAutoStartDecision.shouldStart(
+            provider: .codex,
+            previousSourceLabel: "openai-web",
+            sourceLabel: "openai-web",
+            previous: previous,
+            currentProviderData: current,
+            now: now)
+
+        #expect(decision == nil)
+    }
+
+    @Test
+    func `scheduler verifies text only active window after ping`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartReviewFixTests-text-verify")
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
+        let store = Self.makeUsageStore(settings: settings)
+        let runner = ReviewFixRollingWindowPingRunner()
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+        var refreshCount = 0
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        store._test_providerRefreshOverride = { _ in
+            refreshCount += 1
+            store.snapshots[.codex] = Self.snapshot(
+                primary: RateWindow(
+                    usedPercent: 2,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: "Resets 8:44 PM"),
+                provider: .codex,
+                updatedAt: now)
+        }
+
+        let expired = now.addingTimeInterval(-60)
+        let previous = Self.snapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: expired, resetDescription: nil),
+            provider: .codex,
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            provider: .codex,
+            updatedAt: now)
+
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .codex,
+            previousSourceLabel: "codex-cli",
+            sourceLabel: "codex-cli",
+            previousSnapshot: previous,
+            currentProviderData: current,
+            now: now)
+
+        try await Self.waitForAutoStartToFinish(store: store, provider: .codex)
+        #expect(await runner.count == 1)
+        #expect(refreshCount == 1)
+        #expect(store.rollingWindowAutoStartStatus[.codex] == nil)
+    }
+
+    @Test
+    func `reset description log helper trims missing and present values`() {
+        #expect(UsageStore.rollingWindowAutoStartResetDescription(nil) == "none")
+        #expect(UsageStore.rollingWindowAutoStartResetDescription(
+            RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: "  ")) == "none")
+        #expect(UsageStore.rollingWindowAutoStartResetDescription(
+            RateWindow(
+                usedPercent: 2,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: " Resets 8:44 PM ")) == "Resets 8:44 PM")
+    }
+
+    @Test
     func `OpenAI web dashboard attach does not overwrite codex cli snapshot`() async throws {
         let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartReviewFixTests-dashboard-cli")
         settings._test_liveSystemCodexAccount = Self.liveSystemCodexAccount(email: "web@example.com")

--- a/Tests/CodexBarTests/RollingWindowAutoStartReviewFixTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartReviewFixTests.swift
@@ -1,0 +1,180 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct RollingWindowAutoStartReviewFixTests {
+    @Test
+    func `claude decision starts when model specific weekly window is exhausted`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let expiredSessionReset = now.addingTimeInterval(-60)
+        let modelSpecificExhausted = RateWindow(
+            usedPercent: 100,
+            windowMinutes: 7 * 24 * 60,
+            resetsAt: now.addingTimeInterval(3 * 24 * 60 * 60),
+            resetDescription: nil)
+        let previous = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 5 * 60,
+                resetsAt: expiredSessionReset,
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 25,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(3 * 24 * 60 * 60),
+                resetDescription: nil),
+            tertiary: modelSpecificExhausted,
+            provider: .claude,
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 0,
+                windowMinutes: 5 * 60,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 25,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(3 * 24 * 60 * 60),
+                resetDescription: nil),
+            tertiary: modelSpecificExhausted,
+            provider: .claude,
+            updatedAt: now)
+
+        let decision = RollingWindowAutoStartDecision.shouldStart(
+            provider: .claude,
+            previousSourceLabel: "claude",
+            sourceLabel: "claude",
+            previous: previous,
+            currentProviderData: current,
+            now: now)
+
+        #expect(decision?.resetAt == expiredSessionReset)
+    }
+
+    @Test
+    func `open A I web dashboard attach updates reset snapshot and schedules expired window`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartReviewFixTests-dashboard")
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
+        settings._test_liveSystemCodexAccount = Self.liveSystemCodexAccount(email: "codex@example.com")
+        defer { settings._test_liveSystemCodexAccount = nil }
+        let store = Self.makeUsageStore(settings: settings)
+        let runner = ReviewFixRollingWindowPingRunner()
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+        var refreshCount = 0
+        store._test_providerRefreshOverride = { _ in
+            refreshCount += 1
+        }
+
+        let now = Date()
+        let expired = now.addingTimeInterval(-60)
+        await store.applyOpenAIDashboard(
+            Self.openAIWebDashboard(
+                email: "codex@example.com",
+                primaryLimit: RateWindow(
+                    usedPercent: 20,
+                    windowMinutes: 300,
+                    resetsAt: expired,
+                    resetDescription: nil),
+                updatedAt: now.addingTimeInterval(-120)),
+            targetEmail: "codex@example.com")
+        await store.applyOpenAIDashboard(
+            Self.openAIWebDashboard(
+                email: "codex@example.com",
+                primaryLimit: RateWindow(
+                    usedPercent: 0,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                updatedAt: now),
+            targetEmail: "codex@example.com")
+
+        try await Self.waitForAutoStartToFinish(store: store, provider: .codex)
+        #expect(await runner.count == 1)
+        #expect(refreshCount == 1)
+        #expect(store.lastKnownResetSnapshots[.codex]?.primary?.resetsAt == nil)
+        #expect(store.rollingWindowAutoStartRuntime.attemptedResetAt[.codexLiveSystem] == expired)
+    }
+
+    private static func makeSettingsStore(suite: String) throws -> SettingsStore {
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        return SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+    }
+
+    private static func makeUsageStore(settings: SettingsStore) -> UsageStore {
+        UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: [:])
+    }
+
+    private static func waitForAutoStartToFinish(store: UsageStore, provider: UsageProvider) async throws {
+        for _ in 0..<50 {
+            if !store.rollingWindowAutoStartRuntime.inFlight.contains(where: { $0.provider == provider }) {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        Issue.record("Timed out waiting for rolling window auto-start to finish")
+    }
+
+    private static func snapshot(
+        primary: RateWindow?,
+        secondary: RateWindow? = nil,
+        tertiary: RateWindow? = nil,
+        provider: UsageProvider,
+        updatedAt: Date) -> UsageSnapshot
+    {
+        UsageSnapshot(
+            primary: primary,
+            secondary: secondary,
+            tertiary: tertiary,
+            updatedAt: updatedAt,
+            identity: ProviderIdentitySnapshot(
+                providerID: provider,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: nil))
+    }
+
+    private static func liveSystemCodexAccount(email: String) -> ObservedSystemCodexAccount {
+        ObservedSystemCodexAccount(
+            email: email,
+            codexHomePath: "/tmp/codexbar-live-system",
+            observedAt: Date(),
+            identity: CodexIdentityResolver.resolve(accountId: nil, email: email))
+    }
+
+    private static func openAIWebDashboard(
+        email: String,
+        primaryLimit: RateWindow,
+        updatedAt: Date) -> OpenAIDashboardSnapshot
+    {
+        OpenAIDashboardSnapshot(
+            signedInEmail: email,
+            codeReviewRemainingPercent: nil,
+            creditEvents: [],
+            dailyBreakdown: [],
+            usageBreakdown: [],
+            creditsPurchaseURL: nil,
+            primaryLimit: primaryLimit,
+            updatedAt: updatedAt)
+    }
+}
+
+private actor ReviewFixRollingWindowPingRunner: RollingWindowPingRunning {
+    private(set) var count = 0
+
+    func run(_: RollingWindowPingRequest) async throws {
+        self.count += 1
+    }
+}

--- a/Tests/CodexBarTests/RollingWindowAutoStartReviewFixTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartReviewFixTests.swift
@@ -112,6 +112,8 @@ struct RollingWindowAutoStartReviewFixTests {
             refreshCount += 1
         }
 
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        store.rollingWindowAutoStartRuntime.attemptedResetAt[.codexLiveSystem] = now.addingTimeInterval(-3600)
         await store.applyOpenAIDashboard(
             Self.openAIWebDashboard(
                 email: "codex@example.com",
@@ -120,13 +122,14 @@ struct RollingWindowAutoStartReviewFixTests {
                     windowMinutes: 300,
                     resetsAt: nil,
                     resetDescription: nil),
-                updatedAt: Date()),
+                updatedAt: now),
             targetEmail: "codex@example.com")
 
         try await Self.waitForAutoStartToFinish(store: store, provider: .codex)
         #expect(await runner.count == 1)
         #expect(refreshCount == 1)
         #expect(store.rollingWindowAutoStartRuntime.attemptedInactiveWithoutReset.contains(.codexLiveSystem))
+        #expect(store.rollingWindowAutoStartRuntime.attemptedResetAt[.codexLiveSystem] == nil)
     }
 
     @Test
@@ -260,6 +263,7 @@ struct RollingWindowAutoStartReviewFixTests {
         let store = Self.makeUsageStore(settings: settings)
         let runner = ReviewFixRollingWindowPingRunner()
         store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+        store.rollingWindowAutoStartRuntime.attemptedInactiveWithoutReset.insert(.codexLiveSystem)
         var refreshCount = 0
 
         let now = Date(timeIntervalSince1970: 1_800_000_000)
@@ -297,6 +301,8 @@ struct RollingWindowAutoStartReviewFixTests {
         #expect(await runner.count == 1)
         #expect(refreshCount == 1)
         #expect(store.rollingWindowAutoStartStatus[.codex] == nil)
+        #expect(store.rollingWindowAutoStartRuntime.attemptedResetAt[.codexLiveSystem] == nil)
+        #expect(!store.rollingWindowAutoStartRuntime.attemptedInactiveWithoutReset.contains(.codexLiveSystem))
     }
 
     @Test
@@ -429,7 +435,7 @@ struct RollingWindowAutoStartReviewFixTests {
 private actor ReviewFixRollingWindowPingRunner: RollingWindowPingRunning {
     private(set) var count = 0
     var isEmpty: Bool {
-        self.count < 1
+        self.count == .zero
     }
 
     func run(_: RollingWindowPingRequest) async throws {

--- a/Tests/CodexBarTests/RollingWindowAutoStartReviewFixTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartReviewFixTests.swift
@@ -130,6 +130,71 @@ struct RollingWindowAutoStartReviewFixTests {
     }
 
     @Test
+    func `decision skips inactive codex cli snapshot without previous reset`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            provider: .codex,
+            updatedAt: now)
+
+        let decision = RollingWindowAutoStartDecision.shouldStart(
+            provider: .codex,
+            previousSourceLabel: nil,
+            sourceLabel: "codex-cli",
+            previous: nil,
+            currentProviderData: current,
+            now: now)
+
+        #expect(decision == nil)
+    }
+
+    @Test
+    func `decision skips inactive claude cli snapshot without previous reset`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            provider: .claude,
+            updatedAt: now)
+
+        let decision = RollingWindowAutoStartDecision.shouldStart(
+            provider: .claude,
+            previousSourceLabel: nil,
+            sourceLabel: "claude",
+            previous: nil,
+            currentProviderData: current,
+            now: now)
+
+        #expect(decision == nil)
+    }
+
+    @Test
+    func `scheduler skips codex cli inactive snapshot without prior reset`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartReviewFixTests-cli-no-reset")
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
+        let store = Self.makeUsageStore(settings: settings)
+        let runner = ReviewFixRollingWindowPingRunner()
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+        store._test_providerRefreshOverride = { _ in }
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            provider: .codex,
+            updatedAt: now)
+
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .codex,
+            previousSourceLabel: nil,
+            sourceLabel: "codex-cli",
+            previousSnapshot: nil,
+            currentProviderData: current,
+            now: now)
+
+        #expect(await runner.isEmpty)
+        #expect(store.rollingWindowAutoStartRuntime.attemptedInactiveWithoutReset.isEmpty)
+    }
+
+    @Test
     func `decision skips active codex OpenAI web window with reset description and no reset timestamp`() {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let previous = Self.snapshot(
@@ -158,6 +223,34 @@ struct RollingWindowAutoStartReviewFixTests {
             now: now)
 
         #expect(decision == nil)
+    }
+
+    @Test
+    func `decision starts when current rolling window has expired timestamp and reset description`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let expired = now.addingTimeInterval(-60)
+        let previous = Self.snapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: expired, resetDescription: nil),
+            provider: .codex,
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: expired,
+                resetDescription: "Resets 8:44 PM"),
+            provider: .codex,
+            updatedAt: now)
+
+        let decision = RollingWindowAutoStartDecision.shouldStart(
+            provider: .codex,
+            previousSourceLabel: "codex-cli",
+            sourceLabel: "codex-cli",
+            previous: previous,
+            currentProviderData: current,
+            now: now)
+
+        #expect(decision?.resetAt == expired)
     }
 
     @Test
@@ -335,6 +428,9 @@ struct RollingWindowAutoStartReviewFixTests {
 
 private actor ReviewFixRollingWindowPingRunner: RollingWindowPingRunning {
     private(set) var count = 0
+    var isEmpty: Bool {
+        self.count < 1
+    }
 
     func run(_: RollingWindowPingRequest) async throws {
         self.count += 1

--- a/Tests/CodexBarTests/RollingWindowAutoStartReviewFixTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartReviewFixTests.swift
@@ -306,6 +306,54 @@ struct RollingWindowAutoStartReviewFixTests {
     }
 
     @Test
+    func `scheduler keeps retry state when refreshed reset expired before verification`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartReviewFixTests-stale-refreshed-reset")
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
+        let store = Self.makeUsageStore(settings: settings)
+        let runner = ReviewFixRollingWindowPingRunner(delay: .milliseconds(50))
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+        var refreshCount = 0
+
+        let now = Date()
+        let refreshedReset = now.addingTimeInterval(0.01)
+        store._test_providerRefreshOverride = { _ in
+            refreshCount += 1
+            store.snapshots[.codex] = Self.snapshot(
+                primary: RateWindow(
+                    usedPercent: 1,
+                    windowMinutes: 300,
+                    resetsAt: refreshedReset,
+                    resetDescription: nil),
+                provider: .codex,
+                updatedAt: Date())
+        }
+
+        let expired = now.addingTimeInterval(-60)
+        let previous = Self.snapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: expired, resetDescription: nil),
+            provider: .codex,
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            provider: .codex,
+            updatedAt: now)
+
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .codex,
+            previousSourceLabel: "codex-cli",
+            sourceLabel: "codex-cli",
+            previousSnapshot: previous,
+            currentProviderData: current,
+            now: now)
+
+        try await Self.waitForAutoStartToFinish(store: store, provider: .codex)
+        #expect(await runner.count == 1)
+        #expect(refreshCount == 1)
+        #expect(store.rollingWindowAutoStartStatus[.codex] == "Ping prompt sent.")
+        #expect(store.rollingWindowAutoStartRuntime.attemptedResetAt[.codexLiveSystem] == expired)
+    }
+
+    @Test
     func `reset description log helper trims missing and present values`() {
         #expect(UsageStore.rollingWindowAutoStartResetDescription(nil) == "none")
         #expect(UsageStore.rollingWindowAutoStartResetDescription(
@@ -433,12 +481,20 @@ struct RollingWindowAutoStartReviewFixTests {
 }
 
 private actor ReviewFixRollingWindowPingRunner: RollingWindowPingRunning {
+    private let delay: Duration?
     private(set) var count = 0
     var isEmpty: Bool {
         self.count == .zero
     }
 
+    init(delay: Duration? = nil) {
+        self.delay = delay
+    }
+
     func run(_: RollingWindowPingRequest) async throws {
         self.count += 1
+        if let delay {
+            try await Task.sleep(for: delay)
+        }
     }
 }

--- a/Tests/CodexBarTests/RollingWindowAutoStartReviewFixTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartReviewFixTests.swift
@@ -55,7 +55,7 @@ struct RollingWindowAutoStartReviewFixTests {
     }
 
     @Test
-    func `open A I web dashboard attach updates reset snapshot and schedules expired window`() async throws {
+    func `OpenAI web dashboard attach updates reset snapshot and schedules expired window`() async throws {
         let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartReviewFixTests-dashboard")
         settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
         settings._test_liveSystemCodexAccount = Self.liveSystemCodexAccount(email: "codex@example.com")
@@ -98,6 +98,46 @@ struct RollingWindowAutoStartReviewFixTests {
         #expect(store.rollingWindowAutoStartRuntime.attemptedResetAt[.codexLiveSystem] == expired)
     }
 
+    @Test
+    func `OpenAI web dashboard attach does not overwrite codex cli snapshot`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartReviewFixTests-dashboard-cli")
+        settings._test_liveSystemCodexAccount = Self.liveSystemCodexAccount(email: "web@example.com")
+        defer { settings._test_liveSystemCodexAccount = nil }
+        let store = Self.makeUsageStore(settings: settings)
+
+        let now = Date()
+        let cliReset = now.addingTimeInterval(60 * 60)
+        let cliSnapshot = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 42,
+                windowMinutes: 300,
+                resetsAt: cliReset,
+                resetDescription: nil),
+            accountEmail: "cli@example.com",
+            provider: .codex,
+            updatedAt: now.addingTimeInterval(-60))
+        store.snapshots[.codex] = cliSnapshot
+        store.lastKnownResetSnapshots[.codex] = cliSnapshot
+        store.lastSourceLabels[.codex] = "codex-cli"
+
+        await store.applyOpenAIDashboard(
+            Self.openAIWebDashboard(
+                email: "web@example.com",
+                primaryLimit: RateWindow(
+                    usedPercent: 5,
+                    windowMinutes: 300,
+                    resetsAt: nil,
+                    resetDescription: nil),
+                updatedAt: now),
+            targetEmail: "web@example.com")
+
+        #expect(store.openAIDashboard?.signedInEmail == "web@example.com")
+        #expect(store.snapshots[.codex]?.accountEmail(for: .codex) == "cli@example.com")
+        #expect(store.snapshots[.codex]?.primary?.usedPercent == 42)
+        #expect(store.lastKnownResetSnapshots[.codex]?.primary?.resetsAt == cliReset)
+        #expect(store.lastSourceLabels[.codex] == "codex-cli")
+    }
+
     private static func makeSettingsStore(suite: String) throws -> SettingsStore {
         let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
@@ -131,6 +171,7 @@ struct RollingWindowAutoStartReviewFixTests {
         primary: RateWindow?,
         secondary: RateWindow? = nil,
         tertiary: RateWindow? = nil,
+        accountEmail: String? = nil,
         provider: UsageProvider,
         updatedAt: Date) -> UsageSnapshot
     {
@@ -141,7 +182,7 @@ struct RollingWindowAutoStartReviewFixTests {
             updatedAt: updatedAt,
             identity: ProviderIdentitySnapshot(
                 providerID: provider,
-                accountEmail: nil,
+                accountEmail: accountEmail,
                 accountOrganization: nil,
                 loginMethod: nil))
     }

--- a/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
@@ -328,14 +328,19 @@ struct RollingWindowAutoStartTests {
             route: .codexManagedAccount(accountID),
             previousSourceLabel: nil,
             sourceLabel: "oauth",
-            previousResetAt: resetAt)
+            decision: RollingWindowAutoStartDecision(
+                resetAt: resetAt,
+                resetSource: .previousExpiredReset))
 
         #expect(metadata["provider"] == "codex")
         #expect(metadata["route"] == "codex-managed-account:123456...ABCDEF")
         #expect(metadata["route"]?.contains(accountID.uuidString) == false)
         #expect(metadata["previousSource"] == "none")
         #expect(metadata["source"] == "oauth")
-        #expect(metadata["previousResetAt"] == "2027-01-15T08:00:00.000Z")
+        #expect(metadata["resetAt"] == "2027-01-15T08:00:00.000Z")
+        #expect(metadata["resetSource"] == "previous-expired-reset")
+        #expect(metadata["trigger"] == "expired-previous-reset")
+        #expect(metadata["previousResetAt"] == nil)
         #expect(metadata["expiredResetAt"] == nil)
     }
 

--- a/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
@@ -113,7 +113,7 @@ struct RollingWindowAutoStartTests {
         #expect(command.arguments.contains("--skip-git-repo-check"))
         #expect(command.arguments.contains("gpt-5.4-mini"))
         #expect(command.arguments.contains("model_reasoning_effort=low"))
-        #expect(command.arguments.last == "hi")
+        #expect(command.arguments.last == "Say hi, then stop.")
     }
 
     @Test

--- a/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
@@ -284,16 +284,11 @@ struct RollingWindowAutoStartTests {
     func `scheduler routes codex ping through selected managed account environment`() async throws {
         let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-managed-codex-route")
         settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
-        let managedAccount = ManagedCodexAccount(
-            id: UUID(),
-            email: "managed@example.com",
-            managedHomePath: "/tmp/codexbar-managed-codex-home",
-            createdAt: 1,
-            updatedAt: 1,
-            lastAuthenticatedAt: 1)
-        settings._test_activeManagedCodexAccount = managedAccount
-        settings.codexActiveSource = .managedAccount(id: managedAccount.id)
-        defer { settings._test_activeManagedCodexAccount = nil }
+        let managedID = UUID()
+        let managedHome = "/tmp/codexbar-managed-codex-home"
+        settings._test_activeManagedCodexRemoteHomePath = managedHome
+        settings.codexActiveSource = .liveSystem
+        defer { settings._test_activeManagedCodexRemoteHomePath = nil }
 
         let store = UsageStore(
             fetcher: UsageFetcher(environment: [:]),
@@ -323,11 +318,48 @@ struct RollingWindowAutoStartTests {
             sourceLabel: "oauth",
             previousSnapshot: previous,
             currentProviderData: current,
+            codexActiveSourceOverride: .managedAccount(id: managedID),
             now: now)
 
         try await Self.waitForAutoStartToFinish(store: store, provider: .codex)
         let request = try #require(await runner.lastRequest)
-        #expect(request.environment["CODEX_HOME"] == managedAccount.managedHomePath)
+        #expect(request.environment["CODEX_HOME"] == managedHome)
+    }
+
+    @Test
+    func `scheduler skips selected token account snapshots because prompt cli cannot be account bound`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-token-account-skip")
+        settings.setRollingWindowAutoStartEnabled(provider: .claude, enabled: true)
+        settings.addTokenAccount(provider: .claude, label: "Session", token: "sk-ant-session-token")
+        let account = try #require(settings.selectedTokenAccount(for: .claude))
+        let store = Self.makeUsageStore(settings: settings)
+        let runner = RecordingRollingWindowPingRunner()
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let previous = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(-60),
+                resetDescription: nil),
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            updatedAt: now)
+
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .claude,
+            previousSourceLabel: "claude",
+            sourceLabel: "claude",
+            previousSnapshot: previous,
+            currentProviderData: current,
+            tokenOverride: TokenAccountOverride(provider: .claude, account: account),
+            now: now)
+
+        try await Task.sleep(for: .milliseconds(25))
+        #expect(await runner.isEmpty)
+        #expect(store.rollingWindowAutoStartStatus[.claude] == nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
@@ -327,6 +327,56 @@ struct RollingWindowAutoStartTests {
     }
 
     @Test
+    func `scheduler deduplicates reset attempts per managed codex account`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-managed-codex-dedupe")
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
+        settings._test_activeManagedCodexRemoteHomePath = "/tmp/codexbar-managed-codex-home"
+        defer { settings._test_activeManagedCodexRemoteHomePath = nil }
+
+        let store = Self.makeUsageStore(settings: settings)
+        let runner = RecordingRollingWindowPingRunner(delay: .milliseconds(25))
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+        store._test_providerRefreshOverride = { _ in }
+
+        let firstAccountID = UUID()
+        let secondAccountID = UUID()
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let expired = now.addingTimeInterval(-60)
+        let previous = Self.snapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: expired, resetDescription: nil),
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            updatedAt: now)
+
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .codex,
+            previousSourceLabel: "oauth",
+            sourceLabel: "oauth",
+            previousSnapshot: previous,
+            currentProviderData: current,
+            codexActiveSourceOverride: .managedAccount(id: firstAccountID),
+            now: now)
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .codex,
+            previousSourceLabel: "oauth",
+            sourceLabel: "oauth",
+            previousSnapshot: previous,
+            currentProviderData: current,
+            codexActiveSourceOverride: .managedAccount(id: secondAccountID),
+            now: now)
+        try await Self.waitForAutoStartToFinish(store: store, provider: .codex)
+
+        #expect(await runner.count == 2)
+        #expect(store.rollingWindowAutoStartRuntime.attemptedResetAt[
+            .codexManagedAccount(firstAccountID),
+        ] == expired)
+        #expect(store.rollingWindowAutoStartRuntime.attemptedResetAt[
+            .codexManagedAccount(secondAccountID),
+        ] == expired)
+    }
+
+    @Test
     func `scheduler skips selected token account snapshots because prompt cli cannot be account bound`() async throws {
         let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-token-account-skip")
         settings.setRollingWindowAutoStartEnabled(provider: .claude, enabled: true)
@@ -426,7 +476,7 @@ struct RollingWindowAutoStartTests {
 
         try await Self.waitForAutoStartToFinish(store: store, provider: .codex)
         #expect(await runner.count == 1)
-        #expect(store.rollingWindowAutoStartRuntime.attemptedResetAt[.codex] == nil)
+        #expect(store.rollingWindowAutoStartRuntime.attemptedResetAt[.codexLiveSystem] == nil)
         #expect(store.rollingWindowAutoStartStatus[.codex] == "test ping failed")
     }
 
@@ -451,7 +501,9 @@ struct RollingWindowAutoStartTests {
 
     private static func waitForAutoStartToFinish(store: UsageStore, provider: UsageProvider) async throws {
         for _ in 0..<50 {
-            if !store.rollingWindowAutoStartRuntime.inFlight.contains(provider) { return }
+            if !store.rollingWindowAutoStartRuntime.inFlight.contains(where: { $0.provider == provider }) {
+                return
+            }
             try await Task.sleep(for: .milliseconds(10))
         }
         Issue.record("Timed out waiting for rolling window auto-start to finish")
@@ -473,6 +525,7 @@ struct RollingWindowAutoStartTests {
 
 private actor RecordingRollingWindowPingRunner: RollingWindowPingRunning {
     private let error: Error?
+    private let delay: Duration?
     private(set) var count = 0
     private(set) var requests: [RollingWindowPingRequest] = []
     var isEmpty: Bool {
@@ -483,13 +536,17 @@ private actor RecordingRollingWindowPingRunner: RollingWindowPingRunning {
         self.requests.last
     }
 
-    init(error: Error? = nil) {
+    init(error: Error? = nil, delay: Duration? = nil) {
         self.error = error
+        self.delay = delay
     }
 
     func run(_ request: RollingWindowPingRequest) async throws {
         self.count += 1
         self.requests.append(request)
+        if let delay {
+            try await Task.sleep(for: delay)
+        }
         if let error {
             throw error
         }

--- a/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
@@ -155,6 +155,54 @@ struct RollingWindowAutoStartTests {
     }
 
     @Test
+    func `scheduler routes codex ping through selected managed account environment`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-managed-codex-route")
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
+        let managedAccount = ManagedCodexAccount(
+            id: UUID(),
+            email: "managed@example.com",
+            managedHomePath: "/tmp/codexbar-managed-codex-home",
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1)
+        settings._test_activeManagedCodexAccount = managedAccount
+        settings.codexActiveSource = .managedAccount(id: managedAccount.id)
+        defer { settings._test_activeManagedCodexAccount = nil }
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: ["CODEX_HOME": "/tmp/codexbar-ambient-codex-home"])
+        let runner = RecordingRollingWindowPingRunner()
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+        store._test_providerRefreshOverride = { _ in }
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let previous = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(-60),
+                resetDescription: nil),
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            updatedAt: now)
+
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .codex,
+            previousSnapshot: previous,
+            currentProviderData: current,
+            now: now)
+
+        try await Self.waitForAutoStartToFinish(store: store, provider: .codex)
+        let request = try #require(await runner.lastRequest)
+        #expect(request.environment["CODEX_HOME"] == managedAccount.managedHomePath)
+    }
+
+    @Test
     func `scheduler skips when current snapshot has active window`() async throws {
         let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-scheduler-active")
         settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
@@ -262,8 +310,13 @@ struct RollingWindowAutoStartTests {
 private actor RecordingRollingWindowPingRunner: RollingWindowPingRunning {
     private let error: Error?
     private(set) var count = 0
+    private(set) var requests: [RollingWindowPingRequest] = []
     var isEmpty: Bool {
         self.count < 1
+    }
+
+    var lastRequest: RollingWindowPingRequest? {
+        self.requests.last
     }
 
     init(error: Error? = nil) {
@@ -272,6 +325,7 @@ private actor RecordingRollingWindowPingRunner: RollingWindowPingRunning {
 
     func run(_ request: RollingWindowPingRequest) async throws {
         self.count += 1
+        self.requests.append(request)
         if let error {
             throw error
         }

--- a/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
@@ -217,6 +217,38 @@ struct RollingWindowAutoStartTests {
     }
 
     @Test
+    func `log metadata labels routes and old reset timestamp clearly`() throws {
+        let accountID = try #require(UUID(uuidString: "12345678-90AB-CDEF-1234-567890ABCDEF"))
+        let resetAt = Date(timeIntervalSince1970: 1_800_000_000)
+
+        let metadata = UsageStore.rollingWindowAutoStartLogMetadata(
+            provider: .codex,
+            route: .codexManagedAccount(accountID),
+            previousSourceLabel: nil,
+            sourceLabel: "oauth",
+            previousResetAt: resetAt)
+
+        #expect(metadata["provider"] == "codex")
+        #expect(metadata["route"] == "codex-managed-account:123456...ABCDEF")
+        #expect(metadata["route"]?.contains(accountID.uuidString) == false)
+        #expect(metadata["previousSource"] == "none")
+        #expect(metadata["source"] == "oauth")
+        #expect(metadata["previousResetAt"] == "2027-01-15T08:00:00.000Z")
+        #expect(metadata["expiredResetAt"] == nil)
+    }
+
+    @Test
+    func `log helpers format all route cases and nil timestamps`() throws {
+        let accountID = try #require(UUID(uuidString: "12345678-90AB-CDEF-1234-567890ABCDEF"))
+
+        #expect(UsageStore.rollingWindowAutoStartRouteLabel(.provider(.claude)) == "provider:claude")
+        #expect(UsageStore.rollingWindowAutoStartRouteLabel(.codexLiveSystem) == "codex-live-system")
+        #expect(UsageStore.rollingWindowAutoStartRouteLabel(.codexManagedAccount(accountID)) ==
+            "codex-managed-account:123456...ABCDEF")
+        #expect(UsageStore.rollingWindowAutoStartTimestamp(nil) == "none")
+    }
+
+    @Test
     func `codex command persists a low reasoning mini model session by default`() throws {
         let command = try #require(RollingWindowPingStarter.command(provider: .codex, environment: [:]))
 

--- a/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
@@ -117,6 +117,16 @@ struct RollingWindowAutoStartTests {
     }
 
     @Test
+    func `claude command disables session persistence`() throws {
+        let command = try #require(RollingWindowPingStarter.command(provider: .claude, environment: [:]))
+
+        #expect(command.arguments.contains("-p"))
+        #expect(command.arguments.contains("--no-session-persistence"))
+        #expect(command.arguments.contains("haiku"))
+        #expect(command.arguments.last == "Say hi, then stop.")
+    }
+
+    @Test
     func `scheduler starts once per reset and refreshes after ping`() async throws {
         let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-scheduler-once")
         settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)

--- a/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
@@ -1,0 +1,110 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct RollingWindowAutoStartTests {
+    @Test
+    func `setting is disabled by default and persists when enabled`() throws {
+        let suite = "RollingWindowAutoStartTests-setting"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+
+        #expect(settings.rollingWindowAutoStartEnabled(provider: .codex) == false)
+
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
+
+        #expect(settings.rollingWindowAutoStartEnabled(provider: .codex) == true)
+        #expect(settings.providerConfig(for: .codex)?.rollingWindowAutoStartEnabled == true)
+
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: false)
+
+        #expect(settings.rollingWindowAutoStartEnabled(provider: .codex) == false)
+        #expect(settings.providerConfig(for: .codex)?.rollingWindowAutoStartEnabled == nil)
+    }
+
+    @Test
+    func `decision starts when previous rolling window expired and provider data has no active replacement`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let expired = now.addingTimeInterval(-60)
+        let previous = Self.snapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: expired, resetDescription: nil),
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            updatedAt: now)
+
+        let decision = RollingWindowAutoStartDecision.shouldStart(
+            provider: .codex,
+            previous: previous,
+            currentProviderData: current,
+            now: now)
+
+        #expect(decision?.resetAt == expired)
+    }
+
+    @Test
+    func `decision skips when provider data already has active rolling window`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let previous = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(-60),
+                resetDescription: nil),
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 1,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(5 * 60 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+
+        let decision = RollingWindowAutoStartDecision.shouldStart(
+            provider: .codex,
+            previous: previous,
+            currentProviderData: current,
+            now: now)
+
+        #expect(decision == nil)
+    }
+
+    @Test
+    func `only known prompt harness providers expose auto start support`() {
+        #expect(RollingWindowAutoStartSupport.providers == [.codex, .claude, .opencode])
+        #expect(RollingWindowPingStarter.command(provider: .opencodego, environment: [:]) == nil)
+        #expect(RollingWindowPingStarter.command(provider: .zai, environment: [:]) == nil)
+    }
+
+    @Test
+    func `codex command uses ephemeral low reasoning mini model by default`() throws {
+        let command = try #require(RollingWindowPingStarter.command(provider: .codex, environment: [:]))
+
+        #expect(command.arguments.contains("exec"))
+        #expect(command.arguments.contains("--ephemeral"))
+        #expect(command.arguments.contains("--skip-git-repo-check"))
+        #expect(command.arguments.contains("gpt-5.4-mini"))
+        #expect(command.arguments.contains("model_reasoning_effort=\"low\""))
+        #expect(command.arguments.last == "hi")
+    }
+
+    private static func snapshot(
+        primary: RateWindow?,
+        secondary: RateWindow? = nil,
+        tertiary: RateWindow? = nil,
+        updatedAt: Date) -> UsageSnapshot
+    {
+        UsageSnapshot(
+            primary: primary,
+            secondary: secondary,
+            tertiary: tertiary,
+            updatedAt: updatedAt)
+    }
+}

--- a/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
@@ -52,6 +52,28 @@ struct RollingWindowAutoStartTests {
     }
 
     @Test
+    func `decision starts for codex open A I web snapshots routed through codex cli`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let expired = now.addingTimeInterval(-60)
+        let previous = Self.snapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: expired, resetDescription: nil),
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            updatedAt: now)
+
+        let decision = RollingWindowAutoStartDecision.shouldStart(
+            provider: .codex,
+            previousSourceLabel: "openai-web",
+            sourceLabel: "openai-web",
+            previous: previous,
+            currentProviderData: current,
+            now: now)
+
+        #expect(decision?.resetAt == expired)
+    }
+
+    @Test
     func `decision skips when provider data already has active rolling window`() {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let previous = Self.snapshot(
@@ -104,13 +126,43 @@ struct RollingWindowAutoStartTests {
     }
 
     @Test
-    func `decision skips provider data from credentials that do not match the CLI`() {
+    func `decision skips when secondary quota window is exhausted`() {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let expired = now.addingTimeInterval(-60)
+        let weeklyExhausted = RateWindow(
+            usedPercent: 100,
+            windowMinutes: 7 * 24 * 60,
+            resetsAt: now.addingTimeInterval(2 * 24 * 60 * 60),
+            resetDescription: nil)
+        let previous = Self.snapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: expired, resetDescription: nil),
+            secondary: weeklyExhausted,
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: weeklyExhausted,
+            updatedAt: now)
+
+        let decision = RollingWindowAutoStartDecision.shouldStart(
+            provider: .codex,
+            previousSourceLabel: "codex-cli",
+            sourceLabel: "codex-cli",
+            previous: previous,
+            currentProviderData: current,
+            now: now)
+
+        #expect(decision == nil)
+    }
+
+    @Test
+    func `decision accepts claude web or oauth candidates for scheduler route validation`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let expired = now.addingTimeInterval(-60)
         let previous = Self.snapshot(
             primary: RateWindow(
                 usedPercent: 20,
                 windowMinutes: 300,
-                resetsAt: now.addingTimeInterval(-60),
+                resetsAt: expired,
                 resetDescription: nil),
             updatedAt: now.addingTimeInterval(-120))
         let current = Self.snapshot(
@@ -118,26 +170,19 @@ struct RollingWindowAutoStartTests {
             updatedAt: now)
 
         #expect(RollingWindowAutoStartDecision.shouldStart(
-            provider: .codex,
-            previousSourceLabel: "codex-cli",
-            sourceLabel: "openai-web",
-            previous: previous,
-            currentProviderData: current,
-            now: now) == nil)
-        #expect(RollingWindowAutoStartDecision.shouldStart(
             provider: .claude,
             previousSourceLabel: "claude",
             sourceLabel: "oauth",
             previous: previous,
             currentProviderData: current,
-            now: now) == nil)
+            now: now)?.resetAt == expired)
         #expect(RollingWindowAutoStartDecision.shouldStart(
             provider: .claude,
             previousSourceLabel: "web",
             sourceLabel: "claude",
             previous: previous,
             currentProviderData: current,
-            now: now) == nil)
+            now: now)?.resetAt == expired)
     }
 
     @Test
@@ -206,6 +251,45 @@ struct RollingWindowAutoStartTests {
             previous: previous,
             currentProviderData: current,
             now: now) == nil)
+    }
+
+    @Test
+    func `claude decision skips when weekly quota window is exhausted`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let expiredSessionReset = now.addingTimeInterval(-60)
+        let exhaustedWeekly = RateWindow(
+            usedPercent: 100,
+            windowMinutes: 7 * 24 * 60,
+            resetsAt: now.addingTimeInterval(3 * 24 * 60 * 60),
+            resetDescription: nil)
+        let previous = Self.snapshot(
+            primary: exhaustedWeekly,
+            secondary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 5 * 60,
+                resetsAt: expiredSessionReset,
+                resetDescription: nil),
+            provider: .claude,
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: exhaustedWeekly,
+            secondary: RateWindow(
+                usedPercent: 0,
+                windowMinutes: 5 * 60,
+                resetsAt: nil,
+                resetDescription: nil),
+            provider: .claude,
+            updatedAt: now)
+
+        let decision = RollingWindowAutoStartDecision.shouldStart(
+            provider: .claude,
+            previousSourceLabel: "web",
+            sourceLabel: "web",
+            previous: previous,
+            currentProviderData: current,
+            now: now)
+
+        #expect(decision == nil)
     }
 
     @Test
@@ -310,6 +394,122 @@ struct RollingWindowAutoStartTests {
         #expect(await runner.count == 1)
         #expect(refreshCount == 1)
         #expect(store.rollingWindowAutoStartStatus[.codex] == "Ping prompt sent.")
+    }
+
+    @Test
+    func `scheduler starts codex ping for open A I web snapshot with expired prior reset`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-scheduler-openai-web")
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
+        settings._test_liveSystemCodexAccount = Self.liveSystemCodexAccount(email: "codex@example.com")
+        defer { settings._test_liveSystemCodexAccount = nil }
+        let store = Self.makeUsageStore(settings: settings)
+        let runner = RecordingRollingWindowPingRunner()
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+        var refreshCount = 0
+        store._test_providerRefreshOverride = { _ in
+            refreshCount += 1
+        }
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let expired = now.addingTimeInterval(-60)
+        let previous = Self.snapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: expired, resetDescription: nil),
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            accountEmail: "codex@example.com",
+            updatedAt: now)
+
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .codex,
+            previousSourceLabel: "openai-web",
+            sourceLabel: "openai-web",
+            previousSnapshot: previous,
+            currentProviderData: current,
+            now: now)
+
+        try await Self.waitForAutoStartToFinish(store: store, provider: .codex)
+        #expect(await runner.count == 1)
+        #expect(refreshCount == 1)
+        #expect(store.rollingWindowAutoStartRuntime.attemptedResetAt[.codexLiveSystem] == expired)
+    }
+
+    @Test
+    func `scheduler skips codex open A I web snapshot when live cli account differs`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-scheduler-openai-web-mismatch")
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
+        settings._test_liveSystemCodexAccount = Self.liveSystemCodexAccount(email: "cli@example.com")
+        defer { settings._test_liveSystemCodexAccount = nil }
+        let store = Self.makeUsageStore(settings: settings)
+        let runner = RecordingRollingWindowPingRunner()
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+        store._test_providerRefreshOverride = { _ in }
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let previous = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(-60),
+                resetDescription: nil),
+            accountEmail: "web@example.com",
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            accountEmail: "web@example.com",
+            updatedAt: now)
+
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .codex,
+            previousSourceLabel: "openai-web",
+            sourceLabel: "openai-web",
+            previousSnapshot: previous,
+            currentProviderData: current,
+            now: now)
+
+        try await Task.sleep(for: .milliseconds(25))
+        #expect(await runner.isEmpty)
+        #expect(store.rollingWindowAutoStartStatus[.codex] ==
+            "Skipped: usage account does not match prompt CLI account.")
+    }
+
+    @Test
+    func `scheduler skips claude web snapshot because prompt cli account cannot be verified`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-scheduler-claude-web-mismatch")
+        settings.setRollingWindowAutoStartEnabled(provider: .claude, enabled: true)
+        let store = Self.makeUsageStore(settings: settings)
+        let runner = RecordingRollingWindowPingRunner()
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+        store._test_providerRefreshOverride = { _ in }
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let previous = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(-60),
+                resetDescription: nil),
+            accountEmail: "web@example.com",
+            provider: .claude,
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            accountEmail: "web@example.com",
+            provider: .claude,
+            updatedAt: now)
+
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .claude,
+            previousSourceLabel: "web",
+            sourceLabel: "web",
+            previousSnapshot: previous,
+            currentProviderData: current,
+            now: now)
+
+        try await Task.sleep(for: .milliseconds(25))
+        #expect(await runner.isEmpty)
+        #expect(store.rollingWindowAutoStartStatus[.claude] ==
+            "Skipped: usage account does not match prompt CLI account.")
     }
 
     @Test
@@ -487,7 +687,8 @@ struct RollingWindowAutoStartTests {
 
         try await Task.sleep(for: .milliseconds(25))
         #expect(await runner.isEmpty)
-        #expect(store.rollingWindowAutoStartStatus[.claude] == nil)
+        #expect(store.rollingWindowAutoStartStatus[.claude] ==
+            "Skipped: selected account cannot be pinged through ambient CLI.")
     }
 
     @Test
@@ -591,13 +792,30 @@ struct RollingWindowAutoStartTests {
         primary: RateWindow?,
         secondary: RateWindow? = nil,
         tertiary: RateWindow? = nil,
+        accountEmail: String? = nil,
+        provider: UsageProvider = .codex,
         updatedAt: Date) -> UsageSnapshot
     {
         UsageSnapshot(
             primary: primary,
             secondary: secondary,
             tertiary: tertiary,
-            updatedAt: updatedAt)
+            updatedAt: updatedAt,
+            identity: accountEmail.map {
+                ProviderIdentitySnapshot(
+                    providerID: provider,
+                    accountEmail: $0,
+                    accountOrganization: nil,
+                    loginMethod: nil)
+            })
+    }
+
+    private static func liveSystemCodexAccount(email: String) -> ObservedSystemCodexAccount {
+        ObservedSystemCodexAccount(
+            email: email,
+            codexHomePath: "/tmp/codexbar-live-system",
+            observedAt: Date(),
+            identity: CodexIdentityResolver.resolve(accountId: nil, email: email))
     }
 }
 

--- a/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
@@ -77,6 +77,27 @@ struct RollingWindowAutoStartTests {
     }
 
     @Test
+    func `decision skips when provider data has no rolling window`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let previous = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(-60),
+                resetDescription: nil),
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(primary: nil, updatedAt: now)
+
+        let decision = RollingWindowAutoStartDecision.shouldStart(
+            provider: .codex,
+            previous: previous,
+            currentProviderData: current,
+            now: now)
+
+        #expect(decision == nil)
+    }
+
+    @Test
     func `only known prompt harness providers expose auto start support`() {
         #expect(RollingWindowAutoStartSupport.providers == [.codex, .claude, .opencode])
         #expect(RollingWindowPingStarter.command(provider: .opencodego, environment: [:]) == nil)
@@ -91,8 +112,137 @@ struct RollingWindowAutoStartTests {
         #expect(command.arguments.contains("--ephemeral"))
         #expect(command.arguments.contains("--skip-git-repo-check"))
         #expect(command.arguments.contains("gpt-5.4-mini"))
-        #expect(command.arguments.contains("model_reasoning_effort=\"low\""))
+        #expect(command.arguments.contains("model_reasoning_effort=low"))
         #expect(command.arguments.last == "hi")
+    }
+
+    @Test
+    func `scheduler starts once per reset and refreshes after ping`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-scheduler-once")
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
+        let store = Self.makeUsageStore(settings: settings)
+        let runner = RecordingRollingWindowPingRunner()
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+        var refreshCount = 0
+        store._test_providerRefreshOverride = { _ in
+            refreshCount += 1
+        }
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let expired = now.addingTimeInterval(-60)
+        let previous = Self.snapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: expired, resetDescription: nil),
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            updatedAt: now)
+
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .codex,
+            previousSnapshot: previous,
+            currentProviderData: current,
+            now: now)
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .codex,
+            previousSnapshot: previous,
+            currentProviderData: current,
+            now: now)
+
+        try await Self.waitForAutoStartToFinish(store: store, provider: .codex)
+        #expect(await runner.count == 1)
+        #expect(refreshCount == 1)
+        #expect(store.rollingWindowAutoStartStatus[.codex] == "Ping prompt sent.")
+    }
+
+    @Test
+    func `scheduler skips when current snapshot has active window`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-scheduler-active")
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
+        let store = Self.makeUsageStore(settings: settings)
+        let runner = RecordingRollingWindowPingRunner()
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let previous = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(-60),
+                resetDescription: nil),
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 1,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(300),
+                resetDescription: nil),
+            updatedAt: now)
+
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .codex,
+            previousSnapshot: previous,
+            currentProviderData: current,
+            now: now)
+
+        try await Task.sleep(for: .milliseconds(25))
+        #expect(await runner.isEmpty)
+        #expect(store.rollingWindowAutoStartStatus[.codex] == nil)
+    }
+
+    @Test
+    func `scheduler clears attempted reset after ping failure`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-scheduler-failure")
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
+        let store = Self.makeUsageStore(settings: settings)
+        let runner = RecordingRollingWindowPingRunner(error: TestPingError())
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let expired = now.addingTimeInterval(-60)
+        let previous = Self.snapshot(
+            primary: RateWindow(usedPercent: 20, windowMinutes: 300, resetsAt: expired, resetDescription: nil),
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            updatedAt: now)
+
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .codex,
+            previousSnapshot: previous,
+            currentProviderData: current,
+            now: now)
+
+        try await Self.waitForAutoStartToFinish(store: store, provider: .codex)
+        #expect(await runner.count == 1)
+        #expect(store.rollingWindowAutoStartRuntime.attemptedResetAt[.codex] == nil)
+        #expect(store.rollingWindowAutoStartStatus[.codex] == "test ping failed")
+    }
+
+    private static func makeSettingsStore(suite: String) throws -> SettingsStore {
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        return SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+    }
+
+    private static func makeUsageStore(settings: SettingsStore) -> UsageStore {
+        UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing,
+            environmentBase: [:])
+    }
+
+    private static func waitForAutoStartToFinish(store: UsageStore, provider: UsageProvider) async throws {
+        for _ in 0..<50 {
+            if !store.rollingWindowAutoStartRuntime.inFlight.contains(provider) { return }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        Issue.record("Timed out waiting for rolling window auto-start to finish")
     }
 
     private static func snapshot(
@@ -106,5 +256,30 @@ struct RollingWindowAutoStartTests {
             secondary: secondary,
             tertiary: tertiary,
             updatedAt: updatedAt)
+    }
+}
+
+private actor RecordingRollingWindowPingRunner: RollingWindowPingRunning {
+    private let error: Error?
+    private(set) var count = 0
+    var isEmpty: Bool {
+        self.count < 1
+    }
+
+    init(error: Error? = nil) {
+        self.error = error
+    }
+
+    func run(_ request: RollingWindowPingRequest) async throws {
+        self.count += 1
+        if let error {
+            throw error
+        }
+    }
+}
+
+private struct TestPingError: LocalizedError {
+    var errorDescription: String? {
+        "test ping failed"
     }
 }

--- a/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
@@ -217,11 +217,11 @@ struct RollingWindowAutoStartTests {
     }
 
     @Test
-    func `codex command uses ephemeral low reasoning mini model by default`() throws {
+    func `codex command persists a low reasoning mini model session by default`() throws {
         let command = try #require(RollingWindowPingStarter.command(provider: .codex, environment: [:]))
 
         #expect(command.arguments.contains("exec"))
-        #expect(command.arguments.contains("--ephemeral"))
+        #expect(!command.arguments.contains("--ephemeral"))
         #expect(command.arguments.contains("--skip-git-repo-check"))
         #expect(command.arguments.contains("gpt-5.4-mini"))
         #expect(command.arguments.contains("model_reasoning_effort=low"))

--- a/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
@@ -52,7 +52,7 @@ struct RollingWindowAutoStartTests {
     }
 
     @Test
-    func `decision starts for codex open A I web snapshots routed through codex cli`() {
+    func `decision starts for codex OpenAI web snapshots routed through codex cli`() {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let expired = now.addingTimeInterval(-60)
         let previous = Self.snapshot(
@@ -397,7 +397,7 @@ struct RollingWindowAutoStartTests {
     }
 
     @Test
-    func `scheduler starts codex ping for open A I web snapshot with expired prior reset`() async throws {
+    func `scheduler starts codex ping for OpenAI web snapshot with expired prior reset`() async throws {
         let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-scheduler-openai-web")
         settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
         settings._test_liveSystemCodexAccount = Self.liveSystemCodexAccount(email: "codex@example.com")
@@ -435,7 +435,7 @@ struct RollingWindowAutoStartTests {
     }
 
     @Test
-    func `scheduler skips codex open A I web snapshot when live cli account differs`() async throws {
+    func `scheduler skips codex OpenAI web snapshot when live cli account differs`() async throws {
         let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-scheduler-openai-web-mismatch")
         settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
         settings._test_liveSystemCodexAccount = Self.liveSystemCodexAccount(email: "cli@example.com")
@@ -467,7 +467,6 @@ struct RollingWindowAutoStartTests {
             currentProviderData: current,
             now: now)
 
-        try await Task.sleep(for: .milliseconds(25))
         #expect(await runner.isEmpty)
         #expect(store.rollingWindowAutoStartStatus[.codex] ==
             "Skipped: usage account does not match prompt CLI account.")
@@ -506,10 +505,9 @@ struct RollingWindowAutoStartTests {
             currentProviderData: current,
             now: now)
 
-        try await Task.sleep(for: .milliseconds(25))
         #expect(await runner.isEmpty)
         #expect(store.rollingWindowAutoStartStatus[.claude] ==
-            "Skipped: usage account does not match prompt CLI account.")
+            "Skipped: usage account cannot be verified against prompt CLI account.")
     }
 
     @Test
@@ -685,7 +683,6 @@ struct RollingWindowAutoStartTests {
             tokenOverride: TokenAccountOverride(provider: .claude, account: account),
             now: now)
 
-        try await Task.sleep(for: .milliseconds(25))
         #expect(await runner.isEmpty)
         #expect(store.rollingWindowAutoStartStatus[.claude] ==
             "Skipped: selected account cannot be pinged through ambient CLI.")
@@ -723,7 +720,6 @@ struct RollingWindowAutoStartTests {
             currentProviderData: current,
             now: now)
 
-        try await Task.sleep(for: .milliseconds(25))
         #expect(await runner.isEmpty)
         #expect(store.rollingWindowAutoStartStatus[.codex] == nil)
     }

--- a/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
@@ -42,6 +42,8 @@ struct RollingWindowAutoStartTests {
 
         let decision = RollingWindowAutoStartDecision.shouldStart(
             provider: .codex,
+            previousSourceLabel: "codex-cli",
+            sourceLabel: "codex-cli",
             previous: previous,
             currentProviderData: current,
             now: now)
@@ -69,6 +71,8 @@ struct RollingWindowAutoStartTests {
 
         let decision = RollingWindowAutoStartDecision.shouldStart(
             provider: .codex,
+            previousSourceLabel: "oauth",
+            sourceLabel: "oauth",
             previous: previous,
             currentProviderData: current,
             now: now)
@@ -90,6 +94,8 @@ struct RollingWindowAutoStartTests {
 
         let decision = RollingWindowAutoStartDecision.shouldStart(
             provider: .codex,
+            previousSourceLabel: "codex-cli",
+            sourceLabel: "codex-cli",
             previous: previous,
             currentProviderData: current,
             now: now)
@@ -98,8 +104,114 @@ struct RollingWindowAutoStartTests {
     }
 
     @Test
+    func `decision skips provider data from credentials that do not match the CLI`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let previous = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(-60),
+                resetDescription: nil),
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            updatedAt: now)
+
+        #expect(RollingWindowAutoStartDecision.shouldStart(
+            provider: .codex,
+            previousSourceLabel: "codex-cli",
+            sourceLabel: "openai-web",
+            previous: previous,
+            currentProviderData: current,
+            now: now) == nil)
+        #expect(RollingWindowAutoStartDecision.shouldStart(
+            provider: .claude,
+            previousSourceLabel: "claude",
+            sourceLabel: "oauth",
+            previous: previous,
+            currentProviderData: current,
+            now: now) == nil)
+        #expect(RollingWindowAutoStartDecision.shouldStart(
+            provider: .claude,
+            previousSourceLabel: "web",
+            sourceLabel: "claude",
+            previous: previous,
+            currentProviderData: current,
+            now: now) == nil)
+    }
+
+    @Test
+    func `claude decision selects five hour window instead of weekly primary`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let weeklyReset = now.addingTimeInterval(6 * 24 * 60 * 60)
+        let expiredSessionReset = now.addingTimeInterval(-60)
+        let previous = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 10,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: weeklyReset,
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 5 * 60,
+                resetsAt: expiredSessionReset,
+                resetDescription: nil),
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 10,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: weeklyReset,
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 0,
+                windowMinutes: 5 * 60,
+                resetsAt: nil,
+                resetDescription: nil),
+            updatedAt: now)
+
+        let decision = RollingWindowAutoStartDecision.shouldStart(
+            provider: .claude,
+            previousSourceLabel: "claude",
+            sourceLabel: "claude",
+            previous: previous,
+            currentProviderData: current,
+            now: now)
+
+        #expect(decision?.resetAt == expiredSessionReset)
+    }
+
+    @Test
+    func `claude decision skips weekly only snapshots`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let previous = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 10,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: now.addingTimeInterval(-60),
+                resetDescription: nil),
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 0,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: nil),
+            updatedAt: now)
+
+        #expect(RollingWindowAutoStartDecision.shouldStart(
+            provider: .claude,
+            previousSourceLabel: "claude",
+            sourceLabel: "claude",
+            previous: previous,
+            currentProviderData: current,
+            now: now) == nil)
+    }
+
+    @Test
     func `only known prompt harness providers expose auto start support`() {
-        #expect(RollingWindowAutoStartSupport.providers == [.codex, .claude, .opencode])
+        #expect(RollingWindowAutoStartSupport.providers == [.codex, .claude])
+        #expect(RollingWindowPingStarter.command(provider: .opencode, environment: [:]) == nil)
         #expect(RollingWindowPingStarter.command(provider: .opencodego, environment: [:]) == nil)
         #expect(RollingWindowPingStarter.command(provider: .zai, environment: [:]) == nil)
     }
@@ -149,11 +261,15 @@ struct RollingWindowAutoStartTests {
 
         store.scheduleRollingWindowAutoStartIfNeeded(
             provider: .codex,
+            previousSourceLabel: "codex-cli",
+            sourceLabel: "codex-cli",
             previousSnapshot: previous,
             currentProviderData: current,
             now: now)
         store.scheduleRollingWindowAutoStartIfNeeded(
             provider: .codex,
+            previousSourceLabel: "codex-cli",
+            sourceLabel: "codex-cli",
             previousSnapshot: previous,
             currentProviderData: current,
             now: now)
@@ -203,6 +319,8 @@ struct RollingWindowAutoStartTests {
 
         store.scheduleRollingWindowAutoStartIfNeeded(
             provider: .codex,
+            previousSourceLabel: "oauth",
+            sourceLabel: "oauth",
             previousSnapshot: previous,
             currentProviderData: current,
             now: now)
@@ -238,6 +356,8 @@ struct RollingWindowAutoStartTests {
 
         store.scheduleRollingWindowAutoStartIfNeeded(
             provider: .codex,
+            previousSourceLabel: "codex-cli",
+            sourceLabel: "codex-cli",
             previousSnapshot: previous,
             currentProviderData: current,
             now: now)
@@ -266,6 +386,8 @@ struct RollingWindowAutoStartTests {
 
         store.scheduleRollingWindowAutoStartIfNeeded(
             provider: .codex,
+            previousSourceLabel: "codex-cli",
+            sourceLabel: "codex-cli",
             previousSnapshot: previous,
             currentProviderData: current,
             now: now)

--- a/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
@@ -281,6 +281,52 @@ struct RollingWindowAutoStartTests {
     }
 
     @Test
+    func `scheduler forces refresh after ping when triggering refresh is still registered`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-scheduler-uncoalesced")
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
+        let store = Self.makeUsageStore(settings: settings)
+        let runner = RecordingRollingWindowPingRunner()
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+        var refreshCount = 0
+        store._test_providerRefreshOverride = { _ in
+            refreshCount += 1
+        }
+
+        let lingeringGeneration: UInt64 = 10
+        let lingeringState = ProviderRefreshTaskState(generation: lingeringGeneration)
+        lingeringState.install(task: Task {})
+        lingeringState.markCompleted(retryRequired: false)
+        store.providerRefreshTasks[.codex] = [lingeringState]
+        store.latestProviderRefreshGenerations[.codex] = lingeringGeneration
+        store.providerRefreshTaskGeneration = lingeringGeneration
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let previous = Self.snapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(-60),
+                resetDescription: nil),
+            updatedAt: now.addingTimeInterval(-120))
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            updatedAt: now)
+
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .codex,
+            previousSourceLabel: "codex-cli",
+            sourceLabel: "codex-cli",
+            previousSnapshot: previous,
+            currentProviderData: current,
+            now: now)
+
+        try await Self.waitForAutoStartToFinish(store: store, provider: .codex)
+        #expect(await runner.count == 1)
+        #expect(refreshCount == 1)
+        #expect(store.latestProviderRefreshGenerations[.codex] == lingeringGeneration + 1)
+    }
+
+    @Test
     func `scheduler routes codex ping through selected managed account environment`() async throws {
         let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-managed-codex-route")
         settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)

--- a/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
+++ b/Tests/CodexBarTests/RollingWindowAutoStartTests.swift
@@ -74,6 +74,24 @@ struct RollingWindowAutoStartTests {
     }
 
     @Test
+    func `decision starts for inactive codex OpenAI web snapshot without previous reset`() {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            updatedAt: now)
+
+        let decision = RollingWindowAutoStartDecision.shouldStart(
+            provider: .codex,
+            previousSourceLabel: nil,
+            sourceLabel: "openai-web",
+            previous: nil,
+            currentProviderData: current,
+            now: now)
+
+        #expect(decision?.resetAt == nil)
+    }
+
+    @Test
     func `decision skips when provider data already has active rolling window`() {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let previous = Self.snapshot(
@@ -432,6 +450,41 @@ struct RollingWindowAutoStartTests {
         #expect(await runner.count == 1)
         #expect(refreshCount == 1)
         #expect(store.rollingWindowAutoStartRuntime.attemptedResetAt[.codexLiveSystem] == expired)
+    }
+
+    @Test
+    func `scheduler starts codex ping for inactive OpenAI web snapshot without prior reset`() async throws {
+        let settings = try Self.makeSettingsStore(suite: "RollingWindowAutoStartTests-scheduler-openai-web-no-reset")
+        settings.setRollingWindowAutoStartEnabled(provider: .codex, enabled: true)
+        settings._test_liveSystemCodexAccount = Self.liveSystemCodexAccount(email: "codex@example.com")
+        defer { settings._test_liveSystemCodexAccount = nil }
+        let store = Self.makeUsageStore(settings: settings)
+        let runner = RecordingRollingWindowPingRunner()
+        store.rollingWindowAutoStartRuntime.testRunnerOverride = runner
+        var refreshCount = 0
+        store._test_providerRefreshOverride = { _ in
+            refreshCount += 1
+        }
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let current = Self.snapshot(
+            primary: RateWindow(usedPercent: 0, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            accountEmail: "codex@example.com",
+            updatedAt: now)
+
+        store.scheduleRollingWindowAutoStartIfNeeded(
+            provider: .codex,
+            previousSourceLabel: nil,
+            sourceLabel: "openai-web",
+            previousSnapshot: nil,
+            currentProviderData: current,
+            now: now)
+
+        try await Self.waitForAutoStartToFinish(store: store, provider: .codex)
+        #expect(await runner.count == 1)
+        #expect(refreshCount == 1)
+        #expect(store.rollingWindowAutoStartRuntime.attemptedInactiveWithoutReset.contains(.codexLiveSystem))
+        #expect(store.rollingWindowAutoStartRuntime.attemptedResetAt[.codexLiveSystem] == nil)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds an opt-in **Auto-start rolling window** setting for Codex and Claude.

After a previously active five-hour window expires, a refresh that confirms no active replacement can send one tiny prompt through the matching provider CLI, then refresh usage again.

## Safety boundaries

- Disabled by default.
- Supports Codex and Claude only.
- Requires both the previous and current usage snapshots to come from matching CLI-backed sources.
- Routes Codex through the selected managed account environment instead of the ambient account.
- Selects Claude's five-hour window explicitly rather than treating a weekly window as the session window.
- Sends at most one prompt per expired reset timestamp and account route, while allowing distinct managed accounts to proceed independently.
- Captures the selected Codex account once so dedupe identity and CLI environment cannot diverge during the async ping.
- Clears the matching account attempt marker after failure.
- Uses Claude print mode with `--no-session-persistence`.
- Does not support OpenCode because its displayed usage source cannot be proven to match the CLI credentials used for a prompt.

## Commands

- Codex: `codex exec --skip-git-repo-check -m gpt-5.4-mini -c model_reasoning_effort=low`
- Claude: `claude -p --no-session-persistence --model haiku`

The prompt, timeout, binary, model, and reasoning level remain locally overridable through the documented `CODEXBAR_ROLLING_WINDOW_<PROVIDER>_*` environment keys.

## Validation

- `swift test --filter RollingWindowAutoStartTests` — 16 tests passed
- `make check` — passed, 0 lint violations
- `claude --help` — confirms `--no-session-persistence` is supported only with print mode
- `codex exec --help` — confirms `--skip-git-repo-check`
- Local delta autoreview — clean, no accepted/actionable findings, correctness confidence 0.86
- Full branch autoreview against `origin/main` — clean, no accepted/actionable findings, correctness confidence 0.78
- Current head — `5bd575468051b8905af48958bea172295e2b807d`
- Full CI — must be green on the final rebased head

## Merge status

Prepared, not approved for merge. This intentionally consumes provider quota in the background and still needs maintainer product/auth sign-off plus redacted real-provider behavior proof from the current head.
