### PR TITLE
docs(config): sync provider id list

### DIFF
--- a/Tests/CodexBarTests/ConfigurationDocsProviderIDTests.swift
+++ b/Tests/CodexBarTests/ConfigurationDocsProviderIDTests.swift
@@ -5,8 +5,8 @@ import Testing
 struct ConfigurationDocsProviderIDTests {
     @Test
     func `configuration docs list every provider id in enum order`() throws {
-        let rootURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
-        let docsURL = rootURL.appendingPathComponent("docs/configuration.md")
+        let rootURL = try Self.repoRoot()
+        let docsURL = rootURL.appending(path: "docs/configuration.md")
         let docs = try String(contentsOf: docsURL, encoding: .utf8)
 
         let marker = "## Provider IDs"
@@ -20,5 +20,19 @@ struct ConfigurationDocsProviderIDTests {
         let expectedIDs = UsageProvider.allCases.map(\.rawValue)
 
         #expect(documentedIDs == expectedIDs)
+    }
+
+    private static func repoRoot() throws -> URL {
+        var directory = URL(filePath: #filePath).deletingLastPathComponent()
+        for _ in 0..<12 {
+            let packageManifest = directory.appending(path: "Package.swift")
+            if FileManager.default.fileExists(atPath: packageManifest.path(percentEncoded: false)) {
+                return directory
+            }
+            directory.deleteLastPathComponent()
+        }
+        throw NSError(domain: "ConfigurationDocsProviderIDTests", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Could not locate repo root (Package.swift) from \(#filePath)",
+        ])
     }
 }

--- a/Tests/CodexBarTests/ConfigurationDocsProviderIDTests.swift
+++ b/Tests/CodexBarTests/ConfigurationDocsProviderIDTests.swift
@@ -1,0 +1,24 @@
+import CodexBarCore
+import Foundation
+import Testing
+
+struct ConfigurationDocsProviderIDTests {
+    @Test
+    func `configuration docs list every provider id in enum order`() throws {
+        let rootURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+        let docsURL = rootURL.appendingPathComponent("docs/configuration.md")
+        let docs = try String(contentsOf: docsURL, encoding: .utf8)
+
+        let marker = "## Provider IDs"
+        let sectionStart = try #require(docs.range(of: marker)?.upperBound)
+        let section = docs[sectionStart...]
+        let idsLine = try #require(section.split(separator: "\n").first { $0.hasPrefix("`") })
+
+        let documentedIDs = idsLine
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: CharacterSet(charactersIn: " `.")) }
+        let expectedIDs = UsageProvider.allCases.map(\.rawValue)
+
+        #expect(documentedIDs == expectedIDs)
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,7 +152,7 @@ and never paste real cookie values or readable DevTools screenshots into public 
 
 ## Provider IDs
 Current IDs (see `Sources/CodexBarCore/Providers/Providers.swift`):
-`codex`, `openai`, `azureopenai`, `claude`, `cursor`, `opencode`, `opencodego`, `alibaba`, `factory`, `gemini`, `antigravity`, `copilot`, `zai`, `minimax`, `manus`, `kimi`, `kilo`, `kiro`, `vertexai`, `augment`, `jetbrains`, `kimik2`, `moonshot`, `amp`, `ollama`, `synthetic`, `warp`, `openrouter`, `elevenlabs`, `windsurf`, `perplexity`, `mimo`, `doubao`, `abacus`, `mistral`, `deepseek`, `codebuff`, `crof`, `venice`, `commandcode`, `stepfun`, `bedrock`, `grok`, `groq`, `llmproxy`, `deepgram`.
+`codex`, `openai`, `azureopenai`, `claude`, `cursor`, `opencode`, `opencodego`, `alibaba`, `alibabatokenplan`, `factory`, `gemini`, `antigravity`, `copilot`, `devin`, `zai`, `minimax`, `manus`, `kimi`, `kilo`, `kiro`, `vertexai`, `augment`, `jetbrains`, `kimik2`, `moonshot`, `amp`, `t3chat`, `ollama`, `synthetic`, `warp`, `openrouter`, `elevenlabs`, `windsurf`, `perplexity`, `mimo`, `doubao`, `abacus`, `mistral`, `deepseek`, `codebuff`, `crof`, `venice`, `commandcode`, `stepfun`, `bedrock`, `grok`, `groq`, `llmproxy`, `deepgram`.
 
 ## Ordering
 The order of `providers` controls display/order in the app and CLI. Reorder the array to change ordering.


### PR DESCRIPTION
## Summary
- add the missing `alibabatokenplan`, `devin`, and `t3chat` IDs to the config guide provider list
- add a small docs drift test that compares the documented IDs with `UsageProvider.allCases` in enum order

## Tests
- `swift test --filter ConfigurationDocsProviderIDTests --skip-update`
- `make check`
- `git diff --check`

## Risk
- docs/test-only; no runtime behavior changes