### PR TITLE
fix(i18n): localize hardcoded "tomorrow" in reset time display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Menu bar: reuse the icon-observation signature during provider refreshes instead of computing it twice. Thanks @abe238!
 
 ### Fixed
-- Localization: improve Japanese terminology consistency. Thanks @tukuyomil032!
+- Localization: improve Japanese terminology consistency and localize next-day reset times across all 21 app languages. Thanks @tukuyomil032!
 
 ## 0.36.1 — 2026-06-16
 

--- a/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ar.lproj/Localizable.strings
@@ -707,6 +707,7 @@
 "Resets %@" = "إعادة التعيين %@";
 "Resets in %@" = "إعادة التعيين في %@";
 "Resets now" = "إعادة التعيين الآن";
+"reset_tomorrow_format" = "غدًا، %@";
 "Lasts until reset" = "يستمر حتى إعادة التعيين";
 "Updated %@" = "تحديث %@";
 "Updated %@h ago" = "تم التحديث %@h قبل";

--- a/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ca.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "Replay selected animation" = "Reprodueix l'animació seleccionada";
 "Requires authentication via GitHub Device Flow." = "Requereix autenticació mitjançant el flux de dispositiu de GitHub.";
 "Resets: \\(reset)" = "Es reinicia: \\(reset)";
+"reset_tomorrow_format" = "demà, %@";
 "Rolling five-hour limit" = "Límit mòbil de cinc hores";
 "Search hourly" = "Cerques per hora";
 "Secondary (\\(label))" = "Secundari (\\(label))";

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -707,6 +707,7 @@
 "Resets %@" = "Setzt %@ zurück";
 "Resets in %@" = "Zurückgesetzt in %@";
 "Resets now" = "Wird jetzt zurückgesetzt";
+"reset_tomorrow_format" = "morgen, %@";
 "Lasts until reset" = "Hält bis zum Zurücksetzen an";
 "Updated %@" = "Aktualisiert %@";
 "Updated %@h ago" = "Vor %@h aktualisiert";

--- a/Sources/CodexBar/Resources/en.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/en.lproj/Localizable.strings
@@ -707,6 +707,7 @@
 "Resets %@" = "Resets %@";
 "Resets in %@" = "Resets in %@";
 "Resets now" = "Resets now";
+"reset_tomorrow_format" = "tomorrow, %@";
 "Lasts until reset" = "Lasts until reset";
 "Updated %@" = "Updated %@";
 "Updated %@h ago" = "Updated %@h ago";

--- a/Sources/CodexBar/Resources/es.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/es.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "Replay selected animation" = "Reproducir la animación seleccionada";
 "Requires authentication via GitHub Device Flow." = "Requiere autenticación mediante el flujo de dispositivo de GitHub.";
 "Resets: \\(reset)" = "Se reinicia: \\(reset)";
+"reset_tomorrow_format" = "mañana, %@";
 "Rolling five-hour limit" = "Límite móvil de cinco horas";
 "Search hourly" = "Búsquedas por hora";
 "Secondary (\\(label))" = "Secundario (\\(label))";

--- a/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fa.lproj/Localizable.strings
@@ -707,6 +707,7 @@
 "Resets %@" = "ریست %@";
 "Resets in %@" = "ریست ها در %@";
 "Resets now" = "اکنون بازنشانی می شود";
+"reset_tomorrow_format" = "فردا، %@";
 "Lasts until reset" = "تا زمان ریست ادامه دارد";
 "Updated %@" = "به روزرسانی %@";
 "Updated %@h ago" = "%@h پیش به روزرسانی شده است";

--- a/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/fr.lproj/Localizable.strings
@@ -707,6 +707,7 @@
 "Resets %@" = "Réinitialise %@";
 "Resets in %@" = "Réinitialisé dans %@";
 "Resets now" = "Réinitialise maintenant";
+"reset_tomorrow_format" = "demain, %@";
 "Lasts until reset" = "Dure jusqu'à la réinitialisation";
 "Updated %@" = "%@ mis à jour";
 "Updated %@h ago" = "Mis à jour il y a %@h";

--- a/Sources/CodexBar/Resources/id.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/id.lproj/Localizable.strings
@@ -709,6 +709,7 @@
 "Resets %@" = "Reset %@";
 "Resets in %@" = "Reset dalam %@";
 "Resets now" = "Reset sekarang";
+"reset_tomorrow_format" = "besok, %@";
 "Lasts until reset" = "Bertahan hingga reset";
 "Updated %@" = "Diperbarui %@";
 "Updated %@h ago" = "Diperbarui %@ jam lalu";

--- a/Sources/CodexBar/Resources/it.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/it.lproj/Localizable.strings
@@ -709,6 +709,7 @@
 "Resets %@" = "Si resetta %@";
 "Resets in %@" = "Si reimposta tra %@";
 "Resets now" = "Si resetta ora";
+"reset_tomorrow_format" = "domani, %@";
 "Lasts until reset" = "Valido fino al reset";
 "Updated %@" = "Aggiornato %@";
 "Updated %@h ago" = "Aggiornato %@ h fa";

--- a/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ja.lproj/Localizable.strings
@@ -704,6 +704,7 @@
 "Resets %@" = "%@ にリセット";
 "Resets in %@" = "%@ 後にリセット";
 "Resets now" = "まもなくリセット";
+"reset_tomorrow_format" = "明日 %@";
 "Lasts until reset" = "リセットまで持続";
 "Updated %@" = "%@ に更新";
 "Updated %@h ago" = "%@時間前に更新";

--- a/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/ko.lproj/Localizable.strings
@@ -680,6 +680,7 @@
 "Resets %@" = "%@에 재설정";
 "Resets in %@" = "%@ 후 재설정";
 "Resets now" = "지금 재설정";
+"reset_tomorrow_format" = "내일 %@";
 "Lasts until reset" = "재설정까지 유지";
 "Updated %@" = "%@에 업데이트됨";
 "Updated %@h ago" = "%@시간 전 업데이트됨";

--- a/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/nl.lproj/Localizable.strings
@@ -707,6 +707,7 @@
 "Resets %@" = "Reset %@";
 "Resets in %@" = "Resetten over %@";
 "Resets now" = "Wordt nu gereset";
+"reset_tomorrow_format" = "morgen, %@";
 "Lasts until reset" = "Gaat mee tot reset";
 "Updated %@" = "Bijgewerkt %@";
 "Updated %@h ago" = "%@u geleden bijgewerkt";

--- a/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pl.lproj/Localizable.strings
@@ -709,6 +709,7 @@
 "Resets %@" = "Reset %@";
 "Resets in %@" = "Reset za %@";
 "Resets now" = "Reset teraz";
+"reset_tomorrow_format" = "jutro, %@";
 "Lasts until reset" = "Wystarcza do resetu";
 "Updated %@" = "Zaktualizowano %@";
 "Updated %@h ago" = "Zaktualizowano %@ godz. temu";

--- a/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/pt-BR.lproj/Localizable.strings
@@ -704,6 +704,7 @@
 "Resets %@" = "Renova %@";
 "Resets in %@" = "Renova em %@";
 "Resets now" = "Renova agora";
+"reset_tomorrow_format" = "amanhã, %@";
 "Lasts until reset" = "Dura até a renovação";
 "Updated %@" = "Atualizado %@";
 "Updated %@h ago" = "Atualizado há %@h";

--- a/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/sv.lproj/Localizable.strings
@@ -706,6 +706,7 @@
 "Resets %@" = "Återställs %@";
 "Resets in %@" = "Återställs om %@";
 "Resets now" = "Återställs nu";
+"reset_tomorrow_format" = "imorgon %@";
 "Lasts until reset" = "Räcker till återställning";
 "Updated %@" = "Uppdaterad %@";
 "Updated %@h ago" = "Uppdaterad för %@ h sedan";

--- a/Sources/CodexBar/Resources/th.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/th.lproj/Localizable.strings
@@ -707,6 +707,7 @@
 "Resets %@" = "รีเซ็ต %@";
 "Resets in %@" = "รีเซ็ตใน %@";
 "Resets now" = "รีเซ็ตเดี๋ยวนี้";
+"reset_tomorrow_format" = "พรุ่งนี้ %@";
 "Lasts until reset" = "คงอยู่จนกว่าจะรีเซ็ต";
 "Updated %@" = "อัพเดท %@";
 "Updated %@h ago" = "อัพเดท %@h ที่ผ่านมา";

--- a/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/tr.lproj/Localizable.strings
@@ -705,6 +705,7 @@
 "Resets %@" = "Sıfırlanma: %@";
 "Resets in %@" = "%@ içinde sıfırlanır";
 "Resets now" = "Şimdi sıfırlanır";
+"reset_tomorrow_format" = "yarın, %@";
 "Lasts until reset" = "Sıfırlamaya kadar sürer";
 "Updated %@" = "Güncellendi: %@";
 "Updated %@h ago" = "%@ saat önce güncellendi";

--- a/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/uk.lproj/Localizable.strings
@@ -707,6 +707,7 @@
 "Resets %@" = "Скидання %@";
 "Resets in %@" = "Скидання через %@";
 "Resets now" = "Скидає зараз";
+"reset_tomorrow_format" = "завтра, %@";
 "Lasts until reset" = "Триває до скидання";
 "Updated %@" = "Оновлено %@";
 "Updated %@h ago" = "Оновлено %@ год тому";

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -703,6 +703,7 @@
 "Resets %@" = "Đặt lại %@";
 "Resets in %@" = "Đặt lại sau %@";
 "Resets now" = "Đặt lại ngay";
+"reset_tomorrow_format" = "ngày mai, %@";
 "Lasts until reset" = "Kéo dài cho đến Đặt lại";
 "Updated %@" = "Đã cập nhật %@";
 "Updated %@h ago" = "Đã cập nhật %@ h trước";

--- a/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hans.lproj/Localizable.strings
@@ -681,6 +681,7 @@
 "Resets %@" = "重置于 %@";
 "Resets in %@" = "%@后重置";
 "Resets now" = "立即重置";
+"reset_tomorrow_format" = "明天 %@";
 "Lasts until reset" = "持续到重置";
 "Updated %@" = "更新于 %@";
 "Updated %@h ago" = "%@ 小时前更新";

--- a/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/zh-Hant.lproj/Localizable.strings
@@ -945,6 +945,7 @@
 "Search providers" = "搜尋提供者";
 
 "language_vietnamese" = "越南語";
+"reset_tomorrow_format" = "明天 %@";
 
 "Request quota: %@ / %@" = "請求額度：%@ / %@";
 "language_turkish" = "Türkçe";

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -60,6 +60,7 @@ public enum UsageFormatter {
         switch key {
         case "usage_percent_suffix_left": return "left"
         case "usage_percent_suffix_used": return "used"
+        case "reset_tomorrow_format": return "tomorrow, %@"
         default: return key
         }
     }
@@ -107,7 +108,8 @@ public enum UsageFormatter {
         if let tomorrow = calendar.date(byAdding: .day, value: 1, to: now),
            calendar.isDate(date, inSameDayAs: tomorrow)
         {
-            return "tomorrow, \(date.formatted(.dateTime.hour().minute().locale(self.currentLocale())))"
+            let timeStr = date.formatted(.dateTime.hour().minute().locale(self.currentLocale()))
+            return self.localized("reset_tomorrow_format", timeStr)
         }
         return date.formatted(.dateTime.month(.abbreviated).day().hour().minute().locale(self.currentLocale()))
     }

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -10,6 +10,7 @@ struct UsageFormatterTests {
         "Resets %@",
         "Resets in %@",
         "Resets now",
+        "reset_tomorrow_format",
         "Updated %@",
         "Updated %@h ago",
         "Updated %@m ago",
@@ -103,6 +104,37 @@ struct UsageFormatterTests {
 
         let restored = UsageFormatter.updatedString(from: old, now: now)
         #expect(restored == baseline)
+    }
+
+    @Test
+    func `tomorrow reset description uses localized format`() throws {
+        UsageFormatter.setLocalizationProvider { key in
+            key == "reset_tomorrow_format" ? "明日 %@" : key
+        }
+        UsageFormatter.setLocaleProvider { Locale(identifier: "ja_JP") }
+        defer {
+            UsageFormatter.clearLocalizationProvider()
+            UsageFormatter.clearLocaleProvider()
+        }
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+        let now = try #require(calendar.date(from: DateComponents(
+            year: 2026,
+            month: 6,
+            day: 16,
+            hour: 12)))
+        let reset = try #require(calendar.date(from: DateComponents(
+            year: 2026,
+            month: 6,
+            day: 17,
+            hour: 10,
+            minute: 50)))
+
+        let output = UsageFormatter.resetDescription(from: reset, now: now)
+        #expect(output.hasPrefix("明日 "))
+        #expect(!output.contains("tomorrow"))
+        #expect(!output.contains("%@"))
     }
 
     @Test

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -117,19 +117,11 @@ struct UsageFormatterTests {
             UsageFormatter.clearLocaleProvider()
         }
 
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
-        let now = try #require(calendar.date(from: DateComponents(
-            year: 2026,
-            month: 6,
-            day: 16,
-            hour: 12)))
-        let reset = try #require(calendar.date(from: DateComponents(
-            year: 2026,
-            month: 6,
-            day: 17,
-            hour: 10,
-            minute: 50)))
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_750_000_000))
+        let now = try #require(calendar.date(byAdding: .hour, value: 12, to: today))
+        let tomorrow = try #require(calendar.date(byAdding: .day, value: 1, to: today))
+        let reset = try #require(calendar.date(byAdding: .minute, value: 10 * 60 + 50, to: tomorrow))
 
         let output = UsageFormatter.resetDescription(from: reset, now: now)
         #expect(output.hasPrefix("明日 "))


### PR DESCRIPTION
## Summary

`UsageFormatter.resetDescription()` returned the English word "tomorrow" verbatim regardless of the user's locale setting. Under Japanese (and all other non-English locales) this produced mixed-language output:

> "tomorrow 10:50 にリセット"

**Root cause**

The string was hardcoded directly in Swift:

```swift
return "tomorrow, \(date.formatted(.dateTime.hour().minute().locale(self.currentLocale())))"
```

While same-day and future-date resets were correctly formatted using `DateFormatter` with the current locale, "tomorrow" was never routed through the localization system.

**Fix**

Replaced the hardcoded string with a new `reset_tomorrow_format` key run through `localized()`. Each locale controls the word, punctuation, and word order independently — for example, Japanese omits the comma: `"明日 %@"`.

Added `reset_tomorrow_format` to all 18 supported language files with native translations:

| Locale | Translation |
|--------|-------------|
| `ja` | `明日 %@` |
| `ko` | `내일 %@` |
| `zh-Hans` / `zh-Hant` | `明天 %@` |
| `fr` | `demain, %@` |
| `de` / `nl` | `morgen, %@` |
| `es` | `mañana, %@` |
| `it` | `domani, %@` |
| `pt-BR` | `amanhã, %@` |
| `pl` | `jutro, %@` |
| `sv` | `imorgon %@` |
| `tr` | `yarın, %@` |
| `uk` | `завтра, %@` |
| `ca` | `demà, %@` |
| `vi` | `ngày mai, %@` |
| `id` | `besok, %@` |
| `en` | `tomorrow, %@` |