### PR TITLE
fix: synchronize cookie cache test override

### DIFF
--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -43,6 +43,7 @@ public enum CookieHeaderCache {
     }
 
     private static let log = CodexBarLog.logger(LogCategories.cookieCache)
+    private static let legacyBaseURLOverrideLock = NSLock()
     private nonisolated(unsafe) static var legacyBaseURLOverride: URL?
 
     private struct DisplaySnapshot {
@@ -613,7 +614,9 @@ public enum CookieHeaderCache {
     }
 
     static func setLegacyBaseURLOverrideForTesting(_ url: URL?) {
-        self.legacyBaseURLOverride = url
+        self.legacyBaseURLOverrideLock.withLock {
+            self.legacyBaseURLOverride = url
+        }
     }
 
     static func hasLegacyEntryForTesting(provider: UsageProvider) -> Bool {
@@ -666,8 +669,7 @@ public enum CookieHeaderCache {
     }
 
     private static var legacyMutationLockURL: URL {
-        let base = self.legacyBaseURLOverride
-            ?? self.legacyURL(for: .codex).deletingLastPathComponent()
+        let base = self.currentLegacyBaseURLOverride ?? self.defaultLegacyBaseURL
         return base.appendingPathComponent("cookie-cache.lock")
     }
 
@@ -696,14 +698,23 @@ public enum CookieHeaderCache {
     }
 
     private static func legacyURL(for provider: UsageProvider) -> URL {
-        if let override = self.legacyBaseURLOverride {
+        if let override = self.currentLegacyBaseURLOverride {
             return override.appendingPathComponent("\(provider.rawValue)-cookie.json")
         }
+        return self.defaultLegacyBaseURL.appendingPathComponent("\(provider.rawValue)-cookie.json")
+    }
+
+    private static var currentLegacyBaseURLOverride: URL? {
+        self.legacyBaseURLOverrideLock.withLock {
+            self.legacyBaseURLOverride
+        }
+    }
+
+    private static var defaultLegacyBaseURL: URL {
         let fm = FileManager.default
         let base = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? fm.temporaryDirectory
         return base.appendingPathComponent("CodexBar", isDirectory: true)
-            .appendingPathComponent("\(provider.rawValue)-cookie.json")
     }
 
     private static func key(for provider: UsageProvider, scope: Scope?) -> KeychainCacheStore.Key {

--- a/Tests/CodexBarTests/CookieHeaderCacheTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheTests.swift
@@ -307,6 +307,30 @@ struct CookieHeaderCacheTests {
         #expect(!CookieHeaderCache.hasKeychainEntryForTesting(provider: provider))
     }
 
+    @Test
+    func `legacy URL override supports concurrent teardown reads`() {
+        let legacyBases = [
+            FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true),
+            FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true),
+        ]
+        defer { CookieHeaderCache.setLegacyBaseURLOverrideForTesting(nil) }
+
+        DispatchQueue.concurrentPerform(iterations: 5000) { index in
+            if index.isMultiple(of: 3) {
+                CookieHeaderCache.setLegacyBaseURLOverrideForTesting(legacyBases[index % legacyBases.count])
+            } else if index.isMultiple(of: 5) {
+                CookieHeaderCache.setLegacyBaseURLOverrideForTesting(nil)
+            } else {
+                _ = CookieHeaderCache.legacyURLForTesting(provider: .codex)
+            }
+        }
+
+        CookieHeaderCache.setLegacyBaseURLOverrideForTesting(legacyBases[0])
+        #expect(
+            CookieHeaderCache.legacyURLForTesting(provider: .codex)
+                == legacyBases[0].appendingPathComponent("codex-cookie.json"))
+    }
+
     #if os(macOS)
     @Test
     func `loadForDisplay throttles temporary keychain unavailability then retries`() async throws {


### PR DESCRIPTION
## Summary

- serialize the testing-only legacy cookie-cache base URL override
- keep default legacy path construction outside the override lock
- cover concurrent override teardown and URL reads

## Root cause

The macOS x86 CI shard for #1496 exited with signal 11 while `CookieHeaderCacheTests` was transitioning between a scheduled legacy migration and test teardown. `legacyBaseURLOverride` stored a reference-typed `URL?` in `nonisolated(unsafe)` static state and was read by background migration work while tests assigned a new value or `nil` without synchronization.

## Proof

- `swift test --filter CookieHeaderCacheTests` (25 tests passed)
- `make check`
- Codex autoreview: clean, no accepted/actionable findings
- pre-fix stress observation: 30 suite runs passed on arm64; the original crash was observed on GitHub's x86 macOS shard, so the regression exercises the concurrent access directly rather than claiming deterministic local reproduction
