### PR TITLE
[codex] Fix provider switcher background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - DeepSeek: keep balance refreshes responsive when optional usage-summary work ignores cancellation.
 - OpenRouter: keep credit refreshes responsive when optional key-quota enrichment ignores cancellation.
 - Provider probes: stop waiting indefinitely for inherited output pipes after subprocesses or CLI version checks exit (fixes #1531).
+- Provider switcher: use a continuous menu background instead of a separate light-mode tinted band. Thanks @Zihao-Qi!
 - Menu bar: update visible usage values in place when a manual refresh completes instead of leaving the open provider card stale until the menu is reopened (fixes #1516).
 - Gemini: recognize the current `gemini-api-key` CLI auth setting so API-key sessions show the supported OAuth guidance instead of a misleading not-logged-in error (fixes #1511).
 - Kiro: keep usage refreshes bounded and clean up CLI helpers when they retain output pipes, ignore termination, or are cancelled (fixes #1533). Thanks @kiranmagic7!

--- a/Sources/CodexBar/StatusItemController+SwitcherViews.swift
+++ b/Sources/CodexBar/StatusItemController+SwitcherViews.swift
@@ -41,7 +41,6 @@ final class ProviderSwitcherView: NSView {
     private var hoveredButtonTag: Int?
     private var pressedButtonTag: Int?
     private var selectedSegmentIndex: Int?
-    private let lightModeOverlayLayer = CALayer()
     private static let quotaIndicatorHeight: CGFloat = 2
     private static let quotaIndicatorBottomInset: CGFloat = 2
     private static let quotaIndicatorHorizontalInset: CGFloat = 8
@@ -107,9 +106,6 @@ final class ProviderSwitcherView: NSView {
         Self.clearButtonWidthCache()
         self.wantsLayer = true
         self.layer?.masksToBounds = false
-        self.lightModeOverlayLayer.masksToBounds = false
-        self.layer?.insertSublayer(self.lightModeOverlayLayer, at: 0)
-        self.updateLightModeStyling()
 
         func makeButton(index: Int, segment: Segment) -> NSButton {
             let button: NSButton
@@ -214,14 +210,8 @@ final class ProviderSwitcherView: NSView {
         self.updateButtonStyles()
     }
 
-    override func layout() {
-        super.layout()
-        self.lightModeOverlayLayer.frame = self.bounds
-    }
-
     override func viewDidChangeEffectiveAppearance() {
         super.viewDidChangeEffectiveAppearance()
-        self.updateLightModeStyling()
         self.updateButtonStyles()
     }
 
@@ -715,15 +705,6 @@ final class ProviderSwitcherView: NSView {
 
     private func isLightMode() -> Bool {
         self.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua]) == .aqua
-    }
-
-    private func updateLightModeStyling() {
-        guard self.isLightMode() else {
-            self.lightModeOverlayLayer.backgroundColor = nil
-            return
-        }
-        // The menu card background is very bright in light mode; add a subtle neutral wash to ground the switcher.
-        self.lightModeOverlayLayer.backgroundColor = NSColor.black.withAlphaComponent(0.035).cgColor
     }
 
     private func hoverPlateColor() -> CGColor {


### PR DESCRIPTION
## Summary
Remove the light-mode overlay from the provider switcher row so the switcher inherits the same menu background as the content below it.

## Why
The old row-wide neutral wash made the top switcher look like a separate tinted band in light mode. The selected provider pill and the separator already provide enough structure, so the extra background layer is unnecessary.

## Validation
- `swift test --filter StatusMenuSwitcherLayoutTests`
- `make check`

## Screenshot
Attached: provider switcher with a continuous menu background.
<img width="297" height="58" alt="User attachment" src="https://github.com/user-attachments/assets/737730ef-5f2f-4b9f-b187-cd7cf92f7c73" />
