### PR TITLE
fix(history): persist generic provider utilization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 - Provider switcher: keep Codex quota rows visible when switching away and back during a manual refresh, including menus with usage-history sections. Thanks @Yuxin-Qiao!
 - Bedrock: ignore invalid billing dates when selecting the latest usage values. Thanks @ProspectOre!
+- Usage history: let opted-in providers persist weekly utilization and keep saved charts visible. Thanks @kiranmagic7!
 - Localization: improve Japanese terminology consistency and localize next-day reset times across all 21 app languages. Thanks @tukuyomil032!
 - Menu bar: keep visible quota values stable while a manual refresh is in flight without rewinding background-refresh countdowns. Thanks @Zihao-Qi!
 - Menu bar: stop informational usage-card rows from highlighting like clickable actions. Thanks @elijahfriedman!

--- a/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
@@ -246,18 +246,23 @@ struct PlanUtilizationHistoryChartMenuView: View {
         guard let snapshot else { return nil }
 
         var names: Set<PlanUtilizationSeriesName> = []
-        if snapshot.primary != nil {
-            names.insert(.session)
-        }
-        if snapshot.secondary != nil {
+        switch provider {
+        case .codex:
+            if snapshot.primary != nil { names.insert(.session) }
+            if snapshot.secondary != nil { names.insert(.weekly) }
+        case .claude:
+            if snapshot.primary != nil { names.insert(.session) }
+            if snapshot.secondary != nil { names.insert(.weekly) }
+            if snapshot.tertiary != nil,
+               ProviderDescriptorRegistry.metadata[provider]?.supportsOpus == true
+            {
+                names.insert(.opus)
+            }
+        default:
+            let windows = [snapshot.primary, snapshot.secondary, snapshot.tertiary].compactMap(\.self)
+                + (snapshot.extraRateWindows?.map(\.window) ?? [])
+            guard windows.contains(where: { $0.windowMinutes == 7 * 24 * 60 }) else { return nil }
             names.insert(.weekly)
-        }
-
-        if provider == .claude,
-           snapshot.tertiary != nil,
-           ProviderDescriptorRegistry.metadata[provider]?.supportsOpus == true
-        {
-            names.insert(.opus)
         }
 
         return names

--- a/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
+++ b/Sources/CodexBar/PlanUtilizationHistoryChartMenuView.swift
@@ -260,7 +260,7 @@ struct PlanUtilizationHistoryChartMenuView: View {
             }
         default:
             let windows = [snapshot.primary, snapshot.secondary, snapshot.tertiary].compactMap(\.self)
-                + (snapshot.extraRateWindows?.map(\.window) ?? [])
+                + (snapshot.extraRateWindows?.filter(\.usageKnown).map(\.window) ?? [])
             guard windows.contains(where: { $0.windowMinutes == 7 * 24 * 60 }) else { return nil }
             names.insert(.weekly)
         }

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -18,7 +18,7 @@ extension UsageStore {
         default:
             if self.planUtilizationHistory[provider]?.isEmpty == false {
                 true
-            } else if let snapshot = self.snapshots[provider] {
+            } else if self.settings.historicalTrackingEnabled, let snapshot = self.snapshots[provider] {
                 !self.planUtilizationSeriesSamples(
                     provider: provider,
                     snapshot: snapshot,
@@ -138,6 +138,7 @@ extension UsageStore {
                 samples: samples)
         }
 
+        guard self.shouldRecordPlanUtilizationHistory(for: provider) else { return }
         guard !self.shouldDeferClaudePlanUtilizationHistory(provider: provider) else { return }
 
         var snapshotToPersist: [UsageProvider: PlanUtilizationHistoryBuckets]?
@@ -168,6 +169,15 @@ extension UsageStore {
 
         guard let snapshotToPersist else { return }
         await self.planUtilizationPersistenceCoordinator.enqueue(snapshotToPersist)
+    }
+
+    private func shouldRecordPlanUtilizationHistory(for provider: UsageProvider) -> Bool {
+        switch provider {
+        case .codex, .claude:
+            true
+        default:
+            self.settings.historicalTrackingEnabled
+        }
     }
 
     private nonisolated static func updatedPlanUtilizationHistories(

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -16,7 +16,16 @@ extension UsageStore {
         case .codex, .claude:
             true
         default:
-            false
+            if self.planUtilizationHistory[provider]?.isEmpty == false {
+                true
+            } else if let snapshot = self.snapshots[provider] {
+                !self.planUtilizationSeriesSamples(
+                    provider: provider,
+                    snapshot: snapshot,
+                    capturedAt: snapshot.updatedAt).isEmpty
+            } else {
+                false
+            }
         }
     }
 
@@ -129,7 +138,6 @@ extension UsageStore {
                 samples: samples)
         }
 
-        guard self.supportsPlanUtilizationHistory(for: provider) else { return }
         guard !self.shouldDeferClaudePlanUtilizationHistory(provider: provider) else { return }
 
         var snapshotToPersist: [UsageProvider: PlanUtilizationHistoryBuckets]?

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -417,9 +417,15 @@ extension UsageStore {
                 }
             }
         default:
-            for window in [snapshot.primary, snapshot.secondary, snapshot.tertiary] {
-                guard let window, window.windowMinutes == Self.weeklyWindowMinutes else { continue }
-                appendWindow(window, name: .weekly)
+            let standardWeeklyWindow = [snapshot.primary, snapshot.secondary, snapshot.tertiary]
+                .compactMap(\.self)
+                .first { $0.windowMinutes == Self.weeklyWindowMinutes }
+            let extraWeeklyWindow = snapshot.extraRateWindows?
+                .lazy
+                .map(\.window)
+                .first { $0.windowMinutes == Self.weeklyWindowMinutes }
+            if let weeklyWindow = standardWeeklyWindow ?? extraWeeklyWindow {
+                appendWindow(weeklyWindow, name: .weekly)
             }
         }
 

--- a/Sources/CodexBar/UsageStore+PlanUtilization.swift
+++ b/Sources/CodexBar/UsageStore+PlanUtilization.swift
@@ -422,8 +422,8 @@ extension UsageStore {
                 .first { $0.windowMinutes == Self.weeklyWindowMinutes }
             let extraWeeklyWindow = snapshot.extraRateWindows?
                 .lazy
-                .map(\.window)
-                .first { $0.windowMinutes == Self.weeklyWindowMinutes }
+                .first { $0.usageKnown && $0.window.windowMinutes == Self.weeklyWindowMinutes }?
+                .window
             if let weeklyWindow = standardWeeklyWindow ?? extraWeeklyWindow {
                 appendWindow(weeklyWindow, name: .weekly)
             }

--- a/Tests/CodexBarTests/PlanUtilizationHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/PlanUtilizationHistoryChartMenuViewTests.swift
@@ -49,4 +49,40 @@ struct PlanUtilizationHistoryChartMenuViewTests {
         #expect(model.visibleSeries == ["weekly:10080"])
         #expect(model.selectedSeries == "weekly:10080")
     }
+
+    @Test
+    func `generic unknown weekly extra window does not filter saved history`() {
+        let history = PlanUtilizationSeriesHistory(
+            name: .weekly,
+            windowMinutes: 10080,
+            entries: [
+                PlanUtilizationHistoryEntry(
+                    capturedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                    usedPercent: 42,
+                    resetsAt: nil),
+            ])
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "weekly-reset-only",
+                    title: "Weekly reset",
+                    window: RateWindow(
+                        usedPercent: 0,
+                        windowMinutes: 10080,
+                        resetsAt: Date(timeIntervalSince1970: 1_700_003_600),
+                        resetDescription: nil),
+                    usageKnown: false),
+            ],
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000))
+
+        let model = PlanUtilizationHistoryChartMenuView._modelSnapshotForTesting(
+            histories: [history],
+            provider: .zed,
+            snapshot: snapshot)
+
+        #expect(model.visibleSeries == ["weekly:10080"])
+        #expect(model.selectedSeries == "weekly:10080")
+    }
 }

--- a/Tests/CodexBarTests/PlanUtilizationHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/PlanUtilizationHistoryChartMenuViewTests.swift
@@ -1,3 +1,4 @@
+import CodexBarCore
 import Foundation
 import Testing
 @testable import CodexBar
@@ -22,5 +23,30 @@ struct PlanUtilizationHistoryChartMenuViewTests {
         ])
 
         #expect(merged == [first, second])
+    }
+
+    @Test
+    func `generic primary weekly window keeps weekly history visible`() {
+        let history = PlanUtilizationSeriesHistory(
+            name: .weekly,
+            windowMinutes: 10080,
+            entries: [
+                PlanUtilizationHistoryEntry(
+                    capturedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                    usedPercent: 42,
+                    resetsAt: nil),
+            ])
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(usedPercent: 42, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000))
+
+        let model = PlanUtilizationHistoryChartMenuView._modelSnapshotForTesting(
+            histories: [history],
+            provider: .zai,
+            snapshot: snapshot)
+
+        #expect(model.visibleSeries == ["weekly:10080"])
+        #expect(model.selectedSeries == "weekly:10080")
     }
 }

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
@@ -1074,6 +1074,47 @@ struct UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
+    func `generic history opt in controls recording while saved history stays visible`() async throws {
+        let store = Self.makeStore()
+        let firstDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let before = UsageSnapshot(
+            primary: RateWindow(usedPercent: 42, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: firstDate)
+        store._setSnapshotForTesting(before, provider: .zai)
+        let providerURL = try #require(store.planUtilizationHistoryStore.directoryURL?
+            .appendingPathComponent("zai.json", isDirectory: false))
+
+        #expect(store.settings.historicalTrackingEnabled == false)
+        #expect(store.supportsPlanUtilizationHistory(for: .zai) == false)
+        await store.recordPlanUtilizationHistorySample(provider: .zai, snapshot: before, now: before.updatedAt)
+        #expect(store.planUtilizationHistory(for: .zai).isEmpty)
+        #expect(FileManager.default.fileExists(atPath: providerURL.path) == false)
+
+        store.settings.historicalTrackingEnabled = true
+        #expect(store.supportsPlanUtilizationHistory(for: .zai))
+        await store.recordPlanUtilizationHistorySample(provider: .zai, snapshot: before, now: before.updatedAt)
+        #expect(findSeries(store.planUtilizationHistory(for: .zai), name: .weekly, windowMinutes: 10080)?
+            .entries.map(\.usedPercent) == [42])
+
+        store.settings.historicalTrackingEnabled = false
+        #expect(store.supportsPlanUtilizationHistory(for: .zai))
+        let after = UsageSnapshot(
+            primary: RateWindow(usedPercent: 58, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            secondary: nil,
+            updatedAt: firstDate.addingTimeInterval(3600))
+        await store.recordPlanUtilizationHistorySample(provider: .zai, snapshot: after, now: after.updatedAt)
+        #expect(findSeries(store.planUtilizationHistory(for: .zai), name: .weekly, windowMinutes: 10080)?
+            .entries.map(\.usedPercent) == [42])
+
+        for _ in 0..<20 where !FileManager.default.fileExists(atPath: providerURL.path) {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        #expect(FileManager.default.fileExists(atPath: providerURL.path))
+    }
+
+    @MainActor
+    @Test
     func `concurrent plan history writes coalesce within single hour bucket per series`() async throws {
         let store = Self.makeStore()
         let snapshot = Self.makeSnapshot(provider: .codex, email: "alice@example.com")

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
@@ -1115,6 +1115,64 @@ struct UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
+    func `generic provider persists weekly extra window`() async {
+        let store = Self.makeStore()
+        store.settings.historicalTrackingEnabled = true
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "weekly-budget",
+                    title: "Weekly budget",
+                    window: RateWindow(
+                        usedPercent: 42,
+                        windowMinutes: 10080,
+                        resetsAt: nil,
+                        resetDescription: nil)),
+            ],
+            updatedAt: now)
+
+        await store.recordPlanUtilizationHistorySample(provider: .zai, snapshot: snapshot, now: now)
+
+        #expect(findSeries(store.planUtilizationHistory(for: .zai), name: .weekly, windowMinutes: 10080)?
+            .entries.map(\.usedPercent) == [42])
+    }
+
+    @MainActor
+    @Test
+    func `generic provider prefers standard weekly window over extra window`() async {
+        let store = Self.makeStore()
+        store.settings.historicalTrackingEnabled = true
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: RateWindow(
+                usedPercent: 42,
+                windowMinutes: 10080,
+                resetsAt: nil,
+                resetDescription: nil),
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "extra-weekly-budget",
+                    title: "Extra weekly budget",
+                    window: RateWindow(
+                        usedPercent: 84,
+                        windowMinutes: 10080,
+                        resetsAt: nil,
+                        resetDescription: nil)),
+            ],
+            updatedAt: now)
+
+        await store.recordPlanUtilizationHistorySample(provider: .factory, snapshot: snapshot, now: now)
+
+        #expect(findSeries(store.planUtilizationHistory(for: .factory), name: .weekly, windowMinutes: 10080)?
+            .entries.map(\.usedPercent) == [42])
+    }
+
+    @MainActor
+    @Test
     func `concurrent plan history writes coalesce within single hour bucket per series`() async throws {
         let store = Self.makeStore()
         let snapshot = Self.makeSnapshot(provider: .codex, email: "alice@example.com")

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
@@ -1142,6 +1142,33 @@ struct UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
+    func `generic provider ignores unknown weekly extra window`() async {
+        let store = Self.makeStore()
+        store.settings.historicalTrackingEnabled = true
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            extraRateWindows: [
+                NamedRateWindow(
+                    id: "weekly-reset-only",
+                    title: "Weekly reset",
+                    window: RateWindow(
+                        usedPercent: 0,
+                        windowMinutes: 10080,
+                        resetsAt: now.addingTimeInterval(3600),
+                        resetDescription: nil),
+                    usageKnown: false),
+            ],
+            updatedAt: now)
+
+        await store.recordPlanUtilizationHistorySample(provider: .zed, snapshot: snapshot, now: now)
+
+        #expect(store.planUtilizationHistory(for: .zed).isEmpty)
+    }
+
+    @MainActor
+    @Test
     func `generic provider prefers standard weekly window over extra window`() async {
         let store = Self.makeStore()
         store.settings.historicalTrackingEnabled = true

--- a/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
+++ b/Tests/CodexBarTests/UsageStorePlanUtilizationTests.swift
@@ -1025,6 +1025,55 @@ struct UsageStorePlanUtilizationTests {
 
     @MainActor
     @Test
+    func `generic provider weekly lane is persisted to provider history json`() async throws {
+        let store = Self.makeStore()
+        store.settings.historicalTrackingEnabled = true
+        let accountLabel = "zai-history-org"
+        let firstDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let before = UsageSnapshot(
+            primary: RateWindow(usedPercent: 42, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 15, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            updatedAt: firstDate,
+            identity: ProviderIdentitySnapshot(
+                providerID: .zai,
+                accountEmail: nil,
+                accountOrganization: accountLabel,
+                loginMethod: "pro"))
+        let after = UsageSnapshot(
+            primary: RateWindow(usedPercent: 58, windowMinutes: 10080, resetsAt: nil, resetDescription: nil),
+            secondary: RateWindow(usedPercent: 25, windowMinutes: 300, resetsAt: nil, resetDescription: nil),
+            updatedAt: firstDate.addingTimeInterval(3600),
+            identity: ProviderIdentitySnapshot(
+                providerID: .zai,
+                accountEmail: nil,
+                accountOrganization: accountLabel,
+                loginMethod: "pro"))
+
+        await store.recordPlanUtilizationHistorySample(provider: .zai, snapshot: before, now: before.updatedAt)
+        await store.recordPlanUtilizationHistorySample(provider: .zai, snapshot: after, now: after.updatedAt)
+
+        let histories = store.planUtilizationHistory(for: .zai)
+        #expect(findSeries(histories, name: .weekly, windowMinutes: 10080)?.entries.map(\.usedPercent) == [42, 58])
+
+        let providerURL = try #require(store.planUtilizationHistoryStore.directoryURL?
+            .appendingPathComponent("zai.json", isDirectory: false))
+        var persistedBuckets: PlanUtilizationHistoryBuckets?
+        for _ in 0..<20 {
+            persistedBuckets = store.planUtilizationHistoryStore.load()[.zai]
+            if persistedBuckets?.histories(for: persistedBuckets?.preferredAccountKey).flatMap(\.entries).count == 2 {
+                break
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        #expect(FileManager.default.fileExists(atPath: providerURL.path))
+        let persisted = try #require(persistedBuckets)
+        #expect(persisted.histories(for: persisted.preferredAccountKey)
+            .flatMap(\.entries)
+            .map(\.usedPercent) == [42, 58])
+    }
+
+    @MainActor
+    @Test
     func `concurrent plan history writes coalesce within single hour bucket per series`() async throws {
         let store = Self.makeStore()
         let snapshot = Self.makeSnapshot(provider: .codex, email: "alice@example.com")


### PR DESCRIPTION
## Summary
- Enables plan utilization history support for providers that expose a weekly usage window instead of restricting it to Codex/Claude.
- Keeps the history menu hidden for providers with no saved history and no current sampleable weekly window.
- Adds a regression showing Z.ai writes `zai.json` when `historicalTrackingEnabled` is true.

## Tests
- `swift test --filter UsageStorePlanUtilizationTests`
- `make check`
- `git diff --check`
- `swift test` reports unrelated timing/process-control failures in `AntigravityDeadlineTests`, `DeepSeekUsageFetcherTests`, `CommandCodeUsageFetcherTests`, `KiroStatusProbeTests`, and `SubprocessRunnerTests`.

Fixes #1585
