### PR TITLE
Avoid unnecessary logging work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Display: add a Hide critters option for plain menu bar quota capsules. Thanks @elijahfriedman!
 
 ### Changed
+- Logging: skip message, metadata, and redaction work for filtered or disabled log destinations. Thanks @ProspectOre!
 - Linux CLI: accept an opt-in static SQLite library directory for musl builds. Thanks @Yuxin-Qiao!
 - Linux CLI: add musl source compatibility for static Linux SDK builds. Thanks @Yuxin-Qiao!
 - Cost history: resize the chart details to the hovered day's model breakdown instead of reserving the tallest day. Thanks @elijahfriedman!

--- a/Sources/CodexBarCore/Logging/CodexBarLog.swift
+++ b/Sources/CodexBarCore/Logging/CodexBarLog.swift
@@ -111,15 +111,16 @@ public enum CodexBarLog {
 
     public static func logger(_ category: String) -> CodexBarLogger {
         let logger = Logger(label: "com.steipete.codexbar.\(category)")
-        return CodexBarLogger { level, message, metadata in
-            guard self.shouldLog(level) else { return }
+        return CodexBarLogger(isEnabled: { level in
+            self.shouldLog(level)
+        }, log: { level, message, metadata in
             let swiftLogLevel = level.asSwiftLogLevel
             let safeMessage = LogRedactor.redact(message)
             let meta = metadata?.reduce(into: Logger.Metadata()) { partial, entry in
                 partial[entry.key] = .string(LogRedactor.redact(entry.value))
             }
             logger.log(level: swiftLogLevel, "\(safeMessage)", metadata: meta)
-        }
+        })
     }
 
     public static func parseLevel(_ raw: String?) -> Level? {
@@ -170,37 +171,59 @@ private struct DiscardLogHandler: LogHandler {
 }
 
 public struct CodexBarLogger: Sendable {
+    private let isEnabled: @Sendable (CodexBarLog.Level) -> Bool
     private let logFn: @Sendable (CodexBarLog.Level, String, [String: String]?) -> Void
 
-    fileprivate init(_ logFn: @escaping @Sendable (CodexBarLog.Level, String, [String: String]?) -> Void) {
-        self.logFn = logFn
+    fileprivate init(
+        isEnabled: @escaping @Sendable (CodexBarLog.Level) -> Bool,
+        log: @escaping @Sendable (CodexBarLog.Level, String, [String: String]?) -> Void)
+    {
+        self.isEnabled = isEnabled
+        self.logFn = log
+    }
+
+    init(
+        minimumLevel: CodexBarLog.Level,
+        log: @escaping @Sendable (CodexBarLog.Level, String, [String: String]?) -> Void)
+    {
+        self.isEnabled = { level in level.rank >= minimumLevel.rank }
+        self.logFn = log
+    }
+
+    private func log(
+        _ level: CodexBarLog.Level,
+        _ message: @autoclosure () -> String,
+        metadata: [String: String]?)
+    {
+        guard self.isEnabled(level) else { return }
+        self.logFn(level, message(), metadata)
     }
 
     public func trace(_ message: @autoclosure () -> String, metadata: [String: String]? = nil) {
-        self.logFn(.trace, message(), metadata)
+        self.log(.trace, message(), metadata: metadata)
     }
 
     public func verbose(_ message: @autoclosure () -> String, metadata: [String: String]? = nil) {
-        self.logFn(.verbose, message(), metadata)
+        self.log(.verbose, message(), metadata: metadata)
     }
 
     public func debug(_ message: @autoclosure () -> String, metadata: [String: String]? = nil) {
-        self.logFn(.debug, message(), metadata)
+        self.log(.debug, message(), metadata: metadata)
     }
 
     public func info(_ message: @autoclosure () -> String, metadata: [String: String]? = nil) {
-        self.logFn(.info, message(), metadata)
+        self.log(.info, message(), metadata: metadata)
     }
 
     public func warning(_ message: @autoclosure () -> String, metadata: [String: String]? = nil) {
-        self.logFn(.warning, message(), metadata)
+        self.log(.warning, message(), metadata: metadata)
     }
 
     public func error(_ message: @autoclosure () -> String, metadata: [String: String]? = nil) {
-        self.logFn(.error, message(), metadata)
+        self.log(.error, message(), metadata: metadata)
     }
 
     public func critical(_ message: @autoclosure () -> String, metadata: [String: String]? = nil) {
-        self.logFn(.critical, message(), metadata)
+        self.log(.critical, message(), metadata: metadata)
     }
 }

--- a/Sources/CodexBarCore/Logging/FileLogHandler.swift
+++ b/Sources/CodexBarCore/Logging/FileLogHandler.swift
@@ -39,6 +39,10 @@ final class FileLogSink: @unchecked Sendable {
         self.queue.sync { self.fileURL }
     }
 
+    func isWriteEnabled() -> Bool {
+        self.queue.sync { self.isEnabled }
+    }
+
     func write(_ text: String) {
         self.queue.async {
             guard self.isEnabled else { return }
@@ -104,6 +108,7 @@ struct FileLogHandler: LogHandler {
     }
 
     func log(event: LogEvent) {
+        guard self.sink.isWriteEnabled() else { return }
         let ts = Self.timestamp()
         var combined = self.metadata
         if let metadata = event.metadata { combined.merge(metadata, uniquingKeysWith: { _, new in new }) }

--- a/Sources/CodexBarCore/Logging/LogRedactor.swift
+++ b/Sources/CodexBarCore/Logging/LogRedactor.swift
@@ -24,6 +24,8 @@ public enum LogRedactor {
         pattern: #"sk-api-[^\s"'`;,)>\]]+"#)
 
     public static func redact(_ text: String) -> String {
+        guard self.mayContainSensitiveValue(text) else { return text }
+
         var output = text
         // Email is broad and safe first
         output = self.replace(self.emailRegex, in: output, with: "<redacted-email>")
@@ -36,6 +38,16 @@ public enum LogRedactor {
         output = self.replace(self.cookieHeaderRegex, in: output, with: "$1<redacted>")
         output = self.replace(self.authorizationRegex, in: output, with: "$1<redacted>")
         return output
+    }
+
+    private static func mayContainSensitiveValue(_ text: String) -> Bool {
+        if text.range(of: "@") != nil { return true }
+        if text.range(of: "sk-cp-", options: [.caseInsensitive]) != nil { return true }
+        if text.range(of: "sk-api-", options: [.caseInsensitive]) != nil { return true }
+        if text.range(of: "bearer", options: [.caseInsensitive]) != nil { return true }
+        if text.range(of: "cookie", options: [.caseInsensitive]) != nil { return true }
+        if text.range(of: "authorization", options: [.caseInsensitive]) != nil { return true }
+        return false
     }
 
     private static func makeRegex(pattern: String, options: NSRegularExpression.Options = []) -> NSRegularExpression {

--- a/TestsLinux/CodexBarLoggingPerformanceTests.swift
+++ b/TestsLinux/CodexBarLoggingPerformanceTests.swift
@@ -1,0 +1,82 @@
+import Logging
+import Testing
+@testable import CodexBarCore
+
+@Suite(.serialized)
+struct CodexBarLoggingPerformanceTests {
+    @Test
+    func `filtered log messages are not evaluated`() {
+        let probe = LogEvaluationProbe()
+        let logger = CodexBarLogger(minimumLevel: .info) { _, message, _ in
+            probe.loggedMessages.append(message)
+        }
+
+        logger.debug(probe.expensiveMessage())
+
+        #expect(probe.evaluations == 0)
+        #expect(probe.loggedMessages.isEmpty)
+
+        logger.info(probe.expensiveMessage())
+
+        #expect(probe.evaluations == 1)
+        #expect(probe.loggedMessages == ["evaluated"])
+    }
+
+    @Test
+    func `disabled file logging does not format metadata`() {
+        let sink = FileLogSink()
+        var handler = FileLogHandler(label: "test", sink: sink)
+        let probe = LogEvaluationProbe()
+        handler[metadataKey: "expensive"] = .stringConvertible(ExpensiveMetadataValue {
+            probe.evaluations += 1
+        })
+
+        handler.log(event: LogEvent(
+            level: .info,
+            message: "hello",
+            metadata: nil,
+            source: "test",
+            file: #filePath,
+            function: #function,
+            line: #line))
+
+        #expect(probe.evaluations == 0)
+    }
+
+    @Test
+    func `redactor leaves ordinary log lines unchanged`() {
+        let line = "CodexBar starting version=1.2.3 build=456"
+
+        #expect(LogRedactor.redact(line) == line)
+    }
+
+    @Test
+    func `redactor still redacts sensitive log lines`() {
+        let line = "Authorization: Bearer secret-token\nContact: user@example.com"
+        let redacted = LogRedactor.redact(line)
+
+        #expect(redacted.contains("secret-token") == false)
+        #expect(redacted.contains("user@example.com") == false)
+        #expect(redacted.contains("Authorization: <redacted>"))
+        #expect(redacted.contains("<redacted-email>"))
+    }
+}
+
+private final class LogEvaluationProbe: @unchecked Sendable {
+    var evaluations = 0
+    var loggedMessages: [String] = []
+
+    func expensiveMessage() -> String {
+        self.evaluations += 1
+        return "evaluated"
+    }
+}
+
+private struct ExpensiveMetadataValue: CustomStringConvertible, Sendable {
+    let onRender: @Sendable () -> Void
+
+    var description: String {
+        self.onRender()
+        return "rendered"
+    }
+}


### PR DESCRIPTION
## Summary

- avoid evaluating filtered log messages before the configured level check
- skip file-log timestamp, metadata, and redaction formatting while file logging is disabled
- bypass regex redaction for ordinary lines that cannot match any supported sensitive pattern
- add focused performance-behavior regressions and changelog credit

## Proof

- `swift test --filter CodexBarLoggingPerformanceTests` (4 passed)
- `swift test --filter MiniMaxLogRedactorTests` (10 passed)
- `make check`
- autoreview clean (0.82)

Exact reviewed head: `8c5cdf128ea068d9d521a53de6533143bc26618b`.
