### PR TITLE
Trim app caches on memory pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 - Memory: release idle OpenAI WebViews under system pressure without blocking the main thread. Thanks @ProspectOre!
+- Memory: trim rebuildable menu and OpenAI debug caches under system pressure. Thanks @ProspectOre!
 - Codex web: keep cookie-import deadlines responsive when browser cookie work blocks the shared worker pool.
 - Codex pace: extrapolate historically exhausted weeks for run-out forecasts and avoid contradictory reset headlines. Thanks @Yuxin-Qiao!
 - Localization: correct the German in-progress refresh label. Thanks @ChrisLauinger77!

--- a/Sources/CodexBar/CodexbarApp.swift
+++ b/Sources/CodexBar/CodexbarApp.swift
@@ -353,7 +353,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let updaterController: UpdaterProviding = makeUpdaterController()
     private let confettiOverlayController = ScreenConfettiOverlayController()
     private let confettiLogger = CodexBarLog.logger(LogCategories.confetti)
-    private let memoryPressureMonitor = MemoryPressureMonitor()
+    private lazy var memoryPressureMonitor = MemoryPressureMonitor(trimAppCaches: { [weak self] in
+        self?.trimRebuildableCachesForMemoryPressure() ?? MemoryPressureCacheTrimSummary()
+    })
+
     private var statusController: StatusItemControlling?
     private var store: UsageStore?
     private var settings: SettingsStore?
@@ -513,6 +516,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             fallbackCodexAccountPromotionCoordinator)
     }
 
+    private func trimRebuildableCachesForMemoryPressure() -> MemoryPressureCacheTrimSummary {
+        var summary = MemoryPressureCacheTrimSummary()
+        let statusSummary = self.statusController?.trimRebuildableCachesForMemoryPressure()
+            ?? MemoryPressureCacheTrimSummary()
+        let storeSummary = self.store?.trimRebuildableCachesForMemoryPressure()
+            ?? MemoryPressureCacheTrimSummary()
+        summary.merge(statusSummary)
+        summary.merge(storeSummary)
+        return summary
+    }
+
     #if DEBUG
     private func installDebugMemoryPressureObserverIfNeeded() {
         guard self.debugMemoryPressureObserver == nil else { return }
@@ -541,6 +555,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let isCritical = rawLevel?.caseInsensitiveCompare("critical") == .orderedSame
         if shouldSeedCaches {
             OpenAIDashboardFetcher.seedCachedWebViewsForMemoryPressureProof()
+            self.statusController?.seedRebuildableCachesForMemoryPressureProof()
+            self.store?.seedRebuildableCachesForMemoryPressureProof()
         }
         CodexBarLog.logger(LogCategories.memoryPressure).info(
             "Debug memory pressure notification received",

--- a/Sources/CodexBar/MemoryPressureMonitor.swift
+++ b/Sources/CodexBar/MemoryPressureMonitor.swift
@@ -3,14 +3,57 @@ import Dispatch
 import Foundation
 
 @MainActor
+struct MemoryPressureCacheTrimSummary: Equatable {
+    var menuCardHeights = 0
+    var menuWidths = 0
+    var mergedSwitcherSelections = 0
+    var recycledMenuCardViews = 0
+    var openAIWebDebugLines = 0
+
+    var total: Int {
+        self.menuCardHeights +
+            self.menuWidths +
+            self.mergedSwitcherSelections +
+            self.recycledMenuCardViews +
+            self.openAIWebDebugLines
+    }
+
+    var metadata: [String: String] {
+        [
+            "menuCardHeights": "\(self.menuCardHeights)",
+            "menuWidths": "\(self.menuWidths)",
+            "mergedSwitcherSelections": "\(self.mergedSwitcherSelections)",
+            "recycledMenuCardViews": "\(self.recycledMenuCardViews)",
+            "openAIWebDebugLines": "\(self.openAIWebDebugLines)",
+            "total": "\(self.total)",
+        ]
+    }
+
+    mutating func merge(_ other: MemoryPressureCacheTrimSummary) {
+        self.menuCardHeights += other.menuCardHeights
+        self.menuWidths += other.menuWidths
+        self.mergedSwitcherSelections += other.mergedSwitcherSelections
+        self.recycledMenuCardViews += other.recycledMenuCardViews
+        self.openAIWebDebugLines += other.openAIWebDebugLines
+    }
+}
+
+@MainActor
 final class MemoryPressureMonitor {
+    typealias CacheTrimHandler = @MainActor () -> MemoryPressureCacheTrimSummary
+
     private let logger = CodexBarLog.logger(LogCategories.memoryPressure)
     private let releaseFreeMallocPages: @Sendable () -> Void
+    private let trimAppCaches: CacheTrimHandler
     private var source: DispatchSourceMemoryPressure?
 
-    init(releaseFreeMallocPages: @escaping @Sendable () -> Void = {
-        MemoryPressureRelief.releaseFreeMallocPages()
-    }) {
+    init(
+        trimAppCaches: @escaping CacheTrimHandler = { MemoryPressureCacheTrimSummary() },
+        releaseFreeMallocPages: @escaping @Sendable () -> Void = {
+            MemoryPressureRelief.releaseFreeMallocPages()
+        })
+    {
+        self.trimAppCaches = trimAppCaches
         self.releaseFreeMallocPages = releaseFreeMallocPages
     }
 
@@ -70,6 +113,10 @@ final class MemoryPressureMonitor {
                 "evicted": "\(max(0, cachedWebViewsBefore - cachedWebViewsAfter))",
             ])
         #endif
+        let trimSummary = self.trimAppCaches()
+        if trimSummary.total > 0 {
+            self.logger.info("Trimmed app caches for memory pressure", metadata: trimSummary.metadata)
+        }
         let releaseFreeMallocPages = self.releaseFreeMallocPages
         Task.detached(priority: .utility) {
             releaseFreeMallocPages()

--- a/Sources/CodexBar/Notifications+CodexBar.swift
+++ b/Sources/CodexBar/Notifications+CodexBar.swift
@@ -4,13 +4,13 @@ import Foundation
 extension Notification.Name {
     static let codexbarOpenSettings = Notification.Name("codexbarOpenSettings")
     static let codexbarDebugBlinkNow = Notification.Name("codexbarDebugBlinkNow")
-    static let codexbarWeeklyLimitReset = Notification.Name("codexbarWeeklyLimitReset")
-    static let codexbarProviderConfigDidChange = Notification.Name("codexbarProviderConfigDidChange")
-    static let codexbarQuotaWarningDidPost = Notification.Name("codexbarQuotaWarningDidPost")
     #if DEBUG
     static let codexbarDebugSimulateMemoryPressure =
         Notification.Name("com.steipete.codexbar.debug.simulateMemoryPressure")
     #endif
+    static let codexbarWeeklyLimitReset = Notification.Name("codexbarWeeklyLimitReset")
+    static let codexbarProviderConfigDidChange = Notification.Name("codexbarProviderConfigDidChange")
+    static let codexbarQuotaWarningDidPost = Notification.Name("codexbarQuotaWarningDidPost")
 }
 
 @MainActor

--- a/Sources/CodexBar/StatusItemController+MemoryPressure.swift
+++ b/Sources/CodexBar/StatusItemController+MemoryPressure.swift
@@ -1,4 +1,5 @@
-import Foundation
+import AppKit
+import CodexBarCore
 
 extension StatusItemController {
     func trimRebuildableCachesForMemoryPressure() -> MemoryPressureCacheTrimSummary {
@@ -18,4 +19,31 @@ extension StatusItemController {
 
         return summary
     }
+
+    #if DEBUG
+    func seedRebuildableCachesForMemoryPressureProof() {
+        let menu = NSMenu()
+        let cacheEntry = CachedMergedSwitcherMenuContent(
+            requiredMenuContentVersion: self.menuSession.contentVersion,
+            menuWidth: 300,
+            codexAccountDisplay: nil,
+            tokenAccountDisplay: nil,
+            localizationSignature: self.menuLocalizationSignature(),
+            items: [])
+        self.menuCardHeightCache[
+            MenuCardHeightCacheKey(
+                id: "debug-memory-pressure-card",
+                scope: UsageProvider.codex.rawValue,
+                width: 30000,
+                textScale: Self.menuCardHeightTextScaleToken(),
+                fingerprint: "debug-memory-pressure"),
+        ] = 44
+        self.measuredStandardMenuWidthCache["debug-memory-pressure-width"] = 300
+        self.mergedSwitcherContentCaches[ObjectIdentifier(menu)] = [
+            .overview: cacheEntry,
+            .provider(.codex): cacheEntry,
+        ]
+        self.menuCardViewRecyclePool["debug-memory-pressure-card"] = NSView()
+    }
+    #endif
 }

--- a/Sources/CodexBar/StatusItemController+MemoryPressure.swift
+++ b/Sources/CodexBar/StatusItemController+MemoryPressure.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension StatusItemController {
+    func trimRebuildableCachesForMemoryPressure() -> MemoryPressureCacheTrimSummary {
+        let mergedSwitcherSelectionCount = self.mergedSwitcherContentCaches.values.reduce(0) { total, entries in
+            total + entries.count
+        }
+        let summary = MemoryPressureCacheTrimSummary(
+            menuCardHeights: self.menuCardHeightCache.count,
+            menuWidths: self.measuredStandardMenuWidthCache.count,
+            mergedSwitcherSelections: mergedSwitcherSelectionCount,
+            recycledMenuCardViews: self.menuCardViewRecyclePool.count)
+
+        self.menuCardHeightCache.removeAll(keepingCapacity: false)
+        self.measuredStandardMenuWidthCache.removeAll(keepingCapacity: false)
+        self.mergedSwitcherContentCaches.removeAll(keepingCapacity: false)
+        self.menuCardViewRecyclePool.removeAll(keepingCapacity: false)
+
+        return summary
+    }
+}

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -10,12 +10,17 @@ protocol StatusItemControlling: AnyObject {
     func openMenuFromShortcut()
     func runLoginFlowFromSettings(provider: UsageProvider) async
     func celebrationOriginPoint(for provider: UsageProvider?) -> CGPoint?
+    func trimRebuildableCachesForMemoryPressure() -> MemoryPressureCacheTrimSummary
     func prepareForAppShutdown()
 }
 
 extension StatusItemControlling {
     func celebrationOriginPoint(for provider: UsageProvider?) -> CGPoint? {
         nil
+    }
+
+    func trimRebuildableCachesForMemoryPressure() -> MemoryPressureCacheTrimSummary {
+        MemoryPressureCacheTrimSummary()
     }
 
     func prepareForAppShutdown() {}

--- a/Sources/CodexBar/StatusItemController.swift
+++ b/Sources/CodexBar/StatusItemController.swift
@@ -11,6 +11,9 @@ protocol StatusItemControlling: AnyObject {
     func runLoginFlowFromSettings(provider: UsageProvider) async
     func celebrationOriginPoint(for provider: UsageProvider?) -> CGPoint?
     func trimRebuildableCachesForMemoryPressure() -> MemoryPressureCacheTrimSummary
+    #if DEBUG
+    func seedRebuildableCachesForMemoryPressureProof()
+    #endif
     func prepareForAppShutdown()
 }
 
@@ -22,6 +25,10 @@ extension StatusItemControlling {
     func trimRebuildableCachesForMemoryPressure() -> MemoryPressureCacheTrimSummary {
         MemoryPressureCacheTrimSummary()
     }
+
+    #if DEBUG
+    func seedRebuildableCachesForMemoryPressureProof() {}
+    #endif
 
     func prepareForAppShutdown() {}
 }

--- a/Sources/CodexBar/UsageStore+MemoryPressure.swift
+++ b/Sources/CodexBar/UsageStore+MemoryPressure.swift
@@ -26,4 +26,14 @@ extension UsageStore {
 
         return summary
     }
+
+    #if DEBUG
+    func seedRebuildableCachesForMemoryPressureProof() {
+        self.openAIWebDebugLines = [
+            "debug memory pressure line 1",
+            "debug memory pressure line 2",
+        ]
+        self.openAIDashboardCookieImportDebugLog = self.openAIWebDebugLines.joined(separator: "\n")
+    }
+    #endif
 }

--- a/Sources/CodexBar/UsageStore+MemoryPressure.swift
+++ b/Sources/CodexBar/UsageStore+MemoryPressure.swift
@@ -16,4 +16,14 @@ extension UsageStore {
             }
         }
     }
+
+    func trimRebuildableCachesForMemoryPressure() -> MemoryPressureCacheTrimSummary {
+        let openAIWebDebugLineCount = self.openAIWebDebugLines.count
+        let summary = MemoryPressureCacheTrimSummary(openAIWebDebugLines: openAIWebDebugLineCount)
+
+        self.openAIWebDebugLines.removeAll(keepingCapacity: false)
+        self.openAIDashboardCookieImportDebugLog = nil
+
+        return summary
+    }
 }

--- a/Tests/CodexBarTests/MemoryPressureCacheTrimTests.swift
+++ b/Tests/CodexBarTests/MemoryPressureCacheTrimTests.swift
@@ -1,21 +1,31 @@
 import AppKit
 import CodexBarCore
+import Dispatch
 import Testing
 @testable import CodexBar
 
 @MainActor
 struct MemoryPressureCacheTrimTests {
     @Test
-    func `memory pressure monitor invokes app cache trim handler`() {
+    func `memory pressure monitor invokes app cache trim and allocator relief handlers`() async {
         var handlerCalls = 0
-        let monitor = MemoryPressureMonitor(trimAppCaches: {
-            handlerCalls += 1
-            return MemoryPressureCacheTrimSummary(menuCardHeights: 1)
-        })
+        let releaseProbe = MemoryPressureReleaseProbe()
+        let monitor = MemoryPressureMonitor(
+            trimAppCaches: {
+                handlerCalls += 1
+                return MemoryPressureCacheTrimSummary(menuCardHeights: 1)
+            },
+            releaseFreeMallocPages: {
+                releaseProbe.signal()
+            })
 
         monitor.handleMemoryPressureForTesting(isWarning: true, isCritical: false)
 
         #expect(handlerCalls == 1)
+        let releaseCompleted = await Task.detached {
+            releaseProbe.wait(timeout: .now() + 2)
+        }.value
+        #expect(releaseCompleted)
     }
 
     @Test
@@ -117,5 +127,17 @@ struct MemoryPressureCacheTrimTests {
         settings.mergeIcons = false
         settings.providerDetectionCompleted = true
         return settings
+    }
+}
+
+private final class MemoryPressureReleaseProbe: @unchecked Sendable {
+    private let semaphore = DispatchSemaphore(value: 0)
+
+    func signal() {
+        self.semaphore.signal()
+    }
+
+    func wait(timeout: DispatchTime) -> Bool {
+        self.semaphore.wait(timeout: timeout) == .success
     }
 }

--- a/Tests/CodexBarTests/MemoryPressureCacheTrimTests.swift
+++ b/Tests/CodexBarTests/MemoryPressureCacheTrimTests.swift
@@ -1,0 +1,121 @@
+import AppKit
+import CodexBarCore
+import Testing
+@testable import CodexBar
+
+@MainActor
+struct MemoryPressureCacheTrimTests {
+    @Test
+    func `memory pressure monitor invokes app cache trim handler`() {
+        var handlerCalls = 0
+        let monitor = MemoryPressureMonitor(trimAppCaches: {
+            handlerCalls += 1
+            return MemoryPressureCacheTrimSummary(menuCardHeights: 1)
+        })
+
+        monitor.handleMemoryPressureForTesting(isWarning: true, isCritical: false)
+
+        #expect(handlerCalls == 1)
+    }
+
+    @Test
+    func `status controller trims rebuildable menu caches on memory pressure`() {
+        let controller = self.makeController()
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let key = StatusItemController.MenuCardHeightCacheKey(
+            id: "card",
+            scope: UsageProvider.codex.rawValue,
+            width: 30000,
+            textScale: StatusItemController.menuCardHeightTextScaleToken(),
+            fingerprint: "content:stable")
+        let menu = NSMenu()
+        let entry = CachedMergedSwitcherMenuContent(
+            requiredMenuContentVersion: 0,
+            menuWidth: 300,
+            codexAccountDisplay: nil,
+            tokenAccountDisplay: nil,
+            localizationSignature: "",
+            items: [])
+
+        controller.menuCardHeightCache[key] = 42
+        controller.measuredStandardMenuWidthCache["width"] = 300
+        controller.mergedSwitcherContentCaches[ObjectIdentifier(menu)] = [
+            .overview: entry,
+            .provider(.codex): entry,
+        ]
+        controller.menuCardViewRecyclePool["card"] = NSView()
+
+        let summary = controller.trimRebuildableCachesForMemoryPressure()
+
+        #expect(summary.menuCardHeights == 1)
+        #expect(summary.menuWidths == 1)
+        #expect(summary.mergedSwitcherSelections == 2)
+        #expect(summary.recycledMenuCardViews == 1)
+        #expect(controller.menuCardHeightCache.isEmpty)
+        #expect(controller.measuredStandardMenuWidthCache.isEmpty)
+        #expect(controller.mergedSwitcherContentCaches.isEmpty)
+        #expect(controller.menuCardViewRecyclePool.isEmpty)
+    }
+
+    @Test
+    func `usage store trims OpenAI web debug cache without interrupting active refresh state`() {
+        let store = self.makeStore()
+        let taskToken = UUID()
+
+        store.openAIWebDebugLines = ["line 1", "line 2", "line 3"]
+        store.openAIDashboardCookieImportDebugLog = "line 1\nline 2\nline 3"
+        store.isRefreshing = true
+        store.refreshingProviders = [.codex]
+        store.tokenRefreshInFlight = [.codex]
+        store.openAIDashboardRefreshTaskKey = "codex@example.com:manual"
+        store.openAIDashboardRefreshTaskToken = taskToken
+
+        let summary = store.trimRebuildableCachesForMemoryPressure()
+
+        #expect(summary.openAIWebDebugLines == 3)
+        #expect(store.openAIWebDebugLines.isEmpty)
+        #expect(store.openAIDashboardCookieImportDebugLog == nil)
+        #expect(store.isRefreshing)
+        #expect(store.refreshingProviders == [.codex])
+        #expect(store.tokenRefreshInFlight == [.codex])
+        #expect(store.openAIDashboardRefreshTaskKey == "codex@example.com:manual")
+        #expect(store.openAIDashboardRefreshTaskToken == taskToken)
+    }
+
+    private func makeController() -> StatusItemController {
+        let settings = self.makeSettings()
+        let store = self.makeStore(settings: settings)
+        return StatusItemController(
+            store: store,
+            settings: settings,
+            account: AccountInfo(email: nil, plan: nil),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+    }
+
+    private func makeStore(settings: SettingsStore? = nil) -> UsageStore {
+        let resolvedSettings = settings ?? self.makeSettings()
+        return UsageStore(
+            fetcher: UsageFetcher(),
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            settings: resolvedSettings)
+    }
+
+    private func makeSettings() -> SettingsStore {
+        let suite = "MemoryPressureCacheTrimTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let settings = SettingsStore(
+            userDefaults: defaults,
+            configStore: testConfigStore(suiteName: suite),
+            zaiTokenStore: NoopZaiTokenStore(),
+            syntheticTokenStore: NoopSyntheticTokenStore())
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+        settings.providerDetectionCompleted = true
+        return settings
+    }
+}

--- a/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
+++ b/Tests/CodexBarTests/OpenAIDashboardWebViewCacheTests.swift
@@ -446,9 +446,9 @@ struct OpenAIDashboardWebViewCacheTests {
     @Test
     func `Memory pressure malloc relief runs off the main thread`() async {
         let probe = MemoryPressureThreadProbe()
-        let monitor = MemoryPressureMonitor {
+        let monitor = MemoryPressureMonitor(releaseFreeMallocPages: {
             probe.recordCurrentThread()
-        }
+        })
 
         monitor.handleMemoryPressureForTesting(isWarning: true, isCritical: false)
 


### PR DESCRIPTION
## Summary

- Trim rebuildable menu sizing/content caches and the transient menu-card recycle pool on macOS memory pressure.
- Clear OpenAI web debug buffers without changing provider, auth, session, usage, or refresh state.
- Keep all AppKit/UI cache mutation on the main actor while #1575 keeps allocator relief off the main thread.

Restacked as three incremental commits on landed #1575 (`f6f76ff9`).

## Proof

- `swift test --filter 'MemoryPressureCacheTrimTests|OpenAIDashboardWebViewCacheTests'`: 25 tests passed on the final restack.
- Combined regression proves one pressure event invokes app-cache trim and detached allocator relief handlers.
- Cache regression proves debug buffers clear while active refresh, provider, token refresh, task key, and task token state remain intact.
- `make check`: passed; SwiftLint found 0 violations.
- Full incremental branch autoreview against current `main`: clean, confidence 0.84.

## Live proof

Fresh debug executable; seeded pressure notification through `com.steipete.codexbar.debug.simulateMemoryPressure`:

```text
Debug memory pressure notification received (level=warning seedCaches=1)
Memory pressure OpenAI webview cache (after=1 before=2 evicted=1)
Trimmed app caches for memory pressure (menuCardHeights=1 menuWidths=1 mergedSwitcherSelections=2 openAIWebDebugLines=2 recycledMenuCardViews=1 total=7)
```

The app remained running after the pressure event.

## Review

- Rebased only the incremental contributor commits onto repaired #1575.
- Combined the cache-trim and off-main allocator-relief initializer paths with explicit labels.
- Added separate contributor changelog credit.

Current exact head: `b7022f09`
