### PR TITLE
Add usage data confidence metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Codex: show available manual rate-limit reset credits and their next expiry for signed-in OAuth accounts. Thanks @rogdex24!
 - Linux CLI: publish static musl release tarballs for x86_64 and aarch64. Thanks @Yuxin-Qiao!
 - Documentation: add safe troubleshooting for browser Keychain prompts that persist after uninstall. Thanks @Yuxin-Qiao!
+- Diagnostics: report provider-neutral usage confidence and mark fully decoded Codex OAuth windows exact. Thanks @Yuxin-Qiao!
 - Codex agents: add a read-only `codexbar` skill for bounded, redacted provider usage JSON. Thanks @coygeek!
 - Display: add a Hide critters option for plain menu bar quota capsules. Thanks @elijahfriedman!
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexOAuth/CodexOAuthUsageFetcher.swift
@@ -9,6 +9,7 @@ public struct CodexUsageResponse: Decodable, Sendable {
     public let credits: CreditDetails?
     /// Model-specific limits (e.g. GPT-5.3-Codex-Spark) that sit alongside the primary/weekly windows.
     public let additionalRateLimits: [AdditionalRateLimit]?
+    let additionalRateLimitsDecodeFailed: Bool
 
     enum CodingKeys: String, CodingKey {
         case planType = "plan_type"
@@ -25,10 +26,26 @@ public struct CodexUsageResponse: Decodable, Sendable {
         // Optional and additive: missing/malformed extra limits must never disturb primary/weekly mapping.
         // Decode per element so a single malformed entry cannot discard its valid siblings; a non-array
         // value (or absent field) leaves `additionalRateLimits` nil and primary/weekly mapping untouched.
-        let additionalRateLimits = try? container.decodeIfPresent(
-            [LossyAdditionalRateLimit].self,
-            forKey: .additionalRateLimits)
-        self.additionalRateLimits = additionalRateLimits?.compactMap(\.value)
+        let additionalRateLimitsHadValue = Self.hasNonNilValue(container: container, key: .additionalRateLimits)
+        do {
+            let decoded = try container.decodeIfPresent(
+                [LossyAdditionalRateLimit].self,
+                forKey: .additionalRateLimits)
+            self.additionalRateLimits = decoded?.compactMap(\.value)
+            self.additionalRateLimitsDecodeFailed = decoded?.contains(where: \.decodeFailed) == true
+                || self.additionalRateLimits?.contains(where: \.hasWindowDecodeFailure) == true
+        } catch {
+            self.additionalRateLimits = nil
+            self.additionalRateLimitsDecodeFailed = additionalRateLimitsHadValue
+        }
+    }
+
+    private static func hasNonNilValue(
+        container: KeyedDecodingContainer<CodingKeys>,
+        key: CodingKeys) -> Bool
+    {
+        guard container.contains(key) else { return false }
+        return (try? container.decodeNil(forKey: key)) == false
     }
 
     public enum PlanType: Sendable, Decodable, Equatable {
@@ -152,6 +169,7 @@ public struct CodexUsageResponse: Decodable, Sendable {
         public let limitName: String?
         public let meteredFeature: String?
         public let rateLimit: RateLimitDetails?
+        let rateLimitDecodeFailed: Bool
 
         enum CodingKeys: String, CodingKey {
             case limitName = "limit_name"
@@ -163,7 +181,26 @@ public struct CodexUsageResponse: Decodable, Sendable {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.limitName = try? container.decodeIfPresent(String.self, forKey: .limitName)
             self.meteredFeature = try? container.decodeIfPresent(String.self, forKey: .meteredFeature)
-            self.rateLimit = try? container.decodeIfPresent(RateLimitDetails.self, forKey: .rateLimit)
+            let rateLimitHadValue = Self.hasNonNilValue(container: container, key: .rateLimit)
+            do {
+                self.rateLimit = try container.decodeIfPresent(RateLimitDetails.self, forKey: .rateLimit)
+                self.rateLimitDecodeFailed = false
+            } catch {
+                self.rateLimit = nil
+                self.rateLimitDecodeFailed = rateLimitHadValue
+            }
+        }
+
+        private static func hasNonNilValue(
+            container: KeyedDecodingContainer<CodingKeys>,
+            key: CodingKeys) -> Bool
+        {
+            guard container.contains(key) else { return false }
+            return (try? container.decodeNil(forKey: key)) == false
+        }
+
+        var hasWindowDecodeFailure: Bool {
+            self.rateLimitDecodeFailed || self.rateLimit?.hasWindowDecodeFailure == true
         }
     }
 
@@ -171,10 +208,12 @@ public struct CodexUsageResponse: Decodable, Sendable {
     /// entry cannot discard its valid siblings during array decoding.
     private struct LossyAdditionalRateLimit: Decodable {
         let value: AdditionalRateLimit?
+        let decodeFailed: Bool
 
         init(from decoder: Decoder) throws {
             let container = try decoder.singleValueContainer()
             self.value = try? container.decode(AdditionalRateLimit.self)
+            self.decodeFailed = self.value == nil
         }
     }
 

--- a/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
+++ b/Sources/CodexBarCore/Providers/Codex/CodexProviderDescriptor.swift
@@ -246,8 +246,14 @@ struct CodexOAuthFetchStrategy: ProviderFetchStrategy {
             updatedAt: updatedAt)
 
         if let reconciled {
+            let dataConfidence: UsageDataConfidence = usageResponse.rateLimit?.hasWindowDecodeFailure == true
+                || usageResponse.additionalRateLimitsDecodeFailed
+                ? .unknown
+                : .exact
             return CodexOAuthFetchStrategy().makeResult(
-                usage: reconciled.toUsageSnapshot().withCodexResetCredits(resetCredits),
+                usage: reconciled.toUsageSnapshot()
+                    .withCodexResetCredits(resetCredits)
+                    .withDataConfidence(dataConfidence),
                 credits: credits,
                 sourceLabel: "oauth")
         }

--- a/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
@@ -85,6 +85,7 @@ public struct ProviderDiagnosticAuthSummary: Codable, Sendable {
 
 public struct ProviderDiagnosticUsageSummary: Codable, Sendable {
     public let updatedAt: Date
+    public let dataConfidence: String
     public let windows: [ProviderDiagnosticRateWindow]
     public let extraWindowCount: Int
     public let providerCostPresent: Bool
@@ -122,6 +123,7 @@ public struct ProviderDiagnosticUsageSummary: Codable, Sendable {
         if snapshot.cursorRequests != nil { providerSpecificData.append("cursorRequests") }
 
         self.updatedAt = snapshot.updatedAt
+        self.dataConfidence = snapshot.dataConfidence.rawValue
         self.windows = windows
         self.extraWindowCount = snapshot.extraRateWindows?.count ?? 0
         self.providerCostPresent = snapshot.providerCost != nil

--- a/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
+++ b/Sources/CodexBarCore/Providers/ProviderDiagnosticExport.swift
@@ -91,6 +91,15 @@ public struct ProviderDiagnosticUsageSummary: Codable, Sendable {
     public let providerCostPresent: Bool
     public let providerSpecificData: [String]
 
+    private enum CodingKeys: String, CodingKey {
+        case updatedAt
+        case dataConfidence
+        case windows
+        case extraWindowCount
+        case providerCostPresent
+        case providerSpecificData
+    }
+
     public init(from snapshot: UsageSnapshot) {
         var windows: [ProviderDiagnosticRateWindow] = []
         if let primary = snapshot.primary {
@@ -128,6 +137,17 @@ public struct ProviderDiagnosticUsageSummary: Codable, Sendable {
         self.extraWindowCount = snapshot.extraRateWindows?.count ?? 0
         self.providerCostPresent = snapshot.providerCost != nil
         self.providerSpecificData = providerSpecificData.sorted()
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        self.dataConfidence = try container.decodeIfPresent(String.self, forKey: .dataConfidence)
+            ?? UsageDataConfidence.unknown.rawValue
+        self.windows = try container.decode([ProviderDiagnosticRateWindow].self, forKey: .windows)
+        self.extraWindowCount = try container.decode(Int.self, forKey: .extraWindowCount)
+        self.providerCostPresent = try container.decode(Bool.self, forKey: .providerCostPresent)
+        self.providerSpecificData = try container.decode([String].self, forKey: .providerSpecificData)
     }
 }
 

--- a/Sources/CodexBarCore/UsageFetcher.swift
+++ b/Sources/CodexBarCore/UsageFetcher.swift
@@ -117,6 +117,13 @@ public struct ProviderIdentitySnapshot: Codable, Sendable {
     }
 }
 
+public enum UsageDataConfidence: String, Codable, Equatable, Sendable {
+    case exact
+    case estimated
+    case percentOnly
+    case unknown
+}
+
 public struct UsageSnapshot: Codable, Sendable {
     public let primary: RateWindow?
     public let secondary: RateWindow?
@@ -141,6 +148,7 @@ public struct UsageSnapshot: Codable, Sendable {
     public let subscriptionRenewsAt: Date?
     public let updatedAt: Date
     public let identity: ProviderIdentitySnapshot?
+    public let dataConfidence: UsageDataConfidence
 
     private enum CodingKeys: String, CodingKey {
         case primary
@@ -162,6 +170,7 @@ public struct UsageSnapshot: Codable, Sendable {
         case subscriptionRenewsAt
         case updatedAt
         case identity
+        case dataConfidence
         case accountEmail
         case accountOrganization
         case loginMethod
@@ -190,7 +199,8 @@ public struct UsageSnapshot: Codable, Sendable {
         subscriptionExpiresAt: Date? = nil,
         subscriptionRenewsAt: Date? = nil,
         updatedAt: Date,
-        identity: ProviderIdentitySnapshot? = nil)
+        identity: ProviderIdentitySnapshot? = nil,
+        dataConfidence: UsageDataConfidence = .unknown)
     {
         self.primary = primary
         self.secondary = secondary
@@ -215,6 +225,7 @@ public struct UsageSnapshot: Codable, Sendable {
         self.subscriptionRenewsAt = subscriptionRenewsAt
         self.updatedAt = updatedAt
         self.identity = identity
+        self.dataConfidence = dataConfidence
     }
 
     public func with(extraRateWindows: [NamedRateWindow]?) -> UsageSnapshot {
@@ -259,6 +270,11 @@ public struct UsageSnapshot: Codable, Sendable {
         self.subscriptionExpiresAt = try container.decodeIfPresent(Date.self, forKey: .subscriptionExpiresAt)
         self.subscriptionRenewsAt = try container.decodeIfPresent(Date.self, forKey: .subscriptionRenewsAt)
         self.updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        if let dataConfidence = try container.decodeIfPresent(String.self, forKey: .dataConfidence) {
+            self.dataConfidence = UsageDataConfidence(rawValue: dataConfidence) ?? .unknown
+        } else {
+            self.dataConfidence = .unknown
+        }
         if let identity = try container.decodeIfPresent(ProviderIdentitySnapshot.self, forKey: .identity) {
             self.identity = identity
         } else {
@@ -299,6 +315,9 @@ public struct UsageSnapshot: Codable, Sendable {
         try container.encodeIfPresent(self.subscriptionRenewsAt, forKey: .subscriptionRenewsAt)
         try container.encode(self.updatedAt, forKey: .updatedAt)
         try container.encodeIfPresent(self.identity, forKey: .identity)
+        if self.dataConfidence != .unknown {
+            try container.encode(self.dataConfidence, forKey: .dataConfidence)
+        }
         try container.encodeIfPresent(self.identity?.accountEmail, forKey: .accountEmail)
         try container.encodeIfPresent(self.identity?.accountOrganization, forKey: .accountOrganization)
         try container.encodeIfPresent(self.identity?.loginMethod, forKey: .loginMethod)
@@ -386,6 +405,10 @@ public struct UsageSnapshot: Codable, Sendable {
         self.replacing(identity: .value(identity))
     }
 
+    public func withDataConfidence(_ dataConfidence: UsageDataConfidence) -> UsageSnapshot {
+        self.replacing(dataConfidence: .value(dataConfidence))
+    }
+
     public func scoped(to provider: UsageProvider) -> UsageSnapshot {
         guard let identity else { return self }
         let scopedIdentity = identity.scoped(to: provider)
@@ -444,7 +467,8 @@ public struct UsageSnapshot: Codable, Sendable {
         tertiary: Replacement<RateWindow?> = .unchanged,
         extraRateWindows: Replacement<[NamedRateWindow]?> = .unchanged,
         codexResetCredits: Replacement<CodexRateLimitResetCreditsSnapshot?> = .unchanged,
-        identity: Replacement<ProviderIdentitySnapshot?> = .unchanged) -> UsageSnapshot
+        identity: Replacement<ProviderIdentitySnapshot?> = .unchanged,
+        dataConfidence: Replacement<UsageDataConfidence> = .unchanged) -> UsageSnapshot
     {
         UsageSnapshot(
             primary: primary.resolving(self.primary),
@@ -469,7 +493,8 @@ public struct UsageSnapshot: Codable, Sendable {
             subscriptionExpiresAt: self.subscriptionExpiresAt,
             subscriptionRenewsAt: self.subscriptionRenewsAt,
             updatedAt: self.updatedAt,
-            identity: identity.resolving(self.identity))
+            identity: identity.resolving(self.identity),
+            dataConfidence: dataConfidence.resolving(self.dataConfidence))
     }
 }
 

--- a/Tests/CodexBarTests/CodexOAuthTests.swift
+++ b/Tests/CodexBarTests/CodexOAuthTests.swift
@@ -165,6 +165,73 @@ struct CodexOAuthTests {
     }
 
     @Test
+    func `O auth response with precise windows maps to exact confidence`() throws {
+        let json = """
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 22,
+              "reset_at": 1766948068,
+              "limit_window_seconds": 18000
+            },
+            "secondary_window": {
+              "used_percent": 43,
+              "reset_at": 1767407914,
+              "limit_window_seconds": 604800
+            }
+          }
+        }
+        """
+        let creds = CodexOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: nil,
+            accountId: nil,
+            lastRefresh: Date())
+        let result = try CodexOAuthFetchStrategy._mapResultForTesting(Data(json.utf8), credentials: creds)
+
+        #expect(result.sourceLabel == "oauth")
+        #expect(result.usage.dataConfidence == .exact)
+        #expect(result.usage.primary?.usedPercent == 22)
+        #expect(result.usage.secondary?.usedPercent == 43)
+    }
+
+    @Test
+    func `O auth response with malformed additional window maps to unknown confidence`() throws {
+        let json = """
+        {
+          "rate_limit": {
+            "primary_window": {
+              "used_percent": 22,
+              "reset_at": 1766948068,
+              "limit_window_seconds": 18000
+            }
+          },
+          "additional_rate_limits": [
+            {
+              "limit_name": "GPT-5.3-Codex-Spark",
+              "metered_feature": "gpt_5_3_codex_spark",
+              "rate_limit": {
+                "primary_window": { "used_percent": "bad" }
+              }
+            }
+          ]
+        }
+        """
+        let creds = CodexOAuthCredentials(
+            accessToken: "access",
+            refreshToken: "refresh",
+            idToken: nil,
+            accountId: nil,
+            lastRefresh: Date())
+        let result = try CodexOAuthFetchStrategy._mapResultForTesting(Data(json.utf8), credentials: creds)
+
+        #expect(result.usage.primary?.usedPercent == 22)
+        #expect(result.usage.extraRateWindows == nil)
+        #expect(result.usage.dataConfidence == .unknown)
+    }
+
+    @Test
     func `maps free weekly only window into secondary`() throws {
         let json = """
         {
@@ -352,6 +419,11 @@ struct CodexOAuthTests {
         let snapshot = try CodexOAuthFetchStrategy._mapUsageForTesting(Data(json.utf8), credentials: creds)
         #expect(snapshot?.primary?.usedPercent == 18)
         #expect(snapshot?.secondary == nil)
+
+        let result = try CodexOAuthFetchStrategy._mapResultForTesting(Data(json.utf8), credentials: creds)
+        #expect(result.usage.primary?.usedPercent == 18)
+        #expect(result.usage.secondary == nil)
+        #expect(result.usage.dataConfidence == .unknown)
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
+++ b/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
@@ -36,6 +36,8 @@ struct ProviderDiagnosticExportTests {
         #expect(json.contains("\"provider\""))
         #expect(json.contains("\"openai\""))
         #expect(json.contains("\"auth\""))
+        #expect(json.contains("\"dataConfidence\""))
+        #expect(json.contains("\"unknown\""))
         #expect(json.contains("\"hasResetDescription\""))
         #expect(!json.contains("sk-cp-"))
         #expect(!json.contains("sk-api-"))
@@ -43,6 +45,109 @@ struct ProviderDiagnosticExportTests {
         #expect(!json.contains("raw local text"))
         #expect(!json.contains("errorMessage"))
         #expect(!json.contains("localizedDescription"))
+    }
+
+    @Test
+    func `usage snapshot defaults legacy payloads to unknown confidence without reencoding unknown`() throws {
+        let json = """
+        {
+          "primary": {
+            "usedPercent": 42,
+            "windowMinutes": 300,
+            "hasResetDescription": false
+          },
+          "secondary": null,
+          "tertiary": null,
+          "updatedAt": "2023-11-14T22:13:20Z"
+        }
+        """
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let snapshot = try decoder.decode(UsageSnapshot.self, from: Data(json.utf8))
+        #expect(snapshot.dataConfidence == .unknown)
+
+        let encoded = try self.json(snapshot)
+        #expect(!encoded.contains("dataConfidence"))
+    }
+
+    @Test
+    func `usage snapshot preserves explicit confidence through Codable`() throws {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 12,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(18000),
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now,
+            dataConfidence: .exact)
+
+        let encoded = try self.json(snapshot)
+        #expect(encoded.contains("\"dataConfidence\" : \"exact\""))
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(UsageSnapshot.self, from: Data(encoded.utf8))
+        #expect(decoded.dataConfidence == .exact)
+    }
+
+    @Test
+    func `usage snapshot treats future confidence values as unknown`() throws {
+        let json = """
+        {
+          "primary": null,
+          "secondary": null,
+          "tertiary": null,
+          "updatedAt": "2023-11-14T22:13:20Z",
+          "dataConfidence": "future"
+        }
+        """
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let snapshot = try decoder.decode(UsageSnapshot.self, from: Data(json.utf8))
+
+        #expect(snapshot.dataConfidence == .unknown)
+        #expect(try !self.json(snapshot).contains("dataConfidence"))
+    }
+
+    @Test
+    func `diagnostic usage summary includes confidence`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let summary = ProviderDiagnosticUsageSummary(from: UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 12,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(18000),
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now,
+            dataConfidence: .exact))
+
+        #expect(summary.dataConfidence == "exact")
+    }
+
+    @Test
+    func `unwired provider diagnostics remain unknown confidence`() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snapshot = MiniMaxUsageSnapshot(
+            planName: "Max",
+            availablePrompts: 1000,
+            currentPrompts: 250,
+            remainingPrompts: 750,
+            windowMinutes: 300,
+            usedPercent: 25,
+            resetsAt: now.addingTimeInterval(18000),
+            updatedAt: now)
+
+        let usage = snapshot.toUsageSnapshot()
+        let summary = ProviderDiagnosticUsageSummary(from: usage)
+
+        #expect(usage.dataConfidence == .unknown)
+        #expect(summary.dataConfidence == "unknown")
+        #expect(summary.windows.first?.usedPercent == 25)
     }
 
     @Test

--- a/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
+++ b/Tests/CodexBarTests/ProviderDiagnosticExportTests.swift
@@ -130,6 +130,28 @@ struct ProviderDiagnosticExportTests {
     }
 
     @Test
+    func `diagnostic usage summary defaults legacy payloads to unknown confidence`() throws {
+        let json = """
+        {
+          "updatedAt": "2023-11-14T22:13:20Z",
+          "windows": [],
+          "extraWindowCount": 0,
+          "providerCostPresent": false,
+          "providerSpecificData": []
+        }
+        """
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let summary = try decoder.decode(
+            ProviderDiagnosticUsageSummary.self,
+            from: Data(json.utf8))
+
+        #expect(summary.dataConfidence == "unknown")
+        #expect(try self.json(summary).contains("\"dataConfidence\" : \"unknown\""))
+    }
+
+    @Test
     func `unwired provider diagnostics remain unknown confidence`() {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let snapshot = MiniMaxUsageSnapshot(


### PR DESCRIPTION
## Summary

- Add provider-neutral `UsageDataConfidence` metadata on `UsageSnapshot`.
- Default legacy, future, or unwired snapshots to `unknown` without re-encoding that default into cached snapshot JSON.
- Mark Codex OAuth usage as `exact` only when every advertised primary, weekly, and model-specific window decodes cleanly.
- Surface confidence in safe provider diagnostic JSON; no menu UI, fetch routing, fallback, or quota-calculation changes.
- Preserve decoding of legacy diagnostic JSON that predates the confidence field.

## Why

This is the first observational slice for #1126. `UsageSnapshot` is the shared diagnostic boundary, so confidence stays provider-neutral without leaking fetch-strategy details into UI or notification logic.

## Proof

- Combined Codex OAuth and provider diagnostic suites: 51 tests passed after the final current-main rebase.
- `make check` passed after the final current-main rebase.
- Local compatibility-fix autoreview: clean, confidence 0.86
- Full branch autoreview against `origin/main`: clean, confidence 0.82
- Deterministic OAuth fixtures prove `exact` for fully decoded windows and fail closed to `unknown` for malformed, future, and legacy data.
- Live authenticated Codex diagnostic returned source `openai-web`, usage present, no error, and `dataConfidence: unknown`. The account emitted no rate-limit event, so the branch reports the absence honestly instead of manufacturing positive `exact` proof.

Exact candidate: `3ac8e279cfed15077d92d6450901572722cc103b`. Its tree is identical to reviewed source parent `3de34dfebc02`; the final commit only retriggered CI.

Refs #1126
