### PR TITLE
fix: keep Settings toolbar in sync with dark mode switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.1 — Unreleased
 
+- Settings: keep the native tab toolbar in sync when macOS switches appearance while the window is open (#1484). Thanks @hhh2210!
 - Menu bar: avoid starting a duplicate background provider refresh when the menu closes while its initial missing-data refresh is still in flight.
 - Menu bar: rebuild merged provider content inside AppKit's active tracking run loop so provider switches no longer wait for the menu to close or the default run loop to resume.
 - Diagnostics: enforce probe timeouts even when an underlying provider operation ignores Swift task cancellation.

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -208,6 +208,7 @@ struct SettingsWindowAppearanceBridge: NSViewRepresentable {
 @MainActor
 final class SettingsWindowAppearanceView: NSView {
     private let scheduleReset: SettingsWindowAppearance.ResetScheduler
+    private var colorScheme: ColorScheme?
 
     init(scheduleReset: @escaping SettingsWindowAppearance.ResetScheduler = SettingsWindowAppearance.scheduleReset) {
         self.scheduleReset = scheduleReset
@@ -224,7 +225,13 @@ final class SettingsWindowAppearanceView: NSView {
         self.refreshWindowAppearance()
     }
 
-    func refreshWindowAppearance(for _: ColorScheme? = nil) {
+    func refreshWindowAppearance(for colorScheme: ColorScheme) {
+        guard self.colorScheme != colorScheme else { return }
+        self.colorScheme = colorScheme
+        self.refreshWindowAppearance()
+    }
+
+    private func refreshWindowAppearance() {
         guard let window else { return }
         SettingsWindowAppearance.refresh(window, scheduleReset: self.scheduleReset)
     }

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -43,6 +43,7 @@ struct PreferencesView: View {
     let managedCodexAccountCoordinator: ManagedCodexAccountCoordinator
     let codexAccountPromotionCoordinator: CodexAccountPromotionCoordinator
     let runProviderLoginFlow: @MainActor (UsageProvider) async -> Void
+    @Environment(\.colorScheme) private var colorScheme
     @State private var contentWidth: CGFloat = PreferencesTab.general.preferredWidth
     @State private var contentHeight: CGFloat = PreferencesTab.general.preferredHeight
 
@@ -108,12 +109,20 @@ struct PreferencesView: View {
         .onAppear {
             self.updateLayout(for: self.selection.tab, animate: false)
             self.ensureValidTabSelection()
+            Self.syncSettingsWindowAppearance()
         }
         .onChange(of: self.selection.tab) { _, newValue in
             self.updateLayout(for: newValue, animate: true)
         }
         .onChange(of: self.settings.debugMenuEnabled) { _, _ in
             self.ensureValidTabSelection()
+        }
+        .onChange(of: self.colorScheme) { _, _ in
+            // The Settings scene's native toolbar (the tab bar) can keep a stale
+            // light appearance when the system theme switches while the window
+            // already exists, leaving a light toolbar over dark content. Pin the
+            // window to the live effective appearance so the toolbar redraws.
+            Self.syncSettingsWindowAppearance()
         }
     }
 
@@ -133,11 +142,23 @@ struct PreferencesView: View {
     private static let settingsWindowIdentifier = "com_apple_SwiftUI_Settings_window"
     private static let knownTabTitles = Set(PreferencesTab.allCases.map(\.title))
 
+    private static func settingsWindow() -> NSWindow? {
+        NSApp.windows.first(where: {
+            $0.identifier?.rawValue == self.settingsWindowIdentifier
+                || self.knownTabTitles.contains($0.title)
+        })
+    }
+
+    /// Pin the Settings window to the app's current effective appearance so its
+    /// native toolbar (tab bar) does not get stuck in a stale light appearance
+    /// after the system theme switches. Called on appear and on color-scheme change.
+    private static func syncSettingsWindowAppearance() {
+        guard let window = settingsWindow() else { return }
+        window.appearance = NSApp.effectiveAppearance
+    }
+
     private static func resizeSettingsWindow(width: CGFloat, height: CGFloat, animate: Bool) {
-        guard let window = NSApp.windows.first(where: {
-            $0.identifier?.rawValue == settingsWindowIdentifier
-                || knownTabTitles.contains($0.title)
-        }) else { return }
+        guard let window = settingsWindow() else { return }
         let toolbarHeight = window.frame.height - window.contentLayoutRect.height
         guard toolbarHeight > 0 else { return }
         let newSize = NSSize(width: width, height: height + toolbarHeight)

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -106,19 +106,19 @@ struct PreferencesView: View {
         .padding(.horizontal, 24)
         .padding(.vertical, 16)
         .frame(width: self.contentWidth, height: self.contentHeight)
+        .background {
+            SettingsWindowAppearanceBridge(colorScheme: self.colorScheme)
+                .allowsHitTesting(false)
+        }
         .onAppear {
             self.updateLayout(for: self.selection.tab, animate: false)
             self.ensureValidTabSelection()
-            Self.refreshSettingsWindowAppearance(for: self.colorScheme)
         }
         .onChange(of: self.selection.tab) { _, newValue in
             self.updateLayout(for: newValue, animate: true)
         }
         .onChange(of: self.settings.debugMenuEnabled) { _, _ in
             self.ensureValidTabSelection()
-        }
-        .onChange(of: self.colorScheme) { _, newValue in
-            Self.refreshSettingsWindowAppearance(for: newValue)
         }
     }
 
@@ -145,17 +145,6 @@ struct PreferencesView: View {
         })
     }
 
-    private static func refreshSettingsWindowAppearance(for colorScheme: ColorScheme) {
-        guard let window = settingsWindow() else { return }
-        // Pulse an explicit appearance to redraw SwiftUI's native tab toolbar, then restore inheritance.
-        // Leaving it pinned prevents the environment color scheme from observing the next system change.
-        window.appearance = NSAppearance(named: colorScheme == .dark ? .darkAqua : .aqua)
-        Task { @MainActor [weak window] in
-            await Task.yield()
-            window?.appearance = nil
-        }
-    }
-
     private static func resizeSettingsWindow(width: CGFloat, height: CGFloat, animate: Bool) {
         guard let window = settingsWindow() else { return }
         let toolbarHeight = window.frame.height - window.contentLayoutRect.height
@@ -172,5 +161,71 @@ struct PreferencesView: View {
             self.selection.tab = .general
             self.updateLayout(for: .general, animate: true)
         }
+    }
+}
+
+@MainActor
+enum SettingsWindowAppearance {
+    typealias ResetAction = @MainActor @Sendable () -> Void
+    typealias ResetScheduler = @MainActor @Sendable (@escaping ResetAction) -> Void
+
+    static func refresh(
+        _ window: NSWindow,
+        application: NSApplication = NSApp,
+        scheduleReset: ResetScheduler = Self.scheduleReset)
+    {
+        window.appearanceSource = application
+        // Pulse the exact effective appearance so the native toolbar redraws without
+        // dropping inherited accessibility attributes, then restore KVO inheritance.
+        window.appearance = application.effectiveAppearance
+        scheduleReset { [weak window] in
+            window?.appearance = nil
+            window?.viewsNeedDisplay = true
+        }
+    }
+
+    static func scheduleReset(_ action: @escaping ResetAction) {
+        Task { @MainActor in
+            await Task.yield()
+            action()
+        }
+    }
+}
+
+@MainActor
+struct SettingsWindowAppearanceBridge: NSViewRepresentable {
+    let colorScheme: ColorScheme
+
+    func makeNSView(context: Context) -> SettingsWindowAppearanceView {
+        SettingsWindowAppearanceView()
+    }
+
+    func updateNSView(_ nsView: SettingsWindowAppearanceView, context: Context) {
+        nsView.refreshWindowAppearance(for: self.colorScheme)
+    }
+}
+
+@MainActor
+final class SettingsWindowAppearanceView: NSView {
+    private let scheduleReset: SettingsWindowAppearance.ResetScheduler
+
+    init(scheduleReset: @escaping SettingsWindowAppearance.ResetScheduler = SettingsWindowAppearance.scheduleReset) {
+        self.scheduleReset = scheduleReset
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        self.refreshWindowAppearance()
+    }
+
+    func refreshWindowAppearance(for _: ColorScheme? = nil) {
+        guard let window else { return }
+        SettingsWindowAppearance.refresh(window, scheduleReset: self.scheduleReset)
     }
 }

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -109,7 +109,7 @@ struct PreferencesView: View {
         .onAppear {
             self.updateLayout(for: self.selection.tab, animate: false)
             self.ensureValidTabSelection()
-            Self.syncSettingsWindowAppearance()
+            Self.refreshSettingsWindowAppearance(for: self.colorScheme)
         }
         .onChange(of: self.selection.tab) { _, newValue in
             self.updateLayout(for: newValue, animate: true)
@@ -117,12 +117,8 @@ struct PreferencesView: View {
         .onChange(of: self.settings.debugMenuEnabled) { _, _ in
             self.ensureValidTabSelection()
         }
-        .onChange(of: self.colorScheme) { _, _ in
-            // The Settings scene's native toolbar (the tab bar) can keep a stale
-            // light appearance when the system theme switches while the window
-            // already exists, leaving a light toolbar over dark content. Pin the
-            // window to the live effective appearance so the toolbar redraws.
-            Self.syncSettingsWindowAppearance()
+        .onChange(of: self.colorScheme) { _, newValue in
+            Self.refreshSettingsWindowAppearance(for: newValue)
         }
     }
 
@@ -149,12 +145,15 @@ struct PreferencesView: View {
         })
     }
 
-    /// Pin the Settings window to the app's current effective appearance so its
-    /// native toolbar (tab bar) does not get stuck in a stale light appearance
-    /// after the system theme switches. Called on appear and on color-scheme change.
-    private static func syncSettingsWindowAppearance() {
+    private static func refreshSettingsWindowAppearance(for colorScheme: ColorScheme) {
         guard let window = settingsWindow() else { return }
-        window.appearance = NSApp.effectiveAppearance
+        // Pulse an explicit appearance to redraw SwiftUI's native tab toolbar, then restore inheritance.
+        // Leaving it pinned prevents the environment color scheme from observing the next system change.
+        window.appearance = NSAppearance(named: colorScheme == .dark ? .darkAqua : .aqua)
+        Task { @MainActor [weak window] in
+            await Task.yield()
+            window?.appearance = nil
+        }
     }
 
     private static func resizeSettingsWindow(width: CGFloat, height: CGFloat, animate: Bool) {

--- a/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
+++ b/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
@@ -1,0 +1,64 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct SettingsWindowAppearanceTests {
+    @Test
+    func `bridge pulses exact effective appearance then restores inheritance`() {
+        let application = NSApplication.shared
+        let effectiveAppearance = application.effectiveAppearance
+        let staleSource = NSView()
+        staleSource.appearance = NSAppearance(named: .aqua)
+        let resetCapture = ResetCapture()
+        let bridge = SettingsWindowAppearanceView { resetCapture.actions.append($0) }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        window.appearance = NSAppearance(named: .aqua)
+        window.appearanceSource = staleSource
+        window.contentView = bridge
+
+        let pulseMatchesEffectiveAppearance = window.appearance === effectiveAppearance
+        let sourceIsApplication = (window.appearanceSource as AnyObject?) === application
+        #expect(pulseMatchesEffectiveAppearance)
+        #expect(sourceIsApplication)
+        #expect(resetCapture.actions.count == 1)
+
+        resetCapture.actions[0]()
+
+        #expect(window.appearance == nil)
+        #expect(window.viewsNeedDisplay)
+    }
+
+    @Test
+    func `repeated theme updates cannot leave an explicit appearance`() {
+        let resetCapture = ResetCapture()
+        let bridge = SettingsWindowAppearanceView { resetCapture.actions.append($0) }
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false)
+        window.contentView = bridge
+
+        bridge.refreshWindowAppearance(for: .light)
+        bridge.refreshWindowAppearance(for: .dark)
+        for action in resetCapture.actions {
+            action()
+        }
+
+        let sourceIsApplication = (window.appearanceSource as AnyObject?) === NSApplication.shared
+        #expect(window.appearance == nil)
+        #expect(sourceIsApplication)
+    }
+}
+
+@MainActor
+private final class ResetCapture {
+    var actions: [SettingsWindowAppearance.ResetAction] = []
+}

--- a/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
+++ b/Tests/CodexBarTests/SettingsWindowAppearanceTests.swift
@@ -47,7 +47,9 @@ struct SettingsWindowAppearanceTests {
         window.contentView = bridge
 
         bridge.refreshWindowAppearance(for: .light)
+        bridge.refreshWindowAppearance(for: .light)
         bridge.refreshWindowAppearance(for: .dark)
+        #expect(resetCapture.actions.count == 3)
         for action in resetCapture.actions {
             action()
         }


### PR DESCRIPTION
## Summary

Fix the SwiftUI Settings scene's native tab toolbar staying in the previous macOS appearance while the content has already switched.

## Implementation

- Attach an `NSViewRepresentable` bridge to the actual Settings content so appearance refreshes use that view's containing `NSWindow`, not title/identifier discovery.
- Pulse the application's exact `effectiveAppearance` for one main-actor turn, preserving dynamic accessibility/high-contrast attributes.
- Restore `window.appearance = nil` immediately afterward and keep `appearanceSource` on the application, so future AppKit appearance changes continue through normal inheritance.
- Coalesce duplicate SwiftUI color-scheme updates while still refreshing on first window attachment and real Light/Dark transitions.
- Keep the existing global Settings-window lookup only for its pre-existing resize path.

The original contributor implementation assigned a resolved appearance permanently. In exact built-app testing, Dark to Light worked, but the following Light to Dark transition remained visibly light because the window retained an explicit Aqua override.

## Proof

Exact candidate: `6801237cf373a7d12960550393de6c5bdcf1e470` on macOS 26.5.

- Current `main` did not reproduce the reported stale toolbar in the sampled run, confirming the issue is intermittent rather than deterministic.
- Original contributor head reproduced a deterministic regression: after Dark to Light to Dark, the application was Dark while the Settings window remained explicitly Aqua and visibly light.
- Fresh ad-hoc release package:
  - `CodexGitCommit` matched `6801237c`
  - deep strict code-sign verification passed
  - app and widget were arm64
- Exact packaged-app lifecycle with Settings already open:
  - Dark to Light to Dark updated native toolbar and content on both transitions
  - window bounds remained `546 x 750` throughout
  - settled `NSWindow.appearance` was `nil` after each transition
  - `appearanceSource` remained the application
  - effective appearance changed Aqua to DarkAqua as expected
  - system appearance was restored to Dark
- Public-safe About-pane screenshot SHA-256 values:
  - initial Dark: `73573077ab270b3f179fea91ed3e9ac32c9e8f623202a66188df7fdfc2e35025`
  - Light: `262f8103b30ad6183dd2f1bc0c9cfb6cd7cd39f45c2898b58b96c672c8daac0f`
  - final Dark: `3ebcf3f916bb6e1c02594abe85f70b92a977caec14421c4d225f3f1314df29ac`
- Focused regression tests: 2 passed.
- Full current suite: 431/431 suites passed using the repository's per-suite CI harness.
  - The unisolated host run hit an unrelated stall while Foundation attempted an atomic write into the active signed app-group snapshot container.
  - A deny-only boundary for that live container reproduced clean-runner behavior; the previously stalled suite passed in 1.85 seconds.
- Lint: 0 violations in 1,076 files.
- `swift build`: passed.
- Autoreview: no accepted/actionable findings; patch correct (0.84).
- Public Model Identifier Gate: PASS. No model literals were added; public proof and screenshots contain no account data or non-public identifiers.

The changelog retains contributor credit to @hhh2210.