### PR TITLE
Release idle WebViews on memory pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - LiteLLM: show personal and team spend amounts directly on budget rows while suppressing duplicate budget sections. Thanks @hololee!
 
 ### Fixed
+- Memory: release idle OpenAI WebViews under system pressure without blocking the main thread. Thanks @ProspectOre!
 - Codex web: keep cookie-import deadlines responsive when browser cookie work blocks the shared worker pool.
 - Codex pace: extrapolate historically exhausted weeks for run-out forecasts and avoid contradictory reset headlines. Thanks @Yuxin-Qiao!
 - Localization: correct the German in-progress refresh label. Thanks @ChrisLauinger77!

--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -353,6 +353,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let updaterController: UpdaterProviding = makeUpdaterController()
     private let confettiOverlayController = ScreenConfettiOverlayController()
     private let confettiLogger = CodexBarLog.logger(LogCategories.confetti)
+    private let memoryPressureMonitor = MemoryPressureMonitor()
     private var statusController: StatusItemControlling?
     private var store: UsageStore?
     private var settings: SettingsStore?
@@ -380,6 +381,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         AppNotifications.shared.requestAuthorizationOnStartup()
+        self.memoryPressureMonitor.start()
         self.ensureStatusController()
         KeyboardShortcuts.onKeyUp(for: .openMenu) { [weak self] in
             // KeyboardShortcuts dispatches both normal and menu-tracking hotkeys on the main event loop.
@@ -398,6 +400,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        self.memoryPressureMonitor.stop()
         self.statusController?.prepareForAppShutdown()
         self.confettiOverlayController.dismiss()
         self.dismissAppKitWindowsForShutdown()

--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -362,6 +362,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var managedCodexAccountCoordinator: ManagedCodexAccountCoordinator?
     private var codexAccountPromotionCoordinator: CodexAccountPromotionCoordinator?
     private var hasInstalledWeeklyLimitResetObserver = false
+    #if DEBUG
+    private var debugMemoryPressureObserver: NSObjectProtocol?
+    #endif
     var terminateActiveProcessesForAppShutdown: () -> Void = {
         TTYCommandRunner.terminateActiveProcessesForAppShutdown()
     }
@@ -382,6 +385,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         AppNotifications.shared.requestAuthorizationOnStartup()
         self.memoryPressureMonitor.start()
+        #if DEBUG
+        self.installDebugMemoryPressureObserverIfNeeded()
+        #endif
         self.ensureStatusController()
         KeyboardShortcuts.onKeyUp(for: .openMenu) { [weak self] in
             // KeyboardShortcuts dispatches both normal and menu-tracking hotkeys on the main event loop.
@@ -401,6 +407,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         self.memoryPressureMonitor.stop()
+        #if DEBUG
+        self.removeDebugMemoryPressureObserver()
+        #endif
         self.statusController?.prepareForAppShutdown()
         self.confettiOverlayController.dismiss()
         self.dismissAppKitWindowsForShutdown()
@@ -503,6 +512,45 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             fallbackManagedCodexAccountCoordinator,
             fallbackCodexAccountPromotionCoordinator)
     }
+
+    #if DEBUG
+    private func installDebugMemoryPressureObserverIfNeeded() {
+        guard self.debugMemoryPressureObserver == nil else { return }
+        self.debugMemoryPressureObserver = DistributedNotificationCenter.default().addObserver(
+            forName: .codexbarDebugSimulateMemoryPressure,
+            object: nil,
+            queue: .main)
+        { [weak self] notification in
+            let rawLevel = notification.userInfo?["level"] as? String
+            let shouldSeedCaches = notification.userInfo?["seedCaches"] as? String == "1"
+            MainActor.assumeIsolated {
+                self?.handleDebugMemoryPressureNotification(
+                    rawLevel: rawLevel,
+                    shouldSeedCaches: shouldSeedCaches)
+            }
+        }
+    }
+
+    private func removeDebugMemoryPressureObserver() {
+        guard let observer = self.debugMemoryPressureObserver else { return }
+        DistributedNotificationCenter.default().removeObserver(observer)
+        self.debugMemoryPressureObserver = nil
+    }
+
+    private func handleDebugMemoryPressureNotification(rawLevel: String?, shouldSeedCaches: Bool) {
+        let isCritical = rawLevel?.caseInsensitiveCompare("critical") == .orderedSame
+        if shouldSeedCaches {
+            OpenAIDashboardFetcher.seedCachedWebViewsForMemoryPressureProof()
+        }
+        CodexBarLog.logger(LogCategories.memoryPressure).info(
+            "Debug memory pressure notification received",
+            metadata: [
+                "level": isCritical ? "critical" : "warning",
+                "seedCaches": shouldSeedCaches ? "1" : "0",
+            ])
+        self.memoryPressureMonitor.handleMemoryPressureForTesting(isWarning: !isCritical, isCritical: isCritical)
+    }
+    #endif
 
     deinit {
         NotificationCenter.default.removeObserver(self)

--- a/Sources/CodexBar/MemoryPressureMonitor.swift
+++ b/Sources/CodexBar/MemoryPressureMonitor.swift
@@ -1,0 +1,49 @@
+import CodexBarCore
+import Dispatch
+import Foundation
+
+@MainActor
+final class MemoryPressureMonitor {
+    private let logger = CodexBarLog.logger(LogCategories.memoryPressure)
+    private var source: DispatchSourceMemoryPressure?
+
+    func start() {
+        guard self.source == nil else { return }
+
+        let source = DispatchSource.makeMemoryPressureSource(
+            eventMask: [.warning, .critical],
+            queue: .global(qos: .utility))
+        source.setEventHandler { [weak self, weak source] in
+            let event = source?.data ?? []
+            let isWarning = event.contains(.warning)
+            let isCritical = event.contains(.critical)
+            Task { @MainActor [weak self] in
+                self?.handleMemoryPressure(isWarning: isWarning, isCritical: isCritical)
+            }
+        }
+        self.source = source
+        source.resume()
+    }
+
+    func stop() {
+        self.source?.cancel()
+        self.source = nil
+    }
+
+    deinit {
+        self.source?.cancel()
+    }
+
+    private func handleMemoryPressure(isWarning: Bool, isCritical: Bool) {
+        let level = if isCritical {
+            "critical"
+        } else if isWarning {
+            "warning"
+        } else {
+            "normal"
+        }
+        self.logger.warning("System memory pressure", metadata: ["level": level])
+        OpenAIDashboardFetcher.evictIdleCachedWebViews()
+        MemoryPressureRelief.releaseFreeMallocPages()
+    }
+}

--- a/Sources/CodexBar/MemoryPressureMonitor.swift
+++ b/Sources/CodexBar/MemoryPressureMonitor.swift
@@ -49,7 +49,20 @@ final class MemoryPressureMonitor {
             "normal"
         }
         self.logger.warning("System memory pressure", metadata: ["level": level])
+        #if DEBUG
+        let cachedWebViewsBefore = OpenAIDashboardFetcher.cachedWebViewCountForTesting()
+        #endif
         OpenAIDashboardFetcher.evictIdleCachedWebViews()
+        #if DEBUG
+        let cachedWebViewsAfter = OpenAIDashboardFetcher.cachedWebViewCountForTesting()
+        self.logger.info(
+            "Memory pressure OpenAI webview cache",
+            metadata: [
+                "before": "\(cachedWebViewsBefore)",
+                "after": "\(cachedWebViewsAfter)",
+                "evicted": "\(max(0, cachedWebViewsBefore - cachedWebViewsAfter))",
+            ])
+        #endif
         MemoryPressureRelief.releaseFreeMallocPages()
     }
 }

--- a/Sources/CodexBar/MemoryPressureMonitor.swift
+++ b/Sources/CodexBar/MemoryPressureMonitor.swift
@@ -34,6 +34,12 @@ final class MemoryPressureMonitor {
         self.source?.cancel()
     }
 
+    #if DEBUG
+    func handleMemoryPressureForTesting(isWarning: Bool, isCritical: Bool) {
+        self.handleMemoryPressure(isWarning: isWarning, isCritical: isCritical)
+    }
+    #endif
+
     private func handleMemoryPressure(isWarning: Bool, isCritical: Bool) {
         let level = if isCritical {
             "critical"

--- a/Sources/CodexBar/MemoryPressureMonitor.swift
+++ b/Sources/CodexBar/MemoryPressureMonitor.swift
@@ -5,7 +5,14 @@ import Foundation
 @MainActor
 final class MemoryPressureMonitor {
     private let logger = CodexBarLog.logger(LogCategories.memoryPressure)
+    private let releaseFreeMallocPages: @Sendable () -> Void
     private var source: DispatchSourceMemoryPressure?
+
+    init(releaseFreeMallocPages: @escaping @Sendable () -> Void = {
+        MemoryPressureRelief.releaseFreeMallocPages()
+    }) {
+        self.releaseFreeMallocPages = releaseFreeMallocPages
+    }
 
     func start() {
         guard self.source == nil else { return }
@@ -63,6 +70,9 @@ final class MemoryPressureMonitor {
                 "evicted": "\(max(0, cachedWebViewsBefore - cachedWebViewsAfter))",
             ])
         #endif
-        MemoryPressureRelief.releaseFreeMallocPages()
+        let releaseFreeMallocPages = self.releaseFreeMallocPages
+        Task.detached(priority: .utility) {
+            releaseFreeMallocPages()
+        }
     }
 }

--- a/Sources/CodexBar/Notifications+CodexBar.swift
+++ b/Sources/CodexBar/Notifications+CodexBar.swift
@@ -7,6 +7,10 @@ extension Notification.Name {
     static let codexbarWeeklyLimitReset = Notification.Name("codexbarWeeklyLimitReset")
     static let codexbarProviderConfigDidChange = Notification.Name("codexbarProviderConfigDidChange")
     static let codexbarQuotaWarningDidPost = Notification.Name("codexbarQuotaWarningDidPost")
+    #if DEBUG
+    static let codexbarDebugSimulateMemoryPressure =
+        Notification.Name("com.steipete.codexbar.debug.simulateMemoryPressure")
+    #endif
 }
 
 @MainActor

--- a/Sources/CodexBarCore/Logging/LogCategories.swift
+++ b/Sources/CodexBarCore/Logging/LogCategories.swift
@@ -48,6 +48,7 @@ public enum LogCategories {
     public static let manusAPI = "manus-api"
     public static let manusCookie = "manus-cookie"
     public static let manusWeb = "manus-web"
+    public static let memoryPressure = "memory-pressure"
     public static let minimaxAPITokenStore = "minimax-api-token-store"
     public static let minimaxCookie = "minimax-cookie"
     public static let minimaxCookieStore = "minimax-cookie-store"

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -423,6 +423,10 @@ public struct OpenAIDashboardFetcher {
         OpenAIDashboardWebViewCache.shared.evictAll()
     }
 
+    public static func evictIdleCachedWebViews() {
+        OpenAIDashboardWebViewCache.shared.evictIdle()
+    }
+
     public func probeUsagePage(
         websiteDataStore: WKWebsiteDataStore,
         logger: ((String) -> Void)? = nil,

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardFetcher.swift
@@ -427,6 +427,18 @@ public struct OpenAIDashboardFetcher {
         OpenAIDashboardWebViewCache.shared.evictIdle()
     }
 
+    #if DEBUG
+    public static func seedCachedWebViewsForMemoryPressureProof() {
+        OpenAIDashboardWebViewCache.shared.clearAllForTesting()
+        OpenAIDashboardWebViewCache.shared.cacheEntryForTesting(websiteDataStore: .nonPersistent())
+        OpenAIDashboardWebViewCache.shared.cacheEntryForTesting(websiteDataStore: .nonPersistent(), isBusy: true)
+    }
+
+    public static func cachedWebViewCountForTesting() -> Int {
+        OpenAIDashboardWebViewCache.shared.entryCount
+    }
+    #endif
+
     public func probeUsagePage(
         websiteDataStore: WKWebsiteDataStore,
         logger: ((String) -> Void)? = nil,

--- a/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
+++ b/Sources/CodexBarCore/OpenAIWeb/OpenAIDashboardWebViewCache.swift
@@ -469,6 +469,21 @@ final class OpenAIDashboardWebViewCache {
         }
     }
 
+    func evictIdle() {
+        let idleEntries = self.entries.filter { _, entry in
+            !entry.isBusy
+        }
+        guard !idleEntries.isEmpty else { return }
+
+        for (key, entry) in idleEntries {
+            entry.clearPreservedPage()
+            entry.host.close()
+            self.entries.removeValue(forKey: key)
+        }
+        Self.log.debug("OpenAI idle webviews evicted", metadata: ["count": "\(idleEntries.count)"])
+        self.scheduleNextIdlePrune()
+    }
+
     private func prepareCachedWebViewForIdle(
         _ webView: WKWebView,
         host: OffscreenWebViewHost,

--- a/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
@@ -401,6 +401,25 @@ struct OpenAIDashboardWebViewCacheTests {
         #expect(!cache.hasCachedEntry(for: store2), "Second store should be evicted")
     }
 
+    @Test
+    func `Evict idle removes idle WebViews without interrupting busy WebViews`() {
+        if self.shouldSkipOnCI() { return }
+        let cache = OpenAIDashboardWebViewCache()
+        let idleStore = WKWebsiteDataStore.nonPersistent()
+        let busyStore = WKWebsiteDataStore.nonPersistent()
+
+        cache.cacheEntryForTesting(websiteDataStore: idleStore)
+        cache.cacheEntryForTesting(websiteDataStore: busyStore, isBusy: true)
+
+        cache.evictIdle()
+
+        #expect(!cache.hasCachedEntry(for: idleStore), "Idle WebView should be evicted")
+        #expect(cache.hasCachedEntry(for: busyStore), "Busy WebView should remain cached")
+        #expect(cache.entryCount == 1, "Only the busy entry should remain")
+
+        cache.clearAllForTesting()
+    }
+
     // MARK: - Busy WebView Tests
 
     @Test

--- a/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
@@ -420,6 +420,29 @@ struct OpenAIDashboardWebViewCacheTests {
         cache.clearAllForTesting()
     }
 
+    @Test
+    func `Memory pressure monitor evicts idle shared WebViews without interrupting busy WebViews`() {
+        if self.shouldSkipOnCI() { return }
+        let cache = OpenAIDashboardWebViewCache.shared
+        cache.clearAllForTesting()
+        defer { cache.clearAllForTesting() }
+
+        let idleStore = WKWebsiteDataStore.nonPersistent()
+        let busyStore = WKWebsiteDataStore.nonPersistent()
+
+        cache.cacheEntryForTesting(websiteDataStore: idleStore)
+        cache.cacheEntryForTesting(websiteDataStore: busyStore, isBusy: true)
+
+        #expect(cache.entryCount == 2, "Should have one idle entry and one busy entry before pressure")
+
+        let monitor = MemoryPressureMonitor()
+        monitor.handleMemoryPressureForTesting(isWarning: true, isCritical: false)
+
+        #expect(!cache.hasCachedEntry(for: idleStore), "Memory pressure should evict the idle shared WebView")
+        #expect(cache.hasCachedEntry(for: busyStore), "Memory pressure should not interrupt a busy shared WebView")
+        #expect(cache.entryCount == 1, "Only the busy shared entry should remain")
+    }
+
     // MARK: - Busy WebView Tests
 
     @Test

--- a/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
@@ -443,6 +443,22 @@ struct OpenAIDashboardWebViewCacheTests {
         #expect(cache.entryCount == 1, "Only the busy shared entry should remain")
     }
 
+    @Test
+    func `Memory pressure malloc relief runs off the main thread`() async {
+        let probe = MemoryPressureThreadProbe()
+        let monitor = MemoryPressureMonitor {
+            probe.recordCurrentThread()
+        }
+
+        monitor.handleMemoryPressureForTesting(isWarning: true, isCritical: false)
+
+        let completed = await Task.detached {
+            probe.wait(timeout: .now() + 2)
+        }.value
+        #expect(completed)
+        #expect(probe.wasMainThread == false)
+    }
+
     // MARK: - Busy WebView Tests
 
     @Test
@@ -550,5 +566,26 @@ struct OpenAIDashboardWebViewCacheTests {
 
         cache.clearAllForTesting()
         OpenAIDashboardWebsiteDataStore.clearCacheForTesting()
+    }
+}
+
+private final class MemoryPressureThreadProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private let semaphore = DispatchSemaphore(value: 0)
+    private var recordedMainThread: Bool?
+
+    var wasMainThread: Bool? {
+        self.lock.withLock { self.recordedMainThread }
+    }
+
+    func recordCurrentThread() {
+        self.lock.withLock {
+            self.recordedMainThread = Thread.isMainThread
+        }
+        self.semaphore.signal()
+    }
+
+    func wait(timeout: DispatchTime) -> Bool {
+        self.semaphore.wait(timeout: timeout) == .success
     }
 }


### PR DESCRIPTION
## Summary

- Add a macOS memory-pressure monitor for warning and critical pressure events.
- Evict only idle cached OpenAI dashboard WebViews, preserving active refreshes.
- Run allocator pressure relief off the main actor.
- Add focused cache behavior and debug pressure-path coverage.

## Proof

- `swift test --filter OpenAIDashboardWebViewCacheTests` (22 tests passed after the final current-main rebase)
- `make check` (format and lint clean after the final current-main rebase)
- Full branch autoreview: clean, confidence 0.78
- Exact CI shard command for shard 0: all 120 suite groups passed locally after the prior CI runner failure could not be reproduced.
- Fresh DEBUG runtime notification seeded one idle and one busy WebView, drove the production pressure handler, and logged `before=2 after=1 evicted=1`; the app remained alive.
- Fresh development-signed package launched successfully. Packaging-only Xcode project rewrites were removed.

Exact candidate: `6a82264f`
