### PR TITLE
Fix stale menu after refresh with hosted submenu open

### DIFF
--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -163,6 +163,9 @@ extension StatusItemController {
 
         self.clearMergedSwitcherContentCache(for: menu)
         self.openMenus.removeValue(forKey: key)
+        if self.openMenus.isEmpty {
+            self.parentMenuRebuildPendingAfterHostedSubviewClose = false
+        }
         self.cancelMenuWork(key)
         self.clearMenuHighlight(key)
 

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -405,9 +405,7 @@ extension StatusItemController {
     func refreshOpenMenusAfterHostedSubviewClose() {
         guard self.isMenuRefreshEnabled else { return }
         guard !self.openMenus.isEmpty else { return }
-        self.refreshOpenMenusIfNeeded(
-            allowsParentRebuild: true,
-            respectsParentRebuildDeferral: true)
+        self.refreshOpenMenusIfNeeded(allowsParentRebuild: true)
     }
 
     func refreshOpenMenusAllowingParentRebuild(deferParentRebuildDuringTracking: Bool = false) {

--- a/Sources/CodexBar/StatusItemController+MenuTracking.swift
+++ b/Sources/CodexBar/StatusItemController+MenuTracking.swift
@@ -405,7 +405,19 @@ extension StatusItemController {
     func refreshOpenMenusAfterHostedSubviewClose() {
         guard self.isMenuRefreshEnabled else { return }
         guard !self.openMenus.isEmpty else { return }
+        if self.isMenuDataRefreshInFlight {
+            self.parentMenuRebuildPendingAfterHostedSubviewClose = true
+            return
+        }
+        self.parentMenuRebuildPendingAfterHostedSubviewClose = false
         self.refreshOpenMenusIfNeeded(allowsParentRebuild: true)
+    }
+
+    func completeParentMenuRebuildAfterHostedSubviewCloseIfNeeded() {
+        guard self.parentMenuRebuildPendingAfterHostedSubviewClose else { return }
+        guard !self.isMenuDataRefreshInFlight else { return }
+        guard !self.hasOpenHostedSubviewMenu() else { return }
+        self.refreshOpenMenusAfterHostedSubviewClose()
     }
 
     func refreshOpenMenusAllowingParentRebuild(deferParentRebuildDuringTracking: Bool = false) {

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -135,6 +135,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
     var menuIdentitySignatures: [ObjectIdentifier: String] = [:]
     var codexAccountMenuProjectionRevalidationTask: Task<Void, Never>?
     var openMenuRebuildsClosingHostedSubviewMenus: Set<ObjectIdentifier> = []
+    var parentMenuRebuildPendingAfterHostedSubviewClose = false
     var deferredMenuInteractionRefreshProviders: Set<UsageProvider> = []
     var deferredMenuInteractionRefreshPending: Bool {
         !self.deferredMenuInteractionRefreshProviders.isEmpty
@@ -512,6 +513,7 @@ final class StatusItemController: NSObject, NSMenuDelegate, StatusItemControllin
             refreshOpenMenus: refreshOpenMenus,
             deferOpenParentMenuRebuild: true,
             allowStaleContentDuringDataRefresh: true)
+        self.completeParentMenuRebuildAfterHostedSubviewCloseIfNeeded()
     }
 
     private func observeStoreIconChanges() {

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -681,6 +681,67 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `hosted submenu close waits for active refresh before rebuilding parent`() async {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let store = self.makeCodexStore(settings: settings, dashboardAuthorized: false)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: UsageFetcher().loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        let menuKey = ObjectIdentifier(menu)
+        controller.openMenus[menuKey] = menu
+
+        let submenu = controller.makeHostedSubviewPlaceholderMenu(
+            chartID: StatusItemController.usageBreakdownChartID,
+            provider: .codex)
+        let submenuKey = ObjectIdentifier(submenu)
+        controller.openMenus[submenuKey] = submenu
+        controller.menuRefreshEnabledOverrideForTesting = true
+
+        let openedVersion = controller.menuVersions[menuKey]
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { _ in
+            rebuildCount += 1
+        }
+        defer { controller._test_openMenuRebuildObserver = nil }
+
+        store.isRefreshing = true
+        controller.refreshOpenMenusAfterExplicitStoreAction()
+        controller.menuDidClose(submenu)
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+
+        #expect(controller.openMenus[submenuKey] == nil)
+        #expect(rebuildCount == 0)
+        #expect(controller.menuVersions[menuKey] == openedVersion)
+        #expect(controller.parentMenuRebuildPendingAfterHostedSubviewClose)
+
+        store.isRefreshing = false
+        controller.handleObservedStoreMenuChange()
+        for _ in 0..<20 where rebuildCount == 0 {
+            await Task.yield()
+        }
+
+        #expect(rebuildCount == 1)
+        #expect(controller.menuVersions[menuKey] == controller.menuContentVersion)
+        #expect(!controller.parentMenuRebuildPendingAfterHostedSubviewClose)
+        #expect(!controller.parentMenuRebuildsDeferredDuringTracking.contains(menuKey))
+    }
+
+    @Test
     func `plain open menu refresh preserves pending switcher hosted submenu cleanup`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuOpenRefreshTests.swift
@@ -627,7 +627,7 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `explicit refresh keeps stale parent deferred after hosted submenu closes`() async {
+    func `explicit refresh rebuilds stale parent after hosted submenu closes`() async {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false
@@ -670,14 +670,14 @@ extension StatusMenuTests {
         #expect(controller.menuVersions[menuKey] == openedVersion)
 
         controller.menuDidClose(submenu)
-        for _ in 0..<20 {
+        for _ in 0..<20 where rebuildCount == 0 {
             await Task.yield()
         }
 
         #expect(controller.openMenus[submenuKey] == nil)
-        #expect(rebuildCount == 0)
-        #expect(controller.menuVersions[menuKey] == openedVersion)
-        #expect(controller.parentMenuRebuildsDeferredDuringTracking.contains(menuKey))
+        #expect(rebuildCount == 1)
+        #expect(controller.menuVersions[menuKey] == controller.menuContentVersion)
+        #expect(!controller.parentMenuRebuildsDeferredDuringTracking.contains(menuKey))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fix a stale parent menu after a manual refresh completes while a hosted submenu is open.

## User-visible behavior

If the user opens a hosted submenu, such as a usage/history chart, and then clicks Refresh, the parent menu can keep showing the refresh spinner or stale "Refreshing..." content after the refresh has already completed. Closing the expanded submenu makes the menu update immediately, which makes the refresh look like it was stuck for much longer than it actually was.

## Root Cause

Manual refresh completion invalidates the open parent menu and defers rebuilding it while menu tracking is active. When a hosted submenu was open, closing that submenu still respected the existing parent rebuild deferral, leaving the parent menu on stale content even though the refresh had completed.

## Change

Allow `refreshOpenMenusAfterHostedSubviewClose()` to schedule the pending parent rebuild once the hosted submenu has closed. The parent menu is still not rebuilt while the submenu is open.

## Validation

- `swift test --filter StatusMenuOpenRefreshTests`