### PR TITLE
Bound subprocess output capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - LiteLLM: show personal and team spend amounts directly on budget rows while suppressing duplicate budget sections. Thanks @hololee!
 
 ### Fixed
+- Provider probes: cap captured subprocess output at 1 MiB per stream without dropping valid text at a truncated UTF-8 boundary. Thanks @ProspectOre!
 - Provider switcher: keep Codex quota rows visible when switching away and back during a manual refresh, including menus with usage-history sections. Thanks @Yuxin-Qiao!
 - Bedrock: ignore invalid billing dates when selecting the latest usage values. Thanks @ProspectOre!
 - Localization: improve Japanese terminology consistency and localize next-day reset times across all 21 app languages. Thanks @tukuyomil032!

--- a/Sources/CodexBar/CodexLoginRunner.swift
+++ b/Sources/CodexBar/CodexLoginRunner.swift
@@ -188,6 +188,6 @@ struct CodexLoginRunner {
     }
 
     private static func decode(_ data: Data) -> String {
-        String(decoding: data, as: UTF8.self)
+        ProcessPipeCapture.decodeUTF8(data)
     }
 }

--- a/Sources/CodexBar/CodexLoginRunner.swift
+++ b/Sources/CodexBar/CodexLoginRunner.swift
@@ -188,7 +188,6 @@ struct CodexLoginRunner {
     }
 
     private static func decode(_ data: Data) -> String {
-        guard let text = String(data: data, encoding: .utf8) else { return "" }
-        return text
+        String(decoding: data, as: UTF8.self)
     }
 }

--- a/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
+++ b/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
@@ -59,6 +59,12 @@ package final class ProcessPipeCapture: @unchecked Sendable {
         return self.didReachEOF
     }
 
+    package static func decodeUTF8(_ data: Data) -> String {
+        // A byte cap can split the final scalar; lossy decoding preserves the valid captured prefix.
+        // swiftlint:disable:next optional_data_string_conversion
+        String(decoding: data, as: UTF8.self)
+    }
+
     private func handleReadableData(from handle: FileHandle) {
         self.condition.lock()
         guard !self.isStopping else {

--- a/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
+++ b/Sources/CodexBarCore/Host/Process/ProcessPipeCapture.swift
@@ -1,8 +1,11 @@
 import Foundation
 
 package final class ProcessPipeCapture: @unchecked Sendable {
+    package static let defaultMaxBytes = 1 * 1024 * 1024
+
     private let handle: FileHandle
     private let onData: (@Sendable () -> Void)?
+    private let maxBytes: Int
     private let condition = NSCondition()
     private var data = Data()
     private var activeCallbacks = 0
@@ -11,8 +14,13 @@ package final class ProcessPipeCapture: @unchecked Sendable {
     private var isStopping = false
     private var continuation: CheckedContinuation<Void, Never>?
 
-    package init(pipe: Pipe, onData: (@Sendable () -> Void)? = nil) {
+    package init(
+        pipe: Pipe,
+        maxBytes: Int = ProcessPipeCapture.defaultMaxBytes,
+        onData: (@Sendable () -> Void)? = nil)
+    {
         self.handle = pipe.fileHandleForReading
+        self.maxBytes = max(0, maxBytes)
         self.onData = onData
     }
 
@@ -70,7 +78,10 @@ package final class ProcessPipeCapture: @unchecked Sendable {
             continuation = self.continuation
             self.continuation = nil
         } else {
-            self.data.append(chunk)
+            let remainingBytes = max(0, self.maxBytes - self.data.count)
+            if remainingBytes > 0 {
+                self.data.append(chunk.prefix(remainingBytes))
+            }
         }
         self.activeCallbacks -= 1
         if self.activeCallbacks == 0 {

--- a/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
+++ b/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
@@ -244,8 +244,8 @@ public enum SubprocessRunner {
 
             async let stdoutData = stdoutCapture.finish(timeout: .seconds(1))
             async let stderrData = stderrCapture.finish(timeout: .seconds(1))
-            let stdout = await String(decoding: stdoutData, as: UTF8.self)
-            let stderr = await String(decoding: stderrData, as: UTF8.self)
+            let stdout = await ProcessPipeCapture.decodeUTF8(stdoutData)
+            let stderr = await ProcessPipeCapture.decodeUTF8(stderrData)
 
             if exitCode != 0 {
                 let duration = Date().timeIntervalSince(start)

--- a/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
+++ b/Sources/CodexBarCore/Host/Process/SubprocessRunner.swift
@@ -244,8 +244,8 @@ public enum SubprocessRunner {
 
             async let stdoutData = stdoutCapture.finish(timeout: .seconds(1))
             async let stderrData = stderrCapture.finish(timeout: .seconds(1))
-            let stdout = await String(data: stdoutData, encoding: .utf8) ?? ""
-            let stderr = await String(data: stderrData, encoding: .utf8) ?? ""
+            let stdout = await String(decoding: stdoutData, as: UTF8.self)
+            let stderr = await String(decoding: stderrData, as: UTF8.self)
 
             if exitCode != 0 {
                 let duration = Date().timeIntervalSince(start)

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
@@ -1140,7 +1140,7 @@ extension GeminiStatusProbe {
 
         let data = stdoutCapture.finishSynchronously(timeout: 1)
         stderrCapture.stop()
-        let output = String(decoding: data, as: UTF8.self)
+        let output = ProcessPipeCapture.decodeUTF8(data)
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard process.terminationStatus == 0, !output.isEmpty else {
             return nil

--- a/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Gemini/GeminiStatusProbe.swift
@@ -1140,11 +1140,9 @@ extension GeminiStatusProbe {
 
         let data = stdoutCapture.finishSynchronously(timeout: 1)
         stderrCapture.stop()
-        guard process.terminationStatus == 0,
-              let output = String(data: data, encoding: .utf8)?
-                  .trimmingCharacters(in: .whitespacesAndNewlines),
-                  !output.isEmpty
-        else {
+        let output = String(decoding: data, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard process.terminationStatus == 0, !output.isEmpty else {
             return nil
         }
 

--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -506,8 +506,8 @@ public struct KiroStatusProbe: Sendable {
             throw KiroStatusProbeError.timeout
         }
         return KiroCLIResult(
-            stdout: String(decoding: output.stdout, as: UTF8.self),
-            stderr: String(decoding: output.stderr, as: UTF8.self),
+            stdout: ProcessPipeCapture.decodeUTF8(output.stdout),
+            stderr: ProcessPipeCapture.decodeUTF8(output.stderr),
             terminationStatus: terminationStatus,
             terminatedForIdle: didTerminateForIdle)
     }

--- a/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Kiro/KiroStatusProbe.swift
@@ -506,8 +506,8 @@ public struct KiroStatusProbe: Sendable {
             throw KiroStatusProbeError.timeout
         }
         return KiroCLIResult(
-            stdout: String(data: output.stdout, encoding: .utf8) ?? "",
-            stderr: String(data: output.stderr, encoding: .utf8) ?? "",
+            stdout: String(decoding: output.stdout, as: UTF8.self),
+            stderr: String(decoding: output.stderr, as: UTF8.self),
             terminationStatus: terminationStatus,
             terminatedForIdle: didTerminateForIdle)
     }

--- a/Sources/CodexBarCore/Providers/ProviderVersionDetector.swift
+++ b/Sources/CodexBarCore/Providers/ProviderVersionDetector.swift
@@ -89,7 +89,7 @@ public enum ProviderVersionDetector {
 
         let data = outputCapture.finishSynchronously(timeout: 0.25)
         guard proc.terminationStatus == 0,
-              let text = String(data: data, encoding: .utf8)?
+              let text = String(decoding: data, as: UTF8.self)
                   .split(whereSeparator: \.isNewline).first
         else { return nil }
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/CodexBarCore/Providers/ProviderVersionDetector.swift
+++ b/Sources/CodexBarCore/Providers/ProviderVersionDetector.swift
@@ -89,7 +89,7 @@ public enum ProviderVersionDetector {
 
         let data = outputCapture.finishSynchronously(timeout: 0.25)
         guard proc.terminationStatus == 0,
-              let text = String(decoding: data, as: UTF8.self)
+              let text = ProcessPipeCapture.decodeUTF8(data)
                   .split(whereSeparator: \.isNewline).first
         else { return nil }
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Tests/CodexBarTests/SubprocessRunnerTests.swift
+++ b/Tests/CodexBarTests/SubprocessRunnerTests.swift
@@ -23,6 +23,41 @@ struct SubprocessRunnerTests {
     }
 
     @Test
+    func `bounds oversized stdout while continuing to drain`() async throws {
+        let result = try await SubprocessRunner.run(
+            binary: "/usr/bin/python3",
+            arguments: ["-c", "print('x' * 2_000_000)"],
+            environment: ProcessInfo.processInfo.environment,
+            timeout: 5,
+            label: "python oversized stdout")
+
+        #expect(result.stdout.utf8.count == ProcessPipeCapture.defaultMaxBytes)
+        #expect(result.stderr.isEmpty)
+    }
+
+    @Test
+    func `bounds oversized stderr on failure`() async throws {
+        do {
+            _ = try await SubprocessRunner.run(
+                binary: "/usr/bin/python3",
+                arguments: ["-c", "import sys; sys.stderr.write('e' * 2_000_000); sys.exit(7)"],
+                environment: ProcessInfo.processInfo.environment,
+                timeout: 5,
+                label: "python oversized stderr")
+            Issue.record("Expected non-zero exit")
+        } catch let error as SubprocessRunnerError {
+            guard case let .nonZeroExit(code, stderr) = error else {
+                Issue.record("Expected non-zero exit, got \(error)")
+                return
+            }
+            #expect(code == 7)
+            #expect(stderr.utf8.count == ProcessPipeCapture.defaultMaxBytes)
+        } catch {
+            Issue.record("Expected SubprocessRunnerError, got \(error)")
+        }
+    }
+
+    @Test
     func `returns partial output when detached child keeps pipes open`() async throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("codexbar-subprocess-drain-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/CodexBarTests/SubprocessRunnerTests.swift
+++ b/Tests/CodexBarTests/SubprocessRunnerTests.swift
@@ -36,6 +36,45 @@ struct SubprocessRunnerTests {
     }
 
     @Test
+    func `preserves captured prefix when limit splits three byte scalar`() async throws {
+        let asciiCount = ProcessPipeCapture.defaultMaxBytes - 1
+        let script = "import sys; sys.stdout.buffer.write(b'x' * \(asciiCount) + bytes([0xe2, 0x82, 0xac]) + b'tail')"
+        let result = try await SubprocessRunner.run(
+            binary: "/usr/bin/python3",
+            arguments: ["-c", script],
+            environment: ProcessInfo.processInfo.environment,
+            timeout: 5,
+            label: "python split utf8 stdout")
+
+        #expect(result.stdout.count == ProcessPipeCapture.defaultMaxBytes)
+        #expect(result.stdout.first == "x")
+        #expect(result.stdout.last == "\u{FFFD}")
+        #expect(result.stdout.utf8.count == ProcessPipeCapture.defaultMaxBytes + 2)
+    }
+
+    @Test
+    func `bounds simultaneous oversized stdout and stderr while draining`() async throws {
+        let script = """
+        import sys
+        chunk = 2048
+        for _ in range(2000):
+            sys.stdout.write('o' * chunk)
+            sys.stdout.flush()
+            sys.stderr.write('e' * chunk)
+            sys.stderr.flush()
+        """
+        let result = try await SubprocessRunner.run(
+            binary: "/usr/bin/python3",
+            arguments: ["-c", script],
+            environment: ProcessInfo.processInfo.environment,
+            timeout: 10,
+            label: "python simultaneous oversized output")
+
+        #expect(result.stdout.utf8.count == ProcessPipeCapture.defaultMaxBytes)
+        #expect(result.stderr.utf8.count == ProcessPipeCapture.defaultMaxBytes)
+    }
+
+    @Test
     func `bounds oversized stderr on failure`() async throws {
         do {
             _ = try await SubprocessRunner.run(


### PR DESCRIPTION
## Summary

- Cap each subprocess stdout/stderr capture at 1 MiB while continuing to drain the pipe.
- Keep the existing default call sites intact with an optional capture limit for tests or future callers.
- Add regression coverage for oversized stdout and stderr.

## Why

A noisy or wedged provider CLI could previously append unbounded output into memory. The status, version, credential, and login probes using this path expect small strings or JSON, so bounded diagnostics are enough; continuing to drain the pipe keeps oversized-output children from blocking.

## Impact

This is a shared subprocess guardrail, not a provider-specific change. It covers the common pipe-capture path used by provider version detection, Codex login, Claude direct usage, Gemini process probes, Kiro status probing, Antigravity process/port probing, Bedrock AWS credential export, Vertex `gcloud` token lookup, Amp usage, and Auggie account status. Normal status, token, credential, and version outputs are small; the cap is meant to stop pathological or noisy child processes from growing CodexBar memory without bound while still draining the pipe so the child cannot deadlock.

## Proof

- `swift test --filter SubprocessRunnerTests` passed, 10 tests.
- `.build/lint-tools/bin/swiftformat Sources Tests --lint` passed, 0/1139 files required formatting.
- `.build/lint-tools/bin/swiftlint --strict` passed, 0 violations.
- `swift build --build-tests` passed.
- `git diff --check` passed.
- Before/after harness compiled `ProcessPipeCapture` plus `BoundedTaskJoin` from `upstream/main` and this branch, then streamed `64,000,000` stdout bytes through `/usr/bin/python3`:
  - Before: captured `64,000,000` bytes; benchmark `phys_peak=68,256,272`; `/usr/bin/time -l` peak memory footprint `68,338,240`; max RSS `72,990,720`.
  - After: captured `1,048,576` bytes; benchmark `phys_peak=3,342,792`; `/usr/bin/time -l` peak memory footprint `3,441,144`; max RSS `9,781,248`.
- `make check` local blocker: Node v25.9.0 rejects `node --check docs/site.js` because the file is ESM while the package is not marked as a module. `upstream/main:docs/site.js` starts with the same ESM import, so this is not introduced by this patch.