### PR TITLE
fix: validate release dSYM paths and architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Menu bar: rebuild merged provider content inside AppKit's active tracking run loop so provider switches no longer wait for the menu to close or the default run loop to resume.
 - Diagnostics: enforce probe timeouts even when an underlying provider operation ignores Swift task cancellation.
 - Release: let `package_app.sh` own the single release build pass during signing/notarization, avoiding a redundant pre-build that could churn SwiftPM outputs before packaging. Thanks @ProspectOre!
+- Release: add focused dSYM preflight coverage so missing or wrong-architecture debug symbols fail with the exact path before universal symbol packaging.
 - Kimi: add usage fetching from the official Code API key flow, with optional compatible HTTPS proxy support (#1424). Thanks @kiranmagic7!
 - Menu bar: keep the selected quota percentage visible in Pace mode when pace is temporarily unavailable instead of collapsing to an icon-only status item (fixes #1462).
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Menu bar: rebuild merged provider content inside AppKit's active tracking run loop so provider switches no longer wait for the menu to close or the default run loop to resume.
 - Diagnostics: enforce probe timeouts even when an underlying provider operation ignores Swift task cancellation.
 - Release: let `package_app.sh` own the single release build pass during signing/notarization, avoiding a redundant pre-build that could churn SwiftPM outputs before packaging. Thanks @ProspectOre!
-- Release: add focused dSYM preflight coverage so missing or wrong-architecture debug symbols fail with the exact path before universal symbol packaging.
+- Release: add focused dSYM preflight coverage so missing or wrong-architecture debug symbols fail with the exact path before universal symbol packaging. Thanks @ProspectOre!
 - Kimi: add usage fetching from the official Code API key flow, with optional compatible HTTPS proxy support (#1424). Thanks @kiranmagic7!
 - Menu bar: keep the selected quota percentage visible in Pace mode when pace is temporarily unavailable instead of collapsing to an icon-only status item (fixes #1462).
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -19,12 +19,17 @@ check_package_product_paths() {
   "${ROOT_DIR}/Scripts/test_package_product_paths.sh"
 }
 
+check_release_dsym_paths() {
+  "${ROOT_DIR}/Scripts/test_release_dsym_paths.sh"
+}
+
 cmd="${1:-lint}"
 
 case "$cmd" in
   lint)
     check_codex_parser_hash
     check_package_product_paths
+    check_release_dsym_paths
     ensure_tools
     "${BIN_DIR}/swiftformat" Sources Tests --lint
     "${BIN_DIR}/swiftlint" --strict

--- a/Scripts/release_dsym_paths.sh
+++ b/Scripts/release_dsym_paths.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+codexbar_dsym_dwarf_path() {
+  local dsym_path="$1"
+  local app_name="$2"
+  local dwarf_path="${dsym_path}/Contents/Resources/DWARF/${app_name}"
+
+  if [[ ! -f "$dwarf_path" ]]; then
+    echo "Missing fresh dSYM for ${app_name} at: ${dwarf_path}" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$dwarf_path"
+}
+
+codexbar_require_dsym_dwarf_for_arch() {
+  local dsym_path="$1"
+  local app_name="$2"
+  local arch="$3"
+  local dwarf_path
+
+  if ! dwarf_path=$(codexbar_dsym_dwarf_path "$dsym_path" "$app_name"); then
+    return 1
+  fi
+
+  if ! lipo -archs "$dwarf_path" | tr ' ' '\n' | grep -qx "$arch"; then
+    echo "dSYM at ${dwarf_path} does not contain required architecture: ${arch}" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$dwarf_path"
+}

--- a/Scripts/sign-and-notarize.sh
+++ b/Scripts/sign-and-notarize.sh
@@ -8,6 +8,7 @@ ROOT=$(cd "$(dirname "$0")/.." && pwd)
 source "$ROOT/version.env"
 source "$ROOT/Scripts/release_artifacts.sh"
 source "$ROOT/Scripts/package_product_paths.sh"
+source "$ROOT/Scripts/release_dsym_paths.sh"
 
 # Allow building a universal binary if ARCHES is provided; default to universal (arm64 + x86_64).
 ARCHES_VALUE=${ARCHES:-"arm64 x86_64"}
@@ -105,13 +106,7 @@ if [[ ${#ARCH_LIST[@]} -gt 1 ]]; then
   BINARIES=()
   for ((index = 0; index < ${#ARCH_LIST[@]}; index++)); do
     ARCH="${ARCH_LIST[$index]}"
-    ARCH_DSYM="${DSYM_PATHS[$index]}/Contents/Resources/DWARF/${APP_NAME}"
-    if [[ ! -f "$ARCH_DSYM" ]]; then
-      echo "Missing fresh dSYM for ${ARCH} at: $ARCH_DSYM" >&2
-      exit 1
-    fi
-    if ! lipo -archs "$ARCH_DSYM" | tr ' ' '\n' | grep -qx "$ARCH"; then
-      echo "dSYM at ${ARCH_DSYM} does not contain required architecture: ${ARCH}" >&2
+    if ! ARCH_DSYM=$(codexbar_require_dsym_dwarf_for_arch "${DSYM_PATHS[$index]}" "$APP_NAME" "$ARCH"); then
       exit 1
     fi
     BINARIES+=("$ARCH_DSYM")

--- a/Scripts/sign-and-notarize.sh
+++ b/Scripts/sign-and-notarize.sh
@@ -96,6 +96,15 @@ for ARCH in "${ARCH_LIST[@]}"; do
 done
 
 DSYM_PATH="${DSYM_PATHS[0]}"
+DSYM_DWARF_PATHS=()
+for ((index = 0; index < ${#ARCH_LIST[@]}; index++)); do
+  ARCH="${ARCH_LIST[$index]}"
+  if ! ARCH_DSYM=$(codexbar_require_dsym_dwarf_for_arch "${DSYM_PATHS[$index]}" "$APP_NAME" "$ARCH"); then
+    exit 1
+  fi
+  DSYM_DWARF_PATHS+=("$ARCH_DSYM")
+done
+
 if [[ ${#ARCH_LIST[@]} -gt 1 ]]; then
   MERGED_DSYM_ROOT="${DSYM_STAGE_ROOT}/${APP_NAME}.dSYM-universal"
   MERGED_DSYM="${MERGED_DSYM_ROOT}/${APP_NAME}.dSYM"
@@ -103,15 +112,7 @@ if [[ ${#ARCH_LIST[@]} -gt 1 ]]; then
   mkdir -p "$MERGED_DSYM_ROOT"
   cp -R "$DSYM_PATH" "$MERGED_DSYM"
   DWARF_PATH="${MERGED_DSYM}/Contents/Resources/DWARF/${APP_NAME}"
-  BINARIES=()
-  for ((index = 0; index < ${#ARCH_LIST[@]}; index++)); do
-    ARCH="${ARCH_LIST[$index]}"
-    if ! ARCH_DSYM=$(codexbar_require_dsym_dwarf_for_arch "${DSYM_PATHS[$index]}" "$APP_NAME" "$ARCH"); then
-      exit 1
-    fi
-    BINARIES+=("$ARCH_DSYM")
-  done
-  lipo -create "${BINARIES[@]}" -output "$DWARF_PATH"
+  lipo -create "${DSYM_DWARF_PATHS[@]}" -output "$DWARF_PATH"
   DSYM_PATH="$MERGED_DSYM"
 fi
 if [[ ! -d "$DSYM_PATH" ]]; then

--- a/Scripts/test_release_dsym_paths.sh
+++ b/Scripts/test_release_dsym_paths.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+source "$ROOT/Scripts/release_dsym_paths.sh"
+
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/codexbar-release-dsym-paths.XXXXXX")
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+make_dsym() {
+  local dsym_path="$1"
+  mkdir -p "$dsym_path/Contents/Resources/DWARF"
+  touch "$dsym_path/Contents/Resources/DWARF/CodexBar"
+}
+
+ARM_DSYM="$TEMP_DIR/CodexBar arm64.dSYM"
+UNIVERSAL_DSYM="$TEMP_DIR/CodexBar universal.dSYM"
+WRONG_ARCH_DSYM="$TEMP_DIR/CodexBar stale.dSYM"
+MISSING_DWARF_DSYM="$TEMP_DIR/CodexBar missing.dSYM"
+make_dsym "$ARM_DSYM"
+make_dsym "$UNIVERSAL_DSYM"
+make_dsym "$WRONG_ARCH_DSYM"
+mkdir -p "$MISSING_DWARF_DSYM/Contents/Resources/DWARF"
+
+lipo() {
+  [[ "$1" == "-archs" ]]
+  case "$2" in
+    "$ARM_DSYM/Contents/Resources/DWARF/CodexBar")
+      printf '%s\n' "arm64"
+      ;;
+    "$UNIVERSAL_DSYM/Contents/Resources/DWARF/CodexBar")
+      printf '%s\n' "arm64 x86_64"
+      ;;
+    "$WRONG_ARCH_DSYM/Contents/Resources/DWARF/CodexBar")
+      printf '%s\n' "x86_64"
+      ;;
+    *)
+      echo "unexpected lipo path: $2" >&2
+      return 2
+      ;;
+  esac
+}
+
+arm_dwarf=$(codexbar_require_dsym_dwarf_for_arch "$ARM_DSYM" CodexBar arm64)
+[[ "$arm_dwarf" == "$ARM_DSYM/Contents/Resources/DWARF/CodexBar" ]]
+
+x86_dwarf=$(codexbar_require_dsym_dwarf_for_arch "$UNIVERSAL_DSYM" CodexBar x86_64)
+[[ "$x86_dwarf" == "$UNIVERSAL_DSYM/Contents/Resources/DWARF/CodexBar" ]]
+
+if codexbar_require_dsym_dwarf_for_arch "$MISSING_DWARF_DSYM" CodexBar arm64 \
+  2>"$TEMP_DIR/missing-dwarf.log"; then
+  echo "ERROR: Missing dSYM DWARF file was accepted." >&2
+  exit 1
+fi
+grep -Fq "$MISSING_DWARF_DSYM/Contents/Resources/DWARF/CodexBar" "$TEMP_DIR/missing-dwarf.log"
+
+if codexbar_require_dsym_dwarf_for_arch "$WRONG_ARCH_DSYM" CodexBar arm64 \
+  2>"$TEMP_DIR/wrong-arch.log"; then
+  echo "ERROR: Wrong-architecture dSYM was accepted." >&2
+  exit 1
+fi
+grep -Fq "required architecture: arm64" "$TEMP_DIR/wrong-arch.log"
+
+echo "Release dSYM path tests passed."


### PR DESCRIPTION
## Summary

- Extract the dSYM DWARF path and architecture preflight into a small release helper.
- Use that helper before universal dSYM merging in the signing/notarization script.
- Add shell fixture coverage for valid, missing, and wrong-architecture dSYM DWARF files, and wire it into `make check`.

## Why

The release flow should reject stale or incomplete debug symbols before creating a universal dSYM archive. This keeps the failure close to the path and architecture that caused it, which makes packaging regressions much easier to diagnose.

## Validation

- `bash -n Scripts/release_dsym_paths.sh Scripts/test_release_dsym_paths.sh Scripts/sign-and-notarize.sh Scripts/lint.sh`
- `./Scripts/test_release_dsym_paths.sh`
- `./Scripts/test_package_product_paths.sh`
- `make check`

## Behavior proof

Ran the new helper against a real `clang -g` binary and real `dsymutil` output on June 13, 2026:

```text
Resolved DWARF: SampleApp.dSYM/Contents/Resources/DWARF/SampleApp
DWARF archs: arm64
Wrong-arch failure: dSYM at <tmp>/SampleApp.dSYM/Contents/Resources/DWARF/SampleApp does not contain required architecture: definitely-not-an-arch
Release dSYM path tests passed.
```
