### PR TITLE
ci: enhance i18n health checks across all locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Localization: improve Japanese terminology consistency and localize next-day reset times across all 21 app languages. Thanks @tukuyomil032!
+- Localization: validate placeholder integrity across every app language and repair malformed Vietnamese interpolation tokens. Thanks @Yuxin-Qiao!
 
 ## 0.36.1 — 2026-06-16
 

--- a/Scripts/check-app-locales.mjs
+++ b/Scripts/check-app-locales.mjs
@@ -91,7 +91,13 @@ for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith
   let identicalCount = 0;
 
   for (const key of englishKeys) {
-    if (!catalog[key]) continue;
+    if (!catalog[key]?.trim()) {
+      if (strictLocales.includes(locale) && catalogKeys.includes(key)) {
+        console.error(`\x1b[31m[${locale}] Error: Blank value for strict locale key "${key}".\x1b[0m`);
+        hasErrors = true;
+      }
+      continue;
+    }
 
     if (catalog[key] === english[key]) {
       identicalCount++;

--- a/Scripts/check-app-locales.mjs
+++ b/Scripts/check-app-locales.mjs
@@ -8,6 +8,8 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const resources = path.join(repoRoot, "Sources/CodexBar/Resources");
 const english = readCatalog("en");
 const englishKeys = Object.keys(english).sort();
+const strictLocales = ["ar", "fa", "th"];
+const languageKeys = ["language_arabic", "language_persian", "language_thai"];
 
 function readCatalog(locale) {
   const file = path.join(resources, `${locale}.lproj/Localizable.strings`);
@@ -16,15 +18,25 @@ function readCatalog(locale) {
   return JSON.parse(output);
 }
 
-function tokens(value) {
+function tokenSignature(value) {
   // Exclude explicit `%%` which don't require parameters
   const withoutEscapedPercents = value.replace(/%%/g, "");
   const printfRaw = withoutEscapedPercents.match(/%(?:\d+\$)?(?:\.\d+)?(?:@|d|f)/g) ?? [];
-  // Normalize printf tokens so positional specifiers like %1$@ are compared as %@
-  const printf = printfRaw.map(t => t.replace(/\d+\$/, ""));
+  
+  const printfMap = {};
+  let implicitIndex = 1;
+  for (const t of printfRaw) {
+    const match = t.match(/%(\d+)\$.*?([@df])/);
+    if (match) {
+      printfMap[parseInt(match[1], 10)] = match[2];
+    } else {
+      const type = t.slice(-1);
+      printfMap[implicitIndex++] = type;
+    }
+  }
 
   const swift = value.match(/\\\([^)]*\)/g) ?? [];
-  return [...printf, ...swift].sort();
+  return { printf: printfMap, swift: swift.sort() };
 }
 
 let hasErrors = false;
@@ -43,7 +55,20 @@ for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith
   // 1. Missing keys
   const missingKeys = englishKeys.filter(k => !catalogKeys.includes(k));
   if (missingKeys.length > 0) {
-    console.warn(`\x1b[33m[${locale}] Warning: Missing ${missingKeys.length} keys.\x1b[0m`);
+    if (strictLocales.includes(locale)) {
+      console.error(`\x1b[31m[${locale}] Error: Missing ${missingKeys.length} keys in strict locale.\x1b[0m`);
+      hasErrors = true;
+    } else {
+      console.warn(`\x1b[33m[${locale}] Warning: Missing ${missingKeys.length} keys.\x1b[0m`);
+    }
+  }
+
+  // Ensure critical language keys are present in ALL locales
+  for (const key of languageKeys) {
+    if (!catalog[key] || !catalog[key].trim()) {
+      console.error(`\x1b[31m[${locale}] Error: Missing critical language key "${key}".\x1b[0m`);
+      hasErrors = true;
+    }
   }
 
   // 2. Identical values count
@@ -58,8 +83,8 @@ for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith
     }
 
     // 3. Format placeholder mismatch
-    const tEn = tokens(english[key]);
-    const tLoc = tokens(catalog[key]);
+    const tEn = tokenSignature(english[key]);
+    const tLoc = tokenSignature(catalog[key]);
     if (JSON.stringify(tEn) !== JSON.stringify(tLoc)) {
       console.error(`\x1b[31m[${locale}] Error: Token mismatch for key "${key}"\x1b[0m`);
       console.error(`  en: ${english[key]}  Tokens: ${JSON.stringify(tEn)}`);

--- a/Scripts/check-app-locales.mjs
+++ b/Scripts/check-app-locales.mjs
@@ -78,6 +78,14 @@ if (isTest) {
 let hasErrors = false;
 let checkedCount = 0;
 
+for (const strictLocale of strictLocales) {
+  const dirPath = path.join(resources, `${strictLocale}.lproj`);
+  if (!fs.existsSync(dirPath)) {
+    console.error(`\x1b[31mError: Required strict locale catalog is completely missing: ${strictLocale}.lproj\x1b[0m`);
+    hasErrors = true;
+  }
+}
+
 for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith(".lproj"))) {
   const locale = directory.replace(/\.lproj$/, "");
   if (locale === "en" || locale === "Base") continue;

--- a/Scripts/check-app-locales.mjs
+++ b/Scripts/check-app-locales.mjs
@@ -8,43 +8,78 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const resources = path.join(repoRoot, "Sources/CodexBar/Resources");
 const english = readCatalog("en");
 const englishKeys = Object.keys(english).sort();
-const newLocales = ["ar", "fa", "th"];
-const languageKeys = ["language_arabic", "language_persian", "language_thai"];
-
-for (const locale of newLocales) {
-  const catalog = readCatalog(locale);
-  assertEqual(Object.keys(catalog).sort(), englishKeys, `${locale} catalog keys`);
-  for (const key of englishKeys) {
-    assert(catalog[key].trim(), `${locale}.${key} is blank`);
-    assertEqual(tokens(catalog[key]), tokens(english[key]), `${locale}.${key} tokens`);
-  }
-}
-
-for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith(".lproj"))) {
-  const catalog = readCatalog(directory.replace(/\.lproj$/, ""));
-  for (const key of languageKeys) assert(catalog[key]?.trim(), `${directory} missing ${key}`);
-}
-
-console.log(`app locales OK: ${newLocales.length} complete catalogs, ${englishKeys.length} keys`);
 
 function readCatalog(locale) {
   const file = path.join(resources, `${locale}.lproj/Localizable.strings`);
+  if (!fs.existsSync(file)) return null;
   const output = execFileSync("plutil", ["-convert", "json", "-o", "-", file], { encoding: "utf8" });
   return JSON.parse(output);
 }
 
 function tokens(value) {
-  const printf = value.match(/%(?:\d+\$)?(?:\.\d+)?(?:@|d|f|%)/g) ?? [];
+  // Exclude explicit `%%` which don't require parameters
+  const withoutEscapedPercents = value.replace(/%%/g, "");
+  const printfRaw = withoutEscapedPercents.match(/%(?:\d+\$)?(?:\.\d+)?(?:@|d|f)/g) ?? [];
+  // Normalize printf tokens so positional specifiers like %1$@ are compared as %@
+  const printf = printfRaw.map(t => t.replace(/\d+\$/, ""));
+
   const swift = value.match(/\\\([^)]*\)/g) ?? [];
   return [...printf, ...swift].sort();
 }
 
-function assert(condition, message) {
-  if (!condition) throw new Error(message);
-}
+let hasErrors = false;
+let checkedCount = 0;
 
-function assertEqual(actual, expected, label) {
-  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
-    throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith(".lproj"))) {
+  const locale = directory.replace(/\.lproj$/, "");
+  if (locale === "en" || locale === "Base") continue;
+  
+  const catalog = readCatalog(locale);
+  if (!catalog) continue;
+
+  checkedCount++;
+  const catalogKeys = Object.keys(catalog);
+  
+  // 1. Missing keys
+  const missingKeys = englishKeys.filter(k => !catalogKeys.includes(k));
+  if (missingKeys.length > 0) {
+    console.warn(`\x1b[33m[${locale}] Warning: Missing ${missingKeys.length} keys.\x1b[0m`);
+  }
+
+  // 2. Identical values count
+  let identicalCount = 0;
+  let mismatchedTokensCount = 0;
+
+  for (const key of englishKeys) {
+    if (!catalog[key]) continue;
+    
+    if (catalog[key] === english[key]) {
+      identicalCount++;
+    }
+
+    // 3. Format placeholder mismatch
+    const tEn = tokens(english[key]);
+    const tLoc = tokens(catalog[key]);
+    if (JSON.stringify(tEn) !== JSON.stringify(tLoc)) {
+      console.error(`\x1b[31m[${locale}] Error: Token mismatch for key "${key}"\x1b[0m`);
+      console.error(`  en: ${english[key]}  Tokens: ${JSON.stringify(tEn)}`);
+      console.error(`  ${locale}: ${catalog[key]}  Tokens: ${JSON.stringify(tLoc)}`);
+      mismatchedTokensCount++;
+      hasErrors = true;
+    }
+  }
+
+  // Warn if identical translation count exceeds 15% of the total keys (approx > 150 out of 1050)
+  const identicalRatio = identicalCount / englishKeys.length;
+  if (identicalRatio > 0.15) {
+     console.warn(`\x1b[33m[${locale}] Warning: High number of identical translations: ${identicalCount}/${englishKeys.length} (${(identicalRatio * 100).toFixed(1)}%)\x1b[0m`);
   }
 }
+
+if (hasErrors) {
+  console.error(`\n\x1b[31mi18n checks failed due to token mismatches.\x1b[0m`);
+  process.exit(1);
+} else {
+  console.log(`\n\x1b[32mApp locales OK: Checked ${checkedCount} catalogs, ${englishKeys.length} keys each.\x1b[0m`);
+}
+

--- a/Scripts/check-app-locales.mjs
+++ b/Scripts/check-app-locales.mjs
@@ -36,8 +36,26 @@ function tokenSignature(value) {
     }
   }
 
-  const swift = value.match(/\\\([^)]*\)/g) ?? [];
-  return { printf, swift: swift.sort() };
+  return { printf, swift: swiftInterpolationTokens(value).sort() };
+}
+
+function swiftInterpolationTokens(value) {
+  const tokens = [];
+  for (let index = 0; index < value.length - 1; index += 1) {
+    if (value[index] !== "\\" || value[index + 1] !== "(") continue;
+
+    const start = index;
+    let depth = 1;
+    index += 2;
+    while (index < value.length && depth > 0) {
+      if (value[index] === "(") depth += 1;
+      if (value[index] === ")") depth -= 1;
+      index += 1;
+    }
+    tokens.push(value.slice(start, index));
+    index -= 1;
+  }
+  return tokens;
 }
 
 if (isTest) {
@@ -45,6 +63,14 @@ if (isTest) {
   assertNotEqual(tokenSignature("%1$@ · %2$d"), tokenSignature("%1$d · %2$@"), "positional type swap");
   assertEqual(tokenSignature("%.0f%% used"), tokenSignature("%.0f%% verbraucht"), "escaped percent");
   assertNotEqual(tokenSignature("\\(name): \\(usage)"), tokenSignature("\\(name): \\(value)"), "Swift tokens");
+  assertEqual(
+    tokenSignature("\\(self.store.metadata(for: self.provider).displayName) failed"),
+    tokenSignature("Fehler: \\(self.store.metadata(for: self.provider).displayName)"),
+    "nested Swift interpolation");
+  assertNotEqual(
+    tokenSignature("\\(self.store.metadata(for: self.provider).displayName) failed"),
+    tokenSignature("\\(self.store.metadata(for: self.provider) failed"),
+    "truncated Swift interpolation");
   console.log("app locale checker tests OK");
   process.exit(0);
 }

--- a/Scripts/check-app-locales.mjs
+++ b/Scripts/check-app-locales.mjs
@@ -10,6 +10,7 @@ const english = readCatalog("en");
 const englishKeys = Object.keys(english).sort();
 const strictLocales = ["ar", "fa", "th"];
 const languageKeys = ["language_arabic", "language_persian", "language_thai"];
+const isTest = process.argv.includes("--test");
 
 function readCatalog(locale) {
   const file = path.join(resources, `${locale}.lproj/Localizable.strings`);
@@ -19,24 +20,33 @@ function readCatalog(locale) {
 }
 
 function tokenSignature(value) {
-  // Exclude explicit `%%` which don't require parameters
+  // Exclude explicit `%%`, which does not consume an argument.
   const withoutEscapedPercents = value.replace(/%%/g, "");
   const printfRaw = withoutEscapedPercents.match(/%(?:\d+\$)?(?:\.\d+)?(?:@|d|f)/g) ?? [];
-  
-  const printfMap = {};
+
+  const printf = {};
   let implicitIndex = 1;
-  for (const t of printfRaw) {
-    const match = t.match(/%(\d+)\$.*?([@df])/);
+  for (const token of printfRaw) {
+    const match = token.match(/%(\d+)\$.*?([@df])/);
     if (match) {
-      printfMap[parseInt(match[1], 10)] = match[2];
+      printf[Number.parseInt(match[1], 10)] = match[2];
     } else {
-      const type = t.slice(-1);
-      printfMap[implicitIndex++] = type;
+      printf[implicitIndex] = token.at(-1);
+      implicitIndex += 1;
     }
   }
 
   const swift = value.match(/\\\([^)]*\)/g) ?? [];
-  return { printf: printfMap, swift: swift.sort() };
+  return { printf, swift: swift.sort() };
+}
+
+if (isTest) {
+  assertEqual(tokenSignature("%1$@ · %2$d"), tokenSignature("%2$d · %1$@"), "positional reorder");
+  assertNotEqual(tokenSignature("%1$@ · %2$d"), tokenSignature("%1$d · %2$@"), "positional type swap");
+  assertEqual(tokenSignature("%.0f%% used"), tokenSignature("%.0f%% verbraucht"), "escaped percent");
+  assertNotEqual(tokenSignature("\\(name): \\(usage)"), tokenSignature("\\(name): \\(value)"), "Swift tokens");
+  console.log("app locale checker tests OK");
+  process.exit(0);
 }
 
 let hasErrors = false;
@@ -51,9 +61,9 @@ for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith
 
   checkedCount++;
   const catalogKeys = Object.keys(catalog);
-  
+
   // 1. Missing keys
-  const missingKeys = englishKeys.filter(k => !catalogKeys.includes(k));
+  const missingKeys = englishKeys.filter((key) => !catalogKeys.includes(key));
   if (missingKeys.length > 0) {
     if (strictLocales.includes(locale)) {
       console.error(`\x1b[31m[${locale}] Error: Missing ${missingKeys.length} keys in strict locale.\x1b[0m`);
@@ -61,6 +71,12 @@ for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith
     } else {
       console.warn(`\x1b[33m[${locale}] Warning: Missing ${missingKeys.length} keys.\x1b[0m`);
     }
+  }
+
+  const extraKeys = catalogKeys.filter((key) => !englishKeys.includes(key));
+  if (strictLocales.includes(locale) && extraKeys.length > 0) {
+    console.error(`\x1b[31m[${locale}] Error: Found ${extraKeys.length} extra keys in strict locale.\x1b[0m`);
+    hasErrors = true;
   }
 
   // Ensure critical language keys are present in ALL locales
@@ -73,11 +89,10 @@ for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith
 
   // 2. Identical values count
   let identicalCount = 0;
-  let mismatchedTokensCount = 0;
 
   for (const key of englishKeys) {
     if (!catalog[key]) continue;
-    
+
     if (catalog[key] === english[key]) {
       identicalCount++;
     }
@@ -89,7 +104,6 @@ for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith
       console.error(`\x1b[31m[${locale}] Error: Token mismatch for key "${key}"\x1b[0m`);
       console.error(`  en: ${english[key]}  Tokens: ${JSON.stringify(tEn)}`);
       console.error(`  ${locale}: ${catalog[key]}  Tokens: ${JSON.stringify(tLoc)}`);
-      mismatchedTokensCount++;
       hasErrors = true;
     }
   }
@@ -97,14 +111,25 @@ for (const directory of fs.readdirSync(resources).filter((name) => name.endsWith
   // Warn if identical translation count exceeds 15% of the total keys (approx > 150 out of 1050)
   const identicalRatio = identicalCount / englishKeys.length;
   if (identicalRatio > 0.15) {
-     console.warn(`\x1b[33m[${locale}] Warning: High number of identical translations: ${identicalCount}/${englishKeys.length} (${(identicalRatio * 100).toFixed(1)}%)\x1b[0m`);
+    console.warn(`\x1b[33m[${locale}] Warning: High number of identical translations: ${identicalCount}/${englishKeys.length} (${(identicalRatio * 100).toFixed(1)}%)\x1b[0m`);
   }
 }
 
 if (hasErrors) {
-  console.error(`\n\x1b[31mi18n checks failed due to token mismatches.\x1b[0m`);
+  console.error("\n\x1b[31mApp locale checks failed.\x1b[0m");
   process.exit(1);
-} else {
-  console.log(`\n\x1b[32mApp locales OK: Checked ${checkedCount} catalogs, ${englishKeys.length} keys each.\x1b[0m`);
 }
 
+console.log(`\n\x1b[32mApp locales OK: Checked ${checkedCount} catalogs against ${englishKeys.length} English keys.\x1b[0m`);
+
+function assertEqual(actual, expected, label) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`${label}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}
+
+function assertNotEqual(actual, expected, label) {
+  if (JSON.stringify(actual) === JSON.stringify(expected)) {
+    throw new Error(`${label}: signatures unexpectedly match`);
+  }
+}

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -32,6 +32,7 @@ check_swift_test_sharding() {
 }
 
 check_site_locales() {
+  node "${ROOT_DIR}/Scripts/check-app-locales.mjs" --test
   node "${ROOT_DIR}/Scripts/check-app-locales.mjs"
   node "${ROOT_DIR}/Scripts/check-site-locales.mjs"
   node --check "${ROOT_DIR}/docs/site.js"

--- a/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
+++ b/Sources/CodexBar/Resources/vi.lproj/Localizable.strings
@@ -60,7 +60,7 @@
 "Choose Codex workspace" = "Chọn không gian làm việc Codex";
 "Choose the MiniMax host (global .io or China mainland .com)." = "Chọn máy chủ MiniMax (toàn cầu .io hoặc Trung Quốc đại lục .com).";
 "Choose up to " = "Chọn tối đa";
-"Choose up to \\(Self.maxOverviewProviders) providers" = "Chọn tối đa nhà cung cấp \\(Self.maxOverviewProviders";
+"Choose up to \\(Self.maxOverviewProviders) providers" = "Chọn tối đa nhà cung cấp \\(Self.maxOverviewProviders)";
 "Choose up to \\(count) providers" = "Chọn tối đa \\(count) nhà cung cấp";
 "Choose what to show in the menu bar (Pace shows usage vs. expected)." = "Chọn nội dung sẽ hiển thị trong thanh menu (Tốc độ hiển thị Mức sử dụng so với dự kiến).";
 "Choose which Codex account CodexBar should follow." = "Chọn tài khoản Codex mà CodexBar sẽ tuân theo.";
@@ -155,7 +155,7 @@
 "Keychain access" = "Keychain truy cập";
 "Keychain prompt policy" = "Keychain chính sách nhắc";
 "Last \\(name) fetch failed:" = "Tìm nạp \\(name) lần cuối không thành công:";
-"Last \\(self.store.metadata(for: self.provider).displayName) fetch failed:" = "Lần tìm nạp \\(self.store.metadata(for: self. Nhà cung cấp ) .displayName) lần cuối không thành công:";
+"Last \\(self.store.metadata(for: self.provider).displayName) fetch failed:" = "Lần tìm nạp \\(self.store.metadata(for: self.provider).displayName) lần cuối không thành công:";
 "Last attempt" = "Lần thử cuối cùng";
 "Link" = "Liên kết";
 "Loading animations" = "Đang tải hình động";
@@ -258,7 +258,7 @@
 "Replace critter bars with provider branding icons and a percentage." = "Thay thế các thanh sinh vật bằng Nhà cung cấp biểu tượng nhãn hiệu và tỷ lệ phần trăm.";
 "Replay selected animation" = "Phát lại hoạt ảnh đã chọn";
 "Requires authentication via GitHub Device Flow." = "Yêu cầu xác thực thông qua GitHub Device Flow.";
-"Resets: \\(reset)" = "Đặt lại: \\( Đặt lại )";
+"Resets: \\(reset)" = "Đặt lại: \\(reset)";
 "Rolling five-hour limit" = "Giới hạn 5 giờ liên tục";
 "Search hourly" = "Tìm kiếm hàng giờ";
 "Secondary (\\(label))" = "Phụ (\\(label))";
@@ -342,8 +342,8 @@
 "Window: \\(window)" = "Cửa sổ: \\(window)";
 "Write logs to \\(self.fileLogPath) for debugging." = "Ghi nhật ký vào \\(self.fileLogPath) để gỡ lỗi.";
 "Yes" = "Có";
-"\\(detail.modelCode): \\(usage)" = "\\(detail.modelCode): \\( Mức sử dụng )";
-"\\(name): \\(truncated)" = "\\(name): \\(cắt ngắn)";
+"\\(detail.modelCode): \\(usage)" = "\\(detail.modelCode): \\(usage)";
+"\\(name): \\(truncated)" = "\\(name): \\(truncated)";
 "\\(name): \\(updated) · 30d \\(cost)" = "\\(name): \\(updated) · 30d \\(cost)";
 "\\(name): fetching…\\(elapsed)" = "\\(name): đang tìm nạp…\\(elapsed)";
 "\\(name): last attempt \\(when)" = "\\(name): lần thử cuối cùng \\(when)";


### PR DESCRIPTION
This PR upgrades `check-app-locales.mjs` to systematically iterate through all `.lproj` directories to check for:
1. Missing keys
2. Identical values count to baseline (warns if unusually high)
3. Formatting placeholder mismatches (e.g. `%@` and `\(...)`)

Also includes fixes for formatting placeholder bugs in `vi.lproj`.