### PR TITLE
Reuse the precomputed store icon signature in updateIcons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 - Website: add Poe, Chutes, and Zed to the provider gallery with matching icons and setup documentation.
+- Menu bar: reuse the icon-observation signature during provider refreshes instead of computing it twice. Thanks @abe238!
 
 ### Fixed
 - Provider switcher: use a continuous menu background instead of a separate light-mode tinted band. Thanks @Zihao-Qi!

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -525,8 +525,9 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
                 self.observeStoreIconChanges()
                 let signature = self.storeIconObservationSignature()
                 guard signature != self.lastObservedStoreIconWorkSignature else { return }
-                self.lastObservedStoreIconWorkSignature = signature
-                self.updateIcons()
+                // Reuse the signature we just computed for the change check; `updateIcons` would
+                // otherwise recompute the identical value on the same main-actor turn.
+                self.updateIcons(precomputedStoreIconSignature: signature)
             }
         }
     }
@@ -664,13 +665,19 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
         }
     }
 
-    func updateIcons() {
+    /// Updates the menu bar icons.
+    ///
+    /// The store-icon observer already computes `storeIconObservationSignature()` to decide whether any
+    /// icon work is needed, so it passes that value in via `precomputedStoreIconSignature` to avoid
+    /// recomputing the identical signature on the same main-actor turn. Other callers omit it and let the
+    /// signature refresh here, keeping `lastObservedStoreIconWorkSignature` current as the change gate.
+    func updateIcons(precomputedStoreIconSignature: String? = nil) {
         #if DEBUG
         guard !self.isReleasedForTesting else { return }
         #endif
         MainThreadActivityBreadcrumb.push("updateIcons")
         self.scheduleMenuBarCountdownRefreshIfNeeded()
-        self.lastObservedStoreIconWorkSignature = self.storeIconObservationSignature()
+        self.lastObservedStoreIconWorkSignature = precomputedStoreIconSignature ?? self.storeIconObservationSignature()
         self.beginIconPerfUpdatePass()
         defer {
             self.endIconPerfUpdatePass()

--- a/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
+++ b/Tests/CodexBarTests/StatusItemIconObservationSignatureTests.swift
@@ -225,6 +225,31 @@ struct StatusItemIconObservationSignatureTests {
         #expect(controller.storeIconObservationSignature() != baseline)
     }
 
+    @Test
+    func `updateIcons reuses a precomputed store icon signature instead of recomputing it`() {
+        let (_, _, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-precomputed-reuse")
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let precomputed = "precomputed-store-icon-signature-sentinel"
+        controller.updateIcons(precomputedStoreIconSignature: precomputed)
+
+        // A supplied signature must be stored verbatim; if updateIcons recomputed it, the gate would
+        // never equal the sentinel value.
+        #expect(controller.lastObservedStoreIconWorkSignature == precomputed)
+    }
+
+    @Test
+    func `updateIcons recomputes the store icon signature when none is provided`() {
+        let (_, _, controller) = self.makeController(
+            suiteName: "StatusItemIconObservationSignatureTests-recompute-default")
+        defer { controller.releaseStatusItemsForTesting() }
+
+        controller.updateIcons()
+
+        #expect(controller.lastObservedStoreIconWorkSignature == controller.storeIconObservationSignature())
+    }
+
     private static func makeSnapshot(
         provider: UsageProvider,
         email: String,


### PR DESCRIPTION
## Summary

`updateIcons()` recomputed `storeIconObservationSignature()` on every call, but `observeStoreIconChanges()` had *just* computed that exact signature to decide whether any icon work was needed. So every icon-observer fire serialized the signature **twice** on the same main-actor turn, over identical store/settings state.

This threads the already-computed signature into `updateIcons(precomputedStoreIconSignature:)`, so the observer-driven path computes it once. Every other `updateIcons()` caller (settings changes, the countdown refresh, quota-warning flash, etc.) omits the argument and recomputes exactly as before, keeping `lastObservedStoreIconWorkSignature` current as the change gate. The change is behavior-preserving — it removes a duplicate computation, nothing else.

### Why it matters

`iconObservationToken` reads `refreshingProviders`, so the observer fires on every provider refresh **start and stop**. `storeIconObservationSignature()` isn't free: per visible provider it runs `IconRemainingResolver.resolvedPercents`, `menuBarCreditsRemainingForIcon`, and (in brand-icon + percent mode) `menuBarDisplayText` with the Codex consumer projection. Halving that on the hot refresh path removes redundant main-thread work that scales with the number of enabled providers — in the same spirit as the recent icon-observation churn reductions (e.g. #1297).

## Changes

- `StatusItemController.updateIcons(precomputedStoreIconSignature:)` takes an optional precomputed signature and falls back to recomputing when it is `nil`.
- `observeStoreIconChanges()` passes the signature it already computed for the change check instead of letting `updateIcons()` recompute it.

## Tests

Added two focused cases to `StatusItemIconObservationSignatureTests`:

- `updateIcons reuses a precomputed store icon signature instead of recomputing it` — proves the supplied value is stored verbatim (no recompute).
- `updateIcons recomputes the store icon signature when none is provided` — preserves behavior for the other callers.

## Commands run

- `swift build` — clean
- `swift test --filter StatusItemIconObservationSignatureTests` — 11/11 pass
- `swiftformat --lint Sources/CodexBar/StatusItemController.swift Tests/...` — 0 changes
- `swiftlint --strict <changed files>` — 0 violations

No UI change (behavior-preserving), so no screenshots.

---

P.S. — Abe here: I admire you a ton, Pete! Thank you for CodexBar and for everything you ship for this community. 🙏
