### PR TITLE
Document safe Keychain prompt checks after uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Linux CLI: publish static musl release tarballs for x86_64 and aarch64. Thanks @Yuxin-Qiao!
+- Documentation: add safe troubleshooting for browser Keychain prompts that persist after uninstall. Thanks @Yuxin-Qiao!
 - Codex agents: add a read-only `codexbar` skill for bounded, redacted provider usage JSON. Thanks @coygeek!
 - Display: add a Hide critters option for plain menu bar quota capsules. Thanks @elijahfriedman!
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Wondering if CodexBar scans your disk? It doesn’t crawl your filesystem; it re
     - Open the item → **Access Control** → add `CodexBar.app` under “Always allow access by these applications”.
     - This removes the prompt when CodexBar decrypts cookies for that browser.
   - **Last resort — stop all Keychain reads entirely**: if "Always Allow" doesn't stick (e.g., macOS resets the ACL after a Chromium update or a `partition_id` reset), open **CodexBar → Settings → Advanced → Keychain access** and enable **Disable Keychain access**. CodexBar will no longer touch the Keychain. Browser-cookie-based providers will be skipped, but Claude/Codex OAuth via the CLI still works (it reads `~/.codex` / `~/.claude` config files, not the Keychain).
+  - **Prompt after uninstall?** Deleting the app prevents a new launch from that bundle, but an already-running CodexBar process can keep requesting Keychain access until it quits. Check for that process, a Login Item, another installed copy, or a prompt that names a different requesting binary/path. See [Keychain prompt troubleshooting](docs/keychain-prompts.md) for safe checks and what to include in a support report without sharing secrets.
 - **Files & Folders prompts (folder/volume access)**: CodexBar launches provider CLIs and local probes for some providers. If those helpers read a project directory or external drive, macOS may ask CodexBar for that folder/volume (e.g., Desktop or an external volume). This is driven by the helper’s working directory, not background disk scanning.
 - **What we do not request in the background**: no Screen Recording or Accessibility permissions; user-triggered helper actions may ask macOS for Automation permission to open Terminal. No passwords are stored (browser cookies are reused when you opt in).
 
@@ -179,6 +180,7 @@ Wondering if CodexBar scans your disk? It doesn’t crawl your filesystem; it re
 - UI & icon notes: [docs/ui.md](docs/ui.md)
 - CLI reference: [docs/cli.md](docs/cli.md)
 - Configuration: [docs/configuration.md](docs/configuration.md)
+- Keychain prompts: [docs/keychain-prompts.md](docs/keychain-prompts.md)
 - CLI configuration: [docs/cli-configuration.md](docs/cli-configuration.md)
 - Widgets: [docs/widgets.md](docs/widgets.md)
 - Architecture: [docs/architecture.md](docs/architecture.md)

--- a/docs/keychain-prompts.md
+++ b/docs/keychain-prompts.md
@@ -1,0 +1,87 @@
+---
+summary: "Safe troubleshooting for macOS Keychain and browser Safe Storage prompts."
+read_when:
+  - Investigating Chrome Safe Storage or browser Safe Storage prompts
+  - Explaining prompts that appear after uninstalling CodexBar
+  - Collecting safe support details without exposing secrets
+---
+
+# Keychain prompts
+
+CodexBar can trigger macOS Keychain prompts when an enabled provider imports browser cookies, reads a provider-owned
+OAuth item, or uses a CodexBar-owned cache entry. Chromium browser cookie import commonly asks for the browser's
+Safe Storage item, such as "Chrome Safe Storage", "Brave Safe Storage", or "Microsoft Edge Safe Storage".
+
+CodexBar does not need your browser password. macOS owns the prompt, and the prompt should identify the app or binary
+that is requesting access. For support reports, include that requesting app/path when possible and do not paste
+passwords, cookie headers, OAuth tokens, API keys, or Keychain item values.
+
+## If the prompt appears after uninstalling CodexBar
+
+Deleting `CodexBar.app` prevents a new process from launching from that bundle, but it does not terminate a process
+that is already running from it. That process can continue to request Keychain access until it quits. If macOS still
+shows a prompt such as "CodexBar wants to use your confidential information stored in 'Chrome Safe Storage'", the
+usual causes are:
+
+- A CodexBar process or bundled helper is still running.
+- CodexBar is still enabled in Login Items and relaunched from an existing install.
+- Another copy of `CodexBar.app` exists elsewhere on the machine.
+- The uninstall path did not remove the same copy that launched the process. Finder, Homebrew cask, Sparkle updates,
+  and manually copied apps can leave different install paths in play.
+- The prompt is naming the requesting binary, not proving that the copy you deleted is the one still running.
+
+Safe checks:
+
+```bash
+pgrep -fl 'CodexBar|CodexBarCLI'
+ls -ld /Applications/CodexBar.app
+brew info --cask codexbar
+mdfind 'kMDItemCFBundleIdentifier == "com.steipete.codexbar"'
+```
+
+Also check:
+
+- **Activity Monitor**: search for `CodexBar` and `CodexBarCLI`.
+- **System Settings -> General -> Login Items**: remove CodexBar if it remains listed.
+- **Keychain prompt screenshot**: capture the full prompt, especially any requesting app/path details. Redact user
+  names or unrelated window contents if needed, but do not include secrets.
+
+If you find a still-running process, quit CodexBar from the menu if possible, or quit it from Activity Monitor. If you
+find another installed copy, confirm whether that copy is the one macOS names in the prompt before changing anything
+else.
+
+## Stop CodexBar from using Keychain
+
+If CodexBar is still installed and you want it to stop all Keychain access:
+
+1. Open **CodexBar -> Settings -> Advanced**.
+2. In **Keychain access**, enable **Disable Keychain access**.
+3. Relaunch CodexBar.
+
+This disables Keychain reads and writes from CodexBar. Browser-cookie-based providers will be skipped because
+CodexBar can no longer decrypt browser cookies. Manual cookie headers, API keys, and CLI/OAuth flows that do not rely
+on Keychain can still work where the provider supports them.
+
+## Browser Safe Storage prompts
+
+For normal browser-cookie import prompts, either allow CodexBar in the Keychain item's Access Control list or disable
+Keychain access:
+
+1. Open **Keychain Access.app**.
+2. Select the `login` keychain.
+3. Search for the item named in the prompt, for example `Chrome Safe Storage`.
+4. Open the item, choose **Access Control**, and add `CodexBar.app` under "Always allow access by these applications".
+5. Relaunch CodexBar.
+
+Avoid "Allow all applications" unless you intentionally want every app to access that item. Do not paste or share the
+item's secret value when asking for help.
+
+## What to include in a support issue
+
+- CodexBar version and install source: GitHub release, Homebrew cask, Sparkle update, or another source.
+- macOS version.
+- The uninstall method if this happened after uninstalling.
+- Whether Activity Monitor or `pgrep` still shows CodexBar.
+- Whether System Settings -> General -> Login Items still lists CodexBar.
+- Whether `/Applications/CodexBar.app`, Homebrew cask metadata, or Spotlight finds another copy.
+- A screenshot of the Keychain prompt showing the requested item and requesting app/path, with secrets redacted.


### PR DESCRIPTION
## Summary

- Add safe troubleshooting for browser Safe Storage and provider Keychain prompts.
- Clarify that deleting an app bundle prevents a new launch but does not stop an already-running process from requesting access until it quits.
- Cover running processes, Login Items, alternate installs, Homebrew/Sparkle/Finder paths, and requester-path evidence.
- Link the guide from the README permissions section and docs index.

## Safety boundaries

Documentation only. No auth, Keychain, cookie-import, migration, or diagnostic behavior changes. The guide explicitly tells users not to share passwords, cookies, OAuth tokens, API keys, or Keychain values.

## Proof

Exact reviewed head: `0780fda3bb9c29c532413613b7c9f1f4d3192d9f`

- `make docs-list` passes.
- `git diff --check` passes.
- Exact branch autoreview reports no actionable findings, confidence 0.92.

Refs #1507
