### PR TITLE
Fix Gemini API-key auth detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Settings: use high-contrast selected-content colors for provider sidebar text and icons.
 
 ### Fixed
+- Gemini: recognize the current `gemini-api-key` CLI auth setting so API-key sessions show the supported OAuth guidance instead of a misleading not-logged-in error (fixes #1511).
 - Settings: make the cost history window directly editable by keyboard while preserving the existing stepper and 1–365 day bounds (fixes #1499). Thanks @kiranmagic7!
 
 ## 0.35.0 — 2026-06-14

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
@@ -118,7 +118,7 @@ public enum GeminiStatusProbeError: LocalizedError, Sendable, Equatable {
 
 public enum GeminiAuthType: String, Sendable {
     case oauthPersonal = "oauth-personal"
-    case apiKey = "api-key"
+    case apiKey = "gemini-api-key"
     case vertexAI = "vertex-ai"
     case unknown
 }
@@ -166,6 +166,9 @@ public struct GeminiStatusProbe: Sendable {
             return .unknown
         }
 
+        if selectedType == "api-key" {
+            return .apiKey
+        }
         return GeminiAuthType(rawValue: selectedType) ?? .unknown
     }
 

--- a/Tests/CodexBarTests/GeminiStatusProbeAPITests.swift
+++ b/Tests/CodexBarTests/GeminiStatusProbeAPITests.swift
@@ -15,11 +15,11 @@ struct GeminiStatusProbeAPITests {
         }
     }
 
-    @Test
-    func `rejects api key auth type`() async throws {
+    @Test(arguments: ["gemini-api-key", "api-key"])
+    func `rejects api key auth types`(authType: String) async throws {
         let env = try GeminiTestEnvironment()
         defer { env.cleanup() }
-        try env.writeSettings(authType: "api-key")
+        try env.writeSettings(authType: authType)
 
         let probe = GeminiStatusProbe(timeout: 1, homeDirectory: env.homeURL.path)
         await Self.expectError(.unsupportedAuthType("API key")) {


### PR DESCRIPTION
## Summary
- recognize Gemini CLI's current `gemini-api-key` auth setting
- preserve compatibility with the legacy `api-key` value
- show the supported OAuth guidance instead of a misleading not-logged-in error

Fixes #1511.

## Testing
- `swift test --filter GeminiStatusProbeAPITests --skip-update`
- `make check`
- autoreview clean
