### PR TITLE
fix: verify release dSYM UUIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Diagnostics: enforce probe timeouts even when an underlying provider operation ignores Swift task cancellation.
 - Release: let `package_app.sh` own the single release build pass during signing/notarization, avoiding a redundant pre-build that could churn SwiftPM outputs before packaging. Thanks @ProspectOre!
 - Release: add focused dSYM preflight coverage so missing or wrong-architecture debug symbols fail with the exact path before universal symbol packaging. Thanks @ProspectOre!
+- Release: verify the packaged dSYM UUIDs match the signed app binary before zipping debug symbols, so uploaded symbols cannot silently drift away from the shipped build. Thanks @ProspectOre!
 - Kimi: add usage fetching from the official Code API key flow, with optional compatible HTTPS proxy support (#1424). Thanks @kiranmagic7!
 - Menu bar: keep the selected quota percentage visible in Pace mode when pace is temporarily unavailable instead of collapsing to an icon-only status item (fixes #1462).
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.

--- a/Scripts/release_dsym_paths.sh
+++ b/Scripts/release_dsym_paths.sh
@@ -30,3 +30,46 @@ codexbar_require_dsym_dwarf_for_arch() {
 
   printf '%s\n' "$dwarf_path"
 }
+
+codexbar_dwarf_uuid_for_arch() {
+  local path="$1"
+  local arch="$2"
+  local uuid
+
+  uuid=$(dwarfdump --uuid "$path" | awk -v arch="(${arch})" '$1 == "UUID:" && $3 == arch { print $2; exit }')
+  if [[ -z "$uuid" ]]; then
+    echo "Missing UUID for ${arch} in: ${path}" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$uuid"
+}
+
+codexbar_verify_dsym_matches_binary() {
+  local app_binary="$1"
+  local dsym_dwarf="$2"
+  shift 2
+  local arch app_uuid dsym_uuid
+
+  if [[ ! -f "$app_binary" ]]; then
+    echo "Missing app binary for dSYM UUID verification: ${app_binary}" >&2
+    return 1
+  fi
+  if [[ ! -f "$dsym_dwarf" ]]; then
+    echo "Missing dSYM DWARF file for UUID verification: ${dsym_dwarf}" >&2
+    return 1
+  fi
+
+  for arch in "$@"; do
+    if ! app_uuid=$(codexbar_dwarf_uuid_for_arch "$app_binary" "$arch"); then
+      return 1
+    fi
+    if ! dsym_uuid=$(codexbar_dwarf_uuid_for_arch "$dsym_dwarf" "$arch"); then
+      return 1
+    fi
+    if [[ "$app_uuid" != "$dsym_uuid" ]]; then
+      echo "dSYM UUID mismatch for ${arch}: app=${app_uuid}, dSYM=${dsym_uuid}" >&2
+      return 1
+    fi
+  done
+}

--- a/Scripts/sign-and-notarize.sh
+++ b/Scripts/sign-and-notarize.sh
@@ -10,6 +10,43 @@ source "$ROOT/Scripts/release_artifacts.sh"
 source "$ROOT/Scripts/package_product_paths.sh"
 source "$ROOT/Scripts/release_dsym_paths.sh"
 
+codexbar_dwarf_uuid_for_arch() {
+  local path="$1"
+  local arch="$2"
+  local uuid
+  uuid=$(dwarfdump --uuid "$path" | awk -v arch="(${arch})" '$1 == "UUID:" && $3 == arch { print $2; exit }')
+  if [[ -z "$uuid" ]]; then
+    echo "Missing UUID for ${arch} in: ${path}" >&2
+    return 1
+  fi
+  printf '%s\n' "$uuid"
+}
+
+verify_dsym_matches_app_binary() {
+  local app_binary="$1"
+  local dsym_dwarf="$2"
+  shift 2
+  local arch app_uuid dsym_uuid
+
+  if [[ ! -f "$app_binary" ]]; then
+    echo "Missing app binary for dSYM UUID verification: ${app_binary}" >&2
+    return 1
+  fi
+  if [[ ! -f "$dsym_dwarf" ]]; then
+    echo "Missing dSYM DWARF file for UUID verification: ${dsym_dwarf}" >&2
+    return 1
+  fi
+
+  for arch in "$@"; do
+    app_uuid=$(codexbar_dwarf_uuid_for_arch "$app_binary" "$arch")
+    dsym_uuid=$(codexbar_dwarf_uuid_for_arch "$dsym_dwarf" "$arch")
+    if [[ "$app_uuid" != "$dsym_uuid" ]]; then
+      echo "dSYM UUID mismatch for ${arch}: app=${app_uuid}, dSYM=${dsym_uuid}" >&2
+      return 1
+    fi
+  done
+}
+
 # Allow building a universal binary if ARCHES is provided; default to universal (arm64 + x86_64).
 ARCHES_VALUE=${ARCHES:-"arm64 x86_64"}
 ZIP_NAME=$(codexbar_app_zip_name "$MARKETING_VERSION" "$ARCHES_VALUE")
@@ -119,6 +156,10 @@ if [[ ! -d "$DSYM_PATH" ]]; then
   echo "Missing dSYM at SwiftPM-reported path: $DSYM_PATH" >&2
   exit 1
 fi
+verify_dsym_matches_app_binary \
+  "$APP_BUNDLE/Contents/MacOS/$APP_NAME" \
+  "$DSYM_PATH/Contents/Resources/DWARF/$APP_NAME" \
+  "${ARCH_LIST[@]}"
 "$DITTO_BIN" --norsrc -c -k --keepParent "$DSYM_PATH" "$DSYM_ZIP"
 
 echo "Done: $ZIP_NAME"

--- a/Scripts/sign-and-notarize.sh
+++ b/Scripts/sign-and-notarize.sh
@@ -10,43 +10,6 @@ source "$ROOT/Scripts/release_artifacts.sh"
 source "$ROOT/Scripts/package_product_paths.sh"
 source "$ROOT/Scripts/release_dsym_paths.sh"
 
-codexbar_dwarf_uuid_for_arch() {
-  local path="$1"
-  local arch="$2"
-  local uuid
-  uuid=$(dwarfdump --uuid "$path" | awk -v arch="(${arch})" '$1 == "UUID:" && $3 == arch { print $2; exit }')
-  if [[ -z "$uuid" ]]; then
-    echo "Missing UUID for ${arch} in: ${path}" >&2
-    return 1
-  fi
-  printf '%s\n' "$uuid"
-}
-
-verify_dsym_matches_app_binary() {
-  local app_binary="$1"
-  local dsym_dwarf="$2"
-  shift 2
-  local arch app_uuid dsym_uuid
-
-  if [[ ! -f "$app_binary" ]]; then
-    echo "Missing app binary for dSYM UUID verification: ${app_binary}" >&2
-    return 1
-  fi
-  if [[ ! -f "$dsym_dwarf" ]]; then
-    echo "Missing dSYM DWARF file for UUID verification: ${dsym_dwarf}" >&2
-    return 1
-  fi
-
-  for arch in "$@"; do
-    app_uuid=$(codexbar_dwarf_uuid_for_arch "$app_binary" "$arch")
-    dsym_uuid=$(codexbar_dwarf_uuid_for_arch "$dsym_dwarf" "$arch")
-    if [[ "$app_uuid" != "$dsym_uuid" ]]; then
-      echo "dSYM UUID mismatch for ${arch}: app=${app_uuid}, dSYM=${dsym_uuid}" >&2
-      return 1
-    fi
-  done
-}
-
 # Allow building a universal binary if ARCHES is provided; default to universal (arm64 + x86_64).
 ARCHES_VALUE=${ARCHES:-"arm64 x86_64"}
 ZIP_NAME=$(codexbar_app_zip_name "$MARKETING_VERSION" "$ARCHES_VALUE")
@@ -156,7 +119,7 @@ if [[ ! -d "$DSYM_PATH" ]]; then
   echo "Missing dSYM at SwiftPM-reported path: $DSYM_PATH" >&2
   exit 1
 fi
-verify_dsym_matches_app_binary \
+codexbar_verify_dsym_matches_binary \
   "$APP_BUNDLE/Contents/MacOS/$APP_NAME" \
   "$DSYM_PATH/Contents/Resources/DWARF/$APP_NAME" \
   "${ARCH_LIST[@]}"

--- a/Scripts/test_release_dsym_paths.sh
+++ b/Scripts/test_release_dsym_paths.sh
@@ -17,10 +17,15 @@ ARM_DSYM="$TEMP_DIR/CodexBar arm64.dSYM"
 UNIVERSAL_DSYM="$TEMP_DIR/CodexBar universal.dSYM"
 WRONG_ARCH_DSYM="$TEMP_DIR/CodexBar stale.dSYM"
 MISSING_DWARF_DSYM="$TEMP_DIR/CodexBar missing.dSYM"
+APP_BINARY="$TEMP_DIR/CodexBar.app"
+MATCHING_DWARF="$TEMP_DIR/CodexBar matching"
+MISMATCHED_DWARF="$TEMP_DIR/CodexBar mismatched"
+MISSING_UUID_DWARF="$TEMP_DIR/CodexBar missing UUID"
 make_dsym "$ARM_DSYM"
 make_dsym "$UNIVERSAL_DSYM"
 make_dsym "$WRONG_ARCH_DSYM"
 mkdir -p "$MISSING_DWARF_DSYM/Contents/Resources/DWARF"
+touch "$APP_BINARY" "$MATCHING_DWARF" "$MISMATCHED_DWARF" "$MISSING_UUID_DWARF"
 
 lipo() {
   [[ "$1" == "-archs" ]]
@@ -36,6 +41,29 @@ lipo() {
       ;;
     *)
       echo "unexpected lipo path: $2" >&2
+      return 2
+      ;;
+  esac
+}
+
+dwarfdump() {
+  [[ "$1" == "--uuid" ]]
+  case "$2" in
+    "$APP_BINARY" | "$MATCHING_DWARF")
+      printf '%s\n' \
+        "UUID: AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA (arm64) $2" \
+        "UUID: BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB (x86_64) $2"
+      ;;
+    "$MISMATCHED_DWARF")
+      printf '%s\n' \
+        "UUID: AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA (arm64) $2" \
+        "UUID: CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC (x86_64) $2"
+      ;;
+    "$MISSING_UUID_DWARF")
+      printf '%s\n' "UUID: AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA (arm64) $2"
+      ;;
+    *)
+      echo "unexpected dwarfdump path: $2" >&2
       return 2
       ;;
   esac
@@ -60,5 +88,21 @@ if codexbar_require_dsym_dwarf_for_arch "$WRONG_ARCH_DSYM" CodexBar arm64 \
   exit 1
 fi
 grep -Fq "required architecture: arm64" "$TEMP_DIR/wrong-arch.log"
+
+codexbar_verify_dsym_matches_binary "$APP_BINARY" "$MATCHING_DWARF" arm64 x86_64
+
+if codexbar_verify_dsym_matches_binary "$APP_BINARY" "$MISMATCHED_DWARF" arm64 x86_64 \
+  2>"$TEMP_DIR/mismatched-uuid.log"; then
+  echo "ERROR: Mismatched dSYM UUID was accepted." >&2
+  exit 1
+fi
+grep -Fq "dSYM UUID mismatch for x86_64" "$TEMP_DIR/mismatched-uuid.log"
+
+if codexbar_verify_dsym_matches_binary "$APP_BINARY" "$MISSING_UUID_DWARF" arm64 x86_64 \
+  2>"$TEMP_DIR/missing-uuid.log"; then
+  echo "ERROR: Missing dSYM UUID was accepted." >&2
+  exit 1
+fi
+grep -Fq "Missing UUID for x86_64" "$TEMP_DIR/missing-uuid.log"
 
 echo "Release dSYM path tests passed."


### PR DESCRIPTION
## Summary

- Verify the final packaged dSYM UUIDs against the signed `CodexBar.app` executable before zipping debug symbols.
- Fail release packaging when any requested architecture is missing a UUID or when the app and dSYM UUIDs differ.
- Document the release-symbol guard in the changelog.

## Why

After the stale-product packaging fixes, the next release invariant is that uploaded dSYMs must correspond to the exact app binary being shipped. A mismatched dSYM archive makes crash reports misleading or unsymbolic even when the app zip itself is correct.

## Validation

- `bash -n Scripts/sign-and-notarize.sh`
- `./Scripts/test_package_product_paths.sh`
- Manual fixture: compiled a tiny `clang -g` binary, generated a dSYM with `dsymutil`, verified matching UUIDs pass, then verified a different binary against the same dSYM fails with `dSYM UUID mismatch`.
- `make check`

## Behavior proof

Ran the UUID helper from this branch against real Mach-O binaries and a real `dsymutil` output on June 13, 2026:

```text
matching app UUID: DCD55604-6003-3100-9D34-9F9E2BE160D7
matching dSYM UUID: DCD55604-6003-3100-9D34-9F9E2BE160D7
match verification: passed
mismatch verification: dSYM UUID mismatch for arm64: app=<uuid>, dSYM=<uuid>
```
