### PR TITLE
fix(codex): correct historical pace run-out forecasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - LiteLLM: show personal and team spend amounts directly on budget rows while suppressing duplicate budget sections. Thanks @hololee!
 
 ### Fixed
+- Codex pace: extrapolate historically exhausted weeks for run-out forecasts and avoid contradictory reset headlines. Thanks @Yuxin-Qiao!
 - Settings: switch tabs immediately before animated window resizing and reduce Providers sidebar work. Thanks @elijahfriedman!
 - Menu bar: show provider status markers only for the provider rendered in each icon. Thanks @Zihao-Qi!
 - Codex CLI: make automatic usage reads prefer OAuth and CLI sources instead of blocking on the optional web dashboard.

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -441,8 +441,8 @@ rm -rf "$APP"
 APP="$TMP_APP"
 SPARKLE="$APP/Contents/Frameworks/Sparkle.framework"
 chmod -R u+w "$APP"
-  xattr -cr "$APP"; xattr -dr com.apple.FinderInfo "$APP" 2>/dev/null
-  find "$APP" -exec xattr -d com.apple.FinderInfo {} 2>/dev/null \;
+  xattr -cr "$APP"; xattr -dr com.apple.FinderInfo "$APP" 2>/dev/null || true
+  find "$APP" -exec xattr -d com.apple.FinderInfo {} 2>/dev/null \; || true
 function resign() { xattr -cr "$1"; codesign "${CODESIGN_ARGS[@]}" "$1"; }
 # Validate Sparkle's nested layout before signing so framework layout drift fails clearly.
 SPARKLE_SIGNING_TARGETS=$(codexbar_sparkle_signing_targets "$SPARKLE")
@@ -485,12 +485,12 @@ chmod -R u+w "$APP"
 
 # Strip extended attributes to prevent AppleDouble (._*) files that break code sealing
 chmod -R u+w "$APP"
-  xattr -cr "$APP"; xattr -dr com.apple.FinderInfo "$APP" 2>/dev/null
-  find "$APP" -exec xattr -d com.apple.FinderInfo {} 2>/dev/null \;
+  xattr -cr "$APP"; xattr -dr com.apple.FinderInfo "$APP" 2>/dev/null || true
+  find "$APP" -exec xattr -d com.apple.FinderInfo {} 2>/dev/null \; || true
 find "$APP" -name '._*' -delete
 
 # Sign helper binaries if present
-find "$APP" -exec xattr -d com.apple.FinderInfo {} 2>/dev/null \;
+find "$APP" -exec xattr -d com.apple.FinderInfo {} 2>/dev/null \; || true
 if [[ -f "${APP}/Contents/Helpers/CodexBarCLI" ]]; then
   codesign "${CODESIGN_ARGS[@]}" "${APP}/Contents/Helpers/CodexBarCLI"
 fi
@@ -507,7 +507,7 @@ if [[ -d "${APP}/Contents/PlugIns/CodexBarWidget.appex" ]]; then
     --entitlements "$WIDGET_ENTITLEMENTS" \
     "$APP/Contents/PlugIns/CodexBarWidget.appex"
 fi
-xattr -dr com.apple.FinderInfo "${APP}" 2>/dev/null
+xattr -dr com.apple.FinderInfo "${APP}" 2>/dev/null || true
 
 # Finally sign the app bundle itself
 codesign "${CODESIGN_ARGS[@]}" \

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -432,18 +432,9 @@ elif [[ "$ALLOW_LLDB" == "1" ]]; then
   CODESIGN_ARGS=(--force --sign "$CODESIGN_ID")
 else
   CODESIGN_ID="${APP_IDENTITY:-Developer ID Application: Peter Steinberger (Y5PE65HELJ)}"
-  CODESIGN_ARGS=(--force --options runtime --sign "$CODESIGN_ID")
+  CODESIGN_ARGS=(--force --timestamp --options runtime --sign "$CODESIGN_ID")
 fi
-TMP_APP="/tmp/CodexBar.app"
-rm -rf "$TMP_APP"
-cp -a "$APP" "$TMP_APP"
-rm -rf "$APP"
-APP="$TMP_APP"
-SPARKLE="$APP/Contents/Frameworks/Sparkle.framework"
-chmod -R u+w "$APP"
-  xattr -cr "$APP"; xattr -dr com.apple.FinderInfo "$APP" 2>/dev/null || true
-  find "$APP" -exec xattr -d com.apple.FinderInfo {} 2>/dev/null \; || true
-function resign() { xattr -cr "$1"; codesign "${CODESIGN_ARGS[@]}" "$1"; }
+function resign() { codesign "${CODESIGN_ARGS[@]}" "$1"; }
 # Validate Sparkle's nested layout before signing so framework layout drift fails clearly.
 SPARKLE_SIGNING_TARGETS=$(codexbar_sparkle_signing_targets "$SPARKLE")
 while IFS= read -r SPARKLE_TARGET; do
@@ -484,13 +475,10 @@ fi
 chmod -R u+w "$APP"
 
 # Strip extended attributes to prevent AppleDouble (._*) files that break code sealing
-chmod -R u+w "$APP"
-  xattr -cr "$APP"; xattr -dr com.apple.FinderInfo "$APP" 2>/dev/null || true
-  find "$APP" -exec xattr -d com.apple.FinderInfo {} 2>/dev/null \; || true
+xattr -cr "$APP"
 find "$APP" -name '._*' -delete
 
 # Sign helper binaries if present
-find "$APP" -exec xattr -d com.apple.FinderInfo {} 2>/dev/null \; || true
 if [[ -f "${APP}/Contents/Helpers/CodexBarCLI" ]]; then
   codesign "${CODESIGN_ARGS[@]}" "${APP}/Contents/Helpers/CodexBarCLI"
 fi
@@ -507,7 +495,6 @@ if [[ -d "${APP}/Contents/PlugIns/CodexBarWidget.appex" ]]; then
     --entitlements "$WIDGET_ENTITLEMENTS" \
     "$APP/Contents/PlugIns/CodexBarWidget.appex"
 fi
-xattr -dr com.apple.FinderInfo "${APP}" 2>/dev/null || true
 
 # Finally sign the app bundle itself
 codesign "${CODESIGN_ARGS[@]}" \

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -432,9 +432,18 @@ elif [[ "$ALLOW_LLDB" == "1" ]]; then
   CODESIGN_ARGS=(--force --sign "$CODESIGN_ID")
 else
   CODESIGN_ID="${APP_IDENTITY:-Developer ID Application: Peter Steinberger (Y5PE65HELJ)}"
-  CODESIGN_ARGS=(--force --timestamp --options runtime --sign "$CODESIGN_ID")
+  CODESIGN_ARGS=(--force --options runtime --sign "$CODESIGN_ID")
 fi
-function resign() { codesign "${CODESIGN_ARGS[@]}" "$1"; }
+TMP_APP="/tmp/CodexBar.app"
+rm -rf "$TMP_APP"
+cp -a "$APP" "$TMP_APP"
+rm -rf "$APP"
+APP="$TMP_APP"
+SPARKLE="$APP/Contents/Frameworks/Sparkle.framework"
+chmod -R u+w "$APP"
+  xattr -cr "$APP"; xattr -dr com.apple.FinderInfo "$APP" 2>/dev/null
+  find "$APP" -exec xattr -d com.apple.FinderInfo {} 2>/dev/null \;
+function resign() { xattr -cr "$1"; codesign "${CODESIGN_ARGS[@]}" "$1"; }
 # Validate Sparkle's nested layout before signing so framework layout drift fails clearly.
 SPARKLE_SIGNING_TARGETS=$(codexbar_sparkle_signing_targets "$SPARKLE")
 while IFS= read -r SPARKLE_TARGET; do
@@ -475,10 +484,13 @@ fi
 chmod -R u+w "$APP"
 
 # Strip extended attributes to prevent AppleDouble (._*) files that break code sealing
-xattr -cr "$APP"
+chmod -R u+w "$APP"
+  xattr -cr "$APP"; xattr -dr com.apple.FinderInfo "$APP" 2>/dev/null
+  find "$APP" -exec xattr -d com.apple.FinderInfo {} 2>/dev/null \;
 find "$APP" -name '._*' -delete
 
 # Sign helper binaries if present
+find "$APP" -exec xattr -d com.apple.FinderInfo {} 2>/dev/null \;
 if [[ -f "${APP}/Contents/Helpers/CodexBarCLI" ]]; then
   codesign "${CODESIGN_ARGS[@]}" "${APP}/Contents/Helpers/CodexBarCLI"
 fi
@@ -495,6 +507,7 @@ if [[ -d "${APP}/Contents/PlugIns/CodexBarWidget.appex" ]]; then
     --entitlements "$WIDGET_ENTITLEMENTS" \
     "$APP/Contents/PlugIns/CodexBarWidget.appex"
 fi
+xattr -dr com.apple.FinderInfo "${APP}" 2>/dev/null
 
 # Finally sign the app bundle itself
 codesign "${CODESIGN_ARGS[@]}" \

--- a/Sources/CodexBar/HistoricalUsagePace.swift
+++ b/Sources/CodexBar/HistoricalUsagePace.swift
@@ -831,17 +831,30 @@ enum CodexHistoricalPaceEvaluator {
         crossingCandidates.reserveCapacity(weightedWeeks.count)
 
         for weighted in weightedWeeks {
-            let week = weighted.week
+            var extendedCurve = weighted.week.curve
+            if let capIndex = extendedCurve.firstIndex(where: { $0 >= 100 - Self.epsilon }),
+               capIndex > 0, capIndex < extendedCurve.count - 1
+            {
+                let gridCount = CodexHistoricalDataset.gridPointCount
+                let uCap = Double(capIndex) / Double(gridCount - 1)
+                let valCap = extendedCurve[capIndex]
+                let slope: Double = valCap / uCap
+                for i in capIndex..<extendedCurve.count {
+                    let u = Double(i) / Double(gridCount - 1)
+                    extendedCurve[i] = slope * u
+                }
+            }
+
             let weight = weighted.weight
-            let weekNow = Self.interpolate(curve: week.curve, at: uNow)
+            let weekNow = Self.interpolate(curve: extendedCurve, at: uNow)
             let shift = actual - weekNow
-            let shiftedEnd = Self.clamp((week.curve.last ?? 0) + shift, lower: 0, upper: 100)
+            let shiftedEnd = (extendedCurve.last ?? 0) + shift
             let runOut = shiftedEnd >= 100 - Self.epsilon
             if runOut {
                 weightedRunOutMass += weight
                 if let crossingU = Self.firstCrossing(
                     after: uNow,
-                    curve: week.curve,
+                    curve: extendedCurve,
                     shift: shift,
                     actualAtNow: actual)
                 {
@@ -860,7 +873,10 @@ enum CodexHistoricalPaceEvaluator {
         var willLastToReset = smoothedProbability < 0.5
         var etaSeconds: TimeInterval?
 
-        if !willLastToReset {
+        if actual >= 100 {
+            willLastToReset = false
+            etaSeconds = 0
+        } else if !willLastToReset {
             let values = crossingCandidates.map(\.etaSeconds)
             let weights = crossingCandidates.map(\.weight)
             if values.isEmpty {

--- a/Sources/CodexBar/HistoricalUsagePace.swift
+++ b/Sources/CodexBar/HistoricalUsagePace.swift
@@ -869,7 +869,7 @@ enum CodexHistoricalPaceEvaluator {
             (weightedRunOutMass + 0.5) / (totalWeight + 1),
             lower: 0,
             upper: 1)
-        let runOutProbability: Double? = scopedWeeks.count >= Self.minimumWeeksForRisk ? smoothedProbability : nil
+        var runOutProbability: Double? = scopedWeeks.count >= Self.minimumWeeksForRisk ? smoothedProbability : nil
 
         var willLastToReset = smoothedProbability < 0.5
         var etaSeconds: TimeInterval?
@@ -877,6 +877,7 @@ enum CodexHistoricalPaceEvaluator {
         if actual >= 100 {
             willLastToReset = false
             etaSeconds = 0
+            runOutProbability = 1
         } else if !willLastToReset {
             let values = crossingCandidates.map(\.etaSeconds)
             let weights = crossingCandidates.map(\.weight)

--- a/Sources/CodexBar/HistoricalUsagePace.swift
+++ b/Sources/CodexBar/HistoricalUsagePace.swift
@@ -811,10 +811,11 @@ enum CodexHistoricalPaceEvaluator {
             let weights = weightedWeeks.map(\.weight)
             let historicalMedian = Self.weightedMedian(values: values, weights: weights)
             let linearBaseline = 100 * u
+            // Historical demand can exceed a sustainable quota pace. Never call that excess a reserve.
             expectedCurve[index] = Self.clamp(
                 (lambda * historicalMedian) + ((1 - lambda) * linearBaseline),
                 lower: 0,
-                upper: 100)
+                upper: linearBaseline)
         }
 
         // Expected cumulative usage should be monotone.

--- a/Tests/CodexBarTests/HistoricalUsagePaceBackfillAuthorityTests.swift
+++ b/Tests/CodexBarTests/HistoricalUsagePaceBackfillAuthorityTests.swift
@@ -351,6 +351,48 @@ extension HistoricalUsagePaceTests {
 
     @MainActor
     @Test
+    func `usage store preserves historical Codex pace when work days are off`() throws {
+        let suite = "HistoricalUsagePaceTests-workdays-off-preserve-history-\(UUID().uuidString)"
+        let store = try Self.makeUsageStoreForBackfillTests(
+            suite: suite,
+            historyFileURL: Self.makeTempURL())
+        store.settings.weeklyProgressWorkDays = nil
+
+        let now = Date(timeIntervalSince1970: 0)
+        let duration = TimeInterval(10080 * 60)
+        let resetsAt = now.addingTimeInterval(duration / 2)
+        let window = RateWindow(
+            usedPercent: 60,
+            windowMinutes: 10080,
+            resetsAt: resetsAt,
+            resetDescription: nil)
+        let dataset = CodexHistoricalDataset(weeks: (0..<4).map { index in
+            HistoricalWeekProfile(
+                resetsAt: resetsAt.addingTimeInterval(-duration * Double(index + 1)),
+                windowMinutes: 10080,
+                curve: Self.linearCurve(end: 80))
+        })
+        let expected = try #require(CodexHistoricalPaceEvaluator.evaluate(
+            window: window,
+            now: now,
+            dataset: dataset))
+        let linear = try #require(UsagePace.weekly(window: window, now: now, workDays: nil))
+        store._setCodexHistoricalDatasetForTesting(
+            dataset,
+            accountKey: store.codexOwnershipContext().canonicalKey)
+
+        let computed = try #require(store.weeklyPace(provider: .codex, window: window, now: now))
+
+        #expect(abs(expected.expectedUsedPercent - linear.expectedUsedPercent) > 0.001)
+        #expect(abs(computed.expectedUsedPercent - expected.expectedUsedPercent) < 0.001)
+        #expect(abs(computed.deltaPercent - expected.deltaPercent) < 0.001)
+        #expect(computed.etaSeconds == expected.etaSeconds)
+        #expect(computed.willLastToReset == expected.willLastToReset)
+        #expect(computed.runOutProbability == expected.runOutProbability)
+    }
+
+    @MainActor
+    @Test
     func `usage store preserves historical Codex pace when work days are configured`() throws {
         let suite = "HistoricalUsagePaceTests-workdays-preserve-history-\(UUID().uuidString)"
         let store = try Self.makeUsageStoreForBackfillTests(

--- a/Tests/CodexBarTests/HistoricalUsagePaceTests.swift
+++ b/Tests/CodexBarTests/HistoricalUsagePaceTests.swift
@@ -791,7 +791,7 @@ struct HistoricalUsagePaceTests {
     }
 
     @Test
-    func exhaustedActualReturnsZeroEta() {
+    func exhaustedActualReturnsZeroEta() throws {
         let now = Date()
         let resetsAt = now.addingTimeInterval(3600)
         let week = HistoricalWeekProfile(
@@ -808,9 +808,16 @@ struct HistoricalUsagePaceTests {
                 resetDescription: nil,
                 nextRegenPercent: nil)
 
-            let pace = CodexHistoricalPaceEvaluator.evaluate(window: window, now: now, dataset: dataset)
-            #expect(pace?.willLastToReset == false)
-            #expect(pace?.etaSeconds == 0)
+            let pace = try #require(CodexHistoricalPaceEvaluator.evaluate(
+                window: window,
+                now: now,
+                dataset: dataset))
+            #expect(pace.willLastToReset == false)
+            #expect(pace.etaSeconds == 0)
+            #expect(pace.runOutProbability == 1)
+
+            let detail = UsagePaceText.weeklyDetail(pace: pace, now: now)
+            #expect(detail.rightLabel == "Runs out now · ≈ 100% run-out risk")
         }
     }
 }

--- a/Tests/CodexBarTests/HistoricalUsagePaceTests.swift
+++ b/Tests/CodexBarTests/HistoricalUsagePaceTests.swift
@@ -749,4 +749,62 @@ struct HistoricalUsagePaceTests {
         try await Task.sleep(for: .milliseconds(250))
         #expect(store.codexHistoricalDataset == nil)
     }
+
+    @Test
+    func `exhausted historical weeks extend linearly and don't flatline at 100`() throws {
+        // Build a historical dataset where a week reaches 100% at u = 0.5
+        var earlyExhaustedCurve = [Double]()
+        for i in 0..<CodexHistoricalDataset.gridPointCount {
+            let u = Double(i) / Double(CodexHistoricalDataset.gridPointCount - 1)
+            if u <= 0.5 {
+                earlyExhaustedCurve.append((u / 0.5) * 100)
+            } else {
+                earlyExhaustedCurve.append(100)
+            }
+        }
+        let now = Date()
+        let resetsAt = now.addingTimeInterval(3600)
+        let week = HistoricalWeekProfile(
+            resetsAt: now.addingTimeInterval(-10080 * 60),
+            windowMinutes: 10080,
+            curve: earlyExhaustedCurve)
+        let dataset = CodexHistoricalDataset(weeks: [week, week, week, week, week])
+
+        let window = RateWindow(
+            usedPercent: 80,
+            windowMinutes: 10080,
+            resetsAt: now.addingTimeInterval(0.25 * 10080 * 60),
+            resetDescription: nil)
+
+        let pace = try #require(CodexHistoricalPaceEvaluator.evaluate(
+            window: window,
+            now: now,
+            dataset: dataset))
+
+        #expect(pace.willLastToReset == false)
+        #expect(pace.runOutProbability != nil)
+        #expect(try #require(pace.runOutProbability) > 0)
+    }
+
+    @Test
+    func exhaustedActualReturnsZeroEta() {
+        let now = Date()
+        let resetsAt = now.addingTimeInterval(3600)
+        let week = HistoricalWeekProfile(
+            resetsAt: now.addingTimeInterval(-10080 * 60),
+            windowMinutes: 10080,
+            curve: Array(repeating: 100.0, count: 169))
+        let dataset = CodexHistoricalDataset(weeks: [week, week, week])
+
+        let window = RateWindow(
+            usedPercent: 100, // Exhausted
+            windowMinutes: 10080,
+            resetsAt: resetsAt,
+            resetDescription: nil,
+            nextRegenPercent: nil)
+
+        let pace = CodexHistoricalPaceEvaluator.evaluate(window: window, now: now, dataset: dataset)
+        #expect(pace?.willLastToReset == false)
+        #expect(pace?.etaSeconds == 0)
+    }
 }

--- a/Tests/CodexBarTests/HistoricalUsagePaceTests.swift
+++ b/Tests/CodexBarTests/HistoricalUsagePaceTests.swift
@@ -763,7 +763,6 @@ struct HistoricalUsagePaceTests {
             }
         }
         let now = Date()
-        let resetsAt = now.addingTimeInterval(3600)
         let week = HistoricalWeekProfile(
             resetsAt: now.addingTimeInterval(-10080 * 60),
             windowMinutes: 10080,
@@ -796,15 +795,17 @@ struct HistoricalUsagePaceTests {
             curve: Array(repeating: 100.0, count: 169))
         let dataset = CodexHistoricalDataset(weeks: [week, week, week])
 
-        let window = RateWindow(
-            usedPercent: 100, // Exhausted
-            windowMinutes: 10080,
-            resetsAt: resetsAt,
-            resetDescription: nil,
-            nextRegenPercent: nil)
+        for usedPercent in [100.0, 120.0] {
+            let window = RateWindow(
+                usedPercent: usedPercent,
+                windowMinutes: 10080,
+                resetsAt: resetsAt,
+                resetDescription: nil,
+                nextRegenPercent: nil)
 
-        let pace = CodexHistoricalPaceEvaluator.evaluate(window: window, now: now, dataset: dataset)
-        #expect(pace?.willLastToReset == false)
-        #expect(pace?.etaSeconds == 0)
+            let pace = CodexHistoricalPaceEvaluator.evaluate(window: window, now: now, dataset: dataset)
+            #expect(pace?.willLastToReset == false)
+            #expect(pace?.etaSeconds == 0)
+        }
     }
 }

--- a/Tests/CodexBarTests/HistoricalUsagePaceTests.swift
+++ b/Tests/CodexBarTests/HistoricalUsagePaceTests.swift
@@ -783,6 +783,11 @@ struct HistoricalUsagePaceTests {
         #expect(pace.willLastToReset == false)
         #expect(pace.runOutProbability != nil)
         #expect(try #require(pace.runOutProbability) > 0)
+        #expect(pace.deltaPercent > 0)
+
+        let detail = UsagePaceText.weeklyDetail(pace: pace, now: now)
+        #expect(detail.leftLabel == "5% in deficit")
+        #expect(detail.rightLabel?.contains("Lasts until reset") == false)
     }
 
     @Test

--- a/Tests/CodexBarTests/UsagePaceTests.swift
+++ b/Tests/CodexBarTests/UsagePaceTests.swift
@@ -467,6 +467,23 @@ struct UsagePaceTests {
     }
 
     @Test
+    func `workdays off linear weekly pace keeps deficit sign`() throws {
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 88,
+            windowMinutes: 10080,
+            resetsAt: now.addingTimeInterval(2 * 24 * 3600 + 19 * 3600),
+            resetDescription: nil)
+
+        let pace = try #require(UsagePace.weekly(window: window, now: now, workDays: nil))
+
+        #expect(abs(pace.expectedUsedPercent - (101.0 / 168.0 * 100.0)) < 0.01)
+        #expect(pace.deltaPercent > 25)
+        #expect(pace.stage == .farAhead)
+        #expect(pace.willLastToReset == false)
+    }
+
+    @Test
     func `workday aware pace ignores non weekly windows`() throws {
         let now = Date(timeIntervalSince1970: 0)
         // 300-minute session window — workDays should have no effect

--- a/Tests/CodexBarTests/UsagePaceTextTests.swift
+++ b/Tests/CodexBarTests/UsagePaceTextTests.swift
@@ -101,6 +101,40 @@ struct UsagePaceTextTests {
         #expect(detail.rightLabel == "≈ 45% run-out risk")
     }
 
+    @Test
+    func `weekly pace detail keeps lasts until reset only when rounded risk is zero`() {
+        let now = Date(timeIntervalSince1970: 0)
+        let pace = UsagePace(
+            stage: .farBehind,
+            deltaPercent: -30,
+            expectedUsedPercent: 40,
+            actualUsedPercent: 10,
+            etaSeconds: nil,
+            willLastToReset: true,
+            runOutProbability: 0.02)
+
+        let detail = UsagePaceText.weeklyDetail(pace: pace, now: now)
+
+        #expect(detail.rightLabel == "Lasts until reset · ≈ 0% run-out risk")
+    }
+
+    @Test
+    func `weekly pace detail prefers risk over lasts until reset when rounded risk is material`() {
+        let now = Date(timeIntervalSince1970: 0)
+        let pace = UsagePace(
+            stage: .slightlyBehind,
+            deltaPercent: -9,
+            expectedUsedPercent: 21,
+            actualUsedPercent: 12,
+            etaSeconds: nil,
+            willLastToReset: true,
+            runOutProbability: 0.03)
+
+        let detail = UsagePaceText.weeklyDetail(pace: pace, now: now)
+
+        #expect(detail.rightLabel == "≈ 5% run-out risk")
+    }
+
     // MARK: - Session pace (5-hour window)
 
     @Test

--- a/Tests/CodexBarTests/UsagePaceTextTests.swift
+++ b/Tests/CodexBarTests/UsagePaceTextTests.swift
@@ -67,6 +67,23 @@ struct UsagePaceTextTests {
     }
 
     @Test
+    func `reported weekly state renders deficit and run out headline`() throws {
+        let now = Date(timeIntervalSince1970: 0)
+        let window = RateWindow(
+            usedPercent: 88,
+            windowMinutes: 10080,
+            resetsAt: now.addingTimeInterval((2 * 24 + 19) * 3600),
+            resetDescription: nil)
+        let pace = try #require(UsagePace.weekly(window: window, now: now, workDays: nil))
+
+        let detail = UsagePaceText.weeklyDetail(pace: pace, now: now)
+
+        #expect(detail.leftLabel == "28% in deficit")
+        #expect(detail.rightLabel == "Runs out in 13h 47m")
+        #expect(detail.rightLabel?.contains("Lasts until reset") == false)
+    }
+
+    @Test
     func `weekly pace detail formats rounded risk when available`() {
         let now = Date(timeIntervalSince1970: 0)
         let pace = UsagePace(


### PR DESCRIPTION
Fixes #1544

## Summary

- Remove the unrelated app-packaging/signing rewrite; `Scripts/package_app.sh` is byte-identical to `main`.
- Extrapolate historical weeks that reached 100% early instead of treating censored demand as flat.
- Keep historical pacing active when weekly work-days are off.
- Bound the display expectation by quota-safe linear pace so a projected run-out cannot render as a reserve.
- Report already-exhausted quota as zero ETA and 100% run-out certainty.
- Never combine `Lasts until reset` with a material rounded run-out risk.
- Add maintainer changelog credit for @Yuxin-Qiao.

## Proof

Exact reviewed head: `7ffb96cffb1ed737833db09288ff7eb8bf182699`

- 84 focused historical pace, pace model, and pace text tests pass.
- Reported-state regression: 88% used, 67 hours remaining, work-days off renders `28% in deficit` and `Runs out in 13h 47m`.
- Early-exhaustion regression renders `5% in deficit` with a run-out forecast, never a reserve.
- Exhausted-current regression renders `Runs out now · ≈ 100% run-out risk`.
- `make check` passes with zero format or lint findings.
- Final full branch autoreview: no actionable findings, confidence 0.84.
- Exact ad-hoc package built; deep strict codesign passed; bundle reports `CodexGitCommit=7ffb96cf`; app launched and remained running.
- Live menu screenshot was attempted after capturing the target screen. An orphaned protected Keychain dialog and zero-size CodexBar status-item accessibility frames prevented reliable menu interaction, so no menu screenshot is claimed.

