### PR TITLE
fix: resolve and contain Sparkle signing paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 - Release: let `package_app.sh` own the single release build pass during signing/notarization, avoiding a redundant pre-build that could churn SwiftPM outputs before packaging. Thanks @ProspectOre!
 - Release: add focused dSYM preflight coverage so missing or wrong-architecture debug symbols fail with the exact path before universal symbol packaging. Thanks @ProspectOre!
 - Release: verify the packaged dSYM UUIDs match the signed app binary before zipping debug symbols, so uploaded symbols cannot silently drift away from the shipped build. Thanks @ProspectOre!
-- Release: resolve Sparkle's active framework version before signing nested components and report missing signing targets with their exact paths.
 - Kimi: add usage fetching from the official Code API key flow, with optional compatible HTTPS proxy support (#1424). Thanks @kiranmagic7!
 - Menu bar: keep the selected quota percentage visible in Pace mode when pace is temporarily unavailable instead of collapsing to an icon-only status item (fixes #1462).
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Release: let `package_app.sh` own the single release build pass during signing/notarization, avoiding a redundant pre-build that could churn SwiftPM outputs before packaging. Thanks @ProspectOre!
 - Release: add focused dSYM preflight coverage so missing or wrong-architecture debug symbols fail with the exact path before universal symbol packaging. Thanks @ProspectOre!
 - Release: verify the packaged dSYM UUIDs match the signed app binary before zipping debug symbols, so uploaded symbols cannot silently drift away from the shipped build. Thanks @ProspectOre!
+- Release: resolve Sparkle's active framework version before signing nested components and report missing signing targets with their exact paths. Thanks @ProspectOre!
 - Kimi: add usage fetching from the official Code API key flow, with optional compatible HTTPS proxy support (#1424). Thanks @kiranmagic7!
 - Menu bar: keep the selected quota percentage visible in Pace mode when pace is temporarily unavailable instead of collapsing to an icon-only status item (fixes #1462).
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Release: let `package_app.sh` own the single release build pass during signing/notarization, avoiding a redundant pre-build that could churn SwiftPM outputs before packaging. Thanks @ProspectOre!
 - Release: add focused dSYM preflight coverage so missing or wrong-architecture debug symbols fail with the exact path before universal symbol packaging. Thanks @ProspectOre!
 - Release: verify the packaged dSYM UUIDs match the signed app binary before zipping debug symbols, so uploaded symbols cannot silently drift away from the shipped build. Thanks @ProspectOre!
+- Release: resolve Sparkle's active framework version before signing nested components and report missing signing targets with their exact paths.
 - Kimi: add usage fetching from the official Code API key flow, with optional compatible HTTPS proxy support (#1424). Thanks @kiranmagic7!
 - Menu bar: keep the selected quota percentage visible in Pace mode when pace is temporarily unavailable instead of collapsing to an icon-only status item (fixes #1462).
 - Menu bar: restore native macOS positioning for merged provider dropdowns while preparing current content before AppKit lays out the menu.

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -23,6 +23,10 @@ check_release_dsym_paths() {
   "${ROOT_DIR}/Scripts/test_release_dsym_paths.sh"
 }
 
+check_sparkle_signing_paths() {
+  "${ROOT_DIR}/Scripts/test_sparkle_signing_paths.sh"
+}
+
 cmd="${1:-lint}"
 
 case "$cmd" in
@@ -30,6 +34,7 @@ case "$cmd" in
     check_codex_parser_hash
     check_package_product_paths
     check_release_dsym_paths
+    check_sparkle_signing_paths
     ensure_tools
     "${BIN_DIR}/swiftformat" Sources Tests --lint
     "${BIN_DIR}/swiftlint" --strict

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -17,6 +17,7 @@ esac
 # Load version info
 source "$ROOT/version.env"
 source "$ROOT/Scripts/package_product_paths.sh"
+source "$ROOT/Scripts/sparkle_signing_paths.sh"
 
 # Clean build only when explicitly requested (slower).
 if [[ "${CODEXBAR_FORCE_CLEAN:-0}" == "1" ]]; then
@@ -434,18 +435,11 @@ else
   CODESIGN_ARGS=(--force --timestamp --options runtime --sign "$CODESIGN_ID")
 fi
 function resign() { codesign "${CODESIGN_ARGS[@]}" "$1"; }
-# Sign innermost binaries first, then the framework root to seal resources
-resign "$SPARKLE"
-resign "$SPARKLE/Versions/B/Sparkle"
-resign "$SPARKLE/Versions/B/Autoupdate"
-resign "$SPARKLE/Versions/B/Updater.app"
-resign "$SPARKLE/Versions/B/Updater.app/Contents/MacOS/Updater"
-resign "$SPARKLE/Versions/B/XPCServices/Downloader.xpc"
-resign "$SPARKLE/Versions/B/XPCServices/Downloader.xpc/Contents/MacOS/Downloader"
-resign "$SPARKLE/Versions/B/XPCServices/Installer.xpc"
-resign "$SPARKLE/Versions/B/XPCServices/Installer.xpc/Contents/MacOS/Installer"
-resign "$SPARKLE/Versions/B"
-resign "$SPARKLE"
+# Validate Sparkle's nested layout before signing so framework layout drift fails clearly.
+SPARKLE_SIGNING_TARGETS=$(codexbar_sparkle_signing_targets "$SPARKLE")
+while IFS= read -r SPARKLE_TARGET; do
+  resign "$SPARKLE_TARGET"
+done <<<"$SPARKLE_SIGNING_TARGETS"
 
 if [[ -f "$ICON_TARGET" ]]; then
   cp "$ICON_TARGET" "$APP/Contents/Resources/Icon.icns"

--- a/Scripts/sparkle_signing_paths.sh
+++ b/Scripts/sparkle_signing_paths.sh
@@ -78,13 +78,35 @@ codexbar_sparkle_version_dir() {
 codexbar_require_sparkle_signing_target() {
   local path="$1"
   local label="$2"
+  local trusted_root="$3"
+  local resolved trusted_root_resolved
+
+  if [[ -L "$path" ]]; then
+    echo "ERROR: Sparkle signing target must not be a symlink (${label}): ${path}" >&2
+    return 1
+  fi
 
   if [[ ! -e "$path" ]]; then
     echo "ERROR: Missing Sparkle signing target (${label}): ${path}" >&2
     return 1
   fi
 
-  printf '%s\n' "$path"
+  if ! trusted_root_resolved=$(cd "$trusted_root" 2>/dev/null && pwd -P); then
+    echo "ERROR: Sparkle signing root does not resolve (${label}): ${trusted_root}" >&2
+    return 1
+  fi
+  if [[ -d "$path" ]]; then
+    resolved=$(cd "$path" && pwd -P)
+  else
+    resolved="$(cd "$(dirname "$path")" && pwd -P)/$(basename "$path")"
+  fi
+  if [[ "$resolved" != "$trusted_root_resolved" &&
+    "${resolved#"$trusted_root_resolved"/}" == "$resolved" ]]; then
+    echo "ERROR: Sparkle signing target resolves outside its trusted root (${label}): ${path}" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$resolved"
 }
 
 codexbar_sparkle_signing_targets() {
@@ -94,15 +116,22 @@ codexbar_sparkle_signing_targets() {
     return 1
   fi
 
-  codexbar_require_sparkle_signing_target "$sparkle" "framework root" || return 1
-  codexbar_require_sparkle_signing_target "$version_dir/Sparkle" "framework binary" || return 1
-  codexbar_require_sparkle_signing_target "$version_dir/Autoupdate" "autoupdate tool" || return 1
-  codexbar_require_sparkle_signing_target "$version_dir/Updater.app" "updater app" || return 1
-  codexbar_require_sparkle_signing_target "$version_dir/Updater.app/Contents/MacOS/Updater" "updater executable" || return 1
-  codexbar_require_sparkle_signing_target "$version_dir/XPCServices/Downloader.xpc" "downloader xpc" || return 1
-  codexbar_require_sparkle_signing_target "$version_dir/XPCServices/Downloader.xpc/Contents/MacOS/Downloader" "downloader executable" || return 1
-  codexbar_require_sparkle_signing_target "$version_dir/XPCServices/Installer.xpc" "installer xpc" || return 1
-  codexbar_require_sparkle_signing_target "$version_dir/XPCServices/Installer.xpc/Contents/MacOS/Installer" "installer executable" || return 1
-  codexbar_require_sparkle_signing_target "$version_dir" "framework version" || return 1
-  codexbar_require_sparkle_signing_target "$sparkle" "framework root" || return 1
+  codexbar_require_sparkle_signing_target "$sparkle" "framework root" "$sparkle" || return 1
+  codexbar_require_sparkle_signing_target "$version_dir/Sparkle" "framework binary" "$version_dir" || return 1
+  codexbar_require_sparkle_signing_target "$version_dir/Autoupdate" "autoupdate tool" "$version_dir" || return 1
+  codexbar_require_sparkle_signing_target "$version_dir/Updater.app" "updater app" "$version_dir" || return 1
+  codexbar_require_sparkle_signing_target \
+    "$version_dir/Updater.app/Contents/MacOS/Updater" "updater executable" "$version_dir" || return 1
+  codexbar_require_sparkle_signing_target \
+    "$version_dir/XPCServices/Downloader.xpc" "downloader xpc" "$version_dir" || return 1
+  codexbar_require_sparkle_signing_target \
+    "$version_dir/XPCServices/Downloader.xpc/Contents/MacOS/Downloader" \
+    "downloader executable" "$version_dir" || return 1
+  codexbar_require_sparkle_signing_target \
+    "$version_dir/XPCServices/Installer.xpc" "installer xpc" "$version_dir" || return 1
+  codexbar_require_sparkle_signing_target \
+    "$version_dir/XPCServices/Installer.xpc/Contents/MacOS/Installer" \
+    "installer executable" "$version_dir" || return 1
+  codexbar_require_sparkle_signing_target "$version_dir" "framework version" "$version_dir" || return 1
+  codexbar_require_sparkle_signing_target "$sparkle" "framework root" "$sparkle" || return 1
 }

--- a/Scripts/sparkle_signing_paths.sh
+++ b/Scripts/sparkle_signing_paths.sh
@@ -3,9 +3,14 @@
 codexbar_sparkle_version_dir() {
   local sparkle="$1"
   local versions_dir="${sparkle}/Versions"
+  local versions_root
 
   if [[ ! -d "$versions_dir" ]]; then
     echo "ERROR: Missing Sparkle versions directory: ${versions_dir}" >&2
+    return 1
+  fi
+  if ! versions_root=$(cd "$versions_dir" 2>/dev/null && pwd -P); then
+    echo "ERROR: Sparkle versions directory does not resolve: ${versions_dir}" >&2
     return 1
   fi
 
@@ -15,6 +20,13 @@ codexbar_sparkle_version_dir() {
       echo "ERROR: Sparkle Versions/Current does not resolve: ${versions_dir}/Current" >&2
       return 1
     fi
+    case "$current" in
+      "$versions_root"/*) ;;
+      *)
+        echo "ERROR: Sparkle Versions/Current resolves outside ${versions_root}: ${current}" >&2
+        return 1
+        ;;
+    esac
     printf '%s\n' "$current"
     return
   fi
@@ -37,6 +49,13 @@ codexbar_sparkle_version_dir() {
     1)
       local resolved
       resolved=$(cd "${version_dirs[0]}" && pwd -P)
+      case "$resolved" in
+        "$versions_root"/*) ;;
+        *)
+          echo "ERROR: Sparkle version directory resolves outside ${versions_root}: ${resolved}" >&2
+          return 1
+          ;;
+      esac
       printf '%s\n' "$resolved"
       ;;
     *)

--- a/Scripts/sparkle_signing_paths.sh
+++ b/Scripts/sparkle_signing_paths.sh
@@ -23,6 +23,10 @@ codexbar_sparkle_version_dir() {
   local sparkle="$1"
   local versions_dir="${sparkle}/Versions"
 
+  if [[ -L "$sparkle" ]]; then
+    echo "ERROR: Sparkle framework root must not be a symlink: ${sparkle}" >&2
+    return 1
+  fi
   if [[ -L "$versions_dir" ]]; then
     echo "ERROR: Sparkle versions directory must not be a symlink: ${versions_dir}" >&2
     return 1

--- a/Scripts/sparkle_signing_paths.sh
+++ b/Scripts/sparkle_signing_paths.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+codexbar_sparkle_version_dir() {
+  local sparkle="$1"
+  local versions_dir="${sparkle}/Versions"
+
+  if [[ ! -d "$versions_dir" ]]; then
+    echo "ERROR: Missing Sparkle versions directory: ${versions_dir}" >&2
+    return 1
+  fi
+
+  if [[ -e "$versions_dir/Current" ]]; then
+    local current
+    if ! current=$(cd "$versions_dir/Current" 2>/dev/null && pwd -P); then
+      echo "ERROR: Sparkle Versions/Current does not resolve: ${versions_dir}/Current" >&2
+      return 1
+    fi
+    printf '%s\n' "$current"
+    return
+  fi
+
+  local version_dirs=()
+  local candidate
+  shopt -s nullglob
+  for candidate in "$versions_dir"/*; do
+    if [[ -d "$candidate" ]]; then
+      version_dirs+=("$candidate")
+    fi
+  done
+  shopt -u nullglob
+
+  case "${#version_dirs[@]}" in
+    0)
+      echo "ERROR: Sparkle framework has no version directory under: ${versions_dir}" >&2
+      return 1
+      ;;
+    1)
+      local resolved
+      resolved=$(cd "${version_dirs[0]}" && pwd -P)
+      printf '%s\n' "$resolved"
+      ;;
+    *)
+      echo "ERROR: Sparkle framework has multiple version directories and no Versions/Current symlink: ${versions_dir}" >&2
+      return 1
+      ;;
+  esac
+}
+
+codexbar_require_sparkle_signing_target() {
+  local path="$1"
+  local label="$2"
+
+  if [[ ! -e "$path" ]]; then
+    echo "ERROR: Missing Sparkle signing target (${label}): ${path}" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$path"
+}
+
+codexbar_sparkle_signing_targets() {
+  local sparkle="$1"
+  local version_dir
+  if ! version_dir=$(codexbar_sparkle_version_dir "$sparkle"); then
+    return 1
+  fi
+
+  codexbar_require_sparkle_signing_target "$sparkle" "framework root" || return 1
+  codexbar_require_sparkle_signing_target "$version_dir/Sparkle" "framework binary" || return 1
+  codexbar_require_sparkle_signing_target "$version_dir/Autoupdate" "autoupdate tool" || return 1
+  codexbar_require_sparkle_signing_target "$version_dir/Updater.app" "updater app" || return 1
+  codexbar_require_sparkle_signing_target "$version_dir/Updater.app/Contents/MacOS/Updater" "updater executable" || return 1
+  codexbar_require_sparkle_signing_target "$version_dir/XPCServices/Downloader.xpc" "downloader xpc" || return 1
+  codexbar_require_sparkle_signing_target "$version_dir/XPCServices/Downloader.xpc/Contents/MacOS/Downloader" "downloader executable" || return 1
+  codexbar_require_sparkle_signing_target "$version_dir/XPCServices/Installer.xpc" "installer xpc" || return 1
+  codexbar_require_sparkle_signing_target "$version_dir/XPCServices/Installer.xpc/Contents/MacOS/Installer" "installer executable" || return 1
+  codexbar_require_sparkle_signing_target "$version_dir" "framework version" || return 1
+  codexbar_require_sparkle_signing_target "$sparkle" "framework root" || return 1
+}

--- a/Scripts/sparkle_signing_paths.sh
+++ b/Scripts/sparkle_signing_paths.sh
@@ -23,6 +23,10 @@ codexbar_sparkle_version_dir() {
   local sparkle="$1"
   local versions_dir="${sparkle}/Versions"
 
+  if [[ -L "$versions_dir" ]]; then
+    echo "ERROR: Sparkle versions directory must not be a symlink: ${versions_dir}" >&2
+    return 1
+  fi
   if [[ ! -d "$versions_dir" ]]; then
     echo "ERROR: Missing Sparkle versions directory: ${versions_dir}" >&2
     return 1

--- a/Scripts/sparkle_signing_paths.sh
+++ b/Scripts/sparkle_signing_paths.sh
@@ -1,32 +1,38 @@
 #!/usr/bin/env bash
 
+codexbar_resolve_sparkle_version_child() {
+  local versions_dir="$1"
+  local candidate="$2"
+  local label="$3"
+  local versions_root resolved
+
+  versions_root=$(cd "$versions_dir" && pwd -P)
+  if ! resolved=$(cd "$candidate" 2>/dev/null && pwd -P); then
+    echo "ERROR: Sparkle ${label} does not resolve: ${candidate}" >&2
+    return 1
+  fi
+  if [[ "$(dirname "$resolved")" != "$versions_root" ]]; then
+    echo "ERROR: Sparkle ${label} resolves outside the framework versions directory: ${candidate}" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$resolved"
+}
+
 codexbar_sparkle_version_dir() {
   local sparkle="$1"
   local versions_dir="${sparkle}/Versions"
-  local versions_root
 
   if [[ ! -d "$versions_dir" ]]; then
     echo "ERROR: Missing Sparkle versions directory: ${versions_dir}" >&2
     return 1
   fi
-  if ! versions_root=$(cd "$versions_dir" 2>/dev/null && pwd -P); then
-    echo "ERROR: Sparkle versions directory does not resolve: ${versions_dir}" >&2
-    return 1
-  fi
 
-  if [[ -e "$versions_dir/Current" ]]; then
+  if [[ -e "$versions_dir/Current" || -L "$versions_dir/Current" ]]; then
     local current
-    if ! current=$(cd "$versions_dir/Current" 2>/dev/null && pwd -P); then
-      echo "ERROR: Sparkle Versions/Current does not resolve: ${versions_dir}/Current" >&2
+    if ! current=$(codexbar_resolve_sparkle_version_child "$versions_dir" "$versions_dir/Current" "Versions/Current"); then
       return 1
     fi
-    case "$current" in
-      "$versions_root"/*) ;;
-      *)
-        echo "ERROR: Sparkle Versions/Current resolves outside ${versions_root}: ${current}" >&2
-        return 1
-        ;;
-    esac
     printf '%s\n' "$current"
     return
   fi
@@ -48,14 +54,10 @@ codexbar_sparkle_version_dir() {
       ;;
     1)
       local resolved
-      resolved=$(cd "${version_dirs[0]}" && pwd -P)
-      case "$resolved" in
-        "$versions_root"/*) ;;
-        *)
-          echo "ERROR: Sparkle version directory resolves outside ${versions_root}: ${resolved}" >&2
-          return 1
-          ;;
-      esac
+      if ! resolved=$(codexbar_resolve_sparkle_version_child \
+        "$versions_dir" "${version_dirs[0]}" "version directory"); then
+        return 1
+      fi
       printf '%s\n' "$resolved"
       ;;
     *)

--- a/Scripts/test_sparkle_signing_paths.sh
+++ b/Scripts/test_sparkle_signing_paths.sh
@@ -87,6 +87,14 @@ if codexbar_sparkle_version_dir "$SYMLINKED_VERSIONS" 2>"$TEMP_DIR/symlinked-ver
 fi
 grep -Fq "versions directory must not be a symlink" "$TEMP_DIR/symlinked-versions.log"
 
+SYMLINKED_FRAMEWORK="$TEMP_DIR/Symlinked Sparkle.framework"
+ln -s "$OUTSIDE_SPARKLE" "$SYMLINKED_FRAMEWORK"
+if codexbar_sparkle_version_dir "$SYMLINKED_FRAMEWORK" 2>"$TEMP_DIR/symlinked-framework.log"; then
+  echo "ERROR: Symlinked Sparkle framework root was accepted." >&2
+  exit 1
+fi
+grep -Fq "framework root must not be a symlink" "$TEMP_DIR/symlinked-framework.log"
+
 ESCAPING_SINGLE="$TEMP_DIR/Escaping Single Sparkle.framework"
 mkdir -p "$ESCAPING_SINGLE/Versions"
 ln -s "$OUTSIDE_SPARKLE/Versions/C" "$ESCAPING_SINGLE/Versions/B"

--- a/Scripts/test_sparkle_signing_paths.sh
+++ b/Scripts/test_sparkle_signing_paths.sh
@@ -95,6 +95,28 @@ if codexbar_sparkle_version_dir "$SYMLINKED_FRAMEWORK" 2>"$TEMP_DIR/symlinked-fr
 fi
 grep -Fq "framework root must not be a symlink" "$TEMP_DIR/symlinked-framework.log"
 
+SYMLINKED_TARGET="$TEMP_DIR/Symlinked Target Sparkle.framework"
+make_sparkle_version "$SYMLINKED_TARGET" B
+rm "$SYMLINKED_TARGET/Versions/B/Autoupdate"
+ln -s "$OUTSIDE_SPARKLE/Versions/C/Autoupdate" "$SYMLINKED_TARGET/Versions/B/Autoupdate"
+if codexbar_sparkle_signing_targets \
+  "$SYMLINKED_TARGET" >"$TEMP_DIR/symlinked-target.out" 2>"$TEMP_DIR/symlinked-target.log"; then
+  echo "ERROR: Symlinked Sparkle signing target was accepted." >&2
+  exit 1
+fi
+grep -Fq "signing target must not be a symlink" "$TEMP_DIR/symlinked-target.log"
+
+ESCAPING_TARGET_PARENT="$TEMP_DIR/Escaping Target Parent Sparkle.framework"
+make_sparkle_version "$ESCAPING_TARGET_PARENT" B
+mv "$ESCAPING_TARGET_PARENT/Versions/B/XPCServices" "$TEMP_DIR/displaced-xpc-services"
+ln -s "$OUTSIDE_SPARKLE/Versions/C/XPCServices" "$ESCAPING_TARGET_PARENT/Versions/B/XPCServices"
+if codexbar_sparkle_signing_targets \
+  "$ESCAPING_TARGET_PARENT" >"$TEMP_DIR/escaping-target-parent.out" 2>"$TEMP_DIR/escaping-target-parent.log"; then
+  echo "ERROR: Sparkle signing target with an escaping parent was accepted." >&2
+  exit 1
+fi
+grep -Fq "signing target resolves outside its trusted root" "$TEMP_DIR/escaping-target-parent.log"
+
 ESCAPING_SINGLE="$TEMP_DIR/Escaping Single Sparkle.framework"
 mkdir -p "$ESCAPING_SINGLE/Versions"
 ln -s "$OUTSIDE_SPARKLE/Versions/C" "$ESCAPING_SINGLE/Versions/B"

--- a/Scripts/test_sparkle_signing_paths.sh
+++ b/Scripts/test_sparkle_signing_paths.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+source "$ROOT/Scripts/sparkle_signing_paths.sh"
+
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/codexbar-sparkle-signing.XXXXXX")
+TEMP_DIR=$(cd "$TEMP_DIR" && pwd -P)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+make_sparkle_version() {
+  local sparkle="$1"
+  local version="$2"
+  local version_dir="$sparkle/Versions/$version"
+
+  mkdir -p \
+    "$version_dir/Updater.app/Contents/MacOS" \
+    "$version_dir/XPCServices/Downloader.xpc/Contents/MacOS" \
+    "$version_dir/XPCServices/Installer.xpc/Contents/MacOS"
+  touch \
+    "$version_dir/Sparkle" \
+    "$version_dir/Autoupdate" \
+    "$version_dir/Updater.app/Contents/MacOS/Updater" \
+    "$version_dir/XPCServices/Downloader.xpc/Contents/MacOS/Downloader" \
+    "$version_dir/XPCServices/Installer.xpc/Contents/MacOS/Installer"
+}
+
+SINGLE="$TEMP_DIR/Single Sparkle.framework"
+make_sparkle_version "$SINGLE" B
+single_version=$(codexbar_sparkle_version_dir "$SINGLE")
+[[ "$single_version" == "$SINGLE/Versions/B" ]]
+
+single_targets=$(codexbar_sparkle_signing_targets "$SINGLE")
+grep -Fqx "$SINGLE" <<<"$single_targets"
+grep -Fqx "$SINGLE/Versions/B/Sparkle" <<<"$single_targets"
+grep -Fqx "$SINGLE/Versions/B/XPCServices/Installer.xpc/Contents/MacOS/Installer" <<<"$single_targets"
+
+CURRENT="$TEMP_DIR/Current Sparkle.framework"
+make_sparkle_version "$CURRENT" A
+make_sparkle_version "$CURRENT" C
+ln -s C "$CURRENT/Versions/Current"
+current_version=$(codexbar_sparkle_version_dir "$CURRENT")
+[[ "$current_version" == "$CURRENT/Versions/C" ]]
+
+rm "$CURRENT/Versions/C/Autoupdate"
+if codexbar_sparkle_signing_targets "$CURRENT" >"$TEMP_DIR/missing-target.out" 2>"$TEMP_DIR/missing-target.log"; then
+  echo "ERROR: Missing Sparkle signing target was accepted." >&2
+  exit 1
+fi
+grep -Fq "Autoupdate" "$TEMP_DIR/missing-target.log"
+
+AMBIGUOUS="$TEMP_DIR/Ambiguous Sparkle.framework"
+make_sparkle_version "$AMBIGUOUS" A
+make_sparkle_version "$AMBIGUOUS" B
+if codexbar_sparkle_version_dir "$AMBIGUOUS" 2>"$TEMP_DIR/ambiguous.log"; then
+  echo "ERROR: Ambiguous Sparkle versions were accepted without Versions/Current." >&2
+  exit 1
+fi
+grep -Fq "multiple version directories" "$TEMP_DIR/ambiguous.log"
+
+echo "Sparkle signing path tests passed."

--- a/Scripts/test_sparkle_signing_paths.sh
+++ b/Scripts/test_sparkle_signing_paths.sh
@@ -58,4 +58,26 @@ if codexbar_sparkle_version_dir "$AMBIGUOUS" 2>"$TEMP_DIR/ambiguous.log"; then
 fi
 grep -Fq "multiple version directories" "$TEMP_DIR/ambiguous.log"
 
+OUTSIDE="$TEMP_DIR/OutsideVersion"
+mkdir -p "$OUTSIDE"
+
+ESCAPED_CURRENT="$TEMP_DIR/Escaped Current Sparkle.framework"
+make_sparkle_version "$ESCAPED_CURRENT" A
+rm "$ESCAPED_CURRENT/Versions/Current" 2>/dev/null || true
+ln -s "$OUTSIDE" "$ESCAPED_CURRENT/Versions/Current"
+if codexbar_sparkle_version_dir "$ESCAPED_CURRENT" 2>"$TEMP_DIR/escaped-current.log"; then
+  echo "ERROR: Escaped Sparkle Versions/Current was accepted." >&2
+  exit 1
+fi
+grep -Fq "resolves outside" "$TEMP_DIR/escaped-current.log"
+
+ESCAPED_SINGLE="$TEMP_DIR/Escaped Single Sparkle.framework"
+mkdir -p "$ESCAPED_SINGLE/Versions"
+ln -s "$OUTSIDE" "$ESCAPED_SINGLE/Versions/B"
+if codexbar_sparkle_version_dir "$ESCAPED_SINGLE" 2>"$TEMP_DIR/escaped-single.log"; then
+  echo "ERROR: Escaped single Sparkle version directory was accepted." >&2
+  exit 1
+fi
+grep -Fq "resolves outside" "$TEMP_DIR/escaped-single.log"
+
 echo "Sparkle signing path tests passed."

--- a/Scripts/test_sparkle_signing_paths.sh
+++ b/Scripts/test_sparkle_signing_paths.sh
@@ -58,26 +58,33 @@ if codexbar_sparkle_version_dir "$AMBIGUOUS" 2>"$TEMP_DIR/ambiguous.log"; then
 fi
 grep -Fq "multiple version directories" "$TEMP_DIR/ambiguous.log"
 
-OUTSIDE="$TEMP_DIR/OutsideVersion"
-mkdir -p "$OUTSIDE"
-
-ESCAPED_CURRENT="$TEMP_DIR/Escaped Current Sparkle.framework"
-make_sparkle_version "$ESCAPED_CURRENT" A
-rm "$ESCAPED_CURRENT/Versions/Current" 2>/dev/null || true
-ln -s "$OUTSIDE" "$ESCAPED_CURRENT/Versions/Current"
-if codexbar_sparkle_version_dir "$ESCAPED_CURRENT" 2>"$TEMP_DIR/escaped-current.log"; then
-  echo "ERROR: Escaped Sparkle Versions/Current was accepted." >&2
+BROKEN_CURRENT="$TEMP_DIR/Broken Current Sparkle.framework"
+make_sparkle_version "$BROKEN_CURRENT" B
+ln -s Missing "$BROKEN_CURRENT/Versions/Current"
+if codexbar_sparkle_version_dir "$BROKEN_CURRENT" 2>"$TEMP_DIR/broken-current.log"; then
+  echo "ERROR: Broken Sparkle Versions/Current was accepted." >&2
   exit 1
 fi
-grep -Fq "resolves outside" "$TEMP_DIR/escaped-current.log"
+grep -Fq "Versions/Current does not resolve" "$TEMP_DIR/broken-current.log"
 
-ESCAPED_SINGLE="$TEMP_DIR/Escaped Single Sparkle.framework"
-mkdir -p "$ESCAPED_SINGLE/Versions"
-ln -s "$OUTSIDE" "$ESCAPED_SINGLE/Versions/B"
-if codexbar_sparkle_version_dir "$ESCAPED_SINGLE" 2>"$TEMP_DIR/escaped-single.log"; then
-  echo "ERROR: Escaped single Sparkle version directory was accepted." >&2
+ESCAPING_CURRENT="$TEMP_DIR/Escaping Current Sparkle.framework"
+OUTSIDE_SPARKLE="$TEMP_DIR/Outside Sparkle.framework"
+make_sparkle_version "$ESCAPING_CURRENT" B
+make_sparkle_version "$OUTSIDE_SPARKLE" C
+ln -s "$OUTSIDE_SPARKLE/Versions/C" "$ESCAPING_CURRENT/Versions/Current"
+if codexbar_sparkle_version_dir "$ESCAPING_CURRENT" 2>"$TEMP_DIR/escaping-current.log"; then
+  echo "ERROR: Escaping Sparkle Versions/Current was accepted." >&2
   exit 1
 fi
-grep -Fq "resolves outside" "$TEMP_DIR/escaped-single.log"
+grep -Fq "outside the framework versions directory" "$TEMP_DIR/escaping-current.log"
+
+ESCAPING_SINGLE="$TEMP_DIR/Escaping Single Sparkle.framework"
+mkdir -p "$ESCAPING_SINGLE/Versions"
+ln -s "$OUTSIDE_SPARKLE/Versions/C" "$ESCAPING_SINGLE/Versions/B"
+if codexbar_sparkle_version_dir "$ESCAPING_SINGLE" 2>"$TEMP_DIR/escaping-single.log"; then
+  echo "ERROR: Escaping single Sparkle version directory was accepted." >&2
+  exit 1
+fi
+grep -Fq "outside the framework versions directory" "$TEMP_DIR/escaping-single.log"
 
 echo "Sparkle signing path tests passed."

--- a/Scripts/test_sparkle_signing_paths.sh
+++ b/Scripts/test_sparkle_signing_paths.sh
@@ -78,6 +78,15 @@ if codexbar_sparkle_version_dir "$ESCAPING_CURRENT" 2>"$TEMP_DIR/escaping-curren
 fi
 grep -Fq "outside the framework versions directory" "$TEMP_DIR/escaping-current.log"
 
+SYMLINKED_VERSIONS="$TEMP_DIR/Symlinked Versions Sparkle.framework"
+mkdir -p "$SYMLINKED_VERSIONS"
+ln -s "$OUTSIDE_SPARKLE/Versions" "$SYMLINKED_VERSIONS/Versions"
+if codexbar_sparkle_version_dir "$SYMLINKED_VERSIONS" 2>"$TEMP_DIR/symlinked-versions.log"; then
+  echo "ERROR: Symlinked Sparkle Versions directory was accepted." >&2
+  exit 1
+fi
+grep -Fq "versions directory must not be a symlink" "$TEMP_DIR/symlinked-versions.log"
+
 ESCAPING_SINGLE="$TEMP_DIR/Escaping Single Sparkle.framework"
 mkdir -p "$ESCAPING_SINGLE/Versions"
 ln -s "$OUTSIDE_SPARKLE/Versions/C" "$ESCAPING_SINGLE/Versions/B"


### PR DESCRIPTION
## Summary

- Resolve Sparkle's active framework version from `Versions/Current`, falling back only when there is exactly one version directory.
- Reject canonical Sparkle version paths that resolve outside the copied `Sparkle.framework/Versions` tree.
- Validate each nested Sparkle signing target before invoking `codesign`.
- Add shell fixture coverage for single-version frameworks, `Versions/Current`, missing nested targets, ambiguous version directories, escaped `Versions/Current`, and escaped single-version symlinks.

## Why

The packaging script previously hardcoded `Sparkle.framework/Versions/B`. Resolving the active framework version makes the release flow tolerate Sparkle layout changes while still failing clearly when the copied framework is incomplete, ambiguous, or points outside the packaged framework.

## Validation

- `bash -n Scripts/sparkle_signing_paths.sh Scripts/test_sparkle_signing_paths.sh Scripts/package_app.sh Scripts/lint.sh`
- `./Scripts/test_sparkle_signing_paths.sh`
- `./Scripts/test_package_product_paths.sh`
- `git diff --check`
- `make check`

## Behavior proof

Ran an ad-hoc release package pass from this branch on June 13, 2026:

```text
$ CODEXBAR_SIGNING=adhoc ARCHES="$(uname -m)" ./Scripts/package_app.sh release
Building CodexBarWidget Xcode extension (Release, arm64).
Created /Users/alec/Dev/CodexBar/CodexBar.app
```

Resolved Sparkle signing targets and verified the packaged app after adding containment checks:

```text
Sparkle version dir: CodexBar.app/Contents/Frameworks/Sparkle.framework/Versions/B
Signing target count: 11
CodexBar archs: arm64
Sparkle archs: x86_64 arm64
/Users/alec/Dev/CodexBar/CodexBar.app: valid on disk
/Users/alec/Dev/CodexBar/CodexBar.app: satisfies its Designated Requirement
```
