### PR TITLE
fix: bound optional provider enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@
 ### Fixed
 - Antigravity: retry transient `Text file busy` launch failures while the CLI executable is being replaced.
 - Antigravity: fall back to loopback HTTP for local CLI and language-server probes on Linux, where self-signed localhost TLS cannot be trusted (fixes #1508). Thanks @zodiacfireworks!
-- Command Code: keep showing available credits when optional subscription enrichment fails or times out (fixes #1131).
+- Codebuff: enforce the optional subscription grace period even when the transport ignores cancellation.
+- Command Code: keep showing available credits after the bounded optional subscription grace, including when the transport ignores cancellation (fixes #1131).
 - DeepSeek: keep balance refreshes responsive when optional usage-summary work ignores cancellation.
+- OpenRouter: keep credit refreshes responsive when optional key-quota enrichment ignores cancellation.
 - Menu bar: update visible usage values in place when a manual refresh completes instead of leaving the open provider card stale until the menu is reopened (fixes #1516).
 - Gemini: recognize the current `gemini-api-key` CLI auth setting so API-key sessions show the supported OAuth guidance instead of a misleading not-logged-in error (fixes #1511).
 - Xiaomi MiMo: cancel optional token-plan requests when the required balance request fails instead of delaying the error for up to 30 seconds.

--- a/Sources/CodexBarCore/BoundedTaskJoin.swift
+++ b/Sources/CodexBarCore/BoundedTaskJoin.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+enum BoundedTaskJoinOutcome<Value: Sendable> {
+    case value(Value)
+    case failure(any Error)
+    case timedOut
+}
+
+final class BoundedTaskJoin<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private let sourceTask: Task<Value, Error>
+    private var outcome: BoundedTaskJoinOutcome<Value>?
+    private var continuation: CheckedContinuation<BoundedTaskJoinOutcome<Value>, Never>?
+    private var observerTask: Task<Void, Never>?
+    private var timeoutTask: Task<Void, Never>?
+
+    init(sourceTask: Task<Value, Error>) {
+        self.sourceTask = sourceTask
+    }
+
+    func value(joinGrace: Duration) async -> BoundedTaskJoinOutcome<Value> {
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                self.lock.lock()
+                if let outcome = self.outcome {
+                    self.lock.unlock()
+                    continuation.resume(returning: outcome)
+                    return
+                }
+
+                self.continuation = continuation
+                let sourceTask = self.sourceTask
+                self.observerTask = Task { [weak self] in
+                    do {
+                        let value = try await sourceTask.value
+                        self?.resolve(.value(value), cancelSource: false)
+                    } catch {
+                        self?.resolve(.failure(error), cancelSource: false)
+                    }
+                }
+                self.timeoutTask = Task { [weak self] in
+                    do {
+                        if joinGrace > .zero {
+                            try await Task.sleep(for: joinGrace)
+                        }
+                        self?.resolve(.timedOut, cancelSource: true)
+                    } catch {
+                        // The source completed or the caller canceled the race.
+                    }
+                }
+                self.lock.unlock()
+            }
+        } onCancel: {
+            self.resolve(.failure(CancellationError()), cancelSource: true)
+        }
+    }
+
+    private func resolve(_ outcome: BoundedTaskJoinOutcome<Value>, cancelSource: Bool) {
+        self.lock.lock()
+        guard self.outcome == nil else {
+            self.lock.unlock()
+            return
+        }
+
+        self.outcome = outcome
+        let continuation = self.continuation
+        self.continuation = nil
+        let observerTask = self.observerTask
+        let timeoutTask = self.timeoutTask
+        self.observerTask = nil
+        self.timeoutTask = nil
+        self.lock.unlock()
+
+        if cancelSource {
+            self.sourceTask.cancel()
+        }
+        observerTask?.cancel()
+        timeoutTask?.cancel()
+        continuation?.resume(returning: outcome)
+    }
+}

--- a/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codebuff/CodebuffUsageFetcher.swift
@@ -19,6 +19,36 @@ public enum CodebuffUsageFetcher {
         includeSubscription: Bool = true,
         session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared) async throws -> CodebuffUsageSnapshot
     {
+        try await self.fetchUsage(
+            apiKey: apiKey,
+            environment: environment,
+            includeSubscription: includeSubscription,
+            transport: transport,
+            subscriptionGrace: .seconds(self.subscriptionGraceSeconds))
+    }
+
+    static func _fetchUsageForTesting(
+        apiKey: String,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        includeSubscription: Bool = true,
+        transport: any ProviderHTTPTransport,
+        subscriptionGrace: Duration) async throws -> CodebuffUsageSnapshot
+    {
+        try await self.fetchUsage(
+            apiKey: apiKey,
+            environment: environment,
+            includeSubscription: includeSubscription,
+            transport: transport,
+            subscriptionGrace: subscriptionGrace)
+    }
+
+    private static func fetchUsage(
+        apiKey: String,
+        environment: [String: String],
+        includeSubscription: Bool,
+        transport: any ProviderHTTPTransport,
+        subscriptionGrace: Duration) async throws -> CodebuffUsageSnapshot
+    {
         let trimmed = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             throw CodebuffUsageError.missingCredentials
@@ -31,7 +61,8 @@ public enum CodebuffUsageFetcher {
             apiKey: trimmed,
             baseURL: baseURL,
             includeSubscription: includeSubscription,
-            transport: transport)
+            transport: transport,
+            subscriptionGrace: subscriptionGrace)
 
         return CodebuffUsageSnapshot(
             creditsUsed: usageValues.used,
@@ -53,70 +84,58 @@ public enum CodebuffUsageFetcher {
         apiKey: String,
         baseURL: URL,
         includeSubscription: Bool,
-        transport: any ProviderHTTPTransport) async throws -> (UsagePayload, SubscriptionPayload?)
+        transport: any ProviderHTTPTransport,
+        subscriptionGrace: Duration) async throws -> (UsagePayload, SubscriptionPayload?)
     {
-        try await withThrowingTaskGroup(of: FetchResult.self) { group in
-            group.addTask {
-                try await .usage(self.fetchUsagePayload(apiKey: apiKey, baseURL: baseURL, transport: transport))
+        guard includeSubscription else {
+            return try await (
+                self.fetchUsagePayload(apiKey: apiKey, baseURL: baseURL, transport: transport),
+                nil)
+        }
+
+        let subscriptionTask = Task<SubscriptionPayload?, Error> {
+            try await self.fetchSubscriptionPayload(
+                apiKey: apiKey,
+                baseURL: baseURL,
+                transport: transport)
+        }
+        let usageValues: UsagePayload
+        do {
+            usageValues = try await withTaskCancellationHandler {
+                try await self.fetchUsagePayload(
+                    apiKey: apiKey,
+                    baseURL: baseURL,
+                    transport: transport)
+            } onCancel: {
+                subscriptionTask.cancel()
             }
-            if includeSubscription {
-                group.addTask {
-                    await .subscription(try? self.fetchSubscriptionPayload(
-                        apiKey: apiKey,
-                        baseURL: baseURL,
-                        transport: transport))
-                }
-            }
+        } catch {
+            subscriptionTask.cancel()
+            throw error
+        }
 
-            var usageValues: UsagePayload?
-            var subscriptionValues: SubscriptionPayload?
-            var subscriptionFinished = !includeSubscription
-            var timeoutStarted = false
-
-            while let result = try await group.next() {
-                switch result {
-                case let .usage(payload):
-                    usageValues = payload
-                    if subscriptionFinished {
-                        group.cancelAll()
-                        return (payload, subscriptionValues)
-                    }
-                    if !timeoutStarted {
-                        timeoutStarted = true
-                        group.addTask {
-                            let nanos = UInt64(max(0, Self.subscriptionGraceSeconds) * 1_000_000_000)
-                            try? await Task.sleep(nanoseconds: nanos)
-                            return .subscriptionTimeout
-                        }
-                    }
-
-                case let .subscription(payload):
-                    subscriptionValues = payload
-                    subscriptionFinished = true
-                    if let usageValues {
-                        group.cancelAll()
-                        return (usageValues, payload)
-                    }
-
-                case .subscriptionTimeout:
-                    if let usageValues {
-                        group.cancelAll()
-                        return (usageValues, subscriptionValues)
-                    }
-                }
-            }
-
-            throw CodebuffUsageError.networkError("Usage request did not complete")
+        do {
+            try Task.checkCancellation()
+        } catch {
+            subscriptionTask.cancel()
+            throw error
+        }
+        let race = BoundedTaskJoin(sourceTask: subscriptionTask)
+        switch await race.value(joinGrace: subscriptionGrace) {
+        case let .value(subscriptionValues):
+            try Task.checkCancellation()
+            return (usageValues, subscriptionValues)
+        case .timedOut:
+            try Task.checkCancellation()
+            return (usageValues, nil)
+        case .failure:
+            subscriptionTask.cancel()
+            try Task.checkCancellation()
+            return (usageValues, nil)
         }
     }
 
     // MARK: - Endpoint helpers
-
-    private enum FetchResult {
-        case usage(UsagePayload)
-        case subscription(SubscriptionPayload?)
-        case subscriptionTimeout
-    }
 
     struct UsagePayload {
         let used: Double?

--- a/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/CommandCode/CommandCodeUsageFetcher.swift
@@ -22,9 +22,36 @@ public enum CommandCodeUsageFetcher {
         session transport: any ProviderHTTPTransport = ProviderHTTPClient.shared,
         now: Date = Date()) async throws -> CommandCodeUsageSnapshot
     {
+        try await self.fetchUsage(
+            cookieHeader: cookieHeader,
+            transport: transport,
+            now: now,
+            subscriptionGrace: .seconds(self.subscriptionGraceSeconds))
+    }
+
+    static func _fetchUsageForTesting(
+        cookieHeader: String,
+        transport: any ProviderHTTPTransport,
+        now: Date = Date(),
+        subscriptionGrace: Duration) async throws -> CommandCodeUsageSnapshot
+    {
+        try await self.fetchUsage(
+            cookieHeader: cookieHeader,
+            transport: transport,
+            now: now,
+            subscriptionGrace: subscriptionGrace)
+    }
+
+    private static func fetchUsage(
+        cookieHeader: String,
+        transport: any ProviderHTTPTransport,
+        now: Date,
+        subscriptionGrace: Duration) async throws -> CommandCodeUsageSnapshot
+    {
         let (credits, subscription) = try await self.fetchPayloads(
             cookieHeader: cookieHeader,
-            transport: transport)
+            transport: transport,
+            subscriptionGrace: subscriptionGrace)
 
         let plan: CommandCodePlanCatalog.Plan? = subscription.flatMap { sub in
             CommandCodePlanCatalog.plan(forID: sub.planID)
@@ -48,84 +75,46 @@ public enum CommandCodeUsageFetcher {
             updatedAt: now)
     }
 
-    private enum FetchPart {
-        case credits(CreditsPayload)
-        case subscription(SubscriptionPayload?)
-        case subscriptionFailure(String)
-        case subscriptionTimeout
-    }
-
     private static func fetchPayloads(
         cookieHeader: String,
-        transport: any ProviderHTTPTransport) async throws -> (CreditsPayload, SubscriptionPayload?)
+        transport: any ProviderHTTPTransport,
+        subscriptionGrace: Duration) async throws -> (CreditsPayload, SubscriptionPayload?)
     {
-        try await withThrowingTaskGroup(of: FetchPart.self) { group in
-            group.addTask {
-                try await .credits(self.fetchCredits(cookieHeader: cookieHeader, transport: transport))
+        let subscriptionTask = Task<SubscriptionPayload?, Error> {
+            try await self.fetchSubscription(cookieHeader: cookieHeader, transport: transport)
+        }
+        let credits: CreditsPayload
+        do {
+            credits = try await withTaskCancellationHandler {
+                try await self.fetchCredits(cookieHeader: cookieHeader, transport: transport)
+            } onCancel: {
+                subscriptionTask.cancel()
             }
-            group.addTask {
-                do {
-                    return try await .subscription(self.fetchSubscription(
-                        cookieHeader: cookieHeader,
-                        transport: transport))
-                } catch is CancellationError {
-                    throw CancellationError()
-                } catch {
-                    return .subscriptionFailure(error.localizedDescription)
-                }
-            }
+        } catch {
+            subscriptionTask.cancel()
+            throw error
+        }
 
-            var credits: CreditsPayload?
-            var subscription: SubscriptionPayload?
-            var subscriptionFinished = false
-            var timeoutStarted = false
-
-            while let part = try await group.next() {
-                switch part {
-                case let .credits(payload):
-                    credits = payload
-                    if subscriptionFinished {
-                        try Task.checkCancellation()
-                        group.cancelAll()
-                        return (payload, subscription)
-                    }
-                    if !timeoutStarted {
-                        timeoutStarted = true
-                        group.addTask {
-                            try await Task.sleep(for: .seconds(Self.subscriptionGraceSeconds))
-                            return .subscriptionTimeout
-                        }
-                    }
-
-                case let .subscription(payload):
-                    subscription = payload
-                    subscriptionFinished = true
-                    if let credits {
-                        try Task.checkCancellation()
-                        group.cancelAll()
-                        return (credits, payload)
-                    }
-
-                case let .subscriptionFailure(message):
-                    Self.log.warning("Command Code subscription enrichment failed: \(message)")
-                    subscriptionFinished = true
-                    if let credits {
-                        try Task.checkCancellation()
-                        group.cancelAll()
-                        return (credits, subscription)
-                    }
-
-                case .subscriptionTimeout:
-                    if let credits {
-                        Self.log.warning("Command Code subscription enrichment timed out")
-                        try Task.checkCancellation()
-                        group.cancelAll()
-                        return (credits, subscription)
-                    }
-                }
-            }
-
-            throw CommandCodeUsageError.networkError("Credits request did not complete")
+        do {
+            try Task.checkCancellation()
+        } catch {
+            subscriptionTask.cancel()
+            throw error
+        }
+        let race = BoundedTaskJoin(sourceTask: subscriptionTask)
+        switch await race.value(joinGrace: subscriptionGrace) {
+        case let .value(subscription):
+            try Task.checkCancellation()
+            return (credits, subscription)
+        case .timedOut:
+            try Task.checkCancellation()
+            Self.log.warning("Command Code subscription enrichment timed out")
+            return (credits, nil)
+        case let .failure(error):
+            subscriptionTask.cancel()
+            try Task.checkCancellation()
+            Self.log.warning("Command Code subscription enrichment failed: \(error.localizedDescription)")
+            return (credits, nil)
         }
     }
 

--- a/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/DeepSeek/DeepSeekUsageFetcher.swift
@@ -123,80 +123,6 @@ public enum DeepSeekUsageError: LocalizedError, Sendable {
 
 // MARK: - Fetcher
 
-private final class DeepSeekOptionalSummaryRace: @unchecked Sendable {
-    private let lock = NSLock()
-    private let sourceTask: Task<DeepSeekUsageSummary, Error>
-    private var result: Result<DeepSeekUsageSummary?, Error>?
-    private var continuation: CheckedContinuation<DeepSeekUsageSummary?, Error>?
-    private var observerTask: Task<Void, Never>?
-    private var timeoutTask: Task<Void, Never>?
-
-    init(sourceTask: Task<DeepSeekUsageSummary, Error>) {
-        self.sourceTask = sourceTask
-    }
-
-    func value(joinGrace: Duration) async throws -> DeepSeekUsageSummary? {
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                self.lock.lock()
-                if let result = self.result {
-                    self.lock.unlock()
-                    continuation.resume(with: result)
-                    return
-                }
-
-                self.continuation = continuation
-                let sourceTask = self.sourceTask
-                self.observerTask = Task { [weak self] in
-                    do {
-                        let value = try await sourceTask.value
-                        self?.resolve(.success(value), cancelSource: false)
-                    } catch {
-                        self?.resolve(.failure(error), cancelSource: false)
-                    }
-                }
-                self.timeoutTask = Task { [weak self] in
-                    do {
-                        if joinGrace > .zero {
-                            try await Task.sleep(for: joinGrace)
-                        }
-                        self?.resolve(.success(nil), cancelSource: true)
-                    } catch {
-                        // The source completed or the caller canceled the race.
-                    }
-                }
-                self.lock.unlock()
-            }
-        } onCancel: {
-            self.resolve(.failure(CancellationError()), cancelSource: true)
-        }
-    }
-
-    private func resolve(_ result: Result<DeepSeekUsageSummary?, Error>, cancelSource: Bool) {
-        self.lock.lock()
-        guard self.result == nil else {
-            self.lock.unlock()
-            return
-        }
-
-        self.result = result
-        let continuation = self.continuation
-        self.continuation = nil
-        let observerTask = self.observerTask
-        let timeoutTask = self.timeoutTask
-        self.observerTask = nil
-        self.timeoutTask = nil
-        self.lock.unlock()
-
-        if cancelSource {
-            self.sourceTask.cancel()
-        }
-        observerTask?.cancel()
-        timeoutTask?.cancel()
-        continuation?.resume(with: result)
-    }
-}
-
 public struct DeepSeekUsageFetcher: Sendable {
     private static let log = CodexBarLog.logger(LogCategories.deepSeekUsage)
     private static let balanceURL = URL(string: "https://api.deepseek.com/user/balance")!
@@ -265,7 +191,11 @@ public struct DeepSeekUsageFetcher: Sendable {
 
         let balanceData: Data
         do {
-            balanceData = try await fetchBalanceData(apiKey)
+            balanceData = try await withTaskCancellationHandler {
+                try await fetchBalanceData(apiKey)
+            } onCancel: {
+                summaryTask?.cancel()
+            }
         } catch {
             summaryTask?.cancel()
             throw error
@@ -318,10 +248,15 @@ public struct DeepSeekUsageFetcher: Sendable {
         from task: Task<DeepSeekUsageSummary, Error>,
         joinGrace: Duration) async throws -> DeepSeekUsageSummary?
     {
-        let race = DeepSeekOptionalSummaryRace(sourceTask: task)
-        do {
-            return try await race.value(joinGrace: joinGrace)
-        } catch {
+        let race = BoundedTaskJoin(sourceTask: task)
+        switch await race.value(joinGrace: joinGrace) {
+        case let .value(summary):
+            try Task.checkCancellation()
+            return summary
+        case .timedOut:
+            try Task.checkCancellation()
+            return nil
+        case let .failure(error):
             task.cancel()
             if Task.isCancelled {
                 throw error

--- a/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/OpenRouter/OpenRouterUsageStats.swift
@@ -260,7 +260,7 @@ public struct OpenRouterUsageFetcher: Sendable {
 
             // Optionally fetch key quota/rate-limit info from /key endpoint, but keep this bounded so
             // credits updates are not blocked by a slow or unavailable secondary endpoint.
-            let keyFetch = await fetchKeyData(
+            let keyFetch = try await fetchKeyData(
                 apiKey: apiKey,
                 baseURL: baseURL,
                 timeoutSeconds: Self.rateLimitTimeoutSeconds)
@@ -278,6 +278,8 @@ public struct OpenRouterUsageFetcher: Sendable {
                 keyUsageMonthly: keyFetch.data?.usageMonthly,
                 rateLimit: keyFetch.data?.rateLimit,
                 updatedAt: Date())
+        } catch is CancellationError {
+            throw CancellationError()
         } catch let error as DecodingError {
             Self.log.error("OpenRouter JSON decoding error: \(error.localizedDescription)")
             throw OpenRouterUsageError.parseFailed(error.localizedDescription)
@@ -298,37 +300,47 @@ public struct OpenRouterUsageFetcher: Sendable {
     private static func fetchKeyData(
         apiKey: String,
         baseURL: URL,
-        timeoutSeconds: TimeInterval) async -> OpenRouterKeyFetchResult
+        timeoutSeconds: TimeInterval) async throws -> OpenRouterKeyFetchResult
     {
         let timeout = max(0.1, timeoutSeconds)
-        let timeoutNanoseconds = UInt64(timeout * 1_000_000_000)
+        return try await self.boundedKeyFetch(timeout: .seconds(timeout)) {
+            await Self.fetchKeyDataRequest(
+                apiKey: apiKey,
+                baseURL: baseURL,
+                timeoutSeconds: timeout)
+        }
+    }
 
-        return await withTaskGroup(of: OpenRouterKeyFetchResult.self) { group in
-            group.addTask {
-                await Self.fetchKeyDataRequest(
-                    apiKey: apiKey,
-                    baseURL: baseURL,
-                    timeoutSeconds: timeout)
-            }
-            group.addTask {
-                do {
-                    try await Task.sleep(nanoseconds: timeoutNanoseconds)
-                } catch {
-                    // Cancelled because the /key request finished first.
-                    return OpenRouterKeyFetchResult(data: nil, fetched: false)
-                }
-                guard !Task.isCancelled else {
-                    return OpenRouterKeyFetchResult(data: nil, fetched: false)
-                }
-                Self.log.debug("OpenRouter /key enrichment timed out after \(timeout)s")
-                return OpenRouterKeyFetchResult(data: nil, fetched: false)
-            }
+    static func _boundedKeyFetchForTesting(
+        timeout: Duration,
+        operation: @escaping @Sendable () async -> Void) async throws -> Bool
+    {
+        let result = try await self.boundedKeyFetch(timeout: timeout) {
+            await operation()
+            return OpenRouterKeyFetchResult(data: nil, fetched: true)
+        }
+        return result.fetched
+    }
 
-            let result = await group.next()
-            group.cancelAll()
-            if let result {
-                return result
-            }
+    private static func boundedKeyFetch(
+        timeout: Duration,
+        operation: @escaping @Sendable () async -> OpenRouterKeyFetchResult) async throws -> OpenRouterKeyFetchResult
+    {
+        let sourceTask = Task<OpenRouterKeyFetchResult, Error> {
+            await operation()
+        }
+        let race = BoundedTaskJoin(sourceTask: sourceTask)
+        switch await race.value(joinGrace: timeout) {
+        case let .value(result):
+            try Task.checkCancellation()
+            return result
+        case .timedOut:
+            try Task.checkCancellation()
+            Self.log.debug("OpenRouter /key enrichment timed out")
+            return OpenRouterKeyFetchResult(data: nil, fetched: false)
+        case .failure:
+            sourceTask.cancel()
+            try Task.checkCancellation()
             return OpenRouterKeyFetchResult(data: nil, fetched: false)
         }
     }

--- a/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CodebuffUsageFetcherTests.swift
@@ -82,6 +82,90 @@ struct CodebuffUsageFetcherTests {
     }
 
     @Test
+    func `subscription grace does not wait for transport that ignores cancellation`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            let url = try #require(request.url)
+            if url.path == "/api/v1/usage" {
+                let response = try Self.makeResponse(
+                    url: url,
+                    body: #"{"usage":25,"quota":100,"remainingBalance":75}"#)
+                return (response.1, response.0)
+            }
+            let response = try Self.makeResponse(
+                url: url,
+                body: #"{"subscription":{"displayName":"Pro","status":"active"}}"#)
+            return await withCheckedContinuation { continuation in
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+                    continuation.resume(returning: (response.1, response.0))
+                }
+            }
+        }
+
+        let startedAt = ContinuousClock.now
+        let snapshot = try await CodebuffUsageFetcher._fetchUsageForTesting(
+            apiKey: "cb-test",
+            transport: transport,
+            subscriptionGrace: .milliseconds(20))
+        let elapsed = startedAt.duration(to: .now)
+
+        #expect(snapshot.creditsUsed == 25)
+        #expect(snapshot.tier == nil)
+        #expect(elapsed < .milliseconds(300), "Subscription enrichment delayed usage: \(elapsed)")
+
+        // Let the deliberately cancellation-ignoring test task drain before the test exits.
+        try await Task.sleep(for: .milliseconds(550))
+    }
+
+    @Test
+    func `cancellation stops subscription while usage transport ignores cancellation`() async throws {
+        let usageStarted = CodebuffRequestGate()
+        let subscriptionStarted = CodebuffRequestGate()
+        let subscriptionCancelled = CodebuffRequestGate()
+        let transport = ProviderHTTPTransportStub { request in
+            let url = try #require(request.url)
+            if url.path == "/api/v1/usage" {
+                await usageStarted.open()
+                let response = try Self.makeResponse(
+                    url: url,
+                    body: #"{"usage":25,"quota":100,"remainingBalance":75}"#)
+                return await withCheckedContinuation { continuation in
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+                        continuation.resume(returning: (response.1, response.0))
+                    }
+                }
+            }
+
+            await subscriptionStarted.open()
+            do {
+                try await Task.sleep(for: .seconds(10))
+            } catch {
+                await subscriptionCancelled.open()
+                throw error
+            }
+            let response = try Self.makeResponse(
+                url: url,
+                body: #"{"subscription":{"displayName":"Pro","status":"active"}}"#)
+            return (response.1, response.0)
+        }
+        let task = Task {
+            try await CodebuffUsageFetcher.fetchUsage(
+                apiKey: "cb-test",
+                session: transport)
+        }
+
+        await usageStarted.wait()
+        await subscriptionStarted.wait()
+        let cancellationStartedAt = ContinuousClock.now
+        task.cancel()
+
+        await subscriptionCancelled.wait()
+        #expect(cancellationStartedAt.duration(to: .now) < .milliseconds(300))
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+
+    @Test
     func `api strategy only fetches subscription for credentials file tokens`() {
         let envResolution = ProviderTokenResolution(token: "env-token", source: .environment)
         let fileResolution = ProviderTokenResolution(token: "file-token", source: .authFile)
@@ -328,6 +412,27 @@ struct CodebuffUsageFetcherTests {
             throw URLError(.badServerResponse)
         }
         return (response, Data(body.utf8))
+    }
+}
+
+private actor CodebuffRequestGate {
+    private var isOpen = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !self.isOpen else { return }
+        await withCheckedContinuation { continuation in
+            self.continuations.append(continuation)
+        }
+    }
+
+    func open() {
+        self.isOpen = true
+        let continuations = self.continuations
+        self.continuations.removeAll()
+        for continuation in continuations {
+            continuation.resume()
+        }
     }
 }
 

--- a/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CommandCodeUsageFetcherTests.swift
@@ -96,6 +96,36 @@ struct CommandCodeUsageFetcherTests {
     }
 
     @Test
+    func `subscription grace does not wait for transport that ignores cancellation`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            let path = try #require(request.url?.path)
+            if path.hasSuffix("/credits") {
+                return try Self.response(request: request, statusCode: 200, body: Self.creditsJSON)
+            }
+            let response = try Self.response(request: request, statusCode: 200, body: Self.subscriptionJSON)
+            return await withCheckedContinuation { continuation in
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+                    continuation.resume(returning: response)
+                }
+            }
+        }
+
+        let startedAt = ContinuousClock.now
+        let snapshot = try await CommandCodeUsageFetcher._fetchUsageForTesting(
+            cookieHeader: "session=valid",
+            transport: transport,
+            subscriptionGrace: .milliseconds(20))
+        let elapsed = startedAt.duration(to: .now)
+
+        #expect(snapshot.monthlyCreditsRemaining == 8.7784)
+        #expect(snapshot.plan == nil)
+        #expect(elapsed < .milliseconds(300), "Subscription enrichment delayed credits: \(elapsed)")
+
+        // Let the deliberately cancellation-ignoring test task drain before the test exits.
+        try await Task.sleep(for: .milliseconds(550))
+    }
+
+    @Test
     func `cancellation after credits complete does not return partial snapshot`() async throws {
         let subscriptionStarted = CommandCodeRequestGate()
         let transport = ProviderHTTPTransportStub { request in
@@ -117,6 +147,49 @@ struct CommandCodeUsageFetcherTests {
         try await Task.sleep(for: .milliseconds(50))
         task.cancel()
 
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+
+    @Test
+    func `cancellation cleans up subscription when credits transport ignores cancellation`() async throws {
+        let creditsStarted = CommandCodeRequestGate()
+        let subscriptionStarted = CommandCodeRequestGate()
+        let subscriptionCancelled = CommandCodeRequestGate()
+        let transport = ProviderHTTPTransportStub { request in
+            let path = try #require(request.url?.path)
+            if path.hasSuffix("/credits") {
+                await creditsStarted.open()
+                let response = try Self.response(request: request, statusCode: 200, body: Self.creditsJSON)
+                return await withCheckedContinuation { continuation in
+                    DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+                        continuation.resume(returning: response)
+                    }
+                }
+            }
+            await subscriptionStarted.open()
+            do {
+                try await Task.sleep(for: .seconds(10))
+            } catch {
+                await subscriptionCancelled.open()
+                throw error
+            }
+            return try Self.response(request: request, statusCode: 200, body: Self.subscriptionJSON)
+        }
+        let task = Task {
+            try await CommandCodeUsageFetcher.fetchUsage(
+                cookieHeader: "session=valid",
+                session: transport)
+        }
+
+        await creditsStarted.wait()
+        await subscriptionStarted.wait()
+        let cancellationStartedAt = ContinuousClock.now
+        task.cancel()
+
+        await subscriptionCancelled.wait()
+        #expect(cancellationStartedAt.duration(to: .now) < .milliseconds(300))
         await #expect(throws: CancellationError.self) {
             try await task.value
         }

--- a/Tests/CodexBarTests/DeepSeekUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/DeepSeekUsageFetcherTests.swift
@@ -9,6 +9,7 @@ struct DeepSeekUsageFetcherTests {
         private var started = false
         private var cancelled = false
         private var startedWaiters: [CheckedContinuation<Void, Never>] = []
+        private var cancelledWaiters: [CheckedContinuation<Void, Never>] = []
 
         func markStarted() {
             self.started = true
@@ -27,6 +28,17 @@ struct DeepSeekUsageFetcherTests {
 
         func markCancelled() {
             self.cancelled = true
+            for waiter in self.cancelledWaiters {
+                waiter.resume()
+            }
+            self.cancelledWaiters.removeAll()
+        }
+
+        func waitUntilCancelled() async {
+            if self.cancelled { return }
+            await withCheckedContinuation { continuation in
+                self.cancelledWaiters.append(continuation)
+            }
         }
 
         func wasCancelled() -> Bool {
@@ -505,6 +517,48 @@ struct DeepSeekUsageFetcherTests {
             Issue.record("Expected cancellation")
         } catch is CancellationError {
             #expect(await probe.wasCancelled())
+        }
+    }
+
+    @Test
+    func `parent cancellation stops summary while balance transport ignores cancellation`() async throws {
+        let balanceStarted = AsyncStream<Void>.makeStream(of: Void.self)
+        let probe = SummaryCancellationProbe()
+        let task = Task {
+            try await DeepSeekUsageFetcher._fetchUsageForTesting(
+                apiKey: "test-key",
+                includeOptionalUsage: true,
+                optionalSummaryJoinGrace: .seconds(30),
+                fetchBalanceData: { _ in
+                    balanceStarted.continuation.yield(())
+                    return await withCheckedContinuation { continuation in
+                        DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+                            continuation.resume(returning: Data(Self.sampleBalanceJSON.utf8))
+                        }
+                    }
+                },
+                fetchSummary: { _ in
+                    await probe.markStarted()
+                    do {
+                        try await Task.sleep(for: .seconds(60))
+                        return Self.sampleSummary()
+                    } catch is CancellationError {
+                        await probe.markCancelled()
+                        throw CancellationError()
+                    }
+                })
+        }
+
+        var balanceIterator = balanceStarted.stream.makeAsyncIterator()
+        _ = await balanceIterator.next()
+        await probe.waitUntilStarted()
+        let cancellationStartedAt = ContinuousClock.now
+        task.cancel()
+
+        await probe.waitUntilCancelled()
+        #expect(cancellationStartedAt.duration(to: .now) < .milliseconds(300))
+        await #expect(throws: CancellationError.self) {
+            try await task.value
         }
     }
 

--- a/Tests/CodexBarTests/OpenRouterUsageStatsTests.swift
+++ b/Tests/CodexBarTests/OpenRouterUsageStatsTests.swift
@@ -202,6 +202,27 @@ struct OpenRouterUsageStatsTests {
     }
 
     @Test
+    func `key enrichment timeout does not wait for operation that ignores cancellation`() async throws {
+        let startedAt = ContinuousClock.now
+
+        let fetched = try await OpenRouterUsageFetcher._boundedKeyFetchForTesting(
+            timeout: .milliseconds(20))
+        {
+            await withCheckedContinuation { continuation in
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.5) {
+                    continuation.resume()
+                }
+            }
+        }
+
+        let elapsed = startedAt.duration(to: .now)
+        #expect(!fetched)
+        #expect(elapsed < .milliseconds(300))
+
+        try await Task.sleep(for: .milliseconds(550))
+    }
+
+    @Test
     func `usage snapshot round trip persists open router usage metadata`() throws {
         let openRouter = OpenRouterUsageSnapshot(
             totalCredits: 50,


### PR DESCRIPTION
## Summary
- add a shared bounded join for optional provider work whose transport may ignore task cancellation
- keep Codebuff and Command Code credit refreshes responsive when subscription enrichment hangs
- preserve prompt parent cancellation while required provider requests are still in flight
- apply the same bounded behavior to DeepSeek usage summaries and OpenRouter key-quota enrichment

## Tests
- `swift test --filter 'OpenRouterUsageStatsTests|CommandCodeUsageFetcherTests|CodebuffUsageFetcherTests|DeepSeekUsageFetcherTests'` — 72 tests passed
- `make check` — SwiftFormat clean, SwiftLint 0 violations, package/release path checks passed
- `make test` — all 39 shards passed
- local `autoreview --mode local` — clean after fixing cancellation propagation findings
- post-rebase tree is byte-equivalent to the fully tested tree

## Risk
- provider credentials, endpoints, persistence, and parsing contracts are unchanged
- no live provider, browser-cookie, or Keychain probe was run