### PR TITLE
[codex] Add remote Codex cost logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.36.2 — Unreleased
 
 ### Added
+- Codex: optionally merge remote SSH session logs into local cost summaries. Thanks @raykr!
 - Cursor: show personal on-demand spend alongside the shared team pool. Thanks @yashiels!
 - Codex: show available manual rate-limit reset credits and their next expiry for signed-in OAuth accounts. Thanks @rogdex24!
 - Mistral: add Vibe monthly-plan usage and menu bar metric selection. Thanks @lfmundim!

--- a/README.md
+++ b/README.md
@@ -138,12 +138,12 @@ show an incident indicator.
 - Provider-specific usage meters with reset countdowns.
 - Optional Codex web dashboard enrichments (code review remaining, usage breakdown, credits history).
 - Inline spend and usage charts for API-backed providers such as OpenAI, Claude Admin API, OpenRouter, LiteLLM, z.ai, MiniMax, Mistral, and AWS Bedrock.
-- Configurable cost-usage scans for Codex + Claude, plus reused chart UI for supported provider histories.
+- Configurable cost-usage scans for Codex + Claude, including optional SSH-mirrored remote Codex logs, plus reused chart UI for supported provider histories.
 - Provider status polling with incident badges in the menu and icon overlay.
 - Merge Icons mode to combine providers into one status item + switcher.
 - Display controls for provider icons, labels, bars, reset-time style, and highest-usage auto-selection.
 - Refresh cadence presets (manual, 1m, 2m, 5m, 15m).
-- Bundled CLI (`codexbar`) for scripts and CI (including `codexbar cost --provider codex`, `claude`, or `both` for local cost usage); macOS and Linux CLI builds available.
+- Bundled CLI (`codexbar`) for scripts and CI (including `codexbar cost --provider codex`, `claude`, or `both` for cost usage); macOS and Linux CLI builds available.
 - WidgetKit widgets for supported providers.
 - Localized app and website with a shared 21-language catalog, automatic website detection, persistent pickers, and RTL support.
 - Optional session quota notifications and weekly-reset confetti.

--- a/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexProviderImplementation.swift
@@ -18,6 +18,11 @@ struct CodexProviderImplementation: ProviderImplementation {
         _ = settings.codexUsageDataSource
         _ = settings.codexCookieSource
         _ = settings.codexCookieHeader
+        _ = settings.codexRemoteCostEnabled
+        _ = settings.codexRemoteCostLabel
+        _ = settings.codexRemoteCostSSHTarget
+        _ = settings.codexRemoteCostSSHPort
+        _ = settings.codexRemoteCostHome
     }
 
     @MainActor
@@ -78,6 +83,27 @@ struct CodexProviderImplementation: ProviderImplementation {
                 subtitle: "Stores local Codex usage history (8 weeks) to personalize Pace predictions.",
                 binding: context.boolBinding(\.historicalTrackingEnabled),
                 statusText: nil,
+                actions: [],
+                isVisible: nil,
+                onChange: nil,
+                onAppDidBecomeActive: nil,
+                onAppearWhenEnabled: nil),
+            ProviderSettingsToggleDescriptor(
+                id: "codex-remote-cost-logs",
+                title: "Remote cost logs",
+                subtitle: [
+                    "Merge Codex session JSONL logs from one SSH host into the local cost summary.",
+                    "Use ~/.ssh/config for aliases, keys, and advanced SSH options.",
+                ].joined(separator: " "),
+                binding: context.boolBinding(\.codexRemoteCostEnabled),
+                statusText: {
+                    guard context.settings.codexRemoteCostEnabled else { return nil }
+                    let target = context.settings.codexRemoteCostSSHTarget
+                    guard !target.isEmpty else { return "SSH target is required." }
+                    let port = context.settings.codexRemoteCostSSHPort
+                    let targetText = port.isEmpty ? target : "\(target) (port \(port))"
+                    return "Remote source: \(targetText): \(context.settings.codexRemoteCostHome)"
+                },
                 actions: [],
                 isVisible: nil,
                 onChange: nil,
@@ -177,6 +203,54 @@ struct CodexProviderImplementation: ProviderImplementation {
     @MainActor
     func settingsFields(context: ProviderSettingsContext) -> [ProviderSettingsFieldDescriptor] {
         [
+            ProviderSettingsFieldDescriptor(
+                id: "codex-remote-cost-label",
+                title: "Remote label",
+                subtitle: "Optional label shown in diagnostics and config files.",
+                kind: .plain,
+                placeholder: "Remote",
+                binding: context.stringBinding(\.codexRemoteCostLabel),
+                actions: [],
+                isVisible: {
+                    context.settings.codexRemoteCostEnabled
+                },
+                onActivate: nil),
+            ProviderSettingsFieldDescriptor(
+                id: "codex-remote-cost-ssh-target",
+                title: "SSH target",
+                subtitle: "Host alias or user@host. Put ports, keys, and proxy jumps in ~/.ssh/config when possible.",
+                kind: .plain,
+                placeholder: "user@example.com",
+                binding: context.stringBinding(\.codexRemoteCostSSHTarget),
+                actions: [],
+                isVisible: {
+                    context.settings.codexRemoteCostEnabled
+                },
+                onActivate: nil),
+            ProviderSettingsFieldDescriptor(
+                id: "codex-remote-cost-ssh-port",
+                title: "SSH port",
+                subtitle: "Optional. Leave empty for the SSH default or an ~/.ssh/config alias.",
+                kind: .plain,
+                placeholder: "22",
+                binding: context.stringBinding(\.codexRemoteCostSSHPort),
+                actions: [],
+                isVisible: {
+                    context.settings.codexRemoteCostEnabled
+                },
+                onActivate: nil),
+            ProviderSettingsFieldDescriptor(
+                id: "codex-remote-cost-home",
+                title: "Remote Codex home",
+                subtitle: "Directory containing sessions/ and archived_sessions/. Default: ~/.codex.",
+                kind: .plain,
+                placeholder: "~/.codex",
+                binding: context.stringBinding(\.codexRemoteCostHome),
+                actions: [],
+                isVisible: {
+                    context.settings.codexRemoteCostEnabled
+                },
+                onActivate: nil),
             ProviderSettingsFieldDescriptor(
                 id: "codex-cookie-header",
                 title: "",

--- a/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
+++ b/Sources/CodexBar/Providers/Codex/CodexSettingsStore.swift
@@ -198,6 +198,103 @@ extension SettingsStore {
     }
 
     func ensureCodexCookieLoaded() {}
+
+    var codexRemoteCostSources: [RemoteCodexCostSource] {
+        get {
+            self.providerConfig(for: .codex)?.remoteCodexCostSources ?? []
+        }
+        set {
+            self.updateProviderConfig(provider: .codex) { entry in
+                entry.remoteCodexCostSources = newValue.isEmpty ? nil : newValue
+            }
+        }
+    }
+
+    var enabledCodexRemoteCostSources: [RemoteCodexCostSource] {
+        RemoteCodexCostSource.enabled(self.codexRemoteCostSources)
+    }
+
+    var codexRemoteCostEnabled: Bool {
+        get { self.primaryRemoteCodexCostSource.isEnabled }
+        set {
+            self.updatePrimaryRemoteCodexCostSource { source in
+                source.enabled = newValue
+            }
+        }
+    }
+
+    var codexRemoteCostLabel: String {
+        get { self.primaryRemoteCodexCostSource.sanitizedLabel ?? "" }
+        set {
+            self.updatePrimaryRemoteCodexCostSource { source in
+                source.label = self.normalizedConfigValue(newValue)
+            }
+        }
+    }
+
+    var codexRemoteCostSSHTarget: String {
+        get { self.primaryRemoteCodexCostSource.sanitizedSSHTarget ?? "" }
+        set {
+            self.updatePrimaryRemoteCodexCostSource { source in
+                source.sshTarget = self.normalizedConfigValue(newValue)
+            }
+        }
+    }
+
+    var codexRemoteCostSSHPort: String {
+        get {
+            guard let port = self.primaryRemoteCodexCostSource.sshPort, port > 0 else { return "" }
+            return String(port)
+        }
+        set {
+            self.updatePrimaryRemoteCodexCostSource { source in
+                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                source.sshPort = Int(trimmed)
+            }
+        }
+    }
+
+    var codexRemoteCostHome: String {
+        get { self.primaryRemoteCodexCostSource.sanitizedRemoteCodexHome }
+        set {
+            self.updatePrimaryRemoteCodexCostSource { source in
+                source.remoteCodexHome = self.normalizedConfigValue(newValue) ?? "~/.codex"
+            }
+        }
+    }
+
+    private var primaryRemoteCodexCostSource: RemoteCodexCostSource {
+        var source = self.codexRemoteCostSources.first ?? RemoteCodexCostSource(
+            id: "default",
+            enabled: false,
+            label: "Remote",
+            remoteCodexHome: "~/.codex")
+        if source.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            source.id = "default"
+        }
+        return source
+    }
+
+    private func updatePrimaryRemoteCodexCostSource(_ mutate: (inout RemoteCodexCostSource) -> Void) {
+        self.updateProviderConfig(provider: .codex) { entry in
+            var sources = entry.remoteCodexCostSources ?? []
+            var source = sources.first ?? RemoteCodexCostSource(
+                id: "default",
+                enabled: false,
+                label: "Remote",
+                remoteCodexHome: "~/.codex")
+            if source.id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                source.id = "default"
+            }
+            mutate(&source)
+            if sources.isEmpty {
+                sources = [source]
+            } else {
+                sources[0] = source
+            }
+            entry.remoteCodexCostSources = sources
+        }
+    }
 }
 
 extension SettingsStore {

--- a/Sources/CodexBar/UsageStore+TokenCost.swift
+++ b/Sources/CodexBar/UsageStore+TokenCost.swift
@@ -22,12 +22,14 @@ extension UsageStore {
 
         let scope = self.tokenCostScope(for: .codex)
         let historyDays = self.settings.costUsageHistoryDays
+        let remoteSources = self.settings.enabledCodexRemoteCostSources
         Task { @MainActor [weak self] in
             guard let self else { return }
             guard self.tokenSnapshots[.codex] == nil else { return }
             guard let snapshot = await self.costUsageFetcher.loadCachedCodexTokenSnapshot(
                 now: now,
                 codexHomePath: scope.codexHomePath,
+                remoteCodexCostSources: remoteSources,
                 historyDays: historyDays)
             else {
                 return
@@ -54,10 +56,15 @@ extension UsageStore {
         }
         let homePath = self.settings.activeManagedCodexRemoteHomePath?
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let remoteSignature = self.settings.enabledCodexRemoteCostSources
+            .map(\.signature)
+            .sorted()
+            .joined(separator: ",")
+        let remotePart = remoteSignature.isEmpty ? "" : "|remote=\(remoteSignature)"
         guard let homePath, !homePath.isEmpty else {
-            return (nil, "codex:ambient")
+            return (nil, "codex:ambient\(remotePart)")
         }
-        return (homePath, "codex:managed:\(homePath)")
+        return (homePath, "codex:managed:\(homePath)\(remotePart)")
     }
 
     func tokenSnapshot(

--- a/Sources/CodexBar/UsageStore.swift
+++ b/Sources/CodexBar/UsageStore.swift
@@ -1476,6 +1476,7 @@ extension UsageStore {
         let now = Date()
         let historyDays = self.settings.costUsageHistoryDays
         let costScope = self.tokenCostScope(for: provider)
+        let remoteCodexCostSources = provider == .codex ? self.settings.enabledCodexRemoteCostSources : []
         let costScopeSignature = "\(costScope.signature)|historyDays=\(historyDays)"
         if !force,
            let last = self.lastTokenFetchAt[provider],
@@ -1518,6 +1519,7 @@ extension UsageStore {
                         forceRefresh: force,
                         allowVertexClaudeFallback: !self.isEnabled(.claude),
                         codexHomePath: costScope.codexHomePath,
+                        remoteCodexCostSources: remoteCodexCostSources,
                         historyDays: historyDays)
                 }
                 group.addTask {

--- a/Sources/CodexBarCLI/CLICostCommand.swift
+++ b/Sources/CodexBarCLI/CLICostCommand.swift
@@ -40,17 +40,28 @@ extension CodexBarCLI {
 
         for provider in providers {
             do {
-                // Cost usage is local-only; it does not require web/CLI provider fetches.
+                let remoteSources = Self.remoteCodexCostSources(from: config, provider: provider)
+                let source = RemoteCodexCostSource.enabled(remoteSources).isEmpty ? "local" : "local+remote"
+                // Cost usage is log-based; Codex may merge optional SSH-mirrored logs.
                 let snapshot = try await fetcher.loadTokenSnapshot(
                     provider: provider,
                     forceRefresh: forceRefresh,
+                    remoteCodexCostSources: remoteSources,
                     historyDays: historyDays,
                     refreshPricingInBackground: false)
                 switch format {
                 case .text:
-                    sections.append(Self.renderCostText(provider: provider, snapshot: snapshot, useColor: useColor))
+                    sections.append(Self.renderCostText(
+                        provider: provider,
+                        snapshot: snapshot,
+                        useColor: useColor,
+                        source: source))
                 case .json:
-                    payload.append(Self.makeCostPayload(provider: provider, snapshot: snapshot, error: nil))
+                    payload.append(Self.makeCostPayload(
+                        provider: provider,
+                        snapshot: snapshot,
+                        error: nil,
+                        source: source))
                 }
             } catch {
                 exitCode = Self.mapError(error)
@@ -79,7 +90,8 @@ extension CodexBarCLI {
     static func renderCostText(
         provider: UsageProvider,
         snapshot: CostUsageTokenSnapshot,
-        useColor: Bool) -> String
+        useColor: Bool,
+        source: String = "local") -> String
     {
         let name = ProviderDescriptorRegistry.descriptor(for: provider).metadata.displayName
         let header = Self.costHeaderLine("\(name) Cost (API-rate estimate)", useColor: useColor)
@@ -98,7 +110,9 @@ extension CodexBarCLI {
             "\(historyLabel): \(monthCost) · \($0) tokens"
         } ?? "\(historyLabel): \(monthCost)"
 
-        let hintLine = UsageFormatter.costEstimateHint(provider: provider)
+        let hintLine = source == "local+remote"
+            ? "Estimated from local + remote logs · may differ from your bill"
+            : UsageFormatter.costEstimateHint(provider: provider)
         return [header, todayLine, monthLine, hintLine].joined(separator: "\n")
     }
 
@@ -114,7 +128,8 @@ extension CodexBarCLI {
     static func makeCostPayload(
         provider: UsageProvider,
         snapshot: CostUsageTokenSnapshot?,
-        error: Error?) -> CostPayload
+        error: Error?,
+        source: String = "local") -> CostPayload
     {
         let daily = snapshot?.daily.map { entry in
             CostDailyEntryPayload(
@@ -136,7 +151,7 @@ extension CodexBarCLI {
 
         return CostPayload(
             provider: provider.rawValue,
-            source: "local",
+            source: source,
             updatedAt: snapshot?.updatedAt ?? (error == nil ? nil : Date()),
             currencyCode: snapshot?.currencyCode,
             sessionTokens: snapshot?.sessionTokens,
@@ -147,6 +162,14 @@ extension CodexBarCLI {
             daily: daily,
             totals: snapshot.flatMap(Self.costTotals(from:)),
             error: error.map { Self.makeErrorPayload($0) })
+    }
+
+    static func remoteCodexCostSources(
+        from config: CodexBarConfig,
+        provider: UsageProvider) -> [RemoteCodexCostSource]
+    {
+        guard provider == .codex else { return [] }
+        return config.providerConfig(for: .codex)?.remoteCodexCostSources ?? []
     }
 
     private static func costTotals(from snapshot: CostUsageTokenSnapshot) -> CostTotalsPayload? {

--- a/Sources/CodexBarCLI/CLIHelp.swift
+++ b/Sources/CodexBarCLI/CLIHelp.swift
@@ -63,7 +63,8 @@ extension CodexBarCLI {
                        [--no-color] [--pretty] [--refresh]
 
         Description:
-          Print local token cost usage from Claude/Codex native logs plus supported pi sessions.
+          Print token cost usage from Claude/Codex native logs plus supported pi sessions.
+          Codex can also merge optional SSH-mirrored remote session logs from config.
           This does not require web or CLI access and uses cached scan results unless --refresh is provided.
 
         Examples:

--- a/Sources/CodexBarCLI/CLIServeCommand.swift
+++ b/Sources/CodexBarCLI/CLIServeCommand.swift
@@ -744,10 +744,16 @@ extension CodexBarCLI {
         var payload: [CostPayload] = []
         for provider in providers {
             do {
+                let remoteSources = Self.remoteCodexCostSources(from: config, provider: provider)
                 let snapshot = try await fetcher.loadTokenSnapshot(
                     provider: provider,
-                    forceRefresh: false)
-                payload.append(Self.makeCostPayload(provider: provider, snapshot: snapshot, error: nil))
+                    forceRefresh: false,
+                    remoteCodexCostSources: remoteSources)
+                payload.append(Self.makeCostPayload(
+                    provider: provider,
+                    snapshot: snapshot,
+                    error: nil,
+                    source: RemoteCodexCostSource.enabled(remoteSources).isEmpty ? "local" : "local+remote"))
             } catch {
                 payload.append(Self.makeCostPayload(provider: provider, snapshot: nil, error: error))
             }

--- a/Sources/CodexBarCore/Config/CodexBarConfig.swift
+++ b/Sources/CodexBarCore/Config/CodexBarConfig.swift
@@ -107,6 +107,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
     public var enterpriseHost: String?
     public var tokenAccounts: ProviderTokenAccountData?
     public var codexActiveSource: CodexActiveSource?
+    public var remoteCodexCostSources: [RemoteCodexCostSource]?
     public var quotaWarnings: QuotaWarningConfig?
     public var kiloKnownOrganizations: [KiloOrganization]?
     public var kiloEnabledOrganizationIDs: [String]?
@@ -127,6 +128,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         enterpriseHost: String? = nil,
         tokenAccounts: ProviderTokenAccountData? = nil,
         codexActiveSource: CodexActiveSource? = nil,
+        remoteCodexCostSources: [RemoteCodexCostSource]? = nil,
         quotaWarnings: QuotaWarningConfig? = nil,
         kiloKnownOrganizations: [KiloOrganization]? = nil,
         kiloEnabledOrganizationIDs: [String]? = nil,
@@ -146,6 +148,7 @@ public struct ProviderConfig: Codable, Sendable, Identifiable {
         self.enterpriseHost = enterpriseHost
         self.tokenAccounts = tokenAccounts
         self.codexActiveSource = codexActiveSource
+        self.remoteCodexCostSources = remoteCodexCostSources
         self.quotaWarnings = quotaWarnings
         self.kiloKnownOrganizations = kiloKnownOrganizations
         self.kiloEnabledOrganizationIDs = kiloEnabledOrganizationIDs

--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -31,11 +31,13 @@ public struct CostUsageFetcher: Sendable {
     public func loadCachedCodexTokenSnapshot(
         now: Date = Date(),
         codexHomePath: String? = nil,
+        remoteCodexCostSources: [RemoteCodexCostSource] = [],
         historyDays: Int = 30) async -> CostUsageTokenSnapshot?
     {
         await Self.loadCachedCodexTokenSnapshot(
             now: now,
             codexHomePath: codexHomePath,
+            remoteCodexCostSources: remoteCodexCostSources,
             historyDays: historyDays,
             scannerOptions: self.scannerOptionsOverride())
     }
@@ -47,6 +49,7 @@ public struct CostUsageFetcher: Sendable {
         forceRefresh: Bool = false,
         allowVertexClaudeFallback: Bool = false,
         codexHomePath: String? = nil,
+        remoteCodexCostSources: [RemoteCodexCostSource] = [],
         historyDays: Int = 30,
         refreshPricingInBackground: Bool = true) async throws -> CostUsageTokenSnapshot
     {
@@ -57,6 +60,7 @@ public struct CostUsageFetcher: Sendable {
             forceRefresh: forceRefresh,
             allowVertexClaudeFallback: allowVertexClaudeFallback,
             codexHomePath: codexHomePath,
+            remoteCodexCostSources: remoteCodexCostSources,
             historyDays: historyDays,
             refreshPricingInBackground: refreshPricingInBackground,
             scannerOptions: self.scannerOptionsOverride())
@@ -70,6 +74,7 @@ public struct CostUsageFetcher: Sendable {
         forceRefresh: Bool = false,
         allowVertexClaudeFallback: Bool = false,
         codexHomePath: String? = nil,
+        remoteCodexCostSources: [RemoteCodexCostSource] = [],
         historyDays: Int = 30,
         refreshPricingInBackground: Bool = true,
         automaticCodexScanByteLimit _: Int64?) async throws -> CostUsageTokenSnapshot
@@ -81,6 +86,7 @@ public struct CostUsageFetcher: Sendable {
             forceRefresh: forceRefresh,
             allowVertexClaudeFallback: allowVertexClaudeFallback,
             codexHomePath: codexHomePath,
+            remoteCodexCostSources: remoteCodexCostSources,
             historyDays: historyDays,
             refreshPricingInBackground: refreshPricingInBackground)
     }
@@ -96,6 +102,7 @@ public struct CostUsageFetcher: Sendable {
         forceRefresh: Bool = false,
         allowVertexClaudeFallback: Bool = false,
         codexHomePath: String? = nil,
+        remoteCodexCostSources: [RemoteCodexCostSource] = [],
         historyDays: Int = 30,
         refreshPricingInBackground: Bool = true,
         scannerOptions overrideScannerOptions: CostUsageScanner.Options? = nil,
@@ -154,6 +161,20 @@ public struct CostUsageFetcher: Sendable {
             resolvedPiOptions.refreshMinIntervalSeconds = 0
         }
         let piOptions = resolvedPiOptions
+        let remoteCodexMirrors: [RemoteCodexCostMirror]
+        if provider == .codex {
+            let sources = RemoteCodexCostSource.enabled(remoteCodexCostSources)
+            if sources.isEmpty {
+                remoteCodexMirrors = []
+            } else {
+                remoteCodexMirrors = try await RemoteCodexCostSyncer(cacheRoot: options.cacheRoot)
+                    .syncEnabledSources(
+                        sources,
+                        window: RemoteCodexCostSyncWindow(since: since, until: until))
+            }
+        } else {
+            remoteCodexMirrors = []
+        }
 
         try Task.checkCancellation()
         // The corpus scans below are synchronous and can run for minutes on large session
@@ -162,6 +183,7 @@ public struct CostUsageFetcher: Sendable {
         // scanner-level checks.
         let scanOptions = options
         let daily = try await CostUsageScanExecutor.run { checkCancellation in
+            var reports: [CostUsageDailyReport] = []
             var daily = try CostUsageScanner.loadDailyReportCancellable(
                 provider: provider,
                 since: since,
@@ -169,7 +191,28 @@ public struct CostUsageFetcher: Sendable {
                 now: now,
                 options: scanOptions,
                 checkCancellation: checkCancellation)
+            reports.append(daily)
             try checkCancellation()
+
+            if provider == .codex, !remoteCodexMirrors.isEmpty {
+                for mirror in remoteCodexMirrors {
+                    var remoteOptions = scanOptions
+                    remoteOptions.codexSessionsRoot = mirror.codexHomeMirror
+                        .appendingPathComponent("sessions", isDirectory: true)
+                    remoteOptions.cacheRoot = mirror.scanCacheRoot
+                    remoteOptions.codexTraceDatabaseURL = nil
+                    let remoteDaily = try CostUsageScanner.loadDailyReportCancellable(
+                        provider: provider,
+                        since: since,
+                        until: until,
+                        now: now,
+                        options: remoteOptions,
+                        checkCancellation: checkCancellation)
+                    reports.append(remoteDaily)
+                    try checkCancellation()
+                }
+                daily = CostUsageDailyReport.merged(reports)
+            }
 
             if provider == .vertexai,
                !allowVertexClaudeFallback,
@@ -208,9 +251,13 @@ public struct CostUsageFetcher: Sendable {
     static func loadCachedCodexTokenSnapshot(
         now: Date = Date(),
         codexHomePath: String? = nil,
+        remoteCodexCostSources: [RemoteCodexCostSource] = [],
         historyDays: Int = 30,
         scannerOptions overrideScannerOptions: CostUsageScanner.Options? = nil) async -> CostUsageTokenSnapshot?
     {
+        if !RemoteCodexCostSource.enabled(remoteCodexCostSources).isEmpty {
+            return nil
+        }
         if let codexHomePath = codexHomePath?.trimmingCharacters(in: .whitespacesAndNewlines),
            !codexHomePath.isEmpty
         {

--- a/Sources/CodexBarCore/RemoteCodexCostSource.swift
+++ b/Sources/CodexBarCore/RemoteCodexCostSource.swift
@@ -1,0 +1,426 @@
+import Foundation
+
+public struct RemoteCodexCostSource: Codable, Sendable, Equatable, Identifiable {
+    public static let defaultID = "default"
+    public static let defaultRemoteCodexHome = "~/.codex"
+    public static let defaultSyncTimeoutSeconds = 300
+
+    public var id: String
+    public var enabled: Bool?
+    public var label: String?
+    public var sshTarget: String?
+    public var sshPort: Int?
+    public var remoteCodexHome: String?
+    public var syncTimeoutSeconds: Int?
+
+    public init(
+        id: String = Self.defaultID,
+        enabled: Bool? = true,
+        label: String? = nil,
+        sshTarget: String? = nil,
+        sshPort: Int? = nil,
+        remoteCodexHome: String? = nil,
+        syncTimeoutSeconds: Int? = nil)
+    {
+        self.id = id
+        self.enabled = enabled
+        self.label = label
+        self.sshTarget = sshTarget
+        self.sshPort = sshPort
+        self.remoteCodexHome = remoteCodexHome
+        self.syncTimeoutSeconds = syncTimeoutSeconds
+    }
+
+    public var isEnabled: Bool {
+        self.enabled ?? true
+    }
+
+    public var sanitizedID: String {
+        let trimmed = self.id.trimmingCharacters(in: .whitespacesAndNewlines)
+        let source = trimmed.isEmpty ? Self.defaultID : trimmed
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-")
+        let scalars = source.unicodeScalars.map { scalar -> Character in
+            allowed.contains(scalar) ? Character(scalar) : "-"
+        }
+        let sanitized = String(scalars)
+            .trimmingCharacters(in: CharacterSet(charactersIn: ".-_"))
+        return sanitized.isEmpty ? Self.defaultID : sanitized
+    }
+
+    public var sanitizedLabel: String? {
+        Self.clean(self.label)
+    }
+
+    public var displayLabel: String {
+        self.sanitizedLabel
+            ?? self.sanitizedSSHTarget
+            ?? self.sanitizedID
+    }
+
+    public var connectionDescription: String {
+        let target = self.sanitizedSSHTarget ?? self.displayLabel
+        let port = self.sshPort.flatMap { $0 > 0 ? $0 : nil }.map { " (port \($0))" } ?? ""
+        return "\(target)\(port): \(self.sanitizedRemoteCodexHome)"
+    }
+
+    public var sanitizedSSHTarget: String? {
+        Self.clean(self.sshTarget)
+    }
+
+    public var sanitizedRemoteCodexHome: String {
+        Self.clean(self.remoteCodexHome) ?? Self.defaultRemoteCodexHome
+    }
+
+    public var boundedSyncTimeout: TimeInterval {
+        let raw = self.syncTimeoutSeconds ?? Self.defaultSyncTimeoutSeconds
+        return TimeInterval(max(5, min(600, raw)))
+    }
+
+    public var normalized: RemoteCodexCostSource {
+        RemoteCodexCostSource(
+            id: self.sanitizedID,
+            enabled: self.isEnabled,
+            label: self.sanitizedLabel,
+            sshTarget: self.sanitizedSSHTarget,
+            sshPort: self.sshPort.flatMap { $0 > 0 ? $0 : nil },
+            remoteCodexHome: self.sanitizedRemoteCodexHome,
+            syncTimeoutSeconds: Int(self.boundedSyncTimeout))
+    }
+
+    public var signature: String {
+        let port = self.sshPort.map(String.init) ?? ""
+        return [
+            self.sanitizedID,
+            self.isEnabled ? "1" : "0",
+            self.sanitizedLabel ?? "",
+            self.sanitizedSSHTarget ?? "",
+            port,
+            self.sanitizedRemoteCodexHome,
+            "\(Int(self.boundedSyncTimeout))",
+        ].joined(separator: "|")
+    }
+
+    public static func enabled(_ sources: [RemoteCodexCostSource]) -> [RemoteCodexCostSource] {
+        sources
+            .map(\.normalized)
+            .filter { $0.isEnabled && $0.sanitizedSSHTarget != nil }
+    }
+
+    private static func clean(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+public struct RemoteCodexCostMirror: Sendable, Equatable {
+    public let sourceID: String
+    public let label: String
+    public let codexHomeMirror: URL
+    public let scanCacheRoot: URL
+
+    public init(sourceID: String, label: String, codexHomeMirror: URL, scanCacheRoot: URL) {
+        self.sourceID = sourceID
+        self.label = label
+        self.codexHomeMirror = codexHomeMirror
+        self.scanCacheRoot = scanCacheRoot
+    }
+}
+
+public struct RemoteCodexCostSyncWindow: Sendable, Equatable {
+    public let since: Date
+    public let until: Date
+
+    public init(since: Date, until: Date) {
+        self.since = since
+        self.until = until
+    }
+}
+
+public enum RemoteCodexCostSyncError: LocalizedError, Sendable {
+    case missingRsync
+    case invalidSSHTarget(String)
+    case syncFailed(source: String, details: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingRsync:
+            "Remote Codex cost sync requires /usr/bin/rsync."
+        case let .invalidSSHTarget(target):
+            "Invalid remote Codex SSH target: \(target). Use a Host alias or user@host; put ports in the port field."
+        case let .syncFailed(source, details):
+            "Remote Codex cost sync failed for \(source): \(details)"
+        }
+    }
+}
+
+public struct RemoteCodexCostSyncer: Sendable {
+    private static let rsyncBinary = "/usr/bin/rsync"
+    private static let sshBinary = "/usr/bin/ssh"
+
+    private let cacheRoot: URL?
+
+    public init(cacheRoot: URL? = nil) {
+        self.cacheRoot = cacheRoot
+    }
+
+    public func syncEnabledSources(
+        _ sources: [RemoteCodexCostSource],
+        window: RemoteCodexCostSyncWindow? = nil) async throws -> [RemoteCodexCostMirror]
+    {
+        let enabled = RemoteCodexCostSource.enabled(sources)
+        guard !enabled.isEmpty else { return [] }
+        guard FileManager.default.isExecutableFile(atPath: Self.rsyncBinary) else {
+            throw RemoteCodexCostSyncError.missingRsync
+        }
+
+        var mirrors: [RemoteCodexCostMirror] = []
+        for (index, source) in enabled.enumerated() {
+            try Task.checkCancellation()
+            let mirror = try await self.sync(source: source, index: index, window: window)
+            mirrors.append(mirror)
+        }
+        return mirrors
+    }
+
+    private func sync(
+        source: RemoteCodexCostSource,
+        index: Int,
+        window: RemoteCodexCostSyncWindow?) async throws -> RemoteCodexCostMirror
+    {
+        guard let target = source.sanitizedSSHTarget else {
+            throw RemoteCodexCostSyncError.invalidSSHTarget(source.displayLabel)
+        }
+        guard Self.isValidSSHTarget(target) else {
+            throw RemoteCodexCostSyncError.invalidSSHTarget(target)
+        }
+
+        let root = self.remoteSourceRoot(source: source, index: index)
+        let mirror = root.appendingPathComponent("mirror", isDirectory: true)
+        let scanCache = root.appendingPathComponent("scan-cache", isDirectory: true)
+        try FileManager.default.createDirectory(at: mirror, withIntermediateDirectories: true)
+        try await self.syncDirectory(DirectorySyncRequest(
+            source: source,
+            target: target,
+            component: "sessions",
+            destination: mirror.appendingPathComponent("sessions", isDirectory: true),
+            window: window,
+            required: true))
+        try await self.syncDirectory(DirectorySyncRequest(
+            source: source,
+            target: target,
+            component: "archived_sessions",
+            destination: mirror.appendingPathComponent("archived_sessions", isDirectory: true),
+            window: window,
+            required: false))
+        return RemoteCodexCostMirror(
+            sourceID: source.sanitizedID,
+            label: source.displayLabel,
+            codexHomeMirror: mirror,
+            scanCacheRoot: scanCache)
+    }
+
+    private struct DirectorySyncRequest {
+        var source: RemoteCodexCostSource
+        var target: String
+        var component: String
+        var destination: URL
+        var window: RemoteCodexCostSyncWindow?
+        var required: Bool
+    }
+
+    private func syncDirectory(_ request: DirectorySyncRequest) async throws {
+        try FileManager.default.createDirectory(at: request.destination, withIntermediateDirectories: true)
+        let remoteRoot = Self.trimTrailingSlashes(request.source.sanitizedRemoteCodexHome)
+        let remotePath = Self.escapeRemoteShellPath("\(remoteRoot)/\(request.component)")
+        let remote = "\(request.target):\(remotePath)/"
+        let sshCommand = Self.sshCommand(for: request.source)
+        let list = try await self.remoteJSONLList(request, remotePath: remotePath)
+        guard !list.isEmpty else { return }
+
+        let listFile = request.destination
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(request.component)-files-from", isDirectory: false)
+        try (list.joined(separator: "\n") + "\n").write(to: listFile, atomically: true, encoding: .utf8)
+
+        let args = [
+            "-az",
+            "--prune-empty-dirs",
+            "--files-from=\(listFile.path)",
+            "-e", sshCommand,
+            remote,
+            "\(request.destination.path)/",
+        ]
+
+        do {
+            _ = try await SubprocessRunner.run(
+                binary: Self.rsyncBinary,
+                arguments: args,
+                environment: ProcessInfo.processInfo.environment,
+                timeout: request.source.boundedSyncTimeout,
+                label: "remote-codex-cost-\(request.component)-\(request.source.sanitizedID)")
+        } catch let error as SubprocessRunnerError {
+            if !request.required, Self.isMissingRemoteDirectory(error) { return }
+            throw RemoteCodexCostSyncError.syncFailed(
+                source: request.source.connectionDescription,
+                details: error.localizedDescription)
+        } catch {
+            throw RemoteCodexCostSyncError.syncFailed(
+                source: request.source.connectionDescription,
+                details: error.localizedDescription)
+        }
+    }
+
+    private func remoteJSONLList(_ request: DirectorySyncRequest, remotePath: String) async throws -> [String] {
+        let missingExit = request.required ? "23" : "0"
+        let command = [
+            "if [ -d \(remotePath) ]; then",
+            "cd \(remotePath) && find . -type f -name '*.jsonl' -print;",
+            "else exit \(missingExit); fi",
+        ].joined(separator: " ")
+        let args = Self.sshArguments(for: request.source) + [request.target, command]
+
+        do {
+            let result = try await SubprocessRunner.run(
+                binary: Self.sshBinary,
+                arguments: args,
+                environment: ProcessInfo.processInfo.environment,
+                timeout: min(60, request.source.boundedSyncTimeout),
+                label: "remote-codex-cost-list-\(request.component)-\(request.source.sanitizedID)")
+            return Self.filteredRelativeJSONLPaths(result.stdout, window: request.window)
+        } catch let error as SubprocessRunnerError {
+            if !request.required, Self.isMissingRemoteDirectory(error) { return [] }
+            throw RemoteCodexCostSyncError.syncFailed(
+                source: request.source.connectionDescription,
+                details: error.localizedDescription)
+        } catch {
+            throw RemoteCodexCostSyncError.syncFailed(
+                source: request.source.connectionDescription,
+                details: error.localizedDescription)
+        }
+    }
+
+    private func remoteSourceRoot(source: RemoteCodexCostSource, index: Int) -> URL {
+        let root = self.cacheRoot ?? Self.defaultCacheRoot()
+        let id = source.sanitizedID
+        let suffix = index == 0 ? id : "\(id)-\(index)"
+        return root
+            .appendingPathComponent("cost-usage", isDirectory: true)
+            .appendingPathComponent("remote-codex", isDirectory: true)
+            .appendingPathComponent(suffix, isDirectory: true)
+    }
+
+    private static func defaultCacheRoot() -> URL {
+        let root = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        return root.appendingPathComponent("CodexBar", isDirectory: true)
+    }
+
+    private static func sshCommand(for source: RemoteCodexCostSource) -> String {
+        let args = [Self.sshBinary] + Self.sshArguments(for: source)
+        return args.map(Self.shellQuote).joined(separator: " ")
+    }
+
+    private static func sshArguments(for source: RemoteCodexCostSource) -> [String] {
+        var args = [
+            "-o", "BatchMode=yes",
+            "-o", "ConnectTimeout=10",
+        ]
+        if let port = source.sshPort, port > 0 {
+            args.append(contentsOf: ["-p", "\(port)"])
+        }
+        return args
+    }
+
+    private static func shellQuote(_ text: String) -> String {
+        "'\(text.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+
+    private static func isValidSSHTarget(_ target: String) -> Bool {
+        guard !target.isEmpty else { return false }
+        guard target.rangeOfCharacter(from: .whitespacesAndNewlines) == nil else { return false }
+        guard !target.contains(":") else { return false }
+        return true
+    }
+
+    private static func trimTrailingSlashes(_ path: String) -> String {
+        var value = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        while value.count > 1, value.hasSuffix("/") {
+            value.removeLast()
+        }
+        return value.isEmpty ? RemoteCodexCostSource.defaultRemoteCodexHome : value
+    }
+
+    private static func escapeRemoteShellPath(_ path: String) -> String {
+        let safe = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/._-~")
+        var out = ""
+        for scalar in path.unicodeScalars {
+            if safe.contains(scalar) {
+                out.unicodeScalars.append(scalar)
+            } else {
+                out.append("\\")
+                out.unicodeScalars.append(scalar)
+            }
+        }
+        return out
+    }
+
+    private static func isMissingRemoteDirectory(_ error: SubprocessRunnerError) -> Bool {
+        guard case let .nonZeroExit(_, stderr) = error else { return false }
+        let lower = stderr.lowercased()
+        return lower.contains("no such file")
+            || lower.contains("not found")
+            || lower.contains("change_dir")
+            || lower.contains("missing remote directory")
+    }
+
+    static func filteredRelativeJSONLPaths(
+        _ stdout: String,
+        window: RemoteCodexCostSyncWindow?) -> [String]
+    {
+        let sinceKey = window.map { Self.dayKey(from: $0.since) }
+        let untilKey = window.map { Self.dayKey(from: $0.until) }
+        return stdout
+            .split(whereSeparator: \.isNewline)
+            .map { raw in
+                var path = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                if path.hasPrefix("./") {
+                    path.removeFirst(2)
+                }
+                return path
+            }
+            .filter { path in
+                guard path.lowercased().hasSuffix(".jsonl") else { return false }
+                guard let sinceKey, let untilKey, let pathKey = Self.firstDayKey(in: path) else {
+                    return true
+                }
+                return pathKey >= sinceKey && pathKey <= untilKey
+            }
+            .sorted()
+    }
+
+    private static func dayKey(from date: Date) -> String {
+        let components = Calendar.current.dateComponents([.year, .month, .day], from: date)
+        return String(
+            format: "%04d-%02d-%02d",
+            components.year ?? 1970,
+            components.month ?? 1,
+            components.day ?? 1)
+    }
+
+    private static let dayKeyRegex = try? NSRegularExpression(
+        pattern: "(\\d{4})[-/](\\d{2})[-/](\\d{2})")
+
+    private static func firstDayKey(in text: String) -> String? {
+        guard let regex = self.dayKeyRegex else { return nil }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, range: range),
+              match.numberOfRanges == 4,
+              let year = Range(match.range(at: 1), in: text),
+              let month = Range(match.range(at: 2), in: text),
+              let day = Range(match.range(at: 3), in: text)
+        else {
+            return nil
+        }
+        return "\(text[year])-\(text[month])-\(text[day])"
+    }
+}

--- a/Sources/CodexBarCore/RemoteCodexCostSource.swift
+++ b/Sources/CodexBarCore/RemoteCodexCostSource.swift
@@ -230,12 +230,12 @@ public struct RemoteCodexCostSyncer: Sendable {
     }
 
     private func syncDirectory(_ request: DirectorySyncRequest) async throws {
-        try FileManager.default.createDirectory(at: request.destination, withIntermediateDirectories: true)
         let remoteRoot = Self.trimTrailingSlashes(request.source.sanitizedRemoteCodexHome)
         let remotePath = Self.escapeRemoteShellPath("\(remoteRoot)/\(request.component)")
         let remote = "\(request.target):\(remotePath)/"
         let sshCommand = Self.sshCommand(for: request.source)
         let list = try await self.remoteJSONLList(request, remotePath: remotePath)
+        try Self.resetDirectory(request.destination)
         guard !list.isEmpty else { return }
 
         let listFile = request.destination
@@ -335,11 +335,20 @@ public struct RemoteCodexCostSyncer: Sendable {
         "'\(text.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
 
-    private static func isValidSSHTarget(_ target: String) -> Bool {
+    static func isValidSSHTarget(_ target: String) -> Bool {
         guard !target.isEmpty else { return false }
+        guard !target.hasPrefix("-") else { return false }
         guard target.rangeOfCharacter(from: .whitespacesAndNewlines) == nil else { return false }
         guard !target.contains(":") else { return false }
         return true
+    }
+
+    static func resetDirectory(_ directory: URL) throws {
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: directory.path) {
+            try fileManager.removeItem(at: directory)
+        }
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
     }
 
     private static func trimTrailingSlashes(_ path: String) -> String {

--- a/Tests/CodexBarTests/CLICostTests.swift
+++ b/Tests/CodexBarTests/CLICostTests.swift
@@ -39,6 +39,26 @@ struct CLICostTests {
     }
 
     @Test
+    func `renders remote cost source hint`() {
+        let snap = CostUsageTokenSnapshot(
+            sessionTokens: 1200,
+            sessionCostUSD: 1.25,
+            last30DaysTokens: 9000,
+            last30DaysCostUSD: 9.99,
+            historyDays: 30,
+            daily: [],
+            updatedAt: Date(timeIntervalSince1970: 0))
+
+        let output = CodexBarCLI.renderCostText(
+            provider: .codex,
+            snapshot: snap,
+            useColor: false,
+            source: "local+remote")
+
+        #expect(output.contains("Estimated from local + remote logs"))
+    }
+
+    @Test
     func `encodes cost payload JSON`() throws {
         let payload = CostPayload(
             provider: "claude",

--- a/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
+++ b/Tests/CodexBarTests/ProviderSettingsDescriptorTests.swift
@@ -63,6 +63,42 @@ struct ProviderSettingsDescriptorTests {
     }
 
     @Test
+    func `codex exposes writable remote cost settings when enabled`() throws {
+        let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-codex-remote-cost")
+        let context = fixture.settingsContext(provider: .codex)
+        let implementation = CodexProviderImplementation()
+
+        let toggles = implementation.settingsToggles(context: context)
+        let remoteToggle = try #require(toggles.first(where: { $0.id == "codex-remote-cost-logs" }))
+        #expect(remoteToggle.binding.wrappedValue == false)
+
+        remoteToggle.binding.wrappedValue = true
+        let fields = implementation.settingsFields(context: context).filter { $0.isVisible?() ?? true }
+        let fieldIDs = Set(fields.map(\.id))
+        #expect(fieldIDs.contains("codex-remote-cost-label"))
+        #expect(fieldIDs.contains("codex-remote-cost-ssh-target"))
+        #expect(fieldIDs.contains("codex-remote-cost-ssh-port"))
+        #expect(fieldIDs.contains("codex-remote-cost-home"))
+
+        try #require(fields.first(where: { $0.id == "codex-remote-cost-label" }))
+            .binding.wrappedValue = "GPU host"
+        try #require(fields.first(where: { $0.id == "codex-remote-cost-ssh-target" }))
+            .binding.wrappedValue = "codex-gpu"
+        try #require(fields.first(where: { $0.id == "codex-remote-cost-ssh-port" }))
+            .binding.wrappedValue = "2200"
+        try #require(fields.first(where: { $0.id == "codex-remote-cost-home" }))
+            .binding.wrappedValue = "~/work/.codex"
+
+        let source = try #require(fixture.settings.codexRemoteCostSources.first)
+        #expect(source.enabled == true)
+        #expect(source.label == "GPU host")
+        #expect(source.sshTarget == "codex-gpu")
+        #expect(source.sshPort == 2200)
+        #expect(source.remoteCodexHome == "~/work/.codex")
+        #expect(remoteToggle.statusText?() == "Remote source: codex-gpu (port 2200): ~/work/.codex")
+    }
+
+    @Test
     func `antigravity usage source picker clarifies local ide and agy`() throws {
         let fixture = try self.makeSettingsFixture(suite: "ProviderSettingsDescriptorTests-antigravity-source")
         let context = fixture.settingsContext(provider: .antigravity)

--- a/Tests/CodexBarTests/RemoteCodexCostSourceTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexCostSourceTests.swift
@@ -31,6 +31,31 @@ struct RemoteCodexCostSourceTests {
     }
 
     @Test
+    func `remote codex ssh target rejects option injection`() {
+        #expect(RemoteCodexCostSyncer.isValidSSHTarget("gpu-host"))
+        #expect(RemoteCodexCostSyncer.isValidSSHTarget("user@example.com"))
+        #expect(!RemoteCodexCostSyncer.isValidSSHTarget("-F/tmp/ssh-config"))
+        #expect(!RemoteCodexCostSyncer.isValidSSHTarget("--rsync-path=sh"))
+    }
+
+    @Test
+    func `remote codex sync resets stale mirror files`() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RemoteCodexCostSourceTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let stale = root.appendingPathComponent("stale.jsonl")
+        try Data("stale".utf8).write(to: stale)
+
+        try RemoteCodexCostSyncer.resetDirectory(root)
+
+        #expect(FileManager.default.fileExists(atPath: root.path))
+        #expect(!FileManager.default.fileExists(atPath: stale.path))
+        #expect(try FileManager.default.contentsOfDirectory(atPath: root.path).isEmpty)
+    }
+
+    @Test
     func `remote codex file list filters by date paths`() throws {
         let calendar = Calendar(identifier: .gregorian)
         let since = try #require(calendar.date(from: DateComponents(year: 2026, month: 5, day: 17)))

--- a/Tests/CodexBarTests/RemoteCodexCostSourceTests.swift
+++ b/Tests/CodexBarTests/RemoteCodexCostSourceTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+@testable import CodexBarCore
+
+struct RemoteCodexCostSourceTests {
+    @Test
+    func `remote codex sources normalize and filter enabled ssh targets`() {
+        let sources = [
+            RemoteCodexCostSource(id: " remote host ", enabled: true, sshTarget: "user@example.com"),
+            RemoteCodexCostSource(id: "disabled", enabled: false, sshTarget: "other@example.com"),
+            RemoteCodexCostSource(id: "missing-target", enabled: true),
+        ]
+
+        let enabled = RemoteCodexCostSource.enabled(sources)
+
+        #expect(enabled.count == 1)
+        #expect(enabled.first?.sanitizedID == "remote-host")
+        #expect(enabled.first?.sanitizedRemoteCodexHome == RemoteCodexCostSource.defaultRemoteCodexHome)
+        #expect(enabled.first?.syncTimeoutSeconds == Int(RemoteCodexCostSource.defaultSyncTimeoutSeconds))
+    }
+
+    @Test
+    func `remote codex source connection description includes port`() {
+        let source = RemoteCodexCostSource(
+            label: "Remote",
+            sshTarget: "raykr@swroom.com",
+            sshPort: 12140,
+            remoteCodexHome: "~/.codex")
+
+        #expect(source.connectionDescription == "raykr@swroom.com (port 12140): ~/.codex")
+    }
+
+    @Test
+    func `remote codex file list filters by date paths`() throws {
+        let calendar = Calendar(identifier: .gregorian)
+        let since = try #require(calendar.date(from: DateComponents(year: 2026, month: 5, day: 17)))
+        let until = try #require(calendar.date(from: DateComponents(year: 2026, month: 6, day: 15)))
+        let raw = """
+        ./2026/05/16/rollout-2026-05-16T10-00-00-old.jsonl
+        ./2026/05/17/rollout-2026-05-17T10-00-00-start.jsonl
+        ./2026/06/15/rollout-2026-06-15T10-00-00-today.jsonl
+        ./2026/06/16/rollout-2026-06-16T10-00-00-future.jsonl
+        ./rollout-without-date.jsonl
+        ./notes.txt
+        """
+
+        let filtered = RemoteCodexCostSyncer.filteredRelativeJSONLPaths(
+            raw,
+            window: RemoteCodexCostSyncWindow(since: since, until: until))
+
+        #expect(filtered == [
+            "2026/05/17/rollout-2026-05-17T10-00-00-start.jsonl",
+            "2026/06/15/rollout-2026-06-15T10-00-00-today.jsonl",
+            "rollout-without-date.jsonl",
+        ])
+    }
+
+    @Test
+    func `config round trips remote codex cost sources`() throws {
+        let source = RemoteCodexCostSource(
+            id: "gpu26",
+            enabled: true,
+            label: "GPU26",
+            sshTarget: "gpu26",
+            sshPort: 12139,
+            remoteCodexHome: "/home/raykr/.codex",
+            syncTimeoutSeconds: 90)
+        let config = CodexBarConfig(providers: [
+            ProviderConfig(id: UsageProvider.codex, enabled: true, remoteCodexCostSources: [source]),
+        ])
+
+        let data = try JSONEncoder().encode(config)
+        let decoded = try JSONDecoder().decode(CodexBarConfig.self, from: data).normalized()
+        let decodedSource = try #require(
+            decoded.providerConfig(for: UsageProvider.codex)?.remoteCodexCostSources?.first)
+
+        #expect(decodedSource == source)
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,7 +44,8 @@ See `docs/configuration.md` for the schema.
 ## Command
 - `codexbar` defaults to the `usage` command.
   - `--format text|json` (default: text).
-- `codexbar cost` prints local token cost usage for Claude + Codex without web/CLI access.
+- `codexbar cost` prints token cost usage for Claude + Codex without web/CLI access.
+  - Codex can merge optional SSH-mirrored remote session logs from config.
   - `--format text|json` (default: text).
   - `--refresh` ignores cached scans.
 - `codexbar serve` starts a foreground localhost-only HTTP server for usage and cost JSON.

--- a/docs/codex.md
+++ b/docs/codex.md
@@ -1,15 +1,15 @@
 ---
-summary: "Codex provider data sources: OpenAI web dashboard, Codex CLI RPC, credits, and local cost usage."
+summary: "Codex provider data sources: OpenAI web dashboard, Codex CLI RPC, credits, and local/remote cost usage."
 read_when:
   - Debugging Codex usage/credits parsing
   - Updating OpenAI dashboard scraping or cookie import
   - Changing Codex CLI RPC or diagnostic PTY behavior
-  - Reviewing local cost usage scanning
+  - Reviewing local or remote cost usage scanning
 ---
 
 # Codex provider
 
-Codex has three automatic usage data paths (OAuth API, web dashboard, CLI RPC) plus a manual CLI PTY diagnostic parser and a local cost-usage scanner.
+Codex has three automatic usage data paths (OAuth API, web dashboard, CLI RPC) plus a manual CLI PTY diagnostic parser and a local/remote cost-usage scanner.
 The OAuth API is the default app source when credentials are available; web access is optional for dashboard extras.
 
 ## Data sources + fallback order
@@ -111,7 +111,7 @@ Usage source picker:
 - CLI RPC: `account/rateLimits/read` → credits balance.
 - CLI PTY diagnostics can still parse `Credits:` from saved/manual `/status` output.
 
-## Cost usage (local log scan)
+## Cost usage (local + optional remote log scan)
 - Source files:
   - Native Codex logs:
     - `~/.codex/sessions/YYYY/MM/DD/*.jsonl`
@@ -125,9 +125,17 @@ Usage source picker:
   - pi sessions count assistant-message usage rows and attribute `openai-codex` assistant usage to Codex.
   - pi assistant usage is bucketed by assistant-turn timestamp, so mixed-model pi sessions can contribute to multiple
     days/models correctly.
+- Remote Codex logs:
+  - Enable in Preferences -> Providers -> Codex -> Remote cost logs.
+  - `SSH target` accepts a Host alias or `user@host`. Put keys, proxy jumps, and advanced SSH settings in
+    `~/.ssh/config`; use the optional `SSH port` field only when needed.
+  - `Remote Codex home` defaults to `~/.codex` and should contain `sessions/` plus optional `archived_sessions/`.
+  - Sync uses `/usr/bin/rsync` over `/usr/bin/ssh` in batch mode, mirrors only `*.jsonl`, and keeps per-source scan
+    caches isolated before merging totals with local Codex and supported pi sessions.
 - Cache:
   - Native + merged provider cache: `~/Library/Caches/CodexBar/cost-usage/codex-v2.json`
   - pi session cache: `~/Library/Caches/CodexBar/cost-usage/pi-sessions-v1.json`
+  - Remote mirrors and scan caches: `~/Library/Caches/CodexBar/cost-usage/remote-codex/`
 - Window: configurable 1-365 day rolling history, with a 60s minimum refresh interval.
 
 ## Key files

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -80,7 +80,7 @@ headers, source selection, provider ordering, and token accounts are stored in `
 - Battery saver toggle (currently off by default): reduces routine OpenAI web refreshes but still allows explicit manual refreshes.
 - CLI RPC default: `codex ... app-server` JSON-RPC (`account/read`, `account/rateLimits/read`).
 - CLI PTY: manual diagnostics/parser coverage only; automatic refresh does not launch bare Codex TUI.
-- Local cost usage: scans `CODEX_HOME` (or `~/.codex`) `sessions` and sibling `archived_sessions` JSONL files for the configured history window.
+- Cost usage: scans local `CODEX_HOME` (or `~/.codex`) logs and can merge optional SSH-mirrored remote Codex logs.
 - Status: Statuspage.io (OpenAI).
 - Details: `docs/codex.md`.
 


### PR DESCRIPTION
## Summary

- add optional Codex remote cost sources that mirror `sessions/` and `archived_sessions/` JSONL over SSH/rsync
- merge enabled remote scans with local Codex cost usage in the app, CLI `cost`, and `serve` payloads
- expose Codex provider settings and document SSH configuration
- add maintainer changelog credit for @raykr

## Hardening

- reject option-shaped SSH targets before invoking `ssh` or `rsync`
- reset each mirror only after a successful remote listing, removing deleted files and preventing old hosts or scan windows from contaminating totals
- preserve the previous mirror when listing itself fails
- keep per-source scan caches isolated and disable cached snapshot hydration while remote sources are active
- use batch-mode SSH, bounded subprocesses, and the shared 1 MiB output capture limit

## Verification

Exact head: `d839eec9885097acaa06f226f50fe90420dea7eb`

- 31 focused remote-source, CLI-cost, and provider-settings tests passed
- `make check` passed; SwiftFormat and SwiftLint clean
- initial review found option injection and stale-mirror contamination; both fixed with regressions
- final whole-branch autoreview clean (0.78), no accepted/actionable findings
- live disposable Ubuntu SSH/rsync E2E returned exactly 321 synthetic remote tokens as `source: local+remote`
- after the remote JSONL disappeared, a forced refresh returned an empty daily report instead of the stale 321 tokens
- an option-shaped target failed with `Invalid remote Codex SSH target` before any network process could run

## Privacy

Remote logs remain opt-in. CodexBar copies only JSONL session logs to its local cache and parses them on device; credentials stay in the user's existing SSH configuration or agent.
