### PR TITLE
Add musl CLI artifacts to release workflow

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -22,30 +22,76 @@ jobs:
           - name: linux-x64
             runs-on: ubuntu-24.04
             platform: linux
+            asset-platform: linux
             asset-arch: x86_64
             build-arch: ""
             static-swift-stdlib: true
+            swift-sdk: ""
+            swift-sdk-triple: ""
+            swift-sdk-arch: ""
+            file-arch-pattern: x86-64
           - name: linux-arm64
             runs-on: ubuntu-24.04-arm
             platform: linux
+            asset-platform: linux
             asset-arch: aarch64
             build-arch: ""
             static-swift-stdlib: true
+            swift-sdk: ""
+            swift-sdk-triple: ""
+            swift-sdk-arch: ""
+            file-arch-pattern: aarch64
+          - name: linux-musl-x64
+            runs-on: ubuntu-24.04
+            platform: linux
+            asset-platform: linux-musl
+            asset-arch: x86_64
+            build-arch: ""
+            static-swift-stdlib: false
+            swift-sdk: swift-6.2.1-RELEASE_static-linux-0.0.1
+            swift-sdk-triple: x86_64-swift-linux-musl
+            swift-sdk-arch: x86_64
+            file-arch-pattern: x86-64
+          - name: linux-musl-arm64
+            runs-on: ubuntu-24.04-arm
+            platform: linux
+            asset-platform: linux-musl
+            asset-arch: aarch64
+            build-arch: ""
+            static-swift-stdlib: false
+            swift-sdk: swift-6.2.1-RELEASE_static-linux-0.0.1
+            swift-sdk-triple: aarch64-swift-linux-musl
+            swift-sdk-arch: aarch64
+            file-arch-pattern: aarch64
           - name: macos-arm64
             runs-on: macos-15
             platform: macos
+            asset-platform: macos
             asset-arch: arm64
             build-arch: arm64
             static-swift-stdlib: false
+            swift-sdk: ""
+            swift-sdk-triple: ""
+            swift-sdk-arch: ""
+            file-arch-pattern: ""
           - name: macos-x86_64
             runs-on: macos-15-intel
             platform: macos
+            asset-platform: macos
             asset-arch: x86_64
             build-arch: x86_64
             static-swift-stdlib: false
+            swift-sdk: ""
+            swift-sdk-triple: ""
+            swift-sdk-arch: ""
+            file-arch-pattern: ""
     runs-on: ${{ matrix.runs-on }}
     env:
       RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+      SWIFT_STATIC_LINUX_SDK_URL: https://download.swift.org/swift-6.2.1-release/static-sdk/swift-6.2.1-RELEASE/swift-6.2.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz
+      SWIFT_STATIC_LINUX_SDK_CHECKSUM: 08e1939a504e499ec871b36826569173103e4562769e12b9b8c2a50f098374ad
+      SQLITE_AMALGAMATION_VERSION: "3530200"
+      SQLITE_AMALGAMATION_SHA3_256: 81142986038e18f96c4a54e1a72562ae17e502a916f2a7701eff43388cbf1a40
     steps:
       - uses: actions/checkout@v6
 
@@ -118,6 +164,102 @@ jobs:
           hash -r
           swift --version
 
+      - name: Install Swift Static Linux SDK
+        if: matrix.swift-sdk != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          swift sdk install "$SWIFT_STATIC_LINUX_SDK_URL" --checksum "$SWIFT_STATIC_LINUX_SDK_CHECKSUM"
+          swift sdk list | grep -Fx "${{ matrix.swift-sdk }}"
+
+          sdk_root="$(
+            find "$HOME" -type d -path "*/${{ matrix.swift-sdk }}.artifactbundle/${{ matrix.swift-sdk }}/swift-linux-musl" | head -n1
+          )"
+          if [[ -z "$sdk_root" ]]; then
+            echo "Swift SDK root not found." >&2
+            exit 1
+          fi
+
+          python3 - "$sdk_root/swift-sdk.json" "${{ matrix.swift-sdk-triple }}" <<'PY'
+          import json
+          import sys
+
+          sdk_json_path, target_triple = sys.argv[1], sys.argv[2]
+          with open(sdk_json_path, encoding="utf-8") as handle:
+              sdk_json = json.load(handle)
+
+          target_triples = sdk_json.get("targetTriples", {})
+          if target_triple not in target_triples:
+              raise SystemExit(f"Swift SDK target triple not found: {target_triple}")
+
+          sdk_json["targetTriples"] = {target_triple: target_triples[target_triple]}
+          with open(sdk_json_path, "w", encoding="utf-8") as handle:
+              json.dump(sdk_json, handle, indent=2)
+              handle.write("\n")
+          PY
+
+          for sdk_arch in "$sdk_root"/musl-1.2.5.sdk/*; do
+            if [[ "$(basename "$sdk_arch")" != "${{ matrix.swift-sdk-arch }}" ]]; then
+              rm -rf "$sdk_arch"
+            fi
+          done
+
+      - name: Build static SQLite for musl SDK
+        if: matrix.swift-sdk != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          missing_packages=()
+          for tool in clang openssl unzip; do
+            if ! command -v "$tool" >/dev/null 2>&1; then
+              missing_packages+=("$tool")
+            fi
+          done
+          if [[ "${#missing_packages[@]}" -gt 0 ]]; then
+            sudo apt-get update
+            sudo apt-get install -y "${missing_packages[@]}"
+          fi
+
+          sqlite_zip="$RUNNER_TEMP/sqlite-amalgamation-${SQLITE_AMALGAMATION_VERSION}.zip"
+          sqlite_src="$RUNNER_TEMP/sqlite-src"
+          sqlite_out="$RUNNER_TEMP/sqlite-${{ matrix.swift-sdk-triple }}"
+
+          curl -fsSL "https://www.sqlite.org/2026/sqlite-amalgamation-${SQLITE_AMALGAMATION_VERSION}.zip" -o "$sqlite_zip"
+          actual_sha3="$(openssl dgst -sha3-256 "$sqlite_zip" | awk '{print $NF}')"
+          if [[ "$actual_sha3" != "$SQLITE_AMALGAMATION_SHA3_256" ]]; then
+            echo "SQLite amalgamation checksum mismatch: $actual_sha3" >&2
+            exit 1
+          fi
+
+          rm -rf "$sqlite_src" "$sqlite_out"
+          mkdir -p "$sqlite_src" "$sqlite_out/build" "$sqlite_out/lib"
+          unzip -q "$sqlite_zip" -d "$sqlite_src"
+
+          sdk_bundle="$(
+            find "$HOME" -type d -name "${{ matrix.swift-sdk }}.artifactbundle" | head -n1
+          )"
+          if [[ -z "$sdk_bundle" ]]; then
+            echo "Swift SDK artifact bundle not found." >&2
+            exit 1
+          fi
+          sysroot="$sdk_bundle/${{ matrix.swift-sdk }}/swift-linux-musl/musl-1.2.5.sdk/${{ matrix.swift-sdk-arch }}"
+          if [[ ! -d "$sysroot" ]]; then
+            echo "Swift SDK sysroot not found: $sysroot" >&2
+            exit 1
+          fi
+
+          clang \
+            -target "${{ matrix.swift-sdk-triple }}" \
+            --sysroot="$sysroot" \
+            -O2 \
+            -DSQLITE_OMIT_LOAD_EXTENSION=1 \
+            -c "$sqlite_src/sqlite-amalgamation-${SQLITE_AMALGAMATION_VERSION}/sqlite3.c" \
+            -o "$sqlite_out/build/sqlite3.o"
+          llvm-ar crs "$sqlite_out/lib/libsqlite3.a" "$sqlite_out/build/sqlite3.o"
+
+          echo "CODEXBAR_SQLITE3_LIB_DIR=$sqlite_out/lib" >> "$GITHUB_ENV"
+
       - name: Build CodexBarCLI (release)
         id: build
         shell: bash
@@ -125,7 +267,9 @@ jobs:
           set -euo pipefail
 
           BUILD_ARGS=(swift build -c release --product CodexBarCLI)
-          if [[ -n "${{ matrix.build-arch }}" ]]; then
+          if [[ -n "${{ matrix.swift-sdk }}" ]]; then
+            BUILD_ARGS+=(--swift-sdk "${{ matrix.swift-sdk }}" --triple "${{ matrix.swift-sdk-triple }}")
+          elif [[ -n "${{ matrix.build-arch }}" ]]; then
             BUILD_ARGS+=(--arch "${{ matrix.build-arch }}")
           fi
           if [[ "${{ matrix.static-swift-stdlib }}" == "true" ]]; then
@@ -134,7 +278,9 @@ jobs:
           "${BUILD_ARGS[@]}"
 
           SHOW_BIN_ARGS=(swift build -c release --product CodexBarCLI --show-bin-path)
-          if [[ -n "${{ matrix.build-arch }}" ]]; then
+          if [[ -n "${{ matrix.swift-sdk }}" ]]; then
+            SHOW_BIN_ARGS+=(--swift-sdk "${{ matrix.swift-sdk }}" --triple "${{ matrix.swift-sdk-triple }}")
+          elif [[ -n "${{ matrix.build-arch }}" ]]; then
             SHOW_BIN_ARGS+=(--arch "${{ matrix.build-arch }}")
           fi
           if [[ "${{ matrix.static-swift-stdlib }}" == "true" ]]; then
@@ -184,9 +330,14 @@ jobs:
           if [[ "${{ matrix.platform }}" == "macos" ]]; then
             lipo -archs "$BIN" | tr ' ' '\n' | grep -Fx "${{ matrix.asset-arch }}"
             run_with_timeout "$RUNNER_TEMP/codexbar-cli-smoke-${{ matrix.name }}.txt" "$BIN" config validate --format json
+          elif [[ -n "${{ matrix.swift-sdk }}" ]]; then
+            run_with_timeout "$RUNNER_TEMP/codexbar-cli-help-${{ matrix.name }}.txt" "$BIN" --help
+            run_with_timeout "$RUNNER_TEMP/codexbar-cli-config-${{ matrix.name }}.json" "$BIN" config validate --format json
+            file "$BIN" | grep -q "${{ matrix.file-arch-pattern }}"
+            file "$BIN" | grep -q "statically linked"
           else
             run_with_timeout "$RUNNER_TEMP/codexbar-cli-help-${{ matrix.name }}.txt" "$BIN" --help
-            file "$BIN" | grep -q "${{ matrix.asset-arch }}"
+            file "$BIN" | grep -q "${{ matrix.file-arch-pattern }}"
           fi
           printf '%s\n' "${RELEASE_TAG#v}" > "$BIN_DIR/VERSION"
           VERSION_OUTPUT="$RUNNER_TEMP/codexbar-cli-version-${{ matrix.name }}.txt"
@@ -213,7 +364,7 @@ jobs:
           ln -s "CodexBarCLI" "$OUT_DIR/codexbar"
           printf '%s\n' "${SAFE_REF_NAME#v}" > "$OUT_DIR/VERSION"
 
-          ASSET="CodexBarCLI-${SAFE_REF_NAME}-${{ matrix.platform }}-${{ matrix.asset-arch }}.tar.gz"
+          ASSET="CodexBarCLI-${SAFE_REF_NAME}-${{ matrix.asset-platform }}-${{ matrix.asset-arch }}.tar.gz"
           (cd "$OUT_DIR" && tar czf "$ASSET" CodexBarCLI codexbar VERSION)
           if command -v sha256sum >/dev/null 2>&1; then
             sha256sum "$OUT_DIR/$ASSET" > "$OUT_DIR/$ASSET.sha256"

--- a/.mac-release.env
+++ b/.mac-release.env
@@ -34,4 +34,8 @@ MAC_RELEASE_EXTRA_ASSET_PATTERNS='^CodexBarCLI-v${MARKETING_VERSION}-macos-arm64
 ^CodexBarCLI-v${MARKETING_VERSION}-linux-aarch64\.tar\.gz$
 ^CodexBarCLI-v${MARKETING_VERSION}-linux-aarch64\.tar\.gz\.sha256$
 ^CodexBarCLI-v${MARKETING_VERSION}-linux-x86_64\.tar\.gz$
-^CodexBarCLI-v${MARKETING_VERSION}-linux-x86_64\.tar\.gz\.sha256$'
+^CodexBarCLI-v${MARKETING_VERSION}-linux-x86_64\.tar\.gz\.sha256$
+^CodexBarCLI-v${MARKETING_VERSION}-linux-musl-aarch64\.tar\.gz$
+^CodexBarCLI-v${MARKETING_VERSION}-linux-musl-aarch64\.tar\.gz\.sha256$
+^CodexBarCLI-v${MARKETING_VERSION}-linux-musl-x86_64\.tar\.gz$
+^CodexBarCLI-v${MARKETING_VERSION}-linux-musl-x86_64\.tar\.gz\.sha256$'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.36.2 — Unreleased
 
 ### Added
+- Linux CLI: publish static musl release tarballs for x86_64 and aarch64. Thanks @Yuxin-Qiao!
 - Codex agents: add a read-only `codexbar` skill for bounded, redacted provider usage JSON. Thanks @coygeek!
 - Display: add a Hide critters option for plain menu bar quota capsules. Thanks @elijahfriedman!
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ yay -S codexbar-cli
 ```
 Or download release tarballs from GitHub Releases:
 - macOS: `CodexBarCLI-v<tag>-macos-arm64.tar.gz`, `CodexBarCLI-v<tag>-macos-x86_64.tar.gz`
-- Linux: `CodexBarCLI-v<tag>-linux-aarch64.tar.gz`, `CodexBarCLI-v<tag>-linux-x86_64.tar.gz`
+- Linux (glibc): `CodexBarCLI-v<tag>-linux-aarch64.tar.gz`, `CodexBarCLI-v<tag>-linux-x86_64.tar.gz`
+- Linux (static musl): `CodexBarCLI-v<tag>-linux-musl-aarch64.tar.gz`, `CodexBarCLI-v<tag>-linux-musl-x86_64.tar.gz`
 
 ### First run
 - Open Settings → Providers and enable what you use.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -73,7 +73,7 @@ Uploads not handled automatically—commit/publish appcast + zip to the feed loc
 CodexBar ships a Homebrew **Cask** in `../homebrew-tap`. When installed via Homebrew, CodexBar disables Sparkle and the app
 must be updated via `brew`.
 
-After publishing the GitHub release, `.github/workflows/release-cli.yml` builds the CLI tarballs, uploads `CodexBarCLI-v<version>-{macos-arm64,macos-x86_64,linux-aarch64,linux-x86_64}.tar.gz` plus checksums, then dispatches the Homebrew tap update for both the CLI formula and app cask. If the final dispatch is rate-limited, the tarballs and app zip may still be present; rerun or manually update the tap formula/cask from the published assets.
+After publishing the GitHub release, `.github/workflows/release-cli.yml` builds the macOS, glibc Linux, and static musl Linux CLI tarballs for arm64 and x86_64, uploads them plus checksums, then dispatches the Homebrew tap update for both the CLI formula and app cask. Homebrew continues to use the glibc Linux assets. If the final dispatch is rate-limited, the tarballs and app zip may still be present; rerun or manually update the tap formula/cask from the published assets.
 
 ## Checklist (quick)
 - [ ] Read both this file and `~/Projects/agent-scripts/docs/RELEASING-MAC.md`; resolve any conflicts toward CodexBar’s specifics.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,7 +20,8 @@ Use it when you need usage numbers in scripts, CI, or dashboards without UI.
 - Homebrew formula (Linux today): `brew install steipete/tap/codexbar`.
 - Download release tarballs from GitHub Releases:
   - macOS: `CodexBarCLI-v<tag>-macos-arm64.tar.gz`, `CodexBarCLI-v<tag>-macos-x86_64.tar.gz`
-  - Linux: `CodexBarCLI-v<tag>-linux-aarch64.tar.gz`, `CodexBarCLI-v<tag>-linux-x86_64.tar.gz`
+  - Linux (glibc): `CodexBarCLI-v<tag>-linux-aarch64.tar.gz`, `CodexBarCLI-v<tag>-linux-x86_64.tar.gz`
+  - Linux (static musl): `CodexBarCLI-v<tag>-linux-musl-aarch64.tar.gz`, `CodexBarCLI-v<tag>-linux-musl-x86_64.tar.gz`
 - Extract and run `./codexbar` (symlink) or `./CodexBarCLI`.
 
 ```

--- a/docs/releasing-homebrew.md
+++ b/docs/releasing-homebrew.md
@@ -36,6 +36,7 @@ In `../homebrew-tap`, update the formula at `Formula/codexbar.rb`:
   - macOS: `.../releases/download/v<version>/CodexBarCLI-v<version>-macos-x86_64.tar.gz`
   - Linux: `.../releases/download/v<version>/CodexBarCLI-v<version>-linux-aarch64.tar.gz`
   - Linux: `.../releases/download/v<version>/CodexBarCLI-v<version>-linux-x86_64.tar.gz`
+- Static musl tarballs are also published for manual Linux installs as `linux-musl-aarch64` and `linux-musl-x86_64`; keep the formula on the glibc assets unless intentionally changing its runtime contract.
 - Update all `sha256` values to match those tarballs.
 
 ## 3) Verify install


### PR DESCRIPTION
Refs #1524

Third step of the musl CLI stack. #1609 is landed; this PR is now rebased and retargeted to `main`.

## Summary

- retain existing macOS and glibc Linux release artifacts
- add static musl artifacts for x86_64 and aarch64
- install the checksummed Swift 6.2.1 static Linux SDK and narrow it to the matrix architecture
- build a checksummed target-architecture SQLite 3.53.2 static library through #1609's opt-in linker path
- smoke-test architecture, static linkage, `--help`, config validation, and version reporting
- package distinct `linux-musl-{x86_64,aarch64}` tarballs and checksums
- update release verification patterns and install/release documentation

The per-architecture SDK narrowing is intentional: live static-SDK proof showed that `--triple` alone can select headers from the other bundled architecture during dependency compilation.

Homebrew continues to consume the existing glibc Linux artifacts; this PR does not change that runtime contract.

## Verification

- release workflow YAML/matrix assertions
- `.mac-release.env` shell syntax
- `make check`
- autoreview: clean, no actionable findings (0.76)
- isolated Ubuntu 24.04 x86_64 static-musl build and CLI startup
- exact x86_64 artifact name, VERSION injection, checksum, symlink, archive contents, architecture, and static-link proof
- isolated native arm64 Ubuntu crabbox: static aarch64 build, CLI/config/version execution, checksum, symlink, archive contents, and `linux-musl-aarch64` artifact naming passed
- [six-job release workflow](https://github.com/steipete/CodexBar/actions/runs/27756071000) passed for musl x86_64/aarch64, glibc x86_64/aarch64, and macOS x86_64/arm64
- exact rebased head `462d05bb`; its release diff is content-identical to workflow-proven head `272807bc` (only Git blob IDs changed with the new base)
