### PR TITLE
fix: don't highlight non-interactive menu card items on hover

### DIFF
--- a/Sources/CodexBar/StatusItemController+MenuCardItems.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardItems.swift
@@ -31,7 +31,7 @@ extension StatusItemController {
     {
         if !self.menuCardRenderingEnabledForController {
             let item = NSMenuItem()
-            item.isEnabled = true
+            item.isEnabled = submenu != nil || onClick != nil
             item.representedObject = id
             item.submenu = submenu
             if submenu != nil {
@@ -82,7 +82,7 @@ extension StatusItemController {
 
         let item = NSMenuItem()
         item.view = hosting
-        item.isEnabled = true
+        item.isEnabled = submenu != nil || onClick != nil
         item.representedObject = id
         item.submenu = submenu
         if submenu != nil {

--- a/Sources/CodexBar/StatusItemController+MenuReconcile.swift
+++ b/Sources/CodexBar/StatusItemController+MenuReconcile.swift
@@ -150,6 +150,11 @@ extension StatusItemController {
             (highlightedItem.view as? MenuCardHighlighting)?.setHighlighted(false)
             return
         }
+        guard highlightedItem.isEnabled else {
+            self.highlightedMenuItems.removeValue(forKey: menuKey)
+            (highlightedItem.view as? MenuCardHighlighting)?.setHighlighted(false)
+            return
+        }
         (highlightedItem.view as? MenuCardHighlighting)?.setHighlighted(true)
     }
 
@@ -183,6 +188,7 @@ extension StatusItemController {
         liveItem.representedObject = newItem.representedObject
         liveItem.state = newItem.state
         liveItem.isEnabled = newItem.isEnabled
+        (view as? MenuCardHighlighting)?.setHighlighted(newItem.isEnabled && remainsHighlighted)
         liveItem.image = newItem.image
         liveItem.toolTip = newItem.toolTip
         liveItem.keyEquivalent = newItem.keyEquivalent

--- a/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
+++ b/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
@@ -358,7 +358,7 @@ extension StatusMenuTests {
         defer { controller.releaseStatusItemsForTesting() }
 
         let menu = NSMenu()
-        let liveItem = controller.makeMenuCardItem(Text("before"), id: "menuCard", width: 300)
+        let liveItem = controller.makeMenuCardItem(Text("before"), id: "menuCard", width: 300, onClick: {})
         menu.addItem(liveItem)
         controller.menu(menu, willHighlight: liveItem)
         guard let hosting = liveItem.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
@@ -378,13 +378,53 @@ extension StatusMenuTests {
         #expect(controller.highlightedMenuItems[ObjectIdentifier(menu)] === liveItem)
 
         let scratch = NSMenu()
-        scratch.addItem(controller.makeMenuCardItem(Text("after"), id: "menuCard", width: 300))
+        scratch.addItem(controller.makeMenuCardItem(Text("after"), id: "menuCard", width: 300, onClick: {}))
         controller.reconcileMenuContent(menu, fromIndex: 0, shapes: shapes, with: scratch)
 
         #expect(menu.items[0] === liveItem)
         #expect(liveItem.view === hosting)
         #expect(hosting.highlightState.isHighlighted)
         #expect(controller.highlightedMenuItems[ObjectIdentifier(menu)] === liveItem)
+    }
+
+    @Test
+    func `reconcile clears highlight when a retained card becomes disabled`() {
+        StatusItemController.setMenuRefreshEnabledForTesting(false)
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        let controller = self.makeRecyclingController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = NSMenu()
+        let liveItem = controller.makeMenuCardItem(Text("before"), id: "menuCard", width: 300, onClick: {})
+        menu.addItem(liveItem)
+        controller.menu(menu, willHighlight: liveItem)
+        guard let liveView = liveItem.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
+        else {
+            Issue.record("expected a card hosting view")
+            return
+        }
+        #expect(liveView.highlightState.isHighlighted)
+        #expect(controller.highlightedMenuItems[ObjectIdentifier(menu)] === liveItem)
+
+        let shapes = controller.menuContentShapes(in: menu, fromIndex: 0)
+        let scratch = NSMenu()
+        scratch.addItem(controller.makeMenuCardItem(Text("after"), id: "menuCard", width: 300))
+        controller.reconcileMenuContent(menu, fromIndex: 0, shapes: shapes, with: scratch)
+
+        #expect(menu.items[0] === liveItem)
+        #expect(!liveItem.isEnabled)
+        #expect(controller.highlightedMenuItems[ObjectIdentifier(menu)] == nil)
+        guard let rebuiltView = liveItem.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
+        else {
+            Issue.record("expected the rebuilt card hosting view")
+            return
+        }
+        #expect(!rebuiltView.highlightState.isHighlighted)
     }
 
     @Test
@@ -401,7 +441,7 @@ extension StatusMenuTests {
         defer { controller.releaseStatusItemsForTesting() }
 
         let menu = NSMenu()
-        let item = controller.makeMenuCardItem(Text("card"), id: "menuCard", width: 300)
+        let item = controller.makeMenuCardItem(Text("card"), id: "menuCard", width: 300, onClick: {})
         menu.addItem(item)
 
         let entry = CachedMergedSwitcherMenuContent(
@@ -540,7 +580,7 @@ extension StatusMenuTests {
         defer { controller.releaseStatusItemsForTesting() }
 
         let menu = NSMenu()
-        let item = controller.makeMenuCardItem(Text("card"), id: "menuCard", width: 300)
+        let item = controller.makeMenuCardItem(Text("card"), id: "menuCard", width: 300, onClick: {})
         menu.addItem(item)
         controller.menu(menu, willHighlight: item)
         guard let hosting = item.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
@@ -557,7 +597,7 @@ extension StatusMenuTests {
         #expect(!hosting.highlightState.isHighlighted)
         #expect(controller.highlightedMenuItems[ObjectIdentifier(menu)] == nil)
 
-        let rebuilt = controller.makeMenuCardItem(Text("rebuilt"), id: "menuCard", width: 300)
+        let rebuilt = controller.makeMenuCardItem(Text("rebuilt"), id: "menuCard", width: 300, onClick: {})
         #expect(rebuilt.view === hosting)
         #expect(!hosting.highlightState.isHighlighted)
     }


### PR DESCRIPTION
## Summary

  Avoid highlighting non-interactive menu card rows on hover by only marking
  `NSMenuItem`s enabled when they actually expose interaction.

## Implementation

  - Updated `Sources/CodexBar/StatusItemController+MenuCardItems.swift`
  - Replaced unconditional `item.isEnabled = true` with `item.isEnabled =
  submenu != nil || onClick != nil`
  - Applied the same rule in both the non-rendered menu path and the hosting-
  view path
  - Preserves submenu rows and clickable rows as enabled
  - Leaves informational rows disabled so AppKit does not treat them as hover-
  highlightable actions

## Why

  The previous implementation marked every menu card item as enabled, including
  rows that were purely informational. That caused AppKit to render them like
  interactive menu items on hover, which implied behavior that does not exist.

## Testing

  - Built the app locally
  - Tested the updated hover behavior in the app

## Screenshots
Before:

<img width="317" height="955" alt="Screenshot 2026-06-16 at 3 26 11 PM" src="https://github.com/user-attachments/assets/e5ed9408-3108-4a46-94d9-3eccc6aa347e" />
<img width="334" height="958" alt="Screenshot 2026-06-16 at 3 25 57 PM" src="https://github.com/user-attachments/assets/ea8449bb-4f10-4518-b17a-89c6f5974590" />
After:

<img width="323" height="905" alt="Screenshot 2026-06-16 at 3 50 39 PM" src="https://github.com/user-attachments/assets/2cbcbb30-e577-4c7f-ba00-83d3965e6d22" />

