### PR TITLE
docs: add KodexBar Linux desktop integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Cursor: show personal on-demand spend alongside the shared team pool. Thanks @yashiels!
+- Documentation: link the community KDE Plasma panel integration. Thanks @tylxr59!
 - Codex: show available manual rate-limit reset credits and their next expiry for signed-in OAuth accounts. Thanks @rogdex24!
 - Mistral: add Vibe monthly-plan usage and menu bar metric selection. Thanks @lfmundim!
 - Storage: show a compact segmented provider breakdown with an expandable Other group. Thanks @elijahfriedman!

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ CLI install:
 - [codexbar-waybar](https://github.com/Marouan-chak/codexbar-waybar) — Waybar custom module + GTK4 popover for Hyprland / Sway / other Wayland compositors, built on top of the bundled Linux CLI.
 - [Codexbar GNOME](https://extensions.gnome.org/extension/9841/codexbar/) — GNOME Shell extension that brings CodexBar usage into the desktop panel.
 - [noctalia-codex-usage](https://github.com/rayoplateado/noctalia-codex-usage) — Noctalia/Quickshell plugin that shows Codex 5-hour and weekly usage limits, built on top of the bundled Linux CLI.
-
+- [KodexBar](https://github.com/tylxr59/KodexBar) — KDE Plasma widget that shows CodexBar usage in the Plasma panel, built on top of the bundled Linux CLI.
 
 ## Status bar & terminal integration
 - [showy-quota](https://github.com/enieuwy/showy-quota) — always-on AI plan quota strips for SketchyBar, tmux, and Zellij (standalone WASM plugin), built on `codexbar serve` / the bundled CLI.


### PR DESCRIPTION
## Summary
- Add KodexBar to the Linux desktop integrations list

## Context
KodexBar is a KDE Plasma widget that displays CodexBar usage in the Plasma panel. It is built on top of the bundled Linux CLI and lives in a separate repo because it is Plasma/QML-specific.

I'm still working on getting full feature parity with CodexBar but the groundwork is there.

## Test plan
- Documentation-only change
- Ran `git diff --check`

## Maintainer verification

Exact head: `d29d0d534fe5ae6d91ec96ab625ce5170c835c37`

- verified the linked public repository exists, is MIT-licensed, and is not archived
- inspected its QML integration: it invokes `codexbar usage` and `codexbar cost` with JSON-only output, so the README description is accurate
- hosted Linux x64/arm64, lint, security, and macOS shards 2/3 passed; shards 0/1 remain queued
