### PR TITLE
Update German translation for 'Refreshing'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 - Codex pace: extrapolate historically exhausted weeks for run-out forecasts and avoid contradictory reset headlines. Thanks @Yuxin-Qiao!
+- Localization: correct the German in-progress refresh label. Thanks @ChrisLauinger77!
 - Settings: switch tabs immediately before animated window resizing and reduce Providers sidebar work. Thanks @elijahfriedman!
 - Windsurf: import complete Devin sessions from the current app origin before legacy browser storage. Thanks @kiranmagic7!
 - Antigravity: humanize raw model identifiers while preserving server-provided quota labels. Thanks @bcharleson!

--- a/Sources/CodexBar/Resources/de.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/de.lproj/Localizable.strings
@@ -887,7 +887,7 @@
 "Limits not available" = "Limits nicht verfügbar";
 "No usage yet" = "Noch keine Nutzung";
 "Not fetched yet" = "Noch nicht abgerufen";
-"Refreshing" = "Erfrischend";
+"Refreshing" = "Aktualisiere";
 "Session" = "Sitzung";
 "Source" = "Quelle";
 "State" = "Zustand";


### PR DESCRIPTION
## Summary

- Replace the literal German translation of `Refreshing` with the intended in-progress UI wording.
- Rebase the contributor change onto current `main`.
- Add maintainer changelog credit for @ChrisLauinger77.

## Proof

Exact reviewed head: `084fc5f085a9af0e892042bfaf0ab32d37dfae52`

- App locale checker self-tests pass.
- App locale validation passes across 20 catalogs and 1,053 English keys.
- 24 focused localization catalog, bundle, and live-menu localization tests pass.
- `make check` passes with zero SwiftFormat or SwiftLint findings.
- Final full branch autoreview reports no actionable findings, confidence 0.94.
- Exact ad-hoc package built; deep strict codesign passed; bundle reports `CodexGitCommit=084fc5f0`; isolated German/no-Keychain app stayed running.
- Live menu capture was attempted after removing the stale protected Keychain prompt. macOS continued exposing the CodexBar status item with a zero-size accessibility frame, and screenshots showed no popup after reported verified clicks, so no menu screenshot is claimed.
