### PR TITLE
Reduce release app bundle size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Display: add a Hide critters option for plain menu bar quota capsules. Thanks @elijahfriedman!
 
 ### Changed
+- Packaging: strip local symbols from release executables to reduce the installed app and download size. Thanks @jieshu666!
 - Logging: skip message, metadata, and redaction work for filtered or disabled log destinations. Thanks @ProspectOre!
 - Cost history: cache date parsers per thread to reduce repeated report-decoding overhead. Thanks @ProspectOre!
 - Linux CLI: accept an opt-in static SQLite library directory for musl builds. Thanks @Yuxin-Qiao!

--- a/Scripts/lint.sh
+++ b/Scripts/lint.sh
@@ -19,6 +19,10 @@ check_package_product_paths() {
   "${ROOT_DIR}/Scripts/test_package_product_paths.sh"
 }
 
+check_package_strip() {
+  "${ROOT_DIR}/Scripts/test_package_strip.sh"
+}
+
 check_release_dsym_paths() {
   "${ROOT_DIR}/Scripts/test_release_dsym_paths.sh"
 }
@@ -44,6 +48,7 @@ check_site_locales() {
 run_portable_checks() {
   check_codex_parser_hash
   check_package_product_paths
+  check_package_strip
   check_release_dsym_paths
   check_sparkle_signing_paths
   check_swift_test_sharding

--- a/Scripts/package_app.sh
+++ b/Scripts/package_app.sh
@@ -322,6 +322,17 @@ install_binary() {
   verify_binary_arches "$dest" "${ARCH_LIST[@]}"
 }
 
+strip_release_binary() {
+  local binary="$1"
+  if [[ "$LOWER_CONF" != "release" ]]; then
+    return 0
+  fi
+  if [[ ! -f "$binary" ]]; then
+    return 0
+  fi
+  xcrun strip -x "$binary"
+}
+
 ensure_widget_extension_project() {
   local spec="$ROOT/WidgetExtension/project.yml"
   local project_dir="$ROOT/WidgetExtension/CodexBarWidgetExtension.xcodeproj"
@@ -409,11 +420,15 @@ install_widget_extension() {
 }
 
 install_binary "CodexBar" "$APP/Contents/MacOS/CodexBar"
+strip_release_binary "$APP/Contents/MacOS/CodexBar"
 # Ship CodexBarCLI alongside the app for easy symlinking.
 install_binary "CodexBarCLI" "$APP/Contents/Helpers/CodexBarCLI"
+strip_release_binary "$APP/Contents/Helpers/CodexBarCLI"
 # Watchdog helper: ensures `claude` probes die when CodexBar crashes/gets killed.
 install_binary "CodexBarClaudeWatchdog" "$APP/Contents/Helpers/CodexBarClaudeWatchdog"
+strip_release_binary "$APP/Contents/Helpers/CodexBarClaudeWatchdog"
 install_widget_extension
+strip_release_binary "$APP/Contents/PlugIns/CodexBarWidget.appex/Contents/MacOS/CodexBarWidget"
 
 swiftpm_bin_path "${ARCH_LIST[0]}" PREFERRED_BUILD_DIR
 

--- a/Scripts/test_package_strip.sh
+++ b/Scripts/test_package_strip.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+PACKAGE_SCRIPT="$ROOT/Scripts/package_app.sh"
+FUNCTIONS_FILE=$(mktemp "${TMPDIR:-/tmp}/codexbar-package-strip-functions.XXXXXX")
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/codexbar-package-strip.XXXXXX")
+trap 'rm -rf "$FUNCTIONS_FILE" "$TEMP_DIR"' EXIT
+
+python3 - "$PACKAGE_SCRIPT" "$FUNCTIONS_FILE" <<'PY'
+import sys
+from pathlib import Path
+
+script = Path(sys.argv[1]).read_text()
+start = script.index('strip_release_binary() {')
+end = script.index('\n}\n', start) + 3
+Path(sys.argv[2]).write_text(script[start:end])
+PY
+
+xcrun() {
+  [[ "$1" == "strip" && "$2" == "-x" ]]
+  printf '%s\n' "$3" >> "$STRIP_LOG"
+}
+
+source "$FUNCTIONS_FILE"
+
+binary="$TEMP_DIR/CodexBar"
+touch "$binary"
+
+STRIP_LOG="$TEMP_DIR/release.log"
+LOWER_CONF=release
+strip_release_binary "$binary"
+grep -Fqx "$binary" "$STRIP_LOG"
+
+STRIP_LOG="$TEMP_DIR/debug.log"
+LOWER_CONF=debug
+strip_release_binary "$binary"
+[[ ! -e "$STRIP_LOG" ]]
+
+STRIP_LOG="$TEMP_DIR/missing.log"
+LOWER_CONF=release
+strip_release_binary "$TEMP_DIR/MissingBinary"
+[[ ! -e "$STRIP_LOG" ]]
+
+echo "Package strip tests passed."


### PR DESCRIPTION
## Summary

- strip local symbols from packaged release app, CLI, watchdog, and widget executables before signing
- preserve unstripped debug packages for local debugging
- add a portable packaging-script regression check to `make check`
- document the release-size improvement and credit @jieshu666

## Why

Swift symbol tables dominate the packaged executables. Release-only `strip -x` substantially reduces the installed app and download size while preserving the Mach-O UUID used to match the existing dSYM.

## Exact-head verification

Verified at `d7f1f6dd31b24e0a801416d03e7ba2d915ab9655`:

- `./Scripts/test_package_strip.sh`
- `make check`
- `make test`: all 41 shards passed
- autoreview: clean (0.82), no accepted/actionable findings
- universal release package succeeded for the app, CLI, watchdog, and widget on arm64 and x86_64
- packaged app, CLI, watchdog, and widget executables contained no local symbols
- deep strict code-sign verification passed
- packaged app and dSYM UUIDs matched
- packaged CLI reported version `0.36.2`

Developer ID signing and notarization remain protected release-time verification steps.

The contributor's universal release comparison measured the app zip shrinking from 48,598,232 to 38,769,894 bytes, approximately 20.2%.
