### PR TITLE
Fix Antigravity local probing on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Antigravity: prefer app and `agy` quota summaries, group usage into Gemini and Claude + GPT session/weekly pools, and preserve IDE and OAuth fallbacks. Thanks @Zihao-Qi!
 
 ### Fixed
+- Antigravity: fall back to loopback HTTP for local CLI and language-server probes on Linux, where self-signed localhost TLS cannot be trusted (fixes #1508). Thanks @zodiacfireworks!
 - Gemini: recognize the current `gemini-api-key` CLI auth setting so API-key sessions show the supported OAuth guidance instead of a misleading not-logged-in error (fixes #1511).
 - Settings: make the cost history window directly editable by keyboard while preserving the existing stepper and 1–365 day bounds (fixes #1499). Thanks @kiranmagic7!
 ## 0.35.0 — 2026-06-14

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityProviderDescriptor.swift
@@ -135,10 +135,10 @@ struct AntigravityStatusFetchStrategy: ProviderFetchStrategy {
 }
 
 /// When the Antigravity 2.0 app is closed or unavailable, this strategy spawns
-/// or reuses ``agy`` and talks to the HTTPS localhost server embedded in that
-/// CLI process. ``agy`` is an interactive REPL, not a query command, so
-/// CodexBar never scrapes TUI output here; it only keeps the process alive long
-/// enough for the server to answer quota endpoints.
+/// or reuses ``agy`` and talks to the localhost server embedded in that CLI
+/// process. ``agy`` is an interactive REPL, not a query command, so CodexBar
+/// never scrapes TUI output here; it only keeps the process alive long enough
+/// for the server to answer quota endpoints.
 struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     static let sourceLabel = "cli"
     let id: String = "antigravity.cli-https"
@@ -153,14 +153,10 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
     }
 
     func isAvailable(_ context: ProviderFetchContext) async -> Bool {
-        guard Self.supportsLocalhostServerTrust else { return false }
-        return BinaryLocator.resolveAntigravityBinary(env: context.env) != nil
+        BinaryLocator.resolveAntigravityBinary(env: context.env) != nil
     }
 
     func fetch(_ context: ProviderFetchContext) async throws -> ProviderFetchResult {
-        guard Self.supportsLocalhostServerTrust else {
-            throw AntigravityStatusProbeError.notRunning
-        }
         guard let binary = BinaryLocator.resolveAntigravityBinary(env: context.env) else {
             throw AntigravityStatusProbeError.notRunning
         }
@@ -170,14 +166,6 @@ struct AntigravityCLIHTTPSFetchStrategy: ProviderFetchStrategy {
             resetAfterFetch: Self.shouldResetSessionAfterFetch(context))
         try AntigravitySelectedAccountGuard.validate(result.usage, context: context)
         return result
-    }
-
-    private static var supportsLocalhostServerTrust: Bool {
-        #if os(Linux)
-        false
-        #else
-        true
-        #endif
     }
 
     private func fetchUsingWarmSession(

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+LocalEndpoints.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+LocalEndpoints.swift
@@ -1,0 +1,23 @@
+extension AntigravityStatusProbe {
+    static func cliEndpoints(ports: [Int]) -> [AntigravityConnectionEndpoint] {
+        ports.flatMap { port in
+            self.localProbeSchemes.map { scheme in
+                AntigravityConnectionEndpoint(
+                    scheme: scheme,
+                    port: port,
+                    csrfToken: "",
+                    source: .cliHTTPS)
+            }
+        }
+    }
+
+    static var localProbeSchemes: [String] {
+        #if os(Linux)
+        // FoundationNetworking cannot trust Antigravity's self-signed TLS cert.
+        // Requests remain pinned to 127.0.0.1 in makeRequest.
+        ["https", "http"]
+        #else
+        ["https"]
+        #endif
+    }
+}

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -851,26 +851,20 @@ public struct AntigravityStatusProbe: Sendable {
         return running ? "running" : nil
     }
 
-    // MARK: - CLI HTTPS Fetch
+    // MARK: - CLI Local Fetch
 
     /// Fetch usage data from a known set of local ports (discovered via
     /// ``AntigravityCLISession``'s ``pid``), without requiring a running
     /// ``language_server`` process or CSRF token.
     ///
-    /// The ``agy`` CLI exposes the same ``GetUserStatus`` gRPC-web endpoint on
-    /// its HTTPS port as the desktop ``language_server``. Unlike the desktop
-    /// endpoint, it does not require a CSRF token header.
+    /// The ``agy`` CLI exposes the same ``GetUserStatus`` gRPC-web endpoint as
+    /// the desktop ``language_server``. Unlike the desktop endpoint, it does
+    /// not require a CSRF token header.
     public func fetchFromPorts(_ ports: [Int], deadline: Date? = nil) async throws -> AntigravityStatusSnapshot {
         guard !ports.isEmpty else {
             throw AntigravityStatusProbeError.portDetectionFailed("no listening ports found")
         }
-        let endpoints = ports.map {
-            AntigravityConnectionEndpoint(
-                scheme: "https",
-                port: $0,
-                csrfToken: "",
-                source: .cliHTTPS)
-        }
+        let endpoints = Self.cliEndpoints(ports: ports)
         let context = RequestContext(endpoints: endpoints, timeout: self.timeout, deadline: deadline)
         return try await Self.fetchSnapshot(context: context)
     }
@@ -1293,12 +1287,14 @@ public struct AntigravityStatusProbe: Sendable {
         listeningPorts: [Int],
         languageServerCSRFToken: String) -> [AntigravityConnectionEndpoint]
     {
-        listeningPorts.map {
-            AntigravityConnectionEndpoint(
-                scheme: "https",
-                port: $0,
-                csrfToken: languageServerCSRFToken,
-                source: .languageServer)
+        listeningPorts.flatMap { port in
+            self.localProbeSchemes.map { scheme in
+                AntigravityConnectionEndpoint(
+                    scheme: scheme,
+                    port: port,
+                    csrfToken: languageServerCSRFToken,
+                    source: .languageServer)
+            }
         }
     }
 

--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -317,7 +317,7 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
     }
 
     @Test
-    func `cli HTTPS availability requires supported localhost trust`() async throws {
+    func `cli local strategy availability requires binary`() async throws {
         let binaryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-antigravity-\(UUID().uuidString)")
         try Data("#!/bin/sh\n".utf8).write(to: binaryURL)
@@ -331,6 +331,18 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
         let isAvailable = await strategy.isAvailable(context)
 
         #expect(isAvailable)
+    }
+
+    @Test
+    func `cli local endpoints remain HTTPS only on macOS`() {
+        #expect(
+            AntigravityStatusProbe.cliEndpoints(ports: [55624]) == [
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "https",
+                    port: 55624,
+                    csrfToken: "",
+                    source: .cliHTTPS),
+            ])
     }
 
     @Test

--- a/TestsLinux/AntigravityCLIStrategyLinuxTests.swift
+++ b/TestsLinux/AntigravityCLIStrategyLinuxTests.swift
@@ -5,7 +5,7 @@ import Testing
 #if os(Linux)
 struct AntigravityCLIStrategyLinuxTests {
     @Test
-    func `cli HTTPS is unavailable without Linux localhost trust`() async throws {
+    func `cli local strategy is available with HTTP fallback`() async throws {
         let binaryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-antigravity-\(UUID().uuidString)")
         try Data("#!/bin/sh\n".utf8).write(to: binaryURL)
@@ -28,7 +28,45 @@ struct AntigravityCLIStrategyLinuxTests {
             browserDetection: BrowserDetection(cacheTTL: 0))
         let isAvailable = await AntigravityCLIHTTPSFetchStrategy().isAvailable(context)
 
-        #expect(!isAvailable)
+        #expect(isAvailable)
+    }
+
+    @Test
+    func `cli local endpoints include Linux HTTP fallback`() {
+        #expect(
+            AntigravityStatusProbe.cliEndpoints(ports: [55624]) == [
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "https",
+                    port: 55624,
+                    csrfToken: "",
+                    source: .cliHTTPS),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 55624,
+                    csrfToken: "",
+                    source: .cliHTTPS),
+            ])
+    }
+
+    @Test
+    func `language server endpoints include Linux HTTP fallback`() {
+        #expect(
+            AntigravityStatusProbe.connectionCandidates(
+                listeningPorts: [64440],
+                languageServerCSRFToken: "language-token",
+                extensionServerPort: nil,
+                extensionServerCSRFToken: nil) == [
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "https",
+                    port: 64440,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+                AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                    scheme: "http",
+                    port: 64440,
+                    csrfToken: "language-token",
+                    source: .languageServer),
+            ])
     }
 
     private struct StubClaudeFetcher: ClaudeUsageFetching {


### PR DESCRIPTION
## Summary
- probe Antigravity loopback endpoints over HTTPS first, then HTTP on Linux
- keep macOS HTTPS-only behavior unchanged
- make the CLI strategy available on Linux when the Antigravity binary is present
- preserve contributor credit from #1510

Fixes #1508.
Supersedes #1510 because its fork branch does not allow maintainer edits.

## Security
HTTP fallback is Linux-only and requests remain pinned to `127.0.0.1`; no remote or non-loopback endpoint is permitted.

## Proof
- `swift test --filter AntigravityCLIHTTPSFetchStrategyTests`
- `swift test --filter AntigravityStatusProbeTests`
- `make check`
- branch autoreview: clean

A full local parallel suite exposed existing unrelated timing failures in Codex RPC timeout tests; focused tests are green and this PR must pass complete CI before merge.
