### PR TITLE
fix(opencode): show Zen balance for Go accounts without subscription usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Gemini: keep fnm package discovery bounded when helper descendants retain output pipes or ignore termination (fixes #1534). Thanks @kiranmagic7!
 - Xiaomi MiMo: cancel optional token-plan requests when the required balance request fails instead of delaying the error for up to 30 seconds.
 - Settings: make the cost history window directly editable by keyboard while preserving the existing stepper and 1–365 day bounds (fixes #1499). Thanks @kiranmagic7!
+- OpenCode Go: show Zen balances for accounts without subscription usage windows, including when the balance request takes longer than optional enrichment (fixes #1476). Thanks @kiranmagic7!
 
 ## 0.35.0 — 2026-06-14
 

--- a/Sources/CodexBar/MenuCardView+Costs.swift
+++ b/Sources/CodexBar/MenuCardView+Costs.swift
@@ -2,6 +2,12 @@ import CodexBarCore
 import Foundation
 
 extension UsageMenuCardView.Model {
+    static func isRequiredOpenCodeZenBalance(_ snapshot: UsageSnapshot?) -> Bool {
+        snapshot?.primary == nil &&
+            snapshot?.secondary == nil &&
+            snapshot?.providerCost?.period == "Zen balance"
+    }
+
     static func tokenUsageSnapshot(input: Input) -> CostUsageTokenSnapshot? {
         if usesProviderCostHistoryAsPrimaryDashboard(input.provider), input.snapshot != nil {
             return primaryCostHistorySnapshot(input: input)

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -882,9 +882,10 @@ extension UsageMenuCardView.Model {
         let creditsText = PersonalInfoRedactor.redactEmails(in: rawCreditsText, isEnabled: input.hidePersonalInfo)
         let isClaudeAdminAPI = input.provider == .claude &&
             input.snapshot?.identity?.loginMethod == "Admin API"
+        let isRequiredOpenCodeZenBalance = Self.isRequiredOpenCodeZenBalance(input.snapshot)
         let hidesOptionalProviderCost = ((input.provider == .claude && !isClaudeAdminAPI) ||
             input.provider == .factory ||
-            input.provider == .opencodego) &&
+            (input.provider == .opencodego && !isRequiredOpenCodeZenBalance)) &&
             !input.showOptionalCreditsAndExtraUsage
         let providerCost: ProviderCostSection? = if hidesOptionalProviderCost ||
             (input.provider == .openai && openAIAPIUsage != nil)

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -666,6 +666,11 @@ extension StatusItemController {
         {
             return UsageFormatter.usdString(balance)
         }
+        if provider == .opencodego,
+           let balance = Self.openCodeGoZenBalanceDisplayText(snapshot: snapshot)
+        {
+            return balance
+        }
         if provider == .deepseek,
            let balance = Self.deepSeekBalanceDisplayText(snapshot: snapshot)
         {
@@ -813,6 +818,18 @@ extension StatusItemController {
     nonisolated static func extraUsageSpendDisplayText(snapshot: UsageSnapshot?) -> String? {
         guard let cost = snapshot?.providerCost,
               cost.limit > 0,
+              cost.used >= 0
+        else {
+            return nil
+        }
+        return UsageFormatter.currencyString(cost.used, currencyCode: cost.currencyCode)
+    }
+
+    nonisolated static func openCodeGoZenBalanceDisplayText(snapshot: UsageSnapshot?) -> String? {
+        guard snapshot?.primary == nil,
+              snapshot?.secondary == nil,
+              let cost = snapshot?.providerCost,
+              cost.period == "Zen balance",
               cost.used >= 0
         else {
             return nil

--- a/Sources/CodexBar/StatusItemController+Animation.swift
+++ b/Sources/CodexBar/StatusItemController+Animation.swift
@@ -829,8 +829,7 @@ extension StatusItemController {
         guard snapshot?.primary == nil,
               snapshot?.secondary == nil,
               let cost = snapshot?.providerCost,
-              cost.period == "Zen balance",
-              cost.used >= 0
+              cost.period == "Zen balance"
         else {
             return nil
         }

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -126,17 +126,6 @@ public struct OpenCodeGoUsageFetcher: Sendable {
                 timeout: timeout,
                 session: session)
         }
-        let subscriptionText: String
-        do {
-            subscriptionText = try await self.fetchUsagePage(
-                workspaceID: workspaceID,
-                cookieHeader: requestCookieHeader,
-                timeout: timeout,
-                session: session)
-        } catch {
-            throw error
-        }
-        let snapshot = try self.parseSubscription(text: subscriptionText, now: now)
         let zenBalanceTask = includeZenBalance ? Task {
             try await self.fetchOptionalZenBalance(
                 workspaceID: workspaceID,
@@ -144,6 +133,33 @@ public struct OpenCodeGoUsageFetcher: Sendable {
                 timeout: min(timeout, self.optionalZenBalanceTimeout),
                 session: session)
         } : nil
+        let subscriptionText: String
+        do {
+            subscriptionText = try await self.fetchUsagePage(
+                workspaceID: workspaceID,
+                cookieHeader: requestCookieHeader,
+                timeout: timeout,
+                session: session)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch let error as URLError where error.code == .cancelled {
+            throw CancellationError()
+        } catch let error as OpenCodeGoUsageError {
+            guard case let .parseFailed(message) = error,
+                  message.contains("Missing usage fields"),
+                  let zenBalanceTask
+            else {
+                throw error
+            }
+            let zenBalance = try await self.completedOptionalZenBalance(from: zenBalanceTask)
+            guard let zenBalance else {
+                throw error
+            }
+            return OpenCodeGoUsageSnapshot.zenBalanceOnly(balanceUSD: zenBalance, updatedAt: now)
+        } catch {
+            throw error
+        }
+        let snapshot = try self.parseSubscription(text: subscriptionText, now: now)
         guard let zenBalanceTask else {
             return snapshot
         }

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -148,26 +148,42 @@ public struct OpenCodeGoUsageFetcher: Sendable {
         } catch let error as URLError where error.code == .cancelled {
             throw CancellationError()
         } catch let error as OpenCodeGoUsageError {
-            guard case let .parseFailed(message) = error,
-                  message.contains("Missing usage fields"),
-                  let zenBalanceTask
-            else {
-                throw error
-            }
-            let zenBalance = try await zenBalanceTask.value
-            guard let zenBalance else {
-                throw error
-            }
-            return OpenCodeGoUsageSnapshot.zenBalanceOnly(balanceUSD: zenBalance, updatedAt: now)
+            return try await self.requiredZenBalanceFallback(
+                from: zenBalanceTask,
+                for: error,
+                now: now)
         } catch {
             throw error
         }
-        let snapshot = try self.parseSubscription(text: subscriptionText, now: now)
+        let snapshot: OpenCodeGoUsageSnapshot
+        do {
+            snapshot = try self.parseSubscription(text: subscriptionText, now: now)
+        } catch let error as OpenCodeGoUsageError {
+            return try await self.requiredZenBalanceFallback(
+                from: zenBalanceTask,
+                for: error,
+                now: now)
+        }
         guard let zenBalanceTask else {
             return snapshot
         }
         let zenBalance = try await self.completedOptionalZenBalance(from: zenBalanceTask)
         return snapshot.withZenBalanceUSD(zenBalance)
+    }
+
+    private static func requiredZenBalanceFallback(
+        from task: Task<Double?, Error>?,
+        for error: OpenCodeGoUsageError,
+        now: Date) async throws -> OpenCodeGoUsageSnapshot
+    {
+        guard case let .parseFailed(message) = error,
+              message.contains("Missing usage fields"),
+              let task,
+              let zenBalance = try await task.value
+        else {
+            throw error
+        }
+        return OpenCodeGoUsageSnapshot.zenBalanceOnly(balanceUSD: zenBalance, updatedAt: now)
     }
 
     static func fetchOptionalZenBalance(

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -59,6 +59,13 @@ public struct OpenCodeGoUsageFetcher: Sendable {
         let referer: URL
     }
 
+    struct ZenBalanceRequest: Sendable {
+        let workspaceID: String
+        let cookieHeader: String
+        let timeout: TimeInterval
+        let session: URLSession
+    }
+
     private static let percentKeys = [
         "usagePercent",
         "usedPercent",
@@ -126,6 +133,11 @@ public struct OpenCodeGoUsageFetcher: Sendable {
                 timeout: timeout,
                 session: session)
         }
+        let zenBalanceRequest = ZenBalanceRequest(
+            workspaceID: workspaceID,
+            cookieHeader: requestCookieHeader,
+            timeout: timeout,
+            session: session)
         let subscriptionTask = Task {
             try await self.fetchUsagePage(
                 workspaceID: workspaceID,
@@ -161,6 +173,7 @@ public struct OpenCodeGoUsageFetcher: Sendable {
             return try await self.requiredZenBalanceFallback(
                 from: zenBalanceTask,
                 for: error,
+                request: zenBalanceRequest,
                 now: now)
         } catch {
             throw error
@@ -172,6 +185,7 @@ public struct OpenCodeGoUsageFetcher: Sendable {
             return try await self.requiredZenBalanceFallback(
                 from: zenBalanceTask,
                 for: error,
+                request: zenBalanceRequest,
                 now: now)
         }
         guard let zenBalanceTask else {
@@ -184,19 +198,25 @@ public struct OpenCodeGoUsageFetcher: Sendable {
     static func requiredZenBalanceFallback(
         from task: Task<Double?, Error>?,
         for error: OpenCodeGoUsageError,
+        request: ZenBalanceRequest,
         now: Date) async throws -> OpenCodeGoUsageSnapshot
     {
         guard case let .parseFailed(message) = error,
-              message.contains("Missing usage fields"),
-              let task
+              message.contains("Missing usage fields")
         else {
             throw error
         }
-        let zenBalance = try await withTaskCancellationHandler {
-            try await task.value
-        } onCancel: {
+        let task = task ?? Task {
+            try await self.fetchOptionalZenBalance(
+                workspaceID: request.workspaceID,
+                cookieHeader: request.cookieHeader,
+                timeout: request.timeout,
+                session: request.session)
+        }
+        defer {
             task.cancel()
         }
+        let zenBalance = try await self.completedRequiredZenBalance(from: task)
         guard let zenBalance else {
             throw error
         }

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -148,7 +148,7 @@ public struct OpenCodeGoUsageFetcher: Sendable {
         }
         let zenBalanceTask = includeZenBalance ? Task {
             try await Task.sleep(for: self.optionalZenBalanceStartDelay)
-            return try await self.fetchOptionalZenBalance(
+            return try await self.fetchZenBalance(
                 workspaceID: workspaceID,
                 cookieHeader: requestCookieHeader,
                 timeout: timeout,
@@ -208,7 +208,7 @@ public struct OpenCodeGoUsageFetcher: Sendable {
             throw error
         }
         let task = task ?? Task {
-            try await self.fetchOptionalZenBalance(
+            try await self.fetchZenBalance(
                 workspaceID: request.workspaceID,
                 cookieHeader: request.cookieHeader,
                 timeout: request.timeout,

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -130,7 +130,7 @@ public struct OpenCodeGoUsageFetcher: Sendable {
             try await self.fetchOptionalZenBalance(
                 workspaceID: workspaceID,
                 cookieHeader: requestCookieHeader,
-                timeout: min(timeout, self.optionalZenBalanceTimeout),
+                timeout: timeout,
                 session: session)
         } : nil
         defer {

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -28,6 +28,7 @@ public struct OpenCodeGoUsageFetcher: Sendable {
     private static let baseURL = URL(string: "https://opencode.ai")!
     private static let serverURL = URL(string: "https://opencode.ai/_server")!
     private static let workspacesServerID = "def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f"
+    private static let billingServerID = "c83b78a614689c38ebee981f9b39a8b377716db85c1fd7dbab604adc02d3313d"
 
     private static let userAgent =
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
@@ -268,6 +269,27 @@ public struct OpenCodeGoUsageFetcher: Sendable {
 }
 
 extension OpenCodeGoUsageFetcher {
+    static func fetchZenBillingText(
+        workspaceID: String,
+        cookieHeader: String,
+        timeout: TimeInterval,
+        session: URLSession) async throws -> String
+    {
+        let argsData = try JSONSerialization.data(withJSONObject: [workspaceID])
+        guard let args = String(data: argsData, encoding: .utf8) else {
+            throw OpenCodeGoUsageError.parseFailed("Could not encode billing request.")
+        }
+        return try await self.fetchServerText(
+            request: ServerRequest(
+                serverID: self.billingServerID,
+                args: args,
+                method: "GET",
+                referer: self.zenDashboardURL(workspaceID: workspaceID)),
+            cookieHeader: cookieHeader,
+            timeout: timeout,
+            session: session)
+    }
+
     private static func fetchWorkspaceID(
         cookieHeader: String,
         timeout: TimeInterval,

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -171,16 +171,23 @@ public struct OpenCodeGoUsageFetcher: Sendable {
         return snapshot.withZenBalanceUSD(zenBalance)
     }
 
-    private static func requiredZenBalanceFallback(
+    static func requiredZenBalanceFallback(
         from task: Task<Double?, Error>?,
         for error: OpenCodeGoUsageError,
         now: Date) async throws -> OpenCodeGoUsageSnapshot
     {
         guard case let .parseFailed(message) = error,
               message.contains("Missing usage fields"),
-              let task,
-              let zenBalance = try await task.value
+              let task
         else {
+            throw error
+        }
+        let zenBalance = try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
+        guard let zenBalance else {
             throw error
         }
         return OpenCodeGoUsageSnapshot.zenBalanceOnly(balanceUSD: zenBalance, updatedAt: now)

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -126,23 +126,33 @@ public struct OpenCodeGoUsageFetcher: Sendable {
                 timeout: timeout,
                 session: session)
         }
+        let subscriptionTask = Task {
+            try await self.fetchUsagePage(
+                workspaceID: workspaceID,
+                cookieHeader: requestCookieHeader,
+                timeout: timeout,
+                session: session)
+        }
         let zenBalanceTask = includeZenBalance ? Task {
-            try await self.fetchOptionalZenBalance(
+            try await Task.sleep(for: self.optionalZenBalanceStartDelay)
+            return try await self.fetchOptionalZenBalance(
                 workspaceID: workspaceID,
                 cookieHeader: requestCookieHeader,
                 timeout: timeout,
                 session: session)
         } : nil
         defer {
+            subscriptionTask.cancel()
             zenBalanceTask?.cancel()
         }
         let subscriptionText: String
         do {
-            subscriptionText = try await self.fetchUsagePage(
-                workspaceID: workspaceID,
-                cookieHeader: requestCookieHeader,
-                timeout: timeout,
-                session: session)
+            subscriptionText = try await withTaskCancellationHandler {
+                try await subscriptionTask.value
+            } onCancel: {
+                subscriptionTask.cancel()
+                zenBalanceTask?.cancel()
+            }
         } catch is CancellationError {
             throw CancellationError()
         } catch let error as URLError where error.code == .cancelled {

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageFetcher.swift
@@ -133,6 +133,9 @@ public struct OpenCodeGoUsageFetcher: Sendable {
                 timeout: min(timeout, self.optionalZenBalanceTimeout),
                 session: session)
         } : nil
+        defer {
+            zenBalanceTask?.cancel()
+        }
         let subscriptionText: String
         do {
             subscriptionText = try await self.fetchUsagePage(
@@ -151,7 +154,7 @@ public struct OpenCodeGoUsageFetcher: Sendable {
             else {
                 throw error
             }
-            let zenBalance = try await self.completedOptionalZenBalance(from: zenBalanceTask)
+            let zenBalance = try await zenBalanceTask.value
             guard let zenBalance else {
                 throw error
             }

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageSnapshot.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoUsageSnapshot.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 public struct OpenCodeGoUsageSnapshot: Sendable {
+    public let isBalanceOnly: Bool
     public let hasMonthlyUsage: Bool
     public let rollingUsagePercent: Double
     public let weeklyUsagePercent: Double
@@ -13,6 +14,7 @@ public struct OpenCodeGoUsageSnapshot: Sendable {
     public let updatedAt: Date
 
     public init(
+        isBalanceOnly: Bool = false,
         hasMonthlyUsage: Bool,
         rollingUsagePercent: Double,
         weeklyUsagePercent: Double,
@@ -24,6 +26,7 @@ public struct OpenCodeGoUsageSnapshot: Sendable {
         renewsAt: Date? = nil,
         updatedAt: Date)
     {
+        self.isBalanceOnly = isBalanceOnly
         self.hasMonthlyUsage = hasMonthlyUsage
         self.rollingUsagePercent = rollingUsagePercent
         self.weeklyUsagePercent = weeklyUsagePercent
@@ -36,7 +39,30 @@ public struct OpenCodeGoUsageSnapshot: Sendable {
         self.updatedAt = updatedAt
     }
 
+    public static func zenBalanceOnly(balanceUSD: Double, updatedAt: Date) -> OpenCodeGoUsageSnapshot {
+        OpenCodeGoUsageSnapshot(
+            isBalanceOnly: true,
+            hasMonthlyUsage: false,
+            rollingUsagePercent: 0,
+            weeklyUsagePercent: 0,
+            monthlyUsagePercent: 0,
+            rollingResetInSec: 0,
+            weeklyResetInSec: 0,
+            monthlyResetInSec: 0,
+            zenBalanceUSD: balanceUSD,
+            updatedAt: updatedAt)
+    }
+
     public func toUsageSnapshot() -> UsageSnapshot {
+        if self.isBalanceOnly {
+            return UsageSnapshot(
+                primary: nil,
+                secondary: nil,
+                providerCost: self.providerCostSnapshot,
+                updatedAt: self.updatedAt,
+                identity: nil)
+        }
+
         let rollingReset = self.updatedAt.addingTimeInterval(TimeInterval(self.rollingResetInSec))
         let weeklyReset = self.updatedAt.addingTimeInterval(TimeInterval(self.weeklyResetInSec))
 
@@ -77,20 +103,25 @@ public struct OpenCodeGoUsageSnapshot: Sendable {
             secondary: secondary,
             tertiary: tertiary,
             extraRateWindows: extraWindows,
-            providerCost: self.zenBalanceUSD.map {
-                ProviderCostSnapshot(
-                    used: $0,
-                    limit: 0,
-                    currencyCode: "USD",
-                    period: "Zen balance",
-                    updatedAt: self.updatedAt)
-            },
+            providerCost: self.providerCostSnapshot,
             updatedAt: self.updatedAt,
             identity: nil)
     }
 
+    private var providerCostSnapshot: ProviderCostSnapshot? {
+        self.zenBalanceUSD.map {
+            ProviderCostSnapshot(
+                used: $0,
+                limit: 0,
+                currencyCode: "USD",
+                period: "Zen balance",
+                updatedAt: self.updatedAt)
+        }
+    }
+
     public func withZenBalanceUSD(_ balance: Double?) -> OpenCodeGoUsageSnapshot {
         OpenCodeGoUsageSnapshot(
+            isBalanceOnly: self.isBalanceOnly,
             hasMonthlyUsage: self.hasMonthlyUsage,
             rollingUsagePercent: self.rollingUsagePercent,
             weeklyUsagePercent: self.weeklyUsagePercent,

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoZenBalanceFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoZenBalanceFetcher.swift
@@ -77,6 +77,7 @@ private final class OpenCodeGoOptionalZenBalanceRace: @unchecked Sendable {
 
 extension OpenCodeGoUsageFetcher {
     static let optionalZenBalanceTimeout: TimeInterval = 5
+    static let optionalZenBalanceStartDelay: Duration = .milliseconds(25)
     static let optionalZenBalanceJoinGrace: Duration = .milliseconds(250)
 
     public static func zenDashboardURL(workspaceID raw: String?) -> URL {

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoZenBalanceFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoZenBalanceFetcher.swift
@@ -3,6 +3,78 @@ import Foundation
 import FoundationNetworking
 #endif
 
+private final class OpenCodeGoOptionalZenBalanceRace: @unchecked Sendable {
+    private let lock = NSLock()
+    private let sourceTask: Task<Double?, Error>
+    private var result: Result<Double?, Error>?
+    private var continuation: CheckedContinuation<Double?, Error>?
+    private var observerTask: Task<Void, Never>?
+    private var timeoutTask: Task<Void, Never>?
+
+    init(sourceTask: Task<Double?, Error>) {
+        self.sourceTask = sourceTask
+    }
+
+    func value(timeout: Duration) async throws -> Double? {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                self.lock.lock()
+                if let result = self.result {
+                    self.lock.unlock()
+                    continuation.resume(with: result)
+                    return
+                }
+
+                self.continuation = continuation
+                let sourceTask = self.sourceTask
+                self.observerTask = Task { [weak self] in
+                    do {
+                        let value = try await sourceTask.value
+                        self?.resolve(.success(value), cancelSource: false)
+                    } catch {
+                        self?.resolve(.failure(error), cancelSource: false)
+                    }
+                }
+                self.timeoutTask = Task { [weak self] in
+                    do {
+                        try await Task.sleep(for: timeout)
+                        self?.resolve(.success(nil), cancelSource: true)
+                    } catch {
+                        // The source completed or the caller canceled the race.
+                    }
+                }
+                self.lock.unlock()
+            }
+        } onCancel: {
+            self.resolve(.failure(CancellationError()), cancelSource: true)
+        }
+    }
+
+    private func resolve(_ result: Result<Double?, Error>, cancelSource: Bool) {
+        self.lock.lock()
+        guard self.result == nil else {
+            self.lock.unlock()
+            return
+        }
+
+        self.result = result
+        let continuation = self.continuation
+        self.continuation = nil
+        let observerTask = self.observerTask
+        let timeoutTask = self.timeoutTask
+        self.observerTask = nil
+        self.timeoutTask = nil
+        self.lock.unlock()
+
+        if cancelSource {
+            self.sourceTask.cancel()
+        }
+        observerTask?.cancel()
+        timeoutTask?.cancel()
+        continuation?.resume(with: result)
+    }
+}
+
 extension OpenCodeGoUsageFetcher {
     static let optionalZenBalanceTimeout: TimeInterval = 5
     static let optionalZenBalanceJoinGrace: Duration = .milliseconds(250)
@@ -41,26 +113,8 @@ extension OpenCodeGoUsageFetcher {
     }
 
     static func completedOptionalZenBalance(from task: Task<Double?, Error>) async throws -> Double? {
-        try await withThrowingTaskGroup(of: Double?.self) { group in
-            group.addTask {
-                try await task.value
-            }
-            group.addTask {
-                try await Task.sleep(for: self.optionalZenBalanceJoinGrace)
-                return nil
-            }
-
-            let result = try await group.next()
-            group.cancelAll()
-            guard let value = result else {
-                task.cancel()
-                return nil
-            }
-            if value == nil {
-                task.cancel()
-            }
-            return value
-        }
+        let race = OpenCodeGoOptionalZenBalanceRace(sourceTask: task)
+        return try await race.value(timeout: self.optionalZenBalanceJoinGrace)
     }
 
     static func parseZenBalance(text: String) -> Double? {

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoZenBalanceFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoZenBalanceFetcher.swift
@@ -117,7 +117,13 @@ extension OpenCodeGoUsageFetcher {
 
     static func completedOptionalZenBalance(from task: Task<Double?, Error>) async throws -> Double? {
         let race = OpenCodeGoZenBalanceTaskRace(sourceTask: task)
-        return try await race.value(timeout: self.optionalZenBalanceJoinGrace)
+        do {
+            return try await race.value(timeout: self.optionalZenBalanceJoinGrace)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            return nil
+        }
     }
 
     static func completedRequiredZenBalance(from task: Task<Double?, Error>) async throws -> Double? {
@@ -129,7 +135,7 @@ extension OpenCodeGoUsageFetcher {
         OpenCodeGoZenBalanceParser.parse(text: text)
     }
 
-    private static func fetchZenBalance(
+    static func fetchZenBalance(
         workspaceID: String,
         cookieHeader: String,
         timeout: TimeInterval,

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoZenBalanceFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoZenBalanceFetcher.swift
@@ -143,6 +143,18 @@ extension OpenCodeGoUsageFetcher {
         if self.looksSignedOut(text: text) {
             throw OpenCodeGoUsageError.invalidCredentials
         }
-        return self.parseZenBalance(text: text)
+        if let balance = self.parseZenBalance(text: text) {
+            return balance
+        }
+
+        let billingText = try await self.fetchZenBillingText(
+            workspaceID: workspaceID,
+            cookieHeader: cookieHeader,
+            timeout: timeout,
+            session: session)
+        if self.looksSignedOut(text: billingText) {
+            throw OpenCodeGoUsageError.invalidCredentials
+        }
+        return OpenCodeGoZenBalanceParser.parseBillingServerResponse(text: billingText)
     }
 }

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoZenBalanceFetcher.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoZenBalanceFetcher.swift
@@ -3,7 +3,7 @@ import Foundation
 import FoundationNetworking
 #endif
 
-private final class OpenCodeGoOptionalZenBalanceRace: @unchecked Sendable {
+private final class OpenCodeGoZenBalanceTaskRace: @unchecked Sendable {
     private let lock = NSLock()
     private let sourceTask: Task<Double?, Error>
     private var result: Result<Double?, Error>?
@@ -15,7 +15,7 @@ private final class OpenCodeGoOptionalZenBalanceRace: @unchecked Sendable {
         self.sourceTask = sourceTask
     }
 
-    func value(timeout: Duration) async throws -> Double? {
+    func value(timeout: Duration? = nil) async throws -> Double? {
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 self.lock.lock()
@@ -35,12 +35,14 @@ private final class OpenCodeGoOptionalZenBalanceRace: @unchecked Sendable {
                         self?.resolve(.failure(error), cancelSource: false)
                     }
                 }
-                self.timeoutTask = Task { [weak self] in
-                    do {
-                        try await Task.sleep(for: timeout)
-                        self?.resolve(.success(nil), cancelSource: true)
-                    } catch {
-                        // The source completed or the caller canceled the race.
+                if let timeout {
+                    self.timeoutTask = Task { [weak self] in
+                        do {
+                            try await Task.sleep(for: timeout)
+                            self?.resolve(.success(nil), cancelSource: true)
+                        } catch {
+                            // The source completed or the caller canceled the race.
+                        }
                     }
                 }
                 self.lock.unlock()
@@ -114,8 +116,13 @@ extension OpenCodeGoUsageFetcher {
     }
 
     static func completedOptionalZenBalance(from task: Task<Double?, Error>) async throws -> Double? {
-        let race = OpenCodeGoOptionalZenBalanceRace(sourceTask: task)
+        let race = OpenCodeGoZenBalanceTaskRace(sourceTask: task)
         return try await race.value(timeout: self.optionalZenBalanceJoinGrace)
+    }
+
+    static func completedRequiredZenBalance(from task: Task<Double?, Error>) async throws -> Double? {
+        let race = OpenCodeGoZenBalanceTaskRace(sourceTask: task)
+        return try await race.value()
     }
 
     static func parseZenBalance(text: String) -> Double? {

--- a/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoZenBalanceParser.swift
+++ b/Sources/CodexBarCore/Providers/OpenCodeGo/OpenCodeGoZenBalanceParser.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 enum OpenCodeGoZenBalanceParser {
+    private static let billingScale = 100_000_000.0
+
     static func parse(text: String) -> Double? {
         if let value = self.parseJSON(text: text) {
             return value
@@ -14,6 +16,26 @@ enum OpenCodeGoZenBalanceParser {
         }
         let nearbyPattern = #"(?i)(?:balance|残高)[\s\S]{0,120}?\$\s*([0-9][0-9,]*(?:\.[0-9]+)?)"#
         return self.extractDollarValue(pattern: nearbyPattern, text: text)
+    }
+
+    static func parseBillingServerResponse(text: String) -> Double? {
+        if let data = text.data(using: .utf8),
+           let object = try? JSONSerialization.jsonObject(with: data, options: []),
+           let rawBalance = self.findRawBillingBalance(in: object)
+        {
+            return rawBalance / self.billingScale
+        }
+
+        let customerPattern =
+            #"(?:\"customerID\"|customerID)\s*:\s*(?:\$R\[\d+\]\s*=\s*)?\"[^\"]+\""#
+        guard self.containsMatch(pattern: customerPattern, text: text) else {
+            return nil
+        }
+        let pattern = #"(?:\"balance\"|balance)\s*:\s*(?:\$R\[\d+\]\s*=\s*)?(-?[0-9]+(?:\.[0-9]+)?)"#
+        guard let rawBalance = self.extractNumber(pattern: pattern, text: text) else {
+            return nil
+        }
+        return rawBalance / self.billingScale
     }
 
     private static func parseJSON(text: String) -> Double? {
@@ -50,6 +72,40 @@ enum OpenCodeGoZenBalanceParser {
         return nil
     }
 
+    private static func findRawBillingBalance(in object: Any) -> Double? {
+        if let dict = object as? [String: Any] {
+            if dict["balance"] != nil {
+                guard let customerID = dict["customerID"] as? String,
+                      !customerID.isEmpty
+                else {
+                    return nil
+                }
+                guard let rawBalance = self.doubleValue(from: dict["balance"]) else {
+                    return nil
+                }
+                return rawBalance
+            }
+            for value in dict.values {
+                if let found = self.findRawBillingBalance(in: value) {
+                    return found
+                }
+            }
+        } else if let array = object as? [Any] {
+            for value in array {
+                if let found = self.findRawBillingBalance(in: value) {
+                    return found
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func containsMatch(pattern: String, text: String) -> Bool {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else { return false }
+        let nsrange = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.firstMatch(in: text, options: [], range: nsrange) != nil
+    }
+
     private static func isExplicitBalanceAmountKey(_ key: String) -> Bool {
         let normalized = key
             .lowercased()
@@ -65,6 +121,10 @@ enum OpenCodeGoZenBalanceParser {
     }
 
     private static func extractDollarValue(pattern: String, text: String) -> Double? {
+        self.extractNumber(pattern: pattern, text: text)
+    }
+
+    private static func extractNumber(pattern: String, text: String) -> Double? {
         guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else { return nil }
         let nsrange = NSRange(text.startIndex..<text.endIndex, in: text)
         guard let match = regex.firstMatch(in: text, options: [], range: nsrange),

--- a/Tests/CodexBarTests/OpenCodeGoMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoMenuCardModelTests.swift
@@ -48,11 +48,52 @@ struct OpenCodeGoMenuCardModelTests {
     }
 
     @Test
-    func `zen balance hides when optional usage is disabled`() throws {
+    func `required zen balance renders when optional usage is disabled`() throws {
         let now = Date()
         let snapshot = UsageSnapshot(
             primary: nil,
             secondary: nil,
+            tertiary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 98.76,
+                limit: 0,
+                currencyCode: "USD",
+                period: "Zen balance",
+                updatedAt: now),
+            updatedAt: now,
+            identity: nil)
+        let metadata = try #require(ProviderDefaults.metadata[.opencodego])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .opencodego,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: true,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: false,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.providerCost?.title == "Zen balance")
+        #expect(model.providerCost?.spendLine == "Balance: $98.76")
+    }
+
+    @Test
+    func `subscription zen balance hides when optional usage is disabled`() throws {
+        let now = Date()
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 12, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 34, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
             tertiary: nil,
             providerCost: ProviderCostSnapshot(
                 used: 98.76,

--- a/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
@@ -246,7 +246,7 @@ struct OpenCodeGoUsageFetcherErrorTests {
             }
         }
 
-        #expect(methods.values == ["GET", "GET"])
+        #expect(methods.values == ["GET", "GET", "GET"])
     }
 
     @Test
@@ -434,8 +434,12 @@ struct OpenCodeGoUsageFetcherErrorTests {
             workspaceIDOverride: "https://opencode.ai/workspace/wrk_URL123/billing",
             session: self.makeSession())
 
-        #expect(observedPaths.values.count == 2)
-        #expect(Set(observedPaths.values) == ["/workspace/wrk_URL123/go", "/workspace/wrk_URL123"])
+        #expect(observedPaths.values.count == 3)
+        #expect(Set(observedPaths.values) == [
+            "/workspace/wrk_URL123/go",
+            "/workspace/wrk_URL123",
+            "/_server",
+        ])
     }
 
     @Test
@@ -472,6 +476,58 @@ struct OpenCodeGoUsageFetcherErrorTests {
 
         #expect(snapshot.zenBalanceUSD == 98.76)
         #expect(snapshot.toUsageSnapshot().providerCost?.period == "Zen balance")
+    }
+
+    @Test
+    func `fetcher falls back to billing server when workspace page omits balance`() async throws {
+        defer {
+            OpenCodeGoStubURLProtocol.handler = nil
+        }
+
+        let observedRequests = OpenCodeGoRequestRecorder<URLRequest>()
+        OpenCodeGoStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            observedRequests.append(request)
+            if url.path == "/workspace/wrk_TEST123" {
+                return Self.makeResponse(
+                    url: url,
+                    body: "<html><body>Workspace dashboard without hydrated billing data</body></html>",
+                    statusCode: 200,
+                    contentType: "text/html")
+            }
+            if url.path == "/_server" {
+                return Self.makeResponse(
+                    url: url,
+                    body: #"$R[0]={customerID:"cus_test",balance:$R[1]=9876000000,reload:!1}"#,
+                    statusCode: 200,
+                    contentType: "text/javascript")
+            }
+            return Self.makeResponse(
+                url: url,
+                body: Self.goUsagePageHTML(
+                    workspaceID: "wrk_TEST123",
+                    rolling: UsageWindow(percent: 17, resetInSec: 600),
+                    weekly: UsageWindow(percent: 75, resetInSec: 7200),
+                    monthly: nil),
+                statusCode: 200,
+                contentType: "text/html")
+        }
+
+        let snapshot = try await OpenCodeGoUsageFetcher.fetchUsage(
+            cookieHeader: "auth=test",
+            timeout: 2,
+            workspaceIDOverride: "wrk_TEST123",
+            session: self.makeSession())
+
+        #expect(snapshot.zenBalanceUSD == 98.76)
+        let billingRequest = try #require(observedRequests.values.first { $0.url?.path == "/_server" })
+        let billingURL = try #require(billingRequest.url)
+        let components = try #require(URLComponents(url: billingURL, resolvingAgainstBaseURL: false))
+        let query = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+        #expect(query["id"] == "c83b78a614689c38ebee981f9b39a8b377716db85c1fd7dbab604adc02d3313d")
+        #expect(query["args"] == #"["wrk_TEST123"]"#)
+        #expect(billingRequest.value(forHTTPHeaderField: "Cookie") == "auth=test")
+        #expect(billingRequest.value(forHTTPHeaderField: "Referer") == "https://opencode.ai/workspace/wrk_TEST123")
     }
 
     @Test

--- a/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
@@ -328,6 +328,42 @@ struct OpenCodeGoUsageFetcherErrorTests {
     }
 
     @Test
+    func `zen only account propagates invalid credentials from required balance fetch`() async throws {
+        defer {
+            OpenCodeGoStubURLProtocol.handler = nil
+        }
+
+        OpenCodeGoStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            if url.path == "/workspace/wrk_TEST123" {
+                return Self.makeResponse(
+                    url: url,
+                    body: "Unauthorized",
+                    statusCode: 401,
+                    contentType: "text/plain")
+            }
+            return Self.makeResponse(
+                url: url,
+                body: "<html><title>opencode</title><body>No Go subscription usage</body></html>",
+                statusCode: 200,
+                contentType: "text/html")
+        }
+
+        do {
+            _ = try await OpenCodeGoUsageFetcher.fetchUsage(
+                cookieHeader: "auth=stale",
+                timeout: 2,
+                workspaceIDOverride: "wrk_TEST123",
+                session: self.makeSession())
+            Issue.record("Expected invalid credentials to propagate.")
+        } catch OpenCodeGoUsageError.invalidCredentials {
+            // Expected.
+        } catch {
+            Issue.record("Expected invalidCredentials, got: \(error)")
+        }
+    }
+
+    @Test
     func `zen only account falls back after final subscription parse failure`() async throws {
         defer {
             OpenCodeGoStubURLProtocol.handler = nil

--- a/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
@@ -19,6 +19,28 @@ private final class OpenCodeGoRequestRecorder<Value: Sendable>: @unchecked Senda
     }
 }
 
+private final class OpenCodeGoContinuationBox<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Value, Never>?
+
+    func wait(onReady: @Sendable () -> Void) async -> Value {
+        await withCheckedContinuation { continuation in
+            self.lock.lock()
+            self.continuation = continuation
+            self.lock.unlock()
+            onReady()
+        }
+    }
+
+    func resume(returning value: Value) {
+        self.lock.lock()
+        let continuation = self.continuation
+        self.continuation = nil
+        self.lock.unlock()
+        continuation?.resume(returning: value)
+    }
+}
+
 @Suite(.serialized)
 struct OpenCodeGoUsageFetcherErrorTests {
     @Test
@@ -270,6 +292,42 @@ struct OpenCodeGoUsageFetcherErrorTests {
     }
 
     @Test
+    func `zen only account fetches required balance when optional usage is disabled`() async throws {
+        defer {
+            OpenCodeGoStubURLProtocol.handler = nil
+        }
+
+        let observedPaths = OpenCodeGoRequestRecorder<String>()
+        OpenCodeGoStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            observedPaths.append(url.path)
+            if url.path == "/workspace/wrk_TEST123" {
+                return Self.makeResponse(
+                    url: url,
+                    body: #"<html><body><h2>Current balance $23.75</h2></body></html>"#,
+                    statusCode: 200,
+                    contentType: "text/html")
+            }
+            return Self.makeResponse(
+                url: url,
+                body: "<html><title>opencode</title><body>No Go subscription usage</body></html>",
+                statusCode: 200,
+                contentType: "text/html")
+        }
+
+        let snapshot = try await OpenCodeGoUsageFetcher.fetchUsage(
+            cookieHeader: "auth=test",
+            timeout: 2,
+            workspaceIDOverride: "wrk_TEST123",
+            includeZenBalance: false,
+            session: self.makeSession())
+
+        #expect(snapshot.isBalanceOnly)
+        #expect(snapshot.zenBalanceUSD == 23.75)
+        #expect(observedPaths.values == ["/workspace/wrk_TEST123/go", "/workspace/wrk_TEST123"])
+    }
+
+    @Test
     func `zen only account falls back after final subscription parse failure`() async throws {
         defer {
             OpenCodeGoStubURLProtocol.handler = nil
@@ -309,17 +367,23 @@ struct OpenCodeGoUsageFetcherErrorTests {
     }
 
     @Test
-    func `zen only fallback promptly cancels the required balance task`() async throws {
+    func `zen only fallback promptly cancels when balance task ignores cancellation`() async throws {
         let balanceStarted = AsyncStream<Void>.makeStream(of: Void.self)
+        let balanceContinuation = OpenCodeGoContinuationBox<Double?>()
         let balanceTask = Task<Double?, Error> {
-            balanceStarted.continuation.yield(())
-            try await Task.sleep(for: .seconds(2))
-            return 42.5
+            await balanceContinuation.wait {
+                balanceStarted.continuation.yield(())
+            }
         }
         let fallbackTask = Task {
             try await OpenCodeGoUsageFetcher.requiredZenBalanceFallback(
                 from: balanceTask,
                 for: .parseFailed("Missing usage fields."),
+                request: OpenCodeGoUsageFetcher.ZenBalanceRequest(
+                    workspaceID: "wrk_TEST123",
+                    cookieHeader: "auth=test",
+                    timeout: 2,
+                    session: self.makeSession()),
                 now: Date())
         }
 
@@ -338,14 +402,9 @@ struct OpenCodeGoUsageFetcherErrorTests {
         }
 
         #expect(start.duration(to: .now) < .milliseconds(500))
-        do {
-            _ = try await balanceTask.value
-            Issue.record("Expected required balance task to be canceled.")
-        } catch is CancellationError {
-            // Expected.
-        } catch {
-            Issue.record("Expected CancellationError, got: \(error)")
-        }
+        #expect(balanceTask.isCancelled)
+        balanceContinuation.resume(returning: 42.5)
+        #expect(try await balanceTask.value == 42.5)
     }
 
     @Test

--- a/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
@@ -265,6 +265,42 @@ struct OpenCodeGoUsageFetcherErrorTests {
     }
 
     @Test
+    func `zen only account falls back after final subscription parse failure`() async throws {
+        defer {
+            OpenCodeGoStubURLProtocol.handler = nil
+        }
+
+        OpenCodeGoStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            if url.path == "/workspace/wrk_TEST123" {
+                return Self.makeResponse(
+                    url: url,
+                    body: #"<html><body><h2>Current balance $17.25</h2></body></html>"#,
+                    statusCode: 200,
+                    contentType: "text/html")
+            }
+            return Self.makeResponse(
+                url: url,
+                body: #"<script>rollingUsage:{usagePercent:12}</script>"#,
+                statusCode: 200,
+                contentType: "text/html")
+        }
+
+        let snapshot = try await OpenCodeGoUsageFetcher.fetchUsage(
+            cookieHeader: "auth=test",
+            timeout: 2,
+            workspaceIDOverride: "wrk_TEST123",
+            session: self.makeSession())
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(snapshot.isBalanceOnly)
+        #expect(snapshot.zenBalanceUSD == 17.25)
+        #expect(usage.primary == nil)
+        #expect(usage.secondary == nil)
+        #expect(usage.providerCost?.used == 17.25)
+    }
+
+    @Test
     func `normalizes workspace override from URL into go page path`() async throws {
         defer {
             OpenCodeGoStubURLProtocol.handler = nil

--- a/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
@@ -2,6 +2,23 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
+private final class OpenCodeGoRequestRecorder<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [Value] = []
+
+    func append(_ value: Value) {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        self.storage.append(value)
+    }
+
+    var values: [Value] {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.storage
+    }
+}
+
 @Suite(.serialized)
 struct OpenCodeGoUsageFetcherErrorTests {
     @Test
@@ -79,7 +96,7 @@ struct OpenCodeGoUsageFetcherErrorTests {
             OpenCodeGoStubURLProtocol.handler = nil
         }
 
-        var methods: [String] = []
+        let methods = OpenCodeGoRequestRecorder<String>()
         OpenCodeGoStubURLProtocol.handler = { request in
             guard let url = request.url else { throw URLError(.badURL) }
             methods.append(request.httpMethod ?? "GET")
@@ -125,7 +142,7 @@ struct OpenCodeGoUsageFetcherErrorTests {
         #expect(snapshot.rollingUsagePercent == 22)
         #expect(snapshot.weeklyUsagePercent == 44)
         #expect(snapshot.monthlyUsagePercent == 55)
-        #expect(methods == ["GET", "POST", "GET", "GET"])
+        #expect(methods.values == ["GET", "POST", "GET", "GET"])
     }
 
     @Test
@@ -134,7 +151,7 @@ struct OpenCodeGoUsageFetcherErrorTests {
             OpenCodeGoStubURLProtocol.handler = nil
         }
 
-        var methods: [String] = []
+        let methods = OpenCodeGoRequestRecorder<String>()
         OpenCodeGoStubURLProtocol.handler = { request in
             guard let url = request.url else { throw URLError(.badURL) }
             methods.append(request.httpMethod ?? "GET")
@@ -166,7 +183,7 @@ struct OpenCodeGoUsageFetcherErrorTests {
             }
         }
 
-        #expect(methods == ["GET"])
+        #expect(methods.values == ["GET"])
     }
 
     @Test
@@ -175,7 +192,7 @@ struct OpenCodeGoUsageFetcherErrorTests {
             OpenCodeGoStubURLProtocol.handler = nil
         }
 
-        var methods: [String] = []
+        let methods = OpenCodeGoRequestRecorder<String>()
         OpenCodeGoStubURLProtocol.handler = { request in
             guard let url = request.url else { throw URLError(.badURL) }
             methods.append(request.httpMethod ?? "GET")
@@ -202,20 +219,21 @@ struct OpenCodeGoUsageFetcherErrorTests {
             }
         }
 
-        #expect(methods == ["GET", "GET"])
+        #expect(methods.values == ["GET", "GET"])
     }
 
     @Test
-    func `zen only account returns balance without subscription usage windows`() async throws {
+    func `zen only account waits for balance beyond optional grace`() async throws {
         defer {
             OpenCodeGoStubURLProtocol.handler = nil
         }
 
-        var observedPaths: [String] = []
+        let observedPaths = OpenCodeGoRequestRecorder<String>()
         OpenCodeGoStubURLProtocol.handler = { request in
             guard let url = request.url else { throw URLError(.badURL) }
             observedPaths.append(url.path)
             if url.path == "/workspace/wrk_TEST123" {
+                Thread.sleep(forTimeInterval: 0.4)
                 return Self.makeResponse(
                     url: url,
                     body: #"<html><body><h2>現在の残高 $42.50</h2></body></html>"#,
@@ -242,8 +260,8 @@ struct OpenCodeGoUsageFetcherErrorTests {
         #expect(usage.secondary == nil)
         #expect(usage.providerCost?.used == 42.5)
         #expect(usage.providerCost?.period == "Zen balance")
-        #expect(observedPaths.count == 2)
-        #expect(Set(observedPaths) == ["/workspace/wrk_TEST123/go", "/workspace/wrk_TEST123"])
+        #expect(observedPaths.values.count == 2)
+        #expect(Set(observedPaths.values) == ["/workspace/wrk_TEST123/go", "/workspace/wrk_TEST123"])
     }
 
     @Test
@@ -252,7 +270,7 @@ struct OpenCodeGoUsageFetcherErrorTests {
             OpenCodeGoStubURLProtocol.handler = nil
         }
 
-        var observedPaths: [String] = []
+        let observedPaths = OpenCodeGoRequestRecorder<String>()
         OpenCodeGoStubURLProtocol.handler = { request in
             guard let url = request.url else { throw URLError(.badURL) }
             observedPaths.append(url.path)
@@ -273,8 +291,8 @@ struct OpenCodeGoUsageFetcherErrorTests {
             workspaceIDOverride: "https://opencode.ai/workspace/wrk_URL123/billing",
             session: self.makeSession())
 
-        #expect(observedPaths.count == 2)
-        #expect(Set(observedPaths) == ["/workspace/wrk_URL123/go", "/workspace/wrk_URL123"])
+        #expect(observedPaths.values.count == 2)
+        #expect(Set(observedPaths.values) == ["/workspace/wrk_URL123/go", "/workspace/wrk_URL123"])
     }
 
     @Test

--- a/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
@@ -202,7 +202,48 @@ struct OpenCodeGoUsageFetcherErrorTests {
             }
         }
 
-        #expect(methods == ["GET"])
+        #expect(methods == ["GET", "GET"])
+    }
+
+    @Test
+    func `zen only account returns balance without subscription usage windows`() async throws {
+        defer {
+            OpenCodeGoStubURLProtocol.handler = nil
+        }
+
+        var observedPaths: [String] = []
+        OpenCodeGoStubURLProtocol.handler = { request in
+            guard let url = request.url else { throw URLError(.badURL) }
+            observedPaths.append(url.path)
+            if url.path == "/workspace/wrk_TEST123" {
+                return Self.makeResponse(
+                    url: url,
+                    body: #"<html><body><h2>現在の残高 $42.50</h2></body></html>"#,
+                    statusCode: 200,
+                    contentType: "text/html")
+            }
+            return Self.makeResponse(
+                url: url,
+                body: "<html><title>opencode</title><body>No Go subscription usage</body></html>",
+                statusCode: 200,
+                contentType: "text/html")
+        }
+
+        let snapshot = try await OpenCodeGoUsageFetcher.fetchUsage(
+            cookieHeader: "auth=test",
+            timeout: 2,
+            workspaceIDOverride: "wrk_TEST123",
+            session: self.makeSession())
+        let usage = snapshot.toUsageSnapshot()
+
+        #expect(snapshot.isBalanceOnly)
+        #expect(snapshot.zenBalanceUSD == 42.5)
+        #expect(usage.primary == nil)
+        #expect(usage.secondary == nil)
+        #expect(usage.providerCost?.used == 42.5)
+        #expect(usage.providerCost?.period == "Zen balance")
+        #expect(observedPaths.count == 2)
+        #expect(Set(observedPaths) == ["/workspace/wrk_TEST123/go", "/workspace/wrk_TEST123"])
     }
 
     @Test
@@ -232,7 +273,8 @@ struct OpenCodeGoUsageFetcherErrorTests {
             workspaceIDOverride: "https://opencode.ai/workspace/wrk_URL123/billing",
             session: self.makeSession())
 
-        #expect(observedPaths == ["/workspace/wrk_URL123/go", "/workspace/wrk_URL123"])
+        #expect(observedPaths.count == 2)
+        #expect(Set(observedPaths) == ["/workspace/wrk_URL123/go", "/workspace/wrk_URL123"])
     }
 
     @Test

--- a/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
@@ -270,9 +270,11 @@ struct OpenCodeGoUsageFetcherErrorTests {
             OpenCodeGoStubURLProtocol.handler = nil
         }
 
+        var rootTimeout: TimeInterval?
         OpenCodeGoStubURLProtocol.handler = { request in
             guard let url = request.url else { throw URLError(.badURL) }
             if url.path == "/workspace/wrk_TEST123" {
+                rootTimeout = request.timeoutInterval
                 return Self.makeResponse(
                     url: url,
                     body: #"<html><body><h2>Current balance $17.25</h2></body></html>"#,
@@ -288,7 +290,7 @@ struct OpenCodeGoUsageFetcherErrorTests {
 
         let snapshot = try await OpenCodeGoUsageFetcher.fetchUsage(
             cookieHeader: "auth=test",
-            timeout: 2,
+            timeout: 12,
             workspaceIDOverride: "wrk_TEST123",
             session: self.makeSession())
         let usage = snapshot.toUsageSnapshot()
@@ -298,6 +300,7 @@ struct OpenCodeGoUsageFetcherErrorTests {
         #expect(usage.primary == nil)
         #expect(usage.secondary == nil)
         #expect(usage.providerCost?.used == 17.25)
+        #expect(rootTimeout == 12)
     }
 
     @Test
@@ -427,7 +430,7 @@ struct OpenCodeGoUsageFetcherErrorTests {
 
         #expect(snapshot.rollingUsagePercent == 17)
         #expect(snapshot.zenBalanceUSD == nil)
-        #expect(rootTimeout == 5)
+        #expect(rootTimeout == 60)
     }
 
     @Test

--- a/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
@@ -96,10 +96,10 @@ struct OpenCodeGoUsageFetcherErrorTests {
             OpenCodeGoStubURLProtocol.handler = nil
         }
 
-        let methods = OpenCodeGoRequestRecorder<String>()
+        let requests = OpenCodeGoRequestRecorder<String>()
         OpenCodeGoStubURLProtocol.handler = { request in
             guard let url = request.url else { throw URLError(.badURL) }
-            methods.append(request.httpMethod ?? "GET")
+            requests.append("\(request.httpMethod ?? "GET") \(url.path)")
 
             let workspaceServerID = "def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f"
             if url.query?.contains(workspaceServerID) == true,
@@ -137,12 +137,17 @@ struct OpenCodeGoUsageFetcherErrorTests {
         let snapshot = try await OpenCodeGoUsageFetcher.fetchUsage(
             cookieHeader: "auth=test",
             timeout: 2,
+            includeZenBalance: false,
             session: self.makeSession())
 
         #expect(snapshot.rollingUsagePercent == 22)
         #expect(snapshot.weeklyUsagePercent == 44)
         #expect(snapshot.monthlyUsagePercent == 55)
-        #expect(methods.values == ["GET", "POST", "GET", "GET"])
+        #expect(requests.values == [
+            "GET /_server",
+            "POST /_server",
+            "GET /workspace/wrk_TEST123/go",
+        ])
     }
 
     @Test

--- a/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageFetcherErrorTests.swift
@@ -304,6 +304,46 @@ struct OpenCodeGoUsageFetcherErrorTests {
     }
 
     @Test
+    func `zen only fallback promptly cancels the required balance task`() async throws {
+        let balanceStarted = AsyncStream<Void>.makeStream(of: Void.self)
+        let balanceTask = Task<Double?, Error> {
+            balanceStarted.continuation.yield(())
+            try await Task.sleep(for: .seconds(2))
+            return 42.5
+        }
+        let fallbackTask = Task {
+            try await OpenCodeGoUsageFetcher.requiredZenBalanceFallback(
+                from: balanceTask,
+                for: .parseFailed("Missing usage fields."),
+                now: Date())
+        }
+
+        var iterator = balanceStarted.stream.makeAsyncIterator()
+        _ = await iterator.next()
+        let start = ContinuousClock.now
+        fallbackTask.cancel()
+
+        do {
+            _ = try await fallbackTask.value
+            Issue.record("Expected cancellation to propagate.")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            Issue.record("Expected CancellationError, got: \(error)")
+        }
+
+        #expect(start.duration(to: .now) < .milliseconds(500))
+        do {
+            _ = try await balanceTask.value
+            Issue.record("Expected required balance task to be canceled.")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            Issue.record("Expected CancellationError, got: \(error)")
+        }
+    }
+
+    @Test
     func `normalizes workspace override from URL into go page path`() async throws {
         defer {
             OpenCodeGoStubURLProtocol.handler = nil

--- a/Tests/CodexBarTests/OpenCodeGoUsageParserTests.swift
+++ b/Tests/CodexBarTests/OpenCodeGoUsageParserTests.swift
@@ -60,6 +60,30 @@ struct OpenCodeGoUsageParserTests {
     }
 
     @Test
+    func `parses scaled zen balance from billing server response`() {
+        let text =
+            #";0x00000120;((self.$R=self.$R||{})["server-fn:test"]=[],"# +
+            #"($R=>$R[0]=$R[1]={customerID:"cus_test",balance:$R[2]=2375000000,reload:!1})"# +
+            #"($R["server-fn:test"]))"#
+
+        #expect(OpenCodeGoZenBalanceParser.parseBillingServerResponse(text: text) == 23.75)
+    }
+
+    @Test
+    func `billing server parser ignores unrelated balance metadata`() {
+        let text = #"$R[0]={balanceEnabled:!0,balanceUpdatedAt:1800000000}"#
+
+        #expect(OpenCodeGoZenBalanceParser.parseBillingServerResponse(text: text) == nil)
+    }
+
+    @Test
+    func `billing server parser ignores balance when billing is disabled`() {
+        let text = #"$R[0]={customerID:null,balance:0,reload:!1}"#
+
+        #expect(OpenCodeGoZenBalanceParser.parseBillingServerResponse(text: text) == nil)
+    }
+
+    @Test
     func `zen balance parser ignores metadata before amount`() throws {
         let payload: [String: Any] = [
             "data": [

--- a/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
+++ b/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
@@ -44,6 +44,58 @@ struct StatusItemBalanceDisplayTests {
     }
 
     @Test
+    func `menu bar display text uses zen balance when open code has no subscription`() {
+        let settings = self.makeSettings(
+            suiteName: "StatusItemBalanceDisplayTests-opencodego-zen-only",
+            provider: .opencodego)
+        let (store, controller) = self.makeStoreAndController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 23.75,
+                limit: 0,
+                currencyCode: "USD",
+                period: "Zen balance",
+                updatedAt: Date()),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .opencodego)
+        store._setErrorForTesting(nil, provider: .opencodego)
+
+        let displayText = controller.menuBarDisplayText(for: .opencodego, snapshot: snapshot)
+
+        #expect(displayText == "$23.75")
+    }
+
+    @Test
+    func `menu bar display text keeps open code subscription percentage`() {
+        let settings = self.makeSettings(
+            suiteName: "StatusItemBalanceDisplayTests-opencodego-subscription",
+            provider: .opencodego)
+        let (store, controller) = self.makeStoreAndController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 12, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 34, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            providerCost: ProviderCostSnapshot(
+                used: 23.75,
+                limit: 0,
+                currencyCode: "USD",
+                period: "Zen balance",
+                updatedAt: Date()),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .opencodego)
+        store._setErrorForTesting(nil, provider: .opencodego)
+
+        let displayText = controller.menuBarDisplayText(for: .opencodego, snapshot: snapshot)
+
+        #expect(displayText == "12%")
+    }
+
+    @Test
     func `reset time mode preserves balance when provider has no quota window`() {
         let settings = self.makeSettings(
             suiteName: "StatusItemBalanceDisplayTests-moonshot-reset-time",

--- a/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
+++ b/Tests/CodexBarTests/StatusItemBalanceDisplayTests.swift
@@ -70,6 +70,32 @@ struct StatusItemBalanceDisplayTests {
     }
 
     @Test
+    func `menu bar display text uses negative zen balance when open code is in deficit`() {
+        let settings = self.makeSettings(
+            suiteName: "StatusItemBalanceDisplayTests-opencodego-zen-deficit",
+            provider: .opencodego)
+        let (store, controller) = self.makeStoreAndController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: -4.25,
+                limit: 0,
+                currencyCode: "USD",
+                period: "Zen balance",
+                updatedAt: Date()),
+            updatedAt: Date())
+
+        store._setSnapshotForTesting(snapshot, provider: .opencodego)
+        store._setErrorForTesting(nil, provider: .opencodego)
+
+        let displayText = controller.menuBarDisplayText(for: .opencodego, snapshot: snapshot)
+
+        #expect(displayText == "-$4.25")
+    }
+
+    @Test
     func `menu bar display text keeps open code subscription percentage`() {
         let settings = self.makeSettings(
             suiteName: "StatusItemBalanceDisplayTests-opencodego-subscription",


### PR DESCRIPTION
## Summary
- support OpenCode Zen-only accounts when Go subscription usage windows are absent
- fetch balance from the workspace page, then OpenCode's `billing.get` server query when page hydration omits billing data
- convert raw billing units and require an active billing customer before exposing a balance
- preserve subscription-first behavior and bounded optional enrichment
- make required fallback independent of the optional-usage setting
- propagate required auth failures so stale-cookie recovery can run
- race required fallback against cancellation, including transports that ignore task cancellation
- render balance-only snapshots in the card even when optional extras are disabled
- show signed Zen balances in the menu bar for balance-only accounts while preserving subscription percentages

Fixes #1476

## Tests
- `swift test --filter OpenCodeGo`: 57 passed
- `swift test --filter StatusItemBalanceDisplayTests`: 25 passed
- `make check`: SwiftFormat clean, SwiftLint 0 violations, packaging/release-path checks passed
- `git diff --check`
- local patch autoreview: clean
- full-branch autoreview: clean

## Live proof
- affected Zen-only account confirmed the card shows its Zen balance without Go subscription windows and without `Missing usage fields`
- that test exposed a blank menu-bar metric; fixed at `0d2f1176`
- final positive-balance artifact: https://github.com/steipete/CodexBar/actions/runs/27545638447/artifacts/7638357517
- latest `89e3d5ed` only broadens the same formatter to signed/deficit balances; focused regression verifies `-4.25 USD` renders as `-$4.25`

## Landing notes
- PR branch is source-only; temporary artifact workflow commits were removed
- changelog entry was added by the maintainer, per repository policy, and thanks `@kiranmagic7`
- no maintainer live browser/Keychain probe was run; live account proof came from the affected tester using the ad-hoc artifact