### PR TITLE
fix: bound subprocess output draining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@
 - Antigravity: retry transient `Text file busy` launch failures while the CLI executable is being replaced.
 - Antigravity: fall back to loopback HTTP for local CLI and language-server probes on Linux, where self-signed localhost TLS cannot be trusted (fixes #1508). Thanks @zodiacfireworks!
 - Codebuff: enforce the optional subscription grace period even when the transport ignores cancellation.
+- Codex: keep managed login timeouts bounded while preserving captured output when detached helpers retain stdout or stderr.
 - Command Code: keep showing available credits after the bounded optional subscription grace, including when the transport ignores cancellation (fixes #1131).
 - DeepSeek: keep balance refreshes responsive when optional usage-summary work ignores cancellation.
 - OpenRouter: keep credit refreshes responsive when optional key-quota enrichment ignores cancellation.
+- Provider probes: stop waiting indefinitely for inherited output pipes after a subprocess exits.
 - Menu bar: update visible usage values in place when a manual refresh completes instead of leaving the open provider card stale until the menu is reopened (fixes #1516).
 - Gemini: recognize the current `gemini-api-key` CLI auth setting so API-key sessions show the supported OAuth guidance instead of a misleading not-logged-in error (fixes #1511).
 - Xiaomi MiMo: cancel optional token-plan requests when the required balance request fails instead of delaying the error for up to 30 seconds.

--- a/Sources/CodexBar/CodexLoginRunner.swift
+++ b/Sources/CodexBar/CodexLoginRunner.swift
@@ -19,6 +19,7 @@ struct CodexLoginRunner {
     static func run(
         homePath: String? = nil,
         timeout: TimeInterval = 120,
+        outputDrainTimeout: TimeInterval = 3,
         environment: [String: String] = ProcessInfo.processInfo.environment,
         loginPATH: [String]? = LoginShellPathCache.shared.current) async -> Result
     {
@@ -46,6 +47,8 @@ struct CodexLoginRunner {
             let stderr = Pipe()
             process.standardOutput = stdout
             process.standardError = stderr
+            let stdoutCapture = ProcessPipeCapture(pipe: stdout)
+            let stderrCapture = ProcessPipeCapture(pipe: stderr)
 
             let termination = ProcessTermination()
             process.terminationHandler = { _ in
@@ -59,13 +62,18 @@ struct CodexLoginRunner {
             } catch {
                 return Result(outcome: .launchFailed(error.localizedDescription), output: "")
             }
+            stdoutCapture.start()
+            stderrCapture.start()
 
             let timedOut = await self.wait(timeout: timeout, termination: termination)
             if timedOut {
                 self.terminate(process, processGroup: processGroup)
             }
 
-            let output = await self.combinedOutput(stdout: stdout, stderr: stderr)
+            let output = await self.combinedOutput(
+                stdout: stdoutCapture,
+                stderr: stderrCapture,
+                timeout: outputDrainTimeout)
             if timedOut {
                 return Result(outcome: .timedOut, output: output)
             }
@@ -158,41 +166,25 @@ struct CodexLoginRunner {
         return setpgid(pid, pid) == 0 ? pid : nil
     }
 
-    private static func combinedOutput(stdout: Pipe, stderr: Pipe) async -> String {
-        async let out = self.readToEnd(stdout)
-        async let err = self.readToEnd(stderr)
-        let stdoutText = await out
-        let stderrText = await err
+    private static func combinedOutput(
+        stdout: ProcessPipeCapture,
+        stderr: ProcessPipeCapture,
+        timeout: TimeInterval) async -> String
+    {
+        let drainTimeout = Duration.seconds(max(0, timeout))
+        async let outData = stdout.finish(timeout: drainTimeout)
+        async let errData = stderr.finish(timeout: drainTimeout)
+        let out = await self.decode(outData)
+        let err = await self.decode(errData)
 
-        let merged: String = if !stdoutText.isEmpty, !stderrText.isEmpty {
-            [stdoutText, stderrText].joined(separator: "\n")
+        let merged: String = if !out.isEmpty, !err.isEmpty {
+            [out, err].joined(separator: "\n")
         } else {
-            stdoutText + stderrText
+            out + err
         }
         let trimmed = merged.trimmingCharacters(in: .whitespacesAndNewlines)
         let limited = trimmed.prefix(4000)
         return limited.isEmpty ? L("No output captured.") : String(limited)
-    }
-
-    private static func readToEnd(_ pipe: Pipe, timeout: TimeInterval = 3.0) async -> String {
-        await withTaskGroup(of: String?.self) { group -> String in
-            group.addTask {
-                if #available(macOS 13.0, *) {
-                    if let data = try? pipe.fileHandleForReading.readToEnd() { return self.decode(data) }
-                }
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                return Self.decode(data)
-            }
-            group.addTask {
-                let nanos = UInt64(max(0, timeout) * 1_000_000_000)
-                try? await Task.sleep(nanoseconds: nanos)
-                return nil
-            }
-            let result = await group.next()
-            group.cancelAll()
-            if let result, let text = result { return text }
-            return ""
-        }
     }
 
     private static func decode(_ data: Data) -> String {

--- a/Sources/CodexBarCore/BoundedTaskJoin.swift
+++ b/Sources/CodexBarCore/BoundedTaskJoin.swift
@@ -1,12 +1,12 @@
 import Foundation
 
-enum BoundedTaskJoinOutcome<Value: Sendable> {
+package enum BoundedTaskJoinOutcome<Value: Sendable> {
     case value(Value)
     case failure(any Error)
     case timedOut
 }
 
-final class BoundedTaskJoin<Value: Sendable>: @unchecked Sendable {
+package final class BoundedTaskJoin<Value: Sendable>: @unchecked Sendable {
     private let lock = NSLock()
     private let sourceTask: Task<Value, Error>
     private var outcome: BoundedTaskJoinOutcome<Value>?
@@ -14,11 +14,11 @@ final class BoundedTaskJoin<Value: Sendable>: @unchecked Sendable {
     private var observerTask: Task<Void, Never>?
     private var timeoutTask: Task<Void, Never>?
 
-    init(sourceTask: Task<Value, Error>) {
+    package init(sourceTask: Task<Value, Error>) {
         self.sourceTask = sourceTask
     }
 
-    func value(joinGrace: Duration) async -> BoundedTaskJoinOutcome<Value> {
+    package func value(joinGrace: Duration) async -> BoundedTaskJoinOutcome<Value> {
         await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
                 self.lock.lock()

--- a/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
+++ b/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+package final class ProcessPipeCapture: @unchecked Sendable {
+    private let handle: FileHandle
+    private let condition = NSCondition()
+    private var data = Data()
+    private var activeCallbacks = 0
+    private var isFinished = false
+    private var isStopping = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    package init(pipe: Pipe) {
+        self.handle = pipe.fileHandleForReading
+    }
+
+    package func start() {
+        self.handle.readabilityHandler = { [weak self] handle in
+            self?.handleReadableData(from: handle)
+        }
+    }
+
+    package func finish(timeout: Duration) async -> Data {
+        let drainTask = Task<Void, Error> {
+            await self.waitUntilFinished()
+        }
+        let join = BoundedTaskJoin(sourceTask: drainTask)
+        _ = await join.value(joinGrace: timeout)
+        return self.stopAndSnapshot()
+    }
+
+    package func stop() {
+        _ = self.stopAndSnapshot()
+    }
+
+    private func handleReadableData(from handle: FileHandle) {
+        self.condition.lock()
+        guard !self.isStopping else {
+            self.condition.unlock()
+            return
+        }
+        self.activeCallbacks += 1
+        self.condition.unlock()
+
+        let chunk = handle.availableData
+        var continuation: CheckedContinuation<Void, Never>?
+
+        self.condition.lock()
+        if chunk.isEmpty {
+            self.isFinished = true
+            continuation = self.continuation
+            self.continuation = nil
+        } else {
+            self.data.append(chunk)
+        }
+        self.activeCallbacks -= 1
+        if self.activeCallbacks == 0 {
+            self.condition.broadcast()
+        }
+        self.condition.unlock()
+
+        if chunk.isEmpty {
+            handle.readabilityHandler = nil
+        }
+        continuation?.resume()
+    }
+
+    private func waitUntilFinished() async {
+        await withCheckedContinuation { continuation in
+            self.condition.lock()
+            if self.isFinished || self.isStopping {
+                self.condition.unlock()
+                continuation.resume()
+                return
+            }
+            self.continuation = continuation
+            self.condition.unlock()
+        }
+    }
+
+    private func stopAndSnapshot() -> Data {
+        self.handle.readabilityHandler = nil
+
+        let continuation: CheckedContinuation<Void, Never>?
+        let snapshot: Data
+        self.condition.lock()
+        self.isStopping = true
+        while self.activeCallbacks > 0 {
+            self.condition.wait()
+        }
+        self.isFinished = true
+        continuation = self.continuation
+        self.continuation = nil
+        snapshot = self.data
+        self.condition.unlock()
+
+        continuation?.resume()
+        return snapshot
+    }
+}

--- a/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
+++ b/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
@@ -107,28 +107,6 @@ public enum SubprocessRunner {
         }
     }
 
-    // MARK: - Helpers to move blocking calls off the cooperative thread pool
-
-    /// Reads pipe data on a GCD thread so it does not block the Swift cooperative pool.
-    private static func readDataOffPool(_ fileHandle: FileHandle) async -> Data {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.global().async {
-                var output = Data()
-                while true {
-                    do {
-                        guard let data = try fileHandle.read(upToCount: 64 * 1024), data.isEmpty == false else {
-                            break
-                        }
-                        output.append(data)
-                    } catch {
-                        break
-                    }
-                }
-                continuation.resume(returning: output)
-            }
-        }
-    }
-
     /// Terminates a process and its process group, escalating from SIGTERM to SIGKILL.
     /// Returns `true` if the process was actually killed, `false` if it had already exited.
     @discardableResult
@@ -183,6 +161,8 @@ public enum SubprocessRunner {
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
         process.standardInput = standardInput
+        let stdoutCapture = ProcessPipeCapture(pipe: stdoutPipe)
+        let stderrCapture = ProcessPipeCapture(pipe: stderrPipe)
 
         let termination = ProcessTermination()
         process.terminationHandler = { process in
@@ -193,22 +173,17 @@ public enum SubprocessRunner {
             try process.run()
         } catch {
             process.terminationHandler = nil
-            stdoutPipe.fileHandleForReading.closeFile()
+            stdoutCapture.stop()
             stdoutPipe.fileHandleForWriting.closeFile()
-            stderrPipe.fileHandleForReading.closeFile()
+            stderrCapture.stop()
             stderrPipe.fileHandleForWriting.closeFile()
             throw SubprocessRunnerError.launchFailed(error.localizedDescription)
         }
+        stdoutCapture.start()
+        stderrCapture.start()
 
         let pid = process.processIdentifier
         let processGroup: pid_t? = setpgid(pid, pid) == 0 ? pid : nil
-
-        let stdoutTask = Task<Data, Never> {
-            await self.readDataOffPool(stdoutPipe.fileHandleForReading)
-        }
-        let stderrTask = Task<Data, Never> {
-            await self.readDataOffPool(stderrPipe.fileHandleForReading)
-        }
 
         let exitCodeTask = Task<Int32, Never> {
             await termination.wait()
@@ -249,15 +224,13 @@ public enum SubprocessRunner {
                         "binary": binaryName,
                         "duration_ms": "\(Int(duration * 1000))",
                     ])
-                stdoutTask.cancel()
-                stderrTask.cancel()
                 throw SubprocessRunnerError.timedOut(label)
             }
 
-            let stdoutData = await stdoutTask.value
-            let stderrData = await stderrTask.value
-            let stdout = String(data: stdoutData, encoding: .utf8) ?? ""
-            let stderr = String(data: stderrData, encoding: .utf8) ?? ""
+            async let stdoutData = stdoutCapture.finish(timeout: .seconds(1))
+            async let stderrData = stderrCapture.finish(timeout: .seconds(1))
+            let stdout = await String(data: stdoutData, encoding: .utf8) ?? ""
+            let stderr = await String(data: stderrData, encoding: .utf8) ?? ""
 
             if exitCode != 0 {
                 let duration = Date().timeIntervalSince(start)
@@ -293,8 +266,8 @@ public enum SubprocessRunner {
             // Safety net: ensure the process is dead (may already be killed by timeout timer).
             self.terminateProcess(process, processGroup: processGroup)
             exitCodeTask.cancel()
-            stdoutTask.cancel()
-            stderrTask.cancel()
+            stdoutCapture.stop()
+            stderrCapture.stop()
             throw error
         }
     }

--- a/Tests/CodexBarTests/CodexLoginRunnerTests.swift
+++ b/Tests/CodexBarTests/CodexLoginRunnerTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Testing
 @testable import CodexBar
@@ -36,5 +37,60 @@ struct CodexLoginRunnerTests {
         #expect(result.outcome == .timedOut)
         #expect(result.output.contains("login-finished") == false)
         #expect(elapsed < 2.0, "Timeout should return promptly, took \(elapsed)s")
+    }
+
+    @Test
+    func `login runner bounds output drain when detached child keeps pipes open`() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-login-drain-\(UUID().uuidString)", isDirectory: true)
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let homeDir = root.appendingPathComponent("home", isDirectory: true)
+        let childPIDFile = root.appendingPathComponent("child.pid")
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: homeDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        defer {
+            if let text = try? String(contentsOf: childPIDFile, encoding: .utf8),
+               let childPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            {
+                _ = kill(childPID, SIGKILL)
+            }
+        }
+
+        let codex = binDir.appendingPathComponent("codex")
+        let script = """
+        #!/usr/bin/python3
+        import os
+        import subprocess
+        import sys
+        import time
+
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(5)"],
+            start_new_session=True,
+        )
+        with open(os.environ["CODEXBAR_TEST_CHILD_PID_FILE"], "w") as handle:
+            handle.write(str(child.pid))
+        print("login-started", flush=True)
+        time.sleep(5)
+        """
+        try script.write(to: codex, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: codex.path)
+
+        let start = Date()
+        let result = await CodexLoginRunner.run(
+            homePath: homeDir.path,
+            timeout: 1,
+            outputDrainTimeout: 0.2,
+            environment: [
+                "CODEXBAR_TEST_CHILD_PID_FILE": childPIDFile.path,
+                "PATH": binDir.path,
+            ],
+            loginPATH: nil)
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(result.outcome == .timedOut)
+        #expect(result.output.contains("login-started"))
+        #expect(elapsed < 3.0, "Output drain should stay bounded, took \(elapsed)s")
     }
 }

--- a/Tests/CodexBarTests/SubprocessRunnerTests.swift
+++ b/Tests/CodexBarTests/SubprocessRunnerTests.swift
@@ -2,6 +2,12 @@ import Foundation
 import Testing
 @testable import CodexBarCore
 
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
 struct SubprocessRunnerTests {
     @Test
     func `reads large stdout without deadlock`() async throws {
@@ -14,6 +20,50 @@ struct SubprocessRunnerTests {
 
         #expect(result.stdout.count >= 1_000_000)
         #expect(result.stderr.isEmpty)
+    }
+
+    @Test
+    func `returns partial output when detached child keeps pipes open`() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-subprocess-drain-\(UUID().uuidString)", isDirectory: true)
+        let childPIDFile = root.appendingPathComponent("child.pid")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        defer {
+            if let text = try? String(contentsOf: childPIDFile, encoding: .utf8),
+               let childPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            {
+                _ = kill(childPID, SIGKILL)
+            }
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CODEXBAR_TEST_CHILD_PID_FILE"] = childPIDFile.path
+        let script = """
+        import os
+        import subprocess
+        import sys
+
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(5)"],
+            start_new_session=True,
+        )
+        with open(os.environ["CODEXBAR_TEST_CHILD_PID_FILE"], "w") as handle:
+            handle.write(str(child.pid))
+        print("parent-output", flush=True)
+        """
+
+        let start = Date()
+        let result = try await SubprocessRunner.run(
+            binary: "/usr/bin/python3",
+            arguments: ["-c", script],
+            environment: environment,
+            timeout: 5,
+            label: "detached-output-holder")
+        let elapsed = Date().timeIntervalSince(start)
+
+        #expect(result.stdout.contains("parent-output"))
+        #expect(elapsed < 3, "Output drain should not wait for the detached child, took \(elapsed)s")
     }
 
     /// Regression test for #474: a hung subprocess must be killed and throw `.timedOut`


### PR DESCRIPTION
## Summary
- capture subprocess stdout and stderr incrementally so large output cannot fill a pipe before process exit
- bound post-exit draining when detached descendants retain inherited output handles
- apply the same bounded drain to managed Codex login while preserving partial diagnostics

## Tests
- `swift test --filter 'CodexLoginRunnerTests|SubprocessRunnerTests'` (9 tests)
- `make check`
- `make test` (39/39 shards)
- autoreview: clean, no accepted/actionable findings

## Risk
- no live authentication, Keychain, browser-cookie, or provider probes were run
- process launch, timeout, termination, and provider request behavior are unchanged
