### PR TITLE
fix: bound DeepSeek optional summary wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Antigravity: retry transient `Text file busy` launch failures while the CLI executable is being replaced.
 - Antigravity: fall back to loopback HTTP for local CLI and language-server probes on Linux, where self-signed localhost TLS cannot be trusted (fixes #1508). Thanks @zodiacfireworks!
 - Command Code: keep showing available credits when optional subscription enrichment fails or times out (fixes #1131).
+- DeepSeek: keep balance refreshes responsive when optional usage-summary work ignores cancellation.
 - Menu bar: update visible usage values in place when a manual refresh completes instead of leaving the open provider card stale until the menu is reopened (fixes #1516).
 - Gemini: recognize the current `gemini-api-key` CLI auth setting so API-key sessions show the supported OAuth guidance instead of a misleading not-logged-in error (fixes #1511).
 - Xiaomi MiMo: cancel optional token-plan requests when the required balance request fails instead of delaying the error for up to 30 seconds.

--- a/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekUsageFetcher.swift
@@ -123,6 +123,80 @@ public enum DeepSeekUsageError: LocalizedError, Sendable {
 
 // MARK: - Fetcher
 
+private final class DeepSeekOptionalSummaryRace: @unchecked Sendable {
+    private let lock = NSLock()
+    private let sourceTask: Task<DeepSeekUsageSummary, Error>
+    private var result: Result<DeepSeekUsageSummary?, Error>?
+    private var continuation: CheckedContinuation<DeepSeekUsageSummary?, Error>?
+    private var observerTask: Task<Void, Never>?
+    private var timeoutTask: Task<Void, Never>?
+
+    init(sourceTask: Task<DeepSeekUsageSummary, Error>) {
+        self.sourceTask = sourceTask
+    }
+
+    func value(joinGrace: Duration) async throws -> DeepSeekUsageSummary? {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                self.lock.lock()
+                if let result = self.result {
+                    self.lock.unlock()
+                    continuation.resume(with: result)
+                    return
+                }
+
+                self.continuation = continuation
+                let sourceTask = self.sourceTask
+                self.observerTask = Task { [weak self] in
+                    do {
+                        let value = try await sourceTask.value
+                        self?.resolve(.success(value), cancelSource: false)
+                    } catch {
+                        self?.resolve(.failure(error), cancelSource: false)
+                    }
+                }
+                self.timeoutTask = Task { [weak self] in
+                    do {
+                        if joinGrace > .zero {
+                            try await Task.sleep(for: joinGrace)
+                        }
+                        self?.resolve(.success(nil), cancelSource: true)
+                    } catch {
+                        // The source completed or the caller canceled the race.
+                    }
+                }
+                self.lock.unlock()
+            }
+        } onCancel: {
+            self.resolve(.failure(CancellationError()), cancelSource: true)
+        }
+    }
+
+    private func resolve(_ result: Result<DeepSeekUsageSummary?, Error>, cancelSource: Bool) {
+        self.lock.lock()
+        guard self.result == nil else {
+            self.lock.unlock()
+            return
+        }
+
+        self.result = result
+        let continuation = self.continuation
+        self.continuation = nil
+        let observerTask = self.observerTask
+        let timeoutTask = self.timeoutTask
+        self.observerTask = nil
+        self.timeoutTask = nil
+        self.lock.unlock()
+
+        if cancelSource {
+            self.sourceTask.cancel()
+        }
+        observerTask?.cancel()
+        timeoutTask?.cancel()
+        continuation?.resume(with: result)
+    }
+}
+
 public struct DeepSeekUsageFetcher: Sendable {
     private static let log = CodexBarLog.logger(LogCategories.deepSeekUsage)
     private static let balanceURL = URL(string: "https://api.deepseek.com/user/balance")!
@@ -244,35 +318,15 @@ public struct DeepSeekUsageFetcher: Sendable {
         from task: Task<DeepSeekUsageSummary, Error>,
         joinGrace: Duration) async throws -> DeepSeekUsageSummary?
     {
-        try await withTaskCancellationHandler {
-            do {
-                return try await withThrowingTaskGroup(of: DeepSeekUsageSummary?.self) { group in
-                    group.addTask {
-                        try await task.value
-                    }
-                    group.addTask {
-                        if joinGrace > .zero {
-                            try await Task.sleep(for: joinGrace)
-                        }
-                        return nil
-                    }
-
-                    let result = try await group.next().flatMap(\.self)
-                    if result == nil {
-                        task.cancel()
-                    }
-                    group.cancelAll()
-                    return result
-                }
-            } catch {
-                task.cancel()
-                if Task.isCancelled {
-                    throw error
-                }
-                return nil
-            }
-        } onCancel: {
+        let race = DeepSeekOptionalSummaryRace(sourceTask: task)
+        do {
+            return try await race.value(joinGrace: joinGrace)
+        } catch {
             task.cancel()
+            if Task.isCancelled {
+                throw error
+            }
+            return nil
         }
     }
 

--- a/Tests/CodexBarTests/DeepSeekUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/DeepSeekUsageFetcherTests.swift
@@ -369,6 +369,33 @@ struct DeepSeekUsageFetcherTests {
     }
 
     @Test
+    func `balance grace does not wait for optional summary that ignores cancellation`() async throws {
+        let startedAt = ContinuousClock.now
+        let snapshot = try await DeepSeekUsageFetcher._fetchUsageForTesting(
+            apiKey: "test-key",
+            includeOptionalUsage: true,
+            optionalSummaryJoinGrace: .milliseconds(20),
+            fetchBalanceData: { _ in
+                Data(Self.sampleBalanceJSON.utf8)
+            },
+            fetchSummary: { _ in
+                await withCheckedContinuation { continuation in
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+                        continuation.resume(returning: Self.sampleSummary())
+                    }
+                }
+            })
+        let elapsed = startedAt.duration(to: .now)
+
+        #expect(snapshot.totalBalance == 50.0)
+        #expect(snapshot.usageSummary == nil)
+        #expect(elapsed < .milliseconds(300), "Optional summary delayed balance: \(elapsed)")
+
+        // Let the deliberately cancellation-ignoring test task drain before the test exits.
+        try await Task.sleep(for: .milliseconds(550))
+    }
+
+    @Test
     func `balance returns when optional usage summary fails closed`() async throws {
         let snapshot = try await DeepSeekUsageFetcher._fetchUsageForTesting(
             apiKey: "test-key",


### PR DESCRIPTION
## Summary
- replace the structured task-group race around optional DeepSeek usage summaries with a one-shot continuation race
- return the required balance snapshot after the configured grace even when summary work ignores cancellation
- preserve parent cancellation propagation and fail-closed optional summary errors
- add a regression using deliberately cancellation-ignoring summary work

## Tests
- `swift test --filter DeepSeekUsageFetcherTests` (21 tests passed)
- `make test` (39 shards / 461 selections passed)
- `make check`
- `git diff --check`
- local autoreview clean, no actionable findings

## Risk
- limited to optional DeepSeek usage-summary enrichment; balance parsing, credentials, endpoints, and snapshot projection are unchanged
- no live provider, browser, or Keychain probe was run