### PR TITLE
fix: coalesce deferred menu refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.1 — Unreleased
 
+- Menu bar: avoid starting a duplicate background provider refresh when the menu closes while its initial missing-data refresh is still in flight.
 - Menu bar: rebuild merged provider content inside AppKit's active tracking run loop so provider switches no longer wait for the menu to close or the default run loop to resume.
 - Diagnostics: enforce probe timeouts even when an underlying provider operation ignores Swift task cancellation.
 - Kimi: add usage fetching from the official Code API key flow, with optional compatible HTTPS proxy support (#1424). Thanks @kiranmagic7!

--- a/Sources/CodexBar/StatusItemController+MenuInteractionRefresh.swift
+++ b/Sources/CodexBar/StatusItemController+MenuInteractionRefresh.swift
@@ -124,6 +124,17 @@ extension StatusItemController {
                 self.deferredMenuInteractionRefreshTask = nil
                 return
             }
+            let pendingProviders = self.deferredMenuInteractionRefreshProviders
+            let hasProviderRefreshInFlight = pendingProviders.contains {
+                self.store.refreshingProviders.contains($0)
+            }
+            guard !self.store.isRefreshing, !hasProviderRefreshInFlight else {
+                self.deferredMenuInteractionRefreshTask = nil
+                self.scheduleDeferredMenuInteractionRefreshIfNeeded(
+                    delay: Self.defaultDeferredMenuInteractionRefreshDelay)
+                return
+            }
+            self.clearSatisfiedDeferredMenuInteractionRefreshes(for: Array(pendingProviders))
             let shouldRefreshStore = self.deferredMenuInteractionRefreshPending
             let openAIDashboardRefreshReason = self.deferredOpenAIDashboardRefreshReason
             guard shouldRefreshStore || openAIDashboardRefreshReason != nil else {
@@ -132,13 +143,6 @@ extension StatusItemController {
             }
             guard !self.hasPreparedForAppShutdown else {
                 self.deferredMenuInteractionRefreshTask = nil
-                return
-            }
-            guard !self.store.isRefreshing else {
-                self.deferredMenuInteractionRefreshTask = nil
-                self
-                    .scheduleDeferredMenuInteractionRefreshIfNeeded(delay: Self
-                        .defaultDeferredMenuInteractionRefreshDelay)
                 return
             }
             self.deferredMenuInteractionRefreshTask = nil

--- a/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
+++ b/Tests/CodexBarTests/StatusMenuInstantOpenTests.swift
@@ -1298,11 +1298,19 @@ extension StatusMenuTests {
         defer { StatusItemController.resetDeferredMenuInteractionRefreshDelayForTesting() }
         StatusItemController.setMenuOpenRefreshDelayForTesting(.zero)
         defer { StatusItemController.resetMenuOpenRefreshDelayForTesting() }
+        var deferredRefreshCount = 0
+        controller.onDeferredMenuInteractionRefreshForTesting = {
+            deferredRefreshCount += 1
+        }
 
         let menu = controller.makeMenu()
         controller.menuWillOpen(menu)
         await refreshGate.waitUntilStarted(count: 1)
         controller.menuDidClose(menu)
+        for _ in 0..<80 {
+            await Task.yield()
+        }
+        #expect(deferredRefreshCount == 0)
         await refreshGate.releaseFirst()
 
         for _ in 0..<80 where controller.deferredMenuInteractionRefreshPending {
@@ -1313,6 +1321,7 @@ extension StatusMenuTests {
         }
 
         #expect(await refreshGate.startCount == 1)
+        #expect(deferredRefreshCount == 0)
         #expect(!controller.deferredMenuInteractionRefreshPending)
     }
 


### PR DESCRIPTION
## Summary
- defer menu-close retries while any requested provider refresh is still in flight
- clear provider retries already satisfied by that refresh before deciding whether a full background refresh remains necessary
- add a regression proving the initial missing-data refresh is not started twice

## Proof
- `swift test --filter 'StatusMenuTests/providerSwitchRefreshesMissingDataSuccessfully'`
- `swift test --filter 'StatusMenuTests/providerSwitchMissingDataPreservesRetryAfterFailure'`
- `swift test --filter StatusMenuTests`
- `make check`
- autoreview: clean, no accepted/actionable findings (0.83 confidence)
