### PR TITLE
fix: surface Claude recovery action when no fetch strategy is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Provider probes: stop waiting indefinitely for inherited output pipes after subprocesses or CLI version checks exit (fixes #1531).
 - Menu bar: update visible usage values in place when a manual refresh completes instead of leaving the open provider card stale until the menu is reopened (fixes #1516).
 - Gemini: recognize the current `gemini-api-key` CLI auth setting so API-key sessions show the supported OAuth guidance instead of a misleading not-logged-in error (fixes #1511).
+- Claude: offer the "Re-login at claude.ai" recovery action when no fetch strategy is available, instead of showing only the generic "No available fetch strategy" error (fixes #1425). Thanks @LeoLin990405!
 - Kiro: keep usage refreshes bounded when CLI helpers retain output pipes, ignore termination, or are cancelled (fixes #1533). Thanks @kiranmagic7!
 - Xiaomi MiMo: cancel optional token-plan requests when the required balance request fails instead of delaying the error for up to 30 seconds.
 - Settings: make the cost history window directly editable by keyboard while preserving the existing stepper and 1–365 day bounds (fixes #1499). Thanks @kiranmagic7!

--- a/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Claude/ClaudeProviderImplementation.swift
@@ -229,8 +229,25 @@ struct ClaudeProviderImplementation: ProviderImplementation {
         if self.shouldOpenBrowserForWebSessionError(context: context) {
             return ("Re-login at claude.ai", .loginToProvider(url: "https://claude.ai/"))
         }
-        guard self.shouldOpenTerminalForOAuthError(store: context.store) else { return nil }
-        return ("Open Terminal", .openTerminal(command: "claude"))
+        if self.shouldOpenTerminalForOAuthError(store: context.store) {
+            return ("Open Terminal", .openTerminal(command: "claude"))
+        }
+        // A fully unconfigured Claude provider resolves to no fetch strategy at all
+        // (OAuth, CLI, and web are each unavailable). Without this fallback the menu
+        // surfaces only the generic "No available fetch strategy" error with no next
+        // step; offer the claude.ai sign-in entry point so the user can recover.
+        if Self.isNoAvailableStrategyError(context.store.error(for: .claude)) {
+            return ("Re-login at claude.ai", .loginToProvider(url: "https://claude.ai/"))
+        }
+        return nil
+    }
+
+    /// Whether the surfaced Claude error is the generic "no available fetch
+    /// strategy" outcome produced when every source (OAuth, CLI, web) is
+    /// unavailable. Exposed as a pure seam so recovery routing stays testable
+    /// without constructing live provider state.
+    static func isNoAvailableStrategyError(_ error: String?) -> Bool {
+        error == ProviderFetchError.noAvailableStrategy(.claude).localizedDescription
     }
 
     @MainActor

--- a/Tests/CodexBarTests/ClaudeLoginRecoveryActionTests.swift
+++ b/Tests/CodexBarTests/ClaudeLoginRecoveryActionTests.swift
@@ -1,0 +1,76 @@
+import CodexBarCore
+import Foundation
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct ClaudeLoginRecoveryActionTests {
+    @Test
+    func `fully unconfigured Claude surfaces a recovery action instead of only the generic error`() {
+        let store = Self.makeStore(suite: "ClaudeLoginRecoveryActionTests-no-strategy")
+        store._setErrorForTesting(
+            ProviderFetchError.noAvailableStrategy(.claude).localizedDescription,
+            provider: .claude)
+
+        let context = ProviderMenuLoginContext(
+            provider: .claude,
+            store: store,
+            settings: store.settings,
+            account: store.accountInfo(for: .claude))
+
+        let action = ClaudeProviderImplementation().loginMenuAction(context: context)
+        #expect(action?.label == "Re-login at claude.ai")
+        #expect(action?.action == .loginToProvider(url: "https://claude.ai/"))
+    }
+
+    @Test
+    func `no Claude error does not force a recovery action`() {
+        let store = Self.makeStore(suite: "ClaudeLoginRecoveryActionTests-no-error")
+
+        let context = ProviderMenuLoginContext(
+            provider: .claude,
+            store: store,
+            settings: store.settings,
+            account: store.accountInfo(for: .claude))
+
+        #expect(ClaudeProviderImplementation().loginMenuAction(context: context) == nil)
+    }
+
+    @Test
+    func `no-strategy detection only matches the generic Claude empty-plan error`() {
+        #expect(ClaudeProviderImplementation.isNoAvailableStrategyError(
+            ProviderFetchError.noAvailableStrategy(.claude).localizedDescription))
+        #expect(!ClaudeProviderImplementation.isNoAvailableStrategyError("Some other error"))
+        #expect(!ClaudeProviderImplementation.isNoAvailableStrategyError(nil))
+    }
+
+    private static func makeStore(suite: String) -> UsageStore {
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let configStore = testConfigStore(suiteName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: configStore,
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore(),
+            codexCookieStore: InMemoryCookieHeaderStore(),
+            claudeCookieStore: InMemoryCookieHeaderStore(),
+            cursorCookieStore: InMemoryCookieHeaderStore(),
+            opencodeCookieStore: InMemoryCookieHeaderStore(),
+            factoryCookieStore: InMemoryCookieHeaderStore(),
+            minimaxCookieStore: InMemoryMiniMaxCookieStore(),
+            minimaxAPITokenStore: InMemoryMiniMaxAPITokenStore(),
+            kimiTokenStore: InMemoryKimiTokenStore(),
+            kimiK2TokenStore: InMemoryKimiK2TokenStore(),
+            augmentCookieStore: InMemoryCookieHeaderStore(),
+            ampCookieStore: InMemoryCookieHeaderStore(),
+            copilotTokenStore: InMemoryCopilotTokenStore(),
+            tokenAccountStore: InMemoryTokenAccountStore())
+
+        return UsageStore(
+            fetcher: UsageFetcher(environment: [:]),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: settings,
+            startupBehavior: .testing)
+    }
+}


### PR DESCRIPTION
## What

When Claude resolves to no available fetch strategy (OAuth, CLI, and web all unavailable), the menu surfaced only the generic developer-facing error `No available fetch strategy for claude.` with no next step. This adds a fallback so the menu offers the existing **Re-login at claude.ai** recovery action in that state.

## Why

Per the triage on #1425, the no-strategy state is the documented outcome for a fully unconfigured Claude provider — but the recommended direction was to *show per-source recovery guidance rather than only the generic empty-plan error*.

`loginMenuAction` already offers recovery for the web-session-error and OAuth-error cases. But when **all** sources are unavailable (nothing configured), `shouldOpenBrowserForWebSessionError` requires a `claude.web` attempt that may not exist, and `shouldOpenTerminalForOAuthError` finds no OAuth error → both fall through and the menu shows no action at all, leaving only the raw error string.

## Change

- `ClaudeProviderImplementation.loginMenuAction`: when neither the web nor OAuth recovery branch matches and the surfaced Claude error is `ProviderFetchError.noAvailableStrategy(.claude)`, fall back to the existing `("Re-login at claude.ai", .loginToProvider(url:))` action.
- Extracted a small pure static seam `isNoAvailableStrategyError(_:)` so the routing stays unit-testable without live provider state.

## Scope / safety

- **No detection or auth-boundary changes** — source availability resolution is untouched; this only changes what the menu shows once the result is already "no strategy".
- Reuses the existing `MenuAction.loginToProvider` case and the existing "Re-login at claude.ai" label → **no new user-facing strings, no `.lproj` changes needed**.
- No new public type, no `UsageStore` field.

## Tests

- New `ClaudeLoginRecoveryActionTests` (3 tests, in-memory store seam, no Keychain prompts):
  - fully unconfigured Claude → returns the Re-login recovery action
  - no Claude error → no forced action
  - `isNoAvailableStrategyError` matches only the generic empty-plan error
- Regression `ClaudeSourcePlannerTests` (6) still pass. `swift build` clean, `swiftformat` clean.

## Before / After

- **Before:** menu shows `No available fetch strategy for claude.` and nothing actionable.
- **After:** menu additionally offers **Re-login at claude.ai** so a fully unconfigured user can recover.
