### PR TITLE
test: avoid Antigravity launcher ETXTBSY race

### DIFF
--- a/Tests/CodexBarTests/AntigravityCLISessionTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLISessionTests.swift
@@ -658,7 +658,8 @@ struct AntigravityCLISessionTests {
           echo closed >> \(outputURL.path)
         fi
         """
-        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        // Direct writes close the executable before spawn; atomic replacement can race with exec on Linux.
+        try Data(script.utf8).write(to: scriptURL)
         #expect(chmod(scriptURL.path, 0o700) == 0)
 
         let handle = try AntigravityPTYProcessLauncher().launch(binary: scriptURL.path)

--- a/TestsLinux/AntigravityProcessLauncherLinuxTests.swift
+++ b/TestsLinux/AntigravityProcessLauncherLinuxTests.swift
@@ -36,7 +36,8 @@ struct AntigravityProcessLauncherLinuxTests {
           echo closed >> \(outputURL.path)
         fi
         """
-        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        // Direct writes close the executable before spawn; atomic replacement can race with exec on overlay filesystems.
+        try Data(script.utf8).write(to: scriptURL)
         #expect(chmod(scriptURL.path, 0o700) == 0)
 
         let handle = try AntigravityPTYProcessLauncher().launch(binary: scriptURL.path)


### PR DESCRIPTION
## Summary
- write executable test fixtures directly before spawning them
- avoid Linux `ETXTBSY` failures caused by atomic replacement of a script immediately before `posix_spawn`
- keep macOS and Linux copies of the launcher regression aligned

## Evidence
- observed in the Linux x64 job for PR #1481: `launchFailed("Text file busy")`
- the same PR's Linux arm64 job passed, consistent with a filesystem timing race
- current `main` Linux jobs otherwise pass this unchanged test

## Proof
- `swift test --filter AntigravityCLISessionTests` (45 tests)
- `make check`
- autoreview: clean, confidence 0.90

Internal test reliability only; no application runtime change.
