### PR TITLE
docs(site): surface newer provider cards

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -115,6 +115,9 @@
         <li><a class="provider" style="--brand:#FF6A00" href="https://github.com/steipete/CodexBar/blob/main/docs/alibaba-coding-plan.md">
           <img class="chip-logo" src="./logos/alibaba.svg" alt="" width="20" height="20" /><span class="meta"><span class="name">Alibaba</span><span class="auth">Cookies</span></span>
         </a></li>
+        <li><a class="provider" style="--brand:#FF6A00" href="https://github.com/steipete/CodexBar/blob/main/docs/alibaba-token-plan.md">
+          <img class="chip-logo" src="./logos/alibaba.svg" alt="" width="20" height="20" /><span class="meta"><span class="name">Alibaba Token</span><span class="auth">Cookies</span></span>
+        </a></li>
         <li><a class="provider" style="--brand:#AB87EA" href="https://github.com/steipete/CodexBar/blob/main/docs/gemini.md">
           <img class="chip-logo" src="./logos/gemini.svg" alt="" width="20" height="20" /><span class="meta"><span class="name">Gemini</span><span class="auth">OAuth</span></span>
         </a></li>
@@ -126,6 +129,9 @@
         </a></li>
         <li><a class="provider" style="--brand:#A855F7" href="https://github.com/steipete/CodexBar/blob/main/docs/copilot.md">
           <img class="chip-logo" src="./logos/copilot.svg" alt="" width="20" height="20" /><span class="meta"><span class="name">Copilot</span><span class="auth">Device flow</span></span>
+        </a></li>
+        <li><a class="provider" style="--brand:#0F172A" href="https://github.com/steipete/CodexBar/blob/main/docs/devin.md">
+          <span class="chip">D</span><span class="meta"><span class="name">Devin</span><span class="auth">Bearer / Local</span></span>
         </a></li>
         <li><a class="provider" style="--brand:#E85A6A" href="https://github.com/steipete/CodexBar/blob/main/docs/zai.md">
           <img class="chip-logo no-bg" src="./logos/zai.svg" data-dark-src="./logos/zai-dark.svg" alt="" width="20" height="20" /><span class="meta"><span class="name">z.ai</span><span class="auth">API key</span></span>
@@ -183,6 +189,9 @@
         </a></li>
         <li><a class="provider" style="--brand:#527DF0" href="https://github.com/steipete/CodexBar/blob/main/docs/deepseek.md">
           <img class="chip-logo" src="./logos/deepseek.svg" alt="" width="20" height="20" /><span class="meta"><span class="name">DeepSeek</span><span class="auth">API key</span></span>
+        </a></li>
+        <li><a class="provider" style="--brand:#2563EB" href="https://github.com/steipete/CodexBar/blob/main/docs/providers.md#t3-chat">
+          <span class="chip">T3</span><span class="meta"><span class="name">T3 Chat</span><span class="auth">Cookies</span></span>
         </a></li>
         <li><a class="provider" style="--brand:#44C800;--ink:#0a0a0c" href="https://github.com/steipete/CodexBar/blob/main/docs/codebuff.md">
           <img class="chip-logo no-bg" src="./logos/codebuff.png" data-dark-src="./logos/codebuff-dark.svg" alt="" width="20" height="20" /><span class="meta"><span class="name">Codebuff</span><span class="auth">API key</span></span>


### PR DESCRIPTION
## Summary
- add landing-page provider cards for Alibaba Token Plan, Devin, and T3 Chat
- link each card to existing provider docs so the homepage reflects current documented support
- reuse existing card styles and local assets without adding new media

## Tests
- `git diff --check`
- parsed `docs/index.html` with Python `HTMLParser` and checked local image references exist

## Risk
- Docs/site-only change. No runtime provider behavior changes.