### PR TITLE
Attach Copilot reset time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Antigravity: retry transient `Text file busy` launch failures while the CLI executable is being replaced.
 - Antigravity: fall back to loopback HTTP for local CLI and language-server probes on Linux, where self-signed localhost TLS cannot be trusted (fixes #1508). Thanks @zodiacfireworks!
 - Codebuff: enforce the optional subscription grace period even when the transport ignores cancellation.
+- Copilot: show the shared quota reset date for limited premium and chat usage windows. Thanks @Zihao-Qi!
 - Codex: keep managed login timeouts bounded while preserving captured output when detached helpers retain stdout or stderr.
 - Claude: keep segmented multi-account menus scoped to the selected account while its refresh is in flight (fixes #1527).
 - Command Code: keep showing available credits after the bounded optional subscription grace, including when the transport ignores cancellation (fixes #1131).

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
@@ -66,8 +66,9 @@ public struct CopilotUsageFetcher: Sendable {
         }
 
         let usage = try JSONDecoder().decode(CopilotUsageResponse.self, from: response.data)
-        let premium = Self.makeRateWindow(from: usage.quotaSnapshots.premiumInteractions)
-        let chat = Self.makeRateWindow(from: usage.quotaSnapshots.chat)
+        let resetsAt = Self.parseQuotaResetDate(usage.quotaResetDate)
+        let premium = Self.makeRateWindow(from: usage.quotaSnapshots.premiumInteractions, resetsAt: resetsAt)
+        let chat = Self.makeRateWindow(from: usage.quotaSnapshots.chat, resetsAt: resetsAt)
 
         let primary: RateWindow?
         let secondary: RateWindow?
@@ -137,7 +138,10 @@ public struct CopilotUsageFetcher: Sendable {
         request.setValue("2025-04-01", forHTTPHeaderField: "X-Github-Api-Version")
     }
 
-    static func makeRateWindow(from snapshot: CopilotUsageResponse.QuotaSnapshot?) -> RateWindow? {
+    static func makeRateWindow(
+        from snapshot: CopilotUsageResponse.QuotaSnapshot?,
+        resetsAt: Date? = nil) -> RateWindow?
+    {
         guard let snapshot else { return nil }
         guard !snapshot.isPlaceholder else { return nil }
         guard snapshot.hasPercentRemaining else { return nil }
@@ -148,8 +152,34 @@ public struct CopilotUsageFetcher: Sendable {
 
         return RateWindow(
             usedPercent: usedPercent,
-            windowMinutes: nil, // Not provided
-            resetsAt: nil, // Not provided per-quota in the simplified snapshot
+            windowMinutes: nil,
+            resetsAt: resetsAt,
             resetDescription: overQuotaDescription)
+    }
+
+    static func parseQuotaResetDate(_ value: String?) -> Date? {
+        guard let raw = value?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
+            return nil
+        }
+
+        let fractionalISO = ISO8601DateFormatter()
+        fractionalISO.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractionalISO.date(from: raw) {
+            return date
+        }
+
+        let internetISO = ISO8601DateFormatter()
+        internetISO.formatOptions = [.withInternetDateTime]
+        if let date = internetISO.date(from: raw) {
+            return date
+        }
+
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.isLenient = false
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.date(from: raw)
     }
 }

--- a/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Copilot/CopilotUsageFetcher.swift
@@ -149,11 +149,12 @@ public struct CopilotUsageFetcher: Sendable {
         let overQuotaDescription = snapshot.overQuotaUsedPercent.map { used in
             String(format: "%.0f%% used", used)
         }
+        let effectiveResetsAt = snapshot.unlimited ? nil : resetsAt
 
         return RateWindow(
             usedPercent: usedPercent,
             windowMinutes: nil,
-            resetsAt: resetsAt,
+            resetsAt: effectiveResetsAt,
             resetDescription: overQuotaDescription)
     }
 

--- a/Tests/CodexBarTests/CopilotUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CopilotUsageFetcherTests.swift
@@ -80,6 +80,7 @@ struct CopilotUsageFetcherTests {
                 """
                 {
                   "copilot_plan": "individual",
+                  "quota_reset_date": "2026-07-01",
                   "quota_snapshots": {
                     "chat_messages": {
                       "entitlement": 0,
@@ -98,6 +99,7 @@ struct CopilotUsageFetcherTests {
 
         #expect(snapshot.primary == nil)
         #expect(snapshot.secondary?.usedPercent == 0)
+        #expect(snapshot.secondary?.resetsAt == nil)
         #expect(snapshot.identity?.loginMethod == "Individual")
     }
 

--- a/Tests/CodexBarTests/CopilotUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/CopilotUsageFetcherTests.swift
@@ -102,6 +102,49 @@ struct CopilotUsageFetcherTests {
     }
 
     @Test
+    func `fetch attaches quota reset date to copilot windows`() async throws {
+        let transport = ProviderHTTPTransportStub { request in
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "token gh-token")
+            let response = try HTTPURLResponse(
+                url: #require(request.url),
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"])!
+            let data = Data(
+                """
+                {
+                  "copilot_plan": "individual",
+                  "quota_reset_date": "2026-07-01",
+                  "quota_snapshots": {
+                    "premium_interactions": {
+                      "entitlement": 500,
+                      "remaining": 125,
+                      "percent_remaining": 25,
+                      "quota_id": "premium_interactions"
+                    },
+                    "chat": {
+                      "entitlement": 300,
+                      "remaining": 240,
+                      "percent_remaining": 80,
+                      "quota_id": "chat"
+                    }
+                  }
+                }
+                """.utf8)
+            return (data, response)
+        }
+        let fetcher = CopilotUsageFetcher(token: "gh-token", transport: transport)
+        let expectedReset = try #require(CopilotUsageFetcher.parseQuotaResetDate("2026-07-01"))
+
+        let snapshot = try await fetcher.fetch()
+
+        #expect(snapshot.primary?.usedPercent == 75)
+        #expect(snapshot.primary?.resetsAt == expectedReset)
+        #expect(snapshot.secondary?.usedPercent == 20)
+        #expect(snapshot.secondary?.resetsAt == expectedReset)
+    }
+
+    @Test
     func `makeRateWindow drops business token billing placeholder quota`() {
         // entitlement=0/remaining=0/percent_remaining=100 must not become a "0% used"
         // rate window for Copilot Business token-based billing accounts. (#1258)
@@ -122,5 +165,34 @@ struct CopilotUsageFetcherTests {
             quotaId: "premium_interactions")
         let window = CopilotUsageFetcher.makeRateWindow(from: real)
         #expect(window?.usedPercent == 75)
+    }
+
+    @Test
+    func `makeRateWindow carries reset date`() {
+        let resetDate = Date(timeIntervalSince1970: 1_783_468_800)
+        let real = CopilotUsageResponse.QuotaSnapshot(
+            entitlement: 500,
+            remaining: 125,
+            percentRemaining: 25,
+            quotaId: "premium_interactions")
+
+        let window = CopilotUsageFetcher.makeRateWindow(from: real, resetsAt: resetDate)
+
+        #expect(window?.usedPercent == 75)
+        #expect(window?.resetsAt == resetDate)
+    }
+
+    @Test
+    func `parseQuotaResetDate supports date only and ISO timestamps`() throws {
+        let dateOnly = try #require(ISO8601DateFormatter().date(from: "2026-07-01T00:00:00Z"))
+        let iso = try #require(ISO8601DateFormatter().date(from: "2026-07-01T08:30:45Z"))
+        let fractionalFormatter = ISO8601DateFormatter()
+        fractionalFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let fractionalISO = try #require(fractionalFormatter.date(from: "2026-07-01T08:30:45.123Z"))
+
+        #expect(CopilotUsageFetcher.parseQuotaResetDate("2026-07-01") == dateOnly)
+        #expect(CopilotUsageFetcher.parseQuotaResetDate("2026-07-01T08:30:45Z") == iso)
+        #expect(CopilotUsageFetcher.parseQuotaResetDate("2026-07-01T08:30:45.123Z") == fractionalISO)
+        #expect(CopilotUsageFetcher.parseQuotaResetDate(" ") == nil)
     }
 }


### PR DESCRIPTION
## Summary

This PR adds Copilot quota reset time support.

GitHub’s Copilot usage endpoint can return `quota_reset_date` together with quota snapshots. We now parse that value and attach it to Copilot `RateWindow`s so the UI/CLI can show when Premium and Chat quotas reset.

The reset time is only shown for limited quotas. If a Copilot quota snapshot is explicitly marked as `unlimited`, we keep the quota visible but suppress the reset countdown, because unlimited quotas do not actually reset.

## Changes

- Parse Copilot `quota_reset_date` from the usage response.
- Attach the parsed reset date to Premium and Chat `RateWindow`s.
- Support date-only and ISO timestamp reset formats.
- Avoid showing reset countdowns for unlimited Copilot quotas.
- Add focused tests for reset date parsing, reset attachment, and unlimited quota behavior.

## Screenshot

Before/after example showing Copilot Premium and Chat reset countdowns:
<img width="299" height="178" alt="Screenshot 2026-06-14 at 20 19 56" src="https://github.com/user-attachments/assets/5572cf7c-7c5f-412f-a5ef-8ffe24e3e0af" />

## Verification

- `swift test --filter CopilotUsageFetcherTests`
- `make check`