### PR TITLE
fix: retry transient Antigravity launch failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Antigravity: prefer app and `agy` quota summaries, group usage into Gemini and Claude + GPT session/weekly pools, and preserve IDE and OAuth fallbacks. Thanks @Zihao-Qi!
 
 ### Fixed
+- Antigravity: retry transient `Text file busy` launch failures while the CLI executable is being replaced.
 - Antigravity: fall back to loopback HTTP for local CLI and language-server probes on Linux, where self-signed localhost TLS cannot be trusted (fixes #1508). Thanks @zodiacfireworks!
 - Menu bar: update visible usage values in place when a manual refresh completes instead of leaving the open provider card stale until the menu is reopened (fixes #1516).
 - Gemini: recognize the current `gemini-api-key` CLI auth setting so API-key sessions show the supported OAuth guidance instead of a misleading not-logged-in error (fixes #1511).

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityCLISession.swift
@@ -829,6 +829,23 @@ struct AntigravityPTYProcessLauncher: AntigravityCLIProcessLaunching {
         return signals
     }
 
+    static func spawnWithTextBusyRetry(
+        maxAttempts: Int = 3,
+        retryDelay: TimeInterval = 0.01,
+        spawn: () -> Int32) -> Int32
+    {
+        var result = spawn()
+        guard maxAttempts > 1 else { return result }
+
+        for _ in 1..<maxAttempts where result == ETXTBSY {
+            if retryDelay > 0 {
+                Thread.sleep(forTimeInterval: retryDelay)
+            }
+            result = spawn()
+        }
+        return result
+    }
+
     func launch(binary: String) throws -> any AntigravityCLIProcessHandle {
         var primaryFD: Int32 = -1
         var secondaryFD: Int32 = -1
@@ -914,8 +931,10 @@ struct AntigravityPTYProcessLauncher: AntigravityCLIProcessLaunching {
         }
 
         var pid: pid_t = 0
-        let spawnResult = binary.withCString { execPath in
-            posix_spawn(&pid, execPath, &fileActions, &attr, cArgs, cEnv)
+        let spawnResult = Self.spawnWithTextBusyRetry {
+            binary.withCString { execPath in
+                posix_spawn(&pid, execPath, &fileActions, &attr, cArgs, cEnv)
+            }
         }
         guard spawnResult == 0 else {
             try? primaryHandle.close()

--- a/Tests/CodexBarTests/AntigravityCLISessionTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLISessionTests.swift
@@ -628,6 +628,32 @@ struct AntigravityCLISessionTests {
     }
 
     @Test
+    func `pty launcher retries transient text busy spawn errors`() {
+        var attempts = 0
+
+        let result = AntigravityPTYProcessLauncher.spawnWithTextBusyRetry(retryDelay: 0) {
+            attempts += 1
+            return attempts < 3 ? ETXTBSY : 0
+        }
+
+        #expect(result == 0)
+        #expect(attempts == 3)
+    }
+
+    @Test
+    func `pty launcher does not retry other spawn errors`() {
+        var attempts = 0
+
+        let result = AntigravityPTYProcessLauncher.spawnWithTextBusyRetry(retryDelay: 0) {
+            attempts += 1
+            return EACCES
+        }
+
+        #expect(result == EACCES)
+        #expect(attempts == 1)
+    }
+
+    @Test
     func `pty launcher uses home and closes unrelated descriptors`() throws {
         let tempDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("antigravity-spawn-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary

- retry Antigravity PTY process creation only when `posix_spawn` returns `ETXTBSY`
- bound retries to three attempts with a short delay
- preserve immediate failure for all other launch errors
- add regression coverage for retry and fail-fast behavior

## Why

PR #1521 exposed an unrelated Linux x64 CI flake in `AntigravityProcessLauncherLinuxTests`: the temporary executable returned `Text file busy` while arm64 passed. The same transient can occur when the installed `agy` executable is being replaced during a refresh.

## Validation

- `swift test --filter AntigravityCLISessionTests` (48 passed)
- `make check`
- local Codex autoreview: clean
