### PR TITLE
fix: close browser cookie isolation bypass

### DIFF
--- a/Sources/CodexBarCore/BrowserCookieAccessGate.swift
+++ b/Sources/CodexBarCore/BrowserCookieAccessGate.swift
@@ -4,6 +4,17 @@ import Foundation
 import os.lock
 import SweetCookieKit
 
+enum BrowserCookieStoreAccessDecision: Equatable {
+    case allowed
+    case suppressed
+}
+
+struct BrowserCookieStoreAccessSuppressedError: LocalizedError {
+    var errorDescription: String? {
+        "Browser cookie store access is suppressed for this process."
+    }
+}
+
 public enum BrowserCookieAccessGate {
     private struct State {
         var loaded = false
@@ -15,15 +26,22 @@ public enum BrowserCookieAccessGate {
     private static let cooldownInterval: TimeInterval = 60 * 60 * 6
     private static let log = CodexBarLog.logger(LogCategories.browserCookieGate)
 
-    static func allowsCookieStoreAccess(homeDirectories: [URL]) -> Bool {
-        guard self.isRunningUnderTests,
-              ProcessInfo.processInfo.environment["CODEXBAR_ALLOW_TEST_BROWSER_COOKIE_ACCESS"] != "1"
+    static let allowTestCookieAccessEnvironmentKey = "CODEXBAR_ALLOW_TEST_BROWSER_COOKIE_ACCESS"
+
+    static func cookieStoreAccessDecision(
+        homeDirectories: [URL],
+        processName: String = ProcessInfo.processInfo.processName,
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> BrowserCookieStoreAccessDecision
+    {
+        guard self.isRunningUnderTests(processName: processName, environment: environment),
+              environment[self.allowTestCookieAccessEnvironmentKey] != "1"
         else {
-            return true
+            return .allowed
         }
 
         let defaultHomes = Set(BrowserCookieClient.defaultHomeDirectories().map(Self.normalizedPath))
-        return homeDirectories.allSatisfy { !defaultHomes.contains(Self.normalizedPath($0)) }
+        let usesDefaultHome = homeDirectories.contains { defaultHomes.contains(Self.normalizedPath($0)) }
+        return usesDefaultHome ? .suppressed : .allowed
     }
 
     public static func shouldAttempt(_ browser: Browser, now: Date = Date()) -> Bool {
@@ -108,10 +126,11 @@ public enum BrowserCookieAccessGate {
 
     private static let safeStorageLabels: [(service: String, account: String)] = Browser.safeStorageLabels
 
-    private static var isRunningUnderTests: Bool {
-        let processName = ProcessInfo.processInfo.processName
-        let environment = ProcessInfo.processInfo.environment
-        return processName == "swiftpm-testing-helper"
+    private static func isRunningUnderTests(
+        processName: String,
+        environment: [String: String]) -> Bool
+    {
+        processName == "swiftpm-testing-helper"
             || processName.hasSuffix("PackageTests")
             || environment["XCTestConfigurationFilePath"] != nil
             || environment["SWIFT_TESTING"] != nil
@@ -137,14 +156,25 @@ public enum BrowserCookieAccessGate {
 }
 
 extension BrowserCookieClient {
+    public func codexBarStores(for browser: Browser) throws -> [BrowserCookieStore] {
+        guard BrowserCookieAccessGate.cookieStoreAccessDecision(
+            homeDirectories: self.configuration.homeDirectories) == .allowed
+        else {
+            throw BrowserCookieStoreAccessSuppressedError()
+        }
+        guard BrowserCookieAccessGate.shouldAttempt(browser) else { return [] }
+        return self.stores(for: browser)
+    }
+
     public func codexBarRecords(
         matching query: BrowserCookieQuery,
         in browser: Browser,
         logger: ((String) -> Void)? = nil) throws -> [BrowserCookieStoreRecords]
     {
-        guard BrowserCookieAccessGate.allowsCookieStoreAccess(homeDirectories: self.configuration.homeDirectories)
+        guard BrowserCookieAccessGate.cookieStoreAccessDecision(
+            homeDirectories: self.configuration.homeDirectories) == .allowed
         else {
-            return []
+            throw BrowserCookieStoreAccessSuppressedError()
         }
         guard BrowserCookieAccessGate.shouldAttempt(browser) else { return [] }
         return try self.records(matching: query, in: browser, logger: logger)

--- a/Sources/CodexBarCore/BrowserDetection.swift
+++ b/Sources/CodexBarCore/BrowserDetection.swift
@@ -65,10 +65,14 @@ public final class BrowserDetection: Sendable {
     /// This is intentionally stricter than `isAppInstalled`: for Chromium browsers, we only return true
     /// when profile data exists (to avoid unnecessary Keychain prompts).
     public func isCookieSourceAvailable(_ browser: Browser) -> Bool {
-        // Safari does not need Keychain decryption, but tests must not inspect the real cookie store.
+        let homeURL = URL(fileURLWithPath: self.homeDirectory, isDirectory: true)
+        guard BrowserCookieAccessGate.cookieStoreAccessDecision(homeDirectories: [homeURL]) == .allowed else {
+            return false
+        }
+
+        // Safari does not need Keychain decryption and can still yield cookies if its storage path changes.
         if browser == .safari {
-            return BrowserCookieAccessGate.allowsCookieStoreAccess(
-                homeDirectories: [URL(fileURLWithPath: self.homeDirectory)])
+            return true
         }
 
         // For browsers that typically require keychain-backed decryption, ensure an actual cookie store exists.

--- a/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Alibaba/AlibabaCodingPlanCookieImporter.swift
@@ -187,7 +187,7 @@ public enum AlibabaCodingPlanCookieImporter {
     }
 }
 
-private enum AlibabaChromiumCookieFallbackImporter {
+enum AlibabaChromiumCookieFallbackImporter {
     private struct ChromiumCookieRecord {
         let domain: String
         let name: String
@@ -217,9 +217,10 @@ private enum AlibabaChromiumCookieFallbackImporter {
     static func importSession(
         browser: Browser,
         domains: [String],
+        cookieClient: BrowserCookieClient = BrowserCookieClient(),
         logger: ((String) -> Void)? = nil) throws -> AlibabaCodingPlanCookieImporter.SessionInfo?
     {
-        let stores = BrowserCookieClient().stores(for: browser).filter { $0.databaseURL != nil }
+        let stores = try cookieClient.codexBarStores(for: browser).filter { $0.databaseURL != nil }
         guard !stores.isEmpty else { return nil }
 
         logger?("[alibaba-cookie] Trying \(browser.displayName) Chromium fallback")

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
@@ -133,7 +133,7 @@ public enum MiMoCookieImporter {
             browserDetection: browserDetection,
             logger: logger,
             loadRecords: { browserSource, query, log in
-                try Self.cookieClient.records(
+                try Self.cookieClient.codexBarRecords(
                     matching: query,
                     in: browserSource,
                     logger: log)

--- a/Sources/CodexBarCore/Providers/Mistral/MistralCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/Mistral/MistralCookieImporter.swift
@@ -47,7 +47,7 @@ public enum MistralCookieImporter {
         for browserSource in installedBrowsers {
             do {
                 let query = BrowserCookieQuery(domains: self.cookieDomains)
-                let sources = try Self.cookieClient.records(
+                let sources = try Self.cookieClient.codexBarRecords(
                     matching: query,
                     in: browserSource,
                     logger: log)

--- a/Tests/CodexBarTests/AlibabaCodingPlanCookieImporterTests.swift
+++ b/Tests/CodexBarTests/AlibabaCodingPlanCookieImporterTests.swift
@@ -8,11 +8,10 @@ import SweetCookieKit
 
 @Suite(.serialized)
 struct AlibabaCodingPlanCookieImporterTests {
-    @Test
+    @Test(.disabled(
+        if: ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] == "1",
+        "Default-home cookie access is explicitly enabled for this test run."))
     func `default home import is suppressed before profile and keychain access`() throws {
-        guard ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] != "1"
-        else { return }
-
         let profileProbeCount = OSAllocatedUnfairLock(initialState: 0)
         let keychainProbeCount = OSAllocatedUnfairLock(initialState: 0)
         let defaultHome = try #require(BrowserCookieClient.defaultHomeDirectories().first)
@@ -43,11 +42,10 @@ struct AlibabaCodingPlanCookieImporterTests {
         #expect(keychainProbeCount.withLock { $0 } == 0)
     }
 
-    @Test
+    @Test(.disabled(
+        if: ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] == "1",
+        "Default-home cookie access is explicitly enabled for this test run."))
     func `chromium fallback rejects default client before keychain access`() {
-        guard ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] != "1"
-        else { return }
-
         let keychainProbeCount = OSAllocatedUnfairLock(initialState: 0)
         _ = KeychainAccessGate.withTaskOverrideForTesting(false) {
             KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in

--- a/Tests/CodexBarTests/AlibabaCodingPlanCookieImporterTests.swift
+++ b/Tests/CodexBarTests/AlibabaCodingPlanCookieImporterTests.swift
@@ -1,11 +1,69 @@
 import Foundation
+import os.lock
 import Testing
 @testable import CodexBarCore
 
 #if os(macOS)
 import SweetCookieKit
 
+@Suite(.serialized)
 struct AlibabaCodingPlanCookieImporterTests {
+    @Test
+    func `default home import is suppressed before profile and keychain access`() throws {
+        guard ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] != "1"
+        else { return }
+
+        let profileProbeCount = OSAllocatedUnfairLock(initialState: 0)
+        let keychainProbeCount = OSAllocatedUnfairLock(initialState: 0)
+        let defaultHome = try #require(BrowserCookieClient.defaultHomeDirectories().first)
+        let detection = BrowserDetection(
+            homeDirectory: defaultHome.path,
+            cacheTTL: 0,
+            fileExists: { _ in
+                profileProbeCount.withLock { $0 += 1 }
+                return true
+            },
+            directoryContents: { _ in
+                profileProbeCount.withLock { $0 += 1 }
+                return ["Default"]
+            })
+
+        _ = KeychainAccessGate.withTaskOverrideForTesting(false) {
+            KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in
+                keychainProbeCount.withLock { $0 += 1 }
+                return .allowed
+            } operation: {
+                #expect(throws: AlibabaCodingPlanSettingsError.self) {
+                    _ = try AlibabaCodingPlanCookieImporter.importSession(browserDetection: detection)
+                }
+            }
+        }
+
+        #expect(profileProbeCount.withLock { $0 } == 0)
+        #expect(keychainProbeCount.withLock { $0 } == 0)
+    }
+
+    @Test
+    func `chromium fallback rejects default client before keychain access`() {
+        guard ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] != "1"
+        else { return }
+
+        let keychainProbeCount = OSAllocatedUnfairLock(initialState: 0)
+        _ = KeychainAccessGate.withTaskOverrideForTesting(false) {
+            KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in
+                keychainProbeCount.withLock { $0 += 1 }
+                return .allowed
+            } operation: {
+                #expect(throws: BrowserCookieStoreAccessSuppressedError.self) {
+                    _ = try AlibabaChromiumCookieFallbackImporter.importSession(
+                        browser: .chrome,
+                        domains: ["example.com"])
+                }
+            }
+        }
+        #expect(keychainProbeCount.withLock { $0 } == 0)
+    }
+
     @Test
     func `domain matching requires exact or label bounded suffix`() {
         #expect(AlibabaCodingPlanCookieImporter.matchesCookieDomain("console.aliyun.com"))

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -8,7 +8,9 @@ import SweetCookieKit
 
 @Suite(.serialized)
 struct BrowserDetectionTests {
-    @Test
+    @Test(.disabled(
+        if: ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] == "1",
+        "Default-home cookie access is explicitly enabled for this test run."))
     func `default home detection is suppressed before profile probes`() throws {
         let probeCount = OSAllocatedUnfairLock(initialState: 0)
         let defaultHome = try #require(BrowserCookieClient.defaultHomeDirectories().first)
@@ -28,7 +30,9 @@ struct BrowserDetectionTests {
         #expect(probeCount.withLock { $0 } == 0)
     }
 
-    @Test
+    @Test(.disabled(
+        if: ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] == "1",
+        "Default-home cookie access is explicitly enabled for this test run."))
     func `default client reports structured suppression before store discovery`() {
         let client = BrowserCookieClient()
 
@@ -61,20 +65,18 @@ struct BrowserDetectionTests {
             environment: [:]) == .allowed)
     }
 
-    @Test
+    @Test(.disabled(
+        if: ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] == "1",
+        "Default-home cookie access is explicitly enabled for this test run."))
     func `safari is installed but default cookie access is disabled during tests`() {
-        guard ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] != "1"
-        else { return }
-
         #expect(BrowserDetection(cacheTTL: 0).isAppInstalled(.safari) == true)
         #expect(BrowserDetection(cacheTTL: 0).isCookieSourceAvailable(.safari) == false)
     }
 
-    @Test
+    @Test(.disabled(
+        if: ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] == "1",
+        "Default-home cookie access is explicitly enabled for this test run."))
     func `default cookie candidates exclude safari during tests`() {
-        guard ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] != "1"
-        else { return }
-
         let detection = BrowserDetection(cacheTTL: 0)
         let browsers: [Browser] = [.safari, .chrome, .firefox]
         #expect(browsers.cookieImportCandidates(using: detection).contains(.safari) == false)

--- a/Tests/CodexBarTests/BrowserDetectionTests.swift
+++ b/Tests/CodexBarTests/BrowserDetectionTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os.lock
 import Testing
 @testable import CodexBarCore
 
@@ -8,8 +9,62 @@ import SweetCookieKit
 @Suite(.serialized)
 struct BrowserDetectionTests {
     @Test
+    func `default home detection is suppressed before profile probes`() throws {
+        let probeCount = OSAllocatedUnfairLock(initialState: 0)
+        let defaultHome = try #require(BrowserCookieClient.defaultHomeDirectories().first)
+        let detection = BrowserDetection(
+            homeDirectory: defaultHome.path,
+            cacheTTL: 0,
+            fileExists: { _ in
+                probeCount.withLock { $0 += 1 }
+                return false
+            },
+            directoryContents: { _ in
+                probeCount.withLock { $0 += 1 }
+                return nil
+            })
+
+        _ = detection.isCookieSourceAvailable(.chrome)
+        #expect(probeCount.withLock { $0 } == 0)
+    }
+
+    @Test
+    func `default client reports structured suppression before store discovery`() {
+        let client = BrowserCookieClient()
+
+        #expect(throws: BrowserCookieStoreAccessSuppressedError.self) {
+            _ = try client.codexBarStores(for: .chrome)
+        }
+        #expect(throws: BrowserCookieStoreAccessSuppressedError.self) {
+            _ = try client.codexBarRecords(
+                matching: BrowserCookieQuery(domains: ["example.com"]),
+                in: .safari)
+        }
+    }
+
+    @Test
+    func `cookie store decision allows production and explicit test opt in`() {
+        let defaultHomes = BrowserCookieClient.defaultHomeDirectories()
+        let testProcess = "swiftpm-testing-helper"
+
+        #expect(BrowserCookieAccessGate.cookieStoreAccessDecision(
+            homeDirectories: defaultHomes,
+            processName: testProcess,
+            environment: [:]) == .suppressed)
+        #expect(BrowserCookieAccessGate.cookieStoreAccessDecision(
+            homeDirectories: defaultHomes,
+            processName: testProcess,
+            environment: [BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey: "1"]) == .allowed)
+        #expect(BrowserCookieAccessGate.cookieStoreAccessDecision(
+            homeDirectories: defaultHomes,
+            processName: "CodexBar",
+            environment: [:]) == .allowed)
+    }
+
+    @Test
     func `safari is installed but default cookie access is disabled during tests`() {
-        guard ProcessInfo.processInfo.environment["CODEXBAR_ALLOW_TEST_BROWSER_COOKIE_ACCESS"] != "1" else { return }
+        guard ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] != "1"
+        else { return }
 
         #expect(BrowserDetection(cacheTTL: 0).isAppInstalled(.safari) == true)
         #expect(BrowserDetection(cacheTTL: 0).isCookieSourceAvailable(.safari) == false)
@@ -17,7 +72,8 @@ struct BrowserDetectionTests {
 
     @Test
     func `default cookie candidates exclude safari during tests`() {
-        guard ProcessInfo.processInfo.environment["CODEXBAR_ALLOW_TEST_BROWSER_COOKIE_ACCESS"] != "1" else { return }
+        guard ProcessInfo.processInfo.environment[BrowserCookieAccessGate.allowTestCookieAccessEnvironmentKey] != "1"
+        else { return }
 
         let detection = BrowserDetection(cacheTTL: 0)
         let browsers: [Browser] = [.safari, .chrome, .firefox]
@@ -31,20 +87,21 @@ struct BrowserDetectionTests {
     }
 
     @Test
-    func `cookie client skips real browser stores during tests`() throws {
-        guard ProcessInfo.processInfo.environment["CODEXBAR_ALLOW_TEST_BROWSER_COOKIE_ACCESS"] != "1" else { return }
+    func `cookie client permits isolated chromium stores during tests`() throws {
+        let temp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let profile = temp
+            .appendingPathComponent("Library/Application Support/Google/Chrome/Default/Network")
+        try FileManager.default.createDirectory(at: profile, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: profile.appendingPathComponent("Cookies").path, contents: Data())
+        defer { try? FileManager.default.removeItem(at: temp) }
 
-        let records = try BrowserCookieClient().codexBarRecords(
-            matching: BrowserCookieQuery(domains: ["example.com"]),
-            in: .safari)
-        #expect(records.isEmpty)
-    }
-
-    @Test
-    func `cookie client permits isolated browser stores during tests`() {
-        let tempHome = URL(fileURLWithPath: "/tmp/codexbar-browser-cookie-client")
-        let client = BrowserCookieClient(configuration: .init(homeDirectories: [tempHome]))
-        #expect(BrowserCookieAccessGate.allowsCookieStoreAccess(homeDirectories: client.configuration.homeDirectories))
+        let client = BrowserCookieClient(configuration: .init(homeDirectories: [temp]))
+        let stores = try KeychainAccessGate.withTaskOverrideForTesting(false) {
+            try KeychainAccessPreflight.withCheckGenericPasswordOverrideForTesting { _, _ in .allowed } operation: {
+                try client.codexBarStores(for: .chrome)
+            }
+        }
+        #expect(stores.count == 1)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- follow up the externally merged #1489 by closing the reviewed Alibaba fallback bypass
- return a structured suppression error before default-home browser profile, SQLite, or Keychain access
- route all browser-cookie record/store imports through the shared gate while preserving production and explicit test opt-in behavior
- add focused coverage for detection, direct clients, Alibaba fallback, temporary-home fixtures, and sibling raw-client call sites

## Reproduction and isolation proof
- On the assigned #1489 head, a redacted host characterization with real browser profiles present observed a default-profile probe and one real Chromium store group through the unguarded paths.
- On this candidate, default-home detection records zero profile probes.
- Direct default-home record/store clients return the structured suppression error before discovery.
- Alibaba import and its Chromium fallback record zero Keychain preflights.
- A temporary Chromium home remains discoverable, explicit test opt-in remains allowed, and normal production process classification remains allowed.
- No cookie values, account data, or identifying profile paths were captured or published.

## Validation
- `swift test --filter BrowserDetectionTests --filter AlibabaCodingPlanCookieImporterTests`: 21 tests, 2 suites passed
- broader focused provider run: 66 tests, 6 suites passed
- deterministic CI runner: all 431 discovered suites passed
- `make lint`: 0 violations across 1,076 files
- `swift build -c release`: passed
- autoreview: clean on the uncommitted candidate and clean again on the exact rebased branch
- Public Model Identifier Gate: PASS for exact diff, tests, fixtures, sanitized proof, and non-published build artifacts

No changelog entry: this only repairs test/infrastructure isolation; production default-home behavior is unchanged.
