### PR TITLE
fix: don't highlight non-interactive menu card items on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Localization: improve Japanese terminology consistency and localize next-day reset times across all 21 app languages. Thanks @tukuyomil032!
+- Menu bar: stop informational usage-card rows from highlighting like clickable actions. Thanks @elijahfriedman!
 
 ## 0.36.1 — 2026-06-16
 

--- a/Sources/CodexBar/StatusItemController+CodexStackedMenu.swift
+++ b/Sources/CodexBar/StatusItemController+CodexStackedMenu.swift
@@ -34,7 +34,8 @@ extension StatusItemController {
                     id: "menuCard-\(cardIndex)",
                     width: context.menuWidth,
                     heightCacheScope: account.id,
-                    heightCacheFingerprint: model.heightFingerprint(section: "card")))
+                    heightCacheFingerprint: model.heightFingerprint(section: "card"),
+                    containsInteractiveControls: true))
                 cardIndex += 1
                 if account.id != section.accounts.last?.id {
                     menu.addItem(.separator())
@@ -52,7 +53,8 @@ extension StatusItemController {
                 id: "menuCard",
                 width: context.menuWidth,
                 heightCacheScope: context.currentProvider.rawValue,
-                heightCacheFingerprint: model.heightFingerprint(section: "card")))
+                heightCacheFingerprint: model.heightFingerprint(section: "card"),
+                containsInteractiveControls: true))
         }
         menu.addItem(.separator())
         if self.addStorageMenuCardSection(to: menu, provider: context.currentProvider, width: context.menuWidth) {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -193,7 +193,10 @@ extension StatusItemController {
             (previous.view as? MenuCardHighlighting)?.setHighlighted(false)
         }
 
-        if let item, item.isEnabled {
+        if let item,
+           item.isEnabled,
+           (item.view as? MenuCardHighlighting)?.allowsMenuHighlight != false
+        {
             self.highlightedMenuItems[key] = item
             (item.view as? MenuCardHighlighting)?.setHighlighted(true)
         } else {
@@ -639,7 +642,8 @@ extension StatusItemController {
             id: "menuCard",
             width: context.menuWidth,
             heightCacheScope: context.currentProvider.rawValue,
-            heightCacheFingerprint: model.heightFingerprint(section: "card")))
+            heightCacheFingerprint: model.heightFingerprint(section: "card"),
+            containsInteractiveControls: true))
         if self.addStorageMenuCardSection(to: menu, provider: context.currentProvider, width: context.menuWidth) {
             menu.addItem(.separator())
         }
@@ -661,7 +665,8 @@ extension StatusItemController {
                 id: "menuCard",
                 width: context.menuWidth,
                 heightCacheScope: context.currentProvider.rawValue,
-                heightCacheFingerprint: model.heightFingerprint(section: "card")))
+                heightCacheFingerprint: model.heightFingerprint(section: "card"),
+                containsInteractiveControls: true))
             menu.addItem(.separator())
         } else {
             for (index, model) in cards.enumerated() {
@@ -670,7 +675,8 @@ extension StatusItemController {
                     id: "menuCard-\(index)",
                     width: context.menuWidth,
                     heightCacheScope: "\(context.currentProvider.rawValue)-\(index)",
-                    heightCacheFingerprint: model.heightFingerprint(section: "card")))
+                    heightCacheFingerprint: model.heightFingerprint(section: "card"),
+                    containsInteractiveControls: true))
                 if index < cards.count - 1 {
                     menu.addItem(.separator())
                 }
@@ -1265,7 +1271,8 @@ extension StatusItemController {
                 width: width,
                 heightCacheScope: provider.rawValue,
                 heightCacheFingerprint: model.heightFingerprint(section: "usage"),
-                submenu: usageSubmenu))
+                submenu: usageSubmenu,
+                containsInteractiveControls: true))
         } else {
             let headerView = UsageMenuCardHeaderSectionView(
                 model: model,
@@ -1276,7 +1283,8 @@ extension StatusItemController {
                 id: "menuCardHeader",
                 width: width,
                 heightCacheScope: provider.rawValue,
-                heightCacheFingerprint: model.heightFingerprint(section: "header")))
+                heightCacheFingerprint: model.heightFingerprint(section: "header"),
+                containsInteractiveControls: true))
         }
 
         if hasStorage || hasCredits || hasExtraUsage || hasCost {

--- a/Sources/CodexBar/StatusItemController+MenuCardItems.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardItems.swift
@@ -27,11 +27,13 @@ extension StatusItemController {
         submenu: NSMenu? = nil,
         submenuIndicatorAlignment: Alignment = .topTrailing,
         submenuIndicatorTopPadding: CGFloat = 8,
+        containsInteractiveControls: Bool = false,
         onClick: (() -> Void)? = nil) -> NSMenuItem
     {
+        let allowsMenuHighlight = submenu != nil || onClick != nil
         if !self.menuCardRenderingEnabledForController {
             let item = NSMenuItem()
-            item.isEnabled = submenu != nil || onClick != nil
+            item.isEnabled = allowsMenuHighlight
             item.representedObject = id
             item.submenu = submenu
             if submenu != nil {
@@ -55,7 +57,10 @@ extension StatusItemController {
             {
                 view
             }
-            recycled.prepareForReuse(rootView: wrapped, onClick: onClick)
+            recycled.prepareForReuse(
+                rootView: wrapped,
+                allowsMenuHighlight: allowsMenuHighlight,
+                onClick: onClick)
             hosting = recycled
         } else {
             let highlightState = MenuCardHighlightState()
@@ -68,7 +73,11 @@ extension StatusItemController {
             {
                 view
             }
-            hosting = MenuCardItemHostingView(rootView: wrapped, highlightState: highlightState, onClick: onClick)
+            hosting = MenuCardItemHostingView(
+                rootView: wrapped,
+                highlightState: highlightState,
+                allowsMenuHighlight: allowsMenuHighlight,
+                onClick: onClick)
         }
         let height = self.cachedMenuCardHeight(
             for: id,
@@ -82,7 +91,7 @@ extension StatusItemController {
 
         let item = NSMenuItem()
         item.view = hosting
-        item.isEnabled = submenu != nil || onClick != nil
+        item.isEnabled = allowsMenuHighlight || containsInteractiveControls
         item.representedObject = id
         item.submenu = submenu
         if submenu != nil {

--- a/Sources/CodexBar/StatusItemController+MenuCardItems.swift
+++ b/Sources/CodexBar/StatusItemController+MenuCardItems.swift
@@ -31,7 +31,7 @@ extension StatusItemController {
     {
         if !self.menuCardRenderingEnabledForController {
             let item = NSMenuItem()
-            item.isEnabled = true
+            item.isEnabled = submenu != nil || onClick != nil
             item.representedObject = id
             item.submenu = submenu
             if submenu != nil {
@@ -82,7 +82,7 @@ extension StatusItemController {
 
         let item = NSMenuItem()
         item.view = hosting
-        item.isEnabled = true
+        item.isEnabled = submenu != nil || onClick != nil
         item.representedObject = id
         item.submenu = submenu
         if submenu != nil {

--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -60,7 +60,14 @@ extension StatusItemController {
 
 @MainActor
 protocol MenuCardHighlighting: AnyObject {
+    var allowsMenuHighlight: Bool { get }
     func setHighlighted(_ highlighted: Bool)
+}
+
+extension MenuCardHighlighting {
+    var allowsMenuHighlight: Bool {
+        true
+    }
 }
 
 @MainActor
@@ -83,6 +90,7 @@ final class MenuHostingView<Content: View>: NSHostingView<Content> {
 @MainActor
 final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, MenuCardHighlighting, MenuCardMeasuring {
     let highlightState: MenuCardHighlightState
+    private(set) var allowsMenuHighlight: Bool
     private var onClick: (() -> Void)?
     private var hasClickRecognizer = false
 
@@ -96,8 +104,14 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
         return NSSize(width: self.frame.width, height: size.height)
     }
 
-    init(rootView: Content, highlightState: MenuCardHighlightState, onClick: (() -> Void)? = nil) {
+    init(
+        rootView: Content,
+        highlightState: MenuCardHighlightState,
+        allowsMenuHighlight: Bool,
+        onClick: (() -> Void)? = nil)
+    {
         self.highlightState = highlightState
+        self.allowsMenuHighlight = allowsMenuHighlight
         self.onClick = onClick
         super.init(rootView: rootView)
         if onClick != nil {
@@ -109,8 +123,9 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
     /// `rootView` is diffed in place by SwiftUI instead of tearing down and recreating the
     /// hosting view and its graph. Callers must construct `rootView` around this view's own
     /// `highlightState` so menu hover highlighting keeps driving the rendered content.
-    func prepareForReuse(rootView: Content, onClick: (() -> Void)?) {
+    func prepareForReuse(rootView: Content, allowsMenuHighlight: Bool, onClick: (() -> Void)?) {
         self.rootView = rootView
+        self.allowsMenuHighlight = allowsMenuHighlight
         self.onClick = onClick
         if onClick != nil, !self.hasClickRecognizer {
             self.installClickRecognizer()
@@ -126,6 +141,7 @@ final class MenuCardItemHostingView<Content: View>: NSHostingView<Content>, Menu
 
     required init(rootView: Content) {
         self.highlightState = MenuCardHighlightState()
+        self.allowsMenuHighlight = false
         self.onClick = nil
         super.init(rootView: rootView)
     }

--- a/Sources/CodexBar/StatusItemController+MenuReconcile.swift
+++ b/Sources/CodexBar/StatusItemController+MenuReconcile.swift
@@ -150,7 +150,9 @@ extension StatusItemController {
             (highlightedItem.view as? MenuCardHighlighting)?.setHighlighted(false)
             return
         }
-        guard highlightedItem.isEnabled else {
+        guard highlightedItem.isEnabled,
+              (highlightedItem.view as? MenuCardHighlighting)?.allowsMenuHighlight != false
+        else {
             self.highlightedMenuItems.removeValue(forKey: menuKey)
             (highlightedItem.view as? MenuCardHighlighting)?.setHighlighted(false)
             return
@@ -187,7 +189,8 @@ extension StatusItemController {
         liveItem.representedObject = newItem.representedObject
         liveItem.state = newItem.state
         liveItem.isEnabled = newItem.isEnabled
-        (view as? MenuCardHighlighting)?.setHighlighted(newItem.isEnabled && remainsHighlighted)
+        let allowsHighlight = (view as? MenuCardHighlighting)?.allowsMenuHighlight != false
+        (view as? MenuCardHighlighting)?.setHighlighted(newItem.isEnabled && allowsHighlight && remainsHighlighted)
         liveItem.image = newItem.image
         liveItem.toolTip = newItem.toolTip
         liveItem.keyEquivalent = newItem.keyEquivalent

--- a/Sources/CodexBar/StatusItemController+MenuReconcile.swift
+++ b/Sources/CodexBar/StatusItemController+MenuReconcile.swift
@@ -150,6 +150,11 @@ extension StatusItemController {
             (highlightedItem.view as? MenuCardHighlighting)?.setHighlighted(false)
             return
         }
+        guard highlightedItem.isEnabled else {
+            self.highlightedMenuItems.removeValue(forKey: menuKey)
+            (highlightedItem.view as? MenuCardHighlighting)?.setHighlighted(false)
+            return
+        }
         (highlightedItem.view as? MenuCardHighlighting)?.setHighlighted(true)
     }
 
@@ -183,6 +188,7 @@ extension StatusItemController {
         liveItem.representedObject = newItem.representedObject
         liveItem.state = newItem.state
         liveItem.isEnabled = newItem.isEnabled
+        (view as? MenuCardHighlighting)?.setHighlighted(newItem.isEnabled && remainsHighlighted)
         liveItem.image = newItem.image
         liveItem.toolTip = newItem.toolTip
         liveItem.keyEquivalent = newItem.keyEquivalent

--- a/Sources/CodexBar/StatusItemController+MenuReconcile.swift
+++ b/Sources/CodexBar/StatusItemController+MenuReconcile.swift
@@ -179,7 +179,6 @@ extension StatusItemController {
         let submenu = newItem.submenu
         newItem.submenu = nil
         liveItem.view = view
-        (view as? MenuCardHighlighting)?.setHighlighted(remainsHighlighted)
         liveItem.submenu = submenu
         liveItem.title = newItem.title
         liveItem.attributedTitle = newItem.attributedTitle

--- a/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
+++ b/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
@@ -358,7 +358,7 @@ extension StatusMenuTests {
         defer { controller.releaseStatusItemsForTesting() }
 
         let menu = NSMenu()
-        let liveItem = controller.makeMenuCardItem(Text("before"), id: "menuCard", width: 300)
+        let liveItem = controller.makeMenuCardItem(Text("before"), id: "menuCard", width: 300, onClick: {})
         menu.addItem(liveItem)
         controller.menu(menu, willHighlight: liveItem)
         guard let hosting = liveItem.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
@@ -378,13 +378,53 @@ extension StatusMenuTests {
         #expect(controller.highlightedMenuItems[ObjectIdentifier(menu)] === liveItem)
 
         let scratch = NSMenu()
-        scratch.addItem(controller.makeMenuCardItem(Text("after"), id: "menuCard", width: 300))
+        scratch.addItem(controller.makeMenuCardItem(Text("after"), id: "menuCard", width: 300, onClick: {}))
         controller.reconcileMenuContent(menu, fromIndex: 0, shapes: shapes, with: scratch)
 
         #expect(menu.items[0] === liveItem)
         #expect(liveItem.view === hosting)
         #expect(hosting.highlightState.isHighlighted)
         #expect(controller.highlightedMenuItems[ObjectIdentifier(menu)] === liveItem)
+    }
+
+    @Test
+    func `reconcile clears highlight when a retained card becomes disabled`() {
+        StatusItemController.setMenuRefreshEnabledForTesting(false)
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        let controller = self.makeRecyclingController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = NSMenu()
+        let liveItem = controller.makeMenuCardItem(Text("before"), id: "menuCard", width: 300, onClick: {})
+        menu.addItem(liveItem)
+        controller.menu(menu, willHighlight: liveItem)
+        guard let liveView = liveItem.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
+        else {
+            Issue.record("expected a card hosting view")
+            return
+        }
+        #expect(liveView.highlightState.isHighlighted)
+        #expect(controller.highlightedMenuItems[ObjectIdentifier(menu)] === liveItem)
+
+        let shapes = controller.menuContentShapes(in: menu, fromIndex: 0)
+        let scratch = NSMenu()
+        scratch.addItem(controller.makeMenuCardItem(Text("after"), id: "menuCard", width: 300))
+        controller.reconcileMenuContent(menu, fromIndex: 0, shapes: shapes, with: scratch)
+
+        #expect(menu.items[0] === liveItem)
+        #expect(!liveItem.isEnabled)
+        #expect(controller.highlightedMenuItems[ObjectIdentifier(menu)] == nil)
+        guard let rebuiltView = liveItem.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
+        else {
+            Issue.record("expected the rebuilt card hosting view")
+            return
+        }
+        #expect(!rebuiltView.highlightState.isHighlighted)
     }
 
     @Test
@@ -401,7 +441,7 @@ extension StatusMenuTests {
         defer { controller.releaseStatusItemsForTesting() }
 
         let menu = NSMenu()
-        let item = controller.makeMenuCardItem(Text("card"), id: "menuCard", width: 300)
+        let item = controller.makeMenuCardItem(Text("card"), id: "menuCard", width: 300, onClick: {})
         menu.addItem(item)
 
         let entry = CachedMergedSwitcherMenuContent(
@@ -540,7 +580,7 @@ extension StatusMenuTests {
         defer { controller.releaseStatusItemsForTesting() }
 
         let menu = NSMenu()
-        let item = controller.makeMenuCardItem(Text("card"), id: "menuCard", width: 300)
+        let item = controller.makeMenuCardItem(Text("card"), id: "menuCard", width: 300, onClick: {})
         menu.addItem(item)
         controller.menu(menu, willHighlight: item)
         guard let hosting = item.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
@@ -557,7 +597,7 @@ extension StatusMenuTests {
         #expect(!hosting.highlightState.isHighlighted)
         #expect(controller.highlightedMenuItems[ObjectIdentifier(menu)] == nil)
 
-        let rebuilt = controller.makeMenuCardItem(Text("rebuilt"), id: "menuCard", width: 300)
+        let rebuilt = controller.makeMenuCardItem(Text("rebuilt"), id: "menuCard", width: 300, onClick: {})
         #expect(rebuilt.view === hosting)
         #expect(!hosting.highlightState.isHighlighted)
     }

--- a/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
+++ b/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
@@ -36,6 +36,33 @@ extension StatusMenuTests {
     }
 
     @Test
+    func `menu card enabled state follows interaction affordances`() {
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        let controller = self.makeRecyclingController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        for renderingEnabled in [false, true] {
+            StatusItemController.menuCardRenderingEnabled = renderingEnabled
+
+            let informational = controller.makeMenuCardItem(Text("Info"), id: "info", width: 300)
+            let clickable = controller.makeMenuCardItem(Text("Click"), id: "click", width: 300, onClick: {})
+            let submenu = controller.makeMenuCardItem(
+                Text("Submenu"),
+                id: "submenu",
+                width: 300,
+                submenu: NSMenu())
+
+            #expect(!informational.isEnabled)
+            #expect(clickable.isEnabled)
+            #expect(submenu.isEnabled)
+        }
+    }
+
+    @Test
     func `merged menu width uses widest provider action set`() {
         let settings = self.makeSettings()
         settings.statusChecksEnabled = false

--- a/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
+++ b/Tests/CodexBarTests/MenuCardViewRecyclingTests.swift
@@ -40,15 +40,19 @@ extension StatusMenuTests {
         let previousRendering = StatusItemController.menuCardRenderingEnabled
         defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
 
-        let settings = self.makeSettings()
-        settings.statusChecksEnabled = false
-        let controller = self.makeRecyclingController(settings: settings)
-        defer { controller.releaseStatusItemsForTesting() }
-
         for renderingEnabled in [false, true] {
             StatusItemController.menuCardRenderingEnabled = renderingEnabled
+            let settings = self.makeSettings()
+            settings.statusChecksEnabled = false
+            let controller = self.makeRecyclingController(settings: settings)
+            defer { controller.releaseStatusItemsForTesting() }
 
             let informational = controller.makeMenuCardItem(Text("Info"), id: "info", width: 300)
+            let embedded = controller.makeMenuCardItem(
+                Text("Embedded"),
+                id: "embedded",
+                width: 300,
+                containsInteractiveControls: true)
             let clickable = controller.makeMenuCardItem(Text("Click"), id: "click", width: 300, onClick: {})
             let submenu = controller.makeMenuCardItem(
                 Text("Submenu"),
@@ -57,9 +61,43 @@ extension StatusMenuTests {
                 submenu: NSMenu())
 
             #expect(!informational.isEnabled)
+            #expect(embedded.isEnabled == renderingEnabled)
             #expect(clickable.isEnabled)
             #expect(submenu.isEnabled)
         }
+    }
+
+    @Test
+    func `embedded controls stay enabled without highlighting the card`() {
+        StatusItemController.setMenuRefreshEnabledForTesting(false)
+        let previousRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = true
+        defer { StatusItemController.menuCardRenderingEnabled = previousRendering }
+
+        let settings = self.makeSettings()
+        settings.statusChecksEnabled = false
+        let controller = self.makeRecyclingController(settings: settings)
+        defer { controller.releaseStatusItemsForTesting() }
+
+        let menu = NSMenu()
+        let item = controller.makeMenuCardItem(
+            Text("Embedded"),
+            id: "embedded",
+            width: 300,
+            containsInteractiveControls: true)
+        menu.addItem(item)
+
+        controller.menu(menu, willHighlight: item)
+
+        #expect(item.isEnabled)
+        #expect(controller.highlightedMenuItems[ObjectIdentifier(menu)] == nil)
+        guard let hosting = item.view as? MenuCardItemHostingView<MenuCardSectionContainerView<Text>>
+        else {
+            Issue.record("expected a card hosting view")
+            return
+        }
+        #expect(!hosting.allowsMenuHighlight)
+        #expect(!hosting.highlightState.isHighlighted)
     }
 
     @Test


### PR DESCRIPTION
## Summary

  Avoid highlighting non-interactive menu card rows on hover by only marking
  `NSMenuItem`s enabled when they actually expose interaction.

## Implementation

  - Updated `Sources/CodexBar/StatusItemController+MenuCardItems.swift`
  - Replaced unconditional `item.isEnabled = true` with `item.isEnabled =
  submenu != nil || onClick != nil`
  - Applied the same rule in both the non-rendered menu path and the hosting-
  view path
  - Preserves submenu rows and clickable rows as enabled
  - Leaves informational rows disabled so AppKit does not treat them as hover-
  highlightable actions

## Why

  The previous implementation marked every menu card item as enabled, including
  rows that were purely informational. That caused AppKit to render them like
  interactive menu items on hover, which implied behavior that does not exist.

## Testing

  - Built the app locally
  - Tested the updated hover behavior in the app
  - Ran `swift test --filter MenuCardViewRecyclingTests`
  - Swift Testing reported 17 tests in 1 suite passed

## Screenshots
Before:

<img width="317" height="955" alt="Screenshot 2026-06-16 at 3 26 11 PM" src="https://github.com/user-attachments/assets/e5ed9408-3108-4a46-94d9-3eccc6aa347e" />
<img width="334" height="958" alt="Screenshot 2026-06-16 at 3 25 57 PM" src="https://github.com/user-attachments/assets/ea8449bb-4f10-4518-b17a-89c6f5974590" />
After:

<img width="323" height="905" alt="Screenshot 2026-06-16 at 3 50 39 PM" src="https://github.com/user-attachments/assets/2cbcbb30-e577-4c7f-ba00-83d3965e6d22" />
