### PR TITLE
fix: keep Command Code credits available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 - Antigravity: retry transient `Text file busy` launch failures while the CLI executable is being replaced.
 - Antigravity: fall back to loopback HTTP for local CLI and language-server probes on Linux, where self-signed localhost TLS cannot be trusted (fixes #1508). Thanks @zodiacfireworks!
+- Command Code: keep showing available credits when optional subscription enrichment fails or times out (fixes #1131).
 - Menu bar: update visible usage values in place when a manual refresh completes instead of leaving the open provider card stale until the menu is reopened (fixes #1516).
 - Gemini: recognize the current `gemini-api-key` CLI auth setting so API-key sessions show the supported OAuth guidance instead of a misleading not-logged-in error (fixes #1511).
 - Xiaomi MiMo: cancel optional token-plan requests when the required balance request fails instead of delaying the error for up to 30 seconds.

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
@@ -85,6 +85,7 @@ public enum CommandCodeUsageFetcher {
                 case let .credits(payload):
                     credits = payload
                     if subscriptionFinished {
+                        try Task.checkCancellation()
                         group.cancelAll()
                         return (payload, subscription)
                     }
@@ -100,6 +101,7 @@ public enum CommandCodeUsageFetcher {
                     subscription = payload
                     subscriptionFinished = true
                     if let credits {
+                        try Task.checkCancellation()
                         group.cancelAll()
                         return (credits, payload)
                     }
@@ -108,6 +110,7 @@ public enum CommandCodeUsageFetcher {
                     Self.log.warning("Command Code subscription enrichment failed: \(message)")
                     subscriptionFinished = true
                     if let credits {
+                        try Task.checkCancellation()
                         group.cancelAll()
                         return (credits, subscription)
                     }
@@ -115,6 +118,7 @@ public enum CommandCodeUsageFetcher {
                 case .subscriptionTimeout:
                     if let credits {
                         Self.log.warning("Command Code subscription enrichment timed out")
+                        try Task.checkCancellation()
                         group.cancelAll()
                         return (credits, subscription)
                     }

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
@@ -8,6 +8,7 @@ import FoundationNetworking
 public enum CommandCodeUsageFetcher {
     private static let log = CodexBarLog.logger(LogCategories.commandcodeUsage)
     private static let requestTimeoutSeconds: TimeInterval = 15
+    private static let subscriptionGraceSeconds: TimeInterval = 2
     private static let apiBase = URL(string: "https://api.commandcode.ai")!
     private static let creditsPath = "/internal/billing/credits"
     private static let subscriptionsPath = "/internal/billing/subscriptions"
@@ -21,11 +22,9 @@ public enum CommandCodeUsageFetcher {
         session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         now: Date = Date()) async throws -> CommandCodeUsageSnapshot
     {
-        async let creditsResult = self.fetchCredits(cookieHeader: cookieHeader, transport: transport)
-        async let subscriptionResult = self.fetchSubscription(cookieHeader: cookieHeader, transport: transport)
-
-        let credits = try await creditsResult
-        let subscription = try await subscriptionResult
+        let (credits, subscription) = try await self.fetchPayloads(
+            cookieHeader: cookieHeader,
+            transport: transport)
 
         let plan: CommandCodePlanCatalog.Plan? = subscription.flatMap { sub in
             CommandCodePlanCatalog.plan(forID: sub.planID)
@@ -47,6 +46,83 @@ public enum CommandCodeUsageFetcher {
             billingPeriodEnd: subscription?.currentPeriodEnd,
             subscriptionStatus: subscription?.status,
             updatedAt: now)
+    }
+
+    private enum FetchPart {
+        case credits(CreditsPayload)
+        case subscription(SubscriptionPayload?)
+        case subscriptionFailure(String)
+        case subscriptionTimeout
+    }
+
+    private static func fetchPayloads(
+        cookieHeader: String,
+        transport: any ProviderHTTPTransport) async throws -> (CreditsPayload, SubscriptionPayload?)
+    {
+        try await withThrowingTaskGroup(of: FetchPart.self) { group in
+            group.addTask {
+                try await .credits(self.fetchCredits(cookieHeader: cookieHeader, transport: transport))
+            }
+            group.addTask {
+                do {
+                    return try await .subscription(self.fetchSubscription(
+                        cookieHeader: cookieHeader,
+                        transport: transport))
+                } catch is CancellationError {
+                    throw CancellationError()
+                } catch {
+                    return .subscriptionFailure(error.localizedDescription)
+                }
+            }
+
+            var credits: CreditsPayload?
+            var subscription: SubscriptionPayload?
+            var subscriptionFinished = false
+            var timeoutStarted = false
+
+            while let part = try await group.next() {
+                switch part {
+                case let .credits(payload):
+                    credits = payload
+                    if subscriptionFinished {
+                        group.cancelAll()
+                        return (payload, subscription)
+                    }
+                    if !timeoutStarted {
+                        timeoutStarted = true
+                        group.addTask {
+                            try await Task.sleep(for: .seconds(Self.subscriptionGraceSeconds))
+                            return .subscriptionTimeout
+                        }
+                    }
+
+                case let .subscription(payload):
+                    subscription = payload
+                    subscriptionFinished = true
+                    if let credits {
+                        group.cancelAll()
+                        return (credits, payload)
+                    }
+
+                case let .subscriptionFailure(message):
+                    Self.log.warning("Command Code subscription enrichment failed: \(message)")
+                    subscriptionFinished = true
+                    if let credits {
+                        group.cancelAll()
+                        return (credits, subscription)
+                    }
+
+                case .subscriptionTimeout:
+                    if let credits {
+                        Self.log.warning("Command Code subscription enrichment timed out")
+                        group.cancelAll()
+                        return (credits, subscription)
+                    }
+                }
+            }
+
+            throw CommandCodeUsageError.networkError("Credits request did not complete")
+        }
     }
 
     // MARK: - Endpoints
@@ -101,6 +177,9 @@ public enum CommandCodeUsageFetcher {
         do {
             response = try await transport.response(for: request)
         } catch {
+            if error is CancellationError || (error as? URLError)?.code == .cancelled || Task.isCancelled {
+                throw CancellationError()
+            }
             throw CommandCodeUsageError.networkError(error.localizedDescription)
         }
         if response.statusCode == 401 || response.statusCode == 403 {

--- a/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Testing
 @testable import CodexBarCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Tests for `CommandCodeUsageFetcher` parsers and the cookie/snapshot derivation,
 /// using real responses captured from api.commandcode.ai for an active "individual-go" plan.
@@ -47,6 +50,94 @@ struct CommandCodeUsageFetcherTests {
         let data = Data(#"{"success":true,"data":null}"#.utf8)
         let payload = try CommandCodeUsageFetcher.parseSubscription(data: data)
         #expect(payload == nil)
+    }
+
+    @Test
+    func `subscription failure preserves required credits`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            let path = try #require(request.url?.path)
+            if path.hasSuffix("/credits") {
+                return try Self.response(request: request, statusCode: 200, body: Self.creditsJSON)
+            }
+            return try Self.response(request: request, statusCode: 503, body: #"{"error":"unavailable"}"#)
+        }
+
+        let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
+            cookieHeader: "session=valid",
+            session: transport,
+            now: Date(timeIntervalSince1970: 123))
+
+        #expect(snapshot.monthlyCreditsRemaining == 8.7784)
+        #expect(snapshot.plan == nil)
+        #expect(snapshot.billingPeriodEnd == nil)
+        #expect(snapshot.updatedAt == Date(timeIntervalSince1970: 123))
+    }
+
+    @Test
+    func `subscription timeout does not hold credits for full request timeout`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            let path = try #require(request.url?.path)
+            if path.hasSuffix("/credits") {
+                return try Self.response(request: request, statusCode: 200, body: Self.creditsJSON)
+            }
+            try await Task.sleep(for: .seconds(10))
+            return try Self.response(request: request, statusCode: 200, body: Self.subscriptionJSON)
+        }
+
+        let startedAt = ContinuousClock.now
+        let snapshot = try await CommandCodeUsageFetcher.fetchUsage(
+            cookieHeader: "session=valid",
+            session: transport)
+        let elapsed = startedAt.duration(to: .now)
+
+        #expect(snapshot.monthlyCreditsRemaining == 8.7784)
+        #expect(snapshot.plan == nil)
+        #expect(elapsed < .seconds(3), "Subscription enrichment delayed credits: \(elapsed)")
+    }
+
+    @Test
+    func `cancellation after credits complete does not return partial snapshot`() async throws {
+        let subscriptionStarted = CommandCodeRequestGate()
+        let transport = ProviderHTTPTransportStub { request in
+            let path = try #require(request.url?.path)
+            if path.hasSuffix("/credits") {
+                return try Self.response(request: request, statusCode: 200, body: Self.creditsJSON)
+            }
+            await subscriptionStarted.open()
+            try await Task.sleep(for: .seconds(10))
+            return try Self.response(request: request, statusCode: 200, body: Self.subscriptionJSON)
+        }
+        let task = Task {
+            try await CommandCodeUsageFetcher.fetchUsage(
+                cookieHeader: "session=valid",
+                session: transport)
+        }
+
+        await subscriptionStarted.wait()
+        try await Task.sleep(for: .milliseconds(50))
+        task.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+
+    @Test
+    func `successful unknown active subscription still fails explicitly`() async {
+        let unknownPlanJSON = Self.subscriptionJSON.replacingOccurrences(
+            of: #""planId":"individual-go""#,
+            with: #""planId":"individual-future""#)
+        let transport = ProviderHTTPTransportStub { request in
+            let path = try #require(request.url?.path)
+            let body = path.hasSuffix("/credits") ? Self.creditsJSON : unknownPlanJSON
+            return try Self.response(request: request, statusCode: 200, body: body)
+        }
+
+        await #expect(throws: CommandCodeUsageError.unknownPlan("individual-future")) {
+            try await CommandCodeUsageFetcher.fetchUsage(
+                cookieHeader: "session=valid",
+                session: transport)
+        }
     }
 
     @Test
@@ -109,5 +200,40 @@ struct CommandCodeUsageFetcherTests {
         #expect(CommandCodeCookieHeader.override(from: nil) == nil)
         #expect(CommandCodeCookieHeader.override(from: "") == nil)
         #expect(CommandCodeCookieHeader.override(from: "   ") == nil)
+    }
+
+    private static func response(
+        request: URLRequest,
+        statusCode: Int,
+        body: String) throws -> (Data, URLResponse)
+    {
+        let url = try #require(request.url)
+        let response = try #require(HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil))
+        return (Data(body.utf8), response)
+    }
+}
+
+private actor CommandCodeRequestGate {
+    private var isOpen = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !self.isOpen else { return }
+        await withCheckedContinuation { continuation in
+            self.continuations.append(continuation)
+        }
+    }
+
+    func open() {
+        self.isOpen = true
+        let continuations = self.continuations
+        self.continuations.removeAll()
+        for continuation in continuations {
+            continuation.resume()
+        }
     }
 }

--- a/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
@@ -123,6 +123,37 @@ struct CommandCodeUsageFetcherTests {
     }
 
     @Test
+    func `cancellation wins when optional transport ignores cancellation then fails`() async throws {
+        let subscriptionStarted = CommandCodeRequestGate()
+        let transport = ProviderHTTPTransportStub { request in
+            let path = try #require(request.url?.path)
+            if path.hasSuffix("/credits") {
+                return try Self.response(request: request, statusCode: 200, body: Self.creditsJSON)
+            }
+            await subscriptionStarted.open()
+            do {
+                try await Task.sleep(for: .seconds(10))
+            } catch {
+                // Simulate a transport that converts cancellation into an ordinary endpoint failure.
+            }
+            return try Self.response(request: request, statusCode: 503, body: #"{"error":"unavailable"}"#)
+        }
+        let task = Task {
+            try await CommandCodeUsageFetcher.fetchUsage(
+                cookieHeader: "session=valid",
+                session: transport)
+        }
+
+        await subscriptionStarted.wait()
+        try await Task.sleep(for: .milliseconds(50))
+        task.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+
+    @Test
     func `successful unknown active subscription still fails explicitly`() async {
         let unknownPlanJSON = Self.subscriptionJSON.replacingOccurrences(
             of: #""planId":"individual-go""#,


### PR DESCRIPTION
## Summary

- keep Command Code credits strict while treating subscription data as optional enrichment
- bound subscription enrichment to a two-second grace period after credits arrive
- preserve cancellation instead of publishing a partial snapshot from a cancelled refresh
- keep successful unknown active plans as explicit catalog errors

Fixes #1131.

## Proof

- `swift test --filter CommandCodeUsageFetcherTests` (13 tests)
- `make check`
- `/Users/steipete/Projects/agent-skills/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean after two accepted cancellation findings)
