### PR TITLE
Codex/fix antigravity status shift

### DIFF
--- a/Sources/CodexBar/StatusItemController+MenuReconcile.swift
+++ b/Sources/CodexBar/StatusItemController+MenuReconcile.swift
@@ -4,6 +4,7 @@ import AppKit
 /// into the recycle pool so reconciliation can still compare row shapes afterwards.
 struct MenuRowShape {
     let isSeparator: Bool
+    let requiresNativeImageReplacement: Bool
     let id: String?
     let viewClassName: String?
 }
@@ -14,9 +15,20 @@ extension StatusItemController {
         return menu.items[fromIndex...].map { item in
             MenuRowShape(
                 isSeparator: item.isSeparatorItem,
+                requiresNativeImageReplacement: self.shouldReplaceNativeImageItemDuringReconcile(item),
                 id: item.representedObject as? String,
                 viewClassName: item.view.map { String(describing: type(of: $0)) })
         }
+    }
+
+    /// Identifies leaf AppKit image items that should be replaced instead of updated in place.
+    ///
+    /// AppKit can retain stale layout state for standard image-backed menu items after repeated
+    /// in-place updates, which makes rows such as "Status Page" drift horizontally. Submenu rows
+    /// stay on the normal reconciliation path because replacing their parent item can disturb an
+    /// active submenu.
+    private func shouldReplaceNativeImageItemDuringReconcile(_ item: NSMenuItem) -> Bool {
+        !item.isSeparatorItem && item.view == nil && item.image != nil && item.submenu == nil
     }
 
     /// Position-wise in-place reconciliation: live rows whose shape matches the freshly
@@ -44,6 +56,9 @@ extension StatusItemController {
         func updatable(_ shape: MenuRowShape, _ newItem: NSMenuItem) -> Bool {
             guard shape.isSeparator == newItem.isSeparatorItem else { return false }
             if shape.isSeparator { return true }
+            guard !shape.requiresNativeImageReplacement,
+                  !self.shouldReplaceNativeImageItemDuringReconcile(newItem)
+            else { return false }
             guard shape.id == newItem.representedObject as? String else { return false }
             return shape.viewClassName == newItem.view.map { String(describing: type(of: $0)) }
         }

--- a/Sources/CodexBar/StatusItemController+MenuReconcile.swift
+++ b/Sources/CodexBar/StatusItemController+MenuReconcile.swift
@@ -115,7 +115,10 @@ extension StatusItemController {
             let index = fromIndex + offset
             let liveItem = liveItems[offset]
             let newItem = newItems[offset]
-            if liveItem.isSeparatorItem == newItem.isSeparatorItem {
+            let requiresNativeImageReplacement =
+                self.shouldReplaceNativeImageItemDuringReconcile(liveItem) ||
+                self.shouldReplaceNativeImageItemDuringReconcile(newItem)
+            if liveItem.isSeparatorItem == newItem.isSeparatorItem, !requiresNativeImageReplacement {
                 if !liveItem.isSeparatorItem {
                     self.swapMenuItemContents(liveItem, newItem)
                 }

--- a/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
+++ b/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
@@ -141,7 +141,7 @@ extension StatusMenuTests {
     }
 
     @Test
-    func `merged data tick reconciles items in place without churn`() {
+    func `merged data tick keeps row count and card views stable`() {
         StatusItemController.setMenuRefreshEnabledForTesting(false)
         let previousRendering = StatusItemController.menuCardRenderingEnabled
         StatusItemController.menuCardRenderingEnabled = true
@@ -175,15 +175,14 @@ extension StatusMenuTests {
         controller.selectedMenuProvider = .codex
         let menu = controller.makeMenu()
         controller.populateMenu(menu, provider: .codex)
-        let itemsBefore = menu.items.map(ObjectIdentifier.init)
+        let itemCountBefore = menu.items.count
         let cardViewsBefore = self.cardViewIdentities(in: menu)
         #expect(!cardViewsBefore.isEmpty)
 
         controller.invalidateMenus(allowStaleContentDuringDataRefresh: true)
         controller.populateMenu(menu, provider: .codex)
 
-        let itemsAfter = menu.items.map(ObjectIdentifier.init)
-        #expect(itemsAfter == itemsBefore, "data-only repopulate should not remove or insert menu items")
+        #expect(menu.items.count == itemCountBefore, "data-only repopulate should keep row count stable")
         let cardViewsAfter = self.cardViewIdentities(in: menu)
         for (id, identity) in cardViewsBefore {
             #expect(cardViewsAfter[id] == identity, "card \(id) should reuse its hosting view")

--- a/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
+++ b/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
@@ -238,6 +238,37 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `cached provider content replaces native image rows and preserves switch back items`() {
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        let controller = self.makeRecyclingController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let outgoing = NSMenuItem(title: "Status Page", action: nil, keyEquivalent: "")
+        outgoing.image = NSImage(size: NSSize(width: 16, height: 16))
+        let incoming = NSMenuItem(title: "Dashboard", action: nil, keyEquivalent: "")
+        incoming.image = NSImage(size: NSSize(width: 16, height: 16))
+        let menu = NSMenu()
+        menu.addItem(outgoing)
+
+        let displacedOutgoing = controller.replaceMenuContentKeepingRowsVisible(
+            menu,
+            fromIndex: 0,
+            with: [incoming])
+
+        #expect(menu.items.first === incoming)
+        #expect(displacedOutgoing.first === outgoing)
+
+        let displacedIncoming = controller.replaceMenuContentKeepingRowsVisible(
+            menu,
+            fromIndex: 0,
+            with: displacedOutgoing)
+
+        #expect(menu.items.first === outgoing)
+        #expect(displacedIncoming.first === incoming)
+    }
+
+    @Test
     func `cached provider content swap preserves both item sets for switch back`() {
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false

--- a/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
@@ -224,6 +224,68 @@ struct StatusMenuSwitcherRefreshTests {
     }
 
     @Test
+    func `native image menu rows are replaced during reconciliation`() {
+        let settings = Self.makeSettings()
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = NSMenu()
+        let liveItem = Self.nativeImageItem(title: "Status Page")
+        menu.addItem(liveItem)
+        let shapes = controller.menuContentShapes(in: menu, fromIndex: 0)
+
+        let scratch = NSMenu()
+        let freshItem = Self.nativeImageItem(title: "Status Page")
+        scratch.addItem(freshItem)
+
+        controller.reconcileMenuContent(menu, fromIndex: 0, shapes: shapes, with: scratch)
+
+        #expect(menu.items.count == 1)
+        #expect(ObjectIdentifier(menu.items[0]) == ObjectIdentifier(freshItem))
+        #expect(ObjectIdentifier(menu.items[0]) != ObjectIdentifier(liveItem))
+    }
+
+    @Test
+    func `native image submenu rows reconcile in place`() {
+        let settings = Self.makeSettings()
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = NSMenu()
+        let liveItem = Self.nativeImageItem(title: "System Account")
+        liveItem.submenu = NSMenu(title: "System Account")
+        menu.addItem(liveItem)
+        let shapes = controller.menuContentShapes(in: menu, fromIndex: 0)
+
+        let scratch = NSMenu()
+        let freshItem = Self.nativeImageItem(title: "System Account")
+        freshItem.submenu = NSMenu(title: "System Account")
+        scratch.addItem(freshItem)
+
+        controller.reconcileMenuContent(menu, fromIndex: 0, shapes: shapes, with: scratch)
+
+        #expect(menu.items.count == 1)
+        #expect(ObjectIdentifier(menu.items[0]) == ObjectIdentifier(liveItem))
+        #expect(ObjectIdentifier(menu.items[0]) != ObjectIdentifier(freshItem))
+    }
+
+    @Test
     func `provider switch does not cache stale rows after required invalidation`() async throws {
         let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
         StatusItemController.menuCardRenderingEnabled = false
@@ -384,5 +446,11 @@ struct StatusMenuSwitcherRefreshTests {
         switcherView.subviews
             .compactMap { $0 as? NSButton }
             .sorted { $0.tag < $1.tag }
+    }
+
+    private static func nativeImageItem(title: String) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.image = NSImage(size: NSSize(width: 16, height: 16))
+        return item
     }
 }


### PR DESCRIPTION
## Summary

Fix a menu layout drift where native AppKit image rows, most visibly `Status Page`, could shift horizontally after repeated provider switching such as selecting Antigravity.

The fix keeps the existing open-menu reconciliation path, but avoids in-place updates for leaf native image-backed `NSMenuItem`s. Those rows are now replaced so AppKit gets a fresh layout state. Image-backed submenu parent rows are intentionally excluded from this replacement path to avoid disturbing active submenus.

## Why

The issue was caused by reusing standard AppKit menu items with images during open-menu reconciliation. AppKit can retain stale internal layout state for these rows after repeated in-place updates, causing the title/icon alignment to drift right.

Antigravity exposed this reliably, but the risky row type is shared across providers, so the fix belongs in the shared menu reconciler rather than in Antigravity-specific code.

## Changes

- Mark leaf native image menu rows as replacement-only during reconciliation.
- Exclude submenu parent rows from the replacement workaround.
- Document the AppKit layout workaround in the reconciler.
- Add regression coverage for replacing leaf native image rows like `Status Page`.
- Add coverage that image-backed submenu parent rows like `System Account` still reconcile in place.
- Update the recycling test to keep the important invariant: row count and card views stay stable, while leaf image rows may be replaced.

## Validation

- `swift test --filter StatusMenuSwitcherRefreshTests`
- `make check`
- `make test`

## Screenshots

Before: `Status Page` drifts right after repeated Antigravity selection.

<img width="302" height="81" alt="Screenshot 2026-06-15 at 13 24 59" src="https://github.com/user-attachments/assets/3f0e10b7-77a1-4bbb-bb53-a7e754060fad" />

After: native image rows stay aligned.

<img width="303" height="77" alt="Screenshot 2026-06-15 at 15 42 28" src="https://github.com/user-attachments/assets/6cc1cdfa-b0b5-49cf-a1fd-ac03d9b9d6c6" />