### PR TITLE
Add opt-in SQLite path for static Linux CLI builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Codex agents: add a read-only `codexbar` skill for bounded, redacted provider usage JSON. Thanks @coygeek!
 
 ### Changed
+- Linux CLI: accept an opt-in static SQLite library directory for musl builds. Thanks @Yuxin-Qiao!
 - Linux CLI: add musl source compatibility for static Linux SDK builds. Thanks @Yuxin-Qiao!
 - Cost history: resize the chart details to the hovered day's model breakdown instead of reserving the tallest day. Thanks @elijahfriedman!
 - Antigravity: use current backend quota labels in menus and widgets while preferring a usable quota lane over an exhausted one. Thanks @Yuxin-Qiao!

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,14 @@ let sweetCookieKitDependency: Package.Dependency =
     ? .package(path: sweetCookieKitPath)
     : .package(url: "https://github.com/steipete/SweetCookieKit", from: "0.4.1")
 
+let sqlite3LibDir = ProcessInfo.processInfo.environment["CODEXBAR_SQLITE3_LIB_DIR"]?
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+let sqlite3LinkerSettings: [LinkerSetting] = if let sqlite3LibDir, !sqlite3LibDir.isEmpty {
+    [.unsafeFlags(["-L\(sqlite3LibDir)"], .when(platforms: [.linux]))]
+} else {
+    []
+}
+
 let package = Package(
     name: "CodexBar",
     defaultLocalization: "en",
@@ -53,7 +61,8 @@ let package = Package(
                 ],
                 swiftSettings: [
                     .enableUpcomingFeature("StrictConcurrency"),
-                ]),
+                ],
+                linkerSettings: sqlite3LinkerSettings),
             .executableTarget(
                 name: "CodexBarCLI",
                 dependencies: [
@@ -63,7 +72,8 @@ let package = Package(
                 path: "Sources/CodexBarCLI",
                 swiftSettings: [
                     .enableUpcomingFeature("StrictConcurrency"),
-                ]),
+                ],
+                linkerSettings: sqlite3LinkerSettings),
             .testTarget(
                 name: "CodexBarLinuxTests",
                 dependencies: ["CodexBarCore", "CodexBarCLI"],


### PR DESCRIPTION
Refs #1524

Second step of the musl CLI stack, now rebased as one commit on the landed #1620 source-compatibility base.

## Summary

- add an opt-in `CODEXBAR_SQLITE3_LIB_DIR` Package.swift build contract
- pass that directory as a Linux-only linker search path for `CodexBarCore` and `CodexBarCLI`
- keep default builds unchanged when the variable is unset, empty, or whitespace-only

The Swift Static Linux SDK does not ship `libsqlite3.a`, while SweetCookieKit links SQLite. Release callers can now provide a target-architecture static library without changing normal macOS or glibc builds.

No release workflow or artifact-matrix changes are included here; #1610 consumes this hook.

## Verification

- exact `swift package dump-package` assertions for unset, blank, and a configured path containing spaces
- `swift test --filter CLIEntryTests` (22 tests)
- `make check`
- autoreview: clean, no actionable findings (0.87)
- isolated Ubuntu 24.04 x86_64 build with checksummed Swift 6.2.1 static Linux SDK and SQLite 3.53.2 amalgamation
- resulting CodexBarCLI: x86-64 static ELF; `--help` and `config validate --format json` both executed successfully
