### PR TITLE
feat: add dashboard url handling for z.ai api regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Memory: trim rebuildable menu and OpenAI debug caches under system pressure. Thanks @ProspectOre!
 - Provider plans: keep Claude and Kiro plan matching on one rendered line to avoid bogus labels from adjacent usage hints. Thanks @elijahfriedman!
 - Codex web: keep cookie-import deadlines responsive when browser cookie work blocks the shared worker pool.
+- z.ai: open the usage dashboard for the configured global or China API region. Thanks @renbaoshuo!
 - Codex pace: extrapolate historically exhausted weeks for run-out forecasts and avoid contradictory reset headlines. Thanks @Yuxin-Qiao!
 - Localization: correct the German in-progress refresh label. Thanks @ChrisLauinger77!
 - Localization: correct misleading literal German UI translations. Thanks @madebyjulz!

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -152,7 +152,10 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         NSWorkspace.shared.open(url)
     }
 
-    func dashboardURL(for provider: UsageProvider) -> URL? {
+    func dashboardURL(
+        for provider: UsageProvider,
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> URL?
+    {
         if provider == .alibaba {
             return self.settings.alibabaCodingPlanAPIRegion.dashboardURL
         }
@@ -165,7 +168,9 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
         }
 
         if provider == .zai {
-            return self.settings.zaiAPIRegion.dashboardURL
+            return ZaiUsageFetcher.resolveDashboardURL(
+                region: self.settings.zaiAPIRegion,
+                environment: environment)
         }
 
         let meta = self.store.metadata(for: provider)

--- a/Sources/CodexBar/StatusItemController+Actions.swift
+++ b/Sources/CodexBar/StatusItemController+Actions.swift
@@ -164,6 +164,10 @@ extension StatusItemController: StatusItemMenuPersistentActionDelegate {
             return self.settings.opencodegoDashboardURL
         }
 
+        if provider == .zai {
+            return self.settings.zaiAPIRegion.dashboardURL
+        }
+
         let meta = self.store.metadata(for: provider)
         let urlString: String? = if provider == .claude, self.store.isClaudeSubscription() {
             meta.subscriptionDashboardURL ?? meta.dashboardURL

--- a/Sources/CodexBarCore/Providers/Zai/ZaiAPIRegion.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiAPIRegion.swift
@@ -32,4 +32,13 @@ public enum ZaiAPIRegion: String, CaseIterable, Sendable {
     public var modelUsageURL: URL {
         URL(string: self.baseURLString)!.appendingPathComponent(Self.modelUsagePath)
     }
+
+    public var dashboardURL: URL {
+        switch self {
+        case .global:
+            URL(string: "https://z.ai/manage-apikey/subscription")!
+        case .bigmodelCN:
+            URL(string: "https://bigmodel.cn/coding-plan/personal/usage")!
+        }
+    }
 }

--- a/Sources/CodexBarCore/Providers/Zai/ZaiAPIRegion.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiAPIRegion.swift
@@ -36,7 +36,7 @@ public enum ZaiAPIRegion: String, CaseIterable, Sendable {
     public var dashboardURL: URL {
         switch self {
         case .global:
-            URL(string: "https://z.ai/manage-apikey/subscription")!
+            URL(string: "https://z.ai/manage-apikey/coding-plan/personal/my-plan")!
         case .bigmodelCN:
             URL(string: "https://bigmodel.cn/coding-plan/personal/usage")!
         }

--- a/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiProviderDescriptor.swift
@@ -20,7 +20,7 @@ public enum ZaiProviderDescriptor {
                 defaultEnabled: false,
                 isPrimaryProvider: false,
                 usesAccountFallback: false,
-                dashboardURL: "https://z.ai/manage-apikey/subscription",
+                dashboardURL: ZaiAPIRegion.global.dashboardURL.absoluteString,
                 statusPageURL: nil),
             branding: ProviderBranding(
                 iconStyle: .zai,

--- a/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
+++ b/Sources/CodexBarCore/Providers/Zai/ZaiUsageStats.swift
@@ -309,6 +309,21 @@ public struct ZaiUsageFetcher: Sendable {
         return region.quotaLimitURL
     }
 
+    /// Resolves the canonical dashboard for the effective quota endpoint without opening custom override hosts.
+    public static func resolveDashboardURL(
+        region: ZaiAPIRegion,
+        environment: [String: String] = ProcessInfo.processInfo.environment) -> URL
+    {
+        let quotaHost = self.resolveQuotaURL(region: region, environment: environment).host?.lowercased()
+        if quotaHost == ZaiAPIRegion.global.quotaLimitURL.host?.lowercased() {
+            return ZaiAPIRegion.global.dashboardURL
+        }
+        if quotaHost == ZaiAPIRegion.bigmodelCN.quotaLimitURL.host?.lowercased() {
+            return ZaiAPIRegion.bigmodelCN.dashboardURL
+        }
+        return region.dashboardURL
+    }
+
     /// Fetches usage stats from z.ai using the provided API key
     public static func fetchUsage(
         apiKey: String,

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -103,6 +103,33 @@ struct StatusMenuTests {
     }
 
     @Test
+    func `zai dashboard action follows selected region`() {
+        self.disableMenuCardsForTesting()
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = false
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: self.makeStatusBarForTesting())
+
+        settings.zaiAPIRegion = .global
+        #expect(controller.dashboardURL(for: .zai) == ZaiAPIRegion.global.dashboardURL)
+        #expect(controller.dashboardURL(for: .zai)?.absoluteString == "https://z.ai/manage-apikey/subscription")
+
+        settings.zaiAPIRegion = .bigmodelCN
+        #expect(controller.dashboardURL(for: .zai) == ZaiAPIRegion.bigmodelCN.dashboardURL)
+        #expect(controller.dashboardURL(for: .zai)?.absoluteString == "https://bigmodel.cn/coding-plan/personal/usage")
+    }
+
+    @Test
     func `opencode go dashboard action follows configured workspace`() {
         self.disableMenuCardsForTesting()
         let settings = self.makeSettings()

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -125,6 +125,11 @@ struct StatusMenuTests {
         #expect(
             controller.dashboardURL(for: .zai)?.absoluteString ==
                 "https://z.ai/manage-apikey/coding-plan/personal/my-plan")
+        #expect(
+            controller.dashboardURL(
+                for: .zai,
+                environment: [ZaiSettingsReader.apiHostKey: "open.bigmodel.cn"]) ==
+                ZaiAPIRegion.bigmodelCN.dashboardURL)
 
         settings.zaiAPIRegion = .bigmodelCN
         #expect(controller.dashboardURL(for: .zai) == ZaiAPIRegion.bigmodelCN.dashboardURL)

--- a/Tests/CodexBarTests/StatusMenuTests.swift
+++ b/Tests/CodexBarTests/StatusMenuTests.swift
@@ -122,7 +122,9 @@ struct StatusMenuTests {
 
         settings.zaiAPIRegion = .global
         #expect(controller.dashboardURL(for: .zai) == ZaiAPIRegion.global.dashboardURL)
-        #expect(controller.dashboardURL(for: .zai)?.absoluteString == "https://z.ai/manage-apikey/subscription")
+        #expect(
+            controller.dashboardURL(for: .zai)?.absoluteString ==
+                "https://z.ai/manage-apikey/coding-plan/personal/my-plan")
 
         settings.zaiAPIRegion = .bigmodelCN
         #expect(controller.dashboardURL(for: .zai) == ZaiAPIRegion.bigmodelCN.dashboardURL)

--- a/Tests/CodexBarTests/ZaiProviderTests.swift
+++ b/Tests/CodexBarTests/ZaiProviderTests.swift
@@ -624,4 +624,26 @@ struct ZaiAPIRegionTests {
         let url = ZaiUsageFetcher.resolveQuotaURL(region: .global, environment: env)
         #expect(url.absoluteString == "https://open.bigmodel.cn/api/monitor/usage/quota/limit")
     }
+
+    @Test
+    func `dashboard follows known endpoint overrides`() {
+        let china = ZaiUsageFetcher.resolveDashboardURL(
+            region: .global,
+            environment: [ZaiSettingsReader.apiHostKey: "open.bigmodel.cn"])
+        #expect(china == ZaiAPIRegion.bigmodelCN.dashboardURL)
+
+        let global = ZaiUsageFetcher.resolveDashboardURL(
+            region: .bigmodelCN,
+            environment: [ZaiSettingsReader.apiHostKey: "api.z.ai"])
+        #expect(global == ZaiAPIRegion.global.dashboardURL)
+    }
+
+    @Test
+    func `dashboard keeps selected region for custom endpoint override`() {
+        let dashboard = ZaiUsageFetcher.resolveDashboardURL(
+            region: .bigmodelCN,
+            environment: [ZaiSettingsReader.apiHostKey: "zai.internal.example"])
+
+        #expect(dashboard == ZaiAPIRegion.bigmodelCN.dashboardURL)
+    }
 }

--- a/Tests/CodexBarTests/ZaiProviderTests.swift
+++ b/Tests/CodexBarTests/ZaiProviderTests.swift
@@ -587,6 +587,19 @@ struct ZaiThreeLimitTests {
 
 struct ZaiAPIRegionTests {
     @Test
+    func `dashboard URLs follow selected region`() {
+        #expect(
+            ZaiAPIRegion.global.dashboardURL.absoluteString ==
+                "https://z.ai/manage-apikey/coding-plan/personal/my-plan")
+        #expect(
+            ZaiAPIRegion.bigmodelCN.dashboardURL.absoluteString ==
+                "https://bigmodel.cn/coding-plan/personal/usage")
+        #expect(
+            ZaiProviderDescriptor.descriptor.metadata.dashboardURL ==
+                ZaiAPIRegion.global.dashboardURL.absoluteString)
+    }
+
+    @Test
     func `defaults to global endpoint`() {
         let url = ZaiUsageFetcher.resolveQuotaURL(region: .global, environment: [:])
         #expect(url.absoluteString == "https://api.z.ai/api/monitor/usage/quota/limit")

--- a/docs/zai.md
+++ b/docs/zai.md
@@ -25,6 +25,11 @@ z.ai is API-token based. No browser cookies.
   - `authorization: Bearer <token>`
   - `accept: application/json`
 
+## Usage dashboard
+- Global: `https://z.ai/manage-apikey/coding-plan/personal/my-plan`
+- BigModel China: `https://bigmodel.cn/coding-plan/personal/usage`
+- CodexBar's Usage Dashboard action follows the configured API region.
+
 ## Parsing + mapping
 - Response fields:
   - `data.limits[]` → each limit entry.


### PR DESCRIPTION
## Summary

- Open the z.ai usage dashboard for the provider's configured API region.
- Use the canonical global personal-plan URL.
- Keep the China region on the direct bigmodel.cn usage page.
- Align provider metadata, docs, tests, and changelog credit.

## Proof

- Combined Zai provider and status-menu selection: 166 tests passed after the final current-main rebase.
- `make check` passed after the final current-main rebase.
- Local repair autoreview clean at 0.88; full branch review clean at 0.82.
- Official global legacy path redirects to the canonical target; direct HTTP checks returned 200 for both regional destinations.
- Source diff is unchanged after the current-main rebase.

Exact candidate: `cb34cb58`

## Screenshot

<img width="1602" height="725" alt="z.ai China usage dashboard action" src="https://github.com/user-attachments/assets/033f7f67-8459-495a-a978-5806a40d033d" />
