### PR TITLE
fix: refresh open menu usage values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 - Antigravity: fall back to loopback HTTP for local CLI and language-server probes on Linux, where self-signed localhost TLS cannot be trusted (fixes #1508). Thanks @zodiacfireworks!
+- Menu bar: update visible usage values in place when a manual refresh completes instead of leaving the open provider card stale until the menu is reopened (fixes #1516).
 - Gemini: recognize the current `gemini-api-key` CLI auth setting so API-key sessions show the supported OAuth guidance instead of a misleading not-logged-in error (fixes #1511).
 - Settings: make the cost history window directly editable by keyboard while preserving the existing stepper and 1–365 day bounds (fixes #1499). Thanks @kiranmagic7!
 

--- a/Sources/CodexBar/MenuCardRefreshMonitor.swift
+++ b/Sources/CodexBar/MenuCardRefreshMonitor.swift
@@ -1,0 +1,45 @@
+import CodexBarCore
+import Observation
+
+struct MenuCardLiveSubtitle {
+    let text: String
+    let style: UsageMenuCardView.Model.SubtitleStyle
+}
+
+/// Updates values in an already-hosted card without rebuilding its tracked NSMenu.
+@MainActor
+@Observable
+final class MenuCardRefreshMonitor {
+    typealias ModelResolver = @MainActor (UsageProvider) -> UsageMenuCardView.Model?
+
+    private let resolveModel: ModelResolver
+    var isManualRefreshInFlight = false
+
+    init(resolveModel: @escaping ModelResolver) {
+        self.resolveModel = resolveModel
+    }
+
+    func model(
+        for provider: UsageProvider,
+        fallback: UsageMenuCardView.Model) -> UsageMenuCardView.Model
+    {
+        guard !self.isManualRefreshInFlight,
+              let resolved = self.resolveModel(provider),
+              fallback.hasCompatibleTrackedLayout(with: resolved)
+        else {
+            return fallback
+        }
+        return resolved
+    }
+
+    func subtitle(
+        for provider: UsageProvider,
+        fallback: MenuCardLiveSubtitle) -> MenuCardLiveSubtitle
+    {
+        if self.isManualRefreshInFlight {
+            return MenuCardLiveSubtitle(text: "\(L("Refreshing"))…", style: .loading)
+        }
+        guard let model = self.resolveModel(provider) else { return fallback }
+        return MenuCardLiveSubtitle(text: model.subtitleText, style: model.subtitleStyle)
+    }
+}

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -36,6 +36,89 @@ extension UsageMenuCardView.Model {
             self.tokenUsage != nil
     }
 
+    func hasCompatibleTrackedLayout(with candidate: Self) -> Bool {
+        guard self.provider == candidate.provider,
+              self.metrics.count == candidate.metrics.count,
+              self.usageNotes == candidate.usageNotes,
+              (self.openAIAPIUsage == nil) == (candidate.openAIAPIUsage == nil),
+              self.creditsText == candidate.creditsText,
+              (self.creditsRemaining == nil) == (candidate.creditsRemaining == nil),
+              self.creditsHintText == candidate.creditsHintText,
+              self.placeholder == candidate.placeholder,
+              Self.hasCompatibleDashboardLayout(self.inlineUsageDashboard, candidate.inlineUsageDashboard),
+              Self.hasCompatibleProviderCostLayout(self.providerCost, candidate.providerCost),
+              Self.hasCompatibleTokenUsageLayout(self.tokenUsage, candidate.tokenUsage)
+        else {
+            return false
+        }
+
+        return zip(self.metrics, candidate.metrics).allSatisfy { current, refreshed in
+            current.id == refreshed.id &&
+                current.title == refreshed.title &&
+                current.percentStyle == refreshed.percentStyle &&
+                (current.statusText == nil) == (refreshed.statusText == nil) &&
+                (current.resetText == nil) == (refreshed.resetText == nil) &&
+                (current.detailText == nil) == (refreshed.detailText == nil) &&
+                (current.detailLeftText == nil) == (refreshed.detailLeftText == nil) &&
+                (current.detailRightText == nil) == (refreshed.detailRightText == nil) &&
+                current.cardStyle == refreshed.cardStyle
+        }
+    }
+
+    private static func hasCompatibleDashboardLayout(
+        _ current: InlineUsageDashboardModel?,
+        _ candidate: InlineUsageDashboardModel?) -> Bool
+    {
+        switch (current, candidate) {
+        case (nil, nil):
+            true
+        case let (current?, candidate?):
+            current.valueStyle == candidate.valueStyle &&
+                current.kpis.count == candidate.kpis.count &&
+                current.points.count == candidate.points.count &&
+                current.detailLines.count == candidate.detailLines.count &&
+                zip(current.kpis, candidate.kpis).allSatisfy {
+                    $0.title == $1.title && $0.emphasis == $1.emphasis
+                } &&
+                zip(current.points, candidate.points).allSatisfy {
+                    $0.id == $1.id && $0.label == $1.label
+                }
+        default:
+            false
+        }
+    }
+
+    private static func hasCompatibleProviderCostLayout(
+        _ current: ProviderCostSection?,
+        _ candidate: ProviderCostSection?) -> Bool
+    {
+        switch (current, candidate) {
+        case (nil, nil):
+            true
+        case let (current?, candidate?):
+            current.title == candidate.title &&
+                (current.percentUsed == nil) == (candidate.percentUsed == nil) &&
+                (current.percentLine == nil) == (candidate.percentLine == nil)
+        default:
+            false
+        }
+    }
+
+    private static func hasCompatibleTokenUsageLayout(
+        _ current: TokenUsageSection?,
+        _ candidate: TokenUsageSection?) -> Bool
+    {
+        switch (current, candidate) {
+        case (nil, nil):
+            true
+        case let (current?, candidate?):
+            current.hintLine == candidate.hintLine &&
+                current.errorLine == candidate.errorLine
+        default:
+            false
+        }
+    }
+
     static func progressColor(for provider: UsageProvider) -> Color {
         if provider == .elevenlabs {
             return Color(nsColor: .labelColor)

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -41,8 +41,11 @@ extension UsageMenuCardView.Model {
               self.metrics.count == candidate.metrics.count,
               self.usageNotes == candidate.usageNotes,
               (self.openAIAPIUsage == nil) == (candidate.openAIAPIUsage == nil),
-              self.creditsText == candidate.creditsText,
-              (self.creditsRemaining == nil) == (candidate.creditsRemaining == nil),
+              Self.hasCompatibleCreditsLayout(
+                  currentText: self.creditsText,
+                  currentRemaining: self.creditsRemaining,
+                  candidateText: candidate.creditsText,
+                  candidateRemaining: candidate.creditsRemaining),
               self.creditsHintText == candidate.creditsHintText,
               self.placeholder == candidate.placeholder,
               Self.hasCompatibleDashboardLayout(self.inlineUsageDashboard, candidate.inlineUsageDashboard),
@@ -62,6 +65,25 @@ extension UsageMenuCardView.Model {
                 (current.detailLeftText == nil) == (refreshed.detailLeftText == nil) &&
                 (current.detailRightText == nil) == (refreshed.detailRightText == nil) &&
                 current.cardStyle == refreshed.cardStyle
+        }
+    }
+
+    private static func hasCompatibleCreditsLayout(
+        currentText: String?,
+        currentRemaining: Double?,
+        candidateText: String?,
+        candidateRemaining: Double?) -> Bool
+    {
+        switch (currentText, candidateText) {
+        case (nil, nil):
+            return true
+        case let (currentText?, candidateText?):
+            guard (currentRemaining == nil) == (candidateRemaining == nil) else { return false }
+            // Numeric balances render as a fixed single line beside the full-scale label.
+            // Multiline workspace balances retain their measured text until the menu reopens.
+            return currentRemaining != nil || currentText == candidateText
+        default:
+            return false
         }
     }
 

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -1,37 +1,6 @@
 import AppKit
 import CodexBarCore
-import Observation
 import SwiftUI
-
-struct MenuCardLiveSubtitle {
-    let text: String
-    let style: UsageMenuCardView.Model.SubtitleStyle
-}
-
-/// Narrow observable bridge for updating an already-hosted card subtitle without rebuilding
-/// the tracked NSMenu.
-@MainActor
-@Observable
-final class MenuCardRefreshMonitor {
-    typealias SubtitleResolver = @MainActor (UsageProvider) -> MenuCardLiveSubtitle?
-
-    private let resolveSubtitle: SubtitleResolver
-    var isManualRefreshInFlight = false
-
-    init(resolveSubtitle: @escaping SubtitleResolver) {
-        self.resolveSubtitle = resolveSubtitle
-    }
-
-    func subtitle(
-        for provider: UsageProvider,
-        fallback: MenuCardLiveSubtitle) -> MenuCardLiveSubtitle
-    {
-        if self.isManualRefreshInFlight {
-            return MenuCardLiveSubtitle(text: "\(L("Refreshing"))…", style: .loading)
-        }
-        return self.resolveSubtitle(provider) ?? fallback
-    }
-}
 
 enum UsageMenuCardLayout {
     static let horizontalPadding: CGFloat = 20
@@ -159,6 +128,7 @@ struct UsageMenuCardView: View {
     let model: Model
     let width: CGFloat
     @Environment(\.menuItemHighlighted) private var isHighlighted
+    @Environment(\.menuCardRefreshMonitor) private var refreshMonitor
 
     static func popupMetricTitle(provider: UsageProvider, metric: Model.Metric) -> String {
         if provider == .openrouter, metric.id == "primary" {
@@ -168,43 +138,44 @@ struct UsageMenuCardView: View {
     }
 
     var body: some View {
+        let liveModel = self.liveModel
         VStack(alignment: .leading, spacing: 6) {
             UsageMenuCardHeaderView(model: self.model)
 
-            if self.hasDetails {
+            if self.hasDetails(model: liveModel) {
                 Divider()
             }
 
-            if !self.model.usesStackedDetailLayout {
-                if let dashboard = self.model.inlineUsageDashboard {
+            if !liveModel.usesStackedDetailLayout {
+                if let dashboard = liveModel.inlineUsageDashboard {
                     InlineUsageDashboardContent(model: dashboard)
-                } else if !self.model.usageNotes.isEmpty {
-                    UsageNotesContent(notes: self.model.usageNotes)
-                } else if let placeholder = self.model.placeholder {
+                } else if !liveModel.usageNotes.isEmpty {
+                    UsageNotesContent(notes: liveModel.usageNotes)
+                } else if let placeholder = liveModel.placeholder {
                     Text(placeholder)
                         .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
                         .font(.subheadline)
                 }
             } else {
-                let hasUsage = self.model.hasUsageContent
-                let hasCredits = self.model.creditsText != nil
-                let hasProviderCost = self.model.providerCost != nil
-                let hasCost = self.model.tokenUsage != nil || hasProviderCost
+                let hasUsage = liveModel.hasUsageContent
+                let hasCredits = liveModel.creditsText != nil
+                let hasProviderCost = liveModel.providerCost != nil
+                let hasCost = liveModel.tokenUsage != nil || hasProviderCost
 
                 VStack(alignment: .leading, spacing: 12) {
                     if hasUsage {
                         VStack(alignment: .leading, spacing: 12) {
-                            ForEach(self.model.metrics, id: \.id) { metric in
+                            ForEach(liveModel.metrics, id: \.id) { metric in
                                 MetricRow(
                                     metric: metric,
-                                    title: Self.popupMetricTitle(provider: self.model.provider, metric: metric),
-                                    progressColor: self.model.progressColor)
+                                    title: Self.popupMetricTitle(provider: liveModel.provider, metric: metric),
+                                    progressColor: liveModel.progressColor)
                             }
-                            if let dashboard = self.model.inlineUsageDashboard {
+                            if let dashboard = liveModel.inlineUsageDashboard {
                                 InlineUsageDashboardContent(model: dashboard)
-                            } else if !self.model.usageNotes.isEmpty {
-                                UsageNotesContent(notes: self.model.usageNotes)
-                            } else if let placeholder = self.model.placeholder {
+                            } else if !liveModel.usageNotes.isEmpty {
+                                UsageNotesContent(notes: liveModel.usageNotes)
+                            } else if let placeholder = liveModel.placeholder {
                                 Text(placeholder)
                                     .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
                                     .font(.subheadline)
@@ -214,34 +185,36 @@ struct UsageMenuCardView: View {
                     if hasUsage, hasCredits || hasCost {
                         Divider()
                     }
-                    if let credits = self.model.creditsText {
+                    if let credits = liveModel.creditsText {
                         CreditsBarContent(
                             creditsText: credits,
-                            creditsRemaining: self.model.creditsRemaining,
-                            hintText: self.model.creditsHintText,
-                            hintCopyText: self.model.creditsHintCopyText,
-                            progressColor: self.model.progressColor)
+                            creditsRemaining: liveModel.creditsRemaining,
+                            hintText: liveModel.creditsHintText,
+                            hintCopyText: liveModel.creditsHintCopyText,
+                            progressColor: liveModel.progressColor)
                     }
                     if hasCredits, hasCost {
                         Divider()
                     }
-                    if let providerCost = self.model.providerCost {
+                    if let providerCost = liveModel.providerCost {
                         ProviderCostContent(
                             section: providerCost,
-                            progressColor: self.model.progressColor)
+                            progressColor: liveModel.progressColor)
                     }
-                    if hasProviderCost, self.model.tokenUsage != nil {
+                    if hasProviderCost, liveModel.tokenUsage != nil {
                         Divider()
                     }
-                    if let tokenUsage = self.model.tokenUsage {
+                    if let tokenUsage = liveModel.tokenUsage {
                         VStack(alignment: .leading, spacing: 6) {
                             Text(L("cost_header_estimated"))
                                 .font(.body)
                                 .fontWeight(.medium)
                             Text(tokenUsage.sessionLine)
                                 .font(.footnote)
+                                .lineLimit(1)
                             Text(tokenUsage.monthLine)
                                 .font(.footnote)
+                                .lineLimit(1)
                             if let hint = tokenUsage.hintLine, !hint.isEmpty {
                                 Text(hint)
                                     .font(.footnote)
@@ -262,25 +235,30 @@ struct UsageMenuCardView: View {
                         }
                     }
                 }
-                .padding(.bottom, self.model.creditsText == nil ? 6 : 0)
+                .padding(.bottom, liveModel.creditsText == nil ? 6 : 0)
             }
         }
         .padding(.horizontal, UsageMenuCardLayout.horizontalPadding)
         .padding(
             .top,
-            self.hasDetails
+            self.hasDetails(model: liveModel)
                 ? UsageMenuCardLayout.sectionTopPadding
                 : UsageMenuCardLayout.headerOnlyVerticalPadding)
         .padding(
             .bottom,
-            self.hasDetails
+            self.hasDetails(model: liveModel)
                 ? UsageMenuCardLayout.sectionBottomPadding
                 : UsageMenuCardLayout.headerOnlyVerticalPadding)
         .frame(width: self.width, alignment: .leading)
     }
 
-    private var hasDetails: Bool {
-        self.model.hasUsageContent || self.model.usesStackedDetailLayout
+    private var liveModel: Model {
+        guard self.model.usesLiveSubtitle else { return self.model }
+        return self.refreshMonitor?.model(for: self.model.provider, fallback: self.model) ?? self.model
+    }
+
+    private func hasDetails(model: Model) -> Bool {
+        model.hasUsageContent || model.usesStackedDetailLayout
     }
 }
 
@@ -431,13 +409,13 @@ private struct ProviderCostContent: View {
                     accessibilityLabel: L("Extra usage spent"))
             }
             HStack(alignment: .firstTextBaseline) {
-                Text(self.section.spendLine)
-                    .font(.footnote)
+                Text(self.section.spendLine).font(.footnote).lineLimit(1)
                 Spacer()
                 if let percentLine = self.section.percentLine {
                     Text(percentLine)
                         .font(.footnote)
                         .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
+                        .lineLimit(1)
                 }
             }
         }
@@ -568,30 +546,32 @@ struct UsageMenuCardUsageSectionView: View {
     let bottomPadding: CGFloat
     let width: CGFloat
     @Environment(\.menuItemHighlighted) private var isHighlighted
+    @Environment(\.menuCardRefreshMonitor) private var refreshMonitor
 
     var body: some View {
+        let liveModel = self.liveModel
         VStack(alignment: .leading, spacing: 12) {
-            if self.model.metrics.isEmpty {
-                if let dashboard = self.model.inlineUsageDashboard {
+            if liveModel.metrics.isEmpty {
+                if let dashboard = liveModel.inlineUsageDashboard {
                     InlineUsageDashboardContent(model: dashboard)
-                } else if !self.model.usageNotes.isEmpty {
-                    UsageNotesContent(notes: self.model.usageNotes)
-                } else if let placeholder = self.model.placeholder {
+                } else if !liveModel.usageNotes.isEmpty {
+                    UsageNotesContent(notes: liveModel.usageNotes)
+                } else if let placeholder = liveModel.placeholder {
                     Text(placeholder)
                         .foregroundStyle(MenuHighlightStyle.secondary(self.isHighlighted))
                         .font(.subheadline)
                 }
             } else {
-                ForEach(self.model.metrics, id: \.id) { metric in
+                ForEach(liveModel.metrics, id: \.id) { metric in
                     MetricRow(
                         metric: metric,
-                        title: UsageMenuCardView.popupMetricTitle(provider: self.model.provider, metric: metric),
-                        progressColor: self.model.progressColor)
+                        title: UsageMenuCardView.popupMetricTitle(provider: liveModel.provider, metric: metric),
+                        progressColor: liveModel.progressColor)
                 }
-                if let dashboard = self.model.inlineUsageDashboard {
+                if let dashboard = liveModel.inlineUsageDashboard {
                     InlineUsageDashboardContent(model: dashboard)
-                } else if !self.model.usageNotes.isEmpty {
-                    UsageNotesContent(notes: self.model.usageNotes)
+                } else if !liveModel.usageNotes.isEmpty {
+                    UsageNotesContent(notes: liveModel.usageNotes)
                 }
             }
             if self.showBottomDivider {
@@ -603,6 +583,11 @@ struct UsageMenuCardUsageSectionView: View {
         .padding(.bottom, self.bottomPadding)
         .frame(width: self.width, alignment: .leading)
     }
+
+    private var liveModel: UsageMenuCardView.Model {
+        guard self.model.usesLiveSubtitle else { return self.model }
+        return self.refreshMonitor?.model(for: self.model.provider, fallback: self.model) ?? self.model
+    }
 }
 
 struct UsageMenuCardCreditsSectionView: View {
@@ -611,16 +596,18 @@ struct UsageMenuCardCreditsSectionView: View {
     let topPadding: CGFloat
     let bottomPadding: CGFloat
     let width: CGFloat
+    @Environment(\.menuCardRefreshMonitor) private var refreshMonitor
 
     var body: some View {
-        if let credits = self.model.creditsText {
+        let liveModel = self.liveModel
+        if let credits = liveModel.creditsText {
             VStack(alignment: .leading, spacing: 6) {
                 CreditsBarContent(
                     creditsText: credits,
-                    creditsRemaining: self.model.creditsRemaining,
-                    hintText: self.model.creditsHintText,
-                    hintCopyText: self.model.creditsHintCopyText,
-                    progressColor: self.model.progressColor)
+                    creditsRemaining: liveModel.creditsRemaining,
+                    hintText: liveModel.creditsHintText,
+                    hintCopyText: liveModel.creditsHintCopyText,
+                    progressColor: liveModel.progressColor)
                 if self.showBottomDivider {
                     Divider()
                 }
@@ -630,6 +617,11 @@ struct UsageMenuCardCreditsSectionView: View {
             .padding(.bottom, self.bottomPadding)
             .frame(width: self.width, alignment: .leading)
         }
+    }
+
+    private var liveModel: UsageMenuCardView.Model {
+        guard self.model.usesLiveSubtitle else { return self.model }
+        return self.refreshMonitor?.model(for: self.model.provider, fallback: self.model) ?? self.model
     }
 }
 
@@ -696,21 +688,25 @@ struct UsageMenuCardCostSectionView: View {
     let bottomPadding: CGFloat
     let width: CGFloat
     @Environment(\.menuItemHighlighted) private var isHighlighted
+    @Environment(\.menuCardRefreshMonitor) private var refreshMonitor
 
     var body: some View {
-        let hasTokenCost = self.model.tokenUsage != nil
+        let liveModel = self.liveModel
+        let hasTokenCost = liveModel.tokenUsage != nil
         return Group {
             if hasTokenCost {
                 VStack(alignment: .leading, spacing: 10) {
-                    if let tokenUsage = self.model.tokenUsage {
+                    if let tokenUsage = liveModel.tokenUsage {
                         VStack(alignment: .leading, spacing: 6) {
                             Text(L("cost_header_estimated"))
                                 .font(.body)
                                 .fontWeight(.medium)
                             Text(tokenUsage.sessionLine)
                                 .font(.caption)
+                                .lineLimit(1)
                             Text(tokenUsage.monthLine)
                                 .font(.caption)
+                                .lineLimit(1)
                             if let hint = tokenUsage.hintLine, !hint.isEmpty {
                                 Text(hint)
                                     .font(.footnote)
@@ -738,6 +734,11 @@ struct UsageMenuCardCostSectionView: View {
             }
         }
     }
+
+    private var liveModel: UsageMenuCardView.Model {
+        guard self.model.usesLiveSubtitle else { return self.model }
+        return self.refreshMonitor?.model(for: self.model.provider, fallback: self.model) ?? self.model
+    }
 }
 
 struct UsageMenuCardExtraUsageSectionView: View {
@@ -745,19 +746,26 @@ struct UsageMenuCardExtraUsageSectionView: View {
     let topPadding: CGFloat
     let bottomPadding: CGFloat
     let width: CGFloat
+    @Environment(\.menuCardRefreshMonitor) private var refreshMonitor
 
     var body: some View {
+        let liveModel = self.liveModel
         Group {
-            if let providerCost = self.model.providerCost {
+            if let providerCost = liveModel.providerCost {
                 ProviderCostContent(
                     section: providerCost,
-                    progressColor: self.model.progressColor)
+                    progressColor: liveModel.progressColor)
                     .padding(.horizontal, UsageMenuCardLayout.horizontalPadding)
                     .padding(.top, self.topPadding)
                     .padding(.bottom, self.bottomPadding)
                     .frame(width: self.width, alignment: .leading)
             }
         }
+    }
+
+    private var liveModel: UsageMenuCardView.Model {
+        guard self.model.usesLiveSubtitle else { return self.model }
+        return self.refreshMonitor?.model(for: self.model.provider, fallback: self.model) ?? self.model
     }
 }
 

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -659,6 +659,7 @@ private struct CreditsBarContent: View {
                 HStack(alignment: .firstTextBaseline) {
                     Text(self.creditsText)
                         .font(.caption)
+                        .lineLimit(1)
                     Spacer()
                     Text(self.scaleText)
                         .font(.caption)

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -97,8 +97,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     let store: UsageStore
     let settings: SettingsStore
     lazy var menuCardRefreshMonitor = MenuCardRefreshMonitor { [weak self] provider in
-        guard let model = self?.menuCardModel(for: provider) else { return nil }
-        return MenuCardLiveSubtitle(text: model.subtitleText, style: model.subtitleStyle)
+        self?.menuCardModel(for: provider)
     }
 
     let account: AccountInfo

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -101,6 +101,16 @@ struct StatusMenuPersistentRefreshTests {
             statusBar: .system)
     }
 
+    private static func makeTokenSnapshot() -> CostUsageTokenSnapshot {
+        CostUsageTokenSnapshot(
+            sessionTokens: 123,
+            sessionCostUSD: 0.12,
+            last30DaysTokens: 456,
+            last30DaysCostUSD: 1.23,
+            daily: [],
+            updatedAt: Date())
+    }
+
     @Test
     func `refresh menu item is view backed so mouse activation keeps the menu open`() throws {
         let settings = self.makeSettings()
@@ -289,6 +299,104 @@ struct StatusMenuPersistentRefreshTests {
 
         monitor.isManualRefreshInFlight = true
         #expect(monitor.subtitle(for: .codex, fallback: fallback).style == .loading)
+    }
+
+    @Test
+    func `refresh monitor updates compatible usage values after manual refresh completes`() throws {
+        let settings = self.makeSettings()
+        let controller = self.makeController(settings: settings)
+        let now = Date()
+        controller.store.snapshots[.claude] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 10,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 20,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(7200),
+                resetDescription: nil),
+            updatedAt: now)
+        let fallback = try #require(controller.menuCardModel(for: .claude))
+        controller.menuCardRefreshMonitor.isManualRefreshInFlight = true
+
+        controller.store.snapshots[.claude] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 65,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 75,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(7200),
+                resetDescription: nil),
+            updatedAt: now.addingTimeInterval(1))
+
+        let inFlight = controller.menuCardRefreshMonitor.model(for: .claude, fallback: fallback)
+        #expect(inFlight.metrics.map(\.percent) == fallback.metrics.map(\.percent))
+
+        controller.menuCardRefreshMonitor.isManualRefreshInFlight = false
+        let refreshed = controller.menuCardRefreshMonitor.model(for: .claude, fallback: fallback)
+        let expected = try #require(controller.menuCardModel(for: .claude))
+
+        #expect(refreshed.metrics.map(\.percent) == expected.metrics.map(\.percent))
+        #expect(refreshed.metrics.map(\.percent) != fallback.metrics.map(\.percent))
+    }
+
+    @Test
+    func `refresh monitor preserves tracked layout when refresh adds usage sections`() throws {
+        let settings = self.makeSettings()
+        let controller = self.makeController(settings: settings)
+        let fallback = try #require(controller.menuCardModel(for: .claude))
+        #expect(fallback.metrics.isEmpty)
+
+        controller.store.snapshots[.claude] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 25,
+                windowMinutes: 300,
+                resetsAt: Date().addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date())
+
+        let refreshed = controller.menuCardRefreshMonitor.model(for: .claude, fallback: fallback)
+
+        #expect(refreshed.metrics.isEmpty)
+        #expect(refreshed.placeholder == fallback.placeholder)
+    }
+
+    @Test
+    func `refresh monitor preserves tracked layout when token error appears`() throws {
+        let settings = self.makeSettings()
+        settings.costUsageEnabled = true
+        let controller = self.makeController(settings: settings)
+        controller.store._setTokenSnapshotForTesting(Self.makeTokenSnapshot(), provider: .claude)
+        let fallback = try #require(controller.menuCardModel(for: .claude))
+        #expect(fallback.tokenUsage?.errorLine == nil)
+
+        controller.store._setTokenErrorForTesting("New token usage error", provider: .claude)
+        let refreshed = controller.menuCardRefreshMonitor.model(for: .claude, fallback: fallback)
+
+        #expect(refreshed.tokenUsage?.errorLine == nil)
+    }
+
+    @Test
+    func `refresh monitor preserves tracked layout when token error text changes`() throws {
+        let settings = self.makeSettings()
+        settings.costUsageEnabled = true
+        let controller = self.makeController(settings: settings)
+        controller.store._setTokenSnapshotForTesting(Self.makeTokenSnapshot(), provider: .claude)
+        controller.store._setTokenErrorForTesting("Old token usage error", provider: .claude)
+        let fallback = try #require(controller.menuCardModel(for: .claude))
+
+        controller.store._setTokenErrorForTesting(
+            "A longer replacement error that could occupy more lines",
+            provider: .claude)
+        let refreshed = controller.menuCardRefreshMonitor.model(for: .claude, fallback: fallback)
+
+        #expect(refreshed.tokenUsage?.errorLine == "Old token usage error")
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -346,6 +346,59 @@ struct StatusMenuPersistentRefreshTests {
     }
 
     @Test
+    func `refresh monitor updates single line credit balances`() throws {
+        let settings = self.makeSettings()
+        let controller = self.makeController(
+            settings: settings,
+            account: AccountInfo(email: "test@example.com", plan: "pro"))
+        let now = Date()
+        controller.store.snapshots[.codex] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 10,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now)
+        controller.store.credits = CreditsSnapshot(remaining: 80, events: [], updatedAt: now)
+        let fallback = try #require(controller.menuCardModel(for: .codex))
+
+        controller.store.credits = CreditsSnapshot(
+            remaining: 42,
+            events: [],
+            updatedAt: now.addingTimeInterval(1))
+        let refreshed = controller.menuCardRefreshMonitor.model(for: .codex, fallback: fallback)
+
+        #expect(refreshed.creditsRemaining == 42)
+        #expect(refreshed.creditsText != fallback.creditsText)
+    }
+
+    @Test
+    func `refresh monitor preserves multiline workspace credit text`() throws {
+        let settings = self.makeSettings()
+        let controller = self.makeController(settings: settings)
+        controller.store.snapshots[.amp] = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            ampUsage: AmpUsageDetails(
+                individualCredits: 12,
+                workspaceBalances: [AmpWorkspaceBalance(name: "Team", remaining: 7)]),
+            updatedAt: Date())
+        let fallback = try #require(controller.menuCardModel(for: .amp))
+
+        controller.store.snapshots[.amp] = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            ampUsage: AmpUsageDetails(
+                individualCredits: 10,
+                workspaceBalances: [AmpWorkspaceBalance(name: "Team", remaining: 3)]),
+            updatedAt: Date())
+        let refreshed = controller.menuCardRefreshMonitor.model(for: .amp, fallback: fallback)
+
+        #expect(refreshed.creditsText == fallback.creditsText)
+    }
+
+    @Test
     func `refresh monitor preserves tracked layout when refresh adds usage sections`() throws {
         let settings = self.makeSettings()
         let controller = self.makeController(settings: settings)


### PR DESCRIPTION
## Summary

- refresh visible provider usage, credit, and cost values after a manual refresh without rebuilding the tracked native menu
- accept only model updates that preserve the already-measured row structure and keep variable-height text stable until the next menu rebuild
- cover successful value updates and layout-changing fallback cases

## Tests

- `make check`
- `swift test --filter StatusMenuPersistentRefreshTests` (17 tests passed)
- local structured autoreview: no accepted/actionable findings

Fixes #1516
