### PR TITLE
Pin status-bar menus to the system appearance (fix dark menu in Light mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.34.1 — Unreleased
 
-- Menu bar: pin the status-item dropdown to the current system appearance so it follows the Light/Dark setting instead of inheriting the menu bar's vibrant appearance, which rendered the menu dark in Light mode whenever a dark or strongly-colored window or wallpaper sat behind the menu bar.
+- Menu bar: pin the status-item dropdown to the current system appearance so it follows the Light/Dark setting instead of inheriting the menu bar's vibrant appearance, which rendered the menu dark in Light mode whenever a dark or strongly-colored window or wallpaper sat behind the menu bar (#1490). Thanks @npapridonu!
 - Xiaomi MiMo: show paid and granted balance components alongside token-plan usage without requiring a duplicate provider (#1309). Thanks @AdrianSimionov!
 - Xiaomi MiMo: add an opt-in local session-log fallback for token accounting when browser quota authentication is unavailable (#1284). Thanks @LeoLin990405!
 - Settings: keep the native tab toolbar in sync when macOS switches appearance while the window is open (#1484). Thanks @hhh2210!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.34.1 — Unreleased
 
+- Menu bar: pin the status-item dropdown to the current system appearance so it follows the Light/Dark setting instead of inheriting the menu bar's vibrant appearance, which rendered the menu dark in Light mode whenever a dark or strongly-colored window or wallpaper sat behind the menu bar.
 - Xiaomi MiMo: show paid and granted balance components alongside token-plan usage without requiring a duplicate provider (#1309). Thanks @AdrianSimionov!
 - Settings: keep the native tab toolbar in sync when macOS switches appearance while the window is open (#1484). Thanks @hhh2210!
 - Menu bar: avoid starting a duplicate background provider refresh when the menu closes while its initial missing-data refresh is still in flight.

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -65,6 +65,10 @@ extension StatusItemController {
         let trace = self.beginMenuOperationTrace("menuWillOpen", breadcrumb: "menuWillOpen")
         defer { self.endMenuOperationTrace(trace, menu: menu, provider: self.menuProvider(for: menu)) }
 
+        // Keep the menu drawing in the current system appearance rather than the menu bar's
+        // (possibly dark) vibrant appearance. Done before any early return so submenus match too.
+        self.pinMenuToSystemAppearance(menu)
+
         self.cancelDeferredMenuInteractionRefreshTask()
         self.cancelClosedMenuRebuild(menu)
 
@@ -830,6 +834,7 @@ extension StatusItemController {
                     }
                     let submenu = NSMenu(title: title)
                     submenu.autoenablesItems = false
+                    self.pinMenuToSystemAppearance(submenu)
                     for submenuItem in submenuItems {
                         let child = NSMenuItem(title: submenuItem.title, action: nil, keyEquivalent: "")
                         child.state = submenuItem.isChecked ? .on : .off
@@ -961,7 +966,20 @@ extension StatusItemController {
         menu.autoenablesItems = false
         menu.delegate = self
         menu.persistentActionDelegate = self
+        self.pinMenuToSystemAppearance(menu)
         return menu
+    }
+
+    /// Pins a status-bar menu to the system (app) appearance so it follows the user's Light/Dark
+    /// setting. Without this, `NSStatusItem` dropdown menus inherit the *menu bar's* vibrant
+    /// appearance, which macOS renders dark whenever a dark or strongly-colored window/wallpaper
+    /// sits behind the menu bar — even when the system is in Light mode. Re-applied on every open
+    /// so it stays correct if the user switches appearance while the app keeps the menu alive.
+    func pinMenuToSystemAppearance(_ menu: NSMenu) {
+        let appearance = NSApp.effectiveAppearance
+        if menu.appearance?.name != appearance.name {
+            menu.appearance = appearance
+        }
     }
 
     private func makeProviderSwitcherItem(

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -990,17 +990,6 @@ extension StatusItemController {
         }
     }
 
-    static func systemMenuAppearanceName(
-        interfaceStyle: String?,
-        increaseContrast: Bool) -> NSAppearance.Name
-    {
-        let isDark = interfaceStyle?.caseInsensitiveCompare("Dark") == .orderedSame
-        if increaseContrast {
-            return isDark ? .accessibilityHighContrastDarkAqua : .accessibilityHighContrastAqua
-        }
-        return isDark ? .darkAqua : .aqua
-    }
-
     private func makeProviderSwitcherItem(
         providers: [UsageProvider],
         includesOverview: Bool,

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -980,6 +980,11 @@ extension StatusItemController {
         if menu.appearance?.name != appearance.name {
             menu.appearance = appearance
         }
+        for item in menu.items {
+            if let submenu = item.submenu {
+                self.pinMenuToSystemAppearance(submenu)
+            }
+        }
     }
 
     private func makeProviderSwitcherItem(

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -67,7 +67,7 @@ extension StatusItemController {
 
         // Keep the menu drawing in the current system appearance rather than the menu bar's
         // (possibly dark) vibrant appearance. Done before any early return so submenus match too.
-        self.pinMenuToSystemAppearance(menu)
+        StatusMenuAppearance.pin(menu)
 
         self.cancelDeferredMenuInteractionRefreshTask()
         self.cancelClosedMenuRebuild(menu)
@@ -834,7 +834,6 @@ extension StatusItemController {
                     }
                     let submenu = NSMenu(title: title)
                     submenu.autoenablesItems = false
-                    self.pinMenuToSystemAppearance(submenu)
                     for submenuItem in submenuItems {
                         let child = NSMenuItem(title: submenuItem.title, action: nil, keyEquivalent: "")
                         child.state = submenuItem.isChecked ? .on : .off
@@ -966,28 +965,8 @@ extension StatusItemController {
         menu.autoenablesItems = false
         menu.delegate = self
         menu.persistentActionDelegate = self
-        self.pinMenuToSystemAppearance(menu)
+        StatusMenuAppearance.pin(menu)
         return menu
-    }
-
-    /// Pins a status-bar menu to the system appearance so it follows the user's Light/Dark
-    /// setting. Without this, `NSStatusItem` dropdown menus inherit the *menu bar's* vibrant
-    /// appearance, which macOS renders dark whenever a dark or strongly-colored window/wallpaper
-    /// sits behind the menu bar — even when the system is in Light mode. Re-applied on every open
-    /// so it stays correct if the user switches appearance while the app keeps the menu alive.
-    func pinMenuToSystemAppearance(_ menu: NSMenu) {
-        let name = Self.systemMenuAppearanceName(
-            interfaceStyle: UserDefaults.standard.string(forKey: "AppleInterfaceStyle"),
-            increaseContrast: NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast)
-        guard let appearance = NSAppearance(named: name) else { return }
-        if menu.appearance?.name != appearance.name {
-            menu.appearance = appearance
-        }
-        for item in menu.items {
-            if let submenu = item.submenu {
-                self.pinMenuToSystemAppearance(submenu)
-            }
-        }
     }
 
     private func makeProviderSwitcherItem(

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -970,13 +970,16 @@ extension StatusItemController {
         return menu
     }
 
-    /// Pins a status-bar menu to the system (app) appearance so it follows the user's Light/Dark
+    /// Pins a status-bar menu to the system appearance so it follows the user's Light/Dark
     /// setting. Without this, `NSStatusItem` dropdown menus inherit the *menu bar's* vibrant
     /// appearance, which macOS renders dark whenever a dark or strongly-colored window/wallpaper
     /// sits behind the menu bar — even when the system is in Light mode. Re-applied on every open
     /// so it stays correct if the user switches appearance while the app keeps the menu alive.
     func pinMenuToSystemAppearance(_ menu: NSMenu) {
-        let appearance = NSApp.effectiveAppearance
+        let name = Self.systemMenuAppearanceName(
+            interfaceStyle: UserDefaults.standard.string(forKey: "AppleInterfaceStyle"),
+            increaseContrast: NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast)
+        guard let appearance = NSAppearance(named: name) else { return }
         if menu.appearance?.name != appearance.name {
             menu.appearance = appearance
         }
@@ -985,6 +988,17 @@ extension StatusItemController {
                 self.pinMenuToSystemAppearance(submenu)
             }
         }
+    }
+
+    static func systemMenuAppearanceName(
+        interfaceStyle: String?,
+        increaseContrast: Bool) -> NSAppearance.Name
+    {
+        let isDark = interfaceStyle?.caseInsensitiveCompare("Dark") == .orderedSame
+        if increaseContrast {
+            return isDark ? .accessibilityHighContrastDarkAqua : .accessibilityHighContrastAqua
+        }
+        return isDark ? .darkAqua : .aqua
     }
 
     private func makeProviderSwitcherItem(

--- a/Sources/CodexBar/StatusItemController+MenuAppearance.swift
+++ b/Sources/CodexBar/StatusItemController+MenuAppearance.swift
@@ -1,0 +1,14 @@
+import AppKit
+
+extension StatusItemController {
+    static func systemMenuAppearanceName(
+        interfaceStyle: String?,
+        increaseContrast: Bool) -> NSAppearance.Name
+    {
+        let isDark = interfaceStyle?.caseInsensitiveCompare("Dark") == .orderedSame
+        if increaseContrast {
+            return isDark ? .accessibilityHighContrastDarkAqua : .accessibilityHighContrastAqua
+        }
+        return isDark ? .darkAqua : .aqua
+    }
+}

--- a/Sources/CodexBar/StatusItemController+MenuAppearance.swift
+++ b/Sources/CodexBar/StatusItemController+MenuAppearance.swift
@@ -1,14 +1,13 @@
 import AppKit
 
-extension StatusItemController {
-    static func systemMenuAppearanceName(
-        interfaceStyle: String?,
-        increaseContrast: Bool) -> NSAppearance.Name
-    {
-        let isDark = interfaceStyle?.caseInsensitiveCompare("Dark") == .orderedSame
-        if increaseContrast {
-            return isDark ? .accessibilityHighContrastDarkAqua : .accessibilityHighContrastAqua
-        }
-        return isDark ? .darkAqua : .aqua
+@MainActor
+enum StatusMenuAppearance {
+    static func pin(_ menu: NSMenu) {
+        self.pin(menu, to: NSApplication.shared.effectiveAppearance)
+    }
+
+    static func pin(_ menu: NSMenu, to appearance: NSAppearance) {
+        // The exact effective appearance carries accessibility attributes that its name can omit.
+        menu.appearance = appearance
     }
 }

--- a/Tests/CodexBarTests/StatusMenuAppearanceTests.swift
+++ b/Tests/CodexBarTests/StatusMenuAppearanceTests.swift
@@ -1,0 +1,60 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+extension StatusMenuTests {
+    @Test
+    func `status menu follows current system appearance when created and opened`() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let expectedAppearance = StatusItemController.systemMenuAppearanceName(
+            interfaceStyle: UserDefaults.standard.string(forKey: "AppleInterfaceStyle"),
+            increaseContrast: NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast)
+        let menu = controller.makeMenu()
+        #expect(menu.appearance?.name == expectedAppearance)
+
+        let isDark = expectedAppearance == .darkAqua || expectedAppearance == .accessibilityHighContrastDarkAqua
+        let staleAppearance: NSAppearance.Name = isDark ? .aqua : .darkAqua
+        menu.appearance = NSAppearance(named: staleAppearance)
+        let submenu = NSMenu()
+        submenu.appearance = NSAppearance(named: staleAppearance)
+        let submenuItem = NSMenuItem()
+        submenuItem.submenu = submenu
+        menu.addItem(submenuItem)
+        controller.menuWillOpen(menu)
+        #expect(menu.appearance?.name == expectedAppearance)
+        #expect(submenu.appearance?.name == expectedAppearance)
+        controller.menuDidClose(menu)
+    }
+
+    @Test
+    func `system menu appearance follows global interface style and contrast`() {
+        #expect(StatusItemController.systemMenuAppearanceName(
+            interfaceStyle: nil,
+            increaseContrast: false) == .aqua)
+        #expect(StatusItemController.systemMenuAppearanceName(
+            interfaceStyle: "Dark",
+            increaseContrast: false) == .darkAqua)
+        #expect(StatusItemController.systemMenuAppearanceName(
+            interfaceStyle: nil,
+            increaseContrast: true) == .accessibilityHighContrastAqua)
+        #expect(StatusItemController.systemMenuAppearanceName(
+            interfaceStyle: "dark",
+            increaseContrast: true) == .accessibilityHighContrastDarkAqua)
+    }
+}

--- a/Tests/CodexBarTests/StatusMenuAppearanceTests.swift
+++ b/Tests/CodexBarTests/StatusMenuAppearanceTests.swift
@@ -1,60 +1,51 @@
 import AppKit
-import CodexBarCore
 import Testing
 @testable import CodexBar
 
-extension StatusMenuTests {
+@MainActor
+struct StatusMenuAppearanceTests {
     @Test
-    func `status menu follows current system appearance when created and opened`() {
-        self.disableMenuCardsForTesting()
-        let settings = self.makeSettings()
-        settings.statusChecksEnabled = false
-        settings.refreshFrequency = .manual
+    func `pin uses the exact application effective appearance`() {
+        let menu = NSMenu()
+        let effectiveAppearance = NSApplication.shared.effectiveAppearance
 
-        let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
-        let controller = StatusItemController(
-            store: store,
-            settings: settings,
-            account: fetcher.loadAccountInfo(),
-            updater: DisabledUpdaterController(),
-            preferencesSelection: PreferencesSelection(),
-            statusBar: self.makeStatusBarForTesting())
-        defer { controller.releaseStatusItemsForTesting() }
+        StatusMenuAppearance.pin(menu)
 
-        let expectedAppearance = StatusItemController.systemMenuAppearanceName(
-            interfaceStyle: UserDefaults.standard.string(forKey: "AppleInterfaceStyle"),
-            increaseContrast: NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast)
-        let menu = controller.makeMenu()
-        #expect(menu.appearance?.name == expectedAppearance)
-
-        let isDark = expectedAppearance == .darkAqua || expectedAppearance == .accessibilityHighContrastDarkAqua
-        let staleAppearance: NSAppearance.Name = isDark ? .aqua : .darkAqua
-        menu.appearance = NSAppearance(named: staleAppearance)
-        let submenu = NSMenu()
-        submenu.appearance = NSAppearance(named: staleAppearance)
-        let submenuItem = NSMenuItem()
-        submenuItem.submenu = submenu
-        menu.addItem(submenuItem)
-        controller.menuWillOpen(menu)
-        #expect(menu.appearance?.name == expectedAppearance)
-        #expect(submenu.appearance?.name == expectedAppearance)
-        controller.menuDidClose(menu)
+        #expect(menu.appearance === effectiveAppearance)
     }
 
     @Test
-    func `system menu appearance follows global interface style and contrast`() {
-        #expect(StatusItemController.systemMenuAppearanceName(
-            interfaceStyle: nil,
-            increaseContrast: false) == .aqua)
-        #expect(StatusItemController.systemMenuAppearanceName(
-            interfaceStyle: "Dark",
-            increaseContrast: false) == .darkAqua)
-        #expect(StatusItemController.systemMenuAppearanceName(
-            interfaceStyle: nil,
-            increaseContrast: true) == .accessibilityHighContrastAqua)
-        #expect(StatusItemController.systemMenuAppearanceName(
-            interfaceStyle: "dark",
-            increaseContrast: true) == .accessibilityHighContrastDarkAqua)
+    func `pin replaces a distinct appearance with the same name`() throws {
+        let menu = NSMenu()
+        let initialAppearance = try #require(NSAppearance(named: .aqua))
+        let replacementAppearance = try #require(NSAppearance(appearanceNamed: .aqua, bundle: .main))
+        #expect(initialAppearance.name == replacementAppearance.name)
+        #expect(initialAppearance !== replacementAppearance)
+        menu.appearance = initialAppearance
+
+        StatusMenuAppearance.pin(menu, to: replacementAppearance)
+
+        #expect(menu.appearance === replacementAppearance)
+    }
+
+    @Test
+    func `submenus inherit each refreshed root appearance`() throws {
+        let menu = NSMenu()
+        let submenu = NSMenu()
+        let item = NSMenuItem(title: "Details", action: nil, keyEquivalent: "")
+        item.submenu = submenu
+        menu.addItem(item)
+
+        let lightAppearance = try #require(NSAppearance(named: .aqua))
+        StatusMenuAppearance.pin(menu, to: lightAppearance)
+        #expect(menu.appearance === lightAppearance)
+        #expect(submenu.appearance == nil)
+        #expect(submenu.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .aqua)
+
+        let darkAppearance = try #require(NSAppearance(named: .darkAqua))
+        StatusMenuAppearance.pin(menu, to: darkAppearance)
+        #expect(menu.appearance === darkAppearance)
+        #expect(submenu.appearance == nil)
+        #expect(submenu.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua)
     }
 }

--- a/Tests/CodexBarTests/StatusMenuAppearanceTests.swift
+++ b/Tests/CodexBarTests/StatusMenuAppearanceTests.swift
@@ -4,6 +4,16 @@ import Testing
 
 @MainActor
 struct StatusMenuAppearanceTests {
+    private final class AppearanceTrackingMenu: NSMenu {
+        var appearanceAssignmentCount = 0
+
+        override var appearance: NSAppearance? {
+            didSet {
+                self.appearanceAssignmentCount += 1
+            }
+        }
+    }
+
     @Test
     func `pin uses the exact application effective appearance`() {
         let menu = NSMenu()
@@ -15,17 +25,16 @@ struct StatusMenuAppearanceTests {
     }
 
     @Test
-    func `pin replaces a distinct appearance with the same name`() throws {
-        let menu = NSMenu()
-        let initialAppearance = try #require(NSAppearance(named: .aqua))
-        let replacementAppearance = try #require(NSAppearance(appearanceNamed: .aqua, bundle: .main))
-        #expect(initialAppearance.name == replacementAppearance.name)
-        #expect(initialAppearance !== replacementAppearance)
-        menu.appearance = initialAppearance
+    func `pin reassigns an appearance even when its name is unchanged`() throws {
+        let menu = AppearanceTrackingMenu()
+        let appearance = try #require(NSAppearance(named: .aqua))
+        menu.appearance = appearance
+        let assignmentsBeforePin = menu.appearanceAssignmentCount
 
-        StatusMenuAppearance.pin(menu, to: replacementAppearance)
+        StatusMenuAppearance.pin(menu, to: appearance)
 
-        #expect(menu.appearance === replacementAppearance)
+        #expect(menu.appearance === appearance)
+        #expect(menu.appearanceAssignmentCount == assignmentsBeforePin + 1)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -211,60 +211,6 @@ struct StatusMenuTests {
     }
 
     @Test
-    func `status menu follows current system appearance when created and opened`() {
-        self.disableMenuCardsForTesting()
-        let settings = self.makeSettings()
-        settings.statusChecksEnabled = false
-        settings.refreshFrequency = .manual
-
-        let fetcher = UsageFetcher()
-        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
-        let controller = StatusItemController(
-            store: store,
-            settings: settings,
-            account: fetcher.loadAccountInfo(),
-            updater: DisabledUpdaterController(),
-            preferencesSelection: PreferencesSelection(),
-            statusBar: self.makeStatusBarForTesting())
-        defer { controller.releaseStatusItemsForTesting() }
-
-        let expectedAppearance = StatusItemController.systemMenuAppearanceName(
-            interfaceStyle: UserDefaults.standard.string(forKey: "AppleInterfaceStyle"),
-            increaseContrast: NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast)
-        let menu = controller.makeMenu()
-        #expect(menu.appearance?.name == expectedAppearance)
-
-        let isDark = expectedAppearance == .darkAqua || expectedAppearance == .accessibilityHighContrastDarkAqua
-        let staleAppearance: NSAppearance.Name = isDark ? .aqua : .darkAqua
-        menu.appearance = NSAppearance(named: staleAppearance)
-        let submenu = NSMenu()
-        submenu.appearance = NSAppearance(named: staleAppearance)
-        let submenuItem = NSMenuItem()
-        submenuItem.submenu = submenu
-        menu.addItem(submenuItem)
-        controller.menuWillOpen(menu)
-        #expect(menu.appearance?.name == expectedAppearance)
-        #expect(submenu.appearance?.name == expectedAppearance)
-        controller.menuDidClose(menu)
-    }
-
-    @Test
-    func `system menu appearance follows global interface style and contrast`() {
-        #expect(StatusItemController.systemMenuAppearanceName(
-            interfaceStyle: nil,
-            increaseContrast: false) == .aqua)
-        #expect(StatusItemController.systemMenuAppearanceName(
-            interfaceStyle: "Dark",
-            increaseContrast: false) == .darkAqua)
-        #expect(StatusItemController.systemMenuAppearanceName(
-            interfaceStyle: nil,
-            increaseContrast: true) == .accessibilityHighContrastAqua)
-        #expect(StatusItemController.systemMenuAppearanceName(
-            interfaceStyle: "dark",
-            increaseContrast: true) == .accessibilityHighContrastDarkAqua)
-    }
-
-    @Test
     func `merged menu open does not persist resolved provider when selection is nil`() {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -228,11 +228,14 @@ struct StatusMenuTests {
             statusBar: self.makeStatusBarForTesting())
         defer { controller.releaseStatusItemsForTesting() }
 
-        let expectedAppearance = NSApp.effectiveAppearance.name
+        let expectedAppearance = StatusItemController.systemMenuAppearanceName(
+            interfaceStyle: UserDefaults.standard.string(forKey: "AppleInterfaceStyle"),
+            increaseContrast: NSWorkspace.shared.accessibilityDisplayShouldIncreaseContrast)
         let menu = controller.makeMenu()
         #expect(menu.appearance?.name == expectedAppearance)
 
-        let staleAppearance: NSAppearance.Name = expectedAppearance == .darkAqua ? .aqua : .darkAqua
+        let isDark = expectedAppearance == .darkAqua || expectedAppearance == .accessibilityHighContrastDarkAqua
+        let staleAppearance: NSAppearance.Name = isDark ? .aqua : .darkAqua
         menu.appearance = NSAppearance(named: staleAppearance)
         let submenu = NSMenu()
         submenu.appearance = NSAppearance(named: staleAppearance)
@@ -243,6 +246,22 @@ struct StatusMenuTests {
         #expect(menu.appearance?.name == expectedAppearance)
         #expect(submenu.appearance?.name == expectedAppearance)
         controller.menuDidClose(menu)
+    }
+
+    @Test
+    func `system menu appearance follows global interface style and contrast`() {
+        #expect(StatusItemController.systemMenuAppearanceName(
+            interfaceStyle: nil,
+            increaseContrast: false) == .aqua)
+        #expect(StatusItemController.systemMenuAppearanceName(
+            interfaceStyle: "Dark",
+            increaseContrast: false) == .darkAqua)
+        #expect(StatusItemController.systemMenuAppearanceName(
+            interfaceStyle: nil,
+            increaseContrast: true) == .accessibilityHighContrastAqua)
+        #expect(StatusItemController.systemMenuAppearanceName(
+            interfaceStyle: "dark",
+            increaseContrast: true) == .accessibilityHighContrastDarkAqua)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -234,8 +234,14 @@ struct StatusMenuTests {
 
         let staleAppearance: NSAppearance.Name = expectedAppearance == .darkAqua ? .aqua : .darkAqua
         menu.appearance = NSAppearance(named: staleAppearance)
+        let submenu = NSMenu()
+        submenu.appearance = NSAppearance(named: staleAppearance)
+        let submenuItem = NSMenuItem()
+        submenuItem.submenu = submenu
+        menu.addItem(submenuItem)
         controller.menuWillOpen(menu)
         #expect(menu.appearance?.name == expectedAppearance)
+        #expect(submenu.appearance?.name == expectedAppearance)
         controller.menuDidClose(menu)
     }
 

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -211,6 +211,35 @@ struct StatusMenuTests {
     }
 
     @Test
+    func `status menu follows current system appearance when created and opened`() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let expectedAppearance = NSApp.effectiveAppearance.name
+        let menu = controller.makeMenu()
+        #expect(menu.appearance?.name == expectedAppearance)
+
+        let staleAppearance: NSAppearance.Name = expectedAppearance == .darkAqua ? .aqua : .darkAqua
+        menu.appearance = NSAppearance(named: staleAppearance)
+        controller.menuWillOpen(menu)
+        #expect(menu.appearance?.name == expectedAppearance)
+        controller.menuDidClose(menu)
+    }
+
+    @Test
     func `merged menu open does not persist resolved provider when selection is nil`() {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()


### PR DESCRIPTION
## Problem and reproduction

The reported failure is an `NSStatusItem` menu inheriting the menu bar's vibrant appearance, which can render a dark dropdown while macOS is set to Light.

On current `main` and macOS 26.5, I could not reproduce the incorrect dark menu in Light even with a black/dark menu-bar backdrop. The report remains credible for older AppKit/macOS behavior, and the final fix is intentionally narrow.

## Final design

- Pin only the root status menu to the exact `NSApplication.shared.effectiveAppearance` when it is created and immediately before every open.
- Assign the exact appearance object instead of reconstructing Aqua/Dark Aqua names, preserving dynamic accessibility and high-contrast attributes that an appearance name can omit.
- Let descriptor and hosted submenus inherit from the refreshed root rather than recursively installing stale explicit overrides.
- Keep the existing persistent `NSMenu` and SwiftUI-backed menu rows unchanged.

The maintainer changelog entry thanks @npapridonu, and the contributor commit remains in branch history.

## Exact validation

Candidate: `862fd6840132277fbff6a24d6d4fb8c3fd89f6f8`, including current `main` `87f67e3efcac16b16c5fb6690a4ef931ce63b559`.

- `swift test --filter StatusMenuAppearanceTests`: 3 tests passed.
- Deterministic suite runner: all 435 discovered suites passed, one suite per shard.
- `./Scripts/lint.sh lint`: 0 violations across 1082 files; package-path and release dSYM path regressions also passed.
- `swift build -c release`: passed.
- `CODEXBAR_SIGNING=adhoc ./Scripts/package_app.sh debug`: passed.
- `codesign --verify --deep --strict CodexBar.app`: passed.
- Packaged app: version 0.34.1, build 84, arm64.
- App executable SHA-256: `c0791de59d6f66a5d3cc7d69a6dd392f7e80ef443feaecdb03bc2599b14cd326`.
- `$autoreview`: clean, no actionable findings; overall patch correct (0.84 confidence).
- Public Model Identifier Gate: **PASS**. Exact diff/tests/public text add no model identifiers; raw local logs were not published; the screenshot contains only public product UI and no account, path, credential, or private payload.

## Built-app proof

The exact packaged app was launched with a temporary configuration and no account data. In one persistent app process I opened the same status menu in manual Dark, switched to Light and delivered the standard macOS appearance-change notification to the isolated process, enabled Auto (effective Dark at test time), then enabled Increase Contrast. The menu returned the expected Light/Dark appearance, inherited correctly through the persistent/custom menu content, and high contrast preserved the stronger border and opaque background instead of collapsing to plain Aqua.

Host settings were restored exactly to manual Dark, Auto absent, Increase Contrast off, and Reduce Transparency off. Two displays were online, but the external display was mirrored; see residual risk below.

![Light, Dark, Auto, and Increase Contrast proof](https://raw.githubusercontent.com/steipete/CodexBar/c377b6683c9b5922759888a2a5396a101d3f590e/.github/pr-proof/1490-status-menu-appearance.png)

Proof image SHA-256: `666df10bd17df7c2085f0fa254652bd505369baf7c7d069830d40bf784bc896e`.

## Residual risk

- The original failure did not reproduce on macOS 26.5 current `main`; an older affected macOS VM was unavailable.
- The external display was mirrored from the main display, so independent per-display menu placement could not be exercised. Appearance is system-global and the fix deliberately does not derive appearance from any display or wallpaper.
- The screenshot lives on the dedicated `proof/pr1490-status-menu-appearance` branch so the contributor PR diff remains code/test/changelog only; that proof branch can be deleted after the owner decision.
