### PR TITLE
test: stabilize Antigravity readiness error assertion

### DIFF
--- a/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
+++ b/Tests/CodexBarTests/AntigravityCLIHTTPSFetchStrategyTests.swift
@@ -723,7 +723,7 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
     }
 
     @Test
-    func `cli HTTPS reports last readiness error when ports never become usable`() async {
+    func `cli HTTPS reports latest readiness error when ports never become usable`() async {
         let fetchAttempts = AntigravityCLICounter()
 
         do {
@@ -741,8 +741,9 @@ struct AntigravityCLIHTTPSFetchStrategyTests {
                     }))
             Issue.record("Expected readiness polling to throw")
         } catch let AntigravityStatusProbeError.apiError(message) {
-            #expect(fetchAttempts.value > 1)
-            #expect(message == "HTTP 500: warming attempt \(fetchAttempts.value)")
+            let attempts = fetchAttempts.value
+            #expect(attempts >= 1)
+            #expect(message == "HTTP 500: warming attempt \(attempts)")
         } catch {
             Issue.record("Expected apiError, got \(error)")
         }


### PR DESCRIPTION
## Summary
- keep the Antigravity readiness-error test focused on preserving the latest fetch error
- avoid requiring more than one wall-clock polling attempt in CI

## Context
The retry behavior is already covered by separate Antigravity tests. This assertion can fail on faster CI/test-runtime combinations when the wait exits after a single fetch attempt, while still returning the latest readiness error correctly.

## Test plan
- `arch -x86_64 swift test --scratch-path .build/x86-antigravity-separate-pr-check --filter AntigravityCLIHTTPSFetchStrategyTests --skip-update`