### PR TITLE
Fix opencodego manual cookie usage on Linux CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Menu bar: show provider status markers only for the provider rendered in each icon. Thanks @Zihao-Qi!
 - Codex CLI: make automatic usage reads prefer OAuth and CLI sources instead of blocking on the optional web dashboard.
 - Codex web: apply `--web-timeout` to the full cookie import, account verification, retry, and dashboard fetch path.
+- OpenCode Go: allow configured manual cookies in the Linux CLI while keeping browser-cookie import gated to macOS. Thanks @Yuxin-Qiao!
 - Provider probes: cap captured subprocess output at 1 MiB per stream without dropping valid text at a truncated UTF-8 boundary. Thanks @ProspectOre!
 - Provider switcher: keep Codex quota rows visible when switching away and back during a manual refresh, including menus with usage-history sections. Thanks @Yuxin-Qiao!
 - Bedrock: ignore invalid billing dates when selecting the latest usage values. Thanks @ProspectOre!

--- a/Sources/CodexBarCLI/CLIUsageCommand.swift
+++ b/Sources/CodexBarCLI/CLIUsageCommand.swift
@@ -551,6 +551,11 @@ extension CodexBarCLI {
         if provider == .codex, sourceMode == .auto {
             return false
         }
+        if provider == .opencodego,
+           settings?.opencodego?.cookieSource == .manual
+        {
+            return false
+        }
         if provider == .ollama,
            sourceMode == .auto
         {

--- a/Tests/CodexBarTests/CLIEntryTests.swift
+++ b/Tests/CodexBarTests/CLIEntryTests.swift
@@ -326,6 +326,38 @@ final class CLIEntryTests: XCTestCase {
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(.api, provider: .kilo))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(
             .auto,
+            provider: .opencodego,
+            settings: ProviderSettingsSnapshot.make(
+                opencodego: .init(
+                    cookieSource: .manual,
+                    manualCookieHeader: "auth=manual",
+                    workspaceID: nil))))
+        XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(
+            .web,
+            provider: .opencodego,
+            settings: ProviderSettingsSnapshot.make(
+                opencodego: .init(
+                    cookieSource: .manual,
+                    manualCookieHeader: "auth=manual",
+                    workspaceID: nil))))
+        XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .opencodego,
+            settings: ProviderSettingsSnapshot.make(
+                opencodego: .init(
+                    cookieSource: .auto,
+                    manualCookieHeader: nil,
+                    workspaceID: nil))))
+        XCTAssertTrue(CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
+            provider: .opencode,
+            settings: ProviderSettingsSnapshot.make(
+                opencode: .init(
+                    cookieSource: .manual,
+                    manualCookieHeader: "auth=manual",
+                    workspaceID: nil))))
+        XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(
+            .auto,
             provider: .ollama,
             environment: ["OLLAMA_API_KEY": "ollama-test"]))
         XCTAssertFalse(CodexBarCLI.sourceModeRequiresWebSupport(


### PR DESCRIPTION
Fixes #1596

## Root cause

- The non-macOS CLI web-support gate checked the effective source mode and provider catalog before OpenCode Go resolved its configured cookie source.
- OpenCode Go advertises web support for automatic mode, so Linux exited before `OpenCodeWebCookieSupport.resolveCookieHeader` could use a manual cookie.
- Manual cookie normalization needs no browser, WebKit, or Keychain access.

## Fix

- Keep the non-macOS web-support gate.
- Exempt only OpenCode Go with `cookieSource: manual`.
- Keep automatic/browser cookie import unavailable on non-macOS.
- Preserve the newer Codex and Ollama provider-specific source exceptions from current `main`.
- Add regression coverage for manual OpenCode Go, automatic OpenCode Go, and unrelated OpenCode settings.

## Maintainer validation

Exact candidate: `fca6adeb`

- `swift test --filter 'CLIEntryTests|OpenCodeGo|Zen'` - 22 CLI gate tests and 57 OpenCode Go/Zen provider tests passed after the final current-main rebase.
- `make check` - passed after the final current-main rebase; SwiftFormat clean and SwiftLint reported zero violations.
- Codex autoreview of the full branch against current `main` - clean, confidence 0.86.
- Fresh Ubuntu 24.04 x86_64 Crabbox proof built the static release CLI from the exact candidate with Swift 6.2.1. Explicit web mode plus a configured manual test cookie reached the real OpenCode Go provider path and returned an endpoint/auth response rather than the non-macOS platform gate. The lease was released after the passing run.
- macOS provider-path validation found no usable browser session cookie; no positive account-usage claim is made.
