### PR TITLE
fix: smooth providers settings tab switching without waiting on resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - LiteLLM: show personal and team spend amounts directly on budget rows while suppressing duplicate budget sections. Thanks @hololee!
 
 ### Fixed
+- Settings: switch tabs immediately before animated window resizing and reduce Providers sidebar work. Thanks @elijahfriedman!
 - Menu bar: show provider status markers only for the provider rendered in each icon. Thanks @Zihao-Qi!
 - Provider probes: cap captured subprocess output at 1 MiB per stream without dropping valid text at a truncated UTF-8 boundary. Thanks @ProspectOre!
 - Provider switcher: keep Codex quota rows visible when switching away and back during a manual refresh, including menus with usage-history sections. Thanks @Yuxin-Qiao!

--- a/Sources/CodexBar/PreferencesProvidersPane.swift
+++ b/Sources/CodexBar/PreferencesProvidersPane.swift
@@ -57,7 +57,7 @@ struct ProvidersPane: View {
                 orderedProviders: self.providers,
                 store: self.store,
                 isEnabled: { provider in self.binding(for: provider) },
-                subtitle: { provider in self.providerSubtitle(provider) },
+                subtitle: { provider in self.providerSidebarSubtitle(provider) },
                 searchText: self.$providerSearchText,
                 selection: self.$selectedProvider,
                 moveProviders: { fromOffsets, toOffset in
@@ -231,6 +231,27 @@ struct ProvidersPane: View {
             .presentation(context: presentationContext)
             ?? ProviderPresentation(detailLine: ProviderPresentation.standardDetailLine)
         let detailLine = presentation.detailLine(presentationContext)
+
+        return "\(detailLine)\n\(usageText)"
+    }
+
+    func providerSidebarSubtitle(_ provider: UsageProvider) -> String {
+        let meta = self.store.metadata(for: provider)
+        let usageText: String = if let snapshot = self.store.snapshot(for: provider) {
+            snapshot.updatedAt.relativeDescription()
+        } else if self.store.isStale(provider: provider) {
+            L("last_fetch_failed")
+        } else {
+            L("usage_not_fetched_yet")
+        }
+
+        let detailLine: String = if let sourceLabel = self.store.lastSourceLabels[provider], !sourceLabel.isEmpty {
+            sourceLabel
+        } else if let version = self.store.version(for: provider), !version.isEmpty {
+            "\(meta.cliName) \(version)"
+        } else {
+            meta.cliName
+        }
 
         return "\(detailLine)\n\(usageText)"
     }

--- a/Sources/CodexBar/PreferencesView.swift
+++ b/Sources/CodexBar/PreferencesView.swift
@@ -34,6 +34,29 @@ enum PreferencesTab: String, CaseIterable, Hashable {
     }
 }
 
+struct PreferencesTabLayoutCoordinator {
+    private(set) var bindingHandledTab: PreferencesTab?
+
+    mutating func beginBindingSelection(from current: PreferencesTab, to requested: PreferencesTab) -> Bool {
+        guard current != requested else { return false }
+        self.bindingHandledTab = requested
+        return true
+    }
+
+    mutating func layoutForObservedSelection(
+        _ observed: PreferencesTab,
+        current: PreferencesTab) -> PreferencesTab?
+    {
+        guard observed == current else { return nil }
+        defer { self.bindingHandledTab = nil }
+        return self.bindingHandledTab == observed ? nil : observed
+    }
+
+    func layoutForDeferredSelection(_ requested: PreferencesTab, current: PreferencesTab) -> PreferencesTab? {
+        current == requested ? requested : nil
+    }
+}
+
 @MainActor
 struct PreferencesView: View {
     @Bindable var settings: SettingsStore
@@ -46,6 +69,7 @@ struct PreferencesView: View {
     @Environment(\.colorScheme) private var colorScheme
     @State private var contentWidth: CGFloat = PreferencesTab.general.preferredWidth
     @State private var contentHeight: CGFloat = PreferencesTab.general.preferredHeight
+    @State private var tabLayoutCoordinator = PreferencesTabLayoutCoordinator()
 
     init(
         settings: SettingsStore,
@@ -70,7 +94,7 @@ struct PreferencesView: View {
     }
 
     var body: some View {
-        TabView(selection: self.$selection.tab) {
+        TabView(selection: self.tabSelectionBinding) {
             GeneralPane(settings: self.settings, store: self.store)
                 .tabItem { Label(L("tab_general"), systemImage: "gearshape") }
                 .tag(PreferencesTab.general)
@@ -115,11 +139,32 @@ struct PreferencesView: View {
             self.ensureValidTabSelection()
         }
         .onChange(of: self.selection.tab) { _, newValue in
-            self.updateLayout(for: newValue, animate: true)
+            guard let tab = self.tabLayoutCoordinator.layoutForObservedSelection(
+                newValue,
+                current: self.selection.tab)
+            else { return }
+            self.updateLayout(for: tab, animate: true)
         }
         .onChange(of: self.settings.debugMenuEnabled) { _, _ in
             self.ensureValidTabSelection()
         }
+    }
+
+    private var tabSelectionBinding: Binding<PreferencesTab> {
+        Binding(
+            get: { self.selection.tab },
+            set: { newValue in
+                let oldValue = self.selection.tab
+                guard self.tabLayoutCoordinator.beginBindingSelection(from: oldValue, to: newValue) else { return }
+                self.selection.tab = newValue
+                Task { @MainActor in
+                    guard let tab = self.tabLayoutCoordinator.layoutForDeferredSelection(
+                        newValue,
+                        current: self.selection.tab)
+                    else { return }
+                    self.updateLayout(for: tab, animate: true)
+                }
+            })
     }
 
     private func updateLayout(for tab: PreferencesTab, animate: Bool) {

--- a/Tests/CodexBarTests/PreferencesTabLayoutCoordinatorTests.swift
+++ b/Tests/CodexBarTests/PreferencesTabLayoutCoordinatorTests.swift
@@ -1,0 +1,64 @@
+import Testing
+@testable import CodexBar
+
+struct PreferencesTabLayoutCoordinatorTests {
+    @Test
+    func `binding selection defers one layout and suppresses observed duplicate`() {
+        var coordinator = PreferencesTabLayoutCoordinator()
+
+        let beganSelection = coordinator.beginBindingSelection(from: .general, to: .providers)
+        #expect(beganSelection)
+        #expect(coordinator.bindingHandledTab == .providers)
+        let observedLayout = coordinator.layoutForObservedSelection(.providers, current: .providers)
+        #expect(observedLayout == nil)
+        #expect(coordinator.bindingHandledTab == nil)
+        #expect(coordinator.layoutForDeferredSelection(.providers, current: .providers) == .providers)
+    }
+
+    @Test
+    func `same tab selection schedules no layout`() {
+        var coordinator = PreferencesTabLayoutCoordinator()
+
+        let beganSelection = coordinator.beginBindingSelection(from: .general, to: .general)
+        #expect(!beganSelection)
+        #expect(coordinator.bindingHandledTab == nil)
+    }
+
+    @Test
+    func `programmatic selection performs observed layout`() {
+        var coordinator = PreferencesTabLayoutCoordinator()
+
+        let observedLayout = coordinator.layoutForObservedSelection(.about, current: .about)
+        #expect(observedLayout == .about)
+        #expect(coordinator.bindingHandledTab == nil)
+    }
+
+    @Test
+    func `rapid tab clicks ignore stale observation and deferred layout`() {
+        var coordinator = PreferencesTabLayoutCoordinator()
+
+        let beganProviders = coordinator.beginBindingSelection(from: .general, to: .providers)
+        let beganAbout = coordinator.beginBindingSelection(from: .providers, to: .about)
+        let staleObservedLayout = coordinator.layoutForObservedSelection(.providers, current: .about)
+        #expect(beganProviders)
+        #expect(beganAbout)
+        #expect(staleObservedLayout == nil)
+        #expect(coordinator.bindingHandledTab == .about)
+        #expect(coordinator.layoutForDeferredSelection(.providers, current: .about) == nil)
+        let currentObservedLayout = coordinator.layoutForObservedSelection(.about, current: .about)
+        #expect(currentObservedLayout == nil)
+        #expect(coordinator.layoutForDeferredSelection(.about, current: .about) == .about)
+    }
+
+    @Test
+    func `programmatic selection replaces pending binding layout`() {
+        var coordinator = PreferencesTabLayoutCoordinator()
+
+        let beganSelection = coordinator.beginBindingSelection(from: .general, to: .providers)
+        let programmaticLayout = coordinator.layoutForObservedSelection(.advanced, current: .advanced)
+        #expect(beganSelection)
+        #expect(programmaticLayout == .advanced)
+        #expect(coordinator.bindingHandledTab == nil)
+        #expect(coordinator.layoutForDeferredSelection(.providers, current: .advanced) == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Commit the selected settings tab before scheduling animated window resizing.
- Use a focused coordinator to suppress duplicate layout work and ignore stale rapid-click callbacks.
- Keep programmatic tab changes responsive.
- Use lightweight provider sidebar subtitles while retaining rich presentation for the selected provider detail.

## Proof

- `swift test --filter 'PreferencesTabLayoutCoordinatorTests|ProvidersPaneCoverageTests'` (32 tests passed)
- Coordinator coverage: one-layout tab clicks, same-tab no-op, programmatic selection, rapid clicks, stale observations, and interrupted deferred layout.
- `make check`
- `autoreview --mode uncommitted` (clean, confidence 0.82)
- `./Scripts/compile_and_run.sh`: exact `0f924baa` bundle built, signed, launched, and remained running.

## Screen recording
Now:

https://github.com/user-attachments/assets/160ecf26-372a-44b1-9bce-b80d82363933