### PR TITLE
test: isolate browser cookie discovery

### DIFF
--- a/Sources/CodexBarCore/BrowserCookieAccessGate.swift
+++ b/Sources/CodexBarCore/BrowserCookieAccessGate.swift
@@ -15,6 +15,17 @@ public enum BrowserCookieAccessGate {
     private static let cooldownInterval: TimeInterval = 60 * 60 * 6
     private static let log = CodexBarLog.logger(LogCategories.browserCookieGate)
 
+    static func allowsCookieStoreAccess(homeDirectories: [URL]) -> Bool {
+        guard self.isRunningUnderTests,
+              ProcessInfo.processInfo.environment["CODEXBAR_ALLOW_TEST_BROWSER_COOKIE_ACCESS"] != "1"
+        else {
+            return true
+        }
+
+        let defaultHomes = Set(BrowserCookieClient.defaultHomeDirectories().map(Self.normalizedPath))
+        return homeDirectories.allSatisfy { !defaultHomes.contains(Self.normalizedPath($0)) }
+    }
+
     public static func shouldAttempt(_ browser: Browser, now: Date = Date()) -> Bool {
         guard browser.usesKeychainForCookieDecryption else { return true }
         guard !KeychainAccessGate.isDisabled else { return false }
@@ -97,6 +108,19 @@ public enum BrowserCookieAccessGate {
 
     private static let safeStorageLabels: [(service: String, account: String)] = Browser.safeStorageLabels
 
+    private static var isRunningUnderTests: Bool {
+        let processName = ProcessInfo.processInfo.processName
+        let environment = ProcessInfo.processInfo.environment
+        return processName == "swiftpm-testing-helper"
+            || processName.hasSuffix("PackageTests")
+            || environment["XCTestConfigurationFilePath"] != nil
+            || environment["SWIFT_TESTING"] != nil
+    }
+
+    private static func normalizedPath(_ url: URL) -> String {
+        url.standardizedFileURL.resolvingSymlinksInPath().path
+    }
+
     private static func loadIfNeeded(_ state: inout State) {
         guard !state.loaded else { return }
         state.loaded = true
@@ -118,6 +142,10 @@ extension BrowserCookieClient {
         in browser: Browser,
         logger: ((String) -> Void)? = nil) throws -> [BrowserCookieStoreRecords]
     {
+        guard BrowserCookieAccessGate.allowsCookieStoreAccess(homeDirectories: self.configuration.homeDirectories)
+        else {
+            return []
+        }
         guard BrowserCookieAccessGate.shouldAttempt(browser) else { return [] }
         return try self.records(matching: query, in: browser, logger: logger)
     }

--- a/Sources/CodexBarCore/BrowserDetection.swift
+++ b/Sources/CodexBarCore/BrowserDetection.swift
@@ -65,10 +65,10 @@ public final class BrowserDetection: Sendable {
     /// This is intentionally stricter than `isAppInstalled`: for Chromium browsers, we only return true
     /// when profile data exists (to avoid unnecessary Keychain prompts).
     public func isCookieSourceAvailable(_ browser: Browser) -> Bool {
-        // We always allow Safari cookie attempts: no Keychain prompts, and it can still yield cookies
-        // even if the on-disk location changes across macOS versions.
+        // Safari does not need Keychain decryption, but tests must not inspect the real cookie store.
         if browser == .safari {
-            return true
+            return BrowserCookieAccessGate.allowsCookieStoreAccess(
+                homeDirectories: [URL(fileURLWithPath: self.homeDirectory)])
         }
 
         // For browsers that typically require keychain-backed decryption, ensure an actual cookie store exists.

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -8,16 +8,43 @@ import SweetCookieKit
 @Suite(.serialized)
 struct BrowserDetectionTests {
     @Test
-    func `safari always installed`() {
+    func `safari is installed but default cookie access is disabled during tests`() {
+        guard ProcessInfo.processInfo.environment["CODEXBAR_ALLOW_TEST_BROWSER_COOKIE_ACCESS"] != "1" else { return }
+
         #expect(BrowserDetection(cacheTTL: 0).isAppInstalled(.safari) == true)
-        #expect(BrowserDetection(cacheTTL: 0).isCookieSourceAvailable(.safari) == true)
+        #expect(BrowserDetection(cacheTTL: 0).isCookieSourceAvailable(.safari) == false)
     }
 
     @Test
-    func `filter installed includes safari`() {
+    func `default cookie candidates exclude safari during tests`() {
+        guard ProcessInfo.processInfo.environment["CODEXBAR_ALLOW_TEST_BROWSER_COOKIE_ACCESS"] != "1" else { return }
+
         let detection = BrowserDetection(cacheTTL: 0)
         let browsers: [Browser] = [.safari, .chrome, .firefox]
-        #expect(browsers.cookieImportCandidates(using: detection).contains(.safari))
+        #expect(browsers.cookieImportCandidates(using: detection).contains(.safari) == false)
+    }
+
+    @Test
+    func `explicit isolated home keeps safari cookie source available`() {
+        let detection = BrowserDetection(homeDirectory: "/tmp/codexbar-browser-detection", cacheTTL: 0)
+        #expect(detection.isCookieSourceAvailable(.safari))
+    }
+
+    @Test
+    func `cookie client skips real browser stores during tests`() throws {
+        guard ProcessInfo.processInfo.environment["CODEXBAR_ALLOW_TEST_BROWSER_COOKIE_ACCESS"] != "1" else { return }
+
+        let records = try BrowserCookieClient().codexBarRecords(
+            matching: BrowserCookieQuery(domains: ["example.com"]),
+            in: .safari)
+        #expect(records.isEmpty)
+    }
+
+    @Test
+    func `cookie client permits isolated browser stores during tests`() {
+        let tempHome = URL(fileURLWithPath: "/tmp/codexbar-browser-cookie-client")
+        let client = BrowserCookieClient(configuration: .init(homeDirectories: [tempHome]))
+        #expect(BrowserCookieAccessGate.allowsCookieStoreAccess(homeDirectories: client.configuration.homeDirectories))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- prevent tests from scanning real browser cookie stores through default home-directory clients
- preserve isolated temporary-home cookie fixtures and an explicit opt-in override
- cover both browser detection and direct `BrowserCookieClient` paths

## Proof
- `swift test --filter BrowserDetectionTests`
- `swift test --filter MainThreadHangWatchdogTests`
- full `swift test`: 3,946/3,947 passed in 85s; only the existing load-sensitive watchdog timing case failed, then passed in isolation
- `make check`
- autoreview: clean

`CodexBarCore` compiled in release mode. The repository's release test target does not compile because existing test-only APIs are `DEBUG`-gated.
