### PR TITLE
fix: read Windsurf Devin session from app origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 - Settings: switch tabs immediately before animated window resizing and reduce Providers sidebar work. Thanks @elijahfriedman!
+- Windsurf: import complete Devin sessions from the current app origin before legacy browser storage. Thanks @kiranmagic7!
 - Menu bar: show provider status markers only for the provider rendered in each icon. Thanks @Zihao-Qi!
 - Codex CLI: make automatic usage reads prefer OAuth and CLI sources instead of blocking on the optional web dashboard.
 - Provider probes: cap captured subprocess output at 1 MiB per stream without dropping valid text at a truncated UTF-8 boundary. Thanks @ProspectOre!

--- a/Sources/CodexBarCore/Providers/Windsurf/WindsurfDevinSessionImporter.swift
+++ b/Sources/CodexBarCore/Providers/Windsurf/WindsurfDevinSessionImporter.swift
@@ -148,6 +148,20 @@ enum WindsurfDevinSessionImporter {
         let url: URL
     }
 
+    struct LocalStorageSnapshot: Equatable {
+        let storage: [String: String]
+        let sourceSuffix: String?
+    }
+
+    typealias LocalStorageOriginEntries = (
+        origin: URL,
+        entries: [SweetCookieKit.ChromiumLocalStorageEntry])
+
+    static let localStorageOrigins = [
+        URL(string: "https://app.devin.ai")!,
+        URL(string: "https://windsurf.com")!,
+    ]
+
     private static func importSessions(
         browserDetection: BrowserDetection,
         browsers: [Browser],
@@ -162,10 +176,13 @@ enum WindsurfDevinSessionImporter {
         }
 
         for candidate in candidates {
-            let storage = self.readLocalStorage(from: candidate.url, logger: logger)
-            guard let session = self.session(from: storage, sourceLabel: candidate.label) else { continue }
-            logger("Found Windsurf devin session in \(candidate.label)")
-            sessions.append(session)
+            let snapshots = self.readLocalStorageSnapshots(from: candidate.url, logger: logger)
+            for snapshot in snapshots {
+                let sourceLabel = self.sourceLabel(candidate.label, suffix: snapshot.sourceSuffix)
+                guard let session = self.session(from: snapshot.storage, sourceLabel: sourceLabel) else { continue }
+                logger("Found Windsurf devin session in \(sourceLabel)")
+                sessions.append(session)
+            }
         }
 
         return self.deduplicateSessions(sessions)
@@ -213,35 +230,72 @@ enum WindsurfDevinSessionImporter {
         }
     }
 
-    private static func readLocalStorage(
+    private static func readLocalStorageSnapshots(
         from levelDBURL: URL,
-        logger: ((String) -> Void)? = nil) -> [String: String]
+        logger: ((String) -> Void)? = nil) -> [LocalStorageSnapshot]
     {
-        var storage: [String: String] = [:]
-
-        let entries = SweetCookieKit.ChromiumLocalStorageReader.readEntries(
-            for: "https://windsurf.com",
-            in: levelDBURL,
-            logger: logger)
-
-        for entry in entries where Self.targetKeys.contains(entry.key) {
-            storage[entry.key] = self.decodedStorageValue(entry.value)
-        }
-
-        if storage.count == Self.targetKeys.count {
-            return storage
+        let originEntries = Self.localStorageOrigins.map { origin in
+            let entries = SweetCookieKit.ChromiumLocalStorageReader.readEntries(
+                for: origin.absoluteString,
+                in: levelDBURL,
+                logger: logger)
+            return (origin: origin, entries: entries)
         }
 
         let textEntries = SweetCookieKit.ChromiumLocalStorageReader.readTextEntries(
             in: levelDBURL,
             logger: logger)
+        return self.localStorageSnapshots(from: originEntries, textEntries: textEntries)
+    }
 
-        for entry in textEntries {
+    static func localStorageSnapshots(
+        from originEntries: [LocalStorageOriginEntries],
+        textEntries: [SweetCookieKit.ChromiumLevelDBTextEntry]) -> [LocalStorageSnapshot]
+    {
+        var snapshots = self.localStorageSnapshots(from: originEntries)
+        let textStorage = self.storage(from: textEntries)
+        if textStorage.count == Self.targetKeys.count {
+            snapshots.append(LocalStorageSnapshot(storage: textStorage, sourceSuffix: nil))
+        }
+
+        return snapshots
+    }
+
+    static func localStorageSnapshots(from originEntries: [LocalStorageOriginEntries]) -> [LocalStorageSnapshot] {
+        originEntries.compactMap { originEntry in
+            let storage = self.storage(from: originEntry.entries)
+            guard storage.count == Self.targetKeys.count else { return nil }
+            return LocalStorageSnapshot(
+                storage: storage,
+                sourceSuffix: originEntry.origin.host ?? originEntry.origin.absoluteString)
+        }
+    }
+
+    private static func storage(
+        from entries: [SweetCookieKit.ChromiumLocalStorageEntry]) -> [String: String]
+    {
+        var storage: [String: String] = [:]
+        for entry in entries where storage[entry.key] == nil && Self.targetKeys.contains(entry.key) {
+            storage[entry.key] = self.decodedStorageValue(entry.value)
+        }
+        return storage
+    }
+
+    private static func storage(
+        from entries: [SweetCookieKit.ChromiumLevelDBTextEntry]) -> [String: String]
+    {
+        var storage: [String: String] = [:]
+        for entry in entries {
             guard storage[entry.key] == nil, Self.targetKeys.contains(entry.key) else { continue }
             storage[entry.key] = self.decodedStorageValue(entry.value)
         }
 
         return storage
+    }
+
+    private static func sourceLabel(_ label: String, suffix: String?) -> String {
+        guard let suffix else { return label }
+        return "\(label) (\(suffix))"
     }
 
     private static let targetKeys: Set<String> = [

--- a/Sources/CodexBarCore/Providers/Windsurf/WindsurfWebFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Windsurf/WindsurfWebFetcher.swift
@@ -119,7 +119,8 @@ public enum WindsurfWebFetcherError: LocalizedError, Sendable {
     public var errorDescription: String? {
         switch self {
         case .noSessionData:
-            "No Windsurf web session found in Chromium localStorage. Sign in to windsurf.com in Chrome or Edge first."
+            "No Windsurf web session found in Chromium localStorage. " +
+                "Sign in to app.devin.ai or windsurf.com in Chrome first."
         case let .invalidManualSession(message):
             "Invalid Windsurf session payload: \(message)"
         case let .apiCallFailed(message):

--- a/Tests/CodexBarTests/WindsurfDevinSessionImporterTests.swift
+++ b/Tests/CodexBarTests/WindsurfDevinSessionImporterTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SweetCookieKit
 import Testing
 @testable import CodexBarCore
 
@@ -9,6 +10,14 @@ struct WindsurfDevinSessionImporterTests {
         #expect(!WindsurfDevinSessionImporter.fallbackBrowsers.contains(.chrome))
         #expect(WindsurfDevinSessionImporter.fallbackBrowsersExcluding([.chrome, .edge]).first == .chromeBeta)
         #expect(!WindsurfDevinSessionImporter.fallbackBrowsersExcluding([.chrome, .edge]).contains(.edge))
+    }
+
+    @Test
+    func `reads Devin app storage before legacy Windsurf origin`() {
+        #expect(WindsurfDevinSessionImporter.localStorageOrigins.map(\.absoluteString) == [
+            "https://app.devin.ai",
+            "https://windsurf.com",
+        ])
     }
 
     @Test
@@ -34,6 +43,82 @@ struct WindsurfDevinSessionImporterTests {
         #expect(session?.session.accountID == "account-123")
         #expect(session?.session.primaryOrgID == "org-456")
         #expect(session?.sourceLabel == "Chrome Default")
+    }
+
+    @Test
+    func `keeps partial app origin separate from complete legacy origin`() throws {
+        let appOrigin = try #require(URL(string: "https://app.devin.ai"))
+        let legacyOrigin = try #require(URL(string: "https://windsurf.com"))
+
+        let snapshots = WindsurfDevinSessionImporter.localStorageSnapshots(from: [
+            (
+                origin: appOrigin,
+                entries: [
+                    Self.entry(origin: appOrigin, key: "devin_session_token", value: "app-session"),
+                    Self.entry(origin: appOrigin, key: "devin_auth1_token", value: "app-auth1"),
+                ]),
+            (
+                origin: legacyOrigin,
+                entries: [
+                    Self.entry(origin: legacyOrigin, key: "devin_session_token", value: "legacy-session"),
+                    Self.entry(origin: legacyOrigin, key: "devin_auth1_token", value: "legacy-auth1"),
+                    Self.entry(origin: legacyOrigin, key: "devin_account_id", value: "legacy-account"),
+                    Self.entry(origin: legacyOrigin, key: "devin_primary_org_id", value: "legacy-org"),
+                ]),
+        ])
+
+        #expect(snapshots == [
+            WindsurfDevinSessionImporter.LocalStorageSnapshot(
+                storage: [
+                    "devin_session_token": "legacy-session",
+                    "devin_auth1_token": "legacy-auth1",
+                    "devin_account_id": "legacy-account",
+                    "devin_primary_org_id": "legacy-org",
+                ],
+                sourceSuffix: "windsurf.com"),
+        ])
+    }
+
+    @Test
+    func `keeps text entry fallback after structured origin snapshots`() throws {
+        let appOrigin = try #require(URL(string: "https://app.devin.ai"))
+
+        let snapshots = WindsurfDevinSessionImporter.localStorageSnapshots(
+            from: [
+                (
+                    origin: appOrigin,
+                    entries: [
+                        Self.entry(origin: appOrigin, key: "devin_session_token", value: "stale-app-session"),
+                        Self.entry(origin: appOrigin, key: "devin_auth1_token", value: "stale-app-auth1"),
+                        Self.entry(origin: appOrigin, key: "devin_account_id", value: "stale-app-account"),
+                        Self.entry(origin: appOrigin, key: "devin_primary_org_id", value: "stale-app-org"),
+                    ]),
+            ],
+            textEntries: [
+                Self.textEntry(key: "devin_session_token", value: "legacy-text-session"),
+                Self.textEntry(key: "devin_auth1_token", value: "legacy-text-auth1"),
+                Self.textEntry(key: "devin_account_id", value: "legacy-text-account"),
+                Self.textEntry(key: "devin_primary_org_id", value: "legacy-text-org"),
+            ])
+
+        #expect(snapshots == [
+            WindsurfDevinSessionImporter.LocalStorageSnapshot(
+                storage: [
+                    "devin_session_token": "stale-app-session",
+                    "devin_auth1_token": "stale-app-auth1",
+                    "devin_account_id": "stale-app-account",
+                    "devin_primary_org_id": "stale-app-org",
+                ],
+                sourceSuffix: "app.devin.ai"),
+            WindsurfDevinSessionImporter.LocalStorageSnapshot(
+                storage: [
+                    "devin_session_token": "legacy-text-session",
+                    "devin_auth1_token": "legacy-text-auth1",
+                    "devin_account_id": "legacy-text-account",
+                    "devin_primary_org_id": "legacy-text-org",
+                ],
+                sourceSuffix: nil),
+        ])
     }
 
     @Test
@@ -68,5 +153,17 @@ struct WindsurfDevinSessionImporterTests {
         #expect(deduplicated[0].sourceLabel == "Chrome Default")
         #expect(deduplicated[0].session.sessionToken == "devin-session-token$abc")
         #expect(deduplicated[1].session.sessionToken == "devin-session-token$def")
+    }
+
+    private static func entry(origin: URL, key: String, value: String) -> ChromiumLocalStorageEntry {
+        ChromiumLocalStorageEntry(
+            origin: origin.absoluteString,
+            key: key,
+            value: value,
+            rawValueLength: value.utf8.count)
+    }
+
+    private static func textEntry(key: String, value: String) -> ChromiumLevelDBTextEntry {
+        ChromiumLevelDBTextEntry(key: key, value: value)
     }
 }

--- a/Tests/CodexBarTests/WindsurfWebFetcherTests.swift
+++ b/Tests/CodexBarTests/WindsurfWebFetcherTests.swift
@@ -1,9 +1,18 @@
 import Foundation
+import SweetCookieKit
 import Testing
 @testable import CodexBarCore
 
 @Suite(.serialized)
 struct WindsurfWebFetcherTests {
+    @Test
+    func `missing session guidance names current and legacy origins`() {
+        let message = WindsurfWebFetcherError.noSessionData.errorDescription
+
+        #expect(message?.contains("app.devin.ai") == true)
+        #expect(message?.contains("windsurf.com") == true)
+    }
+
     private struct ResponseFixture {
         let planName: String
         let dailyRemaining: Int
@@ -219,6 +228,80 @@ struct WindsurfWebFetcherTests {
         #expect(snapshot.identity?.loginMethod == "Teams")
         #expect(snapshot.primary?.usedPercent == 36)
         #expect(snapshot.secondary?.usedPercent == 20)
+    }
+
+    @Test
+    func `auto import uses complete legacy origin when app origin is partial`() async throws {
+        defer {
+            WindsurfDevinSessionImporter.importSessionsOverrideForTesting = nil
+            WindsurfDevinSessionImporter.importPreferredSessionsOverrideForTesting = nil
+            WindsurfDevinSessionImporter.importFallbackSessionsOverrideForTesting = nil
+            WindsurfWebFetcherStubURLProtocol.requests = []
+            WindsurfWebFetcherStubURLProtocol.handler = nil
+        }
+
+        let appOrigin = try #require(URL(string: "https://app.devin.ai"))
+        let legacyOrigin = try #require(URL(string: "https://windsurf.com"))
+        let snapshots = WindsurfDevinSessionImporter.localStorageSnapshots(from: [
+            (
+                origin: appOrigin,
+                entries: [
+                    Self.localStorageEntry(origin: appOrigin, key: "devin_session_token", value: "app-session"),
+                    Self.localStorageEntry(origin: appOrigin, key: "devin_auth1_token", value: "app-auth1"),
+                ]),
+            (
+                origin: legacyOrigin,
+                entries: [
+                    Self.localStorageEntry(origin: legacyOrigin, key: "devin_session_token", value: "legacy-session"),
+                    Self.localStorageEntry(origin: legacyOrigin, key: "devin_auth1_token", value: "legacy-auth1"),
+                    Self.localStorageEntry(origin: legacyOrigin, key: "devin_account_id", value: "legacy-account"),
+                    Self.localStorageEntry(origin: legacyOrigin, key: "devin_primary_org_id", value: "legacy-org"),
+                ]),
+        ])
+
+        let sessionInfos = snapshots.compactMap { snapshot in
+            WindsurfDevinSessionImporter.session(
+                from: snapshot.storage,
+                sourceLabel: "Chrome Default (\(snapshot.sourceSuffix ?? "unknown"))")
+        }
+        WindsurfDevinSessionImporter.importPreferredSessionsOverrideForTesting = { _, _ in sessionInfos }
+
+        WindsurfWebFetcherStubURLProtocol.requests = []
+        WindsurfWebFetcherStubURLProtocol.handler = { request in
+            let url = try #require(request.url)
+            #expect(request.value(forHTTPHeaderField: "x-devin-session-token") == "legacy-session")
+            #expect(request.value(forHTTPHeaderField: "x-devin-auth1-token") == "legacy-auth1")
+            #expect(request.value(forHTTPHeaderField: "x-devin-account-id") == "legacy-account")
+            #expect(request.value(forHTTPHeaderField: "x-devin-primary-org-id") == "legacy-org")
+
+            let body = try WindsurfPlanStatusProtoCodec.decodeRequest(Self.requestBodyData(from: request))
+            #expect(body.authToken == "legacy-session")
+
+            return Self.makeResponse(
+                url: url,
+                body: Self.makePlanStatusResponse(ResponseFixture(
+                    planName: "Pro",
+                    dailyRemaining: 70,
+                    weeklyRemaining: 85,
+                    planEndUnix: 1_777_888_000,
+                    dailyResetUnix: 1_777_900_000,
+                    weeklyResetUnix: 1_778_000_000)),
+                contentType: "application/proto",
+                statusCode: 200)
+        }
+
+        let snapshot = try await WindsurfWebFetcher.fetchUsage(
+            browserDetection: BrowserDetection(cacheTTL: 0),
+            cookieSource: .auto,
+            timeout: 2,
+            session: self.makeSession())
+
+        #expect(snapshots.count == 1)
+        #expect(sessionInfos.map(\.sourceLabel) == ["Chrome Default (windsurf.com)"])
+        #expect(WindsurfWebFetcherStubURLProtocol.requests.count == 1)
+        #expect(snapshot.identity?.loginMethod == "Pro")
+        #expect(snapshot.primary?.usedPercent == 30)
+        #expect(snapshot.secondary?.usedPercent == 15)
     }
 
     @Test
@@ -438,6 +521,14 @@ struct WindsurfWebFetcherTests {
         }
         data.append(UInt8(remaining))
         return data
+    }
+
+    private static func localStorageEntry(origin: URL, key: String, value: String) -> ChromiumLocalStorageEntry {
+        ChromiumLocalStorageEntry(
+            origin: origin.absoluteString,
+            key: key,
+            value: value,
+            rawValueLength: value.utf8.count)
     }
 }
 

--- a/docs/windsurf.md
+++ b/docs/windsurf.md
@@ -21,7 +21,8 @@ Usage source picker:
 
 ### Web API fetch order
 1) **Manual session bundle** (when Cookie source = Manual).
-2) **Browser localStorage import** — extracts the active `devin_*` session values from Chromium browsers.
+2) **Browser localStorage import** — extracts complete `devin_*` session bundles from Chromium browsers, checking
+   `app.devin.ai` before the legacy `windsurf.com` origin.
 
 ### Local SQLite cache
 - File: `~/Library/Application Support/Windsurf/User/globalStorage/state.vscdb`.
@@ -99,7 +100,9 @@ UsageSnapshot (daily/weekly quota %)
 
 - **Browsers scanned**: Chrome, Edge, Brave, Arc, Vivaldi, Chromium, and compatible Chromium forks.
 - **Local storage path**: `~/Library/Application Support/<Browser>/<Profile>/Local Storage/leveldb/`
-- **Origin**: `https://windsurf.com`
+- **Origins**: `https://app.devin.ai`, then legacy `https://windsurf.com`
+- Values from different structured origins are never combined. A partial app-origin bundle cannot contaminate a
+  complete legacy-origin fallback.
 - **Required keys**:
   - `devin_session_token`
   - `devin_auth1_token`
@@ -143,7 +146,8 @@ UsageSnapshot (daily/weekly quota %)
 ## Troubleshooting
 
 ### "No Windsurf web session found in Chromium localStorage"
-- Sign in to [windsurf.com](https://windsurf.com) in Chrome, Edge, or another Chromium browser.
+- Sign in to [app.devin.ai](https://app.devin.ai) or [windsurf.com](https://windsurf.com) in Chrome, Edge, or another
+  Chromium browser.
 - Grant Full Disk Access to CodexBar (System Settings → Privacy & Security → Full Disk Access).
 - Try Manual mode and paste the JSON session bundle directly.
 


### PR DESCRIPTION
## Summary

- Read complete Windsurf-compatible sessions from `https://app.devin.ai` before the legacy `https://windsurf.com` origin.
- Keep structured origins isolated so partial app-origin values cannot contaminate a complete legacy session.
- Preserve the raw LevelDB text scan as a separate final fallback candidate.
- Update runtime guidance and provider docs for both origins.

## Proof

- Exact rebased head: `54e83c212e520682202f95e8e18cf89734a61d9a`
- `swift test --filter 'WindsurfDevinSessionImporterTests|WindsurfWebFetcherTests'` (18 tests passed)
- `make check`
- `autoreview --mode uncommitted` (clean, confidence 0.82)
- Live Chrome/account flow: authenticated through `app.devin.ai`, followed its Devin Desktop **View usage** SSO handoff, and confirmed all four required fields were present at `windsurf.com` without reading their values.
- Exact-head CLI returned `windsurf-web`, plan present, daily and weekly windows present, no error.

## Scope note

The current live `app.devin.ai` account had no `devin_session_token`, `devin_auth1_token`, `devin_account_id`, or `devin_primary_org_id` localStorage keys. The new-origin path is fixture-covered but could not be live-proved with this account. This PR is additive compatibility and references, but does not by itself close, #1564.

Refs #1564
