### PR TITLE
Fix Antigravity local TLS errors on Linux (fix #1508)

### DIFF
--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -123,11 +123,7 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     }
 
     private static var supportsLocalhostServerTrust: Bool {
-        #if os(Linux)
-        false
-        #else
         true
-        #endif
     }
 
     private func fetchUsingWarmSession(

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -510,12 +510,19 @@ public struct AntigravityStatusProbe: Sendable {
         guard !ports.isEmpty else {
             throw AntigravityStatusProbeError.portDetectionFailed("no listening ports found")
         }
-        let endpoints = ports.map {
-            AntigravityConnectionEndpoint(
-                scheme: "https",
-                port: $0,
-                csrfToken: "",
-                source: .cliHTTPS)
+        let endpoints = ports.flatMap { port in
+            [
+                AntigravityConnectionEndpoint(
+                    scheme: "https",
+                    port: port,
+                    csrfToken: "",
+                    source: .cliHTTPS),
+                AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: port,
+                    csrfToken: "",
+                    source: .cliHTTPS)
+            ]
         }
         let context = RequestContext(endpoints: endpoints, timeout: self.timeout, deadline: deadline)
         return try await Self.fetchSnapshot(context: context)
@@ -887,12 +894,19 @@ public struct AntigravityStatusProbe: Sendable {
         listeningPorts: [Int],
         languageServerCSRFToken: String) -> [AntigravityConnectionEndpoint]
     {
-        listeningPorts.map {
-            AntigravityConnectionEndpoint(
-                scheme: "https",
-                port: $0,
-                csrfToken: languageServerCSRFToken,
-                source: .languageServer)
+        listeningPorts.flatMap { port in
+            [
+                AntigravityConnectionEndpoint(
+                    scheme: "https",
+                    port: port,
+                    csrfToken: languageServerCSRFToken,
+                    source: .languageServer),
+                AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: port,
+                    csrfToken: languageServerCSRFToken,
+                    source: .languageServer)
+            ]
         }
     }
 

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -273,6 +273,11 @@ extension AntigravityStatusProbeTests {
                     source: .languageServer),
                 AntigravityStatusProbe.AntigravityConnectionEndpoint(
                     scheme: "http",
+                    port: 64440,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
                     port: 64432,
                     csrfToken: "extension-token",
                     source: .extensionServer),
@@ -285,7 +290,7 @@ extension AntigravityStatusProbeTests {
     }
 
     @Test
-    func `connection candidates restrict plain http probing to the declared extension port`() {
+    func `connection candidates include plain http probing for language server ports`() {
         let candidates = AntigravityStatusProbe.connectionCandidates(
             listeningPorts: [64440, 64441],
             languageServerCSRFToken: "language-token",
@@ -300,7 +305,17 @@ extension AntigravityStatusProbeTests {
                     csrfToken: "language-token",
                     source: .languageServer),
                 AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 64440,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
                     scheme: "https",
+                    port: 64441,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
                     port: 64441,
                     csrfToken: "language-token",
                     source: .languageServer),
@@ -324,6 +339,11 @@ extension AntigravityStatusProbeTests {
             candidates == [
                 AntigravityStatusProbe.AntigravityConnectionEndpoint(
                     scheme: "https",
+                    port: 64440,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
                     port: 64440,
                     csrfToken: "language-token",
                     source: .languageServer),
@@ -354,7 +374,7 @@ extension AntigravityStatusProbeTests {
                     scheme: "http",
                     port: 64432,
                     csrfToken: "language-token",
-                    source: .extensionServer),
+                    source: .languageServer),
             ])
     }
 
@@ -376,6 +396,11 @@ extension AntigravityStatusProbeTests {
         #expect(
             endpoints == [
                 resolvedEndpoint,
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 64440,
+                    csrfToken: "language-token",
+                    source: .languageServer),
                 AntigravityStatusProbe.AntigravityConnectionEndpoint(
                     scheme: "http",
                     port: 64432,
@@ -407,6 +432,11 @@ extension AntigravityStatusProbeTests {
         #expect(
             endpoints == [
                 resolvedEndpoint,
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 64440,
+                    csrfToken: "language-token",
+                    source: .languageServer),
                 AntigravityStatusProbe.AntigravityConnectionEndpoint(
                     scheme: "http",
                     port: 64432,
@@ -443,6 +473,11 @@ extension AntigravityStatusProbeTests {
                     port: 64440,
                     csrfToken: "language-token",
                     source: .languageServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 64440,
+                    csrfToken: "language-token",
+                    source: .languageServer),
             ])
     }
 
@@ -470,7 +505,17 @@ extension AntigravityStatusProbeTests {
                     csrfToken: "language-token",
                     source: .languageServer),
                 AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 64432,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
                     scheme: "https",
+                    port: 64440,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
                     port: 64440,
                     csrfToken: "language-token",
                     source: .languageServer),

--- a/TestsLinux/AntigravityCLIStrategyLinuxTests.swift
+++ b/TestsLinux/AntigravityCLIStrategyLinuxTests.swift
@@ -28,7 +28,7 @@ struct AntigravityCLIStrategyLinuxTests {
             browserDetection: BrowserDetection(cacheTTL: 0))
         let isAvailable = await AntigravityCLIHTTPSFetchStrategy().isAvailable(context)
 
-        #expect(!isAvailable)
+        #expect(isAvailable)
     }
 
     private struct StubClaudeFetcher: ClaudeUsageFetching {


### PR DESCRIPTION
## Related issue

Closes #1508

## Context & Problem

On Linux, CodexBar fails to query the local Antigravity server due to strict SSL certificate verification errors. Because Swift's FoundationNetworking on Linux relies on libcurl and lacks Apple's Security.framework (SecTrust), CodexBar cannot manually bypass or trust the self-signed certificates natively generated by Antigravity, causing the cli-https strategy to fail entirely.

## Solution

During a deep-dive investigation of the Antigravity language server endpoints, we discovered that it exposes both an HTTPS port and a plain HTTP port.

This PR introduces an HTTP scheme fallback mechanism for local probing, allowing Linux environments to safely communicate with the local server over HTTP when HTTPS validation is unsupported.

## Evidence

<img width="1000" height="1045" alt="image" src="https://github.com/user-attachments/assets/95559bd0-26df-44d5-b468-9b38971faa6e" />
