### PR TITLE
perf: remove redundant release prebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Menu bar: avoid starting a duplicate background provider refresh when the menu closes while its initial missing-data refresh is still in flight.
 - Menu bar: rebuild merged provider content inside AppKit's active tracking run loop so provider switches no longer wait for the menu to close or the default run loop to resume.
 - Diagnostics: enforce probe timeouts even when an underlying provider operation ignores Swift task cancellation.
-- Release: let `package_app.sh` own the single release build pass during signing/notarization, avoiding a redundant pre-build that could churn SwiftPM outputs before packaging.
+- Release: let `package_app.sh` own the single release build pass during signing/notarization, avoiding a redundant pre-build that could churn SwiftPM outputs before packaging. Thanks @ProspectOre!
 - Kimi: add usage fetching from the official Code API key flow, with optional compatible HTTPS proxy support (#1424). Thanks @kiranmagic7!
 - Menu bar: keep the selected quota percentage visible in Pace mode when pace is temporarily unavailable instead of collapsing to an icon-only status item (fixes #1462).
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Menu bar: avoid starting a duplicate background provider refresh when the menu closes while its initial missing-data refresh is still in flight.
 - Menu bar: rebuild merged provider content inside AppKit's active tracking run loop so provider switches no longer wait for the menu to close or the default run loop to resume.
 - Diagnostics: enforce probe timeouts even when an underlying provider operation ignores Swift task cancellation.
+- Release: let `package_app.sh` own the single release build pass during signing/notarization, avoiding a redundant pre-build that could churn SwiftPM outputs before packaging.
 - Kimi: add usage fetching from the official Code API key flow, with optional compatible HTTPS proxy support (#1424). Thanks @kiranmagic7!
 - Menu bar: keep the selected quota percentage visible in Pace mode when pace is temporarily unavailable instead of collapsing to an icon-only status item (fixes #1462).
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.

--- a/Scripts/sign-and-notarize.sh
+++ b/Scripts/sign-and-notarize.sh
@@ -32,9 +32,6 @@ trap 'rm -rf "$NOTARIZATION_TEMP_DIR"' EXIT
 chmod 600 "$API_KEY_PATH"
 
 ARCH_LIST=( ${ARCHES_VALUE} )
-for ARCH in "${ARCH_LIST[@]}"; do
-  swift build -c release --arch "$ARCH"
-done
 ARCHES="${ARCHES_VALUE}" ./Scripts/package_app.sh release
 
 ENTITLEMENTS_DIR="$ROOT/.build/entitlements"


### PR DESCRIPTION
## Summary

- Remove the redundant `swift build -c release --arch ...` loop from `Scripts/sign-and-notarize.sh`.
- Keep `package_app.sh` as the single owner of release build and product staging.
- Document the release-flow simplification in the changelog.

## Why

`sign-and-notarize.sh` immediately calls `ARCHES=... ./Scripts/package_app.sh release`, and `package_app.sh` already builds every requested architecture before staging binaries and dSYMs. Running a separate pre-build first adds time and extra SwiftPM output churn without changing the packaged app.

## Validation

- `bash -n Scripts/sign-and-notarize.sh`
- Verified `Scripts/sign-and-notarize.sh` no longer contains a standalone `swift build -c release --arch` invocation.
- `./Scripts/test_package_product_paths.sh`
- `make check`

## Behavior proof

Ran an ad-hoc release package pass from this branch on June 13, 2026:

```text
$ CODEXBAR_SIGNING=adhoc ARCHES="$(uname -m)" ./Scripts/package_app.sh release
Build complete! (308.57 sec)
Build complete! (76.47 sec)
Building CodexBarWidget Xcode extension (Release, arm64).
Created /Users/alec/Dev/CodexBar/CodexBar.app
```

Artifact and signature checks after packaging:

```text
CodexBar archs: arm64
CodexBarCLI archs: arm64
Widget archs: arm64
/Users/alec/Dev/CodexBar/CodexBar.app: valid on disk
/Users/alec/Dev/CodexBar/CodexBar.app: satisfies its Designated Requirement
```
