### PR TITLE
Prove Claude cookie cache isolation

### DIFF
--- a/Tests/CodexBarTests/CookieHeaderCacheTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheTests.swift
@@ -776,6 +776,10 @@ struct CookieHeaderCacheTests {
 
     private func withIsolatedCookieCache<T>(_ operation: () -> T) -> T {
         KeychainCacheStore.withServiceOverrideForTesting("cookie-isolation-\(UUID().uuidString)") {
+            let legacyBase = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            CookieHeaderCache.setLegacyBaseURLOverrideForTesting(legacyBase)
+            defer { CookieHeaderCache.setLegacyBaseURLOverrideForTesting(nil) }
             KeychainCacheStore.setTestStoreForTesting(true)
             defer { KeychainCacheStore.setTestStoreForTesting(false) }
             CookieHeaderCache.resetDisplayCacheForTesting()

--- a/Tests/CodexBarTests/CookieHeaderCacheTests.swift
+++ b/Tests/CodexBarTests/CookieHeaderCacheTests.swift
@@ -78,6 +78,119 @@ struct CookieHeaderCacheTests {
     }
 
     @Test
+    func `claude cookie scopes isolate browser cache from managed accounts`() {
+        self.withIsolatedCookieCache {
+            let accountA = UUID()
+            let accountB = UUID()
+
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-browser",
+                sourceLabel: "Safari")
+            CookieHeaderCache.store(
+                provider: .claude,
+                scope: .managedAccount(accountA),
+                cookieHeader: "sessionKey=sk-ant-account-a",
+                sourceLabel: "Chrome")
+            CookieHeaderCache.store(
+                provider: .claude,
+                scope: .managedAccount(accountB),
+                cookieHeader: "sessionKey=sk-ant-account-b",
+                sourceLabel: "Edge")
+
+            #expect(CookieHeaderCache.load(provider: .claude)?.cookieHeader == "sessionKey=sk-ant-browser")
+            #expect(CookieHeaderCache.load(provider: .claude, scope: .managedAccount(accountA))?
+                .cookieHeader == "sessionKey=sk-ant-account-a")
+            #expect(CookieHeaderCache.load(provider: .claude, scope: .managedAccount(accountB))?
+                .cookieHeader == "sessionKey=sk-ant-account-b")
+
+            CookieHeaderCache.clear(provider: .claude)
+            #expect(CookieHeaderCache.load(provider: .claude) == nil)
+            #expect(CookieHeaderCache.load(provider: .claude, scope: .managedAccount(accountA))?
+                .cookieHeader == "sessionKey=sk-ant-account-a")
+            #expect(CookieHeaderCache.load(provider: .claude, scope: .managedAccount(accountB))?
+                .cookieHeader == "sessionKey=sk-ant-account-b")
+
+            CookieHeaderCache.clear(provider: .claude, scope: .managedAccount(accountA))
+            #expect(CookieHeaderCache.load(provider: .claude, scope: .managedAccount(accountA)) == nil)
+            #expect(CookieHeaderCache.load(provider: .claude, scope: .managedAccount(accountB))?
+                .cookieHeader == "sessionKey=sk-ant-account-b")
+        }
+    }
+
+    @Test
+    func `claude unreadable managed store sentinel is isolated from account cookies`() {
+        self.withIsolatedCookieCache {
+            let accountID = UUID()
+
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-global",
+                sourceLabel: "Safari")
+            CookieHeaderCache.store(
+                provider: .claude,
+                scope: .managedAccount(accountID),
+                cookieHeader: "sessionKey=sk-ant-account",
+                sourceLabel: "Chrome")
+            CookieHeaderCache.store(
+                provider: .claude,
+                scope: .managedStoreUnreadable,
+                cookieHeader: "sessionKey=sk-ant-unreadable-store",
+                sourceLabel: "Unreadable managed account store")
+
+            CookieHeaderCache.clear(provider: .claude, scope: .managedAccount(accountID))
+            #expect(CookieHeaderCache.load(provider: .claude, scope: .managedAccount(accountID)) == nil)
+            #expect(CookieHeaderCache.load(provider: .claude)?.cookieHeader == "sessionKey=sk-ant-global")
+            #expect(CookieHeaderCache.load(provider: .claude, scope: .managedStoreUnreadable)?
+                .cookieHeader == "sessionKey=sk-ant-unreadable-store")
+
+            CookieHeaderCache.clear(provider: .claude)
+            #expect(CookieHeaderCache.load(provider: .claude) == nil)
+            #expect(CookieHeaderCache.load(provider: .claude, scope: .managedStoreUnreadable)?
+                .cookieHeader == "sessionKey=sk-ant-unreadable-store")
+
+            let cleared = CookieHeaderCache.clearAllScopesDetailed(provider: .claude)
+            #expect(cleared == CookieHeaderCache.ClearSummary(clearedCount: 1, failedCount: 0))
+            #expect(CookieHeaderCache.load(provider: .claude, scope: .managedStoreUnreadable) == nil)
+        }
+    }
+
+    @Test
+    func `claude clear all scopes does not remove other provider cookie caches`() {
+        self.withIsolatedCookieCache {
+            let claudeAccount = UUID()
+            let codexAccount = UUID()
+
+            CookieHeaderCache.store(
+                provider: .claude,
+                cookieHeader: "sessionKey=sk-ant-claude-global",
+                sourceLabel: "Safari")
+            CookieHeaderCache.store(
+                provider: .claude,
+                scope: .managedAccount(claudeAccount),
+                cookieHeader: "sessionKey=sk-ant-claude-account",
+                sourceLabel: "Chrome")
+            CookieHeaderCache.store(provider: .codex, cookieHeader: "auth=codex-global", sourceLabel: "Chrome")
+            CookieHeaderCache.store(
+                provider: .codex,
+                scope: .managedAccount(codexAccount),
+                cookieHeader: "auth=codex-account",
+                sourceLabel: "Safari")
+            CookieHeaderCache.store(provider: .perplexity, cookieHeader: "pplx=web", sourceLabel: "Chrome")
+
+            let cleared = CookieHeaderCache.clearAllScopesDetailed(provider: .claude)
+
+            #expect(cleared == CookieHeaderCache.ClearSummary(clearedCount: 2, failedCount: 0))
+            #expect(CookieHeaderCache.load(provider: .claude) == nil)
+            #expect(CookieHeaderCache.load(provider: .claude, scope: .managedAccount(claudeAccount)) == nil)
+            #expect(CookieHeaderCache.load(provider: .codex)?.cookieHeader == "auth=codex-global")
+            #expect(CookieHeaderCache.load(provider: .codex, scope: .managedAccount(codexAccount))?
+                .cookieHeader == "auth=codex-account")
+            #expect(CookieHeaderCache.load(provider: .perplexity)?.cookieHeader == "pplx=web")
+        }
+    }
+
+    @Test
     func `migrates legacy file to keychain`() {
         KeychainCacheStore.setTestStoreForTesting(true)
         defer { KeychainCacheStore.setTestStoreForTesting(false) }
@@ -658,6 +771,16 @@ struct CookieHeaderCacheTests {
             #expect(cleared.clearedCount >= 3)
             #expect(cleared.failedCount == 0)
             #expect(KeychainCacheStore.keys(category: "cookie").isEmpty)
+        }
+    }
+
+    private func withIsolatedCookieCache<T>(_ operation: () -> T) -> T {
+        KeychainCacheStore.withServiceOverrideForTesting("cookie-isolation-\(UUID().uuidString)") {
+            KeychainCacheStore.setTestStoreForTesting(true)
+            defer { KeychainCacheStore.setTestStoreForTesting(false) }
+            CookieHeaderCache.resetDisplayCacheForTesting()
+            defer { CookieHeaderCache.resetDisplayCacheForTesting() }
+            return operation()
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Claude-specific cookie cache isolation tests
- prove global browser-derived Claude cookies stay separate from managed account cookie scopes
- prove the unreadable managed-store sentinel is isolated from account/global cookies
- prove clearing Claude cookie scopes does not remove other providers' cookie caches

## Why
Issue #1287 is still open for broader Claude auth lifecycle closure criteria, including storage behavior and account isolation. This PR adds focused proof for the cookie-cache storage and isolation piece without changing runtime behavior.

This does not claim to close #1287 by itself; it covers the storage/account-isolation test slice only.

## Proof
Local `swift test --filter CookieHeaderCacheTests`:

```text
Suite CookieHeaderCacheTests passed after 0.121 seconds.
Test run with 28 tests in 1 suite passed after 0.122 seconds.
```

Local `make check`:

```text
SwiftFormat completed in 0.29s.
0/1099 files require formatting.
Done linting! Found 0 violations, 0 serious in 1098 files.
```

Full terminal transcript for this branch:
- [part 1](https://github.com/steipete/CodexBar/pull/1539#issuecomment-4703795806)
- [part 2](https://github.com/steipete/CodexBar/pull/1539#issuecomment-4703795870)

CI artifacts for this branch:
- [lint-build-test](https://github.com/steipete/CodexBar/actions/runs/27516701673/job/81326551417): passed
- [build-linux-cli x64](https://github.com/steipete/CodexBar/actions/runs/27516701673/job/81326551396): passed
- [build-linux-cli arm64](https://github.com/steipete/CodexBar/actions/runs/27516701673/job/81326551425): passed
- GitGuardian Security Checks: passed

Refs #1287
