### PR TITLE
feat: parse and format resetTime for local Antigravity quota summary

### DIFF
--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -430,6 +430,12 @@ extension UsageMenuCardView.Model {
         namedWindow: NamedRateWindow,
         input: Input) -> String?
     {
+        if namedWindow.window.resetsAt != nil {
+            return self.resetText(
+                for: namedWindow.window,
+                style: input.resetTimeDisplayStyle,
+                now: input.now)
+        }
         if input.provider == .antigravity,
            self.isAntigravityQuotaSummaryWindow(namedWindow)
         {

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityQuotaSummaryParser.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityQuotaSummaryParser.swift
@@ -15,8 +15,25 @@ struct AntigravityQuotaSummaryBucket: Sendable, Equatable {
     let bucketId: String
     let displayName: String
     let remainingFraction: Double?
+    let resetTime: Date?
     let resetDescription: String?
     let disabled: Bool
+
+    init(
+        bucketId: String,
+        displayName: String,
+        remainingFraction: Double?,
+        resetTime: Date? = nil,
+        resetDescription: String?,
+        disabled: Bool)
+    {
+        self.bucketId = bucketId
+        self.displayName = displayName
+        self.remainingFraction = remainingFraction
+        self.resetTime = resetTime
+        self.resetDescription = resetDescription
+        self.disabled = disabled
+    }
 }
 
 extension AntigravityStatusProbe {
@@ -57,10 +74,12 @@ extension AntigravityStatusProbe {
         let bucketId = payload.bucketId?.trimmingCharacters(in: .whitespacesAndNewlines)
         let displayName = payload.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let resolvedBucketId = bucketId, !resolvedBucketId.isEmpty else { return nil }
+        let resetTime = payload.resetTime.flatMap { Self.parseDate($0) }
         return AntigravityQuotaSummaryBucket(
             bucketId: resolvedBucketId,
             displayName: self.nonEmpty(displayName) ?? resolvedBucketId,
             remainingFraction: payload.resolvedRemainingFraction,
+            resetTime: resetTime,
             resetDescription: payload.description,
             disabled: payload.disabled ?? false)
     }
@@ -119,6 +138,7 @@ private struct QuotaSummaryBucketPayload: Decodable {
     let disabled: Bool?
     let remainingFraction: Double?
     let remaining: QuotaSummaryRemainingPayload?
+    let resetTime: String?
 
     var resolvedRemainingFraction: Double? {
         self.remainingFraction ?? self.remaining?.remainingFraction

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -267,7 +267,7 @@ public struct AntigravityStatusSnapshot: Sendable {
                 let window = RateWindow(
                     usedPercent: usedPercent,
                     windowMinutes: Self.windowMinutes(forQuotaBucket: bucket),
-                    resetsAt: nil,
+                    resetsAt: bucket.resetTime,
                     resetDescription: bucket.resetDescription)
                 return NamedRateWindow(
                     id: Self.quotaSummaryWindowID(for: bucket),
@@ -905,7 +905,7 @@ public struct AntigravityStatusProbe: Sendable {
         return "\(code.rawValue)"
     }
 
-    private static func parseDate(_ value: String) -> Date? {
+    static func parseDate(_ value: String) -> Date? {
         if let date = ISO8601DateFormatter().date(from: value) {
             return date
         }

--- a/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
+++ b/Tests/CodexBarTests/AntigravityQuotaSummaryTests.swift
@@ -45,6 +45,15 @@ struct AntigravityQuotaSummaryTests {
         #expect(windows.map(\.window.windowMinutes) == [300, 10080, 300, 10080])
         #expect(windows.map { $0.window.remainingPercent.rounded() } == [91, 82, 73, 64])
         #expect(windows.map(\.usageKnown) == [true, true, true, true])
+
+        let expectedDates = [
+            ISO8601DateFormatter().date(from: "2026-06-15T11:39:34Z"),
+            ISO8601DateFormatter().date(from: "2026-06-19T08:45:39Z"),
+            ISO8601DateFormatter().date(from: "2026-06-15T12:52:10Z"),
+            ISO8601DateFormatter().date(from: "2026-06-20T00:39:54Z"),
+        ]
+        #expect(windows.map(\.window.resetsAt) == expectedDates)
+
         #expect(usage.primary?.remainingPercent.rounded() == 82)
         #expect(usage.secondary?.remainingPercent.rounded() == 64)
         #expect(usage.tertiary == nil)
@@ -267,13 +276,15 @@ private func antigravityQuotaSummaryJSON() -> String {
                 "bucketId": "gemini-weekly",
                 "displayName": "Weekly Limit",
                 "remaining": { "remainingFraction": 0.82 },
-                "description": "You have used some of your weekly limit, it will fully refresh in 5 days, 11 hours."
+                "description": "You have used some of your weekly limit, it will fully refresh in 5 days, 11 hours.",
+                "resetTime": "2026-06-19T08:45:39Z"
               },
               {
                 "bucketId": "gemini-5h",
                 "displayName": "Five Hour Limit",
                 "remaining": { "remainingFraction": 0.91 },
-                "description": "You have used some of your 5-hour limit, it will fully refresh in 4 hours."
+                "description": "You have used some of your 5-hour limit, it will fully refresh in 4 hours.",
+                "resetTime": "2026-06-15T11:39:34Z"
               }
             ]
           },
@@ -285,13 +296,15 @@ private func antigravityQuotaSummaryJSON() -> String {
                 "bucketId": "3p-weekly",
                 "displayName": "Weekly Limit",
                 "remaining": { "remainingFraction": 0.64 },
-                "description": "You have used some of your weekly limit, it will fully refresh in 6 days, 22 hours."
+                "description": "You have used some of your weekly limit, it will fully refresh in 6 days, 22 hours.",
+                "resetTime": "2026-06-20T00:39:54Z"
               },
               {
                 "bucketId": "3p-5h",
                 "displayName": "Five Hour Limit",
                 "remaining": { "remainingFraction": 0.73 },
-                "description": "You have used some of your 5-hour limit, it will fully refresh in 3 hours, 38 minutes."
+                "description": "You have used some of your 5-hour limit, it will fully refresh in 3 hours, 38 minutes.",
+                "resetTime": "2026-06-15T12:52:10Z"
               }
             ]
           }


### PR DESCRIPTION
### Summary
Completes the Antigravity quota summary restructuring from PR #1509. Prior to this change, local status probes (`RetrieveUserQuotaSummary`) did not parse the `resetTime` field, leaving `RateWindow.resetsAt` as `nil` and relying on brittle parsing of the English `resetDescription` text.

This change:
- Decodes the `resetTime` ISO8601 string from the local quota summary JSON payload.
- Populates `RateWindow.resetsAt` with the parsed date.
- Renders the structured reset time via the unified `resetText` formatter in `MenuCardView+ModelHelpers`, ensuring proper localization and formatting.

### Commands Run
- `make check`
- `swift test --filter Antigravity`

### UI / Screenshots
| Before | After |
| --- | --- |
| <img width="602" height="596" alt="Codex_agy_usage_before" src="https://github.com/user-attachments/assets/614f09d9-796d-492b-99ea-e40bbd8051a2" /> | <img width="594" height="598" alt="Codex_agy_usage_after" src="https://github.com/user-attachments/assets/74a6eee2-838a-4c54-ad97-e1ee404cb288" /> |

- Local LSP/CLI status now displays structured reset times (e.g., "Resets tomorrow, 12:39 AM" or "Resets Jun 19 at 4:45 PM") rather than falling back to raw English description text.
- OAuth remains unchanged (retains its model-level structured reset times).