### PR TITLE
test: cover provider descriptor icon resources

### DIFF
--- a/Tests/CodexBarTests/ProviderIconResourcesTests.swift
+++ b/Tests/CodexBarTests/ProviderIconResourcesTests.swift
@@ -110,6 +110,19 @@ struct ProviderIconResourcesTests {
         #expect(visiblePixels < 240)
     }
 
+    @Test
+    func `registered providers resolve bundled brand icons`() {
+        ProviderBrandIcon.resetCacheForTesting()
+        defer { ProviderBrandIcon.resetCacheForTesting() }
+
+        for provider in UsageProvider.allCases {
+            let descriptor = ProviderDescriptorRegistry.descriptor(for: provider)
+            #expect(
+                ProviderBrandIcon.image(for: provider) != nil,
+                "Missing icon resource \(descriptor.branding.iconResourceName).svg for \(provider.rawValue)")
+        }
+    }
+
     private static func repoRoot() throws -> URL {
         var dir = URL(filePath: #filePath).deletingLastPathComponent()
         for _ in 0..<12 {


### PR DESCRIPTION
## Summary
- add provider icon coverage for every registered provider descriptor
- verify the UI brand-icon loader can resolve each descriptor's bundled SVG resource
- keep the check beside the existing provider icon resource tests

## Tests
- `swift test --filter ProviderIconResourcesTests --skip-update`
- `make check`
- `git diff --check`

## Risk
- Test-only change. No runtime behavior changes.