### PR TITLE
fix(antigravity): humanize raw model id labels and add localization fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Codex pace: extrapolate historically exhausted weeks for run-out forecasts and avoid contradictory reset headlines. Thanks @Yuxin-Qiao!
 - Settings: switch tabs immediately before animated window resizing and reduce Providers sidebar work. Thanks @elijahfriedman!
 - Windsurf: import complete Devin sessions from the current app origin before legacy browser storage. Thanks @kiranmagic7!
+- Antigravity: humanize raw model identifiers while preserving server-provided quota labels. Thanks @bcharleson!
 - Menu bar: show provider status markers only for the provider rendered in each icon. Thanks @Zihao-Qi!
 - Codex CLI: make automatic usage reads prefer OAuth and CLI sources instead of blocking on the optional web dashboard.
 - Codex web: apply `--web-timeout` to the full cookie import, account verification, retry, and dashboard fetch path.

--- a/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
+++ b/Sources/CodexBarCore/Providers/Antigravity/AntigravityStatusProbe.swift
@@ -356,6 +356,49 @@ public struct AntigravityStatusSnapshot: Sendable {
         return .other
     }
 
+    static func quotaDisplayLabel(_ quota: AntigravityModelQuota) -> String {
+        let trimmed = quota.label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.isEmpty || trimmed == quota.modelId else { return quota.label }
+        return Self.humanizedModelID(quota.modelId)
+    }
+
+    static func humanizedModelID(_ modelId: String) -> String {
+        let parts = modelId.split(separator: "-").map(String.init)
+        var words: [String] = []
+        var index = 0
+
+        while index < parts.count {
+            let part = parts[index]
+            if Self.isSingleDigit(part), index + 1 < parts.count, Self.isSingleDigit(parts[index + 1]) {
+                var versionParts = [part]
+                index += 1
+                while index < parts.count, Self.isSingleDigit(parts[index]) {
+                    versionParts.append(parts[index])
+                    index += 1
+                }
+                words.append(versionParts.joined(separator: "."))
+                continue
+            }
+
+            if part.allSatisfy({ $0.isNumber || $0 == "." }) {
+                words.append(part)
+            } else if Self.modelLabelAcronyms.contains(part.lowercased()) {
+                words.append(part.uppercased())
+            } else {
+                words.append(part.prefix(1).uppercased() + part.dropFirst())
+            }
+            index += 1
+        }
+
+        return words.joined(separator: " ")
+    }
+
+    private static let modelLabelAcronyms: Set<String> = ["ai", "api", "gpt", "oss"]
+
+    private static func isSingleDigit(_ value: String) -> Bool {
+        value.count == 1 && value.allSatisfy(\.isNumber)
+    }
+
     private static func rateWindow(for quota: AntigravityModelQuota) -> RateWindow {
         RateWindow(
             usedPercent: 100 - quota.remainingPercent,
@@ -558,7 +601,7 @@ public struct AntigravityStatusSnapshot: Sendable {
                     id: m.quota.modelId == compactFallbackModelID
                         ? Self.compactFallbackWindowID(modelID: m.quota.modelId)
                         : m.quota.modelId,
-                    title: m.quota.label,
+                    title: Self.quotaDisplayLabel(m.quota),
                     window: Self.rateWindow(for: m.quota),
                     usageKnown: m.quota.remainingFraction != nil)
             }

--- a/Tests/CodexBarTests/AntigravityModelLabelTests.swift
+++ b/Tests/CodexBarTests/AntigravityModelLabelTests.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import CodexBarCore
+
+struct AntigravityModelLabelTests {
+    @Test
+    func `humanizes raw model ids when label matches model id`() {
+        #expect(AntigravityStatusSnapshot.humanizedModelID("gemini-3-pro-preview") == "Gemini 3 Pro Preview")
+        #expect(AntigravityStatusSnapshot.humanizedModelID("gemini-2.5-flash") == "Gemini 2.5 Flash")
+        #expect(AntigravityStatusSnapshot.humanizedModelID("example-3-1-pro-low") == "Example 3.1 Pro Low")
+        #expect(AntigravityStatusSnapshot.humanizedModelID("gpt-api-oss") == "GPT API OSS")
+        #expect(AntigravityStatusSnapshot.humanizedModelID("").isEmpty)
+    }
+
+    @Test
+    func `preserves custom model labels`() {
+        let quota = AntigravityModelQuota(
+            label: "Custom enterprise label",
+            modelId: "gemini-3-pro-preview",
+            remainingFraction: 1,
+            resetTime: nil,
+            resetDescription: nil)
+
+        #expect(AntigravityStatusSnapshot.quotaDisplayLabel(quota) == "Custom enterprise label")
+    }
+}

--- a/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
+++ b/Tests/CodexBarTests/AntigravityStatusProbeTests.swift
@@ -1630,14 +1630,14 @@ extension AntigravityStatusProbeTests {
         let snapshot = AntigravityStatusSnapshot(
             modelQuotas: [
                 AntigravityModelQuota(
-                    label: "gemini-3-pro-high",
-                    modelId: "gemini-3-pro-high",
+                    label: "gemini-3-pro-preview",
+                    modelId: "gemini-3-pro-preview",
                     remainingFraction: 1,
                     resetTime: nil,
                     resetDescription: nil),
                 AntigravityModelQuota(
-                    label: "gemini-3-1-pro-low",
-                    modelId: "gemini-3-1-pro-low",
+                    label: "gemini-2.5-pro",
+                    modelId: "gemini-2.5-pro",
                     remainingFraction: 1,
                     resetTime: nil,
                     resetDescription: nil),


### PR DESCRIPTION
## Summary

Antigravity quota responses can expose raw model identifiers as display labels. This change humanizes generated labels while preserving custom server-provided labels.

- Convert hyphenated identifiers into readable title case.
- Preserve dotted versions and combine consecutive single-digit version components.
- Preserve known acronyms such as GPT, AI, API, and OSS.
- Leave custom labels unchanged.
- Keep empty identifiers empty.
- Apply generated labels only when the server label is empty or matches the raw identifier.
- Add changelog credit for @bcharleson.

The original unrelated localization fallback was removed. Compatibility targets the current Antigravity response shape only.

## Public model gate

Test fixtures use publicly documented Google model identifiers such as `gemini-3-pro-preview` and `gemini-2.5-flash`. No unannounced model identifiers are included.

## Proof

Exact rebased head: `c6e9d4faf97b66ec9364816e41a04f84b52bfefa`

- 62 focused Antigravity probe and label tests pass.
- `make check` passes.
- Autoreview: no actionable findings, confidence 0.86.
- Live authenticated CLI probe: app source returned primary and secondary usage plus four extra model windows; every extra window had a nonempty humanized title; no probe error.
