### PR TITLE
Trim menu formatting work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - Provider switcher: keep Codex quota rows visible when switching away and back during a manual refresh, including menus with usage-history sections. Thanks @Yuxin-Qiao!
+- Bedrock: ignore invalid billing dates when selecting the latest usage values. Thanks @ProspectOre!
 - Localization: improve Japanese terminology consistency and localize next-day reset times across all 21 app languages. Thanks @tukuyomil032!
 - Menu bar: keep visible quota values stable while a manual refresh is in flight without rewinding background-refresh countdowns. Thanks @Zihao-Qi!
 - Menu bar: stop informational usage-card rows from highlighting like clickable actions. Thanks @elijahfriedman!

--- a/Sources/CodexBar/MenuCardView+Costs.swift
+++ b/Sources/CodexBar/MenuCardView+Costs.swift
@@ -133,35 +133,77 @@ extension UsageMenuCardView.Model {
     private static func bedrockLatestBillingDay(from entries: [CostUsageDailyReport.Entry])
         -> CostUsageDailyReport.Entry?
     {
-        entries.max { lhs, rhs in
-            let lDate = Self.bedrockBillingDate(from: lhs.date) ?? .distantPast
-            let rDate = Self.bedrockBillingDate(from: rhs.date) ?? .distantPast
-            if lDate != rDate { return lDate < rDate }
-            let lCost = lhs.costUSD ?? -1
-            let rCost = rhs.costUSD ?? -1
-            if lCost != rCost { return lCost < rCost }
-            let lTokens = lhs.totalTokens ?? -1
-            let rTokens = rhs.totalTokens ?? -1
-            if lTokens != rTokens { return lTokens < rTokens }
-            return lhs.date < rhs.date
+        entries.compactMap { entry -> (entry: CostUsageDailyReport.Entry, dayKey: String)? in
+            guard let dayKey = bedrockBillingDayKey(from: entry.date) else { return nil }
+            return (entry, dayKey)
         }
+        .max { lhs, rhs in
+            if lhs.dayKey != rhs.dayKey { return lhs.dayKey < rhs.dayKey }
+            let lCost = lhs.entry.costUSD ?? -1
+            let rCost = rhs.entry.costUSD ?? -1
+            if lCost != rCost { return lCost < rCost }
+            let lTokens = lhs.entry.totalTokens ?? -1
+            let rTokens = rhs.entry.totalTokens ?? -1
+            if lTokens != rTokens { return lTokens < rTokens }
+            return lhs.entry.date < rhs.entry.date
+        }?.entry
     }
 
     private static func bedrockDisplayDate(from text: String) -> String? {
-        guard let date = bedrockBillingDate(from: text) else { return nil }
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = "MMM d"
-        return formatter.string(from: date)
+        guard let dayKey = bedrockBillingDayKey(from: text) else { return nil }
+        let monthStart = dayKey.index(dayKey.startIndex, offsetBy: 5)
+        let monthEnd = dayKey.index(monthStart, offsetBy: 2)
+        let dayStart = dayKey.index(dayKey.startIndex, offsetBy: 8)
+        guard
+            let month = Int(dayKey[monthStart..<monthEnd]),
+            let day = Int(dayKey[dayStart...]),
+            (1...Self.bedrockMonthAbbreviations.count).contains(month),
+            (1...31).contains(day)
+        else { return nil }
+        return "\(Self.bedrockMonthAbbreviations[month - 1]) \(day)"
     }
 
-    private static func bedrockBillingDate(from text: String) -> Date? {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone(secondsFromGMT: 0)
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.date(from: text.trimmingCharacters(in: .whitespacesAndNewlines))
+    private static let bedrockMonthAbbreviations = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ]
+
+    private static func bedrockBillingDayKey(from text: String) -> String? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count == 10 else { return nil }
+        for (offset, character) in trimmed.enumerated() {
+            switch offset {
+            case 4, 7:
+                guard character == "-" else { return nil }
+            default:
+                guard character.isNumber else { return nil }
+            }
+        }
+        let monthStart = trimmed.index(trimmed.startIndex, offsetBy: 5)
+        let monthEnd = trimmed.index(monthStart, offsetBy: 2)
+        let dayStart = trimmed.index(trimmed.startIndex, offsetBy: 8)
+        let yearEnd = trimmed.index(trimmed.startIndex, offsetBy: 4)
+        guard
+            let year = Int(trimmed[..<yearEnd]),
+            let month = Int(trimmed[monthStart..<monthEnd]),
+            let day = Int(trimmed[dayStart...]),
+            (1...Self.bedrockMonthAbbreviations.count).contains(month),
+            (1...Self.daysInBedrockBillingMonth(month, year: year)).contains(day)
+        else { return nil }
+        return trimmed
+    }
+
+    private static func daysInBedrockBillingMonth(_ month: Int, year: Int) -> Int {
+        switch month {
+        case 2:
+            if year.isMultiple(of: 400) { return 29 }
+            if year.isMultiple(of: 100) { return 28 }
+            return year.isMultiple(of: 4) ? 29 : 28
+        case 4, 6, 9, 11:
+            return 30
+        default:
+            return 31
+        }
     }
 
     static func providerCostSection(

--- a/Sources/CodexBarCore/CostUsageFetcher.swift
+++ b/Sources/CodexBarCore/CostUsageFetcher.swift
@@ -279,18 +279,20 @@ public struct CostUsageFetcher: Sendable {
         historyDays: Int = 30) -> CostUsageTokenSnapshot
     {
         // Pick the most recent day; break ties by cost/tokens to keep a stable "session" row.
-        let currentDay = daily.data.max { lhs, rhs in
-            let lDate = CostUsageDateParser.parse(lhs.date) ?? .distantPast
-            let rDate = CostUsageDateParser.parse(rhs.date) ?? .distantPast
-            if lDate != rDate { return lDate < rDate }
-            let lCost = lhs.costUSD ?? -1
-            let rCost = rhs.costUSD ?? -1
-            if lCost != rCost { return lCost < rCost }
-            let lTokens = lhs.totalTokens ?? -1
-            let rTokens = rhs.totalTokens ?? -1
-            if lTokens != rTokens { return lTokens < rTokens }
-            return lhs.date < rhs.date
+        let currentDay = daily.data.compactMap { entry -> (entry: CostUsageDailyReport.Entry, date: Date)? in
+            guard let date = CostUsageDateParser.parse(entry.date) else { return nil }
+            return (entry, date)
         }
+        .max { lhs, rhs in
+            if lhs.date != rhs.date { return lhs.date < rhs.date }
+            let lCost = lhs.entry.costUSD ?? -1
+            let rCost = rhs.entry.costUSD ?? -1
+            if lCost != rCost { return lCost < rCost }
+            let lTokens = lhs.entry.totalTokens ?? -1
+            let rTokens = rhs.entry.totalTokens ?? -1
+            if lTokens != rTokens { return lTokens < rTokens }
+            return lhs.entry.date < rhs.entry.date
+        }?.entry
         // Prefer summary totals when present; fall back to summing daily entries.
         let totalFromSummary = daily.summary?.totalCostUSD
         let totalFromEntries = daily.data.compactMap(\.costUSD).reduce(0, +)

--- a/Sources/CodexBarCore/UsageFormatter.swift
+++ b/Sources/CodexBarCore/UsageFormatter.swift
@@ -241,11 +241,7 @@ public enum UsageFormatter {
             return "\(sign)\(formatted)\(unit.suffix)"
         }
 
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.usesGroupingSeparator = true
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+        return "\(value)"
     }
 
     public static func byteCountString(_ bytes: Int64) -> String {

--- a/Tests/CodexBarTests/BedrockMenuCardTests.swift
+++ b/Tests/CodexBarTests/BedrockMenuCardTests.swift
@@ -71,6 +71,14 @@ struct BedrockMenuCardTests {
                     modelsUsed: ["Amazon Bedrock"],
                     modelBreakdowns: nil),
                 CostUsageDailyReport.Entry(
+                    date: "2026-06-31",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 40,
+                    costUSD: 99,
+                    modelsUsed: ["Amazon Bedrock"],
+                    modelBreakdowns: nil),
+                CostUsageDailyReport.Entry(
                     date: "2026-05-12",
                     inputTokens: nil,
                     outputTokens: nil,

--- a/Tests/CodexBarTests/BedrockMenuCardTests.swift
+++ b/Tests/CodexBarTests/BedrockMenuCardTests.swift
@@ -57,7 +57,7 @@ struct BedrockMenuCardTests {
         let metadata = try #require(ProviderDefaults.metadata[.bedrock])
         let tokenSnapshot = CostUsageTokenSnapshot(
             sessionTokens: nil,
-            sessionCostUSD: 12.34,
+            sessionCostUSD: 23.45,
             last30DaysTokens: nil,
             last30DaysCostUSD: 56.78,
             historyDays: 7,
@@ -116,6 +116,6 @@ struct BedrockMenuCardTests {
             hidePersonalInfo: false,
             now: now))
 
-        #expect(model.tokenUsage?.sessionLine == "Latest billing day (May 13): $12.34")
+        #expect(model.tokenUsage?.sessionLine == "Latest billing day (May 13): $23.45")
     }
 }

--- a/Tests/CodexBarTests/BedrockMenuCardTests.swift
+++ b/Tests/CodexBarTests/BedrockMenuCardTests.swift
@@ -50,4 +50,64 @@ struct BedrockMenuCardTests {
         #expect(model.tokenUsage?.monthLine == "Last 7 days: $56.78")
         #expect(model.tokenUsage?.hintLine == "AWS Cost Explorer billing can lag.")
     }
+
+    @Test
+    func `bedrock cost section picks latest valid billing day`() throws {
+        let now = Date()
+        let metadata = try #require(ProviderDefaults.metadata[.bedrock])
+        let tokenSnapshot = CostUsageTokenSnapshot(
+            sessionTokens: nil,
+            sessionCostUSD: 12.34,
+            last30DaysTokens: nil,
+            last30DaysCostUSD: 56.78,
+            historyDays: 7,
+            daily: [
+                CostUsageDailyReport.Entry(
+                    date: "not-a-day",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 10,
+                    costUSD: 99,
+                    modelsUsed: ["Amazon Bedrock"],
+                    modelBreakdowns: nil),
+                CostUsageDailyReport.Entry(
+                    date: "2026-05-12",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 20,
+                    costUSD: 12.34,
+                    modelsUsed: ["Amazon Bedrock"],
+                    modelBreakdowns: nil),
+                CostUsageDailyReport.Entry(
+                    date: "2026-05-13",
+                    inputTokens: nil,
+                    outputTokens: nil,
+                    totalTokens: 30,
+                    costUSD: 23.45,
+                    modelsUsed: ["Amazon Bedrock"],
+                    modelBreakdowns: nil),
+            ],
+            updatedAt: now)
+        let model = UsageMenuCardView.Model.make(.init(
+            provider: .bedrock,
+            metadata: metadata,
+            snapshot: nil,
+            credits: nil,
+            creditsError: nil,
+            dashboard: nil,
+            dashboardError: nil,
+            tokenSnapshot: tokenSnapshot,
+            tokenError: nil,
+            account: AccountInfo(email: nil, plan: nil),
+            isRefreshing: false,
+            lastError: nil,
+            usageBarsShowUsed: false,
+            resetTimeDisplayStyle: .countdown,
+            tokenCostUsageEnabled: true,
+            showOptionalCreditsAndExtraUsage: true,
+            hidePersonalInfo: false,
+            now: now))
+
+        #expect(model.tokenUsage?.sessionLine == "Latest billing day (May 13): $12.34")
+    }
 }

--- a/Tests/CodexBarTests/CostUsageDecodingTests.swift
+++ b/Tests/CodexBarTests/CostUsageDecodingTests.swift
@@ -365,6 +365,33 @@ struct CostUsageDecodingTests {
     }
 
     @Test
+    func `token snapshot rejects impossible later calendar day`() throws {
+        let json = """
+        {
+          "type": "daily",
+          "data": [
+            {
+              "date": "2026-05-13",
+              "totalTokens": 30,
+              "costUSD": 23.45
+            },
+            {
+              "date": "2026-06-31",
+              "totalTokens": 40,
+              "costUSD": 99.00
+            }
+          ]
+        }
+        """
+
+        let report = try JSONDecoder().decode(CostUsageDailyReport.self, from: Data(json.utf8))
+        let snapshot = CostUsageFetcher.tokenSnapshot(from: report, now: Date())
+
+        #expect(snapshot.sessionTokens == 30)
+        #expect(snapshot.sessionCostUSD == 23.45)
+    }
+
+    @Test
     func `token snapshot uses summary total cost when available`() throws {
         let json = """
         {

--- a/Tests/CodexBarTests/UsageFormatterTests.swift
+++ b/Tests/CodexBarTests/UsageFormatterTests.swift
@@ -231,6 +231,13 @@ struct UsageFormatterTests {
     }
 
     @Test
+    func `token count string formats small values without grouping`() {
+        #expect(UsageFormatter.tokenCountString(0) == "0")
+        #expect(UsageFormatter.tokenCountString(987) == "987")
+        #expect(UsageFormatter.tokenCountString(-42) == "-42")
+    }
+
+    @Test
     func `clean plan maps O auth to ollama`() {
         #expect(UsageFormatter.cleanPlanName("oauth") == "Ollama")
     }


### PR DESCRIPTION
## Summary
- Avoid building a formatter for token counts below 1,000, where grouping never changes the output.
- Replace repeated Bedrock billing-day date parsing with validated `yyyy-MM-dd` day-key comparison and direct month/day rendering.
- Add focused coverage for small token counts and Bedrock latest valid billing-day selection.

## Before / After
Temporary benchmark harness, not committed. Same checksums before/after.

Baseline: `main` at `ac01d736`
Branch: `5ab41dc1`
Command: `/usr/bin/time -l swift test --skip-build --filter FormatterHotPathBenchmarkTests`

| Probe | Before | After | Change |
| --- | ---: | ---: | ---: |
| `tokenCountString` small values, 2,000,000 calls | 19.073202s | 0.870158s | 21.9x faster |
| Bedrock menu model, 5,000 builds over 30 daily entries | 13.940430s | 1.064601s | 13.1x faster |
| Focused run wall time | 38.14s | 2.94s | 13.0x faster |
| Max resident set size | 299.7 MiB | 108.9 MiB | 63.7% lower |
| Peak memory footprint | 27.4 MiB | 27.2 MiB | effectively flat |

Checksums:
- `tokenCountStringSmallValues`: `5780000` before and after
- `bedrockMenuModel`: `175000` before and after

## Verification
- `swift test --filter UsageFormatterTests` passed: 34 tests
- `swift test --filter BedrockMenuCardTests` passed: 2 tests
- `swift build --build-tests` passed
- `swiftlint --strict` passed: 0 violations in 1138 files
- `git diff --check` passed

## Notes
- No new logging, persistence, network behavior, or secrets handling.
- The fresh `main` benchmark worktree needed the local Sparkle framework symlink workaround under `.build/out/Products/Debug/PackageFrameworks` before running the focused test binary.
