### PR TITLE
feat: resize cost history menu card to the hovered day's content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Codex agents: add a read-only `codexbar` skill for bounded, redacted provider usage JSON. Thanks @coygeek!
 
 ### Changed
+- Cost history: resize the chart details to the hovered day's model breakdown instead of reserving the tallest day. Thanks @elijahfriedman!
 - Antigravity: use current backend quota labels in menus and widgets while preferring a usable quota lane over an exhausted one. Thanks @Yuxin-Qiao!
 - Pi: cache session filename and timestamp parsers to reduce cost-history refresh overhead. Thanks @ProspectOre!
 - Menu bar: reuse the icon-observation signature during provider refreshes instead of computing it twice. Thanks @abe238!

--- a/Sources/CodexBar/CostHistoryChartMenuView.swift
+++ b/Sources/CodexBar/CostHistoryChartMenuView.swift
@@ -42,6 +42,7 @@ struct CostHistoryChartMenuView: View {
     private let historyDays: Int
     private let windowLabel: String?
     private let width: CGFloat
+    private let onHeightChange: ((CGFloat) -> Void)?
     @State private var selectedDateKey: String?
 
     init(
@@ -51,6 +52,7 @@ struct CostHistoryChartMenuView: View {
         currencyCode: String = "USD",
         historyDays: Int = 30,
         windowLabel: String? = nil,
+        onHeightChange: ((CGFloat) -> Void)? = nil,
         width: CGFloat)
     {
         self.provider = provider
@@ -59,12 +61,14 @@ struct CostHistoryChartMenuView: View {
         self.currencyCode = currencyCode
         self.historyDays = max(1, min(365, historyDays))
         self.windowLabel = windowLabel
+        self.onHeightChange = onHeightChange
         self.width = width
     }
 
     var body: some View {
         let model = Self.makeModel(provider: self.provider, daily: self.daily)
-        VStack(alignment: .leading, spacing: 10) {
+        let selectedDateKey = self.selectedDateKey ?? Self.defaultSelectedDateKey(model: model)
+        VStack(alignment: .leading, spacing: Self.outerSpacing) {
             if model.points.isEmpty {
                 Text(L("No cost history data."))
                     .font(.footnote)
@@ -98,7 +102,7 @@ struct CostHistoryChartMenuView: View {
                     }
                 }
                 .chartLegend(.hidden)
-                .frame(height: 130)
+                .frame(height: Self.chartHeight)
                 .accessibilityLabel(L("Cost history chart"))
                 .accessibilityValue(
                     model.points.isEmpty
@@ -123,7 +127,7 @@ struct CostHistoryChartMenuView: View {
                     }
                 }
 
-                let detail = self.detailContent(model: model)
+                let detail = self.detailContent(selectedDateKey: selectedDateKey, model: model)
                 VStack(alignment: .leading, spacing: Self.detailSpacing) {
                     Text(detail.primary)
                         .font(.caption)
@@ -131,7 +135,7 @@ struct CostHistoryChartMenuView: View {
                         .lineLimit(1)
                         .truncationMode(.tail)
                         .frame(height: Self.detailPrimaryLineHeight, alignment: .leading)
-                    if model.maxRenderedBreakdownRows > 0 {
+                    if !detail.rows.isEmpty {
                         ScrollView(.vertical) {
                             VStack(alignment: .leading, spacing: Self.detailSpacing) {
                                 ForEach(detail.rows) { row in
@@ -174,31 +178,18 @@ struct CostHistoryChartMenuView: View {
                                     }
                                     .frame(height: Self.detailRowHeight(for: row), alignment: .leading)
                                 }
-                                ForEach(
-                                    0..<max(model.maxRenderedBreakdownRows - detail.rows.count, 0),
-                                    id: \.self)
-                                { _ in
-                                    Text(" ")
-                                        .font(.caption)
-                                        .frame(height: Self.compactDetailRowHeight, alignment: .leading)
-                                        .opacity(0)
-                                }
                             }
                         }
                         .scrollIndicators(
                             Self.detailRowsNeedScrolling(itemCount: detail.rows.count) ? .visible : .hidden)
                         .frame(
-                            height: Self.detailRowsViewportHeight(
-                                maxBreakdownRows: model.maxRenderedBreakdownRows,
-                                maxRowsHeight: model.maxDetailRowsHeight),
+                            height: Self.detailRowsViewportHeight(rows: detail.rows),
                             alignment: .topLeading)
-                        .id(self.selectedDateKey)
+                        .id(selectedDateKey)
                     }
                 }
                 .frame(
-                    height: Self.detailBlockHeight(
-                        maxBreakdownRows: model.maxRenderedBreakdownRows,
-                        maxRowsHeight: model.maxDetailRowsHeight),
+                    height: Self.detailBlockHeight(rows: detail.rows),
                     alignment: .topLeading)
             }
 
@@ -211,11 +202,12 @@ struct CostHistoryChartMenuView: View {
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .truncationMode(.head)
+                    .frame(height: Self.detailPrimaryLineHeight, alignment: .leading)
             }
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 10)
-        .frame(minWidth: self.width, maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, Self.verticalPadding)
+        .frame(minWidth: self.width, maxWidth: .infinity, alignment: .top)
     }
 
     private struct Model {
@@ -227,8 +219,6 @@ struct CostHistoryChartMenuView: View {
         let barColor: Color
         let peakKey: String?
         let maxCostUSD: Double
-        let maxRenderedBreakdownRows: Int
-        let maxDetailRowsHeight: CGFloat
     }
 
     private static let selectionBandColor = Color(nsColor: .labelColor).opacity(0.1)
@@ -239,6 +229,25 @@ struct CostHistoryChartMenuView: View {
     private static let compactDetailRowHeight: CGFloat = 36
     private static let expandedDetailRowHeight: CGFloat = 44
     private static let detailSpacing: CGFloat = 6
+    private static let chartHeight: CGFloat = 130
+    private static let outerSpacing: CGFloat = 10
+    static let verticalPadding: CGFloat = 10
+
+    /// Deterministic total height of the rendered card for a given selection. NSMenu's modal
+    /// tracking run loop never delivers SwiftUI `onPreferenceChange`, so the live height can't be
+    /// measured via a GeometryReader while the menu is open. Every component height is fixed, so
+    /// we compute the total directly and resize from the hover handler instead.
+    private static func totalCardHeight(rows: [DetailRow], hasTotal: Bool) -> CGFloat {
+        var height = self.verticalPadding * 2
+        height += self.chartHeight
+        height += self.outerSpacing
+        height += self.detailBlockHeight(rows: rows)
+        if hasTotal {
+            height += self.outerSpacing
+            height += self.detailPrimaryLineHeight
+        }
+        return height
+    }
 
     static func windowLabel(days: Int) -> String {
         if days == 1 {
@@ -279,8 +288,6 @@ struct CostHistoryChartMenuView: View {
 
         var peak: (key: String, costUSD: Double)?
         var maxCostUSD: Double = 0
-        var maxRenderedBreakdownRows = 0
-        var detailRowMetrics: [(count: Int, height: CGFloat)] = []
         for entry in sorted {
             guard let costUSD = entry.costUSD, costUSD >= 0 else { continue }
             guard let date = self.dateFromDayKey(entry.date) else { continue }
@@ -293,9 +300,6 @@ struct CostHistoryChartMenuView: View {
             pointsByKey[entry.date] = point
             entriesByKey[entry.date] = entry
             dateKeys.append((entry.date, date))
-            let rowMetric = Self.renderedBreakdownRowsMetric(for: entry)
-            detailRowMetrics.append(rowMetric)
-            maxRenderedBreakdownRows = max(maxRenderedBreakdownRows, rowMetric.count)
             if let cur = peak {
                 if costUSD > cur.costUSD { peak = (entry.date, costUSD) }
             } else {
@@ -311,11 +315,6 @@ struct CostHistoryChartMenuView: View {
         }()
 
         let barColor = Self.barColor(for: provider)
-        let maxDetailRowsHeight = detailRowMetrics.reduce(CGFloat(0)) { currentMax, metric in
-            let fillerRows = max(maxRenderedBreakdownRows - metric.count, 0)
-            let filledHeight = metric.height + (CGFloat(fillerRows) * Self.compactDetailRowHeight)
-            return max(currentMax, filledHeight)
-        }
         return Model(
             points: points,
             pointsByDateKey: pointsByKey,
@@ -324,9 +323,7 @@ struct CostHistoryChartMenuView: View {
             axisDates: axisDates,
             barColor: barColor,
             peakKey: maxCostUSD > 0 ? peak?.key : nil,
-            maxCostUSD: maxCostUSD,
-            maxRenderedBreakdownRows: maxRenderedBreakdownRows,
-            maxDetailRowsHeight: maxDetailRowsHeight)
+            maxCostUSD: maxCostUSD)
     }
 
     private static func barColor(for provider: UsageProvider) -> Color {
@@ -356,36 +353,28 @@ struct CostHistoryChartMenuView: View {
         return model.pointsByDateKey[key]
     }
 
-    private static func renderedBreakdownRowsMetric(for entry: DailyEntry) -> (count: Int, height: CGFloat) {
-        guard let breakdown = entry.modelBreakdowns, !breakdown.isEmpty else { return (0, 0) }
-        let renderedRows = Array(
-            self.orderedBreakdownItems(breakdown)
-                .prefix(self.detailViewportRowCount(itemCount: breakdown.count)))
-        let height = renderedRows.reduce(CGFloat(0)) { total, item in
-            total + self.detailRowHeight(hasModeSubtitle: Self.hasModeSubtitle(item))
-        }
-        return (renderedRows.count, height)
-    }
-
     private static func hasModeSubtitle(_ item: CostUsageDailyReport.ModelBreakdown) -> Bool {
         item.standardCostUSD != nil || item.priorityCostUSD != nil
     }
 
-    private static func detailBlockHeight(maxBreakdownRows: Int, maxRowsHeight: CGFloat) -> CGFloat {
-        guard maxBreakdownRows > 0 else { return self.detailPrimaryLineHeight }
-        return self.detailPrimaryLineHeight +
-            self.detailRowsViewportHeight(
-                maxBreakdownRows: maxBreakdownRows,
-                maxRowsHeight: maxRowsHeight) +
-            self.detailSpacing
+    private static func detailBlockHeight(rows: [DetailRow]) -> CGFloat {
+        guard !rows.isEmpty else { return self.detailPrimaryLineHeight }
+        return self.detailPrimaryLineHeight + self.detailRowsViewportHeight(rows: rows) + self.detailSpacing
     }
 
-    private static func detailRowsViewportHeight(
-        maxBreakdownRows: Int,
-        maxRowsHeight: CGFloat) -> CGFloat
-    {
-        guard maxBreakdownRows > 0 else { return 0 }
-        return maxRowsHeight + (CGFloat(maxBreakdownRows - 1) * self.detailSpacing)
+    private static func detailRowsViewportHeight(rows: [DetailRow]) -> CGFloat {
+        let visibleRows = Array(rows.prefix(self.maxVisibleDetailLines))
+        guard !visibleRows.isEmpty else { return 0 }
+
+        let rowHeights = visibleRows.reduce(CGFloat(0)) { total, row in
+            total + self.detailRowHeight(for: row)
+        }
+        let spacing = CGFloat(max(visibleRows.count - 1, 0)) * self.detailSpacing
+        return rowHeights + spacing
+    }
+
+    private static func defaultSelectedDateKey(model: Model) -> String? {
+        model.dateKeys.last?.key
     }
 
     private func selectionBandRect(model: Model, proxy: ChartProxy, geo: GeometryProxy) -> CGRect? {
@@ -445,7 +434,17 @@ struct CostHistoryChartMenuView: View {
 
         if self.selectedDateKey != nearest {
             self.selectedDateKey = nearest
+            // Resize directly from the hover handler: this runs synchronously inside NSMenu's
+            // tracking run loop, unlike SwiftUI preference callbacks which are never delivered
+            // while the menu is open.
+            self.notifyHeightChange(selectedDateKey: nearest, model: model)
         }
+    }
+
+    private func notifyHeightChange(selectedDateKey: String?, model: Model) {
+        guard let onHeightChange = self.onHeightChange else { return }
+        let rows = selectedDateKey.map { self.breakdownRows(key: $0, model: model) } ?? []
+        onHeightChange(Self.totalCardHeight(rows: rows, hasTotal: self.totalCostUSD != nil))
     }
 
     private func nearestDateKey(to date: Date, model: Model) -> String? {
@@ -462,8 +461,8 @@ struct CostHistoryChartMenuView: View {
         return best?.key
     }
 
-    private func detailContent(model: Model) -> DetailContent {
-        guard let key = self.selectedDateKey,
+    private func detailContent(selectedDateKey: String?, model: Model) -> DetailContent {
+        guard let key = selectedDateKey,
               let point = model.pointsByDateKey[key],
               let date = Self.dateFromDayKey(key)
         else {
@@ -558,5 +557,47 @@ struct CostHistoryChartMenuView: View {
     private static func breakdownAccentOpacity(for index: Int) -> Double {
         let opacity = 0.75 - (Double(index) * 0.12)
         return max(0.3, opacity)
+    }
+}
+
+extension CostHistoryChartMenuView {
+    static func _defaultSelectedDateKeyForTesting(provider: UsageProvider, daily: [DailyEntry]) -> String? {
+        self.defaultSelectedDateKey(model: self.makeModel(provider: provider, daily: daily))
+    }
+
+    static func _detailViewportHeightForTesting(modeSubtitlePresence: [Bool]) -> CGFloat {
+        let rows = modeSubtitlePresence.enumerated().map { index, hasModeSubtitle in
+            DetailRow(
+                id: "\(index)",
+                title: "Row \(index)",
+                subtitle: "Subtitle",
+                modeSubtitle: hasModeSubtitle ? "Mode" : nil,
+                accentColor: .blue)
+        }
+        return self.detailRowsViewportHeight(rows: rows)
+    }
+
+    static func _detailBlockHeightForTesting(modeSubtitlePresence: [Bool]) -> CGFloat {
+        let rows = modeSubtitlePresence.enumerated().map { index, hasModeSubtitle in
+            DetailRow(
+                id: "\(index)",
+                title: "Row \(index)",
+                subtitle: "Subtitle",
+                modeSubtitle: hasModeSubtitle ? "Mode" : nil,
+                accentColor: .blue)
+        }
+        return self.detailBlockHeight(rows: rows)
+    }
+
+    static func _totalCardHeightForTesting(modeSubtitlePresence: [Bool], hasTotal: Bool) -> CGFloat {
+        let rows = modeSubtitlePresence.enumerated().map { index, hasModeSubtitle in
+            DetailRow(
+                id: "\(index)",
+                title: "Row \(index)",
+                subtitle: "Subtitle",
+                modeSubtitle: hasModeSubtitle ? "Mode" : nil,
+                accentColor: .blue)
+        }
+        return self.totalCardHeight(rows: rows, hasTotal: hasTotal)
     }
 }

--- a/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
+++ b/Sources/CodexBar/StatusItemController+HostedSubmenus.swift
@@ -386,6 +386,12 @@ extension StatusItemController {
             return true
         }
 
+        // The SwiftUI view needs the callback at init, but the hosting view doesn't exist yet.
+        // A relay breaks the cycle: the closure captures relay strongly, relay holds the view weakly.
+        final class HostingRelay {
+            weak var hosting: MenuHostingView<CostHistoryChartMenuView>?
+        }
+        let relay = HostingRelay()
         let chartView = CostHistoryChartMenuView(
             provider: provider,
             daily: tokenSnapshot.daily,
@@ -393,14 +399,18 @@ extension StatusItemController {
             currencyCode: tokenSnapshot.currencyCode,
             historyDays: tokenSnapshot.historyDays,
             windowLabel: tokenSnapshot.historyLabel,
+            onHeightChange: { height in
+                relay.hosting?.applyMeasuredHeight(width: width, height: height)
+            },
             width: width)
-        let hosting = MenuHostingView(rootView: chartView)
-        hosting.frame = NSRect(
-            origin: .zero,
-            size: NSSize(width: width, height: self.hostedSubviewFittingHeight(for: hosting, width: width)))
+        let resolvedHosting = MenuHostingView(rootView: chartView)
+        relay.hosting = resolvedHosting
+        resolvedHosting.applyMeasuredHeight(
+            width: width,
+            height: self.hostedSubviewFittingHeight(for: resolvedHosting, width: width))
 
         let chartItem = NSMenuItem()
-        chartItem.view = hosting
+        chartItem.view = resolvedHosting
         chartItem.isEnabled = true
         chartItem.representedObject = Self.costHistoryChartID
         chartItem.toolTip = provider.rawValue

--- a/Sources/CodexBar/StatusItemController+MenuPresentation.swift
+++ b/Sources/CodexBar/StatusItemController+MenuPresentation.swift
@@ -82,8 +82,33 @@ final class MenuCardHighlightState {
 }
 
 final class MenuHostingView<Content: View>: NSHostingView<Content> {
+    /// The height AppKit should give this item's menu row. NSMenu reads `intrinsicContentSize`
+    /// (not the explicit `frame`) when it lays out custom-view rows, so a measured height that
+    /// only lives in `frame` is silently reverted to the open-time row height — leaving the
+    /// SwiftUI content centered in a stale, oversized row. Routing the height through the
+    /// intrinsic size is the channel the menu actually honors.
+    private var measuredHeight: CGFloat?
+
     override var allowsVibrancy: Bool {
         true
+    }
+
+    override var intrinsicContentSize: NSSize {
+        guard let measuredHeight else { return super.intrinsicContentSize }
+        return NSSize(width: NSView.noIntrinsicMetric, height: measuredHeight)
+    }
+
+    func applyMeasuredHeight(width: CGFloat, height: CGFloat) {
+        let resolvedHeight = max(1, ceil(height))
+        guard self.measuredHeight != resolvedHeight || self.frame.height != resolvedHeight else { return }
+
+        self.measuredHeight = resolvedHeight
+        self.frame = NSRect(
+            origin: self.frame.origin,
+            size: NSSize(width: width, height: resolvedHeight))
+        self.invalidateIntrinsicContentSize()
+        self.layoutSubtreeIfNeeded()
+        self.superview?.layoutSubtreeIfNeeded()
     }
 }
 

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -1,8 +1,45 @@
 import CodexBarCore
+import SwiftUI
 import Testing
 @testable import CodexBar
 
 struct CostHistoryChartMenuViewTests {
+    @Test
+    @MainActor
+    func `model breakdown keeps every item behind a bounded scrolling viewport`() {
+        let breakdown = (1...6).map { index in
+            CostUsageDailyReport.ModelBreakdown(
+                modelName: "model-\(index)",
+                costUSD: Double(index),
+                totalTokens: index * 100)
+        }
+
+        let ordered = CostHistoryChartMenuView.orderedBreakdownItems(breakdown)
+
+        #expect(ordered.map(\.modelName) == [
+            "model-6",
+            "model-5",
+            "model-4",
+            "model-3",
+            "model-2",
+            "model-1",
+        ])
+        #expect(CostHistoryChartMenuView.detailViewportRowCount(itemCount: ordered.count) == 4)
+        #expect(CostHistoryChartMenuView.detailRowsNeedScrolling(itemCount: ordered.count))
+    }
+
+    @Test
+    @MainActor
+    func `menu hosting view publishes measured height through intrinsic size`() {
+        let hosting = MenuHostingView(rootView: EmptyView())
+        hosting.frame = CGRect(x: 0, y: 0, width: 320, height: 1)
+
+        hosting.applyMeasuredHeight(width: 320, height: 123.2)
+
+        #expect(hosting.frame.size == CGSize(width: 320, height: 124))
+        #expect(hosting.intrinsicContentSize.height == 124)
+    }
+
     @Test
     @MainActor
     func `cost history defaults selection to latest day`() {

--- a/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
+++ b/Tests/CodexBarTests/CostHistoryChartMenuViewTests.swift
@@ -1,45 +1,72 @@
+import CodexBarCore
 import Testing
 @testable import CodexBar
-@testable import CodexBarCore
 
 struct CostHistoryChartMenuViewTests {
     @Test
     @MainActor
-    func `window label keeps today for one day and dynamic labels otherwise`() {
-        #expect(CostHistoryChartMenuView.windowLabel(days: 1) == "Today")
-        #expect(CostHistoryChartMenuView.windowLabel(days: 7) == "Last 7 days")
-        #expect(CostHistoryChartMenuView.windowLabel(days: 30) == "Last 30 days")
+    func `cost history defaults selection to latest day`() {
+        let daily = [
+            CostUsageDailyReport.Entry(
+                date: "2026-06-07",
+                inputTokens: 100,
+                outputTokens: 50,
+                totalTokens: 150,
+                costUSD: 1.25,
+                modelsUsed: ["gpt-5.5"],
+                modelBreakdowns: nil),
+            CostUsageDailyReport.Entry(
+                date: "2026-06-09",
+                inputTokens: 200,
+                outputTokens: 75,
+                totalTokens: 275,
+                costUSD: 2.5,
+                modelsUsed: ["gpt-5.5"],
+                modelBreakdowns: nil),
+        ]
+
+        #expect(
+            CostHistoryChartMenuView._defaultSelectedDateKeyForTesting(
+                provider: .codex,
+                daily: daily) == "2026-06-09")
     }
 
     @Test
     @MainActor
-    func `model breakdown keeps every item behind a bounded scrolling viewport`() {
-        let breakdown = (1...6).map { index in
-            CostUsageDailyReport.ModelBreakdown(
-                modelName: "model-\(index)",
-                costUSD: Double(index),
-                totalTokens: index * 100)
-        }
+    func `cost history detail height follows visible rows and caps at viewport limit`() {
+        let singleRowHeight = CostHistoryChartMenuView._detailViewportHeightForTesting(modeSubtitlePresence: [false])
+        let twoRowHeight = CostHistoryChartMenuView._detailViewportHeightForTesting(modeSubtitlePresence: [false, true])
+        let fourRowHeight = CostHistoryChartMenuView._detailViewportHeightForTesting(
+            modeSubtitlePresence: [false, false, false, false])
+        let fiveRowHeight = CostHistoryChartMenuView._detailViewportHeightForTesting(
+            modeSubtitlePresence: [false, false, false, false, true])
 
-        let ordered = CostHistoryChartMenuView.orderedBreakdownItems(breakdown)
+        #expect(singleRowHeight < twoRowHeight)
+        #expect(twoRowHeight < fourRowHeight)
+        #expect(fiveRowHeight == fourRowHeight)
 
-        #expect(ordered.map(\.modelName) == [
-            "model-6",
-            "model-5",
-            "model-4",
-            "model-3",
-            "model-2",
-            "model-1",
-        ])
-        #expect(ordered.count == 6)
-        #expect(CostHistoryChartMenuView.detailViewportRowCount(itemCount: ordered.count) == 4)
-        #expect(CostHistoryChartMenuView.detailRowsNeedScrolling(itemCount: ordered.count))
+        let emptyBlockHeight = CostHistoryChartMenuView._detailBlockHeightForTesting(modeSubtitlePresence: [])
+        let populatedBlockHeight = CostHistoryChartMenuView._detailBlockHeightForTesting(modeSubtitlePresence: [false])
+        #expect(emptyBlockHeight < populatedBlockHeight)
     }
 
     @Test
     @MainActor
-    func `short model breakdown does not scroll or reserve extra rows`() {
-        #expect(CostHistoryChartMenuView.detailViewportRowCount(itemCount: 3) == 3)
-        #expect(CostHistoryChartMenuView.detailRowsNeedScrolling(itemCount: 3) == false)
+    func `cost history total card height grows with rows and the total line`() {
+        let oneRow = CostHistoryChartMenuView._totalCardHeightForTesting(
+            modeSubtitlePresence: [false],
+            hasTotal: false)
+        let threeRows = CostHistoryChartMenuView._totalCardHeightForTesting(
+            modeSubtitlePresence: [false, false, false],
+            hasTotal: false)
+        #expect(oneRow < threeRows)
+
+        let withoutTotal = CostHistoryChartMenuView._totalCardHeightForTesting(
+            modeSubtitlePresence: [false],
+            hasTotal: false)
+        let withTotal = CostHistoryChartMenuView._totalCardHeightForTesting(
+            modeSubtitlePresence: [false],
+            hasTotal: true)
+        #expect(withTotal > withoutTotal)
     }
 }


### PR DESCRIPTION
## Summary

Resize the cost-history menu card to the hovered day's actual model breakdown instead of reserving the tallest day's height. The row grows and shrinks with the current selection while keeping breakdowns beyond four rows scrollable.

## Implementation

- Compute total height from the chart, selected detail rows, optional total, fixed spacing, and padding.
- Default selection to the latest valid day.
- Report height changes synchronously from the chart hover handler, which runs during NSMenu tracking.
- Publish the measured height through MenuHostingView intrinsicContentSize, the sizing channel NSMenu honors for custom rows.
- Use a weak hosting relay to avoid a SwiftUI/hosting-view retain cycle.
- Preserve ordered model breakdowns and cap the visible viewport at four rows.

## Verification

Exact candidate: dea6c861d02e679a13900b210e3925bce5c22e5a

- 14 focused cost-history and hosted-submenu tests passed after the final rebase.
- Coverage includes 0/1/3/4/>4 row height behavior, optional totals, latest-day selection, ordered six-item scrolling, initial hosted sizing, and AppKit intrinsic-size publication.
- make check passed with zero format or lint findings.
- Full-branch Codex autoreview found no accepted/actionable findings, confidence 0.82.
- Exact ad-hoc package completed and passed deep strict code-sign verification.
- Packaged app reports git commit dea6c861 and remained alive after launch.
- Existing screenshots below show short, medium, and tall selections. Exact live hover recapture was attempted; a pending macOS App Data consent sheet on this machine blocks synthetic menu interaction.

## Screenshots

<img width="311" height="265" alt="Short cost-history detail selection" src="https://github.com/user-attachments/assets/6db5826d-dd88-4828-a779-9971636f5cfb" />
<img width="312" height="350" alt="Tall cost-history detail selection" src="https://github.com/user-attachments/assets/c9db6064-2e1b-42eb-b9b7-d02edb0d0745" />
<img width="312" height="295" alt="Medium cost-history detail selection" src="https://github.com/user-attachments/assets/2bf0dd07-f40c-42b8-90cf-6e054f4d7885" />
