### PR TITLE
Keep Codex quota visible during refresh switchback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - LiteLLM: show personal and team spend amounts directly on budget rows while suppressing duplicate budget sections. Thanks @hololee!
 
 ### Fixed
+- Provider switcher: keep Codex quota rows visible when switching away and back during a manual refresh, including menus with usage-history sections. Thanks @Yuxin-Qiao!
 - Localization: improve Japanese terminology consistency and localize next-day reset times across all 21 app languages. Thanks @tukuyomil032!
 - Menu bar: keep visible quota values stable while a manual refresh is in flight without rewinding background-refresh countdowns. Thanks @Zihao-Qi!
 - Menu bar: stop informational usage-card rows from highlighting like clickable actions. Thanks @elijahfriedman!

--- a/Sources/CodexBar/MenuCardRefreshMonitor.swift
+++ b/Sources/CodexBar/MenuCardRefreshMonitor.swift
@@ -41,11 +41,9 @@ final class MenuCardRefreshMonitor {
             if fallback.hasCompatibleTrackedLayout(with: frozen) {
                 return frozen
             }
-            // A rebuilding menu may temporarily lose metric rows, but every other section must retain its layout.
-            if fallback.metrics.isEmpty,
-               !frozen.metrics.isEmpty,
-               fallback.hasCompatibleTrackedLayoutIgnoringMetrics(with: frozen)
-            {
+            // A rebuilding menu may temporarily lose some metric rows, but retained rows and other sections
+            // must still match the frozen layout.
+            if fallback.hasCompatibleTrackedMetricSubset(of: frozen) {
                 return frozen
             }
             return fallback

--- a/Sources/CodexBar/MenuCardRefreshMonitor.swift
+++ b/Sources/CodexBar/MenuCardRefreshMonitor.swift
@@ -41,7 +41,11 @@ final class MenuCardRefreshMonitor {
             if fallback.hasCompatibleTrackedLayout(with: frozen) {
                 return frozen
             }
-            if fallback.metrics.isEmpty, !frozen.metrics.isEmpty {
+            // A rebuilding menu may temporarily lose metric rows, but every other section must retain its layout.
+            if fallback.metrics.isEmpty,
+               !frozen.metrics.isEmpty,
+               fallback.hasCompatibleTrackedLayoutIgnoringMetrics(with: frozen)
+            {
                 return frozen
             }
             return fallback

--- a/Sources/CodexBar/MenuCardRefreshMonitor.swift
+++ b/Sources/CodexBar/MenuCardRefreshMonitor.swift
@@ -35,12 +35,16 @@ final class MenuCardRefreshMonitor {
         fallback: UsageMenuCardView.Model) -> UsageMenuCardView.Model
     {
         guard !self.isManualRefreshInFlight else {
-            guard let frozen = self.frozenManualRefreshModels[provider],
-                  fallback.hasCompatibleTrackedLayout(with: frozen)
-            else {
+            guard let frozen = self.frozenManualRefreshModels[provider] else {
                 return fallback
             }
-            return frozen
+            if fallback.hasCompatibleTrackedLayout(with: frozen) {
+                return frozen
+            }
+            if fallback.metrics.isEmpty, !frozen.metrics.isEmpty {
+                return frozen
+            }
+            return fallback
         }
 
         guard let resolved = self.resolveModel(provider),

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -84,6 +84,17 @@ extension UsageMenuCardView.Model {
         self.hasCompatibleTrackedLayout(with: candidate, includeMetrics: false)
     }
 
+    func hasCompatibleTrackedMetricSubset(of candidate: Self) -> Bool {
+        guard self.metrics.count < candidate.metrics.count,
+              self.hasCompatibleTrackedLayoutIgnoringMetrics(with: candidate)
+        else {
+            return false
+        }
+        return self.metrics.allSatisfy { metric in
+            candidate.metrics.contains { Self.hasCompatibleMetricLayout(metric, $0) }
+        }
+    }
+
     private func hasCompatibleTrackedLayout(with candidate: Self, includeMetrics: Bool) -> Bool {
         guard self.provider == candidate.provider,
               !includeMetrics || self.metrics.count == candidate.metrics.count,
@@ -104,17 +115,19 @@ extension UsageMenuCardView.Model {
         }
 
         guard includeMetrics else { return true }
-        return zip(self.metrics, candidate.metrics).allSatisfy { current, refreshed in
-            current.id == refreshed.id &&
-                current.title == refreshed.title &&
-                current.percentStyle == refreshed.percentStyle &&
-                (current.statusText == nil) == (refreshed.statusText == nil) &&
-                (current.resetText == nil) == (refreshed.resetText == nil) &&
-                (current.detailText == nil) == (refreshed.detailText == nil) &&
-                (current.detailLeftText == nil) == (refreshed.detailLeftText == nil) &&
-                (current.detailRightText == nil) == (refreshed.detailRightText == nil) &&
-                current.cardStyle == refreshed.cardStyle
-        }
+        return zip(self.metrics, candidate.metrics).allSatisfy(Self.hasCompatibleMetricLayout)
+    }
+
+    private static func hasCompatibleMetricLayout(_ current: Metric, _ candidate: Metric) -> Bool {
+        current.id == candidate.id &&
+            current.title == candidate.title &&
+            current.percentStyle == candidate.percentStyle &&
+            (current.statusText == nil) == (candidate.statusText == nil) &&
+            (current.resetText == nil) == (candidate.resetText == nil) &&
+            (current.detailText == nil) == (candidate.detailText == nil) &&
+            (current.detailLeftText == nil) == (candidate.detailLeftText == nil) &&
+            (current.detailRightText == nil) == (candidate.detailRightText == nil) &&
+            current.cardStyle == candidate.cardStyle
     }
 
     private static func hasCompatibleCreditsLayout(

--- a/Sources/CodexBar/MenuCardView+ModelHelpers.swift
+++ b/Sources/CodexBar/MenuCardView+ModelHelpers.swift
@@ -77,8 +77,16 @@ extension UsageMenuCardView.Model {
     }
 
     func hasCompatibleTrackedLayout(with candidate: Self) -> Bool {
+        self.hasCompatibleTrackedLayout(with: candidate, includeMetrics: true)
+    }
+
+    func hasCompatibleTrackedLayoutIgnoringMetrics(with candidate: Self) -> Bool {
+        self.hasCompatibleTrackedLayout(with: candidate, includeMetrics: false)
+    }
+
+    private func hasCompatibleTrackedLayout(with candidate: Self, includeMetrics: Bool) -> Bool {
         guard self.provider == candidate.provider,
-              self.metrics.count == candidate.metrics.count,
+              !includeMetrics || self.metrics.count == candidate.metrics.count,
               self.usageNotes == candidate.usageNotes,
               (self.openAIAPIUsage == nil) == (candidate.openAIAPIUsage == nil),
               Self.hasCompatibleCreditsLayout(
@@ -95,6 +103,7 @@ extension UsageMenuCardView.Model {
             return false
         }
 
+        guard includeMetrics else { return true }
         return zip(self.metrics, candidate.metrics).allSatisfy { current, refreshed in
             current.id == refreshed.id &&
                 current.title == refreshed.title &&

--- a/Sources/CodexBar/MenuCardView.swift
+++ b/Sources/CodexBar/MenuCardView.swift
@@ -126,6 +126,7 @@ struct UsageMenuCardView: View {
     }
 
     let model: Model
+    var layoutModel: Model?
     let width: CGFloat
     @Environment(\.menuItemHighlighted) private var isHighlighted
     @Environment(\.menuCardRefreshMonitor) private var refreshMonitor
@@ -140,7 +141,7 @@ struct UsageMenuCardView: View {
     var body: some View {
         let liveModel = self.liveModel
         VStack(alignment: .leading, spacing: 6) {
-            UsageMenuCardHeaderView(model: self.model)
+            UsageMenuCardHeaderView(model: self.layoutModel ?? self.model)
 
             if self.hasDetails(model: liveModel) {
                 Divider()

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -637,12 +637,13 @@ extension StatusItemController {
             return true
         }
 
+        let renderedModel = self.menuCardRefreshMonitor.model(for: model.provider, fallback: model)
         menu.addItem(self.makeMenuCardItem(
-            UsageMenuCardView(model: model, width: context.menuWidth),
+            UsageMenuCardView(model: renderedModel, width: context.menuWidth),
             id: "menuCard",
             width: context.menuWidth,
             heightCacheScope: context.currentProvider.rawValue,
-            heightCacheFingerprint: model.heightFingerprint(section: "card"),
+            heightCacheFingerprint: renderedModel.heightFingerprint(section: "card"),
             containsInteractiveControls: true))
         if self.addStorageMenuCardSection(to: menu, provider: context.currentProvider, width: context.menuWidth) {
             menu.addItem(.separator())
@@ -660,12 +661,13 @@ extension StatusItemController {
         context: MenuCardContext)
     {
         if cards.isEmpty, let model = self.menuCardModel(for: context.selectedProvider) {
+            let renderedModel = self.menuCardRefreshMonitor.model(for: model.provider, fallback: model)
             menu.addItem(self.makeMenuCardItem(
-                UsageMenuCardView(model: model, width: context.menuWidth),
+                UsageMenuCardView(model: renderedModel, width: context.menuWidth),
                 id: "menuCard",
                 width: context.menuWidth,
                 heightCacheScope: context.currentProvider.rawValue,
-                heightCacheFingerprint: model.heightFingerprint(section: "card"),
+                heightCacheFingerprint: renderedModel.heightFingerprint(section: "card"),
                 containsInteractiveControls: true))
             menu.addItem(.separator())
         } else {

--- a/Sources/CodexBar/StatusItemController+Menu.swift
+++ b/Sources/CodexBar/StatusItemController+Menu.swift
@@ -620,6 +620,7 @@ extension StatusItemController {
         }
 
         guard let model = self.menuCardModel(for: context.selectedProvider) else { return false }
+        let renderedModel = self.menuCardRefreshMonitor.model(for: model.provider, fallback: model)
         if context.openAIContext.hasOpenAIWebMenuItems || self
             .hasOpenAIAPIUsageSubmenu(provider: context.currentProvider)
         {
@@ -631,15 +632,14 @@ extension StatusItemController {
             self.addMenuCardSections(
                 to: menu,
                 model: model,
-                provider: context.currentProvider,
+                layoutModel: renderedModel,
                 width: context.menuWidth,
                 webItems: webItems)
             return true
         }
 
-        let renderedModel = self.menuCardRefreshMonitor.model(for: model.provider, fallback: model)
         menu.addItem(self.makeMenuCardItem(
-            UsageMenuCardView(model: renderedModel, width: context.menuWidth),
+            UsageMenuCardView(model: model, layoutModel: renderedModel, width: context.menuWidth),
             id: "menuCard",
             width: context.menuWidth,
             heightCacheScope: context.currentProvider.rawValue,
@@ -663,7 +663,7 @@ extension StatusItemController {
         if cards.isEmpty, let model = self.menuCardModel(for: context.selectedProvider) {
             let renderedModel = self.menuCardRefreshMonitor.model(for: model.provider, fallback: model)
             menu.addItem(self.makeMenuCardItem(
-                UsageMenuCardView(model: renderedModel, width: context.menuWidth),
+                UsageMenuCardView(model: model, layoutModel: renderedModel, width: context.menuWidth),
                 id: "menuCard",
                 width: context.menuWidth,
                 heightCacheScope: context.currentProvider.rawValue,
@@ -1243,14 +1243,15 @@ extension StatusItemController {
     private func addMenuCardSections(
         to menu: NSMenu,
         model: UsageMenuCardView.Model,
-        provider: UsageProvider,
+        layoutModel: UsageMenuCardView.Model,
         width: CGFloat,
         webItems: OpenAIWebMenuItems)
     {
-        let hasUsageBlock = model.hasUsageContent
-        let hasCredits = model.creditsText != nil
-        let hasExtraUsage = model.providerCost != nil
-        let hasCost = model.tokenUsage != nil
+        let provider = layoutModel.provider
+        let hasUsageBlock = layoutModel.hasUsageContent
+        let hasCredits = layoutModel.creditsText != nil
+        let hasExtraUsage = layoutModel.providerCost != nil
+        let hasCost = layoutModel.tokenUsage != nil
         let hasStorage = self.store.storageFootprintText(for: provider) != nil
         let bottomPadding = CGFloat(hasCredits ? 4 : 6)
         let sectionSpacing = CGFloat(6)
@@ -1260,6 +1261,7 @@ extension StatusItemController {
         if hasUsageBlock {
             let usageView = UsageMenuCardHeaderAndUsageSectionView(
                 model: model,
+                layoutModel: layoutModel,
                 bottomPadding: usageBottomPadding,
                 width: width)
             let usageSubmenu = self.makeUsageSubmenu(
@@ -1272,12 +1274,12 @@ extension StatusItemController {
                 id: "menuCardUsage",
                 width: width,
                 heightCacheScope: provider.rawValue,
-                heightCacheFingerprint: model.heightFingerprint(section: "usage"),
+                heightCacheFingerprint: layoutModel.heightFingerprint(section: "usage"),
                 submenu: usageSubmenu,
                 containsInteractiveControls: true))
         } else {
             let headerView = UsageMenuCardHeaderSectionView(
-                model: model,
+                model: layoutModel,
                 showDivider: false,
                 width: width)
             menu.addItem(self.makeMenuCardItem(
@@ -1285,7 +1287,7 @@ extension StatusItemController {
                 id: "menuCardHeader",
                 width: width,
                 heightCacheScope: provider.rawValue,
-                heightCacheFingerprint: model.heightFingerprint(section: "header"),
+                heightCacheFingerprint: layoutModel.heightFingerprint(section: "header"),
                 containsInteractiveControls: true))
         }
 
@@ -1315,7 +1317,7 @@ extension StatusItemController {
                 id: "menuCardCredits",
                 width: width,
                 heightCacheScope: provider.rawValue,
-                heightCacheFingerprint: model.heightFingerprint(section: "credits"),
+                heightCacheFingerprint: layoutModel.heightFingerprint(section: "credits"),
                 submenu: creditsSubmenu))
             if webItems.canShowBuyCredits {
                 menu.addItem(self.makeBuyCreditsItem())
@@ -1336,7 +1338,7 @@ extension StatusItemController {
                 id: "menuCardExtraUsage",
                 width: width,
                 heightCacheScope: provider.rawValue,
-                heightCacheFingerprint: model.heightFingerprint(section: "extraUsage"),
+                heightCacheFingerprint: layoutModel.heightFingerprint(section: "extraUsage"),
                 submenu: extraUsageSubmenu))
         }
         if hasCost {

--- a/Sources/CodexBar/UsageMenuCardHeaderAndUsageSectionView.swift
+++ b/Sources/CodexBar/UsageMenuCardHeaderAndUsageSectionView.swift
@@ -2,13 +2,14 @@ import SwiftUI
 
 struct UsageMenuCardHeaderAndUsageSectionView: View {
     let model: UsageMenuCardView.Model
+    let layoutModel: UsageMenuCardView.Model
     let bottomPadding: CGFloat
     let width: CGFloat
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             UsageMenuCardHeaderSectionView(
-                model: self.model,
+                model: self.layoutModel,
                 showDivider: true,
                 width: self.width)
             UsageMenuCardUsageSectionView(

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -421,6 +421,69 @@ struct StatusMenuPersistentRefreshTests {
     }
 
     @Test
+    func `manual refresh uses fallback when empty quota gains credit content`() throws {
+        let settings = self.makeSettings()
+        let controller = self.makeController(
+            settings: settings,
+            account: AccountInfo(email: "test@example.com", plan: "pro"))
+        let now = Date()
+        controller.store.snapshots[.codex] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 21,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now)
+        let frozen = try #require(controller.menuCardModel(for: .codex))
+        controller.menuCardRefreshMonitor.beginManualRefresh(frozenModels: [.codex: frozen])
+
+        controller.store.snapshots[.codex] = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            updatedAt: now.addingTimeInterval(1))
+        controller.store.credits = CreditsSnapshot(
+            remaining: 42,
+            events: [],
+            updatedAt: now.addingTimeInterval(1))
+        let fallback = try #require(controller.menuCardModel(for: .codex))
+        let inFlight = controller.menuCardRefreshMonitor.model(for: .codex, fallback: fallback)
+
+        #expect(frozen.metrics.count == 1)
+        #expect(fallback.metrics.isEmpty)
+        #expect(fallback.creditsText != nil)
+        #expect(inFlight.metrics.isEmpty)
+        #expect(inFlight.creditsText == fallback.creditsText)
+    }
+
+    @Test
+    func `manual refresh uses fallback when empty quota gains a placeholder`() throws {
+        let settings = self.makeSettings()
+        let controller = self.makeController(settings: settings)
+        let now = Date()
+        controller.store.snapshots[.claude] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 21,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: now)
+        let frozen = try #require(controller.menuCardModel(for: .claude))
+        controller.menuCardRefreshMonitor.beginManualRefresh(frozenModels: [.claude: frozen])
+
+        controller.store.snapshots.removeValue(forKey: .claude)
+        let fallback = try #require(controller.menuCardModel(for: .claude))
+        let inFlight = controller.menuCardRefreshMonitor.model(for: .claude, fallback: fallback)
+
+        #expect(frozen.metrics.count == 1)
+        #expect(fallback.metrics.isEmpty)
+        #expect(fallback.placeholder != nil)
+        #expect(inFlight.metrics.isEmpty)
+        #expect(inFlight.placeholder == fallback.placeholder)
+    }
+
+    @Test
     func `refresh monitor updates single line credit balances`() throws {
         let settings = self.makeSettings()
         let controller = self.makeController(

--- a/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuPersistentRefreshTests.swift
@@ -421,6 +421,51 @@ struct StatusMenuPersistentRefreshTests {
     }
 
     @Test
+    func `manual refresh preserves frozen quota when supplemental metric remains`() throws {
+        let settings = self.makeSettings()
+        let controller = self.makeController(
+            settings: settings,
+            account: AccountInfo(email: "test@example.com", plan: "pro"))
+        let now = Date()
+        controller.store.openAIDashboard = OpenAIDashboardSnapshot(
+            signedInEmail: "test@example.com",
+            codeReviewRemainingPercent: 88,
+            creditEvents: [],
+            dailyBreakdown: [],
+            usageBreakdown: [],
+            creditsPurchaseURL: nil,
+            updatedAt: now)
+        controller.store.openAIDashboardAttachmentAuthorized = true
+        controller.store.openAIDashboardRequiresLogin = false
+        controller.store.snapshots[.codex] = UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: 21,
+                windowMinutes: 300,
+                resetsAt: now.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: RateWindow(
+                usedPercent: 12,
+                windowMinutes: 10080,
+                resetsAt: now.addingTimeInterval(7 * 24 * 60 * 60),
+                resetDescription: nil),
+            updatedAt: now)
+        let frozen = try #require(controller.menuCardModel(for: .codex))
+        controller.menuCardRefreshMonitor.beginManualRefresh(frozenModels: [.codex: frozen])
+
+        controller.store.snapshots[.codex] = UsageSnapshot(
+            primary: nil,
+            secondary: nil,
+            updatedAt: now.addingTimeInterval(1))
+        let fallback = try #require(controller.menuCardModel(for: .codex))
+        let inFlight = controller.menuCardRefreshMonitor.model(for: .codex, fallback: fallback)
+
+        #expect(frozen.metrics.count == 3)
+        #expect(fallback.metrics.map(\.id) == ["code-review"])
+        #expect(inFlight.metrics.map(\.id) == frozen.metrics.map(\.id))
+        #expect(inFlight.metrics.first?.percentLabel == "79% left")
+    }
+
+    @Test
     func `manual refresh uses fallback when empty quota gains credit content`() throws {
         let settings = self.makeSettings()
         let controller = self.makeController(

--- a/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
@@ -148,6 +148,7 @@ struct StatusMenuSwitcherRefreshTests {
         settings.refreshFrequency = .manual
         settings.mergeIcons = true
         settings.selectedMenuProvider = .codex
+        settings.openAIWebAccessEnabled = true
         Self.enableCodexAndClaude(settings)
         Self.disableOverview(settings)
 
@@ -271,10 +272,22 @@ struct StatusMenuSwitcherRefreshTests {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         store._setSnapshotForTesting(Self.quotaSnapshot(usedPercent: 21, updatedAt: now), provider: .codex)
         store._setSnapshotForTesting(Self.quotaSnapshot(usedPercent: 44, updatedAt: now), provider: .claude)
+        let event = CreditEvent(date: now, service: "CLI", creditsUsed: 1)
+        let breakdown = OpenAIDashboardSnapshot.makeDailyBreakdown(from: [event], maxDays: 30)
+        store.openAIDashboard = OpenAIDashboardSnapshot(
+            signedInEmail: "test@example.com",
+            codeReviewRemainingPercent: nil,
+            creditEvents: [event],
+            dailyBreakdown: breakdown,
+            usageBreakdown: breakdown,
+            creditsPurchaseURL: nil,
+            updatedAt: now)
+        store.openAIDashboardAttachmentAuthorized = true
+        store.openAIDashboardRequiresLogin = false
         let controller = StatusItemController(
             store: store,
             settings: settings,
-            account: fetcher.loadAccountInfo(),
+            account: AccountInfo(email: "test@example.com", plan: "pro"),
             updater: DisabledUpdaterController(),
             preferencesSelection: PreferencesSelection(),
             statusBar: .system)
@@ -316,6 +329,10 @@ struct StatusMenuSwitcherRefreshTests {
         await Self.waitForRebuildCount(2, rebuildCount: { rebuildCount })
         #expect(settings.selectedMenuProvider == .codex)
 
+        let usageItem = menu.items.first { ($0.representedObject as? String) == "menuCardUsage" }
+        #expect(usageItem != nil)
+        #expect(menu.items.contains { ($0.representedObject as? String) == "menuCardHeader" } == false)
+
         let emptyFallback = try #require(controller.menuCardModel(for: .codex))
         let inFlight = controller.menuCardRefreshMonitor.model(for: .codex, fallback: emptyFallback)
         let subtitle = controller.menuCardRefreshMonitor.subtitle(
@@ -329,6 +346,8 @@ struct StatusMenuSwitcherRefreshTests {
         gate.resume()
         await controller.manualRefreshTask?.value
         #expect(!controller.menuCardRefreshMonitor.isManualRefreshInFlight)
+        let completed = controller.menuCardRefreshMonitor.model(for: .codex, fallback: emptyFallback)
+        #expect(completed.metrics.isEmpty)
     }
 
     @Test

--- a/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
+++ b/Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift
@@ -4,6 +4,31 @@ import Testing
 @testable import CodexBar
 
 @MainActor
+private final class SwitcherRefreshManualGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var isOpen = false
+
+    func wait() async {
+        if self.isOpen {
+            self.isOpen = false
+            return
+        }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func resume() {
+        if let continuation = self.continuation {
+            continuation.resume()
+            self.continuation = nil
+        } else {
+            self.isOpen = true
+        }
+    }
+}
+
+@MainActor
 @Suite(.serialized)
 struct StatusMenuSwitcherRefreshTests {
     @Test
@@ -224,6 +249,89 @@ struct StatusMenuSwitcherRefreshTests {
     }
 
     @Test
+    func `manual refresh keeps codex quota visible after switching away and back`() async throws {
+        let previousMenuCardRendering = StatusItemController.menuCardRenderingEnabled
+        StatusItemController.menuCardRenderingEnabled = false
+        StatusItemController.setMenuRefreshEnabledForTesting(true)
+        defer {
+            StatusItemController.menuCardRenderingEnabled = previousMenuCardRendering
+            StatusItemController.resetMenuRefreshEnabledForTesting()
+        }
+
+        let settings = Self.makeSettings()
+        settings.statusChecksEnabled = false
+        settings.refreshFrequency = .manual
+        settings.mergeIcons = true
+        settings.selectedMenuProvider = .codex
+        Self.enableCodexAndClaude(settings)
+        Self.disableOverview(settings)
+
+        let fetcher = UsageFetcher()
+        let store = UsageStore(fetcher: fetcher, browserDetection: BrowserDetection(cacheTTL: 0), settings: settings)
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        store._setSnapshotForTesting(Self.quotaSnapshot(usedPercent: 21, updatedAt: now), provider: .codex)
+        store._setSnapshotForTesting(Self.quotaSnapshot(usedPercent: 44, updatedAt: now), provider: .claude)
+        let controller = StatusItemController(
+            store: store,
+            settings: settings,
+            account: fetcher.loadAccountInfo(),
+            updater: DisabledUpdaterController(),
+            preferencesSelection: PreferencesSelection(),
+            statusBar: .system)
+        defer {
+            controller.manualRefreshTask?.cancel()
+            controller.releaseStatusItemsForTesting()
+        }
+
+        let gate = SwitcherRefreshManualGate()
+        controller._test_manualRefreshOperation = {
+            await gate.wait()
+        }
+        defer { controller._test_manualRefreshOperation = nil }
+
+        let menu = controller.makeMenu()
+        controller.menuWillOpen(menu)
+        let selectedButton = try #require(Self.switcherButtons(in: menu).first { $0.state == .on })
+        let alternateButton = try #require(Self.switcherButtons(in: menu).first { $0.state == .off })
+
+        controller.refreshNow()
+        #expect(controller.menuCardRefreshMonitor.isManualRefreshInFlight)
+
+        store._setSnapshotForTesting(
+            UsageSnapshot(primary: nil, secondary: nil, updatedAt: now.addingTimeInterval(1)),
+            provider: .codex)
+
+        var rebuildCount = 0
+        controller._test_openMenuRebuildObserver = { _ in
+            rebuildCount += 1
+        }
+        defer { controller._test_openMenuRebuildObserver = nil }
+
+        let initialSwitcher = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        #expect(initialSwitcher._test_simulateRuntimeClick(buttonTag: alternateButton.tag))
+        await Self.waitForRebuildCount(1, rebuildCount: { rebuildCount })
+
+        let alternateSwitcher = try #require(menu.items.first?.view as? ProviderSwitcherView)
+        #expect(alternateSwitcher._test_simulateRuntimeClick(buttonTag: selectedButton.tag))
+        await Self.waitForRebuildCount(2, rebuildCount: { rebuildCount })
+        #expect(settings.selectedMenuProvider == .codex)
+
+        let emptyFallback = try #require(controller.menuCardModel(for: .codex))
+        let inFlight = controller.menuCardRefreshMonitor.model(for: .codex, fallback: emptyFallback)
+        let subtitle = controller.menuCardRefreshMonitor.subtitle(
+            for: .codex,
+            fallback: MenuCardLiveSubtitle(text: emptyFallback.subtitleText, style: emptyFallback.subtitleStyle))
+
+        #expect(emptyFallback.metrics.isEmpty)
+        #expect(subtitle.text == "Refreshing…")
+        #expect(inFlight.metrics.first?.percentLabel == "79% left")
+
+        gate.resume()
+        await controller.manualRefreshTask?.value
+        #expect(!controller.menuCardRefreshMonitor.isManualRefreshInFlight)
+    }
+
+    @Test
     func `native image menu rows are replaced during reconciliation`() {
         let settings = Self.makeSettings()
         let fetcher = UsageFetcher()
@@ -425,6 +533,17 @@ struct StatusMenuSwitcherRefreshTests {
             provider: .claude,
             isSelected: false,
             activeProviders: activeProviders)
+    }
+
+    private static func quotaSnapshot(usedPercent: Double, updatedAt: Date) -> UsageSnapshot {
+        UsageSnapshot(
+            primary: RateWindow(
+                usedPercent: usedPercent,
+                windowMinutes: 300,
+                resetsAt: updatedAt.addingTimeInterval(3600),
+                resetDescription: nil),
+            secondary: nil,
+            updatedAt: updatedAt)
     }
 
     private static func waitForRebuildCount(


### PR DESCRIPTION
## Summary
- Keep the frozen manual-refresh quota model visible when a provider switchback rebuilds Codex from an empty fallback while refresh is still in flight.
- Preserve the existing layout-compatibility fallback for real layout changes.
- Add a merged provider switcher regression test for Codex -> Claude -> Codex during manual refresh.

## Context
Follow-up to #1583 / #1329. This does not touch the menu hang or memory-heavy performance path; the v0.36.1 feedback indicates that side is basically resolved. The remaining gap is the refresh switchback path where old quota bars should stay visible instead of becoming empty / Refreshing-only before fresher results arrive.

## Validation
- swift test --filter 'manual refresh keeps codex quota visible after switching away and back'
- swift test --filter 'StatusMenuSwitcherRefreshTests|StatusMenuPersistentRefreshTests|MenuCardRefreshTests' (33 tests)
- git diff --check
- swiftformat Sources/CodexBar/MenuCardRefreshMonitor.swift Tests/CodexBarTests/StatusMenuSwitcherRefreshTests.swift