### PR TITLE
fix: keep token account menu data scoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Antigravity: fall back to loopback HTTP for local CLI and language-server probes on Linux, where self-signed localhost TLS cannot be trusted (fixes #1508). Thanks @zodiacfireworks!
 - Codebuff: enforce the optional subscription grace period even when the transport ignores cancellation.
 - Codex: keep managed login timeouts bounded while preserving captured output when detached helpers retain stdout or stderr.
+- Claude: keep segmented multi-account menus scoped to the selected account while its refresh is in flight (fixes #1527).
 - Command Code: keep showing available credits after the bounded optional subscription grace, including when the transport ignores cancellation (fixes #1131).
 - DeepSeek: keep balance refreshes responsive when optional usage-summary work ignores cancellation.
 - OpenRouter: keep credit refreshes responsive when optional key-quota enrichment ignores cancellation.

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -1029,7 +1029,12 @@ extension StatusItemController {
             width: width,
             onSelect: { [weak self, weak menu] index -> Task<Void, Never>? in
                 guard let self, let menu else { return nil }
+                guard display.accounts.indices.contains(index) else { return nil }
+                let selectedAccount = display.accounts[index]
                 self.settings.setActiveTokenAccountIndex(index, for: display.provider)
+                self.store.activateCachedTokenAccountSnapshot(
+                    provider: display.provider,
+                    accountID: selectedAccount.id)
                 self.applyIcon(phase: nil)
                 self.deferSwitcherMenuRebuildIfStillVisible(menu, provider: display.provider)
                 return Task { @MainActor [weak self, weak menu] in
@@ -1038,7 +1043,7 @@ extension StatusItemController {
                         await self.store.refreshProvider(display.provider)
                     }
                     guard let menu else { return }
-                    self.refreshOpenMenuIfStillVisible(menu, provider: display.provider)
+                    self.deferSwitcherMenuRebuildIfStillVisible(menu, provider: display.provider)
                 }
             })
         let item = NSMenuItem()

--- a/Sources/CodexBar/UsageStore+TokenAccounts.swift
+++ b/Sources/CodexBar/UsageStore+TokenAccounts.swift
@@ -33,6 +33,32 @@ struct CodexAccountUsageSnapshot: Identifiable {
     }
 }
 
+extension UsageStore {
+    func activateCachedTokenAccountSnapshot(provider: UsageProvider, accountID: UUID) {
+        guard let cached = self.accountSnapshots[provider]?.first(where: { $0.account.id == accountID }) else {
+            self.snapshots.removeValue(forKey: provider)
+            self.errors.removeValue(forKey: provider)
+            self.lastSourceLabels.removeValue(forKey: provider)
+            self.lastKnownResetSnapshots.removeValue(forKey: provider)
+            return
+        }
+
+        if let snapshot = cached.snapshot {
+            self.snapshots[provider] = snapshot
+            self.lastKnownResetSnapshots[provider] = snapshot
+        } else {
+            self.snapshots.removeValue(forKey: provider)
+            self.lastKnownResetSnapshots.removeValue(forKey: provider)
+        }
+        self.errors[provider] = cached.error
+        if let sourceLabel = cached.sourceLabel {
+            self.lastSourceLabels[provider] = sourceLabel
+        } else {
+            self.lastSourceLabels.removeValue(forKey: provider)
+        }
+    }
+}
+
 private struct TokenAccountFetchResult {
     let index: Int
     let account: ProviderTokenAccount

--- a/Tests/CodexBarTests/StatusMenuTokenAccountSwitcherTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTokenAccountSwitcherTests.swift
@@ -381,6 +381,8 @@ final class StatusMenuTokenAccountSwitcherTests: XCTestCase {
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
         store.snapshots[.claude] = self.snapshot(percent: 11)
         store.lastKnownResetSnapshots[.claude] = self.snapshot(percent: 11)
+        store.errors[.claude] = "primary-error"
+        store.lastSourceLabels[.claude] = "primary-cache"
         store.accountSnapshots[.claude] = [
             TokenAccountUsageSnapshot(
                 account: accounts[0],
@@ -412,6 +414,7 @@ final class StatusMenuTokenAccountSwitcherTests: XCTestCase {
 
         XCTAssertEqual(store.snapshot(for: .claude)?.primary?.usedPercent, 72)
         XCTAssertEqual(store.lastKnownResetSnapshots[.claude]?.primary?.usedPercent, 72)
+        XCTAssertNil(store.errors[.claude])
         XCTAssertEqual(store.sourceLabel(for: .claude), "secondary-cache")
 
         await blocker.waitUntilStarted(count: 1)
@@ -437,6 +440,8 @@ final class StatusMenuTokenAccountSwitcherTests: XCTestCase {
         let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
         store.snapshots[.claude] = self.snapshot(percent: 11)
         store.lastKnownResetSnapshots[.claude] = self.snapshot(percent: 11)
+        store.errors[.claude] = "primary-error"
+        store.lastSourceLabels[.claude] = "primary-cache"
         store.accountSnapshots[.claude] = [
             TokenAccountUsageSnapshot(
                 account: accounts[0],
@@ -463,6 +468,8 @@ final class StatusMenuTokenAccountSwitcherTests: XCTestCase {
 
         XCTAssertNil(store.snapshot(for: .claude))
         XCTAssertNil(store.lastKnownResetSnapshots[.claude])
+        XCTAssertNil(store.errors[.claude])
+        XCTAssertNil(store.lastSourceLabels[.claude])
 
         await blocker.waitUntilStarted(count: 1)
         await blocker.resumeAll(with: .success(self.snapshot(percent: 45)))

--- a/Tests/CodexBarTests/StatusMenuTokenAccountSwitcherTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTokenAccountSwitcherTests.swift
@@ -355,6 +355,118 @@ final class StatusMenuTokenAccountSwitcherTests: XCTestCase {
         await blocker.waitUntilStarted(count: 1)
         await blocker.resumeAll(with: .success(self.snapshot(percent: 17)))
         await selectionTask.value
+        for _ in 0..<20 where rebuildCount < 2 {
+            await Task.yield()
+        }
+        XCTAssertEqual(rebuildCount, 2)
+    }
+
+    func test_tokenAccountSwitchUsesSelectedAccountCacheWhileRefreshIsInFlight() async throws {
+        self.disableMenuCardsForTesting()
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
+        defer { StatusItemController.setMenuRefreshEnabledForTesting(false) }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.multiAccountMenuLayout = .segmented
+        self.enableOnlyClaude(settings)
+        settings.addTokenAccount(provider: .claude, label: "Primary", token: "Bearer sk-ant-oat-primary")
+        settings.addTokenAccount(provider: .claude, label: "Secondary", token: "Bearer sk-ant-oat-secondary")
+        settings.setActiveTokenAccountIndex(0, for: .claude)
+        let accounts = settings.tokenAccounts(for: .claude)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store.snapshots[.claude] = self.snapshot(percent: 11)
+        store.lastKnownResetSnapshots[.claude] = self.snapshot(percent: 11)
+        store.accountSnapshots[.claude] = [
+            TokenAccountUsageSnapshot(
+                account: accounts[0],
+                snapshot: self.snapshot(percent: 11),
+                error: nil,
+                sourceLabel: "primary-cache"),
+            TokenAccountUsageSnapshot(
+                account: accounts[1],
+                snapshot: self.snapshot(percent: 72),
+                error: nil,
+                sourceLabel: "secondary-cache"),
+        ]
+        let blocker = BlockingTokenAccountFetchStrategy()
+        self.installBlockingClaudeProvider(on: store, blocker: blocker)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu(for: .claude)
+        controller.menuWillOpen(menu)
+        let switcher = try XCTUnwrap(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first)
+
+        let selectionTask = try XCTUnwrap(switcher._test_select(index: 1))
+
+        XCTAssertEqual(store.snapshot(for: .claude)?.primary?.usedPercent, 72)
+        XCTAssertEqual(store.lastKnownResetSnapshots[.claude]?.primary?.usedPercent, 72)
+        XCTAssertEqual(store.sourceLabel(for: .claude), "secondary-cache")
+
+        await blocker.waitUntilStarted(count: 1)
+        await blocker.resumeAll(with: .success(self.snapshot(percent: 45)))
+        await selectionTask.value
+    }
+
+    func test_tokenAccountSwitchClearsPreviousAccountSnapshotWithoutSelectedCache() async throws {
+        self.disableMenuCardsForTesting()
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.multiAccountMenuLayout = .segmented
+        self.enableOnlyClaude(settings)
+        settings.addTokenAccount(provider: .claude, label: "Primary", token: "Bearer sk-ant-oat-primary")
+        settings.addTokenAccount(provider: .claude, label: "Secondary", token: "Bearer sk-ant-oat-secondary")
+        settings.setActiveTokenAccountIndex(0, for: .claude)
+        let accounts = settings.tokenAccounts(for: .claude)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        store.snapshots[.claude] = self.snapshot(percent: 11)
+        store.lastKnownResetSnapshots[.claude] = self.snapshot(percent: 11)
+        store.accountSnapshots[.claude] = [
+            TokenAccountUsageSnapshot(
+                account: accounts[0],
+                snapshot: self.snapshot(percent: 11),
+                error: nil,
+                sourceLabel: "primary-cache"),
+        ]
+        let blocker = BlockingTokenAccountFetchStrategy()
+        self.installBlockingClaudeProvider(on: store, blocker: blocker)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu(for: .claude)
+        controller.menuWillOpen(menu)
+        let switcher = try XCTUnwrap(menu.items.compactMap { $0.view as? TokenAccountSwitcherView }.first)
+
+        let selectionTask = try XCTUnwrap(switcher._test_select(index: 1))
+
+        XCTAssertNil(store.snapshot(for: .claude))
+        XCTAssertNil(store.lastKnownResetSnapshots[.claude])
+
+        await blocker.waitUntilStarted(count: 1)
+        await blocker.resumeAll(with: .success(self.snapshot(percent: 45)))
+        await selectionTask.value
     }
 }
 


### PR DESCRIPTION
## Summary
- promote the selected token account's cached snapshot before rebuilding the segmented menu
- clear provider-level usage and reset backfill state when the selected account has no cache, preventing cross-account stale data
- use the switcher-safe tracked-menu rebuild after the selected account refresh completes

Fixes #1527.

## Tests
- `swift test --filter 'StatusMenu(TokenAccountSwitcher|PersistentRefresh|OpenRefresh)Tests'` (48 tests)
- `make check`
- `make test` (39/39 shards)
- autoreview: clean, no accepted/actionable findings

## Risk
- no live Claude authentication, Keychain, browser-cookie, or provider probes were run
- token account fetching and credential routing are unchanged
