### PR TITLE
Cache cost usage date parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 - Logging: skip message, metadata, and redaction work for filtered or disabled log destinations. Thanks @ProspectOre!
+- Cost history: cache date parsers per thread to reduce repeated report-decoding overhead. Thanks @ProspectOre!
 - Linux CLI: accept an opt-in static SQLite library directory for musl builds. Thanks @Yuxin-Qiao!
 - Linux CLI: add musl source compatibility for static Linux SDK builds. Thanks @Yuxin-Qiao!
 - Cost history: resize the chart details to the hovered day's model breakdown instead of reserving the tallest day. Thanks @elijahfriedman!

--- a/Sources/CodexBarCore/CostUsageModels.swift
+++ b/Sources/CodexBarCore/CostUsageModels.swift
@@ -734,27 +734,32 @@ private struct CostUsageAnyCodingKey: CodingKey {
 }
 
 enum CostUsageDateParser {
+    private static let isoWithFractionalSecondsKey = "CostUsageDateParser.isoWithFractionalSeconds"
+    private static let isoInternetDateTimeKey = "CostUsageDateParser.isoInternetDateTime"
+    private static let dayFormatterKey = "CostUsageDateParser.dayFormatter"
+    private static let monthDayYearFormatterKey = "CostUsageDateParser.monthDayYearFormatter"
+    private static let monthYearFormatterKey = "CostUsageDateParser.monthYearFormatter"
+    private static let fullMonthYearFormatterKey = "CostUsageDateParser.fullMonthYearFormatter"
+    private static let yearMonthFormatterKey = "CostUsageDateParser.yearMonthFormatter"
+
     static func parse(_ text: String?) -> Date? {
         guard let text, !text.isEmpty else { return nil }
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        let iso = ISO8601DateFormatter()
-        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        if let d = iso.date(from: trimmed) { return d }
-        iso.formatOptions = [.withInternetDateTime]
-        if let d = iso.date(from: trimmed) { return d }
-
-        let day = DateFormatter()
-        day.locale = Locale(identifier: "en_US_POSIX")
-        day.timeZone = TimeZone.current
-        day.dateFormat = "yyyy-MM-dd"
-        if let d = day.date(from: trimmed) { return d }
-
-        let monthDayYear = DateFormatter()
-        monthDayYear.locale = Locale(identifier: "en_US_POSIX")
-        monthDayYear.timeZone = TimeZone.current
-        monthDayYear.dateFormat = "MMM d, yyyy"
-        if let d = monthDayYear.date(from: trimmed) { return d }
+        if let d = self.isoFormatter(
+            key: self.isoWithFractionalSecondsKey,
+            options: [.withInternetDateTime, .withFractionalSeconds])
+            .date(from: trimmed)
+        { return d }
+        if let d = self.isoFormatter(key: self.isoInternetDateTimeKey, options: [.withInternetDateTime])
+            .date(from: trimmed)
+        { return d }
+        if let d = self.dateFormatter(key: self.dayFormatterKey, format: "yyyy-MM-dd").date(from: trimmed) {
+            return d
+        }
+        if let d = self.dateFormatter(key: self.monthDayYearFormatterKey, format: "MMM d, yyyy")
+            .date(from: trimmed)
+        { return d }
 
         return nil
     }
@@ -763,24 +768,45 @@ enum CostUsageDateParser {
         guard let text, !text.isEmpty else { return nil }
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        let monthYear = DateFormatter()
-        monthYear.locale = Locale(identifier: "en_US_POSIX")
-        monthYear.timeZone = TimeZone.current
-        monthYear.dateFormat = "MMM yyyy"
-        if let d = monthYear.date(from: trimmed) { return d }
-
-        let fullMonthYear = DateFormatter()
-        fullMonthYear.locale = Locale(identifier: "en_US_POSIX")
-        fullMonthYear.timeZone = TimeZone.current
-        fullMonthYear.dateFormat = "MMMM yyyy"
-        if let d = fullMonthYear.date(from: trimmed) { return d }
-
-        let ym = DateFormatter()
-        ym.locale = Locale(identifier: "en_US_POSIX")
-        ym.timeZone = TimeZone.current
-        ym.dateFormat = "yyyy-MM"
-        if let d = ym.date(from: trimmed) { return d }
+        if let d = self.dateFormatter(key: self.monthYearFormatterKey, format: "MMM yyyy").date(from: trimmed) {
+            return d
+        }
+        if let d = self.dateFormatter(key: self.fullMonthYearFormatterKey, format: "MMMM yyyy").date(from: trimmed) {
+            return d
+        }
+        if let d = self.dateFormatter(key: self.yearMonthFormatterKey, format: "yyyy-MM").date(from: trimmed) {
+            return d
+        }
 
         return nil
+    }
+
+    private static func isoFormatter(
+        key: String,
+        options: ISO8601DateFormatter.Options) -> ISO8601DateFormatter
+    {
+        let threadDict = Thread.current.threadDictionary
+        if let cached = threadDict[key] as? ISO8601DateFormatter {
+            return cached
+        }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = options
+        threadDict[key] = formatter
+        return formatter
+    }
+
+    private static func dateFormatter(key: String, format: String) -> DateFormatter {
+        let threadDict = Thread.current.threadDictionary
+        let timeZone = TimeZone.current
+        let cacheKey = "\(key).\(timeZone.identifier)"
+        if let cached = threadDict[cacheKey] as? DateFormatter {
+            return cached
+        }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timeZone
+        formatter.dateFormat = format
+        threadDict[cacheKey] = formatter
+        return formatter
     }
 }

--- a/Tests/CodexBarTests/CostUsageDecodingTests.swift
+++ b/Tests/CodexBarTests/CostUsageDecodingTests.swift
@@ -332,6 +332,25 @@ struct CostUsageDecodingTests {
     }
 
     @Test
+    func `selects most recent supported month format`() throws {
+        let json = """
+        {
+          "type": "monthly",
+          "data": [
+            { "month": "Dec 2025", "totalTokens": 100, "costUSD": 1.00 },
+            { "month": "January 2026", "totalTokens": 200, "costUSD": 2.00 },
+            { "month": "2026-02", "totalTokens": 300, "costUSD": 3.00 }
+          ]
+        }
+        """
+
+        let report = try JSONDecoder().decode(CostUsageMonthlyReport.self, from: Data(json.utf8))
+        let selected = CostUsageFetcher.selectMostRecentMonth(from: report.data)
+        #expect(selected?.month == "2026-02")
+        #expect(selected?.totalTokens == 300)
+    }
+
+    @Test
     func `token snapshot selects most recent day`() throws {
         let json = """
         {

--- a/Tests/CodexBarTests/CostUsageDecodingTests.swift
+++ b/Tests/CodexBarTests/CostUsageDecodingTests.swift
@@ -351,6 +351,36 @@ struct CostUsageDecodingTests {
     }
 
     @Test
+    func `date parsers handle concurrent mixed formats`() async {
+        let dateInputs = [
+            "2026-02-03T04:05:06.789Z",
+            "2026-02-03T04:05:06Z",
+            "2026-02-03",
+            "Feb 3, 2026",
+        ]
+        let monthInputs = ["Feb 2026", "February 2026", "2026-02"]
+
+        await withTaskGroup(of: Bool.self) { group in
+            for _ in 0..<32 {
+                group.addTask {
+                    for _ in 0..<250 {
+                        guard dateInputs.allSatisfy({ CostUsageDateParser.parse($0) != nil }),
+                              monthInputs.allSatisfy({ CostUsageDateParser.parseMonth($0) != nil })
+                        else {
+                            return false
+                        }
+                    }
+                    return true
+                }
+            }
+
+            for await succeeded in group {
+                #expect(succeeded)
+            }
+        }
+    }
+
+    @Test
     func `token snapshot selects most recent day`() throws {
         let json = """
         {


### PR DESCRIPTION
## Summary

- cache ISO 8601 and localized cost-report date formatters per thread
- preserve current timezone changes in cache keys
- preserve all existing parse formats and precedence
- add mixed-format concurrent parse coverage and changelog credit

## Proof

- `swift test --filter CostUsageDecodingTests` - 19 tests passed after the current-main rebase
- `swift test --filter OpenAIDashboardBrowserCookieImporterTests` - 13 tests passed
- 32 concurrent workers, 56,000 mixed parses: passed in about 2.5 seconds
- direct 14,000-parse benchmark: uncached 2.42 seconds, cached 0.59 seconds, about 4.1x faster
- `make check` passed after the current-main rebase
- whole-branch Codex autoreview clean, confidence 0.85
- exact CI shard 3/4 command passed all 120 groups locally while the Intel hosted shard completed successfully
- prior exact head passed Linux x64/arm64, three macOS shards, and security before its remaining old-base job was cancelled after #1570 made that head conflicting

Exact candidate: `c29f4e5b`.
