### PR TITLE
fix(settings): make cost history days editable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Ollama: replace the bundled provider icon with the cleaner official mark while preserving native template tinting. Thanks @mattab178!
 
+### Fixed
+- Settings: make the cost history window directly editable by keyboard while preserving the existing stepper and 1–365 day bounds (fixes #1499). Thanks @kiranmagic7!
+
 ## 0.35.0 — 2026-06-14
 
 ### Added

--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -130,16 +130,7 @@ struct GeneralPane: View {
                                 .fixedSize(horizontal: false, vertical: true)
 
                             if self.settings.costUsageEnabled {
-                                Stepper(
-                                    value: self.$settings.costUsageHistoryDays,
-                                    in: 1...365,
-                                    step: 1)
-                                {
-                                    Text(String(
-                                        format: L("cost_history_days_title"),
-                                        self.settings.costUsageHistoryDays))
-                                        .font(.footnote)
-                                }
+                                CostHistoryDaysEditor(settings: self.settings)
 
                                 Text(L("cost_auto_refresh_info"))
                                     .font(.footnote)
@@ -267,5 +258,35 @@ struct GeneralPane: View {
         return Text(String(format: L("cost_status_no_data"), name))
             .font(.footnote)
             .foregroundStyle(.tertiary)
+    }
+}
+
+@MainActor
+struct CostHistoryDaysEditor: View {
+    @Bindable var settings: SettingsStore
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Stepper(
+                value: self.$settings.costUsageHistoryDays,
+                in: 1...365,
+                step: 1)
+            {
+                Text(String(
+                    format: L("cost_history_days_title"),
+                    self.settings.costUsageHistoryDays))
+                    .font(.footnote)
+            }
+
+            TextField(
+                L("cost_history_days_title"),
+                value: self.$settings.costUsageHistoryDays,
+                format: .number)
+                .labelsHidden()
+                .textFieldStyle(.roundedBorder)
+                .font(.footnote)
+                .monospacedDigit()
+                .frame(width: 64)
+        }
     }
 }

--- a/Sources/CodexBar/PreferencesGeneralPane.swift
+++ b/Sources/CodexBar/PreferencesGeneralPane.swift
@@ -265,21 +265,25 @@ struct GeneralPane: View {
 struct CostHistoryDaysEditor: View {
     @Bindable var settings: SettingsStore
 
+    static func title(days: Int) -> String {
+        String(format: L("cost_history_days_title"), days)
+    }
+
     var body: some View {
+        let title = Self.title(days: self.settings.costUsageHistoryDays)
+
         HStack(alignment: .firstTextBaseline, spacing: 8) {
             Stepper(
                 value: self.$settings.costUsageHistoryDays,
                 in: 1...365,
                 step: 1)
             {
-                Text(String(
-                    format: L("cost_history_days_title"),
-                    self.settings.costUsageHistoryDays))
+                Text(title)
                     .font(.footnote)
             }
 
             TextField(
-                L("cost_history_days_title"),
+                title,
                 value: self.$settings.costUsageHistoryDays,
                 format: .number)
                 .labelsHidden()

--- a/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
+++ b/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
@@ -53,6 +53,16 @@ struct PreferencesPaneSmokeTests {
     }
 
     @Test
+    func `cost history days editor builds with clamped settings binding`() {
+        let settings = Self.makeSettingsStore(suite: "PreferencesPaneSmokeTests-cost-history-days")
+
+        settings.costUsageHistoryDays = 999
+        #expect(settings.costUsageHistoryDays == 365)
+
+        _ = CostHistoryDaysEditor(settings: settings).body
+    }
+
+    @Test
     func `language preference updates global localization resolver`() {
         let previousLanguage = UserDefaults.standard.object(forKey: "appLanguage")
         let previousAppleLanguages = UserDefaults.standard.object(forKey: "AppleLanguages")

--- a/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
+++ b/Tests/CodexBarTests/PreferencesPaneSmokeTests.swift
@@ -58,6 +58,8 @@ struct PreferencesPaneSmokeTests {
 
         settings.costUsageHistoryDays = 999
         #expect(settings.costUsageHistoryDays == 365)
+        #expect(CostHistoryDaysEditor.title(days: 365).contains("365"))
+        #expect(!CostHistoryDaysEditor.title(days: 365).contains("%d"))
 
         _ = CostHistoryDaysEditor(settings: settings).body
     }


### PR DESCRIPTION
## Summary
- fixes #1499 by keeping the existing cost history Stepper and adding a direct numeric field for keyboard entry
- keeps the same `costUsageHistoryDays` setting and existing 1...365 clamp
- adds smoke coverage for the new editor and clamp behavior

## Tests
- `swift test --filter PreferencesPaneSmokeTests/cost --skip-update` (built successfully but matched 0 Swift Testing tests; reran suite-level filter below)
- `swift test --filter PreferencesPaneSmokeTests --skip-update` (6 tests passed)
- `make check` (SwiftFormat clean, SwiftLint 0 violations, packaging/release-path checks passed)
- `git diff --check`
- autoreview: clean, no accepted/actionable findings
- `./Scripts/compile_and_run.sh` (built, tested, packaged, relaunched, app remained running)

## UI proof
- Peekaboo entered `999` in the numeric field and committed it; the field and visible label both updated to `365`
- accessibility inspection reported `History window: 365 days`, with no raw `%d` placeholder
- restored the setting to its prior unset/default state after verification

## Risk
- narrow settings UI change; storage key and clamp behavior are unchanged
