### PR TITLE
fix: renew Claude web cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - MiniMax: retry the China API region when the global token endpoint reports a structured invalid-key response.
 - Menu refresh: scope manual refreshes to the visible provider, keep Command-R consistent with mouse refresh, and avoid animated refresh-row compositing. Thanks @jangisaac-dev!
 - Localization: improve Catalan app and website translations. Thanks @pmontp19!
+- Claude web: persist renewed session cookies after successful usage requests so imported sessions stay current. Thanks @ProspectOre!
 - Kiro: keep parsed usage available when the optional account probe times out or fails. Thanks @Yuxin-Qiao!
 - Cursor: ignore an exhausted Auto or API subquota only when another independent quota remains usable, while preserving the overall cap. Thanks @Yuxin-Qiao!
 - Memory: release idle OpenAI WebViews under system pressure without blocking the main thread. Thanks @ProspectOre!

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -473,13 +473,14 @@ public enum CookieHeaderCache {
         do {
             return try self.withLegacyMutationLock {
                 guard self.currentEntryMatches(expected, provider: provider, scope: scope) else { return false }
+                // Keep the expected Keychain row intact when legacy cleanup fails so fallback can replace it.
+                if scope == nil, self.removeLegacyEntry(for: provider) == .failed {
+                    return false
+                }
                 let key = self.key(for: provider, scope: scope)
                 let result = KeychainCacheStore.clearResult(key: key)
                 guard result != .failed else { return false }
                 self.updateDisplaySnapshot(key: key, entry: nil)
-                if scope == nil {
-                    return self.removeLegacyEntry(for: provider) != .failed
-                }
                 return true
             }
         } catch {

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -93,6 +93,7 @@ public enum CookieHeaderCache {
     private static let displayStalenessInterval: TimeInterval = 30
     private static let displayUnavailableRetryInterval: TimeInterval = 1
     #if DEBUG
+    @TaskLocal private static var taskLegacyBaseURLOverride: URL?
     @TaskLocal private static var legacyRemovalFailureOverride = false
     #endif
 
@@ -743,6 +744,17 @@ public enum CookieHeaderCache {
         }
     }
 
+    #if DEBUG
+    static func withLegacyBaseURLOverrideForTesting<T>(
+        _ url: URL?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$taskLegacyBaseURLOverride.withValue(url) {
+            try await operation()
+        }
+    }
+    #endif
+
     static func hasLegacyEntryForTesting(provider: UsageProvider) -> Bool {
         self.loadLegacyEntry(for: provider) != nil
     }
@@ -829,7 +841,12 @@ public enum CookieHeaderCache {
     }
 
     private static var currentLegacyBaseURLOverride: URL? {
-        self.legacyBaseURLOverrideLock.withLock {
+        #if DEBUG
+        if let taskOverride = self.taskLegacyBaseURLOverride {
+            return taskOverride
+        }
+        #endif
+        return self.legacyBaseURLOverrideLock.withLock {
             self.legacyBaseURLOverride
         }
     }

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -748,6 +748,15 @@ public enum CookieHeaderCache {
     #if DEBUG
     static func withLegacyBaseURLOverrideForTesting<T>(
         _ url: URL?,
+        operation: () throws -> T) rethrows -> T
+    {
+        try self.$taskLegacyBaseURLOverride.withValue(url) {
+            try operation()
+        }
+    }
+
+    static func withLegacyBaseURLOverrideForTesting<T>(
+        _ url: URL?,
         operation: () async throws -> T) async rethrows -> T
     {
         try await self.$taskLegacyBaseURLOverride.withValue(url) {
@@ -861,5 +870,97 @@ public enum CookieHeaderCache {
 
     private static func key(for provider: UsageProvider, scope: Scope?) -> KeychainCacheStore.Key {
         KeychainCacheStore.Key.cookie(provider: provider, scopeIdentifier: scope?.keychainIdentifier)
+    }
+}
+
+extension CookieHeaderCache {
+    enum ConditionalMutationObservation {
+        case authoritative(Entry?)
+        case keychainTemporarilyUnavailable(legacyEntry: Entry?)
+
+        var entry: Entry? {
+            switch self {
+            case let .authoritative(entry): entry
+            case .keychainTemporarilyUnavailable: nil
+            }
+        }
+    }
+
+    /// Captures enough state to conditionally persist an asynchronous refresh after a transient
+    /// Keychain read failure without mistaking an untouched legacy entry for a concurrent write.
+    static func observeForConditionalMutation(
+        provider: UsageProvider,
+        scope: Scope? = nil) -> ConditionalMutationObservation
+    {
+        do {
+            return try self.withLegacyMutationLock {
+                let key = self.key(for: provider, scope: scope)
+                switch KeychainCacheStore.load(key: key, as: Entry.self) {
+                case let .found(entry):
+                    return .authoritative(entry)
+                case .temporarilyUnavailable:
+                    let legacyEntry = scope == nil ? self.loadLegacyEntry(for: provider) : nil
+                    return .keychainTemporarilyUnavailable(legacyEntry: legacyEntry)
+                case .invalid:
+                    KeychainCacheStore.clear(key: key)
+                case .missing:
+                    break
+                }
+                guard scope == nil else { return .authoritative(nil) }
+                return .authoritative(self.migrateLegacyEntryIfNeededLocked(provider: provider))
+            }
+        } catch {
+            self.log.error("Cookie cache observation lock failed: \(error)")
+            return .keychainTemporarilyUnavailable(legacyEntry: nil)
+        }
+    }
+
+    /// Stores against a state captured by `observeForConditionalMutation`. A transient initial
+    /// Keychain failure may proceed only after Keychain recovers as missing and legacy state is unchanged.
+    @discardableResult
+    static func storeIfObservationCurrent(
+        provider: UsageProvider,
+        scope: Scope? = nil,
+        expected: ConditionalMutationObservation,
+        cookieHeader: String,
+        sourceLabel: String,
+        now: Date = Date()) -> Bool
+    {
+        let trimmed = cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let normalized = CookieHeaderNormalizer.normalize(trimmed), !normalized.isEmpty else { return false }
+        let entry = Entry(cookieHeader: normalized, storedAt: now, sourceLabel: sourceLabel)
+        do {
+            return try self.withLegacyMutationLock {
+                guard self.currentStateMatches(expected, provider: provider, scope: scope) else { return false }
+                return self.store(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
+            }
+        } catch {
+            self.log.error("Cookie cache observed store lock failed: \(error)")
+            return false
+        }
+    }
+
+    private static func currentStateMatches(
+        _ expected: ConditionalMutationObservation,
+        provider: UsageProvider,
+        scope: Scope?) -> Bool
+    {
+        switch expected {
+        case let .authoritative(entry):
+            return self.currentEntryMatches(entry, provider: provider, scope: scope)
+        case let .keychainTemporarilyUnavailable(expectedLegacyEntry):
+            let key = self.key(for: provider, scope: scope)
+            guard case .missing = KeychainCacheStore.load(key: key, as: Entry.self) else { return false }
+            guard scope == nil else { return true }
+            return self.optionalEntriesMatch(self.loadLegacyEntry(for: provider), expectedLegacyEntry)
+        }
+    }
+
+    private static func optionalEntriesMatch(_ current: Entry?, _ expected: Entry?) -> Bool {
+        switch (current, expected) {
+        case (nil, nil): true
+        case let (current?, expected?): self.entriesMatch(current, expected)
+        default: false
+        }
     }
 }

--- a/Sources/CodexBarCore/CookieHeaderCache.swift
+++ b/Sources/CodexBarCore/CookieHeaderCache.swift
@@ -430,26 +430,104 @@ public enum CookieHeaderCache {
         let entry = Entry(cookieHeader: normalized, storedAt: now, sourceLabel: sourceLabel)
         do {
             try self.withLegacyMutationLock {
-                self.store(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
+                _ = self.store(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
             }
         } catch {
             self.log.error("Cookie cache store lock failed: \(error)")
         }
     }
 
+    /// Stores only while the cache still matches the entry observed before an asynchronous refresh.
+    /// A nil expected entry means the cache must still be empty.
+    @discardableResult
+    static func storeIfCurrent(
+        provider: UsageProvider,
+        scope: Scope? = nil,
+        expected: Entry?,
+        cookieHeader: String,
+        sourceLabel: String,
+        now: Date = Date()) -> Bool
+    {
+        let trimmed = cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let normalized = CookieHeaderNormalizer.normalize(trimmed), !normalized.isEmpty else { return false }
+        let entry = Entry(cookieHeader: normalized, storedAt: now, sourceLabel: sourceLabel)
+        do {
+            return try self.withLegacyMutationLock {
+                guard self.currentEntryMatches(expected, provider: provider, scope: scope) else { return false }
+                return self.store(entry: entry, provider: provider, scope: scope, sourceLabel: sourceLabel)
+            }
+        } catch {
+            self.log.error("Cookie cache conditional store lock failed: \(error)")
+            return false
+        }
+    }
+
+    /// Clears only while the cache still matches the entry that produced a failed asynchronous refresh.
+    @discardableResult
+    static func clearIfCurrent(
+        provider: UsageProvider,
+        scope: Scope? = nil,
+        expected: Entry?) -> Bool
+    {
+        do {
+            return try self.withLegacyMutationLock {
+                guard self.currentEntryMatches(expected, provider: provider, scope: scope) else { return false }
+                let key = self.key(for: provider, scope: scope)
+                let result = KeychainCacheStore.clearResult(key: key)
+                guard result != .failed else { return false }
+                self.updateDisplaySnapshot(key: key, entry: nil)
+                if scope == nil {
+                    return self.removeLegacyEntry(for: provider) != .failed
+                }
+                return true
+            }
+        } catch {
+            self.log.error("Cookie cache conditional clear lock failed: \(error)")
+            return false
+        }
+    }
+
+    private static func currentEntryMatches(
+        _ expected: Entry?,
+        provider: UsageProvider,
+        scope: Scope?) -> Bool
+    {
+        let key = self.key(for: provider, scope: scope)
+        switch KeychainCacheStore.load(key: key, as: Entry.self) {
+        case let .found(current):
+            return self.entriesMatch(current, expected)
+        case .missing:
+            if scope == nil, let legacy = self.loadLegacyEntry(for: provider) {
+                return self.entriesMatch(legacy, expected)
+            }
+            return expected == nil
+        case .invalid, .temporarilyUnavailable:
+            return false
+        }
+    }
+
+    private static func entriesMatch(_ current: Entry, _ expected: Entry?) -> Bool {
+        guard let expected else { return false }
+        return current.cookieHeader == expected.cookieHeader
+            && current.storedAt == expected.storedAt
+            && current.sourceLabel == expected.sourceLabel
+    }
+
+    @discardableResult
     private static func store(
         entry: Entry,
         provider: UsageProvider,
         scope: Scope?,
-        sourceLabel: String)
+        sourceLabel: String) -> Bool
     {
         let key = self.key(for: provider, scope: scope)
-        guard KeychainCacheStore.storeResult(key: key, entry: entry) else { return }
+        guard KeychainCacheStore.storeResult(key: key, entry: entry) else { return false }
         self.updateDisplaySnapshot(key: key, entry: entry)
         if scope == nil {
             _ = self.removeLegacyEntry(for: provider)
         }
         self.log.debug("Cookie cache stored", metadata: ["provider": provider.rawValue, "source": sourceLabel])
+        return true
     }
 
     @discardableResult

--- a/Sources/CodexBarCore/KeychainCacheStore.swift
+++ b/Sources/CodexBarCore/KeychainCacheStore.swift
@@ -298,6 +298,15 @@ public enum KeychainCacheStore {
         }
     }
 
+    public static func withClearFailureStatusOverrideForTesting<T>(
+        _ status: OSStatus?,
+        operation: () async throws -> T) async rethrows -> T
+    {
+        try await self.$clearFailureStatusOverride.withValue(status) {
+            try await operation()
+        }
+    }
+
     public static func withKeysFailureStatusOverrideForTesting<T>(
         _ status: OSStatus?,
         operation: () throws -> T) rethrows -> T

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -222,9 +222,7 @@ public enum ClaudeWebAPIFetcher {
     {
         let log: (String) -> Void = { msg in logger?(msg) }
         let sessionKey = sessionKeyInfo.key
-        let renewalTracker = cacheSourceLabel.map { _ in
-            ClaudeWebSessionKeyRenewalTracker(initialSessionKey: sessionKey)
-        }
+        let renewalTracker = ClaudeWebSessionKeyRenewalTracker(initialSessionKey: sessionKey)
 
         // Fetch organization info
         let organization = try await fetchOrganizationInfo(
@@ -234,17 +232,16 @@ public enum ClaudeWebAPIFetcher {
             renewalTracker: renewalTracker)
         log("Organization resolved")
 
-        let usageSessionKey = renewalTracker?.sessionKey ?? sessionKey
         var usage = try await fetchUsageData(
             orgId: organization.id,
-            sessionKey: usageSessionKey,
+            sessionKey: renewalTracker.sessionKey,
             logger: log,
             renewalTracker: renewalTracker)
         if usage.extraUsageCost == nil,
            let extra = await ClaudeWebExtraUsageCost.fetch(
                baseURL: Self.baseURL,
                orgId: organization.id,
-               sessionKey: renewalTracker?.sessionKey ?? sessionKey,
+               sessionKey: renewalTracker.sessionKey,
                logger: log,
                renewalTracker: renewalTracker)
         {
@@ -261,7 +258,7 @@ public enum ClaudeWebAPIFetcher {
                 loginMethod: usage.loginMethod)
         }
         if let account = await fetchAccountInfo(
-            sessionKey: renewalTracker?.sessionKey ?? sessionKey,
+            sessionKey: renewalTracker.sessionKey,
             orgId: organization.id,
             logger: log,
             renewalTracker: renewalTracker)
@@ -292,7 +289,7 @@ public enum ClaudeWebAPIFetcher {
                 loginMethod: usage.loginMethod)
         }
         if let cacheSourceLabel {
-            let renewedCookieHeader = renewalTracker?.renewedCookieHeader
+            let renewedCookieHeader = renewalTracker.renewedCookieHeader
             CookieHeaderCache.store(
                 provider: .claude,
                 cookieHeader: renewedCookieHeader ?? "sessionKey=\(sessionKey)",

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -965,8 +965,7 @@ private final class ClaudeWebSessionKeyRenewalTracker: @unchecked Sendable {
 
     func observe(response: HTTPURLResponse) {
         guard response.statusCode == 200,
-              let sessionKey = Self.sessionKey(fromSetCookieHeaders: response.allHeaderFields),
-              sessionKey != self.initialSessionKey
+              let sessionKey = Self.sessionKey(fromSetCookieHeaders: response.allHeaderFields)
         else {
             return
         }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -4,6 +4,21 @@ import SweetCookieKit
 import FoundationNetworking
 #endif
 
+enum ClaudeWebHTTPTransport {
+    #if DEBUG
+    @TaskLocal static var overrideForTesting: (any ProviderHTTPTransport)?
+    #endif
+
+    static var current: any ProviderHTTPTransport {
+        #if DEBUG
+        if let override = self.overrideForTesting {
+            return override
+        }
+        #endif
+        return ProviderHTTPClient.shared
+    }
+}
+
 /// Fetches Claude usage data directly from the claude.ai API using browser session cookies.
 ///
 /// This approach mirrors what Claude Usage Tracker does, but automatically extracts the session key
@@ -338,7 +353,7 @@ public enum ClaudeWebAPIFetcher {
             request.timeoutInterval = 20
 
             do {
-                let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
+                let (data, response) = try await ClaudeWebHTTPTransport.current.data(for: request)
                 let http = response as? HTTPURLResponse
                 let contentType = http?.allHeaderFields["Content-Type"] as? String
                 let truncated = data.prefix(Self.maxProbeBytes)
@@ -475,7 +490,7 @@ public enum ClaudeWebAPIFetcher {
         request.httpMethod = "GET"
         request.timeoutInterval = 15
 
-        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
+        let (data, response) = try await ClaudeWebHTTPTransport.current.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FetchError.invalidResponse
@@ -507,7 +522,7 @@ public enum ClaudeWebAPIFetcher {
         request.httpMethod = "GET"
         request.timeoutInterval = 15
 
-        let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
+        let (data, response) = try await ClaudeWebHTTPTransport.current.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FetchError.invalidResponse
@@ -710,7 +725,7 @@ public enum ClaudeWebAPIFetcher {
         request.timeoutInterval = 15
 
         do {
-            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
+            let (data, response) = try await ClaudeWebHTTPTransport.current.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else { return nil }
             renewalTracker?.observe(response: httpResponse)
             logger?("Account API status: \(httpResponse.statusCode)")
@@ -1045,7 +1060,7 @@ private enum ClaudeWebExtraUsageCost {
         request.timeoutInterval = 15
 
         do {
-            let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
+            let (data, response) = try await ClaudeWebHTTPTransport.current.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else { return nil }
             renewalTracker?.observe(response: httpResponse)
             logger?("Overage API status: \(httpResponse.statusCode)")

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -147,8 +147,9 @@ public enum ClaudeWebAPIFetcher {
         {
             log("Using cached cookie header from \(cached.sourceLabel)")
             do {
-                return try await self.fetchUsage(
+                return try await self.fetchUsageAndRenewCache(
                     cookieHeader: cached.cookieHeader,
+                    sourceLabel: cached.sourceLabel,
                     targetOrganizationID: targetOrganizationID,
                     logger: log)
             } catch let error as FetchError {
@@ -166,15 +167,11 @@ public enum ClaudeWebAPIFetcher {
         let sessionInfo = try extractSessionKeyInfo(browserDetection: browserDetection, logger: log)
         log("Found session key (\(sessionInfo.cookieCount) cookies)")
 
-        let usage = try await self.fetchUsage(
+        return try await self.fetchUsage(
             using: sessionInfo,
             targetOrganizationID: targetOrganizationID,
-            logger: log)
-        CookieHeaderCache.store(
-            provider: .claude,
-            cookieHeader: "sessionKey=\(sessionInfo.key)",
-            sourceLabel: sessionInfo.sourceLabel)
-        return usage
+            logger: log,
+            cacheSourceLabel: sessionInfo.sourceLabel)
     }
 
     public static func fetchUsage(
@@ -196,23 +193,60 @@ public enum ClaudeWebAPIFetcher {
         targetOrganizationID: String? = nil,
         logger: ((String) -> Void)? = nil) async throws -> WebUsageData
     {
+        try await self.fetchUsage(
+            using: sessionKeyInfo,
+            targetOrganizationID: targetOrganizationID,
+            logger: logger,
+            cacheSourceLabel: nil)
+    }
+
+    private static func fetchUsageAndRenewCache(
+        cookieHeader: String,
+        sourceLabel: String,
+        targetOrganizationID: String?,
+        logger: ((String) -> Void)? = nil) async throws -> WebUsageData
+    {
+        let sessionInfo = try self.sessionKeyInfo(cookieHeader: cookieHeader)
+        return try await self.fetchUsage(
+            using: sessionInfo,
+            targetOrganizationID: targetOrganizationID,
+            logger: logger,
+            cacheSourceLabel: sourceLabel)
+    }
+
+    private static func fetchUsage(
+        using sessionKeyInfo: SessionKeyInfo,
+        targetOrganizationID: String?,
+        logger: ((String) -> Void)?,
+        cacheSourceLabel: String?) async throws -> WebUsageData
+    {
         let log: (String) -> Void = { msg in logger?(msg) }
         let sessionKey = sessionKeyInfo.key
+        let renewalTracker = cacheSourceLabel.map { _ in
+            ClaudeWebSessionKeyRenewalTracker(initialSessionKey: sessionKey)
+        }
 
         // Fetch organization info
         let organization = try await fetchOrganizationInfo(
             sessionKey: sessionKey,
             targetOrganizationID: targetOrganizationID,
-            logger: log)
+            logger: log,
+            renewalTracker: renewalTracker)
         log("Organization resolved")
 
-        var usage = try await fetchUsageData(orgId: organization.id, sessionKey: sessionKey, logger: log)
+        let usageSessionKey = renewalTracker?.sessionKey ?? sessionKey
+        var usage = try await fetchUsageData(
+            orgId: organization.id,
+            sessionKey: usageSessionKey,
+            logger: log,
+            renewalTracker: renewalTracker)
         if usage.extraUsageCost == nil,
            let extra = await ClaudeWebExtraUsageCost.fetch(
                baseURL: Self.baseURL,
                orgId: organization.id,
-               sessionKey: sessionKey,
-               logger: log)
+               sessionKey: renewalTracker?.sessionKey ?? sessionKey,
+               logger: log,
+               renewalTracker: renewalTracker)
         {
             usage = WebUsageData(
                 sessionPercentUsed: usage.sessionPercentUsed,
@@ -226,7 +260,12 @@ public enum ClaudeWebAPIFetcher {
                 accountEmail: usage.accountEmail,
                 loginMethod: usage.loginMethod)
         }
-        if let account = await fetchAccountInfo(sessionKey: sessionKey, orgId: organization.id, logger: log) {
+        if let account = await fetchAccountInfo(
+            sessionKey: renewalTracker?.sessionKey ?? sessionKey,
+            orgId: organization.id,
+            logger: log,
+            renewalTracker: renewalTracker)
+        {
             usage = WebUsageData(
                 sessionPercentUsed: usage.sessionPercentUsed,
                 sessionResetsAt: usage.sessionResetsAt,
@@ -251,6 +290,16 @@ public enum ClaudeWebAPIFetcher {
                 accountOrganization: name,
                 accountEmail: usage.accountEmail,
                 loginMethod: usage.loginMethod)
+        }
+        if let cacheSourceLabel {
+            let renewedCookieHeader = renewalTracker?.renewedCookieHeader
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: renewedCookieHeader ?? "sessionKey=\(sessionKey)",
+                sourceLabel: cacheSourceLabel)
+            if renewedCookieHeader != nil {
+                log("Stored renewed Claude session key from Set-Cookie")
+            }
         }
         return usage
     }
@@ -419,7 +468,8 @@ public enum ClaudeWebAPIFetcher {
     private static func fetchOrganizationInfo(
         sessionKey: String,
         targetOrganizationID: String? = nil,
-        logger: ((String) -> Void)? = nil) async throws -> OrganizationInfo
+        logger: ((String) -> Void)? = nil,
+        renewalTracker: ClaudeWebSessionKeyRenewalTracker? = nil) async throws -> OrganizationInfo
     {
         let url = URL(string: "\(baseURL)/organizations")!
         var request = URLRequest(url: url)
@@ -433,6 +483,7 @@ public enum ClaudeWebAPIFetcher {
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FetchError.invalidResponse
         }
+        renewalTracker?.observe(response: httpResponse)
 
         logger?("Organizations API status: \(httpResponse.statusCode)")
 
@@ -449,7 +500,8 @@ public enum ClaudeWebAPIFetcher {
     private static func fetchUsageData(
         orgId: String,
         sessionKey: String,
-        logger: ((String) -> Void)? = nil) async throws -> WebUsageData
+        logger: ((String) -> Void)? = nil,
+        renewalTracker: ClaudeWebSessionKeyRenewalTracker? = nil) async throws -> WebUsageData
     {
         let url = URL(string: "\(baseURL)/organizations/\(orgId)/usage")!
         var request = URLRequest(url: url)
@@ -463,6 +515,7 @@ public enum ClaudeWebAPIFetcher {
         guard let httpResponse = response as? HTTPURLResponse else {
             throw FetchError.invalidResponse
         }
+        renewalTracker?.observe(response: httpResponse)
 
         logger?("Usage API status: \(httpResponse.statusCode)")
 
@@ -649,7 +702,8 @@ public enum ClaudeWebAPIFetcher {
     private static func fetchAccountInfo(
         sessionKey: String,
         orgId: String?,
-        logger: ((String) -> Void)? = nil) async -> WebAccountInfo?
+        logger: ((String) -> Void)? = nil,
+        renewalTracker: ClaudeWebSessionKeyRenewalTracker? = nil) async -> WebAccountInfo?
     {
         let url = URL(string: "\(baseURL)/account")!
         var request = URLRequest(url: url)
@@ -661,6 +715,7 @@ public enum ClaudeWebAPIFetcher {
         do {
             let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else { return nil }
+            renewalTracker?.observe(response: httpResponse)
             logger?("Account API status: \(httpResponse.statusCode)")
             guard httpResponse.statusCode == 200 else { return nil }
             return Self.parseAccountInfo(data, orgId: orgId)
@@ -873,6 +928,80 @@ public enum ClaudeWebAPIFetcher {
     #endif
 }
 
+private final class ClaudeWebSessionKeyRenewalTracker: @unchecked Sendable {
+    private let initialSessionKey: String
+    private let lock = NSLock()
+    private var currentSessionKey: String
+
+    init(initialSessionKey: String) {
+        self.initialSessionKey = initialSessionKey
+        self.currentSessionKey = initialSessionKey
+    }
+
+    var sessionKey: String {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.currentSessionKey
+    }
+
+    var renewedCookieHeader: String? {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        guard self.currentSessionKey != self.initialSessionKey else { return nil }
+        return "sessionKey=\(self.currentSessionKey)"
+    }
+
+    func observe(response: HTTPURLResponse) {
+        guard response.statusCode == 200,
+              let sessionKey = Self.sessionKey(fromSetCookieHeaders: response.allHeaderFields),
+              sessionKey != self.initialSessionKey
+        else {
+            return
+        }
+        self.lock.lock()
+        self.currentSessionKey = sessionKey
+        self.lock.unlock()
+    }
+
+    private static func sessionKey(fromSetCookieHeaders fields: [AnyHashable: Any]) -> String? {
+        for (key, value) in fields {
+            guard String(describing: key).caseInsensitiveCompare("Set-Cookie") == .orderedSame else {
+                continue
+            }
+            for header in self.setCookieHeaderValues(from: value) {
+                if let sessionKey = self.sessionKey(fromSetCookieHeader: header) {
+                    return sessionKey
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func setCookieHeaderValues(from value: Any) -> [String] {
+        if let values = value as? [String] {
+            return values
+        }
+        if let values = value as? [Any] {
+            return values.map { String(describing: $0) }
+        }
+        return [String(describing: value)]
+    }
+
+    private static func sessionKey(fromSetCookieHeader header: String) -> String? {
+        let pattern = #"(?i)(?:^|[,\r\n])\s*sessionKey=([^;,\r\n]+)"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let range = NSRange(header.startIndex..<header.endIndex, in: header)
+        guard let match = regex.firstMatch(in: header, range: range),
+              match.numberOfRanges >= 2,
+              let valueRange = Range(match.range(at: 1), in: header)
+        else {
+            return nil
+        }
+        let value = String(header[valueRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return value.hasPrefix("sk-ant-") ? value : nil
+    }
+}
+
 private enum ClaudeWebExtraUsageCost {
     // MARK: - Extra usage cost (Claude "Extra")
 
@@ -908,7 +1037,8 @@ private enum ClaudeWebExtraUsageCost {
         baseURL: String,
         orgId: String,
         sessionKey: String,
-        logger: ((String) -> Void)? = nil) async -> ProviderCostSnapshot?
+        logger: ((String) -> Void)? = nil,
+        renewalTracker: ClaudeWebSessionKeyRenewalTracker? = nil) async -> ProviderCostSnapshot?
     {
         let url = URL(string: "\(baseURL)/organizations/\(orgId)/overage_spend_limit")!
         var request = URLRequest(url: url)
@@ -920,6 +1050,7 @@ private enum ClaudeWebExtraUsageCost {
         do {
             let (data, response) = try await ProviderHTTPClient.shared.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse else { return nil }
+            renewalTracker?.observe(response: httpResponse)
             logger?("Overage API status: \(httpResponse.statusCode)")
             guard httpResponse.statusCode == 200 else { return nil }
             return Self.parseOverageSpendLimit(data)

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -170,9 +170,9 @@ public enum ClaudeWebAPIFetcher {
         logger: ((String) -> Void)? = nil) async throws -> WebUsageData
     {
         let log: (String) -> Void = { msg in logger?("[claude-web] \(msg)") }
-        var expectedCachedEntry: CookieHeaderCache.Entry?
+        var cacheObservation = CookieHeaderCache.observeForConditionalMutation(provider: .claude)
 
-        if let cached = CookieHeaderCache.load(provider: .claude),
+        if let cached = cacheObservation.entry,
            !cached.cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         {
             log("Using cached cookie header from \(cached.sourceLabel)")
@@ -185,7 +185,7 @@ public enum ClaudeWebAPIFetcher {
                 switch error {
                 case .unauthorized, .noSessionKeyFound, .invalidSessionKey:
                     let cleared = CookieHeaderCache.clearIfCurrent(provider: .claude, expected: cached)
-                    expectedCachedEntry = cleared ? nil : cached
+                    cacheObservation = .authoritative(cleared ? nil : cached)
                 default:
                     throw error
                 }
@@ -202,7 +202,7 @@ public enum ClaudeWebAPIFetcher {
             targetOrganizationID: targetOrganizationID,
             logger: log,
             cacheSourceLabel: sessionInfo.sourceLabel,
-            expectedCachedEntry: expectedCachedEntry,
+            expectedCacheObservation: cacheObservation,
             persistInitialSessionKey: true)
     }
 
@@ -230,7 +230,7 @@ public enum ClaudeWebAPIFetcher {
             targetOrganizationID: targetOrganizationID,
             logger: logger,
             cacheSourceLabel: nil,
-            expectedCachedEntry: nil)
+            expectedCacheObservation: .authoritative(nil))
     }
 
     private static func fetchUsageAndRenewCache(
@@ -244,7 +244,7 @@ public enum ClaudeWebAPIFetcher {
             targetOrganizationID: targetOrganizationID,
             logger: logger,
             cacheSourceLabel: cachedEntry.sourceLabel,
-            expectedCachedEntry: cachedEntry)
+            expectedCacheObservation: .authoritative(cachedEntry))
     }
 
     private static func fetchUsage(
@@ -252,7 +252,7 @@ public enum ClaudeWebAPIFetcher {
         targetOrganizationID: String?,
         logger: ((String) -> Void)?,
         cacheSourceLabel: String?,
-        expectedCachedEntry: CookieHeaderCache.Entry?,
+        expectedCacheObservation: CookieHeaderCache.ConditionalMutationObservation,
         persistInitialSessionKey: Bool = false) async throws -> WebUsageData
     {
         let log: (String) -> Void = { msg in logger?(msg) }
@@ -327,7 +327,7 @@ public enum ClaudeWebAPIFetcher {
             self.persistSessionKeyIfNeeded(
                 source: (sessionKey, cacheSourceLabel),
                 renewedCookieHeader: renewalTracker.renewedCookieHeader,
-                expectedCachedEntry: expectedCachedEntry,
+                expectedCacheObservation: expectedCacheObservation,
                 persistInitialSessionKey: persistInitialSessionKey,
                 logger: log)
         }
@@ -963,15 +963,15 @@ extension ClaudeWebAPIFetcher {
     private static func persistSessionKeyIfNeeded(
         source: (initialSessionKey: String, label: String),
         renewedCookieHeader: String?,
-        expectedCachedEntry: CookieHeaderCache.Entry?,
+        expectedCacheObservation: CookieHeaderCache.ConditionalMutationObservation,
         persistInitialSessionKey: Bool,
         logger: (String) -> Void)
     {
         let importedCookieHeader = persistInitialSessionKey ? "sessionKey=\(source.initialSessionKey)" : nil
         guard let cookieHeader = renewedCookieHeader ?? importedCookieHeader else { return }
-        let stored = CookieHeaderCache.storeIfCurrent(
+        let stored = CookieHeaderCache.storeIfObservationCurrent(
             provider: .claude,
-            expected: expectedCachedEntry,
+            expected: expectedCacheObservation,
             cookieHeader: cookieHeader,
             sourceLabel: source.label)
         if renewedCookieHeader != nil {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -308,15 +308,12 @@ public enum ClaudeWebAPIFetcher {
                 loginMethod: usage.loginMethod)
         }
         if let cacheSourceLabel {
-            let renewedCookieHeader = renewalTracker.renewedCookieHeader
-            let stored = CookieHeaderCache.storeIfCurrent(
-                provider: .claude,
-                expected: expectedCachedEntry,
-                cookieHeader: renewedCookieHeader ?? "sessionKey=\(sessionKey)",
-                sourceLabel: cacheSourceLabel)
-            if renewedCookieHeader != nil {
-                log(stored ? "Stored renewed Claude session key" : "Skipped renewal because the cache changed")
-            }
+            self.persistSessionKeyIfNeeded(
+                initialSessionKey: sessionKey,
+                renewedCookieHeader: renewalTracker.renewedCookieHeader,
+                sourceLabel: cacheSourceLabel,
+                expectedCachedEntry: expectedCachedEntry,
+                logger: log)
         }
         return usage
     }
@@ -943,6 +940,27 @@ public enum ClaudeWebAPIFetcher {
     }
 
     #endif
+}
+
+extension ClaudeWebAPIFetcher {
+    private static func persistSessionKeyIfNeeded(
+        initialSessionKey: String,
+        renewedCookieHeader: String?,
+        sourceLabel: String,
+        expectedCachedEntry: CookieHeaderCache.Entry?,
+        logger: (String) -> Void)
+    {
+        let importedCookieHeader = expectedCachedEntry == nil ? "sessionKey=\(initialSessionKey)" : nil
+        guard let cookieHeader = renewedCookieHeader ?? importedCookieHeader else { return }
+        let stored = CookieHeaderCache.storeIfCurrent(
+            provider: .claude,
+            expected: expectedCachedEntry,
+            cookieHeader: cookieHeader,
+            sourceLabel: sourceLabel)
+        if renewedCookieHeader != nil {
+            logger(stored ? "Stored renewed Claude session key" : "Skipped renewal because the cache changed")
+        }
+    }
 }
 
 private final class ClaudeWebSessionKeyRenewalTracker: @unchecked Sendable {

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -156,6 +156,7 @@ public enum ClaudeWebAPIFetcher {
         logger: ((String) -> Void)? = nil) async throws -> WebUsageData
     {
         let log: (String) -> Void = { msg in logger?("[claude-web] \(msg)") }
+        var expectedCachedEntry: CookieHeaderCache.Entry?
 
         if let cached = CookieHeaderCache.load(provider: .claude),
            !cached.cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -163,14 +164,14 @@ public enum ClaudeWebAPIFetcher {
             log("Using cached cookie header from \(cached.sourceLabel)")
             do {
                 return try await self.fetchUsageAndRenewCache(
-                    cookieHeader: cached.cookieHeader,
-                    sourceLabel: cached.sourceLabel,
+                    cachedEntry: cached,
                     targetOrganizationID: targetOrganizationID,
                     logger: log)
             } catch let error as FetchError {
                 switch error {
                 case .unauthorized, .noSessionKeyFound, .invalidSessionKey:
-                    CookieHeaderCache.clear(provider: .claude)
+                    let cleared = CookieHeaderCache.clearIfCurrent(provider: .claude, expected: cached)
+                    expectedCachedEntry = cleared ? nil : cached
                 default:
                     throw error
                 }
@@ -186,7 +187,8 @@ public enum ClaudeWebAPIFetcher {
             using: sessionInfo,
             targetOrganizationID: targetOrganizationID,
             logger: log,
-            cacheSourceLabel: sessionInfo.sourceLabel)
+            cacheSourceLabel: sessionInfo.sourceLabel,
+            expectedCachedEntry: expectedCachedEntry)
     }
 
     public static func fetchUsage(
@@ -212,28 +214,30 @@ public enum ClaudeWebAPIFetcher {
             using: sessionKeyInfo,
             targetOrganizationID: targetOrganizationID,
             logger: logger,
-            cacheSourceLabel: nil)
+            cacheSourceLabel: nil,
+            expectedCachedEntry: nil)
     }
 
     private static func fetchUsageAndRenewCache(
-        cookieHeader: String,
-        sourceLabel: String,
+        cachedEntry: CookieHeaderCache.Entry,
         targetOrganizationID: String?,
         logger: ((String) -> Void)? = nil) async throws -> WebUsageData
     {
-        let sessionInfo = try self.sessionKeyInfo(cookieHeader: cookieHeader)
+        let sessionInfo = try self.sessionKeyInfo(cookieHeader: cachedEntry.cookieHeader)
         return try await self.fetchUsage(
             using: sessionInfo,
             targetOrganizationID: targetOrganizationID,
             logger: logger,
-            cacheSourceLabel: sourceLabel)
+            cacheSourceLabel: cachedEntry.sourceLabel,
+            expectedCachedEntry: cachedEntry)
     }
 
     private static func fetchUsage(
         using sessionKeyInfo: SessionKeyInfo,
         targetOrganizationID: String?,
         logger: ((String) -> Void)?,
-        cacheSourceLabel: String?) async throws -> WebUsageData
+        cacheSourceLabel: String?,
+        expectedCachedEntry: CookieHeaderCache.Entry?) async throws -> WebUsageData
     {
         let log: (String) -> Void = { msg in logger?(msg) }
         let sessionKey = sessionKeyInfo.key
@@ -305,12 +309,13 @@ public enum ClaudeWebAPIFetcher {
         }
         if let cacheSourceLabel {
             let renewedCookieHeader = renewalTracker.renewedCookieHeader
-            CookieHeaderCache.store(
+            let stored = CookieHeaderCache.storeIfCurrent(
                 provider: .claude,
+                expected: expectedCachedEntry,
                 cookieHeader: renewedCookieHeader ?? "sessionKey=\(sessionKey)",
                 sourceLabel: cacheSourceLabel)
             if renewedCookieHeader != nil {
-                log("Stored renewed Claude session key from Set-Cookie")
+                log(stored ? "Stored renewed Claude session key" : "Skipped renewal because the cache changed")
             }
         }
         return usage

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -33,6 +33,68 @@ enum ClaudeWebSessionKeyImport {
     }
 }
 
+private actor ClaudeWebBrowserFetchGate {
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    private var ownerID: UUID?
+    private var waiters: [Waiter] = []
+
+    func acquire(id: UUID) async -> Bool {
+        if Task.isCancelled { return false }
+        guard self.ownerID != nil else {
+            self.ownerID = id
+            return true
+        }
+        return await withCheckedContinuation { continuation in
+            self.waiters.append(Waiter(id: id, continuation: continuation))
+        }
+    }
+
+    func cancel(id: UUID) {
+        if self.ownerID == id { return }
+        guard let index = self.waiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = self.waiters.remove(at: index)
+        waiter.continuation.resume(returning: false)
+    }
+
+    func release(id: UUID) {
+        guard self.ownerID == id else { return }
+        guard !self.waiters.isEmpty else {
+            self.ownerID = nil
+            return
+        }
+        let waiter = self.waiters.removeFirst()
+        self.ownerID = waiter.id
+        waiter.continuation.resume(returning: true)
+    }
+}
+
+private enum ClaudeWebBrowserFetchSerialization {
+    private static let gate = ClaudeWebBrowserFetchGate()
+
+    static func run<T>(_ operation: () async throws -> T) async throws -> T {
+        let id = UUID()
+        let acquired = await withTaskCancellationHandler {
+            await self.gate.acquire(id: id)
+        } onCancel: {
+            Task { await self.gate.cancel(id: id) }
+        }
+        guard acquired else { throw CancellationError() }
+        do {
+            try Task.checkCancellation()
+            let value = try await operation()
+            await self.gate.release(id: id)
+            return value
+        } catch {
+            await self.gate.release(id: id)
+            throw error
+        }
+    }
+}
+
 /// Fetches Claude usage data directly from the claude.ai API using browser session cookies.
 ///
 /// This approach mirrors what Claude Usage Tracker does, but automatically extracts the session key
@@ -169,41 +231,12 @@ public enum ClaudeWebAPIFetcher {
         targetOrganizationID: String? = nil,
         logger: ((String) -> Void)? = nil) async throws -> WebUsageData
     {
-        let log: (String) -> Void = { msg in logger?("[claude-web] \(msg)") }
-        var cacheObservation = CookieHeaderCache.observeForConditionalMutation(provider: .claude)
-
-        if let cached = cacheObservation.entry,
-           !cached.cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        {
-            log("Using cached cookie header from \(cached.sourceLabel)")
-            do {
-                return try await self.fetchUsageAndRenewCache(
-                    cachedEntry: cached,
-                    targetOrganizationID: targetOrganizationID,
-                    logger: log)
-            } catch let error as FetchError {
-                switch error {
-                case .unauthorized, .noSessionKeyFound, .invalidSessionKey:
-                    let cleared = CookieHeaderCache.clearIfCurrent(provider: .claude, expected: cached)
-                    cacheObservation = .authoritative(cleared ? nil : cached)
-                default:
-                    throw error
-                }
-            } catch {
-                throw error
-            }
+        try await ClaudeWebBrowserFetchSerialization.run {
+            try await self.fetchUsageSerialized(
+                browserDetection: browserDetection,
+                targetOrganizationID: targetOrganizationID,
+                logger: logger)
         }
-
-        let sessionInfo = try extractSessionKeyInfo(browserDetection: browserDetection, logger: log)
-        log("Found session key (\(sessionInfo.cookieCount) cookies)")
-
-        return try await self.fetchUsage(
-            using: sessionInfo,
-            targetOrganizationID: targetOrganizationID,
-            logger: log,
-            cacheSourceLabel: sessionInfo.sourceLabel,
-            expectedCacheObservation: cacheObservation,
-            persistInitialSessionKey: true)
     }
 
     public static func fetchUsage(
@@ -1158,6 +1191,52 @@ private enum ClaudeWebExtraUsageCost {
         }
     }
 }
+
+#if os(macOS)
+extension ClaudeWebAPIFetcher {
+    fileprivate static func fetchUsageSerialized(
+        browserDetection: BrowserDetection,
+        targetOrganizationID: String?,
+        logger: ((String) -> Void)?) async throws -> WebUsageData
+    {
+        let log: (String) -> Void = { msg in logger?("[claude-web] \(msg)") }
+        var cacheObservation = CookieHeaderCache.observeForConditionalMutation(provider: .claude)
+
+        if let cached = cacheObservation.entry,
+           !cached.cookieHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            log("Using cached cookie header from \(cached.sourceLabel)")
+            do {
+                return try await self.fetchUsageAndRenewCache(
+                    cachedEntry: cached,
+                    targetOrganizationID: targetOrganizationID,
+                    logger: log)
+            } catch let error as FetchError {
+                switch error {
+                case .unauthorized, .noSessionKeyFound, .invalidSessionKey:
+                    let cleared = CookieHeaderCache.clearIfCurrent(provider: .claude, expected: cached)
+                    cacheObservation = .authoritative(cleared ? nil : cached)
+                default:
+                    throw error
+                }
+            } catch {
+                throw error
+            }
+        }
+
+        let sessionInfo = try extractSessionKeyInfo(browserDetection: browserDetection, logger: log)
+        log("Found session key (\(sessionInfo.cookieCount) cookies)")
+
+        return try await self.fetchUsage(
+            using: sessionInfo,
+            targetOrganizationID: targetOrganizationID,
+            logger: log,
+            cacheSourceLabel: sessionInfo.sourceLabel,
+            expectedCacheObservation: cacheObservation,
+            persistInitialSessionKey: true)
+    }
+}
+#endif
 
 private struct ClaudeWebOrganizationResponse: Decodable {
     let uuid: String

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -19,6 +19,20 @@ enum ClaudeWebHTTPTransport {
     }
 }
 
+enum ClaudeWebSessionKeyImport {
+    #if DEBUG
+    @TaskLocal static var overrideForTesting: ClaudeWebAPIFetcher.SessionKeyInfo?
+    #endif
+
+    static var currentOverride: ClaudeWebAPIFetcher.SessionKeyInfo? {
+        #if DEBUG
+        self.overrideForTesting
+        #else
+        nil
+        #endif
+    }
+}
+
 /// Fetches Claude usage data directly from the claude.ai API using browser session cookies.
 ///
 /// This approach mirrors what Claude Usage Tracker does, but automatically extracts the session key
@@ -188,7 +202,8 @@ public enum ClaudeWebAPIFetcher {
             targetOrganizationID: targetOrganizationID,
             logger: log,
             cacheSourceLabel: sessionInfo.sourceLabel,
-            expectedCachedEntry: expectedCachedEntry)
+            expectedCachedEntry: expectedCachedEntry,
+            persistInitialSessionKey: true)
     }
 
     public static func fetchUsage(
@@ -237,7 +252,8 @@ public enum ClaudeWebAPIFetcher {
         targetOrganizationID: String?,
         logger: ((String) -> Void)?,
         cacheSourceLabel: String?,
-        expectedCachedEntry: CookieHeaderCache.Entry?) async throws -> WebUsageData
+        expectedCachedEntry: CookieHeaderCache.Entry?,
+        persistInitialSessionKey: Bool = false) async throws -> WebUsageData
     {
         let log: (String) -> Void = { msg in logger?(msg) }
         let sessionKey = sessionKeyInfo.key
@@ -309,10 +325,10 @@ public enum ClaudeWebAPIFetcher {
         }
         if let cacheSourceLabel {
             self.persistSessionKeyIfNeeded(
-                initialSessionKey: sessionKey,
+                source: (sessionKey, cacheSourceLabel),
                 renewedCookieHeader: renewalTracker.renewedCookieHeader,
-                sourceLabel: cacheSourceLabel,
                 expectedCachedEntry: expectedCachedEntry,
+                persistInitialSessionKey: persistInitialSessionKey,
                 logger: log)
         }
         return usage
@@ -433,6 +449,7 @@ public enum ClaudeWebAPIFetcher {
         browserDetection: BrowserDetection,
         logger: ((String) -> Void)? = nil) throws -> SessionKeyInfo
     {
+        if let override = ClaudeWebSessionKeyImport.currentOverride { return override }
         let log: (String) -> Void = { msg in logger?(msg) }
 
         let cookieDomains = ["claude.ai"]
@@ -944,19 +961,19 @@ public enum ClaudeWebAPIFetcher {
 
 extension ClaudeWebAPIFetcher {
     private static func persistSessionKeyIfNeeded(
-        initialSessionKey: String,
+        source: (initialSessionKey: String, label: String),
         renewedCookieHeader: String?,
-        sourceLabel: String,
         expectedCachedEntry: CookieHeaderCache.Entry?,
+        persistInitialSessionKey: Bool,
         logger: (String) -> Void)
     {
-        let importedCookieHeader = expectedCachedEntry == nil ? "sessionKey=\(initialSessionKey)" : nil
+        let importedCookieHeader = persistInitialSessionKey ? "sessionKey=\(source.initialSessionKey)" : nil
         guard let cookieHeader = renewedCookieHeader ?? importedCookieHeader else { return }
         let stored = CookieHeaderCache.storeIfCurrent(
             provider: .claude,
             expected: expectedCachedEntry,
             cookieHeader: cookieHeader,
-            sourceLabel: sourceLabel)
+            sourceLabel: source.label)
         if renewedCookieHeader != nil {
             logger(stored ? "Stored renewed Claude session key" : "Skipped renewal because the cache changed")
         }

--- a/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Claude/ClaudeWeb/ClaudeWebAPIFetcher.swift
@@ -975,17 +975,16 @@ private final class ClaudeWebSessionKeyRenewalTracker: @unchecked Sendable {
     }
 
     private static func sessionKey(fromSetCookieHeaders fields: [AnyHashable: Any]) -> String? {
-        for (key, value) in fields {
-            guard String(describing: key).caseInsensitiveCompare("Set-Cookie") == .orderedSame else {
-                continue
-            }
-            for header in self.setCookieHeaderValues(from: value) {
-                if let sessionKey = self.sessionKey(fromSetCookieHeader: header) {
-                    return sessionKey
-                }
-            }
+        guard let value = fields.first(where: {
+            String(describing: $0.key).caseInsensitiveCompare("Set-Cookie") == .orderedSame
+        })?.value else {
+            return nil
         }
-        return nil
+        var latestSessionKey: String?
+        for header in self.setCookieHeaderValues(from: value) {
+            latestSessionKey = self.sessionKey(fromSetCookieHeader: header) ?? latestSessionKey
+        }
+        return latestSessionKey
     }
 
     private static func setCookieHeaderValues(from value: Any) -> [String] {
@@ -1002,14 +1001,19 @@ private final class ClaudeWebSessionKeyRenewalTracker: @unchecked Sendable {
         let pattern = #"(?i)(?:^|[,\r\n])\s*sessionKey=([^;,\r\n]+)"#
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
         let range = NSRange(header.startIndex..<header.endIndex, in: header)
-        guard let match = regex.firstMatch(in: header, range: range),
-              match.numberOfRanges >= 2,
-              let valueRange = Range(match.range(at: 1), in: header)
-        else {
-            return nil
+        var latestSessionKey: String?
+        for match in regex.matches(in: header, range: range) {
+            guard match.numberOfRanges >= 2,
+                  let valueRange = Range(match.range(at: 1), in: header)
+            else {
+                continue
+            }
+            let value = String(header[valueRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if value.hasPrefix("sk-ant-") {
+                latestSessionKey = value
+            }
         }
-        let value = String(header[valueRange]).trimmingCharacters(in: .whitespacesAndNewlines)
-        return value.hasPrefix("sk-ant-") ? value : nil
+        return latestSessionKey
     }
 }
 

--- a/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
@@ -190,9 +190,13 @@ struct ClaudeWebCookieRenewalTests {
         "sessionKey=sk-ant-renewed-token; Path=/; HttpOnly; Secure; SameSite=Lax"
 
     private func withIsolatedCookieCache<T>(_ operation: () async throws -> T) async rethrows -> T {
-        try await KeychainCacheStore.withServiceOverrideForTesting("claude-web-renewal-\(UUID().uuidString)") {
+        let legacyBase = FileManager.default.temporaryDirectory
+            .appendingPathComponent("claude-web-renewal-\(UUID().uuidString)", isDirectory: true)
+        return try await KeychainCacheStore.withServiceOverrideForTesting("claude-web-renewal-\(UUID().uuidString)") {
             KeychainCacheStore.setTestStoreForTesting(true)
             defer { KeychainCacheStore.setTestStoreForTesting(false) }
+            CookieHeaderCache.setLegacyBaseURLOverrideForTesting(legacyBase)
+            defer { CookieHeaderCache.setLegacyBaseURLOverrideForTesting(nil) }
             CookieHeaderCache.resetDisplayCacheForTesting()
             defer { CookieHeaderCache.resetDisplayCacheForTesting() }
             return try await operation()

--- a/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
@@ -33,6 +33,34 @@ struct ClaudeWebCookieRenewalTests {
     }
 
     @Test
+    func `cached fetch without renewal does not block concurrent renewal`() async throws {
+        try await self.withIsolatedCookieCache {
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-old-token",
+                sourceLabel: "Chrome",
+                now: Date(timeIntervalSince1970: 1))
+            defer { CookieHeaderCache.clear(provider: .claude) }
+            let initial = try #require(CookieHeaderCache.load(provider: .claude))
+
+            try await self.withClaudeWebStub { request in
+                try Self.response(for: request, setCookie: nil)
+            } operation: {
+                _ = try await ClaudeWebAPIFetcher.fetchUsage(browserDetection: BrowserDetection(cacheTTL: 0))
+            }
+
+            let renewed = CookieHeaderCache.storeIfCurrent(
+                provider: .claude,
+                expected: initial,
+                cookieHeader: "sessionKey=sk-ant-concurrent-renewal",
+                sourceLabel: "Chrome")
+            #expect(renewed)
+            #expect(CookieHeaderCache.load(provider: .claude)?.cookieHeader ==
+                "sessionKey=sk-ant-concurrent-renewal")
+        }
+    }
+
+    @Test
     func `manual web session fetch does not rewrite cached cookie`() async throws {
         try await self.withIsolatedCookieCache {
             CookieHeaderCache.store(

--- a/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
@@ -193,13 +193,13 @@ struct ClaudeWebCookieRenewalTests {
         let legacyBase = FileManager.default.temporaryDirectory
             .appendingPathComponent("claude-web-renewal-\(UUID().uuidString)", isDirectory: true)
         return try await KeychainCacheStore.withServiceOverrideForTesting("claude-web-renewal-\(UUID().uuidString)") {
-            KeychainCacheStore.setTestStoreForTesting(true)
-            defer { KeychainCacheStore.setTestStoreForTesting(false) }
-            CookieHeaderCache.setLegacyBaseURLOverrideForTesting(legacyBase)
-            defer { CookieHeaderCache.setLegacyBaseURLOverrideForTesting(nil) }
-            CookieHeaderCache.resetDisplayCacheForTesting()
-            defer { CookieHeaderCache.resetDisplayCacheForTesting() }
-            return try await operation()
+            try await CookieHeaderCache.withLegacyBaseURLOverrideForTesting(legacyBase) {
+                KeychainCacheStore.setTestStoreForTesting(true)
+                defer { KeychainCacheStore.setTestStoreForTesting(false) }
+                CookieHeaderCache.resetDisplayCacheForTesting()
+                defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+                return try await operation()
+            }
         }
     }
 

--- a/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
@@ -61,6 +61,46 @@ struct ClaudeWebCookieRenewalTests {
     }
 
     @Test
+    func `browser fallback replaces stale cache when conditional clear fails`() async throws {
+        try await self.withIsolatedCookieCache {
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-stale-token",
+                sourceLabel: "Chrome")
+            defer { CookieHeaderCache.clear(provider: .claude) }
+            let imported = ClaudeWebAPIFetcher.SessionKeyInfo(
+                key: "sk-ant-imported-token",
+                sourceLabel: "Safari",
+                cookieCount: 1)
+
+            try await KeychainCacheStore.withClearFailureStatusOverrideForTesting(errSecInteractionNotAllowed) {
+                try await ClaudeWebSessionKeyImport.$overrideForTesting.withValue(imported) {
+                    try await self.withClaudeWebStub { request in
+                        let isStale = request.value(forHTTPHeaderField: "Cookie") ==
+                            "sessionKey=sk-ant-stale-token"
+                        if request.url?.path == "/api/organizations", isStale {
+                            let url = try #require(request.url)
+                            return Self.jsonResponse(
+                                url: url,
+                                body: "{}",
+                                statusCode: 401,
+                                setCookie: nil)
+                        }
+                        return try Self.response(for: request, setCookie: nil)
+                    } operation: {
+                        _ = try await ClaudeWebAPIFetcher.fetchUsage(
+                            browserDetection: BrowserDetection(cacheTTL: 0))
+                    }
+                }
+            }
+
+            let cached = try #require(CookieHeaderCache.load(provider: .claude))
+            #expect(cached.cookieHeader == "sessionKey=sk-ant-imported-token")
+            #expect(cached.sourceLabel == "Safari")
+        }
+    }
+
+    @Test
     func `manual web session fetch does not rewrite cached cookie`() async throws {
         try await self.withIsolatedCookieCache {
             CookieHeaderCache.store(

--- a/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
@@ -98,6 +98,52 @@ struct ClaudeWebCookieRenewalTests {
         }
     }
 
+    @Test
+    func `renewal can return to initial session key`() async throws {
+        try await self.withIsolatedCookieCache {
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-initial-token",
+                sourceLabel: "Chrome")
+            defer { CookieHeaderCache.clear(provider: .claude) }
+            let usageCookies = RequestHeaderLog()
+            let overageCookies = RequestHeaderLog()
+            let accountCookies = RequestHeaderLog()
+
+            try await self.withClaudeWebStub { request in
+                let path = request.url?.path
+                switch path {
+                case "/api/organizations/org-123/usage":
+                    usageCookies.append(request.value(forHTTPHeaderField: "Cookie"))
+                case "/api/organizations/org-123/overage_spend_limit":
+                    overageCookies.append(request.value(forHTTPHeaderField: "Cookie"))
+                case "/api/account":
+                    accountCookies.append(request.value(forHTTPHeaderField: "Cookie"))
+                default:
+                    break
+                }
+                let setCookie: String? = switch path {
+                case "/api/organizations":
+                    "sessionKey=sk-ant-intermediate-token; Path=/; HttpOnly"
+                case "/api/organizations/org-123/usage":
+                    "sessionKey=sk-ant-initial-token; Path=/; HttpOnly"
+                default:
+                    nil
+                }
+                return try Self.response(for: request, setCookie: setCookie)
+            } operation: {
+                _ = try await ClaudeWebAPIFetcher.fetchUsage(browserDetection: BrowserDetection(cacheTTL: 0))
+
+                #expect(usageCookies.values == ["sessionKey=sk-ant-intermediate-token"])
+                #expect(overageCookies.values == ["sessionKey=sk-ant-initial-token"])
+                #expect(accountCookies.values == ["sessionKey=sk-ant-initial-token"])
+                let cached = try #require(CookieHeaderCache.load(provider: .claude))
+                #expect(cached.cookieHeader == "sessionKey=sk-ant-initial-token")
+                #expect(cached.sourceLabel == "Chrome")
+            }
+        }
+    }
+
     private static let renewedSessionCookie =
         "sessionKey=sk-ant-renewed-token; Path=/; HttpOnly; Secure; SameSite=Lax"
 

--- a/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
@@ -40,13 +40,18 @@ struct ClaudeWebCookieRenewalTests {
                 cookieHeader: "sessionKey=sk-ant-cache-token",
                 sourceLabel: "Chrome")
             defer { CookieHeaderCache.clear(provider: .claude) }
+            let usageCookies = RequestHeaderLog()
 
             try await self.withClaudeWebStub { request in
-                try Self.response(for: request, setCookie: Self.renewedSessionCookie)
+                if request.url?.path == "/api/organizations/org-123/usage" {
+                    usageCookies.append(request.value(forHTTPHeaderField: "Cookie"))
+                }
+                return try Self.response(for: request, setCookie: Self.renewedSessionCookie)
             } operation: {
                 let usage = try await ClaudeWebAPIFetcher.fetchUsage(cookieHeader: "sessionKey=sk-ant-manual-token")
 
                 #expect(usage.sessionPercentUsed == 11)
+                #expect(usageCookies.values == ["sessionKey=sk-ant-renewed-token"])
                 let cached = try #require(CookieHeaderCache.load(provider: .claude))
                 #expect(cached.cookieHeader == "sessionKey=sk-ant-cache-token")
                 #expect(cached.sourceLabel == "Chrome")

--- a/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct ClaudeWebCookieRenewalTests {
+    @Test
+    func `cached web session key renews from set cookie after successful fetch`() async throws {
+        try await self.withIsolatedCookieCache {
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-old-token",
+                sourceLabel: "Chrome")
+            defer { CookieHeaderCache.clear(provider: .claude) }
+            let usageCookies = RequestHeaderLog()
+
+            try await self.withClaudeWebStub { request in
+                if request.url?.path == "/api/organizations/org-123/usage" {
+                    usageCookies.append(request.value(forHTTPHeaderField: "Cookie"))
+                }
+                return try Self.response(for: request, setCookie: Self.renewedSessionCookie)
+            } operation: {
+                let usage = try await ClaudeWebAPIFetcher.fetchUsage(browserDetection: BrowserDetection(cacheTTL: 0))
+
+                #expect(usage.sessionPercentUsed == 11)
+                #expect(usage.weeklyPercentUsed == 22)
+                #expect(usageCookies.values == ["sessionKey=sk-ant-renewed-token"])
+                let cached = try #require(CookieHeaderCache.load(provider: .claude))
+                #expect(cached.cookieHeader == "sessionKey=sk-ant-renewed-token")
+                #expect(cached.sourceLabel == "Chrome")
+            }
+        }
+    }
+
+    @Test
+    func `manual web session fetch does not rewrite cached cookie`() async throws {
+        try await self.withIsolatedCookieCache {
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-cache-token",
+                sourceLabel: "Chrome")
+            defer { CookieHeaderCache.clear(provider: .claude) }
+
+            try await self.withClaudeWebStub { request in
+                try Self.response(for: request, setCookie: Self.renewedSessionCookie)
+            } operation: {
+                let usage = try await ClaudeWebAPIFetcher.fetchUsage(cookieHeader: "sessionKey=sk-ant-manual-token")
+
+                #expect(usage.sessionPercentUsed == 11)
+                let cached = try #require(CookieHeaderCache.load(provider: .claude))
+                #expect(cached.cookieHeader == "sessionKey=sk-ant-cache-token")
+                #expect(cached.sourceLabel == "Chrome")
+            }
+        }
+    }
+
+    private static let renewedSessionCookie =
+        "sessionKey=sk-ant-renewed-token; Path=/; HttpOnly; Secure; SameSite=Lax"
+
+    private func withIsolatedCookieCache<T>(_ operation: () async throws -> T) async rethrows -> T {
+        try await KeychainCacheStore.withServiceOverrideForTesting("claude-web-renewal-\(UUID().uuidString)") {
+            KeychainCacheStore.setTestStoreForTesting(true)
+            defer { KeychainCacheStore.setTestStoreForTesting(false) }
+            CookieHeaderCache.resetDisplayCacheForTesting()
+            defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+            return try await operation()
+        }
+    }
+
+    private func withClaudeWebStub<T>(
+        handler: @escaping @Sendable (URLRequest) throws -> (HTTPURLResponse, Data),
+        operation: () async throws -> T) async rethrows -> T
+    {
+        let registered = URLProtocol.registerClass(ClaudeWebCookieRenewalStubURLProtocol.self)
+        ClaudeWebCookieRenewalStubURLProtocol.handler = handler
+        defer {
+            if registered {
+                URLProtocol.unregisterClass(ClaudeWebCookieRenewalStubURLProtocol.self)
+            }
+            ClaudeWebCookieRenewalStubURLProtocol.handler = nil
+        }
+        return try await operation()
+    }
+
+    private static func response(
+        for request: URLRequest,
+        setCookie: String) throws -> (HTTPURLResponse, Data)
+    {
+        let url = try #require(request.url)
+        switch url.path {
+        case "/api/organizations":
+            return self.jsonResponse(
+                url: url,
+                body: #"[{"uuid":"org-123","name":"Test Org","capabilities":["chat"]}]"#,
+                setCookie: setCookie)
+        case "/api/organizations/org-123/usage":
+            return self.jsonResponse(
+                url: url,
+                body: """
+                {
+                  "five_hour": { "utilization": 11 },
+                  "seven_day": { "utilization": 22 }
+                }
+                """,
+                setCookie: setCookie)
+        case "/api/account", "/api/organizations/org-123/overage_spend_limit":
+            return self.jsonResponse(url: url, body: "{}", statusCode: 404, setCookie: setCookie)
+        default:
+            return self.jsonResponse(url: url, body: "{}", statusCode: 404, setCookie: setCookie)
+        }
+    }
+
+    private static func jsonResponse(
+        url: URL,
+        body: String,
+        statusCode: Int = 200,
+        setCookie: String) -> (HTTPURLResponse, Data)
+    {
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: "HTTP/1.1",
+            headerFields: [
+                "Content-Type": "application/json",
+                "Set-Cookie": setCookie,
+            ])!
+        return (response, Data(body.utf8))
+    }
+}
+
+private final class ClaudeWebCookieRenewalStubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override static func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "claude.ai"
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        do {
+            let (response, data) = try handler(self.request)
+            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            self.client?.urlProtocol(self, didLoad: data)
+            self.client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            self.client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+private final class RequestHeaderLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String?] = []
+
+    var values: [String?] {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.storage
+    }
+
+    func append(_ value: String?) {
+        self.lock.lock()
+        self.storage.append(value)
+        self.lock.unlock()
+    }
+}

--- a/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
@@ -76,15 +76,13 @@ struct ClaudeWebCookieRenewalTests {
         handler: @escaping @Sendable (URLRequest) throws -> (HTTPURLResponse, Data),
         operation: () async throws -> T) async rethrows -> T
     {
-        let registered = URLProtocol.registerClass(ClaudeWebCookieRenewalStubURLProtocol.self)
-        ClaudeWebCookieRenewalStubURLProtocol.handler = handler
-        defer {
-            if registered {
-                URLProtocol.unregisterClass(ClaudeWebCookieRenewalStubURLProtocol.self)
-            }
-            ClaudeWebCookieRenewalStubURLProtocol.handler = nil
+        let transport = ProviderHTTPTransportHandler { request in
+            let (response, data) = try handler(request)
+            return (data, response)
         }
-        return try await operation()
+        return try await ClaudeWebHTTPTransport.$overrideForTesting.withValue(transport) {
+            try await operation()
+        }
     }
 
     private static func response(
@@ -131,35 +129,6 @@ struct ClaudeWebCookieRenewalTests {
             ])!
         return (response, Data(body.utf8))
     }
-}
-
-private final class ClaudeWebCookieRenewalStubURLProtocol: URLProtocol {
-    nonisolated(unsafe) static var handler: (@Sendable (URLRequest) throws -> (HTTPURLResponse, Data))?
-
-    override static func canInit(with request: URLRequest) -> Bool {
-        request.url?.host == "claude.ai"
-    }
-
-    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
-        request
-    }
-
-    override func startLoading() {
-        guard let handler = Self.handler else {
-            self.client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
-        }
-        do {
-            let (response, data) = try handler(self.request)
-            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            self.client?.urlProtocol(self, didLoad: data)
-            self.client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            self.client?.urlProtocol(self, didFailWithError: error)
-        }
-    }
-
-    override func stopLoading() {}
 }
 
 private final class RequestHeaderLog: @unchecked Sendable {

--- a/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
@@ -144,6 +144,48 @@ struct ClaudeWebCookieRenewalTests {
         }
     }
 
+    @Test
+    func `last session key assignment in one response wins`() async throws {
+        try await self.withIsolatedCookieCache {
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-old-token",
+                sourceLabel: "Chrome")
+            defer { CookieHeaderCache.clear(provider: .claude) }
+            let usageCookies = RequestHeaderLog()
+            let overageCookies = RequestHeaderLog()
+            let accountCookies = RequestHeaderLog()
+
+            try await self.withClaudeWebStub { request in
+                let path = request.url?.path
+                switch path {
+                case "/api/organizations/org-123/usage":
+                    usageCookies.append(request.value(forHTTPHeaderField: "Cookie"))
+                case "/api/organizations/org-123/overage_spend_limit":
+                    overageCookies.append(request.value(forHTTPHeaderField: "Cookie"))
+                case "/api/account":
+                    accountCookies.append(request.value(forHTTPHeaderField: "Cookie"))
+                default:
+                    break
+                }
+                let setCookie = path == "/api/organizations"
+                    ? "sessionKey=sk-ant-first-token; Expires=Wed, 21 Oct 2030 07:28:00 GMT; Path=/, "
+                    + "sessionKey=sk-ant-final-token; Path=/; HttpOnly"
+                    : nil
+                return try Self.response(for: request, setCookie: setCookie)
+            } operation: {
+                _ = try await ClaudeWebAPIFetcher.fetchUsage(browserDetection: BrowserDetection(cacheTTL: 0))
+
+                #expect(usageCookies.values == ["sessionKey=sk-ant-final-token"])
+                #expect(overageCookies.values == ["sessionKey=sk-ant-final-token"])
+                #expect(accountCookies.values == ["sessionKey=sk-ant-final-token"])
+                let cached = try #require(CookieHeaderCache.load(provider: .claude))
+                #expect(cached.cookieHeader == "sessionKey=sk-ant-final-token")
+                #expect(cached.sourceLabel == "Chrome")
+            }
+        }
+    }
+
     private static let renewedSessionCookie =
         "sessionKey=sk-ant-renewed-token; Path=/; HttpOnly; Secure; SameSite=Lax"
 

--- a/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
@@ -101,6 +101,104 @@ struct ClaudeWebCookieRenewalTests {
     }
 
     @Test
+    func `concurrent cached fetches serialize session key rotations`() async throws {
+        try await self.withIsolatedCookieCache {
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-initial-token",
+                sourceLabel: "Chrome")
+            defer { CookieHeaderCache.clear(provider: .claude) }
+            let probe = ConcurrentClaudeFetchProbe()
+            let transport = ProviderHTTPTransportHandler { request in
+                let setCookie: String? = if request.url?.path == "/api/organizations" {
+                    await probe.organizationSessionCookie(
+                        requestCookie: request.value(forHTTPHeaderField: "Cookie"))
+                } else {
+                    nil
+                }
+                let (response, data) = try Self.response(for: request, setCookie: setCookie)
+                return (data, response)
+            }
+
+            try await ClaudeWebHTTPTransport.$overrideForTesting.withValue(transport) {
+                let first = Task {
+                    try await ClaudeWebAPIFetcher.fetchUsage(browserDetection: BrowserDetection(cacheTTL: 0))
+                }
+                await probe.waitForOrganizationCount(1)
+                let second = Task {
+                    try await ClaudeWebAPIFetcher.fetchUsage(browserDetection: BrowserDetection(cacheTTL: 0))
+                }
+                for _ in 0..<20 {
+                    await Task.yield()
+                }
+                #expect(await probe.organizationRequestCount == 1)
+
+                await probe.releaseFirstRequest()
+                _ = try await first.value
+                _ = try await second.value
+            }
+
+            #expect(await probe.organizationRequestCookies == [
+                "sessionKey=sk-ant-initial-token",
+                "sessionKey=sk-ant-first-rotation",
+            ])
+            #expect(CookieHeaderCache.load(provider: .claude)?.cookieHeader ==
+                "sessionKey=sk-ant-second-rotation")
+        }
+    }
+
+    @Test
+    func `cancelled waiting fetch relinquishes the serialization gate`() async throws {
+        try await self.withIsolatedCookieCache {
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-initial-token",
+                sourceLabel: "Chrome")
+            defer { CookieHeaderCache.clear(provider: .claude) }
+            let probe = ConcurrentClaudeFetchProbe()
+            let transport = ProviderHTTPTransportHandler { request in
+                let setCookie: String? = if request.url?.path == "/api/organizations" {
+                    await probe.organizationSessionCookie(
+                        requestCookie: request.value(forHTTPHeaderField: "Cookie"))
+                } else {
+                    nil
+                }
+                let (response, data) = try Self.response(for: request, setCookie: setCookie)
+                return (data, response)
+            }
+
+            try await ClaudeWebHTTPTransport.$overrideForTesting.withValue(transport) {
+                let first = Task {
+                    try await ClaudeWebAPIFetcher.fetchUsage(browserDetection: BrowserDetection(cacheTTL: 0))
+                }
+                await probe.waitForOrganizationCount(1)
+                let cancelled = Task {
+                    try await ClaudeWebAPIFetcher.fetchUsage(browserDetection: BrowserDetection(cacheTTL: 0))
+                }
+                for _ in 0..<20 {
+                    await Task.yield()
+                }
+                cancelled.cancel()
+                await #expect(throws: CancellationError.self) {
+                    try await cancelled.value
+                }
+                #expect(await probe.organizationRequestCount == 1)
+
+                await probe.releaseFirstRequest()
+                _ = try await first.value
+                _ = try await ClaudeWebAPIFetcher.fetchUsage(browserDetection: BrowserDetection(cacheTTL: 0))
+            }
+
+            #expect(await probe.organizationRequestCookies == [
+                "sessionKey=sk-ant-initial-token",
+                "sessionKey=sk-ant-first-rotation",
+            ])
+            #expect(CookieHeaderCache.load(provider: .claude)?.cookieHeader ==
+                "sessionKey=sk-ant-second-rotation")
+        }
+    }
+
+    @Test
     func `manual web session fetch does not rewrite cached cookie`() async throws {
         try await self.withIsolatedCookieCache {
             CookieHeaderCache.store(
@@ -345,5 +443,49 @@ private final class RequestHeaderLog: @unchecked Sendable {
         self.lock.lock()
         self.storage.append(value)
         self.lock.unlock()
+    }
+}
+
+private actor ConcurrentClaudeFetchProbe {
+    private var requestCookies: [String?] = []
+    private var organizationCountWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var firstRequestReleased = false
+    private var firstRequestReleaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    var organizationRequestCount: Int {
+        self.requestCookies.count
+    }
+
+    var organizationRequestCookies: [String?] {
+        self.requestCookies
+    }
+
+    func organizationSessionCookie(requestCookie: String?) async -> String {
+        self.requestCookies.append(requestCookie)
+        let ordinal = self.requestCookies.count
+        let readyWaiters = self.organizationCountWaiters.filter { $0.0 <= ordinal }
+        self.organizationCountWaiters.removeAll { $0.0 <= ordinal }
+        readyWaiters.forEach { $0.1.resume() }
+        if ordinal == 1, !self.firstRequestReleased {
+            await withCheckedContinuation { continuation in
+                self.firstRequestReleaseWaiters.append(continuation)
+            }
+        }
+        let value = ordinal == 1 ? "sk-ant-first-rotation" : "sk-ant-second-rotation"
+        return "sessionKey=\(value); Path=/; HttpOnly"
+    }
+
+    func waitForOrganizationCount(_ count: Int) async {
+        if self.requestCookies.count >= count { return }
+        await withCheckedContinuation { continuation in
+            self.organizationCountWaiters.append((count, continuation))
+        }
+    }
+
+    func releaseFirstRequest() {
+        self.firstRequestReleased = true
+        let waiters = self.firstRequestReleaseWaiters
+        self.firstRequestReleaseWaiters.removeAll()
+        waiters.forEach { $0.resume() }
     }
 }

--- a/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
+++ b/Tests/CodexBarTests/ClaudeWebCookieRenewalTests.swift
@@ -59,6 +59,45 @@ struct ClaudeWebCookieRenewalTests {
         }
     }
 
+    @Test
+    func `usage response renewal propagates to later requests and cache`() async throws {
+        try await self.withIsolatedCookieCache {
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-old-token",
+                sourceLabel: "Chrome")
+            defer { CookieHeaderCache.clear(provider: .claude) }
+            let usageCookies = RequestHeaderLog()
+            let overageCookies = RequestHeaderLog()
+            let accountCookies = RequestHeaderLog()
+
+            try await self.withClaudeWebStub { request in
+                let path = request.url?.path
+                switch path {
+                case "/api/organizations/org-123/usage":
+                    usageCookies.append(request.value(forHTTPHeaderField: "Cookie"))
+                case "/api/organizations/org-123/overage_spend_limit":
+                    overageCookies.append(request.value(forHTTPHeaderField: "Cookie"))
+                case "/api/account":
+                    accountCookies.append(request.value(forHTTPHeaderField: "Cookie"))
+                default:
+                    break
+                }
+                return try Self.response(
+                    for: request,
+                    setCookie: path == "/api/organizations/org-123/usage" ? Self.renewedSessionCookie : nil)
+            } operation: {
+                _ = try await ClaudeWebAPIFetcher.fetchUsage(browserDetection: BrowserDetection(cacheTTL: 0))
+
+                #expect(usageCookies.values == ["sessionKey=sk-ant-old-token"])
+                #expect(overageCookies.values == ["sessionKey=sk-ant-renewed-token"])
+                #expect(accountCookies.values == ["sessionKey=sk-ant-renewed-token"])
+                let cached = try #require(CookieHeaderCache.load(provider: .claude))
+                #expect(cached.cookieHeader == "sessionKey=sk-ant-renewed-token")
+            }
+        }
+    }
+
     private static let renewedSessionCookie =
         "sessionKey=sk-ant-renewed-token; Path=/; HttpOnly; Secure; SameSite=Lax"
 
@@ -87,7 +126,7 @@ struct ClaudeWebCookieRenewalTests {
 
     private static func response(
         for request: URLRequest,
-        setCookie: String) throws -> (HTTPURLResponse, Data)
+        setCookie: String?) throws -> (HTTPURLResponse, Data)
     {
         let url = try #require(request.url)
         switch url.path {
@@ -117,16 +156,17 @@ struct ClaudeWebCookieRenewalTests {
         url: URL,
         body: String,
         statusCode: Int = 200,
-        setCookie: String) -> (HTTPURLResponse, Data)
+        setCookie: String?) -> (HTTPURLResponse, Data)
     {
+        var headerFields = ["Content-Type": "application/json"]
+        if let setCookie {
+            headerFields["Set-Cookie"] = setCookie
+        }
         let response = HTTPURLResponse(
             url: url,
             statusCode: statusCode,
             httpVersion: "HTTP/1.1",
-            headerFields: [
-                "Content-Type": "application/json",
-                "Set-Cookie": setCookie,
-            ])!
+            headerFields: headerFields)!
         return (response, Data(body.utf8))
     }
 }

--- a/Tests/CodexBarTests/CookieHeaderCacheConditionalMutationTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheConditionalMutationTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct CookieHeaderCacheConditionalMutationTests {
+    @Test
+    func `legacy clear failure still permits replacing the keychain entry`() {
+        self.withIsolatedCookieCache {
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-stale",
+                sourceLabel: "Chrome")
+            let stale = CookieHeaderCache.load(provider: .claude)
+            #expect(stale != nil)
+            guard let stale else { return }
+
+            CookieHeaderCache.store(
+                CookieHeaderCache.Entry(
+                    cookieHeader: "sessionKey=sk-ant-legacy",
+                    storedAt: Date(timeIntervalSince1970: 1),
+                    sourceLabel: "Legacy"),
+                to: CookieHeaderCache.legacyURLForTesting(provider: .claude))
+
+            let cleared = CookieHeaderCache.withLegacyRemovalFailureForTesting {
+                CookieHeaderCache.clearIfCurrent(provider: .claude, expected: stale)
+            }
+            let replaced = CookieHeaderCache.storeIfCurrent(
+                provider: .claude,
+                expected: stale,
+                cookieHeader: "sessionKey=sk-ant-fresh",
+                sourceLabel: "Safari")
+
+            #expect(!cleared)
+            #expect(replaced)
+            #expect(CookieHeaderCache.load(provider: .claude)?.cookieHeader == "sessionKey=sk-ant-fresh")
+            #expect(!CookieHeaderCache.hasLegacyEntryForTesting(provider: .claude))
+        }
+    }
+
+    private func withIsolatedCookieCache<T>(_ operation: () -> T) -> T {
+        KeychainCacheStore.withServiceOverrideForTesting("cookie-conditional-\(UUID().uuidString)") {
+            let legacyBase = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            CookieHeaderCache.setLegacyBaseURLOverrideForTesting(legacyBase)
+            defer { CookieHeaderCache.setLegacyBaseURLOverrideForTesting(nil) }
+            KeychainCacheStore.setTestStoreForTesting(true)
+            defer { KeychainCacheStore.setTestStoreForTesting(false) }
+            CookieHeaderCache.resetDisplayCacheForTesting()
+            defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+            return operation()
+        }
+    }
+}

--- a/Tests/CodexBarTests/CookieHeaderCacheConditionalMutationTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheConditionalMutationTests.swift
@@ -4,6 +4,55 @@ import Testing
 
 @Suite(.serialized)
 struct CookieHeaderCacheConditionalMutationTests {
+    #if os(macOS)
+    @Test
+    func `temporary keychain read permits fresh replacement when legacy state is unchanged`() {
+        self.withIsolatedCookieCache {
+            let legacy = CookieHeaderCache.Entry(
+                cookieHeader: "sessionKey=sk-ant-legacy",
+                storedAt: Date(timeIntervalSince1970: 1),
+                sourceLabel: "Legacy")
+            CookieHeaderCache.store(legacy, to: CookieHeaderCache.legacyURLForTesting(provider: .claude))
+
+            let observation = KeychainCacheStore.withLoadFailureStatusOverrideForTesting(errSecInteractionNotAllowed) {
+                CookieHeaderCache.observeForConditionalMutation(provider: .claude)
+            }
+            let replaced = CookieHeaderCache.storeIfObservationCurrent(
+                provider: .claude,
+                expected: observation,
+                cookieHeader: "sessionKey=sk-ant-fresh",
+                sourceLabel: "Safari")
+
+            #expect(observation.entry == nil)
+            #expect(replaced)
+            #expect(CookieHeaderCache.load(provider: .claude)?.cookieHeader == "sessionKey=sk-ant-fresh")
+            #expect(!CookieHeaderCache.hasLegacyEntryForTesting(provider: .claude))
+        }
+    }
+
+    @Test
+    func `temporary keychain read does not overwrite a concurrent keychain entry`() {
+        self.withIsolatedCookieCache {
+            let observation = KeychainCacheStore.withLoadFailureStatusOverrideForTesting(errSecInteractionNotAllowed) {
+                CookieHeaderCache.observeForConditionalMutation(provider: .claude)
+            }
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-concurrent",
+                sourceLabel: "Chrome")
+
+            let replaced = CookieHeaderCache.storeIfObservationCurrent(
+                provider: .claude,
+                expected: observation,
+                cookieHeader: "sessionKey=sk-ant-fresh",
+                sourceLabel: "Safari")
+
+            #expect(!replaced)
+            #expect(CookieHeaderCache.load(provider: .claude)?.cookieHeader == "sessionKey=sk-ant-concurrent")
+        }
+    }
+    #endif
+
     @Test
     func `legacy clear failure still permits replacing the keychain entry`() {
         self.withIsolatedCookieCache {
@@ -42,13 +91,11 @@ struct CookieHeaderCacheConditionalMutationTests {
         KeychainCacheStore.withServiceOverrideForTesting("cookie-conditional-\(UUID().uuidString)") {
             let legacyBase = FileManager.default.temporaryDirectory
                 .appendingPathComponent(UUID().uuidString, isDirectory: true)
-            CookieHeaderCache.setLegacyBaseURLOverrideForTesting(legacyBase)
-            defer { CookieHeaderCache.setLegacyBaseURLOverrideForTesting(nil) }
-            KeychainCacheStore.setTestStoreForTesting(true)
-            defer { KeychainCacheStore.setTestStoreForTesting(false) }
-            CookieHeaderCache.resetDisplayCacheForTesting()
-            defer { CookieHeaderCache.resetDisplayCacheForTesting() }
-            return operation()
+            return CookieHeaderCache.withLegacyBaseURLOverrideForTesting(legacyBase) {
+                KeychainCacheStore.setTestStoreForTesting(true)
+                defer { KeychainCacheStore.setTestStoreForTesting(false) }
+                return operation()
+            }
         }
     }
 }

--- a/Tests/CodexBarTests/CookieHeaderCacheTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheTests.swift
@@ -30,6 +30,90 @@ struct CookieHeaderCacheTests {
     }
 
     @Test
+    func `conditional mutation does not overwrite or clear a newer entry`() {
+        self.withIsolatedCookieCache {
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-initial",
+                sourceLabel: "Chrome")
+            let loaded = CookieHeaderCache.load(provider: .claude)
+            #expect(loaded != nil)
+            guard let initial = loaded else { return }
+
+            let renewed = CookieHeaderCache.storeIfCurrent(
+                provider: .claude,
+                expected: initial,
+                cookieHeader: "sessionKey=sk-ant-newer",
+                sourceLabel: "Chrome")
+            let staleStore = CookieHeaderCache.storeIfCurrent(
+                provider: .claude,
+                expected: initial,
+                cookieHeader: "sessionKey=sk-ant-older",
+                sourceLabel: "Chrome")
+            let staleClear = CookieHeaderCache.clearIfCurrent(provider: .claude, expected: initial)
+
+            #expect(renewed)
+            #expect(!staleStore)
+            #expect(!staleClear)
+            #expect(CookieHeaderCache.load(provider: .claude)?.cookieHeader == "sessionKey=sk-ant-newer")
+        }
+    }
+
+    @Test
+    func `conditional clear failure still permits replacing the same entry`() {
+        self.withIsolatedCookieCache {
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-stale",
+                sourceLabel: "Chrome")
+            let loaded = CookieHeaderCache.load(provider: .claude)
+            #expect(loaded != nil)
+            guard let stale = loaded else { return }
+
+            let cleared = KeychainCacheStore.withClearFailureStatusOverrideForTesting(errSecInteractionNotAllowed) {
+                CookieHeaderCache.clearIfCurrent(provider: .claude, expected: stale)
+            }
+            let replaced = CookieHeaderCache.storeIfCurrent(
+                provider: .claude,
+                expected: stale,
+                cookieHeader: "sessionKey=sk-ant-fresh",
+                sourceLabel: "Safari")
+
+            #expect(!cleared)
+            #expect(replaced)
+            #expect(CookieHeaderCache.load(provider: .claude)?.cookieHeader == "sessionKey=sk-ant-fresh")
+        }
+    }
+
+    @Test
+    func `conditional mutation recognizes a legacy entry after migration failure`() {
+        self.withIsolatedCookieCache {
+            let legacy = CookieHeaderCache.Entry(
+                cookieHeader: "sessionKey=sk-ant-legacy",
+                storedAt: Date(timeIntervalSince1970: 1),
+                sourceLabel: "Chrome")
+            CookieHeaderCache.store(legacy, to: CookieHeaderCache.legacyURLForTesting(provider: .claude))
+
+            let loaded = KeychainCacheStore.withStoreFailureStatusOverrideForTesting(errSecInteractionNotAllowed) {
+                CookieHeaderCache.load(provider: .claude)
+            }
+            #expect(loaded?.cookieHeader == legacy.cookieHeader)
+            guard let loaded else { return }
+
+            let cleared = CookieHeaderCache.clearIfCurrent(provider: .claude, expected: loaded)
+            let replaced = CookieHeaderCache.storeIfCurrent(
+                provider: .claude,
+                expected: nil,
+                cookieHeader: "sessionKey=sk-ant-fresh",
+                sourceLabel: "Safari")
+
+            #expect(cleared)
+            #expect(replaced)
+            #expect(CookieHeaderCache.load(provider: .claude)?.cookieHeader == "sessionKey=sk-ant-fresh")
+        }
+    }
+
+    @Test
     func `stores separate codex entries per managed account scope`() {
         KeychainCacheStore.setTestStoreForTesting(true)
         defer { KeychainCacheStore.setTestStoreForTesting(false) }


### PR DESCRIPTION
## Summary
- renew Claude Web session keys from successful `Set-Cookie: sessionKey=...` responses
- reuse a rotated session key for later requests in the same Web fetch
- serialize cache-backed browser refreshes so every successful concurrent rotation becomes the next refresh's input
- track renewal for manual cookie fetches too, while keeping manual cookies read-only so they do not rewrite cached browser-derived state

## Root cause
Claude Web usage requests reused a cached `sessionKey` but ignored `Set-Cookie` renewal headers from claude.ai. Once the cached key aged out, later refreshes could keep sending stale credentials. The first patch fixed browser/cache-backed fetches, but the manual-cookie path still skipped the renewal tracker because persistence provenance was also controlling in-memory renewal tracking. Concurrent successful refreshes could also begin from the same cached key, rotate independently, and reject the later valid rotation during conditional persistence.

## Fix
- create the renewal tracker for every Claude Web fetch
- use the tracker's current session key for `/usage`, extra usage, and account calls
- persist browser/cache renewals only when the cached entry is still current, with keychain and legacy mutations serialized
- leave an unchanged cached entry untouched so a concurrent renewal can still conditionally replace it
- conditionally persist a successful browser fallback against the rejected cached entry even when clearing that entry failed
- preserve that expected Keychain entry when legacy cleanup itself fails, so the fresh browser session can still replace it
- preserve an initial temporary Keychain-read observation and allow the fresh browser session to persist only after Keychain recovers as missing with unchanged legacy state
- reject that fallback persistence when a concurrent Keychain or legacy write changes the observed state
- extend the manual-cookie regression test to assert that `/usage` receives the renewed key while the cached browser cookie remains unchanged
- isolate renewal tests with a task-local HTTP transport instead of process-wide `URLProtocol` registration
- directly verify that a usage-response rotation reaches later overage/account requests and the shared cache
- accept every valid successful-response session key, including a rotation back to the fetch's initial key
- honor the final valid `sessionKey` assignment when one response contains multiple setters
- isolate renewal tests from both the real Keychain service and the default legacy cookie file
- serialize automatic/browser-backed fetches through a cancellation-aware FIFO gate before cache observation
- leave manual-cookie and direct-session fetches outside that gate so they remain independent and read-only
- remove cancelled waiters without retaining completed IDs, preserving progress without cancellation-state growth

## Proof
- exact candidate: `3a465a8ea8776e3e41bfd9f4ef47b1676dc7227b`, mergeable with current main `43b7e46c4785b918de0bddc5b83789936f2aab6d`
- source and test commits are range-diff exact; the only rebase resolution retained both additive changelog entries
- exact-head `swift test --filter 'ClaudeWebCookieRenewalTests|CookieHeaderCacheTests|CookieHeaderCacheConditionalMutationTests'`: 45 tests passed
- conditional-mutation regressions cover failed legacy cleanup followed by exact stale-Keychain replacement, temporary Keychain recovery with unchanged legacy state, and concurrent Keychain precedence
- concurrency regressions prove A→B then B→C request ordering, final cache C, and cancelled-waiter progress
- exact-head `make check`: green; 0 formatting changes and 0 lint violations
- exact candidate `make test`: all 42 groups / 495 selections passed
- first late repair autoreview: clean (0.82)
- temporary-Keychain repair autoreview: clean (0.78)
- final current-main whole-branch autoreview: clean (0.82)
- concurrent-rotation repair autoreview: clean after its cancellation finding was fixed (0.86)
- final exact whole-branch autoreview: clean (0.82)

Source-identical pre-rebase redacted live Claude Web fetch on 2026-06-14 17:06 Pacific:

```text
[claude-web] Found sessionKey in Safari
[claude-web] Found session key (24 cookies)
[claude-web] Organizations API status: 200
[claude-web] Organization resolved
[claude-web] Usage API status: 200
[claude-web] Account API status: 200
Cookie cache stored provider=claude source=Safari
```

Source-identical pre-rebase redacted live header probe on 2026-06-14 17:06 Pacific:

```text
cache-source: Safari
initial-sessionKey-sha256-12: e42266eaa620
organizations-status: 200
organizations-set-cookie-count: 1
organizations-sessionKey-set-cookie: no
usage-request-sessionKey-sha256-12: e42266eaa620
usage-used-renewed-sessionKey: not-applicable-no-renewal
usage-status: 200
usage-set-cookie-count: 1
usage-sessionKey-set-cookie: no
```

Source-identical pre-rebase redacted renewal watcher proof on 2026-06-15 05:43 Pacific:

```text
renewal_observed source=Safari initial=e42266eaa620 observed_from=usage renewed=e42266eaa620 changed=no usage_status=200 used_renewed=no followup_status=200 followup_used_observed=yes
```

This shows claude.ai emitted a live `Set-Cookie: sessionKey=...` response from the usage endpoint, and a follow-up request using that observed sessionKey succeeded with HTTP 200. The emitted value matched the existing key, so this is same-value sessionKey renewal proof rather than rotation proof.

## Proof limitation
Live proof now shows claude.ai emitting `Set-Cookie: sessionKey=...` and accepting a follow-up request with the observed key. The observed value matched the initial key, so the live artifact proves same-value renewal and follow-up reuse, while rotated-value behavior remains covered by request-header regression tests.

Refs #1287
