### PR TITLE
Fix usage pace risk label consistency

### DIFF
--- a/Sources/CodexBar/UsagePaceText.swift
+++ b/Sources/CodexBar/UsagePaceText.swift
@@ -60,6 +60,9 @@ enum UsagePaceText {
         guard let runOutProbability = pace.runOutProbability else { return etaLabel }
         let roundedRisk = self.roundedRiskPercent(runOutProbability)
         let riskLabel = L("≈ %d%% run-out risk", roundedRisk)
+        if pace.willLastToReset, roundedRisk > 0 {
+            return riskLabel
+        }
         if let etaLabel {
             return L("%@ · %@", etaLabel, riskLabel)
         }

--- a/Tests/CodexBarTests/UsagePaceTextTests.swift
+++ b/Tests/CodexBarTests/UsagePaceTextTests.swift
@@ -83,6 +83,24 @@ struct UsagePaceTextTests {
         #expect(detail.rightLabel == "Runs out in 2d · ≈ 70% run-out risk")
     }
 
+    @Test
+    func `weekly pace detail does not combine lasts until reset with run out risk`() {
+        let now = Date(timeIntervalSince1970: 0)
+        let pace = UsagePace(
+            stage: .slightlyBehind,
+            deltaPercent: -9,
+            expectedUsedPercent: 21,
+            actualUsedPercent: 12,
+            etaSeconds: nil,
+            willLastToReset: true,
+            runOutProbability: 0.45)
+
+        let detail = UsagePaceText.weeklyDetail(pace: pace, now: now)
+
+        #expect(detail.leftLabel == "9% in reserve")
+        #expect(detail.rightLabel == "≈ 45% run-out risk")
+    }
+
     // MARK: - Session pace (5-hour window)
 
     @Test


### PR DESCRIPTION
## Summary
- avoid rendering `Lasts until reset` together with a nonzero rounded run out risk
- keep the risk label visible when historical pace marks the quota as lasting but still reports material risk
- add regression coverage for the reported 45% risk state

Refs #1544

## Tests
- `swift test --filter UsagePaceTextTests`
- `make check`

## Notes
This intentionally does not change Codex historical pace authority or work day fallback behavior. It only removes the contradictory text state while maintainers decide the larger pacing semantics.