### PR TITLE
Fix Antigravity quota edge handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Antigravity: fall back to loopback HTTP for local CLI and language-server probes on Linux, where self-signed localhost TLS cannot be trusted (fixes #1508). Thanks @zodiacfireworks!
 - Gemini: recognize the current `gemini-api-key` CLI auth setting so API-key sessions show the supported OAuth guidance instead of a misleading not-logged-in error (fixes #1511).
 - Settings: make the cost history window directly editable by keyboard while preserving the existing stepper and 1–365 day bounds (fixes #1499). Thanks @kiranmagic7!
+
 ## 0.35.0 — 2026-06-14
 
 ### Added

--- a/Sources/CodexBar/IconRemainingResolver.swift
+++ b/Sources/CodexBar/IconRemainingResolver.swift
@@ -21,6 +21,15 @@ enum IconRemainingResolver {
         return projection.visibleRateLanes.compactMap { projection.rateWindow(for: $0) }
     }
 
+    private static func antigravityVisibleWindows(snapshot: UsageSnapshot) -> [RateWindow] {
+        var windows = [snapshot.primary, snapshot.secondary, snapshot.tertiary].compactMap(\.self)
+        let compactFallbacks = snapshot.extraRateWindows?
+            .filter { $0.usageKnown && $0.id.hasPrefix("antigravity-compact-fallback-") }
+            .map(\.window) ?? []
+        windows.append(contentsOf: compactFallbacks)
+        return windows
+    }
+
     static func resolvedWindows(
         snapshot: UsageSnapshot,
         style: IconStyle,
@@ -34,7 +43,7 @@ enum IconRemainingResolver {
                 secondary: windows.dropFirst().first)
         }
         if style == .antigravity {
-            let windows = [snapshot.primary, snapshot.secondary, snapshot.tertiary].compactMap(\.self)
+            let windows = self.antigravityVisibleWindows(snapshot: snapshot)
             return (
                 primary: windows.first,
                 secondary: windows.dropFirst().first)
@@ -71,7 +80,7 @@ enum IconRemainingResolver {
                 secondary: windows.dropFirst().first?.remainingPercent)
         }
         if style == .antigravity {
-            let windows = [snapshot.primary, snapshot.secondary, snapshot.tertiary].compactMap(\.self)
+            let windows = self.antigravityVisibleWindows(snapshot: snapshot)
             return (
                 primary: windows.first?.remainingPercent,
                 secondary: windows.dropFirst().first?.remainingPercent)

--- a/Sources/CodexBar/MenuBarMetricWindowResolver.swift
+++ b/Sources/CodexBar/MenuBarMetricWindowResolver.swift
@@ -20,11 +20,20 @@ enum MenuBarMetricWindowResolver {
         case .extraUsage:
             return Self.extraUsageWindow(snapshot: snapshot)
         case .tertiary:
-            return Self.window(in: snapshot, following: Self.tertiaryOrder(for: provider))
+            return Self.requestedWindow(
+                provider: provider,
+                snapshot: snapshot,
+                lanes: Self.tertiaryOrder(for: provider))
         case .primary:
-            return Self.window(in: snapshot, following: Self.primaryOrder(for: provider))
+            return Self.requestedWindow(
+                provider: provider,
+                snapshot: snapshot,
+                lanes: Self.primaryOrder(for: provider))
         case .secondary:
-            return Self.window(in: snapshot, following: Self.secondaryOrder(for: provider))
+            return Self.requestedWindow(
+                provider: provider,
+                snapshot: snapshot,
+                lanes: Self.secondaryOrder(for: provider))
         case .average:
             return Self.averageWindow(provider: provider, snapshot: snapshot, supportsAverage: supportsAverage)
         case .automatic:
@@ -91,6 +100,7 @@ enum MenuBarMetricWindowResolver {
                 primary: snapshot.primary,
                 secondary: snapshot.secondary,
                 tertiary: snapshot.tertiary)
+                ?? self.mostConstrainedAntigravityLegacyExtraWindow(snapshot: snapshot)
         }
         if provider == .perplexity {
             return snapshot.automaticPerplexityWindow()
@@ -126,6 +136,7 @@ enum MenuBarMetricWindowResolver {
     }
 
     private static let antigravityQuotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
+    private static let antigravityCompactFallbackWindowIDPrefix = "antigravity-compact-fallback-"
 
     private static func mostConstrainedAntigravityQuotaSummaryWindow(snapshot: UsageSnapshot) -> RateWindow? {
         let windows = snapshot.extraRateWindows?
@@ -133,6 +144,27 @@ enum MenuBarMetricWindowResolver {
             .map(\.window) ?? []
         guard !windows.isEmpty else { return nil }
         return windows.max(by: { $0.usedPercent < $1.usedPercent })
+    }
+
+    private static func mostConstrainedAntigravityLegacyExtraWindow(snapshot: UsageSnapshot) -> RateWindow? {
+        let windows = snapshot.extraRateWindows?
+            .filter {
+                $0.usageKnown && $0.id.hasPrefix(Self.antigravityCompactFallbackWindowIDPrefix)
+            }
+            .map(\.window) ?? []
+        guard !windows.isEmpty else { return nil }
+        return windows.max(by: { $0.usedPercent < $1.usedPercent })
+    }
+
+    private static func requestedWindow(
+        provider: UsageProvider,
+        snapshot: UsageSnapshot,
+        lanes: [Lane]) -> RateWindow?
+    {
+        self.window(in: snapshot, following: lanes)
+            ?? (provider == .antigravity
+                ? self.mostConstrainedAntigravityLegacyExtraWindow(snapshot: snapshot)
+                : nil)
     }
 
     private static func window(in snapshot: UsageSnapshot, following lanes: [Lane]) -> RateWindow? {

--- a/Sources/CodexBar/SessionQuotaNotifications.swift
+++ b/Sources/CodexBar/SessionQuotaNotifications.swift
@@ -179,6 +179,7 @@ extension UsageStore {
             [snapshot.primary, snapshot.secondary, snapshot.tertiary]
                 .compactMap(\.self)
                 .filter {
+                    // Legacy Antigravity family lanes historically drive session notifications.
                     $0.windowMinutes == windowMinutes
                         || (windowMinutes == 5 * 60 && $0.windowMinutes == nil)
                 }

--- a/Sources/CodexBar/SessionQuotaNotifications.swift
+++ b/Sources/CodexBar/SessionQuotaNotifications.swift
@@ -135,6 +135,12 @@ extension UsageStore {
         snapshot: UsageSnapshot) -> (window: RateWindow, source: SessionQuotaWindowSource)?
     {
         guard provider != .mimo else { return nil }
+        if provider == .antigravity, Self.hasAntigravityQuotaSummaryWindows(snapshot: snapshot) {
+            guard let window = Self.antigravityQuotaSummaryWindow(snapshot: snapshot, windowMinutes: 5 * 60) else {
+                return nil
+            }
+            return (window, .antigravityQuotaSummary)
+        }
         if let primary = snapshot.primary, Self.isSessionWindow(primary) {
             return (primary, .primary)
         }
@@ -147,6 +153,28 @@ extension UsageStore {
     private static func isSessionWindow(_ window: RateWindow) -> Bool {
         guard let minutes = window.windowMinutes else { return true }
         return minutes <= 6 * 60
+    }
+
+    private static let antigravityQuotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
+
+    static func hasAntigravityQuotaSummaryWindows(snapshot: UsageSnapshot) -> Bool {
+        snapshot.extraRateWindows?.contains {
+            $0.id.hasPrefix(Self.antigravityQuotaSummaryWindowIDPrefix)
+        } == true
+    }
+
+    static func antigravityQuotaSummaryWindow(
+        snapshot: UsageSnapshot,
+        windowMinutes: Int) -> RateWindow?
+    {
+        snapshot.extraRateWindows?
+            .filter {
+                $0.usageKnown
+                    && $0.id.hasPrefix(Self.antigravityQuotaSummaryWindowIDPrefix)
+                    && $0.window.windowMinutes == windowMinutes
+            }
+            .map(\.window)
+            .max { $0.usedPercent < $1.usedPercent }
     }
 }
 

--- a/Sources/CodexBar/SessionQuotaNotifications.swift
+++ b/Sources/CodexBar/SessionQuotaNotifications.swift
@@ -139,7 +139,10 @@ extension UsageStore {
             guard let window = Self.antigravityWindow(snapshot: snapshot, windowMinutes: 5 * 60) else {
                 return nil
             }
-            return (window, .antigravityDuration)
+            let source: SessionQuotaWindowSource = Self.hasAntigravityQuotaSummaryWindows(snapshot: snapshot)
+                ? .antigravityQuotaSummary
+                : .antigravityLegacy
+            return (window, source)
         }
         if let primary = snapshot.primary, Self.isSessionWindow(primary) {
             return (primary, .primary)

--- a/Sources/CodexBar/SessionQuotaNotifications.swift
+++ b/Sources/CodexBar/SessionQuotaNotifications.swift
@@ -178,7 +178,10 @@ extension UsageStore {
         } else {
             [snapshot.primary, snapshot.secondary, snapshot.tertiary]
                 .compactMap(\.self)
-                .filter { $0.windowMinutes == windowMinutes }
+                .filter {
+                    $0.windowMinutes == windowMinutes
+                        || (windowMinutes == 5 * 60 && $0.windowMinutes == nil)
+                }
         }
         return windows.max { $0.usedPercent < $1.usedPercent }
     }

--- a/Sources/CodexBar/SessionQuotaNotifications.swift
+++ b/Sources/CodexBar/SessionQuotaNotifications.swift
@@ -135,11 +135,11 @@ extension UsageStore {
         snapshot: UsageSnapshot) -> (window: RateWindow, source: SessionQuotaWindowSource)?
     {
         guard provider != .mimo else { return nil }
-        if provider == .antigravity, Self.hasAntigravityQuotaSummaryWindows(snapshot: snapshot) {
-            guard let window = Self.antigravityQuotaSummaryWindow(snapshot: snapshot, windowMinutes: 5 * 60) else {
+        if provider == .antigravity {
+            guard let window = Self.antigravityWindow(snapshot: snapshot, windowMinutes: 5 * 60) else {
                 return nil
             }
-            return (window, .antigravityQuotaSummary)
+            return (window, .antigravityDuration)
         }
         if let primary = snapshot.primary, Self.isSessionWindow(primary) {
             return (primary, .primary)
@@ -163,18 +163,24 @@ extension UsageStore {
         } == true
     }
 
-    static func antigravityQuotaSummaryWindow(
+    static func antigravityWindow(
         snapshot: UsageSnapshot,
         windowMinutes: Int) -> RateWindow?
     {
-        snapshot.extraRateWindows?
-            .filter {
-                $0.usageKnown
-                    && $0.id.hasPrefix(Self.antigravityQuotaSummaryWindowIDPrefix)
-                    && $0.window.windowMinutes == windowMinutes
-            }
-            .map(\.window)
-            .max { $0.usedPercent < $1.usedPercent }
+        let windows: [RateWindow] = if Self.hasAntigravityQuotaSummaryWindows(snapshot: snapshot) {
+            snapshot.extraRateWindows?
+                .filter {
+                    $0.usageKnown
+                        && $0.id.hasPrefix(Self.antigravityQuotaSummaryWindowIDPrefix)
+                        && $0.window.windowMinutes == windowMinutes
+                }
+                .map(\.window) ?? []
+        } else {
+            [snapshot.primary, snapshot.secondary, snapshot.tertiary]
+                .compactMap(\.self)
+                .filter { $0.windowMinutes == windowMinutes }
+        }
+        return windows.max { $0.usedPercent < $1.usedPercent }
     }
 }
 

--- a/Sources/CodexBar/SettingsStore+TokenAccounts.swift
+++ b/Sources/CodexBar/SettingsStore+TokenAccounts.swift
@@ -238,9 +238,8 @@ extension SettingsStore {
         }
         guard !hasMatchingRemainingAccount else { return }
 
-        let store = self.antigravityOAuthCredentialsStore
         Self.clearMatchingAntigravitySharedCredentials(
-            store: store,
+            store: self.antigravityOAuthCredentialsStore,
             removedCredentials: removedCredentials)
     }
 
@@ -248,20 +247,42 @@ extension SettingsStore {
         store: AntigravityOAuthCredentialsStore,
         removedCredentials: AntigravityOAuthCredentials)
     {
-        Task.detached(priority: .utility) {
-            do {
-                guard let sharedCredentials = try store.load(),
-                      antigravityCredentialsMatchAccount(sharedCredentials, removedCredentials)
-                else {
-                    return
-                }
-                try store.deleteIfPresent()
-            } catch {
-                CodexBarLog.logger(LogCategories.tokenAccounts).warning(
-                    "Failed to clear Antigravity OAuth cache after account removal",
-                    metadata: ["error": error.localizedDescription])
+        do {
+            try store.deleteIfPresent { sharedCredentials in
+                self.antigravitySharedCredentialsMatchRemovedAccount(
+                    sharedCredentials,
+                    removedCredentials)
             }
+        } catch {
+            CodexBarLog.logger(LogCategories.tokenAccounts).warning(
+                "Failed to clear Antigravity OAuth cache after account removal",
+                metadata: ["error": error.localizedDescription])
         }
+    }
+
+    private nonisolated static func antigravitySharedCredentialsMatchRemovedAccount(
+        _ shared: AntigravityOAuthCredentials,
+        _ removed: AntigravityOAuthCredentials) -> Bool
+    {
+        if let sharedRefreshToken = self.normalizedAntigravityCredentialToken(shared.refreshToken),
+           let removedRefreshToken = self.normalizedAntigravityCredentialToken(removed.refreshToken)
+        {
+            return sharedRefreshToken == removedRefreshToken
+        }
+        if let sharedAccessToken = self.normalizedAntigravityCredentialToken(shared.accessToken),
+           let removedAccessToken = self.normalizedAntigravityCredentialToken(removed.accessToken)
+        {
+            return sharedAccessToken == removedAccessToken
+        }
+        guard self.normalizedAntigravityCredentialToken(shared.refreshToken) == nil,
+              self.normalizedAntigravityCredentialToken(removed.refreshToken) == nil,
+              self.normalizedAntigravityCredentialToken(shared.accessToken) == nil,
+              self.normalizedAntigravityCredentialToken(removed.accessToken) == nil
+        else {
+            return false
+        }
+        return self.normalizedAntigravityAccountEmail(shared.resolvedAccountEmail)
+            == self.normalizedAntigravityAccountEmail(removed.resolvedAccountEmail)
     }
 
     private nonisolated static func antigravityCredentialsMatchAccount(

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -478,6 +478,8 @@ extension SettingsStore {
         let migrationKey = "antigravityTwoPoolMetricPreferenceMigrated"
         guard !userDefaults.bool(forKey: migrationKey) else { return preferences }
 
+        // Tagged builds through v0.35 used primary=Claude, secondary=Gemini Pro,
+        // and tertiary=Gemini Flash. Remap those meanings once to the two-pool schema.
         var migrated = preferences
         switch MenuBarMetricPreference(rawValue: migrated[UsageProvider.antigravity.rawValue] ?? "") {
         case .primary:

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -464,13 +464,32 @@ extension SettingsStore {
 
     private static func loadMenuBarMetricPreferences(userDefaults: UserDefaults) -> [String: String] {
         let storedPreferences = userDefaults.dictionary(forKey: "menuBarMetricPreferences") as? [String: String] ?? [:]
-        if !storedPreferences.isEmpty {
-            return storedPreferences
+        let preferences: [String: String] = if !storedPreferences.isEmpty {
+            storedPreferences
+        } else if let menuBarMetricRaw = userDefaults.string(forKey: "menuBarMetricPreference"),
+                  let legacyPreference = MenuBarMetricPreference(rawValue: menuBarMetricRaw)
+        {
+            Dictionary(
+                uniqueKeysWithValues: UsageProvider.allCases.map { ($0.rawValue, legacyPreference.rawValue) })
+        } else {
+            [:]
         }
-        guard let menuBarMetricRaw = userDefaults.string(forKey: "menuBarMetricPreference"),
-              let legacyPreference = MenuBarMetricPreference(rawValue: menuBarMetricRaw)
-        else { return [:] }
-        return Dictionary(uniqueKeysWithValues: UsageProvider.allCases.map { ($0.rawValue, legacyPreference.rawValue) })
+
+        let migrationKey = "antigravityTwoPoolMetricPreferenceMigrated"
+        guard !userDefaults.bool(forKey: migrationKey) else { return preferences }
+
+        var migrated = preferences
+        switch MenuBarMetricPreference(rawValue: migrated[UsageProvider.antigravity.rawValue] ?? "") {
+        case .primary:
+            migrated[UsageProvider.antigravity.rawValue] = MenuBarMetricPreference.secondary.rawValue
+        case .secondary:
+            migrated[UsageProvider.antigravity.rawValue] = MenuBarMetricPreference.primary.rawValue
+        case .automatic, .tertiary, .extraUsage, .average, .none:
+            break
+        }
+        userDefaults.set(migrated, forKey: "menuBarMetricPreferences")
+        userDefaults.set(true, forKey: migrationKey)
+        return migrated
     }
 
     private static func loadMultiAccountMenuLayoutRaw(userDefaults: UserDefaults) -> String {

--- a/Sources/CodexBar/SettingsStore.swift
+++ b/Sources/CodexBar/SettingsStore.swift
@@ -484,7 +484,9 @@ extension SettingsStore {
             migrated[UsageProvider.antigravity.rawValue] = MenuBarMetricPreference.secondary.rawValue
         case .secondary:
             migrated[UsageProvider.antigravity.rawValue] = MenuBarMetricPreference.primary.rawValue
-        case .automatic, .tertiary, .extraUsage, .average, .none:
+        case .tertiary:
+            migrated[UsageProvider.antigravity.rawValue] = MenuBarMetricPreference.primary.rawValue
+        case .automatic, .extraUsage, .average, .none:
             break
         }
         userDefaults.set(migrated, forKey: "menuBarMetricPreferences")

--- a/Sources/CodexBar/UsageStore+HighestUsage.swift
+++ b/Sources/CodexBar/UsageStore+HighestUsage.swift
@@ -64,7 +64,9 @@ extension UsageStore {
                 snapshot.primary?.usedPercent,
                 snapshot.secondary?.usedPercent,
                 snapshot.tertiary?.usedPercent,
-            ].compactMap(\.self)
+            ].compactMap(\.self) + (provider == .antigravity
+                ? Self.antigravityLegacyExtraUsedPercents(snapshot: snapshot)
+                : [])
             guard !percents.isEmpty else { return true }
             return percents.allSatisfy { $0 >= 100 }
         }
@@ -78,5 +80,11 @@ extension UsageStore {
         snapshot.extraRateWindows?
             .filter { $0.usageKnown && $0.id.hasPrefix(Self.antigravityQuotaSummaryWindowIDPrefix) }
             .map(\.window.usedPercent)
+    }
+
+    private nonisolated static func antigravityLegacyExtraUsedPercents(snapshot: UsageSnapshot) -> [Double] {
+        snapshot.extraRateWindows?
+            .filter { $0.usageKnown && !$0.id.hasPrefix(Self.antigravityQuotaSummaryWindowIDPrefix) }
+            .map(\.window.usedPercent) ?? []
     }
 }

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -382,6 +382,22 @@ extension UsageStore {
             appendWindow(snapshot.primary, name: .session)
             appendWindow(snapshot.secondary, name: .weekly)
             appendWindow(snapshot.tertiary, name: .opus)
+        case .antigravity:
+            let namedWeeklyWindows = snapshot.extraRateWindows?
+                .filter {
+                    $0.usageKnown
+                        && $0.id.hasPrefix("antigravity-quota-summary-")
+                        && $0.window.windowMinutes == Self.weeklyWindowMinutes
+                }
+                .map(\.window) ?? []
+            if let mostUsedWeeklyWindow = namedWeeklyWindows.max(by: { $0.usedPercent < $1.usedPercent }) {
+                appendWindow(mostUsedWeeklyWindow, name: .weekly)
+            } else {
+                for window in [snapshot.primary, snapshot.secondary, snapshot.tertiary] {
+                    guard let window, window.windowMinutes == Self.weeklyWindowMinutes else { continue }
+                    appendWindow(window, name: .weekly)
+                }
+            }
         default:
             for window in [snapshot.primary, snapshot.secondary, snapshot.tertiary] {
                 guard let window, window.windowMinutes == Self.weeklyWindowMinutes else { continue }

--- a/Sources/CodexBar/UsageStore+QuotaWarnings.swift
+++ b/Sources/CodexBar/UsageStore+QuotaWarnings.swift
@@ -78,14 +78,13 @@ extension UsageStore {
             state.firedThresholds.formUnion(QuotaWarningNotificationLogic.firedThresholdsAfterWarning(
                 threshold: threshold,
                 thresholds: thresholds))
-            self.sessionQuotaNotifier.postQuotaWarning(
-                event: QuotaWarningEvent(
+            self.postQuotaWarning(
+                QuotaWarningEvent(
                     window: window,
                     threshold: threshold,
                     currentRemaining: currentRemaining,
                     accountDisplayName: accountDisplayName),
-                provider: provider,
-                soundEnabled: self.settings.quotaWarningSoundEnabled)
+                provider: provider)
         }
 
         state.lastRemaining = currentRemaining

--- a/Sources/CodexBar/UsageStore+QuotaWarnings.swift
+++ b/Sources/CodexBar/UsageStore+QuotaWarnings.swift
@@ -1,0 +1,102 @@
+import CodexBarCore
+import Foundation
+
+@MainActor
+extension UsageStore {
+    func handleQuotaWarningTransitions(provider: UsageProvider, snapshot: UsageSnapshot) {
+        guard self.settings.quotaWarningNotificationsEnabled else { return }
+
+        let accountDisplayName = self.quotaWarningAccountDisplayName(provider: provider, snapshot: snapshot)
+        let source: SessionQuotaWindowSource? = if provider == .antigravity {
+            Self.hasAntigravityQuotaSummaryWindows(snapshot: snapshot)
+                ? .antigravityQuotaSummary
+                : .antigravityLegacy
+        } else {
+            nil
+        }
+        let primaryWindow: RateWindow?
+        let secondaryWindow: RateWindow?
+        if provider == .antigravity {
+            primaryWindow = Self.antigravityWindow(snapshot: snapshot, windowMinutes: 5 * 60)
+            secondaryWindow = Self.antigravityWindow(snapshot: snapshot, windowMinutes: 7 * 24 * 60)
+        } else {
+            primaryWindow = provider == .mimo ? nil : snapshot.primary
+            secondaryWindow = provider == .mimo ? nil : snapshot.secondary
+        }
+        self.handleQuotaWarningTransition(
+            provider: provider,
+            window: .session,
+            rateWindow: primaryWindow,
+            source: source,
+            accountDisplayName: accountDisplayName)
+        self.handleQuotaWarningTransition(
+            provider: provider,
+            window: .weekly,
+            rateWindow: secondaryWindow,
+            source: source,
+            accountDisplayName: accountDisplayName)
+    }
+
+    private func handleQuotaWarningTransition(
+        provider: UsageProvider,
+        window: QuotaWarningWindow,
+        rateWindow: RateWindow?,
+        source: SessionQuotaWindowSource?,
+        accountDisplayName: String?)
+    {
+        let key = QuotaWarningStateKey(provider: provider, window: window)
+        guard self.settings.quotaWarningEnabled(provider: provider, window: window) else {
+            self.quotaWarningState.removeValue(forKey: key)
+            return
+        }
+        guard let rateWindow else {
+            self.quotaWarningState.removeValue(forKey: key)
+            return
+        }
+
+        let thresholds = self.settings.resolvedQuotaWarningThresholds(provider: provider, window: window)
+        let currentRemaining = rateWindow.remainingPercent
+        let previousState = self.quotaWarningState[key]
+        if let previousState, previousState.source != source {
+            self.quotaWarningState[key] = QuotaWarningState(
+                lastRemaining: currentRemaining,
+                source: source)
+            return
+        }
+        var state = previousState ?? QuotaWarningState(source: source)
+        let cleared = QuotaWarningNotificationLogic.thresholdsToClear(
+            currentRemaining: currentRemaining,
+            alreadyFired: state.firedThresholds)
+        state.firedThresholds.subtract(cleared)
+
+        if let threshold = QuotaWarningNotificationLogic.crossedThreshold(
+            previousRemaining: state.lastRemaining,
+            currentRemaining: currentRemaining,
+            thresholds: thresholds,
+            alreadyFired: state.firedThresholds)
+        {
+            state.firedThresholds.formUnion(QuotaWarningNotificationLogic.firedThresholdsAfterWarning(
+                threshold: threshold,
+                thresholds: thresholds))
+            self.sessionQuotaNotifier.postQuotaWarning(
+                event: QuotaWarningEvent(
+                    window: window,
+                    threshold: threshold,
+                    currentRemaining: currentRemaining,
+                    accountDisplayName: accountDisplayName),
+                provider: provider,
+                soundEnabled: self.settings.quotaWarningSoundEnabled)
+        }
+
+        state.lastRemaining = currentRemaining
+        self.quotaWarningState[key] = state
+    }
+
+    private func quotaWarningAccountDisplayName(provider: UsageProvider, snapshot: UsageSnapshot) -> String? {
+        guard !self.settings.hidePersonalInfo else { return nil }
+        let account = snapshot.accountEmail(for: provider)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let account, !account.isEmpty else { return nil }
+        return account
+    }
+}

--- a/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
+++ b/Sources/CodexBar/UsageStore+WidgetSnapshot.swift
@@ -125,6 +125,14 @@ extension UsageStore {
         {
             return rows
         }
+        if provider == .antigravity,
+           snapshot.primary == nil,
+           snapshot.secondary == nil,
+           let rows = Self.antigravityLegacyExtraWidgetRows(snapshot: snapshot),
+           !rows.isEmpty
+        {
+            return rows
+        }
 
         let primaryTitle: String = {
             if provider == .grok,
@@ -155,6 +163,7 @@ extension UsageStore {
     }
 
     private nonisolated static let antigravityQuotaSummaryWindowIDPrefix = "antigravity-quota-summary-"
+    private nonisolated static let antigravityCompactFallbackWindowIDPrefix = "antigravity-compact-fallback-"
 
     private nonisolated static func antigravityQuotaSummaryWidgetRows(
         snapshot: UsageSnapshot) -> [WidgetSnapshot.WidgetUsageRowSnapshot]?
@@ -169,6 +178,20 @@ extension UsageStore {
                 id: namedWindow.id,
                 title: namedWindow.title,
                 percentLeft: namedWindow.usageKnown ? namedWindow.window.remainingPercent : nil)
+        }
+    }
+
+    private nonisolated static func antigravityLegacyExtraWidgetRows(
+        snapshot: UsageSnapshot) -> [WidgetSnapshot.WidgetUsageRowSnapshot]?
+    {
+        let windows = snapshot.extraRateWindows?
+            .filter { $0.id.hasPrefix(Self.antigravityCompactFallbackWindowIDPrefix) && $0.usageKnown }
+        guard let windows, !windows.isEmpty else { return nil }
+        return windows.map { namedWindow in
+            WidgetSnapshot.WidgetUsageRowSnapshot(
+                id: namedWindow.id,
+                title: namedWindow.title,
+                percentLeft: namedWindow.window.remainingPercent)
         }
     }
 }

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -756,6 +756,7 @@ final class UsageStore {
     enum SessionQuotaWindowSource: String {
         case primary
         case copilotSecondaryFallback
+        case antigravityQuotaSummary
     }
 
     struct QuotaWarningStateKey: Hashable {
@@ -849,8 +850,15 @@ final class UsageStore {
         guard self.settings.quotaWarningNotificationsEnabled else { return }
 
         let accountDisplayName = self.quotaWarningAccountDisplayName(provider: provider, snapshot: snapshot)
-        let primaryWindow = provider == .mimo ? nil : snapshot.primary
-        let secondaryWindow = provider == .mimo ? nil : snapshot.secondary
+        let primaryWindow: RateWindow?
+        let secondaryWindow: RateWindow?
+        if provider == .antigravity, Self.hasAntigravityQuotaSummaryWindows(snapshot: snapshot) {
+            primaryWindow = Self.antigravityQuotaSummaryWindow(snapshot: snapshot, windowMinutes: 5 * 60)
+            secondaryWindow = Self.antigravityQuotaSummaryWindow(snapshot: snapshot, windowMinutes: 7 * 24 * 60)
+        } else {
+            primaryWindow = provider == .mimo ? nil : snapshot.primary
+            secondaryWindow = provider == .mimo ? nil : snapshot.secondary
+        }
         self.handleQuotaWarningTransition(
             provider: provider,
             window: .session,

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -756,7 +756,8 @@ final class UsageStore {
     enum SessionQuotaWindowSource: String {
         case primary
         case copilotSecondaryFallback
-        case antigravityDuration
+        case antigravityQuotaSummary
+        case antigravityLegacy
     }
 
     struct QuotaWarningStateKey: Hashable {

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -771,6 +771,13 @@ final class UsageStore {
         var source: SessionQuotaWindowSource?
     }
 
+    func postQuotaWarning(_ event: QuotaWarningEvent, provider: UsageProvider) {
+        self.sessionQuotaNotifier.postQuotaWarning(
+            event: event,
+            provider: provider,
+            soundEnabled: self.settings.quotaWarningSoundEnabled)
+    }
+
     func handleSessionQuotaTransition(provider: UsageProvider, snapshot: UsageSnapshot) {
         // Session quota notifications are tied to the primary session window. Copilot free plans can
         // expose only chat quota, so allow Copilot to fall back to secondary for transition tracking.

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -756,7 +756,7 @@ final class UsageStore {
     enum SessionQuotaWindowSource: String {
         case primary
         case copilotSecondaryFallback
-        case antigravityQuotaSummary
+        case antigravityDuration
     }
 
     struct QuotaWarningStateKey: Hashable {
@@ -852,9 +852,9 @@ final class UsageStore {
         let accountDisplayName = self.quotaWarningAccountDisplayName(provider: provider, snapshot: snapshot)
         let primaryWindow: RateWindow?
         let secondaryWindow: RateWindow?
-        if provider == .antigravity, Self.hasAntigravityQuotaSummaryWindows(snapshot: snapshot) {
-            primaryWindow = Self.antigravityQuotaSummaryWindow(snapshot: snapshot, windowMinutes: 5 * 60)
-            secondaryWindow = Self.antigravityQuotaSummaryWindow(snapshot: snapshot, windowMinutes: 7 * 24 * 60)
+        if provider == .antigravity {
+            primaryWindow = Self.antigravityWindow(snapshot: snapshot, windowMinutes: 5 * 60)
+            secondaryWindow = Self.antigravityWindow(snapshot: snapshot, windowMinutes: 7 * 24 * 60)
         } else {
             primaryWindow = provider == .mimo ? nil : snapshot.primary
             secondaryWindow = provider == .mimo ? nil : snapshot.secondary

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -768,6 +768,7 @@ final class UsageStore {
     struct QuotaWarningState {
         var lastRemaining: Double?
         var firedThresholds: Set<Int> = []
+        var source: SessionQuotaWindowSource?
     }
 
     func handleSessionQuotaTransition(provider: UsageProvider, snapshot: UsageSnapshot) {
@@ -845,86 +846,6 @@ final class UsageStore {
         self.sessionQuotaLogger.info(message)
 
         self.sessionQuotaNotifier.post(transition: transition, provider: provider, badge: nil)
-    }
-
-    func handleQuotaWarningTransitions(provider: UsageProvider, snapshot: UsageSnapshot) {
-        guard self.settings.quotaWarningNotificationsEnabled else { return }
-
-        let accountDisplayName = self.quotaWarningAccountDisplayName(provider: provider, snapshot: snapshot)
-        let primaryWindow: RateWindow?
-        let secondaryWindow: RateWindow?
-        if provider == .antigravity {
-            primaryWindow = Self.antigravityWindow(snapshot: snapshot, windowMinutes: 5 * 60)
-            secondaryWindow = Self.antigravityWindow(snapshot: snapshot, windowMinutes: 7 * 24 * 60)
-        } else {
-            primaryWindow = provider == .mimo ? nil : snapshot.primary
-            secondaryWindow = provider == .mimo ? nil : snapshot.secondary
-        }
-        self.handleQuotaWarningTransition(
-            provider: provider,
-            window: .session,
-            rateWindow: primaryWindow,
-            accountDisplayName: accountDisplayName)
-        self.handleQuotaWarningTransition(
-            provider: provider,
-            window: .weekly,
-            rateWindow: secondaryWindow,
-            accountDisplayName: accountDisplayName)
-    }
-
-    private func handleQuotaWarningTransition(
-        provider: UsageProvider,
-        window: QuotaWarningWindow,
-        rateWindow: RateWindow?,
-        accountDisplayName: String?)
-    {
-        let key = QuotaWarningStateKey(provider: provider, window: window)
-        guard self.settings.quotaWarningEnabled(provider: provider, window: window) else {
-            self.quotaWarningState.removeValue(forKey: key)
-            return
-        }
-        guard let rateWindow else {
-            self.quotaWarningState.removeValue(forKey: key)
-            return
-        }
-
-        let thresholds = self.settings.resolvedQuotaWarningThresholds(provider: provider, window: window)
-        let currentRemaining = rateWindow.remainingPercent
-        var state = self.quotaWarningState[key] ?? QuotaWarningState()
-        let cleared = QuotaWarningNotificationLogic.thresholdsToClear(
-            currentRemaining: currentRemaining,
-            alreadyFired: state.firedThresholds)
-        state.firedThresholds.subtract(cleared)
-
-        if let threshold = QuotaWarningNotificationLogic.crossedThreshold(
-            previousRemaining: state.lastRemaining,
-            currentRemaining: currentRemaining,
-            thresholds: thresholds,
-            alreadyFired: state.firedThresholds)
-        {
-            state.firedThresholds.formUnion(QuotaWarningNotificationLogic.firedThresholdsAfterWarning(
-                threshold: threshold,
-                thresholds: thresholds))
-            self.sessionQuotaNotifier.postQuotaWarning(
-                event: QuotaWarningEvent(
-                    window: window,
-                    threshold: threshold,
-                    currentRemaining: currentRemaining,
-                    accountDisplayName: accountDisplayName),
-                provider: provider,
-                soundEnabled: self.settings.quotaWarningSoundEnabled)
-        }
-
-        state.lastRemaining = currentRemaining
-        self.quotaWarningState[key] = state
-    }
-
-    private func quotaWarningAccountDisplayName(provider: UsageProvider, snapshot: UsageSnapshot) -> String? {
-        guard !self.settings.hidePersonalInfo else { return nil }
-        let account = snapshot.accountEmail(for: provider)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let account, !account.isEmpty else { return nil }
-        return account
     }
 
     private func refreshStatus(_ provider: UsageProvider) async {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityOAuthCredentialsStore.swift
@@ -408,6 +408,7 @@ public enum AntigravityOAuthConfig {
 
 public struct AntigravityOAuthCredentialsStore: @unchecked Sendable {
     public static let environmentCredentialsKey = "ANTIGRAVITY_OAUTH_CREDENTIALS_JSON"
+    private static let fileLock = NSLock()
 
     public let fileURL: URL
     private let fileManager: FileManager
@@ -418,22 +419,45 @@ public struct AntigravityOAuthCredentialsStore: @unchecked Sendable {
     }
 
     public func load() throws -> AntigravityOAuthCredentials? {
+        try Self.fileLock.withLock {
+            try self.loadUnlocked()
+        }
+    }
+
+    private func loadUnlocked() throws -> AntigravityOAuthCredentials? {
         guard self.fileManager.fileExists(atPath: self.fileURL.path) else { return nil }
         let data = try Data(contentsOf: self.fileURL)
         return try JSONDecoder().decode(AntigravityOAuthCredentials.self, from: data)
     }
 
     public func save(_ credentials: AntigravityOAuthCredentials) throws {
-        let data = try JSONEncoder.antigravityCredentials.encode(credentials)
-        let directory = self.fileURL.deletingLastPathComponent()
-        if !self.fileManager.fileExists(atPath: directory.path) {
-            try self.fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Self.fileLock.withLock {
+            let data = try JSONEncoder.antigravityCredentials.encode(credentials)
+            let directory = self.fileURL.deletingLastPathComponent()
+            if !self.fileManager.fileExists(atPath: directory.path) {
+                try self.fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            }
+            try data.write(to: self.fileURL, options: [.atomic])
+            try self.applySecurePermissionsIfNeeded()
         }
-        try data.write(to: self.fileURL, options: [.atomic])
-        try self.applySecurePermissionsIfNeeded()
     }
 
     public func deleteIfPresent() throws {
+        try Self.fileLock.withLock {
+            try self.deleteIfPresentUnlocked()
+        }
+    }
+
+    public func deleteIfPresent(
+        matching predicate: (AntigravityOAuthCredentials) -> Bool) throws
+    {
+        try Self.fileLock.withLock {
+            guard let credentials = try self.loadUnlocked(), predicate(credentials) else { return }
+            try self.deleteIfPresentUnlocked()
+        }
+    }
+
+    private func deleteIfPresentUnlocked() throws {
         guard self.fileManager.fileExists(atPath: self.fileURL.path) else { return }
         try self.fileManager.removeItem(at: self.fileURL)
     }

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityRemoteUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityRemoteUsageFetcher.swift
@@ -241,9 +241,9 @@ public struct AntigravityRemoteUsageFetcher: Sendable {
     {
         var verifiedByModelID = Dictionary(
             uniqueKeysWithValues: verifiedQuotas.map { (Self.quotaKey($0), $0) })
-        var merged = modelQuotas.map { modelQuota in
+        var merged = modelQuotas.compactMap { modelQuota -> AntigravityModelQuota? in
             guard let verifiedQuota = verifiedByModelID.removeValue(forKey: Self.quotaKey(modelQuota)) else {
-                return modelQuota
+                return nil
             }
             let resetTime = verifiedQuota.resetTime ?? modelQuota.resetTime
             return AntigravityModelQuota(

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+Deadline.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+Deadline.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+extension AntigravityStatusProbe {
+    static func fetch(
+        processInfo: ProcessInfoResult,
+        timeout: TimeInterval,
+        deadline: Date) async throws -> AntigravityStatusSnapshot
+    {
+        guard let portTimeout = timeoutForNextAttempt(timeout: timeout, deadline: deadline) else {
+            throw AntigravityStatusProbeError.timedOut
+        }
+        let ports = try await Self.listeningPorts(pid: processInfo.pid, timeout: portTimeout)
+        let endpoint = try await Self.resolveWorkingEndpoint(
+            candidateEndpoints: Self.connectionCandidates(
+                listeningPorts: ports,
+                languageServerCSRFToken: processInfo.csrfToken,
+                extensionServerPort: processInfo.extensionPort,
+                extensionServerCSRFToken: processInfo.extensionServerCSRFToken),
+            timeout: timeout,
+            deadline: deadline)
+        let context = RequestContext(
+            endpoints: Self.requestEndpoints(
+                resolvedEndpoint: endpoint,
+                listeningPorts: ports,
+                languageServerCSRFToken: processInfo.csrfToken,
+                extensionServerPort: processInfo.extensionPort,
+                extensionServerCSRFToken: processInfo.extensionServerCSRFToken),
+            timeout: timeout,
+            deadline: deadline)
+
+        return try await Self.fetchSnapshot(context: context)
+    }
+
+    static func timeoutForNextAttempt(timeout: TimeInterval, deadline: Date?) -> TimeInterval? {
+        guard let deadline else { return timeout }
+        let remaining = deadline.timeIntervalSinceNow
+        guard remaining > 0 else { return nil }
+        return min(timeout, remaining)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+Deadline.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+Deadline.swift
@@ -3,28 +3,55 @@ import Foundation
 extension AntigravityStatusProbe {
     private static let processProbeLog = CodexBarLog.logger(LogCategories.antigravity)
 
+    private enum ProcessSnapshotFetchFailure {
+        case antigravity(AntigravityStatusProbeError)
+        case url(URLError)
+        case cancellation
+        case other(String)
+
+        init(_ error: Error) {
+            if let error = error as? AntigravityStatusProbeError {
+                self = .antigravity(error)
+            } else if let error = error as? URLError {
+                self = .url(error)
+            } else if error is CancellationError {
+                self = .cancellation
+            } else {
+                self = .other(error.localizedDescription)
+            }
+        }
+
+        var error: Error {
+            switch self {
+            case let .antigravity(error):
+                error
+            case let .url(error):
+                error
+            case .cancellation:
+                CancellationError()
+            case let .other(message):
+                AntigravityStatusProbeError.apiError(message)
+            }
+        }
+    }
+
     private enum ProcessSnapshotFetchOutcome {
         case success(index: Int, snapshot: AntigravityStatusSnapshot)
-        case failure(index: Int, pid: Int, error: AntigravityStatusProbeError)
+        case failure(index: Int, pid: Int, failure: ProcessSnapshotFetchFailure)
     }
 
     static func fetchProcessSnapshots(
         processInfos: [ProcessInfoResult],
         fetch: @escaping @Sendable (ProcessInfoResult) async throws -> AntigravityStatusSnapshot)
-        async -> (snapshots: [AntigravityStatusSnapshot], lastError: AntigravityStatusProbeError?)
+        async -> (snapshots: [AntigravityStatusSnapshot], lastError: Error?)
     {
         let outcomes = await withTaskGroup(of: ProcessSnapshotFetchOutcome.self) { group in
             for (index, processInfo) in processInfos.enumerated() {
                 group.addTask {
                     do {
                         return try await .success(index: index, snapshot: fetch(processInfo))
-                    } catch let error as AntigravityStatusProbeError {
-                        return .failure(index: index, pid: processInfo.pid, error: error)
                     } catch {
-                        return .failure(
-                            index: index,
-                            pid: processInfo.pid,
-                            error: .apiError(error.localizedDescription))
+                        return .failure(index: index, pid: processInfo.pid, failure: .init(error))
                     }
                 }
             }
@@ -40,12 +67,13 @@ extension AntigravityStatusProbe {
         }
 
         var snapshots: [AntigravityStatusSnapshot] = []
-        var lastError: AntigravityStatusProbeError?
+        var lastError: Error?
         for outcome in outcomes {
             switch outcome {
             case let .success(_, snapshot):
                 snapshots.append(snapshot)
-            case let .failure(_, pid, error):
+            case let .failure(_, pid, failure):
+                let error = failure.error
                 lastError = error
                 Self.processProbeLog.debug("Antigravity local process probe failed", metadata: [
                     "pid": "\(pid)",

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+Deadline.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+Deadline.swift
@@ -12,6 +12,8 @@ extension AntigravityStatusProbe {
         init(_ error: Error) {
             if let error = error as? AntigravityStatusProbeError {
                 self = .antigravity(error)
+            } else if let error = error as? URLError, error.code == .cancelled {
+                self = .cancellation
             } else if let error = error as? URLError {
                 self = .url(error)
             } else if error is CancellationError {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+Deadline.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+Deadline.swift
@@ -1,6 +1,61 @@
 import Foundation
 
 extension AntigravityStatusProbe {
+    private static let processProbeLog = CodexBarLog.logger(LogCategories.antigravity)
+
+    private enum ProcessSnapshotFetchOutcome {
+        case success(index: Int, snapshot: AntigravityStatusSnapshot)
+        case failure(index: Int, pid: Int, error: AntigravityStatusProbeError)
+    }
+
+    static func fetchProcessSnapshots(
+        processInfos: [ProcessInfoResult],
+        fetch: @escaping @Sendable (ProcessInfoResult) async throws -> AntigravityStatusSnapshot)
+        async -> (snapshots: [AntigravityStatusSnapshot], lastError: AntigravityStatusProbeError?)
+    {
+        let outcomes = await withTaskGroup(of: ProcessSnapshotFetchOutcome.self) { group in
+            for (index, processInfo) in processInfos.enumerated() {
+                group.addTask {
+                    do {
+                        return try await .success(index: index, snapshot: fetch(processInfo))
+                    } catch let error as AntigravityStatusProbeError {
+                        return .failure(index: index, pid: processInfo.pid, error: error)
+                    } catch {
+                        return .failure(
+                            index: index,
+                            pid: processInfo.pid,
+                            error: .apiError(error.localizedDescription))
+                    }
+                }
+            }
+
+            var ordered = [ProcessSnapshotFetchOutcome?](repeating: nil, count: processInfos.count)
+            for await outcome in group {
+                switch outcome {
+                case let .success(index, _), let .failure(index, _, _):
+                    ordered[index] = outcome
+                }
+            }
+            return ordered.compactMap(\.self)
+        }
+
+        var snapshots: [AntigravityStatusSnapshot] = []
+        var lastError: AntigravityStatusProbeError?
+        for outcome in outcomes {
+            switch outcome {
+            case let .success(_, snapshot):
+                snapshots.append(snapshot)
+            case let .failure(_, pid, error):
+                lastError = error
+                Self.processProbeLog.debug("Antigravity local process probe failed", metadata: [
+                    "pid": "\(pid)",
+                    "error": error.localizedDescription,
+                ])
+            }
+        }
+        return (snapshots, lastError)
+    }
+
     static func fetch(
         processInfo: ProcessInfoResult,
         timeout: TimeInterval,

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+Deadline.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe+Deadline.swift
@@ -43,7 +43,7 @@ extension AntigravityStatusProbe {
     static func fetchProcessSnapshots(
         processInfos: [ProcessInfoResult],
         fetch: @escaping @Sendable (ProcessInfoResult) async throws -> AntigravityStatusSnapshot)
-        async -> (snapshots: [AntigravityStatusSnapshot], lastError: Error?)
+        async throws -> (snapshots: [AntigravityStatusSnapshot], lastError: Error?)
     {
         let outcomes = await withTaskGroup(of: ProcessSnapshotFetchOutcome.self) { group in
             for (index, processInfo) in processInfos.enumerated() {
@@ -73,6 +73,9 @@ extension AntigravityStatusProbe {
             case let .success(_, snapshot):
                 snapshots.append(snapshot)
             case let .failure(_, pid, failure):
+                if case .cancellation = failure {
+                    throw CancellationError()
+                }
                 let error = failure.error
                 lastError = error
                 Self.processProbeLog.debug("Antigravity local process probe failed", metadata: [

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -1460,7 +1460,7 @@ public struct AntigravityStatusProbe: Sendable {
                 payload: RequestPayload(
                     path: self.quotaSummaryPath,
                     body: ["forceRefresh": true]),
-                context: context,
+                context: self.quotaSummaryRequestContext(from: context),
                 send: send,
                 parse: self.parseQuotaSummaryResponse)
             guard quotaSummary.quotaSummary?.groups.contains(where: { group in
@@ -1499,6 +1499,16 @@ public struct AntigravityStatusProbe: Sendable {
                 send: send,
                 parse: self.parseCommandModelResponse)
         }
+    }
+
+    private static func quotaSummaryRequestContext(from context: RequestContext) -> RequestContext {
+        guard let deadline = context.deadline else { return context }
+        let remaining = max(0, deadline.timeIntervalSinceNow)
+        let quotaSummaryBudget = remaining / 2
+        return RequestContext(
+            endpoints: context.endpoints,
+            timeout: min(context.timeout, quotaSummaryBudget),
+            deadline: Date().addingTimeInterval(quotaSummaryBudget))
     }
 
     private static func identityRequestContext(from context: RequestContext) -> RequestContext {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -1309,8 +1309,13 @@ public struct AntigravityStatusProbe: Sendable {
         testConnectivity: @escaping @Sendable (AntigravityConnectionEndpoint, TimeInterval) async -> Bool = Self
             .testEndpointConnectivity) async throws -> AntigravityConnectionEndpoint
     {
-        for endpoint in candidateEndpoints {
-            guard let attemptTimeout = timeoutForNextAttempt(timeout: timeout, deadline: deadline) else {
+        for (index, endpoint) in candidateEndpoints.enumerated() {
+            let remainingAttemptCount = candidateEndpoints.count - index
+            guard let attemptTimeout = timeoutForEndpointAttempt(
+                timeout: timeout,
+                deadline: deadline,
+                remainingAttemptCount: remainingAttemptCount)
+            else {
                 throw AntigravityStatusProbeError.timedOut
             }
             let ok = await testConnectivity(endpoint, attemptTimeout)
@@ -1325,6 +1330,17 @@ public struct AntigravityStatusProbe: Sendable {
             return fallback
         }
         throw AntigravityStatusProbeError.portDetectionFailed("no working API port found")
+    }
+
+    private static func timeoutForEndpointAttempt(
+        timeout: TimeInterval,
+        deadline: Date?,
+        remainingAttemptCount: Int) -> TimeInterval?
+    {
+        guard let deadline else { return timeout }
+        let remaining = deadline.timeIntervalSinceNow
+        guard remaining > 0 else { return nil }
+        return min(timeout, remaining / Double(max(1, remainingAttemptCount)))
     }
 
     static func fallbackProbePort(ports: [Int], extensionPort: Int?) -> Int? {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -373,22 +373,9 @@ public struct AntigravityStatusSnapshot: Sendable {
     private static func rateWindow(for quota: AntigravityModelQuota) -> RateWindow {
         RateWindow(
             usedPercent: 100 - quota.remainingPercent,
-            windowMinutes: self.inferredWindowMinutes(resetTime: quota.resetTime),
+            windowMinutes: nil,
             resetsAt: quota.resetTime,
             resetDescription: quota.resetDescription)
-    }
-
-    private static func inferredWindowMinutes(resetTime: Date?) -> Int? {
-        guard let resetTime else { return nil }
-        let seconds = resetTime.timeIntervalSinceNow
-        guard seconds > 0 else { return nil }
-        if seconds <= 6 * 60 * 60 {
-            return 300
-        }
-        if seconds >= 6 * 24 * 60 * 60, seconds <= 8 * 24 * 60 * 60 {
-            return 10080
-        }
-        return nil
     }
 
     private static func modelOrderPrecedes(

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -756,32 +756,20 @@ public struct AntigravityStatusProbe: Sendable {
     {
         let deadline = Date().addingTimeInterval(self.timeout)
         let processInfos = try await Self.detectProcessInfos(timeout: self.timeout, scope: self.processScope)
-        var snapshots: [AntigravityStatusSnapshot] = []
-        var lastError: Error?
-
-        for processInfo in processInfos {
-            do {
-                let snapshot = try await Self.fetch(
-                    processInfo: processInfo,
-                    timeout: self.timeout,
-                    deadline: deadline)
-                snapshots.append(snapshot)
-            } catch {
-                lastError = error
-                Self.log.debug("Antigravity local process probe failed", metadata: [
-                    "pid": "\(processInfo.pid)",
-                    "error": error.localizedDescription,
-                ])
-            }
+        let result = await Self.fetchProcessSnapshots(processInfos: processInfos) { processInfo in
+            try await Self.fetch(
+                processInfo: processInfo,
+                timeout: self.timeout,
+                deadline: deadline)
         }
 
         if let bestSnapshot = Self.preferredLocalSnapshot(
-            snapshots,
+            result.snapshots,
             matchingAccountEmail: expectedAccountEmail)
         {
             return bestSnapshot
         }
-        throw lastError ?? AntigravityStatusProbeError.notRunning
+        throw result.lastError ?? AntigravityStatusProbeError.notRunning
     }
 
     public func fetchPlanInfoSummary() async throws -> AntigravityPlanInfoSummary? {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -154,11 +154,12 @@ public struct AntigravityStatusSnapshot: Sendable {
             nil
         }
 
-        let primary = (primaryQuota ?? fallbackQuota).map(Self.rateWindow(for:))
+        let primary = primaryQuota.map(Self.rateWindow(for:))
         let secondary = secondaryQuota.map(Self.rateWindow(for:))
         let extraWindows = Self.extraRateWindows(
             from: normalized,
             summaryCandidates: summaryCandidates,
+            compactFallbackModelID: fallbackQuota?.modelId,
             representedPools: Set([
                 primaryQuota.map { _ in AntigravityUsagePool.gemini },
                 secondaryQuota.map { _ in AntigravityUsagePool.claudeGPT },
@@ -555,6 +556,7 @@ public struct AntigravityStatusSnapshot: Sendable {
     private static func extraRateWindows(
         from models: [AntigravityNormalizedModel],
         summaryCandidates: [AntigravityNormalizedModel],
+        compactFallbackModelID: String?,
         representedPools: Set<AntigravityUsagePool>) -> [NamedRateWindow]
     {
         let resetOnlyPoolWindows = [AntigravityUsagePool.gemini, .claudeGPT].compactMap { pool -> NamedRateWindow? in
@@ -578,7 +580,9 @@ public struct AntigravityStatusSnapshot: Sendable {
             .sorted(by: Self.modelOrderPrecedes)
             .map { m in
                 NamedRateWindow(
-                    id: m.quota.modelId,
+                    id: m.quota.modelId == compactFallbackModelID
+                        ? Self.compactFallbackWindowID(modelID: m.quota.modelId)
+                        : m.quota.modelId,
                     title: m.quota.label,
                     window: Self.rateWindow(for: m.quota),
                     usageKnown: m.quota.remainingFraction != nil)
@@ -592,6 +596,10 @@ public struct AntigravityStatusSnapshot: Sendable {
             }
             return lhsPool.sortRank < rhsPool.sortRank
         } + distinctWindows
+    }
+
+    private static func compactFallbackWindowID(modelID: String) -> String {
+        "antigravity-compact-fallback-\(modelID)"
     }
 
     private static func shouldShowDistinctExtraWindow(_ model: AntigravityNormalizedModel) -> Bool {
@@ -744,13 +752,17 @@ public struct AntigravityStatusProbe: Sendable {
     public func fetch(matchingAccountEmail expectedAccountEmail: String? = nil) async throws
         -> AntigravityStatusSnapshot
     {
+        let deadline = Date().addingTimeInterval(self.timeout)
         let processInfos = try await Self.detectProcessInfos(timeout: self.timeout, scope: self.processScope)
         var snapshots: [AntigravityStatusSnapshot] = []
         var lastError: Error?
 
         for processInfo in processInfos {
             do {
-                let snapshot = try await Self.fetch(processInfo: processInfo, timeout: self.timeout)
+                let snapshot = try await Self.fetch(
+                    processInfo: processInfo,
+                    timeout: self.timeout,
+                    deadline: deadline)
                 snapshots.append(snapshot)
             } catch {
                 lastError = error
@@ -768,30 +780,6 @@ public struct AntigravityStatusProbe: Sendable {
             return bestSnapshot
         }
         throw lastError ?? AntigravityStatusProbeError.notRunning
-    }
-
-    private static func fetch(
-        processInfo: ProcessInfoResult,
-        timeout: TimeInterval) async throws -> AntigravityStatusSnapshot
-    {
-        let ports = try await Self.listeningPorts(pid: processInfo.pid, timeout: timeout)
-        let endpoint = try await Self.resolveWorkingEndpoint(
-            candidateEndpoints: Self.connectionCandidates(
-                listeningPorts: ports,
-                languageServerCSRFToken: processInfo.csrfToken,
-                extensionServerPort: processInfo.extensionPort,
-                extensionServerCSRFToken: processInfo.extensionServerCSRFToken),
-            timeout: timeout)
-        let context = RequestContext(
-            endpoints: Self.requestEndpoints(
-                resolvedEndpoint: endpoint,
-                listeningPorts: ports,
-                languageServerCSRFToken: processInfo.csrfToken,
-                extensionServerPort: processInfo.extensionPort,
-                extensionServerCSRFToken: processInfo.extensionServerCSRFToken),
-            timeout: timeout)
-
-        return try await Self.fetchSnapshot(context: context)
     }
 
     public func fetchPlanInfoSummary() async throws -> AntigravityPlanInfoSummary? {
@@ -1340,11 +1328,15 @@ public struct AntigravityStatusProbe: Sendable {
     static func resolveWorkingEndpoint(
         candidateEndpoints: [AntigravityConnectionEndpoint],
         timeout: TimeInterval,
+        deadline: Date? = nil,
         testConnectivity: @escaping @Sendable (AntigravityConnectionEndpoint, TimeInterval) async -> Bool = Self
             .testEndpointConnectivity) async throws -> AntigravityConnectionEndpoint
     {
         for endpoint in candidateEndpoints {
-            let ok = await testConnectivity(endpoint, timeout)
+            guard let attemptTimeout = timeoutForNextAttempt(timeout: timeout, deadline: deadline) else {
+                throw AntigravityStatusProbeError.timedOut
+            }
+            let ok = await testConnectivity(endpoint, attemptTimeout)
             if ok { return endpoint }
         }
         if let fallback = fallbackProbeEndpoint(candidateEndpoints) {
@@ -1432,10 +1424,7 @@ public struct AntigravityStatusProbe: Sendable {
         }
 
         func timeoutForNextAttempt() -> TimeInterval? {
-            guard let deadline else { return self.timeout }
-            let remaining = deadline.timeIntervalSinceNow
-            guard remaining > 0 else { return nil }
-            return min(self.timeout, remaining)
+            AntigravityStatusProbe.timeoutForNextAttempt(timeout: self.timeout, deadline: self.deadline)
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -1487,7 +1487,7 @@ public struct AntigravityStatusProbe: Sendable {
                 payload: RequestPayload(
                     path: self.getUserStatusPath,
                     body: self.defaultRequestBody()),
-                context: context,
+                context: self.legacyUserStatusRequestContext(from: context),
                 send: send,
                 parse: self.parseUserStatusResponse)
         } catch {
@@ -1499,6 +1499,16 @@ public struct AntigravityStatusProbe: Sendable {
                 send: send,
                 parse: self.parseCommandModelResponse)
         }
+    }
+
+    private static func legacyUserStatusRequestContext(from context: RequestContext) -> RequestContext {
+        guard let deadline = context.deadline else { return context }
+        let remaining = max(0, deadline.timeIntervalSinceNow)
+        let userStatusBudget = remaining / 2
+        return RequestContext(
+            endpoints: context.endpoints,
+            timeout: min(context.timeout, userStatusBudget),
+            deadline: Date().addingTimeInterval(userStatusBudget))
     }
 
     private static func quotaSummaryRequestContext(from context: RequestContext) -> RequestContext {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -743,7 +743,7 @@ public struct AntigravityStatusProbe: Sendable {
     {
         let deadline = Date().addingTimeInterval(self.timeout)
         let processInfos = try await Self.detectProcessInfos(timeout: self.timeout, scope: self.processScope)
-        let result = await Self.fetchProcessSnapshots(processInfos: processInfos) { processInfo in
+        let result = try await Self.fetchProcessSnapshots(processInfos: processInfos) { processInfo in
             try await Self.fetch(
                 processInfo: processInfo,
                 timeout: self.timeout,

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -576,7 +576,9 @@ public struct AntigravityStatusSnapshot: Sendable {
         }
 
         let distinctWindows = models
-            .filter(Self.shouldShowDistinctExtraWindow)
+            .filter {
+                $0.quota.modelId == compactFallbackModelID || Self.shouldShowDistinctExtraWindow($0)
+            }
             .sorted(by: Self.modelOrderPrecedes)
             .map { m in
                 NamedRateWindow(

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -553,7 +553,7 @@ struct WidgetUsageRow: Identifiable, Equatable {
            limit == 2,
            rows.contains(where: { $0.id.hasPrefix("antigravity-quota-summary-") })
         {
-            return ["Gemini ", "Claude + GPT "].compactMap { titlePrefix in
+            var selected = ["Gemini ", "Claude + GPT "].compactMap { titlePrefix in
                 rows
                     .filter { $0.title.hasPrefix(titlePrefix) }
                     .min { lhs, rhs in
@@ -569,6 +569,24 @@ struct WidgetUsageRow: Identifiable, Equatable {
                         }
                     }
             }
+            let selectedIDs = Set(selected.map(\.id))
+            let fallbackRows = rows.enumerated()
+                .filter { !selectedIDs.contains($0.element.id) }
+                .sorted { lhs, rhs in
+                    switch (lhs.element.percentLeft, rhs.element.percentLeft) {
+                    case let (.some(left), .some(right)):
+                        left == right ? lhs.offset < rhs.offset : left < right
+                    case (.some, .none):
+                        true
+                    case (.none, .some):
+                        false
+                    case (.none, .none):
+                        lhs.offset < rhs.offset
+                    }
+                }
+                .map(\.element)
+            selected.append(contentsOf: fallbackRows.prefix(max(0, limit - selected.count)))
+            return selected
         }
         return Array(rows.prefix(max(0, limit)))
     }

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -321,7 +321,7 @@ private struct SwitcherSmallUsageView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            ForEach(WidgetUsageRow.rows(for: self.entry)) { row in
+            ForEach(WidgetUsageRow.rows(for: self.entry, limit: 2)) { row in
                 UsageBarRow(
                     title: row.title,
                     percentLeft: row.percentLeft,
@@ -411,7 +411,7 @@ private struct SmallUsageView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HeaderView(provider: self.entry.provider, updatedAt: self.entry.updatedAt)
-            ForEach(WidgetUsageRow.rows(for: self.entry)) { row in
+            ForEach(WidgetUsageRow.rows(for: self.entry, limit: 2)) { row in
                 UsageBarRow(
                     title: row.title,
                     percentLeft: row.percentLeft,
@@ -505,31 +505,34 @@ struct WidgetUsageRow: Identifiable, Equatable {
     let title: String
     let percentLeft: Double?
 
-    static func rows(for entry: WidgetSnapshot.ProviderEntry) -> [WidgetUsageRow] {
+    static func rows(for entry: WidgetSnapshot.ProviderEntry, limit: Int? = nil) -> [WidgetUsageRow] {
+        let rows: [WidgetUsageRow]
         if let usageRows = entry.usageRows {
-            return usageRows.map { row in
+            rows = usageRows.map { row in
                 WidgetUsageRow(id: row.id, title: row.title, percentLeft: row.percentLeft)
             }
+        } else {
+            let metadata = ProviderDefaults.metadata[entry.provider]
+            var defaultRows = [
+                WidgetUsageRow(
+                    id: "primary",
+                    title: metadata?.sessionLabel ?? "Session",
+                    percentLeft: entry.primary?.remainingPercent),
+                WidgetUsageRow(
+                    id: "secondary",
+                    title: metadata?.weeklyLabel ?? "Weekly",
+                    percentLeft: entry.secondary?.remainingPercent),
+            ]
+            if metadata?.supportsOpus == true {
+                defaultRows.append(WidgetUsageRow(
+                    id: "tertiary",
+                    title: metadata?.opusLabel ?? "Opus",
+                    percentLeft: entry.tertiary?.remainingPercent))
+            }
+            rows = defaultRows.filter { $0.percentLeft != nil }
         }
-
-        let metadata = ProviderDefaults.metadata[entry.provider]
-        var rows = [
-            WidgetUsageRow(
-                id: "primary",
-                title: metadata?.sessionLabel ?? "Session",
-                percentLeft: entry.primary?.remainingPercent),
-            WidgetUsageRow(
-                id: "secondary",
-                title: metadata?.weeklyLabel ?? "Weekly",
-                percentLeft: entry.secondary?.remainingPercent),
-        ]
-        if metadata?.supportsOpus == true {
-            rows.append(WidgetUsageRow(
-                id: "tertiary",
-                title: metadata?.opusLabel ?? "Opus",
-                percentLeft: entry.tertiary?.remainingPercent))
-        }
-        return rows.filter { $0.percentLeft != nil }
+        guard let limit else { return rows }
+        return Array(rows.prefix(max(0, limit)))
     }
 }
 

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -567,7 +567,7 @@ struct WidgetUsageRow: Identifiable, Equatable {
         }
         guard let limit else { return rows }
         if entry.provider == .antigravity,
-           limit == 2,
+           limit >= 2,
            rows.contains(where: { $0.id.hasPrefix("antigravity-quota-summary-") })
         {
             var selected = ["Gemini ", "Claude + GPT "].compactMap { titlePrefix in

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -345,7 +345,10 @@ private struct SwitcherMediumUsageView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            ForEach(WidgetUsageRow.rows(for: self.entry)) { row in
+            ForEach(WidgetUsageRow.rows(
+                for: self.entry,
+                limit: WidgetUsageRow.mediumWidgetRowLimit(for: self.entry)))
+            { row in
                 UsageBarRow(
                     title: row.title,
                     percentLeft: row.percentLeft,
@@ -440,7 +443,10 @@ private struct MediumUsageView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HeaderView(provider: self.entry.provider, updatedAt: self.entry.updatedAt)
-            ForEach(WidgetUsageRow.rows(for: self.entry)) { row in
+            ForEach(WidgetUsageRow.rows(
+                for: self.entry,
+                limit: WidgetUsageRow.mediumWidgetRowLimit(for: self.entry)))
+            { row in
                 UsageBarRow(
                     title: row.title,
                     percentLeft: row.percentLeft,
@@ -512,6 +518,17 @@ struct WidgetUsageRow: Identifiable, Equatable {
     let percentLeft: Double?
 
     static func smallWidgetRowLimit(for entry: WidgetSnapshot.ProviderEntry) -> Int? {
+        self.antigravityQuotaSummaryRowLimit(for: entry, limit: 2)
+    }
+
+    static func mediumWidgetRowLimit(for entry: WidgetSnapshot.ProviderEntry) -> Int? {
+        self.antigravityQuotaSummaryRowLimit(for: entry, limit: 3)
+    }
+
+    private static func antigravityQuotaSummaryRowLimit(
+        for entry: WidgetSnapshot.ProviderEntry,
+        limit: Int) -> Int?
+    {
         guard entry.provider == .antigravity,
               entry.usageRows?.contains(where: {
                   $0.id.hasPrefix("antigravity-quota-summary-")
@@ -519,7 +536,7 @@ struct WidgetUsageRow: Identifiable, Equatable {
         else {
             return nil
         }
-        return 2
+        return limit
     }
 
     static func rows(for entry: WidgetSnapshot.ProviderEntry, limit: Int? = nil) -> [WidgetUsageRow] {

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -321,7 +321,10 @@ private struct SwitcherSmallUsageView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            ForEach(WidgetUsageRow.rows(for: self.entry, limit: 2)) { row in
+            ForEach(WidgetUsageRow.rows(
+                for: self.entry,
+                limit: WidgetUsageRow.smallWidgetRowLimit(for: self.entry)))
+            { row in
                 UsageBarRow(
                     title: row.title,
                     percentLeft: row.percentLeft,
@@ -411,7 +414,10 @@ private struct SmallUsageView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HeaderView(provider: self.entry.provider, updatedAt: self.entry.updatedAt)
-            ForEach(WidgetUsageRow.rows(for: self.entry, limit: 2)) { row in
+            ForEach(WidgetUsageRow.rows(
+                for: self.entry,
+                limit: WidgetUsageRow.smallWidgetRowLimit(for: self.entry)))
+            { row in
                 UsageBarRow(
                     title: row.title,
                     percentLeft: row.percentLeft,
@@ -504,6 +510,17 @@ struct WidgetUsageRow: Identifiable, Equatable {
     let id: String
     let title: String
     let percentLeft: Double?
+
+    static func smallWidgetRowLimit(for entry: WidgetSnapshot.ProviderEntry) -> Int? {
+        guard entry.provider == .antigravity,
+              entry.usageRows?.contains(where: {
+                  $0.id.hasPrefix("antigravity-quota-summary-")
+              }) == true
+        else {
+            return nil
+        }
+        return 2
+    }
 
     static func rows(for entry: WidgetSnapshot.ProviderEntry, limit: Int? = nil) -> [WidgetUsageRow] {
         let rows: [WidgetUsageRow]

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -556,7 +556,18 @@ struct WidgetUsageRow: Identifiable, Equatable {
             return ["Gemini ", "Claude + GPT "].compactMap { titlePrefix in
                 rows
                     .filter { $0.title.hasPrefix(titlePrefix) }
-                    .min { ($0.percentLeft ?? 100) < ($1.percentLeft ?? 100) }
+                    .min { lhs, rhs in
+                        switch (lhs.percentLeft, rhs.percentLeft) {
+                        case let (.some(left), .some(right)):
+                            left < right
+                        case (.some, .none):
+                            true
+                        case (.none, .some):
+                            false
+                        case (.none, .none):
+                            false
+                        }
+                    }
             }
         }
         return Array(rows.prefix(max(0, limit)))

--- a/Sources/CodexBarWidget/CodexBarWidgetViews.swift
+++ b/Sources/CodexBarWidget/CodexBarWidgetViews.swift
@@ -532,6 +532,16 @@ struct WidgetUsageRow: Identifiable, Equatable {
             rows = defaultRows.filter { $0.percentLeft != nil }
         }
         guard let limit else { return rows }
+        if entry.provider == .antigravity,
+           limit == 2,
+           rows.contains(where: { $0.id.hasPrefix("antigravity-quota-summary-") })
+        {
+            return ["Gemini ", "Claude + GPT "].compactMap { titlePrefix in
+                rows
+                    .filter { $0.title.hasPrefix(titlePrefix) }
+                    .min { ($0.percentLeft ?? 100) < ($1.percentLeft ?? 100) }
+            }
+        }
         return Array(rows.prefix(max(0, limit)))
     }
 }

--- a/Tests/CodexBarTests/AntigravityCompactFallbackTests.swift
+++ b/Tests/CodexBarTests/AntigravityCompactFallbackTests.swift
@@ -19,9 +19,33 @@ struct AntigravityCompactFallbackTests {
 
         let usage = try snapshot.toUsageSnapshot()
 
-        #expect(usage.primary?.usedPercent == 64)
+        #expect(usage.primary == nil)
         #expect(usage.secondary == nil)
         #expect(usage.tertiary == nil)
+        #expect(usage.extraRateWindows?.map(\.id) == ["antigravity-compact-fallback-MODEL_PLACEHOLDER_NEW"])
+        #expect(usage.extraRateWindows?.map(\.title) == ["Experimental Model"])
+        #expect(usage.extraRateWindows?.map(\.window.usedPercent) == [64])
+    }
+
+    @Test
+    func `remote unclassified model remains detail only`() throws {
+        let snapshot = AntigravityStatusSnapshot(
+            modelQuotas: [
+                AntigravityModelQuota(
+                    label: "Experimental Model",
+                    modelId: "MODEL_PLACEHOLDER_NEW",
+                    remainingFraction: 0.36,
+                    resetTime: nil,
+                    resetDescription: nil),
+            ],
+            accountEmail: nil,
+            accountPlan: nil,
+            source: .remote)
+
+        let usage = try snapshot.toUsageSnapshot()
+
+        #expect(usage.primary == nil)
+        #expect(usage.secondary == nil)
         #expect(usage.extraRateWindows?.map(\.id) == ["MODEL_PLACEHOLDER_NEW"])
     }
 }

--- a/Tests/CodexBarTests/AntigravityCompactFallbackTests.swift
+++ b/Tests/CodexBarTests/AntigravityCompactFallbackTests.swift
@@ -1,7 +1,29 @@
+import Foundation
 import Testing
 @testable import CodexBarCore
 
 struct AntigravityCompactFallbackTests {
+    @Test
+    func `model quota reset proximity does not imply window duration`() throws {
+        let resetTime = Date().addingTimeInterval(2 * 60 * 60)
+        let snapshot = AntigravityStatusSnapshot(
+            modelQuotas: [
+                AntigravityModelQuota(
+                    label: "Gemini 3.1 Pro (Low)",
+                    modelId: "MODEL_PLACEHOLDER_M36",
+                    remainingFraction: 0.5,
+                    resetTime: resetTime,
+                    resetDescription: nil),
+            ],
+            accountEmail: nil,
+            accountPlan: nil)
+
+        let usage = try snapshot.toUsageSnapshot()
+
+        #expect(usage.primary?.windowMinutes == nil)
+        #expect(usage.primary?.resetsAt == resetTime)
+    }
+
     @Test
     func `local unclassified model remains available as compact fallback`() throws {
         let snapshot = AntigravityStatusSnapshot(

--- a/Tests/CodexBarTests/AntigravityCompactFallbackTests.swift
+++ b/Tests/CodexBarTests/AntigravityCompactFallbackTests.swift
@@ -48,4 +48,25 @@ struct AntigravityCompactFallbackTests {
         #expect(usage.secondary == nil)
         #expect(usage.extraRateWindows?.map(\.id) == ["MODEL_PLACEHOLDER_NEW"])
     }
+
+    @Test
+    func `fully unused local model remains available as compact fallback`() throws {
+        let snapshot = AntigravityStatusSnapshot(
+            modelQuotas: [
+                AntigravityModelQuota(
+                    label: "Experimental Model",
+                    modelId: "MODEL_PLACEHOLDER_NEW",
+                    remainingFraction: 1,
+                    resetTime: nil,
+                    resetDescription: nil),
+            ],
+            accountEmail: nil,
+            accountPlan: nil,
+            source: .local)
+
+        let usage = try snapshot.toUsageSnapshot()
+
+        #expect(usage.extraRateWindows?.map(\.id) == ["antigravity-compact-fallback-MODEL_PLACEHOLDER_NEW"])
+        #expect(usage.extraRateWindows?.map(\.window.usedPercent) == [0])
+    }
 }

--- a/Tests/CodexBarTests/AntigravityDeadlineTests.swift
+++ b/Tests/CodexBarTests/AntigravityDeadlineTests.swift
@@ -131,6 +131,36 @@ struct AntigravityDeadlineTests {
     }
 
     @Test
+    func `cancelled process request rejects partial success`() async {
+        let processInfos = [
+            AntigravityStatusProbe.ProcessInfoResult(
+                pid: 1,
+                extensionPort: nil,
+                extensionServerCSRFToken: nil,
+                csrfToken: "first",
+                commandLine: "first"),
+            AntigravityStatusProbe.ProcessInfoResult(
+                pid: 2,
+                extensionPort: nil,
+                extensionServerCSRFToken: nil,
+                csrfToken: "second",
+                commandLine: "second"),
+        ]
+
+        await #expect(throws: CancellationError.self) {
+            try await AntigravityStatusProbe.fetchProcessSnapshots(processInfos: processInfos) { processInfo in
+                if processInfo.pid == 2 {
+                    throw URLError(.cancelled)
+                }
+                return AntigravityStatusSnapshot(
+                    modelQuotas: [],
+                    accountEmail: "partial@example.com",
+                    accountPlan: nil)
+            }
+        }
+    }
+
+    @Test
     func `shared deadline reserves time for later endpoint probes`() async throws {
         let endpoints = [
             AntigravityStatusProbe.AntigravityConnectionEndpoint(

--- a/Tests/CodexBarTests/AntigravityDeadlineTests.swift
+++ b/Tests/CodexBarTests/AntigravityDeadlineTests.swift
@@ -113,7 +113,7 @@ struct AntigravityDeadlineTests {
                 source: .languageServer),
         ]
         let recorder = AntigravityTimeoutRecorder()
-        let deadline = Date().addingTimeInterval(0.2)
+        let deadline = Date().addingTimeInterval(2)
 
         let resolved = try await AntigravityStatusProbe.resolveWorkingEndpoint(
             candidateEndpoints: endpoints,
@@ -131,7 +131,7 @@ struct AntigravityDeadlineTests {
         let timeouts = recorder.snapshot()
         #expect(resolved.port == 64002)
         #expect(timeouts.count == 2)
-        #expect(timeouts[0] < 0.12)
+        #expect(timeouts[0] < 1.1)
         #expect(timeouts[1] > 0)
     }
 }

--- a/Tests/CodexBarTests/AntigravityDeadlineTests.swift
+++ b/Tests/CodexBarTests/AntigravityDeadlineTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+private final class AntigravityTimeoutRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var timeouts: [TimeInterval] = []
+
+    func append(_ timeout: TimeInterval) {
+        self.lock.withLock {
+            self.timeouts.append(timeout)
+        }
+    }
+
+    func snapshot() -> [TimeInterval] {
+        self.lock.withLock {
+            self.timeouts
+        }
+    }
+}
+
+struct AntigravityDeadlineTests {
+    @Test
+    func `shared deadline reduces later probe timeout`() async throws {
+        let endpoints = [
+            AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                scheme: "https",
+                port: 64001,
+                csrfToken: "token",
+                source: .languageServer),
+            AntigravityStatusProbe.AntigravityConnectionEndpoint(
+                scheme: "https",
+                port: 64002,
+                csrfToken: "token",
+                source: .languageServer),
+        ]
+        let recorder = AntigravityTimeoutRecorder()
+        let deadline = Date().addingTimeInterval(0.2)
+
+        let resolved = try await AntigravityStatusProbe.resolveWorkingEndpoint(
+            candidateEndpoints: endpoints,
+            timeout: 1,
+            deadline: deadline,
+            testConnectivity: { endpoint, timeout in
+                recorder.append(timeout)
+                if endpoint.port == 64001 {
+                    try? await Task.sleep(for: .milliseconds(80))
+                    return false
+                }
+                return true
+            })
+
+        let timeouts = recorder.snapshot()
+        #expect(resolved.port == 64002)
+        #expect(timeouts.count == 2)
+        #expect(timeouts[1] < timeouts[0])
+        #expect(timeouts[1] < 0.18)
+    }
+}

--- a/Tests/CodexBarTests/AntigravityDeadlineTests.swift
+++ b/Tests/CodexBarTests/AntigravityDeadlineTests.swift
@@ -83,7 +83,7 @@ struct AntigravityDeadlineTests {
     }
 
     @Test
-    func `shared deadline reduces later probe timeout`() async throws {
+    func `shared deadline reserves time for later endpoint probes`() async throws {
         let endpoints = [
             AntigravityStatusProbe.AntigravityConnectionEndpoint(
                 scheme: "https",
@@ -106,7 +106,7 @@ struct AntigravityDeadlineTests {
             testConnectivity: { endpoint, timeout in
                 recorder.append(timeout)
                 if endpoint.port == 64001 {
-                    try? await Task.sleep(for: .milliseconds(80))
+                    try? await Task.sleep(for: .seconds(timeout))
                     return false
                 }
                 return true
@@ -115,7 +115,7 @@ struct AntigravityDeadlineTests {
         let timeouts = recorder.snapshot()
         #expect(resolved.port == 64002)
         #expect(timeouts.count == 2)
-        #expect(timeouts[1] < timeouts[0])
-        #expect(timeouts[1] < 0.18)
+        #expect(timeouts[0] < 0.12)
+        #expect(timeouts[1] > 0)
     }
 }

--- a/Tests/CodexBarTests/AntigravityDeadlineTests.swift
+++ b/Tests/CodexBarTests/AntigravityDeadlineTests.swift
@@ -46,7 +46,7 @@ private final class AntigravityConcurrencyRecorder: @unchecked Sendable {
 
 struct AntigravityDeadlineTests {
     @Test
-    func `process candidates probe concurrently while preserving result order`() async {
+    func `process candidates probe concurrently while preserving result order`() async throws {
         let processInfos = [
             AntigravityStatusProbe.ProcessInfoResult(
                 pid: 1,
@@ -63,7 +63,9 @@ struct AntigravityDeadlineTests {
         ]
         let concurrency = AntigravityConcurrencyRecorder()
 
-        let result = await AntigravityStatusProbe.fetchProcessSnapshots(processInfos: processInfos) { processInfo in
+        let result = try await AntigravityStatusProbe.fetchProcessSnapshots(
+            processInfos: processInfos)
+        { processInfo in
             concurrency.begin()
             defer { concurrency.end() }
             if processInfo.pid == 1 {
@@ -83,7 +85,7 @@ struct AntigravityDeadlineTests {
     }
 
     @Test
-    func `process candidate transport error preserves url error identity`() async {
+    func `process candidate transport error preserves url error identity`() async throws {
         let processInfo = AntigravityStatusProbe.ProcessInfoResult(
             pid: 1,
             extensionPort: nil,
@@ -91,11 +93,41 @@ struct AntigravityDeadlineTests {
             csrfToken: "token",
             commandLine: "command")
 
-        let result = await AntigravityStatusProbe.fetchProcessSnapshots(processInfos: [processInfo]) { _ in
+        let result = try await AntigravityStatusProbe.fetchProcessSnapshots(processInfos: [processInfo]) { _ in
             throw URLError(.cannotConnectToHost)
         }
 
         #expect((result.lastError as? URLError)?.code == .cannotConnectToHost)
+    }
+
+    @Test
+    func `process candidate cancellation rejects partial success`() async {
+        let processInfos = [
+            AntigravityStatusProbe.ProcessInfoResult(
+                pid: 1,
+                extensionPort: nil,
+                extensionServerCSRFToken: nil,
+                csrfToken: "first",
+                commandLine: "first"),
+            AntigravityStatusProbe.ProcessInfoResult(
+                pid: 2,
+                extensionPort: nil,
+                extensionServerCSRFToken: nil,
+                csrfToken: "second",
+                commandLine: "second"),
+        ]
+
+        await #expect(throws: CancellationError.self) {
+            try await AntigravityStatusProbe.fetchProcessSnapshots(processInfos: processInfos) { processInfo in
+                if processInfo.pid == 2 {
+                    throw CancellationError()
+                }
+                return AntigravityStatusSnapshot(
+                    modelQuotas: [],
+                    accountEmail: "partial@example.com",
+                    accountPlan: nil)
+            }
+        }
     }
 
     @Test

--- a/Tests/CodexBarTests/AntigravityDeadlineTests.swift
+++ b/Tests/CodexBarTests/AntigravityDeadlineTests.swift
@@ -19,7 +19,69 @@ private final class AntigravityTimeoutRecorder: @unchecked Sendable {
     }
 }
 
+private final class AntigravityConcurrencyRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var activeCount = 0
+    private var maximumActiveCount = 0
+
+    func begin() {
+        self.lock.withLock {
+            self.activeCount += 1
+            self.maximumActiveCount = max(self.maximumActiveCount, self.activeCount)
+        }
+    }
+
+    func end() {
+        self.lock.withLock {
+            self.activeCount -= 1
+        }
+    }
+
+    func maximum() -> Int {
+        self.lock.withLock {
+            self.maximumActiveCount
+        }
+    }
+}
+
 struct AntigravityDeadlineTests {
+    @Test
+    func `process candidates probe concurrently while preserving result order`() async {
+        let processInfos = [
+            AntigravityStatusProbe.ProcessInfoResult(
+                pid: 1,
+                extensionPort: nil,
+                extensionServerCSRFToken: nil,
+                csrfToken: "first",
+                commandLine: "first"),
+            AntigravityStatusProbe.ProcessInfoResult(
+                pid: 2,
+                extensionPort: nil,
+                extensionServerCSRFToken: nil,
+                csrfToken: "second",
+                commandLine: "second"),
+        ]
+        let concurrency = AntigravityConcurrencyRecorder()
+
+        let result = await AntigravityStatusProbe.fetchProcessSnapshots(processInfos: processInfos) { processInfo in
+            concurrency.begin()
+            defer { concurrency.end() }
+            if processInfo.pid == 1 {
+                try await Task.sleep(for: .milliseconds(120))
+            } else {
+                try await Task.sleep(for: .milliseconds(20))
+            }
+            return AntigravityStatusSnapshot(
+                modelQuotas: [],
+                accountEmail: "\(processInfo.pid)@example.com",
+                accountPlan: nil)
+        }
+
+        #expect(concurrency.maximum() == 2)
+        #expect(result.snapshots.map(\.accountEmail) == ["1@example.com", "2@example.com"])
+        #expect(result.lastError == nil)
+    }
+
     @Test
     func `shared deadline reduces later probe timeout`() async throws {
         let endpoints = [

--- a/Tests/CodexBarTests/AntigravityDeadlineTests.swift
+++ b/Tests/CodexBarTests/AntigravityDeadlineTests.swift
@@ -83,6 +83,22 @@ struct AntigravityDeadlineTests {
     }
 
     @Test
+    func `process candidate transport error preserves url error identity`() async {
+        let processInfo = AntigravityStatusProbe.ProcessInfoResult(
+            pid: 1,
+            extensionPort: nil,
+            extensionServerCSRFToken: nil,
+            csrfToken: "token",
+            commandLine: "command")
+
+        let result = await AntigravityStatusProbe.fetchProcessSnapshots(processInfos: [processInfo]) { _ in
+            throw URLError(.cannotConnectToHost)
+        }
+
+        #expect((result.lastError as? URLError)?.code == .cannotConnectToHost)
+    }
+
+    @Test
     func `shared deadline reserves time for later endpoint probes`() async throws {
         let endpoints = [
             AntigravityStatusProbe.AntigravityConnectionEndpoint(

--- a/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
+++ b/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
@@ -185,6 +185,37 @@ struct AntigravityQuotaSummaryTests {
         ])
         #expect(usage.primary?.remainingPercent.rounded() == 90)
     }
+
+    @Test
+    func `quota summary timeout reserves deadline for legacy fallback`() async throws {
+        let endpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "https",
+            port: 64440,
+            csrfToken: "token",
+            source: .languageServer)
+        let paths = AntigravityQuotaSummaryPathRecorder()
+
+        let snapshot = try await AntigravityStatusProbe.fetchSnapshot(
+            context: AntigravityStatusProbe.RequestContext(
+                endpoints: [endpoint],
+                timeout: 1,
+                deadline: Date().addingTimeInterval(0.2)),
+            send: { payload, _, timeout in
+                paths.append(payload.path)
+                if payload.path.contains("RetrieveUserQuotaSummary") {
+                    try await Task.sleep(for: .seconds(timeout))
+                    throw AntigravityStatusProbeError.timedOut
+                }
+                return Data(antigravityUserStatusJSON().utf8)
+            })
+        let usage = try snapshot.toUsageSnapshot()
+
+        #expect(paths.snapshot() == [
+            "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary",
+            "/exa.language_server_pb.LanguageServerService/GetUserStatus",
+        ])
+        #expect(usage.primary?.remainingPercent.rounded() == 90)
+    }
 }
 
 private func antigravityQuotaSummaryJSON() -> String {

--- a/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
+++ b/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
@@ -216,6 +216,41 @@ struct AntigravityQuotaSummaryTests {
         ])
         #expect(usage.primary?.remainingPercent.rounded() == 90)
     }
+
+    @Test
+    func `user status timeout reserves deadline for command model fallback`() async throws {
+        let endpoint = AntigravityStatusProbe.AntigravityConnectionEndpoint(
+            scheme: "https",
+            port: 64440,
+            csrfToken: "token",
+            source: .languageServer)
+        let paths = AntigravityQuotaSummaryPathRecorder()
+
+        let snapshot = try await AntigravityStatusProbe.fetchSnapshot(
+            context: AntigravityStatusProbe.RequestContext(
+                endpoints: [endpoint],
+                timeout: 1,
+                deadline: Date().addingTimeInterval(0.3)),
+            send: { payload, _, timeout in
+                paths.append(payload.path)
+                if payload.path.contains("RetrieveUserQuotaSummary") {
+                    throw AntigravityStatusProbeError.apiError("unsupported")
+                }
+                if payload.path.contains("GetUserStatus") {
+                    try await Task.sleep(for: .seconds(timeout))
+                    throw AntigravityStatusProbeError.timedOut
+                }
+                return Data(antigravityCommandModelConfigJSON().utf8)
+            })
+        let usage = try snapshot.toUsageSnapshot()
+
+        #expect(paths.snapshot() == [
+            "/exa.language_server_pb.LanguageServerService/RetrieveUserQuotaSummary",
+            "/exa.language_server_pb.LanguageServerService/GetUserStatus",
+            "/exa.language_server_pb.LanguageServerService/GetCommandModelConfigs",
+        ])
+        #expect(usage.primary?.remainingPercent.rounded() == 90)
+    }
 }
 
 private func antigravityQuotaSummaryJSON() -> String {
@@ -314,6 +349,20 @@ private func antigravityUserStatusJSON() -> String {
           ]
         }
       }
+    }
+    """
+}
+
+private func antigravityCommandModelConfigJSON() -> String {
+    """
+    {
+      "clientModelConfigs": [
+        {
+          "label": "Gemini 3 Pro Low",
+          "modelOrAlias": { "model": "gemini-3-pro-low" },
+          "quotaInfo": { "remainingFraction": 0.9, "resetTime": "2025-12-24T10:00:00Z" }
+        }
+      ]
     }
     """
 }

--- a/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
+++ b/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
@@ -199,7 +199,7 @@ struct AntigravityQuotaSummaryTests {
             context: AntigravityStatusProbe.RequestContext(
                 endpoints: [endpoint],
                 timeout: 1,
-                deadline: Date().addingTimeInterval(0.2)),
+                deadline: Date().addingTimeInterval(2)),
             send: { payload, _, timeout in
                 paths.append(payload.path)
                 if payload.path.contains("RetrieveUserQuotaSummary") {
@@ -230,7 +230,7 @@ struct AntigravityQuotaSummaryTests {
             context: AntigravityStatusProbe.RequestContext(
                 endpoints: [endpoint],
                 timeout: 1,
-                deadline: Date().addingTimeInterval(0.3)),
+                deadline: Date().addingTimeInterval(2)),
             send: { payload, _, timeout in
                 paths.append(payload.path)
                 if payload.path.contains("RetrieveUserQuotaSummary") {

--- a/Tests/CodexBarTests/AntigravityRemoteUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/AntigravityRemoteUsageFetcherTests.swift
@@ -664,6 +664,72 @@ struct AntigravityRemoteUsageFetcherTests {
     }
 
     @Test
+    func `remote fetch drops full quota rows absent from partial verification`() async throws {
+        let env = try GeminiTestEnvironment()
+        defer { env.cleanup() }
+        try env.writeAntigravityCredentials(
+            accessToken: "token",
+            refreshToken: nil,
+            expiry: Date().addingTimeInterval(3600),
+            idToken: GeminiAPITestHelpers.makeIDToken(email: "user@example.com"),
+            email: "user@example.com")
+
+        let dataLoader = GeminiAPITestHelpers.dataLoader { request in
+            guard let url = request.url else {
+                throw URLError(.badURL)
+            }
+            if url.path == "/v1internal:loadCodeAssist" {
+                return GeminiAPITestHelpers.response(
+                    url: url.absoluteString,
+                    status: 200,
+                    body: GeminiAPITestHelpers.loadCodeAssistResponse(
+                        tierId: "standard-tier",
+                        projectId: "managed-project-123"))
+            }
+            if url.path == "/v1internal:fetchAvailableModels" {
+                return GeminiAPITestHelpers.response(
+                    url: url.absoluteString,
+                    status: 200,
+                    body: GeminiAPITestHelpers.jsonData([
+                        "models": [
+                            "claude-sonnet-4": [
+                                "displayName": "Claude Sonnet 4",
+                                "quotaInfo": ["remainingFraction": 1],
+                            ],
+                            "gemini-2.5-pro": [
+                                "displayName": "Gemini 2.5 Pro",
+                                "quotaInfo": ["remainingFraction": 1],
+                            ],
+                        ],
+                    ]))
+            }
+            if url.path == "/v1internal:retrieveUserQuota" {
+                return GeminiAPITestHelpers.response(
+                    url: url.absoluteString,
+                    status: 200,
+                    body: GeminiAPITestHelpers.jsonData([
+                        "buckets": [
+                            [
+                                "modelId": "gemini-2.5-pro",
+                                "remainingFraction": 0.5,
+                            ],
+                        ],
+                    ]))
+            }
+            return GeminiAPITestHelpers.response(url: url.absoluteString, status: 404, body: Data())
+        }
+
+        let snapshot = try await AntigravityRemoteUsageFetcher(
+            timeout: 1,
+            homeDirectory: env.homeURL.path,
+            dataLoader: dataLoader)
+            .fetch()
+
+        #expect(snapshot.modelQuotas.map(\.modelId) == ["gemini-2.5-pro"])
+        #expect(snapshot.modelQuotas.map(\.remainingFraction) == [0.5])
+    }
+
+    @Test
     func `remote fetch refreshes expired shared google token`() async throws {
         let env = try GeminiTestEnvironment()
         defer { env.cleanup() }

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -122,6 +122,34 @@ struct CodexBarWidgetProviderTests {
     }
 
     @Test
+    func `small antigravity widget keeps nonstandard quota groups visible`() {
+        let entry = WidgetSnapshot.ProviderEntry(
+            provider: .antigravity,
+            updatedAt: Date(),
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            usageRows: [
+                WidgetSnapshot.WidgetUsageRowSnapshot(
+                    id: "antigravity-quota-summary-other-session",
+                    title: "Other Session",
+                    percentLeft: 70),
+                WidgetSnapshot.WidgetUsageRowSnapshot(
+                    id: "antigravity-quota-summary-other-weekly",
+                    title: "Other Weekly",
+                    percentLeft: 40),
+            ],
+            creditsRemaining: nil,
+            codeReviewRemainingPercent: nil,
+            tokenUsage: nil,
+            dailyUsage: [])
+
+        let rows = WidgetUsageRow.rows(for: entry, limit: 2)
+
+        #expect(rows.map(\.title) == ["Other Weekly", "Other Session"])
+    }
+
+    @Test
     func `provider choice supports alibaba`() {
         #expect(ProviderChoice(provider: .alibaba) == .alibaba)
         #expect(ProviderChoice.alibaba.provider == .alibaba)

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -62,6 +62,31 @@ struct CodexBarWidgetProviderTests {
 
         #expect(rows.map(\.title) == ["Gemini Weekly", "Claude + GPT Session"])
         #expect(rows.compactMap(\.percentLeft) == [20, 5])
+        #expect(WidgetUsageRow.smallWidgetRowLimit(for: entry) == 2)
+    }
+
+    @Test
+    func `small widget preserves tertiary rows for other providers`() {
+        let entry = WidgetSnapshot.ProviderEntry(
+            provider: .cursor,
+            updatedAt: Date(),
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            usageRows: [
+                WidgetSnapshot.WidgetUsageRowSnapshot(id: "one", title: "One", percentLeft: 90),
+                WidgetSnapshot.WidgetUsageRowSnapshot(id: "two", title: "Two", percentLeft: 80),
+                WidgetSnapshot.WidgetUsageRowSnapshot(id: "three", title: "Three", percentLeft: 70),
+            ],
+            creditsRemaining: nil,
+            codeReviewRemainingPercent: nil,
+            tokenUsage: nil,
+            dailyUsage: [])
+
+        let limit = WidgetUsageRow.smallWidgetRowLimit(for: entry)
+
+        #expect(limit == nil)
+        #expect(WidgetUsageRow.rows(for: entry, limit: limit).map(\.id) == ["one", "two", "three"])
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -5,6 +5,29 @@ import Testing
 
 struct CodexBarWidgetProviderTests {
     @Test
+    func `small widget limits custom usage rows`() {
+        let entry = WidgetSnapshot.ProviderEntry(
+            provider: .antigravity,
+            updatedAt: Date(),
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            usageRows: [
+                WidgetSnapshot.WidgetUsageRowSnapshot(id: "one", title: "One", percentLeft: 90),
+                WidgetSnapshot.WidgetUsageRowSnapshot(id: "two", title: "Two", percentLeft: 80),
+                WidgetSnapshot.WidgetUsageRowSnapshot(id: "three", title: "Three", percentLeft: 70),
+                WidgetSnapshot.WidgetUsageRowSnapshot(id: "four", title: "Four", percentLeft: 60),
+            ],
+            creditsRemaining: nil,
+            codeReviewRemainingPercent: nil,
+            tokenUsage: nil,
+            dailyUsage: [])
+
+        #expect(WidgetUsageRow.rows(for: entry, limit: 2).map(\.id) == ["one", "two"])
+        #expect(WidgetUsageRow.rows(for: entry).count == 4)
+    }
+
+    @Test
     func `provider choice supports alibaba`() {
         #expect(ProviderChoice(provider: .alibaba) == .alibaba)
         #expect(ProviderChoice.alibaba.provider == .alibaba)

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -63,6 +63,10 @@ struct CodexBarWidgetProviderTests {
         #expect(rows.map(\.title) == ["Gemini Weekly", "Claude + GPT Session"])
         #expect(rows.compactMap(\.percentLeft) == [20, 5])
         #expect(WidgetUsageRow.smallWidgetRowLimit(for: entry) == 2)
+        #expect(WidgetUsageRow.mediumWidgetRowLimit(for: entry) == 3)
+        #expect(WidgetUsageRow.rows(
+            for: entry,
+            limit: WidgetUsageRow.mediumWidgetRowLimit(for: entry)).count == 3)
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -64,9 +64,14 @@ struct CodexBarWidgetProviderTests {
         #expect(rows.compactMap(\.percentLeft) == [20, 5])
         #expect(WidgetUsageRow.smallWidgetRowLimit(for: entry) == 2)
         #expect(WidgetUsageRow.mediumWidgetRowLimit(for: entry) == 3)
-        #expect(WidgetUsageRow.rows(
+        let mediumRows = WidgetUsageRow.rows(
             for: entry,
-            limit: WidgetUsageRow.mediumWidgetRowLimit(for: entry)).count == 3)
+            limit: WidgetUsageRow.mediumWidgetRowLimit(for: entry))
+        #expect(mediumRows.map(\.title) == [
+            "Gemini Weekly",
+            "Claude + GPT Session",
+            "Claude + GPT Weekly",
+        ])
     }
 
     @Test

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -90,6 +90,38 @@ struct CodexBarWidgetProviderTests {
     }
 
     @Test
+    func `small antigravity widget prefers known quota rows`() {
+        let entry = WidgetSnapshot.ProviderEntry(
+            provider: .antigravity,
+            updatedAt: Date(),
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            usageRows: [
+                WidgetSnapshot.WidgetUsageRowSnapshot(
+                    id: "antigravity-quota-summary-gemini-session",
+                    title: "Gemini Session",
+                    percentLeft: nil),
+                WidgetSnapshot.WidgetUsageRowSnapshot(
+                    id: "antigravity-quota-summary-gemini-weekly",
+                    title: "Gemini Weekly",
+                    percentLeft: 100),
+                WidgetSnapshot.WidgetUsageRowSnapshot(
+                    id: "antigravity-quota-summary-third-party-session",
+                    title: "Claude + GPT Session",
+                    percentLeft: 80),
+            ],
+            creditsRemaining: nil,
+            codeReviewRemainingPercent: nil,
+            tokenUsage: nil,
+            dailyUsage: [])
+
+        let rows = WidgetUsageRow.rows(for: entry, limit: 2)
+
+        #expect(rows.map(\.title) == ["Gemini Weekly", "Claude + GPT Session"])
+    }
+
+    @Test
     func `provider choice supports alibaba`() {
         #expect(ProviderChoice(provider: .alibaba) == .alibaba)
         #expect(ProviderChoice.alibaba.provider == .alibaba)

--- a/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
+++ b/Tests/CodexBarTests/CodexBarWidgetProviderTests.swift
@@ -28,6 +28,43 @@ struct CodexBarWidgetProviderTests {
     }
 
     @Test
+    func `small antigravity widget keeps one row per quota family`() {
+        let entry = WidgetSnapshot.ProviderEntry(
+            provider: .antigravity,
+            updatedAt: Date(),
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            usageRows: [
+                WidgetSnapshot.WidgetUsageRowSnapshot(
+                    id: "antigravity-quota-summary-gemini-session",
+                    title: "Gemini Session",
+                    percentLeft: 80),
+                WidgetSnapshot.WidgetUsageRowSnapshot(
+                    id: "antigravity-quota-summary-gemini-weekly",
+                    title: "Gemini Weekly",
+                    percentLeft: 20),
+                WidgetSnapshot.WidgetUsageRowSnapshot(
+                    id: "antigravity-quota-summary-third-party-session",
+                    title: "Claude + GPT Session",
+                    percentLeft: 5),
+                WidgetSnapshot.WidgetUsageRowSnapshot(
+                    id: "antigravity-quota-summary-third-party-weekly",
+                    title: "Claude + GPT Weekly",
+                    percentLeft: 60),
+            ],
+            creditsRemaining: nil,
+            codeReviewRemainingPercent: nil,
+            tokenUsage: nil,
+            dailyUsage: [])
+
+        let rows = WidgetUsageRow.rows(for: entry, limit: 2)
+
+        #expect(rows.map(\.title) == ["Gemini Weekly", "Claude + GPT Session"])
+        #expect(rows.compactMap(\.percentLeft) == [20, 5])
+    }
+
+    @Test
     func `provider choice supports alibaba`() {
         #expect(ProviderChoice(provider: .alibaba) == .alibaba)
         #expect(ProviderChoice.alibaba.provider == .alibaba)

--- a/Tests/CodexBarTests/CodexbarTests.swift
+++ b/Tests/CodexBarTests/CodexbarTests.swift
@@ -75,6 +75,30 @@ struct CodexBarTests {
     }
 
     @Test
+    func `antigravity icon uses compact fallback model quota`() {
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            tertiary: nil,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "antigravity-compact-fallback-model",
+                    title: "New Model",
+                    window: RateWindow(
+                        usedPercent: 64,
+                        windowMinutes: nil,
+                        resetsAt: nil,
+                        resetDescription: nil)),
+            ],
+            updatedAt: Date())
+
+        let remaining = IconRemainingResolver.resolvedRemaining(snapshot: snapshot, style: .antigravity)
+
+        #expect(remaining.primary == 36)
+        #expect(remaining.secondary == nil)
+    }
+
+    @Test
     func `perplexity icon falls back to purchased lane when bonus is exhausted`() {
         let snapshot = UsageSnapshot(
             primary: nil,

--- a/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
@@ -7,7 +7,7 @@ import Testing
 struct SettingsStoreAdditionalTests {
     @Test
     @MainActor
-    func `antigravity two pool migration preserves explicit metric meaning`() {
+    func `antigravity two pool migration preserves released metric meaning`() {
         let primaryDefaults = UserDefaults(suiteName: #function + ".primary")!
         primaryDefaults.removePersistentDomain(forName: #function + ".primary")
         primaryDefaults.set(
@@ -41,6 +41,17 @@ struct SettingsStoreAdditionalTests {
         let tertiarySettings = SettingsStore(userDefaults: tertiaryDefaults)
 
         #expect(tertiarySettings.menuBarMetricPreference(for: .antigravity) == .primary)
+
+        let migratedDefaults = UserDefaults(suiteName: #function + ".migrated")!
+        migratedDefaults.removePersistentDomain(forName: #function + ".migrated")
+        migratedDefaults.set(
+            [UsageProvider.antigravity.rawValue: MenuBarMetricPreference.primary.rawValue],
+            forKey: "menuBarMetricPreferences")
+        migratedDefaults.set(true, forKey: "antigravityTwoPoolMetricPreferenceMigrated")
+
+        let migratedSettings = SettingsStore(userDefaults: migratedDefaults)
+
+        #expect(migratedSettings.menuBarMetricPreference(for: .antigravity) == .primary)
     }
 
     @Test

--- a/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
@@ -6,6 +6,34 @@ import Testing
 @MainActor
 struct SettingsStoreAdditionalTests {
     @Test
+    @MainActor
+    func `antigravity two pool migration preserves explicit metric meaning`() {
+        let primaryDefaults = UserDefaults(suiteName: #function + ".primary")!
+        primaryDefaults.removePersistentDomain(forName: #function + ".primary")
+        primaryDefaults.set(
+            [UsageProvider.antigravity.rawValue: MenuBarMetricPreference.primary.rawValue],
+            forKey: "menuBarMetricPreferences")
+
+        let primarySettings = SettingsStore(userDefaults: primaryDefaults)
+
+        #expect(primarySettings.menuBarMetricPreference(for: .antigravity) == .secondary)
+        #expect(primaryDefaults.bool(forKey: "antigravityTwoPoolMetricPreferenceMigrated"))
+
+        let secondaryDefaults = UserDefaults(suiteName: #function + ".secondary")!
+        secondaryDefaults.removePersistentDomain(forName: #function + ".secondary")
+        secondaryDefaults.set(
+            [UsageProvider.antigravity.rawValue: MenuBarMetricPreference.secondary.rawValue],
+            forKey: "menuBarMetricPreferences")
+
+        let secondarySettings = SettingsStore(userDefaults: secondaryDefaults)
+
+        #expect(secondarySettings.menuBarMetricPreference(for: .antigravity) == .primary)
+
+        let reloadedSettings = SettingsStore(userDefaults: secondaryDefaults)
+        #expect(reloadedSettings.menuBarMetricPreference(for: .antigravity) == .primary)
+    }
+
+    @Test
     func `menu bar metric preference handles zai and average`() {
         let settings = Self.makeSettingsStore(suite: "SettingsStoreAdditionalTests-metric")
 

--- a/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreAdditionalTests.swift
@@ -31,6 +31,16 @@ struct SettingsStoreAdditionalTests {
 
         let reloadedSettings = SettingsStore(userDefaults: secondaryDefaults)
         #expect(reloadedSettings.menuBarMetricPreference(for: .antigravity) == .primary)
+
+        let tertiaryDefaults = UserDefaults(suiteName: #function + ".tertiary")!
+        tertiaryDefaults.removePersistentDomain(forName: #function + ".tertiary")
+        tertiaryDefaults.set(
+            [UsageProvider.antigravity.rawValue: MenuBarMetricPreference.tertiary.rawValue],
+            forKey: "menuBarMetricPreferences")
+
+        let tertiarySettings = SettingsStore(userDefaults: tertiaryDefaults)
+
+        #expect(tertiarySettings.menuBarMetricPreference(for: .antigravity) == .primary)
     }
 
     @Test

--- a/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
+++ b/Tests/CodexBarTests/SettingsStoreCoverageTests.swift
@@ -544,7 +544,7 @@ struct SettingsStoreCoverageTests {
     }
 
     @Test
-    func `removing last antigravity oauth account clears matching shared credentials`() async throws {
+    func `removing last antigravity oauth account clears matching shared credentials`() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("antigravity-shared-removal-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -567,8 +567,38 @@ struct SettingsStoreCoverageTests {
         settings.removeTokenAccount(provider: .antigravity, accountID: account.id)
 
         #expect(settings.tokenAccounts(for: .antigravity).isEmpty)
-        let sharedCredentials = try await Self.waitForSharedAntigravityCredentials(in: sharedStore) { $0 == nil }
-        #expect(sharedCredentials == nil)
+        #expect(try sharedStore.load() == nil)
+    }
+
+    @Test
+    func `removing antigravity oauth account preserves freshly reauthenticated credentials`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("antigravity-shared-reauth-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let sharedStore = AntigravityOAuthCredentialsStore(
+            fileURL: root.appendingPathComponent("oauth_creds.json"))
+        let removed = AntigravityOAuthCredentials(
+            accessToken: "removed-access",
+            refreshToken: "removed-refresh",
+            expiryDate: Date(timeIntervalSince1970: 1_700_000_000),
+            email: "user@example.com")
+        let refreshed = AntigravityOAuthCredentials(
+            accessToken: "fresh-access",
+            refreshToken: "fresh-refresh",
+            expiryDate: Date(timeIntervalSince1970: 1_700_000_100),
+            email: "user@example.com")
+        try sharedStore.save(refreshed)
+        let settings = Self.makeSettingsStore(
+            suiteName: "SettingsStoreCoverageTests-antigravity-preserve-reauth",
+            antigravityOAuthCredentialsStore: sharedStore)
+
+        settings.upsertAntigravityOAuthAccount(removed)
+        let account = try #require(settings.selectedTokenAccount(for: .antigravity))
+        settings.removeTokenAccount(provider: .antigravity, accountID: account.id)
+
+        #expect(try sharedStore.load() == refreshed)
     }
 
     @Test

--- a/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
+++ b/Tests/CodexBarTests/UsageStoreHighestUsageTests.swift
@@ -283,6 +283,65 @@ struct UsageStoreHighestUsageTests {
     }
 
     @Test
+    func `automatic metric keeps antigravity when a legacy detail row has quota`() {
+        let settings = SettingsStore(
+            configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-fallback-detail"),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.setMenuBarMetricPreference(.automatic, for: .antigravity)
+
+        let registry = ProviderRegistry.shared
+        if let codexMeta = registry.metadata[.codex] {
+            settings.setProviderEnabled(provider: .codex, metadata: codexMeta, enabled: true)
+        }
+        if let antigravityMeta = registry.metadata[.antigravity] {
+            settings.setProviderEnabled(provider: .antigravity, metadata: antigravityMeta, enabled: true)
+        }
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: RateWindow(usedPercent: 80, windowMinutes: nil, resetsAt: nil, resetDescription: nil),
+                secondary: nil,
+                updatedAt: Date()),
+            provider: .codex)
+        store._setSnapshotForTesting(
+            UsageSnapshot(
+                primary: nil,
+                secondary: nil,
+                tertiary: nil,
+                extraRateWindows: [
+                    NamedRateWindow(
+                        id: "antigravity-compact-fallback-model-a",
+                        title: "Model A",
+                        window: RateWindow(
+                            usedPercent: 100,
+                            windowMinutes: nil,
+                            resetsAt: nil,
+                            resetDescription: nil)),
+                    NamedRateWindow(
+                        id: "model-b",
+                        title: "Model B",
+                        window: RateWindow(
+                            usedPercent: 50,
+                            windowMinutes: nil,
+                            resetsAt: nil,
+                            resetDescription: nil)),
+                ],
+                updatedAt: Date()),
+            provider: .antigravity)
+
+        let highest = store.providerWithHighestUsage()
+        #expect(highest?.provider == .antigravity)
+        #expect(highest?.usedPercent == 100)
+    }
+
+    @Test
     func `automatic metric skips antigravity with no quota lanes`() {
         let settings = SettingsStore(
             configStore: testConfigStore(suiteName: "UsageStoreHighestUsageTests-antigravity-empty"),

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
@@ -842,6 +842,107 @@ struct UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
+    func `antigravity weekly celebration samples stable named bucket maximum`() async {
+        let store = Self.makeStore()
+        let recorder = WeeklyLimitResetEventRecorder(provider: .antigravity, accountLabel: nil)
+        defer { recorder.invalidate() }
+
+        func snapshot(
+            primary: RateWindow,
+            secondary: RateWindow,
+            geminiWeeklyUsed: Double,
+            thirdPartyWeeklyUsed: Double,
+            updatedAt: Date) -> UsageSnapshot
+        {
+            UsageSnapshot(
+                primary: primary,
+                secondary: secondary,
+                tertiary: nil,
+                extraRateWindows: [
+                    NamedRateWindow(
+                        id: "antigravity-quota-summary-gemini-weekly",
+                        title: "Gemini Weekly",
+                        window: RateWindow(
+                            usedPercent: geminiWeeklyUsed,
+                            windowMinutes: 10080,
+                            resetsAt: nil,
+                            resetDescription: nil)),
+                    NamedRateWindow(
+                        id: "antigravity-quota-summary-3p-weekly",
+                        title: "Claude + GPT Weekly",
+                        window: RateWindow(
+                            usedPercent: thirdPartyWeeklyUsed,
+                            windowMinutes: 10080,
+                            resetsAt: nil,
+                            resetDescription: nil)),
+                ],
+                updatedAt: updatedAt)
+        }
+
+        let firstDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let before = snapshot(
+            primary: RateWindow(
+                usedPercent: 80,
+                windowMinutes: 10080,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            geminiWeeklyUsed: 80,
+            thirdPartyWeeklyUsed: 0,
+            updatedAt: firstDate)
+        let representativeChanged = snapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 0,
+                windowMinutes: 10080,
+                resetsAt: nil,
+                resetDescription: nil),
+            geminiWeeklyUsed: 0,
+            thirdPartyWeeklyUsed: 80,
+            updatedAt: firstDate.addingTimeInterval(3600))
+        let reset = snapshot(
+            primary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 300,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 0,
+                windowMinutes: 10080,
+                resetsAt: nil,
+                resetDescription: nil),
+            geminiWeeklyUsed: 0,
+            thirdPartyWeeklyUsed: 0,
+            updatedAt: firstDate.addingTimeInterval(7200))
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .antigravity,
+            snapshot: before,
+            now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(
+            provider: .antigravity,
+            snapshot: representativeChanged,
+            now: representativeChanged.updatedAt)
+        #expect(recorder.events.isEmpty)
+
+        await store.recordPlanUtilizationHistorySample(
+            provider: .antigravity,
+            snapshot: reset,
+            now: reset.updatedAt)
+        #expect(recorder.events.count == 1)
+        #expect(recorder.events.first?.usedPercent == 0)
+    }
+
+    @MainActor
+    @Test
     func `weekly quota celebration fires once across repeated low samples`() async {
         let store = Self.makeStore()
         let accountLabel = "repeated-low@example.com"

--- a/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
+++ b/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
@@ -278,6 +278,30 @@ struct UsageStoreSessionQuotaTransitionTests {
     }
 
     @Test
+    func `antigravity snapshot mode change resets session notification baseline`() {
+        let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-antigravity-mode-change")
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.sessionQuotaNotificationsEnabled = true
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        store.handleSessionQuotaTransition(
+            provider: .antigravity,
+            snapshot: self.antigravityQuotaSummarySnapshot(sessionUsed: 20, weeklyUsed: 20))
+        store.handleSessionQuotaTransition(
+            provider: .antigravity,
+            snapshot: self.antigravityLegacySnapshot(geminiUsed: 100, claudeUsed: 100))
+
+        #expect(notifier.posts.isEmpty)
+    }
+
+    @Test
     func `quota warning disabled does not post`() {
         let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-disabled")
         settings.refreshFrequency = .manual

--- a/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
+++ b/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
@@ -253,7 +253,7 @@ struct UsageStoreSessionQuotaTransitionTests {
     }
 
     @Test
-    func `antigravity legacy session notification uses duration across family slots`() {
+    func `antigravity preserves session notifications for durationless legacy family lanes`() {
         let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-antigravity-legacy-session")
         settings.refreshFrequency = .manual
         settings.statusChecksEnabled = false

--- a/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
+++ b/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
@@ -228,6 +228,31 @@ struct UsageStoreSessionQuotaTransitionTests {
     }
 
     @Test
+    func `antigravity session notification uses quota summary duration instead of family representative`() {
+        let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-antigravity-session")
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.sessionQuotaNotificationsEnabled = true
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        store.handleSessionQuotaTransition(
+            provider: .antigravity,
+            snapshot: self.antigravityQuotaSummarySnapshot(sessionUsed: 20, weeklyUsed: 100))
+        store.handleSessionQuotaTransition(
+            provider: .antigravity,
+            snapshot: self.antigravityQuotaSummarySnapshot(sessionUsed: 100, weeklyUsed: 100))
+
+        #expect(notifier.posts.map(\.provider) == [.antigravity])
+        #expect(notifier.posts.map(\.transition) == [.depleted])
+    }
+
+    @Test
     func `quota warning disabled does not post`() {
         let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-disabled")
         settings.refreshFrequency = .manual
@@ -579,6 +604,35 @@ struct UsageStoreSessionQuotaTransitionTests {
     }
 
     @Test
+    func `antigravity quota warnings use named session and weekly durations`() {
+        let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-antigravity")
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.quotaWarningNotificationsEnabled = true
+        settings.quotaWarningThresholds = [50]
+        settings.setQuotaWarningWindowEnabled(.session, enabled: true)
+        settings.setQuotaWarningWindowEnabled(.weekly, enabled: true)
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        store.handleQuotaWarningTransitions(
+            provider: .antigravity,
+            snapshot: self.antigravityQuotaSummarySnapshot(sessionUsed: 40, weeklyUsed: 40))
+        store.handleQuotaWarningTransitions(
+            provider: .antigravity,
+            snapshot: self.antigravityQuotaSummarySnapshot(sessionUsed: 60, weeklyUsed: 60))
+
+        #expect(notifier.quotaWarningPosts.map(\.provider) == [.antigravity, .antigravity])
+        #expect(notifier.quotaWarningPosts.map(\.event.window) == [.session, .weekly])
+        #expect(notifier.quotaWarningPosts.map(\.event.threshold) == [50, 50])
+    }
+
+    @Test
     func `disabling quota warning window clears fired state`() {
         let settings = self
             .makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-disabled-clears-state")
@@ -650,5 +704,39 @@ struct UsageStoreSessionQuotaTransitionTests {
                     resetsAt: now.addingTimeInterval(6 * 24 * 3600),
                     resetDescription: "Resets in 6 days"),
             ]).toUsageSnapshot()
+    }
+
+    private func antigravityQuotaSummarySnapshot(sessionUsed: Double, weeklyUsed: Double) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: weeklyUsed,
+                windowMinutes: 7 * 24 * 60,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: sessionUsed,
+                windowMinutes: 5 * 60,
+                resetsAt: nil,
+                resetDescription: nil),
+            tertiary: nil,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-gemini-5h",
+                    title: "Gemini Session",
+                    window: RateWindow(
+                        usedPercent: sessionUsed,
+                        windowMinutes: 5 * 60,
+                        resetsAt: nil,
+                        resetDescription: nil)),
+                NamedRateWindow(
+                    id: "antigravity-quota-summary-gemini-weekly",
+                    title: "Gemini Weekly",
+                    window: RateWindow(
+                        usedPercent: weeklyUsed,
+                        windowMinutes: 7 * 24 * 60,
+                        resetsAt: nil,
+                        resetDescription: nil)),
+            ],
+            updatedAt: Date())
     }
 }

--- a/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
+++ b/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
@@ -796,12 +796,12 @@ struct UsageStoreSessionQuotaTransitionTests {
         UsageSnapshot(
             primary: RateWindow(
                 usedPercent: geminiUsed,
-                windowMinutes: 5 * 60,
+                windowMinutes: nil,
                 resetsAt: nil,
                 resetDescription: nil),
             secondary: RateWindow(
                 usedPercent: claudeUsed,
-                windowMinutes: 5 * 60,
+                windowMinutes: nil,
                 resetsAt: nil,
                 resetDescription: nil),
             updatedAt: Date())

--- a/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
+++ b/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
@@ -709,6 +709,36 @@ struct UsageStoreSessionQuotaTransitionTests {
     }
 
     @Test
+    func `antigravity quota warning mode change resets warning baseline`() {
+        let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-antigravity-mode")
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.quotaWarningNotificationsEnabled = true
+        settings.quotaWarningThresholds = [50]
+        settings.setQuotaWarningWindowEnabled(.session, enabled: true)
+        settings.setQuotaWarningWindowEnabled(.weekly, enabled: true)
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        store.handleQuotaWarningTransitions(
+            provider: .antigravity,
+            snapshot: self.antigravityQuotaSummarySnapshot(sessionUsed: 20, weeklyUsed: 20))
+        store.handleQuotaWarningTransitions(
+            provider: .antigravity,
+            snapshot: self.antigravityLegacySnapshot(geminiUsed: 80, claudeUsed: 40))
+
+        #expect(notifier.quotaWarningPosts.isEmpty)
+        let key = UsageStore.QuotaWarningStateKey(provider: .antigravity, window: .session)
+        #expect(store.quotaWarningState[key]?.lastRemaining == 20)
+        #expect(store.quotaWarningState[key]?.source == .antigravityLegacy)
+    }
+
+    @Test
     func `disabling quota warning window clears fired state`() {
         let settings = self
             .makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-disabled-clears-state")

--- a/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
+++ b/Tests/CodexBarTests/UsageStoreSessionQuotaTransitionTests.swift
@@ -253,6 +253,31 @@ struct UsageStoreSessionQuotaTransitionTests {
     }
 
     @Test
+    func `antigravity legacy session notification uses duration across family slots`() {
+        let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-antigravity-legacy-session")
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.sessionQuotaNotificationsEnabled = true
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        store.handleSessionQuotaTransition(
+            provider: .antigravity,
+            snapshot: self.antigravityLegacySnapshot(geminiUsed: 20, claudeUsed: 20))
+        store.handleSessionQuotaTransition(
+            provider: .antigravity,
+            snapshot: self.antigravityLegacySnapshot(geminiUsed: 20, claudeUsed: 100))
+
+        #expect(notifier.posts.map(\.provider) == [.antigravity])
+        #expect(notifier.posts.map(\.transition) == [.depleted])
+    }
+
+    @Test
     func `quota warning disabled does not post`() {
         let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-disabled")
         settings.refreshFrequency = .manual
@@ -633,6 +658,33 @@ struct UsageStoreSessionQuotaTransitionTests {
     }
 
     @Test
+    func `antigravity legacy quota warnings do not infer weekly from family slots`() {
+        let settings = self.makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-antigravity-legacy")
+        settings.refreshFrequency = .manual
+        settings.statusChecksEnabled = false
+        settings.quotaWarningNotificationsEnabled = true
+        settings.quotaWarningThresholds = [50]
+        settings.setQuotaWarningWindowEnabled(.session, enabled: true)
+        settings.setQuotaWarningWindowEnabled(.weekly, enabled: true)
+
+        let notifier = SessionQuotaNotifierSpy()
+        let store = UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            sessionQuotaNotifier: notifier)
+
+        store.handleQuotaWarningTransitions(
+            provider: .antigravity,
+            snapshot: self.antigravityLegacySnapshot(geminiUsed: 40, claudeUsed: 40))
+        store.handleQuotaWarningTransitions(
+            provider: .antigravity,
+            snapshot: self.antigravityLegacySnapshot(geminiUsed: 60, claudeUsed: 60))
+
+        #expect(notifier.quotaWarningPosts.map(\.event.window) == [.session])
+    }
+
+    @Test
     func `disabling quota warning window clears fired state`() {
         let settings = self
             .makeSettings(suiteName: "UsageStoreSessionQuotaTransitionTests-warning-disabled-clears-state")
@@ -737,6 +789,21 @@ struct UsageStoreSessionQuotaTransitionTests {
                         resetsAt: nil,
                         resetDescription: nil)),
             ],
+            updatedAt: Date())
+    }
+
+    private func antigravityLegacySnapshot(geminiUsed: Double, claudeUsed: Double) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: geminiUsed,
+                windowMinutes: 5 * 60,
+                resetsAt: nil,
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: claudeUsed,
+                windowMinutes: 5 * 60,
+                resetsAt: nil,
+                resetDescription: nil),
             updatedAt: Date())
     }
 }

--- a/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
+++ b/Tests/CodexBarTests/UsageStoreWidgetSnapshotTests.swift
@@ -114,6 +114,52 @@ struct UsageStoreWidgetSnapshotTests {
     }
 
     @Test
+    func `widget snapshot labels antigravity compact fallback with model name`() async throws {
+        let suite = "UsageStoreWidgetSnapshotTests-antigravity-compact-fallback"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defaults.removePersistentDomain(forName: suite)
+
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+
+        let store = UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings)
+        let snapshot = try AntigravityStatusSnapshot(
+            modelQuotas: [
+                AntigravityModelQuota(
+                    label: "Experimental Model",
+                    modelId: "MODEL_PLACEHOLDER_NEW",
+                    remainingFraction: 0.36,
+                    resetTime: nil,
+                    resetDescription: nil),
+            ],
+            accountEmail: nil,
+            accountPlan: nil,
+            source: .local)
+            .toUsageSnapshot()
+        store._setSnapshotForTesting(snapshot, provider: .antigravity)
+
+        var widgetSnapshots: [WidgetSnapshot] = []
+        store._test_widgetSnapshotSaveOverride = { widgetSnapshots.append($0) }
+        defer { store._test_widgetSnapshotSaveOverride = nil }
+
+        store.persistWidgetSnapshot(reason: "antigravity-compact-fallback-test")
+        await store.widgetSnapshotPersistTask?.value
+
+        let entry = try #require(widgetSnapshots.last?.entries.first { $0.provider == .antigravity })
+        #expect(entry.primary == nil)
+        #expect(entry.usageRows?.map(\.id) == ["antigravity-compact-fallback-MODEL_PLACEHOLDER_NEW"])
+        #expect(entry.usageRows?.map(\.title) == ["Experimental Model"])
+        #expect(entry.usageRows?.compactMap(\.percentLeft) == [36])
+    }
+
+    @Test
     func `widget snapshot excludes mimo balance from quota rows`() async throws {
         let suite = "UsageStoreWidgetSnapshotTests-mimo-balance"
         let defaults = try #require(UserDefaults(suiteName: suite))


### PR DESCRIPTION
## Summary

- harden Antigravity local probing with shared deadlines, concurrent process selection, cancellation propagation, and fair endpoint budgets
- preserve verified OAuth quota data, atomic credential updates, compact fallback labels, icon selection, warning/reset state, and explicit quota durations
- keep small and medium widgets bounded while selecting the most constrained rows
- migrate persisted Antigravity menu metric choices to the new two-pool layout without changing their meaning

Follow-up hardening for #1509.

## Proof

- `swift test --filter 'Antigravity|CodexBarWidgetProviderTests|SettingsStoreAdditionalTests|MenuBarMetricWindowResolverTests|MenuCardAntigravityTests'` (230 tests passed after current `origin/main` integration)
- `swift test --filter 'AntigravityDeadlineTests|SettingsStoreAdditionalTests'` (13 tests passed)
- `make check` (SwiftFormat and strict SwiftLint clean)
- full `swift test` reached 4,044 tests; one suite-load timing failure in `MainThreadHangWatchdogTests`, which passed all 6 tests when rerun in isolation
- branch-wide autoreview clean after all accepted findings; legacy durationless Antigravity lanes intentionally retain the pre-#1509 session notification behavior

@clawsweeper re-review
