### PR TITLE
Improve Antigravity quota detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 - Ollama: replace the bundled provider icon with the cleaner official mark while preserving native template tinting. Thanks @mattab178!
 
+### Changed
+- Antigravity: prefer app and `agy` quota summaries, group usage into Gemini and Claude + GPT session/weekly pools, and preserve IDE and OAuth fallbacks. Thanks @Zihao-Qi!
+
 ### Fixed
 - Settings: make the cost history window directly editable by keyboard while preserving the existing stepper and 1–365 day bounds (fixes #1499). Thanks @kiranmagic7!
-
 ## 0.35.0 — 2026-06-14
 
 ### Added

--- a/Sources/CodexBar/MenuBarMetricWindowResolver.swift
+++ b/Sources/CodexBar/MenuBarMetricWindowResolver.swift
@@ -84,6 +84,9 @@ enum MenuBarMetricWindowResolver {
 
     private static func automaticWindow(provider: UsageProvider, snapshot: UsageSnapshot) -> RateWindow? {
         if provider == .antigravity {
+            if let window = mostConstrainedAntigravityQuotaSummaryWindow(snapshot: snapshot) {
+                return window
+            }
             return self.mostConstrainedWindow(
                 primary: snapshot.primary,
                 secondary: snapshot.secondary,
@@ -120,6 +123,16 @@ enum MenuBarMetricWindowResolver {
             return extraUsage
         }
         return snapshot.primary ?? snapshot.secondary
+    }
+
+    private static let antigravityQuotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
+
+    private static func mostConstrainedAntigravityQuotaSummaryWindow(snapshot: UsageSnapshot) -> RateWindow? {
+        let windows = snapshot.extraRateWindows?
+            .filter { $0.usageKnown && $0.id.hasPrefix(Self.antigravityQuotaSummaryWindowIDPrefix) }
+            .map(\.window) ?? []
+        guard !windows.isEmpty else { return nil }
+        return windows.max(by: { $0.usedPercent < $1.usedPercent })
     }
 
     private static func window(in snapshot: UsageSnapshot, following lanes: [Lane]) -> RateWindow? {

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -223,26 +223,38 @@ extension UsageMenuCardView.Model {
 
     static func antigravityMetrics(input: Input, snapshot: UsageSnapshot) -> [Metric] {
         let percentStyle: PercentStyle = input.usageBarsShowUsed ? .used : .left
-        var metrics = [
-            Self.antigravityMetric(
+        if Self.hasAntigravityQuotaSummaryWindows(snapshot) {
+            return Self.extraRateWindowMetrics(
+                snapshot: snapshot,
+                input: input,
+                percentStyle: percentStyle)
+        }
+
+        var metrics: [Metric] = []
+        if let primary = snapshot.primary {
+            metrics.append(Self.antigravityMetric(
                 id: "primary",
                 title: L(input.metadata.sessionLabel),
-                window: snapshot.primary,
+                window: primary,
                 input: input,
-                percentStyle: percentStyle),
-            Self.antigravityMetric(
+                percentStyle: percentStyle))
+        }
+        if let secondary = snapshot.secondary {
+            metrics.append(Self.antigravityMetric(
                 id: "secondary",
                 title: L(input.metadata.weeklyLabel),
-                window: snapshot.secondary,
+                window: secondary,
                 input: input,
-                percentStyle: percentStyle),
-            Self.antigravityMetric(
+                percentStyle: percentStyle))
+        }
+        if input.metadata.supportsOpus, let tertiary = snapshot.tertiary {
+            metrics.append(Self.antigravityMetric(
                 id: "tertiary",
                 title: input.metadata.opusLabel.map(L) ?? L("Gemini Flash"),
-                window: snapshot.tertiary,
+                window: tertiary,
                 input: input,
-                percentStyle: percentStyle),
-        ]
+                percentStyle: percentStyle))
+        }
         metrics.append(contentsOf: Self.extraRateWindowMetrics(
             snapshot: snapshot,
             input: input,
@@ -271,10 +283,9 @@ extension UsageMenuCardView.Model {
                 window: namedWindow.window,
                 input: input)
             let usageKnown = namedWindow.usageKnown
-            let resetText = Self.resetText(
-                for: namedWindow.window,
-                style: input.resetTimeDisplayStyle,
-                now: input.now)
+            let resetText = Self.extraRateWindowResetText(
+                namedWindow: namedWindow,
+                input: input)
             let statusText: String? = if usageKnown {
                 nil
             } else if let resetText {
@@ -298,6 +309,49 @@ extension UsageMenuCardView.Model {
                 pacePercent: usageKnown ? paceDetail?.pacePercent : nil,
                 paceOnTop: paceDetail?.paceOnTop ?? true)
         }
+    }
+
+    private static let antigravityQuotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
+
+    private static func hasAntigravityQuotaSummaryWindows(_ snapshot: UsageSnapshot) -> Bool {
+        snapshot.extraRateWindows?.contains(where: self.isAntigravityQuotaSummaryWindow) == true
+    }
+
+    private static func isAntigravityQuotaSummaryWindow(_ namedWindow: NamedRateWindow) -> Bool {
+        namedWindow.id.hasPrefix(self.antigravityQuotaSummaryWindowIDPrefix)
+    }
+
+    private static func extraRateWindowResetText(
+        namedWindow: NamedRateWindow,
+        input: Input) -> String?
+    {
+        if input.provider == .antigravity,
+           self.isAntigravityQuotaSummaryWindow(namedWindow)
+        {
+            return self.antigravityQuotaSummaryResetText(namedWindow.window.resetDescription)
+        }
+        return self.resetText(
+            for: namedWindow.window,
+            style: input.resetTimeDisplayStyle,
+            now: input.now)
+    }
+
+    private static func antigravityQuotaSummaryResetText(_ description: String?) -> String? {
+        guard let description = description?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !description.isEmpty
+        else { return nil }
+
+        if let range = description.range(of: "fully refresh in ", options: .caseInsensitive) {
+            var suffix = String(description[range.upperBound...])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            while suffix.last == "." {
+                suffix.removeLast()
+            }
+            guard !suffix.isEmpty else { return description }
+            return String(format: L("Resets in %@"), suffix)
+        }
+
+        return description
     }
 
     private static func extraRateWindowPaceDetail(

--- a/Sources/CodexBar/Providers/Antigravity/AntigravityProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Antigravity/AntigravityProviderImplementation.swift
@@ -42,7 +42,7 @@ struct AntigravityProviderImplementation: ProviderImplementation {
             ProviderSettingsPickerDescriptor(
                 id: "antigravity-usage-source",
                 title: "Usage source",
-                subtitle: "Auto uses the desktop local API first, then agy CLI, then Google OAuth.",
+                subtitle: "Auto uses Antigravity app, then agy CLI, then IDE; OAuth is used for selected accounts.",
                 binding: usageBinding,
                 options: usageOptions,
                 isVisible: nil,

--- a/Sources/CodexBar/Providers/Antigravity/AntigravityProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Antigravity/AntigravityProviderImplementation.swift
@@ -42,7 +42,8 @@ struct AntigravityProviderImplementation: ProviderImplementation {
             ProviderSettingsPickerDescriptor(
                 id: "antigravity-usage-source",
                 title: "Usage source",
-                subtitle: "Auto uses Antigravity app, then agy CLI, then IDE; OAuth is used for selected accounts.",
+                subtitle: "Auto tries Antigravity app, agy CLI, then IDE; " +
+                    "OAuth follows for selected or signed-in accounts.",
                 binding: usageBinding,
                 options: usageOptions,
                 isVisible: nil,

--- a/Sources/CodexBar/SettingsStore+TokenAccounts.swift
+++ b/Sources/CodexBar/SettingsStore+TokenAccounts.swift
@@ -145,6 +145,7 @@ extension SettingsStore {
         guard let data = self.tokenAccountsData(for: provider), !data.accounts.isEmpty else { return }
         let activeAccountID = data.accounts[data.clampedActiveIndex()].id
         guard let removedIndex = data.accounts.firstIndex(where: { $0.id == accountID }) else { return }
+        let removedAccount = data.accounts[removedIndex]
         let filtered = data.accounts.filter { $0.id != accountID }
         self.updateProviderConfig(provider: provider) { entry in
             if filtered.isEmpty {
@@ -166,6 +167,10 @@ extension SettingsStore {
                 entry.apiKey = nil
             }
         }
+        self.applyTokenAccountRemovalSideEffectsIfNeeded(
+            provider: provider,
+            removedAccount: removedAccount,
+            remainingAccounts: filtered)
         CodexBarLog.logger(LogCategories.tokenAccounts).info(
             "Token account removed",
             metadata: [
@@ -211,5 +216,91 @@ extension SettingsStore {
               support.requiresManualCookieSource
         else { return }
         ProviderCatalog.implementation(for: provider)?.applyTokenAccountCookieSource(settings: self)
+    }
+
+    private func applyTokenAccountRemovalSideEffectsIfNeeded(
+        provider: UsageProvider,
+        removedAccount: ProviderTokenAccount,
+        remainingAccounts: [ProviderTokenAccount])
+    {
+        guard provider == .antigravity else { return }
+        guard let removedCredentials = AntigravityOAuthCredentialsStore.credentials(
+            fromTokenAccountValue: removedAccount.token)
+        else {
+            return
+        }
+        let hasMatchingRemainingAccount = remainingAccounts.contains { account in
+            guard let credentials = AntigravityOAuthCredentialsStore.credentials(fromTokenAccountValue: account.token)
+            else {
+                return false
+            }
+            return Self.antigravityCredentialsMatchAccount(credentials, removedCredentials)
+        }
+        guard !hasMatchingRemainingAccount else { return }
+
+        let store = self.antigravityOAuthCredentialsStore
+        Self.clearMatchingAntigravitySharedCredentials(
+            store: store,
+            removedCredentials: removedCredentials)
+    }
+
+    private nonisolated static func clearMatchingAntigravitySharedCredentials(
+        store: AntigravityOAuthCredentialsStore,
+        removedCredentials: AntigravityOAuthCredentials)
+    {
+        Task.detached(priority: .utility) {
+            do {
+                guard let sharedCredentials = try store.load(),
+                      antigravityCredentialsMatchAccount(sharedCredentials, removedCredentials)
+                else {
+                    return
+                }
+                try store.deleteIfPresent()
+            } catch {
+                CodexBarLog.logger(LogCategories.tokenAccounts).warning(
+                    "Failed to clear Antigravity OAuth cache after account removal",
+                    metadata: ["error": error.localizedDescription])
+            }
+        }
+    }
+
+    private nonisolated static func antigravityCredentialsMatchAccount(
+        _ lhs: AntigravityOAuthCredentials,
+        _ rhs: AntigravityOAuthCredentials) -> Bool
+    {
+        if let lhsEmail = self.normalizedAntigravityAccountEmail(lhs.resolvedAccountEmail),
+           let rhsEmail = self.normalizedAntigravityAccountEmail(rhs.resolvedAccountEmail)
+        {
+            return lhsEmail == rhsEmail
+        }
+        if let lhsRefreshToken = self.normalizedAntigravityCredentialToken(lhs.refreshToken),
+           let rhsRefreshToken = self.normalizedAntigravityCredentialToken(rhs.refreshToken)
+        {
+            return lhsRefreshToken == rhsRefreshToken
+        }
+        if let lhsAccessToken = self.normalizedAntigravityCredentialToken(lhs.accessToken),
+           let rhsAccessToken = self.normalizedAntigravityCredentialToken(rhs.accessToken)
+        {
+            return lhsAccessToken == rhsAccessToken
+        }
+        return false
+    }
+
+    private nonisolated static func normalizedAntigravityAccountEmail(_ email: String?) -> String? {
+        guard let value = email?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !value.isEmpty
+        else {
+            return nil
+        }
+        return value
+    }
+
+    private nonisolated static func normalizedAntigravityCredentialToken(_ token: String?) -> String? {
+        guard let value = token?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty
+        else {
+            return nil
+        }
+        return value
     }
 }

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -147,6 +147,7 @@ final class SettingsStore {
 
     @ObservationIgnored let userDefaults: UserDefaults
     @ObservationIgnored let configStore: CodexBarConfigStore
+    @ObservationIgnored let antigravityOAuthCredentialsStore: AntigravityOAuthCredentialsStore
     @ObservationIgnored var config: CodexBarConfig
     @ObservationIgnored var configPersistTask: Task<Void, Never>?
     @ObservationIgnored var configLoading = false
@@ -204,7 +205,8 @@ final class SettingsStore {
             account: "amp-cookie",
             promptKind: .ampCookie),
         copilotTokenStore: any CopilotTokenStoring = KeychainCopilotTokenStore(),
-        tokenAccountStore: any ProviderTokenAccountStoring = FileTokenAccountStore())
+        tokenAccountStore: any ProviderTokenAccountStoring = FileTokenAccountStore(),
+        antigravityOAuthCredentialsStore: AntigravityOAuthCredentialsStore = AntigravityOAuthCredentialsStore())
     {
         let appGroupID = AppGroupSupport.currentGroupID()
         let appGroupMigration: AppGroupSupport.MigrationResult
@@ -256,6 +258,7 @@ final class SettingsStore {
             stores: legacyStores)
         self.userDefaults = userDefaults
         self.configStore = configStore
+        self.antigravityOAuthCredentialsStore = antigravityOAuthCredentialsStore
         self.config = config
         self.configLoading = true
         let defaultsState = Self.loadDefaultsState(userDefaults: userDefaults)

--- a/Sources/CodexBar/UsageStore+HighestUsage.swift
+++ b/Sources/CodexBar/UsageStore+HighestUsage.swift
@@ -54,6 +54,12 @@ extension UsageStore {
         if provider == .cursor || provider == .antigravity,
            effectivePreference == .automatic
         {
+            if provider == .antigravity,
+               let percents = Self.antigravityQuotaSummaryUsedPercents(snapshot: snapshot),
+               !percents.isEmpty
+            {
+                return percents.allSatisfy { $0 >= 100 }
+            }
             let percents = [
                 snapshot.primary?.usedPercent,
                 snapshot.secondary?.usedPercent,
@@ -64,5 +70,13 @@ extension UsageStore {
         }
 
         return true
+    }
+
+    private nonisolated static let antigravityQuotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
+
+    private nonisolated static func antigravityQuotaSummaryUsedPercents(snapshot: UsageSnapshot) -> [Double]? {
+        snapshot.extraRateWindows?
+            .filter { $0.usageKnown && $0.id.hasPrefix(Self.antigravityQuotaSummaryWindowIDPrefix) }
+            .map(\.window.usedPercent)
     }
 }

--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -119,6 +119,13 @@ extension UsageStore {
                     percentLeft: window.remainingPercent)
             }
         }
+        if provider == .antigravity,
+           let rows = Self.antigravityQuotaSummaryWidgetRows(snapshot: snapshot),
+           !rows.isEmpty
+        {
+            return rows
+        }
+
         let primaryTitle: String = {
             if provider == .grok,
                let dyn = GrokProviderDescriptor.primaryLabel(window: snapshot.primary)
@@ -145,5 +152,23 @@ extension UsageStore {
                 percentLeft: snapshot.tertiary?.remainingPercent))
         }
         return rows.filter { $0.percentLeft != nil }
+    }
+
+    private nonisolated static let antigravityQuotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
+
+    private nonisolated static func antigravityQuotaSummaryWidgetRows(
+        snapshot: UsageSnapshot) -> [WidgetSnapshot.WidgetUsageRowSnapshot]?
+    {
+        guard let windows = snapshot.extraRateWindows?.filter({
+            $0.id.hasPrefix(Self.antigravityQuotaSummaryWindowIDPrefix)
+        }), !windows.isEmpty else {
+            return nil
+        }
+        return windows.map { namedWindow in
+            WidgetSnapshot.WidgetUsageRowSnapshot(
+                id: namedWindow.id,
+                title: namedWindow.title,
+                percentLeft: namedWindow.usageKnown ? namedWindow.window.remainingPercent : nil)
+        }
     }
 }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
@@ -28,13 +28,22 @@ protocol AntigravityCLIProcessLaunching: Sendable {
 }
 
 enum AntigravityCLIAuthenticationPrompt {
-    static let evidence = Data("You are currently not signed in".utf8)
+    static let evidence = Data("Select login method:".utf8)
+    private static let promptPattern = #"select\s+login\s+method\s*:?"#
 
     static func contains(_ output: Data) -> Bool {
-        [
-            self.evidence,
-            Data("Select login method:".utf8),
-        ].contains { output.range(of: $0) != nil }
+        // `agy` briefly prints "You are currently not signed in" before it
+        // auto-refreshes an existing login. The actual blocking state is the
+        // interactive login-method prompt. The exact prompt is a CLI-owned TUI
+        // string, so keep matching tolerant to casing and whitespace changes.
+        if output.range(of: self.evidence) != nil {
+            return true
+        }
+        let asciiBytes = output.map { $0 < 0x80 ? $0 : 0x20 }
+        let text = String(bytes: asciiBytes, encoding: .utf8) ?? ""
+        return text.range(
+            of: self.promptPattern,
+            options: [.regularExpression, .caseInsensitive]) != nil
     }
 }
 
@@ -93,7 +102,7 @@ protocol AntigravityCLISessionLaunchLocking: Sendable {
 /// Manages a bounded background ``agy`` process whose embedded localhost server
 /// provides the same ``GetUserStatus`` endpoint as the desktop Antigravity app's
 /// ``language_server``. The CLI is kept alive in a PTY so its daemon stays bound
-/// to a local port — this lets CodexBar read Claude + Gemini quotas even when
+/// to a local port - this lets CodexBar read Claude + Gemini quotas even when
 /// the desktop Antigravity app is closed.
 ///
 /// The session intentionally does not scrape TUI output. It only launches and

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSnapshotSelection.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalSnapshotSelection.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+extension AntigravityStatusProbe {
+    static func preferredLocalSnapshot(
+        _ snapshots: [AntigravityStatusSnapshot],
+        matchingAccountEmail expectedAccountEmail: String?) -> AntigravityStatusSnapshot?
+    {
+        var candidates = snapshots
+        if let expected = self.normalizedAccountEmail(expectedAccountEmail) {
+            let matches = snapshots.filter {
+                guard let found = self.normalizedAccountEmail($0.accountEmail) else { return false }
+                return found.caseInsensitiveCompare(expected) == .orderedSame
+            }
+            if !matches.isEmpty {
+                candidates = matches
+            }
+        }
+
+        var bestSnapshot: AntigravityStatusSnapshot?
+        var bestScore = Int.min
+        for snapshot in candidates {
+            let score = self.localSnapshotScore(snapshot)
+            if score > bestScore {
+                bestSnapshot = snapshot
+                bestScore = score
+            }
+        }
+        return bestSnapshot
+    }
+
+    private static func normalizedAccountEmail(_ email: String?) -> String? {
+        guard let trimmed = email?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalhostSession.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityLocalhostSession.swift
@@ -1,0 +1,109 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+enum LocalhostTrustPolicy {
+    static func shouldAcceptServerTrust(
+        host: String,
+        authenticationMethod: String,
+        hasServerTrust: Bool) -> Bool
+    {
+        #if !os(Linux)
+        guard authenticationMethod == NSURLAuthenticationMethodServerTrust else { return false }
+        #endif
+        let normalizedHost = host.lowercased()
+        guard normalizedHost == "127.0.0.1" || normalizedHost == "localhost" else { return false }
+        return hasServerTrust
+    }
+}
+
+final class LocalhostSessionDelegate: NSObject {
+    func data(for request: URLRequest, session: URLSession) async throws -> (Data, URLResponse) {
+        let state = LocalhostSessionTaskState()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let task = session.dataTask(with: request) { data, response, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    guard let data, let response else {
+                        continuation.resume(throwing: AntigravityStatusProbeError.apiError("Invalid response"))
+                        return
+                    }
+                    continuation.resume(returning: (data, response))
+                }
+                state.setTask(task)
+                task.resume()
+            }
+        } onCancel: {
+            state.cancel()
+        }
+    }
+
+    private func challengeResult(_ challenge: URLAuthenticationChallenge) -> (
+        disposition: URLSession.AuthChallengeDisposition,
+        credential: URLCredential?)
+    {
+        #if os(Linux)
+        return (.performDefaultHandling, nil)
+        #else
+        let protectionSpace = challenge.protectionSpace
+        let trust = protectionSpace.serverTrust
+        guard LocalhostTrustPolicy.shouldAcceptServerTrust(
+            host: protectionSpace.host,
+            authenticationMethod: protectionSpace.authenticationMethod,
+            hasServerTrust: trust != nil),
+            let trust
+        else {
+            return (.performDefaultHandling, nil)
+        }
+        return (.useCredential, URLCredential(trust: trust))
+        #endif
+    }
+}
+
+extension LocalhostSessionDelegate: URLSessionDelegate {
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?)
+    {
+        self.challengeResult(challenge)
+    }
+}
+
+extension LocalhostSessionDelegate: URLSessionTaskDelegate {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?)
+    {
+        self.challengeResult(challenge)
+    }
+}
+
+private final class LocalhostSessionTaskState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var task: URLSessionDataTask?
+    private var isCancelled = false
+
+    func setTask(_ task: URLSessionDataTask) {
+        self.lock.lock()
+        self.task = task
+        let shouldCancel = self.isCancelled
+        self.lock.unlock()
+
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func cancel() {
+        self.lock.lock()
+        self.isCancelled = true
+        let task = self.task
+        self.lock.unlock()
+        task?.cancel()
+    }
+}

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -52,7 +52,8 @@ public enum AntigravityProviderDescriptor {
             return [oauth]
         case .auto:
             if context.selectedTokenAccountID != nil ||
-                context.env[AntigravityOAuthCredentialsStore.environmentCredentialsKey] != nil
+                context.env[AntigravityOAuthCredentialsStore.environmentCredentialsKey] != nil ||
+                self.hasSharedOAuthCredentials(context: context)
             {
                 return [app, cli, ide, oauth]
             }
@@ -60,6 +61,14 @@ public enum AntigravityProviderDescriptor {
         case .web, .api:
             return []
         }
+    }
+
+    private static func hasSharedOAuthCredentials(context: ProviderFetchContext) -> Bool {
+        let homeURL = context.env["HOME"]
+            .flatMap { $0.isEmpty ? nil : URL(fileURLWithPath: $0, isDirectory: true) }
+            ?? FileManager.default.homeDirectoryForCurrentUser
+        let fileURL = AntigravityOAuthCredentialsStore.defaultURL(home: homeURL)
+        return FileManager.default.fileExists(atPath: fileURL.path)
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -10,10 +10,10 @@ public enum AntigravityProviderDescriptor {
             metadata: ProviderMetadata(
                 id: .antigravity,
                 displayName: "Antigravity",
-                sessionLabel: "Claude",
-                weeklyLabel: "Gemini Pro",
-                opusLabel: "Gemini Flash",
-                supportsOpus: true,
+                sessionLabel: "Gemini",
+                weeklyLabel: "Claude + GPT",
+                opusLabel: nil,
+                supportsOpus: false,
                 supportsCredits: false,
                 creditsHint: "",
                 toggleTitle: "Show Antigravity usage (experimental)",
@@ -41,16 +41,22 @@ public enum AntigravityProviderDescriptor {
     }
 
     private static func resolveStrategies(context: ProviderFetchContext) async -> [any ProviderFetchStrategy] {
-        let local = AntigravityStatusFetchStrategy()
+        let app = AntigravityStatusFetchStrategy(source: .app)
         let cli = AntigravityCLIHTTPSFetchStrategy()
+        let ide = AntigravityStatusFetchStrategy(source: .ide)
         let oauth = AntigravityOAuthFetchStrategy()
         switch context.sourceMode {
         case .cli:
-            return [local, cli]
+            return [app, cli, ide]
         case .oauth:
             return [oauth]
         case .auto:
-            return [local, cli, oauth]
+            if context.selectedTokenAccountID != nil ||
+                context.env[AntigravityOAuthCredentialsStore.environmentCredentialsKey] != nil
+            {
+                return [app, cli, ide, oauth]
+            }
+            return [app, cli, ide]
         case .web, .api:
             return []
         }
@@ -58,25 +64,55 @@ public enum AntigravityProviderDescriptor {
 }
 
 struct AntigravityStatusFetchStrategy: ProviderFetchStrategy {
-    let id: String = "antigravity.local"
+    enum Source: Sendable {
+        case app
+        case ide
+
+        var id: String {
+            switch self {
+            case .app: "antigravity.app-local"
+            case .ide: "antigravity.ide-local"
+            }
+        }
+
+        var processScope: AntigravityStatusProbe.ProcessScope {
+            switch self {
+            case .app: .appOnly
+            case .ide: .ideOnly
+            }
+        }
+
+        var sourceLabel: String {
+            switch self {
+            case .app: "app"
+            case .ide: "ide"
+            }
+        }
+    }
+
+    let source: Source
+    var id: String {
+        self.source.id
+    }
+
     let kind: ProviderFetchKind = .localProbe
+
+    init(source: Source = .app) {
+        self.source = source
+    }
+
     func isAvailable(_: ProviderFetchContext) async -> Bool {
         true
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        // IDE-only: `agy` is owned by AntigravityCLIHTTPSFetchStrategy, which
-        // waits for real API readiness. Probing a half-warmed `agy` here would
-        // burn the timeout on a process that is not yet answering, so the
-        // local probe only handles the running-desktop case and otherwise
-        // fails over to the CLI strategy.
-        let probe = AntigravityStatusProbe(processScope: .ideOnly)
+        let probe = AntigravityStatusProbe(processScope: self.source.processScope)
         let snap = try await probe.fetch()
         let usage = try snap.toUsageSnapshot()
         try AntigravitySelectedAccountGuard.validate(usage, context: context)
         return self.makeResult(
             usage: usage,
-            sourceLabel: "local")
+            sourceLabel: self.source.sourceLabel)
     }
 
     func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {
@@ -84,11 +120,11 @@ struct AntigravityStatusFetchStrategy: ProviderFetchStrategy {
     }
 }
 
-/// When the desktop Antigravity app is closed (no ``language_server`` running),
-/// this strategy spawns or reuses ``agy`` and talks to the HTTPS localhost
-/// server embedded in that CLI process. ``agy`` is an interactive REPL, not a
-/// query command, so CodexBar never scrapes TUI output here; it only keeps the
-/// process alive long enough for the server to answer ``GetUserStatus``.
+/// When the Antigravity 2.0 app is closed or unavailable, this strategy spawns
+/// or reuses ``agy`` and talks to the HTTPS localhost server embedded in that
+/// CLI process. ``agy`` is an interactive REPL, not a query command, so
+/// CodexBar never scrapes TUI output here; it only keeps the process alive long
+/// enough for the server to answer quota endpoints.
 struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     static let sourceLabel = "cli"
     let id: String = "antigravity.cli-https"
@@ -259,7 +295,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     }
 
     func shouldFallback(on _: Error, context: ProviderFetchContext) -> Bool {
-        context.sourceMode == .auto
+        context.sourceMode == .auto || context.sourceMode == .cli
     }
 }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -73,7 +73,7 @@ public enum AntigravityProviderDescriptor {
 }
 
 struct AntigravityStatusFetchStrategy: ProviderFetchStrategy {
-    enum Source: Sendable {
+    enum Source {
         case app
         case ide
 
@@ -116,7 +116,12 @@ struct AntigravityStatusFetchStrategy: ProviderFetchStrategy {
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
         let probe = AntigravityStatusProbe(processScope: self.source.processScope)
-        let snap = try await probe.fetch()
+        let selectedAccountEmail: String? = if context.sourceMode == .auto, context.selectedTokenAccountID != nil {
+            AntigravitySelectedAccountGuard.selectedAccountEmail(context: context)
+        } else {
+            nil
+        }
+        let snap = try await probe.fetch(matchingAccountEmail: selectedAccountEmail)
         let usage = try snap.toUsageSnapshot()
         try AntigravitySelectedAccountGuard.validate(usage, context: context)
         return self.makeResult(

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityQuotaSummaryParser.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityQuotaSummaryParser.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+struct AntigravityQuotaSummary: Sendable, Equatable {
+    let description: String?
+    let groups: [AntigravityQuotaSummaryGroup]
+}
+
+struct AntigravityQuotaSummaryGroup: Sendable, Equatable {
+    let displayName: String
+    let description: String?
+    let buckets: [AntigravityQuotaSummaryBucket]
+}
+
+struct AntigravityQuotaSummaryBucket: Sendable, Equatable {
+    let bucketId: String
+    let displayName: String
+    let remainingFraction: Double?
+    let resetDescription: String?
+    let disabled: Bool
+}
+
+extension AntigravityStatusProbe {
+    static func parseQuotaSummaryResponse(_ data: Data) throws -> AntigravityStatusSnapshot {
+        let decoder = JSONDecoder()
+        let response = try decoder.decode(QuotaSummaryResponse.self, from: data)
+        if let invalid = Self.invalidCode(response.code) {
+            throw AntigravityStatusProbeError.apiError(invalid)
+        }
+        let payload = response.response ?? response.summary ?? response.rootPayload
+        guard let payload else {
+            throw AntigravityStatusProbeError.parseFailed("Missing quota summary")
+        }
+        let groups = payload.groups.compactMap(self.quotaSummaryGroup(from:))
+        guard !groups.isEmpty else {
+            throw AntigravityStatusProbeError.parseFailed("Missing quota groups")
+        }
+        return AntigravityStatusSnapshot(
+            quotaSummary: AntigravityQuotaSummary(
+                description: payload.description,
+                groups: groups),
+            accountEmail: nil,
+            accountPlan: nil,
+            source: .local)
+    }
+
+    private static func quotaSummaryGroup(from payload: QuotaSummaryGroupPayload) -> AntigravityQuotaSummaryGroup? {
+        let displayName = payload.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let buckets = (payload.buckets ?? []).compactMap(self.quotaSummaryBucket(from:))
+        guard !buckets.isEmpty else { return nil }
+        return AntigravityQuotaSummaryGroup(
+            displayName: self.nonEmpty(displayName) ?? "Quota",
+            description: payload.description,
+            buckets: buckets)
+    }
+
+    private static func quotaSummaryBucket(from payload: QuotaSummaryBucketPayload) -> AntigravityQuotaSummaryBucket? {
+        let bucketId = payload.bucketId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayName = payload.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let resolvedBucketId = bucketId, !resolvedBucketId.isEmpty else { return nil }
+        return AntigravityQuotaSummaryBucket(
+            bucketId: resolvedBucketId,
+            displayName: self.nonEmpty(displayName) ?? resolvedBucketId,
+            remainingFraction: payload.resolvedRemainingFraction,
+            resetDescription: payload.description,
+            disabled: payload.disabled ?? false)
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+}
+
+private struct QuotaSummaryResponse: Decodable {
+    let code: CodeValue?
+    let message: String?
+    let response: QuotaSummaryPayload?
+    let summary: QuotaSummaryPayload?
+    let description: String?
+    let groups: [QuotaSummaryGroupPayload]?
+
+    var rootPayload: QuotaSummaryPayload? {
+        guard let groups else { return nil }
+        return QuotaSummaryPayload(description: self.description, groups: groups)
+    }
+}
+
+private struct QuotaSummaryPayload: Decodable {
+    let description: String?
+    let groups: [QuotaSummaryGroupPayload]
+
+    init(description: String?, groups: [QuotaSummaryGroupPayload]) {
+        self.description = description
+        self.groups = groups
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case description
+        case groups
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.description = try container.decodeIfPresent(String.self, forKey: .description)
+        self.groups = try container.decodeIfPresent([QuotaSummaryGroupPayload].self, forKey: .groups) ?? []
+    }
+}
+
+private struct QuotaSummaryGroupPayload: Decodable {
+    let displayName: String?
+    let description: String?
+    let buckets: [QuotaSummaryBucketPayload]?
+}
+
+private struct QuotaSummaryBucketPayload: Decodable {
+    let bucketId: String?
+    let displayName: String?
+    let description: String?
+    let disabled: Bool?
+    let remainingFraction: Double?
+    let remaining: QuotaSummaryRemainingPayload?
+
+    var resolvedRemainingFraction: Double? {
+        self.remainingFraction ?? self.remaining?.remainingFraction
+    }
+}
+
+private struct QuotaSummaryRemainingPayload: Decodable {
+    let remainingFraction: Double?
+
+    private enum CodingKeys: String, CodingKey {
+        case remainingFraction
+        case oneofCase = "case"
+        case value
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let remainingFraction = try container.decodeIfPresent(Double.self, forKey: .remainingFraction) {
+            self.remainingFraction = remainingFraction
+            return
+        }
+        let oneofCase = try container.decodeIfPresent(String.self, forKey: .oneofCase)
+        if oneofCase == "remainingFraction" {
+            self.remainingFraction = try container.decodeIfPresent(Double.self, forKey: .value)
+        } else {
+            self.remainingFraction = nil
+        }
+    }
+}

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityRemoteUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityRemoteUsageFetcher.swift
@@ -210,14 +210,15 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
                 timeout: timeout,
                 dataLoader: dataLoader)
             let modelQuotas = try Self.parseModelQuotas(response)
-            if Self.shouldVerifyFullRemoteQuotas(modelQuotas),
-               let quotaBuckets = try? await Self.fetchQuotaBucketsIfPermitted(
-                   accessToken: accessToken,
-                   projectId: projectId,
-                   timeout: timeout,
-                   dataLoader: dataLoader),
-               Self.hasConsumedQuota(quotaBuckets)
-            {
+            if Self.shouldVerifyFullRemoteQuotas(modelQuotas) {
+                let quotaBuckets = try await Self.fetchQuotaBucketsIfPermitted(
+                    accessToken: accessToken,
+                    projectId: projectId,
+                    timeout: timeout,
+                    dataLoader: dataLoader)
+                guard let quotaBuckets, Self.hasQuotaFractionData(quotaBuckets) else {
+                    return []
+                }
                 return Self.mergeVerifiedQuotas(modelQuotas: modelQuotas, verifiedQuotas: quotaBuckets)
             }
             return modelQuotas
@@ -273,10 +274,9 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
         }
     }
 
-    private static func hasConsumedQuota(_ quotas: [AntigravityModelQuota]) -> Bool {
+    private static func hasQuotaFractionData(_ quotas: [AntigravityModelQuota]) -> Bool {
         quotas.contains { quota in
-            guard let remaining = quota.remainingFraction else { return false }
-            return remaining < 0.999
+            quota.remainingFraction != nil
         }
     }
 
@@ -442,9 +442,10 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
     }
 
     private static func parseQuotaBuckets(_ response: RetrieveUserQuotaResponse) throws -> [AntigravityModelQuota] {
-        guard let buckets = response.buckets, !buckets.isEmpty else {
+        guard let buckets = response.buckets else {
             throw AntigravityRemoteFetchError.parseFailed("No quota buckets in response")
         }
+        guard !buckets.isEmpty else { return [] }
 
         var modelQuotaMap: [String: (fraction: Double?, resetTime: String?)] = [:]
         for bucket in buckets {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+ResponseModels.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+ResponseModels.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+struct UserStatusResponse: Decodable {
+    let code: CodeValue?
+    let message: String?
+    let userStatus: UserStatus?
+}
+
+struct CommandModelConfigResponse: Decodable {
+    let code: CodeValue?
+    let message: String?
+    let clientModelConfigs: [ModelConfig]?
+}
+
+struct UserStatus: Decodable {
+    let email: String?
+    let planStatus: PlanStatus?
+    let cascadeModelConfigData: ModelConfigData?
+    let userTier: UserTier?
+}
+
+struct UserTier: Decodable {
+    let id: String?
+    let name: String?
+    let description: String?
+
+    var preferredName: String? {
+        guard let value = self.name?.trimmingCharacters(in: .whitespacesAndNewlines) else { return nil }
+        return value.isEmpty ? nil : value
+    }
+}
+
+struct PlanStatus: Decodable {
+    let planInfo: PlanInfo?
+}
+
+struct PlanInfo: Decodable {
+    let planName: String?
+    let planDisplayName: String?
+    let displayName: String?
+    let productName: String?
+    let planShortName: String?
+
+    var preferredName: String? {
+        let candidates = [
+            self.planDisplayName,
+            self.displayName,
+            self.productName,
+            self.planName,
+            self.planShortName,
+        ]
+        for candidate in candidates {
+            guard let value = candidate?.trimmingCharacters(in: .whitespacesAndNewlines) else { continue }
+            if !value.isEmpty { return value }
+        }
+        return nil
+    }
+}
+
+struct ModelConfigData: Decodable {
+    let clientModelConfigs: [ModelConfig]?
+}
+
+struct ModelConfig: Decodable {
+    let label: String
+    let modelOrAlias: ModelAlias
+    let quotaInfo: QuotaInfo?
+}
+
+struct ModelAlias: Decodable {
+    let model: String
+}
+
+struct QuotaInfo: Decodable {
+    let remainingFraction: Double?
+    let resetTime: String?
+}
+
+enum CodeValue: Decodable {
+    case int(Int)
+    case string(String)
+
+    var isOK: Bool {
+        switch self {
+        case let .int(value):
+            value == 0
+        case let .string(value):
+            value.lowercased() == "ok" || value.lowercased() == "success" || value == "0"
+        }
+    }
+
+    var rawValue: String {
+        switch self {
+        case let .int(value): "\(value)"
+        case let .string(value): value
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(Int.self) {
+            self = .int(value)
+            return
+        }
+        if let value = try? container.decode(String.self) {
+            self = .string(value)
+            return
+        }
+        throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported code type")
+    }
+}

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -206,14 +206,8 @@ public struct AntigravityStatusSnapshot: Sendable {
             throw AntigravityStatusProbeError.parseFailed("No quota buckets available")
         }
 
-        let constrainedWindows = namedWindows
-            .filter(\.usageKnown)
-            .sorted { lhs, rhs in
-                if lhs.window.usedPercent != rhs.window.usedPercent {
-                    return lhs.window.usedPercent > rhs.window.usedPercent
-                }
-                return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
-            }
+        let primary = Self.quotaSummaryRepresentative(title: "Gemini", in: namedWindows)
+        let secondary = Self.quotaSummaryRepresentative(title: "Claude + GPT", in: namedWindows)
 
         let identity = ProviderIdentitySnapshot(
             providerID: .antigravity,
@@ -221,12 +215,27 @@ public struct AntigravityStatusSnapshot: Sendable {
             accountOrganization: nil,
             loginMethod: accountPlan)
         return UsageSnapshot(
-            primary: constrainedWindows.first?.window,
-            secondary: constrainedWindows.dropFirst().first?.window,
-            tertiary: constrainedWindows.dropFirst(2).first?.window,
+            primary: primary,
+            secondary: secondary,
+            tertiary: nil,
             extraRateWindows: namedWindows,
             updatedAt: Date(),
             identity: identity)
+    }
+
+    private static func quotaSummaryRepresentative(
+        title: String,
+        in windows: [NamedRateWindow]) -> RateWindow?
+    {
+        windows
+            .filter { $0.usageKnown && $0.title.hasPrefix("\(title) ") }
+            .max { lhs, rhs in
+                if lhs.window.usedPercent != rhs.window.usedPercent {
+                    return lhs.window.usedPercent < rhs.window.usedPercent
+                }
+                return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedDescending
+            }?
+            .window
     }
 
     private static func quotaSummaryWindows(from quotaSummary: AntigravityQuotaSummary) -> [NamedRateWindow] {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -1453,6 +1453,11 @@ public struct AntigravityStatusProbe: Sendable {
                 context: context,
                 send: send,
                 parse: self.parseQuotaSummaryResponse)
+            guard quotaSummary.quotaSummary?.groups.contains(where: { group in
+                group.buckets.contains { !$0.disabled && $0.remainingFraction != nil }
+            }) == true else {
+                throw AntigravityStatusProbeError.parseFailed("Quota summary has no usable quota buckets")
+            }
             let identity = try? await self.makeParsedRequest(
                 payload: RequestPayload(
                     path: self.getUserStatusPath,

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -139,8 +139,22 @@ public struct AntigravityStatusSnapshot: Sendable {
         let summaryCandidates = normalized.filter(Self.isSummaryCandidate)
         let primaryQuota = Self.representative(for: .gemini, in: summaryCandidates)
         let secondaryQuota = Self.representative(for: .claudeGPT, in: summaryCandidates)
+        let fallbackQuota: AntigravityModelQuota? = if primaryQuota == nil, secondaryQuota == nil {
+            switch self.source {
+            case .local:
+                Self.fallbackRepresentative(in: normalized.filter {
+                    $0.family == .unknown &&
+                        Self.isSelectableTextModel($0) &&
+                        $0.quota.remainingFraction != nil
+                })
+            case .remote:
+                nil
+            }
+        } else {
+            nil
+        }
 
-        let primary = primaryQuota.map(Self.rateWindow(for:))
+        let primary = (primaryQuota ?? fallbackQuota).map(Self.rateWindow(for:))
         let secondary = secondaryQuota.map(Self.rateWindow(for:))
         let extraWindows = Self.extraRateWindows(
             from: normalized,
@@ -517,6 +531,15 @@ public struct AntigravityStatusSnapshot: Sendable {
             default:
                 return lhs.quota.label.localizedCaseInsensitiveCompare(rhs.quota.label) == .orderedAscending
             }
+        }?.quota
+    }
+
+    private static func fallbackRepresentative(in models: [AntigravityNormalizedModel]) -> AntigravityModelQuota? {
+        models.min { lhs, rhs in
+            if lhs.quota.remainingPercent != rhs.quota.remainingPercent {
+                return lhs.quota.remainingPercent < rhs.quota.remainingPercent
+            }
+            return lhs.quota.label.localizedCaseInsensitiveCompare(rhs.quota.label) == .orderedAscending
         }?.quota
     }
 
@@ -1606,116 +1629,5 @@ public struct AntigravityStatusProbe: Sendable {
             throw AntigravityStatusProbeError.apiError("HTTP \(http.statusCode): \(message)")
         }
         return data
-    }
-}
-
-private struct UserStatusResponse: Decodable {
-    let code: CodeValue?
-    let message: String?
-    let userStatus: UserStatus?
-}
-
-private struct CommandModelConfigResponse: Decodable {
-    let code: CodeValue?
-    let message: String?
-    let clientModelConfigs: [ModelConfig]?
-}
-
-private struct UserStatus: Decodable {
-    let email: String?
-    let planStatus: PlanStatus?
-    let cascadeModelConfigData: ModelConfigData?
-    let userTier: UserTier?
-}
-
-private struct UserTier: Decodable {
-    let id: String?
-    let name: String?
-    let description: String?
-
-    var preferredName: String? {
-        guard let value = name?.trimmingCharacters(in: .whitespacesAndNewlines) else { return nil }
-        return value.isEmpty ? nil : value
-    }
-}
-
-private struct PlanStatus: Decodable {
-    let planInfo: PlanInfo?
-}
-
-private struct PlanInfo: Decodable {
-    let planName: String?
-    let planDisplayName: String?
-    let displayName: String?
-    let productName: String?
-    let planShortName: String?
-
-    var preferredName: String? {
-        let candidates = [
-            planDisplayName,
-            displayName,
-            productName,
-            planName,
-            planShortName,
-        ]
-        for candidate in candidates {
-            guard let value = candidate?.trimmingCharacters(in: .whitespacesAndNewlines) else { continue }
-            if !value.isEmpty { return value }
-        }
-        return nil
-    }
-}
-
-private struct ModelConfigData: Decodable {
-    let clientModelConfigs: [ModelConfig]?
-}
-
-private struct ModelConfig: Decodable {
-    let label: String
-    let modelOrAlias: ModelAlias
-    let quotaInfo: QuotaInfo?
-}
-
-private struct ModelAlias: Decodable {
-    let model: String
-}
-
-private struct QuotaInfo: Decodable {
-    let remainingFraction: Double?
-    let resetTime: String?
-}
-
-enum CodeValue: Decodable {
-    case int(Int)
-    case string(String)
-
-    var isOK: Bool {
-        switch self {
-        case let .int(value):
-            return value == 0
-        case let .string(value):
-            let lower = value.lowercased()
-            return lower == "ok" || lower == "success" || value == "0"
-        }
-    }
-
-    var rawValue: String {
-        switch self {
-        case let .int(value): "\(value)"
-        case let .string(value): value
-        }
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        if let value = try? container.decode(Int.self) {
-            self = .int(value)
-            return
-        }
-        if let value = try? container.decode(String.self) {
-            self = .string(value)
-            return
-        }
-        throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported code type")
     }
 }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -32,9 +32,36 @@ public struct AntigravityModelQuota: Sendable {
 
 private enum AntigravityModelFamily {
     case claude
+    case gpt
     case geminiPro
     case geminiFlash
     case unknown
+}
+
+private enum AntigravityUsagePool: Hashable {
+    case gemini
+    case claudeGPT
+
+    var id: String {
+        switch self {
+        case .gemini: "antigravity-gemini"
+        case .claudeGPT: "antigravity-claude-gpt"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .gemini: "Gemini"
+        case .claudeGPT: "Claude + GPT"
+        }
+    }
+
+    var sortRank: Int {
+        switch self {
+        case .gemini: 0
+        case .claudeGPT: 1
+        }
+    }
 }
 
 private struct AntigravityModelVersion: Comparable {
@@ -68,6 +95,7 @@ public struct AntigravityStatusSnapshot: Sendable {
     public let accountEmail: String?
     public let accountPlan: String?
     public let source: AntigravityModelQuotaSource
+    let quotaSummary: AntigravityQuotaSummary?
 
     public init(
         modelQuotas: [AntigravityModelQuota],
@@ -79,57 +107,48 @@ public struct AntigravityStatusSnapshot: Sendable {
         self.accountEmail = accountEmail
         self.accountPlan = accountPlan
         self.source = source
+        self.quotaSummary = nil
+    }
+
+    init(
+        quotaSummary: AntigravityQuotaSummary,
+        accountEmail: String?,
+        accountPlan: String?,
+        source: AntigravityModelQuotaSource = .local)
+    {
+        self.modelQuotas = []
+        self.accountEmail = accountEmail
+        self.accountPlan = accountPlan
+        self.source = source
+        self.quotaSummary = quotaSummary
     }
 
     public func toUsageSnapshot() throws -> UsageSnapshot {
+        if let quotaSummary {
+            return try Self.usageSnapshot(
+                from: quotaSummary,
+                accountEmail: self.accountEmail,
+                accountPlan: self.accountPlan)
+        }
+
         guard !self.modelQuotas.isEmpty else {
             throw AntigravityStatusProbeError.parseFailed("No quota models available")
         }
 
         let normalized = Self.normalizedModels(self.modelQuotas)
-        let summaryCandidates: [AntigravityNormalizedModel] = switch self.source {
-        case .local:
-            normalized
-        case .remote:
-            normalized.filter(Self.isRemoteSummaryCandidate)
-        }
-        let summaryModels = summaryCandidates.filter { $0.quota.remainingFraction != nil }
-        let primaryQuota = Self.representative(for: .claude, in: summaryModels)
-        let secondaryQuota = Self.representative(for: .geminiPro, in: summaryModels)
-        let tertiaryQuota = Self.representative(for: .geminiFlash, in: summaryModels)
-        let fallbackQuota: AntigravityModelQuota? = if primaryQuota == nil, secondaryQuota == nil,
-                                                       tertiaryQuota == nil
-        {
-            Self.fallbackRepresentative(in: summaryModels)
-        } else {
-            nil
-        }
+        let summaryCandidates = normalized.filter(Self.isSummaryCandidate)
+        let primaryQuota = Self.representative(for: .gemini, in: summaryCandidates)
+        let secondaryQuota = Self.representative(for: .claudeGPT, in: summaryCandidates)
 
-        let primary = (primaryQuota ?? fallbackQuota).map(Self.rateWindow(for:))
+        let primary = primaryQuota.map(Self.rateWindow(for:))
         let secondary = secondaryQuota.map(Self.rateWindow(for:))
-        let tertiary = tertiaryQuota.map(Self.rateWindow(for:))
-
-        // primary/secondary/tertiary keep the 3-family summary for back-compat.
-        // extraRateWindows carries a source-aware set: the full curated list for
-        // .local (verified junk-free), and a filtered list for .remote (catalog noise
-        // hidden, consumed quota always kept). Sorted by family→version→tier.
-        let shownModels: [AntigravityNormalizedModel] = switch self.source {
-        case .local:
-            normalized
-        case .remote:
-            normalized.filter { m in
-                Self.isRemoteSummaryCandidate(m) || (m.quota.remainingFraction ?? 1.0) < 0.999
-            }
-        }
-        let extraWindows = shownModels
-            .sorted(by: Self.modelOrderPrecedes)
-            .map { m in
-                NamedRateWindow(
-                    id: m.quota.modelId,
-                    title: m.quota.label,
-                    window: Self.rateWindow(for: m.quota),
-                    usageKnown: m.quota.remainingFraction != nil)
-            }
+        let extraWindows = Self.extraRateWindows(
+            from: normalized,
+            summaryCandidates: summaryCandidates,
+            representedPools: Set([
+                primaryQuota.map { _ in AntigravityUsagePool.gemini },
+                secondaryQuota.map { _ in AntigravityUsagePool.claudeGPT },
+            ].compactMap(\.self)))
 
         let identity = ProviderIdentitySnapshot(
             providerID: .antigravity,
@@ -139,18 +158,213 @@ public struct AntigravityStatusSnapshot: Sendable {
         return UsageSnapshot(
             primary: primary,
             secondary: secondary,
-            tertiary: tertiary,
+            tertiary: nil,
             extraRateWindows: extraWindows.isEmpty ? nil : extraWindows,
             updatedAt: Date(),
             identity: identity)
     }
 
+    func withIdentity(from snapshot: AntigravityStatusSnapshot?) -> AntigravityStatusSnapshot {
+        guard let snapshot else { return self }
+        let accountEmail = snapshot.accountEmail ?? self.accountEmail
+        let accountPlan = snapshot.accountPlan ?? self.accountPlan
+        if let quotaSummary {
+            return AntigravityStatusSnapshot(
+                quotaSummary: quotaSummary,
+                accountEmail: accountEmail,
+                accountPlan: accountPlan,
+                source: self.source)
+        }
+        return AntigravityStatusSnapshot(
+            modelQuotas: self.modelQuotas,
+            accountEmail: accountEmail,
+            accountPlan: accountPlan,
+            source: self.source)
+    }
+
+    private static func usageSnapshot(
+        from quotaSummary: AntigravityQuotaSummary,
+        accountEmail: String?,
+        accountPlan: String?) throws -> UsageSnapshot
+    {
+        let namedWindows = Self.quotaSummaryWindows(from: quotaSummary)
+        guard !namedWindows.isEmpty else {
+            throw AntigravityStatusProbeError.parseFailed("No quota buckets available")
+        }
+
+        let constrainedWindows = namedWindows
+            .filter(\.usageKnown)
+            .sorted { lhs, rhs in
+                if lhs.window.usedPercent != rhs.window.usedPercent {
+                    return lhs.window.usedPercent > rhs.window.usedPercent
+                }
+                return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+            }
+
+        let identity = ProviderIdentitySnapshot(
+            providerID: .antigravity,
+            accountEmail: accountEmail,
+            accountOrganization: nil,
+            loginMethod: accountPlan)
+        return UsageSnapshot(
+            primary: constrainedWindows.first?.window,
+            secondary: constrainedWindows.dropFirst().first?.window,
+            tertiary: constrainedWindows.dropFirst(2).first?.window,
+            extraRateWindows: namedWindows,
+            updatedAt: Date(),
+            identity: identity)
+    }
+
+    private static func quotaSummaryWindows(from quotaSummary: AntigravityQuotaSummary) -> [NamedRateWindow] {
+        let sortedGroups = quotaSummary.groups.enumerated().sorted { lhs, rhs in
+            let lhsRank = Self.quotaGroupSortRank(lhs.element)
+            let rhsRank = Self.quotaGroupSortRank(rhs.element)
+            if lhsRank != rhsRank {
+                return lhsRank < rhsRank
+            }
+            return lhs.offset < rhs.offset
+        }.map(\.element)
+
+        return sortedGroups.flatMap { group in
+            let groupTitle = Self.displayTitle(forQuotaGroup: group)
+            let sortedBuckets = group.buckets.enumerated().sorted { lhs, rhs in
+                let lhsRank = Self.quotaBucketSortRank(lhs.element)
+                let rhsRank = Self.quotaBucketSortRank(rhs.element)
+                if lhsRank != rhsRank {
+                    return lhsRank < rhsRank
+                }
+                return lhs.offset < rhs.offset
+            }.map(\.element)
+
+            return sortedBuckets.map { bucket in
+                let bucketTitle = Self.displayTitle(forQuotaBucket: bucket)
+                let remainingPercent = Self.remainingPercent(from: bucket.remainingFraction)
+                let usedPercent = remainingPercent.map { 100 - $0 } ?? 0
+                let window = RateWindow(
+                    usedPercent: usedPercent,
+                    windowMinutes: Self.windowMinutes(forQuotaBucket: bucket),
+                    resetsAt: nil,
+                    resetDescription: bucket.resetDescription)
+                return NamedRateWindow(
+                    id: Self.quotaSummaryWindowID(for: bucket),
+                    title: "\(groupTitle) \(bucketTitle)",
+                    window: window,
+                    usageKnown: !bucket.disabled && bucket.remainingFraction != nil)
+            }
+        }
+    }
+
+    static func isQuotaSummaryWindowID(_ id: String) -> Bool {
+        id.hasPrefix(self.quotaSummaryWindowIDPrefix)
+    }
+
+    private static let quotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
+
+    private static func quotaSummaryWindowID(for bucket: AntigravityQuotaSummaryBucket) -> String {
+        self.quotaSummaryWindowIDPrefix + bucket.bucketId
+    }
+
+    private static func remainingPercent(from remainingFraction: Double?) -> Double? {
+        guard let remainingFraction else { return nil }
+        return max(0, min(100, remainingFraction * 100))
+    }
+
+    private static func displayTitle(forQuotaGroup group: AntigravityQuotaSummaryGroup) -> String {
+        let title = group.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lower = title.lowercased()
+        if lower.contains("gemini") {
+            return "Gemini"
+        }
+        if lower.contains("claude") || lower.contains("gpt") {
+            return "Claude + GPT"
+        }
+        let stripped = title.replacingOccurrences(
+            of: #"(?i)\s+models?$"#,
+            with: "",
+            options: .regularExpression)
+        return stripped.isEmpty ? title : stripped
+    }
+
+    private static func displayTitle(forQuotaBucket bucket: AntigravityQuotaSummaryBucket) -> String {
+        switch self.quotaBucketKind(for: bucket) {
+        case .session:
+            "Session"
+        case .weekly:
+            "Weekly"
+        case .other:
+            bucket.displayName
+        }
+    }
+
+    private static func windowMinutes(forQuotaBucket bucket: AntigravityQuotaSummaryBucket) -> Int? {
+        switch self.quotaBucketKind(for: bucket) {
+        case .session:
+            300
+        case .weekly:
+            10080
+        case .other:
+            nil
+        }
+    }
+
+    private enum QuotaBucketKind {
+        case session
+        case weekly
+        case other
+    }
+
+    private static func quotaGroupSortRank(_ group: AntigravityQuotaSummaryGroup) -> Int {
+        let title = group.displayName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if title.contains("gemini") {
+            return 0
+        }
+        if title.contains("claude") || title.contains("gpt") {
+            return 1
+        }
+        return 2
+    }
+
+    private static func quotaBucketSortRank(_ bucket: AntigravityQuotaSummaryBucket) -> Int {
+        switch self.quotaBucketKind(for: bucket) {
+        case .session:
+            0
+        case .weekly:
+            1
+        case .other:
+            2
+        }
+    }
+
+    private static func quotaBucketKind(for bucket: AntigravityQuotaSummaryBucket) -> QuotaBucketKind {
+        let combined = "\(bucket.bucketId) \(bucket.displayName)".lowercased()
+        if combined.contains("5h") || combined.contains("5-hour") || combined.contains("five hour") {
+            return .session
+        }
+        if combined.contains("weekly") {
+            return .weekly
+        }
+        return .other
+    }
+
     private static func rateWindow(for quota: AntigravityModelQuota) -> RateWindow {
         RateWindow(
             usedPercent: 100 - quota.remainingPercent,
-            windowMinutes: nil,
+            windowMinutes: self.inferredWindowMinutes(resetTime: quota.resetTime),
             resetsAt: quota.resetTime,
             resetDescription: quota.resetDescription)
+    }
+
+    private static func inferredWindowMinutes(resetTime: Date?) -> Int? {
+        guard let resetTime else { return nil }
+        let seconds = resetTime.timeIntervalSinceNow
+        guard seconds > 0 else { return nil }
+        if seconds <= 6 * 60 * 60 {
+            return 300
+        }
+        if seconds >= 6 * 24 * 60 * 60, seconds <= 8 * 24 * 60 * 60 {
+            return 10080
+        }
+        return nil
     }
 
     private static func modelOrderPrecedes(
@@ -190,14 +404,19 @@ public struct AntigravityStatusSnapshot: Sendable {
     private static func familyRank(_ family: AntigravityModelFamily) -> Int {
         switch family {
         case .claude: 0
-        case .geminiPro: 1
-        case .geminiFlash: 2
-        case .unknown: 3
+        case .gpt: 1
+        case .geminiPro: 2
+        case .geminiFlash: 3
+        case .unknown: 4
         }
     }
 
-    private static func isRemoteSummaryCandidate(_ model: AntigravityNormalizedModel) -> Bool {
-        model.family != .unknown && !model.isLite && !model.isAutocomplete && !model.isImage
+    private static func isSummaryCandidate(_ model: AntigravityNormalizedModel) -> Bool {
+        self.usagePool(for: model) != nil && self.isSelectableTextModel(model)
+    }
+
+    private static func isSelectableTextModel(_ model: AntigravityNormalizedModel) -> Bool {
+        !model.isLite && !model.isAutocomplete && !model.isImage
     }
 
     private static func normalizedModels(_ models: [AntigravityModelQuota]) -> [AntigravityNormalizedModel] {
@@ -218,7 +437,7 @@ public struct AntigravityStatusSnapshot: Sendable {
             || (label.contains("pro") && label.contains("low"))
 
         let selectionPriority: Int? = switch family {
-        case .claude:
+        case .claude, .gpt:
             0
         case .geminiPro:
             if isLowPriorityGeminiPro, isSelectableTextModel {
@@ -277,22 +496,14 @@ public struct AntigravityStatusSnapshot: Sendable {
     }
 
     private static func representative(
-        for family: AntigravityModelFamily,
+        for pool: AntigravityUsagePool,
         in models: [AntigravityNormalizedModel]) -> AntigravityModelQuota?
     {
-        let candidates = models.filter { $0.family == family && $0.selectionPriority != nil }
+        let candidates = models.filter {
+            Self.usagePool(for: $0) == pool && $0.quota.remainingFraction != nil
+        }
         guard !candidates.isEmpty else { return nil }
         return candidates.min { lhs, rhs in
-            let lhsHasRemainingFraction = lhs.quota.remainingFraction != nil
-            let rhsHasRemainingFraction = rhs.quota.remainingFraction != nil
-            if lhsHasRemainingFraction != rhsHasRemainingFraction {
-                return lhsHasRemainingFraction && !rhsHasRemainingFraction
-            }
-            let lhsPriority = lhs.selectionPriority ?? Int.max
-            let rhsPriority = rhs.selectionPriority ?? Int.max
-            if lhsPriority != rhsPriority {
-                return lhsPriority < rhsPriority
-            }
             if lhs.quota.remainingPercent != rhs.quota.remainingPercent {
                 return lhs.quota.remainingPercent < rhs.quota.remainingPercent
             }
@@ -309,19 +520,73 @@ public struct AntigravityStatusSnapshot: Sendable {
         }?.quota
     }
 
-    private static func fallbackRepresentative(in models: [AntigravityNormalizedModel]) -> AntigravityModelQuota? {
-        guard !models.isEmpty else { return nil }
-        return models.min { lhs, rhs in
-            let lhsHasRemainingFraction = lhs.quota.remainingFraction != nil
-            let rhsHasRemainingFraction = rhs.quota.remainingFraction != nil
-            if lhsHasRemainingFraction != rhsHasRemainingFraction {
-                return lhsHasRemainingFraction && !rhsHasRemainingFraction
+    private static func extraRateWindows(
+        from models: [AntigravityNormalizedModel],
+        summaryCandidates: [AntigravityNormalizedModel],
+        representedPools: Set<AntigravityUsagePool>) -> [NamedRateWindow]
+    {
+        let resetOnlyPoolWindows = [AntigravityUsagePool.gemini, .claudeGPT].compactMap { pool -> NamedRateWindow? in
+            guard !representedPools.contains(pool) else { return nil }
+            let candidates = summaryCandidates.filter { Self.usagePool(for: $0) == pool }
+            guard let resetOnly = candidates.first(where: { model in
+                model.quota.remainingFraction == nil &&
+                    (model.quota.resetTime != nil || model.quota.resetDescription != nil)
+            }) else {
+                return nil
             }
-            if lhs.quota.remainingPercent != rhs.quota.remainingPercent {
-                return lhs.quota.remainingPercent < rhs.quota.remainingPercent
+            return NamedRateWindow(
+                id: pool.id,
+                title: pool.title,
+                window: Self.rateWindow(for: resetOnly.quota),
+                usageKnown: false)
+        }
+
+        let distinctWindows = models
+            .filter(Self.shouldShowDistinctExtraWindow)
+            .sorted(by: Self.modelOrderPrecedes)
+            .map { m in
+                NamedRateWindow(
+                    id: m.quota.modelId,
+                    title: m.quota.label,
+                    window: Self.rateWindow(for: m.quota),
+                    usageKnown: m.quota.remainingFraction != nil)
             }
-            return lhs.quota.label.localizedCaseInsensitiveCompare(rhs.quota.label) == .orderedAscending
-        }?.quota
+
+        return resetOnlyPoolWindows.sorted { lhs, rhs in
+            guard let lhsPool = Self.pool(forExtraWindowID: lhs.id),
+                  let rhsPool = Self.pool(forExtraWindowID: rhs.id)
+            else {
+                return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+            }
+            return lhsPool.sortRank < rhsPool.sortRank
+        } + distinctWindows
+    }
+
+    private static func shouldShowDistinctExtraWindow(_ model: AntigravityNormalizedModel) -> Bool {
+        guard !self.isSummaryCandidate(model) else { return false }
+        if model.quota.remainingFraction == nil {
+            return model.quota.resetTime != nil || model.quota.resetDescription != nil
+        }
+        return model.quota.remainingPercent < 99.9
+    }
+
+    private static func pool(forExtraWindowID id: String) -> AntigravityUsagePool? {
+        switch id {
+        case AntigravityUsagePool.gemini.id: .gemini
+        case AntigravityUsagePool.claudeGPT.id: .claudeGPT
+        default: nil
+        }
+    }
+
+    private static func usagePool(for model: AntigravityNormalizedModel) -> AntigravityUsagePool? {
+        switch model.family {
+        case .geminiPro, .geminiFlash:
+            .gemini
+        case .claude, .gpt:
+            .claudeGPT
+        case .unknown:
+            nil
+        }
     }
 
     private static func family(forModelID modelId: String, label: String) -> AntigravityModelFamily {
@@ -335,6 +600,9 @@ public struct AntigravityStatusSnapshot: Sendable {
     private static func family(from text: String) -> AntigravityModelFamily {
         if text.contains("claude") {
             return .claude
+        }
+        if text.contains("gpt") || text.contains("openai") {
+            return .gpt
         }
         if text.contains("gemini"), text.contains("pro") {
             return .geminiPro
@@ -417,13 +685,11 @@ public enum AntigravityStatusProbeError: LocalizedError, Sendable, Equatable {
 public struct AntigravityStatusProbe: Sendable {
     /// Which local Antigravity processes the probe may attach to.
     public enum ProcessScope: Sendable {
-        /// Match the IDE language server and the `agy` CLI language server.
+        /// Match Antigravity app, Antigravity IDE, and the `agy` CLI language server.
         case ideAndCLI
-        /// Match only the IDE language server. The local fetch strategy
-        /// uses this so it never attaches to a stale or half-warmed `agy`
-        /// process: those accept connections but return transient errors
-        /// on `GetUserStatus`, burning the probe timeout. `agy` is owned
-        /// by `AntigravityCLIHTTPSFetchStrategy`, which has a readiness loop.
+        /// Match only the Antigravity 2.0 app language server.
+        case appOnly
+        /// Match only the Antigravity IDE extension language server.
         case ideOnly
     }
 
@@ -433,6 +699,8 @@ public struct AntigravityStatusProbe: Sendable {
     private static let getUserStatusPath = "/exa.language_server_pb.LanguageServerService/GetUserStatus"
     private static let commandModelConfigPath =
         "/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs"
+    private static let quotaSummaryPath =
+        "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary"
     private static let unleashPath = "/exa.language_server_pb.LanguageServerService/GetUnleashData"
     private static let log = CodexBarLog.logger(LogCategories.antigravity)
 
@@ -442,15 +710,46 @@ public struct AntigravityStatusProbe: Sendable {
     }
 
     public func fetch() async throws -> AntigravityStatusSnapshot {
-        let processInfo = try await Self.detectProcessInfo(timeout: self.timeout, scope: self.processScope)
-        let ports = try await Self.listeningPorts(pid: processInfo.pid, timeout: self.timeout)
+        let processInfos = try await Self.detectProcessInfos(timeout: self.timeout, scope: self.processScope)
+        var bestSnapshot: AntigravityStatusSnapshot?
+        var bestScore = Int.min
+        var lastError: Error?
+
+        for processInfo in processInfos {
+            do {
+                let snapshot = try await Self.fetch(processInfo: processInfo, timeout: self.timeout)
+                let score = Self.localSnapshotScore(snapshot)
+                if score > bestScore {
+                    bestSnapshot = snapshot
+                    bestScore = score
+                }
+            } catch {
+                lastError = error
+                Self.log.debug("Antigravity local process probe failed", metadata: [
+                    "pid": "\(processInfo.pid)",
+                    "error": error.localizedDescription,
+                ])
+            }
+        }
+
+        if let bestSnapshot {
+            return bestSnapshot
+        }
+        throw lastError ?? AntigravityStatusProbeError.notRunning
+    }
+
+    private static func fetch(
+        processInfo: ProcessInfoResult,
+        timeout: TimeInterval) async throws -> AntigravityStatusSnapshot
+    {
+        let ports = try await Self.listeningPorts(pid: processInfo.pid, timeout: timeout)
         let endpoint = try await Self.resolveWorkingEndpoint(
             candidateEndpoints: Self.connectionCandidates(
                 listeningPorts: ports,
                 languageServerCSRFToken: processInfo.csrfToken,
                 extensionServerPort: processInfo.extensionPort,
                 extensionServerCSRFToken: processInfo.extensionServerCSRFToken),
-            timeout: self.timeout)
+            timeout: timeout)
         let context = RequestContext(
             endpoints: Self.requestEndpoints(
                 resolvedEndpoint: endpoint,
@@ -458,7 +757,7 @@ public struct AntigravityStatusProbe: Sendable {
                 languageServerCSRFToken: processInfo.csrfToken,
                 extensionServerPort: processInfo.extensionPort,
                 extensionServerCSRFToken: processInfo.extensionServerCSRFToken),
-            timeout: self.timeout)
+            timeout: timeout)
 
         return try await Self.fetchSnapshot(context: context)
     }
@@ -486,6 +785,29 @@ public struct AntigravityStatusProbe: Sendable {
                     extensionServerCSRFToken: processInfo.extensionServerCSRFToken),
                 timeout: self.timeout),
             parse: Self.parsePlanInfoSummary)
+    }
+
+    static func localSnapshotScore(_ snapshot: AntigravityStatusSnapshot) -> Int {
+        var score = 0
+        if let quotaSummary = snapshot.quotaSummary {
+            let buckets = quotaSummary.groups.flatMap(\.buckets)
+            let knownBuckets = buckets.count(where: { !$0.disabled && $0.remainingFraction != nil })
+            score += 1000
+            score += quotaSummary.groups.count * 10
+            score += buckets.count
+            score += knownBuckets * 20
+        } else {
+            let knownRows = snapshot.modelQuotas.count(where: { $0.remainingFraction != nil })
+            score += snapshot.modelQuotas.count
+            score += knownRows * 10
+        }
+        if snapshot.accountEmail != nil {
+            score += 2
+        }
+        if snapshot.accountPlan != nil {
+            score += 1
+        }
+        return score
     }
 
     public static func isRunning(timeout: TimeInterval = 4.0) async -> Bool {
@@ -586,7 +908,7 @@ public struct AntigravityStatusProbe: Sendable {
             resetDescription: nil)
     }
 
-    private static func invalidCode(_ code: CodeValue?) -> String? {
+    static func invalidCode(_ code: CodeValue?) -> String? {
         guard let code else { return nil }
         if code.isOK { return nil }
         return "\(code.rawValue)"
@@ -642,6 +964,17 @@ public struct AntigravityStatusProbe: Sendable {
         timeout: TimeInterval,
         scope: ProcessScope = .ideAndCLI) async throws -> ProcessInfoResult
     {
+        let processInfos = try await self.detectProcessInfos(timeout: timeout, scope: scope)
+        guard let first = processInfos.first else {
+            throw AntigravityStatusProbeError.notRunning
+        }
+        return first
+    }
+
+    private static func detectProcessInfos(
+        timeout: TimeInterval,
+        scope: ProcessScope = .ideAndCLI) async throws -> [ProcessInfoResult]
+    {
         let env = ProcessInfo.processInfo.environment
         let result = try await SubprocessRunner.run(
             binary: "/bin/ps",
@@ -650,23 +983,35 @@ public struct AntigravityStatusProbe: Sendable {
             timeout: timeout,
             label: "antigravity-ps")
 
-        return try Self.processInfo(fromProcessListOutput: result.stdout, scope: scope)
+        return try Self.processInfos(fromProcessListOutput: result.stdout, scope: scope)
     }
 
     static func processInfo(
         fromProcessListOutput output: String,
         scope: ProcessScope = .ideAndCLI) throws -> ProcessInfoResult
     {
+        let processInfos = try self.processInfos(fromProcessListOutput: output, scope: scope)
+        guard let first = processInfos.first else {
+            throw AntigravityStatusProbeError.notRunning
+        }
+        return first
+    }
+
+    static func processInfos(
+        fromProcessListOutput output: String,
+        scope: ProcessScope = .ideAndCLI) throws -> [ProcessInfoResult]
+    {
         let lines = output.split(separator: "\n")
         var sawTokenlessIDE = false
+        var results: [ProcessInfoResult] = []
         for line in lines {
             let text = String(line)
             guard let match = Self.matchProcessLine(text) else { continue }
             guard let kind = Self.antigravityProcessKind(match.command) else { continue }
-            if scope == .ideOnly, kind == .cli { continue }
+            if !Self.processKind(kind, matches: scope) { continue }
             // The IDE language server authenticates local requests with a
             // `--csrf_token` and must keep requiring it: skip a tokenless IDE
-            // match so a later valid IDE server can still be found (and surface
+            // or app match so a later valid server can still be found (and surface
             // `missingCSRFToken` if none is). The CLI's language server exposes
             // no token flag and needs none, so an empty token is allowed there.
             guard let token = Self.resolvedCSRFToken(forKind: kind, command: match.command) else {
@@ -675,14 +1020,17 @@ public struct AntigravityStatusProbe: Sendable {
             }
             let port = Self.extractPort("--extension_server_port", from: match.command)
             let extensionServerCSRFToken = Self.extractFlag("--extension_server_csrf_token", from: match.command)
-            return ProcessInfoResult(
+            results.append(ProcessInfoResult(
                 pid: match.pid,
                 extensionPort: port,
                 extensionServerCSRFToken: extensionServerCSRFToken,
                 csrfToken: token,
-                commandLine: match.command)
+                commandLine: match.command))
         }
 
+        if !results.isEmpty {
+            return results
+        }
         if sawTokenlessIDE {
             throw AntigravityStatusProbeError.missingCSRFToken
         }
@@ -703,7 +1051,9 @@ public struct AntigravityStatusProbe: Sendable {
     }
 
     enum AntigravityProcessKind: Equatable {
-        /// IDE language server (`language_server*` or `language-server`). Requires a `--csrf_token`.
+        /// Antigravity 2.0 app language server. Requires a `--csrf_token`.
+        case app
+        /// Antigravity IDE extension language server. Requires a `--csrf_token`.
         case ide
         /// CLI language server (`agy` / `antigravity-cli`). Needs no CSRF token.
         case cli
@@ -713,18 +1063,30 @@ public struct AntigravityStatusProbe: Sendable {
         self.antigravityProcessKind(command) != nil
     }
 
-    /// Classify a process command line as the Antigravity IDE language server,
-    /// the Antigravity CLI language server, or neither. The IDE match takes
-    /// precedence so its CSRF-token requirement is preserved.
+    /// Classify a process command line as the Antigravity app language server,
+    /// the Antigravity IDE language server, the Antigravity CLI language server,
+    /// or neither. Desktop language servers take precedence so their CSRF-token
+    /// requirement is preserved.
     static func antigravityProcessKind(_ command: String) -> AntigravityProcessKind? {
         let lower = command.lowercased()
         if Self.isLanguageServerCommandLine(lower), Self.isAntigravityCommandLine(lower) {
-            return .ide
+            return Self.isAntigravityIDECommandLine(lower) ? .ide : .app
         }
         if Self.isAntigravityCLICommandLine(lower) {
             return .cli
         }
         return nil
+    }
+
+    private static func processKind(_ kind: AntigravityProcessKind, matches scope: ProcessScope) -> Bool {
+        switch scope {
+        case .ideAndCLI:
+            true
+        case .appOnly:
+            kind == .app
+        case .ideOnly:
+            kind == .ide
+        }
     }
 
     /// Resolve the CSRF token to use for a matched process, or `nil` when the
@@ -736,13 +1098,13 @@ public struct AntigravityStatusProbe: Sendable {
             return token
         }
         switch kind {
-        case .ide: return nil
+        case .app, .ide: return nil
         case .cli: return ""
         }
     }
 
     private static func isLanguageServerCommandLine(_ lowerCommand: String) -> Bool {
-        let pattern = #"(^|[/\\])language(?:_|-)server(_macos|\.exe)?(\s|$)"#
+        let pattern = #"(^|[/\\])language(?:_|-)server(?:[_-][a-z0-9]+)*(?:\.exe)?(\s|$)"#
         return lowerCommand.range(of: pattern, options: .regularExpression) != nil
     }
 
@@ -762,8 +1124,20 @@ public struct AntigravityStatusProbe: Sendable {
     private static func isAntigravityCommandLine(_ command: String) -> Bool {
         if command.contains("--app_data_dir") && command.contains("antigravity") { return true }
         if command.contains("antigravity.app/") || command.contains("antigravity.app\\") { return true }
+        if command.contains("antigravity ide.app/") || command.contains("antigravity ide.app\\") { return true }
         if command.contains("/antigravity/") || command.contains("\\antigravity\\") { return true }
         return false
+    }
+
+    private static func isAntigravityIDECommandLine(_ lowerCommand: String) -> Bool {
+        [
+            "antigravity ide.app/",
+            "antigravity ide.app\\",
+            "--app_data_dir antigravity-ide",
+            "--app_data_dir=antigravity-ide",
+            "/extensions/antigravity/bin/language_server",
+            "\\extensions\\antigravity\\bin\\language_server",
+        ].contains { lowerCommand.contains($0) }
     }
 
     private static func extractFlag(_ flag: String, from command: String) -> String? {
@@ -1072,6 +1446,28 @@ public struct AntigravityStatusProbe: Sendable {
             sendRequest) async throws -> AntigravityStatusSnapshot
     {
         do {
+            let quotaSummary = try await self.makeParsedRequest(
+                payload: RequestPayload(
+                    path: self.quotaSummaryPath,
+                    body: ["forceRefresh": true]),
+                context: context,
+                send: send,
+                parse: self.parseQuotaSummaryResponse)
+            let identity = try? await self.makeParsedRequest(
+                payload: RequestPayload(
+                    path: self.getUserStatusPath,
+                    body: self.defaultRequestBody()),
+                context: self.identityRequestContext(from: context),
+                send: send,
+                parse: self.parseUserStatusResponse)
+            return quotaSummary.withIdentity(from: identity)
+        } catch {
+            self.log.debug("Antigravity quota summary unavailable; falling back to model quotas", metadata: [
+                "error": error.localizedDescription,
+            ])
+        }
+
+        do {
             return try await self.makeParsedRequest(
                 payload: RequestPayload(
                     path: self.getUserStatusPath,
@@ -1088,6 +1484,13 @@ public struct AntigravityStatusProbe: Sendable {
                 send: send,
                 parse: self.parseCommandModelResponse)
         }
+    }
+
+    private static func identityRequestContext(from context: RequestContext) -> RequestContext {
+        RequestContext(
+            endpoints: context.endpoints,
+            timeout: min(context.timeout, 1),
+            deadline: context.deadline)
     }
 
     private static func makeRequest(
@@ -1201,111 +1604,6 @@ public struct AntigravityStatusProbe: Sendable {
     }
 }
 
-enum LocalhostTrustPolicy {
-    static func shouldAcceptServerTrust(
-        host: String,
-        authenticationMethod: String,
-        hasServerTrust: Bool) -> Bool
-    {
-        #if !os(Linux)
-        guard authenticationMethod == NSURLAuthenticationMethodServerTrust else { return false }
-        #endif
-        let normalizedHost = host.lowercased()
-        guard normalizedHost == "127.0.0.1" || normalizedHost == "localhost" else { return false }
-        return hasServerTrust
-    }
-}
-
-private final class LocalhostSessionDelegate: NSObject {
-    func data(for request: URLRequest, session: URLSession) async throws -> (Data, URLResponse) {
-        let state = LocalhostSessionTaskState()
-        return try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                let task = session.dataTask(with: request) { data, response, error in
-                    if let error {
-                        continuation.resume(throwing: error)
-                        return
-                    }
-                    guard let data, let response else {
-                        continuation.resume(throwing: AntigravityStatusProbeError.apiError("Invalid response"))
-                        return
-                    }
-                    continuation.resume(returning: (data, response))
-                }
-                state.setTask(task)
-                task.resume()
-            }
-        } onCancel: {
-            state.cancel()
-        }
-    }
-
-    private func challengeResult(_ challenge: URLAuthenticationChallenge) -> (
-        disposition: URLSession.AuthChallengeDisposition,
-        credential: URLCredential?)
-    {
-        #if os(Linux)
-        return (.performDefaultHandling, nil)
-        #else
-        let protectionSpace = challenge.protectionSpace
-        let trust = protectionSpace.serverTrust
-        guard LocalhostTrustPolicy.shouldAcceptServerTrust(
-            host: protectionSpace.host,
-            authenticationMethod: protectionSpace.authenticationMethod,
-            hasServerTrust: trust != nil),
-            let trust
-        else {
-            return (.performDefaultHandling, nil)
-        }
-        return (.useCredential, URLCredential(trust: trust))
-        #endif
-    }
-}
-
-extension LocalhostSessionDelegate: URLSessionDelegate {
-    func urlSession(
-        _ session: URLSession,
-        didReceive challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?)
-    {
-        self.challengeResult(challenge)
-    }
-}
-
-extension LocalhostSessionDelegate: URLSessionTaskDelegate {
-    func urlSession(
-        _ session: URLSession,
-        task: URLSessionTask,
-        didReceive challenge: URLAuthenticationChallenge) async -> (URLSession.AuthChallengeDisposition, URLCredential?)
-    {
-        self.challengeResult(challenge)
-    }
-}
-
-private final class LocalhostSessionTaskState: @unchecked Sendable {
-    private let lock = NSLock()
-    private var task: URLSessionDataTask?
-    private var isCancelled = false
-
-    func setTask(_ task: URLSessionDataTask) {
-        self.lock.lock()
-        self.task = task
-        let shouldCancel = self.isCancelled
-        self.lock.unlock()
-
-        if shouldCancel {
-            task.cancel()
-        }
-    }
-
-    func cancel() {
-        self.lock.lock()
-        self.isCancelled = true
-        let task = self.task
-        self.lock.unlock()
-        task?.cancel()
-    }
-}
-
 private struct UserStatusResponse: Decodable {
     let code: CodeValue?
     let message: String?
@@ -1382,7 +1680,7 @@ private struct QuotaInfo: Decodable {
     let resetTime: String?
 }
 
-private enum CodeValue: Decodable {
+enum CodeValue: Decodable {
     case int(Int)
     case string(String)
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -709,20 +709,17 @@ public struct AntigravityStatusProbe: Sendable {
         self.processScope = processScope
     }
 
-    public func fetch() async throws -> AntigravityStatusSnapshot {
+    public func fetch(matchingAccountEmail expectedAccountEmail: String? = nil) async throws
+        -> AntigravityStatusSnapshot
+    {
         let processInfos = try await Self.detectProcessInfos(timeout: self.timeout, scope: self.processScope)
-        var bestSnapshot: AntigravityStatusSnapshot?
-        var bestScore = Int.min
+        var snapshots: [AntigravityStatusSnapshot] = []
         var lastError: Error?
 
         for processInfo in processInfos {
             do {
                 let snapshot = try await Self.fetch(processInfo: processInfo, timeout: self.timeout)
-                let score = Self.localSnapshotScore(snapshot)
-                if score > bestScore {
-                    bestSnapshot = snapshot
-                    bestScore = score
-                }
+                snapshots.append(snapshot)
             } catch {
                 lastError = error
                 Self.log.debug("Antigravity local process probe failed", metadata: [
@@ -732,7 +729,10 @@ public struct AntigravityStatusProbe: Sendable {
             }
         }
 
-        if let bestSnapshot {
+        if let bestSnapshot = Self.preferredLocalSnapshot(
+            snapshots,
+            matchingAccountEmail: expectedAccountEmail)
+        {
             return bestSnapshot
         }
         throw lastError ?? AntigravityStatusProbeError.notRunning

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -171,6 +171,32 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
         ])
     }
 
+    @Test
+    func `auto strategy pipeline preserves oauth fallback for shared credentials file`() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("antigravity-shared-auto-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = AntigravityOAuthCredentialsStore(
+            fileURL: AntigravityOAuthCredentialsStore.defaultURL(home: root))
+        try store.save(AntigravityOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            expiryDate: Date().addingTimeInterval(3600),
+            email: "legacy@example.com"))
+
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: .antigravity)
+        let autoStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeFetchContext(sourceMode: .auto, env: ["HOME": root.path]))
+
+        #expect(autoStrategies.map(\.id) == [
+            "antigravity.app-local",
+            "antigravity.cli-https",
+            "antigravity.ide-local",
+            "antigravity.oauth",
+        ])
+    }
+
     // MARK: - Selected-account guard
 
     @Test
@@ -770,16 +796,21 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
         persistsCLISessions: Bool = false,
         env: [String: String] = [:]) -> ProviderFetchContext
     {
-        ProviderFetchContext(
+        var effectiveEnv = env
+        effectiveEnv["HOME"] = effectiveEnv["HOME"] ??
+            FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-antigravity-empty-home-\(UUID().uuidString)", isDirectory: true)
+            .path
+        return ProviderFetchContext(
             runtime: runtime,
             sourceMode: sourceMode,
             includeCredits: false,
             webTimeout: 1,
             webDebugDumpHTML: false,
             verbose: false,
-            env: env,
+            env: effectiveEnv,
             settings: nil,
-            fetcher: UsageFetcher(environment: env),
+            fetcher: UsageFetcher(environment: effectiveEnv),
             claudeFetcher: StubClaudeFetcher(),
             browserDetection: BrowserDetection(cacheTTL: 0),
             selectedTokenAccountID: selectedTokenAccountID,

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -113,11 +113,19 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
 
         let cliStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
             self.makeFetchContext(sourceMode: .cli))
-        #expect(cliStrategies.map(\.id) == ["antigravity.local", "antigravity.cli-https"])
+        #expect(cliStrategies.map(\.id) == [
+            "antigravity.app-local",
+            "antigravity.cli-https",
+            "antigravity.ide-local",
+        ])
 
         let autoStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
             self.makeFetchContext(sourceMode: .auto))
-        #expect(autoStrategies.map(\.id) == ["antigravity.local", "antigravity.cli-https", "antigravity.oauth"])
+        #expect(autoStrategies.map(\.id) == [
+            "antigravity.app-local",
+            "antigravity.cli-https",
+            "antigravity.ide-local",
+        ])
     }
 
     @Test
@@ -132,9 +140,35 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
         let oauthStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
             self.makeFetchContext(sourceMode: .oauth, selectedTokenAccountID: accountID))
 
-        #expect(autoStrategies.map(\.id) == ["antigravity.local", "antigravity.cli-https", "antigravity.oauth"])
-        #expect(cliStrategies.map(\.id) == ["antigravity.local", "antigravity.cli-https"])
+        #expect(autoStrategies.map(\.id) == [
+            "antigravity.app-local",
+            "antigravity.cli-https",
+            "antigravity.ide-local",
+            "antigravity.oauth",
+        ])
+        #expect(cliStrategies.map(\.id) == [
+            "antigravity.app-local",
+            "antigravity.cli-https",
+            "antigravity.ide-local",
+        ])
         #expect(oauthStrategies.map(\.id) == ["antigravity.oauth"])
+    }
+
+    @Test
+    func `auto strategy pipeline includes oauth when credentials are injected`() async {
+        let descriptor = ProviderDescriptorRegistry.descriptor(for: .antigravity)
+
+        let autoStrategies = await descriptor.fetchPlan.pipeline.resolveStrategies(
+            self.makeFetchContext(
+                sourceMode: .auto,
+                env: self.accountEnv(email: "selected@example.com")))
+
+        #expect(autoStrategies.map(\.id) == [
+            "antigravity.app-local",
+            "antigravity.cli-https",
+            "antigravity.ide-local",
+            "antigravity.oauth",
+        ])
     }
 
     // MARK: - Selected-account guard
@@ -274,7 +308,7 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
     }
 
     @Test
-    func `cli HTTPS falls back to command model configs when user status fails`() async throws {
+    func `cli HTTPS falls back to command model configs when quota summary and user status fail`() async throws {
         let endpoints = [
             AntigravityStatusProbe.AntigravityConnectionEndpoint(
                 scheme: "https",
@@ -292,6 +326,10 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
             send: { payload, _, _ in
                 let attempt = attempts.increment()
                 if attempt == 1 {
+                    #expect(payload.path == "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary")
+                    throw AntigravityStatusProbeError.apiError("quota summary unavailable")
+                }
+                if attempt == 2 {
                     #expect(payload.path == "/exa.language_server_pb.LanguageServerService/GetUserStatus")
                     throw AntigravityStatusProbeError.apiError("user status unavailable")
                 }
@@ -310,7 +348,7 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
             })
 
         #expect(snapshot.modelQuotas.first?.label == "Claude Sonnet")
-        #expect(attempts.value == 2)
+        #expect(attempts.value == 3)
     }
 
     @Test
@@ -461,6 +499,40 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
         } catch {
             Issue.record("Expected authenticationRequired, got \(error)")
         }
+    }
+
+    @Test
+    func `cli HTTPS allows transient automatic sign in banner`() async throws {
+        let output = AntigravityCLIOutputSequence([
+            Data("Welcome. You are currently not signed in.\nSigning in...".utf8),
+            Data("user@example.com\nGemini 3.1 Pro (High)".utf8),
+        ])
+
+        let snapshot = try await AntigravityCLIHTTPSFetchStrategy.waitForSnapshot(
+            pid: 123,
+            deadline: Date().addingTimeInterval(2),
+            dependencies: AntigravityCLIHTTPSFetchStrategy.SnapshotWaitDependencies(
+                pollIntervalNanoseconds: 0,
+                listeningPorts: { _, _ in [50080] },
+                drainOutput: {
+                    output.next()
+                },
+                fetchSnapshot: { _ in
+                    AntigravityStatusSnapshot(
+                        modelQuotas: [
+                            AntigravityModelQuota(
+                                label: "Claude Sonnet",
+                                modelId: "claude-sonnet",
+                                remainingFraction: 1,
+                                resetTime: nil,
+                                resetDescription: nil),
+                        ],
+                        accountEmail: "user@example.com",
+                        accountPlan: "Pro",
+                        source: .local)
+                }))
+
+        #expect(snapshot.accountEmail == "user@example.com")
     }
 
     @Test

--- a/Tests/CodexBarTests/AntigravityCLISessionTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLISessionTests.swift
@@ -719,7 +719,7 @@ struct AntigravityCLISessionTests {
         let handle = try #require(fixture.launcher.handleSnapshot().first)
         handle.enqueueDrainOutput(Data([0xE2, 0x96]))
         let first = await fixture.session.drainOutput()
-        handle.enqueueDrainOutput(Data([0x84]) + Data("You are currently not signed in".utf8))
+        handle.enqueueDrainOutput(Data([0x84]) + Data("Select login method:".utf8))
         let second = await fixture.session.drainOutput()
         let third = await fixture.session.drainOutput()
 
@@ -732,13 +732,23 @@ struct AntigravityCLISessionTests {
     }
 
     @Test
+    func `authentication prompt matcher tolerates prompt casing and spacing`() {
+        #expect(AntigravityCLIHTTPSFetchStrategy.containsAuthenticationPrompt(
+            Data("select  LOGIN\nmethod :".utf8)))
+        #expect(AntigravityCLIHTTPSFetchStrategy.containsAuthenticationPrompt(
+            Data("Select login method:".utf8)))
+        #expect(!AntigravityCLIHTTPSFetchStrategy.containsAuthenticationPrompt(
+            Data("You are currently not signed in".utf8)))
+    }
+
+    @Test
     func `session returns complete new output before retaining only its tail`() async throws {
         let fixture = self.makeFixture()
         fixture.identity.setIdentity(pid: 10, executablePath: "/bin/agy", startEpoch: 100)
 
         _ = try await fixture.session.beginProbe(binary: "/bin/agy")
         let handle = try #require(fixture.launcher.handleSnapshot().first)
-        let prompt = Data("You are currently not signed in".utf8)
+        let prompt = Data("Select login method:".utf8)
         let oversizedRedraw = prompt + Data(repeating: 0x20, count: 8192)
         handle.enqueueDrainOutput(oversizedRedraw)
 

--- a/Tests/CodexBarTests/AntigravityCompactFallbackTests.swift
+++ b/Tests/CodexBarTests/AntigravityCompactFallbackTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import CodexBarCore
+
+struct AntigravityCompactFallbackTests {
+    @Test
+    func `local unclassified model remains available as compact fallback`() throws {
+        let snapshot = AntigravityStatusSnapshot(
+            modelQuotas: [
+                AntigravityModelQuota(
+                    label: "Experimental Model",
+                    modelId: "MODEL_PLACEHOLDER_NEW",
+                    remainingFraction: 0.36,
+                    resetTime: nil,
+                    resetDescription: nil),
+            ],
+            accountEmail: nil,
+            accountPlan: nil,
+            source: .local)
+
+        let usage = try snapshot.toUsageSnapshot()
+
+        #expect(usage.primary?.usedPercent == 64)
+        #expect(usage.secondary == nil)
+        #expect(usage.tertiary == nil)
+        #expect(usage.extraRateWindows?.map(\.id) == ["MODEL_PLACEHOLDER_NEW"])
+    }
+}

--- a/Tests/CodexBarTests/AntigravityLocalSnapshotSelectionTests.swift
+++ b/Tests/CodexBarTests/AntigravityLocalSnapshotSelectionTests.swift
@@ -1,0 +1,46 @@
+import Testing
+@testable import CodexBarCore
+
+struct AntigravityLocalSnapshotSelectionTests {
+    @Test
+    func `selected account wins before quota richness`() throws {
+        let selectedAccount = AntigravityStatusSnapshot(
+            modelQuotas: [
+                AntigravityModelQuota(
+                    label: "Gemini 3 Pro Low",
+                    modelId: "gemini-3-pro-low",
+                    remainingFraction: 0.9,
+                    resetTime: nil,
+                    resetDescription: nil),
+            ],
+            accountEmail: "selected@example.com",
+            accountPlan: "Pro",
+            source: .local)
+        let richerOtherAccount = AntigravityStatusSnapshot(
+            quotaSummary: AntigravityQuotaSummary(
+                description: nil,
+                groups: [
+                    AntigravityQuotaSummaryGroup(
+                        displayName: "Gemini Models",
+                        description: nil,
+                        buckets: [
+                            AntigravityQuotaSummaryBucket(
+                                bucketId: "gemini-5h",
+                                displayName: "Five Hour Limit",
+                                remainingFraction: 0.9,
+                                resetDescription: nil,
+                                disabled: false),
+                        ]),
+                ]),
+            accountEmail: "other@example.com",
+            accountPlan: "Ultra",
+            source: .local)
+
+        let selected = try #require(
+            AntigravityStatusProbe.preferredLocalSnapshot(
+                [richerOtherAccount, selectedAccount],
+                matchingAccountEmail: " SELECTED@example.com "))
+
+        #expect(selected.accountEmail == "selected@example.com")
+    }
+}

--- a/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
+++ b/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
@@ -45,9 +45,9 @@ struct AntigravityQuotaSummaryTests {
         #expect(windows.map(\.window.windowMinutes) == [300, 10080, 300, 10080])
         #expect(windows.map { $0.window.remainingPercent.rounded() } == [91, 82, 73, 64])
         #expect(windows.map(\.usageKnown) == [true, true, true, true])
-        #expect(usage.primary?.remainingPercent.rounded() == 64)
-        #expect(usage.secondary?.remainingPercent.rounded() == 73)
-        #expect(usage.tertiary?.remainingPercent.rounded() == 82)
+        #expect(usage.primary?.remainingPercent.rounded() == 82)
+        #expect(usage.secondary?.remainingPercent.rounded() == 64)
+        #expect(usage.tertiary == nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
+++ b/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
@@ -158,6 +158,33 @@ struct AntigravityQuotaSummaryTests {
         ])
         #expect(usage.primary?.remainingPercent.rounded() == 90)
     }
+
+    @Test
+    func `fetch snapshot falls back when quota summary has no known usage buckets`() async throws {
+        let endpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "https",
+            port: 64440,
+            csrfToken: "token",
+            source: .languageServer)
+        let paths = AntigravityQuotaSummaryPathRecorder()
+
+        let snapshot = try await AntigravityStatusProbe.fetchSnapshot(
+            context: AntigravityStatusProbe.RequestContext(endpoints: [endpoint], timeout: 1),
+            send: { payload, _, _ in
+                paths.append(payload.path)
+                if payload.path.contains("RetrieveUserQuotaSummary") {
+                    return Data(antigravityQuotaSummaryWithoutKnownUsageJSON().utf8)
+                }
+                return Data(antigravityUserStatusJSON().utf8)
+            })
+        let usage = try snapshot.toUsageSnapshot()
+
+        #expect(paths.snapshot() == [
+            "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary",
+            "/exa.language_server_pb.LanguageServerService/GetUserStatus",
+        ])
+        #expect(usage.primary?.remainingPercent.rounded() == 90)
+    }
 }
 
 private func antigravityQuotaSummaryJSON() -> String {
@@ -199,6 +226,33 @@ private func antigravityQuotaSummaryJSON() -> String {
                 "displayName": "Five Hour Limit",
                 "remaining": { "remainingFraction": 0.73 },
                 "description": "You have used some of your 5-hour limit, it will fully refresh in 3 hours, 38 minutes."
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """
+}
+
+private func antigravityQuotaSummaryWithoutKnownUsageJSON() -> String {
+    """
+    {
+      "response": {
+        "groups": [
+          {
+            "displayName": "Gemini Models",
+            "buckets": [
+              {
+                "bucketId": "gemini-weekly",
+                "displayName": "Weekly Limit",
+                "description": "Refreshes later."
+              },
+              {
+                "bucketId": "gemini-5h",
+                "displayName": "Five Hour Limit",
+                "disabled": true,
+                "remaining": { "remainingFraction": 0.5 }
               }
             ]
           }

--- a/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
+++ b/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
@@ -1,0 +1,234 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+private final class AntigravityQuotaSummaryPathRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var paths: [String] = []
+
+    func append(_ path: String) {
+        self.lock.lock()
+        self.paths.append(path)
+        self.lock.unlock()
+    }
+
+    func snapshot() -> [String] {
+        self.lock.lock()
+        let snapshot = self.paths
+        self.lock.unlock()
+        return snapshot
+    }
+}
+
+struct AntigravityQuotaSummaryTests {
+    @Test
+    func `parses quota summary response into two model groups with session before weekly windows`() throws {
+        let snapshot = try AntigravityStatusProbe.parseQuotaSummaryResponse(
+            Data(antigravityQuotaSummaryJSON().utf8))
+
+        #expect(snapshot.modelQuotas.isEmpty)
+        let usage = try snapshot.toUsageSnapshot()
+        let windows = try #require(usage.extraRateWindows)
+
+        #expect(windows.map(\.id) == [
+            "antigravity-quota-summary-gemini-5h",
+            "antigravity-quota-summary-gemini-weekly",
+            "antigravity-quota-summary-3p-5h",
+            "antigravity-quota-summary-3p-weekly",
+        ])
+        #expect(windows.map(\.title) == [
+            "Gemini Session",
+            "Gemini Weekly",
+            "Claude + GPT Session",
+            "Claude + GPT Weekly",
+        ])
+        #expect(windows.map(\.window.windowMinutes) == [300, 10080, 300, 10080])
+        #expect(windows.map { $0.window.remainingPercent.rounded() } == [91, 82, 73, 64])
+        #expect(windows.map(\.usageKnown) == [true, true, true, true])
+        #expect(usage.primary?.remainingPercent.rounded() == 64)
+        #expect(usage.secondary?.remainingPercent.rounded() == 73)
+        #expect(usage.tertiary?.remainingPercent.rounded() == 82)
+    }
+
+    @Test
+    func `parses quota summary oneof remaining value shape`() throws {
+        let json = """
+        {
+          "groups": [
+            {
+              "displayName": "Gemini Models",
+              "buckets": [
+                {
+                  "bucketId": "gemini-weekly",
+                  "displayName": "Weekly Limit",
+                  "remaining": { "case": "remainingFraction", "value": 0.5 }
+                }
+              ]
+            }
+          ]
+        }
+        """
+
+        let snapshot = try AntigravityStatusProbe.parseQuotaSummaryResponse(Data(json.utf8))
+        let usage = try snapshot.toUsageSnapshot()
+
+        #expect(usage.extraRateWindows?.first?.window.remainingPercent == 50)
+    }
+
+    @Test
+    func `fetch snapshot prefers quota summary endpoint and merges identity`() async throws {
+        let endpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "https",
+            port: 64440,
+            csrfToken: "token",
+            source: .languageServer)
+        let paths = AntigravityQuotaSummaryPathRecorder()
+
+        let snapshot = try await AntigravityStatusProbe.fetchSnapshot(
+            context: AntigravityStatusProbe.RequestContext(endpoints: [endpoint], timeout: 1),
+            send: { payload, _, _ in
+                paths.append(payload.path)
+                if payload.path.contains("GetUserStatus") {
+                    return Data(antigravityUserStatusJSON().utf8)
+                }
+                return Data(antigravityQuotaSummaryJSON().utf8)
+            })
+        let usage = try snapshot.toUsageSnapshot()
+
+        #expect(paths.snapshot() == [
+            "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary",
+            "/exa.language_server_pb.LanguageServerService/GetUserStatus",
+        ])
+        #expect(usage.extraRateWindows?.count == 4)
+        #expect(usage.identity?.accountEmail == "test@example.com")
+        #expect(usage.identity?.loginMethod == "Pro")
+    }
+
+    @Test
+    func `fetch snapshot keeps quota summary when identity endpoint fails`() async throws {
+        let endpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "https",
+            port: 64440,
+            csrfToken: "token",
+            source: .languageServer)
+        let paths = AntigravityQuotaSummaryPathRecorder()
+
+        let snapshot = try await AntigravityStatusProbe.fetchSnapshot(
+            context: AntigravityStatusProbe.RequestContext(endpoints: [endpoint], timeout: 1),
+            send: { payload, _, _ in
+                paths.append(payload.path)
+                if payload.path.contains("GetUserStatus") {
+                    return Data(#"{"code":16}"#.utf8)
+                }
+                return Data(antigravityQuotaSummaryJSON().utf8)
+            })
+        let usage = try snapshot.toUsageSnapshot()
+
+        #expect(paths.snapshot() == [
+            "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary",
+            "/exa.language_server_pb.LanguageServerService/GetUserStatus",
+        ])
+        #expect(usage.extraRateWindows?.count == 4)
+        #expect(usage.identity?.accountEmail == nil)
+    }
+
+    @Test
+    func `fetch snapshot falls back to user status when quota summary is unavailable`() async throws {
+        let endpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "https",
+            port: 64440,
+            csrfToken: "token",
+            source: .languageServer)
+        let paths = AntigravityQuotaSummaryPathRecorder()
+
+        let snapshot = try await AntigravityStatusProbe.fetchSnapshot(
+            context: AntigravityStatusProbe.RequestContext(endpoints: [endpoint], timeout: 1),
+            send: { payload, _, _ in
+                paths.append(payload.path)
+                if payload.path.contains("RetrieveUserQuotaSummary") {
+                    return Data(#"{"code":16}"#.utf8)
+                }
+                return Data(antigravityUserStatusJSON().utf8)
+            })
+        let usage = try snapshot.toUsageSnapshot()
+
+        #expect(paths.snapshot() == [
+            "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary",
+            "/exa.language_server_pb.LanguageServerService/GetUserStatus",
+        ])
+        #expect(usage.primary?.remainingPercent.rounded() == 90)
+    }
+}
+
+private func antigravityQuotaSummaryJSON() -> String {
+    """
+    {
+      "response": {
+        "description": "Within each group, models share a weekly limit and a 5-hour limit.",
+        "groups": [
+          {
+            "displayName": "Gemini Models",
+            "description": "Models within this group: Gemini Flash, Gemini Pro",
+            "buckets": [
+              {
+                "bucketId": "gemini-weekly",
+                "displayName": "Weekly Limit",
+                "remaining": { "remainingFraction": 0.82 },
+                "description": "You have used some of your weekly limit, it will fully refresh in 5 days, 11 hours."
+              },
+              {
+                "bucketId": "gemini-5h",
+                "displayName": "Five Hour Limit",
+                "remaining": { "remainingFraction": 0.91 },
+                "description": "You have used some of your 5-hour limit, it will fully refresh in 4 hours."
+              }
+            ]
+          },
+          {
+            "displayName": "Claude and GPT models",
+            "description": "Models within this group: Claude Opus, Claude Sonnet, GPT-OSS",
+            "buckets": [
+              {
+                "bucketId": "3p-weekly",
+                "displayName": "Weekly Limit",
+                "remaining": { "remainingFraction": 0.64 },
+                "description": "You have used some of your weekly limit, it will fully refresh in 6 days, 22 hours."
+              },
+              {
+                "bucketId": "3p-5h",
+                "displayName": "Five Hour Limit",
+                "remaining": { "remainingFraction": 0.73 },
+                "description": "You have used some of your 5-hour limit, it will fully refresh in 3 hours, 38 minutes."
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """
+}
+
+private func antigravityUserStatusJSON() -> String {
+    """
+    {
+      "code": 0,
+      "userStatus": {
+        "email": "test@example.com",
+        "planStatus": {
+          "planInfo": {
+            "planName": "Pro"
+          }
+        },
+        "cascadeModelConfigData": {
+          "clientModelConfigs": [
+            {
+              "label": "Gemini 3 Pro Low",
+              "modelOrAlias": { "model": "gemini-3-pro-low" },
+              "quotaInfo": { "remainingFraction": 0.9, "resetTime": "2025-12-24T10:00:00Z" }
+            }
+          ]
+        }
+      }
+    }
+    """
+}

--- a/Tests/CodexBarTests/AntigravityRemoteUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AntigravityRemoteUsageFetcherTests.swift
@@ -332,9 +332,9 @@ struct AntigravityRemoteUsageFetcherTests {
         #expect(snapshot.accountPlan == "Paid")
 
         let usage = try snapshot.toUsageSnapshot()
-        #expect(usage.primary?.remainingPercent.rounded() == 50)
-        #expect(usage.secondary?.remainingPercent.rounded() == 80)
-        #expect(usage.tertiary?.remainingPercent.rounded() == 20)
+        #expect(usage.primary?.remainingPercent.rounded() == 20)
+        #expect(usage.secondary?.remainingPercent.rounded() == 50)
+        #expect(usage.tertiary == nil)
     }
 
     @Test
@@ -440,13 +440,13 @@ struct AntigravityRemoteUsageFetcherTests {
         let usage = try snapshot.toUsageSnapshot()
 
         #expect(quotaCalls.get() == 1)
-        #expect(usage.primary?.remainingPercent == 100.0)
-        #expect(usage.secondary?.remainingPercent == 60.0)
-        #expect(usage.tertiary?.remainingPercent == 90.0)
+        #expect(usage.primary?.remainingPercent == 60.0)
+        #expect(usage.secondary?.remainingPercent == 100.0)
+        #expect(usage.tertiary == nil)
     }
 
     @Test
-    func `remote fetch keeps full model quotas when verification has no buckets`() async throws {
+    func `remote fetch ignores full model availability when verification has no quota data`() async throws {
         let env = try GeminiTestEnvironment()
         defer { env.cleanup() }
         try env.writeAntigravityCredentials(
@@ -505,10 +505,162 @@ struct AntigravityRemoteUsageFetcherTests {
             homeDirectory: env.homeURL.path,
             dataLoader: dataLoader)
             .fetch()
+
+        #expect(snapshot.modelQuotas.isEmpty)
+        #expect(snapshot.accountEmail == "user@example.com")
+    }
+
+    @Test
+    func `remote fetch propagates quota verification server errors`() async throws {
+        let env = try GeminiTestEnvironment()
+        defer { env.cleanup() }
+        try env.writeAntigravityCredentials(
+            accessToken: "token",
+            refreshToken: nil,
+            expiry: Date().addingTimeInterval(3600),
+            idToken: GeminiAPITestHelpers.makeIDToken(email: "user@example.com"),
+            email: "user@example.com")
+
+        let dataLoader = GeminiAPITestHelpers.dataLoader { request in
+            guard let url = request.url, let host = url.host else {
+                throw URLError(.badURL)
+            }
+
+            switch host {
+            case "cloudcode-pa.googleapis.com":
+                if url.path == "/v1internal:loadCodeAssist" {
+                    return GeminiAPITestHelpers.response(
+                        url: url.absoluteString,
+                        status: 200,
+                        body: GeminiAPITestHelpers.loadCodeAssistResponse(
+                            tierId: "standard-tier",
+                            projectId: "managed-project-123"))
+                }
+                if url.path == "/v1internal:fetchAvailableModels" {
+                    return GeminiAPITestHelpers.response(
+                        url: url.absoluteString,
+                        status: 200,
+                        body: GeminiAPITestHelpers.jsonData([
+                            "models": [
+                                "claude-sonnet-4": [
+                                    "displayName": "Claude Sonnet 4",
+                                    "quotaInfo": ["remainingFraction": 1],
+                                ],
+                                "gemini-2.5-pro": [
+                                    "displayName": "Gemini 2.5 Pro",
+                                    "quotaInfo": ["remainingFraction": 1],
+                                ],
+                            ],
+                        ]))
+                }
+                if url.path == "/v1internal:retrieveUserQuota" {
+                    return GeminiAPITestHelpers.response(
+                        url: url.absoluteString,
+                        status: 503,
+                        body: Data("temporary outage".utf8))
+                }
+                return GeminiAPITestHelpers.response(url: url.absoluteString, status: 404, body: Data())
+            default:
+                return GeminiAPITestHelpers.response(url: url.absoluteString, status: 404, body: Data())
+            }
+        }
+
+        do {
+            _ = try await AntigravityRemoteUsageFetcher(
+                timeout: 1,
+                homeDirectory: env.homeURL.path,
+                dataLoader: dataLoader)
+                .fetch()
+            Issue.record("Expected quota verification server error")
+        } catch let error as AntigravityRemoteFetchError {
+            guard case let .apiError(message) = error else {
+                Issue.record("Unexpected Antigravity error: \(error)")
+                return
+            }
+            #expect(message.contains("HTTP 503"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
+    func `remote fetch keeps full quotas when verified quota endpoint has fractions`() async throws {
+        let env = try GeminiTestEnvironment()
+        defer { env.cleanup() }
+        try env.writeAntigravityCredentials(
+            accessToken: "token",
+            refreshToken: nil,
+            expiry: Date().addingTimeInterval(3600),
+            idToken: GeminiAPITestHelpers.makeIDToken(email: "user@example.com"),
+            email: "user@example.com")
+
+        let dataLoader = GeminiAPITestHelpers.dataLoader { request in
+            guard let url = request.url, let host = url.host else {
+                throw URLError(.badURL)
+            }
+
+            switch host {
+            case "cloudcode-pa.googleapis.com":
+                if url.path == "/v1internal:loadCodeAssist" {
+                    return GeminiAPITestHelpers.response(
+                        url: url.absoluteString,
+                        status: 200,
+                        body: GeminiAPITestHelpers.loadCodeAssistResponse(
+                            tierId: "standard-tier",
+                            projectId: "managed-project-123"))
+                }
+                if url.path == "/v1internal:fetchAvailableModels" {
+                    return GeminiAPITestHelpers.response(
+                        url: url.absoluteString,
+                        status: 200,
+                        body: GeminiAPITestHelpers.jsonData([
+                            "models": [
+                                "claude-sonnet-4": [
+                                    "displayName": "Claude Sonnet 4",
+                                    "quotaInfo": ["remainingFraction": 1],
+                                ],
+                                "gemini-2.5-pro": [
+                                    "displayName": "Gemini 2.5 Pro",
+                                    "quotaInfo": ["remainingFraction": 1],
+                                ],
+                            ],
+                        ]))
+                }
+                if url.path == "/v1internal:retrieveUserQuota" {
+                    return GeminiAPITestHelpers.response(
+                        url: url.absoluteString,
+                        status: 200,
+                        body: GeminiAPITestHelpers.jsonData([
+                            "buckets": [
+                                [
+                                    "modelId": "claude-sonnet-4",
+                                    "remainingFraction": 1,
+                                    "resetTime": "2025-01-01T00:00:00Z",
+                                ],
+                                [
+                                    "modelId": "gemini-2.5-pro",
+                                    "remainingFraction": 1,
+                                    "resetTime": "2025-01-01T00:00:00Z",
+                                ],
+                            ],
+                        ]))
+                }
+                return GeminiAPITestHelpers.response(url: url.absoluteString, status: 404, body: Data())
+            default:
+                return GeminiAPITestHelpers.response(url: url.absoluteString, status: 404, body: Data())
+            }
+        }
+
+        let snapshot = try await AntigravityRemoteUsageFetcher(
+            timeout: 1,
+            homeDirectory: env.homeURL.path,
+            dataLoader: dataLoader)
+            .fetch()
         let usage = try snapshot.toUsageSnapshot()
 
         #expect(usage.primary?.remainingPercent == 100.0)
         #expect(usage.secondary?.remainingPercent == 100.0)
+        #expect(usage.tertiary == nil)
     }
 
     @Test
@@ -830,8 +982,9 @@ struct AntigravityRemoteUsageFetcherTests {
         let usage = try snapshot.toUsageSnapshot()
 
         #expect(quotaCalls.get() == 1)
-        #expect(usage.secondary?.remainingPercent == 60.0)
-        #expect(usage.tertiary?.remainingPercent == 90.0)
+        #expect(usage.primary?.remainingPercent == 60.0)
+        #expect(usage.secondary == nil)
+        #expect(usage.tertiary == nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -78,6 +78,20 @@ struct AntigravityStatusProbeTests {
     }
 
     @Test
+    func `process detection accepts platform suffixed antigravity language server`() throws {
+        let output = """
+          101 /Applications/Antigravity.app/Contents/Resources/bin/language_server_macos_arm \
+          --csrf_token ide-token --app_data_dir antigravity --extension_server_port 54977
+        """
+
+        let result = try AntigravityStatusProbe.processInfo(fromProcessListOutput: output, scope: .appOnly)
+
+        #expect(result.pid == 101)
+        #expect(result.csrfToken == "ide-token")
+        #expect(result.extensionPort == 54977)
+    }
+
+    @Test
     func `process detection accepts antigravity cli without csrf token`() {
         // The CLI launches its language server without a `--csrf_token` flag.
         let node = """
@@ -111,11 +125,16 @@ struct AntigravityStatusProbeTests {
     }
 
     @Test
-    func `process kind distinguishes ide language server from cli`() {
-        let ide = """
+    func `process kind distinguishes app ide language server and cli`() {
+        let app = """
         /Applications/Antigravity.app/Contents/Resources/bin/language_server \
         --csrf_token token --app_data_dir antigravity
         """
+        let ide = """
+        /Applications/Antigravity IDE.app/Contents/Resources/app/extensions/antigravity/bin/language_server_macos_arm \
+        --csrf_token token --app_data_dir antigravity-ide
+        """
+        #expect(AntigravityStatusProbe.antigravityProcessKind(app) == .app)
         #expect(AntigravityStatusProbe.antigravityProcessKind(ide) == .ide)
         #expect(AntigravityStatusProbe.antigravityProcessKind("/Users/test/.local/bin/agy -p hi") == .cli)
         #expect(
@@ -126,20 +145,20 @@ struct AntigravityStatusProbeTests {
 
     @Test
     func `csrf token stays required for ide but optional for cli`() {
-        // IDE with a token returns it.
-        let ideWithToken = """
+        // Desktop app/IDE with a token returns it.
+        let appWithToken = """
         /Applications/Antigravity.app/Contents/Resources/bin/language_server \
         --csrf_token ide-token --app_data_dir antigravity
         """
-        #expect(AntigravityStatusProbe.resolvedCSRFToken(forKind: .ide, command: ideWithToken) == "ide-token")
+        #expect(AntigravityStatusProbe.resolvedCSRFToken(forKind: .app, command: appWithToken) == "ide-token")
 
-        // Tokenless IDE is skipped (nil) so detection keeps scanning for a valid
-        // server and preserves the missing-token diagnostic — no empty-token probe.
-        let ideNoToken = """
+        // Tokenless desktop app is skipped (nil) so detection keeps scanning for a valid
+        // server and preserves the missing-token diagnostic - no empty-token probe.
+        let appNoToken = """
         /Applications/Antigravity.app/Contents/Resources/bin/language_server \
         --app_data_dir antigravity
         """
-        #expect(AntigravityStatusProbe.resolvedCSRFToken(forKind: .ide, command: ideNoToken) == nil)
+        #expect(AntigravityStatusProbe.resolvedCSRFToken(forKind: .app, command: appNoToken) == nil)
 
         // CLI without a token resolves to an empty token (its server needs none).
         #expect(
@@ -170,6 +189,89 @@ struct AntigravityStatusProbeTests {
     }
 
     @Test
+    func `process scan returns all valid app candidates`() throws {
+        let firstApp = "  101 /Applications/Antigravity.app/Contents/Resources/bin/language_server " +
+            "--csrf_token first-token --app_data_dir antigravity"
+        let secondApp = "  102 /Applications/Antigravity.app/Contents/Resources/bin/language_server " +
+            "--csrf_token second-token --app_data_dir antigravity " +
+            "--extension_server_port 64432 --extension_server_csrf_token extension-token"
+        let output = [firstApp, secondApp].joined(separator: "\n")
+
+        let results = try AntigravityStatusProbe.processInfos(fromProcessListOutput: output, scope: .appOnly)
+
+        #expect(results.map(\.pid) == [101, 102])
+        #expect(results.map(\.csrfToken) == ["first-token", "second-token"])
+        #expect(results.last?.extensionPort == 64432)
+        #expect(results.last?.extensionServerCSRFToken == "extension-token")
+    }
+
+    @Test
+    func `local snapshot score prefers quota summary over legacy model quotas`() {
+        let legacy = AntigravityStatusSnapshot(
+            modelQuotas: [
+                AntigravityModelQuota(
+                    label: "Gemini 3 Pro Low",
+                    modelId: "gemini-3-pro-low",
+                    remainingFraction: 0.9,
+                    resetTime: Date(timeIntervalSince1970: 1_700_000_000),
+                    resetDescription: nil),
+                AntigravityModelQuota(
+                    label: "Claude Sonnet",
+                    modelId: "claude-sonnet",
+                    remainingFraction: 0.5,
+                    resetTime: Date(timeIntervalSince1970: 1_700_000_000),
+                    resetDescription: nil),
+            ],
+            accountEmail: "user@example.com",
+            accountPlan: "Pro",
+            source: .local)
+        let summary = AntigravityStatusSnapshot(
+            quotaSummary: AntigravityQuotaSummary(
+                description: nil,
+                groups: [
+                    AntigravityQuotaSummaryGroup(
+                        displayName: "Gemini Models",
+                        description: nil,
+                        buckets: [
+                            AntigravityQuotaSummaryBucket(
+                                bucketId: "gemini-5h",
+                                displayName: "Five Hour Limit",
+                                remainingFraction: 0.9,
+                                resetDescription: nil,
+                                disabled: false),
+                            AntigravityQuotaSummaryBucket(
+                                bucketId: "gemini-weekly",
+                                displayName: "Weekly Limit",
+                                remainingFraction: 0.8,
+                                resetDescription: nil,
+                                disabled: false),
+                        ]),
+                    AntigravityQuotaSummaryGroup(
+                        displayName: "Claude and GPT models",
+                        description: nil,
+                        buckets: [
+                            AntigravityQuotaSummaryBucket(
+                                bucketId: "3p-5h",
+                                displayName: "Five Hour Limit",
+                                remainingFraction: 0.7,
+                                resetDescription: nil,
+                                disabled: false),
+                            AntigravityQuotaSummaryBucket(
+                                bucketId: "3p-weekly",
+                                displayName: "Weekly Limit",
+                                remainingFraction: 0.6,
+                                resetDescription: nil,
+                                disabled: false),
+                        ]),
+                ]),
+            accountEmail: "user@example.com",
+            accountPlan: "Pro",
+            source: .local)
+
+        #expect(AntigravityStatusProbe.localSnapshotScore(summary) > AntigravityStatusProbe.localSnapshotScore(legacy))
+    }
+
+    @Test
     func `process scan reports missing csrf when only tokenless ide matches`() {
         let output = """
           100 /Applications/Antigravity.app/Contents/Resources/bin/language_server --app_data_dir antigravity
@@ -194,25 +296,49 @@ struct AntigravityStatusProbeTests {
     }
 
     @Test
-    func `ideOnly scope skips cli processes and reports not running`() {
+    func `ideOnly scope skips app and cli processes and reports not running`() {
         let output = "  200 /Users/test/.local/bin/agy -p hello"
 
         #expect(throws: AntigravityStatusProbeError.notRunning) {
             try AntigravityStatusProbe.processInfo(fromProcessListOutput: output, scope: .ideOnly)
         }
+
+        let app = "  101 /Applications/Antigravity.app/Contents/Resources/bin/language_server " +
+            "--csrf_token app-token --app_data_dir antigravity"
+        #expect(throws: AntigravityStatusProbeError.notRunning) {
+            try AntigravityStatusProbe.processInfo(fromProcessListOutput: app, scope: .ideOnly)
+        }
     }
 
     @Test
-    func `ideOnly scope still matches ide server listed after cli process`() throws {
+    func `ideOnly scope still matches ide server listed after cli and app processes`() throws {
         let cli = "  200 /Users/test/.local/bin/agy -p hello"
-        let ide = "  101 /Applications/Antigravity.app/Contents/Resources/bin/language_server " +
+        let app = "  101 /Applications/Antigravity.app/Contents/Resources/bin/language_server " +
+            "--csrf_token app-token --app_data_dir antigravity"
+        let ide = "  102 /Applications/Antigravity IDE.app/Contents/Resources/app/extensions/antigravity/bin/" +
+            "language_server_macos_arm " +
             "--csrf_token ide-token --app_data_dir antigravity"
-        let output = cli + "\n" + ide
+        let output = cli + "\n" + app + "\n" + ide
 
         let result = try AntigravityStatusProbe.processInfo(fromProcessListOutput: output, scope: .ideOnly)
 
-        #expect(result.pid == 101)
+        #expect(result.pid == 102)
         #expect(result.csrfToken == "ide-token")
+    }
+
+    @Test
+    func `appOnly scope skips ide and cli processes`() throws {
+        let cli = "  200 /Users/test/.local/bin/agy -p hello"
+        let ide = "  102 /Applications/Antigravity IDE.app/Contents/Resources/app/extensions/antigravity/bin/" +
+            "language_server_macos_arm --csrf_token ide-token --app_data_dir antigravity-ide"
+        let app = "  101 /Applications/Antigravity.app/Contents/Resources/bin/language_server " +
+            "--csrf_token app-token --app_data_dir antigravity"
+        let output = cli + "\n" + ide + "\n" + app
+
+        let result = try AntigravityStatusProbe.processInfo(fromProcessListOutput: output, scope: .appOnly)
+
+        #expect(result.pid == 101)
+        #expect(result.csrfToken == "app-token")
     }
 }
 
@@ -633,9 +759,9 @@ extension AntigravityStatusProbeTests {
         guard let primary = usage.primary else {
             return
         }
-        #expect(primary.remainingPercent.rounded() == 50)
-        #expect(usage.secondary?.remainingPercent.rounded() == 80)
-        #expect(usage.tertiary?.remainingPercent.rounded() == 20)
+        #expect(primary.remainingPercent.rounded() == 20)
+        #expect(usage.secondary?.remainingPercent.rounded() == 50)
+        #expect(usage.tertiary == nil)
     }
 
     @Test
@@ -703,7 +829,7 @@ extension AntigravityStatusProbeTests {
     }
 
     @Test
-    func `claude bar can use thinking variants`() throws {
+    func `claude gpt pool can use thinking variants`() throws {
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
                 AntigravityModelQuota(
@@ -723,11 +849,12 @@ extension AntigravityStatusProbeTests {
             accountPlan: nil)
 
         let usage = try snapshot.toUsageSnapshot()
-        #expect(usage.primary?.remainingPercent.rounded() == 30)
+        #expect(usage.primary == nil)
+        #expect(usage.secondary?.remainingPercent.rounded() == 30)
     }
 
     @Test
-    func `claude bar uses thinking model when it is the only claude option`() throws {
+    func `claude gpt pool uses thinking model when it is the only claude option`() throws {
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
                 AntigravityModelQuota(
@@ -747,12 +874,12 @@ extension AntigravityStatusProbeTests {
             accountPlan: nil)
 
         let usage = try snapshot.toUsageSnapshot()
-        #expect(usage.primary?.remainingPercent.rounded() == 70)
-        #expect(usage.secondary?.remainingPercent.rounded() == 40)
+        #expect(usage.primary?.remainingPercent.rounded() == 40)
+        #expect(usage.secondary?.remainingPercent.rounded() == 70)
     }
 
     @Test
-    func `gemini pro bar unavailable when only excluded variants exist`() throws {
+    func `gemini pool unavailable when only excluded variants exist`() throws {
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
                 AntigravityModelQuota(
@@ -772,12 +899,12 @@ extension AntigravityStatusProbeTests {
             accountPlan: nil)
 
         let usage = try snapshot.toUsageSnapshot()
-        #expect(usage.secondary == nil)
-        #expect(usage.primary?.remainingPercent.rounded() == 30)
+        #expect(usage.primary == nil)
+        #expect(usage.secondary?.remainingPercent.rounded() == 30)
     }
 
     @Test
-    func `gemini pro chooses pro low model`() throws {
+    func `gemini pool chooses most constrained pro variant`() throws {
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
                 AntigravityModelQuota(
@@ -797,11 +924,12 @@ extension AntigravityStatusProbeTests {
             accountPlan: nil)
 
         let usage = try snapshot.toUsageSnapshot()
-        #expect(usage.secondary?.remainingPercent.rounded() == 40)
+        #expect(usage.primary?.remainingPercent.rounded() == 40)
+        #expect(usage.secondary == nil)
     }
 
     @Test
-    func `gemini pro low wins over standard pro when both exist`() throws {
+    func `gemini pool chooses standard pro when it is more constrained than low variant`() throws {
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
                 AntigravityModelQuota(
@@ -821,11 +949,12 @@ extension AntigravityStatusProbeTests {
             accountPlan: nil)
 
         let usage = try snapshot.toUsageSnapshot()
-        #expect(usage.secondary?.remainingPercent.rounded() == 90)
+        #expect(usage.primary?.remainingPercent.rounded() == 10)
+        #expect(usage.secondary == nil)
     }
 
     @Test
-    func `gemini pro prefers model with remaining data over low priority placeholder`() throws {
+    func `gemini pool ignores reset only placeholder when remaining data exists`() throws {
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
                 AntigravityModelQuota(
@@ -845,11 +974,12 @@ extension AntigravityStatusProbeTests {
             accountPlan: nil)
 
         let usage = try snapshot.toUsageSnapshot()
-        #expect(usage.secondary?.remainingPercent.rounded() == 100)
+        #expect(usage.primary?.remainingPercent.rounded() == 100)
+        #expect(usage.secondary == nil)
     }
 
     @Test
-    func `gemini flash does not fallback to lite variant`() throws {
+    func `gemini pool does not fallback to lite flash variant`() throws {
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
                 AntigravityModelQuota(
@@ -870,7 +1000,8 @@ extension AntigravityStatusProbeTests {
 
         let usage = try snapshot.toUsageSnapshot()
         #expect(usage.tertiary == nil)
-        #expect(usage.primary?.remainingPercent.rounded() == 30)
+        #expect(usage.primary == nil)
+        #expect(usage.secondary?.remainingPercent.rounded() == 30)
     }
 
     @Test
@@ -900,9 +1031,9 @@ extension AntigravityStatusProbeTests {
             accountPlan: nil)
 
         let usage = try snapshot.toUsageSnapshot()
-        #expect(usage.primary?.remainingPercent.rounded() == 30)
-        #expect(usage.secondary?.remainingPercent.rounded() == 40)
-        #expect(usage.tertiary?.remainingPercent.rounded() == 100)
+        #expect(usage.primary?.remainingPercent.rounded() == 40)
+        #expect(usage.secondary?.remainingPercent.rounded() == 30)
+        #expect(usage.tertiary == nil)
     }
 
     @Test
@@ -953,14 +1084,14 @@ extension AntigravityStatusProbeTests {
         let usage = try snapshot.toUsageSnapshot()
         #expect(usage.primary?.remainingPercent.rounded() == 100)
         #expect(usage.secondary?.remainingPercent.rounded() == 100)
-        #expect(usage.tertiary?.remainingPercent.rounded() == 100)
+        #expect(usage.tertiary == nil)
         #expect(usage.identity?.accountEmail == "user@example.com")
     }
 }
 
 extension AntigravityStatusProbeTests {
     @Test
-    func `extra rate windows preserve all model quotas in stable family order`() throws {
+    func `known model quota rows collapse into two usage pools`() throws {
         let resetTime = Date(timeIntervalSince1970: 1_775_000_000)
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
@@ -994,23 +1125,9 @@ extension AntigravityStatusProbeTests {
             source: .local)
 
         let usage = try snapshot.toUsageSnapshot()
-        let extraWindows = try #require(usage.extraRateWindows)
-
-        // Local source shows all models. Order: Claude → Gemini Pro (High before Low) → GPT-OSS (unknown, last)
-        #expect(extraWindows.map(\.id) == [
-            "MODEL_PLACEHOLDER_M50",
-            "MODEL_PLACEHOLDER_M52",
-            "MODEL_PLACEHOLDER_M53",
-            "MODEL_PLACEHOLDER_M55",
-        ])
-        #expect(extraWindows.map(\.title) == [
-            "Claude Opus 4.6 (Thinking)",
-            "Gemini 3 Pro (High)",
-            "Gemini 3 Pro (Low)",
-            "GPT-OSS 120B (Medium)",
-        ])
-        #expect(extraWindows.map { $0.window.remainingPercent.rounded() } == [75, 100, 50, 25])
-        #expect(extraWindows.last?.window.resetDescription == "tomorrow")
+        #expect(usage.primary?.remainingPercent.rounded() == 50)
+        #expect(usage.secondary?.remainingPercent.rounded() == 25)
+        #expect(usage.extraRateWindows == nil)
     }
 
     @Test
@@ -1035,17 +1152,34 @@ extension AntigravityStatusProbeTests {
             accountPlan: nil)
 
         let usage = try snapshot.toUsageSnapshot()
+        #expect(usage.primary?.remainingPercent.rounded() == 100)
         #expect(usage.secondary == nil)
-        #expect(usage.tertiary?.remainingPercent.rounded() == 100)
-        let modelWindow = try #require(usage.extraRateWindows?.first {
-            $0.id == "MODEL_PLACEHOLDER_M36"
-        })
+        #expect(usage.tertiary == nil)
+        #expect(usage.extraRateWindows == nil)
+    }
+
+    @Test
+    func `group without remaining fraction preserves reset metadata as unavailable grouped window`() throws {
+        let resetTime = Date(timeIntervalSince1970: 1_735_000_000)
+        let snapshot = AntigravityStatusSnapshot(
+            modelQuotas: [
+                AntigravityModelQuota(
+                    label: "Gemini 3.1 Pro (Low)",
+                    modelId: "MODEL_PLACEHOLDER_M36",
+                    remainingFraction: nil,
+                    resetTime: resetTime,
+                    resetDescription: nil),
+            ],
+            accountEmail: nil,
+            accountPlan: nil)
+
+        let usage = try snapshot.toUsageSnapshot()
+        #expect(usage.primary == nil)
+        let modelWindow = try #require(usage.extraRateWindows?.first)
+        #expect(modelWindow.id == "antigravity-gemini")
+        #expect(modelWindow.title == "Gemini")
         #expect(modelWindow.window.resetsAt == resetTime)
         #expect(modelWindow.usageKnown == false)
-        let knownModelWindow = try #require(usage.extraRateWindows?.first {
-            $0.id == "MODEL_PLACEHOLDER_M47"
-        })
-        #expect(knownModelWindow.usageKnown)
     }
 
     @Test
@@ -1070,7 +1204,7 @@ extension AntigravityStatusProbeTests {
     }
 
     @Test
-    func `filtered variants fall back to a visible primary snapshot`() throws {
+    func `filtered variants stay out of summary but remain distinct extras`() throws {
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
                 AntigravityModelQuota(
@@ -1097,9 +1231,14 @@ extension AntigravityStatusProbeTests {
             source: .local)
 
         let usage = try snapshot.toUsageSnapshot()
-        #expect(usage.primary?.remainingPercent.rounded() == 20)
+        #expect(usage.primary == nil)
         #expect(usage.secondary == nil)
         #expect(usage.tertiary == nil)
+        #expect(usage.extraRateWindows?.map(\.id) == [
+            "gemini-3-pro-lite",
+            "gemini-3-flash-lite",
+            "tab_autocomplete_model",
+        ])
         #expect(usage.accountEmail(for: .antigravity) == "test@example.com")
         #expect(usage.loginMethod(for: .antigravity) == "Pro")
     }
@@ -1107,8 +1246,8 @@ extension AntigravityStatusProbeTests {
     // MARK: - Source-aware filter + sort tests
 
     @Test
-    func `local source shows all models including gpt oss at full remaining fraction`() throws {
-        // Fixture A: 8 opaque-ID models, source .local → all shown (show-all path)
+    func `local source collapses opaque model ids into two usage pools`() throws {
+        // Fixture A: 8 opaque-ID models, source .local -> two grouped quota pools
         let resetTime = Date(timeIntervalSince1970: 1_775_000_000)
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
@@ -1154,7 +1293,7 @@ extension AntigravityStatusProbeTests {
                     remainingFraction: 0.5,
                     resetTime: resetTime,
                     resetDescription: nil),
-                // GPT-OSS pinned at remainingFraction == 1.0 — shown by local show-all
+                // GPT-OSS pinned at remainingFraction == 1.0 - shown by local show-all
                 AntigravityModelQuota(
                     label: "GPT-OSS 120B (Medium)",
                     modelId: "MODEL_PLACEHOLDER_M55",
@@ -1167,46 +1306,15 @@ extension AntigravityStatusProbeTests {
             source: .local)
 
         let usage = try snapshot.toUsageSnapshot()
-        let extraWindows = try #require(usage.extraRateWindows)
-        let ids = extraWindows.map(\.id)
-
-        // All 8 models present
-        #expect(ids.count == 8)
-        // GPT-OSS shown despite remainingFraction == 1.0 (local show-all regression guard)
-        #expect(ids.contains("MODEL_PLACEHOLDER_M55"))
-
-        // Order: Claude (version 4.6 → both at same version, Opus vs Sonnet by label)
-        //        → Gemini Pro 3.1 (High before Low)
-        //        → Gemini Flash 3.5 (High, Medium, Low by tier)
-        //        → GPT-OSS (unknown bucket, last)
-        let titles = extraWindows.map(\.title)
-        // Claude family first
-        let claudeRange = titles.prefix(2)
-        #expect(claudeRange.allSatisfy { $0.lowercased().contains("claude") })
-        // Gemini Pro next
-        let geminiProRange = titles.dropFirst(2).prefix(2)
-        #expect(geminiProRange.allSatisfy { $0.lowercased().contains("gemini") && $0.lowercased().contains("pro") })
-        // Gemini Flash next
-        let geminiFlashRange = titles.dropFirst(4).prefix(3)
-        #expect(geminiFlashRange.allSatisfy { $0.lowercased().contains("gemini") && $0.lowercased().contains("flash") })
-        // GPT-OSS last
-        #expect(titles.last == "GPT-OSS 120B (Medium)")
-
-        // Within Gemini Pro 3.1: High before Low
-        let proTitles = Array(geminiProRange)
-        #expect(proTitles[0].contains("High"))
-        #expect(proTitles[1].contains("Low"))
-
-        // Within Gemini Flash 3.5: High(0) → Medium(1) → Low(2)
-        let flashTitles = Array(geminiFlashRange)
-        #expect(flashTitles[0].contains("High"))
-        #expect(flashTitles[1].contains("Medium"))
-        #expect(flashTitles[2].contains("Low"))
+        #expect(usage.primary?.remainingPercent.rounded() == 30)
+        #expect(usage.secondary?.remainingPercent.rounded() == 70)
+        #expect(usage.extraRateWindows == nil)
     }
 
     @Test
-    func `remote source filters junk models and keeps family recognized ones`() throws {
-        // Fixture B: verified 13 remote models; 6 junk hidden, 7 survivors present
+    func `remote source collapses recognized family models and hides unconsumed junk`() throws {
+        // Fixture B: verified 13 remote models; recognized text models collapse into Gemini,
+        // and unconsumed junk stays hidden.
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
                 // junk: image
@@ -1306,35 +1414,9 @@ extension AntigravityStatusProbeTests {
             source: .remote)
 
         let usage = try snapshot.toUsageSnapshot()
-        let extraWindows = try #require(usage.extraRateWindows)
-        let ids = extraWindows.map(\.id)
-
-        // 6 junk IDs must be absent
-        #expect(!ids.contains("gemini-2-5-flash-image"))
-        #expect(!ids.contains("tab_flash_lite_vertex"))
-        #expect(!ids.contains("gemini-2-5-flash-lite"))
-        #expect(!ids.contains("gemini-3-pro-image"))
-        #expect(!ids.contains("gemini-3-1-flash-lite"))
-        #expect(!ids.contains("tab_jump_flash_lite_vertex"))
-
-        // 7 survivors must be present by ID
-        #expect(ids.contains("gemini-2-5-pro"))
-        #expect(ids.contains("gemini-3-pro-high"))
-        #expect(ids.contains("gemini-3-flash"))
-        #expect(ids.contains("gemini-3-1-pro-low"))
-        #expect(ids.contains("gemini-3-1-pro-high"))
-        #expect(ids.contains("gemini-3-pro-low"))
-        #expect(ids.contains("gemini-2-5-flash"))
-
-        // Version-descending within Gemini Pro: 3.1 before 3 before 2.5
-        let proIds = ids.filter { $0.contains("pro") && !$0.contains("image") }
-        let proIndexOf: (String) -> Int = { id in proIds.firstIndex(of: id) ?? Int.max }
-        #expect(proIndexOf("gemini-3-1-pro-high") < proIndexOf("gemini-3-pro-high"))
-        #expect(proIndexOf("gemini-3-pro-high") < proIndexOf("gemini-2-5-pro"))
-
-        // Within same version, High before Low
-        #expect(proIndexOf("gemini-3-1-pro-high") < proIndexOf("gemini-3-1-pro-low"))
-        #expect(proIndexOf("gemini-3-pro-high") < proIndexOf("gemini-3-pro-low"))
+        #expect(usage.primary?.remainingPercent.rounded() == 100)
+        #expect(usage.secondary == nil)
+        #expect(usage.extraRateWindows == nil)
     }
 
     @Test
@@ -1342,21 +1424,21 @@ extension AntigravityStatusProbeTests {
         // Fixture C: junk models with remainingFraction < 0.999 must be shown
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
-                // consumed tab — should be shown
+                // consumed tab - should be shown
                 AntigravityModelQuota(
                     label: "Tab Flash Lite Vertex",
                     modelId: "tab_flash_lite_vertex",
                     remainingFraction: 0.4,
                     resetTime: nil,
                     resetDescription: nil),
-                // consumed image — should be shown
+                // consumed image - should be shown
                 AntigravityModelQuota(
                     label: "Gemini 3 Pro Image",
                     modelId: "gemini-3-pro-image",
                     remainingFraction: 0.4,
                     resetTime: nil,
                     resetDescription: nil),
-                // unconsumed sibling tab (0.9995 >= 0.999) — should be hidden
+                // unconsumed sibling tab (0.9995 >= 0.999) - should be hidden
                 AntigravityModelQuota(
                     label: "Tab Jump Flash Lite Vertex",
                     modelId: "tab_jump_flash_lite_vertex",
@@ -1422,15 +1504,15 @@ extension AntigravityStatusProbeTests {
 
         let usage = try snapshot.toUsageSnapshot()
 
-        #expect(usage.secondary?.usedPercent == 10)
-        #expect(usage.tertiary?.usedPercent == 20)
+        #expect(usage.primary?.usedPercent == 20)
+        #expect(usage.secondary == nil)
         #expect(usage.extraRateWindows?.map(\.id).contains("gemini-3-pro-image") == true)
         #expect(usage.extraRateWindows?.map(\.id).contains("gemini-3-flash-image") == true)
     }
 
     @Test
     func `remote source yields nil extra windows when all models are unconsumed junk`() throws {
-        // Fixture D: all-junk-unconsumed → extraRateWindows nil
+        // Fixture D: all-junk-unconsumed -> extraRateWindows nil
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
                 AntigravityModelQuota(
@@ -1470,9 +1552,9 @@ extension AntigravityStatusProbeTests {
     }
 
     @Test
-    func `ordering edge cases with unparseable version and equal version differing tier`() throws {
-        // Fixture F: local source; unparseable-version Gemini Pro lands last in pro group;
-        // same-version High precedes Low
+    func `ordering edge cases collapse to most constrained usage pool`() throws {
+        // Fixture F: local source; known Gemini Pro rows collapse into the Gemini pool
+        // using the most constrained remaining fraction.
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
                 AntigravityModelQuota(
@@ -1505,17 +1587,9 @@ extension AntigravityStatusProbeTests {
             source: .local)
 
         let usage = try snapshot.toUsageSnapshot()
-        let extraWindows = try #require(usage.extraRateWindows)
-        let titles = extraWindows.map(\.title)
-
-        // Claude first
-        #expect(titles[0] == "Claude Sonnet 4")
-        // Within Gemini Pro: version-3 models before unparseable-version model
-        // High before Low at same version
-        let proIndex: (String) -> Int = { t in titles.firstIndex(of: t) ?? Int.max }
-        #expect(proIndex("Gemini 3 Pro (High)") < proIndex("Gemini 3 Pro (Low)"))
-        #expect(proIndex("Gemini 3 Pro (High)") < proIndex("Gemini Pro Experimental"))
-        #expect(proIndex("Gemini 3 Pro (Low)") < proIndex("Gemini Pro Experimental"))
+        #expect(usage.primary?.remainingPercent.rounded() == 30)
+        #expect(usage.secondary?.remainingPercent.rounded() == 90)
+        #expect(usage.extraRateWindows == nil)
     }
 
     @Test
@@ -1545,14 +1619,14 @@ extension AntigravityStatusProbeTests {
         let extraWindows = try #require(usage.extraRateWindows)
         let titles = extraWindows.map(\.title)
 
-        // Deterministic: label tiebreaker → Alpha before Zebra
+        // Deterministic: label tiebreaker -> Alpha before Zebra
         #expect(titles == ["Alpha Unknown Model", "Zebra Unknown Model"])
     }
 
     @Test
-    func `hyphenated raw model ids without display name parse minor version`() throws {
+    func `hyphenated raw model ids without display name still map to gemini group`() throws {
         // When the remote catalog omits displayName/label, the raw hyphenated model id
-        // becomes the label. The newer 3.1 entry must still sort before the 3.0 entry.
+        // becomes the label and still participates in the Gemini group.
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
                 AntigravityModelQuota(
@@ -1573,10 +1647,8 @@ extension AntigravityStatusProbeTests {
             source: .remote)
 
         let usage = try snapshot.toUsageSnapshot()
-        let titles = try #require(usage.extraRateWindows).map(\.title)
-
-        // 3.1 parses from the hyphenated id and sorts newest-first, ahead of 3.0.
-        #expect(titles == ["gemini-3-1-pro-low", "gemini-3-pro-high"])
+        #expect(usage.primary?.remainingPercent.rounded() == 100)
+        #expect(usage.extraRateWindows == nil)
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -130,7 +130,7 @@ struct CodexBarWidgetProviderTests {
     }
 
     @Test
-    func `legacy widget usage rows include tertiary slot when supported`() {
+    func `legacy widget usage rows use antigravity grouped slots`() {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let entry = WidgetSnapshot.ProviderEntry(
             provider: .antigravity,
@@ -145,9 +145,9 @@ struct CodexBarWidgetProviderTests {
 
         let rows = WidgetUsageRow.rows(for: entry)
 
-        #expect(rows.map(\.id) == ["primary", "secondary", "tertiary"])
-        #expect(rows.map(\.title) == ["Claude", "Gemini Pro", "Gemini Flash"])
-        #expect(rows.compactMap(\.percentLeft) == [90, 80, 70])
+        #expect(rows.map(\.id) == ["primary", "secondary"])
+        #expect(rows.map(\.title) == ["Gemini", "Claude + GPT"])
+        #expect(rows.compactMap(\.percentLeft) == [90, 80])
     }
 
     @Test

--- a/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
+++ b/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
@@ -94,6 +94,31 @@ struct MenuBarMetricWindowResolverTests {
     }
 
     @Test
+    func `automatic metric uses unclassified antigravity compact fallback`() throws {
+        let antigravitySnapshot = AntigravityStatusSnapshot(
+            modelQuotas: [
+                AntigravityModelQuota(
+                    label: "Experimental Model",
+                    modelId: "MODEL_PLACEHOLDER_NEW",
+                    remainingFraction: 0.36,
+                    resetTime: nil,
+                    resetDescription: nil),
+            ],
+            accountEmail: nil,
+            accountPlan: nil,
+            source: .local)
+        let snapshot = try antigravitySnapshot.toUsageSnapshot()
+
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .automatic,
+            provider: .antigravity,
+            snapshot: snapshot,
+            supportsAverage: false)
+
+        #expect(window?.usedPercent == 64)
+    }
+
+    @Test
     func `explicit antigravity metric keeps requested family lane`() {
         let snapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 0, windowMinutes: nil, resetsAt: nil, resetDescription: "Claude"),

--- a/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
+++ b/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
@@ -57,8 +57,8 @@ struct MenuBarMetricWindowResolverTests {
     }
 
     @Test
-    func `automatic metric ignores untracked antigravity family lane`() throws {
-        let untrackedReset = Date(timeIntervalSince1970: 1000)
+    func `automatic metric uses recognized antigravity gemini pool when claude gpt is reset only`() throws {
+        let resetOnlyReset = Date(timeIntervalSince1970: 1000)
         let exhaustedReset = Date(timeIntervalSince1970: 2000)
         let antigravitySnapshot = AntigravityStatusSnapshot(
             modelQuotas: [
@@ -66,7 +66,7 @@ struct MenuBarMetricWindowResolverTests {
                     label: "Claude Sonnet 4.6",
                     modelId: "claude-sonnet-4-6",
                     remainingFraction: nil,
-                    resetTime: untrackedReset,
+                    resetTime: resetOnlyReset,
                     resetDescription: nil),
                 AntigravityModelQuota(
                     label: "Gemini 3.1 Pro",
@@ -79,7 +79,9 @@ struct MenuBarMetricWindowResolverTests {
             accountPlan: nil,
             source: .local)
         let snapshot = try antigravitySnapshot.toUsageSnapshot()
-        #expect(snapshot.primary == nil)
+        #expect(snapshot.primary?.usedPercent == 100)
+        #expect(snapshot.primary?.resetsAt == exhaustedReset)
+        #expect(snapshot.secondary == nil)
 
         let window = MenuBarMetricWindowResolver.rateWindow(
             preference: .automatic,

--- a/Tests/CodexBarTests/MenuCardAntigravityTests.swift
+++ b/Tests/CodexBarTests/MenuCardAntigravityTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 struct MenuCardAntigravityTests {
     @Test
-    func `antigravity metrics show zero percent for missing families`() throws {
+    func `antigravity metrics omit missing groups`() throws {
         let now = Date()
         let identity = ProviderIdentitySnapshot(
             providerID: .antigravity,
@@ -44,20 +44,14 @@ struct MenuCardAntigravityTests {
             hidePersonalInfo: false,
             now: now))
 
-        #expect(model.metrics.count == 3)
-        #expect(model.metrics.map(\.title) == ["Claude", "Gemini Pro", "Gemini Flash"])
-        #expect(model.metrics[1].percent == 0)
-        #expect(model.metrics[1].percentLabel == "0% left")
-        #expect(model.metrics[1].statusText == nil)
-        #expect(model.metrics[1].detailText == nil)
-        #expect(model.metrics[2].percent == 0)
-        #expect(model.metrics[2].percentLabel == "0% left")
-        #expect(model.metrics[2].statusText == nil)
-        #expect(model.metrics[2].detailText == nil)
+        #expect(model.metrics.count == 1)
+        #expect(model.metrics.map(\.title) == ["Gemini"])
+        #expect(model.metrics[0].percent == 95)
+        #expect(model.metrics[0].percentLabel == "95% left")
     }
 
     @Test
-    func `antigravity untracked metric stays out of family summary`() throws {
+    func `antigravity untracked known row does not duplicate grouped summary`() throws {
         let now = Date(timeIntervalSince1970: 1_735_000_000)
         let resetTime = now.addingTimeInterval(3600)
         let antigravitySnapshot = AntigravityStatusSnapshot(
@@ -106,16 +100,12 @@ struct MenuCardAntigravityTests {
             hidePersonalInfo: false,
             now: now))
 
-        #expect(model.metrics[1].percent == 0)
-        #expect(model.metrics[1].percentLabel == "0% left")
-        #expect(model.metrics[1].resetText == nil)
-        let unknownMetric = try #require(model.metrics.first { $0.title == "Gemini 3.1 Pro (Low)" })
-        #expect(unknownMetric.statusText == "Unavailable - Resets in 1h")
-        #expect(unknownMetric.resetText == nil)
+        #expect(model.metrics.map(\.title) == ["Gemini", "Claude + GPT"])
+        #expect(!model.metrics.contains { $0.title == "Gemini 3.1 Pro (Low)" })
     }
 
     @Test
-    func `antigravity metrics include complete per model quota windows`() throws {
+    func `antigravity metrics collapse complete per model quota windows`() throws {
         let now = Date(timeIntervalSince1970: 1_735_000_000)
         let resetTime = now.addingTimeInterval(3600)
         let antigravitySnapshot = AntigravityStatusSnapshot(
@@ -172,34 +162,27 @@ struct MenuCardAntigravityTests {
             now: now))
 
         #expect(model.metrics.map(\.title) == [
-            "Claude",
-            "Gemini Pro",
-            "Gemini Flash",
-            "Claude Opus 4.6 (Thinking)",
-            "Gemini 3 Pro (High)",
-            "Gemini 3 Pro (Low)",
-            "GPT-OSS 120B (Medium)",
+            "Gemini",
+            "Claude + GPT",
         ])
-        #expect(model.metrics.suffix(4).map(\.percentLabel) == [
-            "75% left",
-            "100% left",
+        #expect(model.metrics.map(\.percentLabel) == [
             "50% left",
             "25% left",
         ])
     }
 
     @Test
-    func `antigravity per model extra windows still render when optional extras are disabled`() throws {
+    func `antigravity distinct extra windows still render when optional extras are disabled`() throws {
         // Regression: the optional-credits/extra-usage setting is Codex-specific and must NOT hide
-        // other providers' core extra windows (here Antigravity per-model quotas).
+        // other providers' core extra windows.
         let now = Date(timeIntervalSince1970: 1_735_000_000)
         let resetTime = now.addingTimeInterval(3600)
         let antigravitySnapshot = AntigravityStatusSnapshot(
             modelQuotas: [
                 AntigravityModelQuota(
-                    label: "Claude Opus 4.6 (Thinking)",
-                    modelId: "MODEL_PLACEHOLDER_M50",
-                    remainingFraction: 0.75,
+                    label: "Experimental Tool",
+                    modelId: "MODEL_PLACEHOLDER_UNKNOWN",
+                    remainingFraction: 0.5,
                     resetTime: resetTime,
                     resetDescription: nil),
                 AntigravityModelQuota(
@@ -234,13 +217,113 @@ struct MenuCardAntigravityTests {
             hidePersonalInfo: false,
             now: now))
 
-        // Per-model extra windows remain visible even with optional extras disabled.
-        #expect(model.metrics.contains { $0.title == "Claude Opus 4.6 (Thinking)" })
-        #expect(model.metrics.contains { $0.title == "Gemini 3 Pro (High)" })
+        // Distinct extra windows remain visible even with optional extras disabled.
+        #expect(model.metrics.contains { $0.title == "Experimental Tool" })
+        #expect(model.metrics.contains { $0.title == "Gemini" })
     }
 
     @Test
-    func `antigravity missing families show full usage in used mode`() throws {
+    func `antigravity quota summary renders named session and weekly rows`() throws {
+        let now = Date(timeIntervalSince1970: 1_735_000_000)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 27,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: "You have used some of your 5-hour limit, it will fully refresh in 3 hours."),
+            secondary: RateWindow(
+                usedPercent: 18,
+                windowMinutes: 10080,
+                resetsAt: nil,
+                resetDescription: "You have used some of your weekly limit, it will fully refresh in 5 days."),
+            tertiary: nil,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-gemini-5h",
+                    title: "Gemini Session",
+                    window: RateWindow(
+                        usedPercent: 9,
+                        windowMinutes: 300,
+                        resetsAt: nil,
+                        resetDescription: "You have used some of your 5-hour limit, it will fully refresh in "
+                            + "4 hours.")),
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-gemini-weekly",
+                    title: "Gemini Weekly",
+                    window: RateWindow(
+                        usedPercent: 18,
+                        windowMinutes: 10080,
+                        resetsAt: nil,
+                        resetDescription: "You have used some of your weekly limit, it will fully refresh in 5 days.")),
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-3p-5h",
+                    title: "Claude + GPT Session",
+                    window: RateWindow(
+                        usedPercent: 27,
+                        windowMinutes: 300,
+                        resetsAt: nil,
+                        resetDescription: "You have used some of your 5-hour limit, it will fully refresh in "
+                            + "3 hours.")),
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-3p-weekly",
+                    title: "Claude + GPT Weekly",
+                    window: RateWindow(
+                        usedPercent: 36,
+                        windowMinutes: 10080,
+                        resetsAt: nil,
+                        resetDescription: "You have used some of your weekly limit, it will fully refresh in 6 days.")),
+            ],
+            updatedAt: now,
+            identity: ProviderIdentitySnapshot(
+                providerID: .antigravity,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "Pro"))
+        let metadata = try #require(ProviderDefaults.metadata[.antigravity])
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .antigravity,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: false,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.metrics.map(\.id) == [
+            "antigravity-quota-summary-gemini-5h",
+            "antigravity-quota-summary-gemini-weekly",
+            "antigravity-quota-summary-3p-5h",
+            "antigravity-quota-summary-3p-weekly",
+        ])
+        #expect(model.metrics.map(\.title) == [
+            "Gemini Session",
+            "Gemini Weekly",
+            "Claude + GPT Session",
+            "Claude + GPT Weekly",
+        ])
+        #expect(model.metrics.map(\.percentLabel) == [
+            "91% left",
+            "82% left",
+            "73% left",
+            "64% left",
+        ])
+        #expect(model.metrics[2].resetText == "Resets in 3 hours")
+    }
+
+    @Test
+    func `antigravity missing groups are omitted in used mode`() throws {
         let now = Date()
         let identity = ProviderIdentitySnapshot(
             providerID: .antigravity,
@@ -279,9 +362,9 @@ struct MenuCardAntigravityTests {
             hidePersonalInfo: false,
             now: now))
 
-        #expect(model.metrics[1].percent == 100)
-        #expect(model.metrics[1].percentLabel == "100% used")
-        #expect(model.metrics[2].percent == 100)
-        #expect(model.metrics[2].percentLabel == "100% used")
+        #expect(model.metrics.count == 1)
+        #expect(model.metrics[0].title == "Gemini")
+        #expect(model.metrics[0].percent == 5)
+        #expect(model.metrics[0].percentLabel == "5% used")
     }
 }

--- a/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
+++ b/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
@@ -184,7 +184,7 @@ struct ProviderDiagnosticExportTests {
             result: .failure(ProviderFetchError.noAvailableStrategy(.antigravity)),
             attempts: [
                 ProviderFetchAttempt(
-                    strategyID: "antigravity.local",
+                    strategyID: "antigravity.ide-local",
                     kind: .localProbe,
                     wasAvailable: true,
                     errorDescription: "unauthenticated local probe"),

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -63,6 +63,19 @@ struct ProviderSettingsDescriptorTests {
     }
 
     @Test
+    func `antigravity usage source picker clarifies local ide and agy`() throws {
+        let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-antigravity-source")
+        let context = fixture.settingsContext(provider: .antigravity)
+
+        let pickers = AntigravityProviderImplementation().settingsPickers(context: context)
+        let usagePicker = try #require(pickers.first(where: { $0.id == "antigravity-usage-source" }))
+
+        #expect(usagePicker.options.map(\.title) == ["Auto", "Google OAuth", "Local API / agy CLI"])
+        #expect(usagePicker.subtitle ==
+            "Auto uses Antigravity app, then agy CLI, then IDE; OAuth is used for selected accounts.")
+    }
+
+    @Test
     func `codex exposes open AI web extras toggle as default off opt in`() throws {
         let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-codex-openai-toggle")
         let context = fixture.settingsContext(provider: .codex)

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -72,7 +72,7 @@ struct ProviderSettingsDescriptorTests {
 
         #expect(usagePicker.options.map(\.title) == ["Auto", "Google OAuth", "Local API / agy CLI"])
         #expect(usagePicker.subtitle ==
-            "Auto uses Antigravity app, then agy CLI, then IDE; OAuth is used for selected accounts.")
+            "Auto tries Antigravity app, agy CLI, then IDE; OAuth follows for selected or signed-in accounts.")
     }
 
     @Test

--- a/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
@@ -544,6 +544,67 @@ struct SettingsStoreCoverageTests {
     }
 
     @Test
+    func `removing last antigravity oauth account clears matching shared credentials`() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("antigravity-shared-removal-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let sharedStore = AntigravityOAuthCredentialsStore(
+            fileURL: root.appendingPathComponent("oauth_creds.json"))
+        let credentials = AntigravityOAuthCredentials(
+            accessToken: "shared-access",
+            refreshToken: "shared-refresh",
+            expiryDate: Date(timeIntervalSince1970: 1_700_000_000),
+            email: "user@example.com")
+        try sharedStore.save(credentials)
+        let settings = Self.makeSettingsStore(
+            suiteName: "SettingsStoreCoverageTests-antigravity-remove-shared",
+            antigravityOAuthCredentialsStore: sharedStore)
+
+        settings.upsertAntigravityOAuthAccount(credentials)
+        let account = try #require(settings.selectedTokenAccount(for: .antigravity))
+        settings.removeTokenAccount(provider: .antigravity, accountID: account.id)
+
+        #expect(settings.tokenAccounts(for: .antigravity).isEmpty)
+        let sharedCredentials = try await Self.waitForSharedAntigravityCredentials(in: sharedStore) { $0 == nil }
+        #expect(sharedCredentials == nil)
+    }
+
+    @Test
+    func `removing antigravity oauth account preserves different shared credentials`() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("antigravity-shared-preserve-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let sharedStore = AntigravityOAuthCredentialsStore(
+            fileURL: root.appendingPathComponent("oauth_creds.json"))
+        let removed = AntigravityOAuthCredentials(
+            accessToken: "removed-access",
+            refreshToken: "removed-refresh",
+            expiryDate: Date(timeIntervalSince1970: 1_700_000_000),
+            email: "removed@example.com")
+        let shared = AntigravityOAuthCredentials(
+            accessToken: "shared-access",
+            refreshToken: "shared-refresh",
+            expiryDate: Date(timeIntervalSince1970: 1_700_000_000),
+            email: "shared@example.com")
+        try sharedStore.save(shared)
+        let settings = Self.makeSettingsStore(
+            suiteName: "SettingsStoreCoverageTests-antigravity-preserve-shared",
+            antigravityOAuthCredentialsStore: sharedStore)
+
+        settings.upsertAntigravityOAuthAccount(removed)
+        let account = try #require(settings.selectedTokenAccount(for: .antigravity))
+        settings.removeTokenAccount(provider: .antigravity, accountID: account.id)
+
+        #expect(settings.tokenAccounts(for: .antigravity).isEmpty)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(try sharedStore.load() == shared)
+    }
+
+    @Test
     func `weekly progress work days defaults to nil and persists across store reload`() throws {
         let suite = "SettingsStoreCoverageTests-weekly-progress-work-days"
         let defaults = try #require(UserDefaults(suiteName: suite))
@@ -575,17 +636,26 @@ struct SettingsStoreCoverageTests {
         #expect(reloaded4.weeklyProgressWorkDays == nil)
     }
 
-    private static func makeSettingsStore(suiteName: String = "SettingsStoreCoverageTests") -> SettingsStore {
+    private static func makeSettingsStore(
+        suiteName: String = "SettingsStoreCoverageTests",
+        antigravityOAuthCredentialsStore: AntigravityOAuthCredentialsStore = AntigravityOAuthCredentialsStore())
+        -> SettingsStore
+    {
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
         defaults.set(false, forKey: "debugDisableKeychainAccess")
         let configStore = testConfigStore(suiteName: suiteName)
-        return Self.makeSettingsStore(userDefaults: defaults, configStore: configStore)
+        return Self.makeSettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            antigravityOAuthCredentialsStore: antigravityOAuthCredentialsStore)
     }
 
     private static func makeSettingsStore(
         userDefaults: UserDefaults,
-        configStore: CodexBarConfigStore) -> SettingsStore
+        configStore: CodexBarConfigStore,
+        antigravityOAuthCredentialsStore: AntigravityOAuthCredentialsStore = AntigravityOAuthCredentialsStore())
+        -> SettingsStore
     {
         SettingsStore(
             userDefaults: userDefaults,
@@ -604,6 +674,22 @@ struct SettingsStoreCoverageTests {
             augmentCookieStore: InMemoryCookieHeaderStore(),
             ampCookieStore: InMemoryCookieHeaderStore(),
             copilotTokenStore: InMemoryCopilotTokenStore(),
-            tokenAccountStore: InMemoryTokenAccountStore())
+            tokenAccountStore: InMemoryTokenAccountStore(),
+            antigravityOAuthCredentialsStore: antigravityOAuthCredentialsStore)
+    }
+
+    private static func waitForSharedAntigravityCredentials(
+        in store: AntigravityOAuthCredentialsStore,
+        matches predicate: (AntigravityOAuthCredentials?) -> Bool) async throws
+        -> AntigravityOAuthCredentials?
+    {
+        for _ in 0..<100 {
+            let credentials = try store.load()
+            if predicate(credentials) {
+                return credentials
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return try store.load()
     }
 }

--- a/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
@@ -157,6 +157,54 @@ struct UsageStoreHighestUsageTests {
     }
 
     @Test
+    func `automatic metric ranks unclassified antigravity compact fallback`() throws {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-unclassified"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.setMenuBarMetricPreference(.automatic, for: .antigravity)
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let antigravityMeta = registry.metadata[.antigravity] {
+            settings.setProviderEnabled(provider: .antigravity, metadata: antigravityMeta, enabled: true)
+        }
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let codexSnapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 50, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+        let antigravitySnapshot = try AntigravityStatusSnapshot(
+            modelQuotas: [
+                AntigravityModelQuota(
+                    label: "Experimental Model",
+                    modelId: "MODEL_PLACEHOLDER_NEW",
+                    remainingFraction: 0.36,
+                    resetTime: nil,
+                    resetDescription: nil),
+            ],
+            accountEmail: nil,
+            accountPlan: nil,
+            source: .local)
+            .toUsageSnapshot()
+
+        store._setSnapshotForTesting(codexSnapshot, provider: .codex)
+        store._setSnapshotForTesting(antigravitySnapshot, provider: .antigravity)
+
+        let highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .antigravity)
+        #expect(highest?.usedPercent == 64)
+    }
+
+    @Test
     func `automatic metric ranks antigravity by constrained gemini family lane`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-constrained-gemini"),

--- a/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
+++ b/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
@@ -6,8 +6,8 @@ import Testing
 @MainActor
 struct UsageStoreWidgetSnapshotTests {
     @Test
-    func `widget snapshot includes antigravity tertiary usage row`() async throws {
-        let suite = "UsageStoreWidgetSnapshotTests-antigravity-tertiary"
+    func `widget snapshot includes antigravity grouped usage rows`() async throws {
+        let suite = "UsageStoreWidgetSnapshotTests-antigravity-grouped"
         let defaults = try #require(UserDefaults(suiteName: suite))
         defaults.removePersistentDomain(forName: suite)
 
@@ -39,13 +39,78 @@ struct UsageStoreWidgetSnapshotTests {
         store._test_widgetSnapshotSaveOverride = { widgetSnapshots.append($0) }
         defer { store._test_widgetSnapshotSaveOverride = nil }
 
-        store.persistWidgetSnapshot(reason: "antigravity-tertiary-test")
+        store.persistWidgetSnapshot(reason: "antigravity-grouped-test")
         await store.widgetSnapshotPersistTask?.value
 
         let entry = try #require(widgetSnapshots.last?.entries.first { $0.provider == .antigravity })
-        #expect(entry.usageRows?.map(\.id) == ["primary", "secondary", "tertiary"])
-        #expect(entry.usageRows?.map(\.title) == ["Claude", "Gemini Pro", "Gemini Flash"])
-        #expect(entry.usageRows?.compactMap(\.percentLeft) == [90, 80, 70])
+        #expect(entry.usageRows?.map(\.id) == ["primary", "secondary"])
+        #expect(entry.usageRows?.map(\.title) == ["Gemini", "Claude + GPT"])
+        #expect(entry.usageRows?.compactMap(\.percentLeft) == [90, 80])
+    }
+
+    @Test
+    func `widget snapshot includes antigravity quota summary rows`() async throws {
+        let suite = "UsageStoreWidgetSnapshotTests-antigravity-quota-summary"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 27, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            tertiary: nil,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-gemini-5h",
+                    title: "Gemini Session",
+                    window: RateWindow(usedPercent: 9, windowMinutes: 300, resetsAt: nil, resetDescription: nil)),
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-gemini-weekly",
+                    title: "Gemini Weekly",
+                    window: RateWindow(usedPercent: 18, windowMinutes: 10080, resetsAt: nil, resetDescription: nil)),
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-3p-5h",
+                    title: "Claude + GPT Session",
+                    window: RateWindow(usedPercent: 27, windowMinutes: 300, resetsAt: nil, resetDescription: nil)),
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-3p-weekly",
+                    title: "Claude + GPT Weekly",
+                    window: RateWindow(usedPercent: 36, windowMinutes: 10080, resetsAt: nil, resetDescription: nil)),
+            ],
+            updatedAt: Date(),
+            identity: ProviderIdentitySnapshot(
+                providerID: .antigravity,
+                accountEmail: nil,
+                accountOrganization: nil,
+                loginMethod: "Pro"))
+
+        store._setSnapshotForTesting(snapshot, provider: .antigravity)
+
+        var widgetSnapshots: [WidgetSnapshot] = []
+        store._test_widgetSnapshotSaveOverride = { widgetSnapshots.append($0) }
+        defer { store._test_widgetSnapshotSaveOverride = nil }
+
+        store.persistWidgetSnapshot(reason: "antigravity-quota-summary-test")
+        await store.widgetSnapshotPersistTask?.value
+
+        let entry = try #require(widgetSnapshots.last?.entries.first { $0.provider == .antigravity })
+        #expect(entry.usageRows?.map(\.title) == [
+            "Gemini Session",
+            "Gemini Weekly",
+            "Claude + GPT Session",
+            "Claude + GPT Weekly",
+        ])
+        #expect(entry.usageRows?.compactMap(\.percentLeft) == [91, 82, 73, 64])
     }
 
     @Test

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -29,10 +29,10 @@ Older local payloads may only include raw Claude, GPT-OSS, Gemini tiers, account
 Current Antigravity IDE local endpoints return `GetUserStatus`, `GetAvailableModels`, and `GetCascadeModelConfigData`
 with five-hour/session reset data, but not the app/CLI `RetrieveUserQuotaSummary` weekly/session grouping. OAuth
 payloads can be less complete and may only prove model availability. Treat `auto` as the authoritative user-facing mode:
-it accepts the first account-matching source in Antigravity app -> `agy` CLI -> Antigravity IDE order, and only adds OAuth
-when CodexBar has a selected/injected Google account. An all-100% `fetchAvailableModels` payload is only accepted after
-`retrieveUserQuota` echoes bucket fractions; this can be an availability-style fallback rather than the full
-Antigravity quota summary.
+it accepts the first account-matching source in Antigravity app -> `agy` CLI -> Antigravity IDE order, and adds OAuth
+when CodexBar has a selected/injected Google account or an existing shared credentials file. An all-100%
+`fetchAvailableModels` payload is only accepted after `retrieveUserQuota` echoes bucket fractions; this can be an
+availability-style fallback rather than the full Antigravity quota summary.
 
 ## OAuth account switching
 
@@ -42,8 +42,8 @@ Antigravity quota summary.
 - When a token account is selected, the OAuth fetcher uses that account before falling back to the shared credentials file.
   In `auto` mode the ambient Antigravity app, `agy` CLI, and IDE probes still run first, but a snapshot whose account
   does not match the selected account is rejected so the pipeline falls through to the account-scoped OAuth fetch (see
-  `AntigravitySelectedAccountGuard`). If no account is selected/injected, `auto` does not use the shared OAuth file;
-  choose explicit `Google OAuth` for that. Explicit `cli`/`oauth` source modes stay authoritative and are not re-checked.
+  `AntigravitySelectedAccountGuard`). If no account is selected/injected, `auto` includes OAuth only when the legacy
+  shared credentials file already exists. Explicit `cli`/`oauth` source modes stay authoritative and are not re-checked.
 - Removing the last saved token account that matches `~/.codexbar/antigravity/oauth_creds.json` deletes that shared file,
   so a removed CodexBar account does not silently continue refreshing through the legacy shared cache.
 - The menu action is labeled `Add Account...`; switching between saved accounts scopes Google OAuth fetches.
@@ -155,11 +155,11 @@ weekly limit shown by Antigravity 2.0.
 
 ### 4) OAuth remote fallback
 
-When source mode is `auto`, OAuth is used after app, `agy` CLI, and IDE paths fail only if CodexBar has a
-selected/injected Google account. The app, `agy` CLI, and IDE probes still run first, but in `auto` mode their snapshots
-are accepted only when the reported account matches the selected account; otherwise the pipeline falls through to this
-account-scoped OAuth fetch. When source mode is `oauth`, only OAuth is used and the shared OAuth file can still be used
-as a fallback credential source.
+When source mode is `auto`, OAuth is used after app, `agy` CLI, and IDE paths fail if CodexBar has a selected/injected
+Google account or an existing shared credentials file. The app, `agy` CLI, and IDE probes still run first, but in
+`auto` mode their snapshots are accepted only when the reported account matches the selected account; otherwise the
+pipeline falls through to this account-scoped OAuth fetch. When source mode is `oauth`, only OAuth is used and the
+shared OAuth file can still be used as a fallback credential source.
 
 ## Request body (summary)
 - Minimal metadata payload:

--- a/docs/antigravity.md
+++ b/docs/antigravity.md
@@ -9,14 +9,30 @@ read_when:
 
 # Antigravity provider
 
-Antigravity supports three usage data sources:
+Antigravity supports four usage data sources:
 
-1. The desktop app's local `language_server` (preferred when the IDE/desktop app is open).
-2. The `agy` CLI's embedded HTTPS localhost server (used when the desktop app is closed).
-3. Google OAuth-backed remote usage (final fallback, and the source used for multi-account switching). The OAuth path can store multiple Google accounts through the shared token-account switcher.
+1. The Antigravity 2.0 app's local `language_server` (preferred when the app is open).
+2. The `agy` CLI's embedded HTTPS localhost server (preferred over the IDE because it exposes richer quota data).
+3. The Antigravity IDE extension `language_server` (used after `agy` CLI because current IDE local payloads only expose session/model quota data).
+4. Google OAuth-backed remote usage (explicit OAuth mode, and the account-scoped fallback used for multi-account switching). The OAuth path can store multiple Google accounts through the shared token-account switcher.
 
-The local and CLI paths both prefer Antigravity's internal `GetUserStatus` quota payload and may fall back to
-`GetCommandModelConfigs`; CodexBar never scrapes the desktop UI or the `agy` TUI.
+The local and CLI paths both prefer Antigravity's internal `RetrieveUserQuotaSummary` quota payload and may fall back to
+`GetUserStatus`, then `GetCommandModelConfigs`; CodexBar never scrapes the desktop UI or the `agy` TUI.
+
+As of Antigravity 2.x, the Antigravity app and `agy` CLI payloads can be richer than Google OAuth and IDE payloads.
+`RetrieveUserQuotaSummary` exposes the same two groups shown by Antigravity's Model Quota UI:
+
+- `Gemini Models`: weekly limit and five-hour limit.
+- `Claude and GPT models`: weekly limit and five-hour limit.
+
+Older local payloads may only include raw Claude, GPT-OSS, Gemini tiers, account plan, and session reset timestamps.
+Current Antigravity IDE local endpoints return `GetUserStatus`, `GetAvailableModels`, and `GetCascadeModelConfigData`
+with five-hour/session reset data, but not the app/CLI `RetrieveUserQuotaSummary` weekly/session grouping. OAuth
+payloads can be less complete and may only prove model availability. Treat `auto` as the authoritative user-facing mode:
+it accepts the first account-matching source in Antigravity app -> `agy` CLI -> Antigravity IDE order, and only adds OAuth
+when CodexBar has a selected/injected Google account. An all-100% `fetchAvailableModels` payload is only accepted after
+`retrieveUserQuota` echoes bucket fractions; this can be an availability-style fallback rather than the full
+Antigravity quota summary.
 
 ## OAuth account switching
 
@@ -24,9 +40,12 @@ The local and CLI paths both prefer Antigravity's internal `GetUserStatus` quota
 - A successful login writes the latest shared credentials to `~/.codexbar/antigravity/oauth_creds.json` and upserts a token-account entry for the Google account.
 - Each token-account entry stores serialized `AntigravityOAuthCredentials` and is injected into remote fetches through `ANTIGRAVITY_OAUTH_CREDENTIALS_JSON`.
 - When a token account is selected, the OAuth fetcher uses that account before falling back to the shared credentials file.
-  In `auto` mode the ambient local desktop and `agy` CLI probes still run first, but a snapshot whose account does not
-  match the selected account is rejected so the pipeline falls through to the account-scoped OAuth fetch (see
-  `AntigravitySelectedAccountGuard`). Explicit `cli`/`oauth` source modes stay authoritative and are not re-checked.
+  In `auto` mode the ambient Antigravity app, `agy` CLI, and IDE probes still run first, but a snapshot whose account
+  does not match the selected account is rejected so the pipeline falls through to the account-scoped OAuth fetch (see
+  `AntigravitySelectedAccountGuard`). If no account is selected/injected, `auto` does not use the shared OAuth file;
+  choose explicit `Google OAuth` for that. Explicit `cli`/`oauth` source modes stay authoritative and are not re-checked.
+- Removing the last saved token account that matches `~/.codexbar/antigravity/oauth_creds.json` deletes that shared file,
+  so a removed CodexBar account does not silently continue refreshing through the legacy shared cache.
 - The menu action is labeled `Add Account...`; switching between saved accounts scopes Google OAuth fetches.
 
 ## Remote OAuth data sources
@@ -35,35 +54,43 @@ The local and CLI paths both prefer Antigravity's internal `GetUserStatus` quota
 - `POST https://cloudcode-pa.googleapis.com/v1internal:onboardUser`
 - `POST https://cloudcode-pa.googleapis.com/v1internal:fetchAvailableModels`
 - `POST https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota`
+- `POST https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuotaSummary` (available, but current observed OAuth
+  responses are model-bucket shaped rather than Antigravity 2.0's two quota groups)
 
 ## Data sources + fallback order
 
-### 1) Desktop local probe
+### 1) Antigravity app local probe
 
-When the Antigravity desktop app is running:
+When the Antigravity 2.0 app is running:
 
 1. **Process detection**
    - Command: `ps -ax -o pid=,command=`.
-   - The desktop local strategy scopes detection to **IDE** language servers only
-     (`AntigravityStatusProbe(processScope: .ideOnly)`). It deliberately does **not**
-     attach to an `agy` CLI process: a stale or still-initializing `agy` accepts the
-     connection but returns transient `GetUserStatus` errors, which would burn the
-     probe timeout. `agy` is owned exclusively by the CLI HTTPS source below, which
-     waits for real API readiness. The probe still classifies both kinds
+   - The app local strategy scopes detection to the **Antigravity app** language server only
+     (`AntigravityStatusProbe(processScope: .appOnly)`). It deliberately does **not**
+     attach to an IDE or `agy` CLI process: a lower-information IDE payload should not mask
+     `agy`'s richer quota summary, and a stale or still-initializing `agy` can accept the
+     connection before it is ready. `agy` is owned exclusively by the CLI HTTPS source below,
+     which waits for real API readiness. The probe still classifies all kinds
      (`processInfo(scope: .ideAndCLI)` is used by `isRunning()` for status reporting):
-     - the **IDE** language server: process name `language_server*` or `language-server` plus
+     - the **Antigravity app** language server: process names such as `language_server`, `language_server_macos`,
+       `language_server_macos_arm`, or `language-server` plus
        Antigravity markers (`--app_data_dir antigravity`, an Antigravity app bundle path,
        or a path containing `/antigravity/`); or
+     - the **IDE** language server: the Antigravity IDE extension language server, usually under
+       `Antigravity IDE.app/.../extensions/antigravity/bin/` with `--app_data_dir antigravity-ide`; or
      - the **CLI**: an `antigravity-cli` / `antigravity_cli` path segment, or the
        `agy` binary (path-anchored so unrelated arguments/binaries do not match).
+   - CodexBar collects all valid local app language-server candidates and probes each reachable one. If multiple
+     app processes are open, it prefers the richer quota-summary snapshot over the legacy `GetUserStatus`
+     two-pool fallback.
    - Extract CLI flags:
      - `--csrf_token <token>`. Requirement depends on the match kind:
-       - **IDE** matches still require it — a tokenless IDE language-server match is
-         skipped so a later valid IDE server can be found, otherwise `missingCSRFToken`
+       - **App/IDE** matches still require it - a tokenless desktop language-server match is
+         skipped so a later valid server can be found, otherwise `missingCSRFToken`
          is reported (unchanged behavior).
        - **CLI** matches accept an empty token, because the CLI's language server
          exposes no `--csrf_token` flag and requires none.
-     - `--extension_server_port <port>` (HTTP fallback; IDE only).
+     - `--extension_server_port <port>` (HTTP fallback; app/IDE only).
      - `--extension_server_csrf_token <token>` (preferred HTTP fallback token when present).
 
 2. **Port discovery**
@@ -79,8 +106,10 @@ When the Antigravity desktop app is running:
 
 4. **Quota fetch**
    - Primary:
+     - `POST https://127.0.0.1:<connectPort>/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary`
+   - Fallback 1:
      - `POST https://127.0.0.1:<connectPort>/exa.language_server_pb.LanguageServerService/GetUserStatus`
-   - Fallback:
+   - Fallback 2:
      - `POST https://127.0.0.1:<connectPort>/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs`
    - If HTTPS fails, retry over HTTP on `extension_server_port`.
 
@@ -99,8 +128,9 @@ CodexBar launches `agy` in a PTY because the CLI exposes its quota server only w
 The implementation still does **not** scrape terminal output; it only keeps the process alive, drains discarded PTY
 rendering, discovers listening ports with `lsof`, and probes the local HTTPS server:
 
-- First: `POST https://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/GetUserStatus`
-- Fallback: `POST https://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs`
+- First: `POST https://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary`
+- Fallback 1: `POST https://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/GetUserStatus`
+- Fallback 2: `POST https://127.0.0.1:<port>/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs`
 
 The fallback can return quota without the account email or plan fields from `GetUserStatus`.
 
@@ -115,12 +145,21 @@ Differences from the desktop local probe:
 - CodexBar records the launched pid + executable identity and conservatively reaps only its own matching stale `agy`
   process on the next launch. It never blind-kills a user-launched `agy`.
 
-### 3) OAuth remote fallback
+### 3) Antigravity IDE local probe
 
-When source mode is `auto`, OAuth is used after both local paths fail. A selected saved Google account scopes the OAuth
-fallback. The local and `agy` CLI probes still run first, but in `auto` mode their snapshots are accepted only when the
-reported account matches the selected account; otherwise the pipeline falls through to this account-scoped OAuth fetch.
-When source mode is `oauth`, only OAuth is used.
+When the Antigravity 2.0 app and `agy` CLI are unavailable, CodexBar probes Antigravity IDE language servers with
+`AntigravityStatusProbe(processScope: .ideOnly)`. Current observed IDE payloads return model-level/session quota data
+through `GetUserStatus`, `GetAvailableModels`, and `GetCascadeModelConfigData`; `RetrieveUserQuotaSummary` returns 404
+from the IDE local server. This means the IDE fallback can show session bars, but should not be expected to provide the
+weekly limit shown by Antigravity 2.0.
+
+### 4) OAuth remote fallback
+
+When source mode is `auto`, OAuth is used after app, `agy` CLI, and IDE paths fail only if CodexBar has a
+selected/injected Google account. The app, `agy` CLI, and IDE probes still run first, but in `auto` mode their snapshots
+are accepted only when the reported account matches the selected account; otherwise the pipeline falls through to this
+account-scoped OAuth fetch. When source mode is `oauth`, only OAuth is used and the shared OAuth file can still be used
+as a fallback credential source.
 
 ## Request body (summary)
 - Minimal metadata payload:
@@ -130,14 +169,27 @@ When source mode is `oauth`, only OAuth is used.
   - `ideVersion: unknown`
 
 ## Parsing and model mapping
-- Source fields:
+- Preferred source fields:
+  - `response.groups[].displayName`
+  - `response.groups[].buckets[].bucketId`
+  - `response.groups[].buckets[].displayName`
+  - `response.groups[].buckets[].remaining.remainingFraction`
+  - `response.groups[].buckets[].description`
+- Legacy source fields:
   - `userStatus.cascadeModelConfigData.clientModelConfigs[].quotaInfo.remainingFraction`
   - `userStatus.cascadeModelConfigData.clientModelConfigs[].quotaInfo.resetTime`
-- Mapping priority:
-  1) Claude family (thinking variants participate in the normal Claude representative selection)
-  2) Gemini Pro Low
-  3) Gemini Flash
-  4) Fallback: lowest remaining percent
+- Preferred quota summary UI:
+  - Render `Gemini Session`, `Gemini Weekly`, `Claude + GPT Session`, and `Claude + GPT Weekly` as named windows.
+  - Keep Antigravity's bucket description as reset prose; infer `windowMinutes` from the bucket ID/display name.
+  - Use the most constrained known bucket as the compact/menu-bar metric.
+- Legacy user-facing quota groups:
+  - `Gemini` groups Gemini Pro and Gemini Flash text models.
+  - `Claude + GPT` groups Claude text models and GPT/GPT-OSS text models.
+- Representative selection:
+  - Hidden model rows such as Lite, autocomplete, and image variants do not drive summary bars.
+  - For each group, CodexBar uses the lowest remaining known quota row and preserves that row's reset metadata.
+  - Rows with reset metadata but no remaining fraction stay visible as unavailable reset context only when their group
+    has no known usage row.
 - `resetTime` parsing:
   - ISO-8601 preferred; numeric epoch seconds as fallback.
 - Identity:
@@ -146,12 +198,11 @@ When source mode is `oauth`, only OAuth is used.
 ## UI mapping
 - Provider metadata:
   - Display: `Antigravity`
-  - Labels: `Claude` (primary), `Gemini Pro` (secondary), `Gemini Flash` (tertiary)
+  - Labels: `Gemini` (primary), `Claude + GPT` (secondary)
 - Status badge: Google Workspace incidents for the Gemini product.
-- Antigravity has independent Claude, Gemini Pro, Gemini Flash, and additional model-specific quota windows such as
-  GPT-OSS. In automatic menu-bar/highest-usage selection, CodexBar treats the provider as exhausted only when the
-  displayed Claude/Gemini summary lanes are exhausted; additional model windows remain visible in detailed usage
-  breakdowns.
+- Antigravity exposes many model rows, but current local payloads show them collapsing into two real usage pools:
+  Gemini and Claude/GPT. Detailed usage should not list every raw Gemini tier unless a future source exposes a genuinely
+  distinct unknown or consumed quota window.
 - Some Antigravity local/CLI model config entries include reset metadata but omit `remainingFraction`. Those windows stay
   in `extraRateWindows` for reset context and are marked with `usageKnown: false`; clients should not render their
   `usedPercent` as a real exhausted quota.


### PR DESCRIPTION
## Summary

This PR improves Antigravity usage detection and display so CodexBar reflects Antigravity's current quota model.

Antigravity quotas are now shown as two shared model pools:

1. Gemini Session
2. Gemini Weekly
3. Claude + GPT Session
4. Claude + GPT Weekly

The session row corresponds to Antigravity's 5-hour limit.

## What Changed

- Prefer richer local Antigravity sources in this order:
  - Antigravity 2.0 app
  - `agy` CLI
  - Antigravity IDE
  - Google OAuth when selected, injected, or already signed in through the shared credentials file
- Add parsing for Antigravity's `RetrieveUserQuotaSummary` endpoint.
- Normalize Antigravity quota groups into `Gemini` and `Claude + GPT`.
- Keep generic primary/secondary lanes semantically aligned with their Gemini and Claude + GPT labels while preserving every session/weekly bucket as a named window.
- Rename the 5-hour limit to `Session`.
- Preserve legacy local unclassified text-model quota fallback for compact and highest-usage displays.
- Preserve legacy model-quota fallback when the full quota summary is unavailable.
- Preserve the OAuth generic Gemini fallback.
- Improve local app/IDE/CLI process detection.
- Keep selected-account identity authoritative when multiple local Antigravity processes are running.
- Update menu, widget, highest-usage, diagnostics, settings copy, and documentation for the quota-summary rows and OAuth fallback.
- Add focused tests for parser, source ordering, local probing, OAuth fallback, multi-account selection, legacy fallback, menu rendering, widget rendering, and account cleanup.

## Notes

The Antigravity IDE may still expose less quota information than the Antigravity 2.0 app. When the full quota summary endpoint is unavailable, CodexBar falls back to the older model/session quota data instead of inventing weekly rows.

## Manual Proof

Attached screenshot shows the expected Antigravity menu output:

- Gemini Session
- Gemini Weekly
- Claude + GPT Session
- Claude + GPT Weekly
<img width="295" height="248" alt="Screenshot 2026-06-13 at 22 28 11" src="https://github.com/user-attachments/assets/3c6085b2-9f63-4104-955d-8c5e2ffc7868" />

## Validation

- `swift test --filter 'AntigravityQuotaSummaryTests|AntigravityStatusProbeTests|AntigravityCompactFallbackTests|MenuBarMetricWindowResolverTests|UsageStoreHighestUsageTests' --skip-update`
  - Passed: 97 tests in 5 suites
- Earlier broad Antigravity matrix
  - Passed: 253 tests in 11 suites
- `make check`
  - Passed with 0 lint violations
- `git diff --check origin/main...HEAD`
  - Passed
- Maintainer autoreview
  - Found and fixed selected-account routing, legacy compact fallback, and mislabeled generic quota lanes
  - Final full-branch review clean with no actionable findings