### PR TITLE
Fix Gemini fnm package discovery pipe hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Menu bar: update visible usage values in place when a manual refresh completes instead of leaving the open provider card stale until the menu is reopened (fixes #1516).
 - Gemini: recognize the current `gemini-api-key` CLI auth setting so API-key sessions show the supported OAuth guidance instead of a misleading not-logged-in error (fixes #1511).
 - Kiro: keep usage refreshes bounded when CLI helpers retain output pipes, ignore termination, or are cancelled (fixes #1533). Thanks @kiranmagic7!
+- Gemini: keep fnm package discovery bounded when helper descendants retain output pipes or ignore termination (fixes #1534). Thanks @kiranmagic7!
 - Xiaomi MiMo: cancel optional token-plan requests when the required balance request fails instead of delaying the error for up to 30 seconds.
 - Settings: make the cost history window directly editable by keyboard while preserving the existing stepper and 1–365 day bounds (fixes #1499). Thanks @kiranmagic7!
 

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
@@ -577,100 +577,6 @@ public struct GeminiStatusProbe: Sendable {
         return nil
     }
 
-    private static func runProcess(
-        executable: String,
-        arguments: [String],
-        environment: [String: String],
-        timeout: TimeInterval) -> String?
-    {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: executable)
-        process.arguments = arguments
-
-        var mergedEnvironment = environment
-        mergedEnvironment["PATH"] = PathBuilder.effectivePATH(
-            purposes: [.tty, .nodeTooling],
-            env: environment,
-            loginPATH: LoginShellPathCache.shared.current)
-        process.environment = mergedEnvironment
-
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.standardOutput = stdout
-        process.standardError = stderr
-        process.standardInput = nil
-
-        final class OutputState: @unchecked Sendable {
-            private let lock = NSLock()
-            private var data = Data()
-
-            func append(_ chunk: Data) {
-                self.lock.lock()
-                self.data.append(chunk)
-                self.lock.unlock()
-            }
-
-            func snapshot() -> Data {
-                self.lock.lock()
-                defer { self.lock.unlock() }
-                return self.data
-            }
-        }
-
-        let output = OutputState()
-        stdout.fileHandleForReading.readabilityHandler = { handle in
-            let data = handle.availableData
-            if !data.isEmpty {
-                output.append(data)
-            }
-        }
-        stderr.fileHandleForReading.readabilityHandler = { handle in
-            _ = handle.availableData
-        }
-
-        let exitSemaphore = DispatchSemaphore(value: 0)
-        process.terminationHandler = { _ in
-            exitSemaphore.signal()
-        }
-
-        do {
-            try process.run()
-        } catch {
-            stdout.fileHandleForReading.readabilityHandler = nil
-            stderr.fileHandleForReading.readabilityHandler = nil
-            return nil
-        }
-
-        let didExit = exitSemaphore.wait(timeout: .now() + timeout) == .success
-        if !didExit {
-            if process.isRunning {
-                process.terminate()
-                if exitSemaphore.wait(timeout: .now() + 0.4) != .success, process.isRunning {
-                    kill(process.processIdentifier, SIGKILL)
-                    _ = exitSemaphore.wait(timeout: .now() + 1.0)
-                }
-            }
-            stdout.fileHandleForReading.readabilityHandler = nil
-            stderr.fileHandleForReading.readabilityHandler = nil
-            return nil
-        }
-
-        Thread.sleep(forTimeInterval: 0.1)
-        stdout.fileHandleForReading.readabilityHandler = nil
-        stderr.fileHandleForReading.readabilityHandler = nil
-        let data = output.snapshot()
-        guard process.terminationStatus == 0,
-              let output = String(data: data, encoding: .utf8)?
-                  .trimmingCharacters(in: .whitespacesAndNewlines),
-                  !output.isEmpty
-        else {
-            return nil
-        }
-
-        return output.components(separatedBy: .newlines).first?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
     private static func findGeminiPackageRoot(startingAt path: String) -> String? {
         let fileManager = FileManager.default
         var currentURL = URL(fileURLWithPath: path).standardizedFileURL
@@ -1176,5 +1082,101 @@ public struct GeminiStatusProbe: Sendable {
         }
 
         return quotas
+    }
+}
+
+extension GeminiStatusProbe {
+    fileprivate static func runProcess(
+        executable: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval) -> String?
+    {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+
+        var mergedEnvironment = environment
+        mergedEnvironment["PATH"] = PathBuilder.effectivePATH(
+            purposes: [.tty, .nodeTooling],
+            env: environment,
+            loginPATH: LoginShellPathCache.shared.current)
+        process.environment = mergedEnvironment
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+        process.standardInput = nil
+
+        final class OutputState: @unchecked Sendable {
+            private let lock = NSLock()
+            private var data = Data()
+
+            func append(_ chunk: Data) {
+                self.lock.lock()
+                self.data.append(chunk)
+                self.lock.unlock()
+            }
+
+            func snapshot() -> Data {
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                return self.data
+            }
+        }
+
+        let output = OutputState()
+        stdout.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if !data.isEmpty {
+                output.append(data)
+            }
+        }
+        stderr.fileHandleForReading.readabilityHandler = { handle in
+            _ = handle.availableData
+        }
+
+        let exitSemaphore = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in
+            exitSemaphore.signal()
+        }
+
+        do {
+            try process.run()
+        } catch {
+            stdout.fileHandleForReading.readabilityHandler = nil
+            stderr.fileHandleForReading.readabilityHandler = nil
+            return nil
+        }
+
+        let didExit = exitSemaphore.wait(timeout: .now() + timeout) == .success
+        if !didExit {
+            if process.isRunning {
+                process.terminate()
+                if exitSemaphore.wait(timeout: .now() + 0.4) != .success, process.isRunning {
+                    kill(process.processIdentifier, SIGKILL)
+                    _ = exitSemaphore.wait(timeout: .now() + 1.0)
+                }
+            }
+            stdout.fileHandleForReading.readabilityHandler = nil
+            stderr.fileHandleForReading.readabilityHandler = nil
+            return nil
+        }
+
+        Thread.sleep(forTimeInterval: 0.1)
+        stdout.fileHandleForReading.readabilityHandler = nil
+        stderr.fileHandleForReading.readabilityHandler = nil
+        let data = output.snapshot()
+        guard process.terminationStatus == 0,
+              let output = String(data: data, encoding: .utf8)?
+                  .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !output.isEmpty
+        else {
+            return nil
+        }
+
+        return output.components(separatedBy: .newlines).first?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
@@ -1086,7 +1086,7 @@ public struct GeminiStatusProbe: Sendable {
 }
 
 extension GeminiStatusProbe {
-    fileprivate static func runProcess(
+    package static func runProcess(
         executable: String,
         arguments: [String],
         environment: [String: String],
@@ -1109,33 +1109,8 @@ extension GeminiStatusProbe {
         process.standardError = stderr
         process.standardInput = nil
 
-        final class OutputState: @unchecked Sendable {
-            private let lock = NSLock()
-            private var data = Data()
-
-            func append(_ chunk: Data) {
-                self.lock.lock()
-                self.data.append(chunk)
-                self.lock.unlock()
-            }
-
-            func snapshot() -> Data {
-                self.lock.lock()
-                defer { self.lock.unlock() }
-                return self.data
-            }
-        }
-
-        let output = OutputState()
-        stdout.fileHandleForReading.readabilityHandler = { handle in
-            let data = handle.availableData
-            if !data.isEmpty {
-                output.append(data)
-            }
-        }
-        stderr.fileHandleForReading.readabilityHandler = { handle in
-            _ = handle.availableData
-        }
+        let stdoutCapture = ProcessPipeCapture(pipe: stdout)
+        let stderrCapture = ProcessPipeCapture(pipe: stderr)
 
         let exitSemaphore = DispatchSemaphore(value: 0)
         process.terminationHandler = { _ in
@@ -1145,29 +1120,26 @@ extension GeminiStatusProbe {
         do {
             try process.run()
         } catch {
-            stdout.fileHandleForReading.readabilityHandler = nil
-            stderr.fileHandleForReading.readabilityHandler = nil
+            process.terminationHandler = nil
+            stdoutCapture.stop()
+            stderrCapture.stop()
             return nil
         }
+        stdoutCapture.start()
+        stderrCapture.start()
+        let pid = process.processIdentifier
+        let processGroup: pid_t? = setpgid(pid, pid) == 0 ? pid : nil
 
         let didExit = exitSemaphore.wait(timeout: .now() + timeout) == .success
         if !didExit {
-            if process.isRunning {
-                process.terminate()
-                if exitSemaphore.wait(timeout: .now() + 0.4) != .success, process.isRunning {
-                    kill(process.processIdentifier, SIGKILL)
-                    _ = exitSemaphore.wait(timeout: .now() + 1.0)
-                }
-            }
-            stdout.fileHandleForReading.readabilityHandler = nil
-            stderr.fileHandleForReading.readabilityHandler = nil
+            SubprocessRunner.terminateProcess(process, processGroup: processGroup)
+            stdoutCapture.stop()
+            stderrCapture.stop()
             return nil
         }
 
-        Thread.sleep(forTimeInterval: 0.1)
-        stdout.fileHandleForReading.readabilityHandler = nil
-        stderr.fileHandleForReading.readabilityHandler = nil
-        let data = output.snapshot()
+        let data = stdoutCapture.finishSynchronously(timeout: 1)
+        stderrCapture.stop()
         guard process.terminationStatus == 0,
               let output = String(data: data, encoding: .utf8)?
                   .trimmingCharacters(in: .whitespacesAndNewlines),

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
@@ -2,6 +2,11 @@ import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
 
 public struct GeminiModelQuota: Sendable {
     public let modelId: String
@@ -590,9 +595,38 @@ public struct GeminiStatusProbe: Sendable {
         process.environment = mergedEnvironment
 
         let stdout = Pipe()
+        let stderr = Pipe()
         process.standardOutput = stdout
-        process.standardError = Pipe()
+        process.standardError = stderr
         process.standardInput = nil
+
+        final class OutputState: @unchecked Sendable {
+            private let lock = NSLock()
+            private var data = Data()
+
+            func append(_ chunk: Data) {
+                self.lock.lock()
+                self.data.append(chunk)
+                self.lock.unlock()
+            }
+
+            func snapshot() -> Data {
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                return self.data
+            }
+        }
+
+        let output = OutputState()
+        stdout.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            if !data.isEmpty {
+                output.append(data)
+            }
+        }
+        stderr.fileHandleForReading.readabilityHandler = { handle in
+            _ = handle.availableData
+        }
 
         let exitSemaphore = DispatchSemaphore(value: 0)
         process.terminationHandler = { _ in
@@ -602,6 +636,8 @@ public struct GeminiStatusProbe: Sendable {
         do {
             try process.run()
         } catch {
+            stdout.fileHandleForReading.readabilityHandler = nil
+            stderr.fileHandleForReading.readabilityHandler = nil
             return nil
         }
 
@@ -609,12 +645,20 @@ public struct GeminiStatusProbe: Sendable {
         if !didExit {
             if process.isRunning {
                 process.terminate()
-                _ = exitSemaphore.wait(timeout: .now() + 0.5)
+                if exitSemaphore.wait(timeout: .now() + 0.4) != .success, process.isRunning {
+                    kill(process.processIdentifier, SIGKILL)
+                    _ = exitSemaphore.wait(timeout: .now() + 1.0)
+                }
             }
+            stdout.fileHandleForReading.readabilityHandler = nil
+            stderr.fileHandleForReading.readabilityHandler = nil
             return nil
         }
 
-        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        Thread.sleep(forTimeInterval: 0.1)
+        stdout.fileHandleForReading.readabilityHandler = nil
+        stderr.fileHandleForReading.readabilityHandler = nil
+        let data = output.snapshot()
         guard process.terminationStatus == 0,
               let output = String(data: data, encoding: .utf8)?
                   .trimmingCharacters(in: .whitespacesAndNewlines),

--- a/Tests/CodexBarTests/GeminiStatusProbeAPITests.swift
+++ b/Tests/CodexBarTests/GeminiStatusProbeAPITests.swift
@@ -1,6 +1,11 @@
 import CodexBarCore
 import Foundation
 import Testing
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
 
 @Suite(.serialized)
 struct GeminiStatusProbeAPITests {
@@ -266,9 +271,17 @@ struct GeminiStatusProbeAPITests {
     }
 
     @Test
-    func `refreshes expired token with fnm bundle layout`() async throws {
+    func `refreshes expired token with fnm bundle layout when fnm keeps stdout open`() async throws {
         let env = try GeminiTestEnvironment()
         defer { env.cleanup() }
+        let childPIDFile = env.homeURL.appendingPathComponent("fnm-child.pid")
+        defer {
+            if let text = try? String(contentsOf: childPIDFile, encoding: .utf8),
+               let childPID = pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines))
+            {
+                _ = kill(childPID, SIGKILL)
+            }
+        }
         try env.writeCredentials(
             accessToken: "old-token",
             refreshToken: "refresh-token",
@@ -290,9 +303,13 @@ struct GeminiStatusProbeAPITests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .path
-        _ = try env.writeFakeFnm(npmRoot: npmRoot, geminiPackageJSONPath: packageJSONPath.path)
+        _ = try env.writeFakeFnm(
+            npmRoot: npmRoot,
+            geminiPackageJSONPath: packageJSONPath.path,
+            holdNpmRootStdoutOpen: true)
 
         let previousPath = ProcessInfo.processInfo.environment["PATH"]
+        let previousPIDFile = ProcessInfo.processInfo.environment["CODEXBAR_TEST_CHILD_PID_FILE"]
         let fakeBinDir = env.homeURL.appendingPathComponent("bin").path
         let pathValue = if let previousPath, !previousPath.isEmpty {
             "\(fakeBinDir):\(binURL.deletingLastPathComponent().path):\(previousPath)"
@@ -300,6 +317,7 @@ struct GeminiStatusProbeAPITests {
             "\(fakeBinDir):\(binURL.deletingLastPathComponent().path)"
         }
         setenv("PATH", pathValue, 1)
+        setenv("CODEXBAR_TEST_CHILD_PID_FILE", childPIDFile.path, 1)
 
         let previousGeminiPath = ProcessInfo.processInfo.environment["GEMINI_CLI_PATH"]
         setenv("GEMINI_CLI_PATH", binURL.path, 1)
@@ -308,6 +326,12 @@ struct GeminiStatusProbeAPITests {
                 setenv("PATH", previousPath, 1)
             } else {
                 unsetenv("PATH")
+            }
+
+            if let previousPIDFile {
+                setenv("CODEXBAR_TEST_CHILD_PID_FILE", previousPIDFile, 1)
+            } else {
+                unsetenv("CODEXBAR_TEST_CHILD_PID_FILE")
             }
 
             if let previousGeminiPath {
@@ -368,8 +392,11 @@ struct GeminiStatusProbeAPITests {
         }
 
         let probe = GeminiStatusProbe(timeout: 2, homeDirectory: env.homeURL.path, dataLoader: dataLoader)
+        let start = Date()
         let snapshot = try await probe.fetch()
+        let elapsed = Date().timeIntervalSince(start)
         #expect(snapshot.accountPlan == "Paid")
+        #expect(elapsed < 3, "fnm package discovery should not wait for inherited stdout EOF, took \(elapsed)s")
 
         let updated = try env.readCredentials()
         #expect(updated["access_token"] as? String == "new-token")

--- a/Tests/CodexBarTests/GeminiStatusProbeAPITests.swift
+++ b/Tests/CodexBarTests/GeminiStatusProbeAPITests.swift
@@ -403,6 +403,58 @@ struct GeminiStatusProbeAPITests {
     }
 
     @Test
+    func `fnm helper timeout hard stops a process that ignores SIGTERM`() throws {
+        let env = try GeminiTestEnvironment()
+        defer { env.cleanup() }
+        let pidFile = env.homeURL.appendingPathComponent("fnm-timeout.pid")
+        let helper = env.homeURL.appendingPathComponent("fnm-timeout")
+        try """
+        #!/bin/sh
+        printf '%s\\n' "$$" > "$1"
+        trap '' TERM
+        while true; do sleep 1; done
+        """.write(to: helper, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: helper.path)
+
+        let start = Date()
+        let result = GeminiStatusProbe.runProcess(
+            executable: helper.path,
+            arguments: [pidFile.path],
+            environment: [:],
+            timeout: 0.5)
+        let elapsed = Date().timeIntervalSince(start)
+        let text = try String(contentsOf: pidFile, encoding: .utf8)
+        let processID = try #require(pid_t(text.trimmingCharacters(in: .whitespacesAndNewlines)))
+        defer { _ = kill(processID, SIGKILL) }
+
+        #expect(result == nil)
+        #expect(kill(processID, 0) == -1)
+        #expect(elapsed < 2, "Ignored SIGTERM should escalate to SIGKILL, took \(elapsed)s")
+    }
+
+    @Test
+    func `fnm helper completed no-output failure returns promptly`() throws {
+        let env = try GeminiTestEnvironment()
+        defer { env.cleanup() }
+        let helper = env.homeURL.appendingPathComponent("fnm-failure")
+        try """
+        #!/bin/sh
+        exit 23
+        """.write(to: helper, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: helper.path)
+
+        let start = Date()
+        let result = GeminiStatusProbe.runProcess(
+            executable: helper.path,
+            arguments: [],
+            environment: [:],
+            timeout: 2)
+
+        #expect(result == nil)
+        #expect(Date().timeIntervalSince(start) < 1)
+    }
+
+    @Test
     func `refreshes expired token with homebrew bundle layout`() async throws {
         let env = try GeminiTestEnvironment()
         defer { env.cleanup() }

--- a/Tests/CodexBarTests/GeminiTestEnvironment.swift
+++ b/Tests/CodexBarTests/GeminiTestEnvironment.swift
@@ -300,12 +300,20 @@ struct GeminiTestEnvironment {
     func writeFakeFnm(
         currentVersion: String = "v24.6.0",
         npmRoot: String? = nil,
-        geminiPackageJSONPath: String) throws -> URL
+        geminiPackageJSONPath: String,
+        holdNpmRootStdoutOpen: Bool = false) throws -> URL
     {
         let binDir = self.homeURL.appendingPathComponent("bin")
         try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
 
         let fnmPath = binDir.appendingPathComponent("fnm")
+        let stdoutHolder = holdNpmRootStdoutOpen
+            ? [
+                "python3 -c 'import os, time; ",
+                #"open(os.environ["CODEXBAR_TEST_CHILD_PID_FILE"], "w").write(str(os.getpid())); "#,
+                "time.sleep(5)' &",
+            ].joined()
+            : ":"
         let script = if let npmRoot {
             """
             #!/bin/bash
@@ -315,6 +323,7 @@ struct GeminiTestEnvironment {
             fi
 
             if [ "$1" = "exec" ] && [ "$4" = "npm" ] && [ "$5" = "root" ] && [ "$6" = "-g" ]; then
+              \(stdoutHolder)
               printf '%s\n' "\(npmRoot)"
               exit 0
             fi

--- a/Tests/CodexBarTests/GeminiTestEnvironment.swift
+++ b/Tests/CodexBarTests/GeminiTestEnvironment.swift
@@ -308,11 +308,22 @@ struct GeminiTestEnvironment {
 
         let fnmPath = binDir.appendingPathComponent("fnm")
         let stdoutHolder = holdNpmRootStdoutOpen
-            ? [
-                "python3 -c 'import os, time; ",
-                #"open(os.environ["CODEXBAR_TEST_CHILD_PID_FILE"], "w").write(str(os.getpid())); "#,
-                "time.sleep(5)' &",
-            ].joined()
+            ? #"""
+            python3 - <<'PY'
+            import os
+            import subprocess
+            import sys
+
+            child = subprocess.Popen(
+                [sys.executable, "-c", "import time; time.sleep(5)"],
+                stdin=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            with open(os.environ["CODEXBAR_TEST_CHILD_PID_FILE"], "w") as handle:
+                handle.write(str(child.pid))
+            PY
+            """#
             : ":"
         let script = if let npmRoot {
             """


### PR DESCRIPTION
## Summary

Fixes #1534.

Gemini fnm package discovery waited for stdout EOF after `fnm` exited. If a descendant inherited stdout, the direct helper could be done while discovery still hung. This captures stdout incrementally, drains stderr so helpers cannot block on a full pipe, and bounds timeout cleanup with SIGKILL escalation.

The regression keeps the existing expired-token fnm OAuth refresh path, but makes fake `fnm exec -- npm root -g` leave stdout open through a child process. The refresh now completes from the parent output instead of waiting for inherited EOF.

## Proof

- `swiftc -swift-version 6 -parse Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift Tests/CodexBarTests/GeminiStatusProbeAPITests.swift Tests/CodexBarTests/GeminiTestEnvironment.swift`

I also attempted focused SwiftPM tests locally, but SwiftPM hung while downloading Sparkle's binary artifact before compilation. CI should run the focused regression under normal package resolution.