### PR TITLE
fix: fail MiMo refresh promptly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Antigravity: fall back to loopback HTTP for local CLI and language-server probes on Linux, where self-signed localhost TLS cannot be trusted (fixes #1508). Thanks @zodiacfireworks!
 - Menu bar: update visible usage values in place when a manual refresh completes instead of leaving the open provider card stale until the menu is reopened (fixes #1516).
 - Gemini: recognize the current `gemini-api-key` CLI auth setting so API-key sessions show the supported OAuth guidance instead of a misleading not-logged-in error (fixes #1511).
+- Xiaomi MiMo: cancel optional token-plan requests when the required balance request fails instead of delaying the error for up to 30 seconds.
 - Settings: make the cost history window directly editable by keyboard while preserving the existing stepper and 1–365 day bounds (fixes #1499). Thanks @kiranmagic7!
 
 ## 0.35.0 — 2026-06-14

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoUsageFetcher.swift
@@ -62,7 +62,8 @@ public enum MiMoUsageFetcher {
     public static func fetchUsage(
         cookieHeader: String,
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        now: Date = Date()) async throws -> MiMoUsageSnapshot
+        now: Date = Date(),
+        session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> MiMoUsageSnapshot
     {
         guard let normalizedCookie = MiMoCookieHeader.normalizedHeader(from: cookieHeader) else {
             throw MiMoSettingsError.invalidCookie
@@ -74,21 +75,79 @@ public enum MiMoUsageFetcher {
         let tokenUsageURL = MiMoSettingsReader.apiURL(environment: environment)
             .appendingPathComponent("tokenPlan/usage")
 
-        async let balanceData = self.fetchAuthenticated(url: balanceURL, cookie: normalizedCookie)
-        let tokenDetailData: Data? = try? await self.fetchAuthenticated(url: tokenDetailURL, cookie: normalizedCookie)
-        let tokenUsageData: Data? = try? await self.fetchAuthenticated(url: tokenUsageURL, cookie: normalizedCookie)
+        let payloads = try await self.fetchPayloads(
+            balanceURL: balanceURL,
+            tokenDetailURL: tokenDetailURL,
+            tokenUsageURL: tokenUsageURL,
+            cookie: normalizedCookie,
+            transport: transport)
 
-        return try await self.parseCombinedSnapshot(
-            balanceData: balanceData,
-            tokenDetailData: tokenDetailData,
-            tokenUsageData: tokenUsageData,
+        return try self.parseCombinedSnapshot(
+            balanceData: payloads.balance,
+            tokenDetailData: payloads.tokenDetail,
+            tokenUsageData: payloads.tokenUsage,
             now: now)
+    }
+
+    private enum FetchPart {
+        case balance(Data)
+        case tokenDetail(Data?)
+        case tokenUsage(Data?)
+    }
+
+    private static func fetchPayloads(
+        balanceURL: URL,
+        tokenDetailURL: URL,
+        tokenUsageURL: URL,
+        cookie: String,
+        transport: any ProviderHTTPTransport) async throws -> (balance: Data, tokenDetail: Data?, tokenUsage: Data?)
+    {
+        try await withThrowingTaskGroup(of: FetchPart.self) { group in
+            group.addTask {
+                try await .balance(self.fetchAuthenticated(
+                    url: balanceURL,
+                    cookie: cookie,
+                    transport: transport))
+            }
+            group.addTask {
+                await .tokenDetail(try? self.fetchAuthenticated(
+                    url: tokenDetailURL,
+                    cookie: cookie,
+                    transport: transport))
+            }
+            group.addTask {
+                await .tokenUsage(try? self.fetchAuthenticated(
+                    url: tokenUsageURL,
+                    cookie: cookie,
+                    transport: transport))
+            }
+
+            var balance: Data?
+            var tokenDetail: Data?
+            var tokenUsage: Data?
+
+            while let part = try await group.next() {
+                switch part {
+                case let .balance(data):
+                    balance = data
+                case let .tokenDetail(data):
+                    tokenDetail = data
+                case let .tokenUsage(data):
+                    tokenUsage = data
+                }
+            }
+
+            guard let balance else {
+                throw MiMoUsageError.networkError("Balance request did not complete")
+            }
+            return (balance, tokenDetail, tokenUsage)
+        }
     }
 
     private static func fetchAuthenticated(
         url: URL,
         cookie: String,
-        environment: [String: String] = ProcessInfo.processInfo.environment) async throws -> Data
+        transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> Data
     {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
@@ -104,7 +163,7 @@ public enum MiMoUsageFetcher {
                 "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36",
             forHTTPHeaderField: "User-Agent")
 
-        let response = try await ProviderHTTPClient.shared.response(for: request)
+        let response = try await transport.response(for: request)
 
         switch response.statusCode {
         case 200:

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -530,6 +530,58 @@ struct MiMoProviderTests {
         #expect(snapshot.currency == "USD")
         #expect(requestedPaths.contains("/api/v1/balance"))
     }
+
+    @Test
+    func `required balance failure cancels optional mimo requests promptly`() async throws {
+        let optionalStarted = MiMoOptionalRequestGate()
+        let transport = ProviderHTTPTransportStub { request in
+            let path = try #require(request.url?.path)
+            if path.hasSuffix("/balance") {
+                await optionalStarted.wait()
+                throw URLError(.userAuthenticationRequired)
+            }
+
+            await optionalStarted.open()
+            try await Task.sleep(for: .seconds(5))
+            let (response, data) = try Self.makeResponse(url: #require(request.url), body: "{}")
+            return (data, response)
+        }
+
+        let startedAt = ContinuousClock.now
+        do {
+            _ = try await MiMoUsageFetcher.fetchUsage(
+                cookieHeader: "userId=123; api-platform_serviceToken=svc-token",
+                environment: ["MIMO_API_URL": "https://mimo.test/api/v1"],
+                session: transport)
+            Issue.record("Expected required balance request to fail")
+        } catch let error as URLError {
+            #expect(error.code == .userAuthenticationRequired)
+        }
+        let elapsed = startedAt.duration(to: .now)
+
+        #expect(elapsed < .seconds(1), "Required failure was delayed by optional requests: \(elapsed)")
+    }
+}
+
+private actor MiMoOptionalRequestGate {
+    private var isOpen = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !self.isOpen else { return }
+        await withCheckedContinuation { continuation in
+            self.continuations.append(continuation)
+        }
+    }
+
+    func open() {
+        self.isOpen = true
+        let continuations = self.continuations
+        self.continuations.removeAll()
+        for continuation in continuations {
+            continuation.resume()
+        }
+    }
 }
 
 extension MiMoProviderTests {


### PR DESCRIPTION
## Summary

- fetch required MiMo balance and optional token-plan endpoints concurrently
- cancel optional requests when the required balance request fails
- keep token-plan endpoint failures best-effort
- add deterministic cancellation regression coverage

## Proof

- `swift test --filter MiMoProviderTests` (33 tests)
- `make check`
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean)
