### PR TITLE
Fix MiMo Firefox session cookie import

### DIFF
--- a/Sources/CodexBarCore/Logging/LogCategories.swift
+++ b/Sources/CodexBarCore/Logging/LogCategories.swift
@@ -56,6 +56,7 @@ public enum LogCategories {
     public static let minimaxCookieStore = "minimax-cookie-store"
     public static let minimaxUsage = "minimax-usage"
     public static let minimaxWeb = "minimax-web"
+    public static let mimoCookie = "mimo-cookie"
     public static let moonshotUsage = "moonshot-usage"
     public static let notifications = "notifications"
     public static let openAIWeb = "openai-web"

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
@@ -229,6 +229,7 @@ public enum MiMoCookieImporter {
             let profileDirectory = URL(fileURLWithPath: profileID, isDirectory: true)
             let sessionRecords = MiMoFirefoxSessionCookieImporter.records(
                 profileDirectory: profileDirectory,
+                persistedRecords: source.records,
                 logger: logger)
             guard !sessionRecords.isEmpty else {
                 if resolvedByProfileID[profileID] == nil {
@@ -376,28 +377,48 @@ enum MiMoFirefoxSessionCookieImporter {
 
     static func records(
         profileDirectory: URL,
+        persistedRecords: [BrowserCookieRecord] = [],
         now: Date = Date(),
         logger: ((String) -> Void)? = nil) -> [BrowserCookieRecord]
     {
         let files = self.sessionRestoreFiles(profileDirectory: profileDirectory)
+        var firstPartialRecords: [BrowserCookieRecord] = []
         for file in files {
             do {
                 let data = try self.readData(from: file)
                 let jsonData = try self.decodeSessionRestoreData(data)
                 let records = try self.cookieRecords(fromJSONData: jsonData, now: now)
-                if !records.isEmpty {
-                    logger?(
-                        "\(profileDirectory.lastPathComponent): found MiMo session cookies in " +
-                            "\(file.lastPathComponent)")
-                    return records
+                guard !records.isEmpty else { continue }
+                let isCurrentRestore = file.lastPathComponent == "recovery.jsonlz4" ||
+                    (file.lastPathComponent == "sessionstore.jsonlz4" &&
+                        file.deletingLastPathComponent().standardizedFileURL == profileDirectory.standardizedFileURL)
+                let persistedKeys = Set(persistedRecords.map { "\($0.name)|\($0.domain)|\($0.path)" })
+                let candidateRecords = isCurrentRestore ? records : records.filter { record in
+                    !persistedKeys.contains("\(record.name)|\(record.domain)|\(record.path)")
                 }
+                guard !candidateRecords.isEmpty else { continue }
+                if firstPartialRecords.isEmpty {
+                    firstPartialRecords = candidateRecords
+                }
+                let candidateKeys = Set(candidateRecords.map { "\($0.name)|\($0.domain)|\($0.path)" })
+                let resolvedRecords = persistedRecords.filter { record in
+                    !candidateKeys.contains("\(record.name)|\(record.domain)|\(record.path)")
+                } + candidateRecords
+                let cookies = BrowserCookieClient.makeHTTPCookies(resolvedRecords, origin: .domainBased)
+                if MiMoCookieHeader.header(from: cookies) != nil {
+                    logger?(
+                        "\(profileDirectory.lastPathComponent): found MiMo session cookies through " +
+                            "\(file.lastPathComponent)")
+                    return candidateRecords
+                }
+                logger?("\(profileDirectory.lastPathComponent): partial MiMo cookies in \(file.lastPathComponent)")
             } catch {
                 logger?(
                     "\(profileDirectory.lastPathComponent): could not read Firefox session restore " +
                         "\(file.lastPathComponent): \(error.localizedDescription)")
             }
         }
-        return []
+        return firstPartialRecords
     }
 
     static func readData(

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
@@ -102,6 +102,7 @@ private let miMoCookieImportOrder: BrowserCookieImportOrder =
     ProviderDefaults.metadata[.mimo]?.browserCookieOrder ?? Browser.defaultImportOrder
 
 public enum MiMoCookieImporter {
+    private static let log = CodexBarLog.logger(LogCategories.mimoCookie)
     private static let cookieClient = BrowserCookieClient()
     private static let cookieDomains = [
         "platform.xiaomimimo.com",
@@ -146,7 +147,10 @@ public enum MiMoCookieImporter {
         loadRecords: (Browser, BrowserCookieQuery, ((String) -> Void)?) throws
             -> [BrowserCookieStoreRecords]) throws -> [SessionInfo]
     {
-        let log: (String) -> Void = { msg in logger?("[mimo-cookie] \(msg)") }
+        let log: (String) -> Void = { msg in
+            logger?("[mimo-cookie] \(msg)")
+            Self.log.debug("\(msg)")
+        }
         var sessions: [SessionInfo] = []
         var accessDeniedHints: [String] = []
         let installed = miMoCookieImportOrder.cookieImportCandidates(using: browserDetection)
@@ -157,7 +161,17 @@ public enum MiMoCookieImporter {
             do {
                 let query = BrowserCookieQuery(domains: self.cookieDomains)
                 let sources = try loadRecords(browserSource, query, log)
-                sessions.append(contentsOf: self.sessionInfos(from: sources, origin: query.origin))
+                let resolvedSources = self.recordsIncludingFirefoxSessionCookies(from: sources, logger: log)
+                let recordCount = sources.reduce(0) { $0 + $1.records.count }
+                let resolvedRecordCount = resolvedSources.reduce(0) { $0 + $1.records.count }
+                if resolvedRecordCount == recordCount {
+                    log("\(browserSource.displayName): \(sources.count) store(s), \(recordCount) record(s)")
+                } else {
+                    log(
+                        "\(browserSource.displayName): \(sources.count) store(s), " +
+                            "\(recordCount) persisted record(s), \(resolvedRecordCount) record(s) after session restore")
+                }
+                sessions.append(contentsOf: self.sessionInfos(from: resolvedSources, origin: query.origin))
             } catch let error as BrowserCookieError {
                 BrowserCookieAccessGate.recordIfNeeded(error)
                 if let hint = error.accessDeniedHint {
@@ -170,11 +184,34 @@ public enum MiMoCookieImporter {
             }
         }
 
+        log("Produced \(sessions.count) session(s) from \(installed.count) browser(s)")
         if sessions.isEmpty, !accessDeniedHints.isEmpty {
             let details = Array(Set(accessDeniedHints)).sorted().joined(separator: " ")
             throw MiMoSettingsError.missingCookie(details: details)
         }
         return sessions
+    }
+
+    static func recordsIncludingFirefoxSessionCookies(
+        from sources: [BrowserCookieStoreRecords],
+        logger: ((String) -> Void)? = nil) -> [BrowserCookieStoreRecords]
+    {
+        sources.map { source in
+            guard source.store.browser.usesGeckoProfileStore else { return source }
+            let profileDirectory = URL(fileURLWithPath: source.store.profile.id, isDirectory: true)
+            let sessionRecords = MiMoFirefoxSessionCookieImporter.records(
+                profileDirectory: profileDirectory,
+                logger: logger)
+            guard !sessionRecords.isEmpty else { return source }
+
+            let existingKeys = Set(source.records.map(self.recordKey))
+            let additionalRecords = sessionRecords.filter { !existingKeys.contains(self.recordKey($0)) }
+            guard !additionalRecords.isEmpty else { return source }
+            logger?(
+                "\(source.label): recovered \(additionalRecords.count) MiMo session cookie(s) " +
+                    "from Firefox session restore")
+            return BrowserCookieStoreRecords(store: source.store, records: source.records + additionalRecords)
+        }
     }
 
     public static func hasSession(
@@ -200,6 +237,9 @@ public enum MiMoCookieImporter {
             guard !mergedRecords.isEmpty else { continue }
             let cookies = BrowserCookieClient.makeHTTPCookies(mergedRecords, origin: origin)
             guard let cookieHeader = MiMoCookieHeader.header(from: cookies) else {
+                let cookieNames = mergedRecords.map(\.name).joined(separator: ", ")
+                let message = "\(label): \(mergedRecords.count) cookie(s) (\(cookieNames))"
+                Self.log.debug("\(message) - missing required [api-platform_serviceToken, userId]")
                 continue
             }
             sessions.append(SessionInfo(cookieHeader: cookieHeader, sourceLabel: label))
@@ -260,6 +300,213 @@ public enum MiMoCookieImporter {
         case (nil, nil):
             false
         }
+    }
+}
+
+enum MiMoFirefoxSessionCookieImporter {
+    private static let sessionRestoreFileNames = [
+        "recovery.jsonlz4",
+        "recovery.baklz4",
+        "previous.jsonlz4",
+        "sessionstore.jsonlz4",
+    ]
+    private static let mozillaLZ4Magic = Data([0x6D, 0x6F, 0x7A, 0x4C, 0x7A, 0x34, 0x30, 0x00])
+
+    static func records(
+        profileDirectory: URL,
+        now: Date = Date(),
+        logger: ((String) -> Void)? = nil) -> [BrowserCookieRecord]
+    {
+        let files = self.sessionRestoreFiles(profileDirectory: profileDirectory)
+        for file in files {
+            do {
+                let data = try Data(contentsOf: file)
+                let jsonData = try self.decodeSessionRestoreData(data)
+                let records = try self.cookieRecords(fromJSONData: jsonData, now: now)
+                if !records.isEmpty {
+                    logger?("\(profileDirectory.lastPathComponent): found MiMo session cookies in \(file.lastPathComponent)")
+                    return records
+                }
+            } catch {
+                logger?(
+                    "\(profileDirectory.lastPathComponent): could not read Firefox session restore " +
+                        "\(file.lastPathComponent): \(error.localizedDescription)")
+            }
+        }
+        return []
+    }
+
+    private static func sessionRestoreFiles(profileDirectory: URL) -> [URL] {
+        let backupDirectory = profileDirectory.appendingPathComponent("sessionstore-backups", isDirectory: true)
+        var files = self.sessionRestoreFileNames.map { backupDirectory.appendingPathComponent($0) }
+        files.append(profileDirectory.appendingPathComponent("sessionstore.jsonlz4"))
+
+        if let upgradeFiles = try? FileManager.default.contentsOfDirectory(
+            at: backupDirectory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles])
+        {
+            files.append(contentsOf: upgradeFiles.filter { $0.lastPathComponent.hasPrefix("upgrade.jsonlz4-") })
+        }
+
+        var seen = Set<String>()
+        return files.filter { file in
+            guard FileManager.default.fileExists(atPath: file.path), !seen.contains(file.path) else { return false }
+            seen.insert(file.path)
+            return true
+        }
+    }
+
+    static func decodeSessionRestoreData(_ data: Data) throws -> Data {
+        guard data.starts(with: self.mozillaLZ4Magic) else { return data }
+        let payload = data.dropFirst(self.mozillaLZ4Magic.count)
+        if let decoded = try? self.decodeLZ4Block(Data(payload)) {
+            return decoded
+        }
+        guard payload.count > 4 else {
+            throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Invalid Firefox jsonlz4 data"))
+        }
+        return try self.decodeLZ4Block(Data(payload.dropFirst(4)))
+    }
+
+    static func cookieRecords(fromJSONData data: Data, now: Date = Date()) throws -> [BrowserCookieRecord] {
+        let root = try JSONSerialization.jsonObject(with: data)
+        var records: [BrowserCookieRecord] = []
+        self.collectCookieRecords(from: root, into: &records, now: now)
+        return records
+    }
+
+    private static func collectCookieRecords(
+        from value: Any,
+        into records: inout [BrowserCookieRecord],
+        now: Date)
+    {
+        if let dictionary = value as? [String: Any] {
+            if let record = self.cookieRecord(from: dictionary, now: now) {
+                records.append(record)
+            }
+            for nested in dictionary.values {
+                self.collectCookieRecords(from: nested, into: &records, now: now)
+            }
+            return
+        }
+
+        if let array = value as? [Any] {
+            for nested in array {
+                self.collectCookieRecords(from: nested, into: &records, now: now)
+            }
+        }
+    }
+
+    private static func cookieRecord(from dictionary: [String: Any], now: Date) -> BrowserCookieRecord? {
+        guard let name = dictionary["name"] as? String,
+              MiMoCookieHeader.knownCookieNames.contains(name),
+              let value = dictionary["value"] as? String,
+              !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let host = (dictionary["host"] as? String) ?? (dictionary["domain"] as? String)
+        else {
+            return nil
+        }
+
+        let domain = host.trimmingCharacters(in: CharacterSet(charactersIn: "."))
+        guard self.domainMatchesMiMo(domain) else { return nil }
+
+        let expiry = self.expiryDate(from: dictionary["expires"] ?? dictionary["expiry"])
+        if let expiry, expiry < now { return nil }
+
+        let path = self.cookiePath(from: dictionary)
+        return BrowserCookieRecord(
+            domain: domain,
+            name: name,
+            path: path,
+            value: value,
+            expires: expiry,
+            isSecure: dictionary["secure"] as? Bool ?? false,
+            isHTTPOnly: (dictionary["httponly"] as? Bool) ?? (dictionary["httpOnly"] as? Bool) ?? false)
+    }
+
+    private static func cookiePath(from dictionary: [String: Any]) -> String {
+        guard let path = dictionary["path"] as? String, !path.isEmpty else {
+            return "/"
+        }
+        return path
+    }
+
+    private static func domainMatchesMiMo(_ domain: String) -> Bool {
+        let lowercased = domain.lowercased()
+        return lowercased == "xiaomimimo.com"
+            || lowercased == "platform.xiaomimimo.com"
+            || lowercased.hasSuffix(".xiaomimimo.com")
+    }
+
+    private static func expiryDate(from value: Any?) -> Date? {
+        switch value {
+        case let int as Int:
+            guard int > 0 else { return nil }
+            return Date(timeIntervalSince1970: TimeInterval(int))
+        case let int64 as Int64:
+            guard int64 > 0 else { return nil }
+            return Date(timeIntervalSince1970: TimeInterval(int64))
+        case let double as Double:
+            guard double > 0 else { return nil }
+            return Date(timeIntervalSince1970: double)
+        default:
+            return nil
+        }
+    }
+
+    private static func decodeLZ4Block(_ input: Data) throws -> Data {
+        let bytes = [UInt8](input)
+        var index = 0
+        var output: [UInt8] = []
+
+        while index < bytes.count {
+            let token = bytes[index]
+            index += 1
+
+            var literalLength = Int(token >> 4)
+            if literalLength == 15 {
+                literalLength += self.readExtendedLength(bytes: bytes, index: &index)
+            }
+            guard index + literalLength <= bytes.count else {
+                throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Invalid LZ4 literal length"))
+            }
+            output.append(contentsOf: bytes[index ..< index + literalLength])
+            index += literalLength
+
+            guard index < bytes.count else { break }
+            guard index + 2 <= bytes.count else {
+                throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Invalid LZ4 offset"))
+            }
+
+            let offset = Int(bytes[index]) | (Int(bytes[index + 1]) << 8)
+            index += 2
+            guard offset > 0, offset <= output.count else {
+                throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Invalid LZ4 back reference"))
+            }
+
+            var matchLength = Int(token & 0x0F) + 4
+            if token & 0x0F == 15 {
+                matchLength += self.readExtendedLength(bytes: bytes, index: &index)
+            }
+
+            for _ in 0 ..< matchLength {
+                output.append(output[output.count - offset])
+            }
+        }
+
+        return Data(output)
+    }
+
+    private static func readExtendedLength(bytes: [UInt8], index: inout Int) -> Int {
+        var length = 0
+        while index < bytes.count {
+            let next = Int(bytes[index])
+            index += 1
+            length += next
+            if next != 255 { break }
+        }
+        return length
     }
 }
 #endif

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
@@ -147,6 +147,20 @@ public enum MiMoCookieImporter {
         loadRecords: (Browser, BrowserCookieQuery, ((String) -> Void)?) throws
             -> [BrowserCookieStoreRecords]) throws -> [SessionInfo]
     {
+        try self.importSessions(
+            browserDetection: browserDetection,
+            logger: logger,
+            loadRecords: loadRecords,
+            loadStores: { try self.cookieClient.codexBarStores(for: $0) })
+    }
+
+    static func importSessions(
+        browserDetection: BrowserDetection,
+        logger: ((String) -> Void)? = nil,
+        loadRecords: (Browser, BrowserCookieQuery, ((String) -> Void)?) throws
+            -> [BrowserCookieStoreRecords],
+        loadStores: (Browser) throws -> [BrowserCookieStore]) throws -> [SessionInfo]
+    {
         let log: (String) -> Void = { msg in
             logger?("[mimo-cookie] \(msg)")
             Self.log.debug("\(msg)")
@@ -161,9 +175,11 @@ public enum MiMoCookieImporter {
             do {
                 let query = BrowserCookieQuery(domains: self.cookieDomains)
                 let sources = try loadRecords(browserSource, query, log)
+                let stores = browserSource.usesGeckoProfileStore ? try loadStores(browserSource) : []
                 let resolvedSources = self.recordsIncludingFirefoxSessionCookies(
                     from: sources,
                     browser: browserSource,
+                    stores: stores,
                     logger: log)
                 let recordCount = sources.reduce(0) { $0 + $1.records.count }
                 let resolvedRecordCount = resolvedSources.reduce(0) { $0 + $1.records.count }
@@ -199,7 +215,7 @@ public enum MiMoCookieImporter {
     static func recordsIncludingFirefoxSessionCookies(
         from sources: [BrowserCookieStoreRecords],
         browser: Browser,
-        homeDirectories: [URL] = BrowserCookieClient.defaultHomeDirectories(),
+        stores: [BrowserCookieStore],
         logger: ((String) -> Void)? = nil) -> [BrowserCookieStoreRecords]
     {
         guard browser.usesGeckoProfileStore else { return sources }
@@ -207,7 +223,7 @@ public enum MiMoCookieImporter {
         var resolvedByProfileID = Dictionary(uniqueKeysWithValues: sources.map { ($0.store.profile.id, $0) })
         var orderedProfileIDs = sources.map(\.store.profile.id)
 
-        for store in self.geckoProfileStores(for: browser, homeDirectories: homeDirectories) {
+        for store in stores where store.browser == browser {
             let profileID = store.profile.id
             let source = resolvedByProfileID[profileID] ?? BrowserCookieStoreRecords(store: store, records: [])
             let profileDirectory = URL(fileURLWithPath: profileID, isDirectory: true)
@@ -222,18 +238,14 @@ public enum MiMoCookieImporter {
                 continue
             }
 
-            let existingKeys = Set(source.records.map(self.recordKey))
-            let additionalRecords = sessionRecords.filter { !existingKeys.contains(self.recordKey($0)) }
-            if additionalRecords.isEmpty {
-                resolvedByProfileID[profileID] = source
-            } else {
-                logger?(
-                    "\(source.label): recovered \(additionalRecords.count) MiMo session cookie(s) " +
-                        "from Firefox session restore")
-                resolvedByProfileID[profileID] = BrowserCookieStoreRecords(
-                    store: source.store,
-                    records: source.records + additionalRecords)
-            }
+            let sessionKeys = Set(sessionRecords.map(self.recordKey))
+            let persistedRecords = source.records.filter { !sessionKeys.contains(self.recordKey($0)) }
+            logger?(
+                "\(source.label): recovered \(sessionRecords.count) MiMo session cookie(s) " +
+                    "from Firefox session restore")
+            resolvedByProfileID[profileID] = BrowserCookieStoreRecords(
+                store: source.store,
+                records: persistedRecords + sessionRecords)
 
             if !orderedProfileIDs.contains(profileID) {
                 orderedProfileIDs.append(profileID)
@@ -330,64 +342,30 @@ public enum MiMoCookieImporter {
             false
         }
     }
-
-    private static func geckoProfileStores(
-        for browser: Browser,
-        homeDirectories: [URL]) -> [BrowserCookieStore]
-    {
-        guard let profilesFolder = browser.geckoProfilesFolder else { return [] }
-
-        let roots = homeDirectories.map { home in
-            home
-                .appendingPathComponent("Library")
-                .appendingPathComponent("Application Support")
-                .appendingPathComponent(profilesFolder)
-                .appendingPathComponent("Profiles")
-        }
-
-        var stores: [BrowserCookieStore] = []
-        for root in roots {
-            guard let entries = try? FileManager.default.contentsOfDirectory(
-                at: root,
-                includingPropertiesForKeys: [.isDirectoryKey],
-                options: [.skipsHiddenFiles])
-            else {
-                continue
-            }
-
-            let profileDirectories = entries.filter { url in
-                (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
-            }
-            .sorted { lhs, rhs in
-                let left = self.geckoProfileSortKey(lhs.lastPathComponent)
-                let right = self.geckoProfileSortKey(rhs.lastPathComponent)
-                if left.rank != right.rank { return left.rank < right.rank }
-                return left.name < right.name
-            }
-
-            stores.append(contentsOf: profileDirectories.map { directory in
-                let profileName = directory.lastPathComponent
-                return BrowserCookieStore(
-                    browser: browser,
-                    profile: BrowserProfile(id: directory.path, name: profileName),
-                    kind: .primary,
-                    label: "\(browser.displayName) \(profileName)",
-                    databaseURL: directory.appendingPathComponent("cookies.sqlite"))
-            })
-        }
-
-        return stores
-    }
-
-    private static func geckoProfileSortKey(_ name: String) -> (rank: Int, name: String) {
-        let lowercased = name.lowercased()
-        if lowercased.contains("default-release") { return (0, lowercased) }
-        if lowercased.contains("default") { return (1, lowercased) }
-        return (2, lowercased)
-    }
 }
 
 enum MiMoFirefoxSessionCookieImporter {
+    enum ImportError: LocalizedError {
+        case inputTooLarge
+        case outputTooLarge
+        case invalidData(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .inputTooLarge:
+                "Firefox session restore file exceeds the 64 MiB safety limit."
+            case .outputTooLarge:
+                "Firefox session restore data exceeds the 128 MiB safety limit."
+            case let .invalidData(message):
+                message
+            }
+        }
+    }
+
+    private static let maxInputBytes = 64 * 1024 * 1024
+    private static let maxOutputBytes = 128 * 1024 * 1024
+    private static let maxJSONNodes = 1_000_000
+    private static let maxCookieRecords = 4096
     private static let sessionRestoreFileNames = [
         "recovery.jsonlz4",
         "recovery.baklz4",
@@ -404,7 +382,7 @@ enum MiMoFirefoxSessionCookieImporter {
         let files = self.sessionRestoreFiles(profileDirectory: profileDirectory)
         for file in files {
             do {
-                let data = try Data(contentsOf: file)
+                let data = try self.readData(from: file)
                 let jsonData = try self.decodeSessionRestoreData(data)
                 let records = try self.cookieRecords(fromJSONData: jsonData, now: now)
                 if !records.isEmpty {
@@ -420,6 +398,18 @@ enum MiMoFirefoxSessionCookieImporter {
             }
         }
         return []
+    }
+
+    static func readData(
+        from file: URL,
+        maxBytes: Int = MiMoFirefoxSessionCookieImporter.maxInputBytes) throws -> Data
+    {
+        guard maxBytes >= 0, maxBytes < Int.max else { throw ImportError.inputTooLarge }
+        let handle = try FileHandle(forReadingFrom: file)
+        defer { try? handle.close() }
+        let data = try handle.read(upToCount: maxBytes + 1) ?? Data()
+        guard data.count <= maxBytes else { throw ImportError.inputTooLarge }
+        return data
     }
 
     private static func sessionRestoreFiles(profileDirectory: URL) -> [URL] {
@@ -443,45 +433,64 @@ enum MiMoFirefoxSessionCookieImporter {
         }
     }
 
-    static func decodeSessionRestoreData(_ data: Data) throws -> Data {
-        guard data.starts(with: self.mozillaLZ4Magic) else { return data }
+    static func decodeSessionRestoreData(
+        _ data: Data,
+        maxOutputBytes: Int = MiMoFirefoxSessionCookieImporter.maxOutputBytes) throws -> Data
+    {
+        guard maxOutputBytes >= 0 else { throw ImportError.outputTooLarge }
+        guard data.starts(with: self.mozillaLZ4Magic) else {
+            guard data.count <= maxOutputBytes else { throw ImportError.outputTooLarge }
+            return data
+        }
         let payload = data.dropFirst(self.mozillaLZ4Magic.count)
-        if let decoded = try? self.decodeLZ4Block(Data(payload)) {
-            return decoded
+        let directError: Error
+        do {
+            return try self.decodeLZ4Block(Data(payload), maxOutputBytes: maxOutputBytes)
+        } catch {
+            directError = error
+            // Some jsonlz4 writers prefix the raw block with its decoded byte count.
         }
         guard payload.count > 4 else {
-            throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Invalid Firefox jsonlz4 data"))
+            throw directError
         }
-        return try self.decodeLZ4Block(Data(payload.dropFirst(4)))
+        do {
+            return try self.decodeLZ4Block(Data(payload.dropFirst(4)), maxOutputBytes: maxOutputBytes)
+        } catch {
+            if case ImportError.outputTooLarge = directError {
+                throw ImportError.outputTooLarge
+            }
+            throw error
+        }
     }
 
-    static func cookieRecords(fromJSONData data: Data, now: Date = Date()) throws -> [BrowserCookieRecord] {
-        let root = try JSONSerialization.jsonObject(with: data)
-        var records: [BrowserCookieRecord] = []
-        self.collectCookieRecords(from: root, into: &records, now: now)
-        return records
-    }
-
-    private static func collectCookieRecords(
-        from value: Any,
-        into records: inout [BrowserCookieRecord],
-        now: Date)
+    static func cookieRecords(
+        fromJSONData data: Data,
+        now: Date = Date(),
+        maxNodes: Int = MiMoFirefoxSessionCookieImporter.maxJSONNodes,
+        maxRecords: Int = MiMoFirefoxSessionCookieImporter.maxCookieRecords) throws -> [BrowserCookieRecord]
     {
-        if let dictionary = value as? [String: Any] {
-            if let record = self.cookieRecord(from: dictionary, now: now) {
-                records.append(record)
+        let root = try JSONSerialization.jsonObject(with: data)
+        var stack: [Any] = [root]
+        var records: [BrowserCookieRecord] = []
+        var visitedNodes = 0
+        while let value = stack.popLast() {
+            visitedNodes += 1
+            guard visitedNodes <= maxNodes else {
+                throw ImportError.invalidData("Firefox session restore JSON is too complex.")
             }
-            for nested in dictionary.values {
-                self.collectCookieRecords(from: nested, into: &records, now: now)
+            if let dictionary = value as? [String: Any] {
+                if let record = self.cookieRecord(from: dictionary, now: now) {
+                    records.append(record)
+                    guard records.count <= maxRecords else {
+                        throw ImportError.invalidData("Firefox session restore contains too many cookie records.")
+                    }
+                }
+                stack.append(contentsOf: dictionary.values)
+            } else if let array = value as? [Any] {
+                stack.append(contentsOf: array)
             }
-            return
         }
-
-        if let array = value as? [Any] {
-            for nested in array {
-                self.collectCookieRecords(from: nested, into: &records, now: now)
-            }
-        }
+        return records
     }
 
     private static func cookieRecord(from dictionary: [String: Any], now: Date) -> BrowserCookieRecord? {
@@ -541,7 +550,7 @@ enum MiMoFirefoxSessionCookieImporter {
         }
     }
 
-    private static func decodeLZ4Block(_ input: Data) throws -> Data {
+    private static func decodeLZ4Block(_ input: Data, maxOutputBytes: Int) throws -> Data {
         let bytes = [UInt8](input)
         var index = 0
         var output: [UInt8] = []
@@ -552,29 +561,37 @@ enum MiMoFirefoxSessionCookieImporter {
 
             var literalLength = Int(token >> 4)
             if literalLength == 15 {
-                literalLength += self.readExtendedLength(bytes: bytes, index: &index)
+                literalLength += try self.readExtendedLength(
+                    bytes: bytes,
+                    index: &index,
+                    limit: maxOutputBytes - literalLength)
             }
-            guard index + literalLength <= bytes.count else {
-                throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Invalid LZ4 literal length"))
+            guard literalLength <= bytes.count - index else {
+                throw ImportError.invalidData("Invalid LZ4 literal length.")
             }
+            guard literalLength <= maxOutputBytes - output.count else { throw ImportError.outputTooLarge }
             output.append(contentsOf: bytes[index..<index + literalLength])
             index += literalLength
 
             guard index < bytes.count else { break }
-            guard index + 2 <= bytes.count else {
-                throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Invalid LZ4 offset"))
+            guard bytes.count - index >= 2 else {
+                throw ImportError.invalidData("Invalid LZ4 offset.")
             }
 
             let offset = Int(bytes[index]) | (Int(bytes[index + 1]) << 8)
             index += 2
             guard offset > 0, offset <= output.count else {
-                throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Invalid LZ4 back reference"))
+                throw ImportError.invalidData("Invalid LZ4 back reference.")
             }
 
             var matchLength = Int(token & 0x0F) + 4
             if token & 0x0F == 15 {
-                matchLength += self.readExtendedLength(bytes: bytes, index: &index)
+                matchLength += try self.readExtendedLength(
+                    bytes: bytes,
+                    index: &index,
+                    limit: maxOutputBytes - matchLength)
             }
+            guard matchLength <= maxOutputBytes - output.count else { throw ImportError.outputTooLarge }
 
             for _ in 0..<matchLength {
                 output.append(output[output.count - offset])
@@ -584,11 +601,12 @@ enum MiMoFirefoxSessionCookieImporter {
         return Data(output)
     }
 
-    private static func readExtendedLength(bytes: [UInt8], index: inout Int) -> Int {
+    private static func readExtendedLength(bytes: [UInt8], index: inout Int, limit: Int) throws -> Int {
         var length = 0
         while index < bytes.count {
             let next = Int(bytes[index])
             index += 1
+            guard length <= limit, next <= limit - length else { throw ImportError.outputTooLarge }
             length += next
             if next != 255 { break }
         }

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
@@ -1,3 +1,4 @@
+import CoreFoundation
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -226,12 +227,12 @@ public enum MiMoCookieImporter {
         for store in stores where store.browser == browser {
             let profileID = store.profile.id
             let source = resolvedByProfileID[profileID] ?? BrowserCookieStoreRecords(store: store, records: [])
-            let profileDirectory = URL(fileURLWithPath: profileID, isDirectory: true)
+            guard let profileDirectory = store.databaseURL?.deletingLastPathComponent() else { continue }
             let sessionRecords = MiMoFirefoxSessionCookieImporter.records(
                 profileDirectory: profileDirectory,
-                persistedRecords: source.records,
                 logger: logger)
-            guard !sessionRecords.isEmpty else {
+            let sessionCookies = BrowserCookieClient.makeHTTPCookies(sessionRecords, origin: .domainBased)
+            guard MiMoCookieHeader.header(from: sessionCookies) != nil else {
                 if resolvedByProfileID[profileID] == nil {
                     continue
                 }
@@ -239,14 +240,12 @@ public enum MiMoCookieImporter {
                 continue
             }
 
-            let sessionKeys = Set(sessionRecords.map(self.recordKey))
-            let persistedRecords = source.records.filter { !sessionKeys.contains(self.recordKey($0)) }
             logger?(
                 "\(source.label): recovered \(sessionRecords.count) MiMo session cookie(s) " +
                     "from Firefox session restore")
             resolvedByProfileID[profileID] = BrowserCookieStoreRecords(
                 store: source.store,
-                records: persistedRecords + sessionRecords)
+                records: sessionRecords)
 
             if !orderedProfileIDs.contains(profileID) {
                 orderedProfileIDs.append(profileID)
@@ -349,6 +348,7 @@ enum MiMoFirefoxSessionCookieImporter {
     enum ImportError: LocalizedError {
         case inputTooLarge
         case outputTooLarge
+        case resourceLimit(String)
         case invalidData(String)
 
         var errorDescription: String? {
@@ -357,6 +357,8 @@ enum MiMoFirefoxSessionCookieImporter {
                 "Firefox session restore file exceeds the 64 MiB safety limit."
             case .outputTooLarge:
                 "Firefox session restore data exceeds the 128 MiB safety limit."
+            case let .resourceLimit(message):
+                message
             case let .invalidData(message):
                 message
             }
@@ -365,60 +367,42 @@ enum MiMoFirefoxSessionCookieImporter {
 
     private static let maxInputBytes = 64 * 1024 * 1024
     private static let maxOutputBytes = 128 * 1024 * 1024
-    private static let maxJSONNodes = 1_000_000
     private static let maxCookieRecords = 4096
     private static let sessionRestoreFileNames = [
         "recovery.jsonlz4",
         "recovery.baklz4",
         "previous.jsonlz4",
-        "sessionstore.jsonlz4",
     ]
     private static let mozillaLZ4Magic = Data([0x6D, 0x6F, 0x7A, 0x4C, 0x7A, 0x34, 0x30, 0x00])
 
     static func records(
         profileDirectory: URL,
-        persistedRecords: [BrowserCookieRecord] = [],
         now: Date = Date(),
         logger: ((String) -> Void)? = nil) -> [BrowserCookieRecord]
     {
         let files = self.sessionRestoreFiles(profileDirectory: profileDirectory)
-        var firstPartialRecords: [BrowserCookieRecord] = []
         for file in files {
             do {
                 let data = try self.readData(from: file)
                 let jsonData = try self.decodeSessionRestoreData(data)
                 let records = try self.cookieRecords(fromJSONData: jsonData, now: now)
-                guard !records.isEmpty else { continue }
-                let isCurrentRestore = file.lastPathComponent == "recovery.jsonlz4" ||
-                    (file.lastPathComponent == "sessionstore.jsonlz4" &&
-                        file.deletingLastPathComponent().standardizedFileURL == profileDirectory.standardizedFileURL)
-                let persistedKeys = Set(persistedRecords.map { "\($0.name)|\($0.domain)|\($0.path)" })
-                let candidateRecords = isCurrentRestore ? records : records.filter { record in
-                    !persistedKeys.contains("\(record.name)|\(record.domain)|\(record.path)")
-                }
-                guard !candidateRecords.isEmpty else { continue }
-                if firstPartialRecords.isEmpty {
-                    firstPartialRecords = candidateRecords
-                }
-                let candidateKeys = Set(candidateRecords.map { "\($0.name)|\($0.domain)|\($0.path)" })
-                let resolvedRecords = persistedRecords.filter { record in
-                    !candidateKeys.contains("\(record.name)|\(record.domain)|\(record.path)")
-                } + candidateRecords
-                let cookies = BrowserCookieClient.makeHTTPCookies(resolvedRecords, origin: .domainBased)
-                if MiMoCookieHeader.header(from: cookies) != nil {
-                    logger?(
-                        "\(profileDirectory.lastPathComponent): found MiMo session cookies through " +
-                            "\(file.lastPathComponent)")
-                    return candidateRecords
-                }
-                logger?("\(profileDirectory.lastPathComponent): partial MiMo cookies in \(file.lastPathComponent)")
+                logger?(
+                    "\(profileDirectory.lastPathComponent): read \(records.count) MiMo session cookie(s) " +
+                        "from \(file.lastPathComponent)")
+                // The first valid Firefox state is authoritative, even when it records logout or partial auth.
+                return records
+            } catch ImportError.inputTooLarge, ImportError.outputTooLarge, ImportError.resourceLimit {
+                logger?(
+                    "\(profileDirectory.lastPathComponent): rejected unsafe Firefox session restore " +
+                        "\(file.lastPathComponent)")
+                return []
             } catch {
                 logger?(
                     "\(profileDirectory.lastPathComponent): could not read Firefox session restore " +
                         "\(file.lastPathComponent): \(error.localizedDescription)")
             }
         }
-        return firstPartialRecords
+        return []
     }
 
     static func readData(
@@ -433,18 +417,15 @@ enum MiMoFirefoxSessionCookieImporter {
         return data
     }
 
-    private static func sessionRestoreFiles(profileDirectory: URL) -> [URL] {
+    static func sessionRestoreFiles(profileDirectory: URL) -> [URL] {
         let backupDirectory = profileDirectory.appendingPathComponent("sessionstore-backups", isDirectory: true)
-        var files = self.sessionRestoreFileNames.map { backupDirectory.appendingPathComponent($0) }
-        files.append(profileDirectory.appendingPathComponent("sessionstore.jsonlz4"))
-
-        if let upgradeFiles = try? FileManager.default.contentsOfDirectory(
+        let upgradeFiles = (try? FileManager.default.contentsOfDirectory(
             at: backupDirectory,
             includingPropertiesForKeys: nil,
-            options: [.skipsHiddenFiles])
-        {
-            files.append(contentsOf: upgradeFiles.filter { $0.lastPathComponent.hasPrefix("upgrade.jsonlz4-") })
-        }
+            options: [.skipsHiddenFiles])) ?? []
+        let files = self.orderedSessionRestoreFileCandidates(
+            profileDirectory: profileDirectory,
+            upgradeFiles: upgradeFiles)
 
         var seen = Set<String>()
         return files.filter { file in
@@ -454,61 +435,66 @@ enum MiMoFirefoxSessionCookieImporter {
         }
     }
 
+    static func orderedSessionRestoreFileCandidates(
+        profileDirectory: URL,
+        upgradeFiles: [URL]) -> [URL]
+    {
+        let backupDirectory = profileDirectory.appendingPathComponent("sessionstore-backups", isDirectory: true)
+        let newestUpgrade = upgradeFiles
+            .filter { $0.lastPathComponent.hasPrefix("upgrade.jsonlz4-") }
+            .max { $0.lastPathComponent < $1.lastPathComponent }
+        return [profileDirectory.appendingPathComponent("sessionstore.jsonlz4")] +
+            self.sessionRestoreFileNames.map { backupDirectory.appendingPathComponent($0) } +
+            (newestUpgrade.map { [$0] } ?? [])
+    }
+
     static func decodeSessionRestoreData(
         _ data: Data,
         maxOutputBytes: Int = MiMoFirefoxSessionCookieImporter.maxOutputBytes) throws -> Data
     {
         guard maxOutputBytes >= 0 else { throw ImportError.outputTooLarge }
         guard data.starts(with: self.mozillaLZ4Magic) else {
-            guard data.count <= maxOutputBytes else { throw ImportError.outputTooLarge }
-            return data
+            throw ImportError.invalidData("Invalid Firefox session restore header.")
         }
         let payload = data.dropFirst(self.mozillaLZ4Magic.count)
-        let directError: Error
-        do {
-            return try self.decodeLZ4Block(Data(payload), maxOutputBytes: maxOutputBytes)
-        } catch {
-            directError = error
-            // Some jsonlz4 writers prefix the raw block with its decoded byte count.
+        guard payload.count >= 4 else {
+            throw ImportError.invalidData("Invalid Firefox session restore size header.")
         }
-        guard payload.count > 4 else {
-            throw directError
+        let sizeBytes = Array(payload.prefix(4))
+        let declaredSize = Int(sizeBytes[0]) |
+            (Int(sizeBytes[1]) << 8) |
+            (Int(sizeBytes[2]) << 16) |
+            (Int(sizeBytes[3]) << 24)
+        guard declaredSize <= maxOutputBytes else { throw ImportError.outputTooLarge }
+        let decoded = try self.decodeLZ4Block(Data(payload.dropFirst(4)), maxOutputBytes: declaredSize)
+        guard decoded.count == declaredSize else {
+            throw ImportError.invalidData("Firefox session restore decoded size does not match its header.")
         }
-        do {
-            return try self.decodeLZ4Block(Data(payload.dropFirst(4)), maxOutputBytes: maxOutputBytes)
-        } catch {
-            if case ImportError.outputTooLarge = directError {
-                throw ImportError.outputTooLarge
-            }
-            throw error
-        }
+        return decoded
     }
 
     static func cookieRecords(
         fromJSONData data: Data,
         now: Date = Date(),
-        maxNodes: Int = MiMoFirefoxSessionCookieImporter.maxJSONNodes,
         maxRecords: Int = MiMoFirefoxSessionCookieImporter.maxCookieRecords) throws -> [BrowserCookieRecord]
     {
-        let root = try JSONSerialization.jsonObject(with: data)
-        var stack: [Any] = [root]
+        guard let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ImportError.invalidData("Firefox session restore root is not an object.")
+        }
+        guard let rawCookies = root["cookies"] else { return [] }
+        guard let cookies = rawCookies as? [Any] else {
+            throw ImportError.invalidData("Firefox session restore cookies are not an array.")
+        }
+        guard cookies.count <= maxRecords else {
+            throw ImportError.resourceLimit("Firefox session restore contains too many cookie records.")
+        }
         var records: [BrowserCookieRecord] = []
-        var visitedNodes = 0
-        while let value = stack.popLast() {
-            visitedNodes += 1
-            guard visitedNodes <= maxNodes else {
-                throw ImportError.invalidData("Firefox session restore JSON is too complex.")
+        for rawCookie in cookies {
+            guard let cookie = rawCookie as? [String: Any] else {
+                throw ImportError.invalidData("Firefox session restore contains a malformed cookie record.")
             }
-            if let dictionary = value as? [String: Any] {
-                if let record = self.cookieRecord(from: dictionary, now: now) {
-                    records.append(record)
-                    guard records.count <= maxRecords else {
-                        throw ImportError.invalidData("Firefox session restore contains too many cookie records.")
-                    }
-                }
-                stack.append(contentsOf: dictionary.values)
-            } else if let array = value as? [Any] {
-                stack.append(contentsOf: array)
+            if let record = self.cookieRecord(from: cookie, now: now) {
+                records.append(record)
             }
         }
         return records
@@ -523,6 +509,7 @@ enum MiMoFirefoxSessionCookieImporter {
         else {
             return nil
         }
+        guard self.hasDefaultOriginAttributes(dictionary) else { return nil }
 
         let domain = host.trimmingCharacters(in: CharacterSet(charactersIn: "."))
         guard self.domainMatchesMiMo(domain) else { return nil }
@@ -539,6 +526,43 @@ enum MiMoFirefoxSessionCookieImporter {
             expires: expiry,
             isSecure: dictionary["secure"] as? Bool ?? false,
             isHTTPOnly: (dictionary["httponly"] as? Bool) ?? (dictionary["httpOnly"] as? Bool) ?? false)
+    }
+
+    private static func hasDefaultOriginAttributes(_ dictionary: [String: Any]) -> Bool {
+        if let isPartitioned = dictionary["isPartitioned"] {
+            guard self.isBoolean(isPartitioned, equalTo: false) else { return false }
+        }
+        guard let rawAttributes = dictionary["originAttributes"] else { return true }
+        if let attributes = rawAttributes as? String {
+            return attributes.isEmpty
+        }
+        guard let attributes = rawAttributes as? [String: Any] else { return false }
+        for (key, value) in attributes {
+            switch key {
+            case "userContextId", "privateBrowsingId":
+                guard self.isZero(value) else { return false }
+            case "firstPartyDomain", "geckoViewSessionContextId", "partitionKey":
+                guard let text = value as? String, text.isEmpty else { return false }
+            default:
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func isZero(_ value: Any) -> Bool {
+        guard let number = value as? NSNumber,
+              CFGetTypeID(number) != CFBooleanGetTypeID(),
+              !["f", "d"].contains(String(cString: number.objCType))
+        else { return false }
+        return number.int64Value == 0
+    }
+
+    private static func isBoolean(_ value: Any, equalTo expected: Bool) -> Bool {
+        guard let number = value as? NSNumber,
+              CFGetTypeID(number) == CFBooleanGetTypeID()
+        else { return false }
+        return number.boolValue == expected
     }
 
     private static func cookiePath(from dictionary: [String: Any]) -> String {

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
@@ -395,7 +395,6 @@ enum MiMoFirefoxSessionCookieImporter {
                 logger?(
                     "\(profileDirectory.lastPathComponent): rejected unsafe Firefox session restore " +
                         "\(file.lastPathComponent)")
-                return []
             } catch {
                 logger?(
                     "\(profileDirectory.lastPathComponent): could not read Firefox session restore " +

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
@@ -228,9 +228,20 @@ public enum MiMoCookieImporter {
             let profileID = store.profile.id
             let source = resolvedByProfileID[profileID] ?? BrowserCookieStoreRecords(store: store, records: [])
             guard let profileDirectory = store.databaseURL?.deletingLastPathComponent() else { continue }
-            let sessionRecords = MiMoFirefoxSessionCookieImporter.records(
+            let loadOutcome = MiMoFirefoxSessionCookieImporter.load(
                 profileDirectory: profileDirectory,
                 logger: logger)
+            let sessionRecords: [BrowserCookieRecord]
+            switch loadOutcome {
+            case let .loaded(records):
+                sessionRecords = records
+            case .unavailable, .resourceLimited:
+                if resolvedByProfileID[profileID] == nil {
+                    continue
+                }
+                resolvedByProfileID[profileID] = source
+                continue
+            }
             let sessionCookies = BrowserCookieClient.makeHTTPCookies(sessionRecords, origin: .domainBased)
             guard MiMoCookieHeader.header(from: sessionCookies) != nil else {
                 if resolvedByProfileID[profileID] == nil {
@@ -345,24 +356,45 @@ public enum MiMoCookieImporter {
 }
 
 enum MiMoFirefoxSessionCookieImporter {
+    enum ResourceLimit: Equatable, Sendable {
+        case inputBytes
+        case outputBytes
+        case cookieRecords
+    }
+
     enum ImportError: LocalizedError {
-        case inputTooLarge
-        case outputTooLarge
-        case resourceLimit(String)
+        case resourceLimit(ResourceLimit)
         case invalidData(String)
 
         var errorDescription: String? {
             switch self {
-            case .inputTooLarge:
+            case .resourceLimit(.inputBytes):
                 "Firefox session restore file exceeds the 64 MiB safety limit."
-            case .outputTooLarge:
+            case .resourceLimit(.outputBytes):
                 "Firefox session restore data exceeds the 128 MiB safety limit."
-            case let .resourceLimit(message):
-                message
+            case .resourceLimit(.cookieRecords):
+                "Firefox session restore contains too many cookie records."
             case let .invalidData(message):
                 message
             }
         }
+    }
+
+    enum LoadOutcome {
+        case loaded([BrowserCookieRecord])
+        case unavailable
+        case resourceLimited(ResourceLimit)
+    }
+
+    struct Limits: Sendable {
+        var inputBytes: Int
+        var outputBytes: Int
+        var cookieRecords: Int
+
+        static let `default` = Limits(
+            inputBytes: MiMoFirefoxSessionCookieImporter.maxInputBytes,
+            outputBytes: MiMoFirefoxSessionCookieImporter.maxOutputBytes,
+            cookieRecords: MiMoFirefoxSessionCookieImporter.maxCookieRecords)
     }
 
     private static let maxInputBytes = 64 * 1024 * 1024
@@ -380,39 +412,55 @@ enum MiMoFirefoxSessionCookieImporter {
         now: Date = Date(),
         logger: ((String) -> Void)? = nil) -> [BrowserCookieRecord]
     {
+        switch self.load(profileDirectory: profileDirectory, now: now, logger: logger) {
+        case let .loaded(records): records
+        case .unavailable, .resourceLimited: []
+        }
+    }
+
+    static func load(
+        profileDirectory: URL,
+        now: Date = Date(),
+        limits: Limits = .default,
+        logger: ((String) -> Void)? = nil) -> LoadOutcome
+    {
         let files = self.sessionRestoreFiles(profileDirectory: profileDirectory)
         for file in files {
             do {
-                let data = try self.readData(from: file)
-                let jsonData = try self.decodeSessionRestoreData(data)
-                let records = try self.cookieRecords(fromJSONData: jsonData, now: now)
+                let data = try self.readData(from: file, maxBytes: limits.inputBytes)
+                let jsonData = try self.decodeSessionRestoreData(data, maxOutputBytes: limits.outputBytes)
+                let records = try self.cookieRecords(
+                    fromJSONData: jsonData,
+                    now: now,
+                    maxRecords: limits.cookieRecords)
                 logger?(
                     "\(profileDirectory.lastPathComponent): read \(records.count) MiMo session cookie(s) " +
                         "from \(file.lastPathComponent)")
                 // The first valid Firefox state is authoritative, even when it records logout or partial auth.
-                return records
-            } catch ImportError.inputTooLarge, ImportError.outputTooLarge, ImportError.resourceLimit {
+                return .loaded(records)
+            } catch let ImportError.resourceLimit(limit) {
                 logger?(
                     "\(profileDirectory.lastPathComponent): rejected unsafe Firefox session restore " +
                         "\(file.lastPathComponent)")
+                return .resourceLimited(limit)
             } catch {
                 logger?(
                     "\(profileDirectory.lastPathComponent): could not read Firefox session restore " +
                         "\(file.lastPathComponent): \(error.localizedDescription)")
             }
         }
-        return []
+        return .unavailable
     }
 
     static func readData(
         from file: URL,
         maxBytes: Int = MiMoFirefoxSessionCookieImporter.maxInputBytes) throws -> Data
     {
-        guard maxBytes >= 0, maxBytes < Int.max else { throw ImportError.inputTooLarge }
+        guard maxBytes >= 0, maxBytes < Int.max else { throw ImportError.resourceLimit(.inputBytes) }
         let handle = try FileHandle(forReadingFrom: file)
         defer { try? handle.close() }
         let data = try handle.read(upToCount: maxBytes + 1) ?? Data()
-        guard data.count <= maxBytes else { throw ImportError.inputTooLarge }
+        guard data.count <= maxBytes else { throw ImportError.resourceLimit(.inputBytes) }
         return data
     }
 
@@ -451,7 +499,7 @@ enum MiMoFirefoxSessionCookieImporter {
         _ data: Data,
         maxOutputBytes: Int = MiMoFirefoxSessionCookieImporter.maxOutputBytes) throws -> Data
     {
-        guard maxOutputBytes >= 0 else { throw ImportError.outputTooLarge }
+        guard maxOutputBytes >= 0 else { throw ImportError.resourceLimit(.outputBytes) }
         guard data.starts(with: self.mozillaLZ4Magic) else {
             throw ImportError.invalidData("Invalid Firefox session restore header.")
         }
@@ -464,8 +512,8 @@ enum MiMoFirefoxSessionCookieImporter {
             (Int(sizeBytes[1]) << 8) |
             (Int(sizeBytes[2]) << 16) |
             (Int(sizeBytes[3]) << 24)
-        guard declaredSize <= maxOutputBytes else { throw ImportError.outputTooLarge }
-        let decoded = try self.decodeLZ4Block(Data(payload.dropFirst(4)), maxOutputBytes: declaredSize)
+        guard declaredSize <= maxOutputBytes else { throw ImportError.resourceLimit(.outputBytes) }
+        let decoded = try self.decodeLZ4Block(Data(payload.dropFirst(4)), maxOutputBytes: maxOutputBytes)
         guard decoded.count == declaredSize else {
             throw ImportError.invalidData("Firefox session restore decoded size does not match its header.")
         }
@@ -485,7 +533,7 @@ enum MiMoFirefoxSessionCookieImporter {
             throw ImportError.invalidData("Firefox session restore cookies are not an array.")
         }
         guard cookies.count <= maxRecords else {
-            throw ImportError.resourceLimit("Firefox session restore contains too many cookie records.")
+            throw ImportError.resourceLimit(.cookieRecords)
         }
         var records: [BrowserCookieRecord] = []
         for rawCookie in cookies {
@@ -613,7 +661,9 @@ enum MiMoFirefoxSessionCookieImporter {
             guard literalLength <= bytes.count - index else {
                 throw ImportError.invalidData("Invalid LZ4 literal length.")
             }
-            guard literalLength <= maxOutputBytes - output.count else { throw ImportError.outputTooLarge }
+            guard literalLength <= maxOutputBytes - output.count else {
+                throw ImportError.resourceLimit(.outputBytes)
+            }
             output.append(contentsOf: bytes[index..<index + literalLength])
             index += literalLength
 
@@ -635,7 +685,9 @@ enum MiMoFirefoxSessionCookieImporter {
                     index: &index,
                     limit: maxOutputBytes - matchLength)
             }
-            guard matchLength <= maxOutputBytes - output.count else { throw ImportError.outputTooLarge }
+            guard matchLength <= maxOutputBytes - output.count else {
+                throw ImportError.resourceLimit(.outputBytes)
+            }
 
             for _ in 0..<matchLength {
                 output.append(output[output.count - offset])
@@ -650,7 +702,9 @@ enum MiMoFirefoxSessionCookieImporter {
         while index < bytes.count {
             let next = Int(bytes[index])
             index += 1
-            guard length <= limit, next <= limit - length else { throw ImportError.outputTooLarge }
+            guard length <= limit, next <= limit - length else {
+                throw ImportError.resourceLimit(.outputBytes)
+            }
             length += next
             if next != 255 { break }
         }

--- a/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
+++ b/Sources/CodexBarCore/Providers/MiMo/MiMoCookieImporter.swift
@@ -161,7 +161,10 @@ public enum MiMoCookieImporter {
             do {
                 let query = BrowserCookieQuery(domains: self.cookieDomains)
                 let sources = try loadRecords(browserSource, query, log)
-                let resolvedSources = self.recordsIncludingFirefoxSessionCookies(from: sources, logger: log)
+                let resolvedSources = self.recordsIncludingFirefoxSessionCookies(
+                    from: sources,
+                    browser: browserSource,
+                    logger: log)
                 let recordCount = sources.reduce(0) { $0 + $1.records.count }
                 let resolvedRecordCount = resolvedSources.reduce(0) { $0 + $1.records.count }
                 if resolvedRecordCount == recordCount {
@@ -169,7 +172,8 @@ public enum MiMoCookieImporter {
                 } else {
                     log(
                         "\(browserSource.displayName): \(sources.count) store(s), " +
-                            "\(recordCount) persisted record(s), \(resolvedRecordCount) record(s) after session restore")
+                            "\(recordCount) persisted record(s), \(resolvedRecordCount) " +
+                            "record(s) after session restore")
                 }
                 sessions.append(contentsOf: self.sessionInfos(from: resolvedSources, origin: query.origin))
             } catch let error as BrowserCookieError {
@@ -194,24 +198,49 @@ public enum MiMoCookieImporter {
 
     static func recordsIncludingFirefoxSessionCookies(
         from sources: [BrowserCookieStoreRecords],
+        browser: Browser,
+        homeDirectories: [URL] = BrowserCookieClient.defaultHomeDirectories(),
         logger: ((String) -> Void)? = nil) -> [BrowserCookieStoreRecords]
     {
-        sources.map { source in
-            guard source.store.browser.usesGeckoProfileStore else { return source }
-            let profileDirectory = URL(fileURLWithPath: source.store.profile.id, isDirectory: true)
+        guard browser.usesGeckoProfileStore else { return sources }
+
+        var resolvedByProfileID = Dictionary(uniqueKeysWithValues: sources.map { ($0.store.profile.id, $0) })
+        var orderedProfileIDs = sources.map(\.store.profile.id)
+
+        for store in self.geckoProfileStores(for: browser, homeDirectories: homeDirectories) {
+            let profileID = store.profile.id
+            let source = resolvedByProfileID[profileID] ?? BrowserCookieStoreRecords(store: store, records: [])
+            let profileDirectory = URL(fileURLWithPath: profileID, isDirectory: true)
             let sessionRecords = MiMoFirefoxSessionCookieImporter.records(
                 profileDirectory: profileDirectory,
                 logger: logger)
-            guard !sessionRecords.isEmpty else { return source }
+            guard !sessionRecords.isEmpty else {
+                if resolvedByProfileID[profileID] == nil {
+                    continue
+                }
+                resolvedByProfileID[profileID] = source
+                continue
+            }
 
             let existingKeys = Set(source.records.map(self.recordKey))
             let additionalRecords = sessionRecords.filter { !existingKeys.contains(self.recordKey($0)) }
-            guard !additionalRecords.isEmpty else { return source }
-            logger?(
-                "\(source.label): recovered \(additionalRecords.count) MiMo session cookie(s) " +
-                    "from Firefox session restore")
-            return BrowserCookieStoreRecords(store: source.store, records: source.records + additionalRecords)
+            if additionalRecords.isEmpty {
+                resolvedByProfileID[profileID] = source
+            } else {
+                logger?(
+                    "\(source.label): recovered \(additionalRecords.count) MiMo session cookie(s) " +
+                        "from Firefox session restore")
+                resolvedByProfileID[profileID] = BrowserCookieStoreRecords(
+                    store: source.store,
+                    records: source.records + additionalRecords)
+            }
+
+            if !orderedProfileIDs.contains(profileID) {
+                orderedProfileIDs.append(profileID)
+            }
         }
+
+        return orderedProfileIDs.compactMap { resolvedByProfileID[$0] }
     }
 
     public static func hasSession(
@@ -301,6 +330,61 @@ public enum MiMoCookieImporter {
             false
         }
     }
+
+    private static func geckoProfileStores(
+        for browser: Browser,
+        homeDirectories: [URL]) -> [BrowserCookieStore]
+    {
+        guard let profilesFolder = browser.geckoProfilesFolder else { return [] }
+
+        let roots = homeDirectories.map { home in
+            home
+                .appendingPathComponent("Library")
+                .appendingPathComponent("Application Support")
+                .appendingPathComponent(profilesFolder)
+                .appendingPathComponent("Profiles")
+        }
+
+        var stores: [BrowserCookieStore] = []
+        for root in roots {
+            guard let entries = try? FileManager.default.contentsOfDirectory(
+                at: root,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles])
+            else {
+                continue
+            }
+
+            let profileDirectories = entries.filter { url in
+                (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+            }
+            .sorted { lhs, rhs in
+                let left = self.geckoProfileSortKey(lhs.lastPathComponent)
+                let right = self.geckoProfileSortKey(rhs.lastPathComponent)
+                if left.rank != right.rank { return left.rank < right.rank }
+                return left.name < right.name
+            }
+
+            stores.append(contentsOf: profileDirectories.map { directory in
+                let profileName = directory.lastPathComponent
+                return BrowserCookieStore(
+                    browser: browser,
+                    profile: BrowserProfile(id: directory.path, name: profileName),
+                    kind: .primary,
+                    label: "\(browser.displayName) \(profileName)",
+                    databaseURL: directory.appendingPathComponent("cookies.sqlite"))
+            })
+        }
+
+        return stores
+    }
+
+    private static func geckoProfileSortKey(_ name: String) -> (rank: Int, name: String) {
+        let lowercased = name.lowercased()
+        if lowercased.contains("default-release") { return (0, lowercased) }
+        if lowercased.contains("default") { return (1, lowercased) }
+        return (2, lowercased)
+    }
 }
 
 enum MiMoFirefoxSessionCookieImporter {
@@ -324,7 +408,9 @@ enum MiMoFirefoxSessionCookieImporter {
                 let jsonData = try self.decodeSessionRestoreData(data)
                 let records = try self.cookieRecords(fromJSONData: jsonData, now: now)
                 if !records.isEmpty {
-                    logger?("\(profileDirectory.lastPathComponent): found MiMo session cookies in \(file.lastPathComponent)")
+                    logger?(
+                        "\(profileDirectory.lastPathComponent): found MiMo session cookies in " +
+                            "\(file.lastPathComponent)")
                     return records
                 }
             } catch {
@@ -471,7 +557,7 @@ enum MiMoFirefoxSessionCookieImporter {
             guard index + literalLength <= bytes.count else {
                 throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Invalid LZ4 literal length"))
             }
-            output.append(contentsOf: bytes[index ..< index + literalLength])
+            output.append(contentsOf: bytes[index..<index + literalLength])
             index += literalLength
 
             guard index < bytes.count else { break }
@@ -490,7 +576,7 @@ enum MiMoFirefoxSessionCookieImporter {
                 matchLength += self.readExtendedLength(bytes: bytes, index: &index)
             }
 
-            for _ in 0 ..< matchLength {
+            for _ in 0..<matchLength {
                 output.append(output[output.count - offset])
             }
         }

--- a/Tests/CodexBarTests/MiMoFirefoxSessionCookieImporterTests.swift
+++ b/Tests/CodexBarTests/MiMoFirefoxSessionCookieImporterTests.swift
@@ -1,0 +1,166 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+#if os(macOS)
+struct MiMoFirefoxSessionCookieImporterTests {
+    @Test
+    func `rejects mismatched decoded size`() throws {
+        let json = #"{"cookies":[]}"#
+        var data = self.mozillaLZ4LiteralFile(json)
+        var mismatchedSize = UInt32(json.utf8.count + 1).littleEndian
+        withUnsafeBytes(of: &mismatchedSize) { data.replaceSubrange(8..<12, with: $0) }
+
+        do {
+            _ = try MiMoFirefoxSessionCookieImporter.decodeSessionRestoreData(data)
+            Issue.record("Expected mismatched Firefox session restore size to fail")
+        } catch let error as MiMoFirefoxSessionCookieImporter.ImportError {
+            guard case .invalidData = error else {
+                Issue.record("Unexpected Firefox session restore error: \(error)")
+                return
+            }
+        }
+    }
+
+    @Test
+    func `canonical large payload bypasses raw size prefix trap`() throws {
+        let padding = String(repeating: "x", count: 65520)
+        let json = #"{"cookies":[],"padding":"\#(padding)"}"#
+
+        let decoded = try MiMoFirefoxSessionCookieImporter.decodeSessionRestoreData(
+            self.mozillaLZ4LiteralFile(json))
+
+        #expect(decoded == Data(json.utf8))
+    }
+
+    @Test
+    func `reads only top level cookies`() throws {
+        let data = Data(#"{"nested":{"cookies":[{"host":".xiaomimimo.com","name":"userId","value":"stale"}]}}"#.utf8)
+
+        let records = try MiMoFirefoxSessionCookieImporter.cookieRecords(fromJSONData: data)
+
+        #expect(records.isEmpty)
+    }
+
+    @Test
+    func `rejects isolated cookie contexts and wrong attribute types`() throws {
+        let data = Data(#"""
+        {"cookies":[
+          {"host":".platform.xiaomimimo.com","name":"api-platform_serviceToken",
+           "value":"clean-token","originAttributes":{
+             "userContextId":0,"privateBrowsingId":0,
+             "firstPartyDomain":"","geckoViewSessionContextId":"","partitionKey":""
+           }},
+          {"host":".xiaomimimo.com","name":"userId","value":"clean-user","originAttributes":"","isPartitioned":false},
+          {"host":".xiaomimimo.com","name":"userId","value":"container-user","originAttributes":{"userContextId":2}},
+          {"host":".xiaomimimo.com","name":"userId","value":"private-user","originAttributes":{"privateBrowsingId":1}},
+          {"host":".platform.xiaomimimo.com","name":"api-platform_ph","value":"partitioned","isPartitioned":true},
+          {"host":".platform.xiaomimimo.com","name":"api-platform_ph","value":"numeric-partition","isPartitioned":0},
+          {"host":".platform.xiaomimimo.com","name":"api-platform_ph","value":"boolean-context","originAttributes":{"userContextId":false}},
+          {"host":".platform.xiaomimimo.com","name":"api-platform_ph","value":"floating-context","originAttributes":{"privateBrowsingId":0.0}},
+          {"host":".platform.xiaomimimo.com","name":"api-platform_ph",
+           "value":"unknown-context","originAttributes":{"futureIsolationKey":"value"}}
+        ]}
+        """#.utf8)
+
+        let records = try MiMoFirefoxSessionCookieImporter.cookieRecords(fromJSONData: data)
+
+        #expect(Set(records.map(\.value)) == Set(["clean-token", "clean-user"]))
+    }
+
+    @Test
+    func `cookie count is bounded before filtering`() throws {
+        let data = Data(#"""
+        {"cookies":[
+          {"host":"example.com","name":"irrelevant","value":"one"},
+          {"host":"example.com","name":"irrelevant","value":"two"}
+        ]}
+        """#.utf8)
+
+        do {
+            _ = try MiMoFirefoxSessionCookieImporter.cookieRecords(fromJSONData: data, maxRecords: 1)
+            Issue.record("Expected Firefox session restore cookie count to be bounded")
+        } catch let error as MiMoFirefoxSessionCookieImporter.ImportError {
+            guard case .resourceLimit = error else {
+                Issue.record("Unexpected Firefox session restore error: \(error)")
+                return
+            }
+        }
+    }
+
+    @Test
+    func `mixed cookie array is malformed after applying count bound`() throws {
+        let oversized = Data(#"{"cookies":[1,2]}"#.utf8)
+        let mixed = Data(#"{"cookies":[{"host":"example.com"},1]}"#.utf8)
+
+        do {
+            _ = try MiMoFirefoxSessionCookieImporter.cookieRecords(fromJSONData: oversized, maxRecords: 1)
+            Issue.record("Expected mixed Firefox session restore cookie count to be bounded")
+        } catch let error as MiMoFirefoxSessionCookieImporter.ImportError {
+            guard case .resourceLimit = error else {
+                Issue.record("Unexpected Firefox session restore error: \(error)")
+                return
+            }
+        }
+
+        do {
+            _ = try MiMoFirefoxSessionCookieImporter.cookieRecords(fromJSONData: mixed, maxRecords: 2)
+            Issue.record("Expected mixed Firefox session restore cookies to be malformed")
+        } catch let error as MiMoFirefoxSessionCookieImporter.ImportError {
+            guard case .invalidData = error else {
+                Issue.record("Unexpected Firefox session restore error: \(error)")
+                return
+            }
+        }
+    }
+
+    @Test
+    func `candidates follow deterministic firefox order with newest upgrade only`() {
+        let profile = URL(fileURLWithPath: "/tmp/firefox/profile", isDirectory: true)
+        let backups = profile.appendingPathComponent("sessionstore-backups", isDirectory: true)
+        let upgrades = [
+            backups.appendingPathComponent("upgrade.jsonlz4-20250101000000"),
+            backups.appendingPathComponent("unrelated.jsonlz4"),
+            backups.appendingPathComponent("upgrade.jsonlz4-20260101000000"),
+        ]
+
+        let candidates = MiMoFirefoxSessionCookieImporter.orderedSessionRestoreFileCandidates(
+            profileDirectory: profile,
+            upgradeFiles: upgrades)
+
+        #expect(candidates.map(\.lastPathComponent) == [
+            "sessionstore.jsonlz4",
+            "recovery.jsonlz4",
+            "recovery.baklz4",
+            "previous.jsonlz4",
+            "upgrade.jsonlz4-20260101000000",
+        ])
+    }
+
+    private func mozillaLZ4LiteralFile(_ json: String) -> Data {
+        var data = Data([0x6D, 0x6F, 0x7A, 0x4C, 0x7A, 0x34, 0x30, 0x00])
+        var decodedSize = UInt32(json.utf8.count).littleEndian
+        withUnsafeBytes(of: &decodedSize) { data.append(contentsOf: $0) }
+        data.append(self.lz4LiteralBlock(Data(json.utf8)))
+        return data
+    }
+
+    private func lz4LiteralBlock(_ payload: Data) -> Data {
+        var output = Data()
+        let literalCount = payload.count
+        if literalCount < 15 {
+            output.append(UInt8(literalCount << 4))
+        } else {
+            output.append(0xF0)
+            var remaining = literalCount - 15
+            while remaining >= 255 {
+                output.append(255)
+                remaining -= 255
+            }
+            output.append(UInt8(remaining))
+        }
+        output.append(payload)
+        return output
+    }
+}
+#endif

--- a/Tests/CodexBarTests/MiMoFirefoxSessionCookieImporterTests.swift
+++ b/Tests/CodexBarTests/MiMoFirefoxSessionCookieImporterTests.swift
@@ -56,8 +56,10 @@ struct MiMoFirefoxSessionCookieImporterTests {
           {"host":".xiaomimimo.com","name":"userId","value":"private-user","originAttributes":{"privateBrowsingId":1}},
           {"host":".platform.xiaomimimo.com","name":"api-platform_ph","value":"partitioned","isPartitioned":true},
           {"host":".platform.xiaomimimo.com","name":"api-platform_ph","value":"numeric-partition","isPartitioned":0},
-          {"host":".platform.xiaomimimo.com","name":"api-platform_ph","value":"boolean-context","originAttributes":{"userContextId":false}},
-          {"host":".platform.xiaomimimo.com","name":"api-platform_ph","value":"floating-context","originAttributes":{"privateBrowsingId":0.0}},
+          {"host":".platform.xiaomimimo.com","name":"api-platform_ph",
+           "value":"boolean-context","originAttributes":{"userContextId":false}},
+          {"host":".platform.xiaomimimo.com","name":"api-platform_ph",
+           "value":"floating-context","originAttributes":{"privateBrowsingId":0.0}},
           {"host":".platform.xiaomimimo.com","name":"api-platform_ph",
            "value":"unknown-context","originAttributes":{"futureIsolationKey":"value"}}
         ]}

--- a/Tests/CodexBarTests/MiMoFirefoxSessionCookieImporterTests.swift
+++ b/Tests/CodexBarTests/MiMoFirefoxSessionCookieImporterTests.swift
@@ -23,6 +23,29 @@ struct MiMoFirefoxSessionCookieImporterTests {
     }
 
     @Test
+    func `too small decoded size falls back to valid backup`() throws {
+        let (temp, profile, backups) = try self.makeFirefoxProfile()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let currentJSON = #"{"cookies":[]}"#
+        var current = self.mozillaLZ4LiteralFile(currentJSON)
+        var tooSmallSize = UInt32(currentJSON.utf8.count - 1).littleEndian
+        withUnsafeBytes(of: &tooSmallSize) { current.replaceSubrange(8..<12, with: $0) }
+        try current.write(to: backups.appendingPathComponent("recovery.jsonlz4"))
+        let backupJSON = #"{"cookies":[{"host":".xiaomimimo.com","name":"userId","value":"backup-user"}]}"#
+        try self.mozillaLZ4LiteralFile(backupJSON)
+            .write(to: backups.appendingPathComponent("recovery.baklz4"))
+
+        let outcome = MiMoFirefoxSessionCookieImporter.load(profileDirectory: profile)
+
+        guard case let .loaded(records) = outcome else {
+            Issue.record("Expected malformed current state to fall back to the valid backup")
+            return
+        }
+        #expect(records.map(\.value) == ["backup-user"])
+    }
+
+    @Test
     func `canonical large payload bypasses raw size prefix trap`() throws {
         let padding = String(repeating: "x", count: 65520)
         let json = #"{"cookies":[],"padding":"\#(padding)"}"#
@@ -117,6 +140,65 @@ struct MiMoFirefoxSessionCookieImporterTests {
     }
 
     @Test
+    func `input limit stops before older backup`() throws {
+        let (temp, profile, backups) = try self.makeFirefoxProfile()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        try Data(repeating: 0x41, count: 5).write(to: backups.appendingPathComponent("recovery.jsonlz4"))
+        try self.mozillaLZ4LiteralFile(#"{"cookies":[]}"#)
+            .write(to: backups.appendingPathComponent("recovery.baklz4"))
+
+        let outcome = MiMoFirefoxSessionCookieImporter.load(
+            profileDirectory: profile,
+            limits: .init(inputBytes: 4, outputBytes: 1024, cookieRecords: 10))
+
+        guard case .resourceLimited(.inputBytes) = outcome else {
+            Issue.record("Expected the current Firefox input limit to stop backup recovery")
+            return
+        }
+    }
+
+    @Test
+    func `output limit stops before older backup`() throws {
+        let (temp, profile, backups) = try self.makeFirefoxProfile()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        var oversized = Data([0x6D, 0x6F, 0x7A, 0x4C, 0x7A, 0x34, 0x30, 0x00])
+        var declaredSize = UInt32(129 * 1024 * 1024).littleEndian
+        withUnsafeBytes(of: &declaredSize) { oversized.append(contentsOf: $0) }
+        try oversized.write(to: backups.appendingPathComponent("recovery.jsonlz4"))
+        try self.mozillaLZ4LiteralFile(#"{"cookies":[]}"#)
+            .write(to: backups.appendingPathComponent("recovery.baklz4"))
+
+        let outcome = MiMoFirefoxSessionCookieImporter.load(profileDirectory: profile)
+
+        guard case .resourceLimited(.outputBytes) = outcome else {
+            Issue.record("Expected the current Firefox output limit to stop backup recovery")
+            return
+        }
+    }
+
+    @Test
+    func `cookie limit stops before older backup`() throws {
+        let (temp, profile, backups) = try self.makeFirefoxProfile()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        try self.mozillaLZ4LiteralFile(#"{"cookies":[1,2]}"#)
+            .write(to: backups.appendingPathComponent("recovery.jsonlz4"))
+        try self.mozillaLZ4LiteralFile(#"{"cookies":[]}"#)
+            .write(to: backups.appendingPathComponent("recovery.baklz4"))
+
+        let outcome = MiMoFirefoxSessionCookieImporter.load(
+            profileDirectory: profile,
+            limits: .init(inputBytes: 1024, outputBytes: 1024, cookieRecords: 1))
+
+        guard case .resourceLimited(.cookieRecords) = outcome else {
+            Issue.record("Expected the current Firefox cookie limit to stop backup recovery")
+            return
+        }
+    }
+
+    @Test
     func `candidates follow deterministic firefox order with newest upgrade only`() {
         let profile = URL(fileURLWithPath: "/tmp/firefox/profile", isDirectory: true)
         let backups = profile.appendingPathComponent("sessionstore-backups", isDirectory: true)
@@ -145,6 +227,15 @@ struct MiMoFirefoxSessionCookieImporterTests {
         withUnsafeBytes(of: &decodedSize) { data.append(contentsOf: $0) }
         data.append(self.lz4LiteralBlock(Data(json.utf8)))
         return data
+    }
+
+    private func makeFirefoxProfile() throws -> (temp: URL, profile: URL, backups: URL) {
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mimo-firefox-limit-\(UUID().uuidString)", isDirectory: true)
+        let profile = temp.appendingPathComponent("default-release", isDirectory: true)
+        let backups = profile.appendingPathComponent("sessionstore-backups", isDirectory: true)
+        try FileManager.default.createDirectory(at: backups, withIntermediateDirectories: true)
+        return (temp, profile, backups)
     }
 
     private func lz4LiteralBlock(_ payload: Data) -> Data {

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -1123,6 +1123,76 @@ extension MiMoProviderTests {
     }
 
     @Test
+    func `mimo importer checks backup after partial firefox recovery`() throws {
+        let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-backup")
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let partial = """
+        {"cookies":[
+          {"host":".platform.xiaomimimo.com","path":"/","name":"api-platform_ph","value":"ph-token"}
+        ]}
+        """
+        let complete = """
+        {"cookies":[
+          {"host":".platform.xiaomimimo.com","path":"/","name":"api-platform_serviceToken","value":"svc-token"},
+          {"host":".xiaomimimo.com","path":"/","name":"userId","value":"1863175063"}
+        ]}
+        """
+        try self.mozillaLZ4LiteralFile(partial).write(to: backups.appendingPathComponent("recovery.jsonlz4"))
+        try self.mozillaLZ4LiteralFile(complete).write(to: backups.appendingPathComponent("recovery.baklz4"))
+
+        let records = MiMoFirefoxSessionCookieImporter.records(profileDirectory: profile)
+        let store = self.makeFirefoxCookieStore(profileDirectory: profile)
+        let sessions = MiMoCookieImporter.sessionInfos(from: [
+            BrowserCookieStoreRecords(store: store, records: records),
+        ])
+
+        #expect(sessions.map(\.cookieHeader) == [
+            "api-platform_serviceToken=svc-token; userId=1863175063",
+        ])
+    }
+
+    @Test
+    func `mimo importer keeps persisted cookie over older firefox backup`() throws {
+        let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-persisted")
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let recovery = """
+        {"cookies":[
+          {"host":".platform.xiaomimimo.com","path":"/","name":"api-platform_ph","value":"ph-token"}
+        ]}
+        """
+        let backup = """
+        {"cookies":[
+          {"host":".platform.xiaomimimo.com","path":"/","name":"api-platform_serviceToken","value":"old-token"},
+          {"host":".xiaomimimo.com","path":"/","name":"userId","value":"old-user"}
+        ]}
+        """
+        try self.mozillaLZ4LiteralFile(recovery).write(to: backups.appendingPathComponent("recovery.jsonlz4"))
+        try self.mozillaLZ4LiteralFile(backup).write(to: backups.appendingPathComponent("recovery.baklz4"))
+
+        let store = self.makeFirefoxCookieStore(profileDirectory: profile)
+        let persisted = BrowserCookieStoreRecords(store: store, records: [
+            BrowserCookieRecord(
+                domain: "platform.xiaomimimo.com",
+                name: "api-platform_serviceToken",
+                path: "/",
+                value: "current-token",
+                expires: Date(timeIntervalSince1970: 1_912_064_978),
+                isSecure: false,
+                isHTTPOnly: false),
+        ])
+        let resolved = MiMoCookieImporter.recordsIncludingFirefoxSessionCookies(
+            from: [persisted],
+            browser: .firefox,
+            stores: [store])
+
+        #expect(MiMoCookieImporter.sessionInfos(from: resolved).map(\.cookieHeader) == [
+            "api-platform_serviceToken=current-token; userId=old-user",
+        ])
+    }
+
+    @Test
     func `mimo importer recovers session cookies when firefox query returns no rows`() throws {
         let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-empty-store")
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -1073,7 +1073,135 @@ extension MiMoProviderTests {
         #expect(sessions.first?.sourceLabel == "Chrome Default")
         #expect(sessions.first?.cookieHeader == "api-platform_serviceToken=token; userId=123")
     }
+
+    @Test
+    func `mimo importer recovers firefox session restore cookies`() throws {
+        let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-session")
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let json = """
+        {
+          "cookies": [
+            {
+              "host": ".platform.xiaomimimo.com",
+              "path": "/",
+              "name": "api-platform_serviceToken",
+              "value": "svc-token",
+              "secure": false,
+              "httponly": false
+            },
+            {
+              "host": ".xiaomimimo.com",
+              "path": "/",
+              "name": "userId",
+              "value": "1863175063",
+              "secure": false,
+              "httponly": false
+            },
+            {
+              "host": ".platform.xiaomimimo.com",
+              "path": "/",
+              "name": "api-platform_ph",
+              "value": "ph-token",
+              "secure": false,
+              "httponly": false
+            }
+          ]
+        }
+        """
+        try self.mozillaLZ4LiteralFile(json).write(to: backups.appendingPathComponent("recovery.jsonlz4"))
+
+        let records = MiMoFirefoxSessionCookieImporter.records(profileDirectory: profile)
+        let store = self.makeFirefoxCookieStore(profileDirectory: profile)
+        let sessions = MiMoCookieImporter.sessionInfos(from: [
+            BrowserCookieStoreRecords(store: store, records: records),
+        ])
+
+        #expect(sessions.map(\.cookieHeader) == [
+            "api-platform_ph=ph-token; api-platform_serviceToken=svc-token; userId=1863175063",
+        ])
+    }
+
+    @Test
+    func `mimo importer merges firefox session restore cookies with persisted cookies`() throws {
+        let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-merge")
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let json = """
+        {
+          "cookies": [
+            {"host": ".platform.xiaomimimo.com", "path": "/", "name": "api-platform_serviceToken", "value": "svc-token"},
+            {"host": ".xiaomimimo.com", "path": "/", "name": "userId", "value": "1863175063"}
+          ]
+        }
+        """
+        try self.mozillaLZ4LiteralFile(json).write(to: backups.appendingPathComponent("recovery.jsonlz4"))
+
+        let store = self.makeFirefoxCookieStore(profileDirectory: profile)
+        let persisted = BrowserCookieStoreRecords(store: store, records: [
+            BrowserCookieRecord(
+                domain: "platform.xiaomimimo.com",
+                name: "cookie-preferences",
+                path: "/",
+                value: "xxx",
+                expires: Date(timeIntervalSince1970: 1_812_064_978),
+                isSecure: false,
+                isHTTPOnly: false),
+        ])
+
+        let resolved = MiMoCookieImporter.recordsIncludingFirefoxSessionCookies(from: [persisted])
+        let sessions = MiMoCookieImporter.sessionInfos(from: resolved)
+
+        #expect(sessions.map(\.cookieHeader) == ["api-platform_serviceToken=svc-token; userId=1863175063"])
+    }
+
+    private func makeFirefoxSessionRestoreProfile(prefix: String) throws -> (
+        temp: URL,
+        profile: URL,
+        backups: URL)
+    {
+        let temp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
+        let profile = temp
+            .appendingPathComponent("Library/Application Support/Firefox/Profiles/n757crxy.default-release-1")
+        let backups = profile.appendingPathComponent("sessionstore-backups", isDirectory: true)
+        try FileManager.default.createDirectory(at: backups, withIntermediateDirectories: true)
+        return (temp: temp, profile: profile, backups: backups)
+    }
+
+    private func makeFirefoxCookieStore(profileDirectory: URL) -> BrowserCookieStore {
+        BrowserCookieStore(
+            browser: .firefox,
+            profile: BrowserProfile(id: profileDirectory.path, name: profileDirectory.lastPathComponent),
+            kind: .primary,
+            label: "Firefox \(profileDirectory.lastPathComponent)",
+            databaseURL: profileDirectory.appendingPathComponent("cookies.sqlite"))
+    }
     #endif
+
+    private func mozillaLZ4LiteralFile(_ json: String) -> Data {
+        var data = Data([0x6D, 0x6F, 0x7A, 0x4C, 0x7A, 0x34, 0x30, 0x00])
+        data.append(self.lz4LiteralBlock(Data(json.utf8)))
+        return data
+    }
+
+    private func lz4LiteralBlock(_ payload: Data) -> Data {
+        var output = Data()
+        let literalCount = payload.count
+        if literalCount < 15 {
+            output.append(UInt8(literalCount << 4))
+        } else {
+            output.append(0xF0)
+            var remaining = literalCount - 15
+            while remaining >= 255 {
+                output.append(255)
+                remaining -= 255
+            }
+            output.append(UInt8(remaining))
+        }
+        output.append(payload)
+        return output
+    }
 
     private static func makeResponse(
         url: URL,

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -1123,7 +1123,7 @@ extension MiMoProviderTests {
     }
 
     @Test
-    func `mimo importer enumerates firefox profiles with session restore cookies only`() throws {
+    func `mimo importer recovers session cookies when firefox query returns no rows`() throws {
         let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-empty-store")
         defer { try? FileManager.default.removeItem(at: temp) }
 
@@ -1140,13 +1140,54 @@ extension MiMoProviderTests {
         let resolved = MiMoCookieImporter.recordsIncludingFirefoxSessionCookies(
             from: [],
             browser: .firefox,
-            homeDirectories: [temp])
+            stores: [self.makeFirefoxCookieStore(profileDirectory: profile)])
 
         #expect(resolved.count == 1)
         #expect(
             URL(fileURLWithPath: resolved.first?.store.profile.id ?? "").standardizedFileURL.path ==
                 profile.standardizedFileURL.path)
         #expect(MiMoCookieImporter.sessionInfos(from: resolved).map(\.cookieHeader) == [
+            "api-platform_serviceToken=svc-token; userId=1863175063",
+        ])
+    }
+
+    @Test
+    func `mimo import path checks firefox stores after an empty domain query`() throws {
+        let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-import")
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let store = self.makeFirefoxCookieStore(profileDirectory: profile)
+        let profilesRoot = profile.deletingLastPathComponent()
+        let json = """
+        {
+          "cookies": [
+            {"host": ".platform.xiaomimimo.com", "path": "/", "name": "api-platform_serviceToken", "value": "svc-token"},
+            {"host": ".xiaomimimo.com", "path": "/", "name": "userId", "value": "1863175063"}
+          ]
+        }
+        """
+        try self.mozillaLZ4LiteralFile(json).write(to: backups.appendingPathComponent("recovery.jsonlz4"))
+
+        let detection = BrowserDetection(
+            homeDirectory: temp.path,
+            cacheTTL: 0,
+            fileExists: { path in
+                path == profilesRoot.path || path == store.databaseURL?.path
+            },
+            directoryContents: { path in
+                path == profilesRoot.path ? [profile.lastPathComponent] : nil
+            })
+        var queriedFirefoxStores = false
+        let sessions = try MiMoCookieImporter.importSessions(
+            browserDetection: detection,
+            loadRecords: { _, _, _ in [] },
+            loadStores: { browser in
+                guard browser == .firefox else { return [] }
+                queriedFirefoxStores = true
+                return [store]
+            })
+
+        #expect(queriedFirefoxStores)
+        #expect(sessions.map(\.cookieHeader) == [
             "api-platform_serviceToken=svc-token; userId=1863175063",
         ])
     }
@@ -1176,15 +1217,93 @@ extension MiMoProviderTests {
                 expires: Date(timeIntervalSince1970: 1_812_064_978),
                 isSecure: false,
                 isHTTPOnly: false),
+            BrowserCookieRecord(
+                domain: "platform.xiaomimimo.com",
+                name: "api-platform_serviceToken",
+                path: "/",
+                value: "stale-token",
+                expires: Date(timeIntervalSince1970: 1_912_064_978),
+                isSecure: false,
+                isHTTPOnly: false),
+            BrowserCookieRecord(
+                domain: "xiaomimimo.com",
+                name: "userId",
+                path: "/",
+                value: "stale-user",
+                expires: Date(timeIntervalSince1970: 1_912_064_978),
+                isSecure: false,
+                isHTTPOnly: false),
         ])
 
         let resolved = MiMoCookieImporter.recordsIncludingFirefoxSessionCookies(
             from: [persisted],
             browser: .firefox,
-            homeDirectories: [temp])
+            stores: [store])
         let sessions = MiMoCookieImporter.sessionInfos(from: resolved)
 
         #expect(sessions.map(\.cookieHeader) == ["api-platform_serviceToken=svc-token; userId=1863175063"])
+    }
+
+    @Test
+    func `firefox session restore input is size bounded`() throws {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mimo-firefox-oversized-\(UUID().uuidString).jsonlz4")
+        defer { try? FileManager.default.removeItem(at: file) }
+        try Data(repeating: 0x41, count: 5).write(to: file)
+
+        do {
+            _ = try MiMoFirefoxSessionCookieImporter.readData(from: file, maxBytes: 4)
+            Issue.record("Expected oversized Firefox session restore input to fail")
+        } catch let error as MiMoFirefoxSessionCookieImporter.ImportError {
+            guard case .inputTooLarge = error else {
+                Issue.record("Unexpected Firefox session restore error: \(error)")
+                return
+            }
+        }
+    }
+
+    @Test
+    func `firefox session restore decompression is size bounded`() throws {
+        var data = Data([0x6D, 0x6F, 0x7A, 0x4C, 0x7A, 0x34, 0x30, 0x00])
+        data.append(contentsOf: [0x1F, 0x41, 0x01, 0x00, 0x14])
+
+        do {
+            _ = try MiMoFirefoxSessionCookieImporter.decodeSessionRestoreData(data, maxOutputBytes: 32)
+            Issue.record("Expected oversized Firefox session restore output to fail")
+        } catch let error as MiMoFirefoxSessionCookieImporter.ImportError {
+            guard case .outputTooLarge = error else {
+                Issue.record("Unexpected Firefox session restore error: \(error)")
+                return
+            }
+        }
+    }
+
+    @Test
+    func `firefox session restore accepts decoded size prefix`() throws {
+        let json = #"{"cookies":[]}"#
+        var data = Data([0x6D, 0x6F, 0x7A, 0x4C, 0x7A, 0x34, 0x30, 0x00])
+        var decodedSize = UInt32(json.utf8.count).littleEndian
+        withUnsafeBytes(of: &decodedSize) { data.append(contentsOf: $0) }
+        data.append(self.lz4LiteralBlock(Data(json.utf8)))
+
+        let decoded = try MiMoFirefoxSessionCookieImporter.decodeSessionRestoreData(data)
+
+        #expect(decoded == Data(json.utf8))
+    }
+
+    @Test
+    func `firefox session restore json traversal is bounded`() throws {
+        let data = Data(#"{"nested":{"cookies":[]}}"#.utf8)
+
+        do {
+            _ = try MiMoFirefoxSessionCookieImporter.cookieRecords(fromJSONData: data, maxNodes: 1)
+            Issue.record("Expected complex Firefox session restore JSON to fail")
+        } catch let error as MiMoFirefoxSessionCookieImporter.ImportError {
+            guard case .invalidData = error else {
+                Issue.record("Unexpected Firefox session restore error: \(error)")
+                return
+            }
+        }
     }
 
     private func makeFirefoxSessionRestoreProfile(prefix: String) throws -> (

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -1130,7 +1130,12 @@ extension MiMoProviderTests {
         let json = """
         {
           "cookies": [
-            {"host": ".platform.xiaomimimo.com", "path": "/", "name": "api-platform_serviceToken", "value": "svc-token"},
+            {
+              "host": ".platform.xiaomimimo.com",
+              "path": "/",
+              "name": "api-platform_serviceToken",
+              "value": "svc-token"
+            },
             {"host": ".xiaomimimo.com", "path": "/", "name": "userId", "value": "1863175063"}
           ]
         }
@@ -1160,7 +1165,12 @@ extension MiMoProviderTests {
         let json = """
         {
           "cookies": [
-            {"host": ".platform.xiaomimimo.com", "path": "/", "name": "api-platform_serviceToken", "value": "svc-token"},
+            {
+              "host": ".platform.xiaomimimo.com",
+              "path": "/",
+              "name": "api-platform_serviceToken",
+              "value": "svc-token"
+            },
             {"host": ".xiaomimimo.com", "path": "/", "name": "userId", "value": "1863175063"}
           ]
         }
@@ -1200,7 +1210,12 @@ extension MiMoProviderTests {
         let json = """
         {
           "cookies": [
-            {"host": ".platform.xiaomimimo.com", "path": "/", "name": "api-platform_serviceToken", "value": "svc-token"},
+            {
+              "host": ".platform.xiaomimimo.com",
+              "path": "/",
+              "name": "api-platform_serviceToken",
+              "value": "svc-token"
+            },
             {"host": ".xiaomimimo.com", "path": "/", "name": "userId", "value": "1863175063"}
           ]
         }

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -1123,7 +1123,7 @@ extension MiMoProviderTests {
     }
 
     @Test
-    func `mimo importer checks backup after partial firefox recovery`() throws {
+    func `current partial firefox state does not resurrect backup credentials`() throws {
         let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-backup")
         defer { try? FileManager.default.removeItem(at: temp) }
 
@@ -1147,13 +1147,31 @@ extension MiMoProviderTests {
             BrowserCookieStoreRecords(store: store, records: records),
         ])
 
-        #expect(sessions.map(\.cookieHeader) == [
-            "api-platform_serviceToken=svc-token; userId=1863175063",
-        ])
+        #expect(records.map(\.name) == ["api-platform_ph"])
+        #expect(sessions.isEmpty)
     }
 
     @Test
-    func `mimo importer keeps persisted cookie over older firefox backup`() throws {
+    func `malformed current firefox state falls back to recovery backup`() throws {
+        let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-corrupt")
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        try Data("not-jsonlz4".utf8).write(to: backups.appendingPathComponent("recovery.jsonlz4"))
+        let complete = """
+        {"cookies":[
+          {"host":".platform.xiaomimimo.com","path":"/","name":"api-platform_serviceToken","value":"svc-token"},
+          {"host":".xiaomimimo.com","path":"/","name":"userId","value":"1863175063"}
+        ]}
+        """
+        try self.mozillaLZ4LiteralFile(complete).write(to: backups.appendingPathComponent("recovery.baklz4"))
+
+        let records = MiMoFirefoxSessionCookieImporter.records(profileDirectory: profile)
+
+        #expect(Set(records.map(\.value)) == Set(["svc-token", "1863175063"]))
+    }
+
+    @Test
+    func `partial firefox state does not merge persisted and stale backup credentials`() throws {
         let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-persisted")
         defer { try? FileManager.default.removeItem(at: temp) }
 
@@ -1181,14 +1199,23 @@ extension MiMoProviderTests {
                 expires: Date(timeIntervalSince1970: 1_912_064_978),
                 isSecure: false,
                 isHTTPOnly: false),
+            BrowserCookieRecord(
+                domain: "xiaomimimo.com",
+                name: "userId",
+                path: "/",
+                value: "current-user",
+                expires: Date(timeIntervalSince1970: 1_912_064_978),
+                isSecure: false,
+                isHTTPOnly: false),
         ])
         let resolved = MiMoCookieImporter.recordsIncludingFirefoxSessionCookies(
             from: [persisted],
             browser: .firefox,
             stores: [store])
 
+        #expect(Set(resolved.first?.records.map(\.value) ?? []) == Set(["current-token", "current-user"]))
         #expect(MiMoCookieImporter.sessionInfos(from: resolved).map(\.cookieHeader) == [
-            "api-platform_serviceToken=current-token; userId=old-user",
+            "api-platform_serviceToken=current-token; userId=current-user",
         ])
     }
 
@@ -1212,15 +1239,16 @@ extension MiMoProviderTests {
         """
         try self.mozillaLZ4LiteralFile(json).write(to: backups.appendingPathComponent("recovery.jsonlz4"))
 
+        let store = self.makeFirefoxCookieStore(
+            profileDirectory: profile,
+            profileID: "opaque-firefox-profile")
         let resolved = MiMoCookieImporter.recordsIncludingFirefoxSessionCookies(
             from: [],
             browser: .firefox,
-            stores: [self.makeFirefoxCookieStore(profileDirectory: profile)])
+            stores: [store])
 
         #expect(resolved.count == 1)
-        #expect(
-            URL(fileURLWithPath: resolved.first?.store.profile.id ?? "").standardizedFileURL.path ==
-                profile.standardizedFileURL.path)
+        #expect(resolved.first?.store.profile.id == "opaque-firefox-profile")
         #expect(MiMoCookieImporter.sessionInfos(from: resolved).map(\.cookieHeader) == [
             "api-platform_serviceToken=svc-token; userId=1863175063",
         ])
@@ -1273,7 +1301,7 @@ extension MiMoProviderTests {
     }
 
     @Test
-    func `mimo importer merges firefox session restore cookies with persisted cookies`() throws {
+    func `complete firefox session state replaces persisted cookies`() throws {
         let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-merge")
         defer { try? FileManager.default.removeItem(at: temp) }
 
@@ -1326,6 +1354,7 @@ extension MiMoProviderTests {
             stores: [store])
         let sessions = MiMoCookieImporter.sessionInfos(from: resolved)
 
+        #expect(Set(resolved.first?.records.map(\.value) ?? []) == Set(["svc-token", "1863175063"]))
         #expect(sessions.map(\.cookieHeader) == ["api-platform_serviceToken=svc-token; userId=1863175063"])
     }
 
@@ -1376,21 +1405,6 @@ extension MiMoProviderTests {
         #expect(decoded == Data(json.utf8))
     }
 
-    @Test
-    func `firefox session restore json traversal is bounded`() throws {
-        let data = Data(#"{"nested":{"cookies":[]}}"#.utf8)
-
-        do {
-            _ = try MiMoFirefoxSessionCookieImporter.cookieRecords(fromJSONData: data, maxNodes: 1)
-            Issue.record("Expected complex Firefox session restore JSON to fail")
-        } catch let error as MiMoFirefoxSessionCookieImporter.ImportError {
-            guard case .invalidData = error else {
-                Issue.record("Unexpected Firefox session restore error: \(error)")
-                return
-            }
-        }
-    }
-
     private func makeFirefoxSessionRestoreProfile(prefix: String) throws -> (
         temp: URL,
         profile: URL,
@@ -1405,10 +1419,13 @@ extension MiMoProviderTests {
         return (temp: temp, profile: profile, backups: backups)
     }
 
-    private func makeFirefoxCookieStore(profileDirectory: URL) -> BrowserCookieStore {
+    private func makeFirefoxCookieStore(
+        profileDirectory: URL,
+        profileID: String? = nil) -> BrowserCookieStore
+    {
         BrowserCookieStore(
             browser: .firefox,
-            profile: BrowserProfile(id: profileDirectory.path, name: profileDirectory.lastPathComponent),
+            profile: BrowserProfile(id: profileID ?? profileDirectory.path, name: profileDirectory.lastPathComponent),
             kind: .primary,
             label: "Firefox \(profileDirectory.lastPathComponent)",
             databaseURL: profileDirectory.appendingPathComponent("cookies.sqlite"))
@@ -1417,6 +1434,8 @@ extension MiMoProviderTests {
 
     private func mozillaLZ4LiteralFile(_ json: String) -> Data {
         var data = Data([0x6D, 0x6F, 0x7A, 0x4C, 0x7A, 0x34, 0x30, 0x00])
+        var decodedSize = UInt32(json.utf8.count).littleEndian
+        withUnsafeBytes(of: &decodedSize) { data.append(contentsOf: $0) }
         data.append(self.lz4LiteralBlock(Data(json.utf8)))
         return data
     }

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -1171,6 +1171,28 @@ extension MiMoProviderTests {
     }
 
     @Test
+    func `oversized current firefox state falls back to recovery backup`() throws {
+        let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-oversized")
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        var oversized = Data([0x6D, 0x6F, 0x7A, 0x4C, 0x7A, 0x34, 0x30, 0x00])
+        var declaredSize = UInt32(129 * 1024 * 1024).littleEndian
+        withUnsafeBytes(of: &declaredSize) { oversized.append(contentsOf: $0) }
+        try oversized.write(to: backups.appendingPathComponent("recovery.jsonlz4"))
+        let complete = """
+        {"cookies":[
+          {"host":".platform.xiaomimimo.com","path":"/","name":"api-platform_serviceToken","value":"svc-token"},
+          {"host":".xiaomimimo.com","path":"/","name":"userId","value":"1863175063"}
+        ]}
+        """
+        try self.mozillaLZ4LiteralFile(complete).write(to: backups.appendingPathComponent("recovery.baklz4"))
+
+        let records = MiMoFirefoxSessionCookieImporter.records(profileDirectory: profile)
+
+        #expect(Set(records.map(\.value)) == Set(["svc-token", "1863175063"]))
+    }
+
+    @Test
     func `partial firefox state does not merge persisted and stale backup credentials`() throws {
         let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-persisted")
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -1171,28 +1171,6 @@ extension MiMoProviderTests {
     }
 
     @Test
-    func `oversized current firefox state falls back to recovery backup`() throws {
-        let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-oversized")
-        defer { try? FileManager.default.removeItem(at: temp) }
-
-        var oversized = Data([0x6D, 0x6F, 0x7A, 0x4C, 0x7A, 0x34, 0x30, 0x00])
-        var declaredSize = UInt32(129 * 1024 * 1024).littleEndian
-        withUnsafeBytes(of: &declaredSize) { oversized.append(contentsOf: $0) }
-        try oversized.write(to: backups.appendingPathComponent("recovery.jsonlz4"))
-        let complete = """
-        {"cookies":[
-          {"host":".platform.xiaomimimo.com","path":"/","name":"api-platform_serviceToken","value":"svc-token"},
-          {"host":".xiaomimimo.com","path":"/","name":"userId","value":"1863175063"}
-        ]}
-        """
-        try self.mozillaLZ4LiteralFile(complete).write(to: backups.appendingPathComponent("recovery.baklz4"))
-
-        let records = MiMoFirefoxSessionCookieImporter.records(profileDirectory: profile)
-
-        #expect(Set(records.map(\.value)) == Set(["svc-token", "1863175063"]))
-    }
-
-    @Test
     func `partial firefox state does not merge persisted and stale backup credentials`() throws {
         let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-persisted")
         defer { try? FileManager.default.removeItem(at: temp) }
@@ -1239,6 +1217,52 @@ extension MiMoProviderTests {
         #expect(MiMoCookieImporter.sessionInfos(from: resolved).map(\.cookieHeader) == [
             "api-platform_serviceToken=current-token; userId=current-user",
         ])
+    }
+
+    @Test
+    func `resource limited firefox state preserves persisted credentials`() throws {
+        let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-persisted-limit")
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        var oversized = Data([0x6D, 0x6F, 0x7A, 0x4C, 0x7A, 0x34, 0x30, 0x00])
+        var declaredSize = UInt32(129 * 1024 * 1024).littleEndian
+        withUnsafeBytes(of: &declaredSize) { oversized.append(contentsOf: $0) }
+        try oversized.write(to: backups.appendingPathComponent("recovery.jsonlz4"))
+        let staleBackup = """
+        {"cookies":[
+          {"host":".platform.xiaomimimo.com","name":"api-platform_serviceToken","value":"old-token"},
+          {"host":".xiaomimimo.com","name":"userId","value":"old-user"}
+        ]}
+        """
+        try self.mozillaLZ4LiteralFile(staleBackup)
+            .write(to: backups.appendingPathComponent("recovery.baklz4"))
+
+        let store = self.makeFirefoxCookieStore(profileDirectory: profile)
+        let persisted = BrowserCookieStoreRecords(store: store, records: [
+            BrowserCookieRecord(
+                domain: "platform.xiaomimimo.com",
+                name: "api-platform_serviceToken",
+                path: "/",
+                value: "current-token",
+                expires: nil,
+                isSecure: true,
+                isHTTPOnly: true),
+            BrowserCookieRecord(
+                domain: "xiaomimimo.com",
+                name: "userId",
+                path: "/",
+                value: "current-user",
+                expires: nil,
+                isSecure: true,
+                isHTTPOnly: false),
+        ])
+
+        let resolved = MiMoCookieImporter.recordsIncludingFirefoxSessionCookies(
+            from: [persisted],
+            browser: .firefox,
+            stores: [store])
+
+        #expect(Set(resolved.first?.records.map(\.value) ?? []) == Set(["current-token", "current-user"]))
     }
 
     @Test
@@ -1297,15 +1321,19 @@ extension MiMoProviderTests {
         """
         try self.mozillaLZ4LiteralFile(json).write(to: backups.appendingPathComponent("recovery.jsonlz4"))
 
+        let firefoxAppPath = "/Applications/\(Browser.firefox.appBundleName).app"
         let detection = BrowserDetection(
             homeDirectory: temp.path,
             cacheTTL: 0,
+            now: Date.init,
             fileExists: { path in
-                path == profilesRoot.path || path == store.databaseURL?.path
+                path == firefoxAppPath || path == profilesRoot.path || path == store.databaseURL?.path
             },
             directoryContents: { path in
                 path == profilesRoot.path ? [profile.lastPathComponent] : nil
-            })
+            },
+            applicationURLs: { _ in [] },
+            profileAccessIssue: { _ in nil })
         var queriedFirefoxStores = false
         let sessions = try MiMoCookieImporter.importSessions(
             browserDetection: detection,
@@ -1391,7 +1419,7 @@ extension MiMoProviderTests {
             _ = try MiMoFirefoxSessionCookieImporter.readData(from: file, maxBytes: 4)
             Issue.record("Expected oversized Firefox session restore input to fail")
         } catch let error as MiMoFirefoxSessionCookieImporter.ImportError {
-            guard case .inputTooLarge = error else {
+            guard case .resourceLimit(.inputBytes) = error else {
                 Issue.record("Unexpected Firefox session restore error: \(error)")
                 return
             }
@@ -1407,7 +1435,7 @@ extension MiMoProviderTests {
             _ = try MiMoFirefoxSessionCookieImporter.decodeSessionRestoreData(data, maxOutputBytes: 32)
             Issue.record("Expected oversized Firefox session restore output to fail")
         } catch let error as MiMoFirefoxSessionCookieImporter.ImportError {
-            guard case .outputTooLarge = error else {
+            guard case .resourceLimit(.outputBytes) = error else {
                 Issue.record("Unexpected Firefox session restore error: \(error)")
                 return
             }

--- a/Tests/CodexBarTests/MiMoProviderTests.swift
+++ b/Tests/CodexBarTests/MiMoProviderTests.swift
@@ -1123,6 +1123,35 @@ extension MiMoProviderTests {
     }
 
     @Test
+    func `mimo importer enumerates firefox profiles with session restore cookies only`() throws {
+        let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-empty-store")
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let json = """
+        {
+          "cookies": [
+            {"host": ".platform.xiaomimimo.com", "path": "/", "name": "api-platform_serviceToken", "value": "svc-token"},
+            {"host": ".xiaomimimo.com", "path": "/", "name": "userId", "value": "1863175063"}
+          ]
+        }
+        """
+        try self.mozillaLZ4LiteralFile(json).write(to: backups.appendingPathComponent("recovery.jsonlz4"))
+
+        let resolved = MiMoCookieImporter.recordsIncludingFirefoxSessionCookies(
+            from: [],
+            browser: .firefox,
+            homeDirectories: [temp])
+
+        #expect(resolved.count == 1)
+        #expect(
+            URL(fileURLWithPath: resolved.first?.store.profile.id ?? "").standardizedFileURL.path ==
+                profile.standardizedFileURL.path)
+        #expect(MiMoCookieImporter.sessionInfos(from: resolved).map(\.cookieHeader) == [
+            "api-platform_serviceToken=svc-token; userId=1863175063",
+        ])
+    }
+
+    @Test
     func `mimo importer merges firefox session restore cookies with persisted cookies`() throws {
         let (temp, profile, backups) = try self.makeFirefoxSessionRestoreProfile(prefix: "mimo-firefox-merge")
         defer { try? FileManager.default.removeItem(at: temp) }
@@ -1149,7 +1178,10 @@ extension MiMoProviderTests {
                 isHTTPOnly: false),
         ])
 
-        let resolved = MiMoCookieImporter.recordsIncludingFirefoxSessionCookies(from: [persisted])
+        let resolved = MiMoCookieImporter.recordsIncludingFirefoxSessionCookies(
+            from: [persisted],
+            browser: .firefox,
+            homeDirectories: [temp])
         let sessions = MiMoCookieImporter.sessionInfos(from: resolved)
 
         #expect(sessions.map(\.cookieHeader) == ["api-platform_serviceToken=svc-token; userId=1863175063"])


### PR DESCRIPTION
## Summary

- recover complete Xiaomi MiMo authentication from Firefox's current session-cookie state when `cookies.sqlite` lacks usable auth rows
- follow Firefox's current/recovery/backup ordering while keeping the first structurally valid state authoritative
- decode only canonical bounded MOZLZ4 data and accept only known MiMo cookies from the default, unpartitioned Firefox context
- keep session and persisted sources independent so partial or stale data is never combined into synthetic authentication

## Maintainer hardening

- rebased on current `main` and removed the stale contributor changelog edit; the maintainer changelog is added after landing
- introduced typed input, decoded-output, and cookie-count limit outcomes
- made resource-limit violations terminal: an unsafe current state can no longer resurrect credentials from an older backup
- preserve current persisted cookies when session recovery is unavailable or resource-limited
- kept ordinary corruption recoverable; a wrong decoded-size header still falls through to a valid backup
- made Firefox-detection coverage independent of apps installed on the test machine

## Safety behavior

- each candidate is capped at 64 MiB input, 128 MiB decoded output, and 4,096 top-level cookies before filtering
- resource-limit violations stop candidate traversal and fail closed
- malformed or unreadable candidates may continue through Firefox's defined recovery order
- the first successfully decoded state remains authoritative even when empty or partial
- non-default container, private-browsing, partitioned, unknown-origin, and wrong-typed origin attributes are rejected
- cookie values are never logged

## Proof

- focused MiMo provider suite: 49 tests passed
- focused Firefox importer suite: 11 tests passed
- `make check`: clean
- full suite: all 47 groups passed; one unrelated Kimi timing assertion passed on the built-in retry
- autoreview: decoded-size corruption finding fixed; final review clean with 0 actionable findings
- production importer parsed this Mac's real current Firefox restore file without exposing data; no authenticated MiMo session was present, so no external authenticated fetch is claimed
- signed app packaged, launched, and remained running from this exact head

Exact reviewed head: `5239ca6b54a7f128713dfe38a64a455be7f80e46`

Thanks @aaronflorey for the contribution.
