### PR TITLE
fix: bound CLI version output draining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Command Code: keep showing available credits after the bounded optional subscription grace, including when the transport ignores cancellation (fixes #1131).
 - DeepSeek: keep balance refreshes responsive when optional usage-summary work ignores cancellation.
 - OpenRouter: keep credit refreshes responsive when optional key-quota enrichment ignores cancellation.
-- Provider probes: stop waiting indefinitely for inherited output pipes after subprocesses or CLI version checks exit.
+- Provider probes: stop waiting indefinitely for inherited output pipes after subprocesses or CLI version checks exit (fixes #1531).
 - Menu bar: update visible usage values in place when a manual refresh completes instead of leaving the open provider card stale until the menu is reopened (fixes #1516).
 - Gemini: recognize the current `gemini-api-key` CLI auth setting so API-key sessions show the supported OAuth guidance instead of a misleading not-logged-in error (fixes #1511).
 - Xiaomi MiMo: cancel optional token-plan requests when the required balance request fails instead of delaying the error for up to 30 seconds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Command Code: keep showing available credits after the bounded optional subscription grace, including when the transport ignores cancellation (fixes #1131).
 - DeepSeek: keep balance refreshes responsive when optional usage-summary work ignores cancellation.
 - OpenRouter: keep credit refreshes responsive when optional key-quota enrichment ignores cancellation.
-- Provider probes: stop waiting indefinitely for inherited output pipes after a subprocess exits.
+- Provider probes: stop waiting indefinitely for inherited output pipes after subprocesses or CLI version checks exit.
 - Menu bar: update visible usage values in place when a manual refresh completes instead of leaving the open provider card stale until the menu is reopened (fixes #1516).
 - Gemini: recognize the current `gemini-api-key` CLI auth setting so API-key sessions show the supported OAuth guidance instead of a misleading not-logged-in error (fixes #1511).
 - Xiaomi MiMo: cancel optional token-plan requests when the required balance request fails instead of delaying the error for up to 30 seconds.

--- a/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
+++ b/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
@@ -28,6 +28,16 @@ package final class ProcessPipeCapture: @unchecked Sendable {
         return self.stopAndSnapshot()
     }
 
+    package func finishSynchronously(timeout: TimeInterval) -> Data {
+        let deadline = Date().addingTimeInterval(max(0, timeout))
+        self.condition.lock()
+        while !self.isFinished, !self.isStopping {
+            guard self.condition.wait(until: deadline) else { break }
+        }
+        self.condition.unlock()
+        return self.stopAndSnapshot()
+    }
+
     package func stop() {
         _ = self.stopAndSnapshot()
     }

--- a/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Grok/GrokStatusProbe.swift
@@ -66,30 +66,20 @@ public struct GrokStatusProbe: Sendable {
 
     public static func detectVersion(env: [String: String] = ProcessInfo.processInfo.environment) -> String? {
         guard let binary = BinaryLocator.resolveGrokBinary(env: env) else { return nil }
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = [binary, "--version"]
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = pipe
-        do {
-            try process.run()
-            process.waitUntilExit()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            guard let output = String(data: data, encoding: .utf8) else { return nil }
-            // Output is like "grok 0.1.210 (8b63e9068c)" — strip the leading "grok " so
-            // callers can prefix the CLI name themselves without duplicating it.
-            let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
-            let firstLine = trimmed.split(separator: "\n").first.map(String.init) ?? trimmed
-            let withoutPrefix = firstLine.replacingOccurrences(
-                of: #"^grok\s+"#,
-                with: "",
-                options: [.regularExpression])
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            return withoutPrefix.isEmpty ? nil : withoutPrefix
-        } catch {
-            return nil
-        }
+        guard let output = ProviderVersionDetector.run(
+            path: binary,
+            args: ["--version"],
+            environment: env,
+            mergeStandardError: true)
+        else { return nil }
+        // Output is like "grok 0.1.210 (8b63e9068c)" — strip the leading "grok " so
+        // callers can prefix the CLI name themselves without duplicating it.
+        let withoutPrefix = output.replacingOccurrences(
+            of: #"^grok\s+"#,
+            with: "",
+            options: [.regularExpression])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return withoutPrefix.isEmpty ? nil : withoutPrefix
     }
 
     public func fetch(env: [String: String] = ProcessInfo.processInfo.environment) async throws -> GrokUsageSnapshot {

--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -224,27 +224,20 @@ public struct KiroStatusProbe: Sendable {
     private static let logger = CodexBarLog.logger(LogCategories.kiro)
 
     public static func detectVersion() -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = ["kiro-cli", "--version"]
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = pipe
-        do {
-            try process.run()
-            process.waitUntilExit()
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            guard let output = String(data: data, encoding: .utf8) else { return nil }
-            // Output is like "kiro-cli 1.23.1"
-            let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
-            if trimmed.hasPrefix("kiro-cli ") {
-                return String(trimmed.dropFirst("kiro-cli ".count))
-            }
-            return trimmed.isEmpty ? nil : trimmed
-        } catch {
-            self.logger.debug("kiro-cli version detection failed: \(error.localizedDescription)")
+        guard let path = TTYCommandRunner.which("kiro-cli"),
+              let output = ProviderVersionDetector.run(
+                  path: path,
+                  args: ["--version"],
+                  mergeStandardError: true)
+        else {
+            self.logger.debug("kiro-cli version detection failed")
             return nil
         }
+        // Output is like "kiro-cli 1.23.1"
+        if output.hasPrefix("kiro-cli ") {
+            return String(output.dropFirst("kiro-cli ".count))
+        }
+        return output
     }
 
     public func fetch() async throws -> KiroUsageSnapshot {

--- a/Sources/CodexBarCore/Providers/ProviderVersionDetector.swift
+++ b/Sources/CodexBarCore/Providers/ProviderVersionDetector.swift
@@ -51,14 +51,23 @@ public enum ProviderVersionDetector {
         return nil
     }
 
-    static func run(path: String, args: [String], timeout: TimeInterval = 2.0) -> String? {
+    static func run(
+        path: String,
+        args: [String],
+        timeout: TimeInterval = 2.0,
+        environment: [String: String]? = nil,
+        mergeStandardError: Bool = false) -> String?
+    {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: path)
         proc.arguments = args
+        proc.environment = environment
         let out = Pipe()
         proc.standardOutput = out
-        proc.standardError = Pipe()
+        proc.standardError = mergeStandardError ? out : FileHandle.nullDevice
         proc.standardInput = nil
+        let outputCapture = ProcessPipeCapture(pipe: out)
+        outputCapture.start()
 
         let exitSemaphore = DispatchSemaphore(value: 0)
         proc.terminationHandler = { _ in
@@ -68,15 +77,17 @@ public enum ProviderVersionDetector {
         do {
             try proc.run()
         } catch {
+            outputCapture.stop()
             return nil
         }
 
         let didExit = exitSemaphore.wait(timeout: .now() + timeout) == .success
         if !didExit, !Self.forceExit(proc, exitSemaphore: exitSemaphore) {
+            outputCapture.stop()
             return nil
         }
 
-        let data = out.fileHandleForReading.readDataToEndOfFile()
+        let data = outputCapture.finishSynchronously(timeout: 0.25)
         guard proc.terminationStatus == 0,
               let text = String(data: data, encoding: .utf8)?
                   .split(whereSeparator: \.isNewline).first

--- a/Tests/CodexBarTests/ProviderVersionDetectorTests.swift
+++ b/Tests/CodexBarTests/ProviderVersionDetectorTests.swift
@@ -1,6 +1,12 @@
 import XCTest
 @testable import CodexBarCore
 
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
 final class ProviderVersionDetectorTests: XCTestCase {
     func test_run_returnsFirstLineForSuccessfulCommand() {
         let version = ProviderVersionDetector.run(
@@ -20,6 +26,48 @@ final class ProviderVersionDetectorTests: XCTestCase {
         let duration = Date().timeIntervalSince(start)
 
         XCTAssertNil(version)
+        XCTAssertLessThan(duration, 2.0)
+    }
+
+    func test_run_returnsOutputWhenDetachedChildKeepsPipeOpen() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("codexbar-version-drain-\(UUID().uuidString)", isDirectory: true)
+        let childPIDFile = root.appendingPathComponent("child.pid")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        defer {
+            if let text = try? String(contentsOf: childPIDFile, encoding: .utf8),
+               let childPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            {
+                _ = kill(childPID, SIGKILL)
+            }
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CODEXBAR_TEST_CHILD_PID_FILE"] = childPIDFile.path
+        let script = """
+        import os
+        import subprocess
+        import sys
+
+        child = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(5)"],
+            start_new_session=True,
+        )
+        with open(os.environ["CODEXBAR_TEST_CHILD_PID_FILE"], "w") as handle:
+            handle.write(str(child.pid))
+        print("grok 1.2.3", flush=True)
+        """
+
+        let start = Date()
+        let version = ProviderVersionDetector.run(
+            path: "/usr/bin/python3",
+            args: ["-c", script],
+            timeout: 1.0,
+            environment: environment)
+        let duration = Date().timeIntervalSince(start)
+
+        XCTAssertEqual(version, "grok 1.2.3")
         XCTAssertLessThan(duration, 2.0)
     }
 }

--- a/Tests/CodexBarTests/ProviderVersionDetectorTests.swift
+++ b/Tests/CodexBarTests/ProviderVersionDetectorTests.swift
@@ -46,22 +46,15 @@ final class ProviderVersionDetectorTests: XCTestCase {
         var environment = ProcessInfo.processInfo.environment
         environment["CODEXBAR_TEST_CHILD_PID_FILE"] = childPIDFile.path
         let script = """
-        import os
-        import subprocess
-        import sys
-
-        child = subprocess.Popen(
-            [sys.executable, "-c", "import time; time.sleep(5)"],
-            start_new_session=True,
-        )
-        with open(os.environ["CODEXBAR_TEST_CHILD_PID_FILE"], "w") as handle:
-            handle.write(str(child.pid))
-        print("grok 1.2.3", flush=True)
+        (trap '' HUP; sleep 5) &
+        child=$!
+        printf '%s' "$child" > "$CODEXBAR_TEST_CHILD_PID_FILE"
+        printf 'grok 1.2.3\\n'
         """
 
         let start = Date()
         let version = ProviderVersionDetector.run(
-            path: "/usr/bin/python3",
+            path: "/bin/sh",
             args: ["-c", script],
             timeout: 1.0,
             environment: environment)
@@ -69,5 +62,9 @@ final class ProviderVersionDetectorTests: XCTestCase {
 
         XCTAssertEqual(version, "grok 1.2.3")
         XCTAssertLessThan(duration, 2.0)
+        let childPID = try XCTUnwrap(
+            pid_t(String(contentsOf: childPIDFile, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)))
+        XCTAssertEqual(kill(childPID, 0), 0, "Descendant should still hold the inherited pipe open")
     }
 }


### PR DESCRIPTION
## Summary

- reuse the incremental process-pipe capture for synchronous CLI version probes
- bound post-exit output draining when descendants retain inherited stdout/stderr
- route Grok and Kiro version detection through the shared bounded helper
- add a detached-child regression that returns the captured version in under two seconds

Fixes #1531.

## Testing

- `swift test --filter ProviderVersionDetectorTests --skip-update` (3/3 passed)
- focused suite repeated 20 times (20/20 passed)
- `swift test --filter SubprocessRunnerTests --skip-update` (7/7 passed)
- `make check` (passed, including SwiftFormat and SwiftLint)
- release `CodexBarCLI` build and synthetic detached-descendant live proof
- local autoreview against `origin/main` (no actionable findings)
- Public Model Identifier Gate (PASS)

The local full-suite run reached an unrelated existing WidgetKit persistence timeout in `CodexAccountScopedRefreshTests`; exact-head GitHub CI passed the macOS full suite and both Linux matrices. No live provider, browser-cookie, or Keychain probes were used.
