### PR TITLE
Add XDG config path support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ Or download release tarballs from GitHub Releases:
 - Optional: Settings → Providers → Codex → OpenAI cookies (Automatic or Manual) to add dashboard extras.
 
 ### Set API keys from the CLI
-Provider toggles and API keys live in `~/.codexbar/config.json`. You can script the same provider list that Settings → Providers uses:
+Provider toggles and API keys live in the resolved CodexBar config file. New installs use
+`~/.config/codexbar/config.json`; existing `~/.codexbar/config.json` installs still load from the legacy path. You can
+script the same provider list that Settings → Providers uses:
 
 ```bash
 codexbar config providers
@@ -144,7 +146,7 @@ show an incident indicator.
 - Privacy-first: on-device parsing by default; browser cookies are opt-in and reused (no passwords stored).
 
 ## Privacy note
-Wondering if CodexBar scans your disk? It doesn’t crawl your filesystem; it reads a small set of known locations (browser cookies/local storage, provider config files, local JSONL logs) when the related features are enabled. Provider tokens and token-account settings live in `~/.codexbar/config.json` with restrictive file permissions. See the discussion and audit notes in [issue #12](https://github.com/steipete/CodexBar/issues/12).
+Wondering if CodexBar scans your disk? It doesn’t crawl your filesystem; it reads a small set of known locations (browser cookies/local storage, provider config files, local JSONL logs) when the related features are enabled. Provider tokens and token-account settings live in the CodexBar config file with restrictive file permissions. See the discussion and audit notes in [issue #12](https://github.com/steipete/CodexBar/issues/12).
 
 ## macOS permissions (why they’re needed)
 - **Full Disk Access (optional)**: only required to read Safari cookies/local storage for web-based providers. If you don’t grant it, use another supported browser, manual cookies/API keys, OAuth, or CLI/local sources where that provider supports them.

--- a/Sources/CodexBarCLI/CLIHelp.swift
+++ b/Sources/CodexBarCLI/CLIHelp.swift
@@ -26,7 +26,7 @@ extension CodexBarCLI {
             Auto falls back to Claude CLI only when cookies are missing.
           - Kilo: app.kilo.ai API.
             Auto falls back to Kilo CLI when API credentials are missing or unauthorized.
-          Token accounts are loaded from ~/.codexbar/config.json.
+          Token accounts are loaded from the resolved CodexBar config file.
           Use --account or --account-index to select a specific token account.
           Use --all-accounts to fetch every token account, or every visible Codex account for Codex.
           Account selection requires a single provider.
@@ -129,7 +129,7 @@ extension CodexBarCLI {
           Validate or print the CodexBar config file (default: validate).
           providers lists persistent provider enablement.
           enable/disable updates the same provider toggle used by Settings.
-          set-api-key stores a provider API key in ~/.codexbar/config.json and enables that provider by default.
+          set-api-key stores a provider API key in the resolved config file and enables that provider by default.
 
         Examples:
           codexbar config validate --format json --pretty

--- a/Sources/CodexBarCore/Config/CodexBarConfigStore.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfigStore.swift
@@ -19,6 +19,7 @@ public enum CodexBarConfigStoreError: LocalizedError {
 
 public struct CodexBarConfigStore: @unchecked Sendable {
     public static let pathEnvironmentKey = "CODEXBAR_CONFIG"
+    public static let xdgConfigHomeEnvironmentKey = "XDG_CONFIG_HOME"
 
     public let fileURL: URL
     private let fileManager: FileManager
@@ -74,7 +75,8 @@ public struct CodexBarConfigStore: @unchecked Sendable {
 
     public static func defaultURL(
         home: URL = FileManager.default.homeDirectoryForCurrentUser,
-        environment: [String: String] = ProcessInfo.processInfo.environment) -> URL
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default) -> URL
     {
         if let override = environment[pathEnvironmentKey]?.trimmingCharacters(in: .whitespacesAndNewlines),
            !override.isEmpty
@@ -82,9 +84,33 @@ public struct CodexBarConfigStore: @unchecked Sendable {
             let expanded = (override as NSString).expandingTildeInPath
             return URL(fileURLWithPath: expanded)
         }
-        return home
+
+        if let xdgConfigHome = environment[xdgConfigHomeEnvironmentKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !xdgConfigHome.isEmpty
+        {
+            let expanded = (xdgConfigHome as NSString).expandingTildeInPath
+            return URL(fileURLWithPath: expanded, isDirectory: true)
+                .appendingPathComponent("codexbar", isDirectory: true)
+                .appendingPathComponent("config.json")
+        }
+
+        let xdgDefault = home
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("codexbar", isDirectory: true)
+            .appendingPathComponent("config.json")
+        if fileManager.fileExists(atPath: xdgDefault.path) {
+            return xdgDefault
+        }
+
+        let legacy = home
             .appendingPathComponent(".codexbar", isDirectory: true)
             .appendingPathComponent("config.json")
+        if fileManager.fileExists(atPath: legacy.path) {
+            return legacy
+        }
+
+        return xdgDefault
     }
 
     private func applySecurePermissionsIfNeeded() throws {

--- a/Sources/CodexBarCore/Config/CodexBarConfigStore.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfigStore.swift
@@ -90,9 +90,11 @@ public struct CodexBarConfigStore: @unchecked Sendable {
             !xdgConfigHome.isEmpty
         {
             let expanded = (xdgConfigHome as NSString).expandingTildeInPath
-            return URL(fileURLWithPath: expanded, isDirectory: true)
-                .appendingPathComponent("codexbar", isDirectory: true)
-                .appendingPathComponent("config.json")
+            if (expanded as NSString).isAbsolutePath {
+                return URL(fileURLWithPath: expanded, isDirectory: true)
+                    .appendingPathComponent("codexbar", isDirectory: true)
+                    .appendingPathComponent("config.json")
+            }
         }
 
         let xdgDefault = home

--- a/Tests/CodexBarTests/ConfigValidationTests.swift
+++ b/Tests/CodexBarTests/ConfigValidationTests.swift
@@ -141,6 +141,24 @@ struct ConfigValidationTests {
     }
 
     @Test
+    func `config store default url ignores relative xdg config home`() throws {
+        let fileManager = FileManager.default
+        let home = try Self.makeTemporaryHome()
+        defer { try? fileManager.removeItem(at: home) }
+        let legacy = Self.legacyConfigURL(in: home)
+        try Self.touch(legacy, fileManager: fileManager)
+
+        let url = CodexBarConfigStore.defaultURL(
+            home: home,
+            environment: [
+                CodexBarConfigStore.xdgConfigHomeEnvironmentKey: "relative-config",
+            ],
+            fileManager: fileManager)
+
+        #expect(url == legacy)
+    }
+
+    @Test
     func `config store default url creates in xdg default for new installs`() throws {
         let fileManager = FileManager.default
         let home = try Self.makeTemporaryHome()

--- a/Tests/CodexBarTests/ConfigValidationTests.swift
+++ b/Tests/CodexBarTests/ConfigValidationTests.swift
@@ -122,4 +122,84 @@ struct ConfigValidationTests {
 
         #expect(url.path.hasSuffix("/tmp/codexbar-test-config.json"))
     }
+
+    @Test
+    func `config store default url honors xdg config home`() throws {
+        let fileManager = FileManager.default
+        let home = try Self.makeTemporaryHome()
+        defer { try? fileManager.removeItem(at: home) }
+        let xdgHome = home.appendingPathComponent("custom-config", isDirectory: true)
+
+        let url = CodexBarConfigStore.defaultURL(
+            home: home,
+            environment: [
+                CodexBarConfigStore.xdgConfigHomeEnvironmentKey: xdgHome.path,
+            ],
+            fileManager: fileManager)
+
+        #expect(url == Self.configURL(in: xdgHome))
+    }
+
+    @Test
+    func `config store default url creates in xdg default for new installs`() throws {
+        let fileManager = FileManager.default
+        let home = try Self.makeTemporaryHome()
+        defer { try? fileManager.removeItem(at: home) }
+
+        let url = CodexBarConfigStore.defaultURL(home: home, environment: [:], fileManager: fileManager)
+
+        #expect(url == Self.configURL(in: home.appendingPathComponent(".config", isDirectory: true)))
+    }
+
+    @Test
+    func `config store default url keeps existing legacy config`() throws {
+        let fileManager = FileManager.default
+        let home = try Self.makeTemporaryHome()
+        defer { try? fileManager.removeItem(at: home) }
+        let legacy = Self.legacyConfigURL(in: home)
+        try Self.touch(legacy, fileManager: fileManager)
+
+        let url = CodexBarConfigStore.defaultURL(home: home, environment: [:], fileManager: fileManager)
+
+        #expect(url == legacy)
+    }
+
+    @Test
+    func `config store default url prefers existing xdg default over legacy config`() throws {
+        let fileManager = FileManager.default
+        let home = try Self.makeTemporaryHome()
+        defer { try? fileManager.removeItem(at: home) }
+        let xdgDefault = Self.configURL(in: home.appendingPathComponent(".config", isDirectory: true))
+        let legacy = Self.legacyConfigURL(in: home)
+        try Self.touch(legacy, fileManager: fileManager)
+        try Self.touch(xdgDefault, fileManager: fileManager)
+
+        let url = CodexBarConfigStore.defaultURL(home: home, environment: [:], fileManager: fileManager)
+
+        #expect(url == xdgDefault)
+    }
+
+    private static func makeTemporaryHome() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexBarConfigStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private static func touch(_ url: URL, fileManager: FileManager) throws {
+        try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data().write(to: url)
+    }
+
+    private static func configURL(in directory: URL) -> URL {
+        directory
+            .appendingPathComponent("codexbar", isDirectory: true)
+            .appendingPathComponent("config.json")
+    }
+
+    private static func legacyConfigURL(in home: URL) -> URL {
+        home
+            .appendingPathComponent(".codexbar", isDirectory: true)
+            .appendingPathComponent("config.json")
+    }
 }

--- a/docs/cli-configuration.md
+++ b/docs/cli-configuration.md
@@ -9,8 +9,8 @@ read_when:
 # CLI configuration
 
 `codexbar config` edits the same resolved config file used by the app's Settings → Providers pane.
-New installs use `~/.config/codexbar/config.json`; `XDG_CONFIG_HOME` and `CODEXBAR_CONFIG` are supported, and
-existing `~/.codexbar/config.json` installs keep using the legacy file when no XDG config exists.
+New installs use `~/.config/codexbar/config.json`; absolute `XDG_CONFIG_HOME` paths and `CODEXBAR_CONFIG` are
+supported, and existing `~/.codexbar/config.json` installs keep using the legacy file when no XDG config exists.
 The CLI writes the file with `0600` permissions.
 
 ## Providers

--- a/docs/cli-configuration.md
+++ b/docs/cli-configuration.md
@@ -8,7 +8,9 @@ read_when:
 
 # CLI configuration
 
-`codexbar config` edits the same `~/.codexbar/config.json` file used by the app's Settings → Providers pane.
+`codexbar config` edits the same resolved config file used by the app's Settings → Providers pane.
+New installs use `~/.config/codexbar/config.json`; `XDG_CONFIG_HOME` and `CODEXBAR_CONFIG` are supported, and
+existing `~/.codexbar/config.json` installs keep using the legacy file when no XDG config exists.
 The CLI writes the file with `0600` permissions.
 
 ## Providers
@@ -64,7 +66,7 @@ sessions instead of an xAI API key for CodexBar's billing view, so enable them w
 `codexbar config enable --provider grok`.
 
 LLM Proxy also needs a base URL. Use `LLM_PROXY_BASE_URL` for CLI runs, or add `"enterpriseHost"` to the provider entry
-in `~/.codexbar/config.json`.
+in the CodexBar config file.
 
 ## Isolated config files
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,7 +36,7 @@ tar -xzf CodexBarCLI-v0.17.0-macos-x86_64.tar.gz
 
 ## Configuration
 CodexBar reads the resolved config file for provider settings, secrets, and ordering. New installs use
-`~/.config/codexbar/config.json`; `XDG_CONFIG_HOME` and `CODEXBAR_CONFIG` are supported, and existing
+`~/.config/codexbar/config.json`; absolute `XDG_CONFIG_HOME` paths and `CODEXBAR_CONFIG` are supported, and existing
 `~/.codexbar/config.json` installs keep using the legacy file when no XDG config exists.
 See `docs/configuration.md` for the schema.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,7 +35,9 @@ tar -xzf CodexBarCLI-v0.17.0-macos-x86_64.tar.gz
 - Dependencies: Swift 6.2+, Commander package (`https://github.com/steipete/Commander`).
 
 ## Configuration
-CodexBar reads `~/.codexbar/config.json` for provider settings, secrets, and ordering.
+CodexBar reads the resolved config file for provider settings, secrets, and ordering. New installs use
+`~/.config/codexbar/config.json`; `XDG_CONFIG_HOME` and `CODEXBAR_CONFIG` are supported, and existing
+`~/.codexbar/config.json` installs keep using the legacy file when no XDG config exists.
 See `docs/configuration.md` for the schema.
 
 ## Command
@@ -84,13 +86,13 @@ See `docs/configuration.md` for the schema.
 - Global flags: `-h/--help`, `-V/--version`, `-v/--verbose`, `--no-color`, `--log-level <trace|verbose|debug|info|warning|error|critical>`, `--json-output`, `--json-only`.
   - `--json-output`: JSONL logs on stderr (machine-readable).
   - `--json-only`: suppress non-JSON output; errors become JSON payloads.
-- `codexbar config validate` checks `~/.codexbar/config.json` for invalid fields.
+- `codexbar config validate` checks the resolved config file for invalid fields.
   - `--format text|json`, `--pretty`, and `--json-only` are supported.
   - Warnings keep exit code 0; errors exit non-zero.
 - `codexbar config dump` prints the normalized config JSON.
 
 ### Token accounts
-The CLI reads multi-account tokens from `~/.codexbar/config.json` (same file as the app).
+The CLI reads multi-account tokens from the same resolved config file as the app.
 - Select a specific account: `--account <label>` (matches the label/email in the file).
 - Select by index (1-based): `--account-index <n>`.
 - Fetch all accounts for the provider: `--all-accounts`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,8 +12,10 @@ CodexBar reads a single JSON config file for CLI and app provider settings.
 API keys, manual cookie headers, source selection, ordering, and token accounts live here. Keychain is still used for runtime cookie caches, browser Safe Storage access, and provider OAuth/device-flow credentials where those flows require it.
 
 ## Location
-- `~/.codexbar/config.json`
-- Override for scripts/tests: set `CODEXBAR_CONFIG=/path/to/config.json`.
+- `CODEXBAR_CONFIG=/path/to/config.json` when set.
+- `$XDG_CONFIG_HOME/codexbar/config.json` when `XDG_CONFIG_HOME` is set.
+- `~/.config/codexbar/config.json` by default for new installs.
+- `~/.codexbar/config.json` for existing legacy installs when no XDG config exists.
 - The directory is created if missing.
 - Permissions are set to `0600` whenever CodexBar writes the file on macOS and Linux.
 
@@ -59,7 +61,7 @@ All provider fields are optional unless noted.
 
 ## Manual cookies
 Use manual cookies when automatic browser import is unavailable, disabled, or too noisy for your setup.
-The app and CLI both read the same `~/.codexbar/config.json`, so a manual cookie saved in the UI is also used by
+The app and CLI both read the same resolved config file, so a manual cookie saved in the UI is also used by
 `codexbar`, and a cookie written by tooling is shown in the app after reload.
 
 `cookieHeader` expects the HTTP `Cookie:` request header value for the provider origin, not a raw Netscape cookie
@@ -142,7 +144,7 @@ LiteLLM also needs a base URL. Set `enterpriseHost` in config or `LITELLM_BASE_U
 
 See [CLI configuration](cli-configuration.md) for scripting examples and output formats.
 
-Manual cookies are secrets. Keep `~/.codexbar/config.json` private, leave its permissions at `0600`, never commit it,
+Manual cookies are secrets. Keep the CodexBar config file private, leave its permissions at `0600`, never commit it,
 and never paste real cookie values or readable DevTools screenshots into public issues.
 
 ### tokenAccounts

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,7 +13,8 @@ API keys, manual cookie headers, source selection, ordering, and token accounts 
 
 ## Location
 - `CODEXBAR_CONFIG=/path/to/config.json` when set.
-- `$XDG_CONFIG_HOME/codexbar/config.json` when `XDG_CONFIG_HOME` is set.
+- `$XDG_CONFIG_HOME/codexbar/config.json` when `XDG_CONFIG_HOME` is set to an absolute path. Relative values are
+  ignored.
 - `~/.config/codexbar/config.json` by default for new installs.
 - `~/.codexbar/config.json` for existing legacy installs when no XDG config exists.
 - The directory is created if missing.


### PR DESCRIPTION
## Summary
- keep `CODEXBAR_CONFIG` as the explicit file override
- support `XDG_CONFIG_HOME/codexbar/config.json` when `XDG_CONFIG_HOME` is set
- default new installs to `~/.config/codexbar/config.json` while preserving existing `~/.codexbar/config.json` installs
- update CLI and config docs for the resolved config path

Fixes #1528

## Resolution order
1. `CODEXBAR_CONFIG`
2. `$XDG_CONFIG_HOME/codexbar/config.json`
3. existing `~/.config/codexbar/config.json`
4. existing `~/.codexbar/config.json`
5. new `~/.config/codexbar/config.json`

## Tests
- `swift test --filter ConfigValidationTests`
- `swift test --filter CLIConfigCommandTests`
- `make check`

## Notes
This does not migrate or move existing config files. It only changes path resolution for reads and writes.