### PR TITLE
Fix LiteLLM team budget handling

### DIFF
--- a/Sources/CodexBar/MenuBarMetricWindowResolver.swift
+++ b/Sources/CodexBar/MenuBarMetricWindowResolver.swift
@@ -114,6 +114,9 @@ enum MenuBarMetricWindowResolver {
         if provider == .factory || provider == .kimi {
             return snapshot.secondary ?? snapshot.primary
         }
+        if provider == .litellm {
+            return snapshot.secondary ?? snapshot.primary
+        }
         if provider == .copilot,
            let primary = snapshot.primary,
            let secondary = snapshot.secondary

--- a/Sources/CodexBar/MenuCardView+Costs.swift
+++ b/Sources/CodexBar/MenuCardView+Costs.swift
@@ -195,7 +195,7 @@ extension UsageMenuCardView.Model {
                 percentLine: nil)
         }
 
-        if provider == .openai || provider == .claude, cost.limit <= 0 {
+        if provider == .openai || provider == .claude || provider == .litellm, cost.limit <= 0 {
             let spend = UsageFormatter.currencyString(cost.used, currencyCode: cost.currencyCode)
             let periodLabel = Self.localizedPeriodLabel(cost.period ?? "Last 30 days")
             return ProviderCostSection(

--- a/Sources/CodexBarCore/Providers/LiteLLM/LiteLLMProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/LiteLLM/LiteLLMProviderDescriptor.swift
@@ -14,7 +14,7 @@ public enum LiteLLMProviderDescriptor {
                 opusLabel: nil,
                 supportsOpus: false,
                 supportsCredits: false,
-                creditsHint: "Reads spend and budget from LiteLLM /user/info.",
+                creditsHint: "Reads spend and budget from LiteLLM key, user, and team info endpoints.",
                 toggleTitle: "Show LiteLLM usage",
                 cliName: "litellm",
                 defaultEnabled: false,

--- a/Sources/CodexBarCore/Providers/LiteLLM/LiteLLMUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/LiteLLM/LiteLLMUsageFetcher.swift
@@ -18,7 +18,7 @@ public enum LiteLLMUsageError: LocalizedError, Sendable {
         case .missingBaseURL:
             "Missing LiteLLM base URL. Set enterpriseHost in ~/.codexbar/config.json or LITELLM_BASE_URL."
         case .missingUserID:
-            "LiteLLM key info did not include a user_id."
+            "LiteLLM key info did not include a user_id or team_id."
         case .invalidURL:
             "LiteLLM URL is invalid."
         case let .apiError(message):
@@ -30,13 +30,13 @@ public enum LiteLLMUsageError: LocalizedError, Sendable {
 }
 
 public struct LiteLLMKeyInfoSnapshot: Codable, Sendable, Equatable {
-    public let userID: String
+    public let userID: String?
     public let teamID: String?
     public let keyName: String?
     public let spendUSD: Double
     public let expiresAt: Date?
 
-    public init(userID: String, teamID: String?, keyName: String?, spendUSD: Double, expiresAt: Date?) {
+    public init(userID: String?, teamID: String?, keyName: String?, spendUSD: Double, expiresAt: Date?) {
         self.userID = userID
         self.teamID = teamID
         self.keyName = keyName
@@ -46,7 +46,7 @@ public struct LiteLLMKeyInfoSnapshot: Codable, Sendable, Equatable {
 }
 
 public struct LiteLLMUsageSnapshot: Codable, Sendable, Equatable {
-    public let userID: String
+    public let userID: String?
     public let accountEmail: String?
     public let personalSpendUSD: Double
     public let personalBudgetUSD: Double?
@@ -80,15 +80,7 @@ public struct LiteLLMUsageSnapshot: Codable, Sendable, Equatable {
                 description: Self.teamDescription(team))
         }
 
-        let providerCost = self.personalBudgetUSD.map {
-            ProviderCostSnapshot(
-                used: self.personalSpendUSD,
-                limit: $0,
-                currencyCode: "USD",
-                period: "Personal budget",
-                resetsAt: self.personalResetAt,
-                updatedAt: self.updatedAt)
-        }
+        let providerCost = self.providerCostSnapshot()
 
         return UsageSnapshot(
             primary: primary,
@@ -129,6 +121,34 @@ public struct LiteLLMUsageSnapshot: Codable, Sendable, Equatable {
             return "\(label): \(UsageFormatter.usdString(team.spendUSD))"
         }
         return "\(label): \(UsageFormatter.usdString(team.spendUSD)) / \(UsageFormatter.usdString(budget))"
+    }
+
+    private func providerCostSnapshot() -> ProviderCostSnapshot? {
+        let spend: Double
+        let budget: Double?
+        let period: String
+        let resetsAt: Date?
+
+        if self.userID == nil, let team = self.teamUsage {
+            spend = team.spendUSD
+            budget = team.budgetUSD
+            period = (team.budgetUSD ?? 0) > 0 ? "Team budget" : "Team spend"
+            resetsAt = team.resetAt
+        } else {
+            spend = self.personalSpendUSD
+            budget = self.personalBudgetUSD
+            period = (self.personalBudgetUSD ?? 0) > 0 ? "Personal budget" : "Personal spend"
+            resetsAt = self.personalResetAt
+        }
+
+        guard spend > 0 || (budget ?? 0) > 0 else { return nil }
+        return ProviderCostSnapshot(
+            used: spend,
+            limit: max(0, budget ?? 0),
+            currencyCode: "USD",
+            period: period,
+            resetsAt: resetsAt,
+            updatedAt: self.updatedAt)
     }
 }
 
@@ -215,6 +235,34 @@ private struct LiteLLMUserInfoResponse: Decodable {
     }
 }
 
+private struct LiteLLMTeamInfoResponse: Decodable {
+    struct TeamInfo: Decodable {
+        let teamAlias: String?
+        let teamID: String?
+        let maxBudget: Double?
+        let spend: Double?
+        let budgetResetAt: String?
+        let budgetDuration: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case teamAlias = "team_alias"
+            case teamID = "team_id"
+            case maxBudget = "max_budget"
+            case spend
+            case budgetResetAt = "budget_reset_at"
+            case budgetDuration = "budget_duration"
+        }
+    }
+
+    let teamID: String?
+    let teamInfo: TeamInfo
+
+    private enum CodingKeys: String, CodingKey {
+        case teamID = "team_id"
+        case teamInfo = "team_info"
+    }
+}
+
 public struct LiteLLMUsageFetcher: Sendable {
     public init() {}
 
@@ -233,12 +281,23 @@ public struct LiteLLMUsageFetcher: Sendable {
             apiKey: cleanedAPIKey,
             baseURL: baseURL,
             transport: transport)
-        return try await self.fetchUserInfo(
-            apiKey: cleanedAPIKey,
-            baseURL: baseURL,
-            keyInfo: keyInfo,
-            transport: transport,
-            updatedAt: updatedAt)
+        if keyInfo.userID != nil {
+            return try await self.fetchUserInfo(
+                apiKey: cleanedAPIKey,
+                baseURL: baseURL,
+                keyInfo: keyInfo,
+                transport: transport,
+                updatedAt: updatedAt)
+        }
+        if keyInfo.teamID != nil {
+            return try await self.fetchTeamInfo(
+                apiKey: cleanedAPIKey,
+                baseURL: baseURL,
+                keyInfo: keyInfo,
+                transport: transport,
+                updatedAt: updatedAt)
+        }
+        throw LiteLLMUsageError.missingUserID
     }
 
     public static func _parseUserInfoForTesting(
@@ -253,12 +312,24 @@ public struct LiteLLMUsageFetcher: Sendable {
         try self.parseKeyInfo(data: data)
     }
 
+    public static func _parseTeamInfoForTesting(
+        _ data: Data,
+        keyInfo: LiteLLMKeyInfoSnapshot,
+        updatedAt: Date) throws -> LiteLLMUsageSnapshot
+    {
+        try self.parseTeamInfo(data: data, keyInfo: keyInfo, updatedAt: updatedAt)
+    }
+
     public static func _keyInfoURLForTesting(baseURL: URL) -> URL {
         self.keyInfoURL(baseURL: baseURL)
     }
 
     public static func _userInfoURLForTesting(baseURL: URL, userID: String) -> URL {
         self.userInfoURL(baseURL: baseURL, userID: userID)
+    }
+
+    public static func _teamInfoURLForTesting(baseURL: URL, teamID: String) -> URL {
+        self.teamInfoURL(baseURL: baseURL, teamID: teamID)
     }
 
     private static func fetchKeyInfo(
@@ -284,14 +355,37 @@ public struct LiteLLMUsageFetcher: Sendable {
         transport: any ProviderHTTPTransport,
         updatedAt: Date) async throws -> LiteLLMUsageSnapshot
     {
+        guard let userID = keyInfo.userID else {
+            throw LiteLLMUsageError.parseFailed("/user/info requested without a user_id")
+        }
         let request = self.request(
-            url: self.userInfoURL(baseURL: baseURL, userID: keyInfo.userID),
+            url: self.userInfoURL(baseURL: baseURL, userID: userID),
             apiKey: apiKey)
         let response = try await transport.response(for: request)
         guard (200..<300).contains(response.statusCode) else {
             throw LiteLLMUsageError.apiError("HTTP \(response.statusCode): \(Self.responseSummary(response.data))")
         }
         return try self.parseUserInfo(data: response.data, keyInfo: keyInfo, updatedAt: updatedAt)
+    }
+
+    private static func fetchTeamInfo(
+        apiKey: String,
+        baseURL: URL,
+        keyInfo: LiteLLMKeyInfoSnapshot,
+        transport: any ProviderHTTPTransport,
+        updatedAt: Date) async throws -> LiteLLMUsageSnapshot
+    {
+        guard let teamID = keyInfo.teamID else {
+            throw LiteLLMUsageError.parseFailed("/team/info requested without a team_id")
+        }
+        let request = self.request(
+            url: self.teamInfoURL(baseURL: baseURL, teamID: teamID),
+            apiKey: apiKey)
+        let response = try await transport.response(for: request)
+        guard (200..<300).contains(response.statusCode) else {
+            throw LiteLLMUsageError.apiError("HTTP \(response.statusCode): \(Self.responseSummary(response.data))")
+        }
+        return try self.parseTeamInfo(data: response.data, keyInfo: keyInfo, updatedAt: updatedAt)
     }
 
     private static func request(url: URL, apiKey: String) -> URLRequest {
@@ -314,6 +408,12 @@ public struct LiteLLMUsageFetcher: Sendable {
             pathComponents: ["user", "info"])
     }
 
+    private static func teamInfoURL(baseURL: URL, teamID: String) -> URL {
+        self.managementBaseURL(baseURL).appending(
+            queryItems: [URLQueryItem(name: "team_id", value: teamID)],
+            pathComponents: ["team", "info"])
+    }
+
     private static func managementBaseURL(_ baseURL: URL) -> URL {
         let path = baseURL.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         guard path.split(separator: "/").last == "v1" else { return baseURL }
@@ -327,12 +427,14 @@ public struct LiteLLMUsageFetcher: Sendable {
     private static func parseKeyInfo(data: Data) throws -> LiteLLMKeyInfoSnapshot {
         do {
             let decoded = try JSONDecoder().decode(LiteLLMKeyInfoResponse.self, from: data)
-            guard let userID = decoded.info.userID, !userID.isEmpty else {
+            let userID = self.nonEmpty(decoded.info.userID)
+            let teamID = self.nonEmpty(decoded.info.teamID)
+            guard userID != nil || teamID != nil else {
                 throw LiteLLMUsageError.missingUserID
             }
             return LiteLLMKeyInfoSnapshot(
                 userID: userID,
-                teamID: decoded.info.teamID,
+                teamID: teamID,
                 keyName: decoded.info.keyName,
                 spendUSD: decoded.info.spend ?? 0,
                 expiresAt: self.parseDate(decoded.info.expires))
@@ -350,8 +452,11 @@ public struct LiteLLMUsageFetcher: Sendable {
     {
         do {
             let decoded = try JSONDecoder().decode(LiteLLMUserInfoResponse.self, from: data)
+            guard let expectedUserID = keyInfo.userID else {
+                throw LiteLLMUsageError.parseFailed("/user/info requested without a user_id")
+            }
             if let responseUserID = decoded.userInfo.userID ?? decoded.userID,
-               responseUserID != keyInfo.userID
+               responseUserID != expectedUserID
             {
                 throw LiteLLMUsageError.parseFailed("user_id did not match /key/info")
             }
@@ -363,7 +468,7 @@ public struct LiteLLMUsageFetcher: Sendable {
             let team = self.preferredTeam(from: decoded.teams, keyTeamID: keyInfo.teamID)
 
             return LiteLLMUsageSnapshot(
-                userID: keyInfo.userID,
+                userID: expectedUserID,
                 accountEmail: accountEmail,
                 personalSpendUSD: decoded.userInfo.spend ?? 0,
                 personalBudgetUSD: decoded.userInfo.maxBudget,
@@ -377,6 +482,46 @@ public struct LiteLLMUsageFetcher: Sendable {
                         resetAt: self.parseDate($0.budgetResetAt),
                         budgetDuration: $0.budgetDuration)
                 },
+                keyName: keyInfo.keyName,
+                keyExpiresAt: keyInfo.expiresAt,
+                updatedAt: updatedAt)
+        } catch let error as LiteLLMUsageError {
+            throw error
+        } catch {
+            throw LiteLLMUsageError.parseFailed(error.localizedDescription)
+        }
+    }
+
+    private static func parseTeamInfo(
+        data: Data,
+        keyInfo: LiteLLMKeyInfoSnapshot,
+        updatedAt: Date) throws -> LiteLLMUsageSnapshot
+    {
+        do {
+            let decoded = try JSONDecoder().decode(LiteLLMTeamInfoResponse.self, from: data)
+            guard let expectedTeamID = keyInfo.teamID else {
+                throw LiteLLMUsageError.parseFailed("/team/info requested without a team_id")
+            }
+            if let responseTeamID = self.firstNonEmpty(decoded.teamInfo.teamID, decoded.teamID),
+               responseTeamID != expectedTeamID
+            {
+                throw LiteLLMUsageError.parseFailed("team_id did not match /key/info")
+            }
+
+            let team = decoded.teamInfo
+            return LiteLLMUsageSnapshot(
+                userID: nil,
+                accountEmail: nil,
+                personalSpendUSD: 0,
+                personalBudgetUSD: nil,
+                personalResetAt: nil,
+                teamUsage: LiteLLMUsageSnapshot.TeamUsage(
+                    id: expectedTeamID,
+                    alias: team.teamAlias,
+                    spendUSD: team.spend ?? 0,
+                    budgetUSD: team.maxBudget,
+                    resetAt: self.parseDate(team.budgetResetAt),
+                    budgetDuration: team.budgetDuration),
                 keyName: keyInfo.keyName,
                 keyExpiresAt: keyInfo.expiresAt,
                 updatedAt: updatedAt)
@@ -415,6 +560,10 @@ public struct LiteLLMUsageFetcher: Sendable {
         values.lazy
             .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
             .first { !$0.isEmpty }
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        self.firstNonEmpty(value)
     }
 
     private static func responseSummary(_ data: Data) -> String {

--- a/Tests/CodexBarTests/LiteLLMMenuCardModelTests.swift
+++ b/Tests/CodexBarTests/LiteLLMMenuCardModelTests.swift
@@ -1,0 +1,46 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+struct LiteLLMMenuCardModelTests {
+    @Test
+    func `litellm spend without budget remains visible`() throws {
+        let now = Date()
+        let metadata = try #require(ProviderDefaults.metadata[.litellm])
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            providerCost: ProviderCostSnapshot(
+                used: 12.5,
+                limit: 0,
+                currencyCode: "USD",
+                period: "Personal spend",
+                updatedAt: now),
+            updatedAt: now)
+
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .litellm,
+            metadata: metadata,
+            snapshot: snapshot,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: nil,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: false,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.providerCost?.title == "API spend")
+        #expect(model.providerCost?.spendLine == "Personal spend: $12.50")
+        #expect(model.providerCost?.percentUsed == nil)
+    }
+}

--- a/Tests/CodexBarTests/LiteLLMUsageFetcherTests.swift
+++ b/Tests/CodexBarTests/LiteLLMUsageFetcherTests.swift
@@ -93,6 +93,36 @@ struct LiteLLMUsageFetcherTests {
     }
 
     @Test
+    func `preserves personal spend when no budget is configured`() throws {
+        let json = """
+        {
+          "user_id": "user-123",
+          "user_info": {
+            "user_id": "user-123",
+            "max_budget": null,
+            "spend": 12.5
+          }
+        }
+        """
+
+        let parsed = try LiteLLMUsageFetcher._parseUserInfoForTesting(
+            Data(json.utf8),
+            keyInfo: LiteLLMKeyInfoSnapshot(
+                userID: "user-123",
+                teamID: nil,
+                keyName: "personal-key",
+                spendUSD: 12.5,
+                expiresAt: nil),
+            updatedAt: Date(timeIntervalSince1970: 1))
+
+        let snapshot = parsed.toUsageSnapshot()
+        #expect(snapshot.primary == nil)
+        #expect(snapshot.providerCost?.used == 12.5)
+        #expect(snapshot.providerCost?.limit == 0)
+        #expect(snapshot.providerCost?.period == "Personal spend")
+    }
+
+    @Test
     func `parses key info identity for user lookup`() throws {
         let json = """
         {
@@ -117,6 +147,25 @@ struct LiteLLMUsageFetcherTests {
     }
 
     @Test
+    func `parses team-only key info without user identity`() throws {
+        let json = """
+        {
+          "info": {
+            "key_name": "team-service-key",
+            "spend": 25.0,
+            "team_id": "team-456"
+          }
+        }
+        """
+
+        let parsed = try LiteLLMUsageFetcher._parseKeyInfoForTesting(Data(json.utf8))
+
+        #expect(parsed.userID == nil)
+        #expect(parsed.teamID == "team-456")
+        #expect(parsed.keyName == "team-service-key")
+    }
+
+    @Test
     func `management urls accept root or v1 base urls`() throws {
         let root = try #require(URL(string: "https://litellm.example.com"))
         let versioned = try #require(URL(string: "https://litellm.example.com/v1"))
@@ -134,6 +183,10 @@ struct LiteLLMUsageFetcherTests {
             LiteLLMUsageFetcher
                 ._userInfoURLForTesting(baseURL: nestedVersioned, userID: "user-123")
                 .absoluteString == "https://gateway.example.com/litellm/user/info?user_id=user-123")
+        #expect(
+            LiteLLMUsageFetcher
+                ._teamInfoURLForTesting(baseURL: nestedVersioned, teamID: "team-456")
+                .absoluteString == "https://gateway.example.com/litellm/team/info?team_id=team-456")
     }
 
     @Test
@@ -201,6 +254,79 @@ struct LiteLLMUsageFetcherTests {
             transport: transport)
 
         #expect(snapshot.userID == "user-123")
+        let requests = await transport.requests()
+        #expect(requests.count == 2)
+    }
+
+    @Test
+    func `fetches team usage for team-only virtual keys`() async throws {
+        let baseURL = try #require(URL(string: "https://litellm.example.com/v1"))
+        let transport = ProviderHTTPTransportStub { request in
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer sk-team")
+
+            let path = request.url?.path
+            let query = request.url?.query
+            let body: String
+            switch path {
+            case "/key/info":
+                #expect(query == nil)
+                body = """
+                {
+                  "info": {
+                    "key_name": "team-service-key",
+                    "team_id": "team-456",
+                    "spend": 25
+                  }
+                }
+                """
+            case "/team/info":
+                #expect(query == "team_id=team-456")
+                body = """
+                {
+                  "team_id": "team-456",
+                  "team_info": {
+                    "team_id": "team-456",
+                    "team_alias": "platform",
+                    "max_budget": 100,
+                    "spend": 25,
+                    "budget_duration": "30d",
+                    "budget_reset_at": "2026-07-01T00:00:00Z"
+                  }
+                }
+                """
+            default:
+                Issue.record("unexpected LiteLLM request path: \(path ?? "nil")")
+                body = "{}"
+            }
+
+            let url = try #require(request.url)
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil))
+            return (Data(body.utf8), response)
+        }
+
+        let snapshot = try await LiteLLMUsageFetcher.fetchUsage(
+            apiKey: "sk-team",
+            baseURL: baseURL,
+            transport: transport,
+            updatedAt: Date(timeIntervalSince1970: 1))
+
+        #expect(snapshot.userID == nil)
+        #expect(snapshot.teamUsage?.id == "team-456")
+        #expect(snapshot.teamUsage?.alias == "platform")
+        #expect(snapshot.teamUsage?.spendUSD == 25)
+        #expect(snapshot.teamUsage?.budgetUSD == 100)
+
+        let usage = snapshot.toUsageSnapshot()
+        #expect(usage.primary == nil)
+        #expect(usage.secondary?.usedPercent == 25)
+        #expect(usage.providerCost?.used == 25)
+        #expect(usage.providerCost?.limit == 100)
+        #expect(usage.providerCost?.period == "Team budget")
+
         let requests = await transport.requests()
         #expect(requests.count == 2)
     }

--- a/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
+++ b/Tests/CodexBarTests/MenuBarMetricWindowResolverTests.swift
@@ -39,6 +39,31 @@ struct MenuBarMetricWindowResolverTests {
     }
 
     @Test
+    func `automatic metric uses team budget for team-bound LiteLLM keys`() {
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 10,
+                windowMinutes: nil,
+                resetsAt: nil,
+                resetDescription: "Personal"),
+            secondary: RateWindow(
+                usedPercent: 80,
+                windowMinutes: nil,
+                resetsAt: nil,
+                resetDescription: "Team"),
+            updatedAt: Date())
+
+        let window = MenuBarMetricWindowResolver.rateWindow(
+            preference: .automatic,
+            provider: .litellm,
+            snapshot: snapshot,
+            supportsAverage: false)
+
+        #expect(window?.usedPercent == 80)
+        #expect(window?.resetDescription == "Team")
+    }
+
+    @Test
     func `automatic metric uses constrained antigravity family lane`() {
         let snapshot = UsageSnapshot(
             primary: RateWindow(usedPercent: 0, windowMinutes: nil, resetsAt: nil, resetDescription: "Claude"),

--- a/docs/litellm.md
+++ b/docs/litellm.md
@@ -36,11 +36,13 @@ The provider calls:
 
 1. `GET /key/info` to discover the authenticated key's `user_id` and `team_id`.
 2. `GET /user/info?user_id=<user_id>` to read personal spend, budget, and teams.
+3. For team-only keys without a `user_id`, `GET /team/info?team_id=<team_id>` to read team spend and budget.
 
-Both requests use `Authorization: Bearer <apiKey>`. CodexBar does not request or store a LiteLLM master key.
+All requests use `Authorization: Bearer <apiKey>`. CodexBar does not request or store a LiteLLM master key.
 
-The primary menu bar value uses `user_info.spend / user_info.max_budget`. If the authenticated key has a team and that
-team is present in `/user/info`, its budget is shown as the secondary window.
+Personal usage is shown as the primary window. If the authenticated key has a team, its exact matching team budget is
+shown as the secondary window and becomes the automatic menu bar metric because that budget is enforced for the key.
+Spend remains visible as an API-spend row when LiteLLM does not configure a budget.
 
 ## Security
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -69,7 +69,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 | Grok | `grok agent stdio` JSON-RPC `x.ai/billing` (`cli`) → grok.com billing gRPC-web via Chrome session cookies (`web`); local `~/.grok/sessions` signals as fallback. |
 | GroqCloud | API key → Prometheus metrics API for request/token/cache-hit rates (`api`). |
 | LLM Proxy | API key + base URL → `/v1/quota-stats` aggregate proxy usage (`api`). |
-| LiteLLM | API key + base URL → `/key/info` then `/user/info` personal and team budget usage (`api`). |
+| LiteLLM | API key + base URL → `/key/info`, then `/user/info` or `/team/info` budget usage (`api`). |
 | Deepgram | API key → project discovery and usage breakdown API (`api`). |
 
 ## Codex


### PR DESCRIPTION
Follow-up to #1542, applying accepted pre-land review findings that arrived while the contributor PR was merging.

## Summary
- use the exact team budget as LiteLLM’s automatic menu bar metric
- support team-only service-account keys through authenticated `/team/info`
- keep personal or team spend visible when no budget is configured
- add focused fetcher, menu metric, and menu card regressions
- clarify management endpoint documentation

## Verification
- `make check`
- `make test` (40/40 shards, 469 selections, on the equivalent reviewed tree)
- focused current-main regressions: 22 tests
- branch autoreview: no accepted/actionable findings
- packaged ad-hoc signed CLI live-tested against `ghcr.io/berriai/litellm-database:main-latest` with disposable PostgreSQL and a team-only virtual key; `/key/info`, `/team/info`, exact `$100` team budget rendering, and cleanup passed