### PR TITLE
feat: add Codex profile home accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Cursor: show personal on-demand spend alongside the shared team pool. Thanks @yashiels!
 - Documentation: link the community KDE Plasma panel integration. Thanks @tylxr59!
+- Codex: expose explicitly configured profile homes as switchable accounts without copying their credentials. Thanks @kiranmagic7!
 - Codex: show available manual rate-limit reset credits and their next expiry for signed-in OAuth accounts. Thanks @rogdex24!
 - Mistral: add Vibe monthly-plan usage and menu bar metric selection. Thanks @lfmundim!
 - Storage: show a compact segmented provider breakdown with an expandable Other group. Thanks @elijahfriedman!

--- a/Sources/CodexBar/OpenAICreditsPurchaseWindowController.swift
+++ b/Sources/CodexBar/OpenAICreditsPurchaseWindowController.swift
@@ -361,6 +361,7 @@ final class OpenAICreditsPurchaseWindowController: NSWindowController, WKNavigat
     private let logger = CodexBarLog.logger(LogCategories.creditsPurchase)
     private var webView: WKWebView?
     private var accountEmail: String?
+    private var cacheScope: CookieHeaderCache.Scope?
     private var pendingAutoStart = false
     private let logHandler = WeakScriptMessageHandler()
 
@@ -374,10 +375,16 @@ final class OpenAICreditsPurchaseWindowController: NSWindowController, WKNavigat
         fatalError("init(coder:) has not been implemented")
     }
 
-    func show(purchaseURL: URL, accountEmail: String?, autoStartPurchase: Bool) {
+    func show(
+        purchaseURL: URL,
+        accountEmail: String?,
+        cacheScope: CookieHeaderCache.Scope?,
+        autoStartPurchase: Bool)
+    {
         let normalizedEmail = Self.normalizeEmail(accountEmail)
-        if self.window == nil || normalizedEmail != self.accountEmail {
+        if self.window == nil || normalizedEmail != self.accountEmail || cacheScope != self.cacheScope {
             self.accountEmail = normalizedEmail
+            self.cacheScope = cacheScope
             self.buildWindow()
         }
         Self.resetDebugLog()
@@ -399,7 +406,9 @@ final class OpenAICreditsPurchaseWindowController: NSWindowController, WKNavigat
     private func buildWindow() {
         let config = WKWebViewConfiguration()
         config.userContentController.add(self.logHandler, name: Self.logHandlerName)
-        config.websiteDataStore = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: self.accountEmail)
+        config.websiteDataStore = OpenAIDashboardWebsiteDataStore.store(
+            forAccountEmail: self.accountEmail,
+            scope: self.cacheScope)
 
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = self

--- a/Sources/CodexBar/OpenAICreditsPurchaseWindowController.swift
+++ b/Sources/CodexBar/OpenAICreditsPurchaseWindowController.swift
@@ -381,6 +381,13 @@ final class OpenAICreditsPurchaseWindowController: NSWindowController, WKNavigat
         cacheScope: CookieHeaderCache.Scope?,
         autoStartPurchase: Bool)
     {
+        guard Self.canOpenPurchaseWindow(accountEmail: accountEmail, cacheScope: cacheScope) else {
+            self.close()
+            self.accountEmail = nil
+            self.cacheScope = nil
+            self.logger.error("Buy credits blocked: scoped account email unavailable")
+            return
+        }
         let normalizedEmail = Self.normalizeEmail(accountEmail)
         if self.window == nil || normalizedEmail != self.accountEmail || cacheScope != self.cacheScope {
             self.accountEmail = normalizedEmail
@@ -475,6 +482,10 @@ final class OpenAICreditsPurchaseWindowController: NSWindowController, WKNavigat
     private static func normalizeEmail(_ email: String?) -> String? {
         guard let raw = email?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else { return nil }
         return raw.lowercased()
+    }
+
+    static func canOpenPurchaseWindow(accountEmail: String?, cacheScope: CookieHeaderCache.Scope?) -> Bool {
+        cacheScope == nil || self.normalizeEmail(accountEmail) != nil
     }
 
     private static func defaultFrame() -> NSRect {

--- a/Sources/CodexBar/ProviderRegistry.swift
+++ b/Sources/CodexBar/ProviderRegistry.swift
@@ -145,6 +145,8 @@ struct ProviderRegistry {
                 env = CodexHomeScope.scopedEnvironment(base: env, codexHome: managedHomePath)
             } else if let liveHomePath = settings.liveSystemCodexHomePath(forActiveSource: codexActiveSource) {
                 env = CodexHomeScope.scopedEnvironment(base: env, codexHome: liveHomePath)
+            } else if let profileHomePath = settings.profileCodexHomePath(forActiveSource: codexActiveSource) {
+                env = CodexHomeScope.scopedEnvironment(base: env, codexHome: profileHomePath)
             }
         }
         return env

--- a/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
@@ -101,7 +101,12 @@ extension SettingsStore {
         guard case let .profileHome(path) = source else {
             return nil
         }
-        return CodexHomeScope.normalizedHomePath(path)
+        guard let normalizedPath = CodexHomeScope.normalizedHomePath(path),
+              self.codexProfileHomePaths.contains(normalizedPath)
+        else {
+            return nil
+        }
+        return normalizedPath
     }
 
     func managedCodexRemoteHomePath(forActiveSource source: CodexActiveSource) -> String? {

--- a/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
@@ -18,6 +18,16 @@ extension SettingsStore {
             .path
     }
 
+    private static func normalizedCodexProfileHomePaths(_ paths: [String]?) -> [String] {
+        var seen: Set<String> = []
+        var result: [String] = []
+        for path in (paths ?? []).compactMap({ CodexHomeScope.normalizedHomePath($0) }) {
+            guard seen.insert(path).inserted else { continue }
+            result.append(path)
+        }
+        return result
+    }
+
     private func loadManagedCodexAccounts() throws -> ManagedCodexAccountSet {
         #if DEBUG
         if CodexManagedRemoteHomeTestingOverride.isUnreadable(for: self) {
@@ -80,6 +90,18 @@ extension SettingsStore {
             return nil
         }
         return path
+    }
+
+    var codexProfileHomePaths: [String] {
+        Self.normalizedCodexProfileHomePaths(
+            self.configSnapshot.providerConfig(for: .codex)?.codexProfileHomePaths)
+    }
+
+    func profileCodexHomePath(forActiveSource source: CodexActiveSource) -> String? {
+        guard case let .profileHome(path) = source else {
+            return nil
+        }
+        return CodexHomeScope.normalizedHomePath(path)
     }
 
     func managedCodexRemoteHomePath(forActiveSource source: CodexActiveSource) -> String? {
@@ -376,6 +398,7 @@ extension SettingsStore {
             return DefaultCodexAccountReconciler(
                 activeSource: activeSource,
                 baseEnvironment: baseEnvironment,
+                profileHomePaths: self.codexProfileHomePaths,
                 managedEnvironmentBuilder: { environment, account in
                     CodexHomeScope.scopedEnvironment(base: environment, codexHome: account.managedHomePath)
                 })
@@ -406,6 +429,7 @@ extension SettingsStore {
                 usesInjectedEnvironment: reconciliationEnvironmentOverride != nil),
             activeSource: activeSource,
             baseEnvironment: baseEnvironment,
+            profileHomePaths: self.codexProfileHomePaths,
             managedEnvironmentBuilder: { environment, account in
                 CodexHomeScope.scopedEnvironment(base: environment, codexHome: account.managedHomePath)
             })
@@ -413,6 +437,7 @@ extension SettingsStore {
         return DefaultCodexAccountReconciler(
             activeSource: activeSource,
             baseEnvironment: baseEnvironment,
+            profileHomePaths: self.codexProfileHomePaths,
             managedEnvironmentBuilder: { environment, account in
                 CodexHomeScope.scopedEnvironment(base: environment, codexHome: account.managedHomePath)
             })

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -615,9 +615,12 @@ extension UsageStore {
         if self.settings.codexCookieSource.isEnabled,
            let normalizedTarget = Self.normalizeCodexAccountScopedEmail(targetEmail)
         {
-            let previous = self.lastOpenAIDashboardTargetEmail
+            let scope = self.codexCookieCacheScopeForOpenAIWeb()
+            let isolationKey = Self.openAIWebTargetIsolationKey(email: normalizedTarget, scope: scope)
+            let previousIsolationKey = self.lastOpenAIDashboardTargetIsolationKey
             self.lastOpenAIDashboardTargetEmail = normalizedTarget
-            if let previous, !previous.isEmpty, previous != normalizedTarget {
+            self.lastOpenAIDashboardTargetIsolationKey = isolationKey
+            if let previousIsolationKey, previousIsolationKey != isolationKey {
                 self.openAIWebAccountDidChange = true
                 self.openAIDashboardCookieImportStatus = "Codex account changed; importing browser cookies…"
             } else {
@@ -626,6 +629,7 @@ extension UsageStore {
             self.openAIDashboardRequiresLogin = true
         } else {
             self.lastOpenAIDashboardTargetEmail = Self.normalizeCodexAccountScopedEmail(targetEmail)
+            self.lastOpenAIDashboardTargetIsolationKey = nil
             self.openAIWebAccountDidChange = false
             self.openAIDashboardRequiresLogin = false
             self.openAIDashboardCookieImportStatus = nil

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexAccountState.swift
@@ -150,6 +150,8 @@ extension UsageStore {
                     .email)
         case .managedAccount:
             Self.normalizeCodexAccountScopedKey(self.currentManagedCodexRuntimeEmail())
+        case let .profileHome(path):
+            Self.normalizeCodexAccountScopedKey(self.currentProfileCodexRuntimeEmail(path: path))
         }
         return CodexAccountScopedRefreshGuard(
             source: source,
@@ -217,6 +219,8 @@ extension UsageStore {
             guard let currentAccountKey = currentGuard.accountKey else { return true }
             return resultAccountKey == currentAccountKey
         case .managedAccount:
+            return false
+        case .profileHome:
             return false
         }
     }
@@ -339,6 +343,8 @@ extension UsageStore {
                 self.settings.codexAccountReconciliationSnapshot.liveSystemAccount?.email)
         case .managedAccount:
             CodexIdentityResolver.normalizeEmail(self.currentManagedCodexRuntimeEmail())
+        case let .profileHome(path):
+            CodexIdentityResolver.normalizeEmail(self.currentProfileCodexRuntimeEmail(path: path))
         }
     }
 
@@ -461,6 +467,12 @@ extension UsageStore {
         case let .managedAccount(id):
             guard let account = snapshot.storedAccounts.first(where: { $0.id == id }) else { return nil }
             return CodexAuthFingerprint.fingerprint(homePath: account.managedHomePath)
+        case let .profileHome(path):
+            guard let profileAccount = snapshot.profileHomeAccount(path: path) else {
+                guard let normalizedPath = CodexHomeScope.normalizedHomePath(path) else { return nil }
+                return CodexAuthFingerprint.fingerprint(homePath: normalizedPath)
+            }
+            return CodexAuthFingerprint.normalize(profileAccount.authFingerprint)
         }
     }
 
@@ -507,6 +519,8 @@ extension UsageStore {
                 return nil
             }
             return self.currentManagedCodexRuntimeEmail()
+        case let .profileHome(path):
+            return self.currentProfileCodexRuntimeEmail(path: path)
         }
     }
 
@@ -544,6 +558,12 @@ extension UsageStore {
                 return .unresolved
             }
             return self.settings.codexAccountReconciliationSnapshot.runtimeIdentity(for: activeStoredAccount)
+        case let .profileHome(path):
+            guard let profileAccount = self.settings.codexAccountReconciliationSnapshot.profileHomeAccount(path: path)
+            else {
+                return .unresolved
+            }
+            return self.settings.codexAccountReconciliationSnapshot.runtimeIdentity(for: profileAccount)
         }
     }
 
@@ -562,6 +582,12 @@ extension UsageStore {
                 return .unresolved
             }
             return self.settings.codexAccountReconciliationSnapshot.runtimeIdentity(for: activeStoredAccount)
+        case let .profileHome(path):
+            guard let profileAccount = self.settings.codexAccountReconciliationSnapshot.profileHomeAccount(path: path)
+            else {
+                return .unresolved
+            }
+            return self.settings.codexAccountReconciliationSnapshot.runtimeIdentity(for: profileAccount)
         }
     }
 
@@ -574,6 +600,14 @@ extension UsageStore {
         }
         return Self.normalizeCodexAccountScopedEmail(
             self.settings.codexAccountReconciliationSnapshot.runtimeEmail(for: activeStoredAccount))
+    }
+
+    func currentProfileCodexRuntimeEmail(path: String) -> String? {
+        guard let profileAccount = self.settings.codexAccountReconciliationSnapshot.profileHomeAccount(path: path)
+        else {
+            return nil
+        }
+        return Self.normalizeCodexAccountScopedEmail(profileAccount.email)
     }
 
     private func clearCodexOpenAIWebStateForAccountTransition(targetEmail: String?) {

--- a/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
+++ b/Sources/CodexBar/Providers/Codex/UsageStore+CodexRefresh.swift
@@ -56,6 +56,8 @@ extension UsageStore {
             "live"
         case let .managedAccount(id):
             "managed:\(id.uuidString)"
+        case let .profileHome(path):
+            "profile:\(path)"
         }
 
         let identityKey = switch expectedGuard.identity {

--- a/Sources/CodexBar/SettingsStore+ConfigPersistence.swift
+++ b/Sources/CodexBar/SettingsStore+ConfigPersistence.swift
@@ -123,6 +123,10 @@ extension SettingsStore {
     }
 
     private func bumpConfigRevision(_ context: ConfigChangeContext) {
+        // Account routing derives from config paths and source selection. Never let an old
+        // reconciliation snapshot survive a config reload, even when another provider changed.
+        self.invalidateCodexAccountReconciliationSnapshotCache()
+        self.cachedCodexAccountMenuProjection = nil
         self.configRevision &+= 1
         CodexBarLog.logger(LogCategories.settings)
             .debug("Config revision bumped (\(context.reason)) -> \(self.configRevision)")

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -199,7 +199,11 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         let autoStart = true
         let accountEmail = self.store.codexAccountEmailForOpenAIDashboard()
         let controller = self.creditsPurchaseWindow ?? OpenAICreditsPurchaseWindowController()
-        controller.show(purchaseURL: url, accountEmail: accountEmail, autoStartPurchase: autoStart)
+        controller.show(
+            purchaseURL: url,
+            accountEmail: accountEmail,
+            cacheScope: self.store.codexCookieCacheScopeForOpenAIWeb(),
+            autoStartPurchase: autoStart)
         self.creditsPurchaseWindow = controller
     }
 

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -198,11 +198,20 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
 
         let autoStart = true
         let accountEmail = self.store.codexAccountEmailForOpenAIDashboard()
+        let cacheScope = self.store.codexCookieCacheScopeForOpenAIWeb()
+        guard OpenAICreditsPurchaseWindowController.canOpenPurchaseWindow(
+            accountEmail: accountEmail,
+            cacheScope: cacheScope)
+        else {
+            self.creditsPurchaseWindow?.close()
+            self.creditsPurchaseWindow = nil
+            return
+        }
         let controller = self.creditsPurchaseWindow ?? OpenAICreditsPurchaseWindowController()
         controller.show(
             purchaseURL: url,
             accountEmail: accountEmail,
-            cacheScope: self.store.codexCookieCacheScopeForOpenAIWeb(),
+            cacheScope: cacheScope,
             autoStartPurchase: autoStart)
         self.creditsPurchaseWindow = controller
     }

--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -875,6 +875,8 @@ extension UsageStore {
             return nil
         case .managedAccount:
             return self.codexAccountEmailForOpenAIDashboard()
+        case let .profileHome(path):
+            return self.currentProfileCodexRuntimeEmail(path: path)
         }
     }
 
@@ -1328,6 +1330,11 @@ extension UsageStore {
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             if let managed, !managed.isEmpty { return managed }
             return nil
+        case let .profileHome(path):
+            let profile = self.currentProfileCodexRuntimeEmail(path: path)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if let profile, !profile.isEmpty { return profile }
+            return nil
         }
     }
 
@@ -1337,6 +1344,8 @@ extension UsageStore {
             nil
         case let .managedAccount(id):
             self.openAIWebManagedTargetStoreIsUnreadable() ? .managedStoreUnreadable : .managedAccount(id)
+        case .profileHome:
+            nil
         }
     }
 }

--- a/Sources/CodexBar/UsageStore+OpenAIWeb.swift
+++ b/Sources/CodexBar/UsageStore+OpenAIWeb.swift
@@ -171,6 +171,10 @@ extension UsageStore {
             await self.failClosedRefreshForMissingManagedCodexTarget()
             return
         }
+        if self.openAIWebProfileTargetEmailIsMissing() {
+            await self.failClosedRefreshForMissingProfileCodexTarget()
+            return
+        }
 
         OpenAIDashboardFetcher.evictAllCachedWebViews()
         await MainActor.run {
@@ -207,6 +211,10 @@ extension UsageStore {
         }
         if self.openAIWebManagedTargetIsMissing() {
             await self.failClosedRefreshForMissingManagedCodexTarget()
+            return
+        }
+        if self.openAIWebProfileTargetEmailIsMissing() {
+            await self.failClosedRefreshForMissingProfileCodexTarget()
             return
         }
 
@@ -404,6 +412,10 @@ extension UsageStore {
             await self.failClosedRefreshForMissingManagedCodexTarget()
             return
         }
+        if self.openAIWebProfileTargetEmailIsMissing() {
+            await self.failClosedRefreshForMissingProfileCodexTarget()
+            return
+        }
 
         let allowCurrentSnapshotFallback = expectedGuard?.source == .liveSystem && expectedGuard?
             .identity == .unresolved
@@ -418,7 +430,9 @@ extension UsageStore {
             await task.value
             return
         }
-        self.handleOpenAIWebTargetEmailChangeIfNeeded(targetEmail: targetEmail)
+        self.handleOpenAIWebTargetEmailChangeIfNeeded(
+            targetEmail: targetEmail,
+            targetScope: self.codexCookieCacheScopeForOpenAIWeb())
 
         let now = Date()
         let minInterval = self.openAIWebRefreshIntervalSeconds()
@@ -799,26 +813,29 @@ extension UsageStore {
 
     // MARK: - OpenAI web account switching
 
-    /// Detect Codex account email changes and clear stale OpenAI web state so the UI can't show the wrong user.
-    /// This does not delete other per-email WebKit cookie stores (we keep multiple accounts around).
-    func handleOpenAIWebTargetEmailChangeIfNeeded(targetEmail: String?) {
+    /// Detect Codex account-source changes and clear stale OpenAI web state so the UI can't show the wrong user.
+    /// This does not delete other isolated WebKit cookie stores (we keep multiple accounts around).
+    func handleOpenAIWebTargetEmailChangeIfNeeded(
+        targetEmail: String?,
+        targetScope: CookieHeaderCache.Scope? = nil)
+    {
         let normalized = targetEmail?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
 
         guard let normalized, !normalized.isEmpty else { return }
 
-        let previous = self.lastOpenAIDashboardTargetEmail
+        let isolationKey = Self.openAIWebTargetIsolationKey(email: normalized, scope: targetScope)
+        let previousIsolationKey = self.lastOpenAIDashboardTargetIsolationKey
         self.lastOpenAIDashboardTargetEmail = normalized
+        self.lastOpenAIDashboardTargetIsolationKey = isolationKey
 
-        if let previous,
-           !previous.isEmpty,
-           previous != normalized
+        if let previousIsolationKey,
+           previousIsolationKey != isolationKey
         {
             let stamp = Date().formatted(date: .abbreviated, time: .shortened)
             self.logOpenAIWeb(
-                "[\(stamp)] Codex account changed: \(previous) → \(normalized); " +
-                    "clearing OpenAI web snapshot")
+                "[\(stamp)] Codex account source changed; clearing OpenAI web snapshot")
             self.openAIWebAccountDidChange = true
             self.openAIDashboard = nil
             self.openAIDashboardAttachmentAuthorized = false
@@ -831,6 +848,13 @@ extension UsageStore {
             self.lastOpenAIDashboardCookieImportAttemptAt = nil
             self.lastOpenAIDashboardCookieImportEmail = nil
         }
+    }
+
+    nonisolated static func openAIWebTargetIsolationKey(
+        email: String,
+        scope: CookieHeaderCache.Scope?) -> String
+    {
+        "\(email.lowercased())|\(scope?.isolationIdentifier ?? "live")"
     }
 
     func importOpenAIDashboardBrowserCookiesNow() async {
@@ -997,6 +1021,7 @@ extension UsageStore {
         }
         return try await OpenAIDashboardFetcher().loadLatestDashboard(
             accountEmail: accountEmail,
+            cacheScope: self.codexCookieCacheScopeForOpenAIWeb(),
             logger: logger,
             debugDumpHTML: timeout != Self.openAIWebPrimaryFetchTimeout,
             allowNavigationTimeoutRetry: allowNavigationTimeoutRetry,
@@ -1041,6 +1066,25 @@ extension UsageStore {
         ].joined(separator: " ")
     }
 
+    private func failClosedForMissingProfileCodexTarget() async -> String? {
+        self.applyOpenAIDashboardCleanup(Set(CodexDashboardCleanup.allCases), preserveVisibleDashboard: false)
+        self.openAIDashboardRequiresLogin = true
+        self.openAIDashboardCookieImportStatus = [
+            "The selected Codex profile has no verified account email.",
+            "Refresh the profile before importing OpenAI cookies.",
+        ].joined(separator: " ")
+        return nil
+    }
+
+    private func failClosedRefreshForMissingProfileCodexTarget() async {
+        self.applyOpenAIDashboardCleanup(Set(CodexDashboardCleanup.allCases), preserveVisibleDashboard: false)
+        self.openAIDashboardRequiresLogin = true
+        self.lastOpenAIDashboardError = [
+            "The selected Codex profile has no verified account email.",
+            "Refresh the profile before refreshing OpenAI web data.",
+        ].joined(separator: " ")
+    }
+
     private func openAIWebCookieImportShouldFailClosed() async -> Bool {
         if self.openAIWebManagedTargetStoreIsUnreadable() {
             _ = await self.failClosedForUnreadableManagedCodexStore()
@@ -1048,6 +1092,10 @@ extension UsageStore {
         }
         if self.openAIWebManagedTargetIsMissing() {
             _ = await self.failClosedForMissingManagedCodexTarget()
+            return true
+        }
+        if self.openAIWebProfileTargetEmailIsMissing() {
+            _ = await self.failClosedForMissingProfileCodexTarget()
             return true
         }
         return false
@@ -1266,6 +1314,7 @@ extension UsageStore {
         self.lastOpenAIDashboardSnapshot = nil
         self.lastOpenAIDashboardAttachmentAuthorized = false
         self.lastOpenAIDashboardTargetEmail = nil
+        self.lastOpenAIDashboardTargetIsolationKey = nil
         self.lastOpenAIDashboardAttemptAt = nil
         self.openAIDashboardRequiresLogin = false
         self.openAIDashboardCookieImportStatus = nil
@@ -1296,6 +1345,13 @@ extension UsageStore {
             return false
         }
         return self.selectedManagedCodexAccountForOpenAIWeb() == nil
+    }
+
+    private func openAIWebProfileTargetEmailIsMissing() -> Bool {
+        guard case let .profileHome(path) = self.settings.codexResolvedActiveSource else {
+            return false
+        }
+        return self.currentProfileCodexRuntimeEmail(path: path) == nil
     }
 
     private func selectedManagedCodexAccountForOpenAIWeb() -> ManagedCodexAccount? {
@@ -1344,8 +1400,8 @@ extension UsageStore {
             nil
         case let .managedAccount(id):
             self.openAIWebManagedTargetStoreIsUnreadable() ? .managedStoreUnreadable : .managedAccount(id)
-        case .profileHome:
-            nil
+        case let .profileHome(path):
+            .profileHome(path)
         }
     }
 }
@@ -1400,7 +1456,9 @@ extension UsageStore {
         let targetEmail = self.currentCodexOpenAIWebTargetEmail(
             allowCurrentSnapshotFallback: true,
             allowLastKnownLiveFallback: true)
-        self.handleOpenAIWebTargetEmailChangeIfNeeded(targetEmail: targetEmail)
+        self.handleOpenAIWebTargetEmailChangeIfNeeded(
+            targetEmail: targetEmail,
+            targetScope: self.codexCookieCacheScopeForOpenAIWeb())
     }
 
     func openAIDashboardFriendlyError(

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -378,6 +378,11 @@ extension UsageStore {
                 return true
             case .liveSystem:
                 return priorEmail != nil && priorEmail == accountEmail
+            case .profileHome:
+                if !allowProviderAccountAuthFingerprintMismatch {
+                    guard self.codexVisibleAccountAuthFingerprintMatches(prior, account: account) else { return false }
+                }
+                return priorEmail != nil && priorEmail == accountEmail
             }
         }
 
@@ -878,6 +883,8 @@ extension UsageStore {
                 return true
             case .liveSystem:
                 return prior.id == account.id
+            case .profileHome:
+                return true
             }
         }
 

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -173,6 +173,7 @@ final class UsageStore {
     @ObservationIgnored var lastOpenAIDashboardSnapshot: OpenAIDashboardSnapshot?
     @ObservationIgnored var lastOpenAIDashboardAttachmentAuthorized: Bool = false
     @ObservationIgnored var lastOpenAIDashboardTargetEmail: String?
+    @ObservationIgnored var lastOpenAIDashboardTargetIsolationKey: String?
     @ObservationIgnored var lastOpenAIDashboardAttemptAt: Date?
     @ObservationIgnored var lastOpenAIDashboardCookieImportAttemptAt: Date?
     @ObservationIgnored var lastOpenAIDashboardCookieImportEmail: String?

--- a/Sources/CodexBarCLI/TokenAccountCLI.swift
+++ b/Sources/CodexBarCLI/TokenAccountCLI.swift
@@ -296,9 +296,9 @@ struct TokenAccountCLIContext {
             config: providerConfig,
             selectedAccount: account)
         if provider == .codex,
-           let managedAccount = self.managedCodexAccount(for: codexActiveSourceOverride)
+           let codexHomePath = self.codexHomePath(for: codexActiveSourceOverride)
         {
-            env = CodexHomeScope.scopedEnvironment(base: env, codexHome: managedAccount.managedHomePath)
+            env = CodexHomeScope.scopedEnvironment(base: env, codexHome: codexHomePath)
         }
         return env
     }
@@ -460,12 +460,13 @@ struct TokenAccountCLIContext {
             storeLoader: storeLoader,
             activeSource: activeSource ?? self.providerConfig(for: .codex)?.codexActiveSource ?? .liveSystem,
             baseEnvironment: self.baseEnvironment,
+            profileHomePaths: self.providerConfig(for: .codex)?.codexProfileHomePaths ?? [],
             managedEnvironmentBuilder: { environment, account in
                 CodexHomeScope.scopedEnvironment(base: environment, codexHome: account.managedHomePath)
             })
     }
 
-    private func managedCodexAccount(for activeSourceOverride: CodexActiveSource?) -> ManagedCodexAccount? {
+    private func codexHomePath(for activeSourceOverride: CodexActiveSource?) -> String? {
         let activeSource: CodexActiveSource = if let activeSourceOverride {
             activeSourceOverride
         } else {
@@ -473,13 +474,23 @@ struct TokenAccountCLIContext {
                 .resolvedSource
         }
 
-        guard case let .managedAccount(id) = activeSource else { return nil }
-        let accounts: ManagedCodexAccountSet? = if let managedCodexAccountStoreURL {
-            try? FileManagedCodexAccountStore(fileURL: managedCodexAccountStoreURL).loadAccounts()
-        } else {
-            try? FileManagedCodexAccountStore().loadAccounts()
+        switch activeSource {
+        case .liveSystem:
+            return nil
+        case let .managedAccount(id):
+            let accounts: ManagedCodexAccountSet? = if let managedCodexAccountStoreURL {
+                try? FileManagedCodexAccountStore(fileURL: managedCodexAccountStoreURL).loadAccounts()
+            } else {
+                try? FileManagedCodexAccountStore().loadAccounts()
+            }
+            return accounts?.account(id: id)?.managedHomePath
+        case let .profileHome(path):
+            guard let normalizedPath = CodexHomeScope.normalizedHomePath(path) else { return nil }
+            let configuredPaths = self.providerConfig(for: .codex)?.codexProfileHomePaths ?? []
+            return configuredPaths.contains {
+                CodexHomeScope.normalizedHomePath($0) == normalizedPath
+            } ? normalizedPath : nil
         }
-        return accounts?.account(id: id)
     }
 
     private func manualCookieHeader(

--- a/Sources/CodexBarCore/CodexHomeScope.swift
+++ b/Sources/CodexBarCore/CodexHomeScope.swift
@@ -1,6 +1,24 @@
 import Foundation
 
 public enum CodexHomeScope {
+    public static func normalizedHomePath(
+        _ rawPath: String?,
+        fileManager: FileManager = .default)
+        -> String?
+    {
+        guard var path = rawPath?.trimmingCharacters(in: .whitespacesAndNewlines), !path.isEmpty else {
+            return nil
+        }
+        if path == "~" {
+            path = fileManager.homeDirectoryForCurrentUser.path
+        } else if path.hasPrefix("~/") {
+            path = fileManager.homeDirectoryForCurrentUser
+                .appendingPathComponent(String(path.dropFirst(2)), isDirectory: true)
+                .path
+        }
+        return URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL.path
+    }
+
     public static func ambientHomeURL(
         env: [String: String],
         fileManager: FileManager = .default)

--- a/Sources/CodexBarCore/CodexHomeScope.swift
+++ b/Sources/CodexBarCore/CodexHomeScope.swift
@@ -15,7 +15,10 @@ public enum CodexHomeScope {
             path = fileManager.homeDirectoryForCurrentUser
                 .appendingPathComponent(String(path.dropFirst(2)), isDirectory: true)
                 .path
+        } else if path.hasPrefix("~") {
+            return nil
         }
+        guard (path as NSString).isAbsolutePath else { return nil }
         return URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL.path
     }
 

--- a/Sources/CodexBarCore/Config/CodexActiveSource.swift
+++ b/Sources/CodexBarCore/Config/CodexActiveSource.swift
@@ -21,13 +21,23 @@ public enum CodexActiveSource: Codable, Equatable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         switch try container.decode(Kind.self, forKey: .kind) {
         case .liveSystem:
-            self = .liveSystem
+            if let path = try container.decodeIfPresent(String.self, forKey: .homePath),
+               !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                self = .profileHome(path: path)
+            } else {
+                self = .liveSystem
+            }
         case .managedAccount:
             let id = try container.decode(UUID.self, forKey: .accountID)
             self = .managedAccount(id: id)
         case .profileHome:
             let path = try container.decode(String.self, forKey: .homePath)
-            self = .profileHome(path: path)
+            if path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                self = .liveSystem
+            } else {
+                self = .profileHome(path: path)
+            }
         }
     }
 
@@ -40,7 +50,9 @@ public enum CodexActiveSource: Codable, Equatable, Sendable {
             try container.encode(Kind.managedAccount, forKey: .kind)
             try container.encode(id, forKey: .accountID)
         case let .profileHome(path):
-            try container.encode(Kind.profileHome, forKey: .kind)
+            // Released builds only understand liveSystem/managedAccount. Keep the envelope
+            // downgrade-readable while newer builds recover the profile selection from homePath.
+            try container.encode(Kind.liveSystem, forKey: .kind)
             try container.encode(path, forKey: .homePath)
         }
     }

--- a/Sources/CodexBarCore/Config/CodexActiveSource.swift
+++ b/Sources/CodexBarCore/Config/CodexActiveSource.swift
@@ -3,15 +3,18 @@ import Foundation
 public enum CodexActiveSource: Codable, Equatable, Sendable {
     case liveSystem
     case managedAccount(id: UUID)
+    case profileHome(path: String)
 
     private enum CodingKeys: String, CodingKey {
         case kind
         case accountID
+        case homePath
     }
 
     private enum Kind: String, Codable {
         case liveSystem
         case managedAccount
+        case profileHome
     }
 
     public init(from decoder: any Decoder) throws {
@@ -22,6 +25,9 @@ public enum CodexActiveSource: Codable, Equatable, Sendable {
         case .managedAccount:
             let id = try container.decode(UUID.self, forKey: .accountID)
             self = .managedAccount(id: id)
+        case .profileHome:
+            let path = try container.decode(String.self, forKey: .homePath)
+            self = .profileHome(path: path)
         }
     }
 
@@ -33,6 +39,9 @@ public enum CodexActiveSource: Codable, Equatable, Sendable {
         case let .managedAccount(id):
             try container.encode(Kind.managedAccount, forKey: .kind)
             try container.encode(id, forKey: .accountID)
+        case let .profileHome(path):
+            try container.encode(Kind.profileHome, forKey: .kind)
+            try container.encode(path, forKey: .homePath)
         }
     }
 }

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -107,6 +107,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
     public var enterpriseHost: String?
     public var tokenAccounts: ProviderTokenAccountData?
     public var codexActiveSource: CodexActiveSource?
+    public var codexProfileHomePaths: [String]?
     public var quotaWarnings: QuotaWarningConfig?
     public var kiloKnownOrganizations: [KiloOrganization]?
     public var kiloEnabledOrganizationIDs: [String]?
@@ -127,6 +128,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         enterpriseHost: String? = nil,
         tokenAccounts: ProviderTokenAccountData? = nil,
         codexActiveSource: CodexActiveSource? = nil,
+        codexProfileHomePaths: [String]? = nil,
         quotaWarnings: QuotaWarningConfig? = nil,
         kiloKnownOrganizations: [KiloOrganization]? = nil,
         kiloEnabledOrganizationIDs: [String]? = nil,
@@ -146,6 +148,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         self.enterpriseHost = enterpriseHost
         self.tokenAccounts = tokenAccounts
         self.codexActiveSource = codexActiveSource
+        self.codexProfileHomePaths = codexProfileHomePaths
         self.quotaWarnings = quotaWarnings
         self.kiloKnownOrganizations = kiloKnownOrganizations
         self.kiloEnabledOrganizationIDs = kiloEnabledOrganizationIDs

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
@@ -11,14 +14,35 @@ public enum CookieHeaderCache {
     public enum Scope: Sendable, Equatable {
         case managedAccount(UUID)
         case managedStoreUnreadable
+        case profileHome(String)
 
-        fileprivate var keychainIdentifier: String {
+        public var isolationIdentifier: String {
             switch self {
             case let .managedAccount(accountID):
                 "managed.\(accountID.uuidString.lowercased())"
             case .managedStoreUnreadable:
                 "managed-store-unreadable"
+            case let .profileHome(path):
+                "profile-home.\(Self.profileHomeDigest(path))"
             }
+        }
+
+        fileprivate var keychainIdentifier: String {
+            self.isolationIdentifier
+        }
+
+        private static func profileHomeDigest(_ path: String) -> String {
+            let standardized = URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL.path
+            #if canImport(CryptoKit)
+            return SHA256.hash(data: Data(standardized.utf8))
+                .map { String(format: "%02x", $0) }
+                .joined()
+            #else
+            let digest = standardized.utf8.reduce(UInt64(14_695_981_039_346_656_037)) { partial, byte in
+                (partial ^ UInt64(byte)) &* 1_099_511_628_211
+            }
+            return String(digest, radix: 16)
+            #endif
         }
     }
 

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardBrowserCookieImporter.swift
@@ -4,6 +4,7 @@ import SweetCookieKit
 import WebKit
 
 @MainActor
+// swiftlint:disable:next type_body_length
 public struct OpenAIDashboardBrowserCookieImporter {
     public struct FoundAccount: Sendable, Hashable {
         public let sourceLabel: String
@@ -94,6 +95,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
         let targetEmail: String?
         let allowAnyAccount: Bool
         let cacheScope: CookieHeaderCache.Scope?
+        let deadline: Date?
     }
 
     private static let cookieDomains = ["chatgpt.com", "openai.com"]
@@ -126,7 +128,8 @@ public struct OpenAIDashboardBrowserCookieImporter {
         let context = ImportContext(
             targetEmail: normalizedTarget,
             allowAnyAccount: allowAnyAccount,
-            cacheScope: cacheScope)
+            cacheScope: cacheScope,
+            deadline: deadline)
 
         if normalizedTarget != nil {
             log("Codex email known; matching required.")
@@ -219,7 +222,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
         cookieHeader: String,
         intoAccountEmail targetEmail: String?,
         allowAnyAccount: Bool = false,
-        cacheScope _: CookieHeaderCache.Scope? = nil,
+        cacheScope: CookieHeaderCache.Scope? = nil,
         deadline: Date? = nil,
         logger: ((String) -> Void)? = nil) async throws -> ImportResult
     {
@@ -249,14 +252,14 @@ public struct OpenAIDashboardBrowserCookieImporter {
             return try await self.persistVerifiedCandidate(
                 candidate: candidate,
                 targetEmail: signedInEmail,
-                verifiedSignedInEmail: signedInEmail,
+                cacheScope: cacheScope,
                 deadline: deadline,
                 logger: log)
         case let .loggedIn(_, signedInEmail):
             return try await self.persistVerifiedCandidate(
                 candidate: candidate,
                 targetEmail: signedInEmail,
-                verifiedSignedInEmail: signedInEmail,
+                cacheScope: cacheScope,
                 deadline: deadline,
                 logger: log)
         case let .mismatch(_, signedInEmail):
@@ -429,7 +432,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
             if let result = try? await self.persistVerifiedCandidate(
                 candidate: candidate,
                 targetEmail: targetEmail,
-                verifiedSignedInEmail: signedInEmail,
+                cacheScope: context.cacheScope,
                 deadline: deadline,
                 logger: log)
             {
@@ -446,7 +449,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
             try await self.handleMismatch(
                 candidate: candidate,
                 signedInEmail: signedInEmail,
-                deadline: deadline,
+                context: context,
                 log: log,
                 diagnostics: &diagnostics)
             _ = try Self.remainingTimeout(until: deadline)
@@ -456,7 +459,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
             if let result = try? await self.persistVerifiedCandidate(
                 candidate: candidate,
                 targetEmail: signedInEmail,
-                verifiedSignedInEmail: signedInEmail,
+                cacheScope: context.cacheScope,
                 deadline: deadline,
                 logger: log)
             {
@@ -574,24 +577,24 @@ public struct OpenAIDashboardBrowserCookieImporter {
     private func handleMismatch(
         candidate: Candidate,
         signedInEmail: String,
-        deadline: Date?,
+        context: ImportContext,
         log: @escaping (String) -> Void,
         diagnostics: inout ImportDiagnostics) async throws
     {
         log("Candidate \(candidate.label) mismatch (\(signedInEmail)); continuing browser search")
         diagnostics.mismatches.append(FoundAccount(sourceLabel: candidate.label, email: signedInEmail))
-        // Mismatch still means we found a valid signed-in session. Persist it keyed by its email so if
-        // the user switches Codex accounts later, we can reuse this session immediately without another
-        // Keychain prompt.
+        // Mismatch still means we found a valid signed-in session. Keep it inside the active source scope;
+        // a profile import must never populate the live account or another profile's WebKit store.
         do {
             try await self.persistCookies(
                 candidate: candidate,
                 accountEmail: signedInEmail,
-                deadline: deadline,
+                cacheScope: context.cacheScope,
+                deadline: context.deadline,
                 logger: log)
         } catch {
             log("Could not cache mismatched session: \(error.localizedDescription)")
-            _ = try Self.remainingTimeout(until: deadline)
+            _ = try Self.remainingTimeout(until: context.deadline)
         }
     }
 
@@ -663,7 +666,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
     private func persistVerifiedCandidate(
         candidate: Candidate,
         targetEmail: String,
-        verifiedSignedInEmail: String,
+        cacheScope: CookieHeaderCache.Scope?,
         deadline: Date?,
         logger: @escaping (String) -> Void) async throws -> ImportResult
     {
@@ -671,6 +674,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
             return try await self.persist(
                 candidate: candidate,
                 targetEmail: targetEmail,
+                cacheScope: cacheScope,
                 deadline: deadline,
                 logger: logger)
         } catch {
@@ -678,7 +682,7 @@ public struct OpenAIDashboardBrowserCookieImporter {
                 throw error
             }
 
-            let signedInEmail = verifiedSignedInEmail.trimmingCharacters(in: .whitespacesAndNewlines)
+            let signedInEmail = targetEmail.trimmingCharacters(in: .whitespacesAndNewlines)
             logger(
                 "Persistent validation timed out after session verification; " +
                     "keeping \(candidate.label) cookies for \(signedInEmail).")
@@ -693,10 +697,13 @@ public struct OpenAIDashboardBrowserCookieImporter {
     private func persist(
         candidate: Candidate,
         targetEmail: String,
+        cacheScope: CookieHeaderCache.Scope?,
         deadline: Date?,
         logger: @escaping (String) -> Void) async throws -> ImportResult
     {
-        let persistent = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: targetEmail)
+        let persistent = OpenAIDashboardWebsiteDataStore.store(
+            forAccountEmail: targetEmail,
+            scope: cacheScope)
         try await self.clearChatGPTCookies(in: persistent, deadline: deadline)
         try await self.setCookies(candidate.cookies, into: persistent, deadline: deadline)
 
@@ -820,10 +827,11 @@ public struct OpenAIDashboardBrowserCookieImporter {
     private func persistCookies(
         candidate: Candidate,
         accountEmail: String,
+        cacheScope: CookieHeaderCache.Scope?,
         deadline: Date?,
         logger: (String) -> Void) async throws
     {
-        let store = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: accountEmail)
+        let store = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: accountEmail, scope: cacheScope)
         try await self.clearChatGPTCookies(in: store, deadline: deadline)
         try await self.setCookies(candidate.cookies, into: store, deadline: deadline)
         logger("Persisted cookies for \(accountEmail) (source=\(candidate.label))")

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -205,12 +205,13 @@ public struct OpenAIDashboardFetcher {
 
     public func loadLatestDashboard(
         accountEmail: String?,
+        cacheScope: CookieHeaderCache.Scope? = nil,
         logger: ((String) -> Void)? = nil,
         debugDumpHTML: Bool = false,
         allowNavigationTimeoutRetry: Bool = true,
         timeout: TimeInterval = 60) async throws -> OpenAIDashboardSnapshot
     {
-        let store = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: accountEmail)
+        let store = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: accountEmail, scope: cacheScope)
         return try await self.loadLatestDashboard(
             websiteDataStore: store,
             logger: logger,
@@ -413,10 +414,13 @@ public struct OpenAIDashboardFetcher {
         hasReturnableData || creditsHeaderPresent
     }
 
-    public func clearSessionData(accountEmail: String?) async {
-        let store = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: accountEmail)
+    public func clearSessionData(
+        accountEmail: String?,
+        cacheScope: CookieHeaderCache.Scope? = nil) async
+    {
+        let store = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: accountEmail, scope: cacheScope)
         OpenAIDashboardWebViewCache.shared.evict(websiteDataStore: store)
-        await OpenAIDashboardWebsiteDataStore.clearStore(forAccountEmail: accountEmail)
+        await OpenAIDashboardWebsiteDataStore.clearStore(forAccountEmail: accountEmail, scope: cacheScope)
     }
 
     public static func evictAllCachedWebViews() {

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -1081,6 +1081,7 @@ public struct OpenAIDashboardFetcher {
 
     public func loadLatestDashboard(
         accountEmail _: String?,
+        cacheScope _: CookieHeaderCache.Scope? = nil,
         logger _: ((String) -> Void)? = nil,
         debugDumpHTML _: Bool = false,
         allowNavigationTimeoutRetry _: Bool = true,

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebsiteDataStore.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebsiteDataStore.swift
@@ -9,28 +9,32 @@ import WebKit
 /// we want to keep multiple signed-in dashboard sessions around (one per email) without clearing cookies.
 ///
 /// Implementation detail: macOS 14+ supports `WKWebsiteDataStore.dataStore(forIdentifier:)`, which creates
-/// persistent isolated stores keyed by an identifier. We derive a stable UUID from the email so the same
-/// account always maps to the same cookie store.
+/// persistent isolated stores keyed by an identifier. We derive a stable UUID from the email and optional
+/// Codex source scope so distinct profiles with the same email never share a cookie store.
 ///
 /// Important: We cache the `WKWebsiteDataStore` instances so the same object is returned for the same
 /// account email. This ensures `OpenAIDashboardWebViewCache` can use object identity for cache lookups.
 @MainActor
 public enum OpenAIDashboardWebsiteDataStore {
-    /// Cached data store instances keyed by normalized email.
+    /// Cached data store instances keyed by normalized email and optional Codex source scope.
     /// Using the same instance ensures stable object identity for WebView cache lookups.
     private static var cachedStores: [String: WKWebsiteDataStore] = [:]
 
-    public static func store(forAccountEmail email: String?) -> WKWebsiteDataStore {
+    public static func store(
+        forAccountEmail email: String?,
+        scope: CookieHeaderCache.Scope? = nil) -> WKWebsiteDataStore
+    {
         guard let normalized = normalizeEmail(email) else { return .default() }
+        let storageKey = self.storageKey(normalizedEmail: normalized, scope: scope)
 
         // Return cached instance if available to maintain stable object identity
-        if let cached = cachedStores[normalized] {
+        if let cached = cachedStores[storageKey] {
             return cached
         }
 
-        let id = Self.identifier(forNormalizedEmail: normalized)
+        let id = Self.identifier(forStorageKey: storageKey)
         let store = WKWebsiteDataStore(forIdentifier: id)
-        self.cachedStores[normalized] = store
+        self.cachedStores[storageKey] = store
         return store
     }
 
@@ -38,10 +42,13 @@ public enum OpenAIDashboardWebsiteDataStore {
     ///
     /// Note: this does *not* impact other accounts, and is safe to use when the stored session is "stuck"
     /// or signed in to a different account than expected.
-    public static func clearStore(forAccountEmail email: String?) async {
+    public static func clearStore(
+        forAccountEmail email: String?,
+        scope: CookieHeaderCache.Scope? = nil) async
+    {
         // Clear only ChatGPT/OpenAI domain data for the per-account store.
         // Avoid deleting the entire persistent store (WebKit requires all WKWebViews using it to be released).
-        let store = self.store(forAccountEmail: email)
+        let store = self.store(forAccountEmail: email, scope: scope)
         await withCheckedContinuation { cont in
             store.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in
                 let filtered = records.filter { record in
@@ -56,7 +63,7 @@ public enum OpenAIDashboardWebsiteDataStore {
 
         // Remove from cache so a fresh instance is created on next access
         if let normalized = normalizeEmail(email) {
-            self.cachedStores.removeValue(forKey: normalized)
+            self.cachedStores.removeValue(forKey: self.storageKey(normalizedEmail: normalized, scope: scope))
         }
     }
 
@@ -74,8 +81,12 @@ public enum OpenAIDashboardWebsiteDataStore {
         return raw.lowercased()
     }
 
-    private static func identifier(forNormalizedEmail email: String) -> UUID {
-        let digest = SHA256.hash(data: Data(email.utf8))
+    private static func storageKey(normalizedEmail: String, scope: CookieHeaderCache.Scope?) -> String {
+        "\(normalizedEmail)|\(scope?.isolationIdentifier ?? "live")"
+    }
+
+    private static func identifier(forStorageKey storageKey: String) -> UUID {
+        let digest = SHA256.hash(data: Data(storageKey.utf8))
         var bytes = Array(digest.prefix(16))
 
         // Make it a well-formed UUID (v4 + RFC4122 variant) while staying deterministic.

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebsiteDataStore.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebsiteDataStore.swift
@@ -72,6 +72,7 @@ public enum OpenAIDashboardWebsiteDataStore {
     public static func clearCacheForTesting() {
         self.cachedStores.removeAll()
     }
+
     #endif
 
     // MARK: - Private
@@ -82,7 +83,8 @@ public enum OpenAIDashboardWebsiteDataStore {
     }
 
     private static func storageKey(normalizedEmail: String, scope: CookieHeaderCache.Scope?) -> String {
-        "\(normalizedEmail)|\(scope?.isolationIdentifier ?? "live")"
+        guard let scope else { return normalizedEmail }
+        return "\(normalizedEmail)|\(scope.isolationIdentifier)"
     }
 
     private static func identifier(forStorageKey storageKey: String) -> UUID {

--- a/Sources/CodexBarCore/Providers/Codex/CodexAccountReconciliation.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexAccountReconciliation.swift
@@ -22,16 +22,13 @@ public enum CodexActiveSourceResolver {
             .liveSystem
         case let .managedAccount(id):
             if let activeStoredAccount = snapshot.activeStoredAccount {
-                self.matchesLiveSystemAccount(
-                    storedAccount: activeStoredAccount,
-                    snapshot: snapshot,
-                    liveSystemAccount: snapshot.liveSystemAccount) ? .liveSystem : .managedAccount(id: id)
+                self.resolvedSource(for: activeStoredAccount, snapshot: snapshot)
             } else {
                 snapshot.liveSystemAccount != nil ? .liveSystem : .managedAccount(id: id)
             }
         case let .profileHome(path):
             if let normalizedPath = snapshot.configuredProfileHomePath(path: path) {
-                .profileHome(path: normalizedPath)
+                self.resolvedProfileSource(path: normalizedPath, snapshot: snapshot)
             } else {
                 .liveSystem
             }
@@ -40,6 +37,35 @@ public enum CodexActiveSourceResolver {
         return CodexResolvedActiveSource(
             persistedSource: persistedSource,
             resolvedSource: resolvedSource)
+    }
+
+    private static func resolvedProfileSource(
+        path: String,
+        snapshot: CodexAccountReconciliationSnapshot) -> CodexActiveSource
+    {
+        if let livePath = snapshot.liveSystemAccount.flatMap({
+            CodexHomeScope.normalizedHomePath($0.codexHomePath)
+        }), livePath == path {
+            return .liveSystem
+        }
+
+        if let storedAccount = snapshot.storedAccounts.first(where: {
+            CodexHomeScope.normalizedHomePath($0.managedHomePath) == path
+        }) {
+            return self.resolvedSource(for: storedAccount, snapshot: snapshot)
+        }
+
+        return .profileHome(path: path)
+    }
+
+    private static func resolvedSource(
+        for storedAccount: ManagedCodexAccount,
+        snapshot: CodexAccountReconciliationSnapshot) -> CodexActiveSource
+    {
+        self.matchesLiveSystemAccount(
+            storedAccount: storedAccount,
+            snapshot: snapshot,
+            liveSystemAccount: snapshot.liveSystemAccount) ? .liveSystem : .managedAccount(id: storedAccount.id)
     }
 
     private static func matchesLiveSystemAccount(

--- a/Sources/CodexBarCore/Providers/Codex/CodexAccountReconciliation.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexAccountReconciliation.swift
@@ -29,6 +29,8 @@ public enum CodexActiveSourceResolver {
             } else {
                 snapshot.liveSystemAccount != nil ? .liveSystem : .managedAccount(id: id)
             }
+        case let .profileHome(path):
+            .profileHome(path: CodexHomeScope.normalizedHomePath(path) ?? path)
         }
 
         return CodexResolvedActiveSource(
@@ -60,6 +62,7 @@ public struct CodexAccountReconciliationSnapshot: Equatable, Sendable {
     public let storedAccounts: [ManagedCodexAccount]
     public let activeStoredAccount: ManagedCodexAccount?
     public let liveSystemAccount: ObservedSystemCodexAccount?
+    public let profileHomeAccounts: [ObservedSystemCodexAccount]
     public let matchingStoredAccountForLiveSystemAccount: ManagedCodexAccount?
     public let activeSource: CodexActiveSource
     public let hasUnreadableAddedAccountStore: Bool
@@ -70,6 +73,7 @@ public struct CodexAccountReconciliationSnapshot: Equatable, Sendable {
         storedAccounts: [ManagedCodexAccount],
         activeStoredAccount: ManagedCodexAccount?,
         liveSystemAccount: ObservedSystemCodexAccount?,
+        profileHomeAccounts: [ObservedSystemCodexAccount] = [],
         matchingStoredAccountForLiveSystemAccount: ManagedCodexAccount?,
         activeSource: CodexActiveSource,
         hasUnreadableAddedAccountStore: Bool,
@@ -79,6 +83,7 @@ public struct CodexAccountReconciliationSnapshot: Equatable, Sendable {
         self.storedAccounts = storedAccounts
         self.activeStoredAccount = activeStoredAccount
         self.liveSystemAccount = liveSystemAccount
+        self.profileHomeAccounts = Self.uniqueProfileHomeAccounts(profileHomeAccounts)
         self.matchingStoredAccountForLiveSystemAccount = matchingStoredAccountForLiveSystemAccount
         self.activeSource = activeSource
         self.hasUnreadableAddedAccountStore = hasUnreadableAddedAccountStore
@@ -90,6 +95,7 @@ public struct CodexAccountReconciliationSnapshot: Equatable, Sendable {
         lhs.storedAccounts.map(AccountIdentity.init) == rhs.storedAccounts.map(AccountIdentity.init)
             && lhs.activeStoredAccount.map(AccountIdentity.init) == rhs.activeStoredAccount.map(AccountIdentity.init)
             && lhs.liveSystemAccount == rhs.liveSystemAccount
+            && lhs.profileHomeAccounts == rhs.profileHomeAccounts
             && lhs.matchingStoredAccountForLiveSystemAccount.map(AccountIdentity.init)
             == rhs.matchingStoredAccountForLiveSystemAccount.map(AccountIdentity.init)
             && lhs.activeSource == rhs.activeSource
@@ -114,8 +120,28 @@ public struct CodexAccountReconciliationSnapshot: Equatable, Sendable {
             fallbackEmail: liveSystemAccount.email)
     }
 
+    public func profileHomeAccount(path: String) -> ObservedSystemCodexAccount? {
+        guard let normalizedPath = CodexHomeScope.normalizedHomePath(path) else { return nil }
+        return self.profileHomeAccounts.first {
+            CodexHomeScope.normalizedHomePath($0.codexHomePath) == normalizedPath
+        }
+    }
+
     private static func normalizeEmail(_ email: String) -> String {
         email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+
+    private static func uniqueProfileHomeAccounts(
+        _ accounts: [ObservedSystemCodexAccount]) -> [ObservedSystemCodexAccount]
+    {
+        var seenPaths: Set<String> = []
+        var result: [ObservedSystemCodexAccount] = []
+        for account in accounts {
+            let path = CodexHomeScope.normalizedHomePath(account.codexHomePath) ?? account.codexHomePath
+            guard seenPaths.insert(path).inserted else { continue }
+            result.append(account)
+        }
+        return result
     }
 }
 
@@ -124,6 +150,7 @@ public struct DefaultCodexAccountReconciler: Sendable {
     public let systemObserver: any CodexSystemAccountObserving
     public let activeSource: CodexActiveSource
     public let baseEnvironment: [String: String]
+    public let profileHomePaths: [String]
     public let managedEnvironmentBuilder: @Sendable ([String: String], ManagedCodexAccount) -> [String: String]
 
     public init(
@@ -133,6 +160,7 @@ public struct DefaultCodexAccountReconciler: Sendable {
         systemObserver: any CodexSystemAccountObserving = DefaultCodexSystemAccountObserver(),
         activeSource: CodexActiveSource = .liveSystem,
         baseEnvironment: [String: String],
+        profileHomePaths: [String] = [],
         managedEnvironmentBuilder: @escaping @Sendable ([String: String], ManagedCodexAccount)
             -> [String: String] = { baseEnvironment, account in
                 CodexHomeScope.scopedEnvironment(base: baseEnvironment, codexHome: account.managedHomePath)
@@ -142,11 +170,13 @@ public struct DefaultCodexAccountReconciler: Sendable {
         self.systemObserver = systemObserver
         self.activeSource = activeSource
         self.baseEnvironment = baseEnvironment
+        self.profileHomePaths = Self.uniqueNormalizedPaths(profileHomePaths)
         self.managedEnvironmentBuilder = managedEnvironmentBuilder
     }
 
     public func loadSnapshot() -> CodexAccountReconciliationSnapshot {
         let liveSystemAccount = self.loadLiveSystemAccount()
+        let profileHomeAccounts = self.loadProfileHomeAccounts(liveSystemAccount: liveSystemAccount)
 
         do {
             let accounts = try self.storeLoader()
@@ -157,7 +187,7 @@ public struct DefaultCodexAccountReconciler: Sendable {
             let activeStoredAccount: ManagedCodexAccount? = switch self.activeSource {
             case let .managedAccount(id):
                 accounts.account(id: id)
-            case .liveSystem:
+            case .liveSystem, .profileHome:
                 nil
             }
             let matchingStoredAccountForLiveSystemAccount = liveSystemAccount.flatMap { liveAccount in
@@ -182,6 +212,9 @@ public struct DefaultCodexAccountReconciler: Sendable {
                 storedAccounts: accounts.accounts,
                 activeStoredAccount: activeStoredAccount,
                 liveSystemAccount: liveSystemAccount,
+                profileHomeAccounts: self.profileHomeAccounts(
+                    profileHomeAccounts,
+                    excludingManagedAccounts: accounts.accounts),
                 matchingStoredAccountForLiveSystemAccount: matchingStoredAccountForLiveSystemAccount,
                 activeSource: self.activeSource,
                 hasUnreadableAddedAccountStore: false,
@@ -192,10 +225,47 @@ public struct DefaultCodexAccountReconciler: Sendable {
                 storedAccounts: [],
                 activeStoredAccount: nil,
                 liveSystemAccount: liveSystemAccount,
+                profileHomeAccounts: profileHomeAccounts,
                 matchingStoredAccountForLiveSystemAccount: nil,
                 activeSource: self.activeSource,
                 hasUnreadableAddedAccountStore: true)
         }
+    }
+
+    private func loadProfileHomeAccounts(
+        liveSystemAccount: ObservedSystemCodexAccount?) -> [ObservedSystemCodexAccount]
+    {
+        let livePath = liveSystemAccount.flatMap { CodexHomeScope.normalizedHomePath($0.codexHomePath) }
+        return self.profileHomePaths.compactMap { path in
+            guard path != livePath else { return nil }
+            return self.loadProfileHomeAccount(homePath: path)
+        }
+    }
+
+    private func loadProfileHomeAccount(homePath: String) -> ObservedSystemCodexAccount? {
+        let environment = CodexHomeScope.scopedEnvironment(base: self.baseEnvironment, codexHome: homePath)
+        let account = UsageFetcher(environment: environment).loadAuthBackedCodexAccount()
+
+        guard let rawEmail = account.email?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawEmail.isEmpty
+        else {
+            return nil
+        }
+
+        let providerAccountID: String? = switch account.identity {
+        case let .providerAccount(id):
+            ManagedCodexAccount.normalizeProviderAccountID(id)
+        case .emailOnly, .unresolved:
+            nil
+        }
+
+        return ObservedSystemCodexAccount(
+            email: rawEmail.lowercased(),
+            workspaceAccountID: providerAccountID,
+            authFingerprint: CodexAuthFingerprint.fingerprint(homePath: homePath),
+            codexHomePath: homePath,
+            observedAt: Date(),
+            identity: account.identity)
     }
 
     private func loadLiveSystemAccount() -> ObservedSystemCodexAccount? {
@@ -235,10 +305,31 @@ public struct DefaultCodexAccountReconciler: Sendable {
             identity: identity)
     }
 
+    private func profileHomeAccounts(
+        _ profileHomeAccounts: [ObservedSystemCodexAccount],
+        excludingManagedAccounts managedAccounts: [ManagedCodexAccount]) -> [ObservedSystemCodexAccount]
+    {
+        let managedPaths = Set(managedAccounts.compactMap { CodexHomeScope.normalizedHomePath($0.managedHomePath) })
+        return profileHomeAccounts.filter { account in
+            guard let path = CodexHomeScope.normalizedHomePath(account.codexHomePath) else { return false }
+            return !managedPaths.contains(path)
+        }
+    }
+
     private func runtimeIdentity(for liveSystemAccount: ObservedSystemCodexAccount) -> CodexIdentity {
         CodexIdentityMatcher.normalized(
             liveSystemAccount.identity,
             fallbackEmail: liveSystemAccount.email)
+    }
+
+    private static func uniqueNormalizedPaths(_ paths: [String]) -> [String] {
+        var seen: Set<String> = []
+        var result: [String] = []
+        for path in paths.compactMap({ CodexHomeScope.normalizedHomePath($0) }) {
+            guard seen.insert(path).inserted else { continue }
+            result.append(path)
+        }
+        return result
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexAccountReconciliation.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexAccountReconciliation.swift
@@ -30,7 +30,11 @@ public enum CodexActiveSourceResolver {
                 snapshot.liveSystemAccount != nil ? .liveSystem : .managedAccount(id: id)
             }
         case let .profileHome(path):
-            .profileHome(path: CodexHomeScope.normalizedHomePath(path) ?? path)
+            if let normalizedPath = snapshot.configuredProfileHomePath(path: path) {
+                .profileHome(path: normalizedPath)
+            } else {
+                .liveSystem
+            }
         }
 
         return CodexResolvedActiveSource(
@@ -63,6 +67,7 @@ public struct CodexAccountReconciliationSnapshot: Equatable, Sendable {
     public let activeStoredAccount: ManagedCodexAccount?
     public let liveSystemAccount: ObservedSystemCodexAccount?
     public let profileHomeAccounts: [ObservedSystemCodexAccount]
+    public let profileHomePaths: [String]
     public let matchingStoredAccountForLiveSystemAccount: ManagedCodexAccount?
     public let activeSource: CodexActiveSource
     public let hasUnreadableAddedAccountStore: Bool
@@ -74,6 +79,7 @@ public struct CodexAccountReconciliationSnapshot: Equatable, Sendable {
         activeStoredAccount: ManagedCodexAccount?,
         liveSystemAccount: ObservedSystemCodexAccount?,
         profileHomeAccounts: [ObservedSystemCodexAccount] = [],
+        profileHomePaths: [String]? = nil,
         matchingStoredAccountForLiveSystemAccount: ManagedCodexAccount?,
         activeSource: CodexActiveSource,
         hasUnreadableAddedAccountStore: Bool,
@@ -84,6 +90,8 @@ public struct CodexAccountReconciliationSnapshot: Equatable, Sendable {
         self.activeStoredAccount = activeStoredAccount
         self.liveSystemAccount = liveSystemAccount
         self.profileHomeAccounts = Self.uniqueProfileHomeAccounts(profileHomeAccounts)
+        self.profileHomePaths = Self.uniqueNormalizedPaths(
+            profileHomePaths ?? profileHomeAccounts.map(\.codexHomePath))
         self.matchingStoredAccountForLiveSystemAccount = matchingStoredAccountForLiveSystemAccount
         self.activeSource = activeSource
         self.hasUnreadableAddedAccountStore = hasUnreadableAddedAccountStore
@@ -96,6 +104,7 @@ public struct CodexAccountReconciliationSnapshot: Equatable, Sendable {
             && lhs.activeStoredAccount.map(AccountIdentity.init) == rhs.activeStoredAccount.map(AccountIdentity.init)
             && lhs.liveSystemAccount == rhs.liveSystemAccount
             && lhs.profileHomeAccounts == rhs.profileHomeAccounts
+            && lhs.profileHomePaths == rhs.profileHomePaths
             && lhs.matchingStoredAccountForLiveSystemAccount.map(AccountIdentity.init)
             == rhs.matchingStoredAccountForLiveSystemAccount.map(AccountIdentity.init)
             && lhs.activeSource == rhs.activeSource
@@ -127,6 +136,15 @@ public struct CodexAccountReconciliationSnapshot: Equatable, Sendable {
         }
     }
 
+    public func configuredProfileHomePath(path: String) -> String? {
+        guard let normalizedPath = CodexHomeScope.normalizedHomePath(path),
+              self.profileHomePaths.contains(normalizedPath)
+        else {
+            return nil
+        }
+        return normalizedPath
+    }
+
     private static func normalizeEmail(_ email: String) -> String {
         email.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
@@ -142,6 +160,18 @@ public struct CodexAccountReconciliationSnapshot: Equatable, Sendable {
             result.append(account)
         }
         return result
+    }
+
+    private static func uniqueNormalizedPaths(_ paths: [String]) -> [String] {
+        var seen: Set<String> = []
+        return paths.compactMap { path in
+            guard let normalizedPath = CodexHomeScope.normalizedHomePath(path),
+                  seen.insert(normalizedPath).inserted
+            else {
+                return nil
+            }
+            return normalizedPath
+        }
     }
 }
 
@@ -215,6 +245,7 @@ public struct DefaultCodexAccountReconciler: Sendable {
                 profileHomeAccounts: self.profileHomeAccounts(
                     profileHomeAccounts,
                     excludingManagedAccounts: accounts.accounts),
+                profileHomePaths: self.profileHomePaths,
                 matchingStoredAccountForLiveSystemAccount: matchingStoredAccountForLiveSystemAccount,
                 activeSource: self.activeSource,
                 hasUnreadableAddedAccountStore: false,
@@ -226,6 +257,7 @@ public struct DefaultCodexAccountReconciler: Sendable {
                 activeStoredAccount: nil,
                 liveSystemAccount: liveSystemAccount,
                 profileHomeAccounts: profileHomeAccounts,
+                profileHomePaths: self.profileHomePaths,
                 matchingStoredAccountForLiveSystemAccount: nil,
                 activeSource: self.activeSource,
                 hasUnreadableAddedAccountStore: true)

--- a/Sources/CodexBarCore/Providers/Codex/CodexDashboardAuthority.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexDashboardAuthority.swift
@@ -30,10 +30,16 @@ public enum CodexDashboardCleanup: String, Codable, CaseIterable, Hashable, Send
 public struct CodexDashboardKnownOwnerCandidate: Equatable, Hashable, Sendable {
     public let identity: CodexIdentity
     public let normalizedEmail: String?
+    public let sourceIsolationIdentifier: String?
 
-    public init(identity: CodexIdentity, normalizedEmail: String?) {
+    public init(
+        identity: CodexIdentity,
+        normalizedEmail: String?,
+        sourceIsolationIdentifier: String? = nil)
+    {
         self.identity = identity
         self.normalizedEmail = normalizedEmail
+        self.sourceIsolationIdentifier = sourceIsolationIdentifier
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -48,6 +54,7 @@ public struct CodexDashboardKnownOwnerCandidate: Equatable, Hashable, Sendable {
             hasher.combine("unresolved")
         }
         hasher.combine(self.normalizedEmail)
+        hasher.combine(self.sourceIsolationIdentifier)
     }
 }
 
@@ -273,7 +280,8 @@ public enum CodexDashboardAuthority {
         Set(candidates.map { candidate in
             CodexDashboardKnownOwnerCandidate(
                 identity: self.normalizeIdentity(candidate.identity),
-                normalizedEmail: CodexIdentityResolver.normalizeEmail(candidate.normalizedEmail))
+                normalizedEmail: CodexIdentityResolver.normalizeEmail(candidate.normalizedEmail),
+                sourceIsolationIdentifier: candidate.sourceIsolationIdentifier)
         })
     }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexDashboardAuthority.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexDashboardAuthority.swift
@@ -278,10 +278,17 @@ public enum CodexDashboardAuthority {
         -> Set<CodexDashboardKnownOwnerCandidate>
     {
         Set(candidates.map { candidate in
-            CodexDashboardKnownOwnerCandidate(
-                identity: self.normalizeIdentity(candidate.identity),
+            let identity = self.normalizeIdentity(candidate.identity)
+            let sourceIsolationIdentifier: String? = switch identity {
+            case .providerAccount:
+                nil
+            case .emailOnly, .unresolved:
+                candidate.sourceIsolationIdentifier
+            }
+            return CodexDashboardKnownOwnerCandidate(
+                identity: identity,
                 normalizedEmail: CodexIdentityResolver.normalizeEmail(candidate.normalizedEmail),
-                sourceIsolationIdentifier: candidate.sourceIsolationIdentifier)
+                sourceIsolationIdentifier: sourceIsolationIdentifier)
         })
     }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexDashboardAuthority.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexDashboardAuthority.swift
@@ -179,15 +179,6 @@ public enum CodexDashboardAuthority {
 
         switch currentIdentity {
         case let .providerAccount(id):
-            let exactMatch = knownOwners.contains { candidate in
-                candidate.identity == .providerAccount(id: id) && candidate.normalizedEmail == dashboardSignedInEmail
-            }
-            if exactMatch {
-                return Self.makeDecision(
-                    disposition: .attach,
-                    reason: .exactProviderAccountMatch,
-                    sourceKind: input.sourceKind)
-            }
             guard expectedScopedEmail != nil else {
                 return Self.makeDecision(
                     disposition: .failClosed,
@@ -198,6 +189,15 @@ public enum CodexDashboardAuthority {
                 return Self.makeDecision(
                     disposition: .displayOnly,
                     reason: .sameEmailAmbiguity(email: dashboardSignedInEmail),
+                    sourceKind: input.sourceKind)
+            }
+            let exactMatch = knownOwners.contains { candidate in
+                candidate.identity == .providerAccount(id: id) && candidate.normalizedEmail == dashboardSignedInEmail
+            }
+            if exactMatch {
+                return Self.makeDecision(
+                    disposition: .attach,
+                    reason: .exactProviderAccountMatch,
                     sourceKind: input.sourceKind)
             }
             return Self.makeDecision(

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderSettingsBuilder.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderSettingsBuilder.swift
@@ -38,6 +38,12 @@ public enum CodexKnownOwnerCatalog {
                 normalizedEmail: CodexIdentityResolver.normalizeEmail(liveSystemAccount.email)))
         }
 
+        for profileAccount in snapshot.profileHomeAccounts {
+            candidates.append(CodexDashboardKnownOwnerCandidate(
+                identity: snapshot.runtimeIdentity(for: profileAccount),
+                normalizedEmail: CodexIdentityResolver.normalizeEmail(profileAccount.email)))
+        }
+
         return candidates
     }
 }
@@ -52,6 +58,8 @@ public enum CodexProviderSettingsBuilder {
             false
         case .managedAccount:
             true
+        case .profileHome:
+            false
         }
 
         return ProviderSettingsSnapshot.CodexProviderSettings(

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderSettingsBuilder.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderSettingsBuilder.swift
@@ -41,7 +41,9 @@ public enum CodexKnownOwnerCatalog {
         for profileAccount in snapshot.profileHomeAccounts {
             candidates.append(CodexDashboardKnownOwnerCandidate(
                 identity: snapshot.runtimeIdentity(for: profileAccount),
-                normalizedEmail: CodexIdentityResolver.normalizeEmail(profileAccount.email)))
+                normalizedEmail: CodexIdentityResolver.normalizeEmail(profileAccount.email),
+                sourceIsolationIdentifier: CookieHeaderCache.Scope.profileHome(profileAccount.codexHomePath)
+                    .isolationIdentifier))
         }
 
         return candidates
@@ -61,6 +63,14 @@ public enum CodexProviderSettingsBuilder {
         case .profileHome:
             false
         }
+        let openAIWebCacheScope: CookieHeaderCache.Scope? = switch input.resolvedActiveSource.resolvedSource {
+        case .liveSystem:
+            nil
+        case let .managedAccount(id):
+            .managedAccount(id)
+        case let .profileHome(path):
+            .profileHome(path)
+        }
 
         return ProviderSettingsSnapshot.CodexProviderSettings(
             usageDataSource: input.usageDataSource,
@@ -70,6 +80,7 @@ public enum CodexProviderSettingsBuilder {
             managedAccountTargetUnavailable: managedSourceSelected
                 && snapshot.hasUnreadableAddedAccountStore == false
                 && snapshot.activeStoredAccount == nil,
+            openAIWebCacheScope: openAIWebCacheScope,
             dashboardAuthorityKnownOwners: CodexKnownOwnerCatalog.candidates(from: snapshot))
     }
 }

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderSettingsBuilder.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderSettingsBuilder.swift
@@ -71,6 +71,12 @@ public enum CodexProviderSettingsBuilder {
         case let .profileHome(path):
             .profileHome(path)
         }
+        let profileAccountTargetUnavailable = switch input.resolvedActiveSource.resolvedSource {
+        case .liveSystem, .managedAccount:
+            false
+        case let .profileHome(path):
+            snapshot.profileHomeAccount(path: path) == nil
+        }
 
         return ProviderSettingsSnapshot.CodexProviderSettings(
             usageDataSource: input.usageDataSource,
@@ -80,6 +86,7 @@ public enum CodexProviderSettingsBuilder {
             managedAccountTargetUnavailable: managedSourceSelected
                 && snapshot.hasUnreadableAddedAccountStore == false
                 && snapshot.activeStoredAccount == nil,
+            profileAccountTargetUnavailable: profileAccountTargetUnavailable,
             openAIWebCacheScope: openAIWebCacheScope,
             dashboardAuthorityKnownOwners: CodexKnownOwnerCatalog.candidates(from: snapshot))
     }

--- a/Sources/CodexBarCore/Providers/Codex/CodexVisibleAccountProjection.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexVisibleAccountProjection.swift
@@ -172,6 +172,31 @@ extension CodexVisibleAccountProjection {
             }
         }
 
+        let livePath = snapshot.liveSystemAccount.flatMap { CodexHomeScope.normalizedHomePath($0.codexHomePath) }
+        let managedPaths = Set(snapshot.storedAccounts.compactMap {
+            CodexHomeScope.normalizedHomePath($0.managedHomePath)
+        })
+        for profileAccount in snapshot.profileHomeAccounts {
+            let profilePath = CodexHomeScope.normalizedHomePath(profileAccount.codexHomePath)
+            guard let profilePath,
+                  profilePath != livePath,
+                  !managedPaths.contains(profilePath)
+            else {
+                continue
+            }
+            drafts.append(VisibleAccountDraft(
+                email: Self.normalizeVisibleEmail(profileAccount.email),
+                workspaceLabel: Self.normalizeWorkspaceLabel(profileAccount.workspaceLabel),
+                workspaceAccountID: profileAccount.workspaceAccountID,
+                authFingerprint: profileAccount.authFingerprint,
+                storedAccountID: nil,
+                selectionSource: .profileHome(path: profilePath),
+                isLive: false,
+                canReauthenticate: false,
+                canRemove: false,
+                identity: snapshot.runtimeIdentity(for: profileAccount)))
+        }
+
         let groupedByEmail = Dictionary(grouping: drafts.indices, by: { drafts[$0].email })
         let visibleAccounts = drafts.map { draft in
             let id = Self.visibleAccountID(for: draft, emailGroupSize: groupedByEmail[draft.email]?.count ?? 0)
@@ -180,6 +205,8 @@ extension CodexVisibleAccountProjection {
                 draft.selectionSource == .liveSystem
             case let .managedAccount(id):
                 draft.selectionSource == .managedAccount(id: id)
+            case let .profileHome(path):
+                draft.selectionSource == .profileHome(path: path)
             }
 
             return CodexVisibleAccount(
@@ -233,6 +260,8 @@ extension CodexVisibleAccountProjection {
             return "live:\(CodexIdentityMatcher.selectionKey(for: draft.identity, fallbackEmail: draft.email))"
         case let .managedAccount(id):
             return "managed:\(id.uuidString.lowercased())"
+        case let .profileHome(path):
+            return "profile:\(path)"
         }
     }
 }

--- a/Sources/CodexBarCore/Providers/Codex/CodexWebDashboardStrategy.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexWebDashboardStrategy.swift
@@ -11,7 +11,8 @@ public struct CodexWebDashboardStrategy: ProviderFetchStrategy {
     public func isAvailable(_ context: ProviderFetchContext) async -> Bool {
         context.sourceMode.usesWeb &&
             !Self.managedAccountStoreIsUnreadable(context) &&
-            !Self.managedAccountTargetIsUnavailable(context)
+            !Self.managedAccountTargetIsUnavailable(context) &&
+            (!Self.profileAccountTargetIsUnavailable(context) || context.sourceMode == .web)
     }
 
     public func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
@@ -23,6 +24,10 @@ public struct CodexWebDashboardStrategy: ProviderFetchStrategy {
         guard !Self.managedAccountTargetIsUnavailable(context) else {
             // If the selected managed account no longer exists in a readable store, web import must not
             // fall back to "any signed-in browser account" for that stale selection.
+            throw OpenAIDashboardFetcher.FetchError.loginRequired
+        }
+        guard !Self.profileAccountTargetIsUnavailable(context) else {
+            // A profile without an auth-backed email cannot safely target browser cookie import.
             throw OpenAIDashboardFetcher.FetchError.loginRequired
         }
 
@@ -63,6 +68,10 @@ public struct CodexWebDashboardStrategy: ProviderFetchStrategy {
 
     private static func managedAccountTargetIsUnavailable(_ context: ProviderFetchContext) -> Bool {
         context.settings?.codex?.managedAccountTargetUnavailable == true
+    }
+
+    private static func profileAccountTargetIsUnavailable(_ context: ProviderFetchContext) -> Bool {
+        context.settings?.codex?.profileAccountTargetUnavailable == true
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexWebDashboardStrategy.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexWebDashboardStrategy.swift
@@ -295,6 +295,7 @@ extension CodexWebDashboardStrategy {
                 intoAccountEmail: routingTargetEmail,
                 allowAnyAccount: allowAnyAccount,
                 preferCachedCookieHeader: preferCachedCookieHeader,
+                cacheScope: context.settings?.codex?.openAIWebCacheScope,
                 deadline: options.deadline,
                 logger: logger)
         let effectiveEmail = routingTargetEmail ?? importResult.signedInEmail?
@@ -302,6 +303,7 @@ extension CodexWebDashboardStrategy {
 
         let dashboard = try await OpenAIDashboardFetcher().loadLatestDashboard(
             accountEmail: effectiveEmail,
+            cacheScope: context.settings?.codex?.openAIWebCacheScope,
             logger: logger,
             debugDumpHTML: options.debugDumpHTML,
             timeout: OpenAIDashboardBrowserCookieImporter.remainingTimeout(until: options.deadline))

--- a/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
@@ -77,6 +77,7 @@ public struct ProviderSettingsSnapshot: Sendable {
         public let manualCookieHeader: String?
         public let managedAccountStoreUnreadable: Bool
         public let managedAccountTargetUnavailable: Bool
+        public let profileAccountTargetUnavailable: Bool
         public let openAIWebCacheScope: CookieHeaderCache.Scope?
         public let dashboardAuthorityKnownOwners: [CodexDashboardKnownOwnerCandidate]
 
@@ -86,6 +87,7 @@ public struct ProviderSettingsSnapshot: Sendable {
             manualCookieHeader: String?,
             managedAccountStoreUnreadable: Bool = false,
             managedAccountTargetUnavailable: Bool = false,
+            profileAccountTargetUnavailable: Bool = false,
             openAIWebCacheScope: CookieHeaderCache.Scope? = nil,
             dashboardAuthorityKnownOwners: [CodexDashboardKnownOwnerCandidate] = [])
         {
@@ -94,6 +96,7 @@ public struct ProviderSettingsSnapshot: Sendable {
             self.manualCookieHeader = manualCookieHeader
             self.managedAccountStoreUnreadable = managedAccountStoreUnreadable
             self.managedAccountTargetUnavailable = managedAccountTargetUnavailable
+            self.profileAccountTargetUnavailable = profileAccountTargetUnavailable
             self.openAIWebCacheScope = openAIWebCacheScope
             self.dashboardAuthorityKnownOwners = dashboardAuthorityKnownOwners
         }

--- a/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/ProviderSettingsSnapshot.swift
@@ -77,6 +77,7 @@ public struct ProviderSettingsSnapshot: Sendable {
         public let manualCookieHeader: String?
         public let managedAccountStoreUnreadable: Bool
         public let managedAccountTargetUnavailable: Bool
+        public let openAIWebCacheScope: CookieHeaderCache.Scope?
         public let dashboardAuthorityKnownOwners: [CodexDashboardKnownOwnerCandidate]
 
         public init(
@@ -85,6 +86,7 @@ public struct ProviderSettingsSnapshot: Sendable {
             manualCookieHeader: String?,
             managedAccountStoreUnreadable: Bool = false,
             managedAccountTargetUnavailable: Bool = false,
+            openAIWebCacheScope: CookieHeaderCache.Scope? = nil,
             dashboardAuthorityKnownOwners: [CodexDashboardKnownOwnerCandidate] = [])
         {
             self.usageDataSource = usageDataSource
@@ -92,6 +94,7 @@ public struct ProviderSettingsSnapshot: Sendable {
             self.manualCookieHeader = manualCookieHeader
             self.managedAccountStoreUnreadable = managedAccountStoreUnreadable
             self.managedAccountTargetUnavailable = managedAccountTargetUnavailable
+            self.openAIWebCacheScope = openAIWebCacheScope
             self.dashboardAuthorityKnownOwners = dashboardAuthorityKnownOwners
         }
     }

--- a/Tests/CodexBarTests/CLIWebFallbackTests.swift
+++ b/Tests/CodexBarTests/CLIWebFallbackTests.swift
@@ -129,6 +129,33 @@ struct CLIWebFallbackTests {
     }
 
     @Test
+    func `codex web strategy fails closed when profile target is unavailable`() async {
+        let settings = ProviderSettingsSnapshot.make(
+            codex: .init(
+                usageDataSource: .auto,
+                cookieSource: .auto,
+                manualCookieHeader: nil,
+                profileAccountTargetUnavailable: true))
+        let strategy = CodexWebDashboardStrategy()
+
+        let autoContext = self.makeContext(sourceMode: .auto, settings: settings)
+        let autoAvailable = await strategy.isAvailable(autoContext)
+        #expect(!autoAvailable)
+
+        let explicitWebContext = self.makeContext(sourceMode: .web, settings: settings)
+        let explicitWebAvailable = await strategy.isAvailable(explicitWebContext)
+        #expect(explicitWebAvailable)
+        do {
+            _ = try await strategy.fetch(explicitWebContext)
+            Issue.record("Expected unavailable profile target to require login")
+        } catch OpenAIDashboardFetcher.FetchError.loginRequired {
+            // Expected before browser import can accept an arbitrary account.
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
     func `claude falls back when no session key`() {
         let context = self.makeContext()
         let strategy = ClaudeWebFetchStrategy(browserDetection: BrowserDetection(cacheTTL: 0))

--- a/Tests/CodexBarTests/CodexActiveSourceConfigTests.swift
+++ b/Tests/CodexBarTests/CodexActiveSourceConfigTests.swift
@@ -112,7 +112,7 @@ struct CodexActiveSourceConfigTests {
     }
 
     @Test
-    func `provider config encodes profile home active source with expected schema`() throws {
+    func `provider config encodes profile home source in downgrade readable envelope`() throws {
         let config = CodexBarConfig(
             providers: [
                 ProviderConfig(
@@ -128,9 +128,12 @@ struct CodexActiveSourceConfigTests {
         let activeSource = try #require(provider["codexActiveSource"] as? [String: Any])
 
         #expect(activeSource.count == 2)
-        #expect(activeSource["kind"] as? String == "profileHome")
+        #expect(activeSource["kind"] as? String == "liveSystem")
         #expect(activeSource["homePath"] as? String == "/Users/test/.codex-work")
         #expect(provider["codexProfileHomePaths"] as? [String] == ["/Users/test/.codex-work"])
+
+        let releasedConfig = try JSONDecoder().decode(ReleasedCodexBarConfig.self, from: data)
+        #expect(releasedConfig.providers.first?.codexActiveSource == .liveSystem)
     }
 
     @Test
@@ -180,5 +183,60 @@ struct CodexActiveSourceConfigTests {
 
         #expect(providerConfig?.codexActiveSource == .profileHome(path: "/Users/test/.codex-work"))
         #expect(providerConfig?.codexProfileHomePaths == ["/Users/test/.codex-work"])
+    }
+
+    @Test
+    func `profile home discriminator written by development builds still decodes`() throws {
+        let data = Data(#"{"kind":"profileHome","homePath":"/Users/test/.codex-work"}"#.utf8)
+
+        let decoded = try JSONDecoder().decode(CodexActiveSource.self, from: data)
+        let canonicalData = try JSONEncoder().encode(decoded)
+        let canonical = try #require(JSONSerialization.jsonObject(with: canonicalData) as? [String: Any])
+
+        #expect(decoded == .profileHome(path: "/Users/test/.codex-work"))
+        #expect(canonical["kind"] as? String == "liveSystem")
+        #expect(canonical["homePath"] as? String == "/Users/test/.codex-work")
+    }
+
+    @Test
+    func `blank profile home sentinel falls back to live system`() throws {
+        let data = Data(#"{"kind":"liveSystem","homePath":"  "}"#.utf8)
+
+        let decoded = try JSONDecoder().decode(CodexActiveSource.self, from: data)
+
+        #expect(decoded == .liveSystem)
+    }
+}
+
+private struct ReleasedCodexBarConfig: Decodable {
+    let providers: [ReleasedProviderConfig]
+}
+
+private struct ReleasedProviderConfig: Decodable {
+    let codexActiveSource: ReleasedCodexActiveSource?
+}
+
+private enum ReleasedCodexActiveSource: Decodable, Equatable {
+    case liveSystem
+    case managedAccount(id: UUID)
+
+    private enum CodingKeys: String, CodingKey {
+        case kind
+        case accountID
+    }
+
+    private enum Kind: String, Decodable {
+        case liveSystem
+        case managedAccount
+    }
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .kind) {
+        case .liveSystem:
+            self = .liveSystem
+        case .managedAccount:
+            self = try .managedAccount(id: container.decode(UUID.self, forKey: .accountID))
+        }
     }
 }

--- a/Tests/CodexBarTests/CodexActiveSourceConfigTests.swift
+++ b/Tests/CodexBarTests/CodexActiveSourceConfigTests.swift
@@ -112,6 +112,28 @@ struct CodexActiveSourceConfigTests {
     }
 
     @Test
+    func `provider config encodes profile home active source with expected schema`() throws {
+        let config = CodexBarConfig(
+            providers: [
+                ProviderConfig(
+                    id: .codex,
+                    codexActiveSource: .profileHome(path: "/Users/test/.codex-work"),
+                    codexProfileHomePaths: ["/Users/test/.codex-work"]),
+            ])
+
+        let data = try JSONEncoder().encode(config)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let providers = try #require(object?["providers"] as? [[String: Any]])
+        let provider = try #require(providers.first(where: { $0["id"] as? String == "codex" }))
+        let activeSource = try #require(provider["codexActiveSource"] as? [String: Any])
+
+        #expect(activeSource.count == 2)
+        #expect(activeSource["kind"] as? String == "profileHome")
+        #expect(activeSource["homePath"] as? String == "/Users/test/.codex-work")
+        #expect(provider["codexProfileHomePaths"] as? [String] == ["/Users/test/.codex-work"])
+    }
+
+    @Test
     func `provider config round trips live system active source`() throws {
         let config = CodexBarConfig(
             providers: [
@@ -140,5 +162,23 @@ struct CodexActiveSourceConfigTests {
         let decoded = try JSONDecoder().decode(CodexBarConfig.self, from: data)
 
         #expect(decoded.providerConfig(for: .codex)?.codexActiveSource == .managedAccount(id: accountID))
+    }
+
+    @Test
+    func `provider config round trips profile home active source`() throws {
+        let config = CodexBarConfig(
+            providers: [
+                ProviderConfig(
+                    id: .codex,
+                    codexActiveSource: .profileHome(path: "/Users/test/.codex-work"),
+                    codexProfileHomePaths: ["/Users/test/.codex-work"]),
+            ])
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(CodexBarConfig.self, from: data)
+        let providerConfig = decoded.providerConfig(for: .codex)
+
+        #expect(providerConfig?.codexActiveSource == .profileHome(path: "/Users/test/.codex-work"))
+        #expect(providerConfig?.codexProfileHomePaths == ["/Users/test/.codex-work"])
     }
 }

--- a/Tests/CodexBarTests/CodexDashboardAuthorityTests.swift
+++ b/Tests/CodexBarTests/CodexDashboardAuthorityTests.swift
@@ -105,6 +105,64 @@ struct CodexDashboardAuthorityTests {
     }
 
     @Test
+    func `provider account exact owner ignores duplicate profile isolation`() {
+        let input = CodexDashboardAuthorityInput(
+            sourceKind: .liveWeb,
+            proof: CodexDashboardOwnershipProofContext(
+                currentIdentity: .providerAccount(id: "acct-owner"),
+                expectedScopedEmail: "owner@example.com",
+                trustedCurrentUsageEmail: nil,
+                dashboardSignedInEmail: "owner@example.com",
+                knownOwners: [
+                    CodexDashboardKnownOwnerCandidate(
+                        identity: .providerAccount(id: "acct-owner"),
+                        normalizedEmail: "owner@example.com",
+                        sourceIsolationIdentifier: "profile-a"),
+                    CodexDashboardKnownOwnerCandidate(
+                        identity: .providerAccount(id: "acct-owner"),
+                        normalizedEmail: "owner@example.com",
+                        sourceIsolationIdentifier: "profile-b"),
+                ]),
+            routing: CodexDashboardRoutingHints(
+                targetEmail: "owner@example.com",
+                lastKnownDashboardRoutingEmail: nil))
+
+        let decision = CodexDashboardAuthority.evaluate(input)
+
+        #expect(decision.disposition == .attach)
+        #expect(decision.reason == .exactProviderAccountMatch)
+    }
+
+    @Test
+    func `email only owners retain profile isolation ambiguity`() {
+        let input = CodexDashboardAuthorityInput(
+            sourceKind: .liveWeb,
+            proof: CodexDashboardOwnershipProofContext(
+                currentIdentity: .emailOnly(normalizedEmail: "shared@example.com"),
+                expectedScopedEmail: "shared@example.com",
+                trustedCurrentUsageEmail: nil,
+                dashboardSignedInEmail: "shared@example.com",
+                knownOwners: [
+                    CodexDashboardKnownOwnerCandidate(
+                        identity: .emailOnly(normalizedEmail: "shared@example.com"),
+                        normalizedEmail: "shared@example.com",
+                        sourceIsolationIdentifier: "profile-a"),
+                    CodexDashboardKnownOwnerCandidate(
+                        identity: .emailOnly(normalizedEmail: "shared@example.com"),
+                        normalizedEmail: "shared@example.com",
+                        sourceIsolationIdentifier: "profile-b"),
+                ]),
+            routing: CodexDashboardRoutingHints(
+                targetEmail: "shared@example.com",
+                lastKnownDashboardRoutingEmail: nil))
+
+        let decision = CodexDashboardAuthority.evaluate(input)
+
+        #expect(decision.disposition == .displayOnly)
+        #expect(decision.reason == .sameEmailAmbiguity(email: "shared@example.com"))
+    }
+
+    @Test
     func `provider account exact owner stays display only when email has another owner`() {
         let input = CodexDashboardAuthorityInput(
             sourceKind: .liveWeb,

--- a/Tests/CodexBarTests/CodexDashboardAuthorityTests.swift
+++ b/Tests/CodexBarTests/CodexDashboardAuthorityTests.swift
@@ -105,6 +105,33 @@ struct CodexDashboardAuthorityTests {
     }
 
     @Test
+    func `provider account exact owner stays display only when email has another owner`() {
+        let input = CodexDashboardAuthorityInput(
+            sourceKind: .liveWeb,
+            proof: CodexDashboardOwnershipProofContext(
+                currentIdentity: .providerAccount(id: "acct-current"),
+                expectedScopedEmail: "shared@example.com",
+                trustedCurrentUsageEmail: nil,
+                dashboardSignedInEmail: "shared@example.com",
+                knownOwners: [
+                    CodexDashboardKnownOwnerCandidate(
+                        identity: .providerAccount(id: "acct-current"),
+                        normalizedEmail: "shared@example.com"),
+                    CodexDashboardKnownOwnerCandidate(
+                        identity: .providerAccount(id: "acct-other"),
+                        normalizedEmail: "shared@example.com"),
+                ]),
+            routing: CodexDashboardRoutingHints(
+                targetEmail: "shared@example.com",
+                lastKnownDashboardRoutingEmail: nil))
+
+        let decision = CodexDashboardAuthority.evaluate(input)
+
+        #expect(decision.disposition == .displayOnly)
+        #expect(decision.reason == .sameEmailAmbiguity(email: "shared@example.com"))
+    }
+
+    @Test
     func `provider account same email ambiguity without exact match returns display only`() {
         let input = CodexDashboardAuthorityInput(
             sourceKind: .liveWeb,

--- a/Tests/CodexBarTests/CodexManagedOpenAIWebTests.swift
+++ b/Tests/CodexBarTests/CodexManagedOpenAIWebTests.swift
@@ -275,6 +275,30 @@ struct CodexManagedOpenAIWebTests {
     }
 
     @Test
+    func `same email profile homes use distinct website data stores`() {
+        OpenAIDashboardWebsiteDataStore.clearCacheForTesting()
+        defer { OpenAIDashboardWebsiteDataStore.clearCacheForTesting() }
+
+        let profileA = CookieHeaderCache.Scope.profileHome("/tmp/codex-profile-a")
+        let profileB = CookieHeaderCache.Scope.profileHome("/tmp/codex-profile-b")
+        let storeA = OpenAIDashboardWebsiteDataStore.store(
+            forAccountEmail: "shared@example.com",
+            scope: profileA)
+        let storeAAgain = OpenAIDashboardWebsiteDataStore.store(
+            forAccountEmail: "SHARED@example.com",
+            scope: profileA)
+        let storeB = OpenAIDashboardWebsiteDataStore.store(
+            forAccountEmail: "shared@example.com",
+            scope: profileB)
+        let liveStore = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: "shared@example.com")
+
+        #expect(storeA === storeAAgain)
+        #expect(storeA !== storeB)
+        #expect(storeA !== liveStore)
+        #expect(storeB !== liveStore)
+    }
+
+    @Test
     func `dashboard refresh does not target stale last known live email`() async {
         let settings = self.makeSettingsStore(suite: "CodexManagedOpenAIWebTests-live-system-refresh-strict-target")
         let isolatedHome = FileManager.default.temporaryDirectory

--- a/Tests/CodexBarTests/CodexManagedOpenAIWebTests.swift
+++ b/Tests/CodexBarTests/CodexManagedOpenAIWebTests.swift
@@ -275,30 +275,6 @@ struct CodexManagedOpenAIWebTests {
     }
 
     @Test
-    func `same email profile homes use distinct website data stores`() {
-        OpenAIDashboardWebsiteDataStore.clearCacheForTesting()
-        defer { OpenAIDashboardWebsiteDataStore.clearCacheForTesting() }
-
-        let profileA = CookieHeaderCache.Scope.profileHome("/tmp/codex-profile-a")
-        let profileB = CookieHeaderCache.Scope.profileHome("/tmp/codex-profile-b")
-        let storeA = OpenAIDashboardWebsiteDataStore.store(
-            forAccountEmail: "shared@example.com",
-            scope: profileA)
-        let storeAAgain = OpenAIDashboardWebsiteDataStore.store(
-            forAccountEmail: "SHARED@example.com",
-            scope: profileA)
-        let storeB = OpenAIDashboardWebsiteDataStore.store(
-            forAccountEmail: "shared@example.com",
-            scope: profileB)
-        let liveStore = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: "shared@example.com")
-
-        #expect(storeA === storeAAgain)
-        #expect(storeA !== storeB)
-        #expect(storeA !== liveStore)
-        #expect(storeB !== liveStore)
-    }
-
-    @Test
     func `dashboard refresh does not target stale last known live email`() async {
         let settings = self.makeSettingsStore(suite: "CodexManagedOpenAIWebTests-live-system-refresh-strict-target")
         let isolatedHome = FileManager.default.temporaryDirectory

--- a/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
+++ b/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
@@ -124,8 +124,89 @@ struct CodexProfileHomeAccountTests {
 
         #expect(settings.codexResolvedActiveSource == .liveSystem)
         #expect(environment["CODEX_HOME"] == "/tmp/ambient-codex")
+        let staleOverrideEnvironment = ProviderRegistry.makeEnvironment(
+            base: ["CODEX_HOME": "/tmp/ambient-codex"],
+            provider: .codex,
+            settings: settings,
+            tokenOverride: nil,
+            codexActiveSourceOverride: .profileHome(path: removedProfileHome.path))
+        #expect(staleOverrideEnvironment["CODEX_HOME"] == "/tmp/ambient-codex")
         #expect(settings.persistResolvedCodexActiveSourceCorrectionIfNeeded())
         #expect(settings.codexActiveSource == .liveSystem)
+    }
+
+    @Test
+    @MainActor
+    func `external config removal immediately invalidates profile routing caches`() throws {
+        let suite = "CodexProfileHomeAccountTests-external-removal"
+        let settings = try Self.makeSettings(suite: suite)
+        let missingLiveHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        let profileHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: profileHome,
+            email: "profile-cache@example.com",
+            plan: "pro")
+        let previousInterval = SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting
+        SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = 60
+        settings._test_codexReconciliationEnvironment = ["CODEX_HOME": missingLiveHome.path]
+        defer {
+            SettingsStore.codexAccountReconciliationSnapshotCacheIntervalOverrideForTesting = previousInterval
+            settings._test_codexReconciliationEnvironment = nil
+            try? FileManager.default.removeItem(at: missingLiveHome)
+            try? FileManager.default.removeItem(at: profileHome)
+        }
+
+        settings.updateProviderConfig(provider: .codex) { entry in
+            entry.codexProfileHomePaths = [profileHome.path]
+            entry.codexActiveSource = .profileHome(path: profileHome.path)
+        }
+        _ = settings.codexAccountReconciliationSnapshot
+        #expect(settings.cachedCodexAccountReconciliationSnapshot != nil)
+        #expect(settings.cachedCodexAccountMenuProjection != nil)
+
+        settings.applyExternalConfig(
+            CodexBarConfig(providers: [
+                ProviderConfig(
+                    id: .codex,
+                    codexActiveSource: .profileHome(path: profileHome.path),
+                    codexProfileHomePaths: []),
+            ]),
+            reason: "profile-removed")
+
+        #expect(settings.cachedCodexAccountReconciliationSnapshot == nil)
+        #expect(settings.cachedCodexAccountMenuProjection == nil)
+        let environment = ProviderRegistry.makeEnvironment(
+            base: ["CODEX_HOME": "/tmp/ambient-codex"],
+            provider: .codex,
+            settings: settings,
+            tokenOverride: nil)
+        #expect(settings.codexResolvedActiveSource == .liveSystem)
+        #expect(environment["CODEX_HOME"] == "/tmp/ambient-codex")
+    }
+
+    @Test
+    @MainActor
+    func `relative profile homes are ignored by app routing`() throws {
+        let settings = try Self.makeSettings(suite: "CodexProfileHomeAccountTests-relative")
+        settings.updateProviderConfig(provider: .codex) { entry in
+            entry.codexProfileHomePaths = ["relative-codex-home", "~someone/.codex"]
+            entry.codexActiveSource = .profileHome(path: "relative-codex-home")
+        }
+
+        #expect(CodexHomeScope.normalizedHomePath("relative-codex-home") == nil)
+        #expect(CodexHomeScope.normalizedHomePath("~someone/.codex") == nil)
+        #expect(settings.codexProfileHomePaths.isEmpty)
+        let environment = ProviderRegistry.makeEnvironment(
+            base: ["CODEX_HOME": "/tmp/ambient-codex"],
+            provider: .codex,
+            settings: settings,
+            tokenOverride: nil,
+            codexActiveSourceOverride: .profileHome(path: "relative-codex-home"))
+        #expect(environment["CODEX_HOME"] == "/tmp/ambient-codex")
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
+++ b/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
@@ -247,6 +247,51 @@ struct CodexProfileHomeAccountTests {
 
     @Test
     @MainActor
+    func `profile without verified email refuses open A I cookie import`() async throws {
+        let suite = "CodexProfileHomeAccountTests-missing-web-email"
+        let settings = try Self.makeSettings(suite: suite)
+        let missingLiveHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        let unreadableProfileHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        settings._test_codexReconciliationEnvironment = ["CODEX_HOME": missingLiveHome.path]
+        settings.updateProviderConfig(provider: .codex) { entry in
+            entry.codexProfileHomePaths = [unreadableProfileHome.path]
+            entry.codexActiveSource = .profileHome(path: unreadableProfileHome.path)
+        }
+        defer {
+            settings._test_codexReconciliationEnvironment = nil
+            try? FileManager.default.removeItem(at: missingLiveHome)
+            try? FileManager.default.removeItem(at: unreadableProfileHome)
+        }
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: ["CODEX_HOME": missingLiveHome.path]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing)
+        var importAttempts = 0
+        store._test_openAIDashboardCookieImportOverride = { _, _, _, _, _ in
+            importAttempts += 1
+            return OpenAIDashboardBrowserCookieImporter.ImportResult(
+                sourceLabel: "test",
+                cookieCount: 1,
+                signedInEmail: "other@example.com",
+                matchesCodexEmail: false)
+        }
+
+        let imported = await store.importOpenAIDashboardCookiesIfNeeded(targetEmail: nil, force: true)
+
+        #expect(imported == nil)
+        #expect(importAttempts == 0)
+        #expect(store.openAIDashboardRequiresLogin)
+        #expect(store.openAIDashboardCookieImportStatus?.contains("no verified account email") == true)
+    }
+
+    @Test
+    @MainActor
     func `profile home matching live home resolves to visible live account`() throws {
         let suite = "CodexProfileHomeAccountTests-live-duplicate"
         let settings = try Self.makeSettings(suite: suite)

--- a/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
+++ b/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
@@ -54,6 +54,7 @@ struct CodexProfileHomeAccountTests {
         #expect(snapshot.liveSystemAccount == nil)
         #expect(snapshot.profileHomeAccounts.map(\.email) == ["profile@example.com"])
         #expect(snapshot.profileHomeAccounts.map(\.codexHomePath) == [normalizedProfilePath])
+        #expect(snapshot.profileHomePaths == [normalizedProfilePath])
         #expect(projection.visibleAccounts.map(\.email) == ["profile@example.com"])
         #expect(projection.activeVisibleAccountID == "profile@example.com")
         #expect(projection.liveVisibleAccountID == nil)
@@ -91,6 +92,76 @@ struct CodexProfileHomeAccountTests {
             tokenOverride: nil)
 
         #expect(environment["CODEX_HOME"] == normalizedProfilePath)
+    }
+
+    @Test
+    @MainActor
+    func `removed profile home falls back without routing stale path`() throws {
+        let suite = "CodexProfileHomeAccountTests-stale-routing"
+        let settings = try Self.makeSettings(suite: suite)
+        let missingLiveHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        let removedProfileHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        settings._test_codexReconciliationEnvironment = ["CODEX_HOME": missingLiveHome.path]
+        settings.updateProviderConfig(provider: .codex) { entry in
+            entry.codexProfileHomePaths = []
+            entry.codexActiveSource = .profileHome(path: removedProfileHome.path)
+        }
+        defer {
+            settings._test_codexReconciliationEnvironment = nil
+            try? FileManager.default.removeItem(at: missingLiveHome)
+            try? FileManager.default.removeItem(at: removedProfileHome)
+        }
+
+        let environment = ProviderRegistry.makeEnvironment(
+            base: ["CODEX_HOME": "/tmp/ambient-codex"],
+            provider: .codex,
+            settings: settings,
+            tokenOverride: nil)
+
+        #expect(settings.codexResolvedActiveSource == .liveSystem)
+        #expect(environment["CODEX_HOME"] == "/tmp/ambient-codex")
+        #expect(settings.persistResolvedCodexActiveSourceCorrectionIfNeeded())
+        #expect(settings.codexActiveSource == .liveSystem)
+    }
+
+    @Test
+    @MainActor
+    func `unreadable configured profile home remains selected and routed`() throws {
+        let suite = "CodexProfileHomeAccountTests-unreadable-routing"
+        let settings = try Self.makeSettings(suite: suite)
+        let missingLiveHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        let unreadableProfileHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        settings._test_codexReconciliationEnvironment = ["CODEX_HOME": missingLiveHome.path]
+        settings.updateProviderConfig(provider: .codex) { entry in
+            entry.codexProfileHomePaths = [unreadableProfileHome.path]
+            entry.codexActiveSource = .profileHome(path: unreadableProfileHome.path)
+        }
+        defer {
+            settings._test_codexReconciliationEnvironment = nil
+            try? FileManager.default.removeItem(at: missingLiveHome)
+            try? FileManager.default.removeItem(at: unreadableProfileHome)
+        }
+
+        let normalizedProfilePath = try #require(CodexHomeScope.normalizedHomePath(unreadableProfileHome.path))
+        let environment = ProviderRegistry.makeEnvironment(
+            base: ["CODEX_HOME": "/tmp/ambient-codex"],
+            provider: .codex,
+            settings: settings,
+            tokenOverride: nil)
+
+        #expect(settings.codexResolvedActiveSource == .profileHome(path: normalizedProfilePath))
+        #expect(settings.codexAccountReconciliationSnapshot.profileHomeAccounts.isEmpty)
+        #expect(environment["CODEX_HOME"] == normalizedProfilePath)
+        #expect(!settings.persistResolvedCodexActiveSourceCorrectionIfNeeded())
+        #expect(settings.codexActiveSource == .profileHome(path: normalizedProfilePath))
     }
 
     private static func writeCodexAuthFile(

--- a/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
+++ b/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
@@ -1,0 +1,138 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@Suite(.serialized)
+struct CodexProfileHomeAccountTests {
+    @MainActor
+    private static func makeSettings(suite: String) throws -> SettingsStore {
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set(true, forKey: "providerDetectionCompleted")
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.providerDetectionCompleted = true
+        return settings
+    }
+
+    @Test
+    @MainActor
+    func `settings store discovers configured codex profile homes`() throws {
+        let suite = "CodexProfileHomeAccountTests-discovery"
+        let settings = try Self.makeSettings(suite: suite)
+        let missingLiveHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        let profileHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: profileHome,
+            email: "Profile@Example.com",
+            plan: "pro",
+            accountID: "acct_profile")
+        settings._test_codexReconciliationEnvironment = ["CODEX_HOME": missingLiveHome.path]
+        settings.updateProviderConfig(provider: .codex) { entry in
+            entry.codexProfileHomePaths = [profileHome.path, profileHome.path]
+        }
+        settings.codexActiveSource = .profileHome(path: profileHome.path)
+        defer {
+            settings._test_codexReconciliationEnvironment = nil
+            try? FileManager.default.removeItem(at: missingLiveHome)
+            try? FileManager.default.removeItem(at: profileHome)
+        }
+
+        let normalizedProfilePath = try #require(CodexHomeScope.normalizedHomePath(profileHome.path))
+        let snapshot = settings.codexAccountReconciliationSnapshot
+        let projection = settings.codexVisibleAccountProjection
+
+        #expect(settings.codexResolvedActiveSource == .profileHome(path: normalizedProfilePath))
+        #expect(snapshot.liveSystemAccount == nil)
+        #expect(snapshot.profileHomeAccounts.map(\.email) == ["profile@example.com"])
+        #expect(snapshot.profileHomeAccounts.map(\.codexHomePath) == [normalizedProfilePath])
+        #expect(projection.visibleAccounts.map(\.email) == ["profile@example.com"])
+        #expect(projection.activeVisibleAccountID == "profile@example.com")
+        #expect(projection.liveVisibleAccountID == nil)
+        #expect(projection.visibleAccounts.first?.selectionSource == .profileHome(path: normalizedProfilePath))
+        #expect(projection.visibleAccounts.first?.isLive == false)
+        #expect(projection.visibleAccounts.first?.canReauthenticate == false)
+        #expect(projection.visibleAccounts.first?.canRemove == false)
+    }
+
+    @Test
+    @MainActor
+    func `provider registry scopes selected codex profile home`() throws {
+        let suite = "CodexProfileHomeAccountTests-routing"
+        let settings = try Self.makeSettings(suite: suite)
+        let profileHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        try Self.writeCodexAuthFile(
+            homeURL: profileHome,
+            email: "profile-route@example.com",
+            plan: "pro")
+        settings.updateProviderConfig(provider: .codex) { entry in
+            entry.codexProfileHomePaths = [profileHome.path]
+            entry.codexActiveSource = .profileHome(path: profileHome.path)
+        }
+        defer {
+            try? FileManager.default.removeItem(at: profileHome)
+        }
+
+        let normalizedProfilePath = try #require(CodexHomeScope.normalizedHomePath(profileHome.path))
+        let environment = ProviderRegistry.makeEnvironment(
+            base: ["CODEX_HOME": "/tmp/ambient-codex"],
+            provider: .codex,
+            settings: settings,
+            tokenOverride: nil)
+
+        #expect(environment["CODEX_HOME"] == normalizedProfilePath)
+    }
+
+    private static func writeCodexAuthFile(
+        homeURL: URL,
+        email: String,
+        plan: String,
+        accountID: String? = nil) throws
+    {
+        try FileManager.default.createDirectory(at: homeURL, withIntermediateDirectories: true)
+        var tokens: [String: Any] = [
+            "accessToken": "access-token",
+            "refreshToken": "refresh-token",
+            "idToken": Self.fakeJWT(email: email, plan: plan, accountID: accountID),
+        ]
+        if let accountID {
+            tokens["account_id"] = accountID
+        }
+        let auth = ["tokens": tokens]
+        let data = try JSONSerialization.data(withJSONObject: auth)
+        try data.write(to: homeURL.appendingPathComponent("auth.json"))
+    }
+
+    private static func fakeJWT(email: String, plan: String, accountID: String? = nil) -> String {
+        let header = (try? JSONSerialization.data(withJSONObject: ["alg": "none"])) ?? Data()
+        var payloadObject: [String: Any] = [
+            "email": email,
+            "chatgpt_plan_type": plan,
+        ]
+        if let accountID {
+            payloadObject["https://api.openai.com/auth"] = [
+                "chatgpt_account_id": accountID,
+            ]
+        }
+        let payload = (try? JSONSerialization.data(withJSONObject: payloadObject)) ?? Data()
+
+        func base64URL(_ data: Data) -> String {
+            data.base64EncodedString()
+                .replacingOccurrences(of: "=", with: "")
+                .replacingOccurrences(of: "+", with: "-")
+                .replacingOccurrences(of: "/", with: "_")
+        }
+
+        return "\(base64URL(header)).\(base64URL(payload))."
+    }
+}

--- a/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
+++ b/Tests/CodexBarTests/CodexProfileHomeAccountTests.swift
@@ -164,6 +164,69 @@ struct CodexProfileHomeAccountTests {
         #expect(settings.codexActiveSource == .profileHome(path: normalizedProfilePath))
     }
 
+    @Test
+    @MainActor
+    func `profile home matching live home resolves to visible live account`() throws {
+        let suite = "CodexProfileHomeAccountTests-live-duplicate"
+        let settings = try Self.makeSettings(suite: suite)
+        let liveHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        let liveAccount = ObservedSystemCodexAccount(
+            email: "live@example.com",
+            codexHomePath: liveHome.path,
+            observedAt: Date())
+        settings._test_liveSystemCodexAccount = liveAccount
+        settings.updateProviderConfig(provider: .codex) { entry in
+            entry.codexProfileHomePaths = [liveHome.path]
+            entry.codexActiveSource = .profileHome(path: liveHome.path)
+        }
+        defer {
+            settings._test_liveSystemCodexAccount = nil
+        }
+
+        let projection = settings.codexVisibleAccountProjection
+
+        #expect(settings.codexResolvedActiveSource == .liveSystem)
+        #expect(projection.visibleAccounts.map(\.email) == ["live@example.com"])
+        #expect(projection.activeVisibleAccountID == "live@example.com")
+        #expect(settings.persistResolvedCodexActiveSourceCorrectionIfNeeded())
+        #expect(settings.codexActiveSource == .liveSystem)
+    }
+
+    @Test
+    @MainActor
+    func `profile home matching managed home resolves to visible managed account`() throws {
+        let suite = "CodexProfileHomeAccountTests-managed-duplicate"
+        let settings = try Self.makeSettings(suite: suite)
+        let managedHome = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true)
+        let managedAccount = ManagedCodexAccount(
+            id: UUID(),
+            email: "managed@example.com",
+            managedHomePath: managedHome.path,
+            createdAt: 1,
+            updatedAt: 2,
+            lastAuthenticatedAt: 3)
+        settings._test_activeManagedCodexAccount = managedAccount
+        settings.updateProviderConfig(provider: .codex) { entry in
+            entry.codexProfileHomePaths = [managedHome.path]
+            entry.codexActiveSource = .profileHome(path: managedHome.path)
+        }
+        defer {
+            settings._test_activeManagedCodexAccount = nil
+        }
+
+        let projection = settings.codexVisibleAccountProjection
+
+        #expect(settings.codexResolvedActiveSource == .managedAccount(id: managedAccount.id))
+        #expect(projection.visibleAccounts.map(\.email) == ["managed@example.com"])
+        #expect(projection.activeVisibleAccountID == "managed@example.com")
+        #expect(settings.persistResolvedCodexActiveSourceCorrectionIfNeeded())
+        #expect(settings.codexActiveSource == .managedAccount(id: managedAccount.id))
+    }
+
     private static func writeCodexAuthFile(
         homeURL: URL,
         email: String,

--- a/Tests/CodexBarTests/CodexProviderSettingsBuilderTests.swift
+++ b/Tests/CodexBarTests/CodexProviderSettingsBuilderTests.swift
@@ -125,4 +125,51 @@ struct CodexProviderSettingsBuilderTests {
             identity: .providerAccount(id: "acct-live"),
             normalizedEmail: "live@example.com")))
     }
+
+    @Test
+    func `builder preserves same email profile owners and scopes web cache`() {
+        let profileA = ObservedSystemCodexAccount(
+            email: "shared@example.com",
+            codexHomePath: "/tmp/codex-profile-a",
+            observedAt: Date(),
+            identity: .emailOnly(normalizedEmail: "shared@example.com"))
+        let profileB = ObservedSystemCodexAccount(
+            email: "shared@example.com",
+            codexHomePath: "/tmp/codex-profile-b",
+            observedAt: Date(),
+            identity: .emailOnly(normalizedEmail: "shared@example.com"))
+        let snapshot = CodexAccountReconciliationSnapshot(
+            storedAccounts: [],
+            activeStoredAccount: nil,
+            liveSystemAccount: nil,
+            profileHomeAccounts: [profileA, profileB],
+            matchingStoredAccountForLiveSystemAccount: nil,
+            activeSource: .profileHome(path: profileA.codexHomePath),
+            hasUnreadableAddedAccountStore: false)
+
+        let settings = CodexProviderSettingsBuilder.make(input: CodexProviderSettingsBuilderInput(
+            usageDataSource: .auto,
+            cookieSource: .auto,
+            manualCookieHeader: nil,
+            reconciliationSnapshot: snapshot,
+            resolvedActiveSource: CodexActiveSourceResolver.resolve(from: snapshot)))
+
+        #expect(settings.openAIWebCacheScope == .profileHome(profileA.codexHomePath))
+        #expect(settings.dashboardAuthorityKnownOwners.count == 2)
+        #expect(Set(settings.dashboardAuthorityKnownOwners.map(\.sourceIsolationIdentifier)).count == 2)
+
+        let decision = CodexDashboardAuthority.evaluate(CodexDashboardAuthorityInput(
+            sourceKind: .liveWeb,
+            proof: CodexDashboardOwnershipProofContext(
+                currentIdentity: .emailOnly(normalizedEmail: "shared@example.com"),
+                expectedScopedEmail: "shared@example.com",
+                trustedCurrentUsageEmail: nil,
+                dashboardSignedInEmail: "shared@example.com",
+                knownOwners: settings.dashboardAuthorityKnownOwners),
+            routing: CodexDashboardRoutingHints(
+                targetEmail: "shared@example.com",
+                lastKnownDashboardRoutingEmail: nil)))
+        #expect(decision.disposition == .displayOnly)
+        #expect(decision.reason == .sameEmailAmbiguity(email: "shared@example.com"))
+    }
 }

--- a/Tests/CodexBarTests/CodexProviderSettingsBuilderTests.swift
+++ b/Tests/CodexBarTests/CodexProviderSettingsBuilderTests.swift
@@ -92,6 +92,30 @@ struct CodexProviderSettingsBuilderTests {
     }
 
     @Test
+    func `builder marks profile without observed account as unavailable`() {
+        let profilePath = "/tmp/codex-profile-missing-auth"
+        let snapshot = CodexAccountReconciliationSnapshot(
+            storedAccounts: [],
+            activeStoredAccount: nil,
+            liveSystemAccount: nil,
+            profileHomeAccounts: [],
+            profileHomePaths: [profilePath],
+            matchingStoredAccountForLiveSystemAccount: nil,
+            activeSource: .profileHome(path: profilePath),
+            hasUnreadableAddedAccountStore: false)
+
+        let settings = CodexProviderSettingsBuilder.make(input: CodexProviderSettingsBuilderInput(
+            usageDataSource: .auto,
+            cookieSource: .auto,
+            manualCookieHeader: nil,
+            reconciliationSnapshot: snapshot,
+            resolvedActiveSource: CodexActiveSourceResolver.resolve(from: snapshot)))
+
+        #expect(settings.profileAccountTargetUnavailable)
+        #expect(settings.openAIWebCacheScope == .profileHome(profilePath))
+    }
+
+    @Test
     func `known owner catalog includes runtime managed and live identities`() {
         let storedAccount = ManagedCodexAccount(
             id: UUID(),
@@ -155,6 +179,7 @@ struct CodexProviderSettingsBuilderTests {
             resolvedActiveSource: CodexActiveSourceResolver.resolve(from: snapshot)))
 
         #expect(settings.openAIWebCacheScope == .profileHome(profileA.codexHomePath))
+        #expect(!settings.profileAccountTargetUnavailable)
         #expect(settings.dashboardAuthorityKnownOwners.count == 2)
         #expect(Set(settings.dashboardAuthorityKnownOwners.map(\.sourceIsolationIdentifier)).count == 2)
 

--- a/Tests/CodexBarTests/CookieHeaderCacheTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheTests.swift
@@ -61,6 +61,36 @@ struct CookieHeaderCacheTests {
     }
 
     @Test
+    func `profile home scopes isolate same email sessions without exposing paths`() {
+        KeychainCacheStore.setTestStoreForTesting(true)
+        defer { KeychainCacheStore.setTestStoreForTesting(false) }
+
+        let provider: UsageProvider = .codex
+        let profileA = CookieHeaderCache.Scope.profileHome("/tmp/codex-profile-a")
+        let profileB = CookieHeaderCache.Scope.profileHome("/tmp/codex-profile-b")
+        CookieHeaderCache.store(
+            provider: provider,
+            scope: profileA,
+            cookieHeader: "auth=profile-a",
+            sourceLabel: "Chrome")
+        CookieHeaderCache.store(
+            provider: provider,
+            scope: profileB,
+            cookieHeader: "auth=profile-b",
+            sourceLabel: "Chrome")
+        defer {
+            CookieHeaderCache.clear(provider: provider, scope: profileA)
+            CookieHeaderCache.clear(provider: provider, scope: profileB)
+        }
+
+        #expect(CookieHeaderCache.load(provider: provider, scope: profileA)?.cookieHeader == "auth=profile-a")
+        #expect(CookieHeaderCache.load(provider: provider, scope: profileB)?.cookieHeader == "auth=profile-b")
+        #expect(CookieHeaderCache.load(provider: provider) == nil)
+        #expect(profileA.isolationIdentifier != profileB.isolationIdentifier)
+        #expect(!profileA.isolationIdentifier.contains("codex-profile-a"))
+    }
+
+    @Test
     func `provider global scope remains available without managed account`() {
         KeychainCacheStore.setTestStoreForTesting(true)
         defer { KeychainCacheStore.setTestStoreForTesting(false) }

--- a/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
@@ -66,6 +66,43 @@ struct OpenAIDashboardWebViewCacheTests {
         OpenAIDashboardWebsiteDataStore.clearCacheForTesting()
     }
 
+    @Test
+    func `same email profile homes use distinct website data stores`() {
+        OpenAIDashboardWebsiteDataStore.clearCacheForTesting()
+        defer { OpenAIDashboardWebsiteDataStore.clearCacheForTesting() }
+
+        let profileA = CookieHeaderCache.Scope.profileHome("/tmp/codex-profile-a")
+        let profileB = CookieHeaderCache.Scope.profileHome("/tmp/codex-profile-b")
+        let storeA = OpenAIDashboardWebsiteDataStore.store(
+            forAccountEmail: "shared@example.com",
+            scope: profileA)
+        let storeAAgain = OpenAIDashboardWebsiteDataStore.store(
+            forAccountEmail: "SHARED@example.com",
+            scope: profileA)
+        let storeB = OpenAIDashboardWebsiteDataStore.store(
+            forAccountEmail: "shared@example.com",
+            scope: profileB)
+        let liveStore = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: "shared@example.com")
+
+        #expect(storeA === storeAAgain)
+        #expect(storeA !== storeB)
+        #expect(storeA !== liveStore)
+        #expect(storeB !== liveStore)
+        #expect(storeA.identifier != storeB.identifier)
+        #expect(storeA.identifier != liveStore.identifier)
+        #expect(storeB.identifier != liveStore.identifier)
+    }
+
+    @Test
+    func `live website data store preserves legacy email identifier`() {
+        OpenAIDashboardWebsiteDataStore.clearCacheForTesting()
+        defer { OpenAIDashboardWebsiteDataStore.clearCacheForTesting() }
+
+        let store = OpenAIDashboardWebsiteDataStore.store(forAccountEmail: " SHARED@EXAMPLE.COM ")
+
+        #expect(store.identifier?.uuidString == "CC61BD27-6855-439F-9D11-F470B7977B90")
+    }
+
     // MARK: - WebView Reuse Tests
 
     @Test

--- a/Tests/CodexBarTests/OpenAIWebAccountSwitchTests.swift
+++ b/Tests/CodexBarTests/OpenAIWebAccountSwitchTests.swift
@@ -61,4 +61,36 @@ struct OpenAIWebAccountSwitchTests {
         store.handleOpenAIWebTargetEmailChangeIfNeeded(targetEmail: "a@example.com")
         #expect(store.openAIDashboard == dash)
     }
+
+    @Test
+    func `clears dashboard when profile source changes with the same email`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "OpenAIWebAccountSwitchTests-profile-source"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+
+        store.handleOpenAIWebTargetEmailChangeIfNeeded(
+            targetEmail: "shared@example.com",
+            targetScope: .profileHome("/tmp/codex-profile-a"))
+        store.openAIDashboard = OpenAIDashboardSnapshot(
+            signedInEmail: "shared@example.com",
+            codeReviewRemainingPercent: 100,
+            creditEvents: [],
+            dailyBreakdown: [],
+            usageBreakdown: [],
+            creditsPurchaseURL: nil,
+            updatedAt: Date())
+
+        store.handleOpenAIWebTargetEmailChangeIfNeeded(
+            targetEmail: "shared@example.com",
+            targetScope: .profileHome("/tmp/codex-profile-b"))
+
+        #expect(store.openAIDashboard == nil)
+        #expect(store.openAIWebAccountDidChange)
+        #expect(store.openAIDashboardRequiresLogin)
+    }
 }

--- a/Tests/CodexBarTests/StatusItemPurchaseURLTests.swift
+++ b/Tests/CodexBarTests/StatusItemPurchaseURLTests.swift
@@ -1,3 +1,4 @@
+import CodexBarCore
 import Foundation
 import Testing
 @testable import CodexBar
@@ -45,5 +46,18 @@ struct StatusItemPurchaseURLTests {
             StatusItemController.sanitizedCreditsPurchaseURL("https://chatgpt.com/backend-api/settings-token")
                 == nil)
         #expect(StatusItemController.sanitizedCreditsPurchaseURL("not a url") == nil)
+    }
+
+    @Test
+    @MainActor
+    func `scoped purchase window requires an account email`() {
+        let scope = CookieHeaderCache.Scope.profileHome("/tmp/codex-profile")
+
+        #expect(!OpenAICreditsPurchaseWindowController.canOpenPurchaseWindow(accountEmail: nil, cacheScope: scope))
+        #expect(!OpenAICreditsPurchaseWindowController.canOpenPurchaseWindow(accountEmail: "  ", cacheScope: scope))
+        #expect(OpenAICreditsPurchaseWindowController.canOpenPurchaseWindow(
+            accountEmail: " owner@example.com ",
+            cacheScope: scope))
+        #expect(OpenAICreditsPurchaseWindowController.canOpenPurchaseWindow(accountEmail: nil, cacheScope: nil))
     }
 }

--- a/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
+++ b/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
@@ -540,6 +540,30 @@ struct TokenAccountEnvironmentPrecedenceTests {
     }
 
     @Test
+    func `codex CLI ignores relative profile homes`() throws {
+        let config = CodexBarConfig(providers: [
+            ProviderConfig(
+                id: .codex,
+                codexActiveSource: .profileHome(path: "relative-codex-home"),
+                codexProfileHomePaths: ["relative-codex-home"]),
+        ])
+        let context = try TokenAccountCLIContext(
+            selection: TokenAccountCLISelection(label: nil, index: nil, allAccounts: false),
+            config: config,
+            verbose: false,
+            baseEnvironment: ["CODEX_HOME": "/tmp/ambient-codex"])
+
+        let environment = context.environment(
+            base: ["CODEX_HOME": "/tmp/ambient-codex"],
+            provider: .codex,
+            account: nil,
+            codexActiveSourceOverride: .profileHome(path: "relative-codex-home"))
+
+        #expect(context.visibleCodexAccounts().visibleAccounts.isEmpty)
+        #expect(environment["CODEX_HOME"] == "/tmp/ambient-codex")
+    }
+
+    @Test
     func `claude ambient explicit CLI source remains CLI in CLI`() throws {
         let config = CodexBarConfig(providers: [ProviderConfig(id: .claude)])
         let tokenContext = try TokenAccountCLIContext(

--- a/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
+++ b/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
@@ -513,6 +513,11 @@ struct TokenAccountEnvironmentPrecedenceTests {
             account: nil,
             codexActiveSourceOverride: .profileHome(path: profileHome.path))
         #expect(profileEnv["CODEX_HOME"] == profileHome.path)
+        #expect(context.settingsSnapshot(
+            for: .codex,
+            account: nil,
+            codexActiveSourceOverride: .profileHome(path: profileHome.path))?.codex?.openAIWebCacheScope
+            == .profileHome(profileHome.path))
 
         let liveEnv = context.environment(
             base: ["CODEX_HOME": ambientHome.path],

--- a/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
+++ b/Tests/CodexBarTests/TokenAccountEnvironmentPrecedenceTests.swift
@@ -437,15 +437,21 @@ struct TokenAccountEnvironmentPrecedenceTests {
     }
 
     @Test
-    func `codex all accounts selection exposes visible managed accounts and scopes CLI homes`() throws {
+    func `codex all accounts selection exposes configured accounts and scopes CLI homes`() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("codex-cli-all-accounts-\(UUID().uuidString)", isDirectory: true)
         let ambientHome = root.appendingPathComponent("ambient", isDirectory: true)
         let firstHome = root.appendingPathComponent("first", isDirectory: true)
         let secondHome = root.appendingPathComponent("second", isDirectory: true)
+        let profileHome = root.appendingPathComponent("profile", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
         try FileManager.default.createDirectory(at: ambientHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: firstHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: secondHome, withIntermediateDirectories: true)
+        try Self.writeCodexAuthFile(
+            homeURL: profileHome,
+            email: "profile@example.com",
+            accountID: "acct_profile")
         let storeURL = root.appendingPathComponent("managed-codex-accounts.json")
         let firstID = UUID()
         let secondID = UUID()
@@ -469,7 +475,10 @@ struct TokenAccountEnvironmentPrecedenceTests {
         ])
         try FileManagedCodexAccountStore(fileURL: storeURL).storeAccounts(accounts)
         let config = CodexBarConfig(providers: [
-            ProviderConfig(id: .codex, codexActiveSource: .managedAccount(id: secondID)),
+            ProviderConfig(
+                id: .codex,
+                codexActiveSource: .managedAccount(id: secondID),
+                codexProfileHomePaths: [profileHome.path]),
         ])
         let context = try TokenAccountCLIContext(
             selection: TokenAccountCLISelection(label: nil, index: nil, allAccounts: true),
@@ -481,10 +490,12 @@ struct TokenAccountEnvironmentPrecedenceTests {
         let projection = context.visibleCodexAccounts()
         #expect(projection.visibleAccounts.map(\.menuDisplayName) == [
             "first@example.com — Team",
+            "profile@example.com",
             "second@example.com",
         ])
         #expect(projection.visibleAccounts.map(\.selectionSource) == [
             .managedAccount(id: firstID),
+            .profileHome(path: profileHome.path),
             .managedAccount(id: secondID),
         ])
         #expect(projection.visibleAccounts.first { $0.email == "second@example.com" }?.isActive == true)
@@ -495,6 +506,13 @@ struct TokenAccountEnvironmentPrecedenceTests {
             account: nil,
             codexActiveSourceOverride: .managedAccount(id: firstID))
         #expect(firstEnv["CODEX_HOME"] == firstHome.path)
+
+        let profileEnv = context.environment(
+            base: ["CODEX_HOME": ambientHome.path],
+            provider: .codex,
+            account: nil,
+            codexActiveSourceOverride: .profileHome(path: profileHome.path))
+        #expect(profileEnv["CODEX_HOME"] == profileHome.path)
 
         let liveEnv = context.environment(
             base: ["CODEX_HOME": ambientHome.path],
@@ -880,6 +898,20 @@ extension TokenAccountEnvironmentPrecedenceTests {
             return nil
         }
         return environment["CODEX_HOME"]
+    }
+
+    fileprivate static func writeCodexAuthFile(homeURL: URL, email: String, accountID: String) throws {
+        try FileManager.default.createDirectory(at: homeURL, withIntermediateDirectories: true)
+        let auth: [String: Any] = [
+            "tokens": [
+                "accessToken": "access-token",
+                "refreshToken": "refresh-token",
+                "idToken": self.fakeJWT(email: email, plan: "pro", accountId: accountID),
+                "account_id": accountID,
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: auth)
+        try data.write(to: homeURL.appendingPathComponent("auth.json"))
     }
 
     fileprivate static func knownOwnerMultiset(

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -40,7 +40,7 @@ Usage source picker:
 - Managed Codex accounts remain the default multi-account path.
 - Advanced users can add existing Codex homes to `~/.codexbar/config.json` with
   `providers[].codexProfileHomePaths`.
-- Each configured path must point at a Codex home that contains `auth.json`.
+- Each configured path must be absolute or start with `~/`, and point at a Codex home that contains `auth.json`.
 - CodexBar reads identity from the configured home, exposes it in the Codex account switcher, and scopes
   remote Codex fetches with `CODEX_HOME`.
 - Profile homes are not copied, reauthenticated, or removed by CodexBar.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -36,6 +36,27 @@ Usage source picker:
   `UsageSnapshot.extraRateWindows` entries (Spark uses a stable `codex-spark` id / `Codex Spark` title).
   When the field is absent, the snapshot is unchanged.
 
+### Advanced profile-home accounts
+- Managed Codex accounts remain the default multi-account path.
+- Advanced users can add existing Codex homes to `~/.codexbar/config.json` with
+  `providers[].codexProfileHomePaths`.
+- Each configured path must point at a Codex home that contains `auth.json`.
+- CodexBar reads identity from the configured home, exposes it in the Codex account switcher, and scopes
+  remote Codex fetches with `CODEX_HOME`.
+- Profile homes are not copied, reauthenticated, or removed by CodexBar.
+
+Example:
+
+```json
+{
+  "id": "codex",
+  "codexProfileHomePaths": [
+    "~/.codex-work",
+    "~/.codex-personal"
+  ]
+}
+```
+
 ### OpenAI web dashboard (optional, off by default)
 - Enable it in Preferences -> Providers -> Codex -> OpenAI web extras.
 - It exists for dashboard-only extras such as code review remaining, usage breakdown, and credits history.


### PR DESCRIPTION
## Summary
- add advanced codexProfileHomePaths config support for existing Codex homes
- expose configured profile homes as selectable Codex accounts without copying or managing auth
- route selected profile home fetches through CODEX_HOME and cover refresh guards, OpenAI web targeting, and visible account matching
- preserve exact provider-account ownership across profile scopes while keeping email-only ambiguity isolated
- block scoped Buy Credits routing when the selected profile has no verified account email
- document the config shape and add focused tests

Fixes #630

## Tests
- exact candidate: `27c9cfcc21abbd2b7689b5124224fae0d67ffedf`
- `swift test --filter CodexProfileHomeAccountTests --skip-update` (6 tests)
- `swift test --filter CodexAccountReconciliationTests`
- `swift test --filter CodexActiveSourceConfigTests`
- `set -o pipefail; make check 2>&1 | tail -80`
- `swift build --product CodexBarCLI --skip-update`
- final authority/purchase/routing/settings proof: 28 focused tests passed
- `make test`: all 41 shards passed before the final one-line Linux fallback signature-parity fix
- final whole-branch autoreview: clean (`0.82`)
- redacted runtime profile-home routing proof below

## Runtime behavior proof
Redacted profile-home routing proof on earlier reviewed head `9c7f2068dc0b39257aa810f55a1876019c2a840e` (later commits only harden selection persistence and dashboard ownership):

- configured a temporary CodexBar config with one `codexProfileHomePaths` entry and `codexActiveSource.kind = profileHome`
- used a temporary Codex-home-shaped profile containing `auth.json` with OAuth/JWT-shaped redacted test credentials
- started the CLI with an ambient `CODEX_HOME=<redacted-ambient-home>` so the proof could detect stale ambient routing
- pinned `CODEX_CLI_PATH` to a local `codex app-server` stub that logs its launch environment and returns fixed rate-limit JSON
- no live provider request, browser cookie import, Keychain read, real account email, API key, or token was printed or used in the proof

Proof output:

```text
proof_payload_count=1
proof_provider=codex
proof_source=codex-cli
proof_version=0.0.0
proof_account_label_redacted=<redacted>
proof_account_email_redacted=<redacted>
proof_login_method=pro
proof_primary_window_present=True
proof_profile_home_auth_json_present=true
proof_codex_total_invocations=2
proof_codex_version_invocations=1
proof_codex_app_server_invocations=1
proof_app_server_codex_home_routed_to_configured_profile=True
proof_app_server_codex_home_not_ambient=True
```

Interpretation: CodexBar discovered the configured profile home as a visible Codex account, then the actual `codex app-server` usage fetch launched with the configured profile home as `CODEX_HOME` instead of the ambient home. The separate version probe is not account-routed and does not affect usage routing.

## Maintainer follow-up
- rebased onto current `main`
- corrected removed profile selections to fall back and persist `.liveSystem`
- preserved configured-but-unreadable profile routing so logged-out profiles remain selectable
- canonicalized profile paths that duplicate live or managed homes to the visible account source
- routed CLI all-account selection through each configured profile `CODEX_HOME`
- canonicalized stable provider-account owners across profile isolation while retaining email-only ambiguity
- failed scoped Buy Credits closed before WebKit store construction when the target email is unavailable
- aligned the Linux dashboard fetcher fallback signature with the scoped implementation
- `swift test --filter 'CodexProfileHomeAccountTests|CodexAccountReconciliationTests|TokenAccountEnvironmentPrecedenceTests|CodexActiveSourceConfigTests'` (69 tests)
- duplicate-home regression rerun: 33 tests
- `make check`
- autoreview: clean after one accepted duplicate-home finding was fixed
- final repair proof: 28 focused routing/authority/settings tests; all 41 shards before the one-line Linux fallback signature-parity fix; whole-branch autoreview clean (`0.82`)
