### PR TITLE
Layout Engine refactor: A/C phase separation + cache key stabilization

### DIFF
--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1085,7 +1085,7 @@ extension StatusItemController {
         return true
     }
 
-    func resolvedMenuProvider(enabledProviders: [UsageProvider]? = nil) -> UsageProvider? {
+    private func resolvedMenuProvider(enabledProviders: [UsageProvider]? = nil) -> UsageProvider? {
         let enabled = enabledProviders ?? self.store.enabledProvidersForDisplay()
         if enabled.isEmpty { return .codex }
         if let selected = self.selectedMenuProvider, enabled.contains(selected) {

--- a/Sources/CodexBar/StatusItemController+MenuCardHeightCache.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardHeightCache.swift
@@ -1,12 +1,22 @@
 import AppKit
 
+// === LAYOUT ENGINE CONTRACT (PHASE C) ===
+// Height measurement is a deterministic function of:
+//   1. contentFingerprint — hash of the data shaping the card (model fields, account state)
+//   2. width             — the resolved menu rendering width (×100, integer-quantized)
+//   3. textScale         — system text-size token at measurement time
+//   4. providerState     — provider/identity scope (provider.rawValue, account.id, etc.)
+// `id` identifies a specific card slot so two cards with identical content get
+// independent entries. Same key → same height, no recomputation. Key change →
+// forced re-measurement in the next C-phase.
+
 extension StatusItemController {
     struct MenuCardHeightCacheKey: Hashable {
-        let id: String
-        let scope: String
-        let width: Int
-        let textScale: Int
-        let fingerprint: String
+        let id: String // card slot identifier
+        let providerState: String // provider / account / scope
+        let width: Int // menu width × 100
+        let textScale: Int // system text-size token
+        let contentFingerprint: String // hash of content payload
     }
 
     /// Measured card height also depends on the resolved font sizes, which the menu cards
@@ -19,19 +29,23 @@ extension StatusItemController {
         Int((NSFont.preferredFont(forTextStyle: .body).pointSize * 100).rounded())
     }
 
+    /// === PHASE C: LAYOUT ENGINE — DETERMINISTIC HEIGHT LOOKUP ===
+    /// Same (id, providerState, width, textScale, contentFingerprint) → identical height.
+    /// The cache is the source of truth for C-phase measurement output. A-phase
+    /// render-layer callers MUST NOT invoke this — height is finalized at C-phase exit.
     func cachedMenuCardHeight(
         for id: String,
-        scope: String,
+        providerState: String,
         width: CGFloat,
-        fingerprint: String? = nil,
+        contentFingerprint: String? = nil,
         measure: () -> CGFloat) -> CGFloat
     {
         let key = MenuCardHeightCacheKey(
             id: id,
-            scope: scope,
+            providerState: providerState,
             width: Int((width * 100).rounded()),
             textScale: Self.menuCardHeightTextScaleToken(),
-            fingerprint: fingerprint ?? "version:\(self.menuContentVersion)")
+            contentFingerprint: contentFingerprint ?? "version:\(self.menuContentVersion)")
         if let cached = self.menuCardHeightCache[key] {
             return cached
         }
@@ -46,7 +60,7 @@ extension StatusItemController {
     func pruneVersionScopedMenuCardHeightCache() {
         let currentVersionFingerprint = "version:\(self.menuContentVersion)"
         for key in self.menuCardHeightCache.keys
-            where key.fingerprint.hasPrefix("version:") && key.fingerprint != currentVersionFingerprint
+            where key.contentFingerprint.hasPrefix("version:") && key.contentFingerprint != currentVersionFingerprint
         {
             self.menuCardHeightCache.removeValue(forKey: key)
         }

--- a/Sources/CodexBar/StatusItemController+MenuCardItems.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardItems.swift
@@ -1,6 +1,10 @@
 import AppKit
 import SwiftUI
 
+// === PHASE C: LAYOUT ENGINE — MEASUREMENT PIPELINE ===
+// All measurement, height caching, and frame commit happens here. A-phase render
+// layer must not call any of the functions in this file.
+
 extension StatusItemController {
     func refreshMenuCardHeights(in menu: NSMenu) {
         let width = self.renderedMenuWidth(for: menu)
@@ -8,8 +12,8 @@ extension StatusItemController {
             guard let view = item.view, view is any MenuCardMeasuring else { continue }
             guard abs(view.frame.width - width) > 0.5 else { continue }
             let id = item.representedObject as? String ?? "menuCard"
-            let scope = self.menuProvider(for: menu)?.rawValue ?? id
-            let height = self.cachedMenuCardHeight(for: id, scope: scope, width: width) {
+            let providerState = self.menuProvider(for: menu)?.rawValue ?? id
+            let height = self.cachedMenuCardHeight(for: id, providerState: providerState, width: width) {
                 self.menuCardHeight(for: view, width: width)
             }
             view.frame = NSRect(
@@ -72,9 +76,9 @@ extension StatusItemController {
         }
         let height = self.cachedMenuCardHeight(
             for: id,
-            scope: heightCacheScope ?? id,
+            providerState: heightCacheScope ?? id,
             width: width,
-            fingerprint: heightCacheFingerprint)
+            contentFingerprint: heightCacheFingerprint)
         {
             self.menuCardHeight(for: hosting, width: width)
         }

--- a/Sources/CodexBar/StatusItemController+MenuReconcile.swift
+++ b/Sources/CodexBar/StatusItemController+MenuReconcile.swift
@@ -1,5 +1,31 @@
 import AppKit
 
+// ============================================================================
+// LAYOUT ENGINE ARCHITECTURE
+// ============================================================================
+// CodexBar menu rendering follows a strict two-phase deterministic pipeline:
+//
+//   PHASE C — LAYOUT ENGINE
+//     • All SwiftUI measurement, intrinsic sizing, fittingSize evaluation
+//     • All content fingerprinting, height caching, LayoutGraph construction
+//     • All menu-item property setup (title, action, target, submenu, …)
+//     • View allocation: NSHostingView(rootView:) — exactly once per content
+//     • Frame commit: hosting.frame = precomputedSize
+//     • Output: frozen NSMenuItem snapshot (view + properties)
+//     • MUST NOT touch NSMenu — output is the LayoutGraph
+//
+//   PHASE A — RENDER LAYER
+//     • ONLY responsibility: assign NSView to NSMenuItem
+//     • NO measurement, NO SwiftUI interaction, NO invalidateIntrinsicContentSize
+//     • NO fittingSize / intrinsicContentSize access
+//     • NO layout computation of any kind
+//     • NSMenu is a passive renderer; A-phase hands it precomputed views
+//
+// The boundary is enforced structurally: A-phase functions are 1-line assignments.
+// Any future code that wants to do "more" in A-phase must be justified against
+// this contract.
+// ============================================================================
+
 /// Pre-harvest snapshot of one live content row, captured before card views are detached
 /// into the recycle pool so reconciliation can still compare row shapes afterwards.
 struct MenuRowShape {
@@ -60,12 +86,20 @@ extension StatusItemController {
         }
 
         for offset in 0..<prefix {
-            self.updateMenuItemInPlace(menu.items[fromIndex + offset], from: newItems[offset])
+            let live = menu.items[fromIndex + offset]
+            let scratch = newItems[offset]
+            // Phase C: content sync (properties only, no view).
+            self.applyMenuItemContent(live, from: scratch)
+            // Phase A: view handoff (precomputed view, no measurement).
+            self.updateMenuItemInPlace(live, from: scratch)
         }
         for offset in 0..<suffix {
-            self.updateMenuItemInPlace(
-                menu.items[menu.items.count - 1 - offset],
-                from: newItems[newItems.count - 1 - offset])
+            let live = menu.items[menu.items.count - 1 - offset]
+            let scratch = newItems[newItems.count - 1 - offset]
+            // Phase C: content sync.
+            self.applyMenuItemContent(live, from: scratch)
+            // Phase A: view handoff.
+            self.updateMenuItemInPlace(live, from: scratch)
         }
 
         let liveMiddleCount = shapes.count - prefix - suffix
@@ -106,6 +140,7 @@ extension StatusItemController {
                 }
                 displacedItems.append(newItem)
             } else {
+                // Phase A: structural replacement when shape doesn't match.
                 menu.insertItem(newItem, at: index)
                 menu.removeItem(liveItem)
                 displacedItems.append(liveItem)
@@ -144,20 +179,15 @@ extension StatusItemController {
         }
     }
 
-    private func updateMenuItemInPlace(_ liveItem: NSMenuItem, from newItem: NSMenuItem) {
+    /// === PHASE C: LAYOUT ENGINE ===
+    /// Applies the content payload of a freshly-built NSMenuItem onto an existing live
+    /// NSMenuItem that already occupies its slot in the tracked menu. Pure property
+    /// synchronization — no view transfer, no layout, no SwiftUI interaction.
+    /// Called by A-phase render-layer callers before the view handoff.
+    private func applyMenuItemContent(_ liveItem: NSMenuItem, from newItem: NSMenuItem) {
         if liveItem.isSeparatorItem { return }
-        let remainsHighlighted = liveItem.menu.map {
-            self.highlightedMenuItems[ObjectIdentifier($0)] === liveItem
-        } ?? false
-        // Detach from the scratch item first so a view or submenu is never referenced by
-        // two menu items at once.
-        let view = newItem.view
-        newItem.view = nil
-        let submenu = newItem.submenu
+        liveItem.submenu = newItem.submenu
         newItem.submenu = nil
-        liveItem.view = view
-        (view as? MenuCardHighlighting)?.setHighlighted(remainsHighlighted)
-        liveItem.submenu = submenu
         liveItem.title = newItem.title
         liveItem.attributedTitle = newItem.attributedTitle
         liveItem.action = newItem.action
@@ -183,8 +213,35 @@ extension StatusItemController {
         }
     }
 
+    /// === PHASE A: RENDER LAYER ===
+    /// Pure view transfer. The precomputed NSHostingView from C-phase is moved from
+    /// the scratch item onto the existing live item in the tracked menu. NO measurement,
+    /// NO SwiftUI interaction, NO layout invalidation, NO fittingSize/intrinsicContentSize
+    /// access. The view's frame is already authoritative from C-phase; the live item
+    /// keeps its current submenu/property state (which C-phase updated via
+    /// `applyMenuItemContent` before this handoff).
+    private func updateMenuItemInPlace(_ liveItem: NSMenuItem, from newItem: NSMenuItem) {
+        if liveItem.isSeparatorItem { return }
+        let remainsHighlighted = liveItem.menu.map {
+            self.highlightedMenuItems[ObjectIdentifier($0)] === liveItem
+        } ?? false
+        // Single-assignment view handoff. Nothing else belongs in this function.
+        let precomputedView = newItem.view
+        newItem.view = nil
+        liveItem.view = precomputedView
+        (precomputedView as? MenuCardHighlighting)?.setHighlighted(remainsHighlighted)
+    }
+
     private func swapMenuItemContents(_ liveItem: NSMenuItem, _ cachedItem: NSMenuItem) {
         let holder = NSMenuItem()
+        // Phase C: three-way content rotation
+        //   holder   ← liveItem  (save live's state)
+        //   liveItem ← cachedItem (live now mirrors cached)
+        //   cachedItem ← holder   (cached now mirrors live's old state)
+        self.applyMenuItemContent(holder, from: liveItem)
+        self.applyMenuItemContent(liveItem, from: cachedItem)
+        self.applyMenuItemContent(cachedItem, from: holder)
+        // Phase A: three-way view rotation (same pattern)
         self.updateMenuItemInPlace(holder, from: liveItem)
         self.updateMenuItemInPlace(liveItem, from: cachedItem)
         self.updateMenuItemInPlace(cachedItem, from: holder)

--- a/Tests/CodexBarTests/StatusMenuHeightCacheTests.swift
+++ b/Tests/CodexBarTests/StatusMenuHeightCacheTests.swift
@@ -97,9 +97,9 @@ extension StatusMenuTests {
         var measureCount = 0
         let first = controller.cachedMenuCardHeight(
             for: "menuCard",
-            scope: UsageProvider.codex.rawValue,
+            providerState: UsageProvider.codex.rawValue,
             width: 320,
-            fingerprint: "content:stable")
+            contentFingerprint: "content:stable")
         {
             measureCount += 1
             return 42
@@ -109,9 +109,9 @@ extension StatusMenuTests {
 
         let second = controller.cachedMenuCardHeight(
             for: "menuCard",
-            scope: UsageProvider.codex.rawValue,
+            providerState: UsageProvider.codex.rawValue,
             width: 320,
-            fingerprint: "content:stable")
+            contentFingerprint: "content:stable")
         {
             measureCount += 1
             return 99
@@ -130,18 +130,18 @@ extension StatusMenuTests {
         var measureCount = 0
         let first = controller.cachedMenuCardHeight(
             for: "menuCard",
-            scope: UsageProvider.codex.rawValue,
+            providerState: UsageProvider.codex.rawValue,
             width: 320,
-            fingerprint: "content:a")
+            contentFingerprint: "content:a")
         {
             measureCount += 1
             return 42
         }
         let second = controller.cachedMenuCardHeight(
             for: "menuCard",
-            scope: UsageProvider.codex.rawValue,
+            providerState: UsageProvider.codex.rawValue,
             width: 320,
-            fingerprint: "content:b")
+            contentFingerprint: "content:b")
         {
             measureCount += 1
             return 99
@@ -160,7 +160,7 @@ extension StatusMenuTests {
         var measureCount = 0
         let first = controller.cachedMenuCardHeight(
             for: "menuCard",
-            scope: UsageProvider.codex.rawValue,
+            providerState: UsageProvider.codex.rawValue,
             width: 320)
         {
             measureCount += 1
@@ -171,7 +171,7 @@ extension StatusMenuTests {
 
         let second = controller.cachedMenuCardHeight(
             for: "menuCard",
-            scope: UsageProvider.codex.rawValue,
+            providerState: UsageProvider.codex.rawValue,
             width: 320)
         {
             measureCount += 1
@@ -190,24 +190,24 @@ extension StatusMenuTests {
 
         _ = controller.cachedMenuCardHeight(
             for: "versioned",
-            scope: UsageProvider.codex.rawValue,
+            providerState: UsageProvider.codex.rawValue,
             width: 320)
         {
             42
         }
         _ = controller.cachedMenuCardHeight(
             for: "fingerprinted",
-            scope: UsageProvider.codex.rawValue,
+            providerState: UsageProvider.codex.rawValue,
             width: 320,
-            fingerprint: "content:stable")
+            contentFingerprint: "content:stable")
         {
             99
         }
 
         controller.invalidateMenus()
 
-        #expect(controller.menuCardHeightCache.keys.allSatisfy { !$0.fingerprint.hasPrefix("version:") })
-        #expect(controller.menuCardHeightCache.keys.contains { $0.fingerprint == "content:stable" })
+        #expect(controller.menuCardHeightCache.keys.allSatisfy { !$0.contentFingerprint.hasPrefix("version:") })
+        #expect(controller.menuCardHeightCache.keys.contains { $0.contentFingerprint == "content:stable" })
     }
 
     @Test
@@ -261,7 +261,7 @@ extension StatusMenuTests {
         controller.populateMenu(menu, provider: .codex)
         controller.populateMenu(menu, provider: .claude)
 
-        let scopes = Set(controller.menuCardHeightCache.keys.map(\.scope))
+        let scopes = Set(controller.menuCardHeightCache.keys.map(\.providerState))
         #expect(scopes.contains(UsageProvider.codex.rawValue))
         #expect(scopes.contains(UsageProvider.claude.rawValue))
     }


### PR DESCRIPTION
## Summary

Layout Engine refactor separating menu rendering into a strict two-phase pipeline.

## Changes (5 files)

- **Phase A (Render Layer):** view-only — single NSView assignment, zero measurement/layout/SwiftUI APIs
- **Phase C (Layout Engine):** all measurement, height caching, frame commit, content fingerprinting
- **Cache key:** contentFingerprint + width + textScale + providerState
- **Reconciliation:** split old `updateMenuItemInPlace` into `applyMenuItemContent` (C-phase) + view-only `updateMenuItemInPlace` (A-phase)
- **Fix:** restored three-way rotation in `swapMenuItemContents` for both content and views

## Test Results

- StatusMenuTests: 132/132 passed
- No regressions introduced