### PR TITLE
Cache Pi session parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Antigravity: use current backend quota labels in menus and widgets while preferring a usable quota lane over an exhausted one. Thanks @Yuxin-Qiao!
+- Pi: cache session filename and timestamp parsers to reduce cost-history refresh overhead. Thanks @ProspectOre!
 - Menu bar: reuse the icon-observation signature during provider refreshes instead of computing it twice. Thanks @abe238!
 - LiteLLM: show personal and team spend amounts directly on budget rows while suppressing duplicate budget sections. Thanks @hololee!
 

--- a/Sources/CodexBarCore/PiSessionCostScanner.swift
+++ b/Sources/CodexBarCore/PiSessionCostScanner.swift
@@ -1,5 +1,20 @@
 import Foundation
 
+private final class PiSessionISO8601FormatterBox: @unchecked Sendable {
+    let lock = NSLock()
+    let withFractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    let plain: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+}
+
 enum PiSessionCostScanner {
     struct Options {
         var piSessionsRoot: URL?
@@ -46,6 +61,9 @@ enum PiSessionCostScanner {
     private static let costScale = 1_000_000_000.0
     private static let maxLineBytes = 16 * 1024 * 1024
     private static let maxSafeRoundedInt = Double(Int.max) - 1
+    private static let sessionStartFilenameRegex = try? NSRegularExpression(
+        pattern: "^(\\d{4}-\\d{2}-\\d{2})T(\\d{2})-(\\d{2})-(\\d{2})-(\\d{3})Z_")
+    private static let isoFormatterBox = PiSessionISO8601FormatterBox()
 
     static func loadDailyReport(
         provider: UsageProvider,
@@ -819,8 +837,7 @@ extension PiSessionCostScanner {
     }
 
     private static func parseSessionStartFromFilename(_ filename: String) -> Date? {
-        let pattern = "^(\\d{4}-\\d{2}-\\d{2})T(\\d{2})-(\\d{2})-(\\d{2})-(\\d{3})Z_"
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        guard let regex = self.sessionStartFilenameRegex else { return nil }
         let range = NSRange(filename.startIndex..<filename.endIndex, in: filename)
         guard let match = regex.firstMatch(in: filename, range: range) else { return nil }
         guard (1...5).allSatisfy({ Range(match.range(at: $0), in: filename) != nil }) else { return nil }
@@ -833,14 +850,10 @@ extension PiSessionCostScanner {
     }
 
     private static func parseISO(_ text: String) -> Date? {
-        let withFractional = ISO8601DateFormatter()
-        withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        if let date = withFractional.date(from: text) {
-            return date
-        }
-        let plain = ISO8601DateFormatter()
-        plain.formatOptions = [.withInternetDateTime]
-        return plain.date(from: text)
+        self.isoFormatterBox.lock.lock()
+        defer { self.isoFormatterBox.lock.unlock() }
+        return self.isoFormatterBox.withFractional.date(from: text)
+            ?? self.isoFormatterBox.plain.date(from: text)
     }
 
     private static func localMidnight(_ date: Date) -> Date {


### PR DESCRIPTION
## Summary
- cache the Pi session filename regex instead of recompiling it for each filename
- reuse a locked pair of ISO8601DateFormatter instances for Pi session start parsing
- keep the change private to PiSessionCostScanner and preserve the same filename format and parse order

## Why
Pi session refreshes walk session directories and parse every candidate filename before deciding whether it falls inside the requested scan window. The previous path rebuilt the regular expression and ISO formatters for each filename, which adds avoidable overhead on larger session directories.

## Proof
Local validation, June 16, 2026 PT:

- `.build/lint-tools/bin/swiftformat Sources Tests --lint`
  - `0/1139 files require formatting`
- `.build/lint-tools/bin/swiftlint --strict`
  - `Found 0 violations, 0 serious in 1138 files`
- `swift test --filter PiSessionCostScannerTests`
  - `10 tests in 1 suite passed after 0.066 seconds`
- `swift build --build-tests`
  - `Build complete! (1.08 sec)`
- `git diff --check`
  - passed with no output

Benchmark harness was temporary and is not committed. Both runs used the same public `PiSessionCostScanner.loadDailyReport` path over 2,500 synthetic session filenames, with `swift test --skip-build --filter PiSessionParserBenchmarkTests` for the timed pass.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| fastest scanner pass | 0.678561s | 0.323273s | 2.1x faster |
| command real time | 6.99s | 3.10s | 2.3x faster |
| user CPU | 2.94s | 1.68s | 1.8x lower |
| max RSS | 177,963,008 bytes | 121,094,144 bytes | 32.0% lower |
| peak memory footprint | 29,098,680 bytes | 28,672,696 bytes | 1.5% lower |
| checksum | 2500 | 2500 | unchanged |

## Risk
Low. NSRegularExpression is immutable after construction, and the shared ISO8601DateFormatter pair is protected by an NSLock, matching the existing scanner timestamp-parser pattern elsewhere in the codebase.
